### PR TITLE
[FIX] spreadsheet: duplicate graph menu links on sheet duplication

### DIFF
--- a/addons/spreadsheet/static/src/chart/plugins/chart_odoo_menu_plugin.js
+++ b/addons/spreadsheet/static/src/chart/plugins/chart_odoo_menu_plugin.js
@@ -1,6 +1,9 @@
 /** @odoo-module */
 import spreadsheet from "@spreadsheet/o_spreadsheet/o_spreadsheet_extended";
-const { coreTypes } = spreadsheet;
+import { omit } from "@web/core/utils/objects";
+
+const { coreTypes, helpers } = spreadsheet;
+const { deepEquals } = helpers;
 
 /** Plugin that link charts with Odoo menus. It can contain either the Id of the odoo menu, or its xml id. */
 export default class ChartOdooMenuPlugin extends spreadsheet.CorePlugin {
@@ -21,6 +24,35 @@ export default class ChartOdooMenuPlugin extends spreadsheet.CorePlugin {
             case "DELETE_FIGURE":
                 this.history.update("odooMenuReference", cmd.id, undefined);
                 break;
+            case "DUPLICATE_SHEET":
+                this.updateOnDuplicateSheet(cmd.sheetId, cmd.sheetIdTo);
+                break;
+        }
+    }
+
+    updateOnDuplicateSheet(sheetIdFrom, sheetIdTo) {
+        for (const oldChartId of this.getters.getChartIds(sheetIdFrom)) {
+            if (!this.odooMenuReference[oldChartId]) {
+                continue;
+            }
+            const oldChartDefinition = this.getters.getChartDefinition(oldChartId);
+            const oldFigure = this.getters.getFigure(sheetIdFrom, oldChartId);
+            const newChartId = this.getters.getChartIds(sheetIdTo).find((newChartId) => {
+                const newChartDefinition = this.getters.getChartDefinition(newChartId);
+                const newFigure = this.getters.getFigure(sheetIdTo, newChartId);
+                return (
+                    deepEquals(oldChartDefinition, newChartDefinition) &&
+                    deepEquals(omit(newFigure, "id"), omit(oldFigure, "id")) // compare size and position
+                );
+            });
+
+            if (newChartId) {
+                this.history.update(
+                    "odooMenuReference",
+                    newChartId,
+                    this.odooMenuReference[oldChartId]
+                );
+            }
         }
     }
 

--- a/addons/spreadsheet/static/tests/charts/model/link_chart_plugin_test.js
+++ b/addons/spreadsheet/static/tests/charts/model/link_chart_plugin_test.js
@@ -3,6 +3,7 @@
 import spreadsheet from "@spreadsheet/o_spreadsheet/o_spreadsheet_extended";
 import { getBasicData } from "@spreadsheet/../tests/utils/data";
 import { createBasicChart } from "@spreadsheet/../tests/utils/commands";
+import { createSpreadsheetWithChart } from "@spreadsheet/../tests/utils/chart";
 import { makeTestEnv } from "@web/../tests/helpers/mock_env";
 import { registry } from "@web/core/registry";
 import { menuService } from "@web/webclient/menus/menu_service";
@@ -172,5 +173,45 @@ QUnit.module(
             });
             assert.equal(model.getters.getChartOdooMenu(chartId), undefined);
         });
+
+        QUnit.test(
+            "Links of Odoo charts are duplicated when duplicating a sheet",
+            async function (assert) {
+                const { model } = await createSpreadsheetWithChart({
+                    type: "odoo_pie",
+                    serverData: this.serverData,
+                });
+                const sheetId = model.getters.getActiveSheetId();
+                const secondSheetId = "mySecondSheetId";
+                const chartId = model.getters.getChartIds(sheetId)[0];
+                model.dispatch("DUPLICATE_SHEET", { sheetId, sheetIdTo: secondSheetId });
+                const newChartId = model.getters.getChartIds(secondSheetId)[0];
+                assert.deepEqual(
+                    model.getters.getChartOdooMenu(newChartId),
+                    model.getters.getChartOdooMenu(chartId)
+                );
+            }
+        );
+
+        QUnit.test(
+            "Links of standard charts are duplicated when duplicating a sheet",
+            async function (assert) {
+                const env = await makeTestEnv({ serverData: this.serverData });
+                const model = new Model({}, { evalContext: { env } });
+                const sheetId = model.getters.getActiveSheetId();
+                const secondSheetId = "mySecondSheetId";
+                createBasicChart(model, chartId);
+                model.dispatch("LINK_ODOO_MENU_TO_CHART", {
+                    chartId,
+                    odooMenuId: 1,
+                });
+                model.dispatch("DUPLICATE_SHEET", { sheetId, sheetIdTo: secondSheetId });
+                const newChartId = model.getters.getChartIds(secondSheetId)[0];
+                assert.deepEqual(
+                    model.getters.getChartOdooMenu(newChartId),
+                    model.getters.getChartOdooMenu(chartId)
+                );
+            }
+        );
     }
 );

--- a/addons/spreadsheet/static/tests/utils/chart.js
+++ b/addons/spreadsheet/static/tests/utils/chart.js
@@ -27,6 +27,7 @@ export function insertChartInSpreadsheet(model, type = "odoo_bar") {
  *
  * @param {Object} params
  * @param {function} [params.mockRPC]
+ * @param {object} [params.serverData]
  * @param {string} [params.type]
  *
  * @returns { Promise<{ model: Model, env: Object }>}
@@ -34,6 +35,7 @@ export function insertChartInSpreadsheet(model, type = "odoo_bar") {
 export async function createSpreadsheetWithChart(params = {}) {
     const model = await createModelWithDataSource({
         mockRPC: params.mockRPC,
+        serverData: params.serverData,
     });
 
     insertChartInSpreadsheet(model, params.type);


### PR DESCRIPTION
The Odoo Menu linked to the graphs would not be duplicated on sheet duplication.

task-3810369

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
