### PR TITLE
[FIX] website_slides_survey:  fix slide creation error handling

### DIFF
--- a/addons/website_slides_survey/controllers/slides.py
+++ b/addons/website_slides_survey/controllers/slides.py
@@ -75,6 +75,9 @@ class WebsiteSlidesSurvey(WebsiteSlides):
         # Then create the slide
         result = super(WebsiteSlidesSurvey, self).create_slide(*args, **post)
 
+        if result.get('error'):
+            return result
+
         if post['slide_category'] == "certification":
             # Set the url to redirect the user to the survey
             result['url'] = '/slides/slide/%s?fullscreen=1' % (slug(request.env['slide.slide'].browse(result['slide_id']))),


### PR DESCRIPTION
The error you're encountering is due to the ``slide_id`` key being missing in the ``result`` dictionary. This is because the ``result`` dictionary contains an error message instead of the expected data when a database constraint is violated.

Traceback:
```
KeyError: 'slide_id'
  File "odoo/http.py", line 2253, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1829, in _serve_db
    return self._transactioning(_serve_ir_http, readonly=ro)
  File "odoo/http.py", line 1849, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1827, in _serve_ir_http
    return self._serve_ir_http(rule, args)
  File "odoo/http.py", line 1834, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2059, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 220, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 740, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/website_slides_survey/controllers/slides.py", line 80, in create_slide
    result['url'] = '/slides/slide/%s?fullscreen=1' % (slug(request.env['slide.slide'].browse(result['slide_id']))),
```
To handle this situation, we should check for the presence of an error in the ``result`` dictionary If an error is found, return the ``result`` directly. Otherwise, proceed with the normal flow.

sentry-5410807138

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
