### PR TITLE
[FIX] web: shared filters embedded actions

### DIFF
--- a/addons/web/static/src/search/control_panel/control_panel.js
+++ b/addons/web/static/src/search/control_panel/control_panel.js
@@ -472,7 +472,7 @@ export class ControlPanel extends Component {
         this.env.searchModel.createNewFavorite({
             description,
             isDefault: true,
-            isShared: userId,
+            isShared: newActionIsShared,
             embeddedActionId: embeddedActionId[0],
         });
         Object.assign(this.state.embeddedInfos, {

--- a/addons/web/static/tests/webclient/actions/embedded_action.test.js
+++ b/addons/web/static/tests/webclient/actions/embedded_action.test.js
@@ -309,6 +309,7 @@ test("a view coming from a embedded can be saved in the embedded actions", async
     onRpc("create_or_replace", ({ args }) => {
         expect(args[0].domain).toBe(`[["name", "=", "Applejack"]]`);
         expect(args[0].embedded_action_id).toBe(4);
+        expect(args[0].user_id).toBe(false);
         return 5; // Fake new filter id
     });
     await mountWithCleanup(WebClient);
@@ -337,6 +338,7 @@ test("a view coming from a embedded can be saved in the embedded actions", async
     });
     await contains(".o_embedded_actions_buttons_wrapper .dropdown").click();
     await contains(".o_save_current_view ").click();
+    await contains("input.form-check-input").click();
     await contains(".o_save_favorite ").click();
     expect(".o_embedded_actions_buttons_wrapper > button").toHaveCount(4, {
         message: "Should have 2 embedded actions in the embedded + the dropdown button",

--- a/odoo/addons/base/tests/test_ir_filters.py
+++ b/odoo/addons/base/tests/test_ir_filters.py
@@ -352,7 +352,7 @@ class TestEmbeddedFilters(FiltersCase):
         Filters.create_or_replace({
             'name': 'b',
             'model_id': 'ir.filters',
-            'user_id': False,
+            'user_id': self.USER_ID,
             'is_default': False,
             'embedded_action_id': self.embedded_action_2.id,
             'embedded_parent_res_id': 1
@@ -365,6 +365,10 @@ class TestEmbeddedFilters(FiltersCase):
         # Check that the filter is correctly linked to one embedded_parent_res_id and is not returned if another one is set
         filters = self.env['ir.filters'].with_user(self.USER_ID).get_filters('ir.filters', embedded_action_id=self.embedded_action_1.id, embedded_parent_res_id=2)
         self.assertItemsEqual(noid(filters), [])
+
+        # Check that a shared filter can be fetched with another user
+        filters = self.env['ir.filters'].with_user(ADMIN_USER_ID).get_filters('ir.filters', embedded_action_id=self.embedded_action_1.id, embedded_parent_res_id=1)
+        self.assertItemsEqual(noid(filters), [dict(name='a', is_default=True, user_id=False, domain='[]', context='{}', sort='[]')])
 
         # If embedded_action_id and embedded_parent_res_id are not set, should return no filters
         filters = self.env['ir.filters'].with_user(self.USER_ID).get_filters('ir.filters')


### PR DESCRIPTION
Previously, when an embedded action was created and shared, the associated favorite filter received an incorrect shareness value. This resulted in the action being shared, but not its filter.

This commit resolves the issue by assigning the correct shareness value to the new favorite filter.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
