### PR TITLE
[FIX] point_of_sale: use different key because pos lot are not the same model as stock lot

### DIFF
--- a/addons/point_of_sale/models/account_move.py
+++ b/addons/point_of_sale/models/account_move.py
@@ -39,7 +39,7 @@ class AccountMove(models.Model):
                             'quantity': line.qty if lot.product_id.tracking == 'lot' else 1.0,
                             'uom_name': line.product_uom_id.name,
                             'lot_name': lot.lot_name,
-                            'lot_id': lot.id,
+                            'pos_lot_id': lot.id,
                         })
 
         return lot_values


### PR DESCRIPTION
0a0c931 and https://github.com/odoo/enterprise/commit/58f4287a171df1b13f80e7b23675bcec6a5b2a6c added the key 'lot_id' to all `_get_invoiced_lot_values` methods.
    
But point_of_sale uses a different model (`pos.pack.operation.lot`) than stock does (`stock.lot`).
    
Using the same key for two different model is confusing, hence we use another key for the `pos.pack.operation.lot`.
    
opw-3847889

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
