### PR TITLE
[FIX] l10n_in: compute hsn code from product

### DIFF
--- a/addons/l10n_in/models/account_move_line.py
+++ b/addons/l10n_in/models/account_move_line.py
@@ -6,10 +6,8 @@ class AccountMoveLine(models.Model):
 
     l10n_in_hsn_code = fields.Char(string="HSN/SAC Code", compute="_compute_l10n_in_hsn_code", store=True, readonly=False, copy=False)
 
-    @api.depends('product_id')
+    @api.depends('product_id', 'product_id.l10n_in_hsn_code')
     def _compute_l10n_in_hsn_code(self):
-        indian_lines = self.filtered(lambda line: line.company_id.account_fiscal_country_id.code == 'IN')
-        (self - indian_lines).l10n_in_hsn_code = False
-        for line in indian_lines:
-            if line.product_id:
+        for line in self:
+            if line.move_id.country_code == 'IN' and line.parent_state == 'draft':
                 line.l10n_in_hsn_code = line.product_id.l10n_in_hsn_code


### PR DESCRIPTION
Before this commit:
creating a move line with a product without hsn code and later adding the hsn code on the product. The
hsn code on the move line doesn't get updated

After this commit:
We solve the above issue and add dependency
of `product_id.l10n_in_hsn_code` on the compute
method

task-3958797

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
