### PR TITLE
[FIX] web_editor: avoid infinite loop during `_onSelectionChange`

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -4286,6 +4286,9 @@ export class OdooEditor extends EventTarget {
      * @param {String} currentKeyPress
      */
     _fixSelectionOnEditableRoot(selection, currentKeyPress) {
+        if (!this.editable.isContentEditable) {
+            return;
+        }
         let nodeAfterCursor = this.editable.childNodes[selection.anchorOffset];
         let nodeBeforeCursor = nodeAfterCursor && nodeAfterCursor.previousElementSibling;
         // Handle arrow key presses.


### PR DESCRIPTION
## Description
On firefox, when posting a message from the full composer with a template with some modifs, the browser falls into an infinite loop of processing events `selectionchange` in a loop ad-infinitum.
When processing the `_onSelectionChange` handle, `_fixSelectionOnEditableRoot` has an assertion that the cursor would be placed on another place than the editable root. But after inlining, the cursor is collapsed in the beginning of the composer, and when normalizing the selection via `getNormalizedCursorPosition` in `setSelection`, the cursor is back in the editable root because it is not editable anymore, which violate the previous assertion.
Instead of fixing `setSelection`, as it's too risky for a stable patch, we enforce the assertion of `_fixSelectionOnEditableRoot` to return early if we are not on the editable root.

## Reference
opw-3950957

PS: special thanks to (nby) and (dmo) for the help :) 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
