### PR TITLE
[FIX] web_editor: don't remove some links codeview

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -4120,9 +4120,12 @@ export class OdooEditor extends EventTarget {
                 restore(); // Make sure to make <br>s visible if needed.
             }
         }
+
+        const tAttrs = ['t-elif', 't-else', 't-esc', 't-foreach', 't-if', 't-out', 't-raw', 't-value'];
         // Remove now empty links
         for (const link of element.querySelectorAll('a')) {
-            if (![...link.childNodes].some(isVisible) && !link.classList.length) {
+            if (![...link.childNodes].some(isVisible) && !link.classList.length
+                && !tAttrs.some(attr => link.hasAttribute(attr))) {
                 link.remove();
             }
         }


### PR DESCRIPTION
**Current behavior:**
When editing an email template with a link, it will get removed
when switching in/out of the codeview editor even if it has some
useful value.

**Expected behavior:**
These links will not be removed.

**Steps to reproduce:**
*Install sale_stock*
1. Go to email templates, select `Shipping: Send by Email`

2. Select the body content, activate the codeview editor mode

3. Some content has been removed, while codeview editor is open,
     reset the template and observe the change

4. This results in a delivery order email not having the
     tracking link in its body

**Cause of the issue:**
On codeview save, we remove empty links- however some links may
have a t-out value and are still lost.

**Fix:**
Check for a t-attribute in the link node's attributes before
removing it.

opw-3919379