### PR TITLE
[FIX] stock: simplify location domains

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -307,11 +307,9 @@ class Product(models.Model):
         # this optimizes [('location_id', 'child_of', locations.ids)]
         # by avoiding the ORM to search for children locations and injecting a
         # lot of location ids into the main query
-        for location in locations:
-            loc_domain = loc_domain and ['|'] + loc_domain or loc_domain
-            loc_domain.append(('location_id.parent_path', '=like', location.parent_path + '%'))
-            dest_loc_domain = dest_loc_domain and ['|'] + dest_loc_domain or dest_loc_domain
-            dest_loc_domain.append(('location_dest_id.parent_path', '=like', location.parent_path + '%'))
+        paths_domain = expression.OR([[('parent_path', '=like', loc.parent_path + '%')] for loc in locations])
+        loc_domain = [('location_id', 'any', paths_domain)]
+        dest_loc_domain = [('location_dest_id', 'any', paths_domain)]
 
         return (
             loc_domain,


### PR DESCRIPTION
The main purpose of this patch is to optimize how the location queries
are generated in saas-17.2 in `stock.orderpoint`:
https://github.com/odoo/odoo/blob/dd2da708bc4a42bba9670b874282a2206d8f5ffe/addons/stock/models/stock_orderpoint.py#L366-L374

The generated query is the same in 17.0. The advantage of the `any` operator is
clarity and simplicity in this case.

In saas-17.2 due to the presence of another branch using
`location_final_id` the generated queries are much more efficient with
```py
        dest_loc_domain = [
            '|',
            '&', ('location_final_id', '!=', False), ('location_final_id', 'any', paths_domain),
            '&', ('location_final_id', '=', False), ('location_dest_id', 'any', paths_domain),
        ]
```
vs (current code in saas-17.2)
```py
            dest_loc_domain = expression.OR([dest_loc_domain, [
                '|',
                    '&', ('location_final_id', '!=', False), ('location_final_id.parent_path', '=like', location.parent_path + '%'),
                    '&', ('location_final_id', '=', False), ('location_dest_id.parent_path', '=like', location.parent_path + '%'),
            ]])
```
https://github.com/odoo/odoo/blob/88e75bb11053e3a16455f7d0e882cf2afd4b79a6/addons/stock/models/product.py#L311-L317

The version using the `any` operator is much faster: in an extreme case
with 6K replenish locations the any-based query runs in 1m50s while the
other runs in more than 3h.

In effect this is an example query generated by the ORM without the use
of `any` (3 replenish locations)
```sql
SELECT
  "stock_move"."product_id",
  "stock_move"."location_id",
  SUM("stock_move"."product_qty")
FROM
  "stock_move"
  LEFT JOIN "stock_location" AS "stock_move__location_id" ON ("stock_move"."location_id" = "stock_move__location_id"."id")
  LEFT JOIN "stock_location" AS "stock_move__location_final_id" ON ("stock_m ove"."location_final_id" = "stock_move__location_final_id"."id")
WHERE
  (
    (
      (
        (
          (
            (
              (
                (
                  (
                    "stock_move"."product_id" IN (16, 17, 18, 20, 21, 23, 24, 12, 13, 14, 25, 30, 26, 37, 31, 5, 8, 29, 32, 6, 28)
                  )
                  AND (
                    "stock_move"."state" IN ('waiting', 'confirmed', 'assigned', 'partially_available')
                  )
                )
                AND (
                  "stock_move"."location_final_id" IS NULL
                  OR (
                    "stock_move__location_final_id"."id" IS NULL
                    OR (
                      NOT (
                        (
                          "stock_move__location_final_id"."parent_path" :: text LIKE '1/7/8/18/%'
                        )
                      )
                    )
                  )
                )
              )
              AND (
                "stock_move"."location _final_id" IS NOT NULL
                OR (
                  (
                    "stock_move"."location_dest_id" NOT IN (
                      SELECT
                        "stock_location"."id"
                      FROM
                        "stock_location"
                      WHERE
                        ("stock_location"."parent_path" :: text LIKE '1/7/8/18/%')
                        AND (( "stock_location"."company _id" IN (1))
                          OR "stock_location"."company_id" IS NULL
                        )
                    )
                  )
                  OR "stock_move"."location_dest_id" IS NULL
                )
              )
            )
            AND (
              "stock_move"."location_final_id" IS NULL
              OR (
                "stock_move__location_final_id"."id" IS NULL
                OR (NOT (("stock_move__location_final_id"."parent_path" :: text LIKE '1/7/8/17/%')))
              )
            )
          )
          AND (
            "stock_move"."location_final_id" IS NOT NULL
            OR (
              (
                "stock_move"."location_dest_id" NOT IN (
                  SELECT
                    "stock_location"."id"
                  FROM
                    "stock_locati on"
                  WHERE
                    ("stock_location"."parent_path" :: text LIKE '1/7/8/17/%')
                    AND (("stock_location"."company_id" IN (1))
                      OR "stock_location"."company_id" IS NULL
                    )
                )
              )
              OR "stock_move"."location_dest_id" IS NULL
            )
          )
        )
        AND (
          "stock_ move"."location_final_id" IS NULL
          OR (
            "stock_move__location_final_id"."id" IS NULL
            OR (
              NOT (( "stock_move__location_final_id"."parent_path" :: text LIKE '1/7/8/34/%')
              )
            )
          )
        )
      )
      AND (
        "stock_move"."location_final_id" IS NOT NULL
        OR (
          (
            "stock_move"."location_dest_id" NOT IN (
              SELECT
                "stock_location"."id"
              FROM
                "stock_location"
              WHERE
                ("stock_location"."parent_path" :: text LIKE '1/7/8/34/%')
                AND (
                  ("stock_location"."company_id" IN (1))
                  OR " stock_location"."company_id" IS NULL
                )
            )
          )
          OR "stock_move"."location_dest_id" IS NULL
        )
      )
    )
    AND (
      (
        ("stock_move__location_id"."parent_path" :: text LIKE '1/7/8/18/%')
        OR ("stock_move__location_id"."parent_path" :: text LIKE '1/7/8/17/%')
      )
      OR ("stock_move__location_id"."parent_path" :: text LIKE '1/7/8/34/%')
    )
  )
  AND (
    "stock_move"."company_id" IN (1)
  )
GROUP BY
  "stock_move"."product_id",
  "stock_move"."location_id"
ORDER BY
  "stock_move"."product_id" ASC,
  "stock_move"."location_id" ASC
```

vs the query using `any` variant:
```sql
SELECT
  "stock_move"."product_id",
  "stock_move"."location_id",
  sum("stock_move"."product_qty")
FROM
  "stock_move"
  LEFT JOIN "stock_location" AS "stock_move__location_id" ON ("stock_move"."location_id" = "stock_move__location_id"."id")
  LEFT JOIN "stock_location" AS "stock_move__location_final_id" ON ("stock_m ove"."location_final_id" = "stock_move__location_final_id"."id")
WHERE
  (
    (
      (
        (
          (
            "stock_move"."product_id" IN (16, 17, 18, 20, 21, 23, 24, 12, 13, 14, 25, 30, 26, 37, 31, 5, 8, 29, 32, 6, 28)
          )
          AND (
            "stock_move"."state" IN ('waiting', 'confirmed', 'assigned', 'partially_available')
          )
        )
        AND (
          "stock_move"."location_final_id" IS NULL
          OR (
            "stock_move__location_final_id"."id" IS NULL
            OR (
              NOT (
                (
                  (
                    ("stock_move__location_final_id"."parent_path" :: text LIKE '1/7/8/18/%')
                    OR ("stock_move__location_final_id "."parent_path" :: text LIKE '1/7/8/17/%')
                  )
                  OR ("stock_move__location_final_id"."parent_path" :: text LIKE '1/7/8/34/%')
                )
              )
            )
          )
        )
      )
      AND (
        "stock_move"."location_final_id" IS NOT NULL
        OR (
          (
            "stock_move"."location_dest_id" NOT IN (
              SELECT
                "stock_location"."id"
              FROM
                "stock_location"
              WHERE
                (
                  (
                    ("stock_location"."parent_path" :: text LIKE '1/7/8/18/%')
                    OR ("stock_location"."parent_path" :: text LIKE '1/7/8/17/%')
                  )
                  OR ("stock_location"."parent_pa th" :: text LIKE '1/7/8/34/%')
                )
                AND (
                  ("stock_location"."company_id" IN (1))
                  OR "stock_location"."company_id" IS NULL
                )
            )
          )
          OR "stock_move"."location_dest_id" IS NULL
        )
      )
    )
    AND (
      (
        ("stock_move__location_id"."parent_path" :: text LIKE '1/7/8/18/%')
        OR ("stock_move__location_id"."parent_path" :: text LIKE '1/7/8/17/%')
      )
      OR ("stock_move__location_id"."parent_path" :: text LIKE '1/7/8/34/%')
    )
  )
  AND (
    "stock_move"."company_id" IN (1)
  )
GROUP BY
  "stock_move"."product_id",
  "stock_move"."location_id"
ORDER BY
  "stock_move"."product_id" ASC,
  "stock_move"."location_id" ASC
```

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
