### PR TITLE
[FIX] web: strike out label when toggling pie chart entry

### DIFF
--- a/addons/web/static/src/views/graph/graph_renderer.js
+++ b/addons/web/static/src/views/graph/graph_renderer.js
@@ -304,12 +304,8 @@ export class GraphRenderer extends Component {
         if (mode === "pie") {
             legendOptions.labels = {
                 generateLabels: (chart) => {
-                    const { data } = chart;
-                    const metaData = data.datasets.map(
-                        (_, index) => chart.getDatasetMeta(index).data
-                    );
-                    const labels = data.labels.map((label, index) => {
-                        const hidden = metaData.some((data) => data[index] && data[index].hidden);
+                    return chart.data.labels.map((label, index) => {
+                        const hidden = !chart.getDataVisibility(index);
                         const fullText = label;
                         const text = shortenLabel(fullText);
                         const fillStyle =
@@ -318,7 +314,6 @@ export class GraphRenderer extends Component {
                                 : getColor(index, cookie.get("color_scheme"));
                         return { text, fullText, fillStyle, hidden, index };
                     });
-                    return labels;
                 },
             };
         } else {

--- a/addons/web/static/tests/views/graph_view_tests.js
+++ b/addons/web/static/tests/views/graph_view_tests.js
@@ -156,6 +156,21 @@ export async function clickOnDataset(graph) {
     });
 }
 
+export async function clickOnLegend(graph, text) {
+    const chart = getChart(graph);
+    const index = chart.legend.legendItems.findIndex((e) => e.text === text);
+    const { left, top, width, height } = chart.legend.legendHitBoxes[index];
+    const rectangle = chart.canvas.getBoundingClientRect();
+    const middle = {
+        x: left + width / 2,
+        y: top + height / 2,
+    };
+    await triggerEvent(chart.canvas, null, "click", {
+        pageX: rectangle.left + middle.x,
+        pageY: rectangle.top + middle.y,
+    });
+}
+
 let serverData;
 let target;
 QUnit.module("Views", (hooks) => {
@@ -2336,6 +2351,18 @@ QUnit.module("Views", (hooks) => {
             );
         }
     );
+
+    QUnit.test("pie chart toggling dataset hides label", async function (assert) {
+        const graph = await makeView({
+            serverData,
+            type: "graph",
+            resModel: "foo",
+            arch: `<graph type="pie"/>`,
+        });
+        checkLabels(assert, graph, ["Total"]);
+        await clickOnLegend(graph, "Total");
+        assert.ok(getChart(graph).legend.legendItems[0].hidden);
+    });
 
     QUnit.test("mode props", async function (assert) {
         assert.expect(2);


### PR DESCRIPTION
Steps to reproduce
==================

- Go to CRM
- Switch to the graph view
- Use the Pie Chart mode
- Click on any label

=> The visibility of the dataset is toggled
   but the label should be crossed out

Solution
========

From the Chart.js v3 migration guide, we can see this

> Element.hidden was replaced by chart level status, usable with getDataVisibility(index) / toggleDataVisibility(index)

https://www.chartjs.org/docs/latest/migration/v3-migration.html

opw-3935183