### PR TITLE
[IMP] account: confirm entries wizard

### DIFF
--- a/addons/account/wizard/account_validate_account_move.py
+++ b/addons/account/wizard/account_validate_account_move.py
@@ -9,6 +9,7 @@ class ValidateAccountMove(models.TransientModel):
     move_ids = fields.Many2many('account.move')
     force_post = fields.Boolean(string="Force", help="Entries in the future are set to be auto-posted by default. Check this checkbox to post them now.")
     display_force_post = fields.Boolean(compute='_compute_display_force_post')
+    is_entries = fields.Boolean(compute='_compute_is_entries')
     abnormal_date_partner_ids = fields.One2many('res.partner', compute='_compute_abnormal_date_partner_ids')
     ignore_abnormal_date = fields.Boolean()
     abnormal_amount_partner_ids = fields.One2many('res.partner', compute='_compute_abnormal_amount_partner_ids')
@@ -19,6 +20,11 @@ class ValidateAccountMove(models.TransientModel):
         today = fields.Date.context_today(self)
         for wizard in self:
             wizard.display_force_post = wizard.move_ids.filtered(lambda m: (m.date or m.invoice_date or today) > today)
+
+    @api.depends('move_ids')
+    def _compute_is_entries(self):
+        for wizard in self:
+            wizard.is_entries = all(move_type == 'entry' for move_type in wizard.move_ids.mapped('move_type'))
 
     @api.depends('move_ids')
     def _compute_abnormal_date_partner_ids(self):

--- a/addons/account/wizard/account_validate_move_view.xml
+++ b/addons/account/wizard/account_validate_move_view.xml
@@ -9,17 +9,26 @@
             <field name="arch" type="xml">
                 <form string="Confirm Entries">
                     <field name="move_ids" invisible="1"/>
-                    <h2 class="mb-4">Validating invoices is a key action. Have you reviewed everything?</h2>
+                    <h2 class="mb-4">
+                        Validating
+                        <t invisible="not is_entries"> entries </t>
+                        <t invisible="is_entries"> invoices </t>
+                        is a key action. Have you reviewed everything?</h2>
                     <group invisible="not display_force_post">
                         <field name="display_force_post" invisible="1"/>
                         <div colspan="2">
-                            Future-dated invoices will auto-confirm on their respective dates.
+                            Future-dated
+                            <t invisible="not is_entries"> entries </t>
+                            <t invisible="is_entries"> invoices </t>
+                            will auto-confirm on their respective dates.
                             <field name="force_post" class="oe_inline"/><label for="force_post" string="Confirm them now"/>
                         </div>
                     </group>
                     <group invisible="not abnormal_date_partner_ids">
                         <div colspan="2">
-                            Invoice dates for
+                            <t invisible="not is_entries"> Entries </t>
+                            <t invisible="is_entries"> Invoices </t>
+                            dates for
                             <field name="abnormal_date_partner_ids" widget="many2many_tags" class="oe_inline"/>
                             fall outside the typical range.
                             <field name="ignore_abnormal_date" class="oe_inline"/><label for="ignore_abnormal_date" string="Ignore future alerts"/>
@@ -27,7 +36,9 @@
                     </group>
                     <group invisible="not abnormal_amount_partner_ids">
                         <div colspan="2">
-                            Invoice amounts for
+                            <t invisible="not is_entries"> Entries </t>
+                            <t invisible="is_entries"> Invoices </t>
+                            amounts for
                             <field name="abnormal_amount_partner_ids" widget="many2many_tags" class="oe_inline"/>
                             fall outside the typical range.
                             <field name="ignore_abnormal_amount" class="oe_inline"/><label for="ignore_abnormal_amount" string="Ignore future alerts"/>


### PR DESCRIPTION
Improving the confirm entires wizard by changing the messages depending on the move type. When every move that are selected to be confirm are entries, the message is changed to put "entries" instead of "invoices"

task-3918364




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
