### PR TITLE
[FIX] project: prevent infinite recurring tasks creation

### DIFF
--- a/addons/project/models/project_task_recurrence.py
+++ b/addons/project/models/project_task_recurrence.py
@@ -81,6 +81,8 @@ class ProjectTaskRecurrence(models.Model):
 
     def _create_next_occurrence(self, occurrence_from):
         self.ensure_one()
+        if self.repeat_type == 'until' and fields.Date.today() > self.repeat_until:
+            return
         # Prevent double mail_followers creation
         self = self.with_context(mail_create_nosubscribe=True)
         self.env['project.task'].sudo().create(

--- a/addons/project/tests/test_project_recurrence.py
+++ b/addons/project/tests/test_project_recurrence.py
@@ -114,6 +114,11 @@ class TestProjectRecurrence(TransactionCase):
 
         with freeze_time(self.date_01_01 + relativedelta(days=32)):
             task.state = '1_done'
+        self.assertEqual(len(task.recurrence_id.task_ids), 2, "Since this is not the last task of the recurrence, next occurrence shouldn't have been created")
+
+        last_recurring_task = task.recurrence_id.task_ids.filtered(lambda t: t != task)
+        with freeze_time(self.date_01_01 + relativedelta(days=32)):
+            last_recurring_task.state = '1_done'
         self.assertEqual(len(task.recurrence_id.task_ids), 2, "Since this is after repeat_until, next occurrence shouldn't have been created")
 
     def test_recurring_settings_change(self):


### PR DESCRIPTION
Steps to reproduce:
-------------------
- in settings, activate "Recurring Tasks"
- create a recurring task with a dateline to today and a recurrence every "1 Days Until tomorrow"
- save
- change the state to "Done"
- on the new created task, change the state to "Done"

Issue:
------
Steps can be repeated indefinitely, creating an infinite number of recurring tasks with a specific end date for the recurrence.

Cause:
------
There is no check with the `repeat_until` field when creating a recurring task.

opw-3941688