### PR TITLE
[FIX] stock: remove company check on quant location_id

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -58,7 +58,7 @@ class StockQuant(models.Model):
     location_id = fields.Many2one(
         'stock.location', 'Location',
         domain=lambda self: self._domain_location_id(),
-        auto_join=True, ondelete='restrict', required=True, index=True, check_company=True)
+        auto_join=True, ondelete='restrict', required=True, index=True)
     warehouse_id = fields.Many2one('stock.warehouse', related='location_id.warehouse_id')
     storage_category_id = fields.Many2one(related='location_id.storage_category_id', store=True)
     cyclic_inventory_frequency = fields.Integer(related='location_id.cyclic_inventory_frequency')


### PR DESCRIPTION
Steps to reproduce:
- Have two companies selected (i.e. San Francisco & Chicago)
- Have 'Storage Locations' option enabled
- Create a product then 'Update Quantity'
- Create a quant and try to select the stock of the other company

Issue:
Only the locations in the first company will be shown. Moreover, in the case of tracked products, if the last quant created was one to a 'transit' location without company (e.g. 'Inter-company transit'), then only internal/transit location without companies will be shown.

The issue comes from the `check_company` clause on the `location_id` field. This will make a check against the `company_id` of the record, which itself is a related field from the location

This doesn't make much sense, as for checking if the company of a location is correct, we check if the company of the location is within the company of the location.

This also introduces the issue mentionned above, as `check_company` will enforce to have ONLY that company & no-company, or just no-company depending on the company of the default location found.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
