### PR TITLE
[FIX] hr_expense: payment_method expense sheet branch company

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -1211,7 +1211,7 @@ class HrExpenseSheet(models.Model):
     def _compute_selectable_payment_method_line_ids(self):
         for sheet in self:
             sheet.selectable_payment_method_line_ids = sheet.company_id.company_expense_allowed_payment_method_line_ids\
-                or self.env['account.payment.method.line'].search([('payment_type', '=', 'outbound'), ('company_id', '=', sheet.company_id.id)])
+                or self.env['account.payment.method.line'].search([('payment_type', '=', 'outbound'), ('company_id', 'parent_of', sheet.company_id.id)])
 
     @api.depends('account_move_ids', 'payment_state', 'approval_state')
     def _compute_state(self):


### PR DESCRIPTION
Add parent company's payment methods on expense sheet

Steps:

- Create a child company and select it in the company selector
- Create an expense paid by company and create report -> On the report view, there is no payment method available
   in the dropdow, we should have the payment methods from
   the parent company

Fix:

Adapt domain for `selectable_payment_method_line_ids`

opw-3917271

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
