### PR TITLE
[FIX] account: find gaps from dashboard perf

### DIFF
--- a/addons/account/models/account_journal_dashboard.py
+++ b/addons/account/models/account_journal_dashboard.py
@@ -909,25 +909,27 @@ class account_journal(models.Model):
 
     def show_sequence_holes(self):
         has_sequence_holes = self._query_has_sequence_holes()
+        domain = expression.OR(
+            [
+                *self.env['account.move']._check_company_domain(self.env.companies),
+                ('journal_id', '=', journal_id),
+                ('sequence_prefix', '=', prefix),
+            ]
+            for journal_id, prefix in has_sequence_holes
+        )
         return {
             'type': 'ir.actions.act_window',
             'name': _("Journal Entries"),
             'res_model': 'account.move',
             'search_view_id': (self.env.ref('account.view_account_move_with_gaps_in_sequence_filter').id, 'search'),
             'view_mode': 'list,form',
-            'domain': expression.OR(
-                [
-                    *self.env['account.move']._check_company_domain(self.env.companies),
-                    ('journal_id', '=', journal_id),
-                    ('sequence_prefix', '=', prefix),
-                ]
-                for journal_id, prefix in has_sequence_holes
-            ),
+            'domain': domain,
             'context': {
                 **self._get_move_action_context(),
                 'search_default_group_by_sequence_prefix': 1,
                 'search_default_irregular_sequences': 1,
                 'expand': 1,
+                'irregular_sequence_domain': domain,
             }
         }
 

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -17,10 +17,10 @@ from odoo.addons.account.tools import format_structured_reference_iso
 from odoo.exceptions import UserError, ValidationError, AccessError, RedirectWarning
 from odoo.osv import expression
 from odoo.tools import (
+    create_index,
     date_utils,
     email_re,
     email_split,
-    flatten,
     float_compare,
     float_is_zero,
     float_repr,
@@ -32,7 +32,7 @@ from odoo.tools import (
     groupby,
     index_exists,
     is_html_empty,
-    create_index,
+    SQL,
 )
 
 _logger = logging.getLogger(__name__)
@@ -816,7 +816,12 @@ class AccountMove(models.Model):
 
     @api.model
     def _get_query_made_hole(self, ids=None):
-        return f"""
+        ids_domain = SQL()
+        if ids:
+            ids_domain = SQL("AND this.id = ANY(%s)", ids)
+        elif irregular_domain := self.env.context.get('irregular_sequence_domain'):
+            ids_domain = SQL("AND this.id IN %s", self._where_calc(irregular_domain).subselect())
+        return SQL("""
                 SELECT this.id
                   FROM account_move this
                   JOIN res_company company ON company.id = this.company_id
@@ -826,8 +831,8 @@ class AccountMove(models.Model):
                  WHERE other.id IS NULL
                    AND this.sequence_number != 1
                    AND this.name != '/'
-                  {"AND this.id = ANY(%(move_ids)s)" if ids is not None else ""}
-        """, {'move_ids': ids} if ids is not None else {}
+                   %s
+        """, ids_domain)
 
     @api.depends('name', 'journal_id')
     def _compute_made_sequence_hole(self):


### PR DESCRIPTION
From the dashboard, we already know in which sequence the gaps are. By filtering the moves based on that information, we can dramatically improve the performance by not querying the whole table.

On a test server queries using this condition went from 10s to 5ms. When opening the list view from the dashboard, 2 queries are run for a total of 20s (`web_search_read` and `web_read_group`)