### PR TITLE
[PERF] stock: only force prefetch for non-cached records

### DIFF
--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -1549,6 +1549,7 @@ class TestMrpOrder(TestMrpCommon):
         (move1 | move2 | move3)._action_confirm()
 
         mo.invalidate_cache(['components_availability', 'components_availability_state'], mo.ids)
+        mo.move_raw_ids.invalidate_cache(['forecast_availability', 'forecast_expected_date'], mo.move_raw_ids.ids)
         self.assertEqual(mo.components_availability, f'Exp {format_date(self.env, tommorrow)}')
         self.assertEqual(mo.components_availability_state, 'late')
 
@@ -1561,6 +1562,7 @@ class TestMrpOrder(TestMrpCommon):
         (move1 | move2 | move3)._action_done()
 
         mo.invalidate_cache(['components_availability', 'components_availability_state'], mo.ids)
+        mo.move_raw_ids.invalidate_cache(['forecast_availability', 'forecast_expected_date'], mo.move_raw_ids.ids)
         self.assertEqual(mo.components_availability, 'Available')
         self.assertEqual(mo.components_availability_state, 'available')
 


### PR DESCRIPTION
Before this commit, `mrp.production._compute_components_availability` and `stock.picking._compute_products_availability` methods would force prefetching/computing of `forecast_availability` on all related moves by more than 1000 at a time by calling `all_moves._fields['forecast_availability'].compute_value(all_moves)`.

This is an issue when the `_compute_xxx_availability` methods are called multiple times in the same request, as we could be missing potential cache hits of `forecast_availability`, because we always recompute it regardless of if it had already been computed.

In this commit I propose adding a check to only force compute the `forecast_availability` of moves whose `forecast_availability` is not already cached.

Since `stock.move._compute_forecast_information` is very slow, this can mean the difference of many seconds in situations where `_compute_xxx_availability` is called multiple times in one request.

As this gets forward ported, there is also a `repair.order._compute_parts_availability` method which would need this fix applied.

Log line stats for editing the quantity of an operation on a picking, which triggers an onchange that calls `_compute_products_availability` three times. (Sorry this is quite unspecific, I can attach a video of how to reproduce in the customer's database on their Help ticket. If a more reproducible example is desired please let me know.)

|                                          | # queries | SQL time | Odoo time |
|------------------------------------------|-----------|----------|-----------|
| before-commit                            | 7021      | 1.210 s  | 8.939 s   |
| after-commit                             | 7013      | 1.100 s  | 3.809 s  |
| after-commit + PR #166784                | 71        | 0.105 s  | 2.435 s   |

The PR https://github.com/odoo/odoo/pull/166784 stats are included just to show that there is not much more to be done in this PR to improve the query count, but that is addressed in the other PR.

(Note that the customer's database is 17.0, not 15.0 - but I figured this could be made in 15.0 and fw-ported.)

opw-3918816