### PR TITLE
[FIX] web: some fixes for embedded actions

### DIFF
--- a/addons/web/static/src/search/control_panel/control_panel.js
+++ b/addons/web/static/src/search/control_panel/control_panel.js
@@ -66,7 +66,11 @@ export class ControlPanel extends Component {
         this.newActionNameRef = useRef("newActionNameRef");
         this.isEmbeddedActionsOrderModifiable = false;
         this.defaultEmbeddedActions = this.env.config.embeddedActions;
-        if (this.env.config.embeddedActions?.length > 0 && !this.env.config.parentActionId) {
+        if (
+            this.env.config.embeddedActions?.length > 0 &&
+            !!this.env.config.embeddedActions[0].id &&
+            !this.env.config.parentActionId
+        ) {
             const { parent_res_model, parent_action_id } = this.env.config.embeddedActions[0];
             this.defaultEmbeddedActions = [
                 {
@@ -485,6 +489,11 @@ export class ControlPanel extends Component {
             action_id,
             id: embeddedActionId[0],
         };
+        this.env.config.setCurrentEmbeddedAction(embeddedActionId);
+        this.env.config.setEmbeddedActions([
+            ...this.state.embeddedInfos.embeddedActions,
+            enrichedNewEmbeddedAction,
+        ]);
         this.state.embeddedInfos.embeddedActions.push(enrichedNewEmbeddedAction);
         const embeddedActionIdStr = embeddedActionId[0].toString();
         visibleEmbeddedActions[embeddedActionIdStr] = true;
@@ -494,7 +503,6 @@ export class ControlPanel extends Component {
             JSON.stringify(visibleEmbeddedActions)
         );
         browser.localStorage.setItem(this.embeddedOrderKey, JSON.stringify(order));
-        this.env.config.setCurrentEmbeddedAction(embeddedActionId);
         this.state.embeddedInfos.currentEmbeddedAction = enrichedNewEmbeddedAction;
         this.state.embeddedInfos.newActionName = `${newActionName} Custom`;
     }
@@ -529,9 +537,9 @@ export class ControlPanel extends Component {
             this.embeddedActionsVisibilityKey,
             JSON.stringify(visibleEmbeddedActions)
         );
-        this.state.embeddedInfos.embeddedActions = embeddedActions.filter(
-            ({ id }) => id !== action.id
-        );
+        const newEmbeddedActions = embeddedActions.filter(({ id }) => id !== action.id);
+        this.env.config.setEmbeddedActions(newEmbeddedActions);
+        this.state.embeddedInfos.embeddedActions = newEmbeddedActions;
         await this.orm.unlink("ir.embedded.actions", [action.id]);
         if (action.id === currentEmbeddedAction?.id) {
             const { active_id, active_model } = this.env.searchModel.globalContext;

--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -1477,6 +1477,16 @@ export function makeActionManager(env, router = _router) {
                 // When restoring, we want to use the last exported ID of the controller
                 props.resId = exportedState.resId;
             }
+            const currentEmbeddedActions =
+                controllerStack[controllerStack.length - 1].embeddedActions;
+            // If the action restored is the parent_action of the current embedded actions, we have to refresh the
+            // embedded_action_ids of the action, as some new ones could have been added or deleted.
+            if (
+                currentEmbeddedActions &&
+                currentEmbeddedActions[0]?.parent_action_id[0] === action.id
+            ) {
+                action.embedded_action_ids = currentEmbeddedActions;
+            }
             Object.assign(controller, _getViewInfo(view, action, views, props));
         }
         return _updateUI(controller, { index });

--- a/addons/web/static/tests/_framework/mock_server/mock_server.js
+++ b/addons/web/static/tests/_framework/mock_server/mock_server.js
@@ -936,7 +936,7 @@ export class MockServer {
         }
         if (action.type === "ir.actions.act_window") {
             action["embedded_action_ids"] = this.embedded_actions.filter(
-                (el) => el && el.parent_action_id === params.action_id
+                (el) => el && el.parent_action_id[0] === params.action_id
             );
         }
         return action;


### PR DESCRIPTION
This commit addresses several issues related to embedded actions, with the main issue being as follows: when entering an action containing embedded actions, creating a new action, and then clicking on the restore breadcrumb, the newly created actions were not displayed. This occurred because the action_service did not re-fetch the embedded actions associated with an action upon restoring a controller. Consequently, the newly created embedded actions, which were not present when the data for the previous action was fetched, were not shown.

The fix ensures that the restored action's embedded actions are refreshed with the current ones if the restored action is the parent action of the current embedded actions.

Additionally, this commit includes a test for this scenario and corrects inaccuracies in other tests.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
