### PR TITLE
[FIX] pos_online_payment: qr code popup doesn't close

### DIFF
--- a/addons/pos_online_payment/static/src/overrides/pos_overrides/components/payment_screen/payment_screen.js
+++ b/addons/pos_online_payment/static/src/overrides/pos_overrides/components/payment_screen/payment_screen.js
@@ -211,8 +211,7 @@ patch(PaymentScreen.prototype, {
         // Without that update, the payment lines printed on the receipt ticket would
         // be invalid.
         const isInvoiceRequested = this.currentOrder.is_to_invoice();
-        const updatedOrder = this.pos.createNewOrder(orderJSON);
-        if (!updatedOrder || this.currentOrder.id !== updatedOrder.id) {
+        if (!orderJSON[0] || this.currentOrder.id !== orderJSON[0].id) {
             this.dialog.add(AlertDialog, {
                 title: _t("Order saving issue"),
                 body: _t("The order has not been saved correctly on the server."),

--- a/addons/pos_online_payment/static/src/overrides/pos_overrides/models/pos_store.js
+++ b/addons/pos_online_payment/static/src/overrides/pos_overrides/models/pos_store.js
@@ -10,8 +10,8 @@ patch(PosStore.prototype, {
             // Therefore, no sensitive information is sent through it, only a
             // notification to invite the local browser to do a safe RPC to
             // the server to check the new state of the order.
-            if (this.get_order()?.server_id === id) {
-                this.pos.update_online_payments_data_with_server(this.pos.get_order(), false);
+            if (this.get_order()?.id === id) {
+                this.update_online_payments_data_with_server(this.get_order(), false);
             }
         });
     },
@@ -40,7 +40,7 @@ patch(PosStore.prototype, {
         if ("paid_order" in opData) {
             opData.is_paid = true;
             // only one line will have the `online_payment_resolver` method
-            order.paymentlines.forEach((line) => line.onlinePaymentResolver?.(true));
+            order.payment_ids.forEach((line) => line.onlinePaymentResolver?.(true));
             return opData;
         } else {
             opData.is_paid = false;


### PR DESCRIPTION
Performing a workflow in the pos app using an online payment method doesn't work. The qr code popup is displayed but right after payment, the popup doesn't close and the order is blocked.

Steps to reproduce:

1. Create an online pos payment method.
2. Activate demo payment provider to make sure the online pos payment method can be used in a pos.config.
3. Open pos and make an order with any amount.
4. Pay the order with the online payment method.
5. Scan the qr code and follow the steps to pay.
6. [BUG] After payment, the qr code popup should close and the screen changes to the receipt screen.

Solution:

The issue is caused by a series of mistake in different refactorings which is mainly about incorrect comparisons of different values. The propose changes fixes the basic workflow listed above.

