### PR TITLE
[FIX] pos_hr: inaccessible close register button

### DIFF
--- a/addons/pos_hr/models/hr_employee.py
+++ b/addons/pos_hr/models/hr_employee.py
@@ -34,7 +34,7 @@ class HrEmployee(models.Model):
         employees_barcode_pin = employees.get_barcodes_and_pin_hashed()
         bp_per_employee_id = {bp_e['id']: bp_e for bp_e in employees_barcode_pin}
 
-        employees = employees.read(fields)
+        employees = employees.read(fields, load=False)
         for employee in employees:
             if employee['user_id'] and employee['user_id'] in manager_ids or employee['id'] in data['pos.config']['data'][0]['advanced_employee_ids']:
                 role = 'manager'

--- a/addons/pos_hr/static/tests/tours/pos_hr_tour.js
+++ b/addons/pos_hr/static/tests/tours/pos_hr_tour.js
@@ -75,5 +75,9 @@ registry.category("web_tour.tours").add("PosHrTour", {
             ProductScreen.totalAmountIs("8.0"),
             Chrome.clickMenuOption("Orders"),
             TicketScreen.nthRowContains(4, "Mitchell Admin", false),
+
+            // Close register should be accessible by the admin user.
+            Chrome.clickMenuOption("Close Register"),
+            Dialog.is("Closing Register"),
         ].flat(),
 });


### PR DESCRIPTION
The "Close Register" button is not visible when "Log in with Employees" options is active even if you logged in using the "manager" employee.

STEPS TO REPRODUCE:

1. Intialize odoo with pos_hr module and demo data.
2. Activate "Log in with Employees".
3. Open pos and select Mitchell Admin as employee.
4. Try the close the session by clicking on the top-right burger menu. [BUG] The "Close Register" button is not visible.

SOLUTION:

This is because when the `hr.employee` records are loaded, the `user_id` field is not in the correct form. `user_id` points to `(<id>, <display name>)` when pos expects it to be just `int | False`.

This commit makes sure that the many2one fields when loading `hr.employee` records point to `int | False` values but specifying "load=False" when calling `read`.

ILLUSTRATION:

Before:

![Screenshot 2024-06-04 at 16 17 56](https://github.com/odoo/odoo/assets/3245568/2789fd1c-91fd-440d-b663-07b0c8725f4e)

After:

![Screenshot 2024-06-04 at 16 17 12](https://github.com/odoo/odoo/assets/3245568/5b099899-ca5c-4ba4-b263-be1741cab01b)
