### PR TITLE
[IMP] account,hr_expense: warn user when reimbursing their own company

### DIFF
--- a/addons/hr_expense/i18n/hr_expense.pot
+++ b/addons/hr_expense/i18n/hr_expense.pot
@@ -2477,3 +2477,11 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:hr_expense.res_config_settings_view_form
 msgid "use OCR to fill data from a picture of the bill"
 msgstr ""
+
+#. module: hr_expense
+#: model_terms:ir.ui.view,arch_db:hr_expense.view_move_form_inherit_expense
+msgid ""
+"Do you really want to invoice your own company? Remove the \"Company Name\" "
+"from the partner to fix the configuration. Cancel this invoice and start "
+"again."
+msgstr ""

--- a/addons/hr_expense/models/hr_expense_sheet.py
+++ b/addons/hr_expense/models/hr_expense_sheet.py
@@ -713,7 +713,6 @@ class HrExpenseSheet(models.Model):
             'ref': self.name,
             'move_type': 'in_invoice',
             'partner_id': self.employee_id.sudo().work_contact_id.id,
-            'partner_bank_id': self.employee_id.sudo().bank_account_id.id,
             'currency_id': self.currency_id.id,
             'line_ids': [Command.create(expense._prepare_move_lines_vals()) for expense in self.expense_line_ids],
             'attachment_ids': [

--- a/addons/hr_expense/tests/test_expenses.py
+++ b/addons/hr_expense/tests/test_expenses.py
@@ -1032,42 +1032,6 @@ class TestExpenses(TestExpenseCommon):
         expense_state = Expense.get_expense_dashboard()
         self.assertEqual(expense_state['to_submit']['amount'], 3000.00)
 
-    def test_payment_register_bank_from_expense_reimbursed_to_employee(self):
-        """
-        Test that creating an expense to be paid to an employee having a commercial partner (the company listed in the
-        employee's contact) will have the employee's bank account in the register payment wizard.
-        """
-        # Set bank account in employee.
-        self.expense_employee.bank_account_id = self.env['res.partner.bank'].create({
-            'acc_number': 'BE32707171912447',
-            'partner_id': self.expense_employee.work_contact_id.id,
-            'acc_type': 'bank',
-        })
-        # Set bank account in company.
-        self.env.company.partner_id.bank_ids = self.env['res.partner.bank'].create({
-            'acc_number': 'BE457268179587463',
-            'partner_id': self.env.company.partner_id.id,
-            'acc_type': 'bank',
-        })
-        # Set commercial partner in employee's contact.
-        self.expense_employee.work_contact_id.commercial_partner_id = self.env.company.partner_id
-
-        expense = self.env['hr.expense'].create({
-            'name': 'expense_1',
-            'total_amount': 10.0,
-            'product_id': self.product_c.id,
-            'payment_mode': 'own_account',
-            'employee_id': self.expense_employee.id
-        })
-        sheet = self.env['hr.expense.sheet'].create(expense._get_default_expense_sheet_values())
-        sheet.action_submit_sheet()
-        sheet.action_approve_expense_sheets()
-        sheet.action_sheet_move_create()
-        action_data = sheet.action_register_payment()
-        with Form(self.env[action_data['res_model']].with_context(action_data['context'])) as wiz_form:
-            self.assertEqual(wiz_form.amount, 10)
-            self.assertEqual(wiz_form.partner_bank_id, self.expense_employee.bank_account_id)
-
     def test_expense_mandatory_analytic_plan_product_category(self):
         """
         Check that when an analytic plan has a mandatory applicability matching

--- a/addons/hr_expense/views/account_move_views.xml
+++ b/addons/hr_expense/views/account_move_views.xml
@@ -18,6 +18,14 @@
                             </div>
                     </button>
                 </xpath>
+
+                <xpath expr="//sheet" position="before">
+                    <field name="show_commercial_partner_warning" invisible="1"/>
+                    <div class="alert alert-warning" role="alert"
+                         invisible="not show_commercial_partner_warning">
+                        Do you really want to invoice your own company? Remove the "Company Name" from the partner to fix the configuration. Cancel this invoice and start again.
+                    </div>
+                </xpath>
             </field>
         </record>
     </data>

--- a/addons/hr_expense/wizard/account_payment_register.py
+++ b/addons/hr_expense/wizard/account_payment_register.py
@@ -11,16 +11,15 @@ class AccountPaymentRegister(models.TransientModel):
     # -------------------------------------------------------------------------
 
     @api.model
-    def _get_batch_available_partner_banks(self, batch_result, journal):
+    def _get_line_batch_key(self, line):
         # OVERRIDE to set the bank account defined on the employee
-        expense_sheet = batch_result['lines'].move_id.expense_sheet_id.filtered(lambda sheet: sheet and sheet.payment_mode == 'own_account')
-        if expense_sheet and batch_result['payment_values']['payment_type'] == 'outbound':
-            # We use sudo since we may not have access to the employee_id record. If the env wasn't already in sudo,
-            # we should un-sudo the record before returning it.
-            sudo_bank_account_id = expense_sheet.employee_id.sudo().bank_account_id
-            return sudo_bank_account_id.sudo(self.env.su)
-        else:
-            return super()._get_batch_available_partner_banks(batch_result, journal)
+        res = super()._get_line_batch_key(line)
+        expense_sheet = line.move_id.expense_sheet_id.filtered(lambda sheet: sheet and sheet.payment_mode == 'own_account')
+        if expense_sheet and not line.move_id.partner_bank_id:
+            res['partner_bank_id'] = expense_sheet.employee_id.sudo().bank_account_id.id \
+                                     or line.partner_id.bank_ids  \
+                                     and line.partner_id.bank_ids.ids[0]
+        return res
 
     def _init_payments(self, to_process, edit_mode=False):
         # OVERRIDE


### PR DESCRIPTION
When creating an expense to be paid to the employee, if the employee's
contact had a parent_id, then when trying to register a payment for that
expense, the bank account of the parent company was used instead. In
https://github.com/odoo/odoo/commit/1ed71ba1fa176de9b0100b96f5af7d76c224e1a2 a fix was made to use the employee's bank account. That fix is
now being reverted and being replaced with this commit instead. If we're
creating an expense to be paid to the employee, we show a warning banner
on the vendor bill and the expense sheet that they're invoicing their
own company.

task-3955593