### PR TITLE
[PERF] base: avoid multiple ormcache computation in multithread

### DIFF
--- a/odoo/addons/base/models/ir_qweb.py
+++ b/odoo/addons/base/models/ir_qweb.py
@@ -386,6 +386,7 @@ from itertools import count, chain
 from lxml import etree
 from dateutil.relativedelta import relativedelta
 from psycopg2.extensions import TransactionRollbackError
+from threading import RLock
 
 from odoo import api, models, tools
 from odoo.modules import registry
@@ -2679,6 +2680,7 @@ def render(template_name, values, load, **options):
         db_name = None
         _Registry__caches = {cache_name: LRU(cache_size) for cache_name, cache_size in registry._REGISTRY_CACHES.items()}
         _Registry__caches_groups = {}
+        _Registry__caches_lock = RLock()
         for cache_name, cache in _Registry__caches.items():
             _Registry__caches_groups.setdefault(cache_name.split('.')[0], []).append(cache)
 

--- a/odoo/modules/registry.py
+++ b/odoo/modules/registry.py
@@ -142,6 +142,7 @@ class Registry(Mapping):
         self._ordinary_tables = None
         self._constraint_queue = deque()
         self.__caches = {cache_name: LRU(cache_size) for cache_name, cache_size in _REGISTRY_CACHES.items()}
+        self.__caches_lock = threading.RLock()
 
         # modules fully loaded (maintained during init phase by `loading` module)
         self._init_modules = set()


### PR DESCRIPTION
In multithreaded mode, when multiple queries arrive before the routing cache is filled,  multiple threads will try to compute the same methods.

This PR adds a single global lock on ormcache to avoid deadlock.

Comparing the requests on /shop on an empty database with website_sale,website_slides,website_event,website_hr_recruitment installed, the response time becomes higher with the number of concurrent requests. This table only compares value before the cache is used.

The tests were only invalidating the 'routing' cache

| concurrency | 1 | 2 | 3 | 4 | 5 |
|--------|--------|--------|--------|--------|--------|
| current situation - cached query only | 0.065117 | 0.0896905 | 0.131192 | 0.179595 | 0.247573
| current situation - non cached query only | 0.40558 | 0.733723 | 1.0675 | 1.40266 | 2.4364
| with the patch applied - cached query only | 0.0624025 | 0.087147 | 0.129508 | 0.18071 | 0.22474
| with the patch applied - non cached query only | 0.599373 | 0.652825 | 0.70965 | 0.766649 | 0.823916

![image](https://github.com/odoo/odoo/assets/10863541/2baa1ad0-f9ea-4857-85b4-6b20cefdb306)

![image](https://github.com/odoo/odoo/assets/10863541/647c6eb5-d86b-44e8-bfec-865a77fb79df)

For parallel workers, no significant difference could be observed with or without this patch.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
