### PR TITLE
[FIX] test_new_api: mitigate babel issue

### DIFF
--- a/odoo/addons/test_new_api/tests/test_properties.py
+++ b/odoo/addons/test_new_api/tests/test_properties.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import babel.dates
 import datetime
 import json
 import unittest
@@ -2392,7 +2393,16 @@ class PropertiesGroupByCase(TestPropertiesMixin):
         self.assertEqual(result[3]['attributes.mydate_count'], 1)
         self.assertEqual(result[3]['attributes.mydate:week'], 'W5 2023')
         self.assertEqual(result[4]['attributes.mydate_count'], 2)
-        self.assertEqual(result[4]['attributes.mydate:week'], 'W1 2022')
+        # Babel issue mitigation
+        # https://github.com/python-babel/babel/pull/621 -- introduced a new bug
+        # https://github.com/python-babel/babel/pull/887 -- proposed a fix but finally closed
+        # https://sources.debian.org/patches/python-babel/2.10.3-1/ -- Debian reverted 621
+        # so this ugly fix is made to have the test working in patched and non patched versions of Babel
+        babel_year = babel.dates.format_date(datetime.datetime(2023, 1, 1), "YYYY", "en_US")  # non patched: '2022' patched: '2023'
+        if babel_year == '2022':  # Broken unpatched babel
+            self.assertEqual(result[4]['attributes.mydate:week'], 'W1 2022')
+        else:  # Patched babel
+            self.assertEqual(result[4]['attributes.mydate:week'], 'W1 2023')
         # check domain
         self.assertEqual(Model.search(result[0]['__domain']), self.message_6 | self.message_7)
         self.assertEqual(Model.search(result[1]['__domain']), self.message_5)


### PR DESCRIPTION
Since Babel issue 621 [0] searching the week number of a date alongside with the year can lead to a wrong year in the result. e.g.: `2023-01-01` gives `W1 2022`

Before the present commit, the tests were surprisingly expecting the wrong result.

An attempt was made [1] to fix the upstream issue but was never merged.

In the meanwhile, Debian reverted the Babel issue 621 [2] in their package.

It means that our test would fail with the patched Debian package like in Ubuntu Noble or Debian Bookworm. On the other hand, if we fix the test to expect the correct value, it would fail on unpatched version of the Babel lib.

So, this commit mitigate the issue by guessing the expected value even if the result is wrong.

[0]: https://github.com/python-babel/babel/pull/621
[1]: https://github.com/python-babel/babel/pull/887
[2]: https://sources.debian.org/patches/python-babel/2.10.3-1/



For reference (from @Xavier-Do )

Pip version and Jammy
```python
In [1]import babel.dates

In [2]: import datetime

In [3]: babel.dates.format_date(datetime.datetime(2023, 1, 1), "EEE w YYYY", "fr_BE")
Out[3]: 'dim. 52 2022'

In [4]: babel.dates.format_date(datetime.datetime(2023, 1, 1), "EEE w YYYY", "en_US")
Out[4]: 'Sun 1 2022'
```

It looks like the week year used is actually not localized, adding a cornercase on Sunday

Noble version

```python
In [1]import babel.dates

In [2]: import datetime

In [3]: babel.dates.format_date(datetime.datetime(2023, 1, 1), "EEE w YYYY", "fr_BE")
Out[3]: 'dim. 52 2022'

In [4]: babel.dates.format_date(datetime.datetime(2023, 1, 1), "EEE w YYYY", "en_US")
Out[4]: 'Sun 1 2023'
```


