### PR TITLE
[IMP] account: automatically use year range sequence format

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3048,9 +3048,9 @@ class AccountMove(models.Model):
             param['date_start'] = date_start
             param['date_end'] = date_end
             if sequence_number_reset in ('year', 'year_range'):
-                param['anti_regex'] = re.sub(r"\?P<\w+>", "?:", self._sequence_monthly_regex.split('(?P<seq>')[0]) + '$'
+                param['anti_regex'] = self._make_regex_non_capturing(self._sequence_monthly_regex.split('(?P<seq>')[0]) + '$'
             elif sequence_number_reset == 'never':
-                param['anti_regex'] = re.sub(r"\?P<\w+>", "?:", self._sequence_yearly_regex.split('(?P<seq>')[0]) + '$'
+                param['anti_regex'] = self._make_regex_non_capturing(self._sequence_yearly_regex.split('(?P<seq>')[0]) + '$'
 
             if param.get('anti_regex') and not self.journal_id.sequence_override_regex:
                 where_string += " AND sequence_prefix !~ %(anti_regex)s "

--- a/addons/account/models/sequence_mixin.py
+++ b/addons/account/models/sequence_mixin.py
@@ -24,11 +24,21 @@ class SequenceMixin(models.AbstractModel):
     _sequence_field = "name"
     _sequence_date_field = "date"
     _sequence_index = False
+
+    prefix = r'(?P<prefix1>.*?)'
+    prefix2 = r'(?P<prefix2>\D)'
+    prefix3 = r'(?P<prefix3>\D+?)'
+    seq = r'(?P<seq>\d*)'
+    month = r'(?P<month>(0[1-9]|1[0-2]))'
     # `(19|20|21)` is for catching 19 20 and 21 century prefixes
-    _sequence_year_range_regex = r'^(?:(?P<prefix1>.*?)(?P<year>((?<=\D)|(?<=^))((19|20|21)\d{2}|(\d{2}(?=\D))))(?P<prefix2>\D)(?P<year_end>((?<=\D)|(?<=^))((19|20|21)\d{2}|(\d{2}(?=\D))))(?P<prefix3>\D+?))?(?P<seq>\d*)(?P<suffix>\D*?)$'
-    _sequence_monthly_regex = r'^(?P<prefix1>.*?)(?P<year>((?<=\D)|(?<=^))((19|20|21)\d{2}|(\d{2}(?=\D))))(?P<prefix2>\D*?)(?P<month>(0[1-9]|1[0-2]))(?P<prefix3>\D+?)(?P<seq>\d*)(?P<suffix>\D*?)$'
-    _sequence_yearly_regex = r'^(?P<prefix1>.*?)(?P<year>((?<=\D)|(?<=^))((19|20|21)?\d{2}))(?P<prefix2>\D+?)(?P<seq>\d*)(?P<suffix>\D*?)$'
-    _sequence_fixed_regex = r'^(?P<prefix1>.*?)(?P<seq>\d{0,9})(?P<suffix>\D*?)$'
+    year = r'(?P<year>((?<=\D)|(?<=^))((19|20|21)\d{2}|(\d{2}(?=\D))))'
+    year_end = r'(?P<year_end>((?<=\D)|(?<=^))((19|20|21)\d{2}|(\d{2}(?=\D))))'
+    suffix = r'(?P<suffix>\D*?)'
+
+    _sequence_year_range_regex = fr'^(?:{prefix}{year}{prefix2}{year_end}{prefix3})?{seq}{suffix}$'
+    _sequence_monthly_regex = fr'^{prefix}{year}(?P<prefix2>\D*?){month}{prefix3}{seq}{suffix}$'
+    _sequence_yearly_regex = fr'^{prefix}(?P<year>((?<=\D)|(?<=^))((19|20|21)?\d{{2}}))(?P<prefix2>\D+?){seq}{suffix}$'
+    _sequence_fixed_regex = fr'^{prefix}(?P<seq>\d{{0,9}}){suffix}$'
 
     sequence_prefix = fields.Char(compute='_compute_split_sequence', store=True)
     sequence_number = fields.Integer(compute='_compute_split_sequence', store=True)

--- a/addons/account/wizard/account_resequence.py
+++ b/addons/account/wizard/account_resequence.py
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
-from odoo.tools.date_utils import get_month, get_fiscal_year
+from odoo.tools.date_utils import get_fiscal_year
 from odoo.tools.misc import format_date
 
-import re
 from collections import defaultdict
 import json
 
@@ -97,7 +96,7 @@ class ReSequenceWizard(models.TransientModel):
         """Compute the proposed new values.
 
         Sets a json string on new_values representing a dictionary thats maps account.move
-        ids to a disctionay containing the name if we execute the action, and information
+        ids to a dictionary containing the name if we execute the action, and information
         relative to the preview widget.
         """
         def _get_move_key(move_id):
