### PR TITLE
[FIX] l10n_es_pos_tbai: undefined orm.call

### DIFF
--- a/addons/l10n_es_pos_tbai/static/src/overrides/components/payment_screen/payment_screen.js
+++ b/addons/l10n_es_pos_tbai/static/src/overrides/components/payment_screen/payment_screen.js
@@ -7,11 +7,10 @@ import { qrCodeSrc } from "@point_of_sale/utils";
 patch(PaymentScreen.prototype, {
     async _postPushOrderResolve(order, order_server_ids) {
         if (this.pos.config.is_spanish) {
-            const l10n_es_pos_tbai_qrurl = await this.orm?.call(
+            const l10n_es_pos_tbai_qrurl = await this.pos.data.call(
                 "pos.order",
                 "get_l10n_es_pos_tbai_qrurl",
-                [order_server_ids],
-                {}
+                [order_server_ids]
             );
             order.l10n_es_pos_tbai_qrsrc = l10n_es_pos_tbai_qrurl
                 ? qrCodeSrc(l10n_es_pos_tbai_qrurl)


### PR DESCRIPTION
Previously, in the fw-port of the original l10n_es_pos_tbai PR for saas-17.2, it was merged without knowing that the `orm.call` doesn't work anymore. We needed to use `this.pos.data.call` instead.

task-id: 3916236