### PR TITLE
[FIX] account: tax_ids autocomplete going to second line

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1072,7 +1072,6 @@
                                                domain="[('type_tax_use', '=?', parent.invoice_filter_type_domain), ('company_id', 'parent_of', parent.company_id), ('country_id', '=', parent.tax_country_id)]"
                                                context="{'append_type_to_tax_name': not parent.invoice_filter_type_domain, 'active_test': True}"
                                                options="{'no_create': True}"
-                                               width="92px"
                                                optional="show"/>
                                         <field name="price_subtotal"
                                                string="Tax excl."/>


### PR DESCRIPTION
Description of the issue this commit addresses:

Before this commit, a fixed width is defined on the tax_ids column of invoice lines. Because of that, when a tax is selected and that it's width is almost exactly the forced width of the column, the autocomplete goes to a second line. In cases where no other cell of the line has a second line, this means that a second line is created just to put an autocomplete. This is not wanted.

---

Steps to reproduce:

1 - Open a new invoice
2 - Add a line and make sure no cell takes two lines before next step
3 - Add a tax which tax_tag will be approximately the width of the column
4 - The autocomplete container is now on a second line.

---

Desired behavior after this commit is merged:

After this commit, the fixed width of the column is removed. Thanks to that, the column is free to have a computed width wich will always handle the position of the autocomplete container.

---

Precision on the decision made for the fix:

Instead of removing the forced width on the column, it would seem logic to simply chose a bigger width. If a defined width has been set, there must be a reason, right? Well because the tax_tag width is dependant on the tax's name and the name having no limit, setting a size of 120px for example would just relocate the bug. The only solution therefore is to have the width of the column be the max width of a tax_tag (~250px) + the width of the autocomplete container (~50px) which is the behavior when no width is set hence the removal.

---

task-feedback

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
