### PR TITLE
[FIX] base: make the company currencies accessible to branches

### DIFF
--- a/addons/test_mail/tests/test_mail_template.py
+++ b/addons/test_mail/tests/test_mail_template.py
@@ -242,7 +242,7 @@ class TestMailTemplateLanguages(TestMailTemplateCommon):
         """ Test 'send_email' on template on a given record, used notably as
         contextual action, with dynamic reports involved """
         self.env.invalidate_all()
-        with self.with_user(self.user_employee.login), self.assertQueryCount(107):  # test_mail: 106
+        with self.with_user(self.user_employee.login), self.assertQueryCount(109):  # test_mail: 109
             mail_id = self.test_template_wreports.with_env(self.env).send_mail(self.test_record.id)
             mail = self.env['mail.mail'].sudo().browse(mail_id)
 

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -225,19 +225,19 @@ class TestBaseMailPerformance(BaseMailPerformance):
     @warmup
     def test_create_mail_with_tracking(self):
         """ Create records inheriting from 'mail.thread' (with field tracking). """
-        with self.assertQueryCount(admin=9, demo=9):
+        with self.assertQueryCount(admin=9, demo=10):
             self.env['mail.performance.thread'].create({'name': 'X'})
 
     @users('admin', 'employee')
     @warmup
     def test_create_mail_simple(self):
-        with self.assertQueryCount(admin=8, employee=8):
+        with self.assertQueryCount(admin=8, employee=9):
             self.env['mail.test.simple'].create({'name': 'Test'})
 
     @users('admin', 'employee')
     @warmup
     def test_create_mail_simple_multi(self):
-        with self.assertQueryCount(admin=8, employee=8):
+        with self.assertQueryCount(admin=8, employee=9):
             self.env['mail.test.simple'].create([{'name': 'Test'}] * 5)
 
     @users('admin', 'employee')
@@ -266,7 +266,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
     def test_adv_activity(self):
         model = self.env['mail.test.activity']
 
-        with self.assertQueryCount(admin=8, employee=8):
+        with self.assertQueryCount(admin=8, employee=9):
             model.create({'name': 'Test'})
 
     @users('admin', 'employee')
@@ -420,7 +420,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
                 composer_form.attachment_ids.add(attachment)
             composer = composer_form.save()
 
-        with self.assertQueryCount(admin=55, employee=55):  # tm+com 54/54
+        with self.assertQueryCount(admin=55, employee=56):  # tm+com 54/54
             composer._action_send_mail()
 
         # notifications
@@ -538,7 +538,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
             )
             composer = composer_form.save()
 
-        with self.assertQueryCount(admin=51, employee=51):
+        with self.assertQueryCount(admin=51, employee=52):
             composer._action_send_mail()
 
         # notifications
@@ -568,7 +568,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
             )
             composer = composer_form.save()
 
-        with self.assertQueryCount(admin=70, employee=70):  # com 62/62
+        with self.assertQueryCount(admin=70, employee=71):  # com 62/62
             composer._action_send_mail()
 
         # notifications
@@ -883,7 +883,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         record = self.container.with_user(self.env.user)
 
         # about 20 (19?) queries per additional customer group
-        with self.assertQueryCount(admin=60, employee=59):
+        with self.assertQueryCount(admin=60, employee=60):
             record.message_post(
                 body=Markup('<p>Test Post Performances</p>'),
                 message_type='comment',
@@ -991,7 +991,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         })
         rec1 = rec.with_context(active_test=False)      # to see inactive records
         self.assertEqual(rec1.message_partner_ids, self.partners | self.env.user.partner_id)
-        with self.assertQueryCount(admin=43, employee=43):
+        with self.assertQueryCount(admin=43, employee=44):
             rec.write({'user_id': self.user_portal.id})
         self.assertEqual(rec1.message_partner_ids, self.partners | self.env.user.partner_id | self.user_portal.partner_id)
         # write tracking message
@@ -1011,7 +1011,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         customer_id = self.customer.id
         user_id = self.user_portal.id
 
