### PR TITLE
[IMP] website: remove the height option of mega menu snippet

### DIFF
--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -1798,7 +1798,7 @@
     </div>
 
     <!-- Scroll to next section button (only for full height) -->
-    <div data-js="ScrollButton" data-selector="section" data-exclude="[data-snippet] :not(.oe_structure) > [data-snippet], .s_instagram_page">
+    <div data-js="ScrollButton" data-selector="section" data-exclude="[data-snippet] :not(.oe_structure) > [data-snippet], .s_instagram_page, .o_mega_menu > section">
         <!-- Min height of section -->
         <we-button-group string="Height" data-show-scroll-button="">
             <we-button data-name="minheight_auto_opt" data-select-class="" title="Fit content">Auto</we-button>


### PR DESCRIPTION
This PR aims to remove the "Height" option of the mega menu snippet along with its dependent option "Scroll Down Button", which is useless in case of mega menu.

![image](https://github.com/odoo/odoo/assets/100135102/d31ccb13-371d-4e07-9a98-c0a9cb103aeb)

task-3477972