### PR TITLE
[FIX] mail: multi recipient duplication

### DIFF
--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -507,12 +507,6 @@ class MailComposer(models.TransientModel):
                 mail_values['failure_type'] = 'mail_bl'
                 # Do not post the mail into the recipient's chatter
                 mail_values['is_notification'] = False
-            elif optout_emails and mail_to in optout_emails:
-                mail_values['state'] = 'cancel'
-                mail_values['failure_type'] = 'mail_optout'
-            elif done_emails and mail_to in done_emails and not mailing_document_based:
-                mail_values['state'] = 'cancel'
-                mail_values['failure_type'] = 'mail_dup'
             # void of falsy values -> error
             elif not mail_to:
                 mail_values['state'] = 'cancel'
@@ -520,6 +514,12 @@ class MailComposer(models.TransientModel):
             elif not mail_to_normalized:
                 mail_values['state'] = 'cancel'
                 mail_values['failure_type'] = 'mail_email_invalid'
+            elif optout_emails and mail_to in optout_emails:
+                mail_values['state'] = 'cancel'
+                mail_values['failure_type'] = 'mail_optout'
+            elif done_emails and mail_to in done_emails and not mailing_document_based:
+                mail_values['state'] = 'cancel'
+                mail_values['failure_type'] = 'mail_dup'
             elif done_emails is not None and not mailing_document_based:
                 done_emails.append(mail_to)
 

--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -491,14 +491,6 @@ class MailComposer(models.TransientModel):
 
         for record_id, mail_values in mail_values_dict.items():
             recipients = recipients_info[record_id]
-            # when having more than 1 recipient: we cannot really decide when a single
-            # email is linked to several to -> skip that part. Mass mailing should
-            # anyway always have a single recipient per record as this is default behavior.
-            if len(recipients['mail_to']) > 1:
-                continue
-
-            mail_to = recipients['mail_to'][0] if recipients['mail_to'] else ''
-            mail_to_normalized = recipients['mail_to_normalized'][0] if recipients['mail_to_normalized'] else ''
 
             # prevent sending to blocked addresses that were included by mistake
             # blacklisted or optout or duplicate -> cancel
@@ -507,21 +499,25 @@ class MailComposer(models.TransientModel):
                 mail_values['failure_type'] = 'mail_bl'
                 # Do not post the mail into the recipient's chatter
                 mail_values['is_notification'] = False
-            # void of falsy values -> error
-            elif not mail_to:
+            # void or falsy values -> error
+            elif not any(recipients['mail_to']):
                 mail_values['state'] = 'cancel'
                 mail_values['failure_type'] = 'mail_email_missing'
-            elif not mail_to_normalized:
+            elif not any(recipients['mail_to_normalized']):
                 mail_values['state'] = 'cancel'
                 mail_values['failure_type'] = 'mail_email_invalid'
-            elif optout_emails and mail_to in optout_emails:
+            elif optout_emails and all(
+                    mail_to in optout_emails for mail_to in recipients['mail_to']
+                ):
                 mail_values['state'] = 'cancel'
                 mail_values['failure_type'] = 'mail_optout'
-            elif done_emails and mail_to in done_emails and not mailing_document_based:
+            elif done_emails and not mailing_document_based and all(
+                    mail_to in done_emails for mail_to in recipients['mail_to']
+                ):
                 mail_values['state'] = 'cancel'
                 mail_values['failure_type'] = 'mail_dup'
             elif done_emails is not None and not mailing_document_based:
-                done_emails.append(mail_to)
+                done_emails.extend(recipients['mail_to'])
 
         return mail_values_dict
 

--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -484,8 +484,8 @@ class MailComposer(models.TransientModel):
     def _process_state(self, mail_values_dict):
         recipients_info = self._process_recipient_values(mail_values_dict)
         blacklist_ids = self._get_blacklist_record_ids(mail_values_dict, recipients_info)
-        optout_emails = self._get_optout_emails(mail_values_dict)
-        done_emails = self._get_done_emails(mail_values_dict)
+        optout_emails = [tools.email_normalize(email) for email in self._get_optout_emails(mail_values_dict)]
+        done_emails = [tools.email_normalize(email) for email in self._get_done_emails(mail_values_dict)]
         # in case of an invoice e.g.
         mailing_document_based = self.env.context.get('mailing_document_based')
 
@@ -507,17 +507,17 @@ class MailComposer(models.TransientModel):
                 mail_values['state'] = 'cancel'
                 mail_values['failure_type'] = 'mail_email_invalid'
             elif optout_emails and all(
-                    mail_to in optout_emails for mail_to in recipients['mail_to']
+                    mail_to in optout_emails for mail_to in recipients['mail_to_normalized']
                 ):
                 mail_values['state'] = 'cancel'
                 mail_values['failure_type'] = 'mail_optout'
             elif done_emails and not mailing_document_based and all(
-                    mail_to in done_emails for mail_to in recipients['mail_to']
+                    mail_to in done_emails for mail_to in recipients['mail_to_normalized']
                 ):
                 mail_values['state'] = 'cancel'
                 mail_values['failure_type'] = 'mail_dup'
             elif done_emails is not None and not mailing_document_based:
-                done_emails.extend(recipients['mail_to'])
+                done_emails.extend(recipients['mail_to_normalized'])
 
         return mail_values_dict
 

