### PR TITLE
[FIX] web, link_tracker: disable link tracking for preview "clicks"

### DIFF
--- a/addons/link_tracker/tests/__init__.py
+++ b/addons/link_tracker/tests/__init__.py
@@ -4,5 +4,4 @@
 from . import common
 from . import test_link_tracker
 from . import test_mail_render_mixin
-from . import test_link_tracker
 from . import test_tracker_http_requests

--- a/addons/link_tracker/tests/__init__.py
+++ b/addons/link_tracker/tests/__init__.py
@@ -5,3 +5,4 @@ from . import common
 from . import test_link_tracker
 from . import test_mail_render_mixin
 from . import test_link_tracker
+from . import test_tracker_http_requests

--- a/addons/link_tracker/tests/test_tracker_http_requests.py
+++ b/addons/link_tracker/tests/test_tracker_http_requests.py
@@ -1,0 +1,44 @@
+from odoo.addons.link_tracker.tests.common import MockLinkTracker
+from odoo.tests import common, tagged
+from odoo.tools import mute_logger
+
+
+@tagged('post_install', '-at_install')
+class TestTrackerHttpRequests(MockLinkTracker, common.HttpCase):
+
+    @mute_logger("odoo.addons.http_routing.models.ir_http", "odoo.http")
+    def test_no_preview_tracking(self):
+        """Ensure that requests with a user agent matching known preview user agents will not be registered as a click"""
+        link_tracker = self.env['link.tracker'].create({
+                'url': 'https://odoo.com',
+                'title': 'Odoo',
+            })
+        self.assertEqual(len(link_tracker.link_click_ids), 0)
+        link = '/r/' + link_tracker.code
+
+        # Check that no click is registrered for a MicrosoftPreview agent
+        self.url_open(
+            link,
+            headers={
+                'User-Agent': 'Mozilla/5.0 MicrosoftPreview/2.0 +https://aka.ms/MicrosoftPreview',
+            }
+        )
+        self.assertEqual(len(link_tracker.link_click_ids), 0)
+
+        # Check that no click is registered for a Google Messages preview agent
+        self.url_open(
+            link,
+            headers={
+                'User-Agent': 'Mozilla/5.0 Google-PageRenderer Google (+https://developers.google.com/+/web/snippet/)'
+            }
+        )
+        self.assertEqual(len(link_tracker.link_click_ids), 0)
+
+        # Check (sanity) that a request from a regular UA does still register the click
+        self.url_open(
+            link,
+            headers={
+                'User-Agent': 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:126.0) Gecko/20100101 Firefox/126.0'
+            }
+        )
+        self.assertEqual(len(link_tracker.link_click_ids), 1)

--- a/addons/mass_mailing_sms/controllers/main.py
+++ b/addons/mass_mailing_sms/controllers/main.py
@@ -94,12 +94,13 @@ class MailingSMSController(http.Controller):
         else:
             trace_id = False
 
-        request.env['link.tracker.click'].sudo().add_click(
-            code,
-            ip=request.httprequest.remote_addr,
-            country_code=country_code,
-            mailing_trace_id=trace_id
-        )
+        if not request.env['ir.http'].is_a_bot():
+            request.env['link.tracker.click'].sudo().add_click(
+                code,
+                ip=request.httprequest.remote_addr,
+                country_code=country_code,
+                mailing_trace_id=trace_id
+            )
         redirect_url = request.env['link.tracker'].get_url_from_code(code)
         if not redirect_url:
             raise NotFound()

--- a/addons/web/models/ir_http.py
+++ b/addons/web/models/ir_http.py
@@ -33,7 +33,7 @@ ALLOWED_DEBUG_MODES = ['', '1', 'assets', 'tests', 'disable-t-cache']
 class Http(models.AbstractModel):
     _inherit = 'ir.http'
 
-    bots = ["bot", "crawl", "slurp", "spider", "curl", "wget", "facebookexternalhit", "whatsapp", "trendsmapresolver", "pinterest", "instagram"]
+    bots = ["bot", "crawl", "slurp", "spider", "curl", "wget", "facebookexternalhit", "whatsapp", "trendsmapresolver", "pinterest", "instagram", "google-pagerenderer", "preview"]
 
     @classmethod
     def is_a_bot(cls):


### PR DESCRIPTION
Some services or applications (Outlook, Google Messages) display
previews of links sent through messages or email. In an effort to
strengten user privacy, these services fetch the previews from their
own servers rather than from the user's device.

Since these services' requests had not been added to the list of
known bot identifiers, they generate parasite "clicks" which don't
match their user.

This commit adds identifiers for the Outlook and Google Messages
service requests to the list of known bot IDs, thereby preventing the
parasite clicks from generating.

task-3672491