@@ -106,7 +105,7 @@ class ReSequenceWizard(models.TransientModel):
             if self.sequence_number_reset == 'year':
                 return move_id.date.year
             elif self.sequence_number_reset == 'year_range':
-                return "%s-%s"%(date_start.year, date_end.year)
+                return "%s-%s" % (date_start.year, date_end.year)
             elif self.sequence_number_reset == 'month':
                 return (move_id.date.year, move_id.date.month)
             return 'default'
@@ -139,7 +138,7 @@ class ReSequenceWizard(models.TransientModel):
                     'month': date_start.month,
                     'year_end': date_end.year % (10 ** format_values['year_end_length']),
                     'year': date_start.year % (10 ** format_values['year_length']),
-                    'seq': i + (format_values['seq'] if j == (len(moves_by_period)-1) else 1),
+                    'seq': i + (format_values['seq'] if j == (len(moves_by_period) - 1) else 1),
                 }) for i in range(len(period_recs))]
 
                 # For all the moves of this period, assign the name by increasing initial name

--- a/addons/account/wizard/account_resequence.py
+++ b/addons/account/wizard/account_resequence.py
@@ -102,11 +102,11 @@ class ReSequenceWizard(models.TransientModel):
         """
         def _get_move_key(move_id):
             company = move_id.company_id
-            year_start, year_end = get_fiscal_year(move_id.date, day=company.fiscalyear_last_day, month=int(company.fiscalyear_last_month))
+            date_start, date_end = get_fiscal_year(move_id.date, day=company.fiscalyear_last_day, month=int(company.fiscalyear_last_month))
             if self.sequence_number_reset == 'year':
                 return move_id.date.year
             elif self.sequence_number_reset == 'year_range':
-                return "%s-%s"%(year_start.year, year_end.year)
+                return "%s-%s"%(date_start.year, date_end.year)
             elif self.sequence_number_reset == 'month':
                 return (move_id.date.year, move_id.date.month)
             return 'default'
@@ -123,7 +123,7 @@ class ReSequenceWizard(models.TransientModel):
             new_values = {}
             for j, period_recs in enumerate(moves_by_period.values()):
                 # compute the new values period by period
-                year_start, year_end = period_recs[0]._get_sequence_date_range(sequence_number_reset)
+                date_start, date_end = period_recs[0]._get_sequence_date_range(sequence_number_reset)
                 for move in period_recs:
                     new_values[move.id] = {
                         'id': move.id,
@@ -131,14 +131,14 @@ class ReSequenceWizard(models.TransientModel):
                         'state': move.state,
                         'date': format_date(self.env, move.date),
                         'server-date': str(move.date),
-                        'server-year-start-date': str(year_start),
+                        'server-year-start-date': str(date_start),
                     }
 
                 new_name_list = [seq_format.format(**{
                     **format_values,
-                    'month': year_start.month,
-                    'year_end': year_end.year % (10 ** format_values['year_end_length']),
-                    'year': year_start.year % (10 ** format_values['year_length']),
+                    'month': date_start.month,
+                    'year_end': date_end.year % (10 ** format_values['year_end_length']),
+                    'year': date_start.year % (10 ** format_values['year_length']),
                     'seq': i + (format_values['seq'] if j == (len(moves_by_period)-1) else 1),
                 }) for i in range(len(period_recs))]
 

--- a/addons/account/wizard/account_resequence.py
+++ b/addons/account/wizard/account_resequence.py
@@ -106,6 +106,8 @@ class ReSequenceWizard(models.TransientModel):
                 return move_id.date.year
             elif self.sequence_number_reset == 'year_range':
                 return "%s-%s" % (date_start.year, date_end.year)
+            elif self.sequence_number_reset == 'year_range_month':
+                return "%s-%s/%s" % (date_start.year, date_end.year, move_id.date.month)
             elif self.sequence_number_reset == 'month':
                 return (move_id.date.year, move_id.date.month)
             return 'default'
@@ -122,7 +124,7 @@ class ReSequenceWizard(models.TransientModel):
             new_values = {}
             for j, period_recs in enumerate(moves_by_period.values()):
                 # compute the new values period by period
-                date_start, date_end = period_recs[0]._get_sequence_date_range(sequence_number_reset)
+                date_start, date_end, forced_year_start, forced_year_end = period_recs[0]._get_sequence_date_range(sequence_number_reset)
                 for move in period_recs:
                     new_values[move.id] = {
                         'id': move.id,
@@ -136,8 +138,8 @@ class ReSequenceWizard(models.TransientModel):
                 new_name_list = [seq_format.format(**{
                     **format_values,
                     'month': date_start.month,
-                    'year_end': date_end.year % (10 ** format_values['year_end_length']),
-                    'year': date_start.year % (10 ** format_values['year_length']),
+                    'year_end': (forced_year_end or date_end.year) % (10 ** format_values['year_end_length']),
+                    'year': (forced_year_start or date_start.year) % (10 ** format_values['year_length']),
                     'seq': i + (format_values['seq'] if j == (len(moves_by_period) - 1) else 1),
                 }) for i in range(len(period_recs))]
 

--- a/addons/l10n_in_edi/tests/test_edi_json.py
+++ b/addons/l10n_in_edi/tests/test_edi_json.py
@@ -114,7 +114,7 @@ class TestEdiJson(L10nInTestInvoicingCommon):
         expected = {
             "Version": "1.1",
             "TranDtls": {"TaxSch": "GST", "SupTyp": "B2B", "RegRev": "N", "IgstOnIntra": "N"},
-            "DocDtls": {"Typ": "INV", "No": "INV/2019/00002", "Dt": "01/01/2019"},
+            "DocDtls": {"Typ": "INV", "No": "INV/18-19/0002", "Dt": "01/01/2019"},
             "SellerDtls": {
                 "Addr1": "Khodiyar Chowk",
                 "Loc": "Amreli",
@@ -158,7 +158,7 @@ class TestEdiJson(L10nInTestInvoicingCommon):
         #=================================== Full discount test =====================================
         json_value = self.env["account.edi.format"]._l10n_in_edi_generate_invoice_json(self.invoice_full_discount)
         expected.update({
-            "DocDtls": {"Typ": "INV", "No": "INV/2019/00003", "Dt": "01/01/2019"},
+            "DocDtls": {"Typ": "INV", "No": "INV/18-19/0003", "Dt": "01/01/2019"},
             "ItemList": [{
                 "SlNo": "1", "PrdDesc": "product_a", "IsServc": "N", "HsnCd": "111111", "Qty": 1.0,
                 "Unit": "UNT", "UnitPrice": 1000.0, "TotAmt": 1000.0, "Discount": 1000.0, "AssAmt": 0.0,
@@ -173,7 +173,7 @@ class TestEdiJson(L10nInTestInvoicingCommon):
         #=================================== Zero quantity test =============================================
         json_value = self.env["account.edi.format"]._l10n_in_edi_generate_invoice_json(self.invoice_zero_qty)
         expected.update({
-            "DocDtls": {"Typ": "INV", "No": "INV/2019/00004", "Dt": "01/01/2019"},
+            "DocDtls": {"Typ": "INV", "No": "INV/18-19/0004", "Dt": "01/01/2019"},
             "ItemList": [{
                 "SlNo": "1", "PrdDesc": "product_a", "IsServc": "N", "HsnCd": "111111", "Qty": 0.0,
                 "Unit": "UNT", "UnitPrice": 1000.0, "TotAmt": 0.0, "Discount": 0.0, "AssAmt": 0.0,
@@ -186,7 +186,7 @@ class TestEdiJson(L10nInTestInvoicingCommon):
         #=================================== Negative unit price test =============================================
         json_value = self.env["account.edi.format"]._l10n_in_edi_generate_invoice_json(self.invoice_negative_unit_price)
         expected.update({
-            "DocDtls": {"Typ": "INV", "No": "INV/2019/00005", "Dt": "01/01/2019"},
+            "DocDtls": {"Typ": "INV", "No": "INV/18-19/0005", "Dt": "01/01/2019"},
             "ItemList": [
                 {
                     "SlNo": "1", "PrdDesc": "product_a", "IsServc": "N", "HsnCd": "111111", "Qty": 1.0,
@@ -210,16 +210,16 @@ class TestEdiJson(L10nInTestInvoicingCommon):
         })
         self.assertDictEqual(json_value, expected, "Indian EDI with negative unit price sent json value is not matched")
 
-        expected.update({"DocDtls": {"Typ": "INV", "No": "INV/2019/00006", "Dt": "01/01/2019"}})
+        expected.update({"DocDtls": {"Typ": "INV", "No": "INV/18-19/0006", "Dt": "01/01/2019"}})
         json_value = self.env["account.edi.format"]._l10n_in_edi_generate_invoice_json(self.invoice_negative_qty)
         self.assertDictEqual(json_value, expected, "Indian EDI with negative quantity sent json value is not matched")
 
-        expected.update({"DocDtls": {"Typ": "INV", "No": "INV/2019/00007", "Dt": "01/01/2019"}})
+        expected.update({"DocDtls": {"Typ": "INV", "No": "INV/18-19/0007", "Dt": "01/01/2019"}})
         json_value = self.env["account.edi.format"]._l10n_in_edi_generate_invoice_json(self.invoice_negative_unit_price_and_qty)
         self.assertDictEqual(json_value, expected, "Indian EDI with negative unit price and quantity sent json value is not matched")
 
         expected.update({
-            "DocDtls": {"Typ": "INV", "No": "INV/2019/00008", "Dt": "01/01/2019"},
+            "DocDtls": {"Typ": "INV", "No": "INV/18-19/0008", "Dt": "01/01/2019"},
             "ItemList": [{
                 "SlNo": "1", "PrdDesc": "product_a", "IsServc": "N", "HsnCd": "111111", "Qty": 1.0,
                 "Unit": "UNT", "UnitPrice": 2000.0, "TotAmt": 2000.0, "Discount": 1400.0, "AssAmt": 600.0,
@@ -236,7 +236,7 @@ class TestEdiJson(L10nInTestInvoicingCommon):
         self.assertDictEqual(json_value, expected, "Indian EDI with negative unit price and quantity sent json value is not matched")
 
         expected.update({
-            "DocDtls": {"Typ": "INV", "No": "INV/2019/00009", "Dt": "01/01/2019"},
+            "DocDtls": {"Typ": "INV", "No": "INV/18-19/0009", "Dt": "01/01/2019"},
             "ItemList": [{
                 "SlNo": "1", "PrdDesc": "product_a", "IsServc": "N", "HsnCd": "111111", "Qty": 1.0,
                 "Unit": "UNT", "UnitPrice": 2000.0, "TotAmt": 2000.0, "Discount": 2000.0, "AssAmt": 0.0,
@@ -261,7 +261,7 @@ class TestEdiJson(L10nInTestInvoicingCommon):
 
         json_value = self.env["account.edi.format"]._l10n_in_edi_generate_invoice_json(self.invoice_cash_rounding)
         expected_copy_rounding.update({
-            "DocDtls": {"Typ": "INV", "No": "INV/2019/00010", "Dt": "01/01/2019"},
+            "DocDtls": {"Typ": "INV", "No": "INV/18-19/0010", "Dt": "01/01/2019"},
             "ValDtls": {
                 "AssVal": 1800.0, "CgstVal": 79.3, "SgstVal": 79.3, "IgstVal": 0.0, "CesVal": 46.59,
                 "StCesVal": 0.0, "Discount": 0.0, "RndOffAmt": -0.19, "TotInvVal": 2005.00

--- a/addons/l10n_in_edi_ewaybill/tests/test_edi_ewaybill_json.py
+++ b/addons/l10n_in_edi_ewaybill/tests/test_edi_ewaybill_json.py
@@ -24,7 +24,7 @@ class TestEdiEwaybillJson(TestEdiJson):
             "transMode": "1",
             "vehicleNo": "GJ11AA1234",
             "vehicleType": "R",
-            "docNo": "INV/2019/00002",
+            "docNo": "INV/18-19/0002",
             "docDate": "01/01/2019",
             "fromGstin": "24AAGCC7144L6ZE",
             "fromTrdName": "Default Company",
@@ -79,7 +79,7 @@ class TestEdiEwaybillJson(TestEdiJson):
         #=================================== Full discount test =====================================
         json_value = self.env["account.edi.format"]._l10n_in_edi_ewaybill_generate_json(self.invoice_full_discount)
         expected.update({
-            "docNo": "INV/2019/00003",
+            "docNo": "INV/18-19/0003",
             "itemList": [{
                 "productName": "product_a", "hsnCode": "111111", "productDesc": "product_a", "quantity": 1.0,
                 "qtyUnit": "UNT", "taxableAmount": 0.0, "cgstRate": 0.0, "sgstRate": 0.0
@@ -98,7 +98,7 @@ class TestEdiEwaybillJson(TestEdiJson):
         #=================================== Zero quantity test =============================================
         json_value = self.env["account.edi.format"]._l10n_in_edi_ewaybill_generate_json(self.invoice_zero_qty)
         expected.update({
-            "docNo": "INV/2019/00004",
+            "docNo": "INV/18-19/0004",
             "itemList": [{
                 "productName": "product_a", "hsnCode": "111111", "productDesc": "product_a", "quantity": 0.0,
                 "qtyUnit": "UNT", "taxableAmount": 0.0, "cgstRate": 0.0, "sgstRate": 0.0


### PR DESCRIPTION
If the fiscal year "last day" setting is not the 31th of december, it
means that the fiscal year is actually staggered on 2 years.
In this case, we don't want the moves prefix to be `INV/2024/XXX` but
`INV/2023-2024/XXX`.

Such fiscal year ranges are used by default in some countries like in
India, Australia..

Note that the `year_range` support was introduced with commit [1].

[1]: b485e4e

task-3653456