### PR TITLE
[FIX]  hr_timesheet: fixed employee domain

### DIFF
--- a/addons/hr_timesheet/models/hr_timesheet.py
+++ b/addons/hr_timesheet/models/hr_timesheet.py
@@ -46,9 +46,10 @@ class AccountAnalyticLine(models.Model):
         return domain
 
     def _domain_employee_id(self):
+        domain = [('company_id', 'in', self._context.get('allowed_company_ids'))]
         if not self.user_has_groups('hr_timesheet.group_hr_timesheet_approver'):
-            return [('user_id', '=', self.env.user.id)]
-        return []
+            expression.AND([domain, ('user_id', '=', self.env.user.id)])
+        return domain
 
     task_id = fields.Many2one(
         'project.task', 'Task', index='btree_not_null',


### PR DESCRIPTION
Steps to reproduce:

- In a multiple company environment, open Timesheets app
- In All Timesheets add a line
- While selecting employee we see that we get all the employees from all companies.

Issue:

- All the employees shouldn't be visible

Cause:

- An empty domain is getting passed.
- Pre saas-17.1 when an empty domain is passed then we get records from within the company.
- From saas-17.1 onward an empty gets every possible record.

Solution:

- Adding the companies to be from allowed_company_ids

task-3918572
