### PR TITLE
[MOV] sale,website_sale: move linked line logic to sale

### DIFF
--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -6,7 +6,7 @@ from datetime import datetime
 
 from dateutil.relativedelta import relativedelta
 
-from odoo import _, api, fields, models, SUPERUSER_ID
+from odoo import SUPERUSER_ID, _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
 from odoo.fields import Command
 from odoo.http import request
@@ -370,7 +370,7 @@ class SaleOrder(models.Model):
         return {
             'line_id': order_line.id,
             'quantity': quantity,
-            'option_ids': list(set(order_line.option_line_ids.filtered(
+            'option_ids': list(set(order_line.linked_line_ids.filtered(
                 lambda sol: sol.order_id == order_line.order_id).ids)
             ),
             'warning': warning,

--- a/addons/website_sale/models/sale_order_line.py
+++ b/addons/website_sale/models/sale_order_line.py
@@ -6,29 +6,10 @@ from odoo import _, api, fields, models
 class SaleOrderLine(models.Model):
     _inherit = 'sale.order.line'
 
-    linked_line_id = fields.Many2one(
-        string="Linked Order Line",
-        comodel_name='sale.order.line',
-        ondelete='cascade',
-        domain="[('order_id', '=', order_id)]",
-        copy=False,
-        index=True,
-    )
-    option_line_ids = fields.One2many(
-        string="Options Linked", comodel_name='sale.order.line', inverse_name='linked_line_id',
-    )
     name_short = fields.Char(compute='_compute_name_short')
     shop_warning = fields.Char(string="Warning")
 
     #=== COMPUTE METHODS ===#
-
-    @api.depends('linked_line_id', 'option_line_ids')
-    def _compute_name(self):
-        """Override to add the compute dependency.
-
-        The custom name logic can be found below in _get_sale_order_line_multiline_description_sale.
-        """
-        super()._compute_name()
 
     @api.depends('product_id.display_name')
     def _compute_name_short(self):
@@ -39,17 +20,6 @@ class SaleOrderLine(models.Model):
             record.name_short = record.product_id.with_context(display_default_code=False).display_name
 
     #=== BUSINESS METHODS ===#
-
-    def _get_sale_order_line_multiline_description_sale(self):
-        description = super()._get_sale_order_line_multiline_description_sale()
-        if self.linked_line_id:
-            description += "\n" + _("Option for: %s", self.linked_line_id.product_id.display_name)
-        if self.option_line_ids:
-            description += "\n" + '\n'.join([
-                _("Option: %s", option_line.product_id.display_name)
-                for option_line in self.option_line_ids
-            ])
-        return description
 
     def get_description_following_lines(self):
         return self.name.splitlines()[1:]


### PR DESCRIPTION
This change moves the linked line logic from website_sale to sale, as it will be used in sale (to link combo lines, see task-3716965) and sale_loyalty (to link reward lines to the lines to which they apply).

Upgrade PR: https://github.com/odoo/upgrade/pull/6102