### PR TITLE
[FIX] account: journal deletion prevent the creation of sub-companies

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -605,9 +605,9 @@ class AccountChartTemplate(models.AbstractModel):
 
         # Set newly created journals as defaults for the company
         if not company.tax_cash_basis_journal_id:
-            company.tax_cash_basis_journal_id = self.ref('caba')
+            company.tax_cash_basis_journal_id = self.ref('caba', raise_if_not_found=False)
         if not company.currency_exchange_journal_id:
-            company.currency_exchange_journal_id = self.ref('exch')
+            company.currency_exchange_journal_id = self.ref('exch', raise_if_not_found=False)
 
         # Setup default Income/Expense Accounts on Sale/Purchase journals
         sale_journal = self.ref("sale", raise_if_not_found=False)


### PR DESCRIPTION
Go to Accounting > Configuration > Journals
Delete the EXCH journal
Go to Settings > Companies, open the main company
Try to create a new branch

Traceback comes up:
"ValueError: External ID not found in the system: account.2_exch"

This occurs because when setting up the new company we are looking for
the ref 'exch'. The system will look for the xmlid
`account.<company_id>_exch` but the journal has been deleted so it will
not be found.

A solution is to avoid blocking the company creation, the user will need
to create the missing journal afterward

opw-3932849