### PR TITLE
[FIX] web: fixed see examples visibility in Kanban Quick Create Column

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_column_quick_create.js
+++ b/addons/web/static/src/views/kanban/kanban_column_quick_create.js
@@ -13,6 +13,10 @@ export class KanbanColumnQuickCreate extends Component {
         onValidate: Function,
         folded: Boolean,
         groupByField: Object,
+        isFirst: { type: Boolean, optional: true },
+    };
+    static defaultProps = {
+        isFirst: false,
     };
 
     setup() {
@@ -52,7 +56,11 @@ export class KanbanColumnQuickCreate extends Component {
     get canShowExamples() {
         const { allowedGroupBys = [], examples = [] } = this.props.exampleData || {};
         const hasExamples = Boolean(examples.length);
-        return hasExamples && allowedGroupBys.includes(this.props.groupByField.name);
+        return (
+            hasExamples &&
+            allowedGroupBys.includes(this.props.groupByField.name) &&
+            this.props.isFirst
+        );
     }
 
     get relatedFieldName() {

--- a/addons/web/static/src/views/kanban/kanban_renderer.xml
+++ b/addons/web/static/src/views/kanban/kanban_renderer.xml
@@ -91,6 +91,7 @@
                         onValidate="props.list.createGroup.bind(props.list)"
                         exampleData="exampleData"
                         groupByField="props.list.groupByField"
+                        isFirst="!props.list.groups.length"
                     />
                     <!-- Kanban Example Background -->
                     <div t-if="props.list.groups.length === 0" class="o_kanban_example_background_container d-flex opacity-50">


### PR DESCRIPTION
Steps to reproduce:

- Open Project app
- Create a new project
- Click on Add new column
- Click on see examples and Click on use this for my project
- Click on Add Column again

Issue:

- See examples is visible again

Cause :

- This is due to not having a constraint to hide the See Examples when there are columns.

Fix:

- Adding a constraint to hide see examples if there is a column already  present

task-3925017

