### PR TITLE
[IMP] loyalty, _*:  no tax for discount amount on order

### DIFF
--- a/addons/loyalty/__manifest__.py
+++ b/addons/loyalty/__manifest__.py
@@ -5,7 +5,7 @@
     'summary': "Use discounts, gift card, eWallets and loyalty programs in different sales channels",
     'category': 'Sales',
     'version': '1.0',
-    'depends': ['product', 'portal'],
+    'depends': ['product', 'portal', 'account'],
     'data': [
         'security/ir.model.access.csv',
         'security/loyalty_security.xml',

--- a/addons/loyalty/models/loyalty_reward.py
+++ b/addons/loyalty/models/loyalty_reward.py
@@ -86,6 +86,12 @@ class LoyaltyReward(models.Model):
     discount_line_product_id = fields.Many2one('product.product', copy=False, ondelete='restrict',
         help="Product used in the sales order to apply the discount. Each reward has its own product for reporting purpose")
     is_global_discount = fields.Boolean(compute='_compute_is_global_discount')
+    tax_ids = fields.Many2many(
+        string="Taxes",
+        help="Taxes to add on the discount line.",
+        comodel_name='account.tax',
+        domain="[('type_tax_use', '=', 'sale'), ('company_id', '=', company_id)]",
+    )
 
     # Product rewards
     reward_product_id = fields.Many2one(

--- a/addons/loyalty/views/loyalty_reward_views.xml
+++ b/addons/loyalty/views/loyalty_reward_views.xml
@@ -37,6 +37,14 @@
 
                         <group string="Discount" invisible="reward_type != 'discount' or program_type in ('gift_card','ewallet')">
                             <field name="discount_max_amount"/>
+                            <field
+                                name="tax_ids"
+                                placeholder="Untaxed discount"
+                                widget="many2many_tags"
+                                options="{'no_create': True}"
+                                invisible="discount_applicability != 'order' or
+                                    discount_mode not in ('per_order','per_point')"
+                            />
                             <field name="discount_product_domain" groups="base.group_no_one" widget="domain" options="{'model': 'product.product', 'in_dialog': true}" invisible="discount_applicability != 'specific'"/>
                             <field name="discount_product_ids" widget="many2many_tags" invisible="discount_applicability != 'specific'"/>
                             <field name="discount_product_category_id" invisible="discount_applicability != 'specific'"/>
@@ -75,6 +83,7 @@
         <field name="model">loyalty.reward</field>
         <field name="arch" type="xml">
             <kanban>
+                <field name="company_id"/>
                 <field name="currency_id"/>
                 <field name="reward_type"/>
                 <field name="discount_applicability"/>

--- a/addons/pos_loyalty/models/loyalty_reward.py
+++ b/addons/pos_loyalty/models/loyalty_reward.py
@@ -24,7 +24,7 @@ class LoyaltyReward(models.Model):
     def _load_pos_data_fields(self, config_id):
         return ['description', 'program_id', 'reward_type', 'required_points', 'clear_wallet', 'currency_id',
                 'discount', 'discount_mode', 'discount_applicability', 'all_discount_product_ids', 'is_global_discount',
-                'discount_max_amount', 'discount_line_product_id', 'reward_product_id',
+                'discount_max_amount', 'discount_line_product_id', 'reward_product_id', 'tax_ids',
                 'multi_product', 'reward_product_ids', 'reward_product_qty', 'reward_product_uom_id', 'reward_product_domain']
 
     def _load_pos_data(self, data):

--- a/addons/sale/tests/test_sale_order_discount.py
+++ b/addons/sale/tests/test_sale_order_discount.py
@@ -30,6 +30,24 @@ class TestSaleOrderDiscount(SaleCommon):
         self.assertEqual(discount_line.product_uom_qty, 1.0)
         self.assertFalse(discount_line.tax_id)
 
+    def test_amount_with_manual_tax(self):
+        self.tax_15pc_excl = self.env['account.tax'].create({
+            'name': "15% Tax excl",
+            'amount_type': 'percent',
+            'amount': 15,
+        })
+        self.wizard.write({
+            'discount_amount': 55,
+            'discount_type': 'amount',
+            'tax_ids': [(6, 0, (self.tax_15pc_excl.id,))],
+        })
+        self.wizard.action_apply_discount()
+
+        discount_line = self.sale_order.order_line[-1]
+        self.assertEqual(discount_line.price_unit, -55)
+        self.assertEqual(discount_line.product_uom_qty, 1.0)
+        self.assertEqual(discount_line.price_total, -63.25)
+
     def test_so_discount(self):
         solines = self.sale_order.order_line
         amount_before_discount = self.sale_order.amount_total

--- a/addons/sale/wizard/sale_order_discount.py
+++ b/addons/sale/wizard/sale_order_discount.py
@@ -24,6 +24,12 @@ class SaleOrderDiscount(models.TransientModel):
         ],
         default='sol_discount',
     )
