### PR TITLE
[FIX] sale: adjustments for industry_fsm_sale fix

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -53,6 +53,12 @@ class SaleOrderLine(models.Model):
         order_date = fields.Datetime.from_string(self.order_id.date_order if self.order_id.date_order and self.order_id.state in ['sale', 'done'] else fields.Datetime.now())
         return order_date + timedelta(days=self.customer_lead or 0.0)
 
+    def _add_prices_to_amount(self, amount_untaxed, amount_tax):
+        return (amount_untaxed + self.price_subtotal, amount_tax + self.price_tax)
+
+    def _get_undiscounted_price(self):
+        return (self.price_subtotal * 100)/(100-self.discount) if self.discount != 100 else (self.price_unit * self.product_uom_qty)
+
     @api.depends('product_uom_qty', 'discount', 'price_unit', 'tax_id')
     def _compute_amount(self):
         """

--- a/addons/sale/tests/test_sale_order.py
+++ b/addons/sale/tests/test_sale_order.py
@@ -90,6 +90,7 @@ class TestSaleOrder(TestSaleCommon):
             - Invoice repeatedly while varrying delivered quantities and check that invoice are always what we expect
         """
         # TODO?: validate invoice and register payments
+        self.sol_serv_deliver.qty_delivered = 2
         self.sale_order.order_line.read(['name', 'price_unit', 'product_uom_qty', 'price_total'])
 
         self.assertEqual(self.sale_order.amount_total, 1240.0, 'Sale: total amount is wrong')
@@ -110,8 +111,8 @@ class TestSaleOrder(TestSaleCommon):
 
         # create invoice: only 'invoice on order' products are invoiced
         invoice = self.sale_order._create_invoices()
-        self.assertEqual(len(invoice.invoice_line_ids), 2, 'Sale: invoice is missing lines')
-        self.assertEqual(invoice.amount_total, 740.0, 'Sale: invoice total amount is wrong')
+        self.assertEqual(len(invoice.invoice_line_ids), 3, 'Sale: invoice is missing lines')
+        self.assertEqual(invoice.amount_total, 1100.0, 'Sale: invoice total amount is wrong')
         self.assertTrue(self.sale_order.invoice_status == 'no', 'Sale: SO status after invoicing should be "nothing to invoice"')
         self.assertTrue(len(self.sale_order.invoice_ids) == 1, 'Sale: invoice is missing')
         self.sale_order.order_line._compute_product_updatable()
@@ -122,8 +123,8 @@ class TestSaleOrder(TestSaleCommon):
             line.qty_delivered = 2 if line.product_id.expense_policy == 'no' else 0
         self.assertTrue(self.sale_order.invoice_status == 'to invoice', 'Sale: SO status after delivery should be "to invoice"')
         invoice2 = self.sale_order._create_invoices()
-        self.assertEqual(len(invoice2.invoice_line_ids), 2, 'Sale: second invoice is missing lines')
-        self.assertEqual(invoice2.amount_total, 500.0, 'Sale: second invoice total amount is wrong')
+        self.assertEqual(len(invoice2.invoice_line_ids), 1, 'Sale: second invoice is missing lines')
+        self.assertEqual(invoice2.amount_total, 140.0, 'Sale: second invoice total amount is wrong')
         self.assertTrue(self.sale_order.invoice_status == 'invoiced', 'Sale: SO status after invoicing everything should be "invoiced"')
         self.assertTrue(len(self.sale_order.invoice_ids) == 2, 'Sale: invoice is missing')
 


### PR DESCRIPTION
### Steps to reproduce the issue:

1. Create a Product with "Service" as Product Type and "Based on Timesheets" as Invoicing Policy
2. Go to _Field Service > Configuration > Projects_ and choose a Project
3. In the _Invoicing_ section, add a line with an Employee and the Service Product you created
4. Create a Task for the Project
5. Add in the _Timesheets_ section a line with the Employee and a duration of one hour
6. Click on "Mark as done", then "Sales Order"
7. The Delivered Quantities have a correct value but the Price of the Sales Order and its Order Lines and the Ordered Quantities are not

### Explanation:

`price_subtotal` is based on `product_uom_qty`, which is currently not accounting for a potential difference between `product.product.uom_id` and `account.analytic.line.product_uom_id`. With `product.product.invoice_policy` beign set to 'delivery', `qty_delivered` is used to calculate the quantity of the invoice and can still change, while `product_uom_qty` is not.

### Reason for the changes:

All added methods lead to an override in `industry_fsm_sale`. Since `sale.order` is never directly involved, the methods will be added to `sale.order.line` if possible. `_compute_line_taxes` is used in a particular context and cannot be moved to `sale.order.line` with minimal changes.
The test is modified in order to work independently of `industry_fsm_sale`.

opw-3858530

odoo/enterprise#63337