### PR TITLE
[FIX] *_sale_product_configurator: prices are wrongly sent to GA

### DIFF
--- a/addons/sale_product_configurator/views/templates.xml
+++ b/addons/sale_product_configurator/views/templates.xml
@@ -139,7 +139,7 @@
                             "widget": "monetary",
                             "display_currency": (pricelist or product).currency_id
                         }'/>
-                    <span class="js_raw_price d-none" t-esc="product.price"/>
+                    <span class="js_raw_price d-none" t-esc="combination_info['price']"/>
                     <p class="css_not_available_msg alert alert-warning">Option not available</p>
                 </td>
             </tr>

--- a/addons/website_sale_product_configurator/static/src/js/website_sale_options.js
+++ b/addons/website_sale_product_configurator/static/src/js/website_sale_options.js
@@ -98,7 +98,7 @@ publicWidget.registry.WebsiteSale.include({
                 'item_name': el.getElementsByClassName('product_display_name')[0].textContent,
                 'quantity': parseFloat(el.getElementsByClassName('js_quantity')[0].value),
                 'currency': currency,
-                'price': parseFloat(el.getElementsByClassName('oe_price')[0].getElementsByClassName('oe_currency_value')[0].textContent),
+                'price': parseFloat(el.getElementsByClassName('js_raw_price')[0].textContent),
             });
         });
         if (productsTrackingInfo.length) {


### PR DESCRIPTION
- Intall website_sale_product_configurator
- Create a product A with price 3 999.00 €
- Add an optional product on product A
- Go to shop page
- Go to product A
- Add to cart
- A modal popup appear
- Finelize cart
--> Issue the price send to datalayer is 3.
Because "3 999,00" is send in the json, endead 3999.00.

Co-Authored-By: "Louis (loti)" <loti@odoo.com>