### PR TITLE
[FIX] website_links: avoid displaying duplicate UTM records

### DIFF
--- a/addons/website_links/static/src/js/website_links.js
+++ b/addons/website_links/static/src/js/website_links.js
@@ -92,7 +92,11 @@ var SelectBox = publicWidget.Widget.extend({
                             // ensure that we do not display "ending matches" if
                             // we may not have loaded all "starting matches".
                             if (startingMatches.length < limit) {
-                                return startingMatches.concat(endingMatches);
+                                const startingMatchesId = startingMatches.map((value) => value.id);
+                                const extraEndingMatches = endingMatches.filter(
+                                    (value) => !startingMatchesId.includes(value.id)
+                                );
+                                return startingMatches.concat(extraEndingMatches);
                             }
                             // In that case, we made one RPC too much but this
                             // was chosen over not making them go in parallel.


### PR DESCRIPTION
Since [1] UTM records that match both at the start of their name and elsewhere within their name are displayed twice in the dropdowns.

This commit filters the "contains" matches in order to include only the ones that do not already appear among the "start" matches.

Steps to reproduce:
- Go to the "Link Tracker" page.
- Click inside the "Campaign" dropdown.

=> Entries appear twice because the empty string is matched both at start and inside the names.

- Create a campaign that begins and ends with the same letter (e.g. "Supers").
- Return to the "Link Tracker" page.
- Click inside the "Campaign" dropdown.
- Type the first letter of the new campaign.

=> The new campaign appears twice in the dropdown list, each time with the first letter highlighted.

[1]: https://github.com/odoo/odoo/commit/2bf71a32000c33754a32599776079a0dc60d2bba

task-3933262
