### PR TITLE
[FIX] mail: no chatter in dialog

### DIFF
--- a/addons/mail/static/src/chatter/web/form_compiler.js
+++ b/addons/mail/static/src/chatter/web/form_compiler.js
@@ -1,7 +1,7 @@
 import { registry } from "@web/core/registry";
 import { SIZES } from "@web/core/ui/ui_service";
 import { patch } from "@web/core/utils/patch";
-import { append, createElement, setAttributes } from "@web/core/utils/xml";
+import { append, createElement, extractAttributes, setAttributes } from "@web/core/utils/xml";
 import { FormCompiler } from "@web/views/form/form_compiler";
 
 function compileChatter(node, params) {
@@ -94,8 +94,11 @@ patch(FormCompiler.prototype, {
         }
         // after sheet bg (standard position, either aside or below)
         if (webClientViewAttachmentViewHookXml) {
+            const { ["t-if"]: tIf } = extractAttributes(chatterContainerHookXml, ["t-if"]);
             setAttributes(chatterContainerHookXml, {
-                "t-if": `!(__comp__.hasFileViewer() and __comp__.uiService.size >= ${SIZES.XXL})`,
+                "t-if": `${
+                    tIf ? tIf : "true"
+                } and (!(__comp__.hasFileViewer() and __comp__.uiService.size >= ${SIZES.XXL}))`,
                 "t-attf-class": `{{ __comp__.uiService.size >= ${SIZES.XXL} and !(__comp__.hasFileViewer() and __comp__.uiService.size >= ${SIZES.XXL}) ? "o-aside" : "" }}`,
             });
             setAttributes(chatterContainerXml, {

--- a/addons/mail/static/tests/chatter/web/chatter.test.js
+++ b/addons/mail/static/tests/chatter/web/chatter.test.js
@@ -20,7 +20,13 @@ import {
 import { DELAY_FOR_SPINNER } from "@mail/chatter/web_portal/chatter";
 import { describe, expect, getFixture, test } from "@odoo/hoot";
 import { Deferred, advanceTime } from "@odoo/hoot-mock";
-import { mockService, onRpc, serverState } from "@web/../tests/web_test_helpers";
+import {
+    defineActions,
+    getService,
+    mockService,
+    onRpc,
+    serverState,
+} from "@web/../tests/web_test_helpers";
 
 describe.current.tags("desktop");
 defineMailModels();
@@ -678,4 +684,21 @@ test("Mentions in composer should still work when using pager", async () => {
     await insertText(".o-mail-Composer-input", "@");
     // all records in DB: Mitchell Admin | Hermit | OdooBot | Public user
     await contains(".o-mail-Composer-suggestion", { count: 4 });
+});
+
+test("form views in dialogs do not have chatter", async () => {
+    defineActions([
+        {
+            id: 1,
+            name: "Partner",
+            res_model: "res.partner",
+            type: "ir.actions.act_window",
+            views: [[false, "form"]],
+            target: "new",
+        },
+    ]);
+    await start();
+    await getService("action").doAction(1);
+    await contains(".o_dialog .o_form_view");
+    await contains(".o-mail-Form-Chatter", { count: 0 });
 });


### PR DESCRIPTION
Before this commit, the chatter was shown in dialog when it should never.

Steps to reproduce:
- Install Time Off (`hr_holidays`)
- Open Time Off app
- Click on a date in the calendar view => The chatter is visible in dialog when it shouldn't

This happens because the Chatter hook had a `t-if` on `!env.inDialog`, but it was overridden by another `t-if` on layout. As a result, the view template never took into consideration of `!env.inDialog`.

This commit fixes the issue by properly combining the 2 `t-if` together.

task-3957107
