### PR TITLE
[PERF] sale_stock: merge forecast date reads

### DIFF
--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -303,13 +303,29 @@ class SaleOrderLine(models.Model):
          2. The quotation hasn't commitment_date, we compute the estimated delivery
             date based on lead time"""
         treated = self.browse()
+        all_move_ids = {
+            move.id
+            for line in self
+            if line.state == 'sale' 
+            for move in line.move_ids
+            if move.product_id == line.product_id
+        }
+        all_moves = self.env['stock.move'].browse(all_move_ids)
+        forecast_expected_date_per_move = dict(all_moves.mapped(lambda m: (m.id, m.forecast_expected_date)))
         # If the state is already in sale the picking is created and a simple forecasted quantity isn't enough
         # Then used the forecasted data of the related stock.move
         for line in self.filtered(lambda l: l.state == 'sale'):
             if not line.display_qty_widget:
                 continue
             moves = line.move_ids.filtered(lambda m: m.product_id == line.product_id)
-            line.forecast_expected_date = max(moves.filtered("forecast_expected_date").mapped("forecast_expected_date"), default=False)
+            line.forecast_expected_date = max(
+                (
+                    forecast_expected_date_per_move[move.id]
+                    for move in moves
+                    if forecast_expected_date_per_move[move.id]
+                ),
+                default=False,
+            )
             line.qty_available_today = 0
             line.free_qty_today = 0
             for move in moves:


### PR DESCRIPTION
Before this commit, `sale.order.line._compute_qty_at_date` method would compute only some `forecast_expected_date` at a time per loop. After this commit, `forecast_expected_date` is computed for all relevant moves in a single call.

Given that `forecast_expected_date` has potential to be a slow computing field, we should minimize the number of times it is called.

Log line stats for loading sale order S05312

|                                                    | # queries | SQL time | Odoo time                  |
|------------------------------------------|---------------|---------------|-------------------------------|
| before-commit                        | 31270       | 5.577 s      | 187.606 s (timeout) |
| after-commit                           | 31114       | 4.078 s      | 10.663 s                     |
| after-commit + PR #166784 | 233            | 0.430 s      | 5.905 s                       |

The PR #166784 stats are included just to show that there is not much more to be done in this PR to improve the query count, but that is addressed in the other PR.  

(Note that the customer's database is 17.0, not 15.0 - but I figured this could be made in 15.0 and fw-ported.)

opw-3920584