--- a/addons/test_mail/tests/test_mail_composer.py
+++ b/addons/test_mail/tests/test_mail_composer.py
@@ -1215,7 +1215,7 @@ class TestComposerResultsMass(TestMailComposer):
             'Mail: currently setting name = email, not taking into account formatted emails'
         )
 
-        # global outgoing: one mail.mail (all customer recipients), * 2 records
+        # global outgoing: one mail.mail (all customer recipients)
         #   Note that employee is not mailed here compared to 'comment' mode as he
         #   is not in the template recipients, only a follower
         # FIXME template is sent only to partners (email_to are transformed) ->
@@ -1225,12 +1225,12 @@ class TestComposerResultsMass(TestMailComposer):
         #   there are more partners than email to notify;
         self.assertEqual(len(self._new_mails), 2, 'Should have created 2 mail.mail')
         self.assertEqual(
-            len(self._mails), (len(new_partners) + 2) * 2,
-            f'Should have sent {(len(new_partners) + 2) * 2} emails, one / recipient ({len(new_partners)} mailed partners + partner_1 + partner_2) * 2 records')
-        for record in self.test_records:
+            len(self._mails), len(new_partners) + 2,
+            f'Should have sent {len(new_partners) + 2} emails, one / recipient ({len(new_partners)} mailed partners + partner_1 + partner_2)')
+        for record, status in zip(self.test_records, ('sent', 'cancel')):
             self.assertMailMail(
                 self.partner_1 + self.partner_2 + new_partners,
-                'sent',
+                status,
                 author=self.partner_employee,
                 email_to_recipients=[
                     [self.partner_1.email_formatted],

--- a/addons/test_mail_full/tests/test_mass_mailing.py
+++ b/addons/test_mail_full/tests/test_mass_mailing.py
@@ -27,6 +27,10 @@ class TestMassMailing(TestMailFullCommon):
         self.env['mail.blacklist'].create({'email': recipients[4].email_normalized})
         # have a duplicate email for 9
         recipient_dup_1 = recipients[9].copy()
+        # have another duplicate for 9, but with 2 emails
+        recipient_dup_2 = recipients[9].copy()
+        recipient_dup_2.email_from += '; "TestCustomer 009" <test.record.009@test.example.com>'
+        recipient_dup_3 = recipient_dup_2.copy()
         # have a void mail
         recipient_void_1 = self.env['mailing.test.optout'].create({'name': 'TestRecord_void_1'})
         # have a falsy mail
@@ -34,7 +38,14 @@ class TestMassMailing(TestMailFullCommon):
             'name': 'TestRecord_falsy_1',
             'email_from': 'falsymail'
         })
-        recipients_all = recipients + recipient_dup_1 + recipient_void_1 + recipient_falsy_1
+        recipients_all = (
+            recipients
+            + recipient_dup_1
+            + recipient_dup_2
+            + recipient_dup_3
+            + recipient_void_1
+            + recipient_falsy_1
+        )
 
         mailing.write({'mailing_domain': [('id', 'in', recipients_all.ids)]})
         mailing.action_put_in_queue()
@@ -55,6 +66,11 @@ class TestMassMailing(TestMailFullCommon):
                 recipient_info['failure_type'] = "mail_bl"
             # duplicates: cancel (cancel mail)
             elif recipient == recipient_dup_1:
+                recipient_info['trace_status'] = "cancel"
+                recipient_info['failure_type'] = "mail_dup"
+            elif recipient == recipient_dup_2:
+                pass
+            elif recipient == recipient_dup_3:
                 recipient_info['trace_status'] = "cancel"
                 recipient_info['failure_type'] = "mail_dup"
             # void: error (failed mail)
@@ -116,6 +132,6 @@ class TestMassMailing(TestMailFullCommon):
                 ]],
                 check_mail=True,)
 
-        # sent: 13, 2 bl, 2 opt-out, 3 invalid -> 6 remaining
-        # ignored: 2 bl + 2 optout + 2 invalid + 1 duplicate; failed: 0
-        self.assertMailingStatistics(mailing, expected=13, delivered=6, sent=6, canceled=7, failed=0)
+        # sent: 15, 2 bl, 3 opt-out, 3 invalid -> 7 remaining
+        # ignored: 2 bl + 3 optout + 2 invalid + 1 duplicate; failed: 0
+        self.assertMailingStatistics(mailing, expected=15, delivered=7, sent=7, canceled=8, failed=0)


### PR DESCRIPTION
Install mass-mailing and crm. Change the email address of Brandon to `a@example.com;b@example.com`. In the list view of crm, add the select all leads and change their customer to Brandon (the customer column is not displayed by default, just make it visible). Create a new mass-mailing with the recipient list as "Lead/Opportunity". Start the campaign. Brandon receives as many emails as there are leads but he shall only receive one.

The system has a known limitation when it comes to filtering duplicates: it skips all records that have multiple recipients. In this case Brandon has two: a@example.com and b@example.com. The de-duplication mechanism was skipped for every lead he was the customer of and each time a new email was sent, spamming him.

In this work we make it possible to also process records with multiple recipients. It is a best-effort and will still let some duplicates through. Nonetheless it solves the current problem with minimal changes.

Note: `any([])` and `any([''])` are both False while `all([])` is True, hence we now check for empty list / empty email first otherwise an empty list would be considered to be opt-out instead of empty.

Task-3927361