### PR TITLE
[IMP] website_event,*: event website facelift

### DIFF
--- a/addons/hr_expense/i18n/hr_expense.pot
+++ b/addons/hr_expense/i18n/hr_expense.pot
@@ -354,6 +354,11 @@ msgid "Attachments of expenses"
 msgstr ""
 
 #. module: hr_expense
+#: model:ir.model,name:hr_expense.model_hr_employee_base
+msgid "Basic Employee"
+msgstr ""
+
+#. module: hr_expense
 #: model:ir.model.fields,help:hr_expense.field_hr_expense__tax_ids
 msgid ""
 "Both price-included and price-excluded taxes will behave as price-included "
@@ -922,6 +927,8 @@ msgstr ""
 
 #. module: hr_expense
 #: model:ir.model.fields,field_description:hr_expense.field_hr_employee__filter_for_expense
+#: model:ir.model.fields,field_description:hr_expense.field_hr_employee_base__filter_for_expense
+#: model:ir.model.fields,field_description:hr_expense.field_hr_employee_public__filter_for_expense
 msgid "Filter For Expense"
 msgstr ""
 
@@ -1569,12 +1576,6 @@ msgstr ""
 #. module: hr_expense
 #: model:ir.model,name:hr_expense.model_hr_employee_public
 msgid "Public Employee"
-msgstr ""
-
-#. module: hr_expense
-#: model:ir.model.fields,field_description:hr_expense.field_product_product__purchase_ok
-#: model:ir.model.fields,field_description:hr_expense.field_product_template__purchase_ok
-msgid "Purchase"
 msgstr ""
 
 #. module: hr_expense
@@ -2257,6 +2258,12 @@ msgstr ""
 msgid ""
 "You cannot approve:\n"
 " %s"
+msgstr ""
+
+#. module: hr_expense
+#. odoo-python
+#: code:addons/hr_expense/models/hr_expense_sheet.py:0
+msgid "You cannot cancel an expense sheet linked to a posted journal entry"
 msgstr ""
 
 #. module: hr_expense

--- a/addons/project_sale_expense/tests/test_project_profitability.py
+++ b/addons/project_sale_expense/tests/test_project_profitability.py
@@ -199,7 +199,7 @@ class TestProjectSaleExpenseProfitability(TestProjectProfitabilityCommon, TestPr
             {'id': 'expenses', 'sequence': expense_sequence, 'billed': expense.currency_id.round(billed), 'to_bill': 0.0},
         )
 
