### PR TITLE
[FIX] test_http: fix patch issue in noble

### DIFF
--- a/odoo/addons/test_http/tests/test_misc.py
+++ b/odoo/addons/test_http/tests/test_misc.py
@@ -127,7 +127,7 @@ class TestHttpMisc(TestHttpBase):
             'X-Forwarded-Host': 'odoo.com',
             'X-Forwarded-Proto': 'https'
         }
-        with patch.dict('odoo.tools.config.options', {'proxy_mode': True}):
+        with patch.dict(odoo.tools.config.options, {'proxy_mode': True}):
             res = self.nodb_url_open('/test_http/geoip', headers=headers)
             res.raise_for_status()
             self.assertEqual(res.json(), {


### PR DESCRIPTION
Since python 3.11, the patch.dict method changed [0] to use pkgutil to resolve names. This new method is not able to patch our `odoo.tools.config.options`.

Fixed by using the object instead of a string literal.

[0]: python/cpython@ab7fcc8fbdc11091370deeb000a787fb02f9b13d
