### PR TITLE
[FIX] stock : traceback when changing quant_id from SML

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -142,12 +142,11 @@ class StockMoveLine(models.Model):
         for record in self:
             if not record.quant_id or record.quantity:
                 continue
-            if float_compare(record.move_id.product_qty, record.quantity, precision_rounding=record.move_id.product_uom.rounding) > 0:
+            if record.move_id and float_compare(record.move_id.product_qty, record.move_id.quantity, precision_rounding=record.move_id.product_uom.rounding) > 0:
                 qty = max(0, min(record.quant_id.available_quantity, record.move_id.product_qty - record.move_id.quantity))
-                record.quantity = record.product_id.uom_id._compute_quantity(qty, record.product_uom_id)
             else:
                 qty = max(0, record.quant_id.available_quantity)
-                record.quantity = record.product_id.uom_id._compute_quantity(qty, record.product_uom_id)
+            record.quantity = record.product_id.uom_id._compute_quantity(qty, record.product_uom_id)
 
     @api.depends('quantity', 'product_uom_id')
     def _compute_quantity_product_uom(self):


### PR DESCRIPTION
Before PR:
when creating a SML and changing the quant_id (pick from), you get a traceback as the stock_move is not yet created

After PR:
Since the issue appears before the real creation of the SML (and thus the SM), reading the uom of the product directly from the SML should not pose any issue

opw-3931980

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
