### PR TITLE
[FIX] analytic: analytic widget glitching line height

### DIFF
--- a/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.scss
+++ b/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.scss
@@ -1,5 +1,7 @@
 .o_field_analytic_distribution {
 
+    height: 0px;
+
     .analytic_distribution_placeholder {
         height: 1.5em;
         width: 20px;


### PR DESCRIPTION
Description of the issue this commit addresses:

When creating an invoice line with the analytic module installed, if the analytic field is show, focusing in on a line adds a little height offset to the entire line which makes the view shaky. This is not wanted.

---

Steps to reproduce:

1 - Install analytic app
2 - Open a new invoice and display the analytic field in the invoice lines
3 - Add a new line, don't add any data inside it.
4 - Focus out, focus in, focus out, focus in.
5 - You can see that focus in adds a few px and focus out removes them.

---

Desired behavior after this commit is merged:

This commit adds a fixed default height to the analyti widget to make sure there is no weird height computation when the focus happens. This way, we can make sure that the line height stays constant whether the focus is in or out of the line.

---

no task-feedback

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
