### PR TITLE
[FIX] base_import: convert limit value in integer when user changes batch limit

### DIFF
--- a/addons/base_import/static/src/import_data_sidepanel/import_data_sidepanel.xml
+++ b/addons/base_import/static/src/import_data_sidepanel/import_data_sidepanel.xml
@@ -68,7 +68,7 @@
                 <div class="d-flex">
                     <div class="o_import_batch_limit w-50 pe-1">
                         <label class="mb-1" for="o_import_batch_limit">Batch limit</label>
-                        <input class="w-100" id="o_import_batch_limit" t-att-value="getOptionValue('limit')" t-on-change="(ev) => this.setOptionValue('limit', ev.target.value)" />
+                        <input class="w-100" id="o_import_batch_limit" t-att-value="getOptionValue('limit')" t-on-change="(ev) => this.setOptionValue('limit', ev.target.value || 1)" />
                     </div>
                     <div class="w-50 ps-1" data-tooltip="Warning: ignores the labels line, empty lines and lines composed only of empty cells">
                         <label class="mb-1" for="o_import_row_start">Start at line</label>


### PR DESCRIPTION
This traceback arises when the user tries to remove the Batch Limit value and test the imported file.

To reproduce this issue:

1) Import a file with large data in any module
2) You see the Batch limit at the left side pannel
3) Remove the default "Batch Limit" value
4) Test the file
5) A traceback will encountered

Error:- 
```
TypeError: '<' not supported between instances of 'int' and 'str'
```

when the user removes  the default batch limit its value will be an empty string.

You can see in [1] that parseFloat('') is "NaN"  so it directly assigns the limit as the value which is an empty string.

[1]
https://github.com/odoo/odoo/blob/2c40a55232fb501dd70b64f7ddbdc4244f365139/addons/base_import/static/src/import_data_sidepanel/import_data_sidepanel.js#L34-L36

which leads to a traceback when a comparison is done between int and str.

https://github.com/odoo/odoo/blob/106c343027e3bab1c94c414f30e914cf673cceec/odoo/models.py#L1318-L1319

After applying this commit will resolve the issue of getting an int value instead of a str.

sentry-5298904064
