### PR TITLE
Master imp tour onboarding ipb

### DIFF
--- a/addons/web/static/src/core/macro.js
+++ b/addons/web/static/src/core/macro.js
@@ -9,6 +9,10 @@ import { Mutex } from "@web/core/utils/concurrency";
  * - Current step index won't be incremented.
  * @property {string | (el: Element, step: MacroStep) => undefined | string} [action]
  * @property {*} [*] - any payload to the step.
+ *
+ * @typedef MacroDescriptor
+ * @property {() => Element | undefined} trigger
+ * @property {() => {}} action
  */
 
 export const ACTION_HELPERS = {

--- a/addons/web_tour/static/src/tour_pointer/tour_pointer.js
+++ b/addons/web_tour/static/src/tour_pointer/tour_pointer.js
@@ -66,9 +66,17 @@ export class TourPointer extends Component {
                 }
             },
         };
-        Object.defineProperty(positionOptions, "position", { get: () => this.position, enumerable: true });
-        const position = usePosition("pointer", () => this.props.pointerState.anchor, positionOptions);
+        Object.defineProperty(positionOptions, "position", {
+            get: () => this.position,
+            enumerable: true,
+        });
+        const position = usePosition(
+            "pointer",
+            () => this.props.pointerState.anchor,
+            positionOptions
+        );
         const rootRef = useRef("pointer");
+        const zoneRef = useRef("zone");
         /** @type {DOMREct | null} */
         let dimensions = null;
         let lastMeasuredContent = null;
