### PR TITLE
[FIX] account:  prevent error when deleting the records in payments

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2552,16 +2552,17 @@ class AccountMove(models.Model):
         If a user is a Billing Administrator/Accountant or if fidu mode is activated, we show a warning,
         but they can delete the moves even if it creates a sequence gap.
         """
-        if not (
-            self.user_has_groups('account.group_account_manager')
-            or self.company_id.quick_edit_mode
-            or self._context.get('force_delete')
-            or self.check_move_sequence_chain()
-        ):
-            raise UserError(_(
-                "You cannot delete this entry, as it has already consumed a sequence number and is not the last one in the chain. "
-                "You should probably revert it instead."
-            ))
+        for record in self:
+            if not (
+                record.user_has_groups('account.group_account_manager')
+                or record.company_id.quick_edit_mode
+                or record._context.get('force_delete')
+                or record.check_move_sequence_chain()
+            ):
+                raise UserError(_(
+                    "You cannot delete this entry, as it has already consumed a sequence number and is not the last one in the chain. "
+                    "You should probably revert it instead."
+                ))
 
     def unlink(self):
         self = self.with_context(skip_invoice_sync=True, dynamic_unlink=True)  # no need to sync to delete everything


### PR DESCRIPTION
This error occurs when a user with ``Billing/Bookkeeper`` rights attempts to delete a payment associated with invoices from different companies.

Steps to reproduce:
- Install the ``account_accountant`` module
- Create a new company (eg: Company A) and switch to it
- Open Accounting > Configuration > Settings > Fiscal Localization > 
  Generic Chart Template > Save
- Enable all companies > Settings > General Settings > Companies > Inter-Company
  Transactions > Save > Again search for Inter-Company Transactions >
  Synchronize invoices/bills > Create as: ``Mitchell Admin`` > Save
- Accounting > Customers > Invoices > Select the one invoice with ``YourCompany`` 
  as a company and ``Register Payment`` > Journal Entry > Reconciled Items > 
  Select all and unreconciled them and the same for another invoice with 
  ``Company A`` as a company
- Go to ``Marc Demo`` in Users > Allowed Companies > add ``Company A`` > Save
- Logout and login with ``Marc Demo``
- Accounting > Customers > Payments > Select both and delete it

``Traceback : ValueError : Expected singleton: res.company(2, 4)``

When we try to delete a payment involving different companies, at line [1] in ``self.company_id``, we are getting the IDs of two companies, which causes an error.

This commit will fix the above error by adding a for loop that checks each record individually.

[1]: https://github.com/odoo/odoo/blob/4fb50c6079dd59f3f82d335dbdf6c65f001c5855/addons/account/models/account_move.py#L2811

sentry-5408865989

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
