### PR TITLE
[IMP] account,l10n_de: GoBD improvements

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -512,6 +512,7 @@ class ResPartner(models.Model):
             else:
                 partner.currency_id = self.env.company.currency_id
 
+    name = fields.Char(tracking=True)
     credit = fields.Monetary(compute='_credit_debit_get', search=_credit_search,
         string='Total Receivable', help="Total amount this customer owes you.",
         groups='account.group_account_invoice,account.group_account_readonly')

--- a/addons/l10n_de/i18n/de.po
+++ b/addons/l10n_de/i18n/de.po
@@ -750,6 +750,17 @@ msgstr "Dreiecksgeschäfte"
 msgid "W-IdNr."
 msgstr "W-IdNr."
 
+#. module: l10n_de
+#. odoo-python
+#: code:addons/l10n_de/models/account_account.py:0
+#, python-format
+msgid ""
+"You can not change the code/name of an account if it contains hashed "
+"entries."
+msgstr ""
+"Sie können den Code/Namen eines Kontos nicht ändern, wenn es Hash-Einträge "
+"enthält."
+
 #. module: l10n_de_reports
 #: code:addons/l10n_de_reports/models/account_generic_tax_report.py:0
 #, python-format

--- a/addons/l10n_de/i18n/l10n_de.pot
+++ b/addons/l10n_de/i18n/l10n_de.pot
@@ -806,6 +806,15 @@ msgstr ""
 msgid "W-IdNr."
 msgstr ""
 
+#. module: l10n_de
+#. odoo-python
+#: code:addons/l10n_de/models/account_account.py:0
+#, python-format
+msgid ""
+"You can not change the code/name of an account if it contains hashed "
+"entries."
+msgstr ""
+
 #. module: l10n_de_reports
 #: code:addons/l10n_de_reports/models/account_generic_tax_report.py:0
 #, python-format

--- a/addons/l10n_de/models/__init__.py
+++ b/addons/l10n_de/models/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import account_account
 from . import account_journal
 from . import account_move
 from . import datev

--- a/addons/l10n_de/models/account_account.py
+++ b/addons/l10n_de/models/account_account.py
@@ -1,0 +1,16 @@
+from odoo import models, _
+from odoo.exceptions import UserError
+
+
+class AccountAccount(models.Model):
+    _inherit = ['account.account']
+
+    def write(self, vals):
+        if 'DE' in self.company_id.account_fiscal_country_id.mapped('code') and ('code' in vals or 'name' in vals):
+            hashed_aml_domain = [
+                ('account_id', 'in', self.ids),
+                ('move_id.inalterable_hash', '!=', False),
+            ]
+            if self.env['account.move.line'].search_count(hashed_aml_domain, limit=1):
+                raise UserError(_("You can not change the code/name of an account if it contains hashed entries."))
+        super().write(vals)

--- a/addons/l10n_de/models/chart_template.py
+++ b/addons/l10n_de/models/chart_template.py
@@ -12,6 +12,7 @@ class AccountChartTemplate(models.AbstractModel):
             self.env.company.id: {
                 'external_report_layout_id': 'l10n_din5008.external_layout_din5008',
                 'paperformat_id': 'l10n_din5008.paperformat_euro_din',
+                'check_account_audit_trail': True,
             }
         }
 

--- a/addons/l10n_de/models/res_company.py
+++ b/addons/l10n_de/models/res_company.py
@@ -10,7 +10,11 @@ import stdnum.exceptions
 class ResCompany(models.Model):
     _inherit = 'res.company'
 
-    l10n_de_stnr = fields.Char(string="St.-Nr.", help="Tax number. Scheme: ??FF0BBBUUUUP, e.g.: 2893081508152 https://de.wikipedia.org/wiki/Steuernummer")
+    l10n_de_stnr = fields.Char(
+        string="St.-Nr.",
+        help="Tax number. Scheme: ??FF0BBBUUUUP, e.g.: 2893081508152 https://de.wikipedia.org/wiki/Steuernummer",
+        tracking=True,
+    )
     l10n_de_widnr = fields.Char(string="W-IdNr.", help="Business identification number.")
 
     @api.depends('country_code')

--- a/addons/l10n_de_audit_trail/__manifest__.py
+++ b/addons/l10n_de_audit_trail/__manifest__.py
@@ -1,0 +1,15 @@
+{
+    'name': 'Germany - audit trail',
+    'version': '1.0',
+    'description': """
+This module is a bridge to auto-install Audit Trail with Germany
+    """,
+    'summary': "Audit trail",
+    'depends': [
+        'l10n_de',
+        'account_audit_trail'
+    ],
+    'installable': True,
+    'auto_install': ['l10n_de'],
+    'license': 'LGPL-3',
+}


### PR DESCRIPTION
* In standard: enable tracking on partner name
* In l10n_de: enable tracking on SteuerNr.
* Constraint on account : "You can not change the code/name of an account if it contains hashed entries."
* enable audit trail by default when loading a new German CoA

taskid: 3950840