### PR TITLE
[FIX] account: make the journal appear on payment method kanban view

### DIFF
--- a/addons/account/views/account_payment_method.xml
+++ b/addons/account/views/account_payment_method.xml
@@ -12,4 +12,22 @@
         </field>
     </record>
 
+    <record id="view_account_payment_method_line_kanban" model="ir.ui.view">
+        <field name="name">account.payment.method.line.kanban</field>
+        <field name="model">account.payment.method.line</field>
+        <field name="arch" type="xml">
+            <kanban>
+                <field name="name"/>
+                <field name="journal_id"/>
+                <templates>
+                    <t t-name="kanban-box">
+                        <div class="oe_kanban_global_click">
+                            <span><field name="name"/> (<field name="journal_id"/>)</span>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>
+        </field>
+    </record>
+
 </odoo>


### PR DESCRIPTION
### Steps to reproduce (on mobile mode):
- Go to Expenses app
- Create a new expense
- Select 'Company' for the 'Paid By' field
- Action > Create Report
- Click on the field 'Payment Method'
- The view displayed does not show the journals, so there can be several 'Manual' for example

### Cause:
There are no kanban view for account.payment.method.line and the default one only shows the name and not the journal.

### Solution:
Create a new kanban view for account.payment.method.line that displays the journal.

opw-3896011