### PR TITLE
[FIX] sale: do not recompute prices on fpos change

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -951,7 +951,6 @@ class SaleOrder(models.Model):
     def action_update_taxes(self):
         self.ensure_one()
 
-        self._recompute_prices()
         self._recompute_taxes()
 
         if self.partner_id:

--- a/addons/sale/tests/test_sale_order.py
+++ b/addons/sale/tests/test_sale_order.py
@@ -722,10 +722,12 @@ class TestSalesTeam(SaleCommon):
         self.assertEqual(order.amount_total, 300)
         self.assertEqual(order.amount_tax, 100)
         order.fiscal_position_id = mapping_a
+        order._recompute_prices()
         order.action_update_taxes()
         self.assertEqual(order.amount_total, 270)
         self.assertEqual(order.amount_tax, 70)
         order.fiscal_position_id = mapping_b
+        order._recompute_prices()
         order.action_update_taxes()
         self.assertEqual(order.amount_total, 252)
         self.assertEqual(order.amount_tax, 52)


### PR DESCRIPTION
To handle some advanced taxes setups, we changed the behavior of the 'Update taxes' so that it would recompute the prices before recomputing the taxes, but some business do not expect that recomputation, despite modifying the taxes.

The businesses needing the prices recomputation will have to trigger it manually, and shouldn't rely on the Update Taxes button for that.

Introduced by 537df32897494f94962637bd2b45d2618ff83e7c

opw-3953806


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
