### PR TITLE
[FIX] sale_stock: prevent negative delivered qty in multi-step delivery returns

### DIFF
--- a/addons/sale_mrp/models/sale_order_line.py
+++ b/addons/sale_mrp/models/sale_order_line.py
@@ -137,7 +137,7 @@ class SaleOrderLine(models.Model):
             )),
             'outgoing_moves': lambda m: (
                 m.state != 'cancel' and not m.scrapped
-                and m.location_dest_id.usage != 'customer' and m.to_refund
+                and m.location_dest_id.usage != 'customer' and m.location_id.usage == "customer" and m.to_refund
             ),
         }
 

--- a/addons/sale_stock/models/sale_order_line.py
+++ b/addons/sale_stock/models/sale_order_line.py
@@ -171,7 +171,7 @@ class SaleOrderLine(models.Model):
         for line in self:  # TODO: maybe one day, this should be done in SQL for performance sake
             if line.qty_delivered_method == 'stock_move':
                 qty = 0.0
-                outgoing_moves, incoming_moves = line._get_outgoing_incoming_moves()
+                outgoing_moves, incoming_moves = line._get_outgoing_incoming_moves(strict=True)
                 for move in outgoing_moves:
                     if move.state != 'done':
                         continue
@@ -288,7 +288,7 @@ class SaleOrderLine(models.Model):
                (not strict and move.rule_id.id in triggering_rule_ids and move.location_final_id.usage == "customer"):
                 if not move.origin_returned_move_id or (move.origin_returned_move_id and move.to_refund):
                     outgoing_moves |= move
-            elif move.location_id.usage == "customer" and move.to_refund:
+            elif move.location_dest_id.usage != "customer" and move.location_id.usage == "customer" and move.to_refund:
                 incoming_moves |= move
 
         return outgoing_moves, incoming_moves


### PR DESCRIPTION
## Issue:
- When multi-step delivery is enabled, validating then issuing a partial or full return on the first step (E.G. WH/Stock to WH/Output) results in negative values on the SO delivered quantity field.

## Steps To Reproduce:
- Enable multi-Step routes in settings.
- Go to warehouses and on the main Warehouse set Outgoing Shipments to "Send goods in output and then deliver (2 steps)"
- go to a product category and set up the 2 steps route on it.
- create a SO and select a product with a quantity more than 1 from the category save then validate
- the first delivery will appear (from WH/Stocl to WH/Output)
- Validate it and then press return and either fill a partial or full return.
- go back to the sales order page you will notice the the delivered quantity is negative of what was returned on the previous step which is wrong.

## Solution:
- The strict mode in sale_stock's `_get_outgoing_incoming_moves` method only considers moves strictly delivered to customers. Despite calling this method with strict=True in `_compute_qty_delivered`, the issue persisted.
- The problem was identified at the end of `_get_outgoing_incoming_moves`, where the method incorrectly accounts for returns. It checks that the return destination's usage is not "customer" but fails to verify if the source is "customer."
- Added a condition to ensure that the source location's usage is "customer" for return moves.

opw-3933009

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
