### PR TITLE
[FIX] mail: discuss notification settings properly handle long text

### DIFF
--- a/addons/mail/static/src/discuss/core/common/notification_settings.scss
+++ b/addons/mail/static/src/discuss/core/common/notification_settings.scss
@@ -1,3 +1,3 @@
-.o-discuss-NotificationSettings {
-    width: 150px;
+.o-discuss-NotificationSettings, .o-mail-NotificationSettings-submenu {
+    max-width: 250px !important;
 }

--- a/addons/mail/static/src/discuss/core/common/notification_settings.xml
+++ b/addons/mail/static/src/discuss/core/common/notification_settings.xml
@@ -5,26 +5,26 @@
         <div class="o-discuss-NotificationSettings">
             <t t-if="props.thread.muteUntilDateTime">
                 <button class="btn w-100 d-flex p-1 opacity-75 opacity-100-hover" t-on-click="selectUnmute">
-                    <div class="d-flex flex-column flex-grow-1 text-start px-2 py-1 rounded">
-                        <span class="fs-6 fw-bold">Unmute Channel</span>
+                    <div class="d-flex flex-column flex-grow-1 px-2 py-1 w-100 rounded">
+                        <span class="fs-6 fw-bold text-wrap text-start text-break">Unmute Channel</span>
                         <span class="fw-normal o-smaller" t-if="muteUntilText" t-out="muteUntilText"/>
                     </div>
                 </button>
             </t>
             <t t-else="">
-                <Dropdown position="'right-start'" onStateChanged="state => {}" togglerClass="`d-flex btn w-100 align-items-center text-truncate p-0`" menuClass="'d-flex flex-column py-0 my-0'" class="'d-flex text-truncate'">
+                <Dropdown position="'right-start'" onStateChanged="state => {}" togglerClass="`d-flex btn w-100 align-items-center p-0`" menuClass="'d-flex flex-column py-0 my-0'" class="'d-flex'">
                     <t t-set-slot="toggler">
                         <button class="btn w-100 d-flex p-1 opacity-75 opacity-100-hover" title="Mute Channel">
                             <div class="d-flex flex-grow-1 align-items-center px-2 py-1 rounded">
-                                <span class="">Mute Channel</span>
+                                <span class="text-wrap text-start text-break">Mute Channel</span>
                                 <div class="flex-grow-1"/>
-                                <i class="fa fa-arrow-right"/>
+                                <i class="ms-2 fa fa-arrow-right"/>
                             </div>
                         </button>
                     </t>
                     <t t-set-slot="default">
                         <t t-foreach="props.thread.MUTES" t-as="item" t-key="item.id">
-                            <DropdownItem class="'o-mail-NotificationSettings-muteDuration btn rounded-0 d-flex align-items-center px-2 py-2 m-0 opacity-75 opacity-100-hover'" title="item.name" onSelected="()=>this.setMute(item.value)"><span class="mx-2" t-out="item.name"/></DropdownItem>
+                            <DropdownItem class="'o-mail-NotificationSettings-muteDuration btn rounded-0 d-flex align-items-center px-2 py-2 m-0 opacity-75 opacity-100-hover'" title="item.name" onSelected="()=>this.setMute(item.value)"><button class="btn p-0 mx-2 text-wrap text-start text-break" t-out="item.name"/></DropdownItem>
                         </t>
                     </t>
                 </Dropdown>
@@ -32,10 +32,10 @@
             <hr class="solid mx-2 my-1"/>
             <t t-foreach="props.thread.SETTINGS" t-as="setting" t-key="setting.id">
                 <button class="btn w-100 d-flex px-1 py-0 opacity-75 opacity-100-hover" t-on-click="() => this.setSetting(setting)">
-                    <div class="d-flex flex-grow-1 align-items-center p-2 rounded">
-                        <span class="fs-6 fw-normal" t-esc="setting.name"/>
+                    <div class="d-flex flex-grow-1 align-items-center p-2 w-100 rounded">
+                        <span class="fs-6 fw-normal text-wrap text-start text-break" t-esc="setting.name"/>
                         <div class="flex-grow-1"/>
-                        <input class="form-check-input" type="radio" t-att-checked="props.thread.custom_notifications === setting.id"/>
+                        <input class="form-check-input ms-2" type="radio" t-att-checked="props.thread.custom_notifications === setting.id"/>
                     </div>
                 </button>
             </t>

--- a/addons/mail/static/tests/discuss_app/discuss_tests.js
+++ b/addons/mail/static/tests/discuss_app/discuss_tests.js
@@ -1971,13 +1971,13 @@ QUnit.test("Notification settings: basic rendering", async () => {
     await contains("button", { text: "All Messages" });
     await contains("button", { text: "Mentions Only" });
     await contains("button", { text: "Nothing" });
-    await click("[title='Mute Channel']");
-    await contains("[title='For 15 minutes']");
-    await contains("[title='For 1 hour']");
-    await contains("[title='For 3 hours']");
-    await contains("[title='For 8 hours']");
-    await contains("[title='For 24 hours']");
-    await contains("[title='Until I turn it back on']");
+    await click("button.dropdown-toggle", { text: "Mute Channel" });
+    await contains("button", { text: "For 15 minutes" });
+    await contains("button", { text: "For 1 hour" });
+    await contains("button", { text: "For 3 hours" });
+    await contains("button", { text: "For 8 hours" });
+    await contains("button", { text: "For 24 hours" });
+    await contains("button", { text: "Until I turn it back on" });
 });
 
 QUnit.test("Notification settings: mute channel will change the style of sidebar", async () => {
@@ -1994,8 +1994,8 @@ QUnit.test("Notification settings: mute channel will change the style of sidebar
         count: 0,
     });
     await click("[title='Notification Settings']");
-    await click("[title='Mute Channel']");
-    await click("[title='For 15 minutes']");
+    await click("button.dropdown-toggle", { text: "Mute Channel" });
+    await click("button", { text: "For 15 minutes" });
     await contains(".o-mail-DiscussSidebar-item", { text: "Mario Party" });
     await contains(".o-mail-DiscussSidebar-item[class*='opacity-50']", { text: "Mario Party" });
 });
@@ -2009,13 +2009,13 @@ QUnit.test("Notification settings: mute/unmute channel works correctly", async (
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await click("[title='Notification Settings']");
-    await click("[title='Mute Channel']");
-    await click("[title='For 15 minutes']");
+    await click("button.dropdown-toggle", { text: "Mute Channel" });
+    await click("button", { text: "For 15 minutes" });
     await click("[title='Notification Settings']");
-    await contains("span", { text: "Unmute Channel" });
+    await contains("button", { text: "Unmute Channel" });
     await click("button", { text: "Unmute Channel" });
     await click("[title='Notification Settings']");
-    await contains("span", { text: "Unmute Channel" });
+    await contains("button", { text: "Unmute Channel" });
 });
 
 QUnit.test("Newly created chat should be at the top of the direct message list", async () => {


### PR DESCRIPTION
Before this commit, the notification settings in discuss app that is used to mute channels was not showing items properly in some languages like vietnamese.

This happens because the width is hard-coded to 150px as to keep the dropdown menu small.

This commit fixes the issue by putting a max-width of 250px for dropdown menu and sub-menu, so that it keeps right positioning of submenu. If text is too long, it know wraps.

![Screenshot 2024-05-24 at 12 06 08](https://github.com/odoo/odoo/assets/6569390/4d727151-2a49-4a20-bfcb-4be4940efc7b)
