### PR TITLE
[FIX] point_of_sale,pos_loyalty,pos_sale:add price_type field in backend

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1164,6 +1164,11 @@ class PosOrderLine(models.Model):
     price_subtotal_incl = fields.Float(string='Tax Incl.', digits=0,
         readonly=True, store=True, compute='_compute_amount_line_all')
     price_extra = fields.Float(string="Price extra")
+    price_type = fields.Selection([
+        ('original', 'Original'),
+        ('manual', 'Manual'),
+        ('automatic', 'Automatic'),
+    ], string='Price Type', default='original')
     margin = fields.Monetary(string="Margin", compute='_compute_margin')
     margin_percent = fields.Float(string="Margin (%)", compute='_compute_margin', digits=(12, 4))
     total_cost = fields.Float(string='Total cost', digits='Product Price', readonly=True)
@@ -1195,7 +1200,7 @@ class PosOrderLine(models.Model):
     @api.model
     def _load_pos_data_fields(self, config_id):
         return [
-            'qty', 'attribute_value_ids', 'custom_attribute_value_ids', 'price_unit', 'skip_change', 'uuid', 'price_subtotal', 'price_subtotal_incl', 'order_id', 'note',
+            'qty', 'attribute_value_ids', 'custom_attribute_value_ids', 'price_unit', 'skip_change', 'uuid', 'price_subtotal', 'price_subtotal_incl', 'order_id', 'note', 'price_type',
             'product_id', 'discount', 'tax_ids', 'combo_line_id', 'pack_lot_ids', 'customer_note', 'refunded_qty', 'price_extra', 'full_product_name', 'refunded_orderline_id', 'combo_parent_id', 'combo_line_ids', 'combo_line_id', 'refund_orderline_ids'
         ]
 

--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -376,7 +376,7 @@ export class PosOrder extends Base {
 
         const lines_to_recompute = this.lines.filter(
             (line) =>
-                line.uiState.price_type === "original" &&
+                line.price_type === "original" &&
                 !(line.combo_line_ids?.length || line.combo_parent_id)
         );
 
@@ -391,7 +391,7 @@ export class PosOrder extends Base {
 
         const attributes_prices = {};
         const combo_parent_lines = this.lines.filter(
-            (line) => line.uiState.price_type === "original" && line.combo_line_ids?.length
+            (line) => line.price_type === "original" && line.combo_line_ids?.length
         );
         for (const pLine of combo_parent_lines) {
             attributes_prices[pLine.id] = computeComboLines(
@@ -414,7 +414,7 @@ export class PosOrder extends Base {
             );
         }
         const combo_children_lines = this.lines.filter(
-            (line) => line.uiState.price_type === "original" && line.combo_parent_id
+            (line) => line.price_type === "original" && line.combo_parent_id
         );
         combo_children_lines.forEach((line) => {
             line.set_unit_price(

--- a/addons/point_of_sale/static/src/app/models/pos_order_line.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order_line.js
@@ -22,7 +22,6 @@ export class PosOrderline extends Base {
 
         // Data that are not saved in the backend
         this.uiState = {
-            price_type: "original",
             hasChange: true,
         };
 
@@ -48,7 +47,7 @@ export class PosOrderline extends Base {
                 this.set_quantity(code.value);
             } else if (code.type === "price") {
                 this.set_unit_price(code.value);
-                this.uiState.price_type = "manual";
+                this.price_type = "manual";
             }
 
             if (product_packaging_by_barcode[code.code]) {
@@ -242,7 +241,7 @@ export class PosOrderline extends Base {
         }
 
         // just like in sale.order changing the qty will recompute the unit price
-        if (!keep_price && this.uiState.price_type === "original") {
+        if (!keep_price && this.price_type === "original") {
             this.set_unit_price(
                 this.product_id.get_price(
                     this.order_id.pricelist_id,

--- a/addons/point_of_sale/static/src/app/screens/product_screen/order_summary/order_summary.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/order_summary/order_summary.js
@@ -129,7 +129,7 @@ export class OrderSummary extends Component {
             } else if (numpadMode === "discount" && val !== "remove") {
                 selectedLine.set_discount(val);
             } else if (numpadMode === "price" && val !== "remove") {
-                selectedLine.uiState.price_type = "manual";
+                selectedLine.price_type = "manual";
                 selectedLine.set_unit_price(val);
             }
         }

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -285,9 +285,7 @@ export class TicketScreen extends Component {
                 tax_ids: refundLine.tax_ids.map((tax) => ["link", tax]),
                 refunded_orderline_id: refundLine,
                 pack_lot_ids: refundLine.pack_lot_ids.map((packLot) => ["link", packLot]),
-            });
-            line.setOptions({
-                uiState: { price_type: "automatic" },
+                price_type: "automatic",
             });
             lines.push(line);
             refundDetail.destination_order_uuid = destinationOrder.uuid;

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -337,18 +337,15 @@ export class PosStore extends Reactive {
         }
 
         const options = {
-            uiState: {
-                price_type: "original",
-            },
             ...opts,
         };
 
         if ("price_unit" in vals) {
             merge = false;
-            options.uiState.price_type = "manual";
         }
 
         const values = {
+            price_type: "price_unit" in vals ? "manual" : "original",
             price_extra: 0,
             price_unit: 0,
             order_id: this.get_order(),

--- a/addons/pos_loyalty/static/src/overrides/models/pos_order.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_order.js
@@ -801,14 +801,10 @@ patch(PosOrder.prototype, {
                 coupon_id: this.models["loyalty.card"].get(rewardLine.coupon_id),
                 tax_ids: rewardLine.tax_ids.map((tax) => ["link", tax]),
             };
-            const newLine = this.models["pos.order.line"].create({
+            this.models["pos.order.line"].create({
                 ...prepareRewards,
                 order_id: this,
-            });
-            newLine.setOptions({
-                uiState: {
-                    price_type: "manual",
-                },
+                price_type: "manual",
             });
         }
         return true;

--- a/addons/pos_sale/static/src/overrides/models/pos_store.js
+++ b/addons/pos_sale/static/src/overrides/models/pos_store.js
@@ -225,7 +225,7 @@ patch(PosStore.prototype, {
                     total: line.price_total,
                 })),
         });
-        new_line.uiState.price_type = "automatic";
+        new_line.price_type = "automatic";
         new_line.set_unit_price(proposed_down_payment);
     },
     selectOrderLine(order, line) {


### PR DESCRIPTION
Before this fix, the `price_type` field was not saved in the backend, which caused a syncrhonisation error when a command was loaded into another PoS.

This commit adds the `price_type` field to the `pos.order.line` model.

