### PR TITLE
[FIX] account: calculate margin for credit notes in reports

### DIFF
--- a/addons/account/report/account_invoice_report.py
+++ b/addons/account/report/account_invoice_report.py
@@ -107,8 +107,8 @@ class AccountInvoiceReport(models.Model):
                    * (NULLIF(COALESCE(uom_line.factor, 1), 0.0) / NULLIF(COALESCE(uom_template.factor, 1), 0.0)),
                    0.0) * currency_table.rate                               AS price_average,
                 CASE
-                    WHEN move.move_type NOT IN ('out_invoice', 'out_receipt') THEN 0.0
-                    ELSE -line.balance * currency_table.rate - (line.quantity / NULLIF(COALESCE(uom_line.factor, 1) / COALESCE(uom_template.factor, 1), 0.0)) * product_standard_price.value_float
+                    WHEN move.move_type NOT IN ('out_invoice', 'out_receipt', 'out_refund') THEN 0.0
+                    ELSE -line.balance * currency_table.rate + SIGN(line.balance) * (line.quantity / NULLIF(COALESCE(uom_line.factor, 1) / COALESCE(uom_template.factor, 1), 0.0)) * product_standard_price.value_float
                 END
                                                                             AS price_margin,
                 line.quantity / NULLIF(COALESCE(uom_line.factor, 1) / COALESCE(uom_template.factor, 1), 0.0) * (CASE WHEN move.move_type IN ('out_invoice','in_refund','out_receipt') THEN -1 ELSE 1 END)

--- a/addons/account/tests/test_account_invoice_report.py
+++ b/addons/account/tests/test_account_invoice_report.py
@@ -118,7 +118,7 @@ class TestAccountInvoiceReport(AccountTestInvoicingCommon):
             [             6,              6,        1,            0,            -800], # price_unit = 12,   currency.rate = 2.0
             [            20,            -20,       -1,            0,             800], # price_unit = 60,   currency.rate = 3.0
             [            20,            -20,       -1,            0,             800], # price_unit = 60,   currency.rate = 3.0
-            [           600,           -600,       -1,            0,             800], # price_unit = 1200, currency.rate = 2.0
+            [           600,           -600,       -1,          200,             800], # price_unit = 1200, currency.rate = 2.0
         ])
 
     def test_invoice_report_multicompany_product_cost(self):
@@ -139,5 +139,5 @@ class TestAccountInvoiceReport(AccountTestInvoicingCommon):
             [             6,              6,        1,            0,            -800], # price_unit = 12,   currency.rate = 2.0
             [            20,            -20,       -1,            0,             800], # price_unit = 60,   currency.rate = 3.0
             [            20,            -20,       -1,            0,             800], # price_unit = 60,   currency.rate = 3.0
-            [           600,           -600,       -1,            0,             800], # price_unit = 1200, currency.rate = 2.0
+            [           600,           -600,       -1,          200,             800], # price_unit = 1200, currency.rate = 2.0
         ])


### PR DESCRIPTION
### Steps to reproduce the issue:

1. Create a product with a purchase price and a sales price
2. Create an invoice with the product
3. Create a credit note with the product
4. Go to Invoice Analysis (Pivot view)
5. Tick the margin option in Measures
6. Set the filters to only have the invoice and the credit note in the analysis
7. The margin is positive while the total is null

### Explanation:

The calculation of `price_margin` in `account.invoice.report` is set to 0 if `move_type` is different from `'out_invoice'` or `'out_receipt'`.
Credit notes are categorized as `'out_refund'`.
https://github.com/odoo/odoo/blob/4c8f7c90119caa8fd0d74eb14c4b3496165d4286/addons/account/report/account_invoice_report.py#L109-L112

### Suggested fix:

The credit note and the invoice's margins should cancel each other.
The current calculation of `price_margin` is subtracting `product.product.standard_price` from `account.move.line.balance` regardless of its value which could be negative, as in the case of `'out_refund'` type `account.move`, thus adapating the value using the sign of line.balance.

opw-3862493