### PR TITLE
[REF] web_tour: prepare to change the default action in tour_compiler

### DIFF
--- a/addons/account/static/src/js/tours/account.js
+++ b/addons/account/static/src/js/tours/account.js
@@ -86,6 +86,7 @@ registry.category("web_tour.tours").add('account_tour', {
         trigger: "button[name=document_layout_save]",
         extra_trigger: "div.modal-dialog",
         content: _t("Configure document layout."),
+        run: "click",
     },
     {
         trigger: "div[name=partner_missing_email] a",

--- a/addons/mail/static/tests/tours/discuss_configuration_tour.js
+++ b/addons/mail/static/tests/tours/discuss_configuration_tour.js
@@ -30,18 +30,22 @@ registry.category("web_tour.tours").add("discuss_configuration_tour", {
         {
             trigger: "button:contains('All Messages')",
             content: _t("Server notification settings"),
+            run: "click",
         },
         {
             trigger: "button:contains('Mentions Only')",
             content: _t("Server notification settings"),
+            run: "click",
         },
         {
             trigger: "button:contains('Nothing')",
             content: _t("Server notification settings"),
+            run: "click",
         },
         {
             trigger: ".modal-header button[aria-label='Close']",
             content: _t("Click to close"),
+            run: "click",
         },
     ],
 });

--- a/addons/point_of_sale/static/src/backend/tours/point_of_sale.js
+++ b/addons/point_of_sale/static/src/backend/tours/point_of_sale.js
@@ -15,6 +15,7 @@ registry.category("web_tour.tours").add("point_of_sale_tour", {
             width: 215,
             position: "right",
             edition: "community",
+            run: "click",
         },
         {
             trigger: '.o_app[data-menu-xmlid="point_of_sale.menu_point_root"]',
@@ -22,6 +23,7 @@ registry.category("web_tour.tours").add("point_of_sale_tour", {
             width: 215,
             position: "bottom",
             edition: "enterprise",
+            run: "click",
         },
         {
             trigger: ".o_pos_kanban button.oe_kanban_action_button",
@@ -31,6 +33,7 @@ registry.category("web_tour.tours").add("point_of_sale_tour", {
                 )
             ),
             position: "bottom",
+            run: "click",
         },
     ],
 });

--- a/addons/pos_hr/static/tests/tours/utils/pos_hr_helpers.js
+++ b/addons/pos_hr/static/tests/tours/utils/pos_hr_helpers.js
@@ -7,6 +7,7 @@ export function clickLoginButton() {
         {
             content: "click login button",
             trigger: ".login-overlay .login-button.select-cashier",
+            run: "click",
         },
     ];
 }
