### PR TITLE
[CLN] sale,*: clean SO views

### DIFF
--- a/addons/delivery/views/sale_order_views.xml
+++ b/addons/delivery/views/sale_order_views.xml
@@ -6,11 +6,10 @@
         <field name="model">sale.order</field>
         <field name="inherit_id" ref="sale.view_order_form"/>
         <field name="arch" type="xml">
-            <field name="partner_id" position='after'>
-                <field name="delivery_set" invisible="1"/>
-                <field name="is_all_service" invisible="1"/>
+            <header position="inside">
+                <!-- modified through an onchange, must be present but not readonly -->
                 <field name="recompute_delivery_price" invisible="1"/>
-            </field>
+            </header>
             <div name="so_button_below_order_lines" position="inside">
                 <button
                     string="Add shipping"
@@ -31,14 +30,6 @@
                     type="object"
                     invisible="is_all_service or recompute_delivery_price or not delivery_set"/>
             </div>
-            <xpath expr="//field[@name='order_line']/form/group/group/field[@name='price_unit']" position="before">
-                <field name="recompute_delivery_price" invisible="1"/>
-                <field name="is_delivery" invisible="1"/>
-            </xpath>
-            <xpath expr="//field[@name='order_line']/list/field[@name='price_unit']" position="before">
-                <field name="recompute_delivery_price" column_invisible="True"/>
-                <field name="is_delivery" column_invisible="True"/>
-            </xpath>
             <xpath expr="//field[@name='order_line']/list" position="attributes">
                 <attribute name="decoration-warning" add="(recompute_delivery_price and is_delivery)" separator="or"/>
             </xpath>

--- a/addons/event_booth_sale/models/sale_order_line.py
+++ b/addons/event_booth_sale/models/sale_order_line.py
@@ -17,19 +17,6 @@ class SaleOrderLine(models.Model):
     event_booth_registration_ids = fields.One2many(
         'event.booth.registration', 'sale_order_line_id', string='Confirmed Registration')
     event_booth_ids = fields.One2many('event.booth', 'sale_order_line_id', string='Confirmed Booths')
-    is_event_booth = fields.Boolean(compute='_compute_is_event_booth')
-
-    @api.depends('product_id.type')
-    def _compute_is_event_booth(self):
-        for record in self:
-            record.is_event_booth = record.product_id.service_tracking == 'event_booth'
-
-    @api.depends('event_booth_ids')
-    def _compute_name_short(self):
-        wbooth = self.filtered(lambda line: line.event_booth_pending_ids)
-        for record in wbooth:
-            record.name_short = record.event_booth_pending_ids.event_id.name
-        super(SaleOrderLine, self - wbooth)._compute_name_short()
 
     @api.depends('event_booth_registration_ids')
     def _compute_event_booth_pending_ids(self):
@@ -83,7 +70,7 @@ class SaleOrderLine(models.Model):
         super()._compute_name()
 
     def _update_event_booths(self, set_paid=False):
-        for so_line in self.filtered('is_event_booth'):
+        for so_line in self.filtered(lambda sol: sol.product_id.service_tracking == 'event_booth'):
             if so_line.event_booth_pending_ids and not so_line.event_booth_ids:
                 unavailable = so_line.event_booth_pending_ids.filtered(lambda booth: not booth.is_available)
                 if unavailable:

--- a/addons/event_booth_sale/views/sale_order_views.xml
+++ b/addons/event_booth_sale/views/sale_order_views.xml
@@ -1,27 +1,30 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<odoo><data>
+<odoo>
 
     <record id="sale_order_view_form" model="ir.ui.view">
         <field name="name">sale.order.view.form.inherit.event.booth.sale</field>
         <field name="model">sale.order</field>
-        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="inherit_id" ref="event_sale.sale_order_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//button[@name='action_view_attendee_list']" position="after">
-                <field name="event_booth_count" invisible="1"/>
-                <button name="action_view_booth_list" type="object" class="oe_stat_button" icon="fa-university"
-                        invisible="event_booth_count == 0">
+            <button name="action_view_attendee_list" position="after">
+                <button
+                    name="action_view_booth_list"
+                    type="object"
+                    class="oe_stat_button"
+                    icon="fa-university"
+                    invisible="event_booth_count == 0"
+                >
                     <field name="event_booth_count" widget="statinfo" string="Booths"/>
                 </button>
-            </xpath>
+            </button>
             <xpath expr="//field[@name='order_line']//list//field[@name='event_ticket_id']" position="after">
-                <field name="is_event_booth" column_invisible="True"/>
                 <field name="event_booth_category_id" column_invisible="True"/>
                 <field name="event_booth_pending_ids" column_invisible="True"/>
             </xpath>
             <xpath expr="//field[@name='order_line']//list//field[@name='product_uom_qty']" position="attributes">
-                <attribute name="readonly">is_event_booth</attribute>
+                <attribute name="readonly" separator="or" add="service_tracking == 'event_booth'"/>
             </xpath>
         </field>
     </record>
 
-</data></odoo>
+</odoo>

--- a/addons/event_sale/views/sale_order_views.xml
+++ b/addons/event_sale/views/sale_order_views.xml
@@ -5,12 +5,15 @@
         <field name="model">sale.order</field>
         <field name="inherit_id" ref="sale.view_order_form" />
         <field name="arch" type="xml">
-            <xpath expr="//sheet/div[hasclass('oe_button_box')]" position="inside">
-                <button name="action_view_attendee_list" type="object"
-                    class="oe_stat_button" icon="fa-users" invisible="attendee_count == 0">
+            <div name="button_box" position="inside">
+                <button name="action_view_attendee_list"
+                        type="object"
+                        class="oe_stat_button"
+                        icon="fa-users"
+                        invisible="attendee_count == 0">
                     <field name="attendee_count" widget="statinfo" string="Attendees"/>
                 </button>
-            </xpath>
+            </div>
             <xpath expr="//field[@name='order_line']//form//field[@name='product_id']" position="after">
                 <field
                     name="event_id"

--- a/addons/l10n_ec_sale/__manifest__.py
+++ b/addons/l10n_ec_sale/__manifest__.py
@@ -11,7 +11,7 @@
     ],
     'data': [
         'views/payment_method_views.xml',
-        'views/sale_views.xml',
+        'views/sale_order_views.xml',
     ],
     'auto_install': True,
     'author': 'Odoo S.A.',

--- a/addons/l10n_ec_sale/views/sale_order_views.xml
+++ b/addons/l10n_ec_sale/views/sale_order_views.xml
@@ -1,12 +1,14 @@
 <odoo>
+
     <record id="view_order_form_inherit_l10n_ec_sale" model="ir.ui.view">
         <field name="name">sale.order.form.inherit.l10n_ec_sale</field>
         <field name="model">sale.order</field>
         <field name="inherit_id" ref="sale.view_order_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='journal_id']" position="after">
+            <field name="journal_id" position="after">
                 <field name="l10n_ec_sri_payment_id" invisible="country_code != 'EC'"/>
-            </xpath>
+            </field>
         </field>
     </record>
+
 </odoo>

