### PR TITLE
[FIX] point_of_sale: show attribute value in backend order

### DIFF
--- a/addons/point_of_sale/static/src/app/store/models.js
+++ b/addons/point_of_sale/static/src/app/store/models.js
@@ -575,7 +575,7 @@ export class Orderline extends PosModel {
         this.price_extra = parseFloat(price_extra) || 0.0;
     }
     set_full_product_name() {
-        this.full_product_name = this.product.display_name;
+        this.full_product_name = this.get_full_product_name_with_variant();
     }
     get_price_extra() {
         return this.price_extra;

--- a/addons/point_of_sale/static/tests/tours/ProductConfigurator.tour.js
+++ b/addons/point_of_sale/static/tests/tours/ProductConfigurator.tour.js
@@ -3,6 +3,7 @@
 import * as ProductScreen from "@point_of_sale/../tests/tours/helpers/ProductScreenTourMethods";
 import * as Chrome from "@point_of_sale/../tests/tours/helpers/ChromeTourMethods";
 import * as ProductConfigurator from "@point_of_sale/../tests/tours/helpers/ProductConfiguratorTourMethods";
+import * as PaymentScreen from "@point_of_sale/../tests/tours/helpers/PaymentScreenTourMethods";
 import { registry } from "@web/core/registry";
 import * as Order from "@point_of_sale/../tests/tours/helpers/generic_components/OrderWidgetMethods";
 import { inLeftSide } from "@point_of_sale/../tests/tours/helpers/utils";
@@ -45,7 +46,7 @@ registry.category("web_tour.tours").add("ProductConfiguratorTour", {
 
             // Check that the product has been added to the order with correct attributes and price
             ProductScreen.selectedOrderlineHas(
-                "Configurable Chair",
+                "Configurable Chair (Red, Metal, Other: Custom Fabric)",
                 "1.0",
                 "11.0"
             ),
@@ -90,6 +91,11 @@ registry.category("web_tour.tours").add("ProductConfiguratorTour", {
             // Active: Other and Leather, Inactive: Wool
             ProductConfigurator.numberRadioOptions(2),
             ProductConfigurator.confirmAttributes(),
+
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Cash"),
+            PaymentScreen.validateButtonIsHighlighted(true),
+            PaymentScreen.clickValidate(),
             Chrome.endTour(),
         ].flat(),
 });

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -579,8 +579,12 @@ class TestUi(TestPointOfSaleHttpCommon):
         fabrics_line = configurable_product.attribute_line_ids[2]
         fabrics_line.product_template_value_ids[1].ptav_active = False
 
-        self.main_pos_config.with_user(self.pos_user).open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config, 'ProductConfiguratorTour', login="pos_user")
+        self.main_pos_config.with_user(self.pos_admin).open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config, 'ProductConfiguratorTour', login="pos_admin")
+
+        paid_order = self.env['pos.order'].search([('state', '=', 'paid')])
+        self.assertEqual(len(paid_order), 1)
+        self.assertTrue('(Red, Metal, Other: Custom Fabric)' in paid_order.lines[0].full_product_name)
 
     def test_05_ticket_screen(self):
         if not loaded_demo_data(self.env):


### PR DESCRIPTION
Currently, when buying products with variants the attribute values are not reflected on the backend order.

Steps to reproduce:
-------------------
* Go to the **Point of Sale** app
* Open a shop session
* Make an order for the product `Desk Organizer`
* Select any option from the product configuration popup
* Pay and Validate the order
* Go in the backend
* Navigate to **Orders**
* Select the last order
> Observation: Selected options for the product are not reflected

Why the fix:
------------
The function `set_full_product_name()` was changed with https://github.com/odoo/odoo/commit/672c853ab7d77ac1cebd2f4d16bd98fc454b2d55

It basically changed the behavior to set the `full_product_name` to `display_name` where it was previously computed with the attribute values.

The fix is based on the fix made for the `pos_retaurant` module. https://github.com/odoo/odoo/commit/3b6455eb979078354e3b1009a354ca7010e5fec9

This will re-introduce a feature removed from the first commit mentioned which is to show the attribute values in full name of the product. This has already been re-introduced in later versions

https://github.com/odoo/odoo/blob/8e00b5337a2ee30e667b0b2e6ff26b7df9fef2e3/addons/point_of_sale/static/src/app/store/models.js#L315-L320

This is in sass-17.2

opw-3950366