### PR TITLE
[FIX] {test_,}mail: functional ir_actions without range_type

### DIFF
--- a/addons/mail/models/ir_actions_server.py
+++ b/addons/mail/models/ir_actions_server.py
@@ -121,7 +121,7 @@ class ServerActions(models.Model):
         }
         if self.activity_date_deadline_range > 0:
             vals['date_deadline'] = fields.Date.context_today(self) + relativedelta(**{
-                self.activity_date_deadline_range_type: self.activity_date_deadline_range})
+                self.activity_date_deadline_range_type or 'days': self.activity_date_deadline_range})
         for record in records:
             user = False
             if self.activity_user_type == 'specific':

--- a/addons/test_mail/tests/test_ir_actions.py
+++ b/addons/test_mail/tests/test_ir_actions.py
@@ -39,3 +39,19 @@ class TestServerActionsEmail(TestMailCommon, TestServerActionsBase):
         self.assertFalse(run_res, 'ir_actions_server: create next activity action correctly finished should return False')
         self.assertEqual(self.env['mail.activity'].search_count([]), before_count + 1)
         self.assertEqual(self.env['mail.activity'].search_count([('summary', '=', 'TestNew')]), 1)
+
+    def test_action_next_activity_due_date(self):
+        """ Make sure we don't crash if a due date is set without a type. """
+        self.action.write({
+            'state': 'next_activity',
+            'activity_user_type': 'specific',
+            'activity_type_id': self.env.ref('mail.mail_activity_data_meeting').id,
+            'activity_summary': 'TestNew',
+            'activity_date_deadline_range': 1,
+            'activity_date_deadline_range_type': False,
+        })
+        before_count = self.env['mail.activity'].search_count([])
+        run_res = self.action.with_context(self.context).run()
+        self.assertFalse(run_res, 'ir_actions_server: create next activity action correctly finished should return False')
+        self.assertEqual(self.env['mail.activity'].search_count([]), before_count + 1)
+        self.assertEqual(self.env['mail.activity'].search_count([('summary', '=', 'TestNew')]), 1)


### PR DESCRIPTION
Steps to reproduce:
- Install "Subscriptions"
- Go to "Configuration" -> "Alerts"
- Create a new alert:
  - Add a name for the alert
  - Action: Create next activty
  - Trigger On: Modification
  - Activtiy: To Do
  - Add a summary
  - Add a note
  - Due Date In: 1
  - Due Date type: Put it blank

Issues:
When triggered the action will result in a traceback due to `activity_date_deadline_range_type`.

https://github.com/odoo/odoo/blob/9a62d0c82cdc47718181aed36cad763499b4a51d/addons/mail/models/ir_actions_server.py#L123-L124

[Linked PR](https://github.com/odoo/enterprise/pull/63816)

opw-3946293