### PR TITLE
[FIX] website_sale: clear session after payment with ewallet

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1830,6 +1830,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
         if order and not order.amount_total and not tx_sudo:
             if order.state != 'sale':
                 order.with_context(send_email=True).with_user(SUPERUSER_ID).action_confirm()
+            request.website.sale_reset()
             return request.redirect(order.get_portal_url())
 
         # clean context and session, then redirect to the confirmation page

--- a/addons/website_sale_loyalty/static/tests/tours/test_ewallet_tour.js
+++ b/addons/website_sale_loyalty/static/tests/tours/test_ewallet_tour.js
@@ -1,0 +1,33 @@
+/** @odoo-module **/
+
+import { registry } from "@web/core/registry";
+import tourUtils from '@website_sale/js/tours/tour_utils';
+import { TourError } from "@web_tour/tour_service/tour_utils";
+
+
+registry.category("web_tour.tours").add('shop_sale_ewallet', {
+    test: true,
+    url: '/shop',
+    steps: () => [
+        // Add a small drawer to the order (50$)
+        ...tourUtils.addToCart({productName: "TEST - Small Drawer"}),
+        tourUtils.goToCart(),
+        {
+            trigger: 'a:contains("Pay with eWallet")'
+        },
+        tourUtils.goToCheckout(),
+        tourUtils.pay(),
+        {
+            trigger: 'div[id="introduction"] h2:contains("Sales Order")'
+        },
+        {
+            trigger: 'a[href="/shop/cart"]',
+            run: function() {
+                const cartQuantity = document.querySelector('.my_cart_quantity');
+                if (cartQuantity.textContent !== '0'){
+                    throw new TourError('cart should be empty and reset after an order is paid using ewallet')
+                }
+            }
+        },
+    ],
+});


### PR DESCRIPTION
## Issue:
- When purchasing consecutive appointments on the website using eWallet, an error occurs: "It is forbidden to modify a sales order which is not in draft status."

## Steps To Reproduce:
- Create an eWallet program and generate a coupon for the test user.
- On the eCommerce site, navigate to the "Appointments" tab.
- Select a paid appointment and pay using eWallet credit.
- After completing the payment, return to the "Appointments" tab.
- Repeat the same steps to purchase another appointment.
- Encounter the error: "It is forbidden to modify a sales order which is not in draft status."

## Solution:
- In `shop_payment_validate`, when an order is fully paid using a discount or eWallet, the eCommerce website context are not cleared.
- To fix this, call the `sale_reset` method before redirecting to the SO page.

opw-3885533


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
