### PR TITLE
[PERF] pos_loyalty: improve perf of _compute_pos_order_count

### DIFF
--- a/addons/pos_loyalty/models/loyalty_program.py
+++ b/addons/pos_loyalty/models/loyalty_program.py
@@ -52,11 +52,34 @@ class LoyaltyProgram(models.Model):
                 program.pos_config_ids = False
 
     def _compute_pos_order_count(self):
-        read_group_res = self.env['pos.order.line']._read_group(
-            [('reward_id', 'in', self.reward_ids.ids)], ['reward_id:array_agg'], ['order_id'])
-        for program in self:
-            program_reward_ids = program.reward_ids.ids
-            program.pos_order_count = sum(1 if any(id in group['reward_id'] for id in program_reward_ids) else 0 for group in read_group_res)
+        query = """
+                WITH reward_to_orders_count AS (
+                 SELECT reward.id                    AS lr_id,
+                        COUNT(DISTINCT pos_order.id) AS orders_count
+                   FROM pos_order_line line
+                   JOIN pos_order ON line.order_id = pos_order.id
+                   JOIN loyalty_reward reward ON line.reward_id = reward.id
+               GROUP BY lr_id
+              ),
+              program_to_reward AS (
+                 SELECT reward.id  AS reward_id,
+                        program.id AS program_id
+                   FROM loyalty_program program
+                   JOIN loyalty_reward reward ON reward.program_id = program.id
+                  WHERE program.id = ANY (%s)
+              )
+       SELECT program_to_reward.program_id,
+              SUM(reward_to_orders_count.orders_count)
+         FROM program_to_reward
+    LEFT JOIN reward_to_orders_count ON reward_to_orders_count.lr_id = program_to_reward.reward_id
+     GROUP BY program_to_reward.program_id
+                """
+        self._cr.execute(query, (self.ids,))
+        res = self._cr.dictfetchall()
+        res = {k['program_id']: k['sum'] for k in res}
+
+        for rec in self:
+            rec.pos_order_count = res[rec.id] or 0
 
     def _compute_total_order_count(self):
         super()._compute_total_order_count()


### PR DESCRIPTION
Current Behavior:

Computation of the field `pos_order_count` on model `loyalty.program` is slow when there is a large number of `pos.order.line` records with `reward_id` set on them.

Cause of the issue:

The list comprehension done here --> https://github.com/odoo/odoo/blob/27ff3e0f64f53caa62c3022bd3b7c41e29a8e721/addons/pos_loyalty/models/loyalty_program.py#L59 The complexity is `O(len(self) * ((len(read_group_res) * len(program_reward_ids)) + len(read_group_res<sum method>)))` which performs slowly if the `self` and `read_group_res`  are large.

Improvement:

Delegate the computation to Postgres and assign the values obtained from the result.

Benchmark:

In method `_compute_pos_order_count`
Number of `pos.order.line` records eligible in computation -->  17803
Where `self` is a a `loyalty.program` recordset

len(self)| Before (in seconds) | After PR (in seconds) |
 |---------|--------|--------|
|1000| 177.28 s | 6.43 s |
|212| 29.73 s| 0.5 s |

Improvement by about 98% on average

opw-3903159
