### PR TITLE
[FIX] mail: fix search message partner function

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -129,6 +129,8 @@ class MailThread(models.AbstractModel):
             ('partner_id', operator, operand),
         ])
         # use inselect to avoid reading thousands of potentially followed objects
+        if not followers:
+            return [('id', 'in', [])]
         return [('id', neg + 'inselect', followers.subselect('res_id'))]
 
     @api.depends('message_follower_ids')

--- a/addons/test_mail/tests/test_mail_followers.py
+++ b/addons/test_mail/tests/test_mail_followers.py
@@ -56,6 +56,8 @@ class BaseFollowersTest(TestMailCommon):
         followed_after = self.env['mail.test.simple'].search([('message_partner_ids', 'in', partner.ids)])
         self.assertTrue(partner in test_record.message_partner_ids)
         self.assertEqual(followed_before + test_record, followed_after)
+        message_partner = self.env['mail.thread']._search_message_partner_ids('in', [])
+        self.assertTrue(message_partner)
 
     def test_field_followers(self):
         test_record = self.test_record.with_user(self.user_employee)


### PR DESCRIPTION
The issue:
Before Odoo 16.2, the _search function returns 0 or [] if the domain expression is false (no record meets the domain condition), therefore, it is not possible to call the function subselect on an integer or list

The Fix:
Always pass a query object

opw-3946440