### PR TITLE
[FIX] stock: propagate destination location from picking to move lines

### DIFF
--- a/addons/mrp_subcontracting/models/stock_move.py
+++ b/addons/mrp_subcontracting/models/stock_move.py
@@ -4,7 +4,7 @@
 from collections import defaultdict
 
 from odoo import fields, models, api, _
-from odoo.exceptions import UserError, AccessError
+from odoo.exceptions import AccessError
 from odoo.tools.float_utils import float_compare, float_is_zero, float_round
 from odoo.tools.misc import OrderedSet
 
@@ -220,6 +220,7 @@ class StockMove(models.Model):
                 'is_subcontract': True,
                 'location_id': move.picking_id.partner_id.with_company(move.company_id).property_stock_subcontractor.id
             })
+            move._action_assign()  # Re-reserve as the write on location_id will break the link
         res = super()._action_confirm(merge=merge, merge_into=merge_into)
         for move in res:
             if move.is_subcontract:

--- a/addons/mrp_subcontracting/tests/test_subcontracting.py
+++ b/addons/mrp_subcontracting/tests/test_subcontracting.py
@@ -161,6 +161,7 @@ class TestSubcontractingFlows(TestMrpSubcontractingCommon):
         picking_form.partner_id = self.subcontractor_partner1
         with picking_form.move_ids_without_package.new() as move:
             move.product_id = self.finished
+            move.product_uom_qty = 1
             move.quantity = 1
             move.picked = True
         picking_receipt = picking_form.save()
@@ -230,6 +231,7 @@ class TestSubcontractingFlows(TestMrpSubcontractingCommon):
         picking_form.partner_id = self.subcontractor_partner1
         with picking_form.move_ids_without_package.new() as move:
             move.product_id = self.finished
+            move.product_uom_qty = 1
             move.quantity = 1
             move.picked = True
         picking_receipt = picking_form.save()
@@ -298,6 +300,7 @@ class TestSubcontractingFlows(TestMrpSubcontractingCommon):
         picking_form.partner_id = self.subcontractor_partner1
         with picking_form.move_ids_without_package.new() as move:
             move.product_id = self.finished
+            move.product_uom_qty = 1
             move.quantity = 1
             move.picked = True
         picking_receipt = picking_form.save()
@@ -367,6 +370,7 @@ class TestSubcontractingFlows(TestMrpSubcontractingCommon):
         picking_form.partner_id = self.subcontractor_partner1
         with picking_form.move_ids_without_package.new() as move:
             move.product_id = self.finished
+            move.product_uom_qty = 1
             move.quantity = 1
             move.picked = True
         picking_receipt1 = picking_form.save()
@@ -377,6 +381,7 @@ class TestSubcontractingFlows(TestMrpSubcontractingCommon):
         picking_form.partner_id = subcontractor_partner2
         with picking_form.move_ids_without_package.new() as move:
             move.product_id = self.finished
+            move.product_uom_qty = 1
             move.quantity = 1
             move.picked = True
         picking_receipt2 = picking_form.save()
@@ -498,6 +503,7 @@ class TestSubcontractingFlows(TestMrpSubcontractingCommon):
         picking_form.partner_id = self.subcontractor_partner1
         with picking_form.move_ids_without_package.new() as move:
             move.product_id = self.finished
+            move.product_uom_qty = 5
             move.quantity = 5
             move.picked = True
         picking_receipt = picking_form.save()
@@ -864,6 +870,7 @@ class TestSubcontractingFlows(TestMrpSubcontractingCommon):
             picking_form.partner_id = self.subcontractor_partner1
             with picking_form.move_ids_without_package.new() as move:
                 move.product_id = self.finished
+                move.product_uom_qty = 3
                 move.quantity = 3
             picking_receipt = picking_form.save()
         picking_receipt.action_confirm()
@@ -1186,6 +1193,7 @@ class TestSubcontractingTracking(TransactionCase):
         picking_form.partner_id = self.subcontractor_partner1
         with picking_form.move_ids_without_package.new() as move:
             move.product_id = self.finished_product
+            move.product_uom_qty = 1
             move.quantity = 1
             move.picked = True
         picking_receipt = picking_form.save()
