### PR TITLE
[FIX] web_editor: remove resizing classes from editable

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -640,6 +640,7 @@ export class OdooEditor extends EventTarget {
         this.addDomListener(this.editable, 'mousedown', this._onMouseDown);
         this.addDomListener(this.editable, 'mouseup', this._onMouseup);
         this.addDomListener(this.editable, 'mousemove', this._onMousemove);
+        this.addDomListener(this.editable, 'mouseleave', this._onMouseLeave);
         this.addDomListener(this.editable, 'paste', this._onPaste);
         this.addDomListener(this.editable, 'dragstart', this._onDragStart);
         this.addDomListener(this.editable, 'drop', this._onDrop);
@@ -4486,6 +4487,12 @@ export class OdooEditor extends EventTarget {
         const direction = {top: 'row', right: 'col', bottom: 'row', left: 'col'}[this._isHoveringTdBorder(ev)] || false;
         if (direction || !this._isResizingTable) {
             this._toggleTableResizeCursor(direction);
+        }
+    }
+
+    _onMouseLeave(ev) {
+        if (!this._isResizingTable) {
+            this._toggleTableResizeCursor(false);
         }
     }
 


### PR DESCRIPTION
Issue:
======
Colorpicker disappears randomly when the selection is in the end column of
the table.

Steps to reptoduce the issue:
=============================
- Go to notes
- Add a table
- Fill the first cell of the last column until the end
- Select some content of the end of the text (we need the toolbar to
  have some part ouside the editable)
- Try to change the color of the text/background
- The toolbar disapears
- You may need to do this multiple times to get the issue and make sure
  to go to the toolbar by sliding the cursor over the visible right edge
  of the table first

Origin of the issue:
====================
The right edge of the table is at the end of the editable so passing by
it will trigger `_onMouseMove`  which will detect that we are hovering
on the td border of the table so it will add the class `o_col_resize` or
`o_row_resize` to the editable.

In `_updateToolbar` we check if we have one of those mentioned classes
we don't show the toolbar so we hide it. That's why when hovering on a
color in the colorpicker it will disappear.

Note: The issue isn't always reproduceable because if we go so fast or
so slow the hovering may not get detected or even get detected and then
removed.

Solution:
=========
When we leave the editable, we toggle the resizeing classes if we are
not in resizing state.

opw-3950584