### PR TITLE
[FIX] mrp: Correct calculation of the unit cost for the finished product

### DIFF
--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -547,8 +547,7 @@ class MrpWorkorder(models.Model):
     def _cal_cost(self):
         total = 0
         for wo in self:
-            duration = sum(wo.time_ids.mapped('duration'))
-            total += (duration / 60.0) * wo.workcenter_id.costs_hour
+            total += (self.duration / 60.0) * wo.workcenter_id.costs_hour
         return total
 
     @api.model


### PR DESCRIPTION
**Steps to reproduce the bug:**
- Create two workers:
    - Worker 1: Hourly Cost = $10
    - Worker 2: Hourly Cost = $6.30

- Create a work center:
    - Cost per hour: $6.66

- Create a storable product “P1”:
    - Component: “C1”, cost: $1.02

- Create a manufacturing order (MO):
    - Product: 1 unit of P1

- Confirm the MO

- Go to the operation and open the work order:
    - Add two time tracking entries for the same date:
        - Worker 1: 29/05/2024 - 08:00
        - Worker 2: 29/05/2024 - 08:00

- Validate the MO
- Go to the MO overview

**Problem:**
The unit cost is $30.64 instead of $23.98

opw-3934566
