### PR TITLE
[IMP] mail: enable the members list for whatsapp channels

### DIFF
--- a/addons/mail/static/src/discuss/core/common/@types/models.d.ts
+++ b/addons/mail/static/src/discuss/core/common/@types/models.d.ts
@@ -7,5 +7,6 @@ declare module "models" {
         onlineMembers: ChannelMember[],
         offlineMembers: ChannelMember[],
         readonly hasMemberList: boolean,
+        private _computeOfflineMembers(): ChannelMember[],
     }
 }

--- a/addons/mail/static/src/discuss/core/common/channel_member_list.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_member_list.xml
@@ -11,7 +11,7 @@
                 </h6>
                 <t t-foreach="props.thread.onlineMembers" t-as="member" t-key="member.id" t-call="discuss.channel_member"/>
             </t>
-            <t t-if="props.thread.offlineMembers.length > 0">
+            <t name="offlineMembers" t-if="props.thread.offlineMembers.length > 0">
                 <h6 class="mx-3 text-700">
                     Offline -
                     <t t-esc="props.thread.offlineMembers.length"/>

--- a/addons/mail/static/src/discuss/core/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/thread_model_patch.js
@@ -27,14 +27,12 @@ const threadPatch = {
             },
         });
         this.offlineMembers = Record.many("ChannelMember", {
-            /** @this {import("models").Thread} */
-            compute() {
-                return this.channelMembers.filter(
-                    (member) => member.persona?.im_status !== "online"
-                );
-            },
+            compute: this._computeOfflineMembers,
             sort: (m1, m2) => (m1.persona?.name < m2.persona?.name ? -1 : 1),
         });
+    },
+    _computeOfflineMembers() {
+        return this.channelMembers.filter((member) => member.persona?.im_status !== "online");
     },
     get avatarUrl() {
         if (this.channel_type === "channel" || this.channel_type === "group") {


### PR DESCRIPTION
**PURPOSE:**

User should be able to see members of the current whatsapp channel.

**SPECIFICATIONS:**

- Enable the Members List for whatsapp channels.
- Display the member related to WhatsApp partner into a separate category `WhatsApp User`.
- WhatsApp partner's `im_status` icon should be WhatsApp icon in green color.

**Related Enterprise PR:** https://github.com/odoo/enterprise/pull/58843

**task**-[3524300](https://www.odoo.com/odoo/my-tasks/3524300?debug=&cids=2)
