### PR TITLE
[FIX] stock: Inter-company feedback

### DIFF
--- a/addons/purchase_stock/tests/test_move_cancel_propagation.py
+++ b/addons/purchase_stock/tests/test_move_cancel_propagation.py
@@ -111,8 +111,7 @@ class TestMoveCancelPropagation(PurchaseTestCommon):
         self.warehouse.write({'delivery_steps': 'pick_ship', 'reception_steps': 'two_steps'})
         self.move.write({
             'picking_id': False,
-            'location_id': self.warehouse.lot_stock_id.id,
-            'location_dest_id': self.warehouse.pick_type_id.default_location_dest_id.id,
+            'picking_type_id': self.warehouse.pick_type_id.id,
             'location_final_id': self.cust_location,
         })
         self.move._action_confirm()
@@ -141,8 +140,7 @@ class TestMoveCancelPropagation(PurchaseTestCommon):
         self.warehouse.write({'delivery_steps': 'pick_ship', 'reception_steps': 'two_steps'})
         self.move.write({
             'picking_id': False,
-            'location_id': self.warehouse.lot_stock_id.id,
-            'location_dest_id': self.warehouse.pick_type_id.default_location_dest_id.id,
+            'picking_type_id': self.warehouse.pick_type_id.id,
             'location_final_id': self.cust_location,
         })
         self.move._action_confirm()
@@ -176,8 +174,7 @@ class TestMoveCancelPropagation(PurchaseTestCommon):
         self.warehouse.write({'delivery_steps': 'pick_pack_ship', 'reception_steps': 'three_steps'})
         self.move.write({
             'picking_id': False,
-            'location_id': self.warehouse.lot_stock_id.id,
-            'location_dest_id': self.warehouse.pick_type_id.default_location_dest_id.id,
+            'picking_type_id': self.warehouse.pick_type_id.id,
             'location_final_id': self.cust_location,
         })
         self.move._action_confirm()
@@ -206,8 +203,7 @@ class TestMoveCancelPropagation(PurchaseTestCommon):
         self.warehouse.write({'delivery_steps': 'pick_pack_ship', 'reception_steps': 'three_steps'})
         self.move.write({
             'picking_id': False,
-            'location_id': self.warehouse.lot_stock_id.id,
-            'location_dest_id': self.warehouse.pick_type_id.default_location_dest_id.id,
+            'picking_type_id': self.warehouse.pick_type_id.id,
             'location_final_id': self.cust_location,
         })
         self.move._action_confirm()

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -583,14 +583,15 @@ Please change the quantity done or the rounding precision of your unit of measur
         for move in self:
             move.show_quant = move.picking_code != 'incoming'\
                            and move.product_id.detailed_type == 'product'
-            move.show_lots_m2o = not move.show_quant\
-                and move.has_tracking != 'none'\
-                and (move.picking_type_id.use_existing_lots or move.state == 'done' or move.origin_returned_move_id.id)
             move.show_lots_text = move.has_tracking != 'none'\
                 and move.picking_type_id.use_create_lots\
                 and not move.picking_type_id.use_existing_lots\
                 and move.state != 'done' \
                 and not move.origin_returned_move_id.id
+            move.show_lots_m2o = not move.show_quant\
+                and not move.show_lots_text\
+                and move.has_tracking != 'none'\
+                and (move.picking_type_id.use_existing_lots or move.state == 'done' or move.origin_returned_move_id.id)
 
     @api.constrains('product_uom')
     def _check_uom(self):

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -205,7 +205,12 @@ class StockMove(models.Model):
                 location_dest = move.picking_id.location_dest_id
             elif move.picking_type_id:
                 location_dest = move.picking_type_id.default_location_dest_id
-            if location_dest and move.location_final_id and move.location_final_id._child_of(location_dest):
+            customer_loc, __ = self.env['stock.warehouse']._get_partner_locations()
+            if location_dest and move.location_final_id and (move.location_final_id._child_of(location_dest) or
+               (location_dest._child_of(customer_loc) and move.partner_id and move.location_final_id._child_of(move.partner_id.property_stock_customer))):
+                # Force the location_final as dest in the following cases:
+                # - The location_final is a sublocation of destination -> Means we reached the end
+                # - The location dest is an out location (i.e. Customers) but the final dest is different (e.g. Inter-Company transfers)
                 location_dest = move.location_final_id
             move.location_dest_id = location_dest
 


### PR DESCRIPTION
Fixes the following issues:
- When moving products to the 'Inter-company transit' location, products were effectively moved to the 'Customers' location instead.
- ~Unable to see lots/serial numbers in locations having no company, such as the 'Customers' location.~
- Duplicate 'Lots/Serial numbers' field in the move details if both 'Create New' & 'Use Existing One' options are picked in the reception picking type.
- ~'No operation made on this lot.' is always displayed in the traceability report after a reload, requiring to leave then re-enter the report instead.~

More information on each issue in its corresponding commit.

task-3853055

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