--- a/addons/l10n_in_sale/__manifest__.py
+++ b/addons/l10n_in_sale/__manifest__.py
@@ -11,7 +11,7 @@
         'sale',
     ],
     'data': [
-        'views/sale_views.xml',
+        'views/sale_order_views.xml',
     ],
     'demo': [
         'data/product_demo.xml',

--- a/addons/l10n_in_sale/views/sale_order_views.xml
+++ b/addons/l10n_in_sale/views/sale_order_views.xml
@@ -1,15 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
+
     <record id="view_order_form_inherit_l10n_in_sale" model="ir.ui.view">
         <field name="name">sale.order.form.inherit.l10n.in.sale</field>
         <field name="model">sale.order</field>
         <field name="inherit_id" ref="sale.view_order_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='partner_id']" position="after">
-                <field name="l10n_in_reseller_partner_id" groups="l10n_in.group_l10n_in_reseller"
+            <field name="partner_id" position="after">
+                <field
+                    name="l10n_in_reseller_partner_id"
+                    groups="l10n_in.group_l10n_in_reseller"
                     invisible="country_code != 'IN'"
                     readonly="state not in ['draft', 'sent']"/>
-            </xpath>
+            </field>
         </field>
     </record>
+
 </odoo>

--- a/addons/l10n_it_edi_doi/views/sale_order_views.xml
+++ b/addons/l10n_it_edi_doi/views/sale_order_views.xml
@@ -13,7 +13,7 @@
             <xpath expr="//search/group" position="inside">
                 <filter string="Declaration of Intent"
                         name="l10n_it_edi_doi_declaration_of_intent"
-                        domain="" context="{'group_by':'l10n_it_edi_doi_id'}"/>
+                        context="{'group_by': 'l10n_it_edi_doi_id'}"/>
             </xpath>
         </field>
     </record>
@@ -58,12 +58,12 @@
                     </div>
                 </button>
             </div>
-            <xpath expr="//header" position="after">
+            <header position="after">
                 <div class="alert alert-warning mb-0" role="alert"
                      invisible="not l10n_it_edi_doi_warning">
                     <field name="l10n_it_edi_doi_warning"/>
                 </div>
-            </xpath>
+            </header>
             <xpath expr="//label[@for='fiscal_position_id']" position="before">
                 <field name="l10n_it_edi_doi_use" invisible="True"/>
                 <field name="l10n_it_edi_doi_id"

--- a/addons/point_of_sale/views/digest_views.xml
+++ b/addons/point_of_sale/views/digest_views.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="digest_digest_view_form" model="ir.ui.view">
-        <field name="name">digest.digest.view.form.inherit.sale.order</field>
+        <field name="name">digest.digest.view.form.inherit.point_of_sale</field>
         <field name="model">digest.digest</field>
         <field name="priority">50</field>
         <field name="inherit_id" ref="digest.digest_digest_view_form" />

--- a/addons/pos_sale/views/sale_order_views.xml
+++ b/addons/pos_sale/views/sale_order_views.xml
@@ -1,26 +1,28 @@
 <?xml version="1.0"?>
 <odoo>
-    <data>
-        <record id="view_order_form_inherit_pos_sale" model="ir.ui.view">
-            <field name="name">sale.order.form.pos.sale</field>
-            <field name="model">sale.order</field>
-            <field name="inherit_id" ref="sale.view_order_form"/>
-            <field name="arch" type="xml">
-                <xpath expr="//button[@name='action_view_invoice']" position="before">
-                    <button type="object"
-                        name="action_view_pos_order"
-                        class="oe_stat_button"
-                        icon="fa-shopping-basket"
-                        invisible="pos_order_count == 0" groups="point_of_sale.group_pos_user">
-                        <div class="o_field_widget o_stat_info">
-                            <span class="o_stat_value d-flex">
-                                <field name="pos_order_count" widget="statinfo" nolabel="1" class="mr4" /> Transferred<br/>
-                                to POS
-                            </span>
-                        </div>
-                    </button>
-                </xpath>
-            </field>
-        </record>
-    </data>
+
+    <record id="view_order_form_inherit_pos_sale" model="ir.ui.view">
+        <field name="name">sale.order.form.pos.sale</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <button name="action_view_invoice" position="before">
+                <button
+                    type="object"
+                    name="action_view_pos_order"
+                    class="oe_stat_button"
+                    icon="fa-shopping-basket"
+                    invisible="pos_order_count == 0" groups="point_of_sale.group_pos_user"
+                >
+                    <div class="o_field_widget o_stat_info">
+                        <span class="o_stat_value d-flex">
+                            <field name="pos_order_count" widget="statinfo" nolabel="1" class="mr4" /> Transferred<br/>
+                            to POS
+                        </span>
+                    </div>
+                </button>
+            </button>
+        </field>
+    </record>
+
 </odoo>

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -926,7 +926,7 @@
         </record>
 
         <record id="view_task_kanban_inherit_view_default_project" model="ir.ui.view" >
-            <field name="name">project.task.kanban.sale.order</field>
+            <field name="name">project.task.kanban</field>
             <field name="model">project.task</field>
             <field name="inherit_id" ref="view_task_kanban"/>
             <field name="mode">primary</field>
@@ -938,7 +938,7 @@
         </record>
 
         <record id="quick_create_task_form_inherit_view_default_project" model="ir.ui.view">
-            <field name="name">project.task.form.quick.create.sale.order.inherited</field>
+            <field name="name">project.task.form.quick.create</field>
             <field name="model">project.task</field>
             <field name="inherit_id" ref="quick_create_task_form"/>
             <field name="mode">primary</field>

--- a/addons/repair/views/sale_order_views.xml
+++ b/addons/repair/views/sale_order_views.xml
@@ -1,23 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <data>
-        <record id="view_sale_order_form_inherit_repair" model="ir.ui.view">
-            <field name="name">sale.order.form.inherit.repair</field>
-            <field name="model">sale.order</field>
-            <field name="inherit_id" ref="sale.view_order_form"/>
-            <field name="arch" type="xml">
-                <xpath expr="//button[@name='action_view_invoice']" position="after">
-                    <button
-                        name="action_show_repair"
-                        type="object"
-                        class="oe_stat_button"
-                        icon="fa-wrench"
-                        invisible="repair_count == 0"
-                        groups="stock.group_stock_user">
-                        <field name="repair_count" widget="statinfo" string="Repairs"/>
-                    </button>
-                </xpath>
-           </field>
-        </record>
-    </data>
+
+    <record id="view_sale_order_form_inherit_repair" model="ir.ui.view">
+        <field name="name">sale.order.form.inherit.repair</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <button name="action_view_invoice" position="after">
+                <button
+                    name="action_show_repair"
+                    type="object"
+                    class="oe_stat_button"
+                    icon="fa-wrench"
+                    invisible="repair_count == 0"
+                    groups="stock.group_stock_user"
+                >
+                    <field name="repair_count" widget="statinfo" string="Repairs"/>
+                </button>
+            </button>
+        </field>
+    </record>
+
 </odoo>

--- a/addons/sale/static/src/js/sale_product_field.js
+++ b/addons/sale/static/src/js/sale_product_field.js
@@ -393,6 +393,12 @@ export const saleOrderLineProductField = {
             readonlyField: dynamicInfo.readonly,
         };
     },
+    fieldDependencies: [
+        { name: 'is_configurable_product', type: 'boolean' },
+        { name: 'product_type', type: 'selection' },
+        { name: 'service_tracking', type: 'selection' },
+        { name: 'product_template_attribute_value_ids', type: 'many2many' },
+    ],
 };
 
 registry.category("fields").add("sol_product_many2one", saleOrderLineProductField);

--- a/addons/sale/static/tests/sale_product_field_tests.js
+++ b/addons/sale/static/tests/sale_product_field_tests.js
@@ -57,7 +57,29 @@ QUnit.module("Fields", (hooks) => {
                         name: {
                             string: "Description",
                             type: "char",
-                        }
+                        },
+                        product_type: {
+                            string: "Type",
+                            type: "selection",
+                        },
+                        service_tracking: {
+                            string: "Service type",
+                            type: "selection",
+                        },
+                        is_configurable_product: {
+                            string: "Is product configurable",
+                            type: "boolean",
+                        },
+                        product_template_attribute_value_ids: {
+                            string: "Product template attributes values",
+                            type: "many2many",
+                            relation: "product.template.attribute.value",
+                        },
+                        // added to the field dependencies by sale_product_matrix module
+                        product_add_mode: {
+                            string: "Configurator mode",
+                            type: "selection",
+                        },
                     },
                     records: [],
                 },

--- a/addons/sale/views/sale_order_line_views.xml
+++ b/addons/sale/views/sale_order_line_views.xml
@@ -35,11 +35,7 @@
                     </div>
                     <group>
                         <group>
-                            <field name="product_updatable" invisible="1"/>
                             <field name="order_id" readonly="1" force_save="1"/>
-                            <field name="product_uom_readonly" invisible="1"/>
-                            <field name="qty_delivered_method" invisible="1"/>
-                            <field name="state" invisible="1"/>
                             <field name="product_id"
                                 readonly="id and not product_updatable"
                                 required="not display_type"
@@ -60,12 +56,8 @@
                             <field name="product_uom_id" groups="!uom.group_uom" invisible="1"/>
                             <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>
                             <field name="order_partner_id" invisible="1"/>
-                            <field name="display_type" invisible="1"/>
-                            <field name="product_updatable" invisible="1"/>
                         </group>
                         <group>
-                            <field name="company_id" invisible="1"/>
-                            <field name="tax_country_id" invisible="1"/>
                             <field name="price_unit"/>
                             <field name="discount" groups="sale.group_discount_per_so_line"/>
                             <field name="price_subtotal"
@@ -112,9 +104,9 @@
                 <field name="product_id"/>
                 <field name="salesman_id"/>
                 <group expand="0" string="Group By">
-                    <filter string="Product" name="product" domain="[]" context="{'group_by':'product_id'}"/>
-                    <filter string="Order" name="order" domain="[]" context="{'group_by':'order_id'}"/>
-                    <filter string="Salesperson" name="salesperson" domain="[]" context="{'group_by':'salesman_id'}"/>
+                    <filter string="Product" name="product" context="{'group_by':'product_id'}"/>
+                    <filter string="Order" name="order" context="{'group_by':'order_id'}"/>
+                    <filter string="Salesperson" name="salesperson" context="{'group_by':'salesman_id'}"/>
                 </group>
             </search>
         </field>

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -230,9 +230,9 @@
         <field name="inherit_id" ref="view_quotation_tree"/>
         <field name="mode">primary</field>
         <field name="arch" type="xml">
-            <xpath expr="//list" position="attributes">
+            <list position="attributes">
                 <attribute name="js_class">sale_onboarding_list</attribute>
-            </xpath>
+            </list>
         </field>
     </record>
 
@@ -242,9 +242,9 @@
         <field name="inherit_id" ref="view_sale_order_kanban"/>
         <field name="mode">primary</field>
         <field name="arch" type="xml">
-            <xpath expr="//kanban" position="attributes">
+            <kanban position="attributes">
                 <attribute name="js_class">sale_onboarding_kanban</attribute>
-            </xpath>
+            </kanban>
         </field>
     </record>
 
@@ -254,35 +254,86 @@
         <field name="arch" type="xml">
             <form string="Sales Order" class="o_sale_order">
             <header>
-                <field name="locked" invisible="1"/>
-                <field name="authorized_transaction_ids" invisible="1"/>
-                <button name="payment_action_capture" type="object" data-hotkey="shift+g"
-                        string="Capture Transaction" class="oe_highlight"
-                        invisible="not authorized_transaction_ids"/>
-                <button name="payment_action_void" type="object"
-                        string="Void Transaction" data-hotkey="shift+v"
-                        confirm="Are you sure you want to void the authorized transaction? This action can't be undone."
-                        invisible="not authorized_transaction_ids"/>
-                <button id="create_invoice" name="%(sale.action_view_sale_advance_payment_inv)d" string="Create Invoice"
-                    type="action" class="btn-primary" data-hotkey="q"
+                <button
+                    name="payment_action_capture"
+                    type="object"
+                    string="Capture Transaction"
+                    data-hotkey="shift+g"
+                    class="oe_highlight"
+                    invisible="not authorized_transaction_ids"/>
+                <button
+                    name="payment_action_void"
+                    type="object"
+                    string="Void Transaction"
+                    data-hotkey="shift+v"
+                    confirm="Are you sure you want to void the authorized transaction? This action can't be undone."
+                    invisible="not authorized_transaction_ids"/>
+                <button
+                    id="create_invoice"
+                    name="%(sale.action_view_sale_advance_payment_inv)d"
+                    type="action"
+                    string="Create Invoice"
+                    class="btn-primary"
+                    data-hotkey="q"
                     invisible="invoice_status != 'to invoice'"/>
-                <button id="create_invoice_percentage" name="%(sale.action_view_sale_advance_payment_inv)d" string="Create Invoice"
-                    type="action" context="{'default_advance_payment_method': 'percentage'}" data-hotkey="q"
+                <button
+                    id="create_invoice_percentage"
+                    name="%(sale.action_view_sale_advance_payment_inv)d"
+                    type="action"
+                    context="{'default_advance_payment_method': 'percentage'}"
+                    string="Create Invoice"
+                    data-hotkey="q"
                     invisible="invoice_status != 'no' or state != 'sale'"/>
-                <button name="action_quotation_send" id="send_by_email_primary" string="Send by Email" type="object" data-hotkey="g"
-                    invisible="state != 'draft'" class="btn-primary"
-                    context="{'validate_analytic': True, 'check_document_layout': True}"/>
-                <button name="action_quotation_send" id="send_proforma_primary" type="object" string="Send PRO-FORMA Invoice" class="btn-primary"
-                    groups="sale.group_proforma_sales"
-                    invisible="state != 'draft' or invoice_count &gt;= 1" context="{'proforma': True, 'validate_analytic': True}"/>
-                <button name="action_confirm" id="action_confirm" data-hotkey="q"
-                    string="Confirm" class="btn-primary" type="object" context="{'validate_analytic': True}"
-                    invisible="state != 'sent'"/>
-                <button name="action_confirm" data-hotkey="q"
-                    string="Confirm" type="object" context="{'validate_analytic': True}"
+                <button
+                    id="send_by_email_primary"
+                    name="action_quotation_send"
+                    type="object"
+                    context="{'validate_analytic': True, 'check_document_layout': True}"
+                    string="Send by Email"
+                    class="btn-primary"
+                    data-hotkey="g"
                     invisible="state != 'draft'"/>
