### PR TITLE
[FIX] hr_holidays: add lastcall during writing if necessary

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -678,11 +678,17 @@ class HolidaysAllocation(models.Model):
         self.add_follower(employee_id)
 
         if 'number_of_days_display' not in values and 'number_of_hours_display' not in values:
-            return super().write(values)
+            res = super().write(values)
+            if 'allocation_type' in values:
+                self._add_lastcalls()
+            return res
 
         previous_consumed_leaves = self.employee_id._get_consumed_leaves(leave_types=self.holiday_status_id)
         result = super().write(values)
         consumed_leaves = self.employee_id._get_consumed_leaves(leave_types=self.holiday_status_id)
+
+        if 'allocation_type' in values:
+            self._add_lastcalls()
         for allocation in self:
             current_excess = dict(consumed_leaves[1]).get(allocation.employee_id, {}) \
                 .get(allocation.holiday_status_id, {}).get('excess_days', {})


### PR DESCRIPTION
Steps to reproduce:
-------------------
- create a regular allocation
- save it
- refuse it
- change the type to accrual and set a plan
- save it
- take a time off

Issue:
------
A traceback occurs.

Cause:
------
The commit 7d874be72b0ca95251a47db54d87e34538ec26e3 remove the default value for the `lastcall` field.
A value is added to `lastcall` only during create.

Therefore during `_process_accrual_plan`, we will have `max(allocation.lastcall, first_level_start_date)`. with `allocation.lastcall = False`.

Solution:
---------
Call `_add_lastcalls` during the write to make sure we have a value if the allocation is accrual.

opw-3946060