### PR TITLE
[IMP] sale*: improve so in mobile view

### DIFF
--- a/addons/account/static/src/components/tax_totals/tax_totals.xml
+++ b/addons/account/static/src/components/tax_totals/tax_totals.xml
@@ -39,7 +39,7 @@
     </t>
 
     <t t-name="account.TaxTotalsField">
-        <table t-if="totals">
+        <table t-if="totals" class="float-end">
             <tbody>
                 <t t-foreach="totals.subtotals" t-as="subtotal" t-key="subtotal['name']">
                     <tr>

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -642,10 +642,11 @@
                                 <field name="tax_id"/>
                                 <field name="company_id"/>
                                 <field name="tax_calculation_rounding_method"/>
+                                <field name="currency_id"/>
                                 <control>
-                                    <create name="add_product_control" string="Add a product"/>
-                                    <create name="add_section_control" string="Add a section" context="{'default_display_type': 'line_section'}"/>
-                                    <create name="add_note_control" string="Add a note" context="{'default_display_type': 'line_note'}"/>
+                                    <create name="add_product_control" string="Add product"/>
+                                    <create name="add_section_control" string="Add section" context="{'default_display_type': 'line_section'}"/>
+                                    <create name="add_note_control" string="Add note" context="{'default_display_type': 'line_note'}"/>
                                     <button name="action_add_from_catalog"
                                             context="{'order_id': parent.id}"
                                             string="Catalog"
@@ -657,7 +658,7 @@
                                         <div t-attf-class="oe_kanban_card oe_kanban_global_click ps-0 pe-0 {{ record.display_type.raw_value ? 'o_is_' + record.display_type.raw_value : '' }}">
                                             <t t-if="!record.display_type.raw_value">
                                                 <div class="row g-0">
-                                                    <div class="col-2 pe-3">
+                                                    <div class="col-2 p-1">
                                                         <img t-att-src="kanban_image('product.product', 'image_128', record.product_id.raw_value)" t-att-title="record.product_id.value" t-att-alt="record.product_id.value" style="max-width: 100%;"/>
                                                     </div>
                                                     <div class="col-10">
@@ -670,9 +671,8 @@
                                                                 <strong t-out="record.product_id.value" />
                                                             </div>
                                                             <div class="col-auto">
-                                                                <strong>Tax excl.: </strong>
                                                                 <t t-set="line_price" t-value="record.price_subtotal.value"/>
-                                                                <strong class="float-end text-end" t-out="line_price" />
+                                                                <strong class="float-end text-end pe-1" t-out="line_price" widget="monetary"/>
                                                             </div>
                                                         </div>
                                                         <div class="row">
@@ -685,11 +685,6 @@
                                                             <div class="col text-muted">
                                                                 Unit Price:
                                                                 <t t-out="record.price_unit.value"/>
-                                                            </div>
-                                                            <div class="col-auto" t-if="record.tax_calculation_rounding_method.raw_value === 'round_per_line'">
-                                                                <strong>Tax incl.: </strong>
-                                                                <t t-set="line_price" t-value="record.price_total.value"/>
-                                                                <strong class="float-end text-end" t-out="line_price" />
                                                             </div>
                                                         </div>
                                                         <t t-if="record.discount?.raw_value">
@@ -715,7 +710,7 @@
                                 </templates>
                             </kanban>
                         </field>
-                        <div class="float-end d-flex gap-1 mb-2 ms-1"
+                        <div class="float-end d-flex gap-1 mb-2"
                              name="so_button_below_order_lines">
                             <button string="Discount"
                                     name="action_open_discount_wizard"

--- a/addons/sale_loyalty/views/sale_order_views.xml
+++ b/addons/sale_loyalty/views/sale_order_views.xml
@@ -14,7 +14,7 @@
                         class="btn btn-secondary"/>
                 <button name="action_open_reward_wizard"
                         type="object"
-                        string="Promotions"
+                        string="Reward"
                         help="Update current promotional lines and select new rewards if applicable."
                         class="btn btn-secondary"/>
             </button>

--- a/addons/sale_margin/views/sale_order_views.xml
+++ b/addons/sale_margin/views/sale_order_views.xml
@@ -8,13 +8,15 @@
         <field name="priority" eval="15"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='tax_totals']" position="after">
-                <label for="margin" groups="base.group_user"/>
-                <div class="text-nowrap" groups="base.group_user">
-                    <field name="margin" class="oe_inline"/>
-                    <field name="amount_untaxed" invisible="1"/>
-                    <span class="oe_inline" invisible="amount_untaxed == 0">
-                        (<field name="margin_percent" nolabel="1" class="oe_inline" widget="percentage"/>)
-                    </span>
+                <div class="d-flex float-end" colspan="2" groups="base.group_user">
+                    <label for="margin"/>
+                    <div>
+                        <field name="margin" class="oe_inline"/>
+                        <field name="amount_untaxed" invisible="1"/>
+                        <span class="oe_inline" invisible="amount_untaxed == 0">
+                            (<field name="margin_percent" nolabel="1" class="oe_inline" widget="percentage"/>)
+                        </span>
+                    </div>
                 </div>
             </xpath>
         </field>


### PR DESCRIPTION
sale*: sale, sale_margin, sale_loyalty

**Prior this commit:**
The so in mobile view was a bit not aligned.

**Post this commit:**
Renamed some buttons, applied correct margin-padding.
Making it function properly in all the mobile devices.

**Affected Version:** master
**Task:** 3964642