### PR TITLE
[FIX] point_of_sale: allow coin/bills value with more decimal places

### DIFF
--- a/addons/point_of_sale/models/pos_bill.py
+++ b/addons/point_of_sale/models/pos_bill.py
@@ -7,7 +7,7 @@ class Bill(models.Model):
     _description = "Coins/Bills"
 
     name = fields.Char("Name")
-    value = fields.Float("Coin/Bill Value", required=True, digits=0)
+    value = fields.Float("Coin/Bill Value", required=True, digits=(16, 4))
     pos_config_ids = fields.Many2many("pos.config")
 
     @api.model


### PR DESCRIPTION
Current behavior:
In certain currencies, you have coin of values like 0.025 that requires more than 2 decimal places. But in the coin/bills view they were not correctly showed. Values like 0.025 would appear as  0.02

Steps to reproduce:
- Create a new company using a currency that needs 3 decimal places (Bahraini Dinar)
- Try to create coin/bills with a value like 0.025
- After saving the last part cannot be seen anymore

opw-3950930
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
