### PR TITLE
[FIX] base,base_import: fix perf issue due to too many savepoint

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -731,7 +731,7 @@ class ResPartner(models.Model):
     def _increase_rank(self, field, n=1):
         if self.ids and field in ['customer_rank', 'supplier_rank']:
             try:
-                with self.env.cr.savepoint(flush=False), mute_logger('odoo.sql_db'):
+                with self.env.cr.savepoint(flush=False), mute_logger('odoo.sql_db'): # TODO savepoint definitly in a loop
                     query = sql.SQL("""
                         SELECT {field} FROM res_partner WHERE ID IN %(partner_ids)s FOR NO KEY UPDATE NOWAIT;
                         UPDATE res_partner SET {field} = {field} + %(n)s

--- a/addons/account_edi/models/account_edi_document.py
+++ b/addons/account_edi/models/account_edi_document.py
@@ -224,7 +224,7 @@ class AccountEdiDocument(models.Model):
             move_to_lock = documents.move_id
             attachments_potential_unlink = documents.sudo().attachment_id.filtered(lambda a: not a.res_model and not a.res_id)
             try:
-                with self.env.cr.savepoint(flush=False):
+                with self.env.cr.savepoint(flush=False): # TODO Savepoint in a loop
                     self._cr.execute('SELECT * FROM account_edi_document WHERE id IN %s FOR UPDATE NOWAIT', [tuple(documents.ids)])
                     self._cr.execute('SELECT * FROM account_move WHERE id IN %s FOR UPDATE NOWAIT', [tuple(move_to_lock.ids)])
 

--- a/addons/auth_signup/models/res_users.py
+++ b/addons/auth_signup/models/res_users.py
@@ -219,7 +219,7 @@ class ResUsers(models.Model):
             if not user.email:
                 raise UserError(_("Cannot send email: user %s has no email address.", user.name))
             email_values['email_to'] = user.email
-            with contextlib.closing(self.env.cr.savepoint()):
+            with contextlib.closing(self.env.cr.savepoint()): # TODO savepoint in loop
                 if account_created_template:
                     account_created_template.send_mail(
                         user.id, force_send=True,

--- a/addons/base_import/models/base_import.py
+++ b/addons/base_import/models/base_import.py
@@ -1308,8 +1308,7 @@ class Import(models.TransientModel):
         :rtype: dict(ids: list(int), messages: list({type, message, record}))
         """
         self.ensure_one()
-        self._cr.execute('SAVEPOINT import')
-
+        savepoint = self._cr.savepoint()
         try:
             input_file_data, import_fields = self._convert_import_data(fields, options)
             # Parse date and float field
@@ -1344,14 +1343,14 @@ class Import(models.TransientModel):
         #       error in the results.
         try:
             if dryrun:
-                self._cr.execute('ROLLBACK TO SAVEPOINT import')
+                savepoint.rollback()
                 # cancel all changes done to the registry/ormcache
                 # we need to clear the cache in case any created id was added to an ormcache and would be missing afterward
                 self.pool.clear_all_caches()
                 # don't propagate to other workers since it was rollbacked
                 self.pool.reset_changes()
             else:
-                self._cr.execute('RELEASE SAVEPOINT import')
+                savepoint.close(rollback=False)
         except psycopg2.InternalError:
             pass
 

--- a/addons/base_import/models/base_import.py
+++ b/addons/base_import/models/base_import.py
@@ -1308,7 +1308,7 @@ class Import(models.TransientModel):
         :rtype: dict(ids: list(int), messages: list({type, message, record}))
         """
         self.ensure_one()
-        savepoint = self._cr.savepoint()
+        savepoint = self._cr.savepoint(flush=False)
         try:
             input_file_data, import_fields = self._convert_import_data(fields, options)
             # Parse date and float field

--- a/addons/crm_iap_enrich/models/crm_lead.py
+++ b/addons/crm_iap_enrich/models/crm_lead.py
@@ -53,7 +53,7 @@ class Lead(models.Model):
         batches = [self[index:index + 50] for index in range(0, len(self), 50)]
         for leads in batches:
             lead_emails = {}
-            with self._cr.savepoint():
+            with self._cr.savepoint():  # TODO savepoint in loop
                 try:
                     self._cr.execute(
                         "SELECT 1 FROM {} WHERE id in %(lead_ids)s FOR UPDATE NOWAIT".format(self._table),

--- a/addons/hr_contract/models/hr_contract.py
+++ b/addons/hr_contract/models/hr_contract.py
@@ -249,7 +249,7 @@ class Contract(models.Model):
             auto_commit = not getattr(threading.current_thread(), 'testing', False)
             for contract in self:
                 try:
-                    with self.env.cr.savepoint():
+                    with self.env.cr.savepoint():  # TODO savepoint in loop, use transaction commit and rollback
                         contract.write(vals)
                 except ValidationError as e:
                     _logger.warning(e)

--- a/addons/product/models/product_template_attribute_line.py
+++ b/addons/product/models/product_template_attribute_line.py
@@ -170,7 +170,7 @@ class ProductTemplateAttributeLine(models.Model):
         ptal_to_archive = self.env['product.template.attribute.line']
         for ptal in self:
             try:
-                with self.env.cr.savepoint(), tools.mute_logger('odoo.sql_db'):
+                with self.env.cr.savepoint(), tools.mute_logger('odoo.sql_db'): # TODO savepoint in loop
                     super(ProductTemplateAttributeLine, ptal).unlink()
             except Exception:
                 # We catch all kind of exceptions to be sure that the operation

--- a/addons/product/models/product_template_attribute_value.py
+++ b/addons/product/models/product_template_attribute_value.py
@@ -139,7 +139,7 @@ class ProductTemplateAttributeValue(models.Model):
         ptav_to_archive = self.env['product.template.attribute.value']
         for ptav in self:
             try:
-                with self.env.cr.savepoint(), tools.mute_logger('odoo.sql_db'):
+                with self.env.cr.savepoint(), tools.mute_logger('odoo.sql_db'): # TODO savepoint in loop
                     super(ProductTemplateAttributeValue, ptav).unlink()
             except Exception:
                 # We catch all kind of exceptions to be sure that the operation

--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -561,7 +561,7 @@ class StockWarehouseOrderpoint(models.Model):
                                 orderpoint.company_id, values))
 
                     try:
-                        with self.env.cr.savepoint():
+                        with self.env.cr.savepoint(): # TODO savepoint in a loop
                             self.env['procurement.group'].with_context(from_orderpoint=True).run(procurements, raise_user_error=raise_user_error)
                     except ProcurementException as errors:
                         orderpoints_exceptions = []

--- a/odoo/addons/base/models/ir_fields.py
+++ b/odoo/addons/base/models/ir_fields.py
@@ -470,7 +470,7 @@ class IrFieldsConverter(models.AbstractModel):
                 name_create_enabled_fields = self.env.context.get('name_create_enabled_fields') or {}
                 if name_create_enabled_fields.get(field.name):
                     try:
-                        with self.env.cr.savepoint():
+                        with self.env.cr.savepoint():  # TODO savepoint that may be in a loop
                             id, _name = RelatedModel.name_create(name=value)
                     except (Exception, psycopg2.IntegrityError):
                         error_msg = _("Cannot create new '%s' records from their name alone. Please create those records manually and try importing again.", RelatedModel._description)

--- a/odoo/addons/base/models/res_users_deletion.py
+++ b/odoo/addons/base/models/res_users_deletion.py
@@ -62,19 +62,18 @@ class ResUsersDeletion(models.Model):
             user_name = user.name
             requester_name = delete_request.create_uid.name
             # Step 1: Delete User
-            try:
-                self.env.cr.execute("SAVEPOINT delete_user")
-                partner = user.partner_id
-                user.unlink()
-                _logger.info("User #%i %r, deleted. Original request from %r.",
-                             user.id, user_name, delete_request.create_uid.name)
-                self.env.cr.execute("RELEASE SAVEPOINT delete_user")
-                delete_request.state = 'done'
-            except Exception as e:
-                _logger.error("User #%i %r could not be deleted. Original request from %r. Related error: %s",
-                             user.id, user_name, requester_name, e)
-                self.env.cr.execute("ROLLBACK TO SAVEPOINT delete_user")
-                delete_request.state = "fail"
+            with self.env.cr.savepoint() as savepoint:  # TODO savepoint in loop, it could be a commit
+                try:
+                    partner = user.partner_id
+                    user.unlink()
+                    _logger.info("User #%i %r, deleted. Original request from %r.",
+                                user.id, user_name, delete_request.create_uid.name)
+                    delete_request.state = 'done'
+                except Exception as e:  # noqa: BLE001
+                    _logger.error("User #%i %r could not be deleted. Original request from %r. Related error: %s",
+                                user.id, user_name, requester_name, e)
+                    savepoint.rollback()
+                    delete_request.state = "fail"
             # make sure we never rollback the work we've done, this can take a long time
             if auto_commit:
                 self.env.cr.commit()
@@ -83,16 +82,15 @@ class ResUsersDeletion(models.Model):
 
             # Step 2: Delete Linked Partner
             #         Could be impossible if the partner is linked to a SO for example
-            try:
-                self.env.cr.execute("SAVEPOINT delete_partner")
-                partner.unlink()
-                _logger.info("Partner #%i %r, deleted. Original request from %r.",
-                             partner.id, user_name, delete_request.create_uid.name)
-                self.env.cr.execute("RELEASE SAVEPOINT delete_partner")
-            except Exception as e:
-                _logger.warning("Partner #%i %r could not be deleted. Original request from %r. Related error: %s",
-                             partner.id, user_name, requester_name, e)
-                self.env.cr.execute("ROLLBACK TO SAVEPOINT delete_partner")
+            with self.env.cr.savepoint() as savepoint:
+                try:
+                    partner.unlink()
+                    _logger.info("Partner #%i %r, deleted. Original request from %r.",
+                                partner.id, user_name, delete_request.create_uid.name)
+                except Exception as e:  # noqa: BLE001
+                    _logger.warning("Partner #%i %r could not be deleted. Original request from %r. Related error: %s",
+                                partner.id, user_name, requester_name, e)
+                    savepoint.rollback()
             # make sure we never rollback the work we've done, this can take a long time
             if auto_commit:
                 self.env.cr.commit()

--- a/odoo/addons/base/models/res_users_deletion.py
+++ b/odoo/addons/base/models/res_users_deletion.py
@@ -62,7 +62,7 @@ class ResUsersDeletion(models.Model):
             user_name = user.name
             requester_name = delete_request.create_uid.name
             # Step 1: Delete User
-            with self.env.cr.savepoint() as savepoint:  # TODO savepoint in loop, it could be a commit
+            with self.env.cr.savepoint(flush=False) as savepoint:  # TODO savepoint in loop, it could be a commit
                 try:
                     partner = user.partner_id
                     user.unlink()
@@ -82,7 +82,7 @@ class ResUsersDeletion(models.Model):
 
             # Step 2: Delete Linked Partner
             #         Could be impossible if the partner is linked to a SO for example
-            with self.env.cr.savepoint() as savepoint:
+            with self.env.cr.savepoint(flush=False) as savepoint:
                 try:
                     partner.unlink()
                     _logger.info("Partner #%i %r, deleted. Original request from %r.",

--- a/odoo/addons/base/wizard/base_partner_merge.py
+++ b/odoo/addons/base/wizard/base_partner_merge.py
@@ -151,7 +151,7 @@ class MergePartnerAutomatic(models.TransientModel):
                     self._cr.execute(query, (dst_partner.id, partner.id, dst_partner.id))
             else:
                 try:
-                    with mute_logger('odoo.sql_db'), self._cr.savepoint():
+                    with mute_logger('odoo.sql_db'), self._cr.savepoint():  # TODO savepoint in loop
                         query = 'UPDATE "%(table)s" SET "%(column)s" = %%s WHERE "%(column)s" IN %%s' % query_dic
                         self._cr.execute(query, (dst_partner.id, tuple(src_partners.ids),))
                 except psycopg2.Error:

--- a/odoo/addons/test_impex/tests/test_load.py
+++ b/odoo/addons/test_impex/tests/test_load.py
@@ -1478,3 +1478,16 @@ class test_inherits(ImporterCase):
             parent._get_external_ids()[parent.id],
             ['xxx.parent'],
         )
+
+
+class CheckSavepoint(ImporterCase):
+    model_name = 'export.unique'
+
+    @mute_logger("odoo.sql_db")
+    def test_max_savepoint(self):
+        savepoint_start = self.env.cr.savepoint_count
+        data = [[str(i)] for i in range(100)] + [[str(i)] for i in range(20)]
+        self.import_(['value'], data)
+        current_savepoint = self.env.cr.savepoint_count - savepoint_start
+        self.assertTrue(current_savepoint < 100, "Too many savepoints in the same transaction (current %d), load method should not create a savepoint for each record" % current_savepoint)
+        self.assertEqual(current_savepoint, 3, "Too many savepoints in the same transaction (current %d)" % current_savepoint)

--- a/odoo/sql_db.py
+++ b/odoo/sql_db.py
@@ -42,6 +42,7 @@ psycopg2.extensions.register_type(psycopg2.extensions.new_array_type((1231,), 'f
 
 _logger = logging.getLogger(__name__)
 _logger_conn = _logger.getChild("connection")
+_logger_savepoint = logging.getLogger("odoo.savepoint.count")
 
 real_time = time.time.__call__  # ensure we have a non patched time for query times when using freezegun
 
@@ -91,6 +92,8 @@ class Savepoint:
         self._cr = cr
         self.closed = False
         cr.execute('SAVEPOINT "%s"' % self.name)
+        if hasattr(self._cr, '_increase_savepoint_count'):
+            self._cr._increase_savepoint_count()
 
     def __enter__(self):
         return self
@@ -144,6 +147,10 @@ class BaseCursor:
         # for managing environments is instantiated by registry.cursor().  It
         # is not done here in order to avoid cyclic module dependencies.
         self.transaction = None
+        self.savepoint_count = 0
+
+    def _increase_savepoint_count(self):
+        self.savepoint_count += 1
 
     def flush(self):
         """ Flush the current transaction, and run precommit hooks. """
@@ -290,6 +297,17 @@ class Cursor(BaseCursor):
 
         self.cache = {}
         self._now = None
+
+    def _increase_savepoint_count(self):
+        super()._increase_savepoint_count()
+        # This is not an abitrary number but linked to the size of the shared memory size that store sub trans info
+        stack_info = False
+        if self.savepoint_count % 10 == 0 and odoo.registry(self.dbname).ready:
+            stack_info = True
+        _logger_savepoint.info("New savepoint: savepoint count %s", self.savepoint_count, stack_info=stack_info)
+
+    def _clear_savepoint_count(self):
+        self.savepoint_count = 0
 
     def __build_dict(self, row):
         return {d.name: row[i] for i, d in enumerate(self._obj.description)}
@@ -475,6 +493,7 @@ class Cursor(BaseCursor):
         self.prerollback.clear()
         self.postrollback.clear()
         self.postcommit.run()
+        self._clear_savepoint_count()
         return result
 
     def rollback(self):
@@ -485,6 +504,7 @@ class Cursor(BaseCursor):
         result = self._cnx.rollback()
         self._now = None
         self.postrollback.run()
+        self._clear_savepoint_count()
         return result
 
     def __getattr__(self, name):

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -846,6 +846,7 @@ class TransactionCase(BaseCase):
         self._savepoint_id = next(savepoint_seq)
         self.cr.execute('SAVEPOINT test_%d' % self._savepoint_id)
         self.addCleanup(self.cr.execute, 'ROLLBACK TO SAVEPOINT test_%d' % self._savepoint_id)
+        self.addCleanup(self.cr._clear_savepoint_count)
 
 
 class SingleTransactionCase(BaseCase):


### PR DESCRIPTION
Global Issue
-----

Each time a save point is created inside a transaction, it creates a
substransaction with its own subxid. As said in the documentation
"The more subtransactions each transaction keeps open (not rolled back or released),
the greater the transaction management overhead. Up to 64 open subxids are cached in shared memory for each backend;
after that point, the storage I/O overhead increases significantly due to additional lookups of subxid entries in pg_subtrans."

https://www.postgresql.org/docs/current/subxacts.html

When the 64 is reach, it causes a huge I/O overhead (waiting for subtrans LRU) on every
transaction and lead to a complete freeze until the transaction that
create that many savepoints is killed.

Problem 1
---------

This amount of save point is reach during an import that eventually
failed. It retries with one savepoint per record. After 10 errors, the
import stops but if those error happen after few hundred correct line.
Hundreds of save point are created with their respective sub transaction
id.

Solution: We only create one savepoint when the import retries for
every record and rollback each time the import face an error.

As consequence, if record depends on previous one imported before the
rollback, some phantom error will appear and if some record sould be in
error due to previous record (unique constraint for ie.) some error can
be missed. Anyway the first error will remain correct.

In addition, in this PR we want to monitor the number of savepoint per
transaction and fire a warning with the stack info when the limit of 60 savepoint per
transaction is reached.

In order to monitor properly all the savepoint, we need to convert the
last cr.execute("SAVEPOINT") to the context manager

Problem 2
---------

Increase rank is call during _post once per partner.
Since https://github.com/odoo/odoo/commit/f12ce318020169b1355538066a8f81f78ecbf007
_do_action_change_account trigger the increase the rank of many partner
in one transaction.

By grouping the call of increase rank by count it reduce drastically the
amount of call to increase_rank and thus the number of savepoint