### PR TITLE
[IMP] project: generic improvement for project app

### DIFF
--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -87,7 +87,7 @@ class Project(models.Model):
 
     favorite_user_ids = fields.Many2many(
         'res.users', 'project_favorite_user_rel', 'project_id', 'user_id',
-        string='Members', export_string_translation=False)
+        string='Members', export_string_translation=False, copy=False)
     is_favorite = fields.Boolean(compute='_compute_is_favorite', readonly=False, search='_search_is_favorite',
         compute_sudo=True, string='Show Project on Dashboard', export_string_translation=False)
     label_tasks = fields.Char(string='Use Tasks as', default=lambda s: _('Tasks'), translate=True,

--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -336,6 +336,7 @@
                     <div name="alias_def" class="mt-2" colspan="2">
                         <label for="alias_name" string="Create tasks by sending an email to"/>
                         <span>
+                            <field name="alias_id" invisible="1"/>
                             <field name="alias_name" placeholder="e.g. office-party"/>@
                             <field name="alias_domain_id" class="oe_inline" placeholder="e.g. mycompany.com"
                                    options="{'no_create': True, 'no_open': True}"/>


### PR DESCRIPTION
This PR addresses two points:

- When duplicating a favourite project, the copy project will not be favourite.
- When creating a new project, the alias domain will be automatically set as
 the company's default alias domain.

task-3940556



