### PR TITLE
[FIX] stock: correct search domain on orderpoint

### DIFF
--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -285,10 +285,10 @@ class StockWarehouseOrderpoint(models.Model):
             orderpoint.qty_to_order_manual = orderpoint.qty_to_order
 
     def _search_qty_to_order(self, operator, value):
-        records = self.search_fetch([('qty_to_order_manual', '=', '0')], ['qty_to_order_computed'])
+        records = self.search_fetch([('qty_to_order_manual', 'in', [0, False])], ['qty_to_order_computed'])
         matched_ids = records.filtered_domain([('qty_to_order_computed', operator, value)]).ids
         return ['|',
-                    '&', ('qty_to_order_manual', '=', '0'), ('qty_to_order_manual', operator, value),
+                    ('qty_to_order_manual', operator, value),
                     ('id', 'in', matched_ids)
                 ]
 

--- a/addons/stock/tests/test_proc_rule.py
+++ b/addons/stock/tests/test_proc_rule.py
@@ -312,6 +312,12 @@ class TestProcRule(TransactionCase):
             'qty_multiple': 10,
         })
         self.assertEqual(orderpoint.qty_to_order, 10.0)  # 15.0 < 14.5 + 10 <= 30.0
+        # Test search on computed field
+        rr = self.env['stock.warehouse.orderpoint'].search([
+            ('qty_to_order', '>', 0),
+            ('product_id', '=', self.productA.id),
+        ])
+        self.assertTrue(rr)
         orderpoint.write({
             'qty_multiple': 1,
         })


### PR DESCRIPTION
Commit 156bed3f430d7 made `qty_to_order` computed + non-stored. A new search method has been introduced but the domain was wrong, resulting no orderpoint were never returned by the search. Any filter on `qty_to_order` result always in giving no record.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
