### PR TITLE
[FIX] sales_team: remove default company

### DIFF
--- a/addons/crm/tests/test_crm_lead.py
+++ b/addons/crm/tests/test_crm_lead.py
@@ -768,18 +768,22 @@ class TestCRMLead(TestCrmCommon):
 
         user_team_leads, team_leads, user_team_opport, team_opport = self.env['crm.team'].create([{
             'name': 'UserTeamLeads',
+            'company_id': self.env.company.id,
             'use_leads': True,
             'member_ids': [(6, 0, [self.env.user.id])],
         }, {
             'name': 'TeamLeads',
+            'company_id': self.env.company.id,
             'use_leads': True,
             'member_ids': [],
         }, {
             'name': 'UserTeamOpportunities',
+            'company_id': self.env.company.id,
             'use_leads': False,
             'member_ids': [(6, 0, [self.env.user.id])],
         }, {
             'name': 'TeamOpportunities',
+            'company_id': self.env.company.id,
             'use_leads': False,
             'member_ids': [],
         }])

--- a/addons/sales_team/models/crm_team.py
+++ b/addons/sales_team/models/crm_team.py
@@ -92,8 +92,7 @@ class CrmTeam(models.Model):
     sequence = fields.Integer('Sequence', default=10)
     active = fields.Boolean(default=True, help="If the active field is set to false, it will allow you to hide the Sales Team without removing it.")
     company_id = fields.Many2one(
-        'res.company', string='Company', index=True,
-        default=lambda self: self.env.company)
+        'res.company', string='Company', index=True)
     currency_id = fields.Many2one(
         "res.currency", string="Currency",
         related='company_id.currency_id', readonly=True)


### PR DESCRIPTION
Purpose
=======
Remove the default company set when manually creating a sales team.

Specification
=============
The sales teams automatically created with the database don't have any company set by default, however when manually creating a sales team the user company gets assigned to it.
Do not auto-set a company for a sales team as this brings a lot of problem and incoherences with the automatically created sales teams. The sales teams can easily be shared, not setting a default company makes life far easier.

Task-3916614

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
