### PR TITLE
[FIX] web_editor: fix error when changing steps snippet column width

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -4816,8 +4816,9 @@ registry.sizing = SnippetOptionWidget.extend({
                         // Find the first element behind the overlay.
                         const sameCoordinatesEls = self.ownerDocument
                             .elementsFromPoint(ev.pageX, ev.pageY);
+                        // Check toBeClickEl has native JS `click` function
                         const toBeClickedEl = sameCoordinatesEls
-                            .find(el => !el.closest("#oe_manipulators"));
+                            .find(el => !el.closest("#oe_manipulators") && typeof el.click === "function");
                         if (toBeClickedEl) {
                             toBeClickedEl.click();
                         }

--- a/addons/website/static/src/snippets/s_process_steps/001.scss
+++ b/addons/website/static/src/snippets/s_process_steps/001.scss
@@ -36,6 +36,7 @@
             width: calc(100% - #{$process-step-icon-size});
             left: calc(50% + #{$process-step-icon-size / 2});
             margin: $grid-gutter-width 0;
+            pointer-events: none;
 
             path {
                 stroke: $border-color;


### PR DESCRIPTION
Steps to Reproduce :
1. Drag and drop a steps snippet
2. Increase the length of any column, in such a way that connector line
between the columns in such a way that it overlay handle button.
3. Click on handle button
-> A trace-back error occurs

Description:
When the method is called, it filters out all the overlay elements and
finds the first element behind the overlay to apply the click function
on it.

The issue arises because the method filters out overlay elements and
selects the first underlying element to apply a click function on it.
However, when the selected element is an SVG or path, which do not
support native JavaScript click methods or events, this causes error.

This fix resolves the trace-back by filtering out elements that lack
native JavaScript click methods or event bindings before calling click.
This prevents the error, ensuring smooth interaction with overlay
elements.

task-3911780