### PR TITLE
expression.py: fixes subsearch of inactive records

### DIFF
--- a/odoo/addons/test_new_api/models/test_new_api.py
+++ b/odoo/addons/test_new_api/models/test_new_api.py
@@ -1204,6 +1204,15 @@ class ModelActiveField(models.Model):
                                        context={'active_test': False})
     active_children_ids = fields.One2many('test_new_api.model_active_field', 'parent_id',
                                           context={'active_test': True})
+    relatives_ids = fields.Many2many(
+        'test_new_api.model_active_field',
+        'model_active_field_relatives_rel', 'source_id', 'dest_id',
+    )
+    all_relatives_ids = fields.Many2many(
+        'test_new_api.model_active_field',
+        'model_active_field_relatives_rel', 'source_id', 'dest_id',
+        context={'active_test': False},
+    )
     parent_active = fields.Boolean(string='Active Parent', related='parent_id.active', store=True)
 
 

--- a/odoo/addons/test_new_api/tests/test_new_fields.py
+++ b/odoo/addons/test_new_api/tests/test_new_fields.py
@@ -3248,8 +3248,8 @@ class TestX2many(TransactionCase):
         self.assertIn(parent, Model.search([('relatives_ids', '=', 'A')]))
         self.assertNotIn(parent, Model.search([('relatives_ids', '=', 'B')]))
         # Same result with the child_of operator
-        self.assertNotIn(parent, Model.search([('relatives_ids', 'child_of', child_a.id)]))  # incorrect
-        self.assertNotIn(parent, Model.search([('relatives_ids', 'child_of', 'A')]))  # incorrect
+        self.assertIn(parent, Model.search([('relatives_ids', 'child_of', child_a.id)]))
+        self.assertIn(parent, Model.search([('relatives_ids', 'child_of', 'A')]))
         self.assertNotIn(parent, Model.search([('relatives_ids', 'child_of', child_b.id)]))
         self.assertNotIn(parent, Model.search([('relatives_ids', 'child_of', 'B')]))
 
@@ -3260,8 +3260,8 @@ class TestX2many(TransactionCase):
         self.assertIn(parent, Model.search([('all_relatives_ids', '=', 'A')]))
         self.assertNotIn(parent, Model.search([('all_relatives_ids', '=', 'B')]))  # incorrect
         # Same result with the child_of operator
-        self.assertNotIn(parent, Model.search([('all_relatives_ids', 'child_of', child_a.id)]))  # incorrect
-        self.assertNotIn(parent, Model.search([('all_relatives_ids', 'child_of', 'A')]))  # incorrect
+        self.assertIn(parent, Model.search([('all_relatives_ids', 'child_of', child_a.id)]))
+        self.assertIn(parent, Model.search([('all_relatives_ids', 'child_of', 'A')]))
         self.assertNotIn(parent, Model.search([('all_relatives_ids', 'child_of', child_b.id)]))  # incorrect
         self.assertNotIn(parent, Model.search([('all_relatives_ids', 'child_of', 'B')]))  # incorrect
 

--- a/odoo/addons/test_new_api/tests/test_new_fields.py
+++ b/odoo/addons/test_new_api/tests/test_new_fields.py
@@ -2337,7 +2337,7 @@ class TestFields(TransactionCaseWithUserDemo):
         )
         self.assertEqual(
             Model.search([('parent_id', 'child_of', 'Parent')]),
-            active_parent + child_of_active,  # missing child_of_inactive
+            active_parent + child_of_active + child_of_inactive,
         )
 
     def test_60_one2many_domain(self):
@@ -3226,10 +3226,10 @@ class TestX2many(TransactionCase):
         self.assertIn(parent, Model.search([('all_children_ids', '=', 'A')]))
         # Same result with the child_of operator
         self.assertIn(parent, Model.search([('all_children_ids', 'child_of', 'A')]))
-        self.assertNotIn(parent, Model.search([('all_children_ids', '=', 'B')]))  # incorrect
+        self.assertIn(parent, Model.search([('all_children_ids', '=', 'B')]))
         # Same result with the child_of operator
         self.assertIn(parent, Model.search([('all_children_ids', 'child_of', 'A')]))
-        self.assertNotIn(parent, Model.search([('all_children_ids', 'child_of', 'B')]))  # incorrect
+        self.assertIn(parent, Model.search([('all_children_ids', 'child_of', 'B')]))
 
     def test_12_active_test_many2many_search(self):
         Model = self.env['test_new_api.model_active_field']
@@ -3258,12 +3258,12 @@ class TestX2many(TransactionCase):
         self.assertIn(parent, Model.search([('all_relatives_ids.name', '=', 'B')]))
         # Same result when it used _name_search
         self.assertIn(parent, Model.search([('all_relatives_ids', '=', 'A')]))
-        self.assertNotIn(parent, Model.search([('all_relatives_ids', '=', 'B')]))  # incorrect
+        self.assertIn(parent, Model.search([('all_relatives_ids', '=', 'B')]))
         # Same result with the child_of operator
         self.assertIn(parent, Model.search([('all_relatives_ids', 'child_of', child_a.id)]))
         self.assertIn(parent, Model.search([('all_relatives_ids', 'child_of', 'A')]))
