### PR TITLE
[FIX] spreadsheet: global filters ignore non-ODOO pivots

### DIFF
--- a/addons/spreadsheet/static/src/pivot/plugins/pivot_core_global_filter_plugin.js
+++ b/addons/spreadsheet/static/src/pivot/plugins/pivot_core_global_filter_plugin.js
@@ -77,6 +77,10 @@ export class PivotCoreGlobalFilterPlugin extends OdooCorePlugin {
             }
             case "DUPLICATE_PIVOT": {
                 const { pivotId, newPivotId } = cmd;
+                const pivotDefinition = this.getters.getPivotCoreDefinition(pivotId);
+                if(pivotDefinition.type !== "ODOO") {
+                    break;
+                }
                 const pivot = deepCopy(this.pivots[pivotId]);
                 this._addPivot(newPivotId, pivot.fieldMatching);
                 break;

--- a/addons/spreadsheet/static/tests/pivots/model/pivot_plugin_test.js
+++ b/addons/spreadsheet/static/tests/pivots/model/pivot_plugin_test.js
@@ -29,6 +29,7 @@ import { THIS_YEAR_GLOBAL_FILTER } from "@spreadsheet/../tests/utils/global_filt
 import * as spreadsheet from "@odoo/o-spreadsheet";
 import { waitForDataLoaded } from "@spreadsheet/helpers/model";
 const { DEFAULT_LOCALE, PIVOT_TABLE_CONFIG } = spreadsheet.constants;
+const { toZone } = spreadsheet.helpers;
 
 QUnit.module("spreadsheet > pivot plugin", {}, () => {
     QUnit.test("can get a pivotId from cell formula", async function (assert) {
@@ -1224,6 +1225,22 @@ QUnit.module("spreadsheet > pivot plugin", {}, () => {
             newPivotId: "new",
         });
         assert.deepEqual(result.reasons, [CommandResult.PivotIdNotFound]);
+    });
+
+    QUnit.test("Spreadsheet pivot table ignored by global fiter plugin", (assert) => {
+        const model = new Model();
+        model.selection.selectZone({ cell: { col: 0, row: 0 }, zone: toZone("A1:A4") });
+        const pivotId = "pivot1";
+        const sheetId = model.getters.getActiveSheetId();
+        model.dispatch("INSERT_NEW_PIVOT", { pivotId, sheetId });
+        model.dispatch("DUPLICATE_PIVOT", {
+            pivotId,
+            newPivotId: "new",
+        });
+        const pivotIds = model.getters.getPivotIds();
+        const pivotDef = model.getters.getPivotCoreDefinition(pivotId);
+        const dupPivotDef = model.getters.getPivotCoreDefinition(pivotIds[1]);
+        assert.deepEqual(dupPivotDef, { ...pivotDef, name: pivotDef.name + " (copy)" });
     });
 
     QUnit.test("isPivotUnused getter", async (assert) => {


### PR DESCRIPTION
How to reproduce:
- go to a runbot (starting saas-17.3, when we introduce the pivot tables)
- insert a  pivot table (spreadsheet pivot)  (select a zone -> top bar menu > insert > pivot table)
- go to its sidepanel and click "duplicate pivot"

==> crash

The plugin PivotCoreGlobalFilterPlugin mishandles the command `DUPLICATE_PIVOT` as it does not differentiate Odoo pivot (which it should handle) and a non-odoo pivot.

Task-3970711

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
