### PR TITLE
[16.0][FIX] stock_landed_costs: Support the case move product_qty was zeroed out

### DIFF
--- a/addons/stock_landed_costs/tests/test_stockvaluationlayer.py
+++ b/addons/stock_landed_costs/tests/test_stockvaluationlayer.py
@@ -171,6 +171,14 @@ class TestStockValuationLCFIFO(TestStockValuationLCCommon):
         self.assertEqual(self.product1.value_svl, 0)
         self.assertEqual(self.product1.quantity_svl, 0)
 
+    def test_alreadyout_1_alt(self):
+        move1 = self._make_in_move(self.product1, 10, unit_cost=10, create_picking=True)
+        move1.move_line_ids.qty_done = 0
+        self._make_lc(move1, 100)
+
+        self.assertEqual(self.product1.value_svl, 0)
+        self.assertEqual(self.product1.quantity_svl, 0)
+
     def test_alreadyout_2(self):
         move1 = self._make_in_move(self.product1, 10, unit_cost=10, create_picking=True)
         move2 = self._make_in_move(self.product1, 10, unit_cost=20)


### PR DESCRIPTION
Before this commit, landed cost could not be validated for a user error for a transfer with the following operation steps:

- Receive 10 with an incoming picking
- Return 10 by zeroing out the move line of the same picking

This behavior was problematic when you had to fix the stock valuation of a product managed with the FIFO costing method under certain circumstances such as follows:

- Receive 10 with unit price 100
- Receive another 10 with unit price 1000 (by mistake with the wrong price)
- Return 10 (now your stock valuation is messed up with unit price 1000)

This commit makes it possible to process landed costs for such transfers.

@qrtl QT4084

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