-                <button name="action_quotation_send" id="send_proforma" type="object" string="Send PRO-FORMA Invoice" groups="sale.group_proforma_sales" invisible="state == 'draft' or invoice_count &gt;= 1" context="{'proforma': True, 'validate_analytic': True}"/>
-                <button name="action_quotation_send" id="send_by_email" string="Send by Email" type="object" invisible="state not in ('sent', 'sale')" data-hotkey="g" context="{'validate_analytic': True, 'check_document_layout': True}"/>
+                <button
+                    id="send_proforma_primary"
+                    name="action_quotation_send"
+                    type="object"
+                    context="{'proforma': True, 'validate_analytic': True}"
+                    string="Send PRO-FORMA Invoice"
+                    class="btn-primary"
+                    groups="sale.group_proforma_sales"
+                    invisible="state != 'draft' or invoice_count &gt;= 1"/>
+                <button
+                    id="action_confirm"
+                    name="action_confirm"
+                    type="object"
+                    context="{'validate_analytic': True}"
+                    string="Confirm"
+                    class="btn-primary"
+                    data-hotkey="q"
+                    invisible="state != 'sent'"/>
+                <button
+                    name="action_confirm"
+                    type="object"
+                    context="{'validate_analytic': True}"
+                    string="Confirm"
+                    data-hotkey="q"
+                    invisible="state != 'draft'"/>
+                <button
+                    id="send_proforma"
+                    name="action_quotation_send"
+                    type="object"
+                    context="{'proforma': True, 'validate_analytic': True}"
+                    string="Send PRO-FORMA Invoice"
+                    invisible="state == 'draft' or invoice_count &gt;= 1"
+                    groups="sale.group_proforma_sales"/>
+                <button
+                    id="send_by_email"
+                    name="action_quotation_send"
+                    type="object"
+                    context="{'validate_analytic': True, 'check_document_layout': True}"
+                    string="Send by Email"
+                    data-hotkey="g"
+                    invisible="state not in ('sent', 'sale')"/>
 
                 <!-- allow to unlock locked orders even if setting is not enabled (e.g. orders synchronized from connectors) -->
                 <button name="action_unlock" type="object" string="Unlock"
@@ -355,12 +406,12 @@
                         <field name="partner_invoice_id"
                               groups="account.group_delivery_invoice_address"
                               options="{'no_quick_create': True}"
-                              context="{'default_type':'invoice', 'show_address': False, 'show_vat': False, 'default_parent_id': partner_id}"
+                              context="{'default_type': 'invoice', 'show_address': False, 'show_vat': False, 'default_parent_id': partner_id}"
                               readonly="state == 'cancel' or locked"/>
                         <field name="partner_shipping_id"
                               groups="account.group_delivery_invoice_address"
                               options="{'no_quick_create': True}"
-                              context="{'default_type':'delivery', 'show_address': False, 'show_vat': False, 'default_parent_id': partner_id}"
+                              context="{'default_type': 'delivery', 'show_address': False, 'show_vat': False, 'default_parent_id': partner_id}"
                               readonly="state == 'cancel' or locked"/>
                     </group>
                     <group name="order_details">
@@ -368,34 +419,47 @@
                         <div class="o_td_label" groups="base.group_no_one" invisible="state in ['sale', 'cancel']">
                             <label for="date_order" string="Quotation Date"/>
                         </div>
-                        <field name="date_order" nolabel="1" groups="base.group_no_one" invisible="state in ['sale', 'cancel']" readonly="state in ['cancel', 'sale']"/>
+                        <field
+                            name="date_order"
+                            nolabel="1"
+                            groups="base.group_no_one"
+                            invisible="state in ['sale', 'cancel']"
+                            readonly="state in ['cancel', 'sale']"/>
                         <div class="o_td_label" invisible="state in ['draft', 'sent']">
                             <label for="date_order" string="Order Date"/>
                         </div>
-                        <field name="date_order" invisible="state in ['draft', 'sent']" readonly="state in ['cancel', 'sale']" nolabel="1"/>
-                        <field name="has_active_pricelist" invisible="1"/>
-                        <field name="show_update_pricelist" invisible="1"/>
+                        <field
+                            name="date_order"
+                            nolabel="1"
+                            invisible="state in ['draft', 'sent']"
+                            readonly="state in ['cancel', 'sale']"/>
                         <label for="pricelist_id"
                                groups="product.group_product_pricelist"
                                invisible="not has_active_pricelist"/>
                         <div groups="product.group_product_pricelist"
                              class="o_row"
                              invisible="not has_active_pricelist">
-                            <field name="pricelist_id" options="{'no_open':True,'no_create': True}" readonly="state in ['cancel', 'sale']"/>
+                            <field
+                                name="pricelist_id"
+                                options="{'no_open': True, 'no_create': True}"
+                                readonly="state in ['cancel', 'sale']"/>
                             <button name="action_update_prices" type="object"
-                                string=" Update Prices"
+                                string="Update Prices"
                                 help="Recompute all prices based on this pricelist"
                                 class="btn-link mb-1 px-0" icon="fa-refresh"
                                 confirm="This will update the unit price of all products based on the new pricelist."
                                 invisible="not show_update_pricelist or state in ['sale', 'cancel']"/>
                         </div>
-                        <field name="country_code" invisible="1"/>
-                        <field name="company_id" invisible="1"/>
                         <field name="currency_id" invisible="1"/>
-                        <field name="pricelist_id" invisible="1" readonly="state in ['cancel', 'sale']" groups="!product.group_product_pricelist"/>
-                        <field name="tax_country_id" invisible="1"/>
-                        <field name="tax_calculation_rounding_method" invisible="1"/>
-                        <field name="payment_term_id" placeholder="Immediate" options="{'no_open': True, 'no_create': True}"/>
+                        <field
+                            name="pricelist_id"
+                            invisible="1"
+                            readonly="state in ['cancel', 'sale']"
+                            groups="!product.group_product_pricelist"/>
+                        <field
+                            name="payment_term_id"
+                            placeholder="Immediate"
+                            options="{'no_open': True, 'no_create': True}"/>
                     </group>
                 </group>
                 <notebook>
@@ -406,16 +470,15 @@
                             mode="list,kanban"
                             readonly="state == 'cancel' or locked">
                             <form>
-                                <field name="display_type" invisible="1"/>
-                                <field name="is_downpayment" invisible="1"/>
                                 <!--
                                     We need the sequence field to be here for new lines to be added at the correct position.
                                     TODO: at some point we want to fix this in the framework so that an invisible field is not required.
                                 -->
                                 <field name="sequence" invisible="1"/>
+                                <!-- Display_type must be specified as non readonly (which would be the case with the default field added by ORM) -->
+                                <field name="display_type" invisible="1"/>
                                 <group>
                                     <group invisible="display_type">
-                                        <field name="product_updatable" invisible="1"/>
                                         <label for="product_id"/>
                                         <div class="d-flex align-items-baseline">
                                             <span class="fa fa-exclamation-triangle text-warning me-1"
@@ -424,40 +487,16 @@
                                             />
                                             <field name="product_id"
                                                 domain="[('sale_ok', '=', True)]"
-                                                context="{
-                                                    'partner_id': parent.partner_id,
-                                                    'quantity': product_uom_qty,
-                                                    'pricelist': parent.pricelist_id,
-                                                    'uom': product_uom_id,
-                                                    'company_id': parent.company_id,
-                                                    'default_uom_id': product_uom_id,
-                                                }"
+                                                context="{'default_uom_id': product_uom_id}"
                                                 readonly="not product_updatable"
                                                 required="not display_type and not is_downpayment"
                                                 force_save="1"
                                                 widget="many2one_barcode"
                                             />
                                         </div>
-                                        <field name="product_type" invisible="1"/>
-                                        <field name="invoice_status" invisible="1"/>
-                                        <field name="qty_to_invoice" invisible="1"/>
-                                        <field name="qty_delivered_method" invisible="1"/>
-                                        <field name="price_total" invisible="1"/>
-                                        <field name="price_tax" invisible="1"/>
-                                        <field name="price_subtotal" invisible="1"/>
-                                        <field name="product_uom_readonly" invisible="1"/>
                                         <label for="product_uom_qty"/>
                                         <div class="o_row" name="ordered_qty">
-                                            <field
-                                                context="{
-                                                    'partner_id': parent.partner_id,
-                                                    'quantity': product_uom_qty,
-                                                    'pricelist': parent.pricelist_id,
-                                                    'uom': product_uom_id,
-                                                    'uom_qty_change': True,
-                                                    'company_id': parent.company_id,
-                                                }"
-                                                name="product_uom_qty"/>
+                                            <field name="product_uom_qty"/>
                                             <field name="product_uom_id" invisible="1" groups="!uom.group_uom"/>
                                             <field
                                                 name="product_uom_id"
@@ -477,7 +516,12 @@
                                             <field name="qty_invoiced"/>
                                         </div>
                                         <field name="price_unit"/>
-                                        <field name="tax_ids" widget="many2many_tax_tags" options="{'no_create': True}" context="{'search_view_ref': 'account.account_tax_view_search'}" domain="[('type_tax_use', '=', 'sale'), ('company_id', 'parent_of', parent.company_id), ('country_id', '=', parent.tax_country_id)]"
+                                        <field
+                                            name="tax_ids"
+                                            widget="many2many_tax_tags"
+                                            options="{'no_create': True}"
+                                            context="{'search_view_ref': 'account.account_tax_view_search'}"
+                                            domain="[('type_tax_use', '=', 'sale'), ('company_id', 'parent_of', parent.company_id), ('country_id', '=', parent.tax_country_id)]"
                                             readonly="qty_invoiced &gt; 0"/>
                                         <t groups="sale.group_discount_per_so_line">
                                             <label for="discount"/>
@@ -485,13 +529,6 @@
                                                 <field name="discount" class="oe_inline"/> %
                                             </div>
                                         </t>
-                                        <!--
-                                            We need the sequence field to be here
-                                            because we want to be able to overwrite the default sequence value in the JS
-                                            in order for new lines to be added at the correct position.
-                                            NOTE: at some point we want to fix this in the framework so that an invisible field is not required.
-                                        -->
-                                        <field name="sequence" invisible="1"/>
                                     </group>
                                     <group invisible="display_type">
                                         <label for="customer_lead"/>
