### PR TITLE
[FIX] calendar, crm: close activity dropdown on option selection

### DIFF
--- a/addons/calendar/static/src/activity/activity_menu_patch.js
+++ b/addons/calendar/static/src/activity/activity_menu_patch.js
@@ -6,6 +6,7 @@ import { patch } from "@web/core/utils/patch";
 patch(ActivityMenu.prototype, {
     openActivityGroup(group) {
         if (group.model === "calendar.event") {
+            this.dropdown.close();
             document.body.click();
             this.action.doAction("calendar.action_calendar_event", {
                 additionalContext: {

--- a/addons/crm/static/src/activity_menu_patch.js
+++ b/addons/crm/static/src/activity_menu_patch.js
@@ -23,6 +23,7 @@ patch(ActivityMenu.prototype, {
         // fetch the data from the button otherwise fetch the ones from the parent (.o_ActivityMenuView_activityGroup).
         const context = {};
         if (group.model === "crm.lead") {
+            this.dropdown.close();
             document.body.click(); // hack to close dropdown
             if (filter === "my") {
                 context["search_default_activities_overdue"] = 1;


### PR DESCRIPTION
[FIX] calendar, crm: close activity dropdown on option selection

Previously, selecting the Lead/Opportunity activity option (CRM
module) or the Today's Meetings option (calendar module) in
the systray activity dropdown would redirect to the appropriate view,
but keep the dropdown open.

This is inconsistent with the behavior for the rest of the options in
the dropdown, which close said dropdown when selected.

This makes it so the dropdown in the systray activity dropdown gets
closed when selecting the Lead/Opportunity option.

task-3874130
