### PR TITLE
[FIX] hr_holidays: search by description

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -354,7 +354,7 @@ class HolidaysRequest(models.Model):
         if not is_officer:
             domain = expression.AND([domain, [('user_id', '=', self.env.user.id)]])
 
-        leaves = self.search(domain)
+        leaves = self.sudo().search(domain)
         return [('id', 'in', leaves.ids)]
 
     @api.depends('holiday_status_id')


### PR DESCRIPTION
Issue:
------
With a user who does not belong to the `hr_holidays.group_hr_holidays_user` group, it is not possible to search for a leave according to the description.

Cause:
------
Since commit eb0ba7f79b8a5c099a6f039af770c54169abe584, we check the groups for the fields used in the search domain.

We place the `private_name` field in the domain which has a group attribute with the value `hr_holidays.group_hr_holidays_user`.

Solution:
---------
Use `sudo` (the return value will only contain the ids and the domain filtered according to `user_id` if we don't have the group).

opw-3907517