### PR TITLE
[FIX] resource: skip recompute of `date_to` if already valid

### DIFF
--- a/addons/resource/models/resource_calendar_leaves.py
+++ b/addons/resource/models/resource_calendar_leaves.py
@@ -54,10 +54,11 @@ class ResourceCalendarLeaves(models.Model):
     def _compute_date_to(self):
         user_tz = timezone(self.env.user.tz or self._context.get('tz') or self.company_id.resource_calendar_id.tz or 'UTC')
         for leave in self:
-            if not leave.date_from:
+            if not leave.date_from or (leave.date_to and leave.date_to > leave.date_from):
                 continue
-            date_to_tz = user_tz.localize(leave.date_from) + relativedelta(hour=23, minute=59, second=59)
-            leave.date_to = date_to_tz.astimezone(utc).replace(tzinfo=None)
+            local_date_from = utc.localize(leave.date_from).astimezone(user_tz)
+            local_date_to = local_date_from + relativedelta(hour=23, minute=59, second=59)
+            leave.date_to = local_date_to.astimezone(utc).replace(tzinfo=None)
 
     @api.constrains('date_from', 'date_to')
     def check_dates(self):

--- a/addons/resource/tests/test_utils.py
+++ b/addons/resource/tests/test_utils.py
@@ -60,6 +60,24 @@ class TestExpression(TransactionCase):
             ))
         )
 
+    def test_resource_calendar_leave_compute_date_to(self):
+        """
+        Test date_to is computed when date_from is changed,
+        except when it already has a valid value.
+        """
+        date_from = Datetime.from_string('2024-05-01 00:00:00')
+        date_to = Datetime.from_string('2024-05-03 23:59:59')
+        leave = self.env['resource.calendar.leaves'].create({
+            'date_from': date_from,
+            'date_to': date_to,
+        })
+
+        leave.date_from -= relativedelta(minutes=5)
+        self.assertEqual(leave.date_to, date_to, "date_to shouldn't get recomputed if still valid")
+
+        leave.date_from += relativedelta(years=5)
+        self.assertGreater(leave.date_to, date_to, "date_to should get recomputed when invalid")
+
     def test_resource_creation_with_date_from(self):
         """
         Test resource creation with a date_from.


### PR DESCRIPTION
Versions
--------
- saas-17.1+

Steps
-----
1. Have Appointments installed;
2. go to Appointments / Configuration / Resource Leaves;
3. create a new Resource Time Off;
4. use the daterange widget to select a start & end date.

Issue
-----
No matter which end date you select, it will be on the same day as the start date.

Cause
-----
Commit bc2ea5fb6d12dc3e6c09c36c7bdc48276fb7960a modified the `resource_calendar_leave_form` to use the `daterange` widget for the `date_from` & `date_to` fields. As a consequence, selecting any `date_from` value triggers the `_compute_date_to` method, overriding the `date_to` field selected by the datepicker.

Solution
--------
If the leave has a `date_to` value, and it is valid (i.e. not earlier than `date_from`), don't recompute the value.

Also fixed an issue computing the `date_to` field by actually converting the `date_from` value to the user's tz:
- `user_tz.localize(date_from)` only adds `tzinfo`, it doesn't change the values from UTC.
- As a consequence, if `date_from` is '2024-05-01 23:00:00' with user tz Europe/Brussels, the compute method will set hh:mm:ss of `date_to` to '23:59:59', then convert it to UTC, so '21:59:59', which is before `date_from`, causing to a validation error.
- Instead, '2024-05-01 23:00:00' should first get converted to local time '2024-05-02 01:00:00', so that `date_to` gets set correctly to '2024-05-02 21:59:59' UTC.

opw-3910990