### PR TITLE
[FIX] mail: no crash on adding a new old activity

### DIFF
--- a/addons/mail/static/src/core/web/activity_model.js
+++ b/addons/mail/static/src/core/web/activity_model.js
@@ -136,11 +136,11 @@ export class Activity extends Record {
     write_uid;
 
     get dateDeadlineFormatted() {
-        return this.date_deadline.toLocaleString(luxon.DateTime.DATE_SHORT);
+        return this.date_deadline?.toLocaleString(luxon.DateTime.DATE_SHORT);
     }
 
     get dateDoneFormatted() {
-        return this.date_done.toLocaleString(luxon.DateTime.DATE_SHORT);
+        return this.date_done?.toLocaleString(luxon.DateTime.DATE_SHORT);
     }
 
     get dateCreateFormatted() {


### PR DESCRIPTION
Before this commit, when adding an outdated activity from kanban activity widget, it crashed with the following error:

TypeError: Cannot read properties of undefined (reading 'toLocaleString')

Steps to reproduce:
- on crm lead schedule call activity and make sure that activity is at least 1 month old
- add activity to the Call Queue
- try to access/edit activity

This happens because of adding an outdated activity, this is automatically considered as an old activity, which leads to its deletion immediately after creation. OWL is rendering the template of `ActivityListPopover` while the activity is deleted, which is a problem because activity doesn't exist therefore its fields have been cleared, such as date_deadline that is undefined instead of a DateTime.

task-3945492

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
