### PR TITLE
[PERF] point_of_sale: use cache to avoid calls to get raw()

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -279,6 +279,8 @@ export class PosStore extends Reactive {
         const date = DateTime.now();
         let pricelistItems = this.models["product.pricelist.item"].getAll();
         let products = this.models["product.product"].getAll();
+        let pricelistItemsRaw = new Map(pricelistItems.map((item) => [item.id, item.raw]));
+        let productsRaw = new Map(products.map((product) => [product.id, product.raw]));
 
         if (data && data.length > 0) {
             if (data[0].model.modelName === "product.product") {
@@ -297,8 +299,10 @@ export class PosStore extends Reactive {
 
         for (const product of products) {
             const applicableRules = {};
+            const productRaw = productsRaw.get(product.id);
 
             for (const item of pricelistItems) {
+                const itemRaw = pricelistItemsRaw.get(item.id);
                 if (!applicableRules[item.pricelist_id.id]) {
                     applicableRules[item.pricelist_id.id] = [];
                 }
@@ -307,14 +311,14 @@ export class PosStore extends Reactive {
                     continue;
                 }
 
-                if (item.raw.product_id && product.id === item.raw.product_id) {
+                if (itemRaw.product_id && product.id === itemRaw.product_id) {
                     applicableRules[item.pricelist_id.id].push(item);
                 } else if (
-                    !item.raw.product_id && item.raw.product_tmpl_id &&
-                    product.raw?.product_tmpl_id === item.raw.product_tmpl_id
+                    !itemRaw.product_id && itemRaw.product_tmpl_id &&
+                    productRaw?.product_tmpl_id === itemRaw.product_tmpl_id
                 ) {
                     applicableRules[item.pricelist_id.id].push(item);
-                } else if (!item.raw.product_tmpl_id && !item.raw.product_id) {
+                } else if (!itemRaw.product_tmpl_id && !itemRaw.product_id) {
                     applicableRules[item.pricelist_id.id].push(item);
                 }
             }


### PR DESCRIPTION
In `computeProductPricelistCache` there are lots of calls to item.raw/product.raw. These calls are located inside nested for loop so the property `raw` is called on average `O(len(products) * len(pricelistItems)`.

Because this property is fixed during the loop iterations, this commit introduces two small maps at the beginning of the function to store the raw property of `pricelistItems` and `products`. That way, you only call the property `O(len(products) + len(pricelistItems))`, leading to an overall speedup of the function, especially when there are lots of products and pricelistItems to load at the opening of a pos.session.

#### speedup

Customer database with 1001 products and 1993 pricelistItems. JS scripting time at session opening: 
 - 25s -> 6s.

opw-3878882

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
