### PR TITLE
[FIX] crm: define 'crm.lead' model to match dependency

### DIFF
--- a/addons/crm/__manifest__.py
+++ b/addons/crm/__manifest__.py
@@ -79,7 +79,13 @@
         'web.qunit_suite_tests': [
             'crm/static/tests/**/*',
             ('remove', 'crm/static/tests/tours/**/*'),
+            ('remove', 'crm/static/tests/mock_server/**/*'),
+            ('remove', 'crm/static/tests/crm_test_helpers.js'),
         ],
+        'web.assets_unit_tests': [
+            'crm/static/tests/mock_server/**/*',
+            'crm/static/tests/crm_test_helpers.js'
+        ]
     },
     'license': 'LGPL-3',
 }

--- a/addons/crm/static/tests/crm_test_helpers.js
+++ b/addons/crm/static/tests/crm_test_helpers.js
@@ -1,0 +1,4 @@
+import { CRMLead } from "@crm/../tests/mock_server/mock_models/crm_lead";
+import { mailModels } from "@mail/../tests/mail_test_helpers";
+
+export const crmModels = { ...mailModels, CRMLead };

--- a/addons/crm/static/tests/mock_server/mock_models/crm_lead.js
+++ b/addons/crm/static/tests/mock_server/mock_models/crm_lead.js
@@ -1,0 +1,5 @@
+import { models } from "@web/../tests/web_test_helpers";
+
+export class CRMLead extends models.ServerModel {
+    _name = "crm.lead";
+}


### PR DESCRIPTION
Purpose of this PR:
Test cases of the `crm_enterprise` require definition of `crm.lead` model.
Defining the model to match the dependency

Part of task:[3818666](https://www.odoo.com/odoo/project/1519/tasks/3818666?cids=2)

Related Enterprise PR: https://github.com/odoo/enterprise/pull/62256