### PR TITLE
[FIX] account_*: tests without accountant

### DIFF
--- a/addons/account/static/tests/tours/tax_group_tests.js
+++ b/addons/account/static/tests/tours/tax_group_tests.js
@@ -7,7 +7,7 @@ import { stepUtils } from "@web_tour/tour_service/tour_utils";
 registry.category("web_tour.tours").add('account_tax_group', {
     test: true,
     url: "/web",
-    steps: () => [stepUtils.showAppsMenuItem(),
+    steps: () => [
     ...accountTourSteps.goToAccountMenu("Go to Invoicing"),
     {
         content: "Go to Vendors",

--- a/addons/web/tests/test_click_everywhere.py
+++ b/addons/web/tests/test_click_everywhere.py
@@ -3,6 +3,8 @@
 import logging
 import odoo.tests
 
+from requests import Session, PreparedRequest, Response
+
 from datetime import datetime
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo
 from dateutil.relativedelta import relativedelta
@@ -35,6 +37,16 @@ class TestMenusDemo(HttpCaseWithUserDemo):
 @odoo.tests.tagged('post_install', '-at_install')
 class TestMenusAdminLight(odoo.tests.HttpCase):
     allow_end_on_form = True
+
+    @classmethod
+    def _request_handler(cls, s: Session, r: PreparedRequest, /, **kw):
+        # mock odoofin requests
+        if '/proxy_rpc_call/v1/get_favorite_institutions' in r.url:
+            r = Response()
+            r.status_code = 200
+            return r
+        return super()._request_handler(s, r, **kw)
+
     def test_01_click_apps_menus_as_admin(self):
         # Due to action_pos_preparation_display_kitchen_display, cliking on the "Kitchen Display"
         # menuitem could open the UI display, which will break the crawler tests as there is no


### PR DESCRIPTION
[FIX] account: invoice plus nightly tests
With the invoice plus PR, nightly tests have started to fail.
- test_01_account_tax_groups_tour: Build Error 66350 - in community, the home icon was clicked twice

[FIX] web: click everywhere external calls
The click everywhere test will open the accounting dashboard which makes API calls to the odoofin server. This possible fix mocks those calls to avoid the `External requests verboten` warning
- test_01_click_apps_menus_as_admin: Build Error 66388