### PR TITLE
[IMP] account: added button for pay from invoice pdf

### DIFF
--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -98,6 +98,7 @@ class ResCompany(models.Model):
         help='International Commercial Terms are a series of predefined commercial terms used in international transactions.')
 
     qr_code = fields.Boolean(string='Display QR-code on invoices')
+    pay_from_pdf = fields.Boolean(string='Display Payment Link in PDF')
 
     invoice_is_email = fields.Boolean('Email by default', default=True)
     invoice_is_download = fields.Boolean('Download by default', default=True)

--- a/addons/account/models/res_config_settings.py
+++ b/addons/account/models/res_config_settings.py
@@ -136,6 +136,7 @@ class ResConfigSettings(models.TransientModel):
     account_fiscal_country_id = fields.Many2one(string="Fiscal Country Code", related="company_id.account_fiscal_country_id", readonly=False, store=False)
 
     qr_code = fields.Boolean(string='Display SEPA QR-code', related='company_id.qr_code', readonly=False)
+    pay_from_pdf = fields.Boolean(string='Display Payment Link in PDF', related='company_id.pay_from_pdf', readonly=False)
     invoice_is_download = fields.Boolean(string='Download', related='company_id.invoice_is_download', readonly=False)
     invoice_is_email = fields.Boolean(string='Send Email', related='company_id.invoice_is_email', readonly=False)
     incoterm_id = fields.Many2one('account.incoterms', string='Default incoterm', related='company_id.incoterm_id', help='International Commercial Terms are a series of predefined commercial terms used in international transactions.', readonly=False)

--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -290,6 +290,9 @@
                                         <p>Scan this QR Code with<br/>your banking application</p>
                                     </div>
                                 </div>
+                                <div t-if="o.display_pay_from_pdf and o.amount_residual > 0" name="pay_from_pdf_button">
+                                    <a t-attf-href="{{o._get_payment_link()}}" style="display: inline-block; padding: 10px 30px; font-weight: bold; background-color: #714B67; color: #fff; border-radius: 5px;">Click To Pay</a>
+                                </div>
                                 <!--terms and conditions-->
                                 <div class="text-muted mb-3" t-attf-style="#{'text-align:justify;text-justify:inter-word;' if o.company_id.terms_type != 'html' else ''}" t-if="not is_html_empty(o.narration)" name="comment">
                                     <span t-field="o.narration"/>

--- a/addons/account/views/res_config_settings_views.xml
+++ b/addons/account/views/res_config_settings_views.xml
@@ -219,6 +219,9 @@
                                 documentation="/applications/finance/accounting/receivables/customer_invoices/epc_qr_code.html">
                                 <field name="qr_code" class="oe_inline"/>
                             </setting>
+                            <setting id="pay_from_invoices_pdf" title="Add a button to your invoices pdf so that your customers can pay from PDF." string="Pay From PDF" company_dependent="1" help="Add a 'Click To Pay' button to your invoices">
+                                <field name="pay_from_pdf" class="oe_inline"/>
+                            </setting>
                         </block>
                         <block title="Vendor Bills" id="account_vendor_bills">
                             <setting id="show_purchase_receipts" help="Activate to create purchase receipt">


### PR DESCRIPTION
This PR introduces a 'Click To Pay' button directly within the invoice PDF.
By clicking this button, users can easily pay the invoice amount. The button
redirects users to the same location as the 'Generate a Payment Link' option.

**task**-3946627