### PR TITLE
[FIX] mail: only show new message separator in the relevant thread

### DIFF
--- a/addons/mail/static/src/core/common/thread.xml
+++ b/addons/mail/static/src/core/common/thread.xml
@@ -21,7 +21,7 @@
                         <DateSection date="msg.dateDay" className="'pt-2'"/>
                         <t t-set="currentDay" t-value="msg.dateDay"/>
                     </t>
-                    <div t-if="msg.threadAsFirstUnread" class="o-mail-Thread-newMessage d-flex align-items-center fw-bolder z-index-1">
+                    <div t-if="msg.threadAsFirstUnread?.eq(props.thread)" class="o-mail-Thread-newMessage d-flex align-items-center fw-bolder z-index-1">
                         <hr class="ms-2 flex-grow-1 border border-danger opacity-50"/><span class="px-2 text-danger">New messages</span><hr class="me-2 flex-grow-1 border border-danger opacity-50"/>
                     </div>
                     <t t-if="msg.isNotification">

--- a/addons/mail/static/tests/core/new_message_separator.test.js
+++ b/addons/mail/static/tests/core/new_message_separator.test.js
@@ -274,3 +274,30 @@ test("show new message separator when message is received while chat window is c
     await contains(".o-mail-ChatWindow");
     await contains(".o-mail-Thread-newMessage hr + span", { text: "New messages" });
 });
+
+test("only show new message separator in its thread", async () => {
+    // when a message acts as the reference for displaying new message separator,
+    // this should applies only when vieweing the message in its thread.
+    const pyEnv = await startServer();
+    const demoPartnerId = pyEnv["res.partner"].create({ name: "Demo" });
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    pyEnv["mail.message"].create({
+        author_id: demoPartnerId,
+        body: "@Mitchell Admin",
+        attachment_ids: [],
+        message_type: "comment",
+        model: "discuss.channel",
+        res_id: channelId,
+        needaction: true,
+    });
+    await start();
+    await openDiscuss(channelId);
+    await contains(".o-mail-Thread-newMessage ~ .o-mail-Message", { text: "@Mitchell Admin" });
+    await click(".o-mail-DiscussSidebar-item", { text: "Inbox" });
+    await contains(".o-mail-Discuss-threadName", { value: "Inbox" });
+    await contains(".o-mail-Message", { text: "@Mitchell Admin" });
+    await contains(".o-mail-Thread-newMessage ~ .o-mail-Message", {
+        count: 0,
+        text: "@Mitchell Admin",
+    });
+});


### PR DESCRIPTION
Before this PR, the new message separator could be displayed in threads other than the one the message belongs to (e.g., Inbox, Starred, and History mailboxes).

This PR restricts the new message separator to the thread the message belongs to.

Steps to reproduce the issue:


- Go to the general channel.
- Mark a message as unread and star it.
- Go to the Starred mailbox.
- The separator is shown.