### PR TITLE
[FIX] account: ensure payment terms validation when enabling EPDs

### DIFF
--- a/addons/account/models/account_payment_term.py
+++ b/addons/account/models/account_payment_term.py
@@ -137,7 +137,7 @@ class AccountPaymentTerm(models.Model):
             results['amount'] += term['foreign_amount']
         return amount_by_date
 
-    @api.constrains('line_ids')
+    @api.constrains('line_ids', 'early_discount')
     def _check_lines(self):
         round_precision = self.env['decimal.precision'].precision_get('Payment Terms')
         for terms in self:


### PR DESCRIPTION
The Early Payment Discount (EPD) functionality is designed to work only with payment terms that include a single 100% line. A validation error is correctly displayed if a user attempts to create an EPD with multiple term lines.

However, a bug existed where users could create a regular payment term with multiple lines, save it, and then enable the EPD, bypassing the validation. This allowed the record to be saved without error, leading to a traceback when the system later attempted to process the EPD, as it does not support multiple term lines.

opw-3945596