### PR TITLE
[FIX] web_editor, mass_mailing: autosave image changes and snippet drops

### DIFF
--- a/addons/mass_mailing/static/src/js/snippets.editor.js
+++ b/addons/mass_mailing/static/src/js/snippets.editor.js
@@ -129,6 +129,8 @@ const MassMailingSnippetsMenu = snippetsEditor.SnippetsMenu.extend({
         if (!$oEditable.find('.oe_drop_zone.oe_insert:not(.oe_vertical):only-child').length) {
             $oEditable.attr('contenteditable', true);
         }
+        // Refocus again to save updates when calling `_onWysiwygBlur`
+        this.$editable.get(0).ownerDocument.defaultView.focus();
     },
     /**
      * @override

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -1366,6 +1366,8 @@ const Wysiwyg = Widget.extend({
             }
             this.odooEditor.unbreakableStepUnactive();
             this.odooEditor.historyStep();
+            // Refocus again to save updates when calling `_onWysiwygBlur`
+            params.node.ownerDocument.defaultView.focus();
         } else {
             return this.odooEditor.execCommand('insert', element);
         }


### PR DESCRIPTION
Issue:
======
Image and icons changes and dropped snippets are not autosaved, changes
are lost when you switch tab.

Steps to reproduce the issue:
=============================
For Image and icon:
- Go to email marketing
- Choose a template with an image
- Update the image and click on another tab directly (A/B tests for
  example)
- Go back to mail body tab, the changes are not saved

For dropped snippets:
- Go to email marketing
- Choose any template
- Click on another tab (A/B tests for example)
- Go back to meil body tab
- Add snippet click directly on another tab
- Go back to mail body tab , the changes are not saved

Origin of the issue:
====================
For Image and Icon:
When we open the image media dialog, `_onWysiwygBlur` is called which
means we lost the focus from the editable view. Old updates are saved
because we call `commitChanges` but the updates after the change of the
image are not since we lost the focus of the wysiwyg. Switching to another
tab will not trigger `blur` event again so we loose the changes. (same
flow for icon change).

For dropped snippets:
The first switch of tabs will trigger the blur event and will commit
changes. When we switch again to the mail body tab, the focus isn't
on the editable, we drop the snippet , still no focus on the editable
so no `blur` event is called and we loose the changes again.

We call `commitChanges` on `onWillUnmount` but we don't pass the
paremeters from `mass_mailing_html_field` to its parent class so we
loose the `urgent` flag which is responsible to save the data before
destroying the component. Passing just the args in `commitChanges` will
produce another issue about `Component is destroyed`. To have a minimal
change in stable we just refocus on the wysiwyg on the mentioned 2 cases
so the updates will be applied when blurring the `wysiwyg`

Solution:
=========
Put the focus again in the editor's window.