### PR TITLE
[FIX] l10n_it_edi: Fix import xml with multiple discounts in line

### DIFF
--- a/addons/l10n_it_edi/models/account_move.py
+++ b/addons/l10n_it_edi/models/account_move.py
@@ -1097,9 +1097,9 @@ class AccountMove(models.Model):
 
         # Discounts
         if elements := element.xpath('.//ScontoMaggiorazione'):
-            element = elements[0]
             # Special case of only 1 percentage discount
             if len(elements) == 1:
+                element = elements[0]
                 if discount_percentage := get_float(element, './/Percentuale'):
                     discount_type = get_text(element, './/Tipo')
                     discount_sign = -1 if discount_type == 'MG' else 1

--- a/addons/l10n_it_edi/tests/test_edi_import.py
+++ b/addons/l10n_it_edi/tests/test_edi_import.py
@@ -228,3 +228,39 @@ class TestItEdiImport(TestItEdi):
                 }
             ],
         }], applied_xml)
+
+    def test_receive_bill_with_multiple_discounts_in_line(self):
+        applied_xml = """
+            <xpath expr="//FatturaElettronicaBody/DatiBeniServizi/DettaglioLinee[1]" position="inside">
+                <ScontoMaggiorazione>
+                    <Tipo>SC</Tipo>
+                    <Percentuale>50.00</Percentuale>
+                </ScontoMaggiorazione>
+                <ScontoMaggiorazione>
+                    <Tipo>SC</Tipo>
+                    <Percentuale>25.00</Percentuale>
+                </ScontoMaggiorazione>
+                <ScontoMaggiorazione>
+                    <Tipo>SC</Tipo>
+                    <Percentuale>20.00</Percentuale>
+                </ScontoMaggiorazione>
+            </xpath>
+
+            <xpath expr="//FatturaElettronicaBody/DatiBeniServizi/DettaglioLinee[1]/PrezzoTotale" position="replace">
+                <PrezzoTotale>1.50</PrezzoTotale>
+            </xpath>
+        """
+
+        self._assert_import_invoice('IT01234567890_FPR01.xml', [{
+            'invoice_date': fields.Date.from_string('2014-12-18'),
+            'amount_untaxed': 1.5,
+            'amount_tax': 0.33,
+            'invoice_line_ids': [
+                {
+                    'quantity': 5.0,
+                    'name': 'DESCRIZIONE DELLA FORNITURA',
+                    'price_unit': 1.0,
+                    'discount': 70.0,
+                }
+            ],
+        }], applied_xml)


### PR DESCRIPTION
When importing XML invoice with multiple discounts in a line, the discount is not calculated correctly.

task-3945345


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
