### PR TITLE
[FIX] repair,sale_stock: display SN/lot in repair order invoices

### DIFF
--- a/addons/repair/models/__init__.py
+++ b/addons/repair/models/__init__.py
@@ -3,6 +3,7 @@
 
 from . import repair
 from . import stock_move
+from . import stock_move_line
 from . import stock_picking
 from . import stock_traceability
 from . import stock_lot

--- a/addons/repair/models/stock_move_line.py
+++ b/addons/repair/models/stock_move_line.py
@@ -1,0 +1,10 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class StockMoveLine(models.Model):
+    _inherit = 'stock.move.line'
+
+    def _should_show_lot_in_invoice(self):
+        return super()._should_show_lot_in_invoice() or self.move_id.repair_line_type

--- a/addons/repair/tests/test_repair.py
+++ b/addons/repair/tests/test_repair.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import Command
 from odoo.exceptions import UserError, ValidationError
 from odoo.tests import tagged, common, Form
 from odoo.tools import float_compare, float_is_zero
@@ -626,3 +627,37 @@ class TestRepair(common.TransactionCase):
         repair_order.move_ids.quantity_done = 1
         repair_order.action_repair_end()
         self.assertEqual(repair_order.state, 'done')
+
+    def test_repair_components_lots_show_in_invoice(self):
+        """
+        Test that the lots of the components of a repair order are shown in the invoice
+        """
+        quant = self.create_quant(self.product_storable_serial, 1)
+        quant.action_apply_inventory()
+        repair_order = self.env['repair.order'].create({
+            'product_id': self.product_product_3.id,
+            'product_uom': self.product_product_3.uom_id.id,
+            'picking_type_id': self.stock_warehouse.repair_type_id.id,
+            'partner_id': self.res_partner_12.id,
+            'move_ids': [
+                Command.create({
+                    'product_id': self.product_storable_serial.id,
+                    'product_uom_qty': 1.0,
+                    'state': 'draft',
+                    'repair_line_type': 'add',
+                })
+            ],
+        })
+        repair_order.action_validate()
+        repair_order.action_repair_start()
+        repair_order.move_ids.quantity_done = 1
+        repair_order.action_repair_end()
+        repair_order.action_create_sale_order()
+        sale_order = repair_order.sale_order_id
+        sale_order.action_confirm()
+        invoice = sale_order._create_invoices()
+        invoice.action_post()
+        res = invoice._get_invoiced_lot_values()
+        self.assertEqual(len(res), 1, "The invoice should have one line")
+        self.assertEqual(res[0]['product_name'], self.product_storable_serial.display_name, "The product name should be the same")
+        self.assertEqual(res[0]['lot_name'], quant.lot_id.name, "The lot name should be the same")

--- a/addons/sale_stock/models/account_move.py
+++ b/addons/sale_stock/models/account_move.py
@@ -62,7 +62,7 @@ class AccountMove(models.Model):
         previous_qties_delivered = defaultdict(float)
         stock_move_lines = current_invoice_amls.sale_line_ids.move_ids.move_line_ids.filtered(lambda sml: sml.state == 'done' and sml.lot_id).sorted(lambda sml: (sml.date, sml.id))
         for sml in stock_move_lines:
-            if sml.product_id not in invoiced_products or 'customer' not in {sml.location_id.usage, sml.location_dest_id.usage}:
+            if sml.product_id not in invoiced_products or not sml._should_show_lot_in_invoice():
                 continue
             product = sml.product_id
             product_uom = product.uom_id

--- a/addons/sale_stock/models/stock.py
+++ b/addons/sale_stock/models/stock.py
@@ -60,6 +60,14 @@ class StockMove(models.Model):
     def _get_all_related_sm(self, product):
         return super()._get_all_related_sm(product) | self.filtered(lambda m: m.sale_line_id.product_id == product)
 
+
+class StockMoveLine(models.Model):
+    _inherit = "stock.move.line"
+
+    def _should_show_lot_in_invoice(self):
+        return 'customer' in {self.location_id.usage, self.location_dest_id.usage}
+
+
 class ProcurementGroup(models.Model):
     _inherit = 'procurement.group'
 


### PR DESCRIPTION
Bug:
Invoices created for sales orders generated by a repair order didn't show SN/lot number for products that are tracked when activating "Display Lots & Serial Numbers on Invoices" setting. This was because the method generating the lots for the report only included stock move lines that had `customer` in its source or destination location usage, which is not the case in the move lines of a repair order.

Fix:
Exclude repair move lines from this check.

Task-3848611

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
