### PR TITLE
[FIX] l10n_ch: Remove wrong BIC in Demo Data

### DIFF
--- a/addons/l10n_ch/demo/demo_company.xml
+++ b/addons/l10n_ch/demo/demo_company.xml
@@ -16,7 +16,6 @@
     <record id="partner_demo_company_bank_account" model="res.partner.bank">
         <field name="acc_type">iban</field>
         <field name="acc_number">CH4431999123000889012</field>
-        <field name="bank_id" ref="base.bank_ing" />
         <field name="partner_id" ref="l10n_ch.partner_demo_company_ch"/>
     </record>
 

--- a/addons/l10n_ch/demo/res_partner_demo.xml
+++ b/addons/l10n_ch/demo/res_partner_demo.xml
@@ -17,7 +17,6 @@
     <record id="bank_iban_main_partner_ch" model="res.partner.bank">
             <field name="acc_type">iban</field>
             <field name="acc_number">CH11 3000 5228 1308 3501 F</field>
-            <field name="bank_id" ref="base.bank_ing" />
             <field name="partner_id" ref="l10n_ch.res_partner_ch_qr"/>
     </record>
 </odoo>


### PR DESCRIPTION
In Switzerland's demo data, the BIC is from a Belgian bank which is wrong. Removing BIC in this case as it's useless.

task-3961609

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
