### PR TITLE
[FIX] pos_hr: make the button "Cash In/Out" available for user

### DIFF
--- a/addons/pos_hr/static/src/js/Chrome.js
+++ b/addons/pos_hr/static/src/js/Chrome.js
@@ -15,7 +15,7 @@ odoo.define('pos_hr.chrome', function (require) {
                 return !this.env.pos.config.module_pos_hr || this.env.pos.get('cashier').role == 'manager' || this.env.pos.get_cashier().user_id[0] === this.env.pos.user.id;
             }
             showCashMoveButton() {
-                return super.showCashMoveButton() && this.env.pos.get('cashier').role == 'manager';
+                return super.showCashMoveButton() && (this.env.pos.get('cashier').role == 'manager' || this.env.pos.get_cashier().user_id);
             }
             shouldShowCashControl() {
                 return super.shouldShowCashControl() && this.env.pos.hasLoggedIn;

--- a/addons/pos_hr/static/tests/tours/PosHrTour.js
+++ b/addons/pos_hr/static/tests/tours/PosHrTour.js
@@ -52,6 +52,7 @@ odoo.define('point_of_sale.tour.PosHr', function (require) {
     NumberPopup.do.clickConfirm();
     ProductScreen.check.isShown();
     ProductScreen.do.clickHomeCategory();
+    PosHr.check.cashInOutVisible(false);
 
     // Create orders and check if the ticket list has the right employee for each order
     // order for employee 2
@@ -63,6 +64,7 @@ odoo.define('point_of_sale.tour.PosHr', function (require) {
     // order for employee 1
     PosHr.do.clickLockButton();
     PosHr.exec.login('Pos Employee1', '2580');
+    PosHr.check.cashInOutVisible();
     TicketScreen.do.clickNewTicket();
     ProductScreen.exec.addOrderline('Desk Pad', '1', '4');
     ProductScreen.check.totalAmountIs('4.0')
@@ -74,6 +76,7 @@ odoo.define('point_of_sale.tour.PosHr', function (require) {
     PosHr.do.clickCashierName();
     SelectionPopup.do.clickItem('Mitchell Admin');
     PosHr.check.cashierNameIs('Mitchell Admin');
+    PosHr.check.cashInOutVisible();
     TicketScreen.do.clickNewTicket();
     ProductScreen.exec.addOrderline('Desk Pad', '1', '8');
     ProductScreen.check.totalAmountIs('8.0')

--- a/addons/pos_hr/static/tests/tours/PosHrTourMethods.js
+++ b/addons/pos_hr/static/tests/tours/PosHrTourMethods.js
@@ -50,6 +50,12 @@ odoo.define('pos_hr.tour.PosHrTourMethods', function (require) {
                 },
             ];
         }
+        cashInOutVisible(visible=true) {
+            const trigger = visible
+                ? ".pos-branding .cash-move-button"
+                : ".pos-branding:not(:has(.cash-move-button))";
+            return [{ trigger, run: () => {} }];
+        }
     }
     class Execute {
         login(name, pin) {


### PR DESCRIPTION
Problem:
In POS, when the "Employees" is installed, a user with a POS access right as "user" can't see the button "Cash In/Out"
Fix for version 15.0 only

Steps to reproduce:
- Install "Point of Sale" and "Employees" apps
- Log in with a user with a "user" right for POS (eg. Marc Demo)
- Start a POS session
- There is no button "Cash In/Out"

opw-3944718



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
