### PR TITLE
[FIX] l10n_in_edi: fix e-invoice for nil zero exempt non gst

### DIFF
--- a/addons/l10n_in_edi/models/account_edi_format.py
+++ b/addons/l10n_in_edi/models/account_edi_format.py
@@ -41,13 +41,28 @@ class AccountEdiFormat(models.Model):
            + self.env.ref("l10n_in.tax_tag_non_gst_supplies").ids
         )
 
+    def _get_l10n_in_gst_tags(self):
+        return (
+           self.env.ref('l10n_in.tax_tag_base_sgst').ids
+           + self.env.ref('l10n_in.tax_tag_base_cgst').ids
+           + self.env.ref('l10n_in.tax_tag_base_igst').ids
+           + self.env.ref('l10n_in.tax_tag_base_cess').ids
+        )
+
+    def _get_l10n_in_non_taxable_tags(self):
+        return (
+            self.env.ref('l10n_in.tax_tag_zero_rated')
+           + self.env.ref("l10n_in.tax_tag_exempt")
+           + self.env.ref("l10n_in.tax_tag_nil_rated")
+           + self.env.ref("l10n_in.tax_tag_non_gst_supplies")
+        ).ids
+
     def _get_move_applicability(self, move):
         # EXTENDS account_edi
         self.ensure_one()
         if self.code != 'in_einvoice_1_03':
             return super()._get_move_applicability(move)
-        all_base_tags = self._get_l10n_in_base_tags()
-        is_under_gst = any(move_line_tag.id in all_base_tags for move_line_tag in move.line_ids.tax_tag_ids)
+        is_under_gst = any(move_line_tag.id in self._get_l10n_in_gst_tags() for move_line_tag in move.line_ids.tax_tag_ids)
         if move.is_sale_document(include_receipts=True) and move.country_code == 'IN' and is_under_gst and move.l10n_in_gst_treatment in (
             "regular",
             "composition",
@@ -83,7 +98,7 @@ class AccountEdiFormat(models.Model):
         error_message += self._l10n_in_validate_partner(move.company_id.partner_id, is_company=True)
         if not re.match("^.{1,16}$", move.name):
             error_message.append(_("Invoice number should not be more than 16 characters"))
-        all_base_tags = self._get_l10n_in_base_tags()
+        all_base_tags = self._get_l10n_in_gst_tags() + self._get_l10n_in_non_taxable_tags()
         for line in move.invoice_line_ids.filtered(lambda line: line.display_type not in ('line_note', 'line_section', 'rounding')):
             if line.price_subtotal < 0:
                 # Line having a negative amount is not allowed.


### PR DESCRIPTION
- Before this commit: The system is sending E invoice requests for the Nil, Zero, Exempt, Non GST supply. which is not required by the government, cause of which E-way bill creation for Bill of Supply is not becoming possible.

- After this commit: Fix this issue by filtering out invoices that only use Nil, Zero, Exempt, Non GST as their taxes.

task - 3957555