### PR TITLE
[PERF] base_automation: compute once on time condition with calendar

### DIFF
--- a/addons/base_automation/models/base_automation.py
+++ b/addons/base_automation/models/base_automation.py
@@ -483,8 +483,8 @@ class BaseAutomation(models.Model):
 
     @api.model
     def _check_delay(self, action, record, record_dt):
-        if action.trg_date_calendar_id and action.trg_date_range_type == 'day':
-            return action.trg_date_calendar_id.plan_days(
+        if self._get_calendar(action, record) and action.trg_date_range_type == 'day':
+            return self._get_calendar(action, record).plan_days(
                 action.trg_date_range,
                 fields.Datetime.from_string(record_dt),
                 compute_leaves=True,
@@ -492,6 +492,10 @@ class BaseAutomation(models.Model):
         else:
             delay = DATE_RANGE_FUNCTION[action.trg_date_range_type](action.trg_date_range)
             return fields.Datetime.from_string(record_dt) + delay
+
+    @api.model
+    def _get_calendar(self, action, record):
+        return action.trg_date_calendar_id
 
     @api.model
     def _check(self, automatic=False, use_new_cursor=False):
@@ -520,12 +524,29 @@ class BaseAutomation(models.Model):
 
             # process action on the records that should be executed
             now = datetime.datetime.now()
+            past_now = {}
+            past_last_run = {}
             for record in records:
                 record_dt = get_record_dt(record)
                 if not record_dt:
                     continue
-                action_dt = self._check_delay(action, record, record_dt)
-                if last_run <= action_dt < now:
+                if action.trg_date_calendar_id and action.trg_date_range_type == 'day':
+                    calendar = self._get_calendar(action, record)
+                    if calendar.id not in past_now:
+                        past_now[calendar.id] = calendar.plan_days(
+                            - action.trg_date_range,
+                            now,
+                            compute_leaves=True,
+                        )
+                        past_last_run[calendar.id] = calendar.plan_days(
+                            - action.trg_date_range,
+                            last_run,
+                            compute_leaves=True,
+                        )
+                    is_process_to_run = past_last_run[calendar.id] <= fields.Datetime.to_datetime(record_dt) < past_now[calendar.id]
+                else:
+                    is_process_to_run = last_run <= self._check_delay(action, record, record_dt) < now
+                if is_process_to_run:
                     try:
                         action._process(record)
                     except Exception:


### PR DESCRIPTION
When using base.automation a timed condition using a calendar, the check
was done for each record to get the datetime with the delay using the
calendar.
Now we invert the logic instead of adding the delay to the record
in a loop datetime field, we substract from the last_run and now once
outside of the loop.
It goes from this logic:
last_run <= record_dt + delay < now
to this:
last_run - delay <= record_dt < now - delay

In a database with 1000 records to check a single calendar:
it went from 15s to 20ms


opw-3876867

https://github.com/odoo/enterprise/pull/65417

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
