### PR TITLE
[FIX] pos_restaurant, pos_self_order: show note in the root module

### DIFF
--- a/addons/pos_restaurant/models/pos_order.py
+++ b/addons/pos_restaurant/models/pos_order.py
@@ -10,6 +10,12 @@ class PosOrderLine(models.Model):
 
     note = fields.Char('Internal Note added by the waiter.')
 
+    def _export_for_ui(self, orderline):
+        return {
+            'note': orderline.note,
+            **super()._export_for_ui(orderline),
+        }
+
 
 class PosOrder(models.Model):
     _inherit = 'pos.order'

--- a/addons/pos_restaurant/static/tests/tours/ControlButtons.tour.js
+++ b/addons/pos_restaurant/static/tests/tours/ControlButtons.tour.js
@@ -43,6 +43,17 @@ registry.category("web_tour.tours").add("ControlButtonsTour", {
                 internalNote: "test note",
                 withClass: ".selected",
             }),
+            // Check that note is imported if come back to the table
+            FloorScreen.backToFloor(),
+            FloorScreen.clickTable("4"),
+            Order.hasLine({
+                productName: "Water",
+                quantity: "5",
+                price: "10.0",
+                internalNote: "test note",
+                withClass: ".selected",
+            }),
+
             ProductScreen.addOrderline("Water", "8", "1", "8.0"),
 
             // Test PrintBillButton

--- a/addons/pos_self_order/models/pos_order.py
+++ b/addons/pos_self_order/models/pos_order.py
@@ -33,12 +33,6 @@ class PosOrderLine(models.Model):
             del vals['combo_parent_uuid']
         return super().write(vals)
 
-    def _export_for_ui(self, orderline):
-        return {
-            'note': orderline.note,
-            **super()._export_for_ui(orderline),
-        }
-
 class PosOrder(models.Model):
     _inherit = "pos.order"
 


### PR DESCRIPTION
Currently, if you have `pos_restaurant` but not `pos_self_order`, if you add a note on one line of the restaurant order, it visually disappears if you change table and then come back to it.

Steps to reproduce:
-------------------
* Install `pos_restanrant`
* Uninstall `pos_self_order`
* Open the restaurant session
* Select a table and add an item to the order
* Write an internal note
  > You can see the note on the line
* Select **Change table**
* Come back to the previous table
> The note is not visible anymore

Why the fix:
------------
The note added is correctly registered but just invisible to the waiter. It is also visible in the display if you send the order in.

The note field is added by the module `pos_restaurant` but loaded to the ui in `pos_self_order`. Technically the module `pos_self_order` gets auto-installed when `pos_restaurant` is installed but some customer might not have `pos_self_order` if they uninstalled it for example.

`pos_self_order` depends on `pos_restaurant` so we can safely move the code that exports it inside the root module (`pos_restaurant`).

The fix starts in 17.0 as in previous versions it was working fine with only `pos_restaurant` installed.

opw-3917013