### PR TITLE
[FIX] web_editor: Prevent page crash in Firefox during screen resize

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -845,6 +845,11 @@ export class OdooEditor extends EventTarget {
     computeFontSizeSelectorValues(fontSizeDropdownEl) {
         fontSizeDropdownEl = fontSizeDropdownEl || this.toolbar.querySelector("#font-size");
 
+        // In case of firefox browser and community version of website module "this.toolbar.querySelector('#font-size')" 
+        // will always be null because El with id "font-size" is not present in toolbar in mobileView.
+        if(!fontSizeDropdownEl) {
+            return;
+        }
         let previousItem = null;
         let previousValue = -1;
         const style = this.document.defaultView.getComputedStyle(this.document.body);


### PR DESCRIPTION
Steps to reproduce:
- Open Firefox.
- Launch the website in edit mode.(community version)
- Decrease the screen size to MD to display the mobile menu.
- Click on the burger menu.
- Previously, these steps would cause the page to crash.

Before this PR:
- The page would crash in Firefox when the above steps were followed.

After this PR:
- The page no longer crashes in Firefox when the above steps are followed.
- The issue was that Firefox was re-rendering the DOM upon clicking the burger menu, which resulted in the element with ID="font-size" not being rendered in the DOM, while Chrome was preserving it.
- The "fontSizeDropdownEl" variable must not be null for the method to execute successfully, which was not the case in Firefox. To address this, a return condition has been added.

Task ID: 3901927