@@ -511,8 +548,6 @@
                                     <label for="invoice_lines"/>
                                     <field name="invoice_lines"/>
                                 </div>
-                                <field name="state" invisible="1"/>
-                                <field name="company_id" invisible="1"/>
                             </form>
                             <list
                                 string="Sales Order Lines"
@@ -527,12 +562,28 @@
                                     <button name="action_add_from_catalog" string="Catalog" type="object" class="px-4 btn-link" context="{'order_id': parent.id}"/>
                                 </control>
 
-                                <field name="sequence" widget="handle" />
-                                <!-- We do not display the type because we don't want the user to be bothered with that information if he has no section or note. -->
+                                <!-- Non readonly invisible fields, must be specified manually, because fields added automatically by the ORM
+                                    are readonly, widgets fieldDependencies too -->
                                 <field name="display_type" column_invisible="True"/>
-                                <field name="product_type" column_invisible="True"/>
-                                <field name="product_updatable" column_invisible="True"/>
-                                <field name="is_downpayment" column_invisible="True"/>
+                                <field name="product_custom_attribute_value_ids" column_invisible="1" >
+                                    <list>
+                                        <field name="custom_product_template_attribute_value_id" />
+                                        <field name="custom_value" />
+                                    </list>
+                                </field>
+                                <field name="product_no_variant_attribute_value_ids" column_invisible="1"/>
+                                <field name="technical_price_unit" column_invisible="1"/>
+                                <field name="linked_line_id" column_invisible="1"/>
+                                <field name="combo_item_id" column_invisible="1"/>
+                                <field name="selected_combo_items" column_invisible="1"/>
+                                <field name="virtual_id" column_invisible="1"/>
+                                <field name="linked_virtual_id" column_invisible="1"/>
+
+                                <!-- Currency, needed for monetary widgets to display the currency symbol -->
+                                <field name="currency_id" column_invisible="True"/>
+
+                                <!-- Standard fields -->
+                                <field name="sequence" widget="handle"/>
                                 <field
                                     name="product_id"
                                     string="Product Variant"
@@ -540,16 +591,8 @@
                                     required="not display_type and not is_downpayment"
                                     force_save="1"
                                     context="{
-                                        'partner_id': parent.partner_id,
-                                        'quantity': product_uom_qty,
-                                        'pricelist': parent.pricelist_id,
-                                        'uom': product_uom_id,
-                                        'company_id': parent.company_id,
                                         'default_lst_price': price_unit,
                                         'default_uom_id': product_uom_id,
-                                    }"
-                                    options="{
-                                        'no_open': True,
                                     }"
                                     optional="hide"
                                     domain="[('sale_ok', '=', True)]"
@@ -559,71 +602,44 @@
                                     readonly="id and not product_updatable"
                                     required="not display_type and not is_downpayment"
                                     context="{
-                                        'partner_id': parent.partner_id,
-                                        'quantity': product_uom_qty,
-                                        'pricelist': parent.pricelist_id,
-                                        'uom': product_uom_id,
-                                        'company_id': parent.company_id,
                                         'default_list_price': price_unit,
                                         'default_uom_id': product_uom_id,
-                                    }"
-                                    options="{
-                                        'no_open': True,
                                     }"
                                     optional="show"
                                     domain="[('sale_ok', '=', True)]"
                                     widget="sol_product_many2one"
                                     placeholder="Type to find a product..."/>
-                                <field name="product_template_attribute_value_ids" column_invisible="1" />
-                                <field name="product_custom_attribute_value_ids" column_invisible="1" >
-                                    <list>
-                                        <field name="custom_product_template_attribute_value_id" />
-                                        <field name="custom_value" />
-                                    </list>
-                                </field>
-                                <field name="product_no_variant_attribute_value_ids" column_invisible="1" />
-                                <field name="is_configurable_product" column_invisible="1" />
-                                <field name="linked_line_id" column_invisible="1"/>
-                                <field name="virtual_id" column_invisible="1"/>
-                                <field name="linked_virtual_id" column_invisible="1"/>
-                                <field name="selected_combo_items" column_invisible="1"/>
-                                <field name="combo_item_id" column_invisible="1"/>
+                                <field name="name" widget="sol_text" optional="show"/>
                                 <field
-                                    name="name"
-                                    widget="sol_text"
-                                    optional="show"
-                                />
-                                <field name="analytic_distribution" widget="analytic_distribution"
-                                           optional="hide"
-                                           groups="analytic.group_analytic_accounting"
-                                           options="{'product_field': 'product_id', 'business_domain': 'sale_order', 'amount_field': 'price_subtotal'}"/>
+                                    name="analytic_distribution"
+                                    widget="analytic_distribution"
+                                    options="{
+                                        'product_field': 'product_id',
+                                        'business_domain': 'sale_order',
+                                        'amount_field': 'price_subtotal',
+                                    }"
+                                    optional="hide"
+                                    groups="analytic.group_analytic_accounting"/>
                                 <field
                                     name="product_uom_qty"
-                                    decoration-info="(not display_type and invoice_status == 'to invoice')" decoration-bf="(not display_type and invoice_status == 'to invoice')"
-                                    context="{
-                                        'partner_id': parent.partner_id,
-                                        'quantity': product_uom_qty,
-                                        'pricelist': parent.pricelist_id,
-                                        'uom': product_uom_id,
-                                        'company_id': parent.company_id
-                                    }"
+                                    decoration-info="(not display_type and invoice_status == 'to invoice')"
+                                    decoration-bf="(not display_type and invoice_status == 'to invoice')"
                                     readonly="is_downpayment"/>
                                 <field
                                     name="qty_delivered"
-                                    decoration-info="(not display_type and invoice_status == 'to invoice')" decoration-bf="(not display_type and invoice_status == 'to invoice')"
                                     string="Delivered"
+                                    decoration-info="(not display_type and invoice_status == 'to invoice')"
+                                    decoration-bf="(not display_type and invoice_status == 'to invoice')"
                                     column_invisible="parent.state != 'sale'"
                                     readonly="qty_delivered_method != 'manual' or is_downpayment"
                                     optional="show"/>
-                                <field name="qty_delivered_method" column_invisible="True"/>
                                 <field
                                     name="qty_invoiced"
-                                    decoration-info="(not display_type and invoice_status == 'to invoice')" decoration-bf="(not display_type and invoice_status == 'to invoice')"
                                     string="Invoiced"
+                                    decoration-info="(not display_type and invoice_status == 'to invoice')"
+                                    decoration-bf="(not display_type and invoice_status == 'to invoice')"
                                     column_invisible="parent.state != 'sale'"
                                     optional="show"/>
-                                <field name="qty_to_invoice" column_invisible="True"/>
-                                <field name="product_uom_readonly" column_invisible="True"/>
                                 <field name="product_uom_id" column_invisible="True" groups="!uom.group_uom"/>
                                 <field
                                     name="product_uom_id"
@@ -631,7 +647,6 @@
                                     readonly="product_uom_readonly"
                                     required="not display_type and not is_downpayment"
                                     widget="many2one_uom"
-                                    context="{'company_id': parent.company_id}"
                                     groups="uom.group_uom"
                                     options='{"no_open": True, "no_create": True}'
                                     width="60px"
@@ -641,10 +656,7 @@
                                     optional="hide"
                                     width="80px"
                                     readonly="parent.state not in ['draft', 'sent', 'sale'] or is_downpayment"/>
-                                <field
-                                    name="price_unit"
-                                    readonly="qty_invoiced &gt; 0"/>
-                                <field name="technical_price_unit" column_invisible="1"/>
+                                <field name="price_unit" readonly="qty_invoiced &gt; 0"/>
                                 <field
                                     name="tax_ids"
                                     widget="many2many_tax_tags"
@@ -659,25 +671,18 @@
                                     groups="sale.group_discount_per_so_line"
                                     width="50px"
                                     optional="show"/>
-                                <field name="is_downpayment" column_invisible="True"/>
-                                <field name="price_subtotal"
-                                       column_invisible="parent.company_price_include == 'tax_included'"
-                                       invisible="is_downpayment"
-                                       string="Amount"/>
-                                <field name="price_total"
-                                       column_invisible="parent.company_price_include == 'tax_excluded'"
-                                       invisible="is_downpayment"
-                                       string="Amount"/>
-                                <!-- Others fields -->
-                                <field name="tax_calculation_rounding_method" column_invisible="True"/>
-                                <field name="state" column_invisible="True"/>
-                                <field name="invoice_status" column_invisible="True"/>
-                                <field name="currency_id" column_invisible="True"/>
-                                <field name="price_tax" column_invisible="True"/>
-                                <field name="company_id" column_invisible="True"/>
+                                <field
+                                    name="price_subtotal"
+                                    string="Amount"
+                                    column_invisible="parent.company_price_include == 'tax_included'"
+                                    invisible="is_downpayment"/>
+                                <field
+                                    name="price_total"
+                                    string="Amount"
+                                    column_invisible="parent.company_price_include == 'tax_excluded'"
+                                    invisible="is_downpayment"/>
                             </list>
                             <kanban class="o_kanban_mobile">
-                                <field name="price_subtotal"/>
                                 <field name="display_type"/>
                                 <field name="currency_id"/>
                                 <control>
@@ -781,10 +786,13 @@
                                 <label for="fiscal_position_id"/>
                                 <div class="o_row">
                                     <field name="fiscal_position_id" options="{'no_create': True}"/>
-                                    <button name="action_update_taxes" type="object"
-                                        string=" Update Taxes"
+                                    <button
+                                        name="action_update_taxes"
+                                        type="object"
+                                        string="Update Taxes"
                                         help="Recompute all taxes based on this fiscal position"
-                                        class="btn-link mb-1 px-0" icon="fa-refresh"
+                                        class="btn-link mb-1 px-0"
+                                        icon="fa-refresh"
                                         confirm="This will update all taxes based on the currently selected fiscal position."
                                         invisible="not show_update_fpos or state in ['sale', 'cancel']"/>
                                 </div>
@@ -801,7 +809,7 @@
                                     <span name="expected_date_span" class="text-muted">Expected: <field name="expected_date" class="oe_inline"/></span>
                                 </div>
                             </group>
-                            <group string="Tracking" name="sale_reporting">
+                            <group name="sale_reporting" string="Tracking">
                                 <field name="origin"/>
                                 <field name="campaign_id" options="{'create_name_field': 'title'}"/>
                                 <field name="medium_id"/>
