### PR TITLE
[FIX] tools: enable the script to keep searching for the user language

### DIFF
--- a/odoo/addons/base/tests/__init__.py
+++ b/odoo/addons/base/tests/__init__.py
@@ -75,3 +75,4 @@ from . import test_config_parameter
 from . import test_ir_module_category
 from . import test_configmanager
 from . import test_num2words_ar
+from . import test_gettext_alias

--- a/odoo/addons/base/tests/test_gettext_alias.py
+++ b/odoo/addons/base/tests/test_gettext_alias.py
@@ -1,0 +1,47 @@
+import inspect
+from unittest.mock import patch
+
+from odoo.tests import common
+from odoo.tools.translate import GettextAlias
+
+
+class TestGettextAlias(common.TransactionCase):
+
+    @patch("odoo.tools.translate.code_translations.get_python_translations")
+    @patch("odoo.modules.get_resource_from_path")
+    @patch.object(GettextAlias, "_get_lang", return_value="fr_FR")
+    def test_get_translation_with_current_frame(self, mock_get_lang, mock_get_resource_from_path, mock_get_python_translations):
+        source = "hello"
+        module = "test_module"
+        lang = "fr_FR"
+
+        mock_get_python_translations.return_value = {source: "bonjour"}
+
+        mock_get_resource_from_path.return_value = [module, "path/to/module"]
+
+        result = GettextAlias()._get_translation(source, module=module)
+
+        mock_get_lang.assert_called_with(inspect.currentframe())
+        mock_get_python_translations.assert_called_with(module, lang)
+        self.assertEqual(result, "bonjour")
+
+    @patch("odoo.tools.translate.code_translations.get_python_translations")
+    @patch("odoo.modules.get_resource_from_path")
+    @patch.object(GettextAlias, "_get_lang", return_value="fr_FR")
+    def test_get_translation_with_one_frame_deeper(self, mock_get_lang, mock_get_resource_from_path, mock_get_python_translations):
+        source = "hello"
+        module = "test_module"
+        lang = "fr_FR"
+
+        mock_get_python_translations.return_value = {source: "bonjour"}
+
+        mock_get_resource_from_path.return_value = [module, "path/to/module"]
+
+        def go_deeper_one_frame():
+            return GettextAlias()._get_translation(source, module=module)
+
+        result = go_deeper_one_frame()
+
+        mock_get_lang.assert_called_with(inspect.currentframe())
+        mock_get_python_translations.assert_called_with(module, lang)
+        self.assertEqual(result, "bonjour")

--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -520,7 +520,18 @@ class GettextAlias(object):
 
     def _get_translation(self, source, module=None):
         try:
-            frame = inspect.currentframe().f_back.f_back
+            frame = inspect.currentframe()
+            translation_file = inspect.getfile(frame)
+            while (source_file := inspect.getfile(frame)) == translation_file:
+                frame = frame.f_back
+            while True:
+                frame_locals = frame.f_locals
+                if "self" in frame_locals or "context" in frame_locals or "context" in frame_locals.get("kwargs", {}):
+                    break
+                frame_back = frame.f_back
+                if inspect.getfile(frame_back) != source_file:
+                    break
+                frame = frame_back
             lang = self._get_lang(frame)
             if lang and lang != 'en_US':
                 if not module:


### PR DESCRIPTION
# Problem
When getting the translation text, the script was going two frames back to return to the actual method where the translation is. Then, it tries to get the user language from `self` but sometimes self is not even defined. Let me show an example:
```python
def method_name(self):
    _('src1')
    return `[_('src2') for i in range(3)]`
```
When reading `'src2'` the script goes back two frames thinking it's in the right frame but it's now in the frame of the list generator which does not have `self` defined. It had to go back one more frame where `self` is defined.

# Solution
A loop was introduced to keep going up in frames till finding the user language within the same translation file.
