### PR TITLE
[FIX] mail: chatter in chat window should scroll to recent

### DIFF
--- a/addons/mail/static/src/core/common/thread.js
+++ b/addons/mail/static/src/core/common/thread.js
@@ -120,13 +120,12 @@ export class Thread extends Component {
                     } else {
                         if (this.props.order === "desc") {
                             this.scrollableRef.el.scrollTop = 0;
-                            this.props.thread.scrollTop = 0;
                         } else {
                             this.scrollableRef.el.scrollTop =
                                 this.scrollableRef.el.scrollHeight -
                                 this.scrollableRef.el.clientHeight;
-                            this.props.thread.scrollTop = "bottom";
                         }
+                        this.props.thread.scrollTop = "bottom";
                     }
                     this.lastJumpPresent = this.props.jumpPresent;
                 }
@@ -275,10 +274,18 @@ export class Thread extends Component {
         });
         onWillDestroy(() => stopOnChange());
         const saveScroll = () => {
-            this.props.thread.scrollTop =
-                ref.el.scrollHeight - ref.el.scrollTop - ref.el.clientHeight < 30
-                    ? "bottom"
-                    : ref.el.scrollTop;
+            const isBottom =
+                this.props.order === "asc"
+                    ? ref.el.scrollHeight - ref.el.scrollTop - ref.el.clientHeight < 30
+                    : ref.el.scrollTop < 30;
+            if (isBottom) {
+                this.props.thread.scrollTop = "bottom";
+            } else {
+                this.props.thread.scrollTop =
+                    this.props.order === "asc"
+                        ? ref.el.scrollTop
+                        : ref.el.scrollHeight - ref.el.scrollTop - ref.el.clientHeight;
+            }
         };
         const setScroll = (value) => {
             ref.el.scrollTop = value;
@@ -310,10 +317,16 @@ export class Thread extends Component {
                 !this.env.messageHighlight?.highlightedMessageId &&
                 thread.scrollTop !== undefined
             ) {
-                const value =
-                    thread.scrollTop === "bottom"
-                        ? ref.el.scrollHeight - ref.el.clientHeight
-                        : thread.scrollTop;
+                let value;
+                if (thread.scrollTop === "bottom") {
+                    value =
+                        this.props.order === "asc" ? ref.el.scrollHeight - ref.el.clientHeight : 0;
+                } else {
+                    value =
+                        this.props.order === "asc"
+                            ? thread.scrollTop
+                            : ref.el.scrollHeight - thread.scrollTop - ref.el.clientHeight;
+                }
                 if (lastSetValue === undefined || Math.abs(lastSetValue - value) > 1) {
                     setScroll(value);
                 }
@@ -372,7 +385,7 @@ export class Thread extends Component {
         this.messageHighlight?.clearHighlight();
         await this.threadService.loadAround(this.props.thread);
         this.props.thread.loadNewer = false;
-        this.props.thread.scrollTop = this.props.order === "desc" ? 0 : "bottom";
+        this.props.thread.scrollTop = "bottom";
         this.state.showJumpPresent = false;
     }
 

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -282,13 +282,12 @@ export class Thread extends Record {
      * @type {ScrollPosition}
      */
     scrollPosition = new ScrollPosition();
-    /** @type {number|'bottom'} */
-    scrollTop = Record.attr("bottom", {
-        /** @this {import("models").Thread} */
-        compute() {
-            return this.type === "chatter" ? 0 : "bottom";
-        },
-    });
+    /**
+     * Stored scoll position of thread from top in ASC order.
+     *
+     * @type {number|'bottom'}
+     */
+    scrollTop = "bottom";
     showOnlyVideo = false;
     transientMessages = Record.many("Message");
     /** @type {'channel'|'chat'|'chatter'|'livechat'|'group'|'mailbox'} */

--- a/addons/mail/static/src/core/web/chatter.js
+++ b/addons/mail/static/src/core/web/chatter.js
@@ -131,11 +131,13 @@ export class Chatter extends Component {
                             return;
                         }
                     }
-                    Promise.all(files.map((file) => this.attachmentUploader.uploadFile(file))).then(() => {
-                        if (this.props.hasParentReloadOnAttachmentsChanged) {
-                            this.reloadParentView();
+                    Promise.all(files.map((file) => this.attachmentUploader.uploadFile(file))).then(
+                        () => {
+                            if (this.props.hasParentReloadOnAttachmentsChanged) {
+                                this.reloadParentView();
+                            }
                         }
-                    })
+                    );
                     this.state.isAttachmentBoxOpened = true;
                 }
             },
@@ -383,7 +385,7 @@ export class Chatter extends Component {
         }
         this.state.isAttachmentBoxOpened = true;
         this.rootRef.el.scrollTop = 0;
-        this.state.thread.scrollTop = 0;
+        this.state.thread.scrollTop = "bottom";
     }
 
     onClickAddAttachments() {
@@ -393,7 +395,7 @@ export class Chatter extends Component {
         this.state.isAttachmentBoxOpened = !this.state.isAttachmentBoxOpened;
         if (this.state.isAttachmentBoxOpened) {
             this.rootRef.el.scrollTop = 0;
-            this.state.thread.scrollTop = 0;
+            this.state.thread.scrollTop = "bottom";
         }
     }
 


### PR DESCRIPTION
Before this commit, when receiving a chatter notification, clicking on notification opens chat window to the oldest message.

This happens because the default scroll top for all chatter threads was 0, taking into account that a chatter thread in form view is in DESC mode (i.e. messages are ordered from top to bottom, from newest to oldest).

However, chatter in chat window is displayed in ASC mode like channels (i.e. messages are ordered from top to bottom, from oldest to newest). Scrolltop 0 means newest in chatter form view, but this becomes oldest in chat window with ASC order.

This commit fixes the issue by normalizing the storing of thread scroll positions to ASC, so that default value is "bottom" regardless of order to display. in ASC, this is handled like before, but in DESC mode it translates "bottom" to 0.

opw-3891999

Before
![before](https://github.com/odoo/odoo/assets/6569390/3210fca1-8693-4aef-bf4f-ae44edcb17bb)
After
![after](https://github.com/odoo/odoo/assets/6569390/542d7939-d976-49f6-afb2-52d26a96d1fa)
