### PR TITLE
[FIX] account: Hide Payment Difference when equals Early Payment Discount

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -349,7 +349,7 @@ msgstr ""
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_account_payment_register_form
-msgid "<b>Early Payment Discount applied.</b>"
+msgid "<b>Early Payment Discount of %(payment_reference) has been applied.</b>"
 msgstr ""
 
 #. module: account

--- a/addons/account/wizard/account_payment_register_views.xml
+++ b/addons/account/wizard/account_payment_register_views.xml
@@ -30,7 +30,7 @@
                     <field name="hide_writeoff_section" invisible="1"/>
 
                     <div role="alert" class="alert alert-info" attrs="{'invisible': [('hide_writeoff_section', '=', False)]}">
-                        <p><b>Early Payment Discount applied.</b></p>
+                        <p><b>Early Payment Discount of <field name="payment_difference"/> has been applied.</b></p>
                     </div>
                     <group>
                         <group name="group1">
@@ -60,7 +60,7 @@
                                    attrs="{'invisible': ['|', ('can_edit_wizard', '=', False), '&amp;', ('can_group_payments', '=', True), ('group_payment', '=', False)]}"/>
                         </group>
                         <group name="group3"
-                               attrs="{'invisible': ['|', ('payment_difference', '=', 0.0), '|', ('can_edit_wizard', '=', False), '&amp;', ('can_group_payments', '=', True), ('group_payment', '=', False)]}">
+                               attrs="{'invisible': ['|', ('payment_difference', '=', 0.0), '|', ('early_payment_discount_mode', '=', True), '|', ('can_edit_wizard', '=', False), '&amp;', ('can_group_payments', '=', True), ('group_payment', '=', False)]}">
                             <label for="payment_difference"/>
                             <div>
                                 <field name="payment_difference"/>


### PR DESCRIPTION

When Payment Difference amount equals Early Payment Discount, Don't show payment difference field and consider full reconciliation.

task-3944830

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
