### PR TITLE
[FIX] website_sale: fix error on abandoned cart computation

### DIFF
--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -53,7 +53,7 @@ class SaleOrder(models.Model):
             # a quotation can be considered as an abandonned cart if it is linked to a website,
             # is in the 'draft' state and has an expiration date
             if order.website_id and order.state == 'draft' and order.date_order:
-                public_partner_id = order.website_id.user_id.partner_id
+                public_partner_id = order.website_id.user_id.sudo().partner_id
                 # by default the expiration date is 1 hour if not specified on the website configuration
                 abandoned_delay = order.website_id.cart_abandoned_delay or 1.0
                 abandoned_datetime = datetime.utcnow() - relativedelta(hours=abandoned_delay)


### PR DESCRIPTION
the public user associated with website does not need to be same company like current user's company and also allowed company different then current user company and it's public user so always archived. when this happens, we could get multi company issue when trying to
compute abandoned cart and try to find public
partner for that website.

issue is triggered , when partner of the associated user is marked as partner_share = True. we may get an access error due to the rule `base.res_partner_rule`.

steps to  reproduce:
1. install website_sale module
2. create an extra company and create public user (A) on it. Ensure the partner of A is also set as belonging to this second company.
3. create extra website also and associated this user (A) to that website.
4. User (A) is public user so it's already archived (this makes the partner of (A) get partner_share = True)
5. Try to access or open sale order

we get an error:

```
USER (id=2) does not have 'read' access right to:
- Public User (res.users)

If you need access, ask an administrator.
```

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
