### PR TITLE
[FIX] web_tour_recorder: Fix traceback running twice the same tour

### DIFF
--- a/addons/web_tour_recorder/static/src/tour_recorder/tour_recorder_service.js
+++ b/addons/web_tour_recorder/static/src/tour_recorder/tour_recorder_service.js
@@ -93,15 +93,17 @@ export const tourRecorderService = {
         function startCustomTour(customTourName, options) {
             const customTours = getCustomTours();
             const customTour = customTours.find((t) => t.name === customTourName);
-            registry.category("web_tour.tours").add(customTour.name, {
-                ...customTour,
-                steps: () => customTour.steps,
-            });
+            if (!registry.category("web_tour.tours").contains(customTour.name)) {
+                registry.category("web_tour.tours").add(customTour.name, {
+                    ...customTour,
+                    steps: () => customTour.steps,
+                });
+                browser.localStorage.setItem(
+                    CUSTOM_RUNNING_TOURS_LOCAL_STORAGE_KEY,
+                    JSON.stringify(customTour)
+                );
+            }
             tour_service.startTour(customTour.name, options);
-            browser.localStorage.setItem(
-                CUSTOM_RUNNING_TOURS_LOCAL_STORAGE_KEY,
-                JSON.stringify(customTour)
-            );
         }
 
         return {

--- a/addons/web_tour_recorder/static/tests/tour_recorder.test.js
+++ b/addons/web_tour_recorder/static/tests/tour_recorder.test.js
@@ -496,3 +496,50 @@ test("Run custom tour", async () => {
 
     expect(["Clicked on div"]).toVerifySteps();
 });
+
+test("Run a custom tour twice doesn't trigger traceback", async () => {
+    await mountWithCleanup(
+        `
+        <div class="o_parent">
+            <div class="click">Bishmillah</div>
+        </div>
+    `,
+        { noMainContainer: true }
+    );
+
+    expect(".o_tour_recorder").toHaveCount(1);
+    click(".o_button_record");
+    await animationFrame();
+    click(".click");
+    await animationFrame();
+    checkTourSteps([".o_parent > div"]);
+
+    click(".o_button_save");
+    await animationFrame();
+    await contains("input[name='name']").click();
+    edit("tour_name");
+    await animationFrame();
+    click("input[name='url']");
+    await animationFrame();
+    edit("");
+    await animationFrame();
+    click(".o_button_save_confirm");
+    await animationFrame();
+    expect(".o_notification_manager .o_notification_body").toHaveText(
+        "Custom tour 'tour_name' has been added."
+    );
+
+    click(".o_debug_manager > button");
+    await contains(".o-dropdown-item:contains('Start Tour')").click();
+
+    expect("table tr td:contains('tour_name')").toHaveCount(1);
+    click(".o_start_tour");
+    await animationFrame();
+
+    click(".o_debug_manager > button");
+    await contains(".o-dropdown-item:contains('Start Tour')").click();
+
+    expect("table tr td:contains('tour_name')").toHaveCount(2);
+    click(".o_start_tour:eq(1)");
+    await animationFrame();
+});


### PR DESCRIPTION
Before this commit, if you run the same tour twice, you get a traceback because the tour_recorder was trying to re-add the tour in the registry of the tours, even if he was already registered.

After this commit, the tour_recorder register the tour only if the tour is not in the registry of the tours.

task-id: 3961677





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
