### PR TITLE
[FIX] link_tracker: disable link tracking for  preview "clicks"

### DIFF
--- a/addons/web/models/ir_http.py
+++ b/addons/web/models/ir_http.py
@@ -30,7 +30,7 @@ ALLOWED_DEBUG_MODES = ['', '1', 'assets', 'tests', 'disable-t-cache']
 class Http(models.AbstractModel):
     _inherit = 'ir.http'
 
-    bots = ["bot", "crawl", "slurp", "spider", "curl", "wget", "facebookexternalhit", "whatsapp", "trendsmapresolver", "pinterest", "instagram"]
+    bots = ["bot", "crawl", "slurp", "spider", "curl", "wget", "facebookexternalhit", "whatsapp", "trendsmapresolver", "pinterest", "instagram", "snippet", "preview"]
 
     @classmethod
     def is_a_bot(cls):


### PR DESCRIPTION
Some services or applications (Outlook, Google Messages) display
previews of links sent through messages or email. In an effort to
strengten user privacy, these services fetch the previews from their
own servers rather than from the user's device.

Since these services' requests had not been added to the list of
known bot identifiers, they generate parasite "clicks" which don't
match their user.

This commit adds identifiers for the Outlook and Google Messages
service requests to the list of known bot IDs, thereby preventing the
parasite clicks from generating.

task-3672491
