### PR TITLE
[FIX] account: Allow skipping bank account creation on reconciliation

### DIFF
--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -4,7 +4,7 @@ import math
 
 from odoo import api, fields, models, _
 from odoo.tools import float_is_zero
-from odoo.tools.misc import formatLang, format_date
+from odoo.tools.misc import formatLang, format_date, str2bool
 from odoo.exceptions import UserError, ValidationError
 
 
@@ -1282,7 +1282,9 @@ class AccountBankStatementLine(models.Model):
     def _find_or_create_bank_account(self):
         bank_account = self.env['res.partner.bank'].search(
             [('company_id', '=', self.company_id.id), ('acc_number', '=', self.account_number)])
-        if not bank_account:
+        if not bank_account and not str2bool(
+            self.env['ir.config_parameter'].sudo().get_param("account.skip_create_bank_account_on_reconcile")
+        ):
             bank_account = self.env['res.partner.bank'].create({
                 'acc_number': self.account_number,
                 'partner_id': self.partner_id.id,


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

This commit introduces system parameter to skip the creation of bank account in the reconciliation of bank statements.

The issue it can solve happens when 2 different commercial entities use the same paying partner (ie a partner that is not a subcontact) to pay their invoices.

When an invoice is paid by the paying partner, Odoo will store the account number that was used for the transfer on account.bank.statement.line. When this statement line is reconciled with an invoice, if the bank account was not stored on the partner previously, a res.partner.bank will be created automatically.
When another payment is coming from the same bank account, Odoo will then select the partner linked to the bank account that it did store previously, even if the payment was for an invoice linked to another partner, and it will not propose the proper invoice in the reconciliation widget, even if it uses an exact match on the payment reference number.

Having a parameter allowing to skip creation of the bank account in Odoo will allow the reconciliation to be based striclty on the reference number.

Current behavior before PR:

Bank account is stored and wrong invoices are proposed by the reconciliation widget

Desired behavior after PR is merged:

Allow to avoid storing bank account and having wrong invoices are proposed by the reconciliation widget


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
