### PR TITLE
[FIX] spreadsheet_dashboard: remove automaticDefaultValue

### DIFF
--- a/addons/spreadsheet_dashboard/static/tests/dashboard/dashboard_action_test.js
+++ b/addons/spreadsheet_dashboard/static/tests/dashboard/dashboard_action_test.js
@@ -243,7 +243,6 @@ QUnit.test("Can delete record tag in the filter by hitting Backspace", async fun
                 label: "Relation Filter",
                 modelName: "product",
                 defaultValue: [37],
-                automaticDefaultValue: true,
             },
         ],
     };


### PR DESCRIPTION
There was still reference on global filter's automaticDefaultValue in the code, but automaticDefaultValue isn't used.

This commit removes the dead code.

Task: [3956477](https://www.odoo.com/web#id=3956477&cids=1&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
