### PR TITLE
[FIX] website(_sale): prevent crash when empty menu url

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -195,7 +195,7 @@ class Website(models.Model):
         :return: True if the menu contains a record like url
         """
         return any(self.env['website.menu'].browse(self._get_menu_ids()).filtered(
-            lambda menu: re.search(r"[/](([^/=?&]+-)?[0-9]+)([/]|$)", menu.url) or menu.group_ids
+            lambda menu: menu.url and re.search(r"[/](([^/=?&]+-)?[0-9]+)([/]|$)", menu.url) or menu.group_ids
         ))
 
     @api.model_create_multi

--- a/addons/website/tests/test_menu.py
+++ b/addons/website/tests/test_menu.py
@@ -342,3 +342,14 @@ class TestMenuHttp(common.HttpCase):
         self.assertIn(b"french_mega_menu_content", page.content)
         page = self.url_open('/%s?edit_translations=1' % fr.url_code)
         self.assertIn(b"french_mega_menu_content", page.content)
+
+    def test_menu_empty_url(self):
+        website = self.env['website'].browse(1)
+        menu = self.env['website.menu'].create({
+            'name': 'Test Empty URL menu',
+            'parent_id': website.menu_id.id,
+            'website_id': website.id,
+        })
+        self.assertFalse(menu.url, "Menu URL should be empty")
+        # this should not crash
+        website.is_menu_cache_disabled()

--- a/addons/website_sale/models/website_menu.py
+++ b/addons/website_sale/models/website_menu.py
@@ -8,7 +8,7 @@ class Menu(models.Model):
 
     def _compute_visible(self):
         """ Hide '/shop' menus to the public user if only logged-in users can access it. """
-        shop_menus = self.filtered(lambda m: m.url[:5] == '/shop')
+        shop_menus = self.filtered(lambda m: m.url and m.url[:5] == '/shop')
         for menu in shop_menus:
             menu.is_visible = menu.website_id.has_ecommerce_access()
 


### PR DESCRIPTION
This PR aims to fix a traceback error occurring on the Homepage when the URL field is empty in any website menu.

Steps to Reproduce:
- Activate Debug mode.
- Navigate to Website -> Configuration -> Menus.
- Create a new menu and leave the URL field empty.
- Go to the Homepage.

Issue:
A traceback error occurs due to a slice operation being performed on the URL field. When the URL field is empty, it is interpreted as a boolean, leading to the error.

Solution:
Added a check to ensure the URL field is set before performing the slice operation.

Along with that, this PR also fixes a issue which was originally fixed in PR [1] but because of task [2], we had decided not to merge it in saas-17.3 (then master).

task-3921988

[1]: (https://github.com/odoo/odoo/pull/160457)
[2]: (https://www.odoo.com/odoo/project/974/tasks/3851453)
