### PR TITLE
[FIX] pos_sms: received broken sms body to customer

### DIFF
--- a/addons/pos_sms/models/pos_order.py
+++ b/addons/pos_sms/models/pos_order.py
@@ -10,8 +10,9 @@ class PosOrder(models.Model):
         self.ensure_one()
         sms_composer = self.env['sms.composer'].with_context(active_id=self.id).create(
             {
-                'composition_mode': 'numbers',
+                'composition_mode': 'comment',
                 'numbers': phone,
+                'recipient_single_number_itf': phone,
                 'template_id': self.config_id.sms_receipt_template_id.id,
                 'res_model': 'pos.order'
             }


### PR DESCRIPTION
Before this commit:
====================
A broken SMS body message was sent to the customer.

After this commit:
===================
The SMS body is now accurately formatted and sent to the customer

task -3969131

