### PR TITLE
[FIX] point_of_sale: respect product context loading

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -2028,13 +2028,14 @@ class PosSession(models.Model):
 
     def find_product_by_barcode(self, barcode):
         load_data_params = self._load_data_params(self.config_id)
+        product_context = load_data_params['product.product'].get('context', [])
         product = self.env['product.product'].search([
             ('barcode', '=', barcode),
             ('sale_ok', '=', True),
             ('available_in_pos', '=', True),
         ])
         if product:
-            return {'product.product': product.read(load_data_params['product.product']['fields'], load=False)}
+            return {'product.product': product.with_context(product_context).read(load_data_params['product.product']['fields'], load=False)}
 
         domain = [('barcode', 'not in', ['', False])]
         loaded_data = self._context.get('loaded_data')
@@ -2056,7 +2057,7 @@ class PosSession(models.Model):
                 product_fields = load_data_params['product.product']['fields']
                 packaging_fields = load_data_params['product.packaging']['fields']
 
-                return {'product.product': packaging.product_id.read(product_fields, load=False), 'product.packaging': packaging.read(packaging_fields, load=False)}
+                return {'product.product': packaging.product_id.with_context(product_context).read(product_fields, load=False), 'product.packaging': packaging.read(packaging_fields, load=False)}
         return {
             'product.product': [],
             'product.packaging': [],

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -478,6 +478,7 @@ export class ProductScreen extends Component {
             domain,
             this.pos.data.fields["product.product"],
             {
+                context: {display_default_code: false},
                 offset: this.state.currentOffset,
                 limit: 30,
             }


### PR DESCRIPTION
Before this commit, loading a product into the PoS via search or barcode would append the internal reference to the product name. This commit fixes the issue by ensuring the 'display_default_code' context is respected when loading products via barcode or name search.

opw-3900842

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
