### PR TITLE
[FIX] web: position properly graph legend tooltips

### DIFF
--- a/addons/web/static/src/views/graph/graph_renderer.js
+++ b/addons/web/static/src/views/graph/graph_renderer.js
@@ -593,6 +593,7 @@ export class GraphRenderer extends Component {
      * @param {Object} legendItem
      */
     onlegendHover(ev, legendItem) {
+        ev = ev.native;
         this.canvasRef.el.style.cursor = "pointer";
         /**
          * The string legendItem.text is an initial segment of legendItem.fullText.
@@ -604,7 +605,7 @@ export class GraphRenderer extends Component {
         if (this.legendTooltip || text === fullText) {
             return;
         }
-        const viewContentTop = this.rootRef.el.getBoundingClientRect().top;
+        const viewContentTop = this.canvasRef.el.getBoundingClientRect().top;
         const legendTooltip = Object.assign(document.createElement("div"), {
             className: "o_tooltip_legend popover p-3 pe-none",
             innerText: fullText,


### PR DESCRIPTION
Since [1] the legends tooltips are misplaced.

A similar issue has been fixed for the main tooltips of the graph view. See [2]

Since [3] the Chart.js lib has been updated and the event received by hovering the legend is now wrapped in an object. To access the native event we also need to access the `native` key of that object.

[1]: https://github.com/odoo/odoo/commit/c8ca9da7bcee2c122a9d6cf8cda89f02823ba42d
[2]: https://github.com/odoo/odoo/commit/c1f08c60b7272e5a30951c53b67427e2f205b722
[3]: https://github.com/odoo/odoo/commit/7e3c1ecdb86110912b15722e600f9571692807ed