### PR TITLE
[IMP] base: translate currency label

### DIFF
--- a/odoo/addons/base/models/res_currency.py
+++ b/odoo/addons/base/models/res_currency.py
@@ -44,8 +44,8 @@ class Currency(models.Model):
     position = fields.Selection([('after', 'After Amount'), ('before', 'Before Amount')], default='after',
         string='Symbol Position', help="Determines where the currency symbol should be placed after or before the amount.")
     date = fields.Date(compute='_compute_date')
-    currency_unit_label = fields.Char(string="Currency Unit")
-    currency_subunit_label = fields.Char(string="Currency Subunit")
+    currency_unit_label = fields.Char(string="Currency Unit", translate=True)
+    currency_subunit_label = fields.Char(string="Currency Subunit", translate=True)
     is_current_company_currency = fields.Boolean(compute='_compute_is_current_company_currency')
 
     _sql_constraints = [


### PR DESCRIPTION
-Before this commit, the `currency_unit_label` and `currency_subunit_label` aren't translate. When a company , ex VietNam company have invoices and if we enable `display amount in word` for it, the `amount in word `which contain `currency_unit_label` is always the same although customer is Vietnamese or not, it still `Dong` while it should be `Đồng in Vietnamese` for VietNamese client
-> Therefore this commit add translate=True for `currency_unit_label` and `currency_subunit_label` to support translation.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
