### PR TITLE
[FIX] sales_team: computing member ids return archived users

### DIFF
--- a/addons/sales_team/models/crm_team.py
+++ b/addons/sales_team/models/crm_team.py
@@ -142,7 +142,7 @@ class CrmTeam(models.Model):
     @api.depends('crm_team_member_ids.active')
     def _compute_member_ids(self):
         for team in self:
-            team.member_ids = team.crm_team_member_ids.user_id
+            team.member_ids = team.crm_team_member_ids.user_id.sudo().filtered('active')
 
     def _inverse_member_ids(self):
         for team in self:


### PR DESCRIPTION
The user who is member of crm team, and contain different
company then current user company, and that user
is archived then we could get multi-company issue
when trying to open sales team form or compute
member warning field.

One way this issue is triggered is when the partner of the associated
user is marked as partner_share=True. We may get an access error due to
the rule base.res_partner_rule.

Steps to reproduce:

1. Install `sales_team` module
2. Create an extra company with a user (U) on it. Ensure the partner of
U is also set as belonging to this second company.
3. Create sales team with empty company. and add user (u)
as member of this team.
4. Archive U (this makes the partner of U get partner_share=True)
Try to access the sales team form from the first company.

During upgrade, when it's try to compute `member_warning`
using compute method - `_compute_member_warning`
it's trigger compute of member_ids
by this line:
`('user_id', 'in', team.member_ids.ids)`
and there is one archived user member in team
and that  will raise access rule error.

solution: when we try to fetch member_ids.user_id, it
should not read or fetch archived user/member.

```
 File "/home/odoo/src/odoo/17.0/addons/sales_team/models/crm_team.py", line 176, in _compute_member_warning
    ('user_id', 'in', team.member_ids.ids)
File "/home/odoo/src/odoo/17.0/odoo/models.py", line 3833, in fetch
    raise self.env['ir.rule']._make_access_error('read', forbidden)
 odoo.exceptions.AccessError: Uh-oh! Looks like you have stumbled upon some top-secret records.

Sorry, test (id=6) doesn't have 'read' access to:
- User (res.users)

If you really, really need access, perhaps you can win over your friendly administrator with a batch of freshly baked cookies.
```

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
