### PR TITLE
[FIX] stock: reserve the needed qty from the quant

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -143,9 +143,11 @@ class StockMoveLine(models.Model):
             if not record.quant_id or record.quantity:
                 continue
             if float_compare(record.move_id.product_qty, record.quantity, precision_rounding=record.move_id.product_uom.rounding) > 0:
-                record.quantity = max(0, min(record.quant_id.available_quantity, record.move_id.product_qty - record.move_id.quantity))
+                qty = max(0, min(record.quant_id.available_quantity, record.move_id.product_qty - record.move_id.quantity))
+                record.quantity = record.product_id.uom_id._compute_quantity(qty, record.product_uom_id)
             else:
-                record.quantity = max(0, record.quant_id.available_quantity)
+                qty = max(0, record.quant_id.available_quantity)
+                record.quantity = record.product_id.uom_id._compute_quantity(qty, record.product_uom_id)
 
     @api.depends('quantity', 'product_uom_id')
     def _compute_quantity_product_uom(self):

--- a/addons/stock/tests/test_move.py
+++ b/addons/stock/tests/test_move.py
@@ -6467,3 +6467,33 @@ class StockMove(TransactionCase):
         ml.write({'product_uom_id': self.uom_unit.id})
         self.assertEqual(quant.reserved_quantity, 2)
         self.assertEqual(ml.quantity * self.uom_unit.ratio, 2)
+
+    def test_move_line_qty_with_quant_in_different_uom(self):
+        """
+        Check that the reserved_quantity of the quant is correctly calculated
+        when the move line is in different UOM.
+        - Quant: 100 units tracked with "Lot 1"
+        - Move: 1 dozen
+        the reserved qty should be 12 units in the quant.
+        """
+        Quant = self.env['stock.quant']
+        lot1 = self.env['stock.lot'].create({
+            'name': 'lot1',
+            'product_id': self.product_lot.id,
+        })
+        move = self.env['stock.move'].create({
+            'name': 'Test move',
+            'product_id': self.product_lot.id,
+            'product_uom_qty': 1,
+            'product_uom': self.uom_dozen.id,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
+        })
+        move._action_confirm()
+        Quant._update_available_quantity(self.product_lot, self.stock_location, 100, lot_id=lot1)
+        quant = Quant._gather(self.product_lot, self.stock_location)
+        move_form = Form(move, view='stock.view_stock_move_operations')
+        with move_form.move_line_ids.new() as ml:
+            ml.quant_id = quant
+        move = move_form.save()
+        self.assertEqual(quant.reserved_quantity, 12)


### PR DESCRIPTION
**Steps to reproduce the bug:**
- Create a storable product P1:
    - uom = KG
    - tracked by lot: L1
    - update the quantity to 50 kg

- Create a storable product P2 with BoM:
    - quantity: 1 unit of P2
    - Component:
        - 50 000 g of P1

- create a MO to produce one unit of P2
- Need 50 000 g of P1, select the lot L1 in the detailed operation

**Problem:**
- only 50 g of P1 is reserved intsead of 50 000g.

opw-3935230
