### PR TITLE
[FIX] l10n_fr_hr_holidays: compute in batch

### DIFF
--- a/addons/l10n_fr_hr_holidays/models/hr_leave.py
+++ b/addons/l10n_fr_hr_holidays/models/hr_leave.py
@@ -89,6 +89,11 @@ class HrLeave(models.Model):
         For example take an employee working mon-wed in a company where the regular calendar is mon-fri.
         If the employee were to take a time off ending on wednesday, the legal duration would count until friday.
         """
-        if self._l10n_fr_leave_applies():
-            return super()._get_durations(resource_calendar=(resource_calendar or self.company_id.resource_calendar_id))
+        if not resource_calendar:
+            fr_leaves = self.filtered(lambda leave: leave._l10n_fr_leave_applies())
+            duration_by_leave_id = super(HrLeave, self - fr_leaves)._get_durations(resource_calendar=resource_calendar)
+            fr_leaves_by_company = fr_leaves.grouped('company_id')
+            for company, leaves in fr_leaves_by_company.items():
+                duration_by_leave_id.update(leaves._get_durations(resource_calendar=company.resource_calendar_id))
+            return duration_by_leave_id
         return super()._get_durations(resource_calendar=resource_calendar)


### PR DESCRIPTION
how to reproduce:
-install l10n_fr_hr_holidays
-install l10n_hk_hr_holidays
-> error of ensure_one

related infos:
first appearance: https://github.com/odoo/odoo/commit/f72ac3a14d76d4fb53ec3a092d08afafe4c35888 version: 17.3

reason:
The _get_durations method is now made to be called in batch, so it should be able to handle multiple records but its logic was not reflecting that due to the condition that is actually making the method implicitly ensure_one.

fix:
adapt the logic to handle multiple records

task-3932806

Note: This task has been retarget to saas 17.3

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
