### PR TITLE
[FIX] mail: remove emoji in xml template

### DIFF
--- a/addons/mail/data/mail_templates_mailgateway.xml
+++ b/addons/mail/data/mail_templates_mailgateway.xml
@@ -36,7 +36,7 @@
     <div t-foreach="attachments" t-as="attachment">
         <a t-attf-href="{{attachment.get_base_url()}}/web/content/{{attachment.id}}?download=1&amp;access_token={{attachment.access_token}}"
            style="font-size: 12px; color: #875A7B; text-decoration:none !important; text-decoration:none; font-weight: 400;">
-            📥 <t t-out="attachment.name"/>
+            <t t-out="attachment.name"/>
         </a>
     </div>
 </div>


### PR DESCRIPTION
The emoji in the xml template results in a parseError
which prevents a new database from being initialised