+    tax_ids = fields.Many2many(
+        string="Taxes",
+        help="Taxes to add on the discount line.",
+        comodel_name='account.tax',
+        domain="[('type_tax_use', '=', 'sale'), ('company_id', '=', company_id)]",
+    )
 
     # CONSTRAINT METHODS #
 
@@ -84,7 +90,7 @@ class SaleOrderDiscount(models.TransientModel):
                 self._prepare_discount_line_values(
                     product=discount_product,
                     amount=self.discount_amount,
-                    taxes=self.env['account.tax'],
+                    taxes=self.tax_ids,
                 )
             ]
         else: # so_discount

--- a/addons/sale/wizard/sale_order_discount_views.xml
+++ b/addons/sale/wizard/sale_order_discount_views.xml
@@ -21,6 +21,13 @@
                                 <field name="discount_percentage"
                                        invisible="discount_type not in ('so_discount', 'sol_discount')"
                                        widget="percentage" nolabel="1"/>
+                                <field
+                                    name="tax_ids"
+                                    placeholder="Untaxed discount"
+                                    widget="many2many_tags"
+                                    options="{'no_create': True}"
+                                    invisible="discount_type != 'amount'"
+                                />
                             </group>
                         </div>
                         <div class="col-sm-7 col-md-8 col-lg-8 col-8">

--- a/addons/sale_loyalty/tests/test_program_numbers.py
+++ b/addons/sale_loyalty/tests/test_program_numbers.py
@@ -614,6 +614,52 @@ class TestSaleCouponProgramNumbers(TestSaleCouponNumbersCommon):
         self._auto_rewards(order, self.all_programs)
         self.assertEqual(order.amount_total, 65.0, "The coupon should not be removed from the order")
 
+    def test_coupon_discount_with_taxes_applied(self):
+        """Ensure coupon discount with taxes applies correctly
+           and doesn't make the order total go below 0.
+        """
+
+        coupon_program = self.env['loyalty.program'].create({
+            'name': '$300 coupon',
+            'program_type': 'coupons',
+            'trigger': 'with_code',
+            'applies_on': 'current',
+            'reward_ids': [(0, 0, {
+                'reward_type': 'discount',
+                'discount_mode': 'per_point',
+                'discount': 300,
+                'discount_applicability': 'order',
+                'required_points': 1,
+                'tax_ids': [(6, 0, (self.tax_15pc_excl.id,))],
+            })],
+        })
+
+        order = self.empty_order
+        self.env['sale.order.line'].create([
+        {
+            'product_id': self.conferenceChair.id,
+            'name': 'Conference Chair',
+            'product_uom_qty': 1.0,
+            'price_unit': 100.0,
+            'order_id': order.id,
+            'tax_id': [(6, 0, (self.tax_15pc_excl.id,))],
+        },
+        ])
+
+        self.env['loyalty.generate.wizard'].with_context(active_id=coupon_program.id).create({
+            'coupon_qty': 1,
+            'points_granted': 1,
+        }).generate_coupons()
+        coupon = coupon_program.coupon_ids
+        self._apply_promo_code(order, coupon.code)
+
+        self.assertEqual(order.amount_tax, 0.0)
+        self.assertEqual(order.amount_untaxed, 0.0, "The untaxed amount should not go below 0")
+        self.assertEqual(
+            order.amount_total, 0.0,
+            "The promotion program should not make the order total go below 0"
+        )
+
     def test_coupon_and_program_discount_fixed_amount(self):
         """ Ensure coupon and program discount both with
             minimum amount rule can cohexists without making
@@ -728,9 +774,9 @@ class TestSaleCouponProgramNumbers(TestSaleCouponNumbersCommon):
         coupon = coupon_program.coupon_ids
         self._apply_promo_code(order, coupon.code)
         self._auto_rewards(order, self.all_programs)
-        self.assertEqual(order.amount_tax, 0.0)
+        self.assertEqual(order.amount_tax, 13.5)
         self.assertEqual(order.amount_untaxed, 0.0, "The untaxed amount should not go below 0")
-        self.assertEqual(order.amount_total, 0.0, "The promotion program should not make the order total go below 0")
+        self.assertEqual(order.amount_total, 13.5, "The promotion program should not make the order total go below 0")
 
         order.order_line[3:].unlink() #remove all coupon
         order._remove_program_from_points(coupon_program)
@@ -743,13 +789,13 @@ class TestSaleCouponProgramNumbers(TestSaleCouponNumbersCommon):
         self._auto_rewards(order, self.all_programs)
         self._apply_promo_code(order, 'test_10pc')
         self._auto_rewards(order, self.all_programs)
-        self.assertAlmostEqual(order.amount_tax, 1.13, 2)
-        self.assertEqual(order.amount_untaxed, 22.72)
+        self.assertAlmostEqual(order.amount_tax, 13.5, 2)
+        self.assertEqual(order.amount_untaxed, 10.35)
         self.assertEqual(order.amount_total, 23.85, "The promotion program should not make the order total go below 0be altered after recomputation")
         # It should stay the same after a recompute, order matters
         self._auto_rewards(order, self.all_programs)
-        self.assertAlmostEqual(order.amount_tax, 1.13, 2)
-        self.assertEqual(order.amount_untaxed, 22.72)
+        self.assertAlmostEqual(order.amount_tax, 13.5, 2)
+        self.assertEqual(order.amount_untaxed, 10.35)
         self.assertEqual(order.amount_total, 23.85, "The promotion program should not make the order total go below 0be altered after recomputation")
 
     def test_coupon_and_coupon_discount_fixed_amount_tax_incl(self):
@@ -814,11 +860,11 @@ class TestSaleCouponProgramNumbers(TestSaleCouponNumbersCommon):
         }).generate_coupons()
         coupon = coupon_program.coupon_ids
         self._apply_promo_code(order, coupon.code)
-        self.assertEqual(order.amount_total, 0.0, "The promotion program should not make the order total go below 0")
-        self.assertEqual(order.amount_tax, 0)
+        self.assertEqual(order.amount_total, 8.18, "The promotion program should not make the order total go below 0")
+        self.assertEqual(order.amount_tax, 8.18)
         self._auto_rewards(order, self.all_programs)
-        self.assertEqual(order.amount_total, 0.0, "The promotion program should not be altered after recomputation")
-        self.assertEqual(order.amount_tax, 0)
+        self.assertEqual(order.amount_total, 8.18, "The promotion program should not be altered after recomputation")
+        self.assertEqual(order.amount_tax, 8.18)
 
         order.order_line[3:].unlink() #remove all coupon
         order._remove_program_from_points(coupon_program)
@@ -831,13 +877,13 @@ class TestSaleCouponProgramNumbers(TestSaleCouponNumbersCommon):
         self._apply_promo_code(order, 'test_10pc')
         self._auto_rewards(order, self.all_programs)
         self.assertEqual(order.amount_total, 9.0, "The promotion program should not make the order total go below 0")
-        self.assertEqual(order.amount_tax, 0.27)
-        self.assertEqual(order.amount_untaxed, 8.73)
+        self.assertEqual(order.amount_tax, 8.18)
+        self.assertEqual(order.amount_untaxed, 0.82)
         # It should stay the same after a recompute, order matters
         self._auto_rewards(order, self.all_programs)
         self.assertEqual(order.amount_total, 9.0, "The promotion program should not make the order total go below 0")
-        self.assertEqual(order.amount_tax, 0.27)
-        self.assertEqual(order.amount_untaxed, 8.73)
+        self.assertEqual(order.amount_tax, 8.18)
+        self.assertEqual(order.amount_untaxed, 0.82)
 
     def test_program_discount_on_multiple_specific_products(self):
         """ Ensure a discount on multiple specific products is correctly computed.
