### PR TITLE
[FIX] im_livechat: do not rely on cookies to save data

### DIFF
--- a/addons/im_livechat/static/src/embed/chatbot/chatbot_service.js
+++ b/addons/im_livechat/static/src/embed/chatbot/chatbot_service.js
@@ -72,7 +72,7 @@ export class ChatBotService {
                 : undefined;
             this.shouldRestore = Boolean(
                 localStorage.getItem(
-                    `im_livechat.chatbot.state.uuid_${this.livechatService.sessionCookie?.uuid}`
+                    `im_livechat.chatbot.state.uuid_${this.livechatService.sessionData?.uuid}`
                 )
             );
         });
@@ -313,7 +313,7 @@ export class ChatBotService {
      * clear outdated storage.
      */
     async restore() {
-        const chatbotStorageKey = `im_livechat.chatbot.state.uuid_${this.livechatService.sessionCookie?.uuid}`;
+        const chatbotStorageKey = `im_livechat.chatbot.state.uuid_${this.livechatService.sessionData?.uuid}`;
         const { _chatbotCurrentStep, _chatbot } = JSON.parse(
             browser.localStorage.getItem(chatbotStorageKey) ?? "{}"
         );
@@ -325,8 +325,8 @@ export class ChatBotService {
      * Clear outdated storage.
      */
     async clear() {
-        const chatbotStorageKey = this.livechatService.sessionCookie
-            ? `im_livechat.chatbot.state.uuid_${this.livechatService.sessionCookie.uuid}`
+        const chatbotStorageKey = this.livechatService.sessionData
+            ? `im_livechat.chatbot.state.uuid_${this.livechatService.sessionData.uuid}`
             : "";
         for (let i = 0; i < browser.localStorage.length; i++) {
             const key = browser.localStorage.key(i);

--- a/addons/im_livechat/static/src/embed/core/autopopup_service.js
+++ b/addons/im_livechat/static/src/embed/core/autopopup_service.js
@@ -2,9 +2,10 @@
 
 import { browser } from "@web/core/browser/browser";
 import { registry } from "@web/core/registry";
+import { expirableStorage } from "./misc";
 
 export class AutopopupService {
-    static COOKIE = "im_livechat_auto_popup";
+    static STORAGE_KEY = "im_livechat_auto_popup";
 
     /**
      * @param {import("@web/env").OdooEnv} env
@@ -13,7 +14,6 @@ export class AutopopupService {
      * "im_livechat.livechat": import("@im_livechat/embed/core/livechat_service").LivechatService,
      * "mail.thread": import("@mail/core/common/thread_service").ThreadService,
      * "mail.store": import("@mail/core/common/store_service").Store,
-     * cookie: typeof import("@web/core/browser/cookie_service").cookieService.start,
      * ui: typeof import("@web/core/ui/ui_service").uiService.start,
      * }} services
      */
@@ -25,14 +25,12 @@ export class AutopopupService {
             "mail.thread": threadService,
             "mail.store": storeService,
             ui,
-            cookie,
         }
     ) {
         this.threadService = threadService;
         this.storeService = storeService;
         this.livechatService = livechatService;
         this.chatbotService = chatbotService;
-        this.cookie = cookie;
         this.ui = ui;
 
         livechatService.initializedDeferred.then(() => {
@@ -41,7 +39,7 @@ export class AutopopupService {
             } else if (this.allowAutoPopup) {
                 browser.setTimeout(async () => {
                     if (await this.shouldOpenChatWindow()) {
-                        this.cookie.setCookie(AutopopupService.COOKIE, JSON.stringify(false));
+                        expirableStorage.setItem(AutopopupService.STORAGE_KEY, false);
                         threadService.openChat();
                     }
                 }, livechatService.rule.auto_popup_timer * 1000);
@@ -65,7 +63,7 @@ export class AutopopupService {
 
     get allowAutoPopup() {
         return Boolean(
-            JSON.parse(this.cookie.current[AutopopupService.COOKIE] ?? "true") !== false &&
+            JSON.parse(expirableStorage.getItem[AutopopupService.STORAGE_KEY] ?? true) !== false &&
                 !this.ui.isSmall &&
                 this.livechatService.rule?.action === "auto_popup" &&
                 (this.livechatService.available || this.chatbotService.available)
@@ -79,7 +77,6 @@ export const autoPopupService = {
         "im_livechat.chatbot",
         "mail.thread",
         "mail.store",
-        "cookie",
         "ui",
     ],
 

--- a/addons/im_livechat/static/src/embed/core/livechat_service.js
+++ b/addons/im_livechat/static/src/embed/core/livechat_service.js
@@ -6,6 +6,7 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { Deferred } from "@web/core/utils/concurrency";
 import { session } from "@web/session";
+import { expirableStorage } from "./misc";
 
 /**
  * @typedef LivechatRule
@@ -28,8 +29,8 @@ export const SESSION_STATE = Object.freeze({
 });
 
 export class LivechatService {
-    SESSION_COOKIE = "im_livechat_session";
-    OPERATOR_COOKIE = "im_livechat_previous_operator_pid";
+    SESSION_STORAGE_KEY = "im_livechat_session";
+    OPERATOR_STORAGE_KEY = "im_livechat_previous_operator_pid";
     /** @type {keyof typeof SESSION_STATE} */
     state = SESSION_STATE.NONE;
     /** @type {LivechatRule} */
@@ -47,7 +48,6 @@ export class LivechatService {
     /**
      * @param {import("@web/env").OdooEnv} env
      * @param {{
-     * cookie: typeof import("@web/core/browser/cookie_service").cookieService.start,
      * bus_service: typeof import("@bus/services/bus_service").busService.start,
      * rpc: typeof import("@web/core/network/rpc_service").rpcService.start,
      * "mail.message": import("@mail/core/common/message_service").MessageService,
@@ -55,7 +55,6 @@ export class LivechatService {
      * }} services
      */
     setup(env, services) {
-        this.cookie = services.cookie;
         this.busService = services.bus_service;
         this.rpc = services.rpc;
         this.messageService = services["mail.message"];
@@ -79,8 +78,8 @@ export class LivechatService {
     }
 
     async _createSession({ persisted = false } = {}) {
-        const chatbotScriptId = this.sessionCookie
-            ? this.sessionCookie.chatbotScriptId
+        const chatbotScriptId = this.sessionData
+            ? this.sessionData.chatbotScriptId
             : this.rule.chatbot?.scriptId;
         const session = await this.rpc(
             "/im_livechat/get_session",
@@ -88,13 +87,13 @@ export class LivechatService {
                 channel_id: this.options.channel_id,
                 anonymous_name: this.userName,
                 chatbot_script_id: chatbotScriptId,
-                previous_operator_id: this.cookie.current[this.OPERATOR_COOKIE],
+                previous_operator_id: expirableStorage.getItem(this.OPERATOR_STORAGE_KEY),
                 persisted,
             },
             { shadow: true }
         );
         if (!session) {
-            this.cookie.deleteCookie(this.SESSION_COOKIE);
+            expirableStorage.removeItem(this.SESSION_STORAGE_KEY);
             this.state = SESSION_STATE.NONE;
             return;
         }
@@ -114,20 +113,24 @@ export class LivechatService {
      * @param {Object} values
      */
     updateSession(values) {
-        const session = JSON.parse(this.cookie.current[this.SESSION_COOKIE] ?? "{}");
+        const session = JSON.parse(expirableStorage.getItem(this.SESSION_STORAGE_KEY) ?? "{}");
         Object.assign(session, {
             visitor_uid: this.visitorUid,
             ...values,
         });
-        this.cookie.deleteCookie(this.SESSION_COOKIE);
-        this.cookie.deleteCookie(this.OPERATOR_COOKIE);
-        this.cookie.setCookie(
-            this.SESSION_COOKIE,
+        expirableStorage.removeItem(this.SESSION_STORAGE_KEY);
+        expirableStorage.removeItem(this.OPERATOR_STORAGE_KEY);
+        expirableStorage.setItem(
+            this.SESSION_STORAGE_KEY,
             JSON.stringify(session).replaceAll("→", " "),
-            60 * 60 * 24
-        ); // 1 day cookie.
+            60 * 60 * 24 // kept for 1 day.
+        );
         if (session?.operator_pid) {
-            this.cookie.setCookie(this.OPERATOR_COOKIE, session.operator_pid[0], 7 * 24 * 60 * 60); // 1 week cookie.
+            expirableStorage.setItem(
+                this.OPERATOR_STORAGE_KEY,
+                session.operator_pid[0],
+                7 * 24 * 60 * 60 // kept for 1 week.
+            );
         }
     }
 
@@ -138,8 +141,8 @@ export class LivechatService {
      * never be called if the session was not persisted.
      */
     async leaveSession({ notifyServer = true } = {}) {
-        const session = JSON.parse(this.cookie.current[this.SESSION_COOKIE] ?? "{}");
-        this.cookie.deleteCookie(this.SESSION_COOKIE);
+        const session = JSON.parse(expirableStorage.getItem(this.SESSION_STORAGE_KEY) ?? "{}");
+        expirableStorage.removeItem(this.SESSION_STORAGE_KEY);
         this.state = SESSION_STATE.CLOSED;
         if (!session?.uuid || !notifyServer) {
             return;
@@ -149,7 +152,7 @@ export class LivechatService {
     }
 
     async getSession({ persisted = false } = {}) {
-        let session = JSON.parse(this.cookie.current[this.SESSION_COOKIE] ?? false);
+        let session = JSON.parse(expirableStorage.getItem(this.SESSION_STORAGE_KEY) ?? false);
         if (session?.uuid && this.state === SESSION_STATE.NONE) {
             // Channel is already created on the server.
             session.messages = await this.rpc("/im_livechat/chat_history", {
@@ -194,19 +197,19 @@ export class LivechatService {
         return true;
     }
 
-    get sessionCookie() {
-        return JSON.parse(this.cookie.current[this.SESSION_COOKIE] ?? "false");
+    get sessionData() {
+        return JSON.parse(expirableStorage.getItem(this.SESSION_STORAGE_KEY) ?? false);
     }
 
     get shouldRestoreSession() {
         if (this.state !== SESSION_STATE.NONE) {
             return false;
         }
-        return Boolean(this.cookie.current[this.SESSION_COOKIE]);
+        return Boolean(expirableStorage.getItem(this.SESSION_STORAGE_KEY));
     }
 
     get shouldDeleteSession() {
-        return this.sessionCookie && this.sessionCookie.visitor_uid !== session.user_id;
+        return this.sessionData && this.sessionData.visitor_uid !== session.user_id;
     }
 
     /**
@@ -217,15 +220,13 @@ export class LivechatService {
     }
 
     get visitorUid() {
-        const sessionCookie = this.sessionCookie;
-        return sessionCookie && "visitor_uid" in sessionCookie
-            ? sessionCookie.visitor_uid
-            : session.user_id;
+        const data = this.sessionData;
+        return data && "visitor_uid" in data ? data.visitor_uid : session.user_id;
     }
 }
 
 export const livechatService = {
-    dependencies: ["cookie", "notification", "rpc", "bus_service", "mail.message", "mail.store"],
+    dependencies: ["notification", "rpc", "bus_service", "mail.message", "mail.store"],
     start(env, services) {
         const livechat = reactive(new LivechatService(env, services));
         if (livechat.shouldDeleteSession) {

--- a/addons/im_livechat/static/src/embed/core/misc.js
+++ b/addons/im_livechat/static/src/embed/core/misc.js
@@ -1,8 +1,40 @@
 /**  @odoo-module */
 
+import { browser } from "@web/core/browser/browser";
+
 export function isValidEmail(val) {
     // http://stackoverflow.com/questions/46155/validate-email-address-in-javascript
     const re =
         /^(([^<>()[\].,;:\s@"]+(\.[^<>()[\].,;:\s@"]+)*)|(".+"))@(([^<>()[\].,;:\s@"]+\.)+[^<>()[\].,;:\s@"]{2,})$/i;
     return re.test(val);
 }
+
+export const expirableStorage = {
+    getItem(key) {
+        const item = browser.localStorage.getItem(key);
+        if (item) {
+            const { expires, value } = JSON.parse(item);
+            if (expires && expires < Date.now()) {
+                localStorage.removeItem(key);
+                return null;
+            }
+            return value;
+        }
+        return null;
+    },
+    /**
+     * @param {string} key
+     * @param {string} value
+     * @param {number} ttl Number of seconds after which the item should expire.
+     */
+    setItem(key, value, ttl) {
+        let expires;
+        if (ttl) {
+            expires = Date.now() + ttl * 1000;
+        }
+        browser.localStorage.setItem(key, JSON.stringify({ value, expires }));
+    },
+    removeItem(key) {
+        browser.localStorage.removeItem(key);
+    },
+};

--- a/addons/im_livechat/static/tests/embed/autopopup_tests.js
+++ b/addons/im_livechat/static/tests/embed/autopopup_tests.js
@@ -2,7 +2,8 @@
 
 import { startServer } from "@bus/../tests/helpers/mock_python_environment";
 
-import { start, setCookie, loadDefaultConfig } from "@im_livechat/../tests/embed/helper/test_utils";
+import { start, loadDefaultConfig } from "@im_livechat/../tests/embed/helper/test_utils";
+import { expirableStorage } from "@im_livechat/embed/core/misc";
 
 import { Command } from "@mail/../tests/helpers/command";
 import { waitUntil } from "@mail/../tests/helpers/test_utils";
@@ -24,7 +25,7 @@ QUnit.test("persisted session", async (assert) => {
         livechat_operator_id: pyEnv.currentPartnerId,
     });
     const [channelInfo] = pyEnv.mockServer._mockDiscussChannelChannelInfo([channelId]);
-    setCookie("im_livechat_session", JSON.stringify(channelInfo));
+    expirableStorage.setItem("im_livechat_session", JSON.stringify(channelInfo));
     await start();
     await waitUntil(".o-mail-ChatWindow");
     assert.containsOnce($, ".o-mail-ChatWindow");

--- a/addons/im_livechat/static/tests/embed/expirable_storage_tests.js
+++ b/addons/im_livechat/static/tests/embed/expirable_storage_tests.js
@@ -1,0 +1,17 @@
+/* @odoo-module */
+
+import { expirableStorage } from "@im_livechat/embed/core/misc";
+
+import { patchDate } from "@web/../tests/helpers/utils";
+
+QUnit.module("expirable storage");
+
+QUnit.test("expire after a said amount of time ", async (assert) => {
+    const KEY = "my_storage_key";
+    const ONE_DAY = 60 * 60 * 24;
+    patchDate(2020, 2, 1, 10, 0, 0);
+    expirableStorage.setItem(KEY, "hello world", ONE_DAY);
+    assert.equal(expirableStorage.getItem(KEY), "hello world");
+    patchDate(2020, 2, 2, 11, 0, 0); // next day (one hour later to make sure it expires)
+    assert.equal(expirableStorage.getItem(KEY), null);
+});

--- a/addons/im_livechat/static/tests/embed/helper/test_utils.js
+++ b/addons/im_livechat/static/tests/embed/helper/test_utils.js
@@ -16,27 +16,9 @@ import { registry } from "@web/core/registry";
 import { patch } from "@web/core/utils/patch";
 import { session } from "@web/session";
 import { registerCleanup } from "@web/../tests/helpers/cleanup";
-import { fakeCookieService } from "@web/../tests/helpers/mock_services";
 import { patchWithCleanup, makeDeferred } from "@web/../tests/helpers/utils";
 import { createWebClient } from "@web/../tests/webclient/helpers";
 import { historyService } from "@im_livechat/embed/core/history_service";
-
-// =============================================================================
-// HELPERS
-// =============================================================================
-
-let cookie = {};
-QUnit.testDone(() => (cookie = {}));
-
-/**
- * Set a cookie to be used by the current test.
- *
- * @param {string} key
- * @param {string} val
- */
-export function setCookie(key, val) {
-    cookie[key] = val;
-}
 
 // =============================================================================
 // SETUP
@@ -88,20 +70,6 @@ patch(setupManager, "im_livechat", {
             "im_livechat.autopopup": autoPopupService,
             "im_livechat.chatbot": chatBotService,
             "im_livechat.history_service": historyService,
-            cookie: {
-                start() {
-                    const service = fakeCookieService.start(...arguments);
-                    return {
-                        ...service,
-                        get current() {
-                            return {
-                                ...service.current,
-                                ...cookie,
-                            };
-                        },
-                    };
-                },
-            },
             ...services,
         };
     },

--- a/addons/im_livechat/static/tests/embed/livechat_service_tests.js
+++ b/addons/im_livechat/static/tests/embed/livechat_service_tests.js
@@ -2,7 +2,8 @@
 
 import { startServer } from "@bus/../tests/helpers/mock_python_environment";
 
-import { loadDefaultConfig, setCookie, start } from "@im_livechat/../tests/embed/helper/test_utils";
+import { loadDefaultConfig, start } from "@im_livechat/../tests/embed/helper/test_utils";
+import { expirableStorage } from "@im_livechat/embed/core/misc";
 
 import { Command } from "@mail/../tests/helpers/command";
 import { click } from "@mail/../tests/helpers/test_utils";
@@ -22,7 +23,7 @@ QUnit.test("persisted session history", async (assert) => {
         livechat_operator_id: pyEnv.currentPartnerId,
     });
     const [channelInfo] = pyEnv.mockServer._mockDiscussChannelChannelInfo([channelId]);
-    setCookie("im_livechat_session", JSON.stringify(channelInfo));
+    expirableStorage.setItem("im_livechat_session", JSON.stringify(channelInfo));
     pyEnv["mail.message"].create({
         author_id: pyEnv.currentPartnerId,
         body: "Old message in history",
@@ -41,7 +42,10 @@ QUnit.test("previous operator prioritized", async (assert) => {
     const userId = pyEnv["res.users"].create({ name: "John Doe", im_status: "online" });
     const previousOperatorId = pyEnv["res.partner"].create({ user_ids: [userId] });
     pyEnv["im_livechat.channel"].write([livechatChannelId], { user_ids: [Command.link(userId)] });
-    setCookie("im_livechat_previous_operator_pid", JSON.stringify(previousOperatorId));
+    expirableStorage.setItem(
+        "im_livechat_previous_operator_pid",
+        JSON.stringify(previousOperatorId)
+    );
     await start();
     await click(".o-livechat-LivechatButton");
     assert.containsOnce($, ".o-mail-Message-author:contains(John Doe)");

--- a/addons/im_livechat/static/tests/embed/livechat_session_tests.js
+++ b/addons/im_livechat/static/tests/embed/livechat_session_tests.js
@@ -2,7 +2,8 @@
 
 import { startServer } from "@bus/../tests/helpers/mock_python_environment";
 
-import { loadDefaultConfig, setCookie, start } from "@im_livechat/../tests/embed/helper/test_utils";
+import { loadDefaultConfig, start } from "@im_livechat/../tests/embed/helper/test_utils";
+import { expirableStorage } from "@im_livechat/embed/core/misc";
 import { LivechatButton } from "@im_livechat/embed/core_ui/livechat_button";
 
 import { Command } from "@mail/../tests/helpers/command";
@@ -25,7 +26,7 @@ QUnit.test("Unsuccessful message post shows session expired", async (assert) => 
         livechat_operator_id: pyEnv.currentPartnerId,
     });
     const [channelInfo] = pyEnv.mockServer._mockDiscussChannelChannelInfo([channelId]);
-    setCookie("im_livechat_session", JSON.stringify(channelInfo));
+    expirableStorage.setItem("im_livechat_session", JSON.stringify(channelInfo));
     await start({
         mockRPC(route) {
             if (route === "/im_livechat/chat_post") {
@@ -68,11 +69,11 @@ QUnit.test("Thread state is saved on the session", async (assert) => {
     await loadDefaultConfig();
     const env = await start();
     await click(".o-livechat-LivechatButton");
-    assert.strictEqual(env.services["im_livechat.livechat"].sessionCookie.state, "open");
+    assert.strictEqual(env.services["im_livechat.livechat"].sessionData.state, "open");
     await click(".o-mail-ChatWindow-header");
-    assert.strictEqual(env.services["im_livechat.livechat"].sessionCookie.state, "folded");
+    assert.strictEqual(env.services["im_livechat.livechat"].sessionData.state, "folded");
     await click(".o-mail-ChatWindow-header");
-    assert.strictEqual(env.services["im_livechat.livechat"].sessionCookie.state, "open");
+    assert.strictEqual(env.services["im_livechat.livechat"].sessionData.state, "open");
 });
 
 QUnit.test("Seen message is saved on the session", async (assert) => {
@@ -80,11 +81,11 @@ QUnit.test("Seen message is saved on the session", async (assert) => {
     await loadDefaultConfig();
     const env = await start();
     await click(".o-livechat-LivechatButton");
-    assert.notOk(env.services["im_livechat.livechat"].sessionCookie.seen_message_id);
+    assert.notOk(env.services["im_livechat.livechat"].sessionData.seen_message_id);
     await insertText(".o-mail-Composer-input", "Hello World!");
     await afterNextRender(() => triggerHotkey("Enter"));
     assert.strictEqual(
-        env.services["im_livechat.livechat"].sessionCookie.seen_message_id,
+        env.services["im_livechat.livechat"].sessionData.seen_message_id,
         env.services["im_livechat.livechat"].thread.seenInfos[0].lastSeenMessage.id
     );
 });

--- a/addons/im_livechat/static/tests/embed/unread_messages_tests.js
+++ b/addons/im_livechat/static/tests/embed/unread_messages_tests.js
@@ -2,7 +2,8 @@
 
 import { startServer } from "@bus/../tests/helpers/mock_python_environment";
 
-import { loadDefaultConfig, setCookie, start } from "@im_livechat/../tests/embed/helper/test_utils";
+import { loadDefaultConfig, start } from "@im_livechat/../tests/embed/helper/test_utils";
+import { expirableStorage } from "@im_livechat/embed/core/misc";
 
 import { Command } from "@mail/../tests/helpers/command";
 import { afterNextRender, waitUntil } from "@mail/../tests/helpers/test_utils";
@@ -22,7 +23,7 @@ QUnit.test("new message from operator displays unread counter", async (assert) =
         livechat_operator_id: pyEnv.currentPartnerId,
     });
     const [channelInfo] = pyEnv.mockServer._mockDiscussChannelChannelInfo([channelId]);
-    setCookie("im_livechat_session", JSON.stringify(channelInfo));
+    expirableStorage.setItem("im_livechat_session", JSON.stringify(channelInfo));
     const env = await start();
     $(".o-mail-Composer-input").blur();
     await afterNextRender(() => {
@@ -50,7 +51,7 @@ QUnit.test("focus on unread livechat marks it as read", async (assert) => {
         livechat_operator_id: pyEnv.currentPartnerId,
     });
     const [channelInfo] = pyEnv.mockServer._mockDiscussChannelChannelInfo([channelId]);
-    setCookie("im_livechat_session", JSON.stringify(channelInfo));
+    expirableStorage.setItem("im_livechat_session", JSON.stringify(channelInfo));
     const env = await start();
     $(".o-mail-Composer-input").blur();
     await afterNextRender(() => {


### PR DESCRIPTION
The live chat uses cookies to save information such as the last operator id or page history. Some websites such as codepen blocks those cookies in which case the live chat can't work properly.

This commit removes the usage of cookies as it is discouraged to save data anyway [1] and replace them by the local storage.

[1]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#data_storage
