### PR TITLE
[IMP] mail: send message in chatter from a chat window

### DIFF
--- a/addons/mail/static/src/chatter/web_portal/composer_patch.js
+++ b/addons/mail/static/src/chatter/web_portal/composer_patch.js
@@ -5,10 +5,10 @@ import { patch } from "@web/core/utils/patch";
 patch(Composer.prototype, {
     get placeholder() {
         if (this.thread && this.thread.model !== "discuss.channel" && !this.props.placeholder) {
-            if (this.props.type === "message") {
-                return _t("Send a message to followers…");
-            } else {
+            if (this.state.isNote) {
                 return _t("Log an internal note…");
+            } else {
+                return _t("Send a message to followers…");
             }
         }
         return super.placeholder;

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -77,9 +77,10 @@
                                     <button t-att-disabled="!state.active" class="o-mail-Composer-attachFiles btn border-0 rounded-pill" title="Attach files" aria-label="Attach files" type="button" t-on-click="onClickAddAttachment"><i class="fa fa-paperclip"/></button>
                                 </t>
                             </FileUploader>
+                            <button t-if="env.inChatWindow and thread and thread.model !== 'discuss.channel'" class="btn border-0 rounded-pill" aria-label="Log Note/Send Message" t-on-click="onClickToggleNote" t-att-class="{'text-success': !this.state.isNote}"><i t-att-class="{'fa-envelope': !this.state.isNote, 'fa-envelope-o': this.state.isNote}" class="fa"/></button>
                             <t t-if="extended and ui.isSmall and props.composer.message" t-call="mail.Composer.sendButton"/>
+                            <button t-if="props.showFullComposer and thread and thread.model !== 'discuss.channel'" class="o-mail-Composer-fullComposer btn border-0 rounded-pill" title="Full composer" aria-label="Full composer" type="button" t-on-click="onClickFullComposer" data-hotkey="shift+c"><i class="fa fa-expand"/></button>
                         </div>
-                        <button t-if="props.showFullComposer and thread and thread.model !== 'discuss.channel'" class="o-mail-Composer-fullComposer btn fa fa-expand px-4 py-2 border-0 rounded-pill" title="Full composer" aria-label="Full composer" type="button" t-on-click="onClickFullComposer" data-hotkey="shift+c"/>
                     </div>
                     <t t-if="!extended" t-call="mail.Composer.sendButton"/>
                 </div>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Send message in chatter from a chat window.

Current behavior before PR:
When notifications are handled in Odoo, it is possible to interact with the chatter of a specific record within a chatwindow (opened from the messaging menu).
However, it is only possible to send log notes from the chatwindow's composer. To send a message/mail, it is necessary to open the form view of the record...

Desired behavior after PR is merged:
There is a new icon displayed in the composer if some conditions are met. This button allows switching between log notes and messages.

Task-3971045