### PR TITLE
[FIX] point_of_sale: simplify onboarding

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -986,22 +986,6 @@ class PosConfig(models.Model):
         else:
             return f"{ref_name}_{self.env.company.id}"
 
-    def _get_scenario_names(self):
-        return [
-            ('furnitures', 'point_of_sale.pos_config_main'),
-            ('clothes', 'point_of_sale.pos_config_clothes'),
-            ('bakery', 'point_of_sale.pos_config_bakery'),
-        ]
-
-    def _get_existing_scenarios(self):
-        result = []
-        for name, base_ref_name in self._get_scenario_names():
-            ref_name = self._get_suffixed_ref_name(base_ref_name)
-            record = self.env.ref(ref_name, raise_if_not_found=False)
-            if record:
-                result.append(name)
-        return result
-
     @api.model
     def hide_predefined_scenarios(self):
         self.env.company.point_of_sale_show_predefined_scenarios = False
@@ -1016,7 +1000,6 @@ class PosConfig(models.Model):
             "has_pos_config": has_pos_config,
             "has_chart_template": has_chart_template,
             "is_restaurant_installed": bool(self.env['ir.module.module'].search_count([('name', '=', 'pos_restaurant'), ('state', '=', 'installed')])),
-            "existing_scenarios": self._get_existing_scenarios(),
             "show_predefined_scenarios": self.env.company.point_of_sale_show_predefined_scenarios,
         }
 

--- a/addons/point_of_sale/static/src/backend/pos_kanban_view/pos_kanban_view.js
+++ b/addons/point_of_sale/static/src/backend/pos_kanban_view/pos_kanban_view.js
@@ -23,7 +23,6 @@ export class PosKanbanController extends KanbanController {
             has_pos_config: true,
             has_chart_template: true,
             is_restaurant_installed: true,
-            existing_scenarios: [],
             show_predefined_scenarios: true,
         };
         onWillStart(() => updatePosKanbanViewState(this.orm, this.initialPosState));
@@ -48,11 +47,12 @@ export class PosKanbanRenderer extends KanbanRenderer {
                 }
                 if (!isInstalledWithDemo) {
                     await this.orm.call("pos.config", functionName);
+                    await this.orm.call("pos.config", "hide_predefined_scenarios");
                 }
             });
         });
         this.hidePredefinedScenarios = useTrackedAsync(async () => {
-            return await this.callWithViewUpdate(() =>
+            return await this.callWithViewUpdate(async () =>
                 this.orm.call("pos.config", "hide_predefined_scenarios")
             );
         });
@@ -67,15 +67,6 @@ export class PosKanbanRenderer extends KanbanRenderer {
         }
     }
 
-    get showScenarios() {
-        const hide = this.posState.has_chart_template && this.enabledScenarios.length === 0;
-        return this.posState.show_predefined_scenarios && !hide;
-    }
-
-    get enabledScenarios() {
-        return [...this.shopScenarios, ...this.restaurantScenarios].filter((s) => s.isEnabled);
-    }
-
     get shopScenarios() {
         return [
             {
@@ -83,21 +74,18 @@ export class PosKanbanRenderer extends KanbanRenderer {
                 description: _t("Multi colors and sizes"),
                 functionName: "load_onboarding_clothes_scenario",
                 iconFile: "clothes-icon.png",
-                isEnabled: !this.posState.existing_scenarios.some((x) => x === "clothes"),
             },
             {
                 name: _t("Furnitures"),
                 description: _t("Stock, product configurator, replenishment, discounts"),
                 functionName: "load_onboarding_furniture_scenario",
                 iconFile: "furniture-icon.png",
-                isEnabled: !this.posState.existing_scenarios.some((x) => x === "furnitures"),
             },
             {
                 name: _t("Bakery"),
                 description: _t("Food, but over the counter"),
                 functionName: "load_onboarding_bakery_scenario",
                 iconFile: "bakery-icon.png",
-                isEnabled: !this.posState.existing_scenarios.some((x) => x === "bakery"),
             },
         ];
     }
@@ -110,7 +98,6 @@ export class PosKanbanRenderer extends KanbanRenderer {
                 description: _t("Tables, menus, kitchen display, etc."),
                 functionName: "load_onboarding_restaurant_scenario",
                 iconFile: "restaurant-icon.png",
-                isEnabled: !this.posState.existing_scenarios.some((x) => x === "restaurant"),
             },
             {
                 name: _t("Bar"),
@@ -118,7 +105,6 @@ export class PosKanbanRenderer extends KanbanRenderer {
                 description: _t("Floor plan, tips, self order, etc."),
                 functionName: "load_onboarding_bar_scenario",
                 iconFile: "cocktail-icon.png",
-                isEnabled: !this.posState.existing_scenarios.some((x) => x === "bar"),
             },
         ];
     }

--- a/addons/point_of_sale/static/src/backend/pos_kanban_view/pos_kanban_view.xml
+++ b/addons/point_of_sale/static/src/backend/pos_kanban_view/pos_kanban_view.xml
@@ -9,7 +9,7 @@
     <t t-name="point_of_sale.PosKanbanRenderer">
         <div class="d-flex flex-column">
             <t t-call="web.KanbanRenderer" />
-            <div class="position-relative container" t-att-class="{ 'border-top mt-2': showTopBorder() }" t-if="showScenarios">
+            <div class="position-relative container" t-att-class="{ 'border-top mt-2': showTopBorder() }" t-if="this.posState.show_predefined_scenarios">
                 <button class="btn btn-link position-absolute top-0 end-0 py-2 px-3 h2" title="Close the scenario choices" t-on-click="() => this.hidePredefinedScenarios.call()">
                     <i class="oi oi-close"></i>
                 </button>
@@ -56,7 +56,7 @@
 
     <t t-name="point_of_sale.ScenarioCard">
         <div class="col-md-4">
-            <div class="card mb-3 rounded-3 scenario-card" t-att-class="{'disabled': !item.isEnabled}" style="max-width: 540px;" t-on-click="() => this.loadScenario.call(item)">
+            <div class="card mb-3 rounded-3 scenario-card" style="max-width: 540px;" t-on-click="() => this.loadScenario.call(item)">
                 <div class="row g-0">
                     <div class="col-md-4">
                         <div class="img-container m-2 d-flex align-items-center justify-content-center">

--- a/addons/pos_restaurant/models/pos_config.py
+++ b/addons/pos_restaurant/models/pos_config.py
@@ -116,14 +116,6 @@ class PosConfig(models.Model):
     def _load_restaurant_data(self):
         convert.convert_file(self.env, 'pos_restaurant', 'data/scenarios/restaurant_data.xml', None, noupdate=True, mode='init', kind='data')
 
-    def _get_scenario_names(self):
-        result = super()._get_scenario_names()
-        return [
-            *result,
-            ('bar', 'pos_restaurant.pos_config_main_bar'),
-            ('restaurant', 'pos_restaurant.pos_config_main_restaurant'),
-        ]
-
     @api.model
     def load_onboarding_bar_scenario(self):
         ref_name = 'pos_restaurant.pos_config_main_bar'


### PR DESCRIPTION
This is regression which removes the feature that we thought would be nice to have. Now, when a scenario is selected, we completely remove the other options in the screen, which prior to this commit, we kept on showing until all the scenarios are exhausted.
