### PR TITLE
[FIX] web: dont access unextended record values in onchanges

### DIFF
--- a/addons/web/static/src/model/relational_model/static_list.js
+++ b/addons/web/static/src/model/relational_model/static_list.js
@@ -544,8 +544,12 @@ export class StaticList extends DataPoint {
                         const changes = {};
                         for (const fieldName in command[2]) {
                             if (["one2many", "many2many"].includes(this.fields[fieldName].type)) {
-                                const invisible = record.activeFields[fieldName].invisible;
-                                if (invisible === "True" || invisible === "1") {
+                                const invisible = record.activeFields[fieldName]?.invisible;
+                                if (
+                                    invisible === "True" ||
+                                    invisible === "1" ||
+                                    !(fieldName in record.activeFields) // this record hasn't been extended
+                                ) {
                                     if (!(command[1] in this._unknownRecordCommands)) {
                                         this._unknownRecordCommands[command[1]] = [];
                                     }


### PR DESCRIPTION
### Steps to reproduce:

- Create a storable product P with a BOM with two raw lines:
	- 1 unit x COMP 1
	- 1 unit x COMP 2
- Create and confirm a manufacturing order for 1 unit of P
- Click on the list icon of the stock move of COMP 1 and close the x2many dialog tab with cancel
- Change the qty_producing of the MO to 1 and then click anywhere on the form of the MO to trigger the associated onchange

### Cause of the Issue:

Clicking on the list icon of the stock.move will trigger the `extendRecord` method:
https://github.com/odoo/odoo/blob/f8182fb625eb3e20c85388d4c342553af4fe7ab9/addons/web/static/src/model/relational_model/static_list.js#L195-L198 This trigger will then add the `move_line_ids` to the fields and active fields of the stock.move of COMP 1.
Closing the x2many dialog and changing the `qty_producing` of the mo will then trigger this onchange call:
https://github.com/odoo/odoo/blob/f8182fb625eb3e20c85388d4c342553af4fe7ab9/addons/mrp/models/mrp_production.py#L806-L807 This one will update the stock move values of both components. However, the stock move associated to COMP 2 was not extended and the `move_line_ids` field that record will be accessed to determine its invisible attribute:
https://github.com/odoo/odoo/blob/f8182fb625eb3e20c85388d4c342553af4fe7ab9/addons/web/static/src/model/relational_model/static_list.js#L546-L547 Since the result is undefined a client error is thrown.

opw-3923341
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
