### PR TITLE
[IMP] web: search_panel imported state cleanup and improvement

### DIFF
--- a/addons/base_import/static/src/import_records/import_records.js
+++ b/addons/base_import/static/src/import_records/import_records.js
@@ -1,10 +1,10 @@
 /** @odoo-module **/
 
+import { Component } from "@odoo/owl";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
-import { archParseBoolean } from "@web/views/utils";
-import { Component } from "@odoo/owl";
+import { exprToBoolean } from "@web/core/utils/strings";
 import { STATIC_ACTIONS_GROUP_NUMBER } from "@web/search/action_menus/action_menus";
 
 const cogMenuRegistry = registry.category("cogMenu");
@@ -45,8 +45,8 @@ export const importRecordsItem = {
         !isSmall &&
         config.actionType === "ir.actions.act_window" &&
         ["kanban", "list"].includes(config.viewType) &&
-        archParseBoolean(config.viewArch.getAttribute("import"), true) &&
-        archParseBoolean(config.viewArch.getAttribute("create"), true),
+        exprToBoolean(config.viewArch.getAttribute("import"), true) &&
+        exprToBoolean(config.viewArch.getAttribute("create"), true),
 };
 
 cogMenuRegistry.add("import-menu", importRecordsItem, { sequence: 1 });

--- a/addons/mail/static/src/js/onchange_on_keydown.js
+++ b/addons/mail/static/src/js/onchange_on_keydown.js
@@ -1,9 +1,9 @@
+import { useEffect } from "@odoo/owl";
 import { patch } from "@web/core/utils/patch";
+import { exprToBoolean } from "@web/core/utils/strings";
 import { useDebounced } from "@web/core/utils/timing";
 import { charField, CharField } from "@web/views/fields/char/char_field";
 import { textField, TextField } from "@web/views/fields/text/text_field";
-import { archParseBoolean } from "@web/views/utils";
-import { useEffect } from "@odoo/owl";
 
 /**
  * Support a key-based onchange in text fields.
@@ -57,7 +57,7 @@ TextField.props = {
 const charExtractProps = charField.extractProps;
 charField.extractProps = (fieldInfo) => {
     return Object.assign(charExtractProps(fieldInfo), {
-        onchangeOnKeydown: archParseBoolean(fieldInfo.attrs.onchange_on_keydown),
+        onchangeOnKeydown: exprToBoolean(fieldInfo.attrs.onchange_on_keydown),
         keydownDebounceDelay: fieldInfo.attrs.keydown_debounce_delay
             ? Number(fieldInfo.attrs.keydown_debounce_delay)
             : 2000,
@@ -67,7 +67,7 @@ charField.extractProps = (fieldInfo) => {
 const textExtractProps = textField.extractProps;
 textField.extractProps = (fieldInfo) => {
     return Object.assign(textExtractProps(fieldInfo), {
-        onchangeOnKeydown: archParseBoolean(fieldInfo.attrs.onchange_on_keydown),
+        onchangeOnKeydown: exprToBoolean(fieldInfo.attrs.onchange_on_keydown),
         keydownDebounceDelay: fieldInfo.attrs.keydown_debounce_delay
             ? Number(fieldInfo.attrs.keydown_debounce_delay)
             : 2000,

--- a/addons/web/static/src/core/utils/strings.js
+++ b/addons/web/static/src/core/utils/strings.js
@@ -342,3 +342,16 @@ export function isEmail(value) {
 export function isNumeric(value) {
     return Boolean(value?.match(/^\d+$/));
 }
+
+/**
+ * Parse the string to check if the value is true or false
+ * If the string is empty, 0, False or false it's considered as false
+ * The rest is considered as true
+ *
+ * @param {string} str
+ * @param {boolean} [trueIfEmpty=false]
+ * @returns {boolean}
+ */
+export function exprToBoolean(str, trueIfEmpty = false) {
+    return str ? !/^false|0$/i.test(str) : trueIfEmpty;
+}

--- a/addons/web/static/src/search/search_arch_parser.js
+++ b/addons/web/static/src/search/search_arch_parser.js
@@ -1,7 +1,8 @@
 import { makeContext } from "@web/core/context";
 import { _t } from "@web/core/l10n/translation";
-import { evaluateExpr, evaluateBooleanExpr } from "@web/core/py_js/py";
+import { evaluateBooleanExpr, evaluateExpr } from "@web/core/py_js/py";
 import { clamp } from "@web/core/utils/numbers";
+import { exprToBoolean } from "@web/core/utils/strings";
 import { visitXML } from "@web/core/utils/xml";
 import { DEFAULT_INTERVAL, toGeneratorId } from "@web/search/utils/dates";
 
