### PR TITLE
[FIX] mail: no chatter in dialog

### DIFF
--- a/addons/mail/static/src/chatter/web/form_compiler.js
+++ b/addons/mail/static/src/chatter/web/form_compiler.js
@@ -1,6 +1,6 @@
 import { registry } from "@web/core/registry";
 import { patch } from "@web/core/utils/patch";
-import { append, createElement, setAttributes } from "@web/core/utils/xml";
+import { append, createElement, extractAttributes, setAttributes } from "@web/core/utils/xml";
 import { FormCompiler } from "@web/views/form/form_compiler";
 
 function compileChatter(node, params) {
@@ -97,8 +97,11 @@ patch(FormCompiler.prototype, {
             isInFormSheetBg: `["COMBO", "BOTTOM_CHATTER"].includes(__comp__.mailLayout(${hasPreview}))`,
             isChatterAside: `["SIDE_CHATTER", "EXTERNAL_COMBO_XXL", "EXTERNAL_COMBO"].includes(__comp__.mailLayout(${hasPreview}))`,
         });
+        const { ["t-if"]: tIf } = extractAttributes(chatterContainerHookXml, ["t-if"]);
         setAttributes(chatterContainerHookXml, {
-            "t-if": `!["COMBO", "NONE"].includes(__comp__.mailLayout(${hasPreview}))`,  // opposite of sheetBgChatterContainerHookXml
+            "t-if": `${
+                tIf ? tIf : "true"
+            } and (!["COMBO", "NONE"].includes(__comp__.mailLayout(${hasPreview})))`, // opposite of sheetBgChatterContainerHookXml
             "t-attf-class": `{{ ["SIDE_CHATTER", "EXTERNAL_COMBO_XXL"].includes(__comp__.mailLayout(${hasPreview})) ? "o-aside" : "mt-4 mt-md-0" }}`,
         });
         append(parentXml, chatterContainerHookXml);

--- a/addons/mail/static/src/chatter/web/form_renderer.js
+++ b/addons/mail/static/src/chatter/web/form_renderer.js
@@ -50,16 +50,20 @@ patch(FormRenderer.prototype, {
         const hasChatter = !!this.mailStore;
         const hasExternalWindow = !!this.mailPopoutService.externalWindow;
         if (hasExternalWindow && hasFile && hasAttachmentContainer) {
-            if (xxl) return "EXTERNAL_COMBO_XXL";  //  chatter on the side, attachment in separate tab
-            return "EXTERNAL_COMBO"  // chatter on the bottom, attachment in separate tab
+            if (xxl) {
+                return "EXTERNAL_COMBO_XXL"; // chatter on the side, attachment in separate tab
+            }
+            return "EXTERNAL_COMBO"; // chatter on the bottom, attachment in separate tab
         }
         if (hasChatter) {
             if (xxl) {
-                if (hasAttachmentContainer && hasFile) return "COMBO";  // chatter on the bottom, attachment on the side
-                return "SIDE_CHATTER";  // chatter on the side, no attachment
+                if (hasAttachmentContainer && hasFile) {
+                    return "COMBO"; // chatter on the bottom, attachment on the side
+                }
+                return "SIDE_CHATTER"; // chatter on the side, no attachment
             }
-            return "BOTTOM_CHATTER";  // chatter on the bottom, no attachment
+            return "BOTTOM_CHATTER"; // chatter on the bottom, no attachment
         }
         return "NONE";
-    }
+    },
 });

--- a/addons/mail/static/tests/chatter/web/chatter.test.js
+++ b/addons/mail/static/tests/chatter/web/chatter.test.js
@@ -20,7 +20,13 @@ import {
 import { DELAY_FOR_SPINNER } from "@mail/chatter/web_portal/chatter";
 import { describe, expect, getFixture, test } from "@odoo/hoot";
 import { Deferred, advanceTime } from "@odoo/hoot-mock";
-import { mockService, onRpc, serverState } from "@web/../tests/web_test_helpers";
+import {
+    defineActions,
+    getService,
+    mockService,
+    onRpc,
+    serverState,
+} from "@web/../tests/web_test_helpers";
 
 describe.current.tags("desktop");
 defineMailModels();
@@ -679,4 +685,21 @@ test("Mentions in composer should still work when using pager", async () => {
     await insertText(".o-mail-Composer-input", "@");
     // all records in DB: Mitchell Admin | Hermit | Public user except OdooBot
     await contains(".o-mail-Composer-suggestion", { count: 3 });
+});
+
+test("form views in dialogs do not have chatter", async () => {
+    defineActions([
+        {
+            id: 1,
+            name: "Partner",
+            res_model: "res.partner",
+            type: "ir.actions.act_window",
+            views: [[false, "form"]],
+            target: "new",
+        },
+    ]);
+    await start();
+    await getService("action").doAction(1);
+    await contains(".o_dialog .o_form_view");
+    await contains(".o-mail-Form-Chatter", { count: 0 });
 });


### PR DESCRIPTION
Before this commit, the chatter was shown in dialog when it should never.

Steps to reproduce:
- Install Time Off (`hr_holidays`)
- Open Time Off app
- Click "New Allocation Request" => The chatter is visible in dialog when it shouldn't

This happens because the Chatter hook had a `t-if` on `!env.inDialog`, but it was overridden by another `t-if` on layout. As a result, the view template never took into consideration of `!env.inDialog`.

This commit fixes the issue by properly combining the 2 `t-if` together.

task-3957107

Before
<img width="1280" alt="before" src="https://github.com/odoo/odoo/assets/6569390/2055b456-a728-4d4b-afd0-7a4faeedd96d">

After
<img width="1277" alt="after" src="https://github.com/odoo/odoo/assets/6569390/cec9739d-9a0b-4e8f-9feb-38cd94f767c1">


