### PR TITLE
[FIX] base, tests: cron/ormcache interaction

### DIFF
--- a/odoo/addons/base/tests/test_ormcache.py
+++ b/odoo/addons/base/tests/test_ormcache.py
@@ -1,11 +1,21 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.tests.common import TransactionCase
+from odoo.tests.common import TransactionCase, tagged
 from odoo.tools import get_cache_key_counter
 from threading import Thread, Barrier
 
+
+@tagged('-at_install', 'post_install')
 class TestOrmcache(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        if cls.registry.registry_invalidated:
+            raise AssertionError('Registry should not be invalidated when starting this test')
+        # this test verifies the actual side effects of signaling changes
+        cls._signal_changes_patcher.stop()
+
     def test_ormcache(self):
         """ Test the effectiveness of the ormcache() decorator. """
         IMD = self.env['ir.model.data']

--- a/odoo/modules/registry.py
+++ b/odoo/modules/registry.py
@@ -883,13 +883,8 @@ class Registry(Mapping):
 
     def signal_changes(self):
         """ Notifies other processes if registry or cache has been invalidated. """
-        if self.in_test_mode():
-            if self.registry_invalidated:
-                self.registry_sequence += 1
-            for cache_name in self.cache_invalidated or ():
-                self.cache_sequences[cache_name] += 1
-            self.registry_invalidated = False
-            self.cache_invalidated.clear()
+        if not self.ready:
+            _logger.warning('Calling signal_changes when registry is not ready is not suported')
             return
 
         if self.registry_invalidated:


### PR DESCRIPTION
The test_cron_process_job test will signal_changes, while the registry is considered not ready and invalidated because this is an at install test.

Also, the signal_changes safeguard is base on test mode, only during HttpCase or if explicitly entered.

This commit fixes the issue but using a patch to make the signal_changes behavior different during tests, and also forbidding to signal_changes if the registry is not ready. This could be an issue if a registry is being loaded, a signal_changes changed is triggered in the middle before committing for a random reason, and the registry_invalidated signal is lost. It looks reasonable to avoid this corner case, forcing to explicitly disable the patch if needed.
