### PR TITLE
[IMP] account: set default to prefix_groups_threshold

### DIFF
--- a/addons/account/models/account_report.py
+++ b/addons/account/models/account_report.py
@@ -55,7 +55,7 @@ class AccountReport(models.Model):
     )
     load_more_limit = fields.Integer(string="Load More Limit")
     search_bar = fields.Boolean(string="Search Bar")
-    prefix_groups_threshold = fields.Integer(string="Prefix Groups Threshold")
+    prefix_groups_threshold = fields.Integer(string="Prefix Groups Threshold", default=4000)
     integer_rounding = fields.Selection(string="Integer Rounding", selection=[('HALF-UP', "Half-up (away from 0)"), ('UP', "Up"), ('DOWN', "Down")])
 
     default_opening_date_filter = fields.Selection(


### PR DESCRIPTION
[IMP] account: set default to prefix_groups_threshold

the prefix_groups_threshold field has no default value on reports. So it means in case a report is using groupby, it'll have no limits at all as for the number of lines to display, and will have to cause perf issues before the user chooses to user the prefix groups.

Solution: Setting default value to 4000 as experimented locally

task-id#3791234

upgrade-pr#https://github.com/odoo/upgrade/pull/6106

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr