### PR TITLE
[IMP] web,*: print UI

### DIFF
--- a/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.scss
+++ b/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.scss
@@ -3,4 +3,8 @@
     textarea {
         resize: none;
     }
+
+    @include media-only(print) {
+        height: auto !important;
+    }
 }

--- a/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.xml
+++ b/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.xml
@@ -16,7 +16,7 @@
                         </span>
                         <t t-if="columnIsProductAndLabel.value and label">
                             <textarea
-                                class="o_input text-wrap border-0 fst-italic"
+                                class="o_input d-print-none text-wrap border-0 fst-italic"
                                 rows="1"
                                 type="text"
                                 t-att-class="sectionAndNoteClasses"
@@ -38,7 +38,7 @@
                             </span>
                         </a>
                         <textarea t-if="(columnIsProductAndLabel.value and label) or (!columnIsProductAndLabel.value and !productName and label)"
-                            class="o_input text-wrap border-0 fst-italic"
+                            class="o_input d-print-none text-wrap border-0 fst-italic"
                             placeholder="Enter a description"
                             readonly="1"
                             rows="1"
@@ -64,7 +64,7 @@
                     </t>
                     <t t-else="">
                         <textarea
-                            class="o_input text-wrap border-0 fst-italic"
+                            class="o_input d-print-none text-wrap border-0 fst-italic"
                             placeholder="Enter a description"
                             rows="1"
                             type="text"
@@ -110,7 +110,7 @@
                     </div>
                     <t t-if="columnIsProductAndLabel.value and (label or labelVisibility.value)">
                         <textarea
-                            class="o_input text-wrap border-0 fst-italic"
+                            class="o_input d-print-none text-wrap border-0 fst-italic"
                             placeholder="Enter a description"
                             rows="1"
                             type="text"
@@ -134,7 +134,7 @@
                     </t>
                     <t t-else="">
                         <textarea
-                            class="o_input text-wrap border-0 fst-italic"
+                            class="o_input d-print-none text-wrap border-0 fst-italic"
                             rows="1"
                             type="text"
                             t-att-class="sectionAndNoteClasses"
@@ -145,6 +145,7 @@
                     </t>
                 </t>
             </t>
+            <div class="d-none d-print-block text-wrap" t-out="label"/>
         </div>
     </t>
 

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1215,7 +1215,7 @@
                                         </sheet>
                                     </form>
                                 </field>
-                                <group col="12" class="oe_invoice_lines_tab">
+                                <group col="12" class="oe_invoice_lines_tab overflow-hidden">
                                     <group colspan="8">
                                         <field name="narration" placeholder="Terms and Conditions" colspan="2" nolabel="1"/>
                                     </group>

--- a/addons/mail/static/src/chatter/web/chatter.xml
+++ b/addons/mail/static/src/chatter/web/chatter.xml
@@ -3,7 +3,7 @@
 
 <t t-name="mail.Chatter">
     <div t-if="state.thread" class="o-mail-Chatter w-100 h-100 flex-grow-1 d-flex flex-column" t-att-class="{ 'overflow-auto': props.isChatterAside, 'o-chatter-disabled': props.threadId === false }" t-on-scroll="onScrollDebounced" t-ref="root">
-        <div class="o-mail-Chatter-top position-sticky top-0" t-att-class="{ 'shadow-sm': state.isTopStickyPinned }" t-ref="top">
+        <div class="o-mail-Chatter-top d-print-none position-sticky top-0" t-att-class="{ 'shadow-sm': state.isTopStickyPinned }" t-ref="top">
             <div class="o-mail-Chatter-topbar d-flex flex-shrink-0 flex-grow-0 overflow-x-auto">
                 <button class="o-mail-Chatter-sendMessage btn text-nowrap me-1" t-att-class="{
                     'btn-primary': state.composerType !== 'note',

--- a/addons/mail/static/src/chatter/web/form_compiler.js
+++ b/addons/mail/static/src/chatter/web/form_compiler.js
@@ -106,7 +106,7 @@ patch(FormCompiler.prototype, {
             "t-if": `${
                 tIf ? tIf : "true"
             } and (!["COMBO", "NONE"].includes(__comp__.mailLayout(${hasPreview})))`, // opposite of sheetBgChatterContainerHookXml
-            "t-attf-class": `{{ ["SIDE_CHATTER", "EXTERNAL_COMBO_XXL"].includes(__comp__.mailLayout(${hasPreview})) ? "o-aside" : "mt-4 mt-md-0" }}`,
+            "t-attf-class": `{{ ["SIDE_CHATTER", "EXTERNAL_COMBO_XXL"].includes(__comp__.mailLayout(${hasPreview})) ? "o-aside w-print-100" : "mt-4 mt-md-0" }}`,
         });
         append(parentXml, chatterContainerHookXml);
         return res;

--- a/addons/mail/static/src/chatter/web/form_renderer.scss
+++ b/addons/mail/static/src/chatter/web/form_renderer.scss
@@ -28,7 +28,7 @@
 
 // Reduce horizontal spacing if the next sibling is an aside chatter
 .o_form_sheet_bg:has(+ .o-mail-Form-chatter.o-aside) {
-    @media (max-width: 1920px) {
+    @media screen and (max-width: 1920px) {
         --formView-sheetBg-padding-right: #{map-get($spacers, 2)};
     }
 }

--- a/addons/mail/static/src/core/common/attachment_view.xml
+++ b/addons/mail/static/src/core/common/attachment_view.xml
@@ -3,13 +3,13 @@
 
     <t t-name="mail.AttachmentView">
         <div t-if="state.thread.attachmentsInWebClientView.length > 0" class="o-mail-Attachment">
-            <div class="o_attachment_control popout" t-on-click="popoutAttachment"><i class="fa fa-window-restore" aria-hidden="Pop out" title="Pop out"/></div>
+            <div class="o_attachment_control popout d-print-none" t-on-click="popoutAttachment"><i class="fa fa-window-restore" aria-hidden="Pop out" title="Pop out"/></div>
             <t t-if="state.thread.mainAttachment">
                 <h3 t-if="!state.thread.mainAttachment.isPdf" class="mt0 mb8 ps-2 text-muted text-center"><t t-esc="displayName"/></h3>
                 <div t-if="state.thread.mainAttachment.isImage" class="o-mail-Attachment-imgContainer">
                     <img id="attachment_img" class="img img-fluid d-block" t-att-src="state.thread.mainAttachment.defaultSource"/>
                 </div>
-                <iframe t-if="state.thread.mainAttachment.isPdf" class="mb48" t-att-src="state.thread.mainAttachment.defaultSource" t-ref="iframeViewerPdf"/>
+                <iframe t-if="state.thread.mainAttachment.isPdf" class="d-print-none mb48" t-att-src="state.thread.mainAttachment.defaultSource" t-ref="iframeViewerPdf"/>
                 <t t-if="state.thread.attachmentsInWebClientView.length > 1">
                     <a class="arrow o_move_previous text-center" href="#" t-on-click.prevent="onClickPrevious">
                         <span class="oi oi-chevron-left"/>

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -130,7 +130,7 @@
     </t>
 
 <t t-name="mail.Message.actions">
-    <div t-if="props.hasActions and message.hasActions and !state.isEditing" class="o-mail-Message-actions"
+    <div t-if="props.hasActions and message.hasActions and !state.isEditing" class="o-mail-Message-actions d-print-none"
         t-att-class="{
             'start-0 ms-3': isAlignedRight,
             'end-0 me-3': (env.inChatWindow or ui.isSmall) and !isAlignedRight,

--- a/addons/mail/static/src/core/common/thread.xml
+++ b/addons/mail/static/src/core/common/thread.xml
@@ -100,7 +100,7 @@
 <t t-name="mail.Thread.jumpPresent">
     <span t-if="props.showJumpPresent and state.showJumpPresent" t-att-class="{
         'm-0 px-4 position-sticky top-0': env.inChatter,
-    }" class="o-mail-Thread-banner o-mail-Thread-bannerHover d-flex justify-content-between alert alert-primary border-0 rounded-0 mb-0 py-1 cursor-pointer shadow-sm small fw-bold" t-on-click="() => this.jumpToPresent()">
+    }" class="o-mail-Thread-banner o-mail-Thread-bannerHover d-flex d-print-none justify-content-between alert alert-primary border-0 rounded-0 mb-0 py-1 cursor-pointer shadow-sm small fw-bold" t-on-click="() => this.jumpToPresent()">
         <span>You're viewing older messages</span>
         <span>Jump to Present<i class="ms-2 fa" t-att-class="{ 'fa-caret-up': props.order !== 'asc', 'fa-caret-down': props.order === 'asc' }"/></span>
     </span>

