### PR TITLE
[FIX] mail: mail_activity mock model default records

### DIFF
--- a/addons/mail/static/tests/mock_server/mock_models/mail_activity_type.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_activity_type.js
@@ -9,17 +9,20 @@ export class MailActivityType extends models.ServerModel {
             id: 1,
             icon: "fa-envelope",
             name: "Email",
+            active: true,
         },
         {
             id: 2,
             category: "phonecall",
             icon: "fa-phone",
             name: "Call",
+            active: true,
         },
         {
             id: 28,
             icon: "fa-upload",
             name: "Upload Document",
+            active: true,
         },
     ];
 }


### PR DESCRIPTION
**Before this PR:**

Default records in `mail_activity` mock model are not set active by default, as a result when you do search operation on `mail.activity` it will check `active_test` and won't return these records.

**After this PR:**

Setting `active` true so these records would pass `active_test`.

Part of task-[3818666](https://www.odoo.com/odoo/project/1519/tasks/3818666?debug=&cids=2)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
