### PR TITLE
[FIX] website_sale: e-commerce search inheritable

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -351,6 +351,8 @@ class WebsiteSale(http.Controller):
         if filter_by_price_enabled:
             # TODO Find an alternative way to obtain the domain through the search metadata.
             Product = request.env['product.template'].with_context(bin_size=True)
+            Product = Product.sudo() if options.get('requires_sudo') else Product
+
             domain = self._get_search_domain(search, category, attrib_values)
 
             # This is ~4 times more efficient than a search for the cheapest and most expensive products


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The method `_add_search_subdomains_hook` allows extending the search domain, but adding a m2o or m2m field to a model without portal access causes an Access Error.

This commit adds the `requires_sudo` key to the options dictionary, enabling developers to inherit the `_get_search_options` method and include this key as needed.

The approach is base on this: https://github.com/odoo/odoo/blob/4bc8ff5aa4f68c9212d51e6f5041b373e327b65d/addons/website/models/mixins.py#L351

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
