### PR TITLE
[FIX] sale_project : Showing related stages only

### DIFF
--- a/addons/sale_project/models/sale_order.py
+++ b/addons/sale_project/models/sale_order.py
@@ -163,7 +163,7 @@ class SaleOrder(models.Model):
             action['res_id'] = self.tasks_ids.id
         # set default project
         default_line = next((sol for sol in self.order_line if sol.product_id.detailed_type == 'service'), self.env['sale.order.line'])
-        default_project_id = default_line.project_id.id or self.project_id.id or self.project_ids[:1].id
+        default_project_id = default_line.project_id.id or self.project_id.id or self.project_ids[:1].id or self.tasks_ids.project_id[:1].id
 
         action['context'] = {
             'default_sale_order_id': self.id,

--- a/addons/sale_project/tests/test_sale_project.py
+++ b/addons/sale_project/tests/test_sale_project.py
@@ -710,3 +710,28 @@ class TestSaleProject(TestSaleProjectCommon):
             sale_order_action = multi_company_project.with_company(company).action_view_sos()
             self.assertEqual(sale_order_action["type"], "ir.actions.act_window")
             self.assertEqual(sale_order_action["res_model"], "sale.order")
+
+    def test_action_view_task_stages(self):
+        SaleOrder = self.env['sale.order'].with_context(tracking_disable=True)
+        SaleOrderLine = self.env['sale.order.line'].with_context(tracking_disable=True)
+
+        sale_order_2 = SaleOrder.create({
+            'partner_id': self.partner.id,
+            'partner_invoice_id': self.partner.id,
+            'partner_shipping_id': self.partner.id,
+        })
+        sale_line_1_order_2 = SaleOrderLine.create({
+            'product_id': self.product_order_service1.id,
+            'product_uom_qty': 10,
+            'product_uom': self.product_order_service1.uom_id.id,
+            'price_unit': self.product_order_service1.list_price,
+            'order_id': sale_order_2.id,
+        })
+
+        self.env['project.task'].create({
+            'name': 'Task',
+            'sale_line_id': sale_line_1_order_2.id,
+            'project_id': self.project_global.id,
+        })
+        action = sale_order_2.action_view_task()
+        self.assertEqual(action["context"]["default_project_id"], self.project_global.id)


### PR DESCRIPTION
**Steps to reproduce:**
	- Install Sale and Project modules
	- Create a project with 1 or 2 stages
	- Create more than 1 task in this project
	- Assign those tasks to a Sale order
	- Go to this sale order and click on tasks smart button

**Current behavior before PR:**
When clicking on the task smart button in a sale order you will see lots of stages that are not associated with the shown tasks' project. This is happening because the value assigned to default_project_id in the context is False.
https://github.com/odoo/odoo/blob/saas-16.4/addons/sale_project/models/sale_order.py#L166

**Desired behavior after PR is merged:**
We are now just showing the stages associated with the shown tasks' project by assigning those tasks' project id to the default_project_id value in context.

opw-3929012