### PR TITLE
[FIX] stock: show forecast button with is_storable

### DIFF
--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -414,6 +414,7 @@
                                     <field name="date" column_invisible="True"/>
                                     <field name="additional" column_invisible="True"/>
                                     <field name="picking_type_id" column_invisible="True"/>
+                                    <field name="is_storable" column_invisible="True"/>
                                     <field name="has_tracking" column_invisible="True"/>
                                     <field name="operation_id" column_invisible="True"/>
                                     <field name="is_done" column_invisible="True"/>

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -152,7 +152,7 @@
                             </group>
                             <group name="packaging" string="Packaging"
                                 colspan="4"
-                                invisible="(type not in ['product', 'consu'] or product_variant_count &gt; 1) and not is_product_variant"
+                                invisible="(type != 'consu' or product_variant_count &gt; 1) and not is_product_variant"
                                 groups="product.group_stock_packaging">
                                 <field colspan="2" name="packaging_ids" nolabel="1" context="{'tree_view_ref':'product.product_packaging_tree_view2', 'default_company_id': company_id}"/>
                             </group>

--- a/addons/purchase/data/mail_templates.xml
+++ b/addons/purchase/data/mail_templates.xml
@@ -7,7 +7,7 @@
             <ul>
                 <li><t t-esc="line.product_id.display_name"/>:</li>
                 Ordered Quantity: <t t-esc="line.product_qty" /> -&gt; <t t-esc="float(product_qty)"/><br/>
-                <t t-if='line.order_id.product_id.type in ("consu", "product")'>
+                <t t-if='line.order_id.product_id.type != "consu"'>
                     Received Quantity: <t t-esc="line.qty_received" /><br/>
                 </t>
                 Billed Quantity: <t t-esc="line.qty_invoiced"/>

--- a/addons/purchase_stock/views/purchase_views.xml
+++ b/addons/purchase_stock/views/purchase_views.xml
@@ -31,8 +31,8 @@
             </xpath>
             <xpath expr="//page/field[@name='order_line']/tree/field[@name='product_qty']" position="after">
                 <field name="forecasted_issue" column_invisible="True"/>
-                <button type="object" name="action_product_forecast_report" title="Forecast Report" icon="fa-area-chart" invisible="not id or not forecasted_issue or product_type != 'product'" class="text-danger"/>
-                <button type="object" name="action_product_forecast_report" title="Forecast Report" icon="fa-area-chart" invisible="not id or forecasted_issue or product_type != 'product'"/>
+                <button type="object" name="action_product_forecast_report" title="Forecast Report" icon="fa-area-chart" invisible="not id or not forecasted_issue or not product_id.is_storable" class="text-danger"/>
+                <button type="object" name="action_product_forecast_report" title="Forecast Report" icon="fa-area-chart" invisible="not id or forecasted_issue or not product_id.is_storable"/>
             </xpath>
             <xpath expr="//div[@name='date_planned_div']" position="inside">
                 <button name="%(action_purchase_vendor_delay_report)d" class="oe_link" type="action" context="{'search_default_partner_id': partner_id}" invisible="state in ['purchase', 'done'] or not partner_id">
@@ -63,7 +63,7 @@
             </xpath>
             <xpath expr="//field[@name='order_line']/tree//field[@name='qty_received']" position="attributes">
                 <attribute name="column_invisible">parent.state not in ('purchase', 'done')</attribute>
-                <attribute name="readonly">product_type in ('consu', 'product')</attribute>
+                <attribute name="readonly">product_type == 'consu'</attribute>
             </xpath>
             <xpath expr="//page[@name='purchase_delivery_invoice']/group/group" position="inside">
                 <field name="default_location_dest_id_usage" invisible="1"/>

--- a/addons/repair/views/repair_views.xml
+++ b/addons/repair/views/repair_views.xml
@@ -145,6 +145,7 @@
                                 <field name="move_lines_count" column_invisible="True"/>
                                 <field name="is_locked" column_invisible="True"/>
                                 <field name="product_uom_category_id" column_invisible="True"/>
+                                <field name="is_storable" column_invisible="True"/>
                                 <field name="has_tracking" column_invisible="True"/>
                                 <field name="display_assign_serial" column_invisible="True"/>
                                 <field name="product_id" context="{'default_is_storable': True}" required="1" readonly="(state != 'draft' and not additional) or move_lines_count &gt; 0"/>

--- a/addons/stock/static/src/widgets/forecast_widget.xml
+++ b/addons/stock/static/src/widgets/forecast_widget.xml
@@ -9,7 +9,7 @@
             Exp <t t-out="forecastExpectedDate"/>
         </span>
         <span t-else="" class="text-danger">Not Available</span>
-        <button t-if="props.record.data.product_type == 'product'" title="Forecasted Report"
+        <button t-if="props.record.data.is_storable" title="Forecasted Report"
                 t-on-click="_openReport" t-att="resId ? {} : {'disabled': ''}"
                 class="o_forecast_report_button btn btn-link o_icon_button ms-2 pt-0">
             <i class="fa fa-fw fa-area-chart"

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -272,6 +272,7 @@
                                     <field name="move_lines_count" column_invisible="True"/>
                                     <field name="is_locked" column_invisible="True"/>
                                     <field name="product_uom_category_id" column_invisible="True"/>
+                                    <field name="is_storable" column_invisible="True"/>
                                     <field name="has_tracking" column_invisible="True"/>
                                     <field name="product_id" context="{'default_is_storable': True}" required="1" readonly="(state != 'draft' and not additional) or move_lines_count &gt; 0" force_save="1"/>
                                     <field name="description_picking" string="Description" optional="hide"/>

--- a/addons/website_sale_stock/views/website_sale_stock_templates.xml
+++ b/addons/website_sale_stock/views/website_sale_stock_templates.xml
@@ -3,7 +3,7 @@
 
     <template id="website_sale_stock_cart_lines" inherit_id="website_sale.cart_lines" name="Shopping Cart Lines">
         <xpath expr="//input[@type='text'][hasclass('quantity')]" position="attributes">
-            <attribute name="t-att-data-max">(line.product_uom_qty + line._get_max_available_qty()) if line.product_id.type == 'product' and not line.product_id.allow_out_of_stock_order else None</attribute>
+            <attribute name="t-att-data-max">(line.product_uom_qty + line._get_max_available_qty()) if line.product_id.is_storable and not line.product_id.allow_out_of_stock_order else None</attribute>
         </xpath>
         <xpath expr="//div[@name='website_sale_cart_line_quantity']" position="after">
             <div class="availability_messages"/>


### PR DESCRIPTION
Followup to storable product refactoring: odoo/odoo#165372

Some references were missed during the refactoring that made it so the forecast button didn't show up in a few cases. This adds in the missing changes/invisible fields so that they show again in: Purchase, Repair, MRP, and Inventory (outgoing deliveries)

Also remove a few other references to the now obsolete "type=product" selection object


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
