### PR TITLE
[FIX] website_sale: fix ribbon bg-color on product

### DIFF
--- a/addons/website_sale/static/src/js/website_sale.editor.js
+++ b/addons/website_sale/static/src/js/website_sale.editor.js
@@ -588,7 +588,7 @@ options.registry.WebsiteSaleProductsItem = options.Class.extend({
         $ribbons.removeClass(htmlClasses);
 
         $ribbons.addClass(ribbon.html_class || '');
-        $ribbons.attr('style', `background-color: ${ribbon.bg_color || ''} !important`);
+        $ribbons.attr('style', `background-color: ${ribbon.bg_color || 'inherit'}`);
         $ribbons.css('color', ribbon.text_color || '');
 
         if (!this.ribbons[ribbonId]) {


### PR DESCRIPTION
The !important attribute has been duplicated in the CSS rule since [1] and [2]. As a result, the background colour CSS rule for the ribbon is broken due to having !important twice.

Steps to reproduce:

- Go to Shop page on website
- Enable edit mode
- Pick a product and create a new Badge/Ribbon
- Change the background color
- Bug -> the bg-color is not set.

[1]: https://github.com/odoo/odoo/commit/c6f4929f65b899736c556f8f0bb7824883a6d893
[2]: https://github.com/odoo/odoo/commit/9ee115b58342b3e0dbc11081e7ff752c10f8bfa9

task-3964071

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
