### PR TITLE
[FIX] web: position properly graph legend tooltips

### DIFF
--- a/addons/web/static/src/views/graph/graph_renderer.js
+++ b/addons/web/static/src/views/graph/graph_renderer.js
@@ -592,7 +592,7 @@ export class GraphRenderer extends Component {
         if (this.legendTooltip || text === fullText) {
             return;
         }
-        const viewContentTop = this.rootRef.el.getBoundingClientRect().top;
+        const viewContentTop = this.canvasRef.el.getBoundingClientRect().top;
         const legendTooltip = Object.assign(document.createElement("div"), {
             className: "o_tooltip_legend popover p-3 pe-none",
             innerText: fullText,


### PR DESCRIPTION
Since [1] the legends tooltips are misplaced.

A similar issue has been fixed for the main tooltips of the graph view. See [2]

[1]: https://github.com/odoo/odoo/commit/c8ca9da7bcee2c122a9d6cf8cda89f02823ba42d
[2]: https://github.com/odoo/odoo/commit/c1f08c60b7272e5a30951c53b67427e2f205b722