### PR TITLE
[16.0][FIX] account: Bank statement line internal_index compute fiels crash for virtual records

### DIFF
--- a/addons/account/models/account_bank_statement_line.py
+++ b/addons/account/models/account_bank_statement_line.py
@@ -253,10 +253,13 @@ class AccountBankStatementLine(models.Model):
         # NOTE: assert self._fields['sequence'].column_type[1] == 'int4'
         # if for any reason it changes (how unlikely), we need to update this code
 
-        for st_line in self.filtered(lambda line: line._origin.id):
-            st_line.internal_index = f'{st_line.date.strftime("%Y%m%d")}' \
-                                      f'{MAXINT - st_line.sequence:0>10}' \
-                                      f'{st_line._origin.id:0>10}'
+        for st_line in self:
+            if not st_line._origin.id:
+                st_line.internal_index = ''
+            else:
+                st_line.internal_index = f'{st_line.date.strftime("%Y%m%d")}' \
+                                        f'{MAXINT - st_line.sequence:0>10}' \
+                                        f'{st_line._origin.id:0>10}'
 
     @api.depends('journal_id', 'currency_id', 'amount', 'foreign_currency_id', 'amount_currency',
                  'move_id.to_check',


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

In bank statement model the field first_line_index is computed depending of internal_index computed field of lines.
https://github.com/Tecnativa/odoo/blob/c50ca7a6885800eb32801aebbcc3a69d71a45d32/addons/account/models/account_bank_statement.py#L117
In lines the field "internal_index" is computed only for existing records
https://github.com/Tecnativa/odoo/blob/c50ca7a6885800eb32801aebbcc3a69d71a45d32/addons/account/models/account_bank_statement.py#L117

**Current behavior before PR:**

In a statement form view with statement lines, if you create a new statement line you have an error because you want not sort by False records

**Desired behavior after PR is merged:**

You can create statement lines in a statement form view

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
