### PR TITLE
[FIX] web: clicking on old style URL link

### DIFF
--- a/addons/web/static/src/core/browser/router.js
+++ b/addons/web/static/src/core/browser/router.js
@@ -289,7 +289,7 @@ browser.addEventListener("click", (ev) => {
             return;
         }
         if (
-            browser.location.origin === url.origin &&
+            browser.location.host === url.host &&
             browser.location.pathname.startsWith("/odoo") &&
             (["/web", "/odoo"].includes(url.pathname) || url.pathname.startsWith("/odoo/")) &&
             ev.target.target !== "_blank"

--- a/addons/web/static/src/core/browser/router.js
+++ b/addons/web/static/src/core/browser/router.js
@@ -170,8 +170,6 @@ export function urlToState(urlObj) {
         }
         Object.assign(state, sanitizedHash);
         const url = browser.location.origin + router.stateToUrl(state);
-        // Change the url of the current history entry to the canonical url
-        browser.history.replaceState(browser.history.state, null, url);
         urlObj.href = url;
     }
 
@@ -232,7 +230,15 @@ let pushArgs;
 let _lockedKeys;
 
 export function startRouter() {
-    state = router.urlToState(new URL(browser.location));
+    const url = new URL(browser.location);
+    state = router.urlToState(url);
+    // ** url-retrocompatibility **
+    if (browser.location.pathname === "/web") {
+        // Change the url of the current history entry to the canonical url.
+        // This change should be done only at the first load, and not when clicking on old style internal urls.
+        // Or when clicking back/forward on the browser.
+        browser.history.replaceState(browser.history.state, null, url.href);
+    }
     pushTimeout = null;
     pushArgs = {
         replace: false,

--- a/addons/web/static/tests/core/router.test.js
+++ b/addons/web/static/tests/core/router.test.js
@@ -1671,6 +1671,45 @@ describe("internal links", () => {
         expect(defaultPrevented).toBe(true);
     });
 
+    test("click on internal link with different protocol does a loadState", async () => {
+        redirect("/odoo");
+        createRouter({ onPushState: () => expect.step("pushState") });
+        const fixture = getFixture();
+        const link = document.createElement("a");
+        link.href = "http://" + browser.location.host + "/odoo/some-action/2";
+        fixture.appendChild(link);
+
+        expect(router.current).toEqual({});
+        expect(browser.location.protocol).not.toBe(link.protocol, {
+            message:
+                "should have different protocols between the current location and the clicked link",
+        });
+
+        let defaultPrevented;
+        browser.addEventListener("click", (ev) => {
+            expect.step("click");
+            defaultPrevented = ev.defaultPrevented;
+            ev.preventDefault();
+        });
+        click("a");
+        await tick();
+        expect(["click"]).toVerifySteps();
+        expect(router.current).toEqual({
+            action: "some-action",
+            actionStack: [
+                {
+                    action: "some-action",
+                },
+                {
+                    action: "some-action",
+                    resId: 2,
+                },
+            ],
+            resId: 2,
+        });
+        expect(defaultPrevented).toBe(true);
+    });
+
     test("click on internal link with hash (key/values)", async () => {
         redirect("/odoo");
         createRouter({

--- a/addons/web/static/tests/core/router.test.js
+++ b/addons/web/static/tests/core/router.test.js
@@ -19,12 +19,18 @@ const _urlToState = (url) => urlToState(new URL(url));
 
 function createRouter(params = {}) {
     if (params.onPushState) {
-        const onPushState = params.onPushState;
-        delete params.onPushState;
         patchWithCleanup(browser.history, {
             pushState() {
                 super.pushState(...arguments);
-                onPushState(...arguments);
+                params.onPushState(...arguments);
+            },
+        });
+    }
+    if (params.onReplaceState) {
+        patchWithCleanup(browser.history, {
+            replaceState() {
+                super.replaceState(...arguments);
+                params.onReplaceState(...arguments);
             },
         });
     }
@@ -1661,6 +1667,47 @@ describe("internal links", () => {
                 },
             ],
             resId: 2,
+        });
+        expect(defaultPrevented).toBe(true);
+    });
+
+    test("click on internal link with hash (key/values)", async () => {
+        redirect("/odoo");
+        createRouter({
+            onPushState: () => expect.step("pushState"),
+            onReplaceState: () => expect.step("replaceState"),
+        });
+        const fixture = getFixture();
+        const link = document.createElement("a");
+        link.href = "/web#action=114&active_id=1&id=22";
+        fixture.appendChild(link);
+
+        expect(router.current).toEqual({});
+
+        let defaultPrevented;
+        browser.addEventListener("click", (ev) => {
+            expect.step("click");
+            defaultPrevented = ev.defaultPrevented;
+            ev.preventDefault();
+        });
+        click("a");
+        await tick();
+        expect(["click"]).toVerifySteps();
+        expect(router.current).toEqual({
+            action: 114,
+            active_id: 1,
+            actionStack: [
+                {
+                    active_id: 1,
+                    action: 114,
+                },
+                {
+                    active_id: 1,
+                    resId: 22,
+                    action: 114,
+                },
+            ],
+            resId: 22,
         });
         expect(defaultPrevented).toBe(true);
     });


### PR DESCRIPTION
- On a record A;
- Click on a link to open a record B (with an old style URL);
- The record B is open;

Before this commit, the record A is missing on the browser history. This
occurs because, when an old style URL is converted into a canonical URL,
a replacement of the current URL is done. This replacement was done to
update the old URL when the URL was copy/paste on the browser.
In this particular case, the replacement is not necessary, because the
current URL is the one of the record A. Doing the replacement, will
remove the record A from the browser history.

Now, the URL retro-compatibility will only update the URL, if the URL in
the browser is the one with the old style.
