### PR TITLE
[FIX] sale_timesheet: get profitability items from all linked projects 

### DIFF
--- a/addons/sale_timesheet/models/project.py
+++ b/addons/sale_timesheet/models/project.py
@@ -500,10 +500,16 @@ class Project(models.Model):
         }
 
     def _get_profitability_items(self, with_action=True):
-        return self._get_profitability_items_from_aal(
+        profitability_items = self._get_profitability_items_from_aal(
             super()._get_profitability_items(with_action),
             with_action
         )
+        for project in self.sale_order_id.project_ids - self:
+            profitability_items = project._get_profitability_items_from_aal(
+                profitability_items,
+                with_action=False,
+            )
+        return profitability_items
 
 
 class ProjectTask(models.Model):


### PR DESCRIPTION
Versions
--------
- 16.0+

Steps
-----
1. Enable analytic accounting;
2. have a sales order with a timesheeted service product;
3. have two projects with different AALs;
4. link both projecs to the same SOL;
5. create timesheets in both projects;
6. open the profitability view of a project.

Issue
-----
The profitability shows shows the total revenue of the SO, but only the cost of that specific project.

Cause
-----
The `_get_profitability_items` override only checks the AAL associated with that project.

Solution
--------
Call `_get_profitability_items` on all projects linked the the project's sales order.

opw-3631672