### PR TITLE
[FIX] pos_self_order: fix test_self_order_mobile

### DIFF
--- a/addons/pos_self_order/tests/self_order_common_test.py
+++ b/addons/pos_self_order/tests/self_order_common_test.py
@@ -137,6 +137,21 @@ class SelfOrderCommonTest(odoo.tests.HttpCase):
 
     def setUp(self):
         super().setUp()
+        journal_obj = self.env['account.journal']
+        main_company = self.env.company
+        self.bank_journal = journal_obj.create({
+            'name': 'Bank Test',
+            'type': 'bank',
+            'company_id': main_company.id,
+            'code': 'BNK',
+            'sequence': 10,
+        })
+
+        self.bank_payment_method = self.env['pos.payment.method'].create({
+            'name': 'Bank',
+            'journal_id': self.bank_journal.id,
+        })
+
         self.pos_config = self.env["pos.config"].create(
             {
                 "name": "BarTest",
@@ -144,6 +159,7 @@ class SelfOrderCommonTest(odoo.tests.HttpCase):
                 "module_pos_restaurant": True,
                 "self_ordering_mode": "consultation",
                 "floor_ids": self.env["restaurant.floor"].search([]),
+                "payment_method_ids": [(4, self.bank_payment_method.id)],
             }
         )
 


### PR DESCRIPTION
The test was failing with no-demo because there wad no payment method configured for the pos config. This commit adds a payment method to the pos config.

Runbot error ID: 66015, 66010, 66011, 66012, 66013, 66014
