### PR TITLE
[FIX] hr_expense: improve the currency rate precision

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -162,7 +162,7 @@ class HrExpense(models.Model):
         string="Is currency_id different from the company_currency_id",
         compute='_compute_is_multiple_currency',
     )
-    currency_rate = fields.Float(compute='_compute_currency_rate', digits=(12, 6), readonly=True, tracking=True)
+    currency_rate = fields.Float(compute='_compute_currency_rate', digits=(16, 9), readonly=True, tracking=True)
     label_currency_rate = fields.Char(compute='_compute_currency_rate', readonly=True)
 
     # Account fields


### PR DESCRIPTION
Summary
-----
When creating an expense in a currency different from the company's currency, the exchange rate is rounded to 6 decimal places. If the rate and the expense amount are high enough, the rounding error affects the expense amount in the company's currency and later, in the journal entries created after the expense is approved.

Steps to Reproduce
-----
    1. Set a strong currency for the company (e.g., USD)
    2. Add a weak currency in the currencies (e.g., IQD)
    3. Create an expense with a high amount (e.g., 1,000,000 for the IQD/USD pair)
    4. Set the weak currency for the expense
    5. Observe the overly rounded amount in the weak currency

Cause
-----
The error comes from the exchange rate being rounded too much and too early.

Fix
-----
Modify "digits" attribute of the "currency_rate" field to increase precision.

Note
-----
Some inaccuracy remains, but expenses rarely exceed 1000 USD for companies using weak currencies, so the number of issues should be reduced.

opw-3684727