### PR TITLE
[IMP] base, tools: Prevent sys.settrace conflicts 

### DIFF
--- a/odoo/addons/base/tests/test_profiler.py
+++ b/odoo/addons/base/tests/test_profiler.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+import sys
 import time
 
 from odoo.exceptions import AccessError
@@ -416,6 +417,9 @@ class TestProfiling(TransactionCase):
         self.assertEqual(entries.pop(0)['exec_context'], ((stack_level, {'letter': 'a'}),))
 
     def test_sync_recorder(self):
+        if sys.gettrace() is not None:
+            self.skipTest(f'Cannot start SyncCollector, settrace already set: {sys.gettrace()}')
+
         def a():
             b()
             c()

--- a/odoo/tools/profiler.py
+++ b/odoo/tools/profiler.py
@@ -234,6 +234,8 @@ class SyncCollector(Collector):
     name = 'traces_sync'
 
     def start(self):
+        if sys.gettrace() is not None:
+            _logger.error("Cannot start SyncCollector, settrace already set: %s", sys.gettrace())
         assert not self._processed, "You cannot start SyncCollector after accessing entries."
         sys.settrace(self.hook)  # todo test setprofile, but maybe not multithread safe
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
sys.settrace prevents coverage.py from working properly:
https://coverage.readthedocs.io/en/7.5.3/trouble.html

The main cause of the problem is that when executing the
SyncCollector profiler we will settrace(None). This makes
the coverage result invalid since the settrace added
by the coverage is not resumed.

Also, it would be possible to have a similar problem
with nested SyncCollector, or if any other tool/code uses
sys.settrace. So, an error is logged when the profiler starts.

Current behavior before PR:
The coverage.py report doesn't correctly track which tests have been run.

Desired behavior after PR is merged:
coverage.py will report all the correct tests.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
