### PR TITLE
[FIX] l10n_in: resolve hsn_autocomplete option selection on keydown

### DIFF
--- a/addons/l10n_in/static/src/components/hsn_autocomplete/hsn_autocomplete.js
+++ b/addons/l10n_in/static/src/components/hsn_autocomplete/hsn_autocomplete.js
@@ -96,7 +96,7 @@ export class L10nInHsnAutoComplete extends CharField {
         if (this.props.l10nInHsnDescription) {
             data[this.props.l10nInHsnDescription] = option.description;
         }
-        this.props.record.update(data);
+        setTimeout(() => this.props.record.update(data));
     }
 }
 


### PR DESCRIPTION
prior this PR, when a user selects an option from the HSN autocomplete
widget using the keyboard, the selected value is not reflected in the input
field.

Technical Reason:
The `onSelect()` method in the HSN autocomplete widget calls `this.props.record.update()`,
followed by a call to `commitChanges()` in `input_field_hook.js` due to the `keydown` event.
Consequently, the update method is called twice: first with the selected option value and
then with the user's typed input value. This sequence results in the input field displaying
the typed value instead of the selected option.

With this PR, selecting an option from the HSN autocomplete widget using the
keyboard correctly updates the input field with the selected value.

task-3961406