### PR TITLE
[FIX] base: `has_group` return False for new id instead of traceback

### DIFF
--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -1081,12 +1081,18 @@ class Users(models.Model):
         """
         self.ensure_one()
 
-        if not (self.env.su or self == self.env.user or self._has_group('base.group_user')):
+        user = self
+        if isinstance(user.id, models.NewId):
+            user = user._origin
+            if not user.id:
+                return False
+
+        if not (self.env.su or user == self.env.user or user._has_group('base.group_user')):
             # this prevents RPC calls from non-internal users to retrieve
             # information about other users
             raise AccessError(_("You can ony call user.has_group() with your current user."))
 
-        result = self._has_group(group_ext_id)
+        result = user._has_group(group_ext_id)
         if group_ext_id == 'base.group_no_one':
             result = result and bool(request and request.session.debug)
         return result

--- a/odoo/addons/base/tests/test_user_has_group.py
+++ b/odoo/addons/base/tests/test_user_has_group.py
@@ -275,3 +275,12 @@ class TestHasGroup(TransactionCase):
             self.registry._Registry__caches['default'],
             "call_cache_clearing_methods() must invalidate user._has_group cache"
         )
+
+    def test_has_group_with_new_id(self):
+        user = self.env['res.users'].new({'partner_id': self.test_user.partner_id.id})
+        self.assertEqual(user.has_group(self.group0), False)
+        self.assertEqual(user.has_group(self.group1), False)
+
+        user2 = self.env['res.users'].new({'partner_id': self.test_user.partner_id.id}, origin=self.test_user)
+        self.assertEqual(user2.has_group(self.group0), True)
+        self.assertEqual(user2.has_group(self.group1), False)


### PR DESCRIPTION
opw-3940549
opw-3943985
opw-3943909
opw-3937897
opw-3932111
