### PR TITLE
[IMP] point_of_sale: email format for sending the receipt

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1011,10 +1011,14 @@ class PosOrder(models.Model):
 
     def _prepare_mail_values(self, email, ticket):
         message = Markup(
-            _("<p>Dear %(client_name)s,<br/>Here is your electronic ticket for the %(pos_name)s. </p>")
+            _("<p>Dear %(client_name)s,<br/>Here is your Receipt %(is_invoiced)sfor \
+            %(pos_name)s amounting in %(amount)s from %(company_name)s. </p>")
         ) % {
             'client_name': self.partner_id.name or _('Customer'),
             'pos_name': self.name,
+            'amount': self.currency_id.format(self.amount_total),
+            'company_name': self.company_id.name,
+            'is_invoiced': "and Invoice " if self.account_move else "",
         }
 
         return {


### PR DESCRIPTION
Before this commit:
==========
- The receipt email content is insufficient and inadequate.

After this commit:
==========
- Receipt emails contain sufficient and satisfactory content.

task-3764070