### PR TITLE
[FIX] sale_timesheet: round recorded hours consistently

### DIFF
--- a/addons/sale_timesheet/models/account_move.py
+++ b/addons/sale_timesheet/models/account_move.py
@@ -26,7 +26,11 @@ class AccountMove(models.Model):
         timesheet_unit_amount_dict = defaultdict(float)
         timesheet_unit_amount_dict.update({data['timesheet_invoice_id'][0]: data['unit_amount'] for data in group_data})
         for invoice in self:
-            total_time = invoice.company_id.project_time_mode_id._compute_quantity(timesheet_unit_amount_dict[invoice.id], invoice.timesheet_encode_uom_id)
+            total_time = invoice.company_id.project_time_mode_id._compute_quantity(
+                timesheet_unit_amount_dict[invoice.id],
+                invoice.timesheet_encode_uom_id,
+                rounding_method='HALF-UP',
+            )
             invoice.timesheet_total_duration = round(total_time)
 
     @api.depends('timesheet_ids')

--- a/addons/sale_timesheet/models/sale_order.py
+++ b/addons/sale_timesheet/models/sale_order.py
@@ -51,7 +51,11 @@ class SaleOrder(models.Model):
         timesheet_unit_amount_dict = defaultdict(float)
         timesheet_unit_amount_dict.update({data['order_id'][0]: data['unit_amount'] for data in group_data})
         for sale_order in self:
-            total_time = sale_order.company_id.project_time_mode_id._compute_quantity(timesheet_unit_amount_dict[sale_order.id], sale_order.timesheet_encode_uom_id)
+            total_time = sale_order.company_id.project_time_mode_id._compute_quantity(
+                timesheet_unit_amount_dict[sale_order.id],
+                sale_order.timesheet_encode_uom_id,
+                rounding_method='HALF-UP',
+            )
             sale_order.timesheet_total_duration = round(total_time)
 
     def _compute_field_value(self, field):


### PR DESCRIPTION
Versions
--------
- 15.0+

Steps
-----
1. Go to Sale / Configuration / Units of Measure Categories;
2. go to Working Time;
3. set rounding precision of Hours to 1.0;
4. create a SO, selling 10 hours of timesheeted service;
5. click confirm;
6. add 9.1 hours to a timesheet for the SO.

Issue
-----
The sale order line displays 9 hours delivered, while a smart button displays 10 hours recorded.

Cause
-----
The smart button displays the value of the `timesheet_total_duration` field, this field gets computed with `_compute_quantity` method of `uom.uom`, which defaults to the `UP` rounding method:
https://github.com/odoo/odoo/blob/b724fbcf6f348ed7a9109a325d366be69c052d1c/addons/uom/models/uom_uom.py#L216

In contrast, the SOL displays the result of `_get_delivered_quantity_by_analytic`, which uses the same `uom.uom` method, but with the `HALF-UP` rounding method: https://github.com/odoo/odoo/blob/b724fbcf6f348ed7a9109a325d366be69c052d1c/addons/sale/models/sale_order_line.py#L387

Solution
--------
Modify the `_compute_timesheet_total_duration` methods of `account.move` and `sale.order` to use the same rounding method as the `_get_delivered_quantity_by_analytic` method.

opw-3949986