### PR TITLE
[FIX] pos*: cancel deleted order from ticket screen

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -888,7 +888,6 @@ class PosOrder(models.Model):
             'res_id': moves and moves.ids[0] or False,
         }
 
-    # this method is unused, and so is the state 'cancel'
     def action_pos_order_cancel(self):
         return self.write({'state': 'cancel'})
 

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -152,9 +152,16 @@ export class TicketScreen extends Component {
             if (order === this.pos.get_order()) {
                 this._selectNextOrder(order);
             }
-            const deleted = this.pos.removeOrder(order, true);
+            const cancelled = this.pos.removeOrder(order, true);
 
-            if (!deleted) {
+            const idToCancel = [...this.pos.pendingOrder.delete];
+
+            if (idToCancel.length > 0) {
+                this.pos.pendingOrder.delete.clear();
+                await this.pos.data.call("pos.order", "action_pos_order_cancel", idToCancel);
+            }
+
+            if (!cancelled) {
                 order.uiState.displayed = true;
             }
 

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -832,13 +832,7 @@ export class PosStore extends Reactive {
             const orders = [...orderToCreate, ...orderToUpdate, ...paidOrdersNotSent];
 
             this.preSyncAllOrders(orders);
-            const idsToDelete = [...this.pendingOrder.delete];
             const context = this.getSyncAllOrdersContext(orders);
-
-            if (idsToDelete.length > 0) {
-                this.pendingOrder.delete.clear();
-                await this.data.ormDelete("pos.order", idsToDelete);
-            }
 
             // Allow us to force the sync of the orders In the case of
             // pos_restaurant is usefull to get unsynced orders

--- a/addons/point_of_sale/views/pos_order_view.xml
+++ b/addons/point_of_sale/views/pos_order_view.xml
@@ -11,7 +11,8 @@
                             invisible="state != 'paid'"/>
                     <button name="refund" string="Return Products" type="object"
                         invisible="state == 'draft' or not has_refundable_lines"/>
-                    <field name="state" widget="statusbar" statusbar_visible="draft,paid,done" />
+                    <field name="state" widget="statusbar" invisible="state == 'cancel'" statusbar_visible="draft,paid,done"/>
+                    <field name="state" widget="statusbar" invisible="state != 'cancel'" statusbar_visible="draft,cancel"/>
                     <field name="has_refundable_lines" invisible="1" />
                 </header>
                 <sheet>
@@ -392,6 +393,7 @@
                 <field name="lines" string="Product" filter_domain="[('lines.product_id', 'ilike', self)]"/>
                 <filter string="Invoiced" name="invoiced" domain="[('state', '=', 'invoiced')]"/>
                 <filter string="Posted" name="posted" domain="[('state', '=', 'done')]"/>
+                <filter string="Cancelled" name="cancelled" domain="[('state', '=', 'cancel')]"/>
                 <separator/>
                 <filter string="Order Date" name="order_date" date="date_order"/>
                 <group expand="0" string="Group By">

--- a/addons/pos_restaurant/static/src/app/floor_screen/table.js
+++ b/addons/pos_restaurant/static/src/app/floor_screen/table.js
@@ -105,12 +105,6 @@ export class Table extends Component {
     get orderCount() {
         // These informations in uiState came from the server websocket
         const table = this.props.table;
-        if (table.uiState.changeCount > 0) {
-            return table.uiState.changeCount;
-        }
-        if (table.uiState.skipCount > 0) {
-            return table.uiState.skipCount;
-        }
 
         // If the table is not synced, we need to count the unsynced orders
         const orderCount = new Set();
@@ -119,6 +113,14 @@ export class Table extends Component {
         );
 
         table.uiState.orderCount = tableOrders.length;
+
+        if (table.uiState.orderCount > 0 && table.uiState.changeCount > 0) {
+            return table.uiState.changeCount;
+        }
+        if (table.uiState.orderCount > 0 && table.uiState.skipCount > 0) {
+            return table.uiState.skipCount;
+        }
+
         for (const order of tableOrders) {
             const changes = getOrderChanges(order, false, this.pos.orderPreparationCategories);
             table.uiState.changeCount += changes.nbrOfChanges;


### PR DESCRIPTION
pos*: point_of_sale, pos_restaurant

Before this commit:
==========
- When orders were deleted from the ticket screen, there was no record of those orders.
- Orders reappeared on the floor screen after being deleted from the ticket screen and with refreshed screen.
- After deleting the order from the ticket screen with changes and coming back to the floor screen without refreshing the screen, a table was displayed with the change count.

After this commit:
===========
- Now, deleted orders from the ticket screen are recorded as cancelled records.
- Orders do not reappear on the floor screen after being deleted from the ticket screen and with refreshed screen.
- After deleting the order from the ticket screen with changes and coming back to the floor screen without refreshing the screen, a table does not display the change count.

task-3950699