### PR TITLE
[FIX] pos_restaurant: inconsistency between takeaway and manually fiscal

### DIFF
--- a/addons/pos_restaurant/static/src/app/control_buttons/control_buttons.js
+++ b/addons/pos_restaurant/static/src/app/control_buttons/control_buttons.js
@@ -49,20 +49,6 @@ patch(ControlButtons.prototype, {
         this.currentOrder.takeaway = isTakeAway;
         this.currentOrder.update({ fiscal_position_id: isTakeAway ? takeawayFp : defaultFp });
     },
-    async clickFiscalPosition() {
-        await super.clickFiscalPosition(...arguments);
-        const takeawayFp = this.pos.config.takeaway_fp_id;
-
-        if (!takeawayFp || !this.pos.config.module_pos_restaurant) {
-            return;
-        }
-
-        if (takeawayFp.id !== this.currentOrder.fiscal_position?.id) {
-            this.currentOrder.takeaway = false;
-        } else {
-            this.currentOrder.takeaway = true;
-        }
-    },
 });
 patch(ControlButtons, {
     components: {

--- a/addons/pos_restaurant/static/src/app/control_buttons/control_buttons.xml
+++ b/addons/pos_restaurant/static/src/app/control_buttons/control_buttons.xml
@@ -24,13 +24,20 @@
                     <button class="btn btn-light rounded-0 fw-bolder" t-on-click="clickTransferOrder">
                         <i class="oi oi-arrow-right me-1" />Transfer / Merge
                     </button>
-                    <button t-if="pos.config.takeaway"
-                            t-attf-class="{{ currentOrder.takeaway ? 'btn-primary' : 'btn-light'}} btn rounded-0 fw-bolder"
-                            t-on-click="clickTakeAway">
-                        <i class="fa fa-car me-1" />Take-away
-                    </button>
                 </t>
             </t>
+        </xpath>
+        <xpath expr="//button[hasclass('o_fiscal_position_button')]" position="after">
+            <button t-if="pos.config.takeaway and props.wrapped"
+                t-attf-class="{{ currentOrder.takeaway ? 'btn-primary' : 'btn-light'}} btn rounded-0 fw-bolder"
+                t-on-click="clickTakeAway">
+                <i t-attf-class="{{ currentOrder.takeaway ? 'fa fa-car' : 'fa fa-cutlery'}} me-1"></i>
+                <span t-if="currentOrder.takeaway">Takaway</span>
+                <span t-else="">Dine in</span>
+            </button>
+        </xpath>
+        <xpath expr="//button[hasclass('o_fiscal_position_button')]" position="attributes">
+            <attribute name="t-if">!pos.config.takeaway</attribute>
         </xpath>
     </t>
 </templates>

--- a/addons/pos_restaurant/static/src/overrides/models/pos_order_line.js
+++ b/addons/pos_restaurant/static/src/overrides/models/pos_order_line.js
@@ -33,4 +33,16 @@ patch(PosOrderline.prototype, {
                 this.skip_change && this.config.module_pos_restaurant,
         };
     },
+    compute_fixed_price(price) {
+        if (
+            this.order_id &&
+            this.config.takeaway &&
+            this.config.takeaway_fp_id?.id === this.order_id.fiscal_position_id?.id &&
+            this.order_id.takeaway
+        ) {
+            price = this.product_id.get_price(this.config.pricelist_id, 1, this.price_extra);
+            return price;
+        }
+        return super.compute_fixed_price(...arguments);
+    },
 });

--- a/addons/pos_restaurant/views/res_config_settings_views.xml
+++ b/addons/pos_restaurant/views/res_config_settings_views.xml
@@ -20,6 +20,7 @@
                 </setting>
                 <setting string="Eat in / Take out" help="Adjust the tax rate based on whether customers are dining in or opting for takeout."  invisible="not pos_module_pos_restaurant">
                     <field name="pos_takeaway"/>
+                    <div class="text-warning mb16" invisible="not pos_takeaway">Taxes must be included in price.</div>
                     <div class="content-group" invisible="not pos_takeaway">
                         <label string="" for="pos_takeaway_fp_id" class="me-2"/>
                         <field name="pos_takeaway_fp_id" placeholder="Alternative Fiscal Position"/>


### PR DESCRIPTION
Before this commit:
===================
Tax mapping used for Eat In/Take Out and the tax button behaved inconsistently
in the case of tax-inclusive prices.

Current behavior:
- Eat In/Take Out applies the fiscal position on the product screen but does not
  impact the order lines, maintaining the same sales price (tax-inclusive).
  Example: Sales price = 10 (with 12% tax included).

- The tax button behaves differently by applying the fiscal position on the
  product screen and the order lines, changing the unit price on the orderlines
  after fiscal position adjustment.
  Example: Sales price = 10 (with 6% tax included).

After this commit:
====================
If the Eat In/Take Out configuration is active:

Updated behavior:
- Replaced the `Tax` button with a `Takeaway` button, set `Dine In` as the
  default button, and on click, change the button to `Takeaway` and apply
  the takeaway fiscal position.

- `Takeaway` button will now maintain the original unit price on the order line
  after the fiscal position is applied. Example: Sales price = 10
  (with 12% tax included) changes to 10 (with 6% tax included) after
  fiscal position adjustment, but the order line will still show the original
  sales price of 10.

task - 3935347