### PR TITLE
[IMP] web_tour_recorder: use drag_and_drop command

### DIFF
--- a/addons/web_tour_recorder/static/src/tour_recorder/tour_recorder.js
+++ b/addons/web_tour_recorder/static/src/tour_recorder/tour_recorder.js
@@ -20,7 +20,7 @@ const getShortestSelector = (paths) => {
     let hasOdooClass = false;
     for (
         let currentElem = paths.pop();
-        currentElem && queryAll(filteredPath.join(" > ")).length !== 1 || !hasOdooClass;
+        (currentElem && queryAll(filteredPath.join(" > ")).length !== 1) || !hasOdooClass;
         currentElem = paths.pop()
     ) {
         if (currentElem.parentElement.contentEditable === "true") {
@@ -139,7 +139,7 @@ export class TourRecorder extends Component {
             JSON.stringify(pathElements.map((e) => e.tagName)) !==
             JSON.stringify(this.originClickEvent.map((e) => e.tagName))
         ) {
-            lastStepInput.run = `drag_and_drop_native ${lastStepInput.trigger}`;
+            lastStepInput.run = `drag_and_drop ${lastStepInput.trigger}`;
             lastStepInput.trigger = getShortestSelector(this.originClickEvent);
         } else {
             const lastStepInput = this.state.steps.at(-1);

--- a/addons/web_tour_recorder/static/tests/tour_recorder.test.js
+++ b/addons/web_tour_recorder/static/tests/tour_recorder.test.js
@@ -409,7 +409,7 @@ test("Drag and drop", async () => {
     await contains(".o_drag").dragAndDrop(".o_drop");
     await animationFrame();
     checkTourSteps([".o_drag"]);
-    expect(tourRecorder.state.steps.map((s) => s.run)).toEqual(["drag_and_drop_native .o_drop"]);
+    expect(tourRecorder.state.steps.map((s) => s.run)).toEqual(["drag_and_drop .o_drop"]);
 });
 
 test("Edit contenteditable", async () => {


### PR DESCRIPTION
Before this commit, the tour recorder was using the drag_and_drop_native command. But the new tours are not using it anymore.

After this commit, the tour recorder will use the
drag_and_drop command istead.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
