### PR TITLE
[IMP] stock_delivery: Adjust HS Code help for more carriers

### DIFF
--- a/addons/stock_delivery/models/product_template.py
+++ b/addons/stock_delivery/models/product_template.py
@@ -8,7 +8,7 @@ class ProductTemplate(models.Model):
 
     hs_code = fields.Char(
         string="HS Code",
-        help="Standardized code for international shipping and goods declaration. At the moment, only used for the FedEx shipping provider.",
+        help="Standardized code for international shipping and goods declaration.",
     )
     country_of_origin = fields.Many2one(
         'res.country',


### PR DESCRIPTION
As time goes on, more delivery intergrations utilize HS codes for international shipments. This means the comment in the product.template field is no longer necessary as there are more modules then just FedEx.
