### PR TITLE
[FIX] web_editor: Image selection popover not opening

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/image_crop.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/image_crop.js
@@ -13,6 +13,7 @@ import {
 } from "@odoo/owl";
 import { useService } from "@web/core/utils/hooks";
 import dom from "@web/legacy/js/core/dom";
+import { preserveCursor } from "@web_editor/js/editor/odoo-editor/src/utils/utils";
 
 export class ImageCrop extends Component {
     static template = 'web_editor.ImageCrop';
@@ -82,6 +83,7 @@ export class ImageCrop extends Component {
         this.media.setAttribute('src', this.initialSrc);
         this.$media.trigger('image_cropper_destroyed');
         this.state.active = false;
+        this.restoreCursor();
     }
 
     /**
@@ -114,6 +116,7 @@ export class ImageCrop extends Component {
         this.$media = $(this.media);
         // Needed for editors in iframes.
         this.document = this.media.ownerDocument;
+        this.restoreCursor = preserveCursor(this.media.ownerDocument);
         // key: ratio identifier, label: displayed to user, value: used by cropper lib
         const src = this.media.getAttribute('src');
         const data = {...this.media.dataset};


### PR DESCRIPTION
Steps to reproduce:
- Drag and drop any snippet with image in it.
- Select image and crop image using transform option.
- Click replace button.
- Image selection popover won't open.

After this commit:
- The "preserveCursor" method has been used to maintain the cursor
state because transform option was losing cursor selection.

task-3930743
