### PR TITLE
[DRAFT][FIX] hr_holidays: fix traceback when click on leave info

### DIFF
--- a/addons/hr_holidays/static/src/dashboard/time_off_card.js
+++ b/addons/hr_holidays/static/src/dashboard/time_off_card.js
@@ -22,6 +22,7 @@ export class TimeOffCardPopover extends Component {
         "allows_negative",
         "max_allowed_negative",
         "onClickNewAllocationRequest?",
+        "errorLeaves",
     ];
 
     setup() {


### PR DESCRIPTION
saas-17.1

Steps to reproduce:
activate debug mode
click on info of time off dashboard

issue:
faced with a traceback

cause:
the prop 'errorLeaves' is unknown or invalid for the component 'TimeOffCardPopover'. 'errorLeaves' was not listed on static props list

Solution:
added 'errorLeaves' in static props list

task-3942534
