### PR TITLE
[FIX] mail: optimize channels as member

### DIFF
--- a/addons/mail/models/discuss/discuss_channel_member.py
+++ b/addons/mail/models/discuss/discuss_channel_member.py
@@ -24,7 +24,7 @@ class ChannelMember(models.Model):
     guest_id = fields.Many2one("mail.guest", "Guest", ondelete="cascade", index=True)
     is_self = fields.Boolean(compute="_compute_is_self", search="_search_is_self")
     # channel
-    channel_id = fields.Many2one("discuss.channel", "Channel", ondelete="cascade", required=True)
+    channel_id = fields.Many2one("discuss.channel", "Channel", ondelete="cascade", required=True, auto_join=True)
     # state
     custom_channel_name = fields.Char('Custom channel name')
     fetched_message_id = fields.Many2one('mail.message', string='Last Fetched', index="btree_not_null")


### PR DESCRIPTION
With tens of millions of channels, the query for getting the channels of the current user goes from 1.2s to 6ms.

`auto_join` makes sense as channels are almost always fetched together with member (and in particular for checking ACL of member).