### PR TITLE
[FIX] stock_account: _run_fifo_vacuum standard_price write

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -491,6 +491,9 @@ class ProductProduct(models.Model):
         # If some negative stock were fixed, we need to recompute the standard price.
         for product in self:
             product = product.with_company(company.id)
+            # Only recompute if we fixed some negative stock
+            if not svls_to_vacuum_by_product[product.id]:
+                continue
             if product.cost_method == 'average' and not float_is_zero(product.quantity_svl,
                                                                       precision_rounding=product.uom_id.rounding):
                 product.sudo().with_context(disable_auto_svl=True).write({'standard_price': product.value_svl / product.quantity_svl})

--- a/addons/stock_account/tests/test_stockvaluation.py
+++ b/addons/stock_account/tests/test_stockvaluation.py
@@ -2827,6 +2827,225 @@ class TestStockValuation(TransactionCase):
         self.assertEqual(move7.stock_valuation_layer_ids.value, 100.0)
         self.assertEqual(self.product1.standard_price, 10)
 
+    def test_average_negative_6(self):
+        """ Receive 10 units, send 8, and change the product's standard price
+        manually. Since there is no negative stock to fix when running the
+        vacuum, the standard price should not be recomputed. Send another 4
+        units and change the standard price again. In this case, since there is
+        negative stock to fix, the standard price should be recomputed.
+        """
+        self.product1.categ_id.property_cost_method = 'average'
+
+        # ---------------------------------------------------------------------
+        # Receive 10@10
+        # ---------------------------------------------------------------------
+        move1 = self.env['stock.move'].create({
+            'name': '10 in',
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
+            'product_id': self.product1.id,
+            'product_uom': self.uom_unit.id,
+            'product_uom_qty': 10.0,
+            'price_unit': 10,
+            'move_line_ids': [(0, 0, {
+                'product_id': self.product1.id,
+                'location_id': self.supplier_location.id,
+                'location_dest_id': self.stock_location.id,
+                'product_uom_id': self.uom_unit.id,
+                'qty_done': 10.0,
+            })]
+        })
+        move1._action_confirm()
+        move1._action_done()
+
+        # stock values for move1
+        self.assertEqual(move1.stock_valuation_layer_ids.value, 100.0)
+        self.assertEqual(move1.stock_valuation_layer_ids.remaining_qty, 10.0)
+        self.assertEqual(move1.stock_valuation_layer_ids.unit_cost, 10.0)
+
+        # account values for move1
+        valuation_aml = self._get_stock_valuation_move_lines()
+        move1_valuation_aml = valuation_aml[-1]
+        self.assertEqual(move1_valuation_aml.debit, 100)
+        self.assertEqual(move1_valuation_aml.credit, 0)
+        input_aml = self._get_stock_input_move_lines()
+        move1_input_aml = input_aml[-1]
+        self.assertEqual(move1_input_aml.debit, 0)
+        self.assertEqual(move1_input_aml.credit, 100)
+
+        self.assertEqual(len(move1.account_move_ids), 1)
+
+        # ---------------------------------------------------------------------
+        # Send 8
+        # ---------------------------------------------------------------------
+        move2 = self.env['stock.move'].create({
+            'name': '8 out',
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
+            'product_id': self.product1.id,
+            'product_uom': self.uom_unit.id,
+            'product_uom_qty': 8.0,
+            'price_unit': 0,
+            'move_line_ids': [(0, 0, {
+                'product_id': self.product1.id,
+                'location_id': self.stock_location.id,
+                'location_dest_id': self.customer_location.id,
+                'product_uom_id': self.uom_unit.id,
+                'qty_done': 8.0,
+            })]
+        })
+        move2._action_confirm()
+        move2._action_done()
+
+        # stock values for move1 and move2
+        self.assertEqual(move1.stock_valuation_layer_ids.remaining_qty, 2.0)
+        self.assertEqual(move2.stock_valuation_layer_ids.value, -80.0)
+        self.assertEqual(move2.stock_valuation_layer_ids.remaining_qty, 0.0)
+
+        # account values for move2
+        valuation_aml = self._get_stock_valuation_move_lines()
+        move2_valuation_aml = valuation_aml[-1]
+        self.assertEqual(move2_valuation_aml.debit, 0)
+        self.assertEqual(move2_valuation_aml.credit, 80)
+        output_aml = self._get_stock_output_move_lines()
+        move2_output_aml = output_aml[-1]
+        self.assertEqual(move2_output_aml.debit, 80)
+        self.assertEqual(move2_output_aml.credit, 0)
+
+        self.assertEqual(len(move2.account_move_ids), 1)
+
+        # ---------------------------------------------------------------------
+        # Run the vacuum
+        # ---------------------------------------------------------------------
+
+        # Change the product's standard price manually to make sure it is not
+        # recomputed
+        self.assertEqual(self.product1.product_tmpl_id.standard_price, 10)
+        self.product1.product_tmpl_id.standard_price = 15
+        self.assertEqual(self.product1.product_tmpl_id.standard_price, 15)
+
+        # Run the vacuum. Since no negative stock was fixed, the standard price
+        # should not have changed. Fix the price again afterward and rerun the
+        # vacuum
+        self.product1._run_fifo_vacuum()
+        self.assertEqual(self.product1.product_tmpl_id.standard_price, 15)
+        self.product1.product_tmpl_id.standard_price = 10
+        self.assertEqual(self.product1.product_tmpl_id.standard_price, 10)
+        self.product1._run_fifo_vacuum()
+
+        self.assertEqual(move1.stock_valuation_layer_ids.value, 100.0)
+        self.assertEqual(move1.stock_valuation_layer_ids.remaining_qty, 2.0)
+        self.assertEqual(move1.stock_valuation_layer_ids.unit_cost, 10.0)
+        self.assertEqual(move2.stock_valuation_layer_ids.value, -80.0)
+        self.assertEqual(move2.stock_valuation_layer_ids.remaining_qty, 0.0)
+
+        self.assertEqual(len(move1.account_move_ids), 1)
+        self.assertEqual(len(move2.account_move_ids), 1)
+
+        self.assertEqual(self.product1.quantity_svl, 2)
+        self.assertEqual(self.product1.value_svl, 20)
+        self.assertEqual(sum(self._get_stock_input_move_lines().mapped('debit')), 0)
+        self.assertEqual(sum(self._get_stock_input_move_lines().mapped('credit')), 100)
+        self.assertEqual(sum(self._get_stock_output_move_lines().mapped('debit')), 80)
+        self.assertEqual(sum(self._get_stock_output_move_lines().mapped('credit')), 0)
+
+        # ---------------------------------------------------------------------
+        # Send 4 more
+        # ---------------------------------------------------------------------
+        move3 = self.env['stock.move'].create({
+            'name': '4 out',
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
+            'product_id': self.product1.id,
+            'product_uom': self.uom_unit.id,
+            'product_uom_qty': 4.0,
+            'price_unit': 0,
+            'move_line_ids': [(0, 0, {
+                'product_id': self.product1.id,
+                'location_id': self.stock_location.id,
+                'location_dest_id': self.customer_location.id,
+                'product_uom_id': self.uom_unit.id,
+                'qty_done': 4.0,
+            })]
+        })
+        move3._action_confirm()
+        move3._action_done()
+
+        # stock values for move3
+        self.assertEqual(move3.stock_valuation_layer_ids.value, -40.0)
+        self.assertEqual(move3.stock_valuation_layer_ids.remaining_qty, -2.0)
+
+        # account values for move3
+        valuation_aml = self._get_stock_valuation_move_lines()
+        move3_valuation_aml = valuation_aml[-1]
+        self.assertEqual(move3_valuation_aml.debit, 0)
+        self.assertEqual(move3_valuation_aml.credit, 40)
+        output_aml = self._get_stock_output_move_lines()
+        move3_output_aml = output_aml[-1]
+        self.assertEqual(move3_output_aml.debit, 40)
+        self.assertEqual(move3_output_aml.credit, 0)
+
+        self.assertEqual(len(move3.account_move_ids), 1)
+
+        # ---------------------------------------------------------------------
+        # Run the vacuum
+        # ---------------------------------------------------------------------
+
+        # Change the product's standard price manually to make sure it is not
+        # recomputed
+        self.assertEqual(self.product1.product_tmpl_id.standard_price, 10)
+        self.product1.product_tmpl_id.standard_price = 15
+        self.assertEqual(self.product1.product_tmpl_id.standard_price, 15)
+
+        # Run the vacuum. Since negative stock was fixed, the standard price
+        # should have changed.
+        self.product1._run_fifo_vacuum()
+        self.assertEqual(self.product1.product_tmpl_id.standard_price, 10)
+
+        self.assertEqual(move1.stock_valuation_layer_ids.value, 100.0)
+        self.assertEqual(move1.stock_valuation_layer_ids.remaining_qty, 0.0)
+        self.assertEqual(move1.stock_valuation_layer_ids.unit_cost, 10.0)
+        self.assertEqual(move2.stock_valuation_layer_ids.value, -80.0)
+        self.assertEqual(move2.stock_valuation_layer_ids.remaining_qty, 0.0)
+        self.assertEqual(move2.stock_valuation_layer_ids.unit_cost, 10.0)
+        self.assertEqual(move3.stock_valuation_layer_ids.value, -40.0)
+        self.assertEqual(move3.stock_valuation_layer_ids.remaining_qty, -2.0)
+        self.assertEqual(move3.stock_valuation_layer_ids.unit_cost, 10.0)
+
+        self.assertEqual(len(move1.account_move_ids), 1)
+        self.assertEqual(len(move2.account_move_ids), 1)
+        self.assertEqual(len(move3.account_move_ids), 1)
+
+        self.assertEqual(self.product1.quantity_svl, -2)
+        self.assertEqual(self.product1.value_svl, -20)
+        self.assertEqual(sum(self._get_stock_input_move_lines().mapped('debit')), 0)
+        self.assertEqual(sum(self._get_stock_input_move_lines().mapped('credit')), 100)
+        self.assertEqual(sum(self._get_stock_output_move_lines().mapped('debit')), 120)
+        self.assertEqual(sum(self._get_stock_output_move_lines().mapped('credit')), 0)
+
+        # ---------------------------------------------------------------------
+        # Ending
+        # ---------------------------------------------------------------------
+        self.assertEqual(move1.stock_valuation_layer_ids.value, 100.0)
+        self.assertEqual(move1.stock_valuation_layer_ids.remaining_qty, 0.0)
+        self.assertEqual(move1.stock_valuation_layer_ids.unit_cost, 10.0)
+        self.assertEqual(sum(move2.stock_valuation_layer_ids.mapped('value')), -80.0)
+        self.assertEqual(sum(move2.stock_valuation_layer_ids.mapped('remaining_qty')), 0.0)
+        self.assertEqual(move3.stock_valuation_layer_ids.value, -40.0)
+        self.assertEqual(move3.stock_valuation_layer_ids.remaining_qty, -2.0)
+        self.assertEqual(move3.stock_valuation_layer_ids.unit_cost, 10.0)
+
+        self.assertEqual(len(move1.account_move_ids), 1)
+        self.assertEqual(len(move2.account_move_ids), 1)
+        self.assertEqual(len(move3.account_move_ids), 1)
+
+        self.assertEqual(self.product1.quantity_svl, -2.0)
+        self.assertEqual(self.product1.value_svl, -20.0)
+        self.assertEqual(sum(self._get_stock_input_move_lines().mapped('debit')), 0)
+        self.assertEqual(sum(self._get_stock_input_move_lines().mapped('credit')), 100)
+        self.assertEqual(sum(self._get_stock_output_move_lines().mapped('debit')), 120)
+        self.assertEqual(sum(self._get_stock_output_move_lines().mapped('credit')), 0)
+
     def test_average_automated_with_cost_change(self):
         """ Test of the handling of a cost change with a negative stock quantity with FIFO+AVCO costing method"""
         self.product1.categ_id.property_cost_method = 'average'

--- a/doc/cla/corporate/forgeflow.md
+++ b/doc/cla/corporate/forgeflow.md
@@ -20,3 +20,4 @@ Jordi Masvidal jordi.masvidal@forgeflow.com https://github.com/JordiMForgeFlow
 Hector Villarreal hector.villarreal@forgeflow.com https://github.com/HviorForgeFlow
 Bernat Puig bernat.puig@forgeflow.com https://github.com/BernatPForgeFlow
 Joan Sisquella joan.sisquella@forgeflow.com https://github.com/JoanSForgeFlow
+Laura Cazorla laura.cazorla@forgeflow.com https://github.com/LauraCForgeFlow


### PR DESCRIPTION
As mentioned in this [comment](https://github.com/odoo/odoo/pull/164295#issuecomment-2139764771), the `stardard_price` field in product was being recomputed even if this product had no negative layers to fix. 

Since standard_price is already recomputed before calling `_run_fifo_vacuum` (in `product_price_update_before_done`, for example), there's no need to recompute it again, especially with a different logic. Please refer to the comment I linked for more details.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
