### PR TITLE
[FIX] base: partial revert a171597d1904de992bcf0e0f

### DIFF
--- a/odoo/addons/base/data/res_partner_demo.xml
+++ b/odoo/addons/base/data/res_partner_demo.xml
@@ -41,7 +41,6 @@
         <record id="main_partner" model="res.partner">
             <field name="email">info@yourcompany.com</field>
             <field name="website">www.example.com</field>
-            <field name="vat">US12345671</field>
         </record>
         <record id="res_partner_1" model="res.partner">
             <field name="name">Wood Corner</field>


### PR DESCRIPTION
Steps to reproduce:
- create a new db `--without-demo=True -i l10n_ar`
- Load demo data

Issue:
Everything goes wild

Cause:

When we instantiate a database without demo data with l10n_ar, the res_partner(1) has the l10n_latam_identification_type_id field set to 'CUIT'. When loading demo data, a VAT number is assigned to res.partner(1)(*), which triggers a constraint error: https://github.com/odoo/odoo/blob/69e31db6ac90874ed6329599fca8f09709efd119/addons/l10n_ar/models/res_partner.py#L60-L61

Since res.partner(1) has the CUIT identification type, its VAT will be checked for correctness here: https://github.com/odoo/odoo/blob/69e31db6ac90874ed6329599fca8f09709efd119/addons/l10n_ar/models/res_partner.py#L106

The dummy VAT added with this PR causes the constraint error: https://github.com/odoo/odoo/commit/a171597d1904de992bcf0e0f606b4c6a4b70b725

(*)By default (even without demo data) there is a "MyCompany" partner: https://github.com/odoo/odoo/blob/7e58f5c5ee772f2a6b4dff7ad3279dc9242ea2b3/odoo/addons/base/data/res_partner_data.xml#L4-L13

Solution:
For 'main_partner' we don't set any vat number. Since some irregularities might happen, if the vat is necesarry for it, adding it to the specific module might be a better choice

commit:https://github.com/odoo/odoo/commit/a171597d1904de992bcf0e0f606b4c6a4b70b725 opw-3907520