### PR TITLE
[FIX] l10n_es_edi_tbai: send simplified invoices for Bizkaia

### DIFF
--- a/addons/l10n_es_edi_tbai/models/account_edi_format.py
+++ b/addons/l10n_es_edi_tbai/models/account_edi_format.py
@@ -365,8 +365,8 @@ class AccountEdiFormat(models.Model):
         export_exempts = invoice.invoice_line_ids.tax_ids.filtered(lambda t: t.l10n_es_exempt_reason == 'E2')
         values['regime_key'] = ['02'] if export_exempts else ['01']
 
-        if invoice.l10n_es_is_simplified:
-            values['regime_key'].append(52)  # code for simplified invoices
+        if invoice.l10n_es_is_simplified and invoice.company_id.l10n_es_tbai_tax_agency != 'bizkaia':
+            values['regime_key'] += ['52']  # code for simplified invoices
 
         return values
 


### PR DESCRIPTION
Before, we could not send any simplified invoice for Bizkaia, because it would give error  B4_2000026: "Las Claves indicadas no son compatibles". En las validaciones dice que "Las claves 51 y 52 sólo son compatibles entre sí"

But normally we send 01 and 52 in case of a simplified invoice.

By removing the 52 however, we see that we can send the simplified invoice.  Also, elsewhere in the XML, it is already clearly indicated that the invoice is simplified anyways.

So, the simple fix for now is to remove the 52 key if the agency is Bizkaia

opw-3938800

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
