### PR TITLE
[FIX] pos_self_order: handle attribute images for JSON serialization

### DIFF
--- a/addons/pos_self_order/models/product_product.py
+++ b/addons/pos_self_order/models/product_product.py
@@ -79,6 +79,11 @@ class ProductProduct(models.Model):
             # Needs to be deep-copied because attributes is potentially mutated
             attributes = deepcopy(self._filter_applicable_attributes(attributes))
 
+        # The image is not JSON serializable
+        for attribute in attributes:
+            for value in attribute["values"]:
+                del value["image"]
+
         return self._add_price_info_to_attributes(
             attributes,
             pos_config_sudo,


### PR DESCRIPTION
Before this commit, loading an attribute value with an image would cause a TypeError due to the image data being of bytes type, which is not JSON serializable. This commit prevents this error by removing the image data before serialization.

opw-3957587

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
