### PR TITLE
[FIX] sale_project: fix tooltip on the product form view

### DIFF
--- a/addons/sale_project/models/product.py
+++ b/addons/sale_project/models/product.py
@@ -66,13 +66,13 @@ class ProductTemplate(models.Model):
                 elif record.service_tracking == 'project_only':
                     record.product_tooltip = _(
                         "Invoice ordered quantities as soon as this service is sold. "
-                        "Create a project for the order with a task for each sales order line "
-                        "to track the time spent."
+                        "Create an empty project for the order to track the time spent."
                     )
                 elif record.service_tracking == 'task_in_project':
                     record.product_tooltip = _(
                         "Invoice ordered quantities as soon as this service is sold. "
-                        "Create an empty project for the order to track the time spent."
+                        "Create a project for the order with a task for each sales order line "
+                        "to track the time spent."
                     )
             elif record.service_policy == 'delivered_milestones':
                 if record.service_tracking == 'no':
@@ -87,13 +87,13 @@ class ProductTemplate(models.Model):
                 elif record.service_tracking == 'project_only':
                     record.product_tooltip = _(
                         "Invoice your milestones when they are reached. "
-                        "Create a project for the order with a task for each sales order line "
-                        "to track the time spent."
+                        "Create an empty project for the order to track the time spent."
                     )
                 elif record.service_tracking == 'task_in_project':
                     record.product_tooltip = _(
                         "Invoice your milestones when they are reached. "
-                        "Create an empty project for the order to track the time spent."
+                        "Create a project for the order with a task for each sales order line "
+                        "to track the time spent."
                     )
             elif record.service_policy == 'delivered_manual':
                 if record.service_tracking == 'no':
@@ -108,13 +108,13 @@ class ProductTemplate(models.Model):
                 elif record.service_tracking == 'project_only':
                     record.product_tooltip = _(
                         "Invoice this service when it is delivered (set the quantity by hand on your sales order lines). "
-                        "Create a project for the order with a task for each sales order line "
-                        "to track the time spent."
+                        "Create an empty project for the order to track the time spent."
                     )
                 elif record.service_tracking == 'task_in_project':
                     record.product_tooltip = _(
                         "Invoice this service when it is delivered (set the quantity by hand on your sales order lines). "
-                        "Create an empty project for the order to track the time spent."
+                        "Create a project for the order with a task for each sales order line "
+                        "to track the time spent."
                     )
 
     def _get_service_to_general_map(self):


### PR DESCRIPTION
Before this commit:
- the tooltip is mismatched to the conditions of service_tracking_type.

After this commit:
- fixes the tooltip of the product in `task_in_project` and `project_only` fields.

ref PR: https://github.com/odoo/odoo/pull/103974

task-3964655
