### PR TITLE
[FIX] web_editor, mass_mailing: wait for snippets to load

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
@@ -441,6 +441,7 @@ export class MassMailingHtmlField extends HtmlField {
         if (this.env.mailingFilterTemplates && this.wysiwyg) {
             this._hideIrrelevantTemplates();
         }
+        this.wysiwyg.odooEditor.activateContenteditable();
     }
     _getCodeViewEl() {
         const codeView = this.wysiwyg &&

--- a/addons/mass_mailing/static/src/js/wysiwyg.js
+++ b/addons/mass_mailing/static/src/js/wysiwyg.js
@@ -136,6 +136,11 @@ const MassMailingWysiwyg = Wysiwyg.extend({
             this.toolbar.$el.find('#create-link').toggleClass('d-none', true);
         }
     },
+    _getEditorOptions: function () {
+        const options = this._super(...arguments);
+        const finalOptions = { autoActivateContentEditable: false, ...options };
+        return finalOptions;
+    },
 });
 
 return MassMailingWysiwyg;

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -248,6 +248,7 @@ export class OdooEditor extends EventTarget {
                 allowCommandVideo: true,
                 renderingClasses: [],
                 allowInlineAtRoot: false,
+                autoActivateContentEditable: true,
             },
             options,
         );
@@ -318,8 +319,10 @@ export class OdooEditor extends EventTarget {
         this.editable.setAttribute('dir', this.options.direction);
 
         // Set contenteditable before clone as FF updates the content at this point.
-        this._activateContenteditable();
-
+        this.canActivateContentEditable = this.options.autoActivateContentEditable;
+        if (this.canActivateContentEditable) {
+            this._activateContenteditable();
+        }
         this._collabClientId = this.options.collaborationClientId;
         this._collabClientAvatarUrl = this.options.collaborationClientAvatarUrl;
 
@@ -2320,6 +2323,11 @@ export class OdooEditor extends EventTarget {
         }
         this.observerActive('_activateContenteditable');
     }
+
+    activateContenteditable() {
+        this.canActivateContentEditable = true;
+        this._activateContenteditable();
+    } 
     _stopContenteditable() {
         this.observerUnactive('_stopContenteditable');
         if (this.options.isRootEditable) {
@@ -4307,7 +4315,10 @@ export class OdooEditor extends EventTarget {
         this._currentMouseState = ev.type;
         this._lastMouseClickPosition = [ev.x, ev.y];
 
-        this._activateContenteditable();
+        if (this.canActivateContentEditable) {
+            this._activateContenteditable();
+        }
+
         // Ignore any changes that might have happened before this point.
         this.observer.takeRecords();
 

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -276,6 +276,7 @@ const Wysiwyg = Widget.extend({
             collaborationClientAvatarUrl: this._getCollaborationClientAvatarUrl(),
             renderingClasses: ['o_dirty', 'o_transform_removal', 'oe_edited_link', 'o_menu_loading', 'o_link_in_selection'],
             foldSnippets: !!options.foldSnippets,
+            autoActivateContentEditable: this.options.autoActivateContentEditable,
         }, editorCollaborationOptions));
 
         this.odooEditor.addEventListener('contentChanged', function () {


### PR DESCRIPTION
Issue:
======
We can update the content of the editable before we choose the theme
which results in unexpected behaviors.

Steps to reproduce the issue:
=============================
- Open the email marketing app
- In the browser dev tools, set a big network throttle
- Create a new mailing
- Write in the editable zone before the template selection has had a
  chance to appear
- Click on design tab in the sidebar
- Traceback

Spec:
=====
We should not be able to write in the editable zone before choosing a
template.

Solution:
=========
We add a new option `waitForSnippets` for the `wysiwyg` to force the
editable element as `contenteditable="false"` until the snippets are
loaded. Once the snippets are loaded we set `contenteditable="true"`
back again.

Note 1: Removing the line of `this._activatecontenteditable` from
`_onMouseDown` in `odooEditor` because it keeps setting the editable
element as `contenteditable="true"` everytime we click. The line can be
safely removed because it's a leftorver from when clicking on links
would set everything to `contenteditable=false` except the link itself,
then clicking somewhere else would reactivate it. (introduced here
https://github.com/odoo/odoo/commit/72dd8d6e3c95f614353b1e87322a67c877c255c7)
. When it was outside the condition, it was hard to guess that it was not
needed anymore when we removed that `contenteditable` hack for links.

Note 2: the `odoo-editor` div in website have `contenteditable=false`
so dropped snippets will not be editable too. We call
`activatecontenteditable` after the drop of the snippets.

task-3901534