### PR TITLE
[FIX] l10n_es_edi_tbai: traceback on credit note posting

### DIFF
--- a/addons/l10n_es_edi_tbai/i18n/es.po
+++ b/addons/l10n_es_edi_tbai/i18n/es.po
@@ -379,6 +379,27 @@ msgid "TicketBAI required"
 msgstr "Se requiere TicketBai"
 
 #. module: l10n_es_edi_tbai
+#. odoo-python
+#: code:addons/l10n_es_edi_tbai/models/account_edi_format.py:0
+#, python-format
+msgid ""
+"TicketBAI: Cannot post a reversal move while the source document (%s) has "
+"not been posted"
+msgstr ""
+"TicketBAI: No se puede contabilizar un movimiento de anulación mientras no "
+"se haya contabilizado el documento de origen (%s)"
+
+#. module: l10n_es_edi_tbai
+#. odoo-python
+#: code:addons/l10n_es_edi_tbai/models/account_edi_format.py:0
+#, python-format
+msgid ""
+"TicketBAI: Cannot post invoice while chain head (%s) has not been posted"
+msgstr ""
+"TicketBAI: No se puede contabilizar la factura mientras no se haya "
+"contabilizado la cabeza de cadena (%s)"
+
+#. module: l10n_es_edi_tbai
 #: model:ir.model.fields,field_description:l10n_es_edi_tbai.field_res_company__l10n_es_tbai_chain_sequence_id
 msgid "TicketBai account.move chain sequence"
 msgstr "Secuencia en cadena TicketBai account.move"

--- a/addons/l10n_es_edi_tbai/i18n/l10n_es_edi_tbai.pot
+++ b/addons/l10n_es_edi_tbai/i18n/l10n_es_edi_tbai.pot
@@ -366,6 +366,23 @@ msgid "TicketBAI required"
 msgstr ""
 
 #. module: l10n_es_edi_tbai
+#. odoo-python
+#: code:addons/l10n_es_edi_tbai/models/account_edi_format.py:0
+#, python-format
+msgid ""
+"TicketBAI: Cannot post a reversal move while the source document (%s) has "
+"not been posted"
+msgstr ""
+
+#. module: l10n_es_edi_tbai
+#. odoo-python
+#: code:addons/l10n_es_edi_tbai/models/account_edi_format.py:0
+#, python-format
+msgid ""
+"TicketBAI: Cannot post invoice while chain head (%s) has not been posted"
+msgstr ""
+
+#. module: l10n_es_edi_tbai
 #: model:ir.model.fields,field_description:l10n_es_edi_tbai.field_res_company__l10n_es_tbai_chain_sequence_id
 msgid "TicketBai account.move chain sequence"
 msgstr ""

--- a/addons/l10n_es_edi_tbai/models/account_edi_format.py
+++ b/addons/l10n_es_edi_tbai/models/account_edi_format.py
@@ -109,8 +109,19 @@ class AccountEdiFormat(models.Model):
             # - If called from a cron, then the re-ordering of jobs should prevent this from triggering
             # - If called manually, then the user will see this error pop up when it triggers
             chain_head = invoice.company_id._get_l10n_es_tbai_last_posted_invoice()
+            error_msg = ''
             if chain_head and chain_head != invoice and not chain_head._l10n_es_tbai_is_in_chain():
-                raise UserError(f"TicketBAI: Cannot post invoice while chain head ({chain_head.name}) has not been posted")
+                error_msg = _("TicketBAI: Cannot post invoice while chain head (%s) has not been posted", chain_head.name)
+            if invoice.move_type == 'out_refund' and not invoice.reversed_entry_id._l10n_es_tbai_is_in_chain():
+                error_msg = _("TicketBAI: Cannot post a reversal move while the source document (%s) has not been posted", invoice.reversed_entry_id.name)
+
+            if error_msg:
+                return {
+                    invoice: {
+                        'error': error_msg,
+                        'blocking_level': 'error',
+                    }
+                }
 
             # Generate the XML values.
             inv_dict = self._get_l10n_es_tbai_invoice_xml(invoice)


### PR DESCRIPTION
With an ES company setup and TicketBAI service active
Create an Invoice
Post it but do not send the Invoice to EDI (disable cron if necessary)
Create a Credit note for the invoice
Send the credit note to EDI service

Traceback will raise
"ValueError: time data '' does not match format '%d-%m-%Y'"

This occurs because we retrieve information of the original invoice
directly from the 'post' XMLs submitted to the government
but we don't have any

opw-3919568
