### PR TITLE
[FIX] base: translation export filename was not shown anymore

### DIFF
--- a/odoo/addons/base/wizard/base_export_language_views.xml
+++ b/odoo/addons/base/wizard/base_export_language_views.xml
@@ -6,6 +6,7 @@
             <field name="model">base.language.export</field>
             <field name="arch" type="xml">
                 <form string="Export Translations">
+                    <field name="name" invisible="1"/> <!-- The name is needed in the BinaryField component used to download the file -->
                     <group invisible="state != 'choose'" string="Export Settings">
                         <field name="lang"/>
                         <field name="format"/>


### PR DESCRIPTION
This recent [commit] removed all uncommented invisible fields from views. This lead to the Translation Export Wizard having the exported file name missing (defaulting to the file size as file name).

Instead of e.g. downloading a file `base.pot`, you would get `1375 kB`.

This commit fixes that by re-adding the invisible `name` field to the view of the Translation Export Wizard, so the download file name is correct again.

[commit]: https://github.com/odoo/odoo/commit/5639ed865c5a3b82bab25b0ecac28c68c02e9306