### PR TITLE
[FIX] web: prevent error while changing the language

### DIFF
--- a/addons/web/controllers/action.py
+++ b/addons/web/controllers/action.py
@@ -94,7 +94,10 @@ class Action(Controller):
                 elif action.get('model'):
                     Model = request.env[action.get('model')]
                     if record_id:
-                        display_names.append(Model.browse(record_id).display_name)
+                        if record_id == 'new':
+                            display_names.append(_("New"))
+                        else:
+                            display_names.append(Model.browse(record_id).display_name)
                     else:
                         # This case cannot be produced by the web client
                         raise BadRequest('Actions with a model should also have a resId')


### PR DESCRIPTION
When the user changes the language in My Profile and tries to save,
a traceback will appear.

Steps to reproduce the error:
- Install ```account_accountant``` and ```hr``` module
- Activate multi languages
- Go to accounting > Dashboard > New Invoice
- Click on the profile icon > My Profile > Change language > Save

Traceback:
```
ValueError: too many values to unpack (expected 1)
  File "odoo/models.py", line 5851, in ensure_one
    _id, = self._ids
ValueError: Expected singleton: account.move('n', 'e', 'w')
  File "odoo/http.py", line 2254, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1829, in _serve_db
    return self._transactioning(_serve_ir_http, readonly=ro)
  File "odoo/http.py", line 1849, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1827, in _serve_ir_http
    return self._serve_ir_http(rule, args)
  File "odoo/http.py", line 1834, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2059, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 220, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 740, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/action.py", line 96, in load_breadcrumbs
    display_names.append(Model.browse(record_id).display_name)
  File "odoo/fields.py", line 1202, in __get__
    record.ensure_one()
  File "odoo/models.py", line 5854, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
```

https://github.com/odoo/odoo/blob/59985860264f7fbd2726a51ff15d7e5101ae8234/addons/web/controllers/action.py#L97
Here, when the user changes the language and tries to save the record.
we received record_id as ('n', 'e', 'w'),
when it tries to access display_name
So it will lead to the above traceback.

This issue is similar to https://github.com/odoo/odoo/pull/163087

sentry-5135218331

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
