### PR TITLE
[FIX] website_slides: fix karma progress bar tooltip

### DIFF
--- a/addons/website_slides/static/src/js/public/components/slide_quiz_finish_dialog/slide_xp_progress_bar.scss
+++ b/addons/website_slides/static/src/js/public/components/slide_quiz_finish_dialog/slide_xp_progress_bar.scss
@@ -1,0 +1,4 @@
+.o_wlides_xp_progressbar_tooltip {
+    top: -14px;
+    max-width: 3rem;
+}

--- a/addons/website_slides/static/src/js/public/components/slide_quiz_finish_dialog/slide_xp_progress_bar.xml
+++ b/addons/website_slides/static/src/js/public/components/slide_quiz_finish_dialog/slide_xp_progress_bar.xml
@@ -2,12 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="website_slides.SlideXPProgressBar" owl="1">
-        <div class="progress position-relative">
-            <div class="tooltip fade show bs-tooltip-top" t-att-class="{'level-up': props.levelUp}" role="tooltip"
-                t-attf-style="left: #{state.rankProgressPercentage}%;">
-                <div class="tooltip-arrow"/>
-                <div class="tooltip-inner" t-out="state.userKarma"/>
-            </div>
+        <div class="progress">
             <div class="progress-bar" t-att-class="{'level-up': props.levelUp}" role="progressbar"
                  t-att-aria-valuenow="props.previousRank.progress" aria-valuemin="0" aria-valuemax="100" aria-label="Progress bar"
                  t-attf-style="width: #{state.rankProgressPercentage}%"/>
@@ -16,6 +11,11 @@
                t-out="state.rankLowerBound"/>
         <small t-if="state.rankUpperBound" class="float-end fw-bold"
                t-att-class="{'d-none': state.hideRankBounds}" t-out="state.rankUpperBound"/>
+        <div class="o_wlides_xp_progressbar_tooltip tooltip fade show bs-tooltip-top position-relative" t-att-class="{'level-up': props.levelUp}" role="tooltip"
+             t-attf-style="left: #{state.rankProgressPercentage}%">
+            <div class="tooltip-arrow"/>
+            <div class="tooltip-inner d-flex justify-content-center w-100" t-out="state.userKarma"/>
+        </div>
     </t>
 
 </templates>


### PR DESCRIPTION
How to reproduce:
- install website_slides with demo data
- Open the course "Basics of Gardening"
- Click on the quiz "Test your knowledge" and solve the quiz
- Click on "Check your answers"

The tooltip displaying how much karma you currently have is not well positioned (it is on top of the progress bar). This fix solves the issue.

Technical note: the involved html code has not changed since version saas-17.2 where it works fine but bootstrap has been upgraded in the mean time from 5.1 to 5.3 (see commit 058212e12b5079eba870bde9775fe98f27928935).

Task-3948059