### PR TITLE
[IMP] analytic: UX Analytic demo data

### DIFF
--- a/addons/analytic/data/analytic_account_demo.xml
+++ b/addons/analytic/data/analytic_account_demo.xml
@@ -14,92 +14,131 @@
         <record id="analytic_absences" model="account.analytic.account">
             <field name="name">Time Off</field>
             <field name="plan_id" ref="analytic.analytic_plan_internal"/>
+            <field name="company_id" eval="False"/>
         </record>
         <record id="analytic_internal" model="account.analytic.account">
             <field name="name">Operating Costs</field>
             <field name="plan_id" ref="analytic.analytic_plan_internal"/>
+            <field name="company_id" eval="False"/>
         </record>
         <record id="analytic_our_super_product" model="account.analytic.account">
             <field name="name">Our Super Product</field>
             <field name="partner_id" ref="base.res_partner_2"/>
             <field name="plan_id" ref="analytic.analytic_plan_projects"/>
+            <field name="company_id" eval="False"/>
         </record>
         <record id="analytic_seagate_p2" model="account.analytic.account">
             <field name="name">Seagate P2</field>
             <field name="partner_id" ref="base.res_partner_2"/>
             <field name="plan_id" ref="analytic.analytic_plan_projects"/>
+            <field name="company_id" eval="False"/>
         </record>
         <record id="analytic_millennium_industries" model="account.analytic.account">
             <field name="name">Millennium Industries</field>
             <field name="partner_id" ref="base.res_partner_3"/>
             <field name="plan_id" ref="analytic.analytic_plan_projects"/>
+            <field name="company_id" eval="False"/>
         </record>
         <record id="analytic_integration_c2c" model="account.analytic.account">
             <field name="name">CampToCamp</field>
             <field name="partner_id" ref="base.res_partner_12"/>
             <field name="plan_id" ref="analytic.analytic_plan_projects"/>
+            <field name="company_id" eval="False"/>
         </record>
         <record id="analytic_agrolait" model="account.analytic.account">
             <field name="name">Deco Addict</field>
             <field name="partner_id" ref="base.res_partner_2"/>
             <field name="plan_id" ref="analytic.analytic_plan_projects"/>
+            <field name="company_id" eval="False"/>
         </record>
         <record id="analytic_asustek" model="account.analytic.account">
             <field name="name">Asustek</field>
             <field name="partner_id" ref="base.res_partner_1"/>
             <field name="plan_id" ref="analytic.analytic_plan_projects"/>
+            <field name="company_id" eval="False"/>
         </record>
         <record id="analytic_deltapc" model="account.analytic.account">
             <field name="name">Delta PC</field>
             <field name="partner_id" ref="base.res_partner_4"/>
             <field name="plan_id" ref="analytic.analytic_plan_projects"/>
+            <field name="company_id" eval="False"/>
         </record>
         <record id="analytic_spark" model="account.analytic.account">
             <field name="name">Spark Systems</field>
             <field name="partner_id" ref="base.res_partner_1"/>
             <field name="plan_id" ref="analytic.analytic_plan_projects"/>
+            <field name="company_id" eval="False"/>
         </record>
         <record id="analytic_nebula" model="account.analytic.account">
             <field name="name">Nebula</field>
             <field name="partner_id" ref="base.res_partner_12"/>
             <field name="plan_id" ref="analytic.analytic_plan_projects"/>
+            <field name="company_id" eval="False"/>
         </record>
         <record id="analytic_luminous_technologies" model="account.analytic.account">
             <field name="name">Luminous Technologies</field>
             <field name="partner_id" ref="base.res_partner_3"/>
             <field name="plan_id" ref="analytic.analytic_plan_projects"/>
+            <field name="company_id" eval="False"/>
         </record>
         <record id="analytic_desertic_hispafuentes" model="account.analytic.account">
             <field name="name">Desertic - Hispafuentes</field>
             <field name="partner_id" ref="base.res_partner_12"/>
             <field name="plan_id" ref="analytic.analytic_plan_projects"/>