@@ -77,10 +85,24 @@ export class TourPointer extends Component {
         let [anchorX, anchorY] = [0, 0];
         useEffect(() => {
             const { el: pointer } = rootRef;
+            const { el: zone } = zoneRef;
             if (pointer) {
                 const hasContentChanged = lastMeasuredContent !== this.content;
                 const hasOpenStateChanged = lastOpenState !== this.isOpen;
                 lastOpenState = this.isOpen;
+
+                // Check is the pointed element is a zone
+                if (this.props.pointerState.isZone) {
+                    const { anchor } = this.props.pointerState;
+                    const { left, top, width, height } = anchor.getBoundingClientRect();
+                    zone.style.minWidth = width + "px";
+                    zone.style.minHeight = height + "px";
+                    zone.style.left = left + "px";
+                    // Update the top only once. Like that it will not be above the header
+                    if (!lastAnchor) {
+                        zone.style.top = top + "px";
+                    }
+                }
 
                 // Content changed: we must re-measure the dimensions of the text.
                 if (hasContentChanged) {

--- a/addons/web_tour/static/src/tour_pointer/tour_pointer.xml
+++ b/addons/web_tour/static/src/tour_pointer/tour_pointer.xml
@@ -26,5 +26,6 @@
                 <t t-out="content" />
             </div>
         </div>
+        <div class="o_tour_dropzone position-fixed pe-none" t-if="props.pointerState.isVisible and props.pointerState.isZone" t-ref="zone" style="border: 3px dashed #714b67;"/>
     </t>
 </templates>

--- a/addons/web_tour/static/src/tour_service/tour_pointer_state.js
+++ b/addons/web_tour/static/src/tour_service/tour_pointer_state.js
@@ -20,6 +20,7 @@ import { getScrollParent } from "./tour_utils";
  * @property {() => {}} [onMouseEnter]
  * @property {() => {}} [onMouseLeave]
  * @property {boolean} isVisible
+ * @property {boolean} isZone
  * @property {Direction} position
  * @property {number} rev
  *
@@ -100,8 +101,9 @@ export function createPointerState() {
     /**
      * @param {TourStep} step
      * @param {HTMLElement} [anchor]
+     * @param {boolean} [isZone] will border de zone. e.g.: a dropzone
      */
-    const pointTo = (anchor, step) => {
+    const pointTo = (anchor, step, isZone) => {
         intersection.setTarget(anchor);
         if (anchor) {
             let { position, content } = step;
@@ -114,7 +116,7 @@ export function createPointerState() {
                     if (document.body.contains(floatingAnchor)) {
                         floatingAnchor.remove();
                     }
-                    setState({ anchor, content, onClick: null, position, isVisible: true });
+                    setState({ anchor, content, isZone, onClick: null, position, isVisible: true });
                     break;
                 }
                 default: {
@@ -125,7 +127,14 @@ export function createPointerState() {
 
                     const scrollParent = getScrollParent(anchor);
                     if (!scrollParent) {
-                        setState({ anchor, content, onClick: null, position, isVisible: true });
+                        setState({
+                            anchor,
+                            content,
+                            isZone,
+                            onClick: null,
+                            position,
+                            isVisible: true,
+                        });
                         return;
                     }
                     const { x, y, width, height } = scrollParent.getBoundingClientRect();
@@ -147,6 +156,7 @@ export function createPointerState() {
                         content,
                         onClick,
                         position,
+                        isZone,
                         isVisible: true,
                     });
                 }

--- a/addons/web_tour/static/src/tour_service/tour_service.js
+++ b/addons/web_tour/static/src/tour_service/tour_service.js
@@ -50,7 +50,7 @@ import { callWithUnloadCheck } from "./tour_utils";
  * @property {string} [consumeEvent] Only in manual mode (onboarding tour). It's the event we want the customer to do.
  * @property {boolean} [mobile] When true, step will only trigger in mobile view.
  * @property {string} [title]
- * @property {string|false|undefined} [shadow_dom] By default, trigger nodes are selected in the main document node 
+ * @property {string|false|undefined} [shadow_dom] By default, trigger nodes are selected in the main document node
  * but this property forces to search in a shadowRoot document.
 
  * @typedef {"manual" | "auto"} TourMode
@@ -334,7 +334,7 @@ export const tourService = {
             const macro = convertToMacro(tour, pointer, options);
             const willUnload = callWithUnloadCheck(() => {
                 if (tour.url && tour.url !== options.startUrl && options.redirect) {
-                    window.location.href = window.location.origin + tour.url;
+                    browser.location.href = browser.location.origin + tour.url;
                 }
             });
             if (!willUnload) {

--- a/addons/web_tour/static/src/tour_service/tour_service.js
+++ b/addons/web_tour/static/src/tour_service/tour_service.js
@@ -8,14 +8,14 @@ import { registry } from "@web/core/registry";
 import { config as transitionConfig } from "@web/core/transition";
 import { session } from "@web/session";
 import { TourPointer } from "../tour_pointer/tour_pointer";
-import { compileStepAuto, compileStepManual, compileTourToMacro } from "./tour_compilers";
+import { compileTourToMacro } from "./tour_compilers";
 import { createPointerState } from "./tour_pointer_state";
 import { tourState } from "./tour_state";
 import { callWithUnloadCheck } from "./tour_utils";
 
 /**
  * @typedef {string} HootSelector
- * @typedef {import("./tour_utils").RunCommand} RunCommand
+ * @typedef {import("./tour_compilers").RunCommand} RunCommand
  *
  * @typedef Tour
  * @property {string} url
@@ -188,8 +188,8 @@ export const tourService = {
                     methods.destroy();
                 },
                 ...methods,
-                async pointTo(anchor, step) {
-                    possiblePointTos.push([tourName, () => methods.pointTo(anchor, step)]);
+                async pointTo(anchor, step, isZone) {
+                    possiblePointTos.push([tourName, () => methods.pointTo(anchor, step, isZone)]);
                     await Promise.resolve();
                     // only done once per macro advance
                     if (!possiblePointTos.length) {
@@ -232,18 +232,14 @@ export const tourService = {
             pointer,
             { mode, stepDelay, keepWatchBrowser, showPointerDuration }
         ) {
-            // IMPROVEMENTS: Custom step compiler. Will probably require decoupling from `mode`.
-            const stepCompiler = mode === "auto" ? compileStepAuto : compileStepManual;
-            const checkDelay = mode === "auto" ? tour.checkDelay : 100;
             const filteredSteps = tour.steps;
             return compileTourToMacro(tour, {
                 filteredSteps,
-                stepCompiler,
+                mode,
                 pointer,
                 stepDelay,
                 keepWatchBrowser,
                 showPointerDuration,
-                checkDelay,
                 onStepConsummed(tour, step) {
                     bus.trigger("STEP-CONSUMMED", { tour, step });
                 },

--- a/addons/web_tour/static/src/tour_service/tour_utils.js
+++ b/addons/web_tour/static/src/tour_service/tour_utils.js
@@ -2,7 +2,6 @@
 import * as hoot from "@odoo/hoot-dom";
 import { markup } from "@odoo/owl";
 import { _t } from "@web/core/l10n/translation";
-import { utils } from "@web/core/ui/ui_service";
 
 /**
  * Calls the given `func` then returns/resolves to `true`
@@ -27,69 +26,6 @@ export function callWithUnloadCheck(func, ...args) {
     }
 }
 
-/**
- * @param {HTMLElement} [element]
- * @param {RunCommand} [runCommand]
- * @returns {string}
- */
-export function getConsumeEventType(element, runCommand) {
-    if (!element) {
-        return "click";
-    }
-    const { classList, tagName, type } = element;
-    const tag = tagName.toLowerCase();
-
-    // Many2one
-    if (classList.contains("o_field_many2one")) {
-        return "autocompleteselect";
-    }
-
-    // Inputs and textareas
-    if (
-        tag === "textarea" ||
-        (tag === "input" &&
-            (!type ||
-                [
-                    "email",
-                    "number",
-                    "password",
-                    "search",
-                    "tel",
-                    "text",
-                    "url",
-                    "date",
-                    "range",
-                ].includes(type)))
-    ) {
-        if (
-            utils.isSmall() &&
-            element.closest(".o_field_widget")?.matches(".o_field_many2one, .o_field_many2many")
-        ) {
-            return "click";
-        }
-        return "input";
-    }
-
-    // Drag & drop run command
-    if (typeof runCommand === "string" && /^drag_and_drop/.test(runCommand)) {
-        // this is a heuristic: the element has to be dragged and dropped but it
-        // doesn't have class 'ui-draggable-handle', so we check if it has an
-        // ui-sortable parent, and if so, we conclude that its event type is 'sort'
-        if (element.closest(".ui-sortable")) {
-            return "sort";
-        }
-        if (
-            (/^drag_and_drop_native/.test(runCommand) && classList.contains("o_draggable")) ||
-            element.closest(".o_draggable") ||
-            element.draggable
-        ) {
-            return "pointerdown";
-        }
-    }
-
-    // Default: click
-    return "click";
-}
 /**
  * @param {HTMLElement} element
  * @returns {HTMLElement | null}

--- a/addons/web_tour/static/tests/tour_service.test.js
+++ b/addons/web_tour/static/tests/tour_service.test.js
@@ -194,7 +194,10 @@ test("points to next step", async () => {
 test("next step with new anchor at same position", async () => {
     tourRegistry.add("tour1", {
         sequence: 10,
-        steps: () => [{ trigger: "button.foo", run: "click" }, { trigger: "button.bar", run: "click"}],
+        steps: () => [
+            { trigger: "button.foo", run: "click" },
+            { trigger: "button.bar", run: "click" },
+        ],
     });
     await makeMockEnv();
 
@@ -499,7 +502,10 @@ test("check tour with inactive steps", async () => {
 test("pointer is added on top of overlay's stack", async () => {
     registry.category("web_tour.tours").add("tour1", {
         sequence: 10,
-        steps: () => [{ trigger: ".modal .a", run: "click" }, { trigger: ".open", run: "click"}],
+        steps: () => [
+            { trigger: ".modal .a", run: "click" },
+            { trigger: ".open", run: "click" },
+        ],
     });
     await makeMockEnv({});
     class DummyDialog extends Component {
@@ -723,6 +729,7 @@ test("scrolling to next step should update the pointer's height", async (assert)
             {
                 trigger: "button.inc",
                 content: stepContent,
+                run: "click",
             },
         ],
     });
@@ -795,7 +802,7 @@ test("scroller pointer to reach next step", async () => {
 
     registry.category("web_tour.tours").add("tour_des_flandres", {
         sequence: 10,
-        steps: () => [{ trigger: "button.inc", content: "Click to increment", run: "click"}],
+        steps: () => [{ trigger: "button.inc", content: "Click to increment", run: "click" }],
     });
     await makeMockEnv();
     class Root extends Component {
@@ -866,17 +873,17 @@ test("manual tour with inactive steps", async () => {
             {
                 isActive: ["auto"],
                 trigger: ".interval input",
-                run: "click",
+                run: "edit 5",
             },
             {
                 isActive: ["auto"],
                 trigger: ".interval input",
-                run: "click",
+                run: "edit 5",
             },
             {
                 isActive: ["manual"],
                 trigger: ".interval input",
-                run: "click",
+                run: "edit 5",
             },
             {
                 isActive: ["auto"],
@@ -921,6 +928,6 @@ test("manual tour with inactive steps", async () => {
     expect(".o_tour_pointer").toHaveCount(1);
     await contains("button.inc").click();
     expect(".o_tour_pointer").toHaveCount(0);
-    await expect(".counter .value").toHaveText("5");
+    expect(".counter .value").toHaveText("5");
     await advanceTime(10000);
 });

--- a/addons/web_tour/static/tests/tour_service.test.js
+++ b/addons/web_tour/static/tests/tour_service.test.js
@@ -166,6 +166,7 @@ test("points to next step", async () => {
         steps: () => [
             {
                 trigger: "button.inc",
+                run: "click",
             },
         ],
     });
@@ -193,7 +194,7 @@ test("points to next step", async () => {
 test("next step with new anchor at same position", async () => {
     tourRegistry.add("tour1", {
         sequence: 10,
-        steps: () => [{ trigger: "button.foo" }, { trigger: "button.bar" }],
+        steps: () => [{ trigger: "button.foo", run: "click" }, { trigger: "button.bar", run: "click"}],
     });
     await makeMockEnv();
 
@@ -498,7 +499,7 @@ test("check tour with inactive steps", async () => {
 test("pointer is added on top of overlay's stack", async () => {
     registry.category("web_tour.tours").add("tour1", {
         sequence: 10,
-        steps: () => [{ trigger: ".modal .a" }, { trigger: ".open" }],
+        steps: () => [{ trigger: ".modal .a", run: "click" }, { trigger: ".open", run: "click"}],
     });
     await makeMockEnv({});
     class DummyDialog extends Component {
@@ -633,6 +634,7 @@ test("should show only 1 pointer at a time", async () => {
         steps: () => [
             {
                 trigger: ".interval input",
+                run: "edit 5",
             },
         ],
     });
@@ -641,6 +643,7 @@ test("should show only 1 pointer at a time", async () => {
         steps: () => [
             {
                 trigger: "button.inc",
+                run: "click",
             },
         ],
     });
@@ -673,7 +676,7 @@ test("perform edit on next step", async () => {
         steps: () => [
             {
                 trigger: ".interval input",
-                run: "click",
+                run: "edit 5",
             },
             {
                 trigger: "button.inc",
@@ -792,7 +795,7 @@ test("scroller pointer to reach next step", async () => {
 
     registry.category("web_tour.tours").add("tour_des_flandres", {
         sequence: 10,
-        steps: () => [{ trigger: "button.inc", content: "Click to increment" }],
+        steps: () => [{ trigger: "button.inc", content: "Click to increment", run: "click"}],
     });
     await makeMockEnv();
     class Root extends Component {


### PR DESCRIPTION
Before this commit, the steps with a run "drag_and_drop" was
showing the element to drag but no info on the dropzone.
The selection of a dropdown item had to be done with a click. If
using Enter or Tab, the step was not validated, eventhough the
result was the same. Same issue, if using any hotkey or validating
form with Enter instead of clicking on the button "Save" for example.
When a user lost the target of the pointer, this one disappear until
the element of the step was visible again.

After this commit, the drops will show the element to drag and
the zone where to drop.
The selection of a dropdown item can be done with Enter or Tab.
The hotkeys and validation though Enter will consume the step.
When an element has been found and pointed but disappear after,
the tour will back step until a step that can find her trigger
in the DOM. Like that the user is a bit less lost.

This changes come in the continuation of the tour refactor and
the change of the default run on a tour step. Before it was
"click", but not anymore, it's just a check. So in the manual
step, the "check step" are just ignored because doesn't need any
user interactions.

task-id: 3922501



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
