### PR TITLE
[IMP] pos*: removed duplicate buttons from dialogue popup

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
@@ -3,20 +3,22 @@
     <t t-name="point_of_sale.ControlButtons">
         <div t-attf-class="flex-{{!props.wrapped ? (ui.isSmall ? 'column' : 'wrap') : 'wrap'}}" class="control-buttons d-flex bg-300 border-bottom">
             <!-- All buttons always displayed -->
-            <SelectPartnerButton partner="partner"/>
-            <button t-if="pos.models['account.fiscal.position'].length" class="control-button o_fiscal_position_button btn btn-light rounded-0 fw-bolder" t-on-click="() => this.clickFiscalPosition()">
-                <i class="fa fa-book me-1" role="img" aria-label="Set fiscal position"
-                title="Set fiscal position" />
-                <t t-if="currentOrder?.fiscal_position_id" t-esc="currentOrder.fiscal_position_id.display_name" />
-                <t t-else="">Tax</t>
-            </button>
-            <OrderlineNoteButton
-                icon="'fa fa-tag'"
-                label="internalNoteLabel"
-                getter="(orderline) => orderline.getNote()"
-                setter="(orderline, note) => orderline.setNote(note)" />
-            <OrderlineNoteButton t-if="!pos.config.module_pos_restaurant"/>
-
+            <SelectPartnerButton partner="partner" t-if="props.wrapped"/>
+            <t t-if="props.wrapped || (ui.isSmall and !props.wrapped)">
+                <button t-if="pos.models['account.fiscal.position'].length"
+                    class="control-button o_fiscal_position_button btn btn-light rounded-0 fw-bolder" t-on-click="() => this.clickFiscalPosition()">
+                    <i class="fa fa-book me-1" role="img" aria-label="Set fiscal position"
+                    title="Set fiscal position" />
+                    <t t-if="currentOrder?.fiscal_position_id" t-esc="currentOrder.fiscal_position_id.display_name" />
+                    <t t-else="">Tax</t>
+                </button>
+                <OrderlineNoteButton
+                    icon="'fa fa-tag'"
+                    label="internalNoteLabel"
+                    getter="(orderline) => orderline.getNote()"
+                    setter="(orderline, note) => orderline.setNote(note)" />
+                <OrderlineNoteButton t-if="!pos.config.module_pos_restaurant"/>
+            </t>
             <!-- All buttons only displayed outside of dialog -->
             <button class="btn btn-light rounded-0 fw-bolder" t-if="props.wrapped and !ui.isSmall and props.onClickMore" t-on-click="props.onClickMore">
                 More...

