### PR TITLE
[FIX] phone_validation: phone numbers in brazil

### DIFF
--- a/addons/phone_validation/tests/test_phonenumbers.py
+++ b/addons/phone_validation/tests/test_phonenumbers.py
@@ -28,11 +28,15 @@ class TestPhonenumbers(BaseCase):
                 '+32456998877',  # all hail Philippe
                 '+1-613-555-0177',  # canada, same phone_code as US
                 '+1-202-555-0124',  # us, same phone_code as CA
+                '+55 11 2345 6789',  # brazil, landline
+                '+55 11 6123 4561',  # brazil, old mobile number
             ],
             [
                 ('BE', '456998877', '32'),
                 ('CA', '6135550177', '1'),
                 ('US', '2025550124', '1'),
+                ('BR', '1123456789', '55'),  # must not have '9' added
+                ('BR', '11961234561', '55'),  # must have '9' added
             ],
         ):
             with self.subTest(source=source):
@@ -44,3 +48,19 @@ class TestPhonenumbers(BaseCase):
                         'phone_code': exp_phone_code,
                     }
                 )
+
+    def test_phone_format_e164_brazil(self):
+        """ In the new brazilian phone numbers system, phone numbers add a '9'
+            in front of the last 8 digits of mobile numbers.
+            Phonenumbers metadata is patched in odoo, however, when E164 is selected,
+            phone numbers aren't formatted, thus patched metadata not being applied.
+            See format_number in phonenumbers "Early exit for E164 case"
+        """
+        for number, expected_number in [
+            ('11 6123 4560', '+5511961234560'),  # mobile number, must have 9 added
+            ('+55 11 6123 4561', '+5511961234561'),  # mobile number, must have 9 added
+            ('11 2345 6789', '+551123456789'),  # landline, must NOT have 9 added
+            ('+55 11 2345 6798', '+551123456798'),  # landline, must NOT have 9 added
+        ]:
+            res = phone_validation.phone_format(number, 'BR', '55', force_format='E164')
+            self.assertEqual(res, expected_number)

--- a/addons/phone_validation/tools/phone_validation.py
+++ b/addons/phone_validation/tools/phone_validation.py
@@ -48,7 +48,13 @@ try:
             else:
                 raise UserError(_('Impossible number %s: probably invalid number of digits.', number))
         if not phonenumbers.is_valid_number(phone_nbr):
-            raise UserError(_('Invalid number %s: probably incorrect prefix.', number))
+            # Force format with international to force metadata to apply
+            formatted_intl = phonenumbers.format_number(phone_nbr, phonenumbers.PhoneNumberFormat.INTERNATIONAL)
+            phone_nbr_intl = phonenumbers.parse(formatted_intl, region=country_code or None, keep_raw_input=True)
+            if not phonenumbers.is_valid_number(phone_nbr_intl):
+                raise UserError(_('Invalid number %s: probably incorrect prefix.', formatted_intl))
+            else:
+                return phone_nbr_intl
 
         return phone_nbr
 


### PR DESCRIPTION
Current behaviour:
---
Brazilian phone numbers are not managed correctly following the 2016 changes in Brazil.
(Adding a 9 to mobile phone numbers)

Cause of the issue:
---
Phonenumbers metadata were patched to add 9 in mobile numbers, however, when E164 is selected, 
phone numbers aren't formatted, thus patched metadata not being applied.
See format_number in phonenumbers "Early exit for E164 case"

Fix:
---
Follow-up of https://github.com/odoo/odoo/commit/861733f1aed8fb0af0d958cdaec153d6f405ae6b 
In phone_validation, before formatting, phone_parse is called, https://github.com/odoo/odoo/blob/bdfb802293d9a3eebb378a15ed65f48b7c3182b2/addons/phone_validation/tools/phone_validation.py#L72 
Old brazilian mobile numbers would be invalid, and raise an error. https://github.com/odoo/odoo/blob/bdfb802293d9a3eebb378a15ed65f48b7c3182b2/addons/phone_validation/tools/phone_validation.py#L51 
Now if the number is invalid, we force format in international, to force apply patched metadata, before re-trying to parse.

opw-3861847

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
