### PR TITLE
[FIX] core: keep translations for null src while upgrade

### DIFF
--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -1566,6 +1566,7 @@ def _get_translation_upgrade_queries(cr, field):
     cleanup_queries = []
 
     if field.translate is True:
+        emtpy_src = """'{"en_US": ""}'::jsonb"""
         query = f"""
             WITH t AS (
                 SELECT it.res_id as res_id, jsonb_object_agg(it.lang, it.value) AS value, bool_or(imd.noupdate) AS noupdate
@@ -1576,7 +1577,8 @@ def _get_translation_upgrade_queries(cr, field):
               GROUP BY it.res_id
             )
             UPDATE {Model._table} m
-               SET "{field.name}" = CASE WHEN t.noupdate IS FALSE THEN t.value || m."{field.name}"
+               SET "{field.name}" = CASE WHEN m."{field.name}" IS NULL THEN {emtpy_src} || t.value
+                                         WHEN t.noupdate IS FALSE THEN t.value || m."{field.name}"
                                          ELSE m."{field.name}" || t.value
                                      END
               FROM t


### PR DESCRIPTION
Before Odoo 16.0, it is possible to have database column whose value is ``NULL`` but still has translation in the ir_translation table. And translations can be displayed correctly in the UI.

How to reproduce before Odoo 16.0:
1. Open the form view of a record with non-required translated field. E.g. product.template.sale_description
2. Create a new record and don't touch the translated field for test
3. Directly click the translation button and fill all translations
4. click save The column for the record's translated field has ``NULL`` value, and the ir_translation table has new translation records with ``NULL`` in the src column

During upgrade, when the column value is converted to jsonb for the translated field by the ORM, it will still be ``NULL``. And in the upgrade script when update the value with all translations, the result will still be ``NULL``. E.g. ``NULL || '{"fr_FR": "french"}'::jsonb``
``NULL || '{"en_US": "english", "fr_FR": "french"}'::jsonb``

In this commit, for the above corner case, we assume the src was empty string instead of NULL. In the above example, the result would be ``'{"en_US": ""}'::jsonb || '{"fr_FR": "french"}'::jsonb`` ``'{"en_US": ""}'::jsonb || '{"en_US": "english", "fr_FR": "french"}'::jsonb``

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
