### PR TITLE
[CLN] product,sale: clean service_tracking logic

### DIFF
--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -54,6 +54,16 @@ class ProductTemplate(models.Model):
         help='A storable product is a product for which you manage stock. The Inventory app has to be installed.\n'
              'A consumable product is a product for which stock is not managed.\n'
              'A service is a non-material product you provide.')
+    service_tracking = fields.Selection(selection=[
+            ('no', 'Nothing'),
+        ],
+        string="Create on Order",
+        default="no",
+        compute="_compute_service_tracking",
+        required=True,
+        store=True,
+        readonly=False,
+    )
     categ_id = fields.Many2one(
         'product.category', 'Product Category',
         change_default=True, default=_get_default_category_id, group_expand='_read_group_categ_id',
@@ -150,16 +160,6 @@ class ProductTemplate(models.Model):
     )
     # Properties
     product_properties = fields.Properties('Properties', definition='categ_id.product_properties_definition', copy=True)
-    service_tracking = fields.Selection(selection=[
-            ('no', 'Nothing'),
-        ],
-        string="Create on Order",
-        default="no",
-        compute="_compute_service_tracking",
-        required=True,
-        store=True,
-        readonly=False,
-    )
 
     @api.depends('type')
     def _compute_service_tracking(self):

--- a/addons/sale/models/product_template.py
+++ b/addons/sale/models/product_template.py
@@ -93,10 +93,8 @@ class ProductTemplate(models.Model):
 
     @api.depends('sale_ok')
     def _compute_service_tracking(self):
-        non_service_products = self.filtered(
-            lambda pt: not pt.sale_ok or pt.type != 'service'
-        )
-        non_service_products.service_tracking = 'no'
+        super()._compute_service_tracking()
+        self.filtered(lambda pt: not pt.sale_ok).service_tracking = 'no'
 
     @api.depends('name')
     def _compute_visible_expense_policy(self):


### PR DESCRIPTION
`service_tracking` field was recently moved from `sale` to `product` but the field was placed in the properties section where it doesn't belong, and its compute method was overridden in `sale` without calling `super`, which is structurally incorrect if other modules extend this method.

task-3959899