@@ -829,7 +837,8 @@
         <field name="priority" eval="15"/>
         <field name="arch" type="xml">
             <search string="Search Sales Order">
-                <field name="name" string="Order"
+                <field name="name"
+                    string="Order"
                     filter_domain="['|', '|', ('name', 'ilike', self), ('client_order_ref', 'ilike', self), ('partner_id', 'child_of', self)]"/>
                 <field name="partner_id" operator="child_of"/>
                 <field name="user_id"/>
@@ -839,7 +848,7 @@
                     will not be searched as often, and if they need to be searched it's usually in the context of products
                     and then they can be searched from the page listing the sale order lines related to a product (from the product itself).
                 -->
-                <filter string="My Orders" domain="[('user_id', '=', uid)]" name="my_sale_orders_filter"/>
+                <filter name="my_sale_orders_filter" string="My Orders" domain="[('user_id', '=', uid)]"/>
                 <filter invisible="1" string="Late Activities" name="activities_overdue"
                     domain="[('my_activity_date_deadline', '&lt;', context_today().strftime('%Y-%m-%d'))]"
                     help="Show all records which has next action date is before today"/>
@@ -848,9 +857,9 @@
                 <filter invisible="1" string="Future Activities" name="activities_upcoming_all"
                     domain="[('my_activity_date_deadline', '&gt;', context_today().strftime('%Y-%m-%d'))]"/>
                 <group expand="0" string="Group By">
-                    <filter string="Salesperson" name="salesperson" domain="[]" context="{'group_by': 'user_id'}"/>
-                    <filter name="customer" string="Customer" domain="[]" context="{'group_by': 'partner_id'}"/>
-                    <filter string="Order Date" name="order_month" domain="[]" context="{'group_by': 'date_order'}"/>
+                    <filter name="salesperson" string="Salesperson" context="{'group_by': 'user_id'}"/>
+                    <filter name="customer" string="Customer" context="{'group_by': 'partner_id'}"/>
+                    <filter name="order_month" string="Order Date" context="{'group_by': 'date_order'}"/>
                 </group>
             </search>
         </field>

--- a/addons/sale/wizard/sale_order_discount_views.xml
+++ b/addons/sale/wizard/sale_order_discount_views.xml
@@ -2,7 +2,7 @@
 <odoo>
 
     <record id="sale_order_line_wizard_form" model="ir.ui.view">
-        <field name="name">sale.order.line.wizard.form</field>
+        <field name="name">sale.order.discount.form</field>
         <field name="model">sale.order.discount</field>
         <field name="arch" type="xml">
             <form>

--- a/addons/sale_crm/views/sale_order_views.xml
+++ b/addons/sale_crm/views/sale_order_views.xml
@@ -14,7 +14,7 @@
         <field name="model">sale.order</field>
         <field name="inherit_id" ref="sale.view_order_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='origin']" position="after">
+            <field name="origin" position="after">
                 <field name="opportunity_id" context="{
                     'default_campaign_id': campaign_id,
                     'default_company_id': company_id,
@@ -24,7 +24,7 @@
                     'default_tag_ids': tag_ids,
                     'default_type': 'opportunity',
                 }"/>
-            </xpath>
+            </field>
         </field>
     </record>
 

--- a/addons/sale_expense/views/sale_order_views.xml
+++ b/addons/sale_expense/views/sale_order_views.xml
@@ -6,17 +6,17 @@
         <field name="model">sale.order</field>
         <field name="inherit_id" ref="sale.view_order_form"/>
         <field name="arch" type="xml">
-            <data>
-               <xpath expr="//button[@name='action_view_invoice']" position="before">
-                   <button type="action"
-                       name="%(sale_expense.hr_expense_action_from_sale_order)d"
-                       class="oe_stat_button"
-                       icon="fa-money"
-                       invisible="expense_count == 0">
-                       <field name="expense_count" widget="statinfo" string="Expenses"/>
-                   </button>
-                </xpath>
-            </data>
+            <button name="action_view_invoice" position="before">
+                <button
+                    name="%(sale_expense.hr_expense_action_from_sale_order)d"
+                    type="action"
+                    class="oe_stat_button"
+                    icon="fa-money"
+                    invisible="expense_count == 0"
+                >
+                    <field name="expense_count" widget="statinfo" string="Expenses"/>
+                </button>
+            </button>
         </field>
     </record>
 

--- a/addons/sale_management/views/digest_views.xml
+++ b/addons/sale_management/views/digest_views.xml
@@ -2,7 +2,7 @@
 <odoo>
 
     <record id="digest_digest_view_form" model="ir.ui.view">
-        <field name="name">digest.digest.view.form.inherit.sale.order</field>
+        <field name="name">digest.digest.view.form.inherit.sale_management</field>
         <field name="model">digest.digest</field>
         <field name="priority">10</field>
         <field name="inherit_id" ref="digest.digest_digest_view_form" />

--- a/addons/sale_management/views/sale_order_template_views.xml
+++ b/addons/sale_management/views/sale_order_template_views.xml
@@ -63,7 +63,6 @@
                                 -->
                                 <field name="sequence" invisible="1"/>
                                 <field name="display_type" invisible="1"/>
-                                <field name="company_id" invisible="1"/>
                                 <group invisible="display_type">
                                     <group>
                                         <field name="product_id" required="not display_type"/>
@@ -91,9 +90,6 @@
                                     <create name="add_section_control" string="Add a section" context="{'default_display_type': 'line_section'}"/>
                                     <create name="add_note_control" string="Add a note" context="{'default_display_type': 'line_note'}"/>
                                 </control>
-
-                                <field name="display_type" column_invisible="True"/>
-                                <field name="company_id" column_invisible="True"/>
                                 <field name="sequence" widget="handle"/>
                                 <field name="product_id"/>
                                 <field name="name"/>
@@ -107,18 +103,19 @@
                     </page>
                     <page string="Optional Products" name="optional_products">
                         <field name="sale_order_template_option_ids">
-                          <list string="Quotation Template Lines" editable="bottom">
-                            <field name="product_id"/>
-                            <field name="name"/>
-                            <field name="quantity"/>
-                            <field name="uom_id" widget="many2one_uom" groups="uom.group_uom"/>
-                            <field name="company_id" column_invisible="True"/>
-                          </list>
+                            <list string="Quotation Template Lines" editable="bottom">
+                                <field name="product_id"/>
+                                <field name="name"/>
+                                <field name="quantity"/>
+                                <field name="uom_id" widget="many2one_uom" groups="uom.group_uom"/>
+                            </list>
                         </field>
                     </page>
                         <page string="Terms &amp; Conditions" name="terms_and_conditions">
-                            <field name="note" nolabel="1"
-                                   placeholder="The Administrator can set default Terms &amp; Conditions in Sales Settings. Terms set here will show up instead if you select this quotation template."/>
+                            <field
+                                name="note"
+                                nolabel="1"
+                                placeholder="The Administrator can set default Terms &amp; Conditions in Sales Settings. Terms set here will show up instead if you select this quotation template."/>
                         </page>
                     </notebook>
                 </sheet>

--- a/addons/sale_management/views/sale_order_views.xml
+++ b/addons/sale_management/views/sale_order_views.xml
@@ -65,7 +65,6 @@
                                 string="Disc.%"
                                 groups="sale.group_discount_per_so_line"
                                 optional="show"/>
-                            <field name="is_present" column_invisible="True" />
                             <button name="button_add_to_order"
                                 type="object"
                                 class="oe_link"
@@ -78,10 +77,11 @@
             </page>
 
             <field name="partner_shipping_id" position="after">
-                <field name="sale_order_template_id"
+                <field
+                    name="sale_order_template_id"
                     options="{'no_create': True}"
-                    groups="sale_management.group_sale_order_template"
-                 readonly="state in ['cancel', 'sale']"/>
+                    readonly="state in ['cancel', 'sale']"
+                    groups="sale_management.group_sale_order_template"/>
             </field>
         </field>
     </record>

--- a/addons/sale_margin/views/sale_order_views.xml
+++ b/addons/sale_margin/views/sale_order_views.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
-    <record model="ir.ui.view" id="sale_margin_sale_order">
+    <record id="sale_margin_sale_order" model="ir.ui.view">
         <field name="name">sale.order.margin.view.form</field>
         <field name="model">sale.order</field>
         <field name="inherit_id" ref="sale.view_order_form"/>
         <field name="priority" eval="15"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='tax_totals']" position="after">
-                <div class="d-flex float-end" colspan="2" groups="base.group_user">
+            <field name="tax_totals" position="after">
+                <div class="d-flex float-end" colspan="2">
                     <label for="margin"/>
                     <div>
                         <field name="margin" class="oe_inline"/>
@@ -18,28 +18,11 @@
                         </span>
                     </div>
                 </div>
-            </xpath>
-        </field>
-    </record>
-
-    <record model="ir.ui.view" id="sale_margin_sale_order_line">
-        <field name="name">sale.order.line.margin.view.form</field>
-        <field name="model">sale.order</field>
-        <field name="inherit_id" ref="sale.view_order_form"/>
-        <field name="arch" type="xml">
-            <xpath expr="//field[@name='order_line']/form//field[@name='price_unit']" position="after">
+            </field>
+            <xpath expr="//field[@name='order_line']//form//field[@name='price_unit']" position="after">
                 <field name="purchase_price" groups="base.group_user"/>
             </xpath>
-        </field>
-    </record>
-
-    <record model="ir.ui.view" id="sale_margin_sale_order_line_form">
-        <field name="name">sale.order.line.list.margin.view.form</field>
-        <field name="model">sale.order</field>
-        <field name="inherit_id" ref="sale.view_order_form"/>
-        <field name="arch" type="xml">
-           <xpath expr="//field[@name='order_line']/list//field[@name='price_unit']" position="after">
-                <field name="price_subtotal" column_invisible="True"/>
+           <xpath expr="//field[@name='order_line']//list//field[@name='price_unit']" position="after">
                 <field name="purchase_price" optional="hide"/>
                 <field name="margin" optional="hide"/>
                 <field name="margin_percent"
@@ -49,7 +32,7 @@
         </field>
     </record>
 
-    <record model="ir.ui.view" id="sale_margin_sale_order_pivot">
+    <record id="sale_margin_sale_order_pivot" model="ir.ui.view">
         <field name="name">sale.order.margin.view.pivot</field>
         <field name="model">sale.order</field>
         <field name="inherit_id" ref="sale.view_sale_order_pivot"/>
@@ -60,7 +43,7 @@
         </field>
     </record>
 