@@ -1311,6 +1319,7 @@ class TestSubcontractingTracking(TransactionCase):
         picking_form.partner_id = self.subcontractor_partner1
         with picking_form.move_ids_without_package.new() as move:
             move.product_id = self.finished_product
+            move.product_uom_qty = todo_nb
             move.quantity = todo_nb
         picking_receipt = picking_form.save()
         picking_receipt.action_confirm()
@@ -1482,6 +1491,7 @@ class TestSubcontractingTracking(TransactionCase):
         picking_form.partner_id = self.subcontractor_partner1
         with picking_form.move_ids_without_package.new() as move:
             move.product_id = finished_product
+            move.product_uom_qty = todo_nb
             move.quantity = todo_nb
             move.picked = True
         picking_receipt = picking_form.save()

--- a/addons/mrp_subcontracting/tests/test_subcontracting_portal_ui.py
+++ b/addons/mrp_subcontracting/tests/test_subcontracting_portal_ui.py
@@ -54,6 +54,7 @@ class TestSubcontractingPortalUi(HttpCase):
         picking_form.partner_id = self.partner_portal
         with picking_form.move_ids_without_package.new() as move:
             move.product_id = self.finished_product
+            move.product_uom_qty = 2
             move.quantity = 2
             move.picked = True
         picking_receipt = picking_form.save()

--- a/addons/mrp_subcontracting_account/tests/test_subcontracting_account.py
+++ b/addons/mrp_subcontracting_account/tests/test_subcontracting_account.py
@@ -288,6 +288,7 @@ class TestAccountSubcontractingFlows(TestMrpSubcontractingCommon):
         picking_form.partner_id = self.subcontractor_partner1
         with picking_form.move_ids_without_package.new() as move:
             move.product_id = self.finished
+            move.product_uom_qty = todo_nb
             move.quantity = todo_nb
         picking_receipt = picking_form.save()
         # Mimic the extra cost on the po line

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -75,7 +75,7 @@ class StockMove(models.Model):
     location_dest_id = fields.Many2one(
         'stock.location', 'Intermediate Location', required=True,
         help='The operations brings product to this location', readonly=False,
-        index=True, store=True, compute='_compute_location_dest_id', precompute=True)
+        index=True, store=True, compute='_compute_location_dest_id', precompute=True, inverse='_set_location_dest_id')
     location_final_id = fields.Many2one(
         'stock.location', 'Destination Location',
         readonly=False, store=True,
@@ -207,6 +207,14 @@ class StockMove(models.Model):
             if location_dest and move.location_final_id and move.location_final_id._child_of(location_dest):
                 location_dest = move.location_final_id
             move.location_dest_id = location_dest
+
+    def _set_location_dest_id(self):
+        for ml in self.move_line_ids:
+            parent_path = [int(loc_id) for loc_id in ml.location_dest_id.parent_path.split('/')[:-1]]
+            if ml.move_id.location_dest_id.id in parent_path:
+                continue
+            loc_dest = ml.move_id.location_dest_id._get_putaway_strategy(ml.product_id, ml.quantity_product_uom)
+            ml.location_dest_id = loc_dest
 
     @api.depends('has_tracking', 'picking_type_id.use_create_lots', 'picking_type_id.use_existing_lots', 'product_id')
     def _compute_display_assign_serial(self):
@@ -638,7 +646,7 @@ Please change the quantity done or the rounding precision of your unit of measur
         receipt_moves_to_reassign = self.env['stock.move']
         move_to_recompute_state = self.env['stock.move']
         move_to_confirm = self.env['stock.move']
-        move_to_check_dest_location = self.env['stock.move']
+        move_to_check_location = self.env['stock.move']
         if 'quantity' in vals:
             if any(move.state == 'cancel' for move in self):
                 raise UserError(_('You cannot change a cancelled stock move, create a new line instead.'))
@@ -669,8 +677,8 @@ Please change the quantity done or the rounding precision of your unit of measur
             self._set_date_deadline(vals.get('date_deadline'))
         if 'move_orig_ids' in vals:
             move_to_recompute_state |= self.filtered(lambda m: m.state not in ['draft', 'cancel', 'done'])
-        if 'location_dest_id' in vals:
-            move_to_check_dest_location = self.filtered(lambda m: m.location_dest_id.id != vals.get('location_dest_id'))
+        if 'location_id' in vals:
+            move_to_check_location = self.filtered(lambda m: m.location_id.id != vals.get('location_id'))
         if 'picking_id' in vals and 'group_id' not in vals:
             picking = self.env['stock.picking'].browse(vals['picking_id'])
             if picking.group_id:
@@ -678,13 +686,14 @@ Please change the quantity done or the rounding precision of your unit of measur
         res = super(StockMove, self).write(vals)
         if move_to_recompute_state:
             move_to_recompute_state._recompute_state()
-        if move_to_check_dest_location:
-            for ml in move_to_check_dest_location.move_line_ids:
-                parent_path = [int(id) for id in ml.location_dest_id.parent_path.split('/')[:-1]]
-                if ml.move_id.location_dest_id.id in parent_path:
-                    continue
-                loc_dest = ml.move_id.location_dest_id._get_putaway_strategy(ml.product_id, ml.quantity_product_uom)
-                ml.location_dest_id = loc_dest
+        if move_to_check_location:
+            for ml in move_to_check_location.move_line_ids:
+                parent_path = [int(loc_id) for loc_id in ml.location_id.parent_path.split('/')[:-1]]
+                if move_to_check_location.location_id.id not in parent_path:
+                    receipt_moves_to_reassign |= move_to_check_location
+                    move_to_check_location.procure_method = 'make_to_stock'
+                    move_to_check_location.move_orig_ids = [Command.clear()]
+                    ml.unlink()
         if move_to_confirm:
             move_to_confirm._action_assign()
         if receipt_moves_to_reassign:

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -5,16 +5,16 @@ import json
 import math
 import time
 from ast import literal_eval
-from datetime import date, timedelta
+from datetime import date
 from collections import defaultdict
 
-from odoo import SUPERUSER_ID, _, api, Command, fields, models
+from odoo import SUPERUSER_ID, _, api, fields, models
 from odoo.addons.stock.models.stock_move import PROCUREMENT_PRIORITIES
 from odoo.addons.web.controllers.utils import clean_action
 from odoo.exceptions import UserError, ValidationError
 from odoo.osv import expression
 from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT, format_datetime, format_date, groupby
-from odoo.tools.float_utils import float_compare, float_is_zero, float_round
+from odoo.tools.float_utils import float_compare, float_is_zero
 
 
 class PickingType(models.Model):
@@ -798,6 +798,20 @@ class Picking(models.Model):
                     'title': ("Warning for %s") % partner.name,
                     'message': partner.picking_warn_msg
                 }}
