### PR TITLE
[FIX] l10n_es_edi_sii: exclude jsondump.json from "SEND & PRINT"

### DIFF
--- a/addons/l10n_es_edi_sii/models/__init__.py
+++ b/addons/l10n_es_edi_sii/models/__init__.py
@@ -4,5 +4,6 @@ from . import account_edi_format
 from . import account_move
 from . import account_tax
 from . import l10n_es_edi_certificate
+from . import mail_template
 from . import res_company
 from . import res_config_settings

--- a/addons/l10n_es_edi_sii/models/mail_template.py
+++ b/addons/l10n_es_edi_sii/models/mail_template.py
@@ -1,0 +1,12 @@
+from odoo import models
+
+
+class MailTemplate(models.Model):
+    _inherit = "mail.template"
+
+    def _get_edi_attachments(self, document):
+        # When an invoice is signed, an electronic document is created (i.e. jsondump.json)
+        # Prevent this document to be added in "SEND & PRINT" wizard
+        if document.name == 'jsondump.json' and document.edi_format_id.code == 'es_sii':
+            return {}
+        return super()._get_edi_attachments(document)


### PR DESCRIPTION
**Steps to reproduce:** (!!! Spanish EDI credentials required !!!)
- Install l10n_es_edi_sii
- Switch to a Spanish company (e.g. ES Company)
- Configure Spanish Localization
- Create an invoice
- Process it by the ES E-invoicing service
- Once processed, an electronic document containing the response of the E-invoicing service is created (i.e. jsondump.json)

**Issue:**
When sending the invoice via "SEND & PRINT" button, the "jsondump.json" file is added in the attachments.

opw-3720984




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
