### PR TITLE
[FIX] sale_project : Public user add products that are based on milestones

### DIFF
--- a/addons/sale_project/models/product.py
+++ b/addons/sale_project/models/product.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models, _
+from odoo import api, fields, models, _, SUPERUSER_ID
 from odoo.exceptions import ValidationError
 
 
@@ -15,7 +15,10 @@ class ProductTemplate(models.Model):
             ('ordered_prepaid', _('Prepaid/Fixed Price')),
             ('delivered_manual', _('Based on Delivered Quantity (Manual)')),
         ]
-        if self.user_has_groups('project.group_project_milestone'):
+        user = self.env['res.users'].sudo().browse(SUPERUSER_ID)
+        if (self.user_has_groups('project.group_project_milestone') or
+                (self.env.user.has_group('base.group_public') and user.has_group('project.group_project_milestone'))
+        ):
             service_policies.insert(1, ('delivered_milestones', _('Based on Milestones')))
         return service_policies
 


### PR DESCRIPTION
**Steps to reproduce:**
	- Install sale_project, E-Commerce module
	- Create a service product and put its invoicing policy as 'Based on milestones'
	- Go to website as Public user and try to add the product you created to the cart

**Current behavior before PR:**
A traceback is happening when a public user try to add a product -that has Based on milestones as invoicing policy- to the cart. This is happening because we check if the user has 'group_project_milestone' https://github.com/odoo/odoo/blob/17.0/addons/sale_project/models/product.py#L18 and if the user is not signed in he won't have this group.

**Desired behavior after PR is merged:**
The public user should be able to add this products. As we are now checking if the user is a public one and if the SUPERUSER has the 'group_project_milestone'.

opw-3956165