### PR TITLE
hr_homeworking_calendar: fix action path and deletion right

### DIFF
--- a/addons/hr_homeworking_calendar/static/src/calendar/common/hr_homeworking_calendar_controller.js
+++ b/addons/hr_homeworking_calendar/static/src/calendar/common/hr_homeworking_calendar_controller.js
@@ -36,7 +36,7 @@ patch(AttendeeCalendarController.prototype, {
                     confirm: async () => {
                         const dayName = record.start.setLocale("en").weekdayLong.toLowerCase();
                         const locationField = `${dayName}_location_id`;
-                        await this.orm.write('hr.employee', [record.rawRecord.employee_id], {[locationField]: false})
+                        await this.orm.write('res.users', [record.rawRecord.user_id], {[locationField]: false})
                         this.model.load();
                     },
                     cancel: () => {

--- a/addons/hr_homeworking_calendar/static/src/calendar/common/hr_homeworking_calendar_controller.js
+++ b/addons/hr_homeworking_calendar/static/src/calendar/common/hr_homeworking_calendar_controller.js
@@ -14,7 +14,7 @@ patch(AttendeeCalendarController.prototype, {
     },
     async editRecord(record, context = {}, shouldFetchFormViewId = true) {
         if (record.homeworking && 'start' in record) {
-            return this.action.doAction('hr_homeworking.set_location_wizard_action', {
+            return this.action.doAction('hr_homeworking_calendar.set_location_wizard_action', {
                 additionalContext: {
                     'default_date': serializeDate(record.start),
                     'default_work_location_id' : record.work_location_id,
@@ -33,13 +33,10 @@ patch(AttendeeCalendarController.prototype, {
                 this.displayDialog(ConfirmationDialog, {
                     title: _t("Confirmation"),
                     body: _t("Are you sure you want to delete this location?"),
-                    confirm: () => {
+                    confirm: async () => {
                         const dayName = record.start.setLocale("en").weekdayLong.toLowerCase();
                         const locationField = `${dayName}_location_id`;
-                        this.orm.call('hr.employee', "write", [
-                            [record.rawRecord.employee_id],
-                            {[locationField]: false}
-                        ]);
+                        await this.orm.write('hr.employee', [record.rawRecord.employee_id], {[locationField]: false})
                         this.model.load();
                     },
                     cancel: () => {
@@ -49,10 +46,8 @@ patch(AttendeeCalendarController.prototype, {
                 this.displayDialog(ConfirmationDialog, {
                     title: _t("Confirmation"),
                     body: _t("Are you sure you want to delete this exception?"),
-                    confirm: () => {
-                        this.orm.call('hr.employee.location', "unlink", [
-                            record.id,
-                        ]);
+                    confirm: async () => {
+                        await this.orm.unlink("hr.employee.location", [parseInt(record.id)]);
                         this.model.load();
                     },
                     cancel: () => {
@@ -64,7 +59,7 @@ patch(AttendeeCalendarController.prototype, {
         }
     },
     openWorkLocationWizard(startDate) {
-        this.action.doAction('hr_homeworking.set_location_wizard_action',{
+        this.action.doAction('hr_homeworking_calendar.set_location_wizard_action',{
             additionalContext: {
                 'default_date': serializeDate(startDate),
                 'dialog_size': 'medium',

--- a/addons/hr_homeworking_calendar/static/tests/calendar_homeworking_tests.js
+++ b/addons/hr_homeworking_calendar/static/tests/calendar_homeworking_tests.js
@@ -307,7 +307,7 @@ QUnit.module("homeworking", ({ beforeEach }) => {
 
         await click(target.querySelector(".o_cw_popover_close"));
         await click(workLocations.at(-2), '.o_worklocation_line');
-        assert.verifySteps(["hr_homeworking.set_location_wizard_action", "2020-12-11"]);
+        assert.verifySteps(["hr_homeworking_calendar.set_location_wizard_action", "2020-12-11"]);
         mockRegistry.add("get_worklocation", previousMock, { force: true });
     });
 
@@ -365,7 +365,7 @@ QUnit.module("homeworking", ({ beforeEach }) => {
         });
         assert.equal(target.querySelector(".fc-col-header-cell[data-date='2020-12-11'] .o_worklocation_btn").textContent, "Home");
         await click(target, ".fc-col-header-cell[data-date='2020-12-10'] .o_worklocation_text");
-        assert.verifySteps(["hr_homeworking.set_location_wizard_action", "2020-12-10"]);
+        assert.verifySteps(["hr_homeworking_calendar.set_location_wizard_action", "2020-12-10"]);
         mockRegistry.add("get_worklocation", previousMock, { force: true });
     });
 
@@ -410,7 +410,7 @@ QUnit.module("homeworking", ({ beforeEach }) => {
         assert.containsOnce(target, ".fc-col-header-cell[data-date='2020-12-11'] .add_wl");
 
         await click(target, ".fc-col-header-cell[data-date='2020-12-11'] .add_wl");
-        assert.verifySteps(["hr_homeworking.set_location_wizard_action", "2020-12-11"]);
+        assert.verifySteps(["hr_homeworking_calendar.set_location_wizard_action", "2020-12-11"]);
         mockRegistry.add("get_worklocation", previousMock, { force: true });
     });
 });

--- a/addons/hr_homeworking_calendar/static/tests/disable_patch.js
+++ b/addons/hr_homeworking_calendar/static/tests/disable_patch.js
@@ -1,0 +1,8 @@
+/** @odoo-module */
+import {
+        unpatchAttendeeCalendarCommonPopover,
+        unpatchAttendeeCalendarCommonPopoverClass
+    } from "@hr_homeworking_calendar/calendar/common/popover/calendar_common_popover";
+
+unpatchAttendeeCalendarCommonPopover();
+unpatchAttendeeCalendarCommonPopoverClass();

--- a/addons/hr_homeworking_calendar/wizard/homework_location_wizard.xml
+++ b/addons/hr_homeworking_calendar/wizard/homework_location_wizard.xml
@@ -10,8 +10,8 @@
                     <div class="o_row w-100">
                         <field name="date"/>
                     </div>
-                    <label for="weekly"/>
-                    <div class="o_row w-100">
+                    <label for="weekly" invisible="not user_can_edit"/>
+                    <div class="o_row w-100" invisible="not user_can_edit">
                         <field name="weekly" class="oe_inline"/>
                         <span class="w-100">
                             Repeat every <field name="day_week_string" class="oe_inline"/>


### PR DESCRIPTION
In this task-3642327, the split between
hr_homeworking and calendar was introduced.
The action's path in js was forgotten and the work_location deletion right is set according to the user edit right. 

task-386625

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
