### PR TITLE
[FIX] mail: localize activity date fields

### DIFF
--- a/addons/mail/static/src/core/web/activity.js
+++ b/addons/mail/static/src/core/web/activity.js
@@ -9,7 +9,12 @@ import { AvatarCardPopover } from "@mail/discuss/web/avatar_card/avatar_card_pop
 import { Component, onMounted, onWillUnmount, useState } from "@odoo/owl";
 
 import { browser } from "@web/core/browser/browser";
-import { deserializeDateTime } from "@web/core/l10n/dates";
+import {
+    deserializeDate,
+    deserializeDateTime,
+    formatDate,
+    formatDateTime,
+} from "@web/core/l10n/dates";
 import { _t } from "@web/core/l10n/translation";
 import { usePopover } from "@web/core/popover/popover_hook";
 import { useService } from "@web/core/utils/hooks";
@@ -52,9 +57,11 @@ export class Activity extends Component {
     }
 
     get displayCreateDate() {
-        return deserializeDateTime(this.props.data.create_date).toLocaleString(
-            luxon.DateTime.DATETIME_SHORT_WITH_SECONDS
-        );
+        return formatDateTime(deserializeDateTime(this.props.data.create_date));
+    }
+
+    get displayDeadlineDate() {
+        return formatDate(deserializeDate(this.props.data.date_deadline));
     }
 
     updateDelayAtNight() {

--- a/addons/mail/static/src/core/web/activity.xml
+++ b/addons/mail/static/src/core/web/activity.xml
@@ -34,7 +34,7 @@
                         <tr><td class="text-end fw-bolder">Activity type</td><td><t t-esc="activity.activity_type_id[1]"/></td></tr>
                         <tr><td class="text-end fw-bolder">Created</td><td><t t-esc="displayCreateDate"/> by <t t-esc="activity.create_uid[1]"/></td></tr>
                         <tr><td class="text-end fw-bolder">Assigned to</td><td><t t-esc="activity.user_id[1]"/></td></tr>
-                        <tr><td class="text-end fw-bolder">Due on</td><td><t t-esc="activity.date_deadline"/></td></tr>
+                        <tr><td class="text-end fw-bolder">Due on</td><td><t t-esc="displayDeadlineDate"/></td></tr>
                     </tbody>
                 </table>
             </div>

--- a/addons/mail/static/tests/tours/activity_date_format_tour.js
+++ b/addons/mail/static/tests/tours/activity_date_format_tour.js
@@ -1,0 +1,43 @@
+/** @odoo-module **/
+
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("mail_activity_date_format", {
+    test: true,
+    steps: () => [
+        {
+            trigger: "button:contains('Activities')",
+        },
+        {
+            trigger: "input[id*='activity_type_id']",
+            run: "click",
+        },
+        {
+            trigger: ".dropdown-item:contains('To-Do')",
+        },
+        {
+            trigger: "div[name='summary'] input",
+            run: "text Go Party",
+        },
+        {
+            trigger: "button:contains('Schedule')",
+        },
+        {
+            trigger: ".o-mail-Activity:contains('Go Party')",
+        },
+        {
+            trigger: ".fa-info-circle",
+            run: "click",
+        },
+        // Format expected from the server for 9 AM at the first day of 2024 is date_format = "%d/%b/%y", time_format = "%I:%M:%S %p".
+        {
+            trigger: ".o-mail-Activity-details tr:contains('Created') td:contains('01/Jan/24 09:00:00 AM')",
+            isCheck: true,
+        },
+        {
+            // Default due date is 5 days after creation date.
+            trigger: ".o-mail-Activity-details tr:contains('Due on') td:contains('06/Jan/24')",
+            isCheck: true,
+        }
+    ],
+});

--- a/addons/mail/tests/test_mail_activity.py
+++ b/addons/mail/tests/test_mail_activity.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from contextlib import contextmanager
 from dateutil.relativedelta import relativedelta
+from freezegun import freeze_time
 from unittest.mock import patch
 
 from odoo import fields
@@ -162,3 +162,23 @@ class TestMailActivityChatter(HttpCase):
             "mail_activity_schedule_from_chatter",
             login="admin",
         )
+
+    def test_mail_activity_date_format(self):
+        with freeze_time("2024-1-1 09:00:00 AM"):
+            LANG_CODE = "en_US"
+            self.env = self.env(context={"lang": LANG_CODE})
+            testuser = self.env['res.users'].create({
+                "email": "testuser@testuser.com",
+                "name": "Test User",
+                "login": "testuser",
+                "password": "testuser",
+            })
+            lang = self.env["res.lang"].search([('code', '=', LANG_CODE)])
+            lang.date_format = "%d/%b/%y"
+            lang.time_format = "%I:%M:%S %p"
+
+            self.start_tour(
+                f"/web#id={testuser.partner_id.id}&model=res.partner",
+                "mail_activity_date_format",
+                login="admin",
+            )


### PR DESCRIPTION
Issue
----

The date fields in the activity view aren't displayed according to the language's date/time formats.

Steps
-----

- Go to Settings -> Translations -> Language.
- Use a custom date & time format.
- Create a new model that has an activity view, say a project task. You'll see the task's deadline is displayed according to your format (correct behavior).
- Add an activity and set a due date.
- The "Created" & "Due On" dates don't match your custom format.

Cause
-----

In the activity component, the dates weren't formated according to the current language's date/time format but rather a hard-coded one.

opw-3929864