### PR TITLE
[IMP] stock: forecast and order correctly base on the reservation_date

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -2137,7 +2137,7 @@ Please change the quantity done or the rounding precision of your unit of measur
                          ('procure_method', '=', 'make_to_stock'),
                          ('reservation_date', '<=', fields.Date.today())]
         moves_to_reserve = self.env['stock.move'].search(expression.AND([static_domain, expression.OR(domains)]),
-                                                         order='reservation_date, priority desc, date asc, id asc')
+                                                         order='priority desc, date asc, id asc')
         moves_to_reserve._action_assign()
 
     def _rollup_move_dests(self, seen=False):

--- a/addons/stock/report/stock_forecasted.py
+++ b/addons/stock/report/stock_forecasted.py
@@ -2,8 +2,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from collections import defaultdict
+from datetime import date
 
 from odoo import api, models
+from odoo.osv.expression import AND
 from odoo.tools import float_is_zero, format_date, float_round, float_compare
 
 
@@ -267,8 +269,14 @@ class StockForecasted(models.AbstractModel):
         in_domain, out_domain = self._move_confirmed_domain(
             product_template_ids, product_ids, wh_location_ids
         )
+        past_domain = [('reservation_date', '<=', date.today())]
+        future_domain = ['|', ('reservation_date', '>', date.today()), ('reservation_date', '=', False)]
 
-        outs = self.env['stock.move'].search(out_domain, order='reservation_date, priority desc, date, id')
+        past_outs = self.env['stock.move'].search(AND([out_domain, past_domain]), order='priority desc, date, id')
+        future_outs = self.env['stock.move'].search(AND([out_domain, future_domain]), order='reservation_date, priority desc, date, id')
+
+        outs = past_outs | future_outs
+
         outs_per_product = defaultdict(list)
         for out in outs:
             outs_per_product[out.product_id.id].append(out)

--- a/addons/stock/tests/test_report.py
+++ b/addons/stock/tests/test_report.py
@@ -1172,7 +1172,9 @@ class TestReports(TestReportsCommon):
 
     def test_report_forecast_11_non_reserved_order(self):
         """ Creates deliveries with different operation type reservation methods.
-        Checks replenishment lines are correctly sorted by reservation_date:
+        Checks replenishment lines are correctly sorted by the flollowing criteria:
+            - If the reservation date is in the past at any time T, use the priority and scheduled date
+            - If the reservation date is in the future, use reservation date, priority and scheduled date
             'manual': always last (no reservation_date)
             'at_confirm': reservation_date = time of creation
             'by_date': reservation_date = scheduled_date - reservation_days_before(_priority)
@@ -1240,11 +1242,11 @@ class TestReports(TestReportsCommon):
         delivery_at_confirm = delivery_form.save()
         delivery_at_confirm.action_confirm()
 
-        # Order should be: delivery_by_date, delivery_at_confirm, delivery_by_date_priority, delivery_manual
+        # Order should be: delivery_at_confirm, delivery_by_date, delivery_by_date_priority, delivery_manual
         _, _, lines = self.get_report_forecast(product_template_ids=self.product_template.ids)
         self.assertEqual(len(lines), 4, "The report must have 4 lines.")
-        self.assertEqual(lines[0]['document_out']['id'], delivery_by_date.id)
-        self.assertEqual(lines[1]['document_out']['id'], delivery_at_confirm.id)
+        self.assertEqual(lines[0]['document_out']['id'], delivery_at_confirm.id)
+        self.assertEqual(lines[1]['document_out']['id'], delivery_by_date.id)
         self.assertEqual(lines[2]['document_out']['id'], delivery_by_date_priority.id)
         self.assertEqual(lines[3]['document_out']['id'], delivery_manual.id)
 


### PR DESCRIPTION
When two pickings have a reservation date in the past the reservation give the priority to the move with the smallest reservation_date (reserve x days before date on picking type). However it's not very obvious for the end user and using the date of the move seems a better idea.

ALso the forecast report doesn't respesct the reservation_date in its forecat. Reconcile correctly the move base on their reservation date.

Task-3530930

closes odoo/odoo#146643

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
