### PR TITLE
[IMP] purchase_stock: don't block mto flow on missing vendor

### DIFF
--- a/addons/mrp_subcontracting/models/stock_picking.py
+++ b/addons/mrp_subcontracting/models/stock_picking.py
@@ -163,6 +163,9 @@ class StockPicking(models.Model):
         }
         return vals
 
+    def _get_subcontract_mo_confirmation_ctx(self):
+        return {}  # To override in mrp_subcontracting_purchase
+
     def _subcontracted_produce(self, subcontract_details):
         self.ensure_one()
         group_move = defaultdict(list)
@@ -188,7 +191,7 @@ class StockPicking(models.Model):
             all_mo.update(grouped_mo.ids)
 
         all_mo = self.env['mrp.production'].browse(sorted(all_mo))
-        all_mo.action_confirm()
+        all_mo.with_context(self._get_subcontract_mo_confirmation_ctx()).action_confirm()
 
         for mo in all_mo:
             move = group_move[mo.procurement_group_id.id][0]

--- a/addons/mrp_subcontracting_purchase/models/stock_picking.py
+++ b/addons/mrp_subcontracting_purchase/models/stock_picking.py
@@ -38,3 +38,8 @@ class StockPicking(models.Model):
     def _get_subcontracting_source_purchase(self):
         moves_subcontracted = self.move_ids.move_dest_ids.raw_material_production_id.move_finished_ids.move_dest_ids.filtered(lambda m: m.is_subcontract)
         return moves_subcontracted.purchase_line_id.order_id
+
+    def _get_subcontract_mo_confirmation_ctx(self):
+        return {
+            'po_to_notify': self.move_ids.purchase_line_id.order_id,
+        }

--- a/addons/mrp_subcontracting_purchase/models/stock_rule.py
+++ b/addons/mrp_subcontracting_purchase/models/stock_rule.py
@@ -48,3 +48,10 @@ class StockRule(models.Model):
         for key, value in extra_delays.items():
             delays[key] += value
         return delays, delay_description + extra_delay_description
+
+    def _notify_responsible(self, procurement):
+        super()._notify_responsible(procurement)
+        origin_order = self.env.context.get('po_to_notify')
+        if origin_order:
+            notified_users = procurement.product_id.responsible_id.partner_id | origin_order.user_id.partner_id
+            self._post_vendor_notification(origin_order, notified_users, procurement.product_id)

--- a/addons/purchase_mrp/models/__init__.py
+++ b/addons/purchase_mrp/models/__init__.py
@@ -6,3 +6,4 @@ from . import purchase
 from . import mrp_production
 from . import mrp_bom
 from . import stock_move
+from . import stock_rule

--- a/addons/purchase_mrp/models/stock_rule.py
+++ b/addons/purchase_mrp/models/stock_rule.py
@@ -1,0 +1,14 @@
+from markupsafe import Markup
+
+from odoo import models, _
+
+
+class StockRule(models.Model):
+    _inherit = 'stock.rule'
+
+    def _notify_responsible(self, procurement):
+        super()._notify_responsible(procurement)
+        origin_orders = procurement.values.get('group_id').mrp_production_ids if procurement.values.get('group_id') else False
+        if origin_orders:
+            notified_users = procurement.product_id.responsible_id.partner_id | origin_orders.user_id.partner_id
+            self._post_vendor_notification(origin_orders, notified_users, procurement.product_id)

--- a/addons/purchase_stock/models/stock_rule.py
+++ b/addons/purchase_stock/models/stock_rule.py
@@ -4,6 +4,7 @@
 from collections import defaultdict
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
+from markupsafe import Markup
 from odoo.tools import float_compare
 
 from odoo import api, fields, models, SUPERUSER_ID, _
@@ -71,9 +72,17 @@ class StockRule(models.Model):
                 lambda s: not s.company_id or s.company_id == procurement.company_id
             )[:1]
 
-            if not supplier:
+            if not supplier and self.env.context.get('from_orderpoint'):
                 msg = _('There is no matching vendor price to generate the purchase order for product %s (no vendor defined, minimum quantity not reached, dates not valid, ...). Go on the product form and complete the list of vendors.', procurement.product_id.display_name)
                 errors.append((procurement, msg))
+            elif not supplier:
+                # If the supplier is not set, we cannot create a PO.
+                moves = procurement.values.get('move_dest_ids', self.env['stock.move'])
+                if moves.propagate_cancel:
+                    moves._action_cancel()
+                moves.procure_method = 'make_to_stock'
+                self._notify_responsible(procurement)
+                return
 
             partner = supplier.partner_id
             # we put `supplier_info` in values for extensibility purposes
@@ -153,6 +162,14 @@ class StockRule(models.Model):
                     if fields.Date.to_date(order_date_planned) < fields.Date.to_date(po.date_order):
                         po.date_order = order_date_planned
             self.env['purchase.order.line'].sudo().create(po_line_values)
+
+    def _post_vendor_notification(self, records_to_notify, users_to_notify, product):
+        notification_msg = Markup(" ").join(Markup("%s") % user._get_html_link(f'@{user.name}') for user in users_to_notify)
+        notification_msg += Markup("<br/>%s <strong>%s</strong>, %s") % (_("No supplier has been found to replenish"), product.display_name, _("this product should be manually replenished."))
+        records_to_notify.message_post(body=notification_msg, partner_ids=users_to_notify.ids)
+
+    def _notify_responsible(self, procurement):
+        pass  # Override in sale_purchase_stock and purchase_mrp to notify salesperson or MO responsible
 
     def _get_lead_days(self, product, **values):
         """Add the company security lead time and the supplier delay to the cumulative delay

--- a/addons/sale_purchase_stock/models/__init__.py
+++ b/addons/sale_purchase_stock/models/__init__.py
@@ -3,3 +3,4 @@
 
 from . import purchase_order
 from . import sale_order
+from . import stock_rule

--- a/addons/sale_purchase_stock/models/stock_rule.py
+++ b/addons/sale_purchase_stock/models/stock_rule.py
@@ -1,0 +1,14 @@
+from markupsafe import Markup
+
+from odoo import models, _
+
+
+class StockRule(models.Model):
+    _inherit = 'stock.rule'
+
+    def _notify_responsible(self, procurement):
+        super()._notify_responsible(procurement)
+        origin_order = procurement.values.get('group_id').sale_id if procurement.values.get('group_id') else False
+        if origin_order:
+            notified_users = procurement.product_id.responsible_id.partner_id | origin_order.user_id.partner_id
+            self._post_vendor_notification(origin_order, notified_users, procurement.product_id)

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1432,7 +1432,7 @@ Please change the quantity done or the rounding precision in your settings.""",
                 origin, move.company_id, values))
         self.env['procurement.group'].run(procurement_requests, raise_user_error=not self.env.context.get('from_orderpoint'))
 
-        move_to_confirm, move_waiting = self.browse(move_to_confirm), self.browse(move_waiting)
+        move_to_confirm, move_waiting = self.browse(move_to_confirm).filtered(lambda m: m.state != 'cancel'), self.browse(move_waiting).filtered(lambda m: m.state != 'cancel')
         move_to_confirm.write({'state': 'confirmed'})
         move_waiting.write({'state': 'waiting'})
         # procure_method sometimes changes with certain workflows so just in case, apply to all moves


### PR DESCRIPTION
This commit removes the exception that was thrown when trying to
resupply a product which has MTO & Buy routes set and missing a vendor
at the same time. Now the corresponding out picking will be made
normally with MTS as a procure method without blocking the user.

Task-3940366

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
