### PR TITLE
[PERF] account, l10n_*: Improve batch send and print performances

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4888,9 +4888,9 @@ class AccountMove(models.Model):
         if self.invoice_pdf_report_id:
             attachments = self.env['account.move.send']._get_invoice_extra_attachments(self)
         else:
-            content, _ = self.env['ir.actions.report']._render('account.account_invoices', self.ids, data={'proforma': True})
+            content, _ = self.env['ir.actions.report']._pre_render_qweb_pdf('account.account_invoices', self.ids, data={'proforma': True})
             attachments = self.env['ir.attachment'].new({
-                'raw': content,
+                'raw': content[self.id],
                 'name': self._get_invoice_proforma_pdf_report_filename(),
                 'mimetype': 'application/pdf',
                 'res_model': self._name,

--- a/addons/account/models/ir_actions_report.py
+++ b/addons/account/models/ir_actions_report.py
@@ -47,7 +47,7 @@ class IrActionsReport(models.Model):
     def _is_invoice_report(self, report_ref):
         return self._get_report(report_ref).report_name in ('account.report_invoice_with_payments', 'account.report_invoice')
 
-    def _render_qweb_pdf(self, report_ref, res_ids=None, data=None):
+    def _pre_render_qweb_pdf(self, report_ref, res_ids=None, data=None):
         # Check for reports only available for invoices.
         # + append context data with the display_name_in_footer parameter
         if self._is_invoice_report(report_ref):
@@ -58,7 +58,19 @@ class IrActionsReport(models.Model):
             if any(x.move_type == 'entry' for x in invoices):
                 raise UserError(_("Only invoices could be printed."))
 
-        return super()._render_qweb_pdf(report_ref, res_ids=res_ids, data=data)
+        content, report_type = super()._pre_render_qweb_pdf(report_ref, res_ids=res_ids, data=data)
+
+        if self._is_invoice_report(report_ref):
+            if report_type == 'html':
+                report = self._get_report(report_ref)
+                bodies, res_ids, *_unused = self._prepare_html(content, report_model=report.model)
+                return {res_id: str(body).encode() for res_id, body in zip(res_ids, bodies)}, 'html'
+            elif report_type == 'pdf':
+                pdf_dict = {res_id: stream['stream'].getvalue() for res_id, stream in content.items()}
+                for stream in content.values():
+                    stream['stream'].close()
+                return pdf_dict, 'pdf'
+        return content, report_type
 
     @api.ondelete(at_uninstall=False)
     def _unlink_except_master_tags(self):

--- a/addons/account_edi_ubl_cii/wizard/account_move_send.py
+++ b/addons/account_edi_ubl_cii/wizard/account_move_send.py
@@ -262,11 +262,16 @@ class AccountMoveSend(models.TransientModel):
         )
 
     @api.model
-    def _link_invoice_documents(self, invoice, invoice_data):
+    def _link_invoice_documents(self, invoices_data):
         # EXTENDS 'account'
-        super()._link_invoice_documents(invoice, invoice_data)
+        super()._link_invoice_documents(invoices_data)
 
-        attachment_vals = invoice_data.get('ubl_cii_xml_attachment_values')
-        if attachment_vals:
-            self.env['ir.attachment'].with_user(SUPERUSER_ID).create(attachment_vals)
-            invoice.invalidate_recordset(fnames=['ubl_cii_xml_id', 'ubl_cii_xml_file'])
+        attachments_vals = [
+            invoice_data.get('ubl_cii_xml_attachment_values')
+            for invoice_data in invoices_data.values()
+            if invoice_data.get('ubl_cii_xml_attachment_values')
+        ]
+        if attachments_vals:
+            attachments = self.env['ir.attachment'].with_user(SUPERUSER_ID).create(attachments_vals)
+            res_ids = [attachment.res_id for attachment in attachments]
+            self.env['account.move'].browse(res_ids).invalidate_recordset(fnames=['ubl_cii_xml_id', 'ubl_cii_xml_file'])

--- a/addons/l10n_th/models/ir_actions_report.py
+++ b/addons/l10n_th/models/ir_actions_report.py
@@ -5,11 +5,11 @@ from odoo.exceptions import UserError
 class IrActionsReport(models.Model):
     _inherit = 'ir.actions.report'
 
-    def _render_qweb_pdf(self, report_ref, res_ids=None, data=None):
+    def _pre_render_qweb_pdf(self, report_ref, res_ids=None, data=None):
         # Check for reports only available for invoices.
         if self._get_report(report_ref).report_name == 'l10n_th.report_commercial_invoice':
             invoices = self.env['account.move'].browse(res_ids)
             if any(not x.is_invoice(include_receipts=True) for x in invoices):
                 raise UserError(_("Only invoices could be printed."))
 
-        return super()._render_qweb_pdf(report_ref, res_ids=res_ids, data=data)
+        return super()._pre_render_qweb_pdf(report_ref, res_ids=res_ids, data=data)

--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -869,7 +869,7 @@ class IrActionsReport(models.Model):
             })
         return attachment_vals_list
 
-    def _render_qweb_pdf(self, report_ref, res_ids=None, data=None):
+    def _pre_render_qweb_pdf(self, report_ref, res_ids=None, data=None):
         if not data:
             data = {}
         if isinstance(res_ids, int):
@@ -881,6 +881,19 @@ class IrActionsReport(models.Model):
             return self._render_qweb_html(report_ref, res_ids, data=data)
 
         self = self.with_context(webp_as_jpg=True)
+        return self._render_qweb_pdf_prepare_streams(report_ref, data, res_ids=res_ids), 'pdf'
+
+    def _render_qweb_pdf(self, report_ref, res_ids=None, data=None):
+        if not data:
+            data = {}
+        if isinstance(res_ids, int):
+            res_ids = [res_ids]
+        data.setdefault('report_type', 'pdf')
+
+        collected_streams, report_type = self._pre_render_qweb_pdf(report_ref, res_ids=res_ids, data=data)
+        if report_type != 'pdf':
+            return collected_streams, report_type
+
         collected_streams = self._render_qweb_pdf_prepare_streams(report_ref, data, res_ids=res_ids)
         has_duplicated_ids = res_ids and len(res_ids) != len(set(res_ids))
 


### PR DESCRIPTION
Problem
---------
When doing the Send & Print on one invoice, or when multiple invoices are selected and the "Download" option is ticked, the PDF generation of the invoices is made synchronously. Generating a simple invoice takes ~2 seconds.

When you're doing the mass Send&Print for 10+ invoices, you can have your screen loading for >20seconds just to get 10+pages of PDF.

Objective
---------
Start digging into that part to see if optimisation can be done to reduce that loading time for UX improvements.

Solution
---------
Rather than calling wkhtmltopdf once per invoice, we allow the creation of all invoices' PDF together through one single call to the library. The PDF containing all the invoices will then be split and return as a dictionary. To do so we decoupled the `_render_qweb_pdf` function:
- `_render_qweb_pdf` returns a aggregate of all the PDF
- `_pre_render_qweb_pdf` returns the dictionary of all PDF split

Furthermore, this commit batches some of the ORM calls; namely, attachments creation and cache invalidation.

Results
---------
| # Input data | Before PR | After PR |
|:-------------:|:----------:|:---------:|
|        1            |     3.3 s       |      3.3 s     |
|        5            |     13.9 s       |      4.4 s     |
|       10            |     27.5 s      |      5.4 s     |
|       20            |     55.16 s     |      8.4 s     |

enterprise-63706
task-3695628

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
