### PR TITLE
[FIX] stock_picking_batch: add missing test for batch move line

### DIFF
--- a/addons/stock_picking_batch/tests/test_batch_picking.py
+++ b/addons/stock_picking_batch/tests/test_batch_picking.py
@@ -458,6 +458,33 @@ class TestBatchPicking02(TransactionCase):
         ])
         self.assertEqual(pickings.move_line_ids.result_package_id, package)
 
+    def test_add_batch_move_line(self):
+        """
+        Adding a stock move line in a batch form triggers a calculation of the
+        default dest location. This test checks if that calculation doesn't
+        raise any exceptions for a new, empty StockMoveLine object.
+        """
+        loc1, loc2 = self.stock_location.child_ids
+        picking = self.env['stock.picking'].create({
+            'location_id': loc1.id,
+            'location_dest_id': loc2.id,
+            'picking_type_id': self.picking_type_internal.id,
+        })
+        batch_form = Form(self.env['stock.picking.batch'])
+        batch_form.picking_ids.add(picking)
+        batch = batch_form.save()
+        batch.action_confirm()
+        confirmed_form = Form(batch)
+        # Adding a new line should not raise an error
+        confirmed_form.move_line_ids.new()
+        # Adding a line should work also for users in storage categories group
+        self.env.user.groups_id += self.env.ref('stock.group_stock_storage_categories')
+        batch_form = Form(self.env['stock.picking.batch'])
+        batch_form.picking_ids.add(picking)
+        batch = batch_form.save()
+        batch.action_confirm()
+        confirmed_form = Form(batch)
+        confirmed_form.move_line_ids.new()
 
     def test_batch_validation_without_backorder(self):
         loc1, loc2 = self.stock_location.child_ids


### PR DESCRIPTION
This is a missing test for odoo/odoo#165753. It also checks the first condition from the `_get_default_dest_location` method, since the test for it was also missing.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