-        self.assertNotIn(parent, Model.search([('all_relatives_ids', 'child_of', child_b.id)]))  # incorrect
-        self.assertNotIn(parent, Model.search([('all_relatives_ids', 'child_of', 'B')]))  # incorrect
+        self.assertIn(parent, Model.search([('all_relatives_ids', 'child_of', child_b.id)]))
+        self.assertIn(parent, Model.search([('all_relatives_ids', 'child_of', 'B')]))
 
     def test_search_many2many(self):
         """ Tests search on many2many fields. """

--- a/odoo/addons/test_new_api/views/test_new_api_views.xml
+++ b/odoo/addons/test_new_api/views/test_new_api_views.xml
@@ -449,5 +449,46 @@
             </field>
         </record>
 
+        <record id="view_model_model_active_field_tree" model="ir.ui.view">
+            <field name="name">Test Active List</field>
+            <field name="model">test_new_api.model_active_field</field>
+            <field name="arch" type="xml">
+                <tree editable='bottom' decoration-muted="not active">
+                    <field name="active"/>
+                    <field name="name"/>
+                    <field name="parent_id"/>
+                    <field name="children_ids" widget="many2many_tags"/>
+                    <field name="all_children_ids" widget="many2many_tags"/>
+                    <field name="relatives_ids" widget="many2many_tags"/>
+                    <field name="all_relatives_ids" widget="many2many_tags"/>
+                </tree>
+            </field>
+        </record>
+
+        <record id="view_model_model_active_field_search" model="ir.ui.view">
+            <field name="name">Test Active Search</field>
+            <field name="model">test_new_api.model_active_field</field>
+            <field name="arch" type="xml">
+                <search string="Search Active Test">
+                    <field name="name" string="By name" filter_domain="[('name', 'ilike', self)]"/>
+                    <field name="parent_id" string="On parent (child_of)" filter_domain="[('parent_id', 'child_of', self)]"/>
+                    <separator/>
+                    <field name="children_ids" string="Children (one2many)"/>
+                    <field name="all_children_ids" string="All Children (one2many)"/>
+                    <separator/>
+                    <field name="relatives_ids" string="Relatives (many2many)"/>
+                    <field name="all_relatives_ids" string="All Relatives (many2many)"/>
+                </search>
+            </field>
+        </record>
+
+        <record id="action_tests_active" model="ir.actions.act_window">
+            <field name="name">Active Tests</field>
+            <field name="res_model">test_new_api.model_active_field</field>
+            <field name="view_mode">tree</field>
+            <field name="search_view_id" ref="view_model_model_active_field_search"/>
+        </record>
+        <menuitem id="menu_active" name="Active Test" action="action_tests_active" parent="menu_main" sequence="12"/>
+
     </data>
 </odoo>

--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -1252,21 +1252,16 @@ class expression(object):
                     ids2 = to_ids(right, comodel, leaf)
                     domain = HIERARCHY_FUNCS[operator]('id', ids2, comodel)
                     ids2 = comodel._search(domain)
-
-                    # rewrite condition in terms of ids2
-                    if comodel == model:
-                        push(('id', 'in', ids2), model, alias)
-                    else:
-                        rel_alias = self.query.make_alias(alias, field.name)
-                        push_result(SQL(
-                            "EXISTS (SELECT 1 FROM %s AS %s WHERE %s = %s AND %s IN %s)",
-                            SQL.identifier(rel_table),
-                            SQL.identifier(rel_alias),
-                            SQL.identifier(rel_alias, rel_id1),
-                            SQL.identifier(alias, 'id'),
-                            SQL.identifier(rel_alias, rel_id2),
-                            tuple(ids2) or (None,),
-                        ))
+                    rel_alias = self.query.make_alias(alias, field.name)
+                    push_result(SQL(
+                        "EXISTS (SELECT 1 FROM %s AS %s WHERE %s = %s AND %s IN %s)",
+                        SQL.identifier(rel_table),
+                        SQL.identifier(rel_alias),
+                        SQL.identifier(rel_alias, rel_id1),
+                        SQL.identifier(alias, 'id'),
+                        SQL.identifier(rel_alias, rel_id2),
+                        tuple(ids2) or (None,),
+                    ))
 
                 elif right is not False:
                     # determine ids2 in comodel


### PR DESCRIPTION
#### [FIX] core: fix expression.py for `child_of` operator on `many2many`

If you use `child_of` on a many2many field where the target model is the same as the root model, the result won't be correct. It will return the records that match the `child_of` operator instead of following the many2many relationship. See the test

Remove the weird `comodel == model` condition, which actually changes the semantics of ids2 and the leaf it generates.

#### [FIX] core: fixes subsearch of inactive records

In some of use cases, there is an inconsistency between a search on relational fields and its definition for inactive records:
- [('many2one', 'child_of', `string`)], doesn't consider archived records into account for the _name_search(<string>), but it should because we always see many2one regardless of the record's active value.
- [('one2many'/'many2many', 'child_of'/'ilike', `string`)], and if the X2many field has context={'active_test': False}, we still filter out inactive records for the _name_search(`string`) performed by the to_ids() method. But we shouldn't, because the definition of the field allows inactive records to be read/viewed through this X2many.

Modify expression.py to fix all these scenarios.

task-3960088