### PR TITLE
[FIX] web: adapt `print-variable()` mixin after Bootstrap migration

### DIFF
--- a/addons/web/static/src/legacy/scss/utils.scss
+++ b/addons/web/static/src/legacy/scss/utils.scss
@@ -468,7 +468,7 @@
 @mixin print-variable($key, $value) {
     @if $value != null {
         $-type: type-of($value);
-        @if $-type == 'string' {
+        @if $-type == 'string' and str-index($value, 'var(') != 1 {
             --#{$key}: '#{$value}';
         } @else if $-type == 'list' {
             --#{$key}: #{inspect($value)};


### PR DESCRIPTION
Prior to this PR the mixin treated CSS variable as strings and escaped their values between quotation marks.

task-3955207

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
