### PR TITLE
[FIX] mail: fix error on main page

### DIFF
--- a/addons/mail/models/res_users.py
+++ b/addons/mail/models/res_users.py
@@ -175,6 +175,8 @@ class Users(models.Model):
         for model_id in records_by_state_by_model:
             model_dic = records_by_state_by_model[model_id]
             model = self.env["ir.model"].sudo().browse(model_id).with_prefetch(tuple(records_by_state_by_model.keys()))
+            if not self.env[model.model].check_access_rights('read', raise_exception=False):
+                continue
             allowed_records = self.env[model.model].search([("id", "in", tuple(model_dic["all"]))])
             if not allowed_records:
                 continue


### PR DESCRIPTION
How to reproduce:
- Install hr_contract
- Employee -> Marc Demo -> In contract... -> Open contract -> Schedule activity
- Assign it to Marc Demo
- Settings -> User -> Marc Demo -> remove rights to “Contracts”
- Login as Marc Demo

You get the following error: "You are not allowed to access 'Contract' (hr.contract) records. ...".

Actually, you cannot create an activity for "Marc Demo" on the contract if he has no right on the hr.contract model. So it only happens when you schedule an activity for Marc Demo before removing him the right to access hr_contract.

The error is raised when the activity summaries to display in the systray are fetched because to determine how many accessible record of each model have activities, the method res_user.systray_get_activities perform a search on the model of the record related to the user activities and in that case the user has no access to hr.contract for which he has an activity scheduled on a record. But that search is useful as it only returns the record that the user has access to, enabling to have the correct count of activities. The root cause is that the raw query at the beginning of the method ignore the access right and returns even activities related to record user cannot read.

In v16, that raw query is replaced by an ORM call which solve the problem but to keep it simple (and maybe avoid performance issue), we do a simple correction here: To prevent that error to occurs, we first check that the user has access to the model before trying to determine to which record the user has access to. That check is anyway done in the search so it doesn't impact the performance.

In the current implementation, the user won't see any activities assigned to him that are related to record he don't have access to. This has been improved in v17, see odoo/odoo#139917.

Technical note: this fix is working from 15.0 to saas-15.2 included. In 15.3, the implementation is changed and not checking the accessible record any more and so avoid the search that cause the error. But unfortunately, when clicking on the activity summary to see them, there is an error as the user has not access to the related record.

Task-3940746