### PR TITLE
[IMP] sale, pos_sale: rename amount paid/unpaid

### DIFF
--- a/addons/pos_sale/models/sale_order.py
+++ b/addons/pos_sale/models/sale_order.py
@@ -10,7 +10,12 @@ class SaleOrder(models.Model):
 
     pos_order_line_ids = fields.One2many('pos.order.line', 'sale_order_origin_id', string="Order lines Transfered to Point of Sale", readonly=True, groups="point_of_sale.group_pos_user")
     pos_order_count = fields.Integer(string='Pos Order Count', compute='_count_pos_order', readonly=True, groups="point_of_sale.group_pos_user")
-    amount_unpaid = fields.Monetary(string='Unpaid Amount', compute='_compute_amount_unpaid', store=True, help="The amount due from the sale order.")
+    amount_unpaid = fields.Monetary(
+        string="Amount To Pay In POS",
+        help="Amount left to pay in POS to avoid double payment or double invoicing.",
+        compute='_compute_amount_unpaid',
+        store=True,
+    )
 
     @api.model
     def _load_pos_data_domain(self, data):

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -242,7 +242,13 @@ class SaleOrder(models.Model):
         compute='_compute_authorized_transaction_ids',
         copy=False,
         compute_sudo=True)
-    amount_paid = fields.Float(compute='_compute_amount_paid', compute_sudo=True)
+    amount_paid = fields.Float(
+        string="Payment Transactions Amount",
+        help="Sum of transactions made in through the online payment form that are in the state"
+             " 'done' or 'authorized' and linked to this order.",
+        compute='_compute_amount_paid',
+        compute_sudo=True,
+    )
 
     # UTMs - enforcing the fact that we want to 'set null' when relation is unlinked
     campaign_id = fields.Many2one(ondelete='set null')


### PR DESCRIPTION
Purpose:
Customers with studio are displaying the fields 'amount_paid' and 'unpaid_amount' but it does not behave as they expect, leading to support tickets.

Post this commit:
Labels of amount_paid change to 'Payment Transactions Amount' and for unpaid_amount change to 'Amount To Pay In POS' with new help messages.

Task-3962158

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
