### PR TITLE
[FIX] l10n_at: Fix account tags on accounts.

### DIFF
--- a/addons/l10n_at/models/template_at.py
+++ b/addons/l10n_at/models/template_at.py
@@ -44,7 +44,7 @@ class AccountChartTemplate(models.AbstractModel):
         super()._setup_utility_bank_accounts(template_code, company, template_data)
         if template_code == "at":
             bank_tags = self.env.ref('l10n_at.account_tag_external_code_2300') | self.env.ref('l10n_at.account_tag_l10n_at_ABIV')
-            company.account_journal_suspense_account_id.tag_ids |= bank_tags
-            company.account_journal_payment_debit_account_id.tag_ids |= bank_tags
-            company.account_journal_payment_credit_account_id.tag_ids |= bank_tags
-            company.transfer_account_id.tag_ids |= self.env.ref('l10n_at.account_tag_external_code_2885') | self.env.ref('l10n_at.account_tag_l10n_at_ABIV')
+            company.account_journal_suspense_account_id.tag_ids = bank_tags
+            company.account_journal_payment_debit_account_id.tag_ids = bank_tags
+            company.account_journal_payment_credit_account_id.tag_ids = bank_tags
+            company.transfer_account_id.tag_ids = self.env.ref('l10n_at.account_tag_external_code_2885') | self.env.ref('l10n_at.account_tag_l10n_at_ABIV')


### PR DESCRIPTION
Since #152894, newly-created accounts are automatically assigned the account tags of their closest preceding account in the CoA.

Unfortunately, the tags that get automatically assigned to the transfer, suspense and outstanding accounts are incorrect:

* Suspense account and outstanding accounts get tags (ABIV, 2780), but should have tags (ABIV, 2300).
* Transfer account gets tags (ABII4, 2885) but should have tags (ABIV, 2885).

As such, we need to set the tags to the correct ones.

Taskid: 3060790