### PR TITLE
[FIX] crm: server action not working for probability field

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -709,6 +709,9 @@ class Lead(models.Model):
                 vals.update({'probability': 100, 'automated_probability': 100})
                 stage_is_won = True
 
+        if 'probability' in vals:
+            vals['probability'] = float(vals['probability'])
+
         # stage change with new stage: update probability and date_closed
         if vals.get('probability', 0) >= 100 or not vals.get('active', True):
             vals['date_closed'] = fields.Datetime.now()


### PR DESCRIPTION
**Before this PR:**
If you create a server action and update probability field in crm
it gives TypeError.

**After this PR:**
Updating probability via server action will not give a TypeError and
updates the probability value to the value you'll pick.

Task-3959066