+
+    @api.onchange('location_id')
+    def _onchange_location_id(self):
+        for move in self.move_ids.filtered(lambda m: m.move_orig_ids):
+            for ml in move.move_line_ids:
+                parent_path = [int(loc_id) for loc_id in ml.location_id.parent_path.split('/')[:-1]]
+                if self.location_id.id not in parent_path:
+                    return {'warning': {
+                            'title': _("Warning: change source location"),
+                            'message': _("Updating the location of this transfer will result in unreservation of the currently assigned items. "
+                                         "An attempt to reserve items at the new location will be made and the link with preceding transfers will be discarded.\n\n"
+                                         "To avoid this, please discard the source location change before saving.")
+                        }
+                    }
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/stock/static/src/views/picking_form/stock_move_one2many.js
+++ b/addons/stock/static/src/views/picking_form/stock_move_one2many.js
@@ -49,6 +49,9 @@ export class StockMoveX2ManyField extends X2ManyField {
     async openRecord(record) {
         if (this.canOpenRecord && !record.isNew) {
             const dirty = await record.isDirty();
+            if (await record._parentRecord.isDirty()){
+                await record._parentRecord.save({ reload: true });
+            }
             if (dirty && 'quantity' in record._changes) {
                 await record.model.root.save({ reload: true });
                 record = record.model.root.data[this.props.name].records.find(e => e.resId === record.resId);


### PR DESCRIPTION
When changing the destination location on a picking, it will also be updated on the included stock moves and stock move lines. However, due the introduction of the compute on the location_dest_id field on a stock move in [1], this propagation no longer works.

This commit restores the updating of the stock moves when changing it on the parent picking.

[1] https://github.com/odoo/odoo/pull/156437

task-3390325

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
