### PR TITLE
[FIX] account: remove placeholder on tax legal notes field

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -8533,11 +8533,6 @@ msgid "Legal Notes"
 msgstr ""
 
 #. module: account
-#: model_terms:ir.ui.view,arch_db:account.view_tax_form
-msgid "Legal Notes ..."
-msgstr ""
-
-#. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_account_position_form
 msgid "Legal Notes..."
 msgstr ""

--- a/addons/account/views/account_tax_views.xml
+++ b/addons/account/views/account_tax_views.xml
@@ -188,7 +188,7 @@
                                     <field name="analytic" invisible="amount_type == 'group'" groups="analytic.group_analytic_accounting" />
                                     <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>
                                     <field name="country_id" required="True"/>
-                                    <field name="invoice_legal_notes" placeholder="Legal Notes ..."/>
+                                    <field name="invoice_legal_notes"/>
                                 </group>
                                 <group name="advanced_booleans">
                                     <field name="price_include" invisible="amount_type == 'group'"/>


### PR DESCRIPTION
Removes a useless placeholder (because it's a repetition of the field name) for the field tax_legal_note that was added in this commit https://github.com/odoo/odoo/commit/4cfb19c6eb9603959eb459c22795c2585d8547a6

task-id: 3873054


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
