### PR TITLE
[FIX] base_import: fix tooltip header color

### DIFF
--- a/addons/base_import/static/src/import_data_content/import_data_content.xml
+++ b/addons/base_import/static/src/import_data_content/import_data_content.xml
@@ -101,8 +101,9 @@
     </t>
 
     <t t-name="ImportDataContent.tooltip" owl="1">
-        <h5 class="border-bottom p-2">Preview</h5>
-        <div class="p-2 pt-0 pe-3">
+        <h5 class="text-reset p-2 m-0">Preview</h5>
+        <hr class="m-0"/>
+        <div class="p-2 pe-3">
             <p
                 t-foreach="lines"
                 t-as="line"


### PR DESCRIPTION
Purpose
=======
Fix the tooltip header color which wasn't reactive to the
theme color (light vs dark theme).
The header text is black instead of white in light theme
and is thus not visible on the tooltip black background.

Specification
=============
Overwritting the h5 color style that is set to a dark color by
the basic bootstrap style.

The border-bottom isn't visible in the dark theme because of the tooltip
border color style. This border style is applied to the external borders of
the tooltip and thus shoudln't be changed.
Replacing the border-bottom class by a hr tag as it is more adequate for a
divider and its color is independant from the tooltip basic border color.

Task-3956309


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
