### PR TITLE
[FIX] point_of_sale: make combo to have the expected price

### DIFF
--- a/addons/point_of_sale/static/src/app/store/models.js
+++ b/addons/point_of_sale/static/src/app/store/models.js
@@ -1958,7 +1958,7 @@ export class Order extends PosModel {
                     .digits
             );
             remainingTotal -= priceUnit;
-            if (comboLine == childLineConf[childLineConf.length - 1]) {
+            if (comboLine.id == childLineConf[childLineConf.length - 1].combo_line_id.id) {
                 priceUnit += remainingTotal;
             }
             const attribute_value_ids = comboLine.configuration?.attribute_value_ids;

--- a/addons/point_of_sale/static/tests/tours/PosComboTour.js
+++ b/addons/point_of_sale/static/tests/tours/PosComboTour.js
@@ -85,3 +85,30 @@ registry.category("web_tour.tours").add("PosComboPriceTaxIncludedTour", {
             // the split screen is tested in `pos_restaurant`
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("PosComboPriceCheckTour", {
+    test: true,
+    url: "/pos/ui",
+    steps: () =>
+        [
+            Dialog.confirm("Open session"),
+            ProductScreen.clickShowProductsMobile(),
+            ProductScreen.clickDisplayedProduct("Desk Combo"),
+            combo.select("Desk Organizer"),
+            combo.isSelected("Desk Organizer"),
+            combo.select("Desk Pad"),
+            combo.isSelected("Desk Pad"),
+            combo.select("Whiteboard Pen"),
+            combo.isSelected("Whiteboard Pen"),
+            Dialog.confirm(),
+            ProductScreen.selectedOrderlineHas("Desk Combo"),
+            ProductScreen.clickOrderline("Desk Organizer"),
+            ProductScreen.selectedOrderlineHas("Desk Organizer", "1.0", "4.45"),
+            ProductScreen.clickOrderline("Desk Pad"),
+            ProductScreen.selectedOrderlineHas("Desk Pad", "1.0", "1.59"),
+            ProductScreen.clickOrderline("Whiteboard Pen"),
+            ProductScreen.selectedOrderlineHas("Whiteboard Pen", "1.0", "0.96"),
+            ProductScreen.totalAmountIs("7.00"),
+            ProductScreen.clickPayButton(),
+        ].flat(),
+});

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1201,6 +1201,34 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'RefundFewQuantities', login="pos_user")
 
+    def test_pos_combo_price(self):
+        """ Check that the combo has the expected price """
+        self.desk_organizer.write({"lst_price": 7})
+        self.desk_pad.write({"lst_price": 2.5})
+        self.whiteboard_pen.write({"lst_price": 1.5})
+
+        combo_lines = [self.env["pos.combo.line"].create({"product_id": product.id, "combo_price": 0})
+                       for product in (self.desk_organizer, self.desk_pad, self.whiteboard_pen)]
+        combos = [self.env["pos.combo"].create({"name": combo_line.product_id.name, "combo_line_ids": [(6, 0, [combo_line.id])]})
+                  for combo_line in combo_lines]
+
+        self.env["product.product"].create(
+            {
+                "available_in_pos": True,
+                "list_price": 7,
+                "name": "Desk Combo",
+                "type": "combo",
+                "taxes_id": False,
+                "categ_id": self.env.ref("product.product_category_1").id,
+                "combo_ids": [
+                    (6, 0, [combo.id for combo in combos])
+                ],
+            }
+        )
+
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'PosComboPriceCheckTour', login="pos_user")
+
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):
     browser_size = '375x667'


### PR DESCRIPTION
Problem:
Combo product can have a price that is not the expected one

Steps to reproduce:
- Install "Point of Sale" app
- Go to POS settings and go to the Tax settings
- In the tab "Advanced Options", check "Included in Price"
- Create a product of type "Combo", set the price to $7.00
- Add 3 combo choices with products prices as $7.00, $2.50 and $1.50 with no extra price
- In the shop, sell this combo
- The total price is $6.99 rather than $7.00

Cause:
The condition supposed to fill the remaining price in the last orderline was always false

opw-3897431



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
