### PR TITLE
[FIX] purchase_requisition : unit price not displaying on report

### DIFF
--- a/addons/purchase_requisition/report/report_purchaserequisition.xml
+++ b/addons/purchase_requisition/report/report_purchaserequisition.xml
@@ -45,7 +45,7 @@
                                     <th class="text-center" groups="uom.group_uom">
                                         <strong>Product UoM</strong>
                                     </th>
-                                    <th t-if="o.type_id == env.ref('purchase_requisition.type_single')">Price Unit</th>
+                                    <th t-if="o.type_id.quantity_copy == 'none'">Price Unit</th>
                                     <th class="text-end"><strong>Scheduled Date</strong></th>
                                 </tr>
                             </thead>
@@ -68,7 +68,7 @@
                                             <span t-field="line_ids.product_uom_id.name"/>
                                         </td>
                                     </t>
-                                    <td t-if="o.type_id == env.ref('purchase_requisition.type_single')">
+                                    <td t-if="o.type_id.quantity_copy == 'none'">
                                         <span t-field="line_ids.price_unit" t-options='{"widget": "monetary", "display_currency": line_ids.requisition_id.currency_id}'/>
                                     </td>
                                     <td class="text-end">


### PR DESCRIPTION
Before PR:
The unit price is shown on the report only if you use the default "blanket order" agreement type.  This causes issues when you want to use custom agreement types.

After PR:
We wanted to omit the unit price when
using the "purchase tender" in 15.0 because it copies the quantities of the previous blanket order and you don't renegociate a price. Therefore I adapted the condition to not show the unit price if we copy the quantities, rather than showing it on only a specific blanket order type.

opw-3912049

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
