### PR TITLE
[FIX] l10n_in_pos: crash after payment

### DIFF
--- a/addons/l10n_in_pos/static/src/overrides/models/pos_order.js
+++ b/addons/l10n_in_pos/static/src/overrides/models/pos_order.js
@@ -48,7 +48,7 @@ patch(PosOrder.prototype, {
                     priceUnit,
                     1,
                     line.product_id,
-                    this.session._product_default_values,
+                    this.config._product_default_values,
                     this.company,
                     this.currency
                 ),


### PR DESCRIPTION
Do a basic sale workflow in pos in an IN company and after validating the order in the payment screen, the app crashes, it doesn't proceed to the receipt screen. This is because we are accessing a value from a wrong object. `_product_default_values` should be accessed from the `config` object, not from `session`.