-        expense_sheet._do_refuse('Test Cancel Expense')
+        expense_sheet.action_reset_expense_sheets()
         expense_profitability = project._get_expenses_profitability_items(False)
         self.assertDictEqual(
             expense_profitability.get('revenues', {}),
@@ -243,7 +243,7 @@ class TestProjectSaleExpenseProfitability(TestProjectProfitabilityCommon, TestPr
             {'id': 'expenses', 'sequence': expense_sequence, 'billed': expense.currency_id.round(-expense_foreign.untaxed_amount_currency * 0.2), 'to_bill': 0.0},
         )
 
-        expense_sheet_foreign._do_refuse('Test Cancel Expense')
+        expense_sheet_foreign.action_reset_expense_sheets()
         expense_profitability = project._get_expenses_profitability_items(False)
         self.assertDictEqual(
             expense_profitability.get('revenues', {}),

--- a/addons/test_event_full/static/src/js/tours/wevent_register_tour.js
+++ b/addons/test_event_full/static/src/js/tours/wevent_register_tour.js
@@ -136,13 +136,18 @@ var initTourSteps = function (eventName) {
 };
 
 var browseTalksSteps = [{
-    content: 'Browse Talks',
-    trigger: 'a:contains("Talks")',
+    content: 'Browse Talks Menu',
+    trigger: 'a[href*="#"]:contains("Talks")',
+    run: "click",
+}, {
+    content: 'Browse Talks Submenu',
+    trigger: 'a.dropdown-item span:contains("Talks")',
     run: "click",
 }, {
     content: 'Check we are on the talk list page',
     trigger: 'h5:contains("Book your talks")',
 }];
+
 
 var browseBackSteps = [{
     content: 'Browse Back',
@@ -154,8 +159,12 @@ var browseBackSteps = [{
 }];
 
 var browseMeetSteps = [{
-    content: 'Browse Meet',
+    content: 'Browse Community Menu',
     trigger: 'a:contains("Community")',
+    run: "click",
+}, {
+    content: 'Browse Rooms',
+    trigger: 'a:contains("Rooms")',
     run: "click",
 }, {
     content: 'Check we are on the community page',
@@ -170,9 +179,9 @@ registry.category("web_tour.tours").add('wevent_register', {
         initTourSteps('Online Reveal'),
         browseTalksSteps,
         discoverTalkSteps('What This Event Is All About', true, true),
-        browseTalksSteps,
+        browseBackSteps,
         discoverTalkSteps('Live Testimonial', false, false, false),
-        browseTalksSteps,
+        browseBackSteps,
         discoverTalkSteps('Our Last Day Together!', true, false, true),
         browseBackSteps,
         browseMeetSteps,

--- a/addons/website_event/controllers/main.py
+++ b/addons/website_event/controllers/main.py
@@ -157,8 +157,8 @@ class WebsiteEventController(http.Controller):
         except ValueError:
             # page not found
             values['path'] = re.sub(r"^website_event\.", '', page)
-            values['from_template'] = 'website_event.default_page'  # .strip('website_event.')
-            page = request.env.user.has_group('website.group_website_designer') and 'website.page_404' or 'http_routing.404'
+            values['from_template'] = 'website_event.default_page&event_id=%s' % event.id
+            page = request.env.user.has_group('website.group_website_designer') and 'website_event.page_404' or 'http_routing.404'
 
         return request.render(page, values)
 

--- a/addons/website_event/models/website.py
+++ b/addons/website_event/models/website.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import models, _
+from odoo import models, _, api
+from odoo.http import request
 from odoo.addons.http_routing.models.ir_http import url_for
 
 class Website(models.Model):
@@ -24,3 +25,15 @@ class Website(models.Model):
         if search_type in ['events', 'all']:
             result.append(self.env['event.event']._search_get_detail(self, order, options))
         return result
+
+    @api.model
+    def new_page(self, name=False, add_menu=False, template='website.default_page', ispage=True, namespace=None, page_values=None, menu_values=None, sections_arch=None):
+        is_event = False
+        if template.startswith('website_event.') and template != 'website_event.template_location':
+            add_menu = False
+            ispage = False
+            is_event = True
+        event_page = super().new_page(name=name, add_menu=add_menu, template=template, ispage=ispage, namespace=namespace, page_values=page_values, menu_values=menu_values, sections_arch=sections_arch)
+        if is_event and request:
+            event_page['url'] = f"/event/{request.params.get('event_id')}/page" + event_page['url']
+        return event_page

--- a/addons/website_event/tests/common.py
+++ b/addons/website_event/tests/common.py
@@ -32,7 +32,7 @@ class OnlineEventCase(EventCase):
         })
 
     def _get_menus(self):
-        return {'Introduction', 'Community', 'Info', 'Location'}
+        return {'Introduction', 'Community', 'Info', 'Practical information'}
 
     def _assert_website_menus(self, event, menus_in=None, menus_out=None):
         self.assertTrue(event.menu_id)
@@ -46,7 +46,8 @@ class OnlineEventCase(EventCase):
         if menus_out:
             self.assertTrue(all(menu_name not in menus.mapped('name') for menu_name in menus_out))
 
-        for page_specific in ['Introduction', 'Location']:
+        for page_specific in ['Introduction']:
+            # 'Practical information' can't be found becuase it doesn't have view
             view = self.env['ir.ui.view'].search(
                 [('name', '=', f'{page_specific} {event.name}')]
             )

--- a/addons/website_event/tests/test_event_menus.py
+++ b/addons/website_event/tests/test_event_menus.py
@@ -24,10 +24,10 @@ class TestEventMenus(OnlineEventCase):
         self.assertTrue(event.location_menu)
         self.assertTrue(event.register_menu)
         self.assertFalse(event.community_menu)
-        self._assert_website_menus(event, ['Introduction', 'Location', 'Info'], menus_out=['Community'])
+        self._assert_website_menus(event, ['Introduction', 'Practical information', 'Info'], menus_out=['Community'])
 
         event.community_menu = True
-        self._assert_website_menus(event, ['Introduction', 'Location', 'Info', 'Community'])
+        self._assert_website_menus(event, ['Introduction', 'Practical information', 'Info', 'Community'])
 
         # test create without any requested menus
         event = self.env['event.event'].create({
@@ -45,7 +45,7 @@ class TestEventMenus(OnlineEventCase):
 
         # test update of website_menu triggering 3 sub menus
         event.write({'website_menu': True})
-        self._assert_website_menus(event, ['Introduction', 'Location', 'Info'], menus_out=['Community'])
+        self._assert_website_menus(event, ['Introduction', 'Practical information', 'Info'], menus_out=['Community'])
 
     @users('user_event_web_manager')
     def test_menu_management_frontend(self):
@@ -56,17 +56,17 @@ class TestEventMenus(OnlineEventCase):
             'website_menu': True,
             'community_menu': False,
         })
-        self._assert_website_menus(event, ['Introduction', 'Location', 'Info'], menus_out=['Community'])
+        self._assert_website_menus(event, ['Introduction', 'Practical information', 'Info'], menus_out=['Community'])
 
         # simulate menu removal from frontend: aka unlinking a menu
         event.menu_id.child_id.filtered(lambda menu: menu.name == 'Introduction').unlink()
 
         self.assertTrue(event.website_menu)
-        self._assert_website_menus(event, ['Location', 'Info'], menus_out=['Introduction', 'Community'])
+        self._assert_website_menus(event, ['Practical information', 'Info'], menus_out=['Introduction', 'Community'])
 
         # re-created from backend
         event.introduction_menu = True
-        self._assert_website_menus(event, ['Introduction', 'Location', 'Info'], menus_out=['Community'])
+        self._assert_website_menus(event, ['Introduction', 'Practical information', 'Info'], menus_out=['Community'])
 
     def test_submenu_url_uniqueness(self):
         """Ensure that the last part of the menus URL (used to retrieve the right view)

--- a/addons/website_event/views/event_templates_page.xml
+++ b/addons/website_event/views/event_templates_page.xml
@@ -60,6 +60,9 @@
                                     <a t-att-href="navbar__back_url" t-att-title="navbar__back_title" t-out="navbar__back_text"/>
                                 </li>
                             </t>
+                            <t t-if="not hide_submenu">
+                                <li class="breadcrumb-item" aria-current="page"><a class="pe-3" t-field="event.name" t-att-href="'/event/%s/register' % (slug(event))"/></li>
+                            </t>
                             <t t-else="">
                                 <li class="breadcrumb-item active" aria-current="page"><span class="pe-3" t-field="event.name"/></li>
                             </t>

--- a/addons/website_event/views/event_templates_page_misc.xml
+++ b/addons/website_event/views/event_templates_page_misc.xml
@@ -8,7 +8,7 @@
     </t>
 </template>
 
-<!-- Default template for the 404 page with create new page button -->
+<!-- Default template for 404 page with create new page button -->
 <template id="page_404" name="Page Not Found">
     <t t-call="website_event.layout">
         <div class="o_not_editable bg-100 pt40">

--- a/addons/website_event/views/event_templates_page_misc.xml
+++ b/addons/website_event/views/event_templates_page_misc.xml
@@ -3,35 +3,42 @@
 
 <!-- Multipage event - Default template when creating a new page -->
 <template id="default_page">
-    <t t-call="website.layout">
+    <t t-call="website_event.layout">
         <div class="oe_structure oe_empty"/>
     </t>
 </template>
 
-<!-- Multipage event - Default template for the Introduction page -->
-<template id="template_intro">
+<!-- Default template for the 404 page with create new page button -->
+<template id="page_404" name="Page Not Found">
     <t t-call="website_event.layout">
-        <div class="oe_structure oe_empty" id="oe_structure_website_event_intro_1"/>
-        <div class="oe_structure">
-            <section class="s_title pt32 pb32" data-vcss="001" data-snippet="s_title" data-name="Title">
-                <div class="container s_allow_columns">
-                    <h1 class="display-3 o_default_snippet_text" style="text-align: center;">Introduction</h1>
+        <div class="o_not_editable bg-100 pt40">
+            <div class="container">
+                <div class="alert alert-info text-center d-lg-flex justify-content-between align-items-center">
+                    <p class="m-lg-0 text-info">This page does not exist, but you can create it as you are editor of this site.</p>
+                    <a role="button" class="btn btn-info js_disable_on_click post_link" data-post_force-top-window="true" t-attf-href="/website/add/#{path}?redirect=1#{from_template and '&amp;template=%s' % from_template}">Create Page</a>
                 </div>
-            </section>
+                <div class="text-center text-muted p-3"><i class="fa fa-info-circle"></i> Edit the content below this line to adapt the default <strong>Page not found</strong> page.</div>
+            </div>
+            <hr/>
         </div>
-        <div class="oe_structure oe_empty" id="oe_structure_website_event_intro_2"/>
     </t>
 </template>
 
 <!-- Multipage event - Default template for the Location page -->
 <template id="template_location">
     <t t-call="website_event.layout">
-        <div class="oe_structure" id="oe_structure_website_event_location_1"/>
+        <div class="oe_structure oe_empty" id="oe_structure_website_event_location_1"/>
+        <div class="oe_structure">
+            <section>
+                <div class="container">
+                    <h3 class="mt-3 mb-4">Event Location</h3>
+                </div>
+            </section>
+        </div>
         <section>
             <div class="container">
                 <div class="row">
                     <div class="col-12">
-                        <h3 class="mt-3 mb-4">Event Location</h3>
                         <h4 class="mb-3" t-field="event.address_id" t-options='{
                             "widget": "contact",
                             "fields": ["name"],
@@ -50,7 +57,7 @@
                 </div>
             </div>
         </section>
-        <div class="oe_structure" id="oe_structure_website_event_location_2"/>
+        <div class="oe_structure oe_empty" id="oe_structure_website_event_location_2"/>
     </t>
 </template>
 

--- a/addons/website_event/views/event_templates_page_registration.xml
+++ b/addons/website_event/views/event_templates_page_registration.xml
@@ -129,15 +129,35 @@
                             <small itemprop="location" t-field="event.organizer_id" t-options="{'widget': 'contact', 'fields': ['phone', 'mobile', 'email']}"/>
                         </div>
                         <!-- Social -->
-                        <div class="o_wevent_sidebar_block">
-                            <h6 class="o_wevent_sidebar_title">Share</h6>
-                            <p>Find out what people see and say about this event, and join the conversation.</p>
-                            <t t-snippet-call="website.s_share">
-                                <t t-set="_no_title" t-value="True"/>
-                                <t t-set="_classes" t-valuef="o_wevent_sidebar_social mx-n1"/>
-                                <t t-set="_link_classes" t-valuef="o_wevent_social_link"/>
-                            </t>
+                        <div class="oe_structure">
+                            <section>
+                                <div class="o_wevent_sidebar_block">
+                                    <h6 class="o_wevent_sidebar_title">Share</h6>
+                                    <p>Find out what people see and say about this event, and join the conversation.</p>
+                                </div>
+                                <div class="s_share text-start o_editable" data-snippet="s_share">
+                                    <a href="https://www.facebook.com/sharer/sharer.php?u={url}" class="s_share_facebook" target="_blank" aria-label="Facebook">
+                                        <i class="fa fa-facebook rounded-circle shadow-sm o_editable_media"/>
+                                    </a>
+                                    <a href="https://twitter.com/intent/tweet?text={title}&amp;url={url}" class="s_share_twitter" target="_blank" aria-label="X">
+                                        <i class="fa fa-twitter rounded-circle shadow-sm o_editable_media"/>
+                                    </a>
+                                    <a href="https://www.linkedin.com/sharing/share-offsite/?url={url}" class="s_share_linkedin" target="_blank" aria-label="LinkedIn">
+                                        <i class="fa fa-linkedin rounded-circle shadow-sm o_editable_media"/>
+                                    </a>
+                                    <a href="https://wa.me/?text={title}" class="s_share_whatsapp" target="_blank" aria-label="WhatsApp">
+                                        <i class="fa fa-whatsapp rounded-circle shadow-sm o_editable_media"/>
+                                    </a>
+                                    <a href="https://pinterest.com/pin/create/button/?url={url}&amp;media={media}&amp;description={title}" class="s_share_pinterest" target="_blank" aria-label="Pinterest">
+                                        <i class="fa fa-pinterest rounded-circle shadow-sm o_editable_media"/>
+                                    </a>
+                                    <a href="mailto:?body={url}&amp;subject={title}" class="s_share_email" aria-label="Email">
+                                        <i class="fa fa-envelope rounded-circle shadow-sm o_editable_media"/>
+                                    </a>
+                                </div>
+                            </section>
                         </div>
+                        <div class="oe_structure oe_empty" id="oe_structure_website_event_side_snippet_1"/>
                     </aside>
                 </div>
             </div>

--- a/addons/website_event_booth/models/event_event.py
+++ b/addons/website_event_booth/models/event_event.py
@@ -50,6 +50,17 @@ class Event(models.Model):
 
     def _get_website_menu_entries(self):
         self.ensure_one()
-        return super(Event, self)._get_website_menu_entries() + [
-            (_('Get A Booth'), '/event/%s/booth' % slug(self), False, 90, 'booth')
-        ]
+        menu_entries = super()._get_website_menu_entries()
+        # Check if 'Exhibitor' menu entry already exists
+        exhibitor_menu_exists = any(entry[0] == _('Exhibitor') for entry in menu_entries)
+        # If 'Exhibitor' menu entry doesn't exist, add it
+        if not exhibitor_menu_exists:
+            menu_entries.extend([
+                (_('Exhibitor'), '#', False, 55, 'booth', False),
+                (_('Get A Booth'), '/event/%s/booth' % slug(self), False, 90, 'booth', 'booth')
+            ])
+        else:
+            menu_entries.append(
+                (_('Get A Booth'), '/event/%s/booth' % slug(self), False, 90, 'booth', 'exhibitor')
+            )
+        return menu_entries

--- a/addons/website_event_booth_exhibitor/static/tests/tours/website_event_booth_exhibitor.js
+++ b/addons/website_event_booth_exhibitor/static/tests/tours/website_event_booth_exhibitor.js
@@ -12,6 +12,10 @@
         trigger: 'a[href*="/event"]:contains("Online Reveal"):first',
         run: "click",
     }, {
+        content: 'Browse Exhibitor Menu',
+        trigger: 'a:contains("Exhibitor")',
+        run: "click",
+    }, {
         content: 'Browse Booths',
         trigger: 'a:contains("Get A Booth")',
         run: "click",

--- a/addons/website_event_booth_sale/static/tests/tours/helpers/WebsiteEventBoothSaleTourMethods.js
+++ b/addons/website_event_booth_sale/static/tests/tours/helpers/WebsiteEventBoothSaleTourMethods.js
@@ -15,6 +15,11 @@
                 run: "click",
             },
             {
+                content: 'Go to "Exhibitor" menu',
+                trigger: 'a:contains("Exhibitor")',
+                run: "click",
+            },
+            {
                 content: 'Go to "Get A Booth" page',
                 trigger: 'li.nav-item a:has(span:contains("Get A Booth"))',
                 run: "click",

--- a/addons/website_event_booth_sale/static/tests/tours/website_event_booth.js
+++ b/addons/website_event_booth_sale/static/tests/tours/website_event_booth.js
@@ -13,6 +13,10 @@ registry.category("web_tour.tours").add('website_event_booth_tour', {
     trigger: 'h5.card-title span:contains("Test Event Booths")',
     run: "click",
 }, {
+    content: 'Go to "Exhibitor" menu',
+    trigger: 'a:contains("Exhibitor")',
+    run: "click",
+}, {
     content: 'Go to "Get A Booth" page',
     trigger: 'li.nav-item a:has(span:contains("Get A Booth"))',
     run: "click",

--- a/addons/website_event_booth_sale/static/tests/tours/website_event_booth_sale_pricelists.js
+++ b/addons/website_event_booth_sale/static/tests/tours/website_event_booth_sale_pricelists.js
@@ -15,8 +15,13 @@ registry.category("web_tour.tours").add('event_booth_sale_pricelists_different_c
         run: "click",
     },
     {
+        content: 'Go to "Exhibitor" menu',
+        trigger: 'a:contains("Exhibitor")',
+        run: "click",
+    },
+    {
         content: 'Go to "Get A Booth" page',
-        trigger: 'li.nav-item a:has(span:contains("Get A Booth"))',
+        trigger: 'a:contains("Get A Booth")',
         run: "click",
     },
     {

--- a/addons/website_event_exhibitor/models/event_event.py
+++ b/addons/website_event_exhibitor/models/event_event.py
@@ -58,6 +58,15 @@ class EventEvent(models.Model):
 
     def _get_website_menu_entries(self):
         self.ensure_one()
-        return super(EventEvent, self)._get_website_menu_entries() + [
-            (_('Exhibitors'), '/event/%s/exhibitors' % slug(self), False, 60, 'exhibitor')
-        ]
+        menu_entries = super()._get_website_menu_entries()
+        exhibitor_menu_exists = any(entry[0] == _('Exhibitor') for entry in menu_entries)
+        if not exhibitor_menu_exists:
+            menu_entries.extend([
+                (_('Exhibitor'), '#', False, 55, 'exhibitor', False),
+                (_('Exhibitors'), '/event/%s/exhibitors' % slug(self), False, 60, 'exhibitor', 'exhibitor')
+            ])
+        else:
+            menu_entries.append(
+                (_('Exhibitors'), '/event/%s/exhibitors' % slug(self), False, 60, 'exhibitor', 'booth')
+            )
+        return menu_entries

--- a/addons/website_event_sale/static/tests/tours/website_event_sale.js
+++ b/addons/website_event_sale/static/tests/tours/website_event_sale.js
@@ -11,7 +11,7 @@ registry.category("web_tour.tours").add('event_buy_tickets', {
             content: "Go to the `Events` page",
             trigger: 'a[href*="/event"]:contains("Conference for Architects TEST"):first',
             run: "click",
-        }, 
+        },
         {
             content: "Open the register modal",
             trigger: 'button:contains("Register")',

--- a/addons/website_event_track/models/event_event.py
+++ b/addons/website_event_track/models/event_event.py
@@ -85,7 +85,8 @@ class Event(models.Model):
     def _get_website_menu_entries(self):
         self.ensure_one()
         return super(Event, self)._get_website_menu_entries() + [
-            (_('Talks'), '/event/%s/track' % slug(self), False, 10, 'track'),
-            (_('Agenda'), '/event/%s/agenda' % slug(self), False, 70, 'track'),
-            (_('Talk Proposals'), '/event/%s/track_proposal' % slug(self), False, 15, 'track_proposal')
+            (_('Talks'), '#', False, 10, 'track', False),
+            (_('Talks'), '/event/%s/track' % slug(self), False, 10, 'track', 'track'),
+            (_('Agenda'), '/event/%s/agenda' % slug(self), False, 70, 'track', 'location'),
+            (_('Propose a talk'), '/event/%s/track_proposal' % slug(self), False, 15, 'track_proposal', 'track')
         ]

--- a/addons/website_event_track/tests/test_event_menus.py
+++ b/addons/website_event_track/tests/test_event_menus.py
@@ -11,9 +11,9 @@ from odoo.tests.common import users
 class TestEventWebsiteTrack(OnlineEventCase):
 
     def _get_menus(self):
-        return super(TestEventWebsiteTrack, self)._get_menus() | set(['Talks', 'Agenda', 'Talk Proposals'])
+        return super()._get_menus() | {'Talks', 'Practical information'}
 
-    @users('user_eventmanager')
+    @users('user_event_web_manager')
     def test_create_menu(self):
         vals = {
             'name': 'TestEvent',
@@ -35,7 +35,7 @@ class TestEventWebsiteTrack(OnlineEventCase):
             'website_track': False,
             'website_track_proposal': False,
         })
-        self._assert_website_menus(event, ['Introduction', 'Location', 'Info', 'Community'], menus_out=['Talks', 'Agenda', 'Talk Proposals'])
+        self._assert_website_menus(event, ['Introduction', 'Practical information', 'Community', 'Info'], menus_out=['Talks'])
 
     @users('user_event_web_manager')
     def test_menu_management_frontend(self):
@@ -55,26 +55,26 @@ class TestEventWebsiteTrack(OnlineEventCase):
 
         introduction_menu = event.menu_id.child_id.filtered(lambda menu: menu.name == 'Introduction')
         introduction_menu.unlink()
-        self._assert_website_menus(event, ['Location', 'Info', 'Community', 'Talks', 'Agenda', 'Talk Proposals'], menus_out=["Introduction"])
+        self._assert_website_menus(event, ['Practical information', 'Info', 'Community', 'Talks'], menus_out=["Introduction"])
 
-        menus = event.menu_id.child_id.filtered(lambda menu: menu.name in ['Agenda', 'Talk Proposals'])
+        menus = event.menu_id.child_id.child_id.filtered(lambda menu: menu.name in ['Agenda', 'Propose a talk'])
         menus.unlink()
         self.assertTrue(event.website_track)
         self.assertFalse(event.website_track_proposal)
 
-        menus = event.menu_id.child_id.filtered(lambda menu: menu.name in ['Talks'])
+        menus = event.menu_id.child_id.child_id.filtered(lambda menu: menu.name == 'Talks')
         menus.unlink()
         self.assertFalse(event.website_track)
         self.assertFalse(event.website_track_proposal)
 
-        self._assert_website_menus(event, ['Location', 'Info', 'Community'], menus_out=["Introduction", "Talks", "Agenda", "Talk Proposals"])
-
-        event.write({'website_track_proposal': True})
-        self.assertFalse(event.website_track)
-        self.assertTrue(event.website_track_proposal)
-        self._assert_website_menus(event, ['Location', 'Info', 'Community', 'Talk Proposals'], menus_out=["Introduction", "Talks", "Agenda"])
+        self._assert_website_menus(event, ['Practical information', 'Info', 'Community'], menus_out=["Introduction", "Talks"])
 
         event.write({'website_track': True})
         self.assertTrue(event.website_track)
         self.assertTrue(event.website_track_proposal)
-        self._assert_website_menus(event, ['Location', 'Info', 'Community', 'Talks', 'Agenda', 'Talk Proposals'], menus_out=["Introduction"])
+        self._assert_website_menus(event, ['Practical information', 'Info', 'Community', 'Talks'], menus_out=["Introduction"])
+
+        event.write({'website_track_proposal': False})
+        self.assertTrue(event.website_track)
+        self.assertFalse(event.website_track_proposal)
+        self._assert_website_menus(event, ['Practical information', 'Info', 'Community', "Talks"], menus_out=["Introduction"])


### PR DESCRIPTION
*=website,website_event_booth,website_event_track,website_event_exhibitor,website_event_booth_exhibitor,website_event_booth_sale,website_event_sale,test_event_full

## Before this PR:
- User can't edit 'Event Location' through website editor
- User can't edit 'Social' Block under Event Registration through website editor
- Ungroup event menus
- Can't create event page that have event's submenus
- User have to manually add event's url path

## After this PR:
- User can edit 'Event Location' using website editor
- User can edit Social Share Block using website editor
- On Event Name click user will redirect to Introduction page
- Regrouped event menus inside parent menus for ease of use
- User can create Event pages with submenus
- User don't have to enter Event's url path manually

#### Note- Some test cases were changed accordingly to work with this PR's flow!
Task-3661323
