### PR TITLE
[FIX] web, website: prevent search engine crawling of neutralized db

### DIFF
--- a/addons/web/views/neutralize_views.xml
+++ b/addons/web/views/neutralize_views.xml
@@ -15,5 +15,8 @@
                 </span>
             </div>
         </xpath>
+        <xpath expr="//head">
+            <meta name="robots" content="noindex, nofollow" />
+        </xpath>
     </template>
 </odoo>

--- a/addons/website/data/neutralize.sql
+++ b/addons/website/data/neutralize.sql
@@ -10,3 +10,7 @@ UPDATE ir_ui_view
 -- disable cdn
 UPDATE website
    SET cdn_activated = false;
+
+-- Update robots.txt to disallow all crawling
+UPDATE website
+   SET robots_txt = E'User-agent: *\nDisallow: /'


### PR DESCRIPTION
This commit implements two changes to prevent search engines from crawling and indexing content on websites marked as neutralized:

- Robots.txt update: The robots.txt field in the website database is updated with a rule disallowing all crawling (User-agent: * \n Disallow: /).
- Robots meta tag injection: An XPath expression is used to inject a robots meta tag with content="noindex, nofollow" within the web.neutralize_banner view's <head> section.

These combined changes ensure a strong signal to search engines to not index neutralized databases.

task-3895772

