### PR TITLE
[ADD] account: Add tax aggregation formula shortcut

### DIFF
--- a/addons/account/models/account_report.py
+++ b/addons/account/models/account_report.py
@@ -272,6 +272,7 @@ class AccountReportLine(models.Model):
     domain_formula = fields.Char(string="Domain Formula Shortcut", help="Internal field to shorten expression_ids creation for the domain engine", inverse='_inverse_domain_formula', store=False)
     account_codes_formula = fields.Char(string="Account Codes Formula Shortcut", help="Internal field to shorten expression_ids creation for the account_codes engine", inverse='_inverse_account_codes_formula', store=False)
     aggregation_formula = fields.Char(string="Aggregation Formula Shortcut", help="Internal field to shorten expression_ids creation for the aggregation engine", inverse='_inverse_aggregation_formula', store=False)
+    tax_tags_formula = fields.Char(string="Tax Tags Formula Shortcut", help="Internal field to shorten expression_ids creation for the tax_tags engine", inverse='_inverse_aggregation_tax_formula', store=False)
 
     _sql_constraints = [
         ('code_uniq', 'unique (code)', "A report line with the same code already exists."),
@@ -361,6 +362,9 @@ class AccountReportLine(models.Model):
     def _inverse_aggregation_formula(self):
         self._create_report_expression(engine='aggregation')
 
+    def _inverse_aggregation_tax_formula(self):
+        self._create_report_expression(engine='tax_tags')
+
     def _inverse_account_codes_formula(self):
         self._create_report_expression(engine='account_codes')
 
@@ -378,6 +382,8 @@ class AccountReportLine(models.Model):
                 subformula, formula = None, report_line.account_codes_formula
             elif engine == 'aggregation' and report_line.aggregation_formula:
                 subformula, formula = None, report_line.aggregation_formula
+            elif engine == 'tax_tags' and report_line.tax_tags_formula:
+                subformula, formula = None, report_line.tax_tags_formula
             else:
                 # If we want to replace a formula shortcut with a full-syntax expression, we need to make the formula field falsy
                 # We can't simply remove it from the xml because it won't be updated


### PR DESCRIPTION
[ADD] account: Add tax_tag shortcut formula

While we are working on a refactor for italian tax report https://github.com/odoo/odoo/pull/164064
We discovered the need for having tax_tag shortcut as the report was getting huge. So, we thought it's the time to have the tax_tags shortcut

Solution: Adding 'tax_tags_formula' for the tax_tags shortcut in a similar way like aggregation_formula

task-id#3969688

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr