### PR TITLE
[FIX] point_of_sale: add +/- button for payment_screen on mobile

### DIFF
--- a/addons/point_of_sale/static/src/app/generic_components/numpad/numpad.xml
+++ b/addons/point_of_sale/static/src/app/generic_components/numpad/numpad.xml
@@ -4,6 +4,7 @@
     <div t-attf-class="{{props.class}} numpad row row-cols-{{buttons.length / 4}} gx-0">
       <button t-foreach="buttons.map((b) => typeof b === 'object' ? b : { value: b })" t-as="button" t-key="button.value"
         t-attf-class="col btn btn-light py-3 border fw-bolder rounded-0 {{ button.class  or '' }}"
+        t-att-value="button.text or button.value"
         t-on-click="() => this.onClick(button.value)"
         t-att-disabled="button.disabled"
         t-esc="button.text or button.value" />

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_lines/payment_lines.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_lines/payment_lines.js
@@ -4,6 +4,7 @@ import { useService } from "@web/core/utils/hooks";
 import { Component, useState } from "@odoo/owl";
 import { usePos } from "@point_of_sale/app/store/pos_hook";
 import { parseFloat } from "@web/views/fields/parsers";
+import { enhancedButtons } from "@point_of_sale/app/generic_components/numpad/numpad";
 
 export class PaymentScreenPaymentLines extends Component {
     static template = "point_of_sale.PaymentScreenPaymentLines";
@@ -38,6 +39,7 @@ export class PaymentScreenPaymentLines extends Component {
         if (this.ui.isSmall) {
             this.dialog.add(NumberPopup, {
                 title: _t("New amount"),
+                buttons: enhancedButtons(),
                 startingValue: this.env.utils.formatCurrency(paymentline.get_amount(), false),
                 getPayload: (num) => {
                     this.props.updateSelectedPaymentline(parseFloat(num));

--- a/addons/point_of_sale/static/tests/tours/utils/numpad_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/numpad_util.js
@@ -1,6 +1,6 @@
 import { queryAll } from "@odoo/hoot-dom";
 
-const buttonTriger = (buttonValue) => `div.numpad.row button.col:contains("${buttonValue}")`;
+const buttonTriger = (buttonValue) => `div.numpad.row button[value="${buttonValue}"]`;
 export const click = (buttonValue) => ({
     content: `click numpad button: ${buttonValue}`,
     trigger: buttonTriger(buttonValue),
@@ -9,7 +9,7 @@ export const click = (buttonValue) => ({
     // button with the value "1". Here we need to match the exact value.
     run: () => {
         queryAll(buttonTriger(buttonValue))
-            .filter((el) => el.innerHTML == buttonValue)
+            .filter((el) => el.innerText === buttonValue)
             .at(0)
             ?.click();
     },


### PR DESCRIPTION
In mobile view, when processing a refund, users were unable to input a custom negative amount using the +/- buttons. Although the negative symbol from the keyboard worked, it was not an intuitive solution.

Steps to reproduce:
1. Access the payment screen on a mobile device.
2. Click on a paymentmethod then click on a paymentline.
2. Attempt to input a custom negative amount for a refund.

Current behavior:
- Users cannot input a custom negative amount using +/- buttons.

Expected behavior:
- Users should be able to input a custom negative amount using the +/- buttons, similar to the desktop version.

This ensures a consistent user experience across both mobile and desktop versions of the payment screen.

Task ID: 3955151


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