@@ -15,6 +16,7 @@ export function clickCashierName() {
         {
             content: "click cashier name",
             trigger: ".oe_status .cashier-name",
+            run: "click",
         },
     ];
 }

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -278,10 +278,12 @@ registry.category("web_tour.tours").add("MergeTableTour", {
             {
                 content: `select linked table`,
                 trigger: 'div.isLinked div.label:contains("4")',
+                run: "click",
             },
             {
                 content: `unlink in edit plan if unlink possible`,
                 trigger: '.edit-buttons button:contains("Unlink")',
+                run: "click",
             },
             Chrome.clickMenuOption("Edit Plan"),
             ...MergeTable.checkMergeTableIsCancelHelpers(),
@@ -308,10 +310,12 @@ registry.category("web_tour.tours").add("MergeTableTour", {
             {
                 content: `select linked table`,
                 trigger: 'div.isLinked div.label:contains("4")',
+                run: "click",
             },
             {
                 content: `unlink in edit plan if unlink possible`,
                 trigger: '.edit-buttons button:contains("Unlink")',
+                run: "click",
             },
             Chrome.clickMenuOption("Edit Plan"),
             ...MergeTable.checkMergeTableIsCancelHelpers(),
@@ -321,6 +325,7 @@ registry.category("web_tour.tours").add("MergeTableTour", {
             {
                 content: `link in edit plan if link possible`,
                 trigger: '.edit-buttons button:contains("Link")',
+                run: "click",
             },
             Chrome.clickMenuOption("Edit Plan"),
             {

--- a/addons/pos_restaurant/static/tests/tours/utils/floor_screen_util.js
+++ b/addons/pos_restaurant/static/tests/tours/utils/floor_screen_util.js
@@ -36,6 +36,7 @@ export function clickFloor(name) {
         {
             content: `click '${name}' floor`,
             trigger: `.floor-selector .button-floor:contains("${name}")`,
+            run: "click",
         },
     ];
 }
@@ -44,6 +45,7 @@ export function clickEditButton(button) {
         {
             content: "add table",
             trigger: `.edit-buttons i[aria-label=${button}]`,
+            run: "click",
         },
     ];
 }

--- a/addons/pos_restaurant/static/tests/tours/utils/product_screen_util.js
+++ b/addons/pos_restaurant/static/tests/tours/utils/product_screen_util.js
@@ -48,6 +48,7 @@ export function tableNameShown(table_name) {
         {
             content: "Table name is shown",
             trigger: `.table-name:contains(${table_name})`,
+            run: "click",
         },
     ];
 }

--- a/addons/pos_restaurant/static/tests/tours/utils/tip_screen_util.js
+++ b/addons/pos_restaurant/static/tests/tours/utils/tip_screen_util.js
@@ -2,6 +2,7 @@ export function clickPercentTip(percent) {
     return [
         {
             trigger: `.tip-screen .percentage:contains("${percent}")`,
+            run: "click",
         },
     ];
 }
@@ -17,6 +18,7 @@ export function clickSettle() {
     return [
         {
             trigger: `.button.highlight.next`,
+            run: "click",
         },
     ];
 }

--- a/addons/pos_self_order/static/tests/tours/utils/cart_page_util.js
+++ b/addons/pos_self_order/static/tests/tours/utils/cart_page_util.js
@@ -2,6 +2,7 @@ export function clickBack() {
     return {
         content: `Click on back button`,
         trigger: `.btn.btn-back`,
+        run: "click",
     };
 }
 
@@ -15,6 +16,7 @@ export function selectTable(table) {
         {
             content: `Click on 'Confirm' button`,
             trigger: `.self_order_popup_table .btn:contains('Confirm')`,
+            run: "click",
         },
     ];
 }
@@ -23,6 +25,7 @@ export function checkProduct(name, price, quantity) {
     return {
         content: `Check product card with ${name} and ${price}`,
         trigger: `.product-card-item:has(strong:contains("${name}")):has(div:contains("${quantity}")):has(div .o-so-tabular-nums:contains("${price}"))`,
+        run: "click",
     };
 }
 
@@ -41,6 +44,7 @@ export function checkAttribute(productName, attributes) {
     return {
         content: `Check product card with ${productName} and ${attributeStringReadable}`,
         trigger: `.product-card-item div:contains("${productName}") + div ${attributeString}`,
+        run: "click",
     };
 }
 
@@ -59,6 +63,7 @@ export function checkCombo(comboName, products) {
         steps.push({
             content: `Check combo ${comboName}`,
             trigger: step,
+            run: "click",
         });
     }
 

--- a/addons/pos_self_order/static/tests/tours/utils/landing_page_util.js
+++ b/addons/pos_self_order/static/tests/tours/utils/landing_page_util.js
@@ -2,6 +2,7 @@ export function selectLocation(locationName) {
     return {
         content: `Click on location '${locationName}'`,
         trigger: `.o_kiosk_eating_location_box h3:contains('${locationName}')`,
+        run: "click",
     };
 }
 

--- a/addons/project/static/tests/tours/project_update_tour_tests.js
+++ b/addons/project/static/tests/tours/project_update_tour_tests.js
@@ -162,5 +162,6 @@ registry.category("web_tour.tours").add('project_update_tour', {
     trigger: '.o_back_button',
     content: 'Go back to the kanban view the project',
     extra_trigger: '.o_list_view',
+    run: "click",
 },
 ]});

--- a/addons/purchase_product_matrix/static/tests/tours/purchase_product_matrix_tour.js
+++ b/addons/purchase_product_matrix/static/tests/tours/purchase_product_matrix_tour.js
@@ -21,7 +21,8 @@ registry.category("web_tour.tours").add('purchase_matrix_tour', {
     auto: true,
     run: "click",
 }, {
-    trigger: "a:contains('Add a product')"
+    trigger: "a:contains('Add a product')",
+    run: "click",
 }, {
     trigger: 'div[name="product_template_id"] input',
     run: "edit Matrix",

--- a/addons/web_tour/static/tests/tour_service_tests.js
+++ b/addons/web_tour/static/tests/tour_service_tests.js
@@ -771,7 +771,7 @@ QUnit.module("Tour service", (hooks) => {
   "run": "click"
 },`;
         const expectedError = [
-            `error: Tour tour1 failed at step content (trigger: .wrong_selector). The error appears to be that one or more elements in the following list cannot be found in DOM.\n {"trigger":".wrong_selector"}`,
+            `error: Tour tour1 failed at step content (trigger: .wrong_selector). The cause is that trigger (.wrong_selector) element cannot be found in DOM.`,
         ];
         assert.verifySteps([expectedWarning, ...expectedError]);
     });
@@ -826,7 +826,7 @@ QUnit.module("Tour service", (hooks) => {
         await mock.advanceTime(750);
 
         const expectedError = [
-            "error: Tour tour2 failed at step .button1. Element has been found. The error seems to be in run()",
+            "error: Tour tour2 failed at step .button1. Element has been found. The error seems to be with step.run",
             "error: Cannot read properties of null (reading 'click')",
             "error: tour not succeeded",
         ];

--- a/addons/website_links/static/tests/tours/website_links.js
+++ b/addons/website_links/static/tests/tours/website_links.js
@@ -8,6 +8,7 @@ function fillSelect2(inputID, search) {
         {
             content: "Click select2 form item",
             trigger: `.o_website_links_utm_forms div.select2-container#s2id_${inputID} > .select2-choice`,
+            run: "click",
         },
         {
             content: "Enter select2 search query",
@@ -17,6 +18,7 @@ function fillSelect2(inputID, search) {
         {
             content: "Select found select2 item",
             trigger: `.select2-drop li:only-child .select2-match:contains("/^${search}$/")`,
+            run: "click",
         },
         {
             content: "Check that select2 is properly filled",

--- a/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
+++ b/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
@@ -412,6 +412,7 @@ stepUtils.autoExpandMoreButtons('.o_form_saved'),
     trigger: '.o_field_widget[name="type"] input[data-value="service"]',
     content: _t('Set to service'),
     position: 'left',
+    run: "click",
 }, {
     mobile: false,
     trigger: ".o_field_widget[name=taxes_id] input",


### PR DESCRIPTION
Currently, in tour_compiler, to check that an element is actually present in the DOM in a step, there are 2 possibilities.
- `isCheck: true` => Checks that the element is in the DOM. The latter can be disabled.
- `run() {}` => Checks that the element is in the DOM (because this is what is done by default). However, if the element is disabled, the step will be aborted.

In the codebase, we can see a lot of `run() {} //it's a check` and `isCheck:true`. However, the behavior is not exactly the same. What's more, there are 2 ways to do "the same thing". In order to clarify the turns API, it was decided to no longer put an action (step.run) by default. (Previously, the default action was the "click" action).
From then on, it is no longer necessary to stipulate `step.isCheck: true` nor `run() {}`.
The corollary is that now, you must explicitly write `run: click`, if you want the click action to be triggered on the target.

This commit sets the stage for making this change.

https://github.com/odoo/enterprise/pull/63711