@@ -1506,13 +1552,13 @@ class TestSaleCouponProgramNumbers(TestSaleCouponNumbersCommon):
         self._auto_rewards(order, program)
 
         self.assertEqual(order.amount_total, 7, 'Price should be 12$ - 5$(discount) = 7$')
-        self.assertEqual(float_compare(order.amount_tax, 7 / 12, precision_rounding=3), 0, '20% Tax included on 7$')
+        self.assertEqual(float_compare(order.amount_tax, 7 / 4, precision_rounding=3), 0, '20% Tax included on 7$')
 
         sol.tax_id = self.tax_10pc_base_incl + self.tax_10pc_excl
         self._auto_rewards(order, program)
 
         self.assertAlmostEqual(order.amount_total, 6, 1, msg='Price should be 11$ - 5$(discount) = 6$')
-        self.assertEqual(float_compare(order.amount_tax, 6 / 12, precision_rounding=3), 0, '20% Tax included on 6$')
+        self.assertEqual(float_compare(order.amount_tax, 6 / 4, precision_rounding=3), 0, '20% Tax included on 6$')
 
     def test_fixed_amount_taxes_attribution_multiline(self):
 
@@ -1562,8 +1608,8 @@ class TestSaleCouponProgramNumbers(TestSaleCouponNumbersCommon):
         self._auto_rewards(order, program)
 
         self.assertAlmostEqual(order.amount_total, 16, 1, msg='Price should be 21$ - 5$(discount) = 16$')
-        # Tax amount = 10% in 10$ + 10% in 11$ - 10% in 5$ (apply on excluded)
-        self.assertEqual(float_compare(order.amount_tax, 5 / 11, precision_rounding=3), 0)
+        # Tax amount = 10% in 10$ + 10% in 11$
+        self.assertEqual(float_compare(order.amount_tax, 5 / 3, precision_rounding=3), 0)
 
         sol2.tax_id = self.tax_10pc_base_incl + self.tax_10pc_excl
         self._auto_rewards(order, program)


### PR DESCRIPTION
_* =sale_loyalty, pos_loyalty, sale

Before this commit:
Taxes are applied to all reward lines regardless of discount mode or discount
applicability .

After this commit:
Reward lines that reflect discounts on the order total will have a unit price
matching the discount amount, and taxes will not be applied unless they are set
manually for that reward or discount. This change applies when the discount mode
is either per point or per order, and the discount applicability is on the order
and also for fixed amount discounts.

task: 3527759

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
