### PR TITLE
[FIX] mail: editing activity from record will pass the proper context

### DIFF
--- a/addons/mail/static/src/core/web/activity_service.js
+++ b/addons/mail/static/src/core/web/activity_service.js
@@ -53,6 +53,7 @@ export class ActivityService {
     }
 
     async edit(activityId) {
+        const activity = this.store.Activity.get(activityId);
         return new Promise((resolve) =>
             this.env.services.action.doAction(
                 {
@@ -63,6 +64,10 @@ export class ActivityService {
                     views: [[false, "form"]],
                     target: "new",
                     res_id: activityId,
+                    context: {
+                        default_res_model: activity.res_model,
+                        default_res_id: activity.res_id,
+                    },
                 },
                 { onClose: resolve }
             )

--- a/addons/mail/static/tests/activity/activity_tests.js
+++ b/addons/mail/static/tests/activity/activity_tests.js
@@ -22,7 +22,7 @@ const views = {
                 <field name="message_ids"/>
             </div>
         </form>`,
-        "mail.compose.message,false,form": `
+    "mail.compose.message,false,form": `
         <form>
             <field name="partner_ids"/>
         </form>`,
@@ -409,6 +409,41 @@ QUnit.test("activity click on edit", async (assert) => {
             assert.strictEqual(action.type, "ir.actions.act_window");
             assert.strictEqual(action.res_model, "mail.activity");
             assert.strictEqual(action.res_id, activityId);
+            return super.doAction(...arguments);
+        },
+    });
+    await click(".o-mail-Activity .btn", { text: "Edit" });
+    assert.verifySteps(["do_action"]);
+});
+
+QUnit.test("activity click on edit should pass correct context", async (assert) => {
+    const pyEnv = await startServer();
+    const partnerId = pyEnv["res.partner"].create({});
+    const mailTemplateId = pyEnv["mail.template"].create({ name: "Dummy mail template" });
+    const [activityTypeId] = pyEnv["mail.activity.type"].search([["name", "=", "Email"]]);
+    const activityId = pyEnv["mail.activity"].create({
+        activity_type_id: activityTypeId,
+        can_write: true,
+        mail_template_ids: [mailTemplateId],
+        res_id: partnerId,
+        res_model: "res.partner",
+    });
+    const { env, openFormView } = await start();
+    await openFormView("res.partner", partnerId);
+    patchWithCleanup(env.services.action, {
+        async doAction(action) {
+            assert.step("do_action");
+            assert.strictEqual(action.type, "ir.actions.act_window");
+            assert.strictEqual(action.res_model, "mail.activity");
+            assert.strictEqual(action.res_id, activityId);
+            assert.deepEqual(
+                action.context,
+                {
+                    default_res_model: "res.partner",
+                    default_res_id: partnerId,
+                },
+                "should pass correct context with default_res_model and default_res_id"
+            );
             return super.doAction(...arguments);
         },
     });


### PR DESCRIPTION
## Issue: 
When creating an activity linked to a record like a lead, if we edit this activity, for example from To-Do to Meeting, we lose the context from the Lead and have a bad context based on the activity instead, resulting in an improper link in the calendar.

## Steps to reproduce:
1. Install CRM (this will also install the rest of the required modules).
2. Create or use an existing Lead.
3. Create a new To-Do activity.
4. Click on edit for this activity and change it to Meeting.
5. Now click on Open Calendar and place the activity.
6. Click on the calendar event we have just created, and we will see a link to "Activity". Click on it.

## Solution: 
To ensure the proper link to the Lead/Opportunity, we need to pass the right context when editing the activity. This issue arose from changes made in `activity_service.js` and the addition of the model `mail.activity.schedule`, which separates the edit and create functions, unlike the behavior we had in 16.0.

opw-3942711


Before
![before](https://github.com/odoo/odoo/assets/6569390/f9671678-5e87-4ccc-b02f-3b277d6325f5)
After
![after](https://github.com/odoo/odoo/assets/6569390/06b7d501-af39-40fa-9054-dcf06a00f9dc)
