### PR TITLE
[FIX] stock: delivery slip has too much info on 1 line

### DIFF
--- a/addons/sale_stock/report/stock_report_deliveryslip.xml
+++ b/addons/sale_stock/report/stock_report_deliveryslip.xml
@@ -2,11 +2,11 @@
 <odoo>
     <template id="report_delivery_document_inherit_sale_stock" inherit_id="stock.report_delivery_document">
         <xpath expr="//div[@name='div_sched_date']" position="after">
-            <div class="col-auto justify-content-end" t-if="o.sudo().sale_id.client_order_ref">
+            <div class="col-auto justify-content-end" style="max-width:25%;" t-if="o.sudo().sale_id.client_order_ref">
                 <strong>Customer Reference:</strong>
                 <p t-field="o.sudo().sale_id.client_order_ref">Customer reference</p>
             </div>
-            <div class="col-auto justify-content-end" t-if="o.sudo().sale_id.incoterm">
+            <div class="col-auto justify-content-end" style="max-width:25%;" t-if="o.sudo().sale_id.incoterm">
                 <strong>Incoterm:</strong>
                 <p t-if="o.sudo().sale_id.incoterm_location" t-out="'%s %s' % (o.sudo().sale_id.incoterm.code, o.sudo().sale_id.incoterm_location)">Incoterm details</p>
                 <p t-else="" t-field="o.sudo().sale_id.incoterm.display_name">Incoterm details</p>

--- a/addons/stock/report/report_deliveryslip.xml
+++ b/addons/stock/report/report_deliveryslip.xml
@@ -46,7 +46,7 @@
                         <span t-field="o.name">WH/OUT/0001</span>
                     </h2>
                     <div class="oe_structure"></div>
-                    <div class="row mt32 mb32">
+                    <div class="row mt32 mb32" name="picking_info">
                         <div t-if="o.origin" class="col-auto" name="div_origin">
                             <strong>Order:</strong>
                             <p t-field="o.origin">S0001</p>

--- a/addons/stock_delivery/views/report_deliveryslip.xml
+++ b/addons/stock_delivery/views/report_deliveryslip.xml
@@ -2,21 +2,44 @@
 <odoo>
     <template id="report_delivery_document2" inherit_id="stock.report_delivery_document">
         <xpath expr="//div[@name='div_sched_date']" position="after">
-            <div t-if="o.picking_type_id.code == 'outgoing' and o.carrier_id" class="col-auto">
-                <strong>Carrier:</strong>
-                <p t-field="o.carrier_id"/>
-            </div>
-            <div t-if="o.shipping_weight" class="col-auto">
-                <strong>Total Weight:</strong>
-                <br/>
-                <span t-field="o.shipping_weight"/>
-                <span t-field="o.weight_uom_name"/>
-            </div>
-            <div t-if="o.carrier_tracking_ref" class="col-auto" style="max-width:30%;">
-                <strong>Tracking Number:</strong>
-                <p t-field="o.carrier_tracking_ref"/>
-            </div>
+            <t t-if="not (o.sudo().sale_id.incoterm or o.sudo().sale_id.client_order_ref)">
+                <div t-if="o.picking_type_id.code == 'outgoing' and o.carrier_id" class="col-auto">
+                    <strong>Carrier:</strong>
+                    <p t-field="o.carrier_id"/>
+                </div>
+                <div t-if="o.shipping_weight" class="col-auto">
+                    <strong>Total Weight:</strong>
+                    <br/>
+                    <span t-field="o.shipping_weight"/>
+                    <span t-field="o.weight_uom_name"/>
+                </div>
+                <div t-if="o.carrier_tracking_ref" class="col-auto" style="max-width:30%;">
+                    <strong>Tracking Number:</strong>
+                    <p t-field="o.carrier_tracking_ref"/>
+                </div>
+            </t>
             <t t-set="has_hs_code" t-value="o.move_ids.filtered(lambda l: l.product_id.hs_code)"/>
+        </xpath>
+
+        <xpath expr="//div[@name='picking_info']" position="after">
+            <t t-if="o.sudo().sale_id.incoterm or o.sudo().sale_id.client_order_ref">
+                <div class="row mb32">
+                    <div t-if="o.picking_type_id.code == 'outgoing' and o.carrier_id" class="col-auto">
+                        <strong>Carrier:</strong>
+                        <p t-field="o.carrier_id"/>
+                    </div>
+                    <div t-if="o.shipping_weight" class="col-auto">
+                        <strong>Total Weight:</strong>
+                        <br/>
+                        <span t-field="o.shipping_weight"/>
+                        <span t-field="o.weight_uom_name"/>
+                    </div>
+                    <div t-if="o.carrier_tracking_ref" class="col-auto" style="max-width:30%;">
+                        <strong>Tracking Number:</strong>
+                        <p t-field="o.carrier_tracking_ref"/>
+                    </div>
+                </div>
+            </t>
         </xpath>
 
         <xpath expr="//table[@name='stock_move_line_table']/thead/tr" position="inside">


### PR DESCRIPTION
Steps to reproduce:
- Create a sale order with customer ref and incoterms set
- Add Shipping and confirm
- On the picking manually set the tracking ref and print

Bug:
1- no max width on (customer ref/incoterms)
2- too much info on a single line

Fix:
set max-width and break the data on two line if too many collumns

opw-3892680

