### PR TITLE
[FIX] mrp: compute days to prepare MO raises warning if unavailable

### DIFF
--- a/addons/mrp/i18n/mrp.pot
+++ b/addons/mrp/i18n/mrp.pot
@@ -674,6 +674,13 @@ msgid "Assign Serial Numbers"
 msgstr ""
 
 #. module: mrp
+#. odoo-python
+#: code:addons/mrp/models/product.py:0
+#, python-format
+msgid "At least one component can not be resupplied."
+msgstr ""
+
+#. module: mrp
 #: model_terms:ir.ui.view,arch_db:mrp.mrp_bom_form_view
 msgid "At the creation of a Manufacturing Order."
 msgstr ""

--- a/addons/mrp/models/product.py
+++ b/addons/mrp/models/product.py
@@ -348,6 +348,15 @@ class ProductProduct(models.Model):
         warehouse = self.env['stock.warehouse'].search([('company_id', '=', company_id)], limit=1)
         for product in self:
             bom_data = self.env['report.mrp.report_bom_structure'].with_context(minimized=True)._get_bom_data(bom_by_products[product], warehouse, product, ignore_stock=True)
+            if bom_data.get('availability_state') == 'unavailable' and not bom_data.get('components_available', True):
+                return {
+                'type': 'ir.actions.client',
+                'tag': 'display_notification',
+                'params': {
+                    'title': _('At least one component can not be resupplied.'),
+                    'sticky': False,
+                    }
+                }
             availability_delay = bom_data.get('resupply_avail_delay')
             product.days_to_prepare_mo = availability_delay - bom_data.get('lead_time', 0) if availability_delay else 0
 

--- a/addons/mrp/tests/test_bom.py
+++ b/addons/mrp/tests/test_bom.py
@@ -1658,3 +1658,14 @@ class TestBoM(TestMrpCommon):
         self.assertFalse(bom.bom_line_ids.operation_id)
         self.assertFalse(bom.byproduct_ids.operation_id)
         self.assertFalse(operation_2.blocked_by_operation_ids)
+
+    def test_compute_days_to_prepare_from_mo_if_unavailable(self):
+        """
+        Checks that a notification is sent when at least one component can not be resupplied.
+        """
+        product = self.bom_1.product_id
+        manufacturing_route_id = self.ref('mrp.route_warehouse0_manufacture')
+        product.route_ids = [Command.set([manufacturing_route_id])]
+        notification = product.product_tmpl_id.action_compute_bom_days()
+        self.assertEqual(product.days_to_prepare_mo, 0.0)
+        self.assertEqual((notification['type'], notification['tag']), ('ir.actions.client', 'display_notification'))


### PR DESCRIPTION
### Steps to reproduce:

- Create a storable product P using the manifacturing route
- Create a BOM for that product with 2 lines: 1 x storable product COMP 1 using buy route and with a set vendor and a delivery lead time of 1 day 1 x storable product COMP 2 without any route or using the buy route without vendor
- In the inventory tab of your storable product P, click on compute the "Days to prepare Manufacturing Order" from BoM

### Current Behavior:

Since the second component is not available, the final product is not available and the number of days to prepare the MO is set to 0 so that nothing happens:
https://github.com/odoo/odoo/blob/2744217900c4eb985bd71919ef86614ab95c0fd0/addons/mrp/report/mrp_report_bom_structure.py#L680-L688

### Expected behavior:

A warning should be raised to notify the user that at least one of the component is not availabe.

opw-3933989
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
