### PR TITLE
[FIX] crm: handle float type values

### DIFF
--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -733,6 +733,11 @@ class IrServerObjectLines(models.Model):
                     expr = int(line.value)
                 except Exception:
                     pass
+            elif line.col1.ttype == 'float':
+                try:
+                    expr = float(line.value)
+                except Exception:
+                    pass
             result[line.id] = expr
         return result
 

--- a/odoo/addons/base/tests/test_ir_actions.py
+++ b/odoo/addons/base/tests/test_ir_actions.py
@@ -44,6 +44,7 @@ class TestServerActionsBase(TransactionCaseWithUserDemo):
         self.res_partner_parent_field = Fields.search([('model', '=', 'res.partner'), ('name', '=', 'parent_id')])
         self.res_partner_children_field = Fields.search([('model', '=', 'res.partner'), ('name', '=', 'child_ids')])
         self.res_partner_category_field = Fields.search([('model', '=', 'res.partner'), ('name', '=', 'category_id')])
+        self.res_partner_credit_limit_field = Fields.search([('model', '=', 'res.partner'), ('name', '=', 'credit_limit')])
         self.res_country_model = Model.search([('model', '=', 'res.country')])
         self.res_country_name_field = Fields.search([('model', '=', 'res.country'), ('name', '=', 'name')])
         self.res_country_code_field = Fields.search([('model', '=', 'res.country'), ('name', '=', 'code')])
@@ -314,6 +315,15 @@ class TestServerActions(TestServerActionsBase):
         # nor execute a server action on it
         with self.assertRaises(AccessError), mute_logger('odoo.addons.base.models.ir_actions'):
             self_demo.with_context(self.context).run()
+
+    def test_90_convert_to_float(self):
+        #make sure eval_value convert the value into float for float-type fields
+        self.action.write({
+            'state': 'object_write',
+            'fields_lines': [Command.create({'col1': self.res_partner_credit_limit_field.id, 'value': '20.99'})],
+        })
+        line = self.action.fields_lines[0]
+        self.assertEqual(line.eval_value()[line.id], 20.99)
 
 
 class TestCustomFields(common.TransactionCase):


### PR DESCRIPTION
Problem: When a user creates an automated action to update a float type field to a value, the value does not get converted into a float, and a TypeError occurs.

Purpose: Typecast the str value into a float, so no traceback error occurs.

Steps to Reproduce on Runbot:
1. Install base_automation, CRM
2. Create an automated action:
- Model: Lead/Opportunity
- Trigger: On update
- Trigger fields: Stage(crm.lead)
- Action to do: Update the record
- Data to write: {probability(crm.lead), value,20}
3. change the stage of a crm opportunity
4. Traceback error occurs TypeError: '>=' not supported between instances of 'str' and 'int'

opw-3962939

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