@@ -46,6 +47,7 @@ export class SearchArchParser {
         this.preSearchItems = [];
         this.searchPanelInfo = {
             className: "",
+            fold: false,
             viewTypes: DEFAULT_VIEWS_WITH_SEARCH_PANEL,
         };
         this.sections = [];
@@ -313,6 +315,9 @@ export class SearchArchParser {
 
         if (searchPanelNode.hasAttribute("class")) {
             this.searchPanelInfo.className = searchPanelNode.getAttribute("class");
+        }
+        if (searchPanelNode.hasAttribute("fold")) {
+            this.searchPanelInfo.fold = exprToBoolean(searchPanelNode.getAttribute("fold"));
         }
         if (searchPanelNode.hasAttribute("view_types")) {
             this.searchPanelInfo.viewTypes = searchPanelNode.getAttribute("view_types").split(",");

--- a/addons/web/static/src/search/search_panel/search_panel.xml
+++ b/addons/web/static/src/search/search_panel/search_panel.xml
@@ -30,7 +30,7 @@
                                 t-attf-class="o_search_panel_section_icon fa {{ category.icon }} fa-rotate-90 mb-2"
                                 t-att-style="category.color and ('color: ' + category.color)"
                             />
-                            <t t-esc="category.values.join('/')" />
+                            <t t-esc="category.values.join(' / ')" />
                         </span>
                     </t>
                     <t t-foreach="filters" t-as="filter" t-key="filter_index">
@@ -57,7 +57,7 @@
             <i class="fa fa-fw fa-angle-double-left"/>
         </button>
         <div t-if="!sections or sections.length === 0" class="o_search_panel_empty_state me-3">
-            <button class="btn w-100 overflow-visible">
+            <button class="btn mt-2 w-100 overflow-visible">
                 <div class="d-flex align-items-center me-2 ms-auto">All</div>
             </button>
         </div>

--- a/addons/web/static/src/search/with_search/with_search.js
+++ b/addons/web/static/src/search/with_search/with_search.js
@@ -60,7 +60,10 @@ export class WithSearch extends Component {
             this.props.searchModelArgs
         );
 
-        useSubEnv({ searchModel: this.searchModel });
+        const searchPanelState = this.props.globalState?.searchPanel
+            ? JSON.parse(this.props.globalState?.searchPanel)
+            : null;
+        useSubEnv({ searchModel: this.searchModel, searchPanelState });
 
         useBus(this.searchModel, "update", this.render);
         useSetupAction({

--- a/addons/web/static/src/views/calendar/calendar_arch_parser.js
+++ b/addons/web/static/src/views/calendar/calendar_arch_parser.js
@@ -1,8 +1,8 @@
 import { browser } from "@web/core/browser/browser";
 import { evaluateExpr } from "@web/core/py_js/py";
+import { exprToBoolean } from "@web/core/utils/strings";
 import { visitXML } from "@web/core/utils/xml";
 import { Field } from "@web/views/fields/field";
-import { archParseBoolean } from "@web/views/utils";
 
 const FIELD_ATTRIBUTE_NAMES = [
     "date_start",
@@ -79,13 +79,13 @@ export class CalendarArchParser {
                         }
                     }
                     if (node.hasAttribute("create")) {
-                        canCreate = archParseBoolean(node.getAttribute("create"), true);
+                        canCreate = exprToBoolean(node.getAttribute("create"), true);
                     }
                     if (node.hasAttribute("delete")) {
-                        canDelete = archParseBoolean(node.getAttribute("delete"), true);
+                        canDelete = exprToBoolean(node.getAttribute("delete"), true);
                     }
                     if (node.hasAttribute("quick_create")) {
-                        quickCreate = archParseBoolean(node.getAttribute("quick_create"), true);
+                        quickCreate = exprToBoolean(node.getAttribute("quick_create"), true);
                         if (quickCreate && node.hasAttribute("quick_create_view_id")) {
                             quickCreateViewId = parseInt(
                                 node.getAttribute("quick_create_view_id"),
@@ -94,16 +94,16 @@ export class CalendarArchParser {
                         }
                     }
                     if (node.hasAttribute("event_open_popup")) {
-                        hasEditDialog = archParseBoolean(node.getAttribute("event_open_popup"));
+                        hasEditDialog = exprToBoolean(node.getAttribute("event_open_popup"));
                     }
                     if (node.hasAttribute("show_unusual_days")) {
-                        showUnusualDays = archParseBoolean(node.getAttribute("show_unusual_days"));
+                        showUnusualDays = exprToBoolean(node.getAttribute("show_unusual_days"));
                     }
                     if (node.hasAttribute("hide_date")) {
-                        isDateHidden = archParseBoolean(node.getAttribute("hide_date"));
+                        isDateHidden = exprToBoolean(node.getAttribute("hide_date"));
                     }
                     if (node.hasAttribute("hide_time")) {
-                        isTimeHidden = archParseBoolean(node.getAttribute("hide_time"));
+                        isTimeHidden = exprToBoolean(node.getAttribute("hide_time"));
                     }
                     if (node.hasAttribute("form_view_id")) {
                         formViewId = parseInt(node.getAttribute("form_view_id"), 10);

--- a/addons/web/static/src/views/fields/boolean_favorite/boolean_favorite_field.js
+++ b/addons/web/static/src/views/fields/boolean_favorite/boolean_favorite_field.js
@@ -1,6 +1,6 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
-import { archParseBoolean } from "@web/views/utils";
+import { exprToBoolean } from "@web/core/utils/strings";
 import { standardFieldProps } from "../standard_field_props";
 
 import { Component } from "@odoo/owl";
@@ -52,7 +52,7 @@ export const booleanFavoriteField = {
         },
     ],
     extractProps: ({ attrs, options }, dynamicInfo) => ({
-        noLabel: archParseBoolean(attrs.nolabel),
+        noLabel: exprToBoolean(attrs.nolabel),
         autosave: "autosave" in options ? Boolean(options.autosave) : true,
         readonly: dynamicInfo.readonly,
     }),

--- a/addons/web/static/src/views/fields/char/char_field.js
+++ b/addons/web/static/src/views/fields/char/char_field.js
@@ -1,13 +1,13 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
-import { archParseBoolean } from "@web/views/utils";
+import { exprToBoolean } from "@web/core/utils/strings";
+import { useDynamicPlaceholder } from "../dynamic_placeholder_hook";
 import { formatChar } from "../formatters";
 import { useInputField } from "../input_field_hook";
 import { standardFieldProps } from "../standard_field_props";
 import { TranslationButton } from "../translation_button";
-import { useDynamicPlaceholder } from "../dynamic_placeholder_hook";
 
-import { Component, useExternalListener, useRef, useEffect } from "@odoo/owl";
+import { Component, useEffect, useExternalListener, useRef } from "@odoo/owl";
 
 export class CharField extends Component {
     static template = "web.CharField";
@@ -81,7 +81,7 @@ export const charField = {
         },
     ],
     extractProps: ({ attrs, options }) => ({
-        isPassword: archParseBoolean(attrs.password),
+        isPassword: exprToBoolean(attrs.password),
         dynamicPlaceholder: options.dynamic_placeholder || false,
         dynamicPlaceholderModelReferenceField:
             options.dynamic_placeholder_model_reference_field || "",

--- a/addons/web/static/src/views/fields/datetime/datetime_field.js
+++ b/addons/web/static/src/views/fields/datetime/datetime_field.js
@@ -11,7 +11,7 @@ import {
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { ensureArray } from "@web/core/utils/arrays";
-import { archParseBoolean } from "@web/views/utils";
+import { exprToBoolean } from "@web/core/utils/strings";
 import { standardFieldProps } from "../standard_field_props";
 
 /**
@@ -125,8 +125,16 @@ export class DateTimeField extends Component {
                     }
                 } else {
                     // If both startDateField and endDateField are set, check if they haven't changed
-                    if (areDatesEqual(toUpdate[this.startDateField], this.props.record.data[this.startDateField]) &&
-                        areDatesEqual(toUpdate[this.endDateField], this.props.record.data[this.endDateField])) {
+                    if (
+                        areDatesEqual(
+                            toUpdate[this.startDateField],
+                            this.props.record.data[this.startDateField]
+                        ) &&
+                        areDatesEqual(
+                            toUpdate[this.endDateField],
+                            this.props.record.data[this.endDateField]
+                        )
+                    ) {
                         delete toUpdate[this.startDateField];
                         delete toUpdate[this.endDateField];
                     }
@@ -295,12 +303,12 @@ export const dateField = {
         endDateField: options[END_DATE_FIELD_OPTION],
         maxDate: options.max_date,
         minDate: options.min_date,
-        alwaysRange: archParseBoolean(options.always_range),
+        alwaysRange: exprToBoolean(options.always_range),
         placeholder: attrs.placeholder,
         required: dynamicInfo.required,
         rounding: options.rounding && parseInt(options.rounding, 10),
         startDateField: options[START_DATE_FIELD_OPTION],
-        warnFuture: archParseBoolean(options.warn_future),
+        warnFuture: exprToBoolean(options.warn_future),
     }),
     fieldDependencies: ({ type, attrs, options }) => {
         const deps = [];

--- a/addons/web/static/src/views/fields/dynamic_widget/dynamic_model_field_selector_char.js
+++ b/addons/web/static/src/views/fields/dynamic_widget/dynamic_model_field_selector_char.js
@@ -1,9 +1,9 @@
-import { CharField, charField } from "@web/views/fields/char/char_field";
 import { registry } from "@web/core/registry";
-import { archParseBoolean } from "@web/views/utils";
+import { exprToBoolean } from "@web/core/utils/strings";
+import { CharField, charField } from "@web/views/fields/char/char_field";
 
-import { DynamicModelFieldSelector } from "./dynamic_model_field_selector";
 import { _t } from "@web/core/l10n/translation";
+import { DynamicModelFieldSelector } from "./dynamic_model_field_selector";
 
 export class DynamicModelFieldSelectorChar extends CharField {
     static template = "web.DynamicModelFieldSelectorChar";
@@ -81,7 +81,7 @@ export const dynamicModelFieldSelectorChar = {
     extractProps({ options }, dynamicInfo) {
         return {
             followRelations: options.follow_relations ?? true,
-            onlySearchable: archParseBoolean(options.only_searchable),
+            onlySearchable: exprToBoolean(options.only_searchable),
             resModel: options.model,
         };
     },

--- a/addons/web/static/src/views/fields/field.js
+++ b/addons/web/static/src/views/fields/field.js
@@ -1,9 +1,10 @@
 import { Domain } from "@web/core/domain";
-import { evaluateExpr, evaluateBooleanExpr } from "@web/core/py_js/py";
+import { evaluateBooleanExpr, evaluateExpr } from "@web/core/py_js/py";
 import { registry } from "@web/core/registry";
 import { utils } from "@web/core/ui/ui_service";
+import { exprToBoolean } from "@web/core/utils/strings";
 import { getFieldContext } from "@web/model/relational_model/utils";
-import { archParseBoolean, getClassNameFromDecoration, X2M_TYPES } from "@web/views/utils";
+import { X2M_TYPES, getClassNameFromDecoration } from "@web/views/utils";
 import { getTooltipInfo } from "./field_tooltip";
 
 import { Component, xml } from "@odoo/owl";
@@ -211,11 +212,11 @@ export class Field extends Component {
             if (["context", "string", "help", "domain"].includes(name)) {
                 fieldInfo[name] = value;
             } else if (name === "on_change") {
-                fieldInfo.onChange = archParseBoolean(value);
+                fieldInfo.onChange = exprToBoolean(value);
             } else if (name === "options") {
                 fieldInfo.options = evaluateExpr(value);
             } else if (name === "force_save") {
-                fieldInfo.forceSave = archParseBoolean(value);
+                fieldInfo.forceSave = exprToBoolean(value);
             } else if (name.startsWith("decoration-")) {
                 // prepare field decorations
                 fieldInfo.decorations[name.replace("decoration-", "")] = value;

--- a/addons/web/static/src/views/fields/properties/properties_field.js
+++ b/addons/web/static/src/views/fields/properties/properties_field.js
@@ -1,21 +1,21 @@
-import { _t } from "@web/core/l10n/translation";
-import { registry } from "@web/core/registry";
-import { user } from "@web/core/user";
-import { standardFieldProps } from "../standard_field_props";
-import { uuid } from "../../utils";
-import { PropertyDefinition } from "./property_definition";
+import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
-import { PropertyValue } from "./property_value";
-import { useBus, useService } from "@web/core/utils/hooks";
+import { _t } from "@web/core/l10n/translation";
 import { usePopover } from "@web/core/popover/popover_hook";
-import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { reposition } from "@web/core/position/utils";
-import { archParseBoolean } from "@web/views/utils";
+import { registry } from "@web/core/registry";
+import { user } from "@web/core/user";
+import { useBus, useService } from "@web/core/utils/hooks";
 import { pick } from "@web/core/utils/objects";
 import { useSortable } from "@web/core/utils/sortable_owl";
+import { exprToBoolean } from "@web/core/utils/strings";
+import { uuid } from "../../utils";
+import { standardFieldProps } from "../standard_field_props";
+import { PropertyDefinition } from "./property_definition";
+import { PropertyValue } from "./property_value";
 
-import { Component, useRef, useState, useEffect, onWillStart } from "@odoo/owl";
+import { Component, onWillStart, useEffect, useRef, useState } from "@odoo/owl";
 
 export class PropertiesField extends Component {
     static template = "web.PropertiesField";
@@ -937,7 +937,7 @@ export const propertiesField = {
         return {
             context: dynamicInfo.context,
             columns: parseInt(attrs.columns || "1"),
-            showAddButton: archParseBoolean(attrs.showAddButton),
+            showAddButton: exprToBoolean(attrs.showAddButton),
         };
     },
 };

--- a/addons/web/static/src/views/fields/stat_info/stat_info_field.js
+++ b/addons/web/static/src/views/fields/stat_info/stat_info_field.js
@@ -1,6 +1,6 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
-import { archParseBoolean } from "@web/views/utils";
+import { exprToBoolean } from "@web/core/utils/strings";
 import { standardFieldProps } from "../standard_field_props";
 
 import { Component } from "@odoo/owl";
@@ -57,7 +57,7 @@ export const statInfoField = {
         return {
             digits,
             labelField: options.label_field,
-            noLabel: archParseBoolean(attrs.nolabel),
+            noLabel: exprToBoolean(attrs.nolabel),
             string,
         };
     },

--- a/addons/web/static/src/views/form/form_arch_parser.js
+++ b/addons/web/static/src/views/form/form_arch_parser.js
@@ -1,12 +1,13 @@
+import { exprToBoolean } from "@web/core/utils/strings";
 import { visitXML } from "@web/core/utils/xml";
 import { Field } from "@web/views/fields/field";
+import { getActiveActions } from "@web/views/utils";
 import { Widget } from "@web/views/widgets/widget";
-import { archParseBoolean, getActiveActions } from "@web/views/utils";
 
 export class FormArchParser {
     parse(xmlDoc, models, modelName) {
         const jsClass = xmlDoc.getAttribute("js_class");
-        const disableAutofocus = archParseBoolean(xmlDoc.getAttribute("disable_autofocus") || "");
+        const disableAutofocus = exprToBoolean(xmlDoc.getAttribute("disable_autofocus") || "");
         const activeActions = getActiveActions(xmlDoc);
         const fieldNodes = {};
         const widgetNodes = {};
@@ -22,7 +23,7 @@ export class FormArchParser {
                 const fieldId = `${fieldInfo.name}_${fieldNextIds[fieldInfo.name]++}`;
                 fieldNodes[fieldId] = fieldInfo;
                 node.setAttribute("field_id", fieldId);
-                if (archParseBoolean(node.getAttribute("default_focus") || "")) {
+                if (exprToBoolean(node.getAttribute("default_focus") || "")) {
                     autofocusFieldId = fieldId;
                 }
                 if (fieldInfo.type === "properties") {

--- a/addons/web/static/src/views/graph/graph_arch_parser.js
+++ b/addons/web/static/src/views/graph/graph_arch_parser.js
@@ -1,6 +1,6 @@
+import { exprToBoolean } from "@web/core/utils/strings";
 import { visitXML } from "@web/core/utils/xml";
 import { GROUPABLE_TYPES } from "@web/search/utils/misc";
-import { archParseBoolean } from "@web/views/utils";
 
 const MODES = ["bar", "line", "pie"];
 const ORDERS = ["ASC", "DESC", "asc", "desc", null];
@@ -12,18 +12,18 @@ export class GraphArchParser {
             switch (node.tagName) {
                 case "graph": {
                     if (node.hasAttribute("disable_linking")) {
-                        archInfo.disableLinking = archParseBoolean(
+                        archInfo.disableLinking = exprToBoolean(
                             node.getAttribute("disable_linking")
                         );
                     }
                     if (node.hasAttribute("stacked")) {
-                        archInfo.stacked = archParseBoolean(node.getAttribute("stacked"));
+                        archInfo.stacked = exprToBoolean(node.getAttribute("stacked"));
                     }
                     if (node.hasAttribute("cumulated")) {
-                        archInfo.cumulated = archParseBoolean(node.getAttribute("cumulated"));
+                        archInfo.cumulated = exprToBoolean(node.getAttribute("cumulated"));
                     }
                     if (node.hasAttribute("cumulated_start")) {
-                        archInfo.cumulatedStart = archParseBoolean(
+                        archInfo.cumulatedStart = exprToBoolean(
                             node.getAttribute("cumulated_start")
                         );
                     }

--- a/addons/web/static/src/views/kanban/kanban_arch_parser.js
+++ b/addons/web/static/src/views/kanban/kanban_arch_parser.js
@@ -1,8 +1,9 @@
+import { exprToBoolean } from "@web/core/utils/strings";
 import { extractAttributes, visitXML } from "@web/core/utils/xml";
 import { stringToOrderBy } from "@web/search/utils/order_by";
 import { Field } from "@web/views/fields/field";
+import { getActiveActions, processButton } from "@web/views/utils";
 import { Widget } from "@web/views/widgets/widget";
-import { archParseBoolean, getActiveActions, processButton } from "@web/views/utils";
 
 /**
  * NOTE ON 't-name="kanban-box"':
@@ -29,20 +30,20 @@ export class KanbanArchParser {
     parse(xmlDoc, models, modelName) {
         const fields = models[modelName].fields;
         const className = xmlDoc.getAttribute("class") || null;
-        const canOpenRecords = archParseBoolean(xmlDoc.getAttribute("can_open"), true);
+        const canOpenRecords = exprToBoolean(xmlDoc.getAttribute("can_open"), true);
         let defaultOrder = stringToOrderBy(xmlDoc.getAttribute("default_order") || null);
         const defaultGroupBy = xmlDoc.getAttribute("default_group_by");
         const limit = xmlDoc.getAttribute("limit");
         const countLimit = xmlDoc.getAttribute("count_limit");
-        const recordsDraggable = archParseBoolean(xmlDoc.getAttribute("records_draggable"), true);
-        const groupsDraggable = archParseBoolean(xmlDoc.getAttribute("groups_draggable"), true);
+        const recordsDraggable = exprToBoolean(xmlDoc.getAttribute("records_draggable"), true);
+        const groupsDraggable = exprToBoolean(xmlDoc.getAttribute("groups_draggable"), true);
         const activeActions = getActiveActions(xmlDoc);
-        activeActions.archiveGroup = archParseBoolean(xmlDoc.getAttribute("archivable"), true);
-        activeActions.createGroup = archParseBoolean(xmlDoc.getAttribute("group_create"), true);
-        activeActions.deleteGroup = archParseBoolean(xmlDoc.getAttribute("group_delete"), true);
-        activeActions.editGroup = archParseBoolean(xmlDoc.getAttribute("group_edit"), true);
+        activeActions.archiveGroup = exprToBoolean(xmlDoc.getAttribute("archivable"), true);
+        activeActions.createGroup = exprToBoolean(xmlDoc.getAttribute("group_create"), true);
+        activeActions.deleteGroup = exprToBoolean(xmlDoc.getAttribute("group_delete"), true);
+        activeActions.editGroup = exprToBoolean(xmlDoc.getAttribute("group_edit"), true);
         activeActions.quickCreate =
-            activeActions.create && archParseBoolean(xmlDoc.getAttribute("quick_create"), true);
+            activeActions.create && exprToBoolean(xmlDoc.getAttribute("quick_create"), true);
         const onCreate = xmlDoc.getAttribute("on_create");
         const quickCreateView = xmlDoc.getAttribute("quick_create_view");
         const tooltipInfo = {};

--- a/addons/web/static/src/views/list/export_all/export_all.js
+++ b/addons/web/static/src/views/list/export_all/export_all.js
@@ -1,7 +1,7 @@
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { registry } from "@web/core/registry";
 import { user } from "@web/core/user";
-import { archParseBoolean } from "@web/views/utils";
+import { exprToBoolean } from "@web/core/utils/strings";
 import { STATIC_ACTIONS_GROUP_NUMBER } from "@web/search/action_menus/action_menus";
 
 import { Component } from "@odoo/owl";
@@ -35,7 +35,7 @@ export const exportAllItem = {
         env.config.viewType === "list" &&
         !env.model.root.selection.length &&
         (await user.hasGroup("base.group_allow_export")) &&
-        archParseBoolean(env.config.viewArch.getAttribute("export_xlsx"), true),
+        exprToBoolean(env.config.viewArch.getAttribute("export_xlsx"), true),
 };
 
 cogMenuRegistry.add("export-all-menu", exportAllItem, { sequence: 10 });

--- a/addons/web/static/src/views/list/list_arch_parser.js
+++ b/addons/web/static/src/views/list/list_arch_parser.js
@@ -1,9 +1,10 @@
-import { Field } from "@web/views/fields/field";
+import { exprToBoolean } from "@web/core/utils/strings";
 import { visitXML } from "@web/core/utils/xml";
-import { stringToOrderBy } from "@web/search/utils/order_by";
-import { archParseBoolean, getActiveActions, getDecoration, processButton } from "@web/views/utils";
-import { encodeObjectForTemplate } from "@web/views/view_compiler";
 import { combineModifiers } from "@web/model/relational_model/utils";
+import { stringToOrderBy } from "@web/search/utils/order_by";
+import { Field } from "@web/views/fields/field";
+import { getActiveActions, getDecoration, processButton } from "@web/views/utils";
+import { encodeObjectForTemplate } from "@web/views/view_compiler";
 import { Widget } from "@web/views/widgets/widget";
 
 export class GroupListArchParser {
@@ -112,7 +113,10 @@ export class ListArchParser {
                     className: node.getAttribute("class"), // for oe_edit_only and oe_read_only
                     optional: node.getAttribute("optional") || false,
                     type: "field",
-                    hasLabel: !(fieldInfo.field.label === false || archParseBoolean(fieldInfo.attrs.nolabel) === true),                    
+                    hasLabel: !(
+                        fieldInfo.field.label === false ||
+                        exprToBoolean(fieldInfo.attrs.nolabel) === true
+                    ),
                     label: (fieldInfo.widget && label && label.toString()) || fieldInfo.string,
                 });
                 return false;
@@ -174,18 +178,18 @@ export class ListArchParser {
             } else if (["tree", "list"].includes(node.tagName)) {
                 const activeActions = {
                     ...getActiveActions(xmlDoc),
-                    exportXlsx: archParseBoolean(xmlDoc.getAttribute("export_xlsx"), true),
+                    exportXlsx: exprToBoolean(xmlDoc.getAttribute("export_xlsx"), true),
                 };
                 treeAttr.activeActions = activeActions;
 
                 treeAttr.className = xmlDoc.getAttribute("class") || null;
                 treeAttr.editable = xmlDoc.getAttribute("editable");
                 treeAttr.multiEdit = activeActions.edit
-                    ? archParseBoolean(node.getAttribute("multi_edit") || "")
+                    ? exprToBoolean(node.getAttribute("multi_edit") || "")
                     : false;
 
                 treeAttr.openFormView = treeAttr.editable
-                    ? archParseBoolean(xmlDoc.getAttribute("open_form_view") || "")
+                    ? exprToBoolean(xmlDoc.getAttribute("open_form_view") || "")
                     : false;
 
                 const limitAttr = node.getAttribute("limit");
@@ -197,7 +201,7 @@ export class ListArchParser {
                 const groupsLimitAttr = node.getAttribute("groups_limit");
                 treeAttr.groupsLimit = groupsLimitAttr && parseInt(groupsLimitAttr, 10);
 
-                treeAttr.noOpen = archParseBoolean(node.getAttribute("no_open") || "");
+                treeAttr.noOpen = exprToBoolean(node.getAttribute("no_open") || "");
                 treeAttr.rawExpand = xmlDoc.getAttribute("expand");
                 treeAttr.decorations = getDecoration(xmlDoc);
 

--- a/addons/web/static/src/views/pivot/pivot_arch_parser.js
+++ b/addons/web/static/src/views/pivot/pivot_arch_parser.js
@@ -1,5 +1,5 @@
+import { exprToBoolean } from "@web/core/utils/strings";
 import { visitXML } from "@web/core/utils/xml";
-import { archParseBoolean } from "@web/views/utils";
 
 export class PivotArchParser {
     parse(arch) {
@@ -16,7 +16,7 @@ export class PivotArchParser {
             switch (node.tagName) {
                 case "pivot": {
                     if (node.hasAttribute("disable_linking")) {
-                        archInfo.disableLinking = archParseBoolean(
+                        archInfo.disableLinking = exprToBoolean(
                             node.getAttribute("disable_linking")
                         );
                     }
@@ -27,7 +27,7 @@ export class PivotArchParser {
                         archInfo.title = node.getAttribute("string");
                     }
                     if (node.hasAttribute("display_quantity")) {
-                        archInfo.displayQuantity = archParseBoolean(
+                        archInfo.displayQuantity = exprToBoolean(
                             node.getAttribute("display_quantity")
                         );
                     }

--- a/addons/web/static/src/views/utils.js
+++ b/addons/web/static/src/views/utils.js
@@ -1,5 +1,6 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
+import { exprToBoolean } from "@web/core/utils/strings";
 import { combineModifiers } from "@web/model/relational_model/utils";
 
 export const X2M_TYPES = ["one2many", "many2many"];
@@ -33,19 +34,6 @@ export const BUTTON_CLICK_PARAMS = [
     // This should be refactor someday
     "noSaveDialog",
 ];
-
-/**
- * Parse the arch to check if is true or false
- * If the string is empty, 0, False or false it's considered as false
- * The rest is considered as true
- *
- * @param {string} str
- * @param {boolean} [trueIfEmpty=false]
- * @returns {boolean}
- */
-export function archParseBoolean(str, trueIfEmpty = false) {
-    return str ? !/^false|0$/i.test(str) : trueIfEmpty;
-}
 
 /**
  * @param {string?} type
@@ -167,12 +155,12 @@ export function getFormattedValue(record, fieldName, attrs) {
 export function getActiveActions(rootNode) {
     const activeActions = {
         type: "view",
-        edit: archParseBoolean(rootNode.getAttribute("edit"), true),
-        create: archParseBoolean(rootNode.getAttribute("create"), true),
-        delete: archParseBoolean(rootNode.getAttribute("delete"), true),
+        edit: exprToBoolean(rootNode.getAttribute("edit"), true),
+        create: exprToBoolean(rootNode.getAttribute("create"), true),
+        delete: exprToBoolean(rootNode.getAttribute("delete"), true),
     };
     activeActions.duplicate =
-        activeActions.create && archParseBoolean(rootNode.getAttribute("duplicate"), true);
+        activeActions.create && exprToBoolean(rootNode.getAttribute("duplicate"), true);
     return activeActions;
 }
 
@@ -224,7 +212,7 @@ export function isNull(value) {
 
 export function processButton(node) {
     const withDefault = {
-        close: (val) => archParseBoolean(val, false),
+        close: (val) => exprToBoolean(val, false),
         context: (val) => val || "{}",
     };
     const clickParams = {};

--- a/addons/web/static/src/webclient/actions/action_hook.js
+++ b/addons/web/static/src/webclient/actions/action_hook.js
@@ -74,35 +74,8 @@ export function useSetupAction(params = {}) {
             if (getGlobalState) {
                 Object.assign(state, getGlobalState());
             }
-            if (rootRef) {
-                const searchPanelEl = rootRef.el.querySelector(".o_content .o_search_panel");
-                if (searchPanelEl) {
-                    state[scrollSymbol] = {
-                        searchPanel: {
-                            left: searchPanelEl.scrollLeft,
-                            top: searchPanelEl.scrollTop,
-                        },
-                    };
-                }
-            }
             return state;
         });
-
-        if (rootRef) {
-            onMounted(() => {
-                const { globalState } = component.props;
-                const scrolling = globalState && globalState[scrollSymbol];
-                if (scrolling) {
-                    const searchPanelEl = rootRef.el.querySelector(".o_content .o_search_panel");
-                    if (searchPanelEl) {
-                        searchPanelEl.scrollLeft =
-                            (scrolling.searchPanel && scrolling.searchPanel.left) || 0;
-                        searchPanelEl.scrollTop =
-                            (scrolling.searchPanel && scrolling.searchPanel.top) || 0;
-                    }
-                }
-            });
-        }
     }
     if (__getLocalState__ && (getLocalState || rootRef)) {
         useCallbackRecorder(__getLocalState__, () => {
@@ -116,8 +89,11 @@ export function useSetupAction(params = {}) {
                         root: { left: rootRef.el.scrollLeft, top: rootRef.el.scrollTop },
                     };
                 } else {
-                    const contentEl = rootRef.el.querySelector(".o_component_with_search_panel > .o_renderer_with_searchpanel," 
-                    + ".o_component_with_search_panel > .o_renderer") || rootRef.el.querySelector(".o_content");
+                    const contentEl =
+                        rootRef.el.querySelector(
+                            ".o_component_with_search_panel > .o_renderer_with_searchpanel," +
+                                ".o_component_with_search_panel > .o_renderer"
+                        ) || rootRef.el.querySelector(".o_content");
                     if (contentEl) {
                         state[scrollSymbol] = {
                             content: { left: contentEl.scrollLeft, top: contentEl.scrollTop },
@@ -137,8 +113,11 @@ export function useSetupAction(params = {}) {
                         rootRef.el.scrollTop = (scrolling.root && scrolling.root.top) || 0;
                         rootRef.el.scrollLeft = (scrolling.root && scrolling.root.left) || 0;
                     } else if (scrolling.content) {
-                        const contentEl = rootRef.el.querySelector(".o_component_with_search_panel > .o_renderer_with_searchpanel," 
-                    + ".o_component_with_search_panel > .o_renderer") || rootRef.el.querySelector(".o_content");
+                        const contentEl =
+                            rootRef.el.querySelector(
+                                ".o_component_with_search_panel > .o_renderer_with_searchpanel," +
+                                    ".o_component_with_search_panel > .o_renderer"
+                            ) || rootRef.el.querySelector(".o_content");
                         if (contentEl) {
                             contentEl.scrollTop = scrolling.content.top || 0;
                             contentEl.scrollLeft = scrolling.content.left || 0;

--- a/addons/web/static/tests/modules/dependencies.test.js
+++ b/addons/web/static/tests/modules/dependencies.test.js
@@ -35,6 +35,7 @@ test("modules only import from allowed folders", () => {
     expect(invalidImportsFrom("core", [])).toEqual({ "@web/core/utils/hooks": ["@web/env"] });
     expect(invalidImportsFrom("search", ["core"])).toEqual({
         // FIXME: this dependency should not exist. Temporarily whitelist it so we don't add more, and remove ASAP
+        "@web/search/search_panel/search_panel": ["@web/webclient/actions/action_hook"],
         "@web/search/with_search/with_search": ["@web/webclient/actions/action_hook"],
     });
     expect(invalidImportsFrom("model", ["core", "search"])).toEqual({

--- a/addons/web_hierarchy/static/src/hierarchy_arch_parser.js
+++ b/addons/web_hierarchy/static/src/hierarchy_arch_parser.js
@@ -3,7 +3,8 @@
 import { visitXML } from "@web/core/utils/xml";
 import { stringToOrderBy } from "@web/search/utils/order_by";
 import { Field } from "@web/views/fields/field";
-import { archParseBoolean, getActiveActions } from "@web/views/utils";
+import { getActiveActions } from "@web/views/utils";
+import { exprToBoolean } from "@web/core/utils/strings";
 
 export class HierarchyArchParser {
     parse(xmlDoc, models, modelName) {
@@ -49,7 +50,7 @@ export class HierarchyArchParser {
                     archInfo.childFieldName = childFieldName;
                 }
                 if (node.hasAttribute("draggable")) {
-                    archInfo.draggable = archParseBoolean(node.getAttribute("draggable"));
+                    archInfo.draggable = exprToBoolean(node.getAttribute("draggable"));
                 }
                 if (node.hasAttribute("icon")) {
                     archInfo.icon = node.getAttribute("icon");


### PR DESCRIPTION
First commit moves and renames the archParseBoolean util from view utils to core/string utils as exprToBoolean. This makes more sense as a general string util and solves some unwanted dependency issues with views.

Second commit seeks to bring back the imported state feature of the search panel which was lost during the owl conversion and partially replaced in the action hook code (to keep track of the scroll state). It adds the search_panel state inside the global state so that it can be restored after changing view. Also adds the expand/collapse status and the search
panel width to the imported state so that both of these can also be restored. It removes the now useless code which handles the scroll state of the search panel inside the action hook code and finally adds the possibility to specify a default value for the expand/collapse state in the arch which defaults to the expanded state.

task-3957255