+            <field name="company_id" eval="False"/>
         </record>
         <record id="analytic_think_big_systems" model="account.analytic.account">
             <field name="name">Lumber Inc</field>
             <field name="partner_id" ref="base.res_partner_18"/>
             <field name="plan_id" ref="analytic.analytic_plan_projects"/>
+            <field name="company_id" eval="False"/>
         </record>
         <record id="analytic_partners_camp_to_camp" model="account.analytic.account">
             <field name="name">Camp to Camp</field>
             <field name="partner_id" ref="base.res_partner_12"/>
             <field name="plan_id" ref="analytic.analytic_plan_projects"/>
+            <field name="company_id" eval="False"/>
         </record>
         <record id="analytic_active_account" model="account.analytic.account">
             <field name="name">Active account</field>
             <field name="active" eval="True"/>
             <field name="plan_id" ref="analytic.analytic_plan_projects"/>
+            <field name="company_id" eval="False"/>
         </record>
         <record id="analytic_administratif" model="account.analytic.account">
             <field name="name">Administrative</field>
             <field name="plan_id" ref="analytic.analytic_plan_departments"/>
+            <field name="company_id" eval="False"/>
         </record>
         <record id="analytic_commercial_marketing" model="account.analytic.account">
             <field name="name">Commercial &amp; Marketing</field>
             <field name="plan_id" ref="analytic.analytic_plan_departments"/>
+            <field name="company_id" eval="False"/>
         </record>
         <record id="analytic_rd_department" model="account.analytic.account">
             <field name="name">Research &amp; Development</field>
             <field name="plan_id" ref="analytic.analytic_plan_departments"/>
+            <field name="company_id" eval="False"/>
+        </record>
+        <record id="analytic_rd_hr" model="account.analytic.account">
+            <field name="name">Human Resources</field>
+            <field name="plan_id" ref="analytic.analytic_plan_departments"/>
+            <field name="company_id" eval="False"/>
+        </record>
+        <record id="analytic_rd_legal" model="account.analytic.account">
+            <field name="name">Legal</field>
+            <field name="plan_id" ref="analytic.analytic_plan_departments"/>
+            <field name="company_id" eval="False"/>
+        </record>
+        <record id="analytic_rd_finance" model="account.analytic.account">
+            <field name="name">Finance</field>
+            <field name="plan_id" ref="analytic.analytic_plan_departments"/>
+            <field name="company_id" eval="False"/>
+        </record>
+        <record id="analytic_rd_production" model="account.analytic.account">
+            <field name="name">Production</field>
+            <field name="plan_id" ref="analytic.analytic_plan_departments"/>
+            <field name="company_id" eval="False"/>
         </record>
     </data>
 </odoo>

--- a/addons/project/data/project_demo.xml
+++ b/addons/project/data/project_demo.xml
@@ -92,6 +92,7 @@
         <record id="analytic_construction" model="account.analytic.account">
             <field name="name">Home Construction</field>
             <field name="plan_id" ref="analytic.analytic_plan_projects"/>
+            <field name="company_id" eval="False"/>
         </record>
 
         <!-- Stage templates -->

--- a/addons/sale_timesheet/data/sale_service_demo.xml
+++ b/addons/sale_timesheet/data/sale_service_demo.xml
@@ -74,6 +74,7 @@
             <field name="code">INT</field>
             <field name="active" eval="True"/>
             <field name="plan_id" ref="analytic.analytic_plan_projects"/>
+            <field name="company_id" eval="False"/>
         </record>
 
         <record id="project_support" model="project.project">


### PR DESCRIPTION
In a multi-company environment, the Analytic Plans "Departments" and "Internal" are optional but have no analytic account. Because analytic account had a default on the env company. We want the analytic account to be available for every company.

Also adding some analytic account.

task-3970078

enterprise: https://github.com/odoo/enterprise/pull/63898




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
