### PR TITLE
[FIX] sale: internal users can always see their quotes from  the portal

### DIFF
--- a/addons/sale/controllers/portal.py
+++ b/addons/sale/controllers/portal.py
@@ -77,17 +77,17 @@ class CustomerPortal(portal.CustomerPortal):
 
         pager_values = portal_pager(
             url=url,
-            total=SaleOrder.search_count(domain),
+            total=SaleOrder.sudo().search_count(domain),
             page=page,
             step=self._items_per_page,
             url_args={'date_begin': date_begin, 'date_end': date_end, 'sortby': sortby},
         )
-        orders = SaleOrder.search(domain, order=sort_order, limit=self._items_per_page, offset=pager_values['offset'])
+        orders = SaleOrder.sudo().search(domain, order=sort_order, limit=self._items_per_page, offset=pager_values['offset'])
 
         values.update({
             'date': date_begin,
-            'quotations': orders.sudo() if quotation_page else SaleOrder,
-            'orders': orders.sudo() if not quotation_page else SaleOrder,
+            'quotations': orders if quotation_page else SaleOrder,
+            'orders': orders if not quotation_page else SaleOrder,
             'page_name': 'quote' if quotation_page else 'order',
             'pager': pager_values,
             'default_url': url,


### PR DESCRIPTION
Problem
---
From the user portal, unlike portal users, internal users could see quotes for which they are the customer iff they had access rights to:
	a. The `sale.order` model
	b. The corresponding sale orders in odoo

Steps
---
* as admin:
    * create an internal user with no access rights to 'Sales' or billing
    * create a sale order, where the customer is the internal user
    * send by email
* as the user:
    * go to the portal, then to your quotations
	(website > my account > documents > quotations)
    * => 403 forbidden, no access to `sale.order`

Note: if the user has some access to Sales, but not to all the documents, they will be able to access the page, but some quotations will be still be missing.

Fix
---
Move the `sudo` to just before the search, so access rights do not matter when we determine for which quotes a user is the customer.

opw-3919714
