### PR TITLE
[FIX] stock : traceback when changing quant_id from SML

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -143,7 +143,7 @@ class StockMoveLine(models.Model):
             if not record.quant_id or record.quantity:
                 continue
             origin_move = record.move_id._origin
-            if float_compare(record.move_id.product_qty, origin_move.quantity, precision_rounding=record.move_id.product_uom.rounding) > 0:
+            if float_compare(record.move_id.product_qty, origin_move.quantity, precision_rounding=record.product_uom.rounding) > 0:
                 record.quantity = max(0, min(record.quant_id.available_quantity, record.move_id.product_qty - origin_move.quantity))
             else:
                 record.quantity = max(0, record.quant_id.available_quantity)


### PR DESCRIPTION
Before PR:
when creating a SML and changing the quant_id (pick from), you get a traceback as the stock_move is not yet created

After PR:
Since the issue appears before the real creation of the SML (and thus the SM), reading the uom of the product directly from the SML should not pose any issue

opw-3931980

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