--- a/addons/mail/static/src/core/web/discuss_sidebar.xml
+++ b/addons/mail/static/src/core/web/discuss_sidebar.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.DiscussSidebar">
-        <div class="o-mail-DiscussSidebar d-flex flex-column overflow-auto flex-shrink-0 h-100 pt-3 border-end z-1 o-mail-discussSidebarBgColor">
+        <div class="o-mail-DiscussSidebar d-flex d-print-none flex-column overflow-auto flex-shrink-0 h-100 pt-3 border-end z-1 o-mail-discussSidebarBgColor">
             <t t-foreach="discussSidebarItems" t-as="item" t-key="item_index" t-component="item"/>
         </div>
     </t>

--- a/addons/onboarding/views/onboarding_templates.xml
+++ b/addons/onboarding/views/onboarding_templates.xml
@@ -44,7 +44,7 @@
                 </div>
             </div>
         </div>
-        <div class="o_onboarding_main position-relative border-bottom overflow-hidden">
+        <div class="o_onboarding_main d-print-none position-relative border-bottom overflow-hidden">
             <div class="o_onboarding_wrap py-3 py-lg-4">
                 <a href="#" data-bs-toggle="modal" data-bs-target=".o_onboarding_modal" class="o_onboarding_btn_close position-absolute top-0 end-0 py-2 px-3 h2" title="Close the onboarding panel"><i class="oi oi-close"/></a>
                 <div class="o_onboarding_steps d-flex" t-out="0"/>

--- a/addons/project/static/src/components/project_right_side_panel/project_right_side_panel.xml
+++ b/addons/project/static/src/components/project_right_side_panel/project_right_side_panel.xml
@@ -9,7 +9,7 @@
                 show="!!state.data.buttons"
             >
                 <div class="o_form_view">
-                    <div class="oe_button_box o-form-buttonbox d-flex flex-wrap">
+                    <div class="oe_button_box o-form-buttonbox d-print-none d-flex flex-wrap">
                         <t t-foreach="state.data.buttons" t-as="button" t-key="button.sequence">
                             <ViewButton
                                 t-if="button.show"

--- a/addons/project/static/src/components/project_task_state_selection/project_task_state_selection.scss
+++ b/addons/project/static/src/components/project_task_state_selection/project_task_state_selection.scss
@@ -1,7 +1,7 @@
 .o_field_project_task_state_selection {
     .o_status {
-        width: 19.5px;
-        height: 19.5px;
+        width: $font-size-base * 1.36;
+        height: $font-size-base * 1.36;
         text-align: center;
         margin-top: -0.5px;
     }
@@ -26,8 +26,8 @@
             vertical-align: -6%;
         }
         .o_status {
-            width: 14.65px;
-            height: 14.65px;
+            width: $font-size-base;
+            height: $font-size-base;
             text-align: center;
         }
         .fa-hourglass-o {

--- a/addons/project/static/src/scss/project_widgets.scss
+++ b/addons/project/static/src/scss/project_widgets.scss
@@ -64,8 +64,8 @@
 
 .o_field_project_state_selection {
     .dropdown-toggle .o_status {
-        width: 19px;
-        height: 19px;
+        width: $font-size-base * 1.36;
+        height: $font-size-base * 1.36;
         text-align: center;
     }
 }

--- a/addons/stock/static/src/scss/stock_overview.scss
+++ b/addons/stock/static/src/scss/stock_overview.scss
@@ -1,15 +1,11 @@
 .o_kanban_dashboard.o_stock_kanban .o_kanban_renderer {
+    --KanbanRecord-width: 48%;
 
-    &.o_kanban_ungrouped {
-        .o_kanban_record {
-            width: 480px;
-        }
+    @include media-only(screen) {
+        --KanbanGroup-width: 480px;
     }
-
-    .o_kanban_group {
-        &:not(.o_column_folded) {
-            --KanbanGroup-width: 480px;
-        }
+    @include media-only(print) {
+        --KanbanGroup-width: 400px;
     }
 }
 

--- a/addons/web/__manifest__.py
+++ b/addons/web/__manifest__.py
@@ -322,6 +322,17 @@ This module provides the core of the Odoo Web Client.
         ],
 
         # ---------------------------------------------------------------------
+        # "DIRECT PRINT" BUNDLE
+        # ---------------------------------------------------------------------
+        "web.assets_web_print": [
+            'web/static/src/scss/functions.scss',
+            'web/static/src/scss/primary_variables_print.scss',
+
+            'web/static/src/**/*.print_variables.scss',
+            ('include', 'web.assets_backend'),
+        ],
+
+        # ---------------------------------------------------------------------
         # COLOR SCHEME BUNDLES
         # ---------------------------------------------------------------------
         "web.assets_web_dark": [

--- a/addons/web/static/src/core/tooltip/tooltip.scss
+++ b/addons/web/static/src/core/tooltip/tooltip.scss
@@ -51,5 +51,9 @@
 
     + .popover-arrow {
         --#{$variable-prefix}popover-bg: #{$tooltip-bg};
+
+        @include media-only(print) {
+            display: none;
+        }
     }
 }

--- a/addons/web/static/src/core/tooltip/tooltip.xml
+++ b/addons/web/static/src/core/tooltip/tooltip.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="web.Tooltip">
-        <div class="o-tooltip tooltip-inner text-start">
+        <div class="o-tooltip tooltip-inner d-print-none text-start">
             <t t-if="props.template" t-call="{{props.template}}" t-call-context="{ env, ...props.info }"/>
             <span t-else="" t-esc="props.tooltip"/>
         </div>

--- a/addons/web/static/src/scss/bootstrap_overridden.scss
+++ b/addons/web/static/src/scss/bootstrap_overridden.scss
@@ -121,6 +121,8 @@ $font-size-sm: $o-font-size-base-small !default;
 $small-font-size: $font-size-sm !default;
 
 $line-height-base: $o-line-height-base !default;
+$line-height-sm: $o-line-height-sm !default;
+$line-height-lg: $o-line-height-lg !default;
 
 $h1-font-size: $font-size-base * 2.0 !default;
 $h2-font-size: $font-size-base * 1.5 !default;
@@ -144,8 +146,8 @@ $table-border-color: $border-color !default;
 $table-group-separator-color: $gray-200 !default;
 $table-cell-padding-x: .75rem !default;
 $table-cell-padding-y: .75rem !default;
-$table-cell-padding-x-sm: .3rem !default;
-$table-cell-padding-y-sm: .5rem !default;
+$table-cell-padding-x-sm: $o-table-cell-padding-x-sm !default;
+$table-cell-padding-y-sm: $o-table-cell-padding-y-sm !default;
 $table-striped-order: even !default;
 
 $table-active-bg-factor: .05 !default;
@@ -199,6 +201,10 @@ $list-group-hover-bg: $dropdown-link-hover-bg !default;
 $list-group-active-color: $o-list-group-active-color !default;
 $list-group-active-bg: $o-list-group-active-bg !default;
 $list-group-action-hover-color: $gray-900 !default;
+
+// Breadcrumbs
+
+$breadcrumb-item-padding-x: $o-breadcrumb-item-padding-x !default;
 
 // Z-index master list
 

--- a/addons/web/static/src/scss/primary_variables.scss
+++ b/addons/web/static/src/scss/primary_variables.scss
@@ -6,6 +6,9 @@
 // Contrast ratio
 $o-frontend-min-contrast-ratio: 2.9 !default;
 
+// Media
+$o-webclient-media: screen !default;
+
 // Color-scheme
 $o-webclient-color-scheme: bright !default;
 
@@ -16,6 +19,8 @@ $o-font-size-base-touch: o-to-rem(16px) !default;
 $o-font-size-base-small: o-to-rem(13px) !default;
 $o-font-size-base-smaller: o-to-rem(12px) !default;
 $o-line-height-base: 1.5 !default; // This is BS default
+$o-line-height-sm : 1.25 !default;
+$o-line-height-lg : 2 !default;
 
 // Global sans-serif fonts stack, defined here as we need to process
 // it before actually using it (to add more unicode support with the special
@@ -119,6 +124,10 @@ $o-main-link-color: darken($o-brand-primary, 5%) !default;
 $o-main-favorite-color: #f3cc00 !default;
 $o-main-code-color: #d2317b !default;
 
+// Tables
+$o-table-cell-padding-x-sm: .3rem !default;
+$o-table-cell-padding-y-sm: .5rem !default;
+
 // Components colors
 $o-component-active-color:  $o-gray-900 !default;
 $o-component-active-bg: mix($o-action, $o-gray-100, 20%) !default;
@@ -203,6 +212,10 @@ $o-label-font-size-factor: 0.8 !default;
 
 $o-list-group-active-color: $o-gray-900 !default;
 $o-list-group-active-bg: lighten(saturate(adjust-hue($o-info, 15), 1.8), 50) !default;
+
+// Breadcrumbs
+
+$o-breadcrumb-item-padding-x: .5rem !default;
 
 
 // == Badges

--- a/addons/web/static/src/scss/primary_variables_print.scss
+++ b/addons/web/static/src/scss/primary_variables_print.scss
@@ -1,0 +1,63 @@
+// Media
+$o-webclient-media: print !default;
+
+// Color-scheme
+$o-webclient-color-scheme: bright !default;
+
+// Colors
+$o-gray-100: #f8f9fa !default;
+$o-gray-200: #e9ecef !default;
+$o-gray-300: #dee2e6 !default;
+$o-gray-400: #ced4da !default;
+$o-gray-500: #adb5bd !default;
+$o-gray-600: #6c757d !default;
+$o-gray-700: #495057 !default;
+$o-gray-800: #343a40 !default;
+$o-gray-900: #212529 !default;
+
+$o-grays: (
+    100: $o-gray-100,
+    200: $o-gray-200,
+    300: $o-gray-300,
+    400: $o-gray-400,
+    500: $o-gray-500,
+    600: $o-gray-600,
+    700: $o-gray-700,
+    800: $o-gray-800,
+    900: $o-gray-900,
+) !default;
+
+// Grid System
+$grid-breakpoints: (
+    xs: 0,
+    sm: 100mm,
+    md: 188mm,
+    lg: 190mm,
+    xl: 220mm,
+    xxl: 250mm,
+) !default;
+
+// Borders
+$o-border-color: var(--border-color, #{$o-gray-500}) !default;
+
+// Webclient
+$o-webclient-background-color: #FFFFFF !default;
+
+// Text
+$o-main-text-color: $o-gray-800 !default;
+
+$o-root-font-size: 13px !default;
+$o-line-height-base: 1.3 !default;
+$o-line-height-sm: 1 !default;
+$o-line-height-lg: 1.5 !default;
+
+// Spacing
+$o-spacer: $o-root-font-size !default;
+$o-horizontal-padding: $o-spacer !default;
+
+// Tables
+$o-table-cell-padding-x-sm: .15rem !default;
+$o-table-cell-padding-y-sm: .25rem !default;
+
+// Breadcrumbs
+$o-breadcrumb-item-padding-x: .15rem !default;

--- a/addons/web/static/src/scss/utilities_custom_backend.scss
+++ b/addons/web/static/src/scss/utilities_custom_backend.scss
@@ -22,7 +22,22 @@ $utilities: map-merge(
 
         // Disable 'bg-X' classes generation.
         // See bootstrap_review_backend.scss
-        "background-color": null
+        "background-color": null,
+
+        "width": map-merge(
+            map-get($utilities, "width"),
+            ( print: true ),
+        ),
     )
 );
+
+// Generate paddings print classes.
+@each $-padding-type in ("padding", "padding-x", "padding-y", "padding-top", "padding-end", "padding-bottom", "padding-start") {
+    $utilities: map-merge(
+        $utilities,
+        (
+            $-padding-type: map-merge(map-get($utilities, $-padding-type), ( print: true )),
+        )
+    );
+}
 

--- a/addons/web/static/src/scss/utils.scss
+++ b/addons/web/static/src/scss/utils.scss
@@ -355,3 +355,23 @@
         }
     }
 }
