### PR TITLE
[FIX] l10n_ar: improve i18n of "Registered Accountants" in COA's name

### DIFF
--- a/addons/l10n_ar/i18n/es_419.po
+++ b/addons/l10n_ar/i18n/es_419.po
@@ -346,7 +346,7 @@ msgstr "Plan Contable Genérico Argentino para Personas Físicas Exentas"
 #: code:addons/l10n_ar/models/template_ar_ri.py:0
 #, python-format
 msgid "Argentine Generic Chart of Accounts for Registered Accountants"
-msgstr "Plan Contable Genérico Argentino para Contadores Públicos"
+msgstr "Plan Contable Genérico Argentino para Responsables Inscriptos"
 
 #. module: l10n_ar
 #: model_terms:ir.ui.view,arch_db:l10n_ar.view_document_type_filter


### PR DESCRIPTION
The old name caused caused some confusion from clients

- Old: "Plan Contable Generico Argentino para Contadores Publicos"
- New: "Plan Contable Genérico Argentino para Responsables Inscriptos"

task-3921529
