### PR TITLE
[FIX] mail, hr_expense: adapt imgContainer styling

### DIFF
--- a/addons/hr_expense/static/src/scss/hr_expense.scss
+++ b/addons/hr_expense/static/src/scss/hr_expense.scss
@@ -62,9 +62,12 @@
 }
 
 .o_center_attachment .o-mail-Attachment-imgContainer {
+    --o-Mail-Attachment-img-margin: #{map-get($spacers, 1)} auto auto auto;
+
     display: flex;
     justify-content: center;
     z-index: -1;
+    padding: 0 map-get($spacers, 3);
 
     img {
         max-height: 100%;

--- a/addons/mail/static/src/core/common/attachment_view.scss
+++ b/addons/mail/static/src/core/common/attachment_view.scss
@@ -28,7 +28,7 @@
             width: 100%;
             height: 100%;
             > img {
-                margin: auto;
+                margin: var(--o-Mail-Attachment-img-margin, auto);
                 box-shadow: 0px 0px 5px rgba(41, 41, 41, 0.43);
             }
         }


### PR DESCRIPTION
This commit adds some spacing around the image container displaying the scanned receipt while aligning it on top by removing its margin.

A custom property is added in /mail to allow margin tweak on the attachment_view component.

task-3946192

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
