### PR TITLE
[PERF] stock: group order point domain by warehouse

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from datetime import timedelta
 from itertools import groupby
 
-from odoo.osv.expression import OR, AND
+from odoo.osv.expression import OR
 from odoo.tools import groupby as groupbyelem
 from operator import itemgetter
 
@@ -2212,13 +2212,27 @@ class StockMove(models.Model):
             This allows us to only recompute the qty_to_order for the orderpoints in the relevant warehouse(s),
             instead of all the orderpoints linked to the product.
         """
-        orderpoint_domain = []
+        prods_by_wh = defaultdict(set)
+        prods_no_wh = set()
         for move in self:
-            domain_for_move = [('product_id', '=', move.product_id.id)]
-            wh_ids = move.location_id.warehouse_id.ids + move.location_dest_id.warehouse_id.ids
-            if wh_ids:
-                domain_for_move = AND([domain_for_move, [('warehouse_id', 'in', wh_ids)]])
-            orderpoint_domain = OR([orderpoint_domain, domain_for_move])
+            source_wh = move.location_id.warehouse_id.id
+            dest_wh = move.location_dest_id.warehouse_id.id
+            if source_wh:
+                prods_by_wh[source_wh].add(move.product_id.id)
+            if dest_wh:
+                prods_by_wh[dest_wh].add(move.product_id.id)
+            if not source_wh and not dest_wh:
+                prods_no_wh.add(move.product_id.id)
+
+        orderpoint_domain = []
+        for wh_id, prod_ids in prods_by_wh.items():
+            orderpoint_domain = OR([orderpoint_domain, [
+                ('warehouse_id', '=', wh_id),
+                ('product_id', 'in', list(prod_ids - prods_no_wh))
+            ]])
+        if prods_no_wh:
+            orderpoint_domain = OR([orderpoint_domain, [('product_id', 'in', list(prods_no_wh))]])
+
         if orderpoint_domain:
             self.env.add_to_compute(
                 self.env['stock.warehouse.orderpoint']._fields['qty_to_order'],


### PR DESCRIPTION
When creating or editing large amounts of stock moves, the logic in the new update_orderpoints function introduced in [1] would result in a very large domain to consider. To improve the performance, we now group the domain by warehouse and make use of set logic to mimimize the resulting orderpoint domain.

[1] https://github.com/odoo/odoo/pull/164300

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