-    <record model="ir.ui.view" id="sale_margin_sale_order_graph">
+    <record id="sale_margin_sale_order_graph" model="ir.ui.view">
         <field name="name">sale.order.margin.view.graph</field>
         <field name="model">sale.order</field>
         <field name="inherit_id" ref="sale.view_sale_order_graph"/>

--- a/addons/sale_mrp/views/sale_order_views.xml
+++ b/addons/sale_mrp/views/sale_order_views.xml
@@ -1,18 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo><data>
+<odoo>
+
     <record id="sale_order_form_mrp" model="ir.ui.view">
         <field name="name">sale.order.inherited.form.mrp</field>
         <field name="model">sale.order</field>
         <field name="inherit_id" ref="sale.view_order_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[@name='button_box']" position="inside">
-                <button class="oe_stat_button" name="action_view_mrp_production" type="object" icon="fa-wrench" invisible="mrp_production_count == 0" groups="mrp.group_mrp_user">
-                    <div class="o_field_widget o_stat_info">
-                        <span class="o_stat_value"><field name="mrp_production_count"/></span>
-                        <span class="o_stat_text">Manufacturing</span>
-                    </div>
+            <div name="button_box" position="inside">
+                <button
+                    name="action_view_mrp_production"
+                    type="object"
+                    class="oe_stat_button"
+                    icon="fa-wrench"
+                    invisible="mrp_production_count == 0"
+                    groups="mrp.group_mrp_user">
+                    <field name="mrp_production_count" widget="statinfo" string="Manufacturing"/>
                 </button>
-            </xpath>
+            </div>
         </field>
     </record>
-</data></odoo> 
+
+</odoo>

--- a/addons/sale_product_matrix/static/src/js/sale_product_field.js
+++ b/addons/sale_product_matrix/static/src/js/sale_product_field.js
@@ -1,5 +1,5 @@
 import { useMatrixConfigurator } from "@product_matrix/js/matrix_configurator_hook";
-import { SaleOrderLineProductField } from "@sale/js/sale_product_field";
+import { SaleOrderLineProductField, saleOrderLineProductField } from "@sale/js/sale_product_field";
 import { patch } from "@web/core/utils/patch";
 
 patch(SaleOrderLineProductField.prototype, {
@@ -19,4 +19,11 @@ patch(SaleOrderLineProductField.prototype, {
             return super._openProductConfigurator(edit);
         }
     },
+});
+
+Object.assign(saleOrderLineProductField, {
+    fieldDependencies: [
+        ...saleOrderLineProductField.fieldDependencies,
+        { name: "product_add_mode", type: "selection"},
+    ],
 });

--- a/addons/sale_product_matrix/views/sale_order_views.xml
+++ b/addons/sale_product_matrix/views/sale_order_views.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
+
     <record id="view_order_form_with_variant_grid" model="ir.ui.view">
-        <field name="name">sale.order.line.variant.grid</field>
+        <field name="name">sale.order.grid</field>
         <field name="model">sale.order</field>
         <field name="inherit_id" ref="sale.view_order_form"/>
         <field name="arch" type="xml">
@@ -11,12 +12,10 @@
                 <field name="grid_product_tmpl_id" invisible="1"/>
                 <field name="grid_update" invisible="1"/>
             </field>
-            <xpath expr="//list/field[@name='product_template_id']" position="after">
-                <field name="product_add_mode" column_invisible="True"/>
-            </xpath>
-            <xpath expr="//notebook//group[@name='sales_person']" position="inside">
+            <group name="sales_person" position="inside">
                 <field name="report_grids" groups="base.group_no_one"/>
-            </xpath>
+            </group>
         </field>
     </record>
+
 </odoo>

--- a/addons/sale_project/views/sale_order_views.xml
+++ b/addons/sale_project/views/sale_order_views.xml
@@ -7,19 +7,35 @@
         <field name="inherit_id" ref="sale.view_order_form"/>
         <field name="priority">10</field>
         <field name="arch" type="xml">
-            <xpath expr="//button[@name='action_view_invoice']" position="before">
-                <field name="show_task_button" invisible="1"/>
-                <field name="show_project_button" invisible="1"/>
-                <field name="show_create_project_button" invisible="1"/>
-                <field name="project_ids" invisible="1"/>
-                <field name="is_product_milestone" invisible="1"/>
-                <button type="object" name="action_view_project_ids" class="oe_stat_button" icon="fa-puzzle-piece" invisible="not show_project_button" groups="project.group_project_user">
+            <button name="action_view_invoice" position="before">
+                <button
+                    name="action_view_project_ids"
+                    type="object"
+                    class="oe_stat_button"
+                    icon="fa-puzzle-piece"
+                    invisible="not show_project_button"
+                    groups="project.group_project_user"
+                >
                     <field name="project_count" widget="statinfo" string="Projects"/>
                 </button>
-                <button class="oe_stat_button" name="action_view_milestone" type="object" icon="fa-check-square-o" invisible="not is_product_milestone or not project_ids or state == 'draft'" groups="project.group_project_milestone">
+                <button
+                    name="action_view_milestone"
+                    type="object"
+                    class="oe_stat_button"
+                    icon="fa-check-square-o"
+                    invisible="not is_product_milestone or not project_ids or state == 'draft'"
+                    groups="project.group_project_milestone"
+                >
                     <field name="milestone_count" widget="statinfo" string="Milestones"/>
                 </button>
-                <button type="object" name="action_view_task" class="oe_stat_button" icon="fa-check" invisible="not show_task_button" groups="project.group_project_user">
+                <button
+                    name="action_view_task"
+                    type="object"
+                    class="oe_stat_button"
+                    icon="fa-check"
+                    invisible="not show_task_button"
+                    groups="project.group_project_user"
+                >
                     <div class="o_field_widget o_stat_info">
                         <span class="o_stat_text">Tasks</span>
                         <span class="o_stat_value">
@@ -28,7 +44,7 @@
                         </span>
                     </div>
                 </button>
-            </xpath>
+            </button>
             <field name="journal_id" position="before">
                 <field name="project_id" groups="project.group_project_user"
                     context="{'default_allow_billable': True, 'default_partner_id': partner_id, 'order_id': id, 'order_state' : state}"/>

--- a/addons/sale_purchase/views/sale_order_views.xml
+++ b/addons/sale_purchase/views/sale_order_views.xml
@@ -1,18 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo><data>
+<odoo>
+
     <record id="sale_order_inherited_form_purchase" model="ir.ui.view">
         <field name="name">sale.order.inherited.form.purchase</field>
         <field name="model">sale.order</field>
         <field name="inherit_id" ref="sale.view_order_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[@name='button_box']" position="inside">
-                <button class="oe_stat_button" name="action_view_purchase_orders" type="object" icon="fa-credit-card" groups='purchase.group_purchase_user' invisible="purchase_order_count == 0">
-                    <div class="o_field_widget o_stat_info">
-                        <span class="o_stat_value"><field name="purchase_order_count"/></span>
-                        <span class="o_stat_text">Purchase</span>
-                    </div>
+            <div name="button_box" position="inside">
+                <button
+                    name="action_view_purchase_orders"
+                    type="object"
+                    class="oe_stat_button"
+                    icon="fa-credit-card"
+                    invisible="purchase_order_count == 0"
+                    groups="purchase.group_purchase_user">
+                    <field name="purchase_order_count" widget="statinfo" string="Purchase"/>
                 </button>
-            </xpath>
+            </div>
         </field>
     </record>
-</data></odoo>
+
+</odoo>

--- a/addons/sale_stock/__manifest__.py
+++ b/addons/sale_stock/__manifest__.py
@@ -25,6 +25,7 @@ Preferences
         'security/ir.model.access.csv',
 
         'views/sale_order_views.xml',
+        'views/sale_order_line_views.xml',
         'views/stock_route_views.xml',
         'views/res_config_settings_views.xml',
         'views/sale_stock_portal_template.xml',

