### PR TITLE
[FIX] product: wrong quantity in the product catalog

### DIFF
--- a/addons/product/models/product_catalog_mixin.py
+++ b/addons/product/models/product_catalog_mixin.py
@@ -91,7 +91,7 @@ class ProductCatalogMixin(models.AbstractModel):
         order_line_info = {}
         default_data = self._default_order_line_values(child_field)
 
-        for product, record_lines in self._get_product_catalog_record_lines(product_ids).items():
+        for product, record_lines in self._get_product_catalog_record_lines(product_ids, child_field=child_field, **kwargs).items():
             order_line_info[product.id] = {
                **record_lines._get_product_catalog_lines_data(parent_record=self, **kwargs),
                'productType': product.type,


### PR DESCRIPTION
Before this commit
==============
When we were clicking on the product catalog  in MO and BOM  it was not showing the correct quantity and correct highlighted product selected in the MO and BOM.

After this commit
=============
This feature is fixed in this commit, correct quantity and highlighted product is shown.

task-3944909
