### PR TITLE
[IMP] mail, im_livechat: change canned response shortcut

### DIFF
--- a/addons/im_livechat/static/src/core/web/suggestion_service_patch.js
+++ b/addons/im_livechat/static/src/core/web/suggestion_service_patch.js
@@ -6,8 +6,6 @@ patch(SuggestionService.prototype, {
     /** @override */
     getSupportedDelimiters(thread) {
         const res = super.getSupportedDelimiters(...arguments);
-        return thread.channel_type === "livechat"
-            ? res.filter((delimiter) => delimiter.at(0) !== "#")
-            : res;
+        return thread.channel_type === "livechat" ? res.filter(({ id }) => id !== "channel") : res;
     },
 });

--- a/addons/im_livechat/static/tests/suggestions.test.js
+++ b/addons/im_livechat/static/tests/suggestions.test.js
@@ -12,7 +12,7 @@ import { defineLivechatModels } from "./livechat_test_helpers";
 describe.current.tags("desktop");
 defineLivechatModels();
 
-test("Suggestions are shown after delimiter was used in text (:)", async () => {
+test("Suggestions are shown after delimiter was used in text (: + letter)", async () => {
     const pyEnv = await startServer();
     pyEnv["mail.canned.response"].create({
         source: "hello",
@@ -28,12 +28,14 @@ test("Suggestions are shown after delimiter was used in text (:)", async () => {
     });
     await start();
     await openDiscuss(channelId);
-    await insertText(".o-mail-Composer-input", ":");
+    await insertText(".o-mail-Composer-input", ":h");
+    await contains(".o-mail-Composer-suggestion strong", { text: "hello" });
+    await insertText(".o-mail-Composer-input", ":", { replace: true });
+    await contains(".o-mail-Composer-suggestion strong", { count: 0 });
+    await insertText(".o-mail-Composer-input", "h");
     await contains(".o-mail-Composer-suggestion strong", { text: "hello" });
     await insertText(".o-mail-Composer-input", ")");
     await contains(".o-mail-Composer-suggestion strong", { count: 0 });
-    await insertText(".o-mail-Composer-input", " :");
-    await contains(".o-mail-Composer-suggestion strong", { text: "hello" });
 });
 
 test("Cannot mention other channels in a livechat", async () => {

--- a/addons/mail/static/src/core/common/extract_suggestions.js
+++ b/addons/mail/static/src/core/common/extract_suggestions.js
@@ -1,0 +1,66 @@
+/**
+ * @typedef {Object} SuggestionTrigger
+ * @property {string} pattern A regex string that defines the start of
+ * a suggestion.
+ * @property {number} [startIndex] The position of the delimiter in the text. If
+ * omitted, any position is allowed.
+ * @property {string} [endPattern] A regex string that defines when to stop
+ * matching a suggestion. If omitted, two consecutive spaces are considered the
+ * end of the suggestion.
+ * @property {string} id A unique id used to identify delimiters
+ */
+
+/**
+ * @typedef {Object} SuggestionMatch
+ * @property {string} term
+ * @property {string} delimiter id of the delimiter related     to the match.
+ * @property {number} start
+ * @property {number} end
+ */
+
+/**
+ *
+ * @param {SuggestionTrigger[]} triggers
+ * @returns {{id: string, regex: RegExp }[]}
+ */
+function generateRegexesFromTriggers(triggers) {
+    const result = [];
+    for (const delimiter of triggers) {
+        const endDelimiter = delimiter.endPattern ?? "\\s{2,}";
+        const endPattern = `${endDelimiter}|${triggers.map((d) => `\\s${d.pattern}`).join("|")}`;
+        const startPattern =
+            delimiter.startIndex === 0
+                ? "^"
+                : delimiter.startIndex
+                ? `.{${delimiter.startIndex}}\\s`
+                : "(?<=^|\\s)";
+        const regex = new RegExp(
+            `${startPattern}(?<delimiter>${delimiter.pattern})(?<term>(?:(?!${endPattern}).)*)`,
+            "g"
+        );
+        result.push({ id: delimiter.id, regex: regex });
+    }
+    return result;
+}
+
+/**
+ * @param {string} text
+ * @param {SuggestionTrigger[]} triggers
+ * @return {SuggestionMatch[]}
+ */
+export function extractSuggestions(text, triggers) {
+    const parsed = generateRegexesFromTriggers(triggers);
+    const matches = [];
+    for (const { id, regex } of parsed) {
+        let match;
+        while ((match = regex.exec(text))) {
+            matches.push({
+                end: regex.lastIndex,
+                start: regex.lastIndex - match[0].length,
+                term: match.groups.term,
+                delimiter: id,
+            });
+        }
+    }
+    return matches;
+}

--- a/addons/mail/static/src/core/common/suggestion_service.js
+++ b/addons/mail/static/src/core/common/suggestion_service.js
@@ -14,8 +14,24 @@ export class SuggestionService {
         this.store = services["mail.store"];
     }
 
-    getSupportedDelimiters(thread) {
-        return [["@"], ["#"], [":"]];
+    /**
+     * @returns {import("./extract_suggestions").SuggestionTrigger[]}
+     */
+    getTriggers(thread) {
+        return [
+            {
+                id: "@",
+                pattern: "@",
+            },
+            {
+                id: "#",
+                pattern: "#",
+            },
+            {
+                id: ":",
+                pattern: ":(?=\\w)",
+            },
+        ];
     }
 
     async fetchSuggestions({ delimiter, term }, { thread } = {}) {

--- a/addons/mail/static/src/discuss/core/common/suggestion_service_patch.js
+++ b/addons/mail/static/src/discuss/core/common/suggestion_service_patch.js
@@ -7,9 +7,12 @@ import { patch } from "@web/core/utils/patch";
 const commandRegistry = registry.category("discuss.channel_commands");
 
 patch(SuggestionService.prototype, {
-    getSupportedDelimiters(thread) {
-        const res = super.getSupportedDelimiters(thread);
-        return thread?.model === "discuss.channel" ? [...res, ["/", 0]] : res;
+    getTriggers(thread) {
+        const res = super.getTriggers(thread);
+        if (thread?.model === "discuss.channel") {
+            res.push({ id: "/", pattern: "/", startIndex: 0 });
+        }
+        return res;
     },
     /**
      * @override


### PR DESCRIPTION
Canned responses are triggered by the ":" shortcut. It's cumbersome as it conflicts with emojis. This changes the canned response shortcut to ensure it is followed by a letter between displaying them so that it does not conflict anymore in most cases.

task-3563893