### PR TITLE
[FIX] mail: avoid url parse error

### DIFF
--- a/addons/mail/tools/link_preview.py
+++ b/addons/mail/tools/link_preview.py
@@ -3,6 +3,7 @@
 
 from lxml import html
 import requests
+from urllib3.exceptions import LocationParseError
 
 
 def get_link_preview_from_url(url, request_session=None):
@@ -27,6 +28,8 @@ def get_link_preview_from_url(url, request_session=None):
         else:
             response = requests.get(url, timeout=3, headers=user_agent, allow_redirects=True, stream=True)
     except requests.exceptions.RequestException:
+        return False
+    except LocationParseError:
         return False
     if not response.ok or not response.headers.get('Content-Type'):
         return False


### PR DESCRIPTION
Getting link preview on invalid links creates problems (eg: https://..), which results in sms and mail to be stuck in a queue and not being sent.

task-3729538

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
