### PR TITLE
[IMP] purchase:  multiple cancel rfq

### DIFF
--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -593,6 +593,8 @@
                 class="o_purchase_order" js_class="purchase_dashboard_list" sample="1">
                     <header>
                         <button name="action_create_invoice" type="object" string="Create Bills"/>
+                        <button name="button_cancel" type="object" string="Cancel"
+                            confirm="Are you sure you want to cancel the selected RFQs/Orders?"/>
                     </header>
                     <field name="priority" optional="show" widget="priority" nolabel="1"/>
                     <field name="partner_ref" optional="hide"/>
@@ -633,6 +635,8 @@
                     sample="1">
                     <header>
                         <button name="action_create_invoice" type="object" string="Create Bills"/>
+                        <button name="button_cancel" type="object" string="Cancel"
+                            confirm="Are you sure you want to cancel the selected RFQs/Orders?"/>
                     </header>
                     <field name="priority" optional="show" widget="priority" nolabel="1"/>
                     <field name="partner_ref" optional="hide"/>


### PR DESCRIPTION
In this commit:
====================
added functionality to display a 'Cancel' menu option in the action button when multiple RFQs are selected. This menu allows cancellation of RFQs or RFQs sent and purchase stages.

TaskId-3857079