### PR TITLE
[IMP] Point_of_sale: suppress pop-up for single-item combo choices

### DIFF
--- a/addons/point_of_sale/static/src/app/store/combo_configurator_popup/combo_configurator_popup.xml
+++ b/addons/point_of_sale/static/src/app/store/combo_configurator_popup/combo_configurator_popup.xml
@@ -2,29 +2,29 @@
 <templates id="template" xml:space="preserve">
     <t t-name="point_of_sale.ComboConfiguratorPopup">
         <Dialog title="props.product.display_name" contentClass="'combo-configurator-popup'">
-            <div t-foreach="props.product.combo_ids" t-as="combo" t-key="combo.id"
-                class="d-flex flex-column m-3 mb-4">
-                <h3 class="me-auto mb-3" t-esc="combo.name"/>
-                <div class="product-list d-grid gap-1">
-                    <div t-foreach="combo.combo_line_ids" t-as="combo_line" t-key="combo_line.id"
-                        class="m-2">
-                        <t t-set="product" t-value="combo_line.product_id"/>
-                        <input type="radio"
-                            t-attf-name="combo-{{combo.id}}"
-                            t-attf-id="combo-{{combo.id}}-combo_line-{{combo_line.id}}"
-                            t-attf-value="{{combo_line.id}}"
-                            t-model="state.combo[combo.id]"
-                            t-att-class="{ 'selected': state.combo[combo.id] == combo_line.id }" />
-                        <label t-attf-for="combo-{{combo.id}}-combo_line-{{combo_line.id}}" class="combo-line h-100 w-100 rounded cursor-pointer transition-base">
-                            <ProductCard name="product.display_name"
-                                class="'flex-column h-100 border'"
-                                productId="product.id"
-                                price="formattedComboPrice(combo_line)"
-                                imageUrl="product.getImageUrl()"
-                                onClick="(ev) => this.onClickProduct({ product, combo_line }, ev)" />
-                        </label>
+            <div t-foreach="props.product.combo_ids" t-as="combo" t-key="combo.id" class="d-flex flex-column m-3 mb-4">
+                <t t-if="shouldShowCombo(combo)">
+                    <h3 class="me-auto mb-3" t-esc="combo.name"/>
+                    <div class="product-list d-grid gap-1">
+                        <div t-foreach="combo.combo_line_ids" t-as="combo_line" t-key="combo_line.id" class="m-2">
+                            <t t-set="product" t-value="combo_line.product_id"/>
+                            <input type="radio"
+                                t-attf-name="combo-{{combo.id}}"
+                                t-attf-id="combo-{{combo.id}}-combo_line-{{combo_line.id}}"
+                                t-attf-value="{{combo_line.id}}"
+                                t-model="state.combo[combo.id]"
+                                t-att-class="{ 'selected': state.combo[combo.id] == combo_line.id }" />
+                            <label t-attf-for="combo-{{combo.id}}-combo_line-{{combo_line.id}}" class="combo-line h-100 w-100 rounded cursor-pointer transition-base">
+                                <ProductCard name="product.display_name"
+                                    class="'flex-column h-100 border'"
+                                    productId="product.id"
+                                    price="formattedComboPrice(combo_line)"
+                                    imageUrl="product.getImageUrl()"
+                                    onClick="(ev) => this.onClickProduct({ product, combo_line }, ev)" />
+                            </label>
+                        </div>
                     </div>
-                </div>
+                </t>
             </div>
             <t t-set-slot="footer">
                 <button class="confirm btn btn-lg btn-primary"
@@ -32,7 +32,6 @@
                     Add to order
                 </button>
                 <div class="ms-auto">
-                    <!-- TODO: Restore the feature the shows the price of the selection. -->
                     <t t-if="!areAllCombosSelected">
                         Complete the selection to proceed
                     </t>


### PR DESCRIPTION
Improved the user experience by eliminating unnecessary pop-ups when ordering combo products with only one item per combo choice. This enhancement streamlines the ordering process and minimizes redundant steps for the user.

Steps to reproduce:
1. Create a combo product with choices.
2. Ensure each combo choice has only one item.
3. Place an order for the combo product.

Current behavior:
- A pop-up appears for each combo choice, even if there is only one item to select.

Expected behavior:
- The pop-up is suppressed for combo choices with only one item, automatically adding the item to the order without prompting the user.
- When all combo choices have only one item, the selection is automatically confirmed without displaying the pop-up.
- If a combo choice has only one product, but that product has variants, the pop-up will still be displayed to allow the user to choose the desired variant.

This improvement simplifies the order process, making it more intuitive and efficient for users.

Task ID: 3958938




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
