### PR TITLE
[FIX] web: add fallback for webclient translations

### DIFF
--- a/addons/web/controllers/webclient.py
+++ b/addons/web/controllers/webclient.py
@@ -103,6 +103,9 @@ class WebClient(http.Controller):
         elif mods is None:
             mods = list(request.env.registry._init_modules) + (odoo.conf.server_wide_modules or [])
 
+        if lang and lang not in {code for code, _ in request.env['res.lang'].sudo().get_installed()}:
+            lang = None
+
         translations_per_module, lang_params = request.env["ir.http"].get_translations_for_webclient(mods, lang)
 
         body = json.dumps({


### PR DESCRIPTION
starts. If the user language cannot be determined, it uses the one set in the html `lang` attribute.

If this language is not installed, the webclient translation route does not return lang parameters such as date fortmat. However, the JS code expects those parameters to be available and missing parameters lead to multiple errors (e.g. when calling `parseDatetime` which requires the date format).

This PR ignore the lang passed to this route if it is not installed in order for it to fallback to the context lang.

Steps to reproduce the issue:
- Create an html page and set the lang attribute value to the IETF Xhosa tag (xh-ZA)
- A request to `/web/webclient/translation` is made and an error is displayed in the console.

opw-3953457
