### PR TITLE
[FIX] stock: prevent keyerror when reloading page

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -387,14 +387,15 @@ class StockQuant(models.Model):
         ctx['no_at_date'] = True
         if self.env.user.has_group('stock.group_stock_user') and not self.env.user.has_group('stock.group_stock_manager'):
             ctx['search_default_my_count'] = True
+        view_id = self.env.ref('stock.view_stock_quant_tree_inventory_editable').id
         action = {
             'name': _('Inventory Adjustments'),
             'view_mode': 'list',
-            'view_id': self.env.ref('stock.view_stock_quant_tree_inventory_editable').id,
             'res_model': 'stock.quant',
             'type': 'ir.actions.act_window',
             'context': ctx,
             'domain': [('location_id.usage', 'in', ['internal', 'transit'])],
+            'views': [(view_id, 'list')],
             'help': """
                 <p class="o_view_nocontent_smiling_face">
                     {}


### PR DESCRIPTION
When the customer opens the product from Physical Inventory and tries to reload the page,
a traceback will appear.

Steps to reproduce the error:
- Go to Inventory > Operations > Physical Inventory
- Open any product > reload the page

Traceback:
```
KeyError: 'views'
  File "odoo/http.py", line 2254, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1829, in _serve_db
    return self._transactioning(_serve_ir_http, readonly=ro)
  File "odoo/http.py", line 1849, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1827, in _serve_ir_http
    return self._serve_ir_http(rule, args)
  File "odoo/http.py", line 1834, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2059, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 220, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 740, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/action.py", line 90, in load_breadcrumbs
    name = act['display_name'] if any(view[1] != 'form' and view[1] != 'search' for view in act['views']) else None
```

https://github.com/odoo/odoo/blob/a0af91d2a7fbf22b610240497a791fa6cb63cc25/addons/stock/models/stock_quant.py#L390-L398
Here, 'views' key is missing in the action.
When the user refreshes the page, 'load_breadcrumbs' method will be called here.
https://github.com/odoo/odoo/blob/afb35b9ea5392eb097e4fc7689cb98a64396aef9/addons/web/controllers/action.py#L90

In the action, 'views' key is not present.
so it will give the above traceback.

Earlier, if the 'views' key was not present in the action, It worked fine.
because 'view_id' was enough for the action.
since 'load_breadcrumbs' method, if 'views' key is not present in the action,
It will give the above traceback.

sentry-5132471164

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