+
+
+// ----------------------------------------------------------------------------
+// Media Type
+// ----------------------------------------------------------------------------
+
+// Conditionally includes SCSS  based on the current media context.
+// It serves two main purposes:
+// 1. Keep the base code clean by avoiding redundant `@media only screen {}`.
+// 2. Reduces CSS footprint by only compiling styles that match the current `$o-webclient-media`.
+
+@mixin media-only($-media) {
+    @if ($-media != null and type-of($-media) == 'string') {
+        @if $-media == $o-webclient-media {
+            @content;
+        }
+    } @else {
+        @warn "'media-only()' - missing argument"
+    }
+}

--- a/addons/web/static/src/search/control_panel/control_panel.scss
+++ b/addons/web/static/src/search/control_panel/control_panel.scss
@@ -1,40 +1,102 @@
 .o_control_panel {
     border-bottom: var(--ControlPanel-border-bottom, #{$o-control-panel-border-bottom});
     background-color: $o-control-panel-background-color;
+    @include media-only(screen) {
+        .o_control_panel_breadcrumbs {
+            --#{$variable-prefix}breadcrumb-font-size: #{$small-font-size};
+            min-width: 200px;
+        }
 
-    .o_control_panel_breadcrumbs {
-        --#{$variable-prefix}breadcrumb-font-size: #{$small-font-size};
-        min-width: 200px;
-    }
+        @include media-breakpoint-down(md) {
+            &.o_mobile_sticky {
+                @include o-position-sticky();
+                z-index: 10;
+            }
+        }
 
-    @include media-breakpoint-down(md) {
-        &.o_mobile_sticky {
-            @include o-position-sticky();
-            z-index: 10;
+        @include media-breakpoint-up(lg) {
+            .o_control_panel_breadcrumbs, .o_control_panel_navigation {
+                flex: 1;
+            }
+
+            .o_control_panel_actions {
+                min-width: MIN(500px, 33%);
+            }
+        }
+
+        @include media-breakpoint-up(xl) {
+            .o_control_panel_actions {
+                min-width: MIN(600px, 33%);
+            }
+        }
+
+        .o_cp_switch_buttons {
+            .btn, .btn:focus {
+                // Boostrap plays around with the z-index of buttons, but this is not needed here
+                // It was causing issues with the hotkey overlay
+                z-index: 0;
+            }
         }
     }
 
-    @include media-breakpoint-up(lg) {
-        .o_control_panel_breadcrumbs, .o_control_panel_navigation {
-            flex: 1
+    // ------------------------------------------------------------------
+    // Print
+    // ------------------------------------------------------------------
+    @include media-only(print) {
+        padding: 0 0 map-get($spacers, 2) !important; // The @page margin will be used instead.
+        margin-bottom: 1rem;
+
+        &, .o_facet_value {
+            font-weight: bold;
         }
 
-        .o_control_panel_actions {
-            min-width: MIN(500px, 33%);
+        .o_control_panel_main {
+            align-items: center !important;
         }
-    }
 
-    @include media-breakpoint-up(xl) {
-        .o_control_panel_actions {
-            min-width: MIN(600px, 33%);
+        .o_searchview_facet_label > i {
+            font-size: $font-size-sm !important;
         }
-    }
 
-    .o_cp_switch_buttons {
-        .btn, .btn:focus {
-            // Boostrap plays around with the z-index of buttons, but this is not needed here
-            // It was causing issues with the hotkey overlay
-            z-index: 0;
+        .o_facet_value {
+            padding-right: map-get($spacers, 2);
+        }
+
+        .o_breadcrumb {
+            flex-direction: row !important;
+            align-items: start;
+            font-family: $o-font-family-monospace;
+
+            a {
+                font-weight: bold !important;
+                color: inherit;
+            }
+
+            .btn.btn-light {
+                border: 0;
+                padding-right: 0 !important;
+                background: transparent;
+                color: inherit;
+            }
+        }
+
+        .o_back_button a, .o_last_breadcrumb_item {
+            font-weight: bold !important;
+            font-size: $font-size-base !important;
+            padding-left: $breadcrumb-item-padding-x;
+        }
+
+        .o_back_button a::after {
+            float: right;
+            padding-left: $breadcrumb-item-padding-x;
+            color: $text-muted;
+            content: var(--breadcrumb-divider, "/");
+        }
+
+        .o_pager_counter > span:nth-child(2) {
+            width: 1em;
+            display: inline-block;
+            text-align: center;
         }
     }
 }
@@ -94,11 +156,5 @@
 @include media-breakpoint-down(md) {
     .o_rtl .o_control_panel .o_back_button:before {
         transform: rotate(180deg);
-    }
-}
-
-@media print {
-    .o_control_panel {
-        display: none;
     }
 }

--- a/addons/web/static/src/search/control_panel/control_panel.variables_print.scss
+++ b/addons/web/static/src/search/control_panel/control_panel.variables_print.scss
@@ -1,0 +1,2 @@
+
+$o-control-panel-border-bottom: 1px solid $o-border-color !default;

--- a/addons/web/static/src/search/control_panel/control_panel.xml
+++ b/addons/web/static/src/search/control_panel/control_panel.xml
@@ -39,7 +39,7 @@
                         </div>
                     </div>
                     <t t-if="env.config.noBreadcrumbs">
-                        <section class="o_control_panel_breadcrumbs_actions d-contents">
+                        <section class="o_control_panel_breadcrumbs_actions d-contents d-print-none">
                             <t t-slot="control-panel-additional-actions"/>
                             <t t-slot="control-panel-status-indicator" />
                         </section>
@@ -70,7 +70,7 @@
                         <i class="fa fa-sliders" />
                     </button>
                     <t t-if="env.config.viewSwitcherEntries?.length > 1">
-                        <div t-if="env.isSmall" class="o_cp_switch_buttons btn-group">
+                        <div t-if="env.isSmall" class="o_cp_switch_buttons btn-group d-print-none">
                             <Dropdown>
                                 <button class="btn btn-secondary o-dropdown-caret">
                                     <t t-set="activeView" t-value="env.config.viewSwitcherEntries.find((view) => view.active)"/>
@@ -153,7 +153,7 @@
         <div t-if="collapsedBreadcrumbs.length || visiblePathBreadcrumbs.length" class="o_breadcrumb d-flex flex-row flex-md-column align-self-stretch justify-content-between min-w-0">
             <t t-if="env.isSmall">
                 <t t-set="previousBreadcrumb" t-value="visiblePathBreadcrumbs.slice(-1)"/>
-                <button class="o_back_button btn btn-link px-1" t-on-click.prevent="() => this.onBreadcrumbClicked(previousBreadcrumb.jsId)">
+                <button class="o_back_button btn btn-link d-print-none px-1" t-on-click.prevent="() => this.onBreadcrumbClicked(previousBreadcrumb.jsId)">
                     <i class="oi oi-fw oi-arrow-left"/>
                 </button>
             </t>
@@ -199,7 +199,7 @@
     </t>
 
     <t t-name="web.Breadcrumb.Actions">
-        <div class="o_control_panel_breadcrumbs_actions d-inline-flex">
+        <div class="o_control_panel_breadcrumbs_actions d-inline-flex d-print-none">
             <t t-slot="control-panel-additional-actions"/>
         </div>
     </t>

--- a/addons/web/static/src/search/search_bar/search_bar.xml
+++ b/addons/web/static/src/search/search_bar/search_bar.xml
@@ -40,7 +40,7 @@
                         <em t-if="!facetValue_first" class="o_facet_values_sep small fw-bold mx-1 opacity-50" t-esc="facet.separator"/>
                         <small class="o_facet_value" t-esc="facetValue"/>
                     </t>
-                    <button class="o_facet_remove oi oi-close btn btn-link py-0 px-2 text-danger"
+                    <button class="o_facet_remove oi oi-close btn btn-link py-0 px-2 text-danger d-print-none"
                         role="button"
                         aria-label="Remove"
                         title="Remove"

--- a/addons/web/static/src/search/search_panel/search_panel.xml
+++ b/addons/web/static/src/search/search_panel/search_panel.xml
@@ -12,7 +12,7 @@
 </t>
 
 <t t-name="web.SearchPanel.Sidebar">
-    <div class="bg-view h-100 o_search_panel_sidebar cursor-pointer" t-on-click="toggleSidebar">
+    <div class="bg-view h-100 o_search_panel_sidebar cursor-pointer d-print-none" t-on-click="toggleSidebar">
         <t t-set="categories" t-value="getCategorySelection()" />
         <t t-set="filters" t-value="getFilterSelection()" />
         <div class="d-flex">

--- a/addons/web/static/src/views/calendar/calendar_controller.scss
+++ b/addons/web/static/src/views/calendar/calendar_controller.scss
@@ -109,3 +109,24 @@ $o-cw-filter-avatar-size: 20px;
         display: none;
     }
 }
+
+//  Print
+@include media-only(print) {
+    html:has(.o_action_manager .o_calendar_view.o_view_controller.o_action) {
+        @extend %o-html-layout-fill;
+
+        .o_calendar_renderer {
+            .fc-theme-standard .fc-scrollgrid {
+                border-top: 0;
+            }
+
+            .o_actionswiper, .o_actionswiper_overflow_container, .o_actionswiper_target_container, .o_calendar_widget, .fc .fc-daygrid-body, .fc-daygrid-body, .fc-scrollgrid-sync-table {
+                height: 100% !important;
+            }
+
+            .fc-col-header, .fc-daygrid-body, .fc-scrollgrid-sync-table {
+                width: 100% !important;
+            }
+        }
+    }
+}

--- a/addons/web/static/src/views/calendar/calendar_controller.xml
+++ b/addons/web/static/src/views/calendar/calendar_controller.xml
@@ -17,8 +17,8 @@
                     <t t-component="searchBarToggler.component" t-props="searchBarToggler.props"/>
                 </t>
                 <div class="o_calendar_container d-grid h-100 bg-view">
-                    <div class="o_calendar_header d-flex align-items-center gap-1 px-3 pe-md-1 py-2 border-bottom">
-                        <div t-if="!env.isSmall" class="o_calendar_navigation_buttons btn-group">
+                    <div class="o_calendar_header d-flex align-items-center gap-1 px-3 pe-md-1 py-2 px-print-0 pt-print-0 border-bottom">
+                        <div t-if="!env.isSmall" class="o_calendar_navigation_buttons btn-group d-print-none">
                             <button
                                 class="o_calendar_button_prev btn btn-secondary d-none d-md-block"
                                 title="Previous"
@@ -32,15 +32,15 @@
                                 t-on-click.stop="() => this.setDate('next')"
                             ><i class="oi oi-arrow-right"/></button>
                         </div>
-                        <ViewScaleSelector scales="scales" currentScale="model.scale" isWeekendVisible="state.isWeekendVisible" setScale.bind="setScale" toggleWeekendVisibility.bind="toggleWeekendVisibility" dropdownClass="'order-3 order-lg-0'"/>
+                        <ViewScaleSelector scales="scales" currentScale="model.scale" isWeekendVisible="state.isWeekendVisible" setScale.bind="setScale" toggleWeekendVisibility.bind="toggleWeekendVisibility" dropdownClass="'d-print-none order-3 order-lg-0'"/>
                         <button
-                            class="btn btn-secondary o_calendar_button_today order-2 order-lg-0 ms-auto ms-lg-0"
+                            class="btn btn-secondary o_calendar_button_today d-print-none order-2 order-lg-0 ms-auto ms-lg-0"
                             t-att-class="env.isSmall ? 'btn-sm btn-light' : 'btn-secondary'"
                             t-on-click.stop="() => this.setDate('today')"
                         >   <span t-if="env.isSmall" class="position-relative pt-1"><t t-esc="today"/><i class="fa fa-calendar-o position-absolute top-50 start-50 translate-middle fs-1"></i></span>
                             <t t-else="">Today</t>
                         </button>
-                        <h5 class="d-inline-flex ms-lg-2 mb-0">
+                        <h5 class="d-inline-flex ps-lg-2 ps-print-0 mb-0">
                             <t t-if="model.meta.scale === 'year'">
                                 <t t-esc="currentYear"/>
                             </t>
@@ -55,13 +55,13 @@
                             </t>
                         </h5>
                     </div>
-                    <div class="o_sidebar_toggler d-none d-md-flex align-items-center border-bottom pe-3">
+                    <div class="o_sidebar_toggler d-none d-md-flex d-print-none align-items-center border-bottom pe-3">
                         <button class="btn btn-light oi oi-panel-right collapsed ms-2 lh-base" t-on-click="toggleSideBar"/>
                     </div>
                     <MobileFilterPanel t-if="env.isSmall" t-props="mobileFilterPanelProps" />
                     <div class="o_calendar_wrapper d-flex overflow-hidden">
                         <t t-if="showCalendar" t-component="props.Renderer" t-props="rendererProps"/>
-                        <div t-if="showSideBar" class="o_calendar_sidebar_container position-relative w-100 w-md-auto bg-view overflow-x-hidden overflow-y-auto">
+                        <div t-if="showSideBar" class="o_calendar_sidebar_container d-print-none position-relative w-100 w-md-auto bg-view overflow-x-hidden overflow-y-auto">
                             <div class="o_calendar_sidebar">
                                 <DatePicker t-if="!env.isSmall" t-props="datePickerProps" />
                                 <FilterPanel t-props="filterPanelProps" />

--- a/addons/web/static/src/views/calendar/calendar_renderer.scss
+++ b/addons/web/static/src/views/calendar/calendar_renderer.scss
@@ -280,8 +280,17 @@
 
             // Row containing "all day" events
             .fc-timegrid-divider.fc-cell-shaded {
+                position: relative;
                 padding: 0;
-                box-shadow: 0 3px 12px 3px rgba(0, 0, 0, 0.16);
+
+                @include media-only(screen) {
+                    &:after {
+                        @include o-position-absolute($border-width, 0, -15px, 0);
+                        background: linear-gradient(0deg, rgba($o-shadow-color, 0), rgba($o-shadow-color, 0.16));
+                        pointer-events: none;
+                        content: "";
+                    }
+                }
             }
 
             @include media-breakpoint-down(md) {

--- a/addons/web/static/src/views/calendar/mobile_filter_panel/calendar_mobile_filter_panel.xml
+++ b/addons/web/static/src/views/calendar/mobile_filter_panel/calendar_mobile_filter_panel.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="web.CalendarMobileFilterPanel">
-        <div class="o_other_calendar_panel d-flex align-items-center" t-on-click="props.toggleSideBar">
+        <div class="o_other_calendar_panel d-flex align-items-center d-print-none" t-on-click="props.toggleSideBar">
             <div class="o_filter me-auto d-flex overflow-auto">
                 <t t-foreach="props.model.filterSections" t-as="section" t-key="section.fieldName">
                     <t t-if="section.filters.length gt 0">

--- a/addons/web/static/src/views/fields/badge/badge_field.scss
+++ b/addons/web/static/src/views/fields/badge/badge_field.scss
@@ -1,7 +1,7 @@
 // TODO: remove second selector when we remove legacy badge field
 .o_field_badge span, span.o_field_badge {
     border: 0;
-    font-size: 12px;
+    font-size: 0.85em;
     user-select: none;
     background-color: $o-gray-300;
     font-weight: 500;

--- a/addons/web/static/src/views/form/button_box/button_box.xml
+++ b/addons/web/static/src/views/form/button_box/button_box.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
 <t t-name="web.Form.ButtonBox" >
-    <div class="o-form-buttonbox position-relative d-flex w-md-auto" t-attf-class="{{ isFull ? 'o_full w-100' : 'o_not_full'}} {{this.props.class}}">
+    <div class="o-form-buttonbox d-print-none position-relative d-flex w-md-auto" t-attf-class="{{ isFull ? 'o_full w-100' : 'o_not_full'}} {{this.props.class}}">
         <t t-slot="{{ button_value }}" t-foreach="visibleButtons" t-as="button" t-key="button_value"/>
         <div t-if="additionalButtons.length" class="oe_stat_button btn position-relative p-0 border-0">
             <Dropdown position="'bottom-end'" menuClass="'o-form-buttonbox o_dropdown_more p-0 border-0'">

--- a/addons/web/static/src/views/form/form_compiler.js
+++ b/addons/web/static/src/views/form/form_compiler.js
@@ -212,7 +212,7 @@ export class FormCompiler extends ViewCompiler {
     compileForm(el, params) {
         const sheetNode = el.querySelector("sheet");
         const displayClasses = sheetNode
-            ? `d-flex {{ __comp__.uiService.size < ${SIZES.XXL} ? "flex-column" : "flex-nowrap h-100" }}`
+            ? `d-flex d-print-block {{ __comp__.uiService.size < ${SIZES.XXL} ? "flex-column" : "flex-nowrap h-100" }}`
             : "d-block";
         const stateClasses =
             "{{ __comp__.props.record.dirty ? 'o_form_dirty' : !__comp__.props.record.isNew ? 'o_form_saved' : '' }}";

--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -238,7 +238,9 @@
 
     // Sheet BG
     .o_form_sheet_bg {
-        --formView-sheetBg-padding-x: #{map-get($spacers, 3)};
+        @include media-only(screen) {
+            --formView-sheetBg-padding-x: #{map-get($spacers, 3)};
+        }
 
         padding-top: map-get($spacers, 2);
         padding-left: var(--formView-sheetBg-padding-x);
@@ -537,10 +539,20 @@
                     // Full width on first x2many or on second x2many if first is invisible
                     &:not(.o_group), &.o_invisible_modifier {
                         .o_field_x2many.o_field_x2many_list .o_list_renderer {
-                            --ListRenderer-margin-x: var(--notebook-margin-x);
-                            --ListRenderer-table-padding-x: var(--notebook-padding-x);
+                            @include media-only(screen) {
+                                --ListRenderer-margin-x: var(--notebook-margin-x);
+                                --ListRenderer-table-padding-x: var(--notebook-padding-x);
 
-                            margin-top: -$o-horizontal-padding;
+                                margin-top: -$o-horizontal-padding;
+                            }
+
+                            @include media-only(print) {
+                                --ListRenderer-margin-x: 0;
+                                --ListRenderer-table-padding-x: var(--notebook-padding-x);
+
+                                margin-top: -$o-horizontal-padding * 0.5;
+                            }
+
 
                             // use original padding-left for handle cell in editable list
                             tr > :first-child.o_handle_cell {

--- a/addons/web/static/src/views/graph/graph_renderer.xml
+++ b/addons/web/static/src/views/graph/graph_renderer.xml
@@ -31,7 +31,7 @@
 
     <t t-name="web.GraphRenderer">
         <div t-att-class="'o_graph_renderer o_renderer h-100 d-flex flex-column border-top ' + props.class" t-ref="root">
-            <div class="d-flex gap-1 flex-shrink-0 mt-2 mx-3 mb-3 overflow-x-auto">
+            <div class="d-flex d-print-none gap-1 flex-shrink-0 mt-2 mx-3 mb-3 overflow-x-auto">
                 <t t-call="{{ props.buttonTemplate }}"/>
             </div>
             <div t-if="model.hasData()" class="o_graph_canvas_container flex-grow-1 position-relative px-3 pb-3" t-ref="container">

--- a/addons/web/static/src/views/kanban/kanban.print_variables.scss
+++ b/addons/web/static/src/views/kanban/kanban.print_variables.scss
@@ -1,0 +1,7 @@
+$o-kanban-background: #FFFFFF !default;
+$o-kanban-default-record-width: 16rem !default;
+$o-kanban-small-record-width: $o-kanban-default-record-width !default;
+
+$o-kanban-record-margin: $o-horizontal-padding / 4 !default;
+$o-kanban-group-padding: $o-horizontal-padding / 2 !default;
+

--- a/addons/web/static/src/views/kanban/kanban_column_quick_create.xml
+++ b/addons/web/static/src/views/kanban/kanban_column_quick_create.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="web.KanbanColumnQuickCreate">
-        <div class="o_column_quick_create flex-shrink-0 flex-grow-1 flex-md-grow-0" t-ref="root">
+        <div class="o_column_quick_create d-print-none flex-shrink-0 flex-grow-1 flex-md-grow-0" t-ref="root">
             <div t-if="props.folded" class="o_quick_create_folded position-sticky z-1 my-3 text-nowrap" t-on-click="unfold">
                 <button class="o_kanban_add_column btn btn-light w-100" aria-label="Add column" data-tooltip="Add column">
                     <i class="fa fa-plus me-2" role="img"/><t t-out="relatedFieldName"/>

--- a/addons/web/static/src/views/kanban/kanban_controller.scss
+++ b/addons/web/static/src/views/kanban/kanban_controller.scss
@@ -1,7 +1,9 @@
 // ------- Kanban View -------
 .o_kanban_view {
     @include media-breakpoint-down(md) {
-        --ControlPanel-border-bottom: none;
+        @include media-only(screen) {
+            --ControlPanel-border-bottom: none;
+        }
 
         &.o_field_x2many_kanban .o_kanban_ghost {
             display: none;
@@ -60,8 +62,16 @@
     padding: var(--Kanban-padding);
     gap: var(--Kanban-gap);
 
-    @include media-breakpoint-down(md) {
-        --KanbanRecord-padding-h: #{$o-kanban-inside-hgutter * 2};
+    @include media-only(print) {
+        --Kanban-gap: #{map-get($spacers, 2)};
+        --KanbanGroup-padding-h: 0;
+        --KanbanRecord-margin-h: 0;
+    }
+
+    @include media-only(print) {
+        @include media-breakpoint-down(md) {
+            --KanbanRecord-padding-h: #{$o-kanban-inside-hgutter * 2};
+        }
     }
 
     // New Kanban
@@ -79,6 +89,10 @@
         overflow-wrap: break-word;
         word-wrap: break-word;
         word-break: break-word;
+
+        @include media-only(print) {
+            font-size: 0.8rem;
+        }
 
         &:not(.o_kanban_ghost) {
             padding: var(--KanbanRecord-padding-v) var(--KanbanRecord-padding-h);

--- a/addons/web/static/src/views/kanban/kanban_header.xml
+++ b/addons/web/static/src/views/kanban/kanban_header.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="web.KanbanHeader">
-        <div class="o_kanban_header position-sticky top-0 z-1" t-ref="root" t-attf-class="{{ !env.isSmall and group.isFolded ? 'pt-2' : 'py-2' }}">
+        <div class="o_kanban_header position-sticky top-0 z-1" t-ref="root" t-attf-class="{{ !env.isSmall and group.isFolded ? 'd-print-none pt-2' : 'py-2 pt-print-0' }}">
             <div class="o_kanban_header_title position-relative d-flex lh-lg">
                 <div t-if="group.isFolded" class="o_column_title d-flex align-items-center pt-1 fs-4 lh-1 text-nowrap opacity-50 opacity-100-hover flex-grow-1"
                      t-on-mouseenter="onTitleMouseEnter" t-on-mouseleave="onTitleMouseLeave">
@@ -15,7 +15,7 @@
                       t-on-mouseenter="onTitleMouseEnter" t-on-mouseleave="onTitleMouseLeave"
                     />
                 <t t-if="env.isSmall or !group.isFolded">
-                    <div class="o_kanban_config">
+                    <div class="o_kanban_config d-print-none">
                         <Dropdown menuClass="'o-dropdown--kanban-config-menu'" position="'bottom-end'">
                             <button class="btn px-2">
                                 <i class="fa fa-gear opacity-50 opacity-100-hover" role="img" aria-label="Settings" title="Settings"/>
@@ -29,7 +29,7 @@
                             </t>
                         </Dropdown>
                     </div>
-                    <button t-if="canQuickCreate()" class="o_kanban_quick_add btn pe-2 me-n2" t-on-click="() => this.quickCreate()">
+                    <button t-if="canQuickCreate()" class="o_kanban_quick_add d-print-none btn pe-2 me-n2" t-on-click="() => this.quickCreate()">
                         <i class="fa fa-plus opacity-75 opacity-100-hover" role="img" aria-label="Quick add" title="Quick add"/>
                     </button>
                 </t>

--- a/addons/web/static/src/views/list/list_renderer.scss
+++ b/addons/web/static/src/views/list/list_renderer.scss
@@ -12,13 +12,19 @@
     margin-right: var(--ListRenderer-margin-x, unset);
 
     // sticky header on desktop
-    @include media-breakpoint-up(md) {
-        height: 100%;
+    @include media-only(screen) {
+        @include media-breakpoint-up(md) {
+            height: 100%;
 
-        .o_list_table thead {
-            @include o-position-sticky(0);
-            z-index: var(--sticky-header-zindex);
+            .o_list_table thead {
+                @include o-position-sticky(0);
+                z-index: var(--sticky-header-zindex);
+            }
         }
+    }
+
+    @include media-only(print) {
+        width: 100% !important;
     }
 
     th, td {
@@ -29,6 +35,12 @@
     .o_list_view & {
         --ListRenderer-thead-padding-y: #{$table-cell-padding-y-sm};
         --ListRenderer-table-padding-x: #{$o-horizontal-padding};
+
+        @include media-only(print) {
+            --ListRenderer-table-padding-x: 0;
+
+            --Tag-font-size: #{$font-size-sm};
+        }
     }
 
     .o_list_table {
@@ -39,6 +51,22 @@
         // for sale order/invoice lines of type section.
         border-collapse: collapse;
         font-variant-numeric: tabular-nums;
+
+        @include media-only(print) {
+            width: 100% !important;
+            border-collapse: separate;
+            border-spacing: 0;
+
+            &.o_list_table_grouped .o_group_header {
+                --table-bg: #{$gray-200};
+                color: color-contrast($gray-200);
+            }
+
+            &.o_list_table_ungrouped {
+                --table-striped-bg: #{$gray-100};
+                --table-striped-color: #{color-contrast($gray-100)};
+            }
+        }
 
         > thead, > tbody, > tfoot {
             > tr > :first-child {
@@ -57,6 +85,10 @@
                 padding-top: var(--ListRenderer-thead-padding-y);
                 background-color: transparent;
                 color: $headings-color;
+
+                @include media-only(print) {
+                    font-weight: $font-weight-bold;
+                }
             }
 
             .o_list_number_th {
@@ -146,6 +178,12 @@
             }
         }
 
+        .o_handle_cell {
+            @include media-only(print) {
+                display: none;
+            }
+        }
+
         .o_column_sortable:not(.o_handle_cell) {
             user-select: none;  // Prevent unwanted selection while sorting
         }
@@ -153,6 +191,10 @@
         .o_list_record_selector {
             width: 40px;  // Don't force to keep o_group_name width dynamic
             vertical-align: middle;
+
+            @include media-only(print) {
+                width: 1.5rem !important;
+            }
         }
 
         .o_list_record_remove, .o_handle_cell, .o_list_record_open_form_view {
@@ -405,37 +447,51 @@
         }
     }
 
-    /**
-    Because of border-collapse, border top and border bottom are 'merged'.
+    @include media-only(screen) {
+        /**
+        Because of border-collapse, border top and border bottom are 'merged'.
 
-    * cell border overlaps row border
-    * when there is a border collapse the first cell (e.g. A1) take over the following cell (e.g. B1 or A2)
-    ┌──┬──┐
-    │A1│B1│
-    ├──┼──┤
-    │A2│B2│
-    └──┴──┘
+        * cell border overlaps row border
+        * when there is a border collapse the first cell (e.g. A1) take over the following cell (e.g. B1 or A2)
+        ┌──┬──┐
+        │A1│B1│
+        ├──┼──┤
+        │A2│B2│
+        └──┴──┘
 
-    So we apply some rules to have the style wanted:
-    */
-    // 1. we set the global separator (gray line) of the table on the row (bottom) and not on the cell (bottom)
-    .o_data_row {
-        border-bottom-width: 1px;
+        So we apply some rules to have the style wanted:
+        */
+        // 1. we set the global separator (gray line) of the table on the row (bottom) and not on the cell (bottom)
+        .o_data_row {
+            border-bottom-width: 1px;
 
-        &:not(.o_selected_row):not(.o_data_row_selected):focus-within > * {
-            $-focus-bg: rgba(var(--#{$variable-prefix}emphasis-color-rgb), #{$table-hover-bg-factor * 2});
+            &:not(.o_selected_row):not(.o_data_row_selected):focus-within > * {
+                $-focus-bg: rgba(var(--#{$variable-prefix}emphasis-color-rgb), #{$table-hover-bg-factor * 2});
 
-            --#{$variable-prefix}table-accent-bg: #{$-focus-bg};
+                --#{$variable-prefix}table-accent-bg: #{$-focus-bg};
+            }
+        }
+
+        // 2. we remove the bottom border (added by BS5) on all cells (this force to show the top border of selected cell)
+        .o_data_row > .o_data_cell {
+            border-bottom-width: 0;
+        }
+        // 3. we add only a bottom border to selected cells (this force to show the bottom border of the selected cell)
+        .o_data_row.o_data_row_selected > .o_data_cell {
+            border-bottom-width: 1px;
         }
     }
 
-    // 2. we remove the bottom border (added by BS5) on all cells (this force to show the top border of selected cell)
-    .o_data_row > .o_data_cell {
-        border-bottom-width: 0;
-    }
-    // 3. we add only a bottom border to selected cells (this force to show the bottom border of the selected cell)
-    .o_data_row.o_data_row_selected > .o_data_cell {
-        border-bottom-width: 1px;
+    @include media-only(print) {
+        .o_data_cell {
+            [type="action"] {
+                display: none;
+            }
+
+            &.w-print-0.p-print-0 {
+                visibility: hidden;
+            }
+        }
     }
 
     .o_data_row.o_dragged {

--- a/addons/web/static/src/views/list/list_renderer.xml
+++ b/addons/web/static/src/views/list/list_renderer.xml
@@ -20,7 +20,7 @@
                         <t t-foreach="columns" t-as="column" t-key="column.id">
                             <th t-if="column.type === 'field'"
                                 t-att-data-name="column.name"
-                                t-att-class="getColumnClass(column) + ' opacity-trigger-hover'"
+                                t-att-class="getColumnClass(column) + ' opacity-trigger-hover w-print-auto'"
                                 t-on-pointerup="onColumnTitleMouseUp"
                                 t-on-click="() => this.onClickSortColumn(column)"
                                 t-on-keydown="(ev) => this.onCellKeydown(ev)"
@@ -41,11 +41,11 @@
                                           t-on-pointerdown.stop.prevent="this.columnWidths.onStartResize"/>
                                 </t>
                             </th>
-                            <th t-else="" t-on-keydown="(ev) => this.onCellKeydown(ev)" t-att-class="{o_list_button: column.type === 'button_group'}"/>
+                            <th t-else="" t-on-keydown="(ev) => this.onCellKeydown(ev)" t-att-class="{'o_list_button w-print-0 p-print-0': column.type === 'button_group'}"/>
                         </t>
-                        <th t-if="hasOpenFormViewColumn" t-on-keydown="(ev) => this.onCellKeydown(ev)" class="o_list_open_form_view"/>
-                        <th t-if="hasActionsColumn" t-on-keydown="(ev) => this.onCellKeydown(ev)" class="o_list_controller o_list_actions_header position-sticky end-0">
-                            <div t-if="displayOptionalFields" class="o_optional_columns_dropdown text-center border-top-0">
+                        <th t-if="hasOpenFormViewColumn" t-on-keydown="(ev) => this.onCellKeydown(ev)" class="o_list_open_form_view w-print-0 p-print-0"/>
+                        <th t-if="hasActionsColumn" t-on-keydown="(ev) => this.onCellKeydown(ev)" class="o_list_controller o_list_actions_header w-print-0 p-print-0 position-sticky end-0">
+                            <div t-if="displayOptionalFields" class="o_optional_columns_dropdown d-print-none text-center border-top-0">
                                 <Dropdown position="'bottom-end'">
                                     <button class="btn p-0" tabindex="-1">
                                         <i class="o_optional_columns_dropdown_toggle oi oi-fw oi-settings-adjust"/>
@@ -88,10 +88,11 @@
                             <td t-if="aggregate" class="o_list_number" >
                                 <span t-esc="aggregate.value" t-att-data-tooltip="aggregate.help"/>
                             </td>
+                            <td t-elif="column.type != 'field'" class="w-print-auto"/>
                             <td t-else=""/>
                         </t>
-                        <td t-if="props.onOpenFormView"/>
-                        <td t-if="displayOptionalFields or activeActions.onDelete" />
+                        <td t-if="props.onOpenFormView" class="w-print-0 p-print-0"/>
+                        <td t-if="displayOptionalFields or activeActions.onDelete" class="w-print-0 p-print-0" />
                     </tr>
                 </tfoot>
             </table>
@@ -246,7 +247,7 @@
                     </td>
                 </t>
                 <t t-if="column.type === 'button_group'">
-                    <td t-on-keydown="(ev) => this.onCellKeydown(ev, group, record)" class="o_data_cell cursor-pointer" t-att-class="getCellClass(column, record)" t-on-click="(ev) => this.onButtonCellClicked(record, column, ev)" tabindex="-1">
+                    <td t-on-keydown="(ev) => this.onCellKeydown(ev, group, record)" class="o_data_cell w-print-0 p-print-0 cursor-pointer" t-att-class="getCellClass(column, record)" t-on-click="(ev) => this.onButtonCellClicked(record, column, ev)" tabindex="-1">
                         <t t-foreach="column.buttons" t-as="button" t-key="button.id">
                             <ViewButton t-if="!evalInvisible(button.invisible, record)"
                                 className="button.className"
@@ -271,7 +272,7 @@
             </t>
 
             <t t-if="props.onOpenFormView">
-                <td class="o_list_record_open_form_view text-center"
+                <td class="o_list_record_open_form_view w-print-0 p-print-0 text-center"
                     t-on-keydown="(ev) => this.onCellKeydown(ev, group, record)"
                     t-on-click.stop="() => isX2Many and record.isNew ? this.displaySaveNotification() : props.onOpenFormView(record)"
                     tabindex="-1"
@@ -288,12 +289,12 @@
             <t t-set="hasX2ManyAction" t-value="isX2Many and (useUnlink ? activeActions.unlink : activeActions.delete)" />
             <t t-if="displayOptionalFields or hasX2ManyAction">
                 <t t-if="hasX2ManyAction">
-                    <td class="o_list_record_remove text-center"
+                    <td class="o_list_record_remove w-print-0 p-print-0 text-center"
                         t-on-keydown="(ev) => this.onCellKeydown(ev, group, record)"
                         t-on-click.stop="() => this.onDeleteRecord(record)"
                         tabindex="-1"
                     >
-                        <button class="fa"
+                        <button class="fa d-print-none"
                             t-att-class="{
                                 'fa-trash-o': !useUnlink and activeActions.delete,
                                 'fa-times': useUnlink and activeActions.unlink,
@@ -304,7 +305,7 @@
                         />
                     </td>
                 </t>
-                <td t-else="" tabindex="-1" />
+                <td t-else="" tabindex="-1" class="w-print-0 p-print-0"/>
             </t>
         </tr>
     </t>

--- a/addons/web/static/src/views/pivot/pivot_controller.xml
+++ b/addons/web/static/src/views/pivot/pivot_controller.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="web.PivotView.Buttons">
-        <div class="o_pivot_buttons d-flex gap-1 mt-2 mx-3 mb-3">
+        <div class="o_pivot_buttons d-flex d-print-none gap-1 mt-2 mx-3 mb-3">
             <div class="btn-group" role="toolbar" aria-label="Main actions">
                 <ReportViewMeasures
                     measures="model.metaData.measures"

--- a/addons/web/static/src/views/pivot/pivot_view.scss
+++ b/addons/web/static/src/views/pivot/pivot_view.scss
@@ -35,6 +35,12 @@
     .o_cp_bottom_left {
         display: block;
     }
+
+    @include media-only(print) {
+        .bg-100, .text-bg-100 {
+            --background-color: transparent;
+        }
+    }
 }
 
 // ------- Sample mode -------

--- a/addons/web/static/src/webclient/navbar/navbar.xml
+++ b/addons/web/static/src/webclient/navbar/navbar.xml
@@ -4,7 +4,7 @@
   <t t-name="web.NavBar">
     <header class="o_navbar" t-ref="root">
       <nav
-        class="o_main_navbar"
+        class="o_main_navbar d-print-none"
         data-command-category="disabled"
       >
         <!-- Apps Menu -->

--- a/addons/web/static/src/webclient/webclient.scss
+++ b/addons/web/static/src/webclient/webclient.scss
@@ -260,3 +260,14 @@ select {
   border-radius: 0;
   font-size: 1em; // Override 75% of .label
 }
+
+//------------------------------------------------------------------------------
+// Print Style
+//------------------------------------------------------------------------------
+
+@include media-only(print) {
+  html, body {
+    print-color-adjust: exact;
+    -webkit-print-color-adjust: exact;
+  }
+}

--- a/addons/web/static/src/webclient/webclient_layout.scss
+++ b/addons/web/static/src/webclient/webclient_layout.scss
@@ -1,7 +1,8 @@
 // ------------------------------------------------------------------
 // Base layout rules, use the 'webclient.scss' file for styling
 // ------------------------------------------------------------------
-html {
+
+%o-html-layout-fill {
   height: 100%;
 
   .o_web_client {
@@ -84,15 +85,23 @@ html {
   }
 }
 
-@media print {
-  html .o_web_client {
-    .o_main_navbar {
-      display: none;
+@include media-only(screen) {
+    html {
+        @extend %o-html-layout-fill;
     }
-    .o_content {
-      position: static;
-      overflow: visible;
-      height: auto;
+}
+
+//------------------------------------------------------------------------------
+// Print Layout
+//------------------------------------------------------------------------------
+
+@include media-only(print) {
+    .o_web_client {
+        max-width: 100%;
     }
-  }
+
+    @page {
+        margin: 0.5cm;
+        size: a4 auto;
+    }
 }

--- a/addons/web/static/tests/views/form/form_compiler.test.js
+++ b/addons/web/static/tests/views/form/form_compiler.test.js
@@ -194,7 +194,7 @@ test("properly compile sheet", () => {
     `;
     const expected = /*xml*/ `
         <t t-translation="off">
-            <div class="o_form_renderer" t-att-class="__comp__.props.class" t-attf-class="{{__comp__.props.record.isInEdition ? 'o_form_editable' : 'o_form_readonly'}} d-flex {{ __comp__.uiService.size &lt; 6 ? &quot;flex-column&quot; : &quot;flex-nowrap h-100&quot; }} {{ __comp__.props.record.dirty ? 'o_form_dirty' : !__comp__.props.record.isNew ? 'o_form_saved' : '' }}" t-ref="compiled_view_root">
+            <div class="o_form_renderer" t-att-class="__comp__.props.class" t-attf-class="{{__comp__.props.record.isInEdition ? 'o_form_editable' : 'o_form_readonly'}} d-flex d-print-block {{ __comp__.uiService.size &lt; 6 ? &quot;flex-column&quot; : &quot;flex-nowrap h-100&quot; }} {{ __comp__.props.record.dirty ? 'o_form_dirty' : !__comp__.props.record.isNew ? 'o_form_saved' : '' }}" t-ref="compiled_view_root">
                 <div class="o_form_sheet_bg">
                     <div class="o_form_statusbar position-relative d-flex justify-content-between mb-0 mb-md-2 pb-2 pb-md-0"><StatusBarButtons/></div>
                     <div>someDiv</div>
@@ -223,7 +223,7 @@ test("properly compile buttonBox invisible in sheet", () => {
         <t t-translation="off">
             <div class="o_form_renderer"
                  t-att-class="__comp__.props.class"
-                 t-attf-class="{{__comp__.props.record.isInEdition ? 'o_form_editable' : 'o_form_readonly'}} d-flex {{ __comp__.uiService.size &lt; 6 ? &quot;flex-column&quot; : &quot;flex-nowrap h-100&quot; }} {{ __comp__.props.record.dirty ? 'o_form_dirty' : !__comp__.props.record.isNew ? 'o_form_saved' : '' }}"
+                 t-attf-class="{{__comp__.props.record.isInEdition ? 'o_form_editable' : 'o_form_readonly'}} d-flex d-print-block {{ __comp__.uiService.size &lt; 6 ? &quot;flex-column&quot; : &quot;flex-nowrap h-100&quot; }} {{ __comp__.props.record.dirty ? 'o_form_dirty' : !__comp__.props.record.isNew ? 'o_form_saved' : '' }}"
                  t-ref="compiled_view_root">
                 <div class="o_form_sheet_bg">
                     <div class="o_form_sheet position-relative">
@@ -371,7 +371,7 @@ test("properly compile empty ButtonBox", () => {
     `;
     const expected = /*xml*/ `
         <t t-translation="off">
-            <div class="o_form_renderer" t-att-class="__comp__.props.class" t-attf-class="{{__comp__.props.record.isInEdition ? 'o_form_editable' : 'o_form_readonly'}} d-flex {{ __comp__.uiService.size &lt; 6 ? &quot;flex-column&quot; : &quot;flex-nowrap h-100&quot; }} {{ __comp__.props.record.dirty ? 'o_form_dirty' : !__comp__.props.record.isNew ? 'o_form_saved' : '' }}" t-ref="compiled_view_root">
+            <div class="o_form_renderer" t-att-class="__comp__.props.class" t-attf-class="{{__comp__.props.record.isInEdition ? 'o_form_editable' : 'o_form_readonly'}} d-flex d-print-block {{ __comp__.uiService.size &lt; 6 ? &quot;flex-column&quot; : &quot;flex-nowrap h-100&quot; }} {{ __comp__.props.record.dirty ? 'o_form_dirty' : !__comp__.props.record.isNew ? 'o_form_saved' : '' }}" t-ref="compiled_view_root">
                 <div class="o_form_sheet_bg">
                     <div class="o_form_sheet position-relative">
                         <div class="oe_button_box" name="button_box">

--- a/addons/web/views/webclient_templates.xml
+++ b/addons/web/views/webclient_templates.xml
@@ -293,15 +293,17 @@
                         fetch(`/web/webclient/translations/${cache_hashes.translations}?lang=${user_context.lang}`);
                     }
                 </script>
+                <t t-call-assets="web.assets_web_print" media="print" t-js="false"/>
+
                 <t t-if="request.httprequest.cookies.get('color_scheme') == 'dark'">
-                    <t t-call-assets="web.assets_web_dark"/>
+                    <t t-call-assets="web.assets_web_dark" media="screen"/>
                 </t>
                 <t t-else="">
-                    <t t-call-assets="web.assets_web"/>
+                    <t t-call-assets="web.assets_web" media="screen"/>
                 </t>
-                <t t-call="web.conditional_assets_tests"/>
+                <t t-call="web.conditional_assets_tests" media="screen"/>
             </t>
-            <t t-set="head" t-value="head_web + (head or '')"/>
+            <t t-set="head" t-value="head_web + (head or '')" media="screen"/>
             <t t-set="body_classname" t-value="'o_web_client'"/>
         </t>
     </template>

--- a/addons/web_editor/static/src/xml/editor.xml
+++ b/addons/web_editor/static/src/xml/editor.xml
@@ -6,7 +6,7 @@
 
     <!-- Editor toolbar -->
     <t t-name="web_editor.toolbar">
-        <div id="toolbar" class="oe-toolbar oe-floating">
+        <div id="toolbar" class="oe-toolbar oe-floating d-print-none">
             <div t-if="props.showStyle" id="style" t-attf-class="btn-group {{ props.dropDirection }}">
                 <button type="button" class="btn dropdown-toggle"
                     data-bs-toggle="dropdown" data-bs-original-title="Text style" tabindex="-1" aria-expanded="false">


### PR DESCRIPTION
*: account,mail,onboarding,project,stock,web_editor

Provides the necessary adaptations to allow users to print the UI with predictable results.
Changes applied include:

- Restricting preexisting bundles to target "screen" media only and adding a new `web.assets_web_print` bundle specifically targeting "print."

- Enabling print utility classes generation for `padding` and `width` properties.

- Introduce `media-only($-media)` SCSS mixin. It aims to avoid the need for compiling "screen only" CSS code inside `@media` queries. An additional advantage is reducing the CSS footprint by compiling SCSS only when it matches the relevant media type.

Enterprise:
- https://github.com/odoo/enterprise/pull/65007

task-3617770



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
