### PR TITLE
[IMP] website: add breadcrumb feature to website page

### DIFF
--- a/addons/website/models/assets.py
+++ b/addons/website/models/assets.py
@@ -47,6 +47,7 @@ class Web_EditorAssets(models.AbstractModel):
                 'menu-secondary-gradient': 'null',
                 'footer-gradient': 'null',
                 'copyright-gradient': 'null',
+                'breadcrumb-gradient': 'null',
                 **preset_gradients,
             })
 

--- a/addons/website/models/website_page.py
+++ b/addons/website/models/website_page.py
@@ -7,6 +7,7 @@ from odoo import api, fields, models
 from odoo.osv import expression
 from odoo.tools import escape_psql, SQL
 from odoo.tools.translate import _
+from odoo.exceptions import ValidationError
 
 
 class WebsitePage(models.Model):
@@ -28,6 +29,7 @@ class WebsitePage(models.Model):
     is_homepage = fields.Boolean(compute='_compute_is_homepage', string='Homepage')
     is_visible = fields.Boolean(compute='_compute_visible', string='Is Visible')
     is_new_page_template = fields.Boolean(string="New Page Template", help='Add this page to the "+New" page templates. It will be added to the "Custom" category.')
+    parent_id = fields.Many2one('website.page', string="Parent Page", domain="[('website_id', '=?', website_id), ('id', '!=', id)]", store=True, readonly=False)
 
     # Page options
     header_overlay = fields.Boolean()
@@ -35,6 +37,10 @@ class WebsitePage(models.Model):
     header_text_color = fields.Char()
     header_visible = fields.Boolean(default=True)
     footer_visible = fields.Boolean(default=True)
+    breadcrumb_overlay = fields.Boolean()
+    breadcrumb_color = fields.Char()
+    breadcrumb_text_color = fields.Char()
+    breadcrumb_visible = fields.Boolean(default=True)
 
     # don't use mixin website_id but use website_id on ir.ui.view instead
     website_id = fields.Many2one(related='view_id.website_id', store=True, readonly=False, ondelete='cascade')

--- a/addons/website/static/src/components/wysiwyg_adapter/page_options.js
+++ b/addons/website/static/src/components/wysiwyg_adapter/page_options.js
@@ -12,6 +12,14 @@ export const pageOptionsCallbacks = {
         footerEl.classList.toggle('d-none', !value);
         footerEl.classList.toggle('o_snippet_invisible', !value);
     },
+    breadcrumb_overlay(value) {
+        this.document.querySelector("main").classList.toggle("o_breadcrumb_overlay", value);
+    },
+    breadcrumb_visible(value) {
+        const breadcrumbEl = this.document.querySelector("#wrapwrap div.o_page_breadcrumb");
+        breadcrumbEl.classList.toggle("d-none", !value);
+        breadcrumbEl.classList.toggle("o_snippet_invisible", !value);
+    },
 };
 export class PageOption {
     /***

--- a/addons/website/static/src/interactions/page_breadcrumb.js
+++ b/addons/website/static/src/interactions/page_breadcrumb.js
@@ -1,0 +1,40 @@
+import { Interaction } from "@web/public/interaction";
+import { registry } from "@web/core/registry";
+
+export class PageBreadcrumb extends Interaction {
+    static selector = "div.o_page_breadcrumb";
+    dynamicContent = {
+        _window: {
+            "t-on-resize": this._updatePageBreadcrumbOnResize,
+        },
+    };
+
+    start() {
+        //need to adjust breadcrumb when page is loaded and interaction initiates
+        this._updatePageBreadcrumbOnResize();
+    }
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
+    /**
+     * Called when the window is resized
+     *
+     * @private
+     */
+    _updatePageBreadcrumbOnResize() {
+        const wrapwrapEl = document.querySelector("div#wrapwrap");
+        const headerHeight = wrapwrapEl
+            ?.querySelector("header#top")
+            ?.getBoundingClientRect().height;
+        if (headerHeight && wrapwrapEl.classList.contains("o_header_overlay")) {
+            this.el.style.top = `${headerHeight}px`;
+        }
+    }
+}
+
+registry.category("public.interactions").add("website.page_breadcrumb", PageBreadcrumb);
+
+registry.category("public.interactions.edit").add("website.page_breadcrumb", {
+    Interaction: PageBreadcrumb,
+});