--- a/addons/point_of_sale/static/tests/tours/utils/product_screen_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/product_screen_util.js
@@ -257,7 +257,12 @@ export function enterOpeningAmount(amount) {
 export function clickFiscalPosition(name, checkIsNeeded = false) {
     const step = [
         clickReview(),
-        ...clickControlButtonMore(),
+        {
+            content: "click more button",
+            trigger: ".mobile-more-button",
+            run: "click",
+            mobile: true,
+        },
         {
             content: "click fiscal position button",
             trigger: ".o_fiscal_position_button",
@@ -272,13 +277,20 @@ export function clickFiscalPosition(name, checkIsNeeded = false) {
 
     if (checkIsNeeded) {
         step.push(
-            ...clickControlButtonMore(),
+            {
+                content: "click more button",
+                trigger: ".mobile-more-button",
+                run: "click",
+                mobile: true,
+            },
             {
                 content: "the fiscal position " + name + " has been set to the order",
-                trigger: `.modal-body .control-buttons button.o_fiscal_position_button:contains("${name}")`,
+                trigger: `.control-buttons button.o_fiscal_position_button:contains("${name}")`,
             },
             {
                 ...Dialog.cancel(),
+                run: "click",
+                mobile: true,
             }
         );
     }
@@ -453,7 +465,12 @@ export function addOrderline(productName, quantity = 1, unitPrice, expectedTotal
 export function addCustomerNote(note) {
     return inLeftSide(
         [
-            clickControlButtonMore(),
+            {
+                content: "click more button",
+                trigger: ".mobile-more-button",
+                run: "click",
+                mobile: true,
+            },
             clickControlButton("Customer Note"),
             TextInputPopup.inputText(note),
             Dialog.confirm(),

--- a/addons/pos_loyalty/static/src/overrides/components/control_buttons/control_buttons.xml
+++ b/addons/pos_loyalty/static/src/overrides/components/control_buttons/control_buttons.xml
@@ -19,17 +19,19 @@
                     <i class="fa fa-barcode me-1"/>Enter Code
                 </button>
             </t>
-            <t t-if="pos.models['loyalty.program'].some((p) => ['coupons', 'promotion'].includes(p.program_type))">
-                <button class="btn btn-light rounded-0 fw-bolder" t-att-class="{'disabled': !pos.get_order().isProgramsResettable()}"
-                    t-on-click="() => this.pos.resetPrograms()" t-if="!props.wrapped">
-                    <i class="fa fa-star me-1"/>Reset Programs
-                </button>
-            </t>
             <t t-if="pos.models['loyalty.program'].length">
                 <button class="control-button btn btn-light rounded-0 fw-bolder"
                     t-attf-class="{{getPotentialRewards().length ? 'highlight text-action' : 'disabled'}}"
                     t-on-click="() => this.clickRewards()">
                     <i class="fa fa-star me-1"/>Reward
+                </button>
+            </t>
+        </xpath>
+        <xpath expr="//t[@t-if='!props.wrapped']/OrderlineNoteButton" position="after">
+            <t t-if="pos.models['loyalty.program'].some((p) => ['coupons', 'promotion'].includes(p.program_type))">
+                <button class="btn btn-light rounded-0 fw-bolder" t-att-class="{'disabled': !pos.get_order().isProgramsResettable()}"
+                    t-on-click="() => this.pos.resetPrograms()">
+                    <i class="fa fa-star me-1"/>Reset Programs
                 </button>
             </t>
         </xpath>

--- a/addons/pos_restaurant/static/src/app/control_buttons/control_buttons.xml
+++ b/addons/pos_restaurant/static/src/app/control_buttons/control_buttons.xml
@@ -13,23 +13,24 @@
                     <span t-esc="currentOrder?.getCustomerCount() || 0" class="px-2 py-1 rounded-circle text-bg-dark fw-bolder small me-1"/>
                     <span>Guests</span>
                 </button>
-
-                <!-- All these buttons will only be displayed in a dialog -->
-                <t t-if="!props.wrapped">
-                    <button class="btn btn-light rounded-0 fw-bolder"
-                        t-att-disabled="pos.get_order()?.get_orderlines()?.reduce((sum, line) => sum + line.qty, 0) lt 2"
-                        t-on-click="() => pos.showScreen('SplitBillScreen')">
-                        <i class="fa fa-files-o me-1"/>Split
-                    </button>
-                    <button class="btn btn-light rounded-0 fw-bolder" t-on-click="clickTransferOrder">
-                        <i class="oi oi-arrow-right me-1" />Transfer / Merge
-                    </button>
-                    <button t-if="pos.config.takeaway"
-                            t-attf-class="{{ currentOrder.takeaway ? 'btn-primary' : 'btn-light'}} btn rounded-0 fw-bolder"
-                            t-on-click="clickTakeAway">
-                        <i class="fa fa-car me-1" />Take-away
-                    </button>
-                </t>
+            </t>
+        </xpath>
+        <xpath expr="//t[@t-if='!props.wrapped']/OrderlineNoteButton" position="after">
+            <!-- All these buttons will only be displayed in a dialog -->
+            <t t-if="pos.config.module_pos_restaurant">
+                <button class="btn btn-light rounded-0 fw-bolder"
+                    t-att-disabled="pos.get_order()?.get_orderlines()?.reduce((sum, line) => sum + line.qty, 0) lt 2"
+                    t-on-click="() => pos.showScreen('SplitBillScreen')">
+                    <i class="fa fa-files-o me-1"/>Split
+                </button>
+                <button class="btn btn-light rounded-0 fw-bolder" t-on-click="clickTransferOrder">
+                    <i class="oi oi-arrow-right me-1" />Transfer / Merge
+                </button>
+                <button t-if="pos.config.takeaway"
+                        t-attf-class="{{ currentOrder.takeaway ? 'btn-primary' : 'btn-light'}} btn rounded-0 fw-bolder"
+                        t-on-click="clickTakeAway">
+                    <i class="fa fa-car me-1" />Take-away
+                </button>
             </t>
         </xpath>
     </t>

--- a/addons/pos_restaurant/static/tests/tours/control_buttons_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/control_buttons_tour.js
@@ -31,7 +31,6 @@ registry.category("web_tour.tours").add("ControlButtonsTour", {
             ProductScreen.clickControlButton("Split"),
             SplitBillScreen.clickBack(),
 
-            ProductScreen.clickControlButtonMore(),
             ProductScreen.clickControlButton("Internal Note"),
             TextInputPopup.inputText("test note"),
             Dialog.confirm(),
@@ -61,7 +60,6 @@ registry.category("web_tour.tours").add("ControlButtonsTour", {
             Dialog.cancel(),
 
             // Test GuestButton
-            ProductScreen.clickControlButtonMore(),
             ProductScreen.clickControlButton("Guests"),
             NumberPopup.enterValue("15"),
             NumberPopup.isShown("15"),


### PR DESCRIPTION
pos*: point_of_sale, pos_discount, pos_restaurant, pos_loyalty, pos_sale

Before this commit:
====================
The orderline (product screen) and the dialogue popup both contained duplicate buttons.

![image](https://github.com/odoo/odoo/assets/127721971/2209040d-45ac-4edf-a9e0-62084df07dee)


After this commit:
==============
Duplicate buttons have been removed from the dialogue popup.

![image](https://github.com/odoo/odoo/assets/127721971/746f3c86-1f4e-444e-baf2-14acd8dac6b9)


task - 3947449

