### PR TITLE
[IMP] account, *: allow generating UBL invoice when PDF already exists

### DIFF
--- a/addons/account/static/src/css/account.css
+++ b/addons/account/static/src/css/account.css
@@ -63,3 +63,9 @@
 .o_field_account_resequence_widget {
     width: 100%;
 }
+
+.account_move_send_warning_checkbox {
+    .form-check-input[type=checkbox] {
+        border: 1px solid black;
+    }
+}

--- a/addons/account/wizard/account_move_send_views.xml
+++ b/addons/account/wizard/account_move_send_views.xml
@@ -14,12 +14,21 @@
                 <field name="show_pdf_template_menu" invisible="1"/>
                 <field name="enable_download" invisible="1"/>
                 <field name="enable_send_mail" invisible="1"/>
+                <field name="enable_force_regenerate" invisible="1"/>
                 <field name="send_mail_readonly" invisible="1"/>
                 <field name="display_mail_composer" invisible="1"/>
                 <field name="mail_lang" invisible="1"/>
 
-                <div class="m-0" name="warnings" invisible="not warnings">
+                <div class="m-0" name="warnings" invisible="not warnings and not enable_force_regenerate">
                     <field name="warnings" class="o_field_html" widget="actionable_errors"/>
+                    <div class="alert alert-info"
+                         role="alert"
+                         invisible="not enable_force_regenerate">
+                        Some of the selected invoices already have associated PDFs files.
+                        If you want to generate these documents in another format, we will create new PDFs files to associate with the invoices.
+                        <br/>
+                        <b class="me-1">I understand and want to overwrite the existing PDF</b><field name="checkbox_force_regenerate" class="account_move_send_warning_checkbox"/>
+                    </div>
                 </div>
 
                 <group>

--- a/addons/account_edi_ubl_cii/models/account_move.py
+++ b/addons/account_edi_ubl_cii/models/account_move.py
@@ -55,7 +55,6 @@ class AccountMove(models.Model):
 
     def _need_ubl_cii_xml(self):
         self.ensure_one()
-        return not self.invoice_pdf_report_id \
-            and not self.ubl_cii_xml_id \
+        return not self.ubl_cii_xml_id \
             and self.is_sale_document() \
             and bool(self.partner_id.commercial_partner_id.ubl_cii_format)

--- a/addons/account_peppol/wizard/account_move_send.py
+++ b/addons/account_peppol/wizard/account_move_send.py
@@ -10,7 +10,7 @@ class AccountMoveSend(models.TransientModel):
     _inherit = 'account.move.send'
 
     checkbox_send_peppol = fields.Boolean(
-        string='Send via PEPPOL',
+        string='PEPPOL',
         compute='_compute_checkbox_send_peppol', store=True, readonly=False,
     )
     enable_peppol = fields.Boolean(compute='_compute_enable_peppol')

--- a/addons/auth_totp/static/tests/totp_flow.js
+++ b/addons/auth_totp/static/tests/totp_flow.js
@@ -53,6 +53,7 @@ function closeProfileDialog({content, totp_state}) {
     return [{
         content,
         trigger,
+        allowDisabled: true,
         run(helpers) {
             const modal = document.querySelector(".o_dialog");
             if (modal) {

--- a/addons/l10n_hu_edi/wizard/account_move_send.py
+++ b/addons/l10n_hu_edi/wizard/account_move_send.py
@@ -55,7 +55,7 @@ class AccountMoveSend(models.TransientModel):
     # -------------------------------------------------------------------------
 
     @api.model
-    def _need_invoice_document(self, invoice):
+    def _need_invoice_document(self, invoice, invoice_data):
         # EXTENDS 'account'
         # If the send & print triggers the NAV 3.0 flow, we want to re-generate the PDF.
         if invoice.country_code != 'HU':

--- a/addons/l10n_it_edi/wizard/account_move_send.py
+++ b/addons/l10n_it_edi/wizard/account_move_send.py
@@ -97,7 +97,7 @@ class AccountMoveSend(models.TransientModel):
     # -------------------------------------------------------------------------
 
     @api.model
-    def _need_invoice_document(self, invoice):
+    def _need_invoice_document(self, invoice, invoice_data):
         # EXTENDS 'account'
         return super()._need_invoice_document(invoice) and not invoice.l10n_it_edi_attachment_id
 

--- a/addons/web/static/src/views/view_compiler.js
+++ b/addons/web/static/src/views/view_compiler.js
@@ -17,7 +17,7 @@ import { toStringExpression, BUTTON_CLICK_PARAMS } from "./utils";
 
 import { xml } from "@odoo/owl";
 
-const BUTTON_STRING_PROPS = ["string", "size", "title", "icon", "id"];
+const BUTTON_STRING_PROPS = ["string", "size", "title", "icon", "id", "disabled"];
 const INTERP_REGEXP = /(\{\{|#\{)(.*?)(\}{1,2})/g;
 
 /**

--- a/addons/web/static/tests/views/form/form_renderer.test.js
+++ b/addons/web/static/tests/views/form/form_renderer.test.js
@@ -55,12 +55,13 @@ test("compile notebook with modifiers", async () => {
     expect(queryAllTexts`.o_notebook_headers .nav-item`).toEqual(["p1", "p2"]);
 });
 
-test("compile header and buttons", async () => {
+test.tags("desktop")("compile header and buttons", async () => {
     Partner._views = {
         form: /*xml*/ `
             <form>
                 <header>
                     <button string="ActionButton" class="oe_highlight" name="action_button" type="object"/>
+                    <button string="DisabledActionButton" class="oe_highlight" name="disabled_action_button" type="object" disabled="disabled"/>
                 </header>
             </form>
         `,
@@ -72,6 +73,7 @@ test("compile header and buttons", async () => {
         resId: 1,
     });
     expect(`.o_statusbar_buttons button[name=action_button]:contains(ActionButton)`).toHaveCount(1);
+    expect(`button[name=disabled_action_button]:disabled`).toHaveCount(1);
 });
 
 test("render field with placeholder", async () => {


### PR DESCRIPTION
*: account_edi_ubl_cii

Previouly, when using the "Send & Print" function on an invoice, if a
PDF was already generated for that invoice, you could no longer generate
the UBL file for it.

This commit allows the user to generate that UBL invoice, though in
order to keep the PDF and UBL files synced, the PDF will be regenerated.
This will display a warning and ask the user for confirmation.

Because this is a feature that will likely be useful for other EDIs, the
bulk of the feature is implemented in account, with minor overrides in
account_edi_ubl_cii to account specifically for UBL invoices.

task-3814178