### PR TITLE
[FIX] purchase_stock: qty_done doesn't exist

### DIFF
--- a/addons/purchase_stock/tests/test_stockvaluation.py
+++ b/addons/purchase_stock/tests/test_stockvaluation.py
@@ -821,7 +821,7 @@ class TestStockValuationWithCOA(AccountTestInvoicingCommon):
         }).action_post()
 
         receipt = po.picking_ids
-        receipt.move_line_ids.qty_done = 1
+        receipt.move_ids.picked = True
         receipt.button_validate()
 
         product_aml = po.invoice_ids.line_ids.filtered('product_id')


### PR DESCRIPTION
Due to change in 17.0 qty_done become picked on the stock.move

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
