### PR TITLE
[FIX] point_of_sale: use correct identifier for taxDetails computation

### DIFF
--- a/addons/point_of_sale/static/src/app/store/models.js
+++ b/addons/point_of_sale/static/src/app/store/models.js
@@ -701,7 +701,7 @@ export class Orderline extends PosModel {
         // Tax details.
         const taxDetails = {};
         for (const taxValues of taxesData.taxes_data) {
-            taxDetails[taxValues.taxId] = {
+            taxDetails[taxValues.id] = {
                 amount: taxValues.tax_amount_factorized,
                 base: taxValues.display_base,
             };


### PR DESCRIPTION
Before this commit, taxValues.taxId was used as the key for taxDetails, which was undefined because it doesn't have a taxId property. The correct property to use is 'id'. This misuse was leading to several problems.

opw-3969647

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