--- a/addons/sale_stock/static/src/widgets/qty_at_date_widget.js
+++ b/addons/sale_stock/static/src/widgets/qty_at_date_widget.js
@@ -87,5 +87,16 @@ export class QtyAtDateWidget extends Component {
 
 export const qtyAtDateWidget = {
     component: QtyAtDateWidget,
+    fieldDependencies: [
+        { name: 'display_qty_widget', type: 'boolean'},
+        { name: 'free_qty_today', type: 'float'},
+        { name: 'forecast_expected_date', type: 'datetime'},
+        { name: 'is_mto', type: 'boolean'},
+        { name: 'qty_available_today', type: 'float'},
+        { name: 'qty_to_deliver', type: 'float'},
+        { name: 'scheduled_date', type: 'datetime'},
+        { name: 'virtual_available_at_date', type: 'float'},
+        { name: 'warehouse_id', type: 'many2one'},
+    ],
 };
 registry.category("view_widgets").add("qty_at_date_widget", qtyAtDateWidget);

--- a/addons/sale_stock/views/sale_order_line_views.xml
+++ b/addons/sale_stock/views/sale_order_line_views.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+
+    <record id="view_order_line_tree_inherit_sale_stock" model="ir.ui.view">
+        <field name="name">sale.order.line.list.sale.stock.location</field>
+        <field name="inherit_id" ref="sale.view_order_line_tree"/>
+        <field name="model">sale.order.line</field>
+        <field name="arch" type="xml">
+            <field name="price_subtotal" position="before">
+                <field name="route_ids" groups="stock.group_adv_location" options="{'no_create': True}"/>
+            </field>
+        </field>
+    </record>
+
+</odoo>

--- a/addons/sale_stock/views/sale_order_views.xml
+++ b/addons/sale_stock/views/sale_order_views.xml
@@ -1,150 +1,115 @@
 <?xml version="1.0"?>
 <odoo>
-    <data>
-        <record id="view_order_form_inherit_sale_stock" model="ir.ui.view">
-            <field name="name">sale.order.form.sale.stock</field>
-            <field name="model">sale.order</field>
-            <field name="inherit_id" ref="sale.view_order_form"/>
-            <field name="arch" type="xml">
-                <xpath expr="//button[@name='action_view_invoice']" position="before">
-                    <button type="object"
-                        name="action_view_delivery"
-                        class="oe_stat_button"
-                        icon="fa-truck"
-                        invisible="delivery_count == 0" groups="stock.group_stock_user">
-                        <field name="delivery_count" widget="statinfo" string="Delivery"/>
-                    </button>
-                </xpath>
-                <xpath expr="//group[@name='sale_shipping']" position="attributes">
-                    <attribute name="groups"></attribute><!-- Remove the res.group on the group and set it on the field directly-->
-                    <attribute name="string">Delivery</attribute>
-                </xpath>
-                <xpath expr="//label[@for='commitment_date']" position="before">
-                    <field name="warehouse_id" invisible="1" readonly="state == 'sale'"/>  <!-- needed for js logic -->
-                    <field name="warehouse_id" options="{'no_create': True}" force_save="1" readonly="state == 'sale'"/>
-                    <field name="incoterm" options="{'no_open': True, 'no_create': True}"/>
-                    <field name="incoterm_location"/>
-                    <field name="picking_policy" required="True" readonly="state not in ['draft', 'sent']"/>
-                </xpath>
-                <xpath expr="//span[@name='expected_date_span']" position="attributes">
-                    <attribute name="invisible">effective_date and commitment_date</attribute>
-                </xpath>
-                <xpath expr="//div[@name='commitment_date_div']" position="replace">
-                    <div class="o_row">
-                        <field name="commitment_date"/>
-                        <span class="text-muted" invisible="effective_date and commitment_date">Expected: <field name="expected_date" class="oe_inline"/></span>
-                    </div>
-                    <field name="effective_date" invisible="not effective_date"/>
-                </xpath>
-                <field name="effective_date" position="after">
-                    <field name="delivery_status" invisible="state != 'sale'"/>
-                </field>
-                <xpath expr="//page[@name='other_information']//field[@name='expected_date']" position="after">
-                    <field name="show_json_popover" invisible="1"/>
-                    <field string=" " name="json_popover" widget="stock_rescheduling_popover" invisible="not show_json_popover"/>
-                </xpath>
-                <xpath expr="//field[@name='order_line']/form/group/group/field[@name='analytic_distribution']" position="before">
-                    <field name="route_ids" widget="many2many_tags" groups="stock.group_adv_location" options="{'no_create': True}"/>
-                </xpath>
-                <xpath expr="//field[@name='order_line']/list/field[@name='analytic_distribution']" position="after">
-                    <field name="route_ids" widget="many2many_tags" groups="stock.group_adv_location" options="{'no_create': True}" optional="hide"/>
-                </xpath>
-           </field>
-        </record>
 
-        <record id="sale_order_tree" model="ir.ui.view">
-            <field name="name">sale.order.list.inherit.sale.stock</field>
-            <field name="model">sale.order</field>
-            <field name="inherit_id" ref="sale.sale_order_tree"/>
-            <field name="arch" type="xml">
-                <field name="tag_ids" position="after">
-                    <field name="warehouse_id"
-                           options="{'no_create': True}"
-                           groups="stock.group_stock_multi_warehouses"
-                           optional="hide" readonly="state == 'sale'"/>
-                </field>
+    <record id="view_order_form_inherit_sale_stock" model="ir.ui.view">
+        <field name="name">sale.order.form.sale.stock</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <button name="action_view_invoice" position="before">
+                <button
+                    name="action_view_delivery"
+                    type="object"
+                    class="oe_stat_button"
+                    icon="fa-truck"
+                    invisible="delivery_count == 0"
+                    groups="stock.group_stock_user"
+                >
+                    <field name="delivery_count" widget="statinfo" string="Delivery"/>
+                </button>
+            </button>
+            <group name="sale_shipping" position="attributes">
+                <attribute name="groups"></attribute><!-- Remove the res.group on the group and set it on the field directly-->
+                <attribute name="string">Delivery</attribute>
+            </group>
+            <label for="commitment_date" position="before">
+                <field name="warehouse_id" options="{'no_create': True}" force_save="1" readonly="state == 'sale'"/>
+                <field name="incoterm" options="{'no_open': True, 'no_create': True}"/>
+                <field name="incoterm_location"/>
+                <field name="picking_policy" required="True" readonly="state not in ['draft', 'sent']"/>
+            </label>
+            <span name="expected_date_span" position="attributes">
+                <attribute name="invisible">effective_date and commitment_date</attribute>
+            </span>
+            <div name="commitment_date_div" position="replace">
+                <div class="o_row">
+                    <field name="commitment_date"/>
+                    <span class="text-muted" invisible="effective_date and commitment_date">Expected: <field name="expected_date" class="oe_inline"/></span>
+                </div>
+                <field name="effective_date" invisible="not effective_date"/>
+                <field name="delivery_status" invisible="state != 'sale'"/>
+            </div>
+            <xpath expr="//page[@name='other_information']//field[@name='expected_date']" position="after">
+                <field string=" " name="json_popover" widget="stock_rescheduling_popover" invisible="not show_json_popover"/>
+            </xpath>
+            <xpath expr="//field[@name='order_line']//form//field[@name='analytic_distribution']" position="before">
+                <field name="route_ids" widget="many2many_tags" groups="stock.group_adv_location" options="{'no_create': True}"/>
+            </xpath>
+            <xpath expr="//field[@name='order_line']//form//field[@name='product_uom_id']" position="after">
+                <widget name="qty_at_date_widget"/>
+            </xpath>
+            <xpath expr="//field[@name='order_line']//list//field[@name='analytic_distribution']" position="after">
+                <field
+                    name="route_ids"
+                    widget="many2many_tags"
+                    groups="stock.group_adv_location"
+                    options="{'no_create': True}"
+                    optional="hide"/>
+            </xpath>
+            <xpath expr="//field[@name='order_line']//list//field[@name='qty_delivered']" position="after">
+                <widget name="qty_at_date_widget" width="20px"/>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="sale_order_tree" model="ir.ui.view">
+        <field name="name">sale.order.list.inherit.sale.stock</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.sale_order_tree"/>
+        <field name="arch" type="xml">
+            <field name="tag_ids" position="after">
+                <field
+                    name="warehouse_id"
+                    options="{'no_create': True}"
+                    readonly="state == 'sale'"
+                    groups="stock.group_stock_multi_warehouses"
+                    optional="hide"
+                />
             </field>
-        </record>
+        </field>
+    </record>
 
-        <record id="view_order_tree" model="ir.ui.view">
-            <field name="name">sale.order.list.inherit.sale.stock</field>
-            <field name="model">sale.order</field>
-            <field name="inherit_id" ref="sale.view_order_tree"/>
-            <field name="arch" type="xml">
-                <xpath expr="//field[@name='commitment_date']" position="attributes">
-                    <attribute name="decoration-danger">
+    <record id="view_order_tree" model="ir.ui.view">
+        <field name="name">sale.order.list.inherit.sale.stock</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_tree"/>
+        <field name="arch" type="xml">
+            <field name="commitment_date" position="attributes">
+                <attribute name="decoration-danger">
+                    (
                         (
-                            (
-                                commitment_date &lt; effective_date
-                                or commitment_date &lt; datetime.datetime.combine(
-                                    datetime.date.today(),
-                                    datetime.time(0,0,0)
-                                ).to_utc().strftime('%Y-%m-%d %H:%M:%S')
-                            )
-                            and delivery_status in ['pending', 'started']
-                            and effective_date &lt;= commitment_date
-                            or delivery_status == 'partial'
+                            commitment_date &lt; effective_date
+                            or commitment_date &lt; datetime.datetime.combine(
+                                datetime.date.today(),
+                                datetime.time(0,0,0)
+                            ).to_utc().strftime('%Y-%m-%d %H:%M:%S')
                         )
-                    </attribute>
-                </xpath>
-                <field name="invoice_status" position="before">
-                    <field name="effective_date" column_invisible="True"/>
-                    <field name="delivery_status"
-                        decoration-success="delivery_status == 'full'"
-                        decoration-warning="delivery_status == 'partial'"
-                        decoration-info="delivery_status in ['pending', 'started']"
-                        widget="badge"
-                        optional="hide"/>
-                </field>
+                        and delivery_status in ['pending', 'started']
+                        and effective_date &lt;= commitment_date
+                        or delivery_status == 'partial'
+                    )
+                </attribute>
             </field>
-        </record>
-
-        <record id="view_order_line_tree_inherit_sale_stock" model="ir.ui.view">
-            <field name="name">sale.order.line.list.sale.stock.location</field>
-            <field name="inherit_id" ref="sale.view_order_line_tree"/>
-            <field name="model">sale.order.line</field>
-            <field name="arch" type="xml">
-                <xpath expr="//field[@name='price_subtotal']" position="before">
-                    <field name="route_ids" widget="many2many_tags" groups="stock.group_adv_location" options="{'no_create': True}"/>
-                </xpath>
+            <field name="invoice_status" position="before">
+                <field
+                    name="delivery_status"
+                    decoration-success="delivery_status == 'full'"
+                    decoration-warning="delivery_status == 'partial'"
+                    decoration-info="delivery_status in ['pending', 'started']"
+                    widget="badge"
+                    optional="hide"/>
             </field>
-        </record>
+        </field>
+    </record>
 
-        <record id="view_order_form_inherit_sale_stock_qty" model="ir.ui.view">
-            <field name="name">sale.order.line.list.sale.stock.qty</field>
-            <field name="inherit_id" ref="sale.view_order_form"/>
-            <field name="model">sale.order</field>
-            <field name="arch" type="xml">
-                <xpath expr="//page/field[@name='order_line']/form/group/group/div[@name='ordered_qty']/field[@name='product_uom_id']" position="after">
-                    <!-- below fields are used in the widget qty_at_date_widget -->
-                    <field name="virtual_available_at_date" invisible="1"/>
-                    <field name="qty_available_today" invisible="1"/>
-                    <field name="free_qty_today" invisible="1"/>
-                    <field name="scheduled_date" invisible="1"/>
-                    <field name="forecast_expected_date" invisible="1"/>
-                    <field name="warehouse_id" invisible="1"/>
-                    <field name="move_ids" invisible="1"/>
-                    <field name="qty_to_deliver" invisible="1"/>
-                    <field name="is_mto" invisible="1"/>
-                    <field name="display_qty_widget" invisible="1"/>
-                    <widget name="qty_at_date_widget"/>
-                </xpath>
-                <xpath expr="//page/field[@name='order_line']/list/field[@name='qty_delivered']" position="after">
-                    <!-- below fields are used in the widget qty_at_date_widget -->
-                    <field name="virtual_available_at_date" column_invisible="True"/>
-                    <field name="qty_available_today" column_invisible="True"/>
-                    <field name="free_qty_today" column_invisible="True"/>
-                    <field name="scheduled_date" column_invisible="True"/>
-                    <field name="forecast_expected_date" column_invisible="True"/>
-                    <field name="warehouse_id" column_invisible="True"/>
-                    <field name="move_ids" column_invisible="True"/>
-                    <field name="qty_to_deliver" column_invisible="True"/>
-                    <field name="is_mto" column_invisible="True"/>
-                    <field name="display_qty_widget" column_invisible="True"/>
-                    <widget name="qty_at_date_widget" width="20px"/>
-                </xpath>
-            </field>
-        </record>
-
-        </data>
 </odoo>

--- a/addons/sale_timesheet/views/sale_order_views.xml
+++ b/addons/sale_timesheet/views/sale_order_views.xml
@@ -1,30 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-        <record id="view_order_form_inherit_sale_timesheet" model="ir.ui.view">
-            <field name="name">sale.order.form.sale.timesheet</field>
-            <field name="model">sale.order</field>
-            <field name="inherit_id" ref="sale_project.view_order_form_inherit_sale_project"/>
-            <field name="arch" type="xml">
-                <data>
-                    <xpath expr="//button[@name='action_view_task']" position="after">
-                        <field name="timesheet_count" invisible="1"/>
-                        <field name="show_hours_recorded_button" invisible="1"/>
-                        <button type="object"
-                           name="action_view_timesheet"
-                           class="oe_stat_button"
-                           icon="fa-clock-o"
-                           invisible="not show_hours_recorded_button"
-                           groups="hr_timesheet.group_hr_timesheet_user">
-                           <div class="o_stat_info">
-                               <span class="o_stat_value">
-                                    <field name="timesheet_total_duration" class="mr4"/>
-                                    <field name="timesheet_encode_uom_id" options="{'no_open': True}"/>
-                                </span>
-                                <span class="o_stat_text">Recorded</span>
-                           </div>
-                        </button>
-                    </xpath>
-                </data>
-           </field>
-        </record>
+
+    <record id="view_order_form_inherit_sale_timesheet" model="ir.ui.view">
+        <field name="name">sale.order.form.sale.timesheet</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale_project.view_order_form_inherit_sale_project"/>
+        <field name="arch" type="xml">
+            <button name="action_view_task" position="after">
+                <button
+                    name="action_view_timesheet"
+                    class="oe_stat_button"
+                    icon="fa-clock-o"
+                    invisible="not show_hours_recorded_button"
+                    groups="hr_timesheet.group_hr_timesheet_user"
+                >
+                    <div class="o_stat_info">
+                        <span class="o_stat_value">
+                            <field name="timesheet_total_duration" class="mr4"/>
+                            <field name="timesheet_encode_uom_id" options="{'no_open': True}"/>
+                        </span>
+                        <span class="o_stat_text">Recorded</span>
+                    </div>
+                </button>
+            </button>
+        </field>
+    </record>
+
 </odoo>

--- a/addons/sale_timesheet/wizard/sale_make_invoice_advance_views.xml
+++ b/addons/sale_timesheet/wizard/sale_make_invoice_advance_views.xml
@@ -6,9 +6,9 @@
         <field name="model">sale.advance.payment.inv</field>
         <field name="inherit_id" ref="sale.view_sale_advance_payment_inv"/>
         <field name="arch" type="xml">
-            <xpath expr="//form" position="attributes">
+            <form position="attributes">
                 <attribute name="disable_autofocus">true</attribute>
-            </xpath>
+            </form>
             <group name="down_payment_specification" position="after">
                 <field name="invoicing_timesheet_enabled" invisible="1"/>
                 <group

--- a/addons/stock_dropshipping/views/sale_order_views.xml
+++ b/addons/stock_dropshipping/views/sale_order_views.xml
@@ -1,23 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <data>
-        <record id="view_order_form_inherit_sale_stock" model="ir.ui.view">
-            <field name="name">sale.order.form.sale.dropshipping</field>
-            <field name="model">sale.order</field>
-            <field name="inherit_id" ref="sale.view_order_form"/>
-            <field name="arch" type="xml">
-                <xpath expr="//button[@name='action_view_delivery']" position="before">
-                    <t groups="purchase.group_purchase_user">
-                        <button type="object"
-                            name="action_view_dropship"
-                            class="oe_stat_button"
-                            icon="fa-truck"
-                            invisible="dropship_picking_count == 0" groups="stock.group_stock_user">
-                            <field name="dropship_picking_count" widget="statinfo" string="Dropship"/>
-                        </button>
-                    </t>
-                </xpath>
-           </field>
-        </record>
-    </data>
+
+    <record id="view_order_form_inherit_sale_stock" model="ir.ui.view">
+        <field name="name">sale.order.form.sale.dropshipping</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale_stock.view_order_form_inherit_sale_stock"/>
+        <field name="arch" type="xml">
+            <button name="action_view_delivery" position="before">
+                <t groups="purchase.group_purchase_user">
+                    <button
+                        name="action_view_dropship"
+                        type="object"
+                        class="oe_stat_button"
+                        icon="fa-truck"
+                        invisible="dropship_picking_count == 0"
+                        groups="stock.group_stock_user">
+                        <field name="dropship_picking_count" widget="statinfo" string="Dropship"/>
+                    </button>
+                </t>
+            </button>
+        </field>
+    </record>
+
 </odoo>

--- a/addons/website_event_booth_sale/models/sale_order_line.py
+++ b/addons/website_event_booth_sale/models/sale_order_line.py
@@ -1,0 +1,14 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = 'sale.order.line'
+
+    @api.depends('event_booth_ids')
+    def _compute_name_short(self):
+        wbooth = self.filtered(lambda line: line.event_booth_pending_ids)
+        for record in wbooth:
+            record.name_short = record.event_booth_pending_ids.event_id.name
+        super(SaleOrderLine, self - wbooth)._compute_name_short()

--- a/addons/website_sale/views/digest_views.xml
+++ b/addons/website_sale/views/digest_views.xml
@@ -2,7 +2,7 @@
 <odoo>
 
     <record id="digest_digest_view_form" model="ir.ui.view">
-        <field name="name">digest.digest.view.form.inherit.website.sale.order</field>
+        <field name="name">digest.digest.view.form.inherit.website_sale</field>
         <field name="model">digest.digest</field>
         <field name="priority">10</field>
         <field name="inherit_id" ref="digest.digest_digest_view_form" />

--- a/addons/website_sale/views/sale_order_views.xml
+++ b/addons/website_sale/views/sale_order_views.xml
@@ -40,31 +40,6 @@
         </field>
     </record>
 
-    <record id="sale_order_view_form_cart_recovery" model="ir.ui.view">
-        <field name="name">sale.order.form.abandoned.cart</field>
-        <field name="model">sale.order</field>
-        <field name="inherit_id" ref="sale.view_order_form"/>
-        <field name="arch" type="xml">
-            <field name="team_id" position="after">
-                <field name="is_abandoned_cart" invisible="1"/>
-                <field name="cart_recovery_email_sent" invisible="1"/>
-            </field>
-            <button name="action_quotation_send" id="send_by_email_primary" position="attributes">
-                <attribute name="invisible">state != 'draft' or (is_abandoned_cart and not cart_recovery_email_sent)</attribute>
-            </button>
-            <button name="action_quotation_send" position="after">
-                <button name="action_recovery_email_send" type="object" id="send_recovery" data-hotkey="l"
-                    string="Send a Recovery Email"
-                    class="btn-primary"
-                    invisible="not is_abandoned_cart or cart_recovery_email_sent"/>
-            </button>
-            <button name="action_quotation_send" id="send_by_email" position="after">
-                <button name="action_quotation_send" id="send_by_email_bis" string="Send by Email" type="object"
-                    invisible="not is_abandoned_cart or cart_recovery_email_sent or state != 'draft'"/>
-            </button>
-        </field>
-    </record>
-
     <record id="action_orders_ecommerce" model="ir.actions.act_window">
         <field name="name">Orders</field>
         <field name="res_model">sale.order</field>
@@ -97,7 +72,7 @@
     </record>
 
     <record id="view_sales_order_filter_ecommerce_abondand" model="ir.ui.view">
-        <field name="name">sale.order.ecommerce.abondand.view</field>
+        <field name="name">sale.order.ecommerce.abandonned.view</field>
         <field name="model">sale.order</field>
         <field name="priority">32</field>
         <field name="arch" type="xml">
@@ -108,7 +83,7 @@
                 <filter string="Recovery Email to Send" name="recovery_email" domain="[('cart_recovery_email_sent', '=', False)]" />
                 <filter string="Recovery Email Sent" name="recovery_email_set" domain="[('cart_recovery_email_sent', '=', True)]" />
                 <group expand="0" string="Group By">
-                    <filter string="Order Date" name="order_date" domain="[]" context="{'group_by':'date_order'}"/>
+                    <filter string="Order Date" name="order_date" context="{'group_by':'date_order'}"/>
                 </group>
                 <!-- Dashboard filter - used by context -->
                 <filter string="Last Week" invisible="1" name="week" domain="[('date_order','&gt;', (context_today() - datetime.timedelta(days=7)).strftime('%Y-%m-%d'))]"/>
@@ -177,6 +152,26 @@
         <field name="model">sale.order</field>
         <field name="inherit_id" ref="sale.view_order_form"/>
         <field name="arch" type="xml">
+            <button name="action_quotation_send" id="send_by_email_primary" position="attributes">
+                <attribute name="invisible" separator="or" add="is_abandoned_cart and not cart_recovery_email_sent"/>
+            </button>
+            <button name="action_quotation_send" position="after">
+                <button
+                    name="action_recovery_email_send"
+                    type="object"
+                    string="Send a Recovery Email"
+                    class="btn-primary"
+                    data-hotkey="l"
+                    invisible="not is_abandoned_cart or cart_recovery_email_sent"/>
+            </button>
+            <button name="action_quotation_send" id="send_by_email" position="after">
+                <button
+                    name="action_quotation_send"
+                    id="send_by_email_bis"
+                    string="Send by Email"
+                    type="object"
+                    invisible="not is_abandoned_cart or cart_recovery_email_sent or state != 'draft'"/>
+            </button>
             <field name="partner_id" position="attributes">
                 <attribute name="context">{
                     'display_website': True,


### PR DESCRIPTION
* drop useless invisible fields (rely on ORM fallback, and js field dependencies when possible)
* clean and harmonize xpaths definitions.  Prefer the use of simplified xpath expressions when possible.
* clean attributes overwrite, prefer using the add/remove API.  Also remove the useless overwrites defining the same value as the base view.
* Clean and harmonize files indentation, remove useless `<data>` nodes.
* Remove empty domains from search filters.
* merge views when targeting the same parent view (some views were targeting specific groups in the past, but this logic has been deprecated and removed from standard code).
* target the shared parent view (between quotes and orders) for shared content, instead of adding the same content in the two inherited views.

Related PRs:
* odoo/odoo#167023
* odoo/enterprise#63350
* odoo/upgrade#6817