### PR TITLE
[IMP] sale_timesheet: improvement of timesheet Portal

### DIFF
--- a/addons/sale_timesheet/controllers/portal.py
+++ b/addons/sale_timesheet/controllers/portal.py
@@ -82,7 +82,8 @@ class SaleTimesheetCustomerPortal(TimesheetCustomerPortal):
 
     def _get_searchbar_sortings(self):
         return super()._get_searchbar_sortings() | {
-            'so_line': {'label': _('Sales Order Item')}
+            'so_line': {'label': _('Sales Order Item')},
+            'timesheet_invoice_id': {'label': _('Invoice')},
         }
 
     def _task_get_page_view_values(self, task, access_token, **kwargs):

--- a/addons/sale_timesheet/models/hr_timesheet.py
+++ b/addons/sale_timesheet/models/hr_timesheet.py
@@ -133,7 +133,7 @@ class AccountAnalyticLine(models.Model):
             thus there is no meaning of showing invoice with ordered quantity.
         """
         domain = super()._timesheet_get_portal_domain()
-        return expression.AND([domain, [('timesheet_invoice_type', 'in', ['billable_time', 'non_billable', 'billable_fixed'])]])
+        return expression.AND([domain, [('timesheet_invoice_type', 'in', ['billable_time', 'non_billable', 'billable_fixed', 'billable_manual', 'billable_milestones'])]])
 
     @api.model
     def _timesheet_get_sale_domain(self, order_lines_ids, invoice_ids):

--- a/addons/sale_timesheet/views/sale_timesheet_portal_templates.xml
+++ b/addons/sale_timesheet/views/sale_timesheet_portal_templates.xml
@@ -4,12 +4,15 @@
     <template id="sale_order_portal_content_inherit" inherit_id="sale.sale_order_portal_template">
         <xpath expr="//t[@t-set='entries']/div/div/div[hasclass('o_download_pdf')]" position="inside">
             <t t-if="sale_order.timesheet_count > 0 and sale_order.state == 'sale'">
-                <a class="btn btn-light flex-grow-1" t-att-href="'/my/timesheets?search_in=so&amp;search=%s' % sale_order.name" title="View Timesheets" role="button">View Timesheets</a>
+                <a class="btn btn-light flex-grow-1" t-att-href="'/my/timesheets?search_in=so&amp;search=%s' % sale_order.name" title="View Timesheets" target="_blank" role="button">View Timesheets</a>
             </t>
         </xpath>
     </template>
 
     <template id="portal_my_timesheets_inherit" inherit_id="hr_timesheet.portal_my_timesheets">
+        <xpath expr="//t[@t-foreach='grouped_timesheets']/tbody/tr[hasclass('table-light')]/th[hasclass('text-end')]" position="attributes">
+            <attribute name="colspan">2</attribute>
+        </xpath>
         <xpath expr="//t[@t-foreach='grouped_timesheets']/tbody/tr[hasclass('table-light')]/th[hasclass('text-end')]" position="before">
             <t t-elif="groupby == 'so_line'">
                 <t t-set="sol" t-value="timesheets[0].so_line"/>
@@ -57,9 +60,11 @@
         </xpath>
         <th name="t_label" position="before">
             <th t-if="not groupby == 'so_line'">Sales Order Item</th>
+            <th t-if="not groupby == 'timesheet_invoice_id'">Invoice</th>
         </th>
         <xpath expr="//tbody//td[hasclass('text-end')]" position="before">
             <td t-if="not groupby == 'so_line'"><span t-field="timesheet.so_line" t-att-title="timesheet.so_line.display_name"></span></td>
+            <td t-if="not groupby == 'timesheet_invoice_id'"><span t-field="timesheet.timesheet_invoice_id" t-att-title="timesheet.timesheet_invoice_id.display_name"></span></td>
         </xpath>
     </template>
 


### PR DESCRIPTION
In this PR:

 - Portal users should be able to see all timesheets linked to a project they are a
   collaborator on, regardless of the invoicing policy.
 - The 'view timesheets' button on the view of Sales Orders (SOs) should open in a new tab.
 - In the timesheets list view in the portal:
    - Added the 'invoice' column between the Sales Order Line (SOL) and the 'hours spent'.
    - Added a sort by 'invoice' option.

task-3908761