### PR TITLE
[FIX] account: re-export pot file

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -341,9 +341,7 @@ msgstr ""
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
-msgid ""
-"<br/>\n"
-"                            on this account:"
+msgid "<br/> on this account:"
 msgstr ""
 
 #. module: account
@@ -14914,7 +14912,7 @@ msgstr ""
 
 #. module: account
 #. odoo-python
-#: code:addons/account/models/account_payment_method.py:0
+#: code:addons/account/models/account_journal.py:0
 #, python-format
 msgid ""
 "You can't have two payment method lines of the same payment type (%s) and "


### PR DESCRIPTION
A fix's term was changing during the fw-port, but it's pot file was not re-exported to match. Therefore, re-export so that it translates properly.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