-        with self.assertQueryCount(admin=101, employee=101):
+        with self.assertQueryCount(admin=101, employee=102):
             rec = self.env['mail.test.ticket'].create({
                 'name': 'Test',
                 'container_id': container_id,
@@ -1388,7 +1388,7 @@ class TestPerformance(BaseMailPerformance):
         attachments = self.env['ir.attachment'].with_user(self.env.user).create(self.test_attachments_vals)
         # enable_logging = self.cr._enable_logging() if self.warm else nullcontext()
         # with self.assertQueryCount(employee=63), enable_logging:
-        with self.assertQueryCount(employee=68):
+        with self.assertQueryCount(employee=69):
             record_container.with_context({}).message_post(
                 body=Markup('<p>Test body <img src="cid:cid1"> <img src="cid:cid2"></p>'),
                 subject='Test Subject',

--- a/addons/test_mail_full/tests/test_mail_performance.py
+++ b/addons/test_mail_full/tests/test_mail_performance.py
@@ -91,7 +91,7 @@ class TestMailPerformance(FullBaseMailPerformance):
         record_ticket = self.env['mail.test.ticket.mc'].browse(self.record_ticket.ids)
         attachments = self.env['ir.attachment'].create(self.test_attachments_vals)
 
-        with self.assertQueryCount(employee=99):  # test_mail_full: 98
+        with self.assertQueryCount(employee=100):  # test_mail_full: 100
             new_message = record_ticket.message_post(
                 attachment_ids=attachments.ids,
                 body=Markup('<p>Test Content</p>'),

--- a/addons/test_mail_sms/tests/test_sms_performance.py
+++ b/addons/test_mail_sms/tests/test_sms_performance.py
@@ -36,7 +36,7 @@ class TestSMSPerformance(BaseMailPerformance, sms_common.SMSCase):
     def test_message_sms_record_1_partner(self):
         record = self.test_record.with_user(self.env.user)
         pids = self.customer.ids
-        with self.subTest("QueryCount"), self.mockSMSGateway(sms_allow_unlink=True), self.assertQueryCount(employee=24):  # tms: 24
+        with self.subTest("QueryCount"), self.mockSMSGateway(sms_allow_unlink=True), self.assertQueryCount(employee=25):  # tms: 25
             messages = record._message_sms(
                 body='Performance Test',
                 partner_ids=pids,
@@ -51,7 +51,7 @@ class TestSMSPerformance(BaseMailPerformance, sms_common.SMSCase):
     def test_message_sms_record_10_partners(self):
         record = self.test_record.with_user(self.env.user)
         pids = self.partners.ids
-        with self.subTest("QueryCount"), self.mockSMSGateway(sms_allow_unlink=True), self.assertQueryCount(employee=24):  # tms: 24
+        with self.subTest("QueryCount"), self.mockSMSGateway(sms_allow_unlink=True), self.assertQueryCount(employee=25):  # tms: 25
             messages = record._message_sms(
                 body='Performance Test',
                 partner_ids=pids,
@@ -65,7 +65,7 @@ class TestSMSPerformance(BaseMailPerformance, sms_common.SMSCase):
     @warmup
     def test_message_sms_record_default(self):
         record = self.test_record.with_user(self.env.user)
-        with self.subTest("QueryCount"), self.mockSMSGateway(sms_allow_unlink=True), self.assertQueryCount(employee=25):  # tms: 25
+        with self.subTest("QueryCount"), self.mockSMSGateway(sms_allow_unlink=True), self.assertQueryCount(employee=26):  # tms: 26
             messages = record._message_sms(
                 body='Performance Test',
             )
@@ -135,5 +135,5 @@ class TestSMSMassPerformance(BaseMailPerformance, sms_common.MockSMS):
             'mass_keep_log': True,
         })
 
-        with self.mockSMSGateway(sms_allow_unlink=True), self.assertQueryCount(employee=58):
+        with self.mockSMSGateway(sms_allow_unlink=True), self.assertQueryCount(employee=59):
             composer.action_send_sms()

--- a/odoo/addons/base/security/base_security.xml
+++ b/odoo/addons/base/security/base_security.xml
@@ -121,7 +121,7 @@
             <field name="model_id" ref="model_res_company"/>
             <field eval="False" name="global"/>
             <field name="groups" eval="[Command.set([ref('base.group_user')])]"/>
-            <field name="domain_force">[('id','in', company_ids)]</field>
+            <field name="domain_force">[('id','parent_of', company_ids)]</field>
         </record>
         <record id="res_company_rule_public" model="ir.rule">
             <field name="name">company rule public</field>


### PR DESCRIPTION
### Steps to reproduce:
- Create a company and a branch
- Switch to the branch and go to the Purchase app
- Create a new Request for quotation
- Click on the quick link to currency
- An Access Error is raised

### Cause:
A rule does not allow branches to access data from the parent company.

### Solution:
Change the rule to make company records accessible to branches by using the 'parent_of' operator.

By changing this rule, some performance test failed because there were more queries than expected. I changed these tests to make them pass.

Linked PR in enterprise: https://github.com/odoo/enterprise/pull/63455

opw-3936447
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
