### PR TITLE
[FIX] l10n_in_ewaybill_stock: transportation_doc_no field visible for By Road 

### DIFF
--- a/addons/l10n_in_ewaybill_stock/views/l10n_in_ewaybill_views.xml
+++ b/addons/l10n_in_ewaybill_stock/views/l10n_in_ewaybill_views.xml
@@ -92,7 +92,7 @@
                             </div>
                         </group>
                         <group>
-                            <label for="transportation_doc_no" invisible="mode != '1' or not mode"/>
+                            <label for="transportation_doc_no" invisible="mode != '1'"/>
                             <label for="transportation_doc_no" invisible="mode != '2'" string="RR No"/>
                             <label for="transportation_doc_no" invisible="mode != '3'" string="Airway Bill"/>
                             <label for="transportation_doc_no" invisible="mode != '4'" string="Bill of lading No"/>
@@ -100,18 +100,19 @@
                                 <field name="transportation_doc_no"
                                        readonly="state != 'pending'"
                                        required="mode in ('2', '3', '4')"
-                                       invisible="mode not in ('2', '3', '4')"/>
+                                       invisible="not mode"/>
                             </div>
 
 
-                            <label for="transportation_doc_date" invisible="mode != '1' or not mode"/>
+                            <label for="transportation_doc_date" invisible="mode != '1'"/>
                             <label for="transportation_doc_date" invisible="mode != '2'" string="RR Date"/>
                             <label for="transportation_doc_date" invisible="mode != '3'" string="Airway Bill Date"/>
                             <label for="transportation_doc_date" invisible="mode != '4'" string="Bill of lading Date"/>
                             <div class="o_row">
                                 <field name="transportation_doc_date"
                                        readonly="state != 'pending'"
-                                       required="mode in ('2', '3', '4')" invisible="mode not in ('2', '3', '4')"/>
+                                       required="mode in ('2', '3', '4')"
+                                       invisible="not mode"/>
                             </div>
                         </group>
                     </group>


### PR DESCRIPTION
Before this commit:
The label for Transporter Doc Number and Date was visible but
the field was seemed to be hidden

After this commit:
We fix the above issue, now the field is visible when
the mode is selected to `By Road`

task-3959862
Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
