### PR TITLE
[FIX] point_of_sale: enable refund for few quantities

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1758,7 +1758,7 @@ export class PosStore extends Reactive {
         const dp = this.models["decimal.precision"].find(
             (dp) => dp.name === "Product Unit of Measure"
         );
-        return floatIsZero(qty, dp);
+        return floatIsZero(qty, dp.digits);
     }
 
     disallowLineQuantityChange() {

--- a/addons/point_of_sale/static/tests/tours/TicketScreen.tour.js
+++ b/addons/point_of_sale/static/tests/tours/TicketScreen.tour.js
@@ -234,3 +234,31 @@ registry.category("web_tour.tours").add("LotRefundTour", {
             ProductScreen.checkFirstLotNumber("123456789"),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("RefundFewQuantities", {
+    test: true,
+    url: "/pos/ui",
+    steps: () =>
+        [
+            Dialog.confirm("Open session"),
+            ProductScreen.clickShowProductsMobile(),
+            ProductScreen.clickDisplayedProduct("Sugar"),
+            ProductScreen.pressNumpad("0", "."),
+            ProductScreen.selectedOrderlineHas("Sugar", "0.00", "0.00"),
+            ProductScreen.pressNumpad("0", "2"),
+            ProductScreen.selectedOrderlineHas("Sugar", "0.02", "0.06"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.isShown(),
+            ReceiptScreen.clickNextOrder(),
+            ProductScreen.clickRefund(),
+            TicketScreen.selectOrder("-0001"),
+            ProductScreen.pressNumpad("0", "."),
+            ProductScreen.pressNumpad("0", "2"),
+            TicketScreen.toRefundTextContains("To Refund: 0.02"),
+            TicketScreen.confirmRefund(),
+            ProductScreen.isShown(),
+            Order.hasLine("Sugar", "-0.02", "-0.06"),
+        ].flat(),
+});

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1187,6 +1187,20 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'BarcodeScanPartnerTour', login="pos_user")
 
+    def test_refund_few_quantities(self):
+        """ Test to check that refund works with quantities of less than 0.5 """
+        self.env['product.product'].create({
+            'name': 'Sugar',
+            'list_price': 3,
+            'taxes_id': False,
+            'available_in_pos': True,
+            'uom_id': self.env.ref('uom.product_uom_kgm').id,
+            'uom_po_id': self.env.ref('uom.product_uom_kgm').id
+        })
+
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'RefundFewQuantities', login="pos_user")
+
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):
     browser_size = '375x667'


### PR DESCRIPTION
Problem:
Product with quantity less than 0.5 can't be refunded

Steps to reproduce:
- Install "Point of Sale" and "Sales" apps
- Go to Sales settings and enable "Units of Measure"
- Create a product and set an UoM (eg. kg)
- Go to the shop, sell 0.4 units of the product
- Refund the last order
- You won't be able to refund the product

Cause:
Compare if the quantity is zero with a "decimal.precision" as precision which is interpreted as a precision of zero.

Solution:
Use the digits of "decimal.precision" as precision

opw-3945427


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
