### PR TITLE
[IMP] l10n_fr_hr_holidays: auto-install l10n_fr for time off

### DIFF
--- a/addons/l10n_fr_hr_holidays/__manifest__.py
+++ b/addons/l10n_fr_hr_holidays/__manifest__.py
@@ -3,10 +3,11 @@
 
 {
     'name': 'France - Time Off',
+    'countries': ['fr'],
     'version': '1.0',
     'category': 'Human Resources/Time Off',
     'summary': 'Management of leaves for part-time workers in France',
-    'depends': ['hr_holidays', 'l10n_fr'],
+    'depends': ['hr_holidays'],
     'auto_install': True,
     'license': 'LGPL-3',
     'data': [

--- a/addons/l10n_fr_hr_holidays/data/l10n_fr_hr_holidays_demo.xml
+++ b/addons/l10n_fr_hr_holidays/data/l10n_fr_hr_holidays_demo.xml
@@ -15,6 +15,23 @@
             ]"
         />
     </record>
+    <record id="base.partner_demo_company_fr" model="res.partner" forcecreate="1">
+        <field name="name">FR Company</field>
+        <field name="vat">FR91746948785</field>
+        <field name="street">Rue Abbé Huet</field>
+        <field name="city">Rennes</field>
+        <field name="country_id" ref="base.fr"/>
+
+        <field name="zip">35043</field>
+        <field name="phone">+33 6 12 34 56 78</field>
+        <field name="email">info@company.frexample.com</field>
+        <field name="website">www.frexample.com</field>
+    </record>
+
+    <record id="base.demo_company_fr" model="res.company" forcecreate="1">
+        <field name="name">FR Company</field>
+        <field name="partner_id" ref="base.partner_demo_company_fr"/>
+    </record>
 
     <record id="l10n_fr_part_time_employee" model="hr.employee">
         <field name="company_id" ref="base.demo_company_fr"/>
@@ -37,9 +54,6 @@
         <field name="color">2</field>
         <field name="has_valid_allocation">True</field>
     </record>
-    <record id="base.demo_company_fr" model="res.company">
-        <field name="l10n_fr_reference_leave_type" ref="l10n_fr_holiday_status_cl"/>
-    </record>
 
     <record id="l10n_fr_hr_holidays_allocation" model="hr.leave.allocation">
         <field name="name">Paid Time Off allocation</field>
@@ -52,5 +66,15 @@
     </record>
     <function model="hr.leave.allocation" name="action_validate">
         <value eval="[ref('l10n_fr_hr_holidays_allocation')]"/>
+    </function>
+
+    <function model="res.company" name="write">
+        <value eval="[ref('base.demo_company_fr')]"/>
+        <value eval="{'l10n_fr_reference_leave_type': [(4, ref('l10n_fr_holiday_status_cl'))]}"/>
+    </function>
+
+    <function model="res.users" name="write">
+        <value eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"/>
+        <value eval="{'company_ids': [(4, ref('base.demo_company_fr'))]}"/>
     </function>
 </odoo>


### PR DESCRIPTION
This commit removes the dependency of `l10n_fr_hr_holidays` on `l10n_fr` and accounting as a result.

Additionally the `countries` key is added to the manifest of `l10n_fr_hr_holidays`, so that it can be installed automatically when a new French company is created.

task: 3956577

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
