### PR TITLE
[FIX] website: allow changing the padding of "Masonry" snippet images

### DIFF
--- a/addons/website/static/src/snippets/s_masonry_block/001.scss
+++ b/addons/website/static/src/snippets/s_masonry_block/001.scss
@@ -6,11 +6,7 @@
 
 .s_masonry_block[data-vcss='001'] .row.o_grid_mode {
     > div.o_grid_item_image {
-        padding: 0 !important;
-    }
-
-    // No padding highlight on the images.
-    &.o_we_padding_highlight > .o_grid_item_image::after {
-        animation: none;
+        --grid-item-padding-y: 0px;
+        --grid-item-padding-x: 0px;
     }
 }


### PR DESCRIPTION
When the grid mode was added in commit [1], the "Padding" grid option was impacting all the grid items at the same time. This was not looking good in the "Masonry" snippet, because the images would have the same padding as the text grid items, while it would look better if they could take the whole space. The padding was therefore forced to 0 px for this snippet images (see commit [2]), preventing this option from having an impact on them.

However, the "Padding" option was improved in commit [3], allowing the padding to be set on the grid items individually. There is therefore no need to block this option for the "Masonry" images anymore.

This commit removes the CSS rules preventing the "Padding" option from being applied on "Masonry" images. Note that the default padding is still set to 0 px, as it looks better, but it can now be modified with the option. Also note that the CSS rule about not showing the padding highlights was not working, as it was forgotten and not adapted when doing commit [3].

[1]: https://github.com/odoo/odoo/commit/cc406afcea7bf5846233a9f97a4a8ac5f618f3ec
[2]: https://github.com/odoo/odoo/commit/85b352af319edec84407f2046cf795b4e5503460
[3]: https://github.com/odoo/odoo/commit/11418cc6f0afcc8e14869f4f38ae0d6d462ac712

task-3970022