### PR TITLE
[FIX] sale_project: get customer invoices on project's updates

### DIFF
--- a/addons/sale_project/models/project.py
+++ b/addons/sale_project/models/project.py
@@ -597,7 +597,7 @@ class Project(models.Model):
                     'to_invoice': amount_to_invoice,
                 }
                 if with_action and self.user_has_groups('sales_team.group_sale_salesman_all_leads, account.group_account_invoice, account.group_account_readonly'):
-                    invoices_revenues['action'] = self._get_action_for_profitability_section(invoices_move_lines.ids, section_id)
+                    invoices_revenues['action'] = self._get_action_for_profitability_section(invoices_move_lines.move_id.ids, section_id)
                 return {
                     'data': [invoices_revenues],
                     'total': {


### PR DESCRIPTION
Steps to reproduce:
-------------------
- create a project
- create an invoice with Analytic Distribution for the project
- go to the project's updates
- in profitability section, click on "Customer Invoices"

Issue:
------
A notification appears:
```
It seems the record with ID X cannot be found. It might have been deleted.
```

Cause:
------
The arguments in JSON format are:
```
"["other_invoice_revenues", [["id", "in", [X]]], X]"
```
with X not corresponding to the invoice id.

They are determined by the method `_get_action_for_profitability_section`. In which the ids are `invoices_move_lines.ids`
(in `_get_revenues_items_from_invoices`).

Solution:
---------
Find the `account.move` from the `account.move.line`.

Note:
Introduced with the commit abd40a461c289bfe092784977077ceb1c7ef12f3

opw-3924836