### PR TITLE
[IMP] website: allow cross-company records access to portal user

### DIFF
--- a/addons/website/models/ir_rule.py
+++ b/addons/website/models/ir_rule.py
@@ -17,6 +17,8 @@ class IrRule(models.Model):
         is_frontend = ir_http.get_request_website()
         Website = self.env['website']
         res['website'] = is_frontend and Website.get_current_website() or Website
+        if self.env.user._is_portal() and not res['website'].specific_user_account:
+            res['company_ids'] = self.env.user.company_ids.ids
         return res
 
     def _compute_domain_keys(self):


### PR DESCRIPTION
### Purpose:
To allow end-customers(portal users) to check documents from multiple companies using single portal account.

### Before this PR:
Even when the admin activates the "Shared Customer Account" option from the settings of the website, records (orders, tickets, etc.) related only to the default company of the user remain visible on website.

### After this PR:
Now, when admin activates 'Shared Customer Account' option then portal user will be able to access records (orders, tickets, etc.) of all allowed companies from single website.

Task-3915955