--- a/addons/website/static/src/scss/primary_variables.scss
+++ b/addons/website/static/src/scss/primary_variables.scss
@@ -21,6 +21,7 @@ $o-base-color-palette: map-merge($o-base-color-palette, (
     'footer-custom': null,
     'copyright': null,
     'copyright-custom': null,
+    'breadcrumb': 1,
 ));
 
 // By default, all user color palette values are null. Each null value is
@@ -2168,6 +2169,7 @@ $o-base-website-values-palette: (
     'menu-secondary-gradient': null,
     'footer-gradient': null,
     'copyright-gradient': null,
+    'breadcrumb-gradient': null,
 
     'header-template': 'default', // 'default' / 'hamburger' / 'vertical' / 'sidebar'
     'header-font-size': null, // Default to BS (normal font-size)

--- a/addons/website/static/src/scss/secondary_variables.scss
+++ b/addons/website/static/src/scss/secondary_variables.scss
@@ -150,7 +150,7 @@ $-actual-user-color-palette: map-merge($-palette-default, $o-user-color-palette)
     'header-sales_three': 'header-sales_three-custom',
     'header-sales_four': 'header-sales_four-custom',
     'footer': 'footer-custom',
-    'copyright': 'copyright-custom'
+    'copyright': 'copyright-custom',
 ) {
     $-base-value: map-get($-actual-user-color-palette, $name);
     @if $-base-value and $-base-value != 'NULL' and type-of($-base-value) != 'number' {

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -201,6 +201,49 @@ body {
         @include body-image-bg-style();
     }
 
+    > main:not(.o_breadcrumb_overlay) {
+        div.o_page_breadcrumb {
+            nav {
+                @include o-apply-colors('breadcrumb');
+                @include o-add-gradient('breadcrumb-gradient');
+            }
+            a {
+                color: inherit !important;
+            }
+        }
+    }
+
+    &.o_header_overlay div.o_page_breadcrumb {
+        @include o-position-absolute(auto, auto, auto, auto);
+        z-index: 1 !important;
+        width: -webkit-fill-available;
+    }
+
+    header#top.d-none ~ main.o_breadcrumb_overlay {
+        div.o_page_breadcrumb {
+            position: absolute;
+            top: 0 !important;
+        }
+    }
+
+    > main.o_breadcrumb_overlay {
+        div.o_page_breadcrumb {
+            @include o-position-absolute(auto, auto, auto, auto);
+            z-index: 1 !important;
+            width: -webkit-fill-available;
+            a {
+                color: inherit !important;
+            }
+            nav {
+                @include o-apply-colors(1);
+                background-color: transparent !important;
+                background-image: none !important;
+                border-color: transparent;
+                color: inherit;
+            }
+        }
+    }
+
     @if o-website-value('layout') != 'full' {
         > main {
             // The color behind the boxed layout is forced by Odoo. The box

--- a/addons/website/static/tests/tours/website_page_options.js
+++ b/addons/website/static/tests/tours/website_page_options.js
@@ -6,6 +6,7 @@ import {
     registerWebsitePreviewTour,
 } from '@website/js/tours/tour_utils';
 
+const breadcrumb = {id: "o_page_breadcrumb", name: "Breadcrumb"};
 
 registerWebsitePreviewTour('website_page_options', {
     url: '/',
@@ -24,8 +25,14 @@ registerWebsitePreviewTour('website_page_options', {
     },
     ...clickOnEditAndWaitEditMode(),
     ...clickOnSnippet({id: 'o_header_standard', name: 'Header'}),
-    changeOption('topMenuColor', 'we-select.o_we_so_color_palette'),
-    changeOption('topMenuColor', 'button[data-color="black-50"]', 'background color', 'bottom', true),
+    changeOption("BaseColorOption", "we-select.o_we_so_color_palette"),
+    changeOption(
+        "BaseColorOption",
+        'button[data-color="black-50"]',
+        "background color",
+        "bottom",
+        true
+    ),
     ...clickOnSave(),
     {
         content: "Check that the header is in black-50",
@@ -33,8 +40,8 @@ registerWebsitePreviewTour('website_page_options', {
     },
     ...clickOnEditAndWaitEditMode(),
     ...clickOnSnippet({id: 'o_header_standard', name: 'Header'}),
-    changeOption("topMenuColor", '[data-page-option-name="header_text_color"]'),
-    changeOption("topMenuColor", 'button[style="background-color:#FF0000;"]', "text color", "bottom", true),
+    changeOption("BaseColorOption", '[data-page-option-name="header_text_color"]'),
+    changeOption("BaseColorOption", 'button[style="background-color:#FF0000;"]', "text color", "bottom", true),
     ...clickOnSave(),
     {
         content: "Check that text color of the header is in red",
@@ -85,3 +92,104 @@ registerWebsitePreviewTour('website_page_options', {
         trigger: ':iframe #wrapwrap:has(.o_footer.d-none.o_snippet_invisible)',
     },
 ]);
+
+registerWebsitePreviewTour(
+    "website_page_breadcrumb",
+    {
+        url: "/contactus",
+        edition: false,
+    },
+    () => [
+        {
+            content: "Check Contact Us page is open",
+            trigger: ":iframe html[data-view-xmlid='website.contactus']",
+        },
+        {
+            content: "Click on Site Menu",
+            trigger: "button[data-menu-xmlid='website.menu_site']",
+            run: "click",
+        },
+        {
+            content: "Click on Properties",
+            trigger: "a[data-menu-xmlid='website.menu_page_properties']",
+            run: "click",
+        },
+        {
+            content: "Enable Parent Page Option",
+            trigger: "div[name='has_parent_page'] input",
+            run: "click",
+        },
+        {
+            content: "Save the changes",
+            trigger: "button.o_form_button_save",
+            run: "click",
+        },
+        {
+            content: "Check Breadcrumb is visible",
+            trigger: ":iframe div[data-name='Breadcrumb']",
+        },
+        ...clickOnEditAndWaitEditMode(),
+        ...clickOnSnippet(breadcrumb),
+        changeOption("WebsiteLevelColor", "we-select.o_we_so_color_palette"),
+        {
+            content: "Change background color of breadcrumb",
+            trigger: "button[data-target='custom-colors']",
+            run: "click",
+        },
+        changeOption(
+            "WebsiteLevelColor",
+            'button[data-color="black-50"]',
+            "background color",
+            "bottom",
+            true
+        ),
+        ...clickOnSave(),
+        {
+            content: "Check that the breadcrumb is in black-50",
+            trigger: ":iframe div#wrapwrap main div.o_page_breadcrumb",
+            run: function () {
+                const rgbString = getComputedStyle(this.anchor)["background-color"];
+                return rgbString === "rgba(0, 0, 0, 0.5)";
+            },
+        },
+        ...clickOnEditAndWaitEditMode(),
+        ...clickOnSnippet(breadcrumb),
+        changeOption("BreadcrumbOptions", "we-select:has([data-visibility]) we-toggler"),
+        changeOption("BreadcrumbOptions", 'we-button[data-visibility="transparent"]'),
+        ...clickOnSave(),
+        {
+            content: "Check that the breadcrumb is transparent",
+            trigger: ":iframe main.o_breadcrumb_overlay",
+        },
+        ...clickOnEditAndWaitEditMode(),
+        ...clickOnSnippet(breadcrumb),
+        changeOption("BaseColorOption", "we-select.o_we_so_color_palette"),
+        changeOption(
+            "BaseColorOption",
+            'button[data-color="black-50"]',
+            "background color",
+            "bottom",
+            true
+        ),
+        ...clickOnSave(),
+        {
+            content: "Check that the breadcrumb is in black-50",
+            trigger: ":iframe .o_page_breadcrumb.bg-black-50",
+        },
+        ...clickOnEditAndWaitEditMode(),
+        ...clickOnSnippet(breadcrumb),
+        changeOption("BreadcrumbOptions", "we-select:has([data-visibility]) we-toggler"),
+        changeOption("BreadcrumbOptions", 'we-button[data-visibility="hidden"]'),
+        ...clickOnSave(),
+        {
+            content: "Check that the breadcrumb is hidden",
+            trigger: ":iframe main:has(div.o_page_breadcrumb.d-none.o_snippet_invisible)",
+        },
+        ...clickOnEditAndWaitEditMode(),
+        {
+            content: "Click on 'breacrumb' in the invisible elements list",
+            trigger: ".o_we_invisible_el_panel .o_we_invisible_entry",
+            run: "click",
+        },
+    ]
+);

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -462,6 +462,7 @@ class TestUi(HttpCaseWithWebsiteUser):
 
     def test_19_website_page_options(self):
         self.start_tour("/odoo", "website_page_options", login="admin")
+        self.start_tour("/contactus", "website_page_breadcrumb", login="admin")
 
     def test_20_snippet_editor_panel_options(self):
         self.start_tour('/@/', 'snippet_editor_panel_options', login='admin')

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -1270,9 +1270,10 @@
         </we-select>
     </div>
 
-    <div data-js="topMenuColor"
+    <div data-js="BaseColorOption"
          data-selector="[data-main-object^='website.page('] #wrapwrap > header"
-         data-no-check="true">
+         data-no-check="true"
+         data-color-option-name="header_overlay">
         <we-colorpicker string="Background"
             class="o_we_sublevel_1"
             id="option_header_transparent_color"
@@ -1446,6 +1447,52 @@
                   data-unit="px"
                   data-save-unit="rem"
                   data-dependencies="!header_effect_scroll_opt"/>
+    </div>
+
+    <!-- Breadcrumb Options -->
+    <div data-js="WebsiteLevelColor"
+         data-selector="#wrapwrap > main div.o_page_breadcrumb"
+         data-no-check="true"
+         groups="website.group_website_designer">
+
+        <we-row string="Background">
+            <we-colorpicker data-customize-website-color="" data-color="breadcrumb"
+                            data-customize-website-layer2-color="" data-layer-color="breadcrumb" data-layer-gradient="breadcrumb-gradient"
+                            data-no-bundle-reload="true"
+                            data-null-value="'NULL'"
+                            data-with-combinations="customizeWebsiteColor"
+                            data-with-gradients="true"/>
+        </we-row>
+    </div>
+
+    <div data-js="BreadcrumbOptions" data-selector="#wrapwrap > main div.o_page_breadcrumb"
+        data-no-check="True">
+        <we-select string="Breadcrumb Position" data-no-preview="true">
+            <we-button data-name="over_content_breadcrumb_visibility_opt"
+                       data-visibility="transparent">Over The Content</we-button>
+            <we-button data-name="regular_breadcrumb_visibility_opt"
+                       data-visibility="regular">Regular</we-button>
+            <we-button data-visibility="hidden">Hidden</we-button>
+        </we-select>
+    </div>
+
+    <div data-js="BaseColorOption" data-selector="#wrapwrap > main div.o_page_breadcrumb"
+         data-no-check="true"
+         data-color-option-name="breadcrumb_overlay">
+        <we-colorpicker string="Overlay"
+            class="o_we_sublevel_1"
+            data-select-style="true"
+            data-prevent-important="true"
+            data-css-property="background-color"
+            data-color-prefix="bg-"
+            data-excluded="theme, common"
+            data-page-option-name="breadcrumb_color"/>
+        <we-colorpicker string="Text Color"
+            class="o_we_sublevel_1"
+            data-select-style="true"
+            data-css-property="color"
+            data-color-prefix="text-"
+            data-page-option-name="breadcrumb_text_color"/>
     </div>
 
     <!-- Footer - Colors & Layouts -->

--- a/addons/website/views/website_pages_views.xml
+++ b/addons/website/views/website_pages_views.xml
@@ -39,8 +39,8 @@
                     <field name="is_in_menu" widget="boolean_toggle" options="{'autosave': False}"/>
                     <button type="action" name="%(website.open_custom_menu)d" context="{'xmlid': 'website.menu_edit_menu'}" string="Edit Menu" class="btn-link" icon="oi-arrow-right"/>
                 </div>
-
-                <field name="is_homepage" string="Is Homepage" widget="boolean_toggle" options="{'autosave': False}"/>
+                <!-- is_homepage toggle auto-save is enabled to update the current homepage for assigning parent_id -->
+                <field name="is_homepage" string="Is Homepage" widget="boolean_toggle"/>
                 <field name="is_published" string="Published" widget="boolean_toggle" options="{'autosave': False}" invisible="not can_publish"/>
             </group>
         </form>
@@ -74,6 +74,14 @@
                 </div>
             </div>
         </xpath>
+        <field name="is_homepage" position="after">
+            <label for="has_parent_page" invisible="is_homepage"/>
+            <div class="d-flex" invisible="is_homepage">
+                <field name="has_parent_page" class="w-25" widget="boolean_toggle" options="{'autosave': False}"/>
+                <label for="parent_id" string="/" invisible="not has_parent_page"/>
+                <field name="parent_id" widget="many2one" invisible="not has_parent_page" required="has_parent_page and not is_homepage" domain="[('website_id','=',website_id),('id','!=',target_model_id)]"/>
+            </div>
+        </field>
         <xpath expr="//group/field[@name='is_published']" position="after">
             <field name="date_publish" widget="datetime"/>
         </xpath>
@@ -107,6 +115,7 @@
             <field name="is_in_menu" string="Is In Main Menu"/>
             <field name="is_seo_optimized"/>
             <field name="is_published"/>
+            <field name="parent_id" widget="many2one" optional="show"/>
 
             <field name="create_uid" column_invisible="True"/>
             <field name="write_uid" widget="many2one_avatar" optional="hide"/>

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -285,10 +285,36 @@
         </t>
     </xpath>
 
+    <!-- Breadcrumb -->
+    <xpath expr="//main/*[1]" position="before">
+        <t t-if="main_object._name == 'website.page' and main_object['parent_id']">
+            <div class="o_page_breadcrumb" data-name="Breadcrumb">
+                    <nav aria-label="breadcrumb">
+                        <t t-set="parent_page" t-value="main_object.parent_id"/>
+                        <ul class="breadcrumb container mb-0 p-2">
+                            <li t-if="parent_page.parent_id and parent_page.parent_id.url">
+                                    <a t-att-href="parent_page.parent_id.url" t-out="parent_page.parent_id.name"/>
+                                    <span class="pe-1"> / </span>
+                            </li>
+                            <li>
+                                <a t-att-href="parent_page.url" t-out="parent_page.name"/>
+                                <span> / </span>
+                            </li>
+                            <li class="px-1">
+                                <span t-out="main_object.name"/>
+                            </li>
+                        </ul>
+                    </nav>
+            </div>
+        </t>
+    </xpath>
+   
+
+
     <!-- Page options -->
     <xpath expr="//div[@id='wrapwrap']" position="before">
         <t groups="website.group_website_restricted_editor">
-            <t t-foreach="['header_overlay', 'header_color', 'header_text_color', 'header_visible', 'footer_visible']" t-as="optionName">
+            <t t-foreach="['header_overlay', 'header_color', 'header_text_color', 'header_visible', 'footer_visible', 'breadcrumb_overlay', 'breadcrumb_color', 'breadcrumb_text_color', 'breadcrumb_visible']" t-as="optionName">
                 <!-- Firefox autocomplete is too aggressive and works on hidden inputs,
                 so we need to disable it (https://bugzilla.mozilla.org/show_bug.cgi?id=520561) -->
                 <input t-if="optionName in main_object" type="hidden" class="o_page_option_data" autocomplete="off" t-att-name="optionName" t-att-value="main_object[optionName]"/>
@@ -304,6 +330,16 @@
         <t t-set="header_text_color_is_class" t-value="'text-' in header_text_color"/>
         <t t-set="header_text_color_class" t-value="header_text_color_is_class and header_text_color or ''"/>
         <t t-set="header_text_color_style" t-value="(not header_text_color_is_class) and header_text_color or ''"/>
+
+        <t t-set="breadcrumb_bg_color" t-value="'breadcrumb_color' in main_object and main_object.breadcrumb_color or ''"/>
+        <t t-set="breadcrumb_bg_color_is_class" t-value="'bg-' in breadcrumb_bg_color"/>
+        <t t-set="breadcrumb_bg_color_class" t-value="breadcrumb_bg_color_is_class and breadcrumb_bg_color or ''"/>
+        <t t-set="breadcrumb_bg_color_style" t-value="(not breadcrumb_bg_color_is_class) and breadcrumb_bg_color or ''"/>
+
+        <t t-set="breadcrumb_text_color" t-value="'breadcrumb_text_color' in main_object and main_object.breadcrumb_text_color or ''"/>
+        <t t-set="breadcrumb_text_color_is_class" t-value="'text-' in breadcrumb_text_color"/>
+        <t t-set="breadcrumb_text_color_class" t-value="breadcrumb_text_color_is_class and breadcrumb_text_color or ''"/>
+        <t t-set="breadcrumb_text_color_style" t-value="(not breadcrumb_text_color_is_class) and breadcrumb_text_color or ''"/>
 
         <div groups="base.group_user" class="o_frontend_to_backend_nav position-fixed d-none">
             <svg class="o_frontend_to_backend_icon position-absolute" width="24px" height="24px"
@@ -339,6 +375,17 @@
     <xpath expr="//footer[@id='bottom']" position="attributes">
         <attribute name="t-attf-class" add="#{'d-none o_snippet_invisible' if 'footer_visible' in main_object and not main_object.footer_visible else ''}" separator=" "/>
         <attribute name="t-att-data-invisible">'1' if 'footer_visible' in main_object and not main_object.footer_visible else None</attribute>
+    </xpath>
+    <xpath expr="//main" position="attributes">
+        <attribute name="t-attf-class" add="#{'o_breadcrumb_overlay' if 'breadcrumb_overlay' in main_object and main_object.breadcrumb_overlay else ''}" />
+    </xpath>
+    <xpath expr="//div[hasclass('o_page_breadcrumb')]" position="attributes">
+        <attribute name="t-attf-class" add="o_page_breadcrumb #{breadcrumb_bg_color_class} #{breadcrumb_text_color_class}" separator=" "/>
+        <attribute name="t-attf-style" add="#{breadcrumb_bg_color_style and ('background-color: %s;' % breadcrumb_bg_color_style)} #{breadcrumb_text_color_style and ('color: %s;' % breadcrumb_text_color_style)}"  separator=" "/>
+    </xpath>
+    <xpath expr="//div[hasclass('o_page_breadcrumb')]" position="attributes">
+        <attribute name="t-attf-class" add="#{'d-none o_snippet_invisible' if 'breadcrumb_visible' in main_object and not main_object.breadcrumb_visible else ''}" separator=" "/>
+        <attribute name="t-att-data-invisible">'1' if 'breadcrumb_visible' in main_object and not main_object.breadcrumb_visible else None</attribute>
     </xpath>
 </template>
 


### PR DESCRIPTION
This PR introduces a breadcrumb feature to website pages, enhancing navigation and user experience. Key features include:

- **Breadcrumb Option in Site Properties**: Users can enable the breadcrumb feature from the site properties form view and select a desired parent page to assign as a breadcrumb to the current website page.

- **Customization Options**: Users can adjust the background color of the breadcrumb and modify visibility settings, such as displaying the breadcrumb over the content or hiding it. Along with that we have also added two other option to adjust background color and text color for over the content option.

task-3791063
