### PR TITLE
[FIX] stock: compute inventory diff qty when quantity_set is updated

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -184,7 +184,7 @@ class StockQuant(models.Model):
         ]
         return super()._search(domain, *args, **kwargs)
 
-    @api.depends('inventory_quantity')
+    @api.depends('inventory_quantity', 'inventory_quantity_set')
     def _compute_inventory_diff_quantity(self):
         for quant in self:
             quant.inventory_diff_quantity = quant.inventory_quantity - quant.quantity


### PR DESCRIPTION
Steps to reproduce the bug:
- Go to the inventory adjustments:
  - Update any quant by setting the counted quantity to 0

Problem:
The line is colored yellow because “is_outdated” is updated to True due to the update of “inventory_quantity”. The “_compute_inventory_diff_quantity” is not triggered because “inventory_quantity” is initially 0, so the dependencies do not detect any change.

opw-3946693
