### PR TITLE
[FIX] stock,mrp,repair: forecast icon

### DIFF
--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -422,6 +422,7 @@
                                     <field name="warehouse_id" column_invisible="True"/>
                                     <field name="is_locked" column_invisible="True"/>
                                     <field name="move_lines_count" column_invisible="True"/>
+                                    <field name="is_storable" column_invisible="True"/>
                                     <field name="location_dest_id" domain="[('id', 'child_of', parent.location_dest_id)]" column_invisible="True"/>
                                     <field name="state" column_invisible="True" force_save="1"/>
                                     <field name="should_consume_qty" column_invisible="True"/>

--- a/addons/repair/views/repair_views.xml
+++ b/addons/repair/views/repair_views.xml
@@ -147,6 +147,7 @@
                                 <field name="product_uom_category_id" column_invisible="True"/>
                                 <field name="has_tracking" column_invisible="True"/>
                                 <field name="display_assign_serial" column_invisible="True"/>
+                                <field name="is_storable" column_invisible="True"/>
                                 <field name="product_id" context="{'default_is_storable': True}" required="1" readonly="(state != 'draft' and not additional) or move_lines_count &gt; 0"/>
                                 <field name="description_picking" string="Description" optional="hide"/>
                                 <field name="date" optional="hide"/>

--- a/addons/stock/static/src/widgets/forecast_widget.xml
+++ b/addons/stock/static/src/widgets/forecast_widget.xml
@@ -9,7 +9,7 @@
             Exp <t t-out="forecastExpectedDate"/>
         </span>
         <span t-else="" class="text-danger">Not Available</span>
-        <button t-if="props.record.data.product_type == 'product'" title="Forecasted Report"
+        <button t-if="props.record.data.is_storable" title="Forecasted Report"
                 t-on-click="_openReport" t-att="resId ? {} : {'disabled': ''}"
                 class="o_forecast_report_button btn btn-link o_icon_button ms-2 pt-0">
             <i class="fa fa-fw fa-area-chart"

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -281,6 +281,7 @@
                                     <field name="show_quant" column_invisible="True"/>
                                     <field name="show_lots_text" column_invisible="True"/>
                                     <field name="show_lots_m2o" column_invisible="True"/>
+                                    <field name="is_storable" column_invisible="True"/>
                                     <field name="is_initial_demand_editable" column_invisible="True"/>
                                     <field name="display_import_lot" column_invisible="True"/>
                                     <field name="picking_type_entire_packs" column_invisible="True"/>


### PR DESCRIPTION
It was not display since an old reference to 'product' type. Replace it by is_storable and add them in view to have a reference in record.data

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
