### PR TITLE
[FIX] account: align 'on' on report invoice pdfs

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -355,7 +355,7 @@
                     <t t-else="">
                         <td>
                             <span t-out="amount_by_group['tax_group_name']">Tax 15%</span>
-                             on 
+                            <span> on </span>
                             <span class="text-nowrap" t-out="amount_by_group['formatted_tax_group_base_amount']">27.00</span>
                         </td>
                         <td class="text-end o_price_total">
@@ -391,7 +391,7 @@
                                 <t t-if="tax_totals['display_tax_base']">
                                     <td>
                                         <span t-out="amount_by_group['tax_group_name']">Tax 15%</span>
-                                         on 
+                                        <span> on </span>
                                         <span class="text-nowrap" t-out="amount_by_group['tax_group_base_amount_company_currency']"
                                                t-options='{"widget": "monetary", "display_currency": o.company_currency_id}'>
                                                27.00


### PR DESCRIPTION
Problem
---
When printing invoices involving different tax groups (from the actions in the invoice form view), the text baseline for the word 'on' and the rest of the text ("<tax_name> on <corresponding_amount>") in the taxes summary are different. (ie the word is misaligned)

Steps
---
IMPORTANT: the bug only appears on newer (~`0.13`) versions of `wkhtmltopdf`
* create an invoice for 2 products,
* make the products use different taxes, form at least 2 different tax groups (if needed configure in Accounting > Configuration > Taxes)
* Actions (cog) > print > Invoices => on the generated pdf the word 'on' is misaligned

Note
---
Fix tested on `wkhtmtopdf 0.13`.
On `wkhtmltopdf 0.12.6` -> already worked, but fix has no visual effect

---
opw-3940888
