### PR TITLE
[FIX] web: fix test test_04_web_content_filename_secure in v16

### DIFF
--- a/addons/web/tests/test_image.py
+++ b/addons/web/tests/test_image.py
@@ -102,6 +102,11 @@ class TestImage(HttpCase):
             'mimetype': 'image/gif',
         })
 
+        def remove_prefix(text, prefix):
+            if text.startswith(prefix):
+                return text[len(prefix):]
+            return text
+
         def assert_filenames(
                 url,
                 expected_filename,
@@ -116,8 +121,8 @@ class TestImage(HttpCase):
                 inline, filename = res.headers['Content-Disposition'].split('; ')
                 filename_star = ''
 
-            filename = filename.removeprefix("filename=").strip('"')
-            filename_star = url_unquote_plus(filename_star.removeprefix("filename*=UTF-8''").strip('"'))
+            filename = remove_prefix(filename, "filename=").strip('"')
+            filename_star = url_unquote_plus(remove_prefix(filename_star, "filename*=UTF-8''").strip('"'))
 
             self.assertEqual(inline, 'inline')
             self.assertEqual(filename, expected_filename, message)


### PR DESCRIPTION
The test web:TestImage.test_04_web_content_filename_secure is failing on the runbot for the version 16 (16.0, saas-16.3 and saas-16.4). The error is 'str' object has no attribute 'removeprefix' and this method has been introduced in python 3.9 while version 16 only support python 3.7.

To solve the problem we replace that method call with a supported equivalent in python 3.7.

Task-3944583