### PR TITLE
[FIX] point_of_sale: email receipt layout

### DIFF
--- a/addons/point_of_sale/static/src/app/printer/render_service.js
+++ b/addons/point_of_sale/static/src/app/printer/render_service.js
@@ -96,7 +96,7 @@ const applyWhenMounted = async ({ el, container, callback }) => {
  */
 export const htmlToCanvas = async (el, options) => {
     if (options.addClass) {
-        el.classList.add(options.addClass);
+        el.classList.add(...options.addClass.split(" "));
     }
     return await applyWhenMounted({
         el,

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
@@ -110,7 +110,7 @@ export class ReceiptScreen extends Component {
                 data: this.pos.orderExportForPrinting(this.pos.get_order()),
                 formatCurrency: this.env.utils.formatCurrency,
             },
-            { addClass: "pos-receipt-print" }
+            { addClass: "pos-receipt-print p-3" }
         );
         await this.pos.data.call("pos.order", action, [[order.id], this.state.input, ticketImage]);
     }


### PR DESCRIPTION
Before this commit:
==========
![before email receipt](https://github.com/user-attachments/assets/9dcb525f-d4e2-4cea-aee5-5642052b8506)


- The email receipt layout was different from what was visible in the POS terminal.

After this commit:
==========
![After email receipt](https://github.com/user-attachments/assets/b915f981-2d95-4762-8539-9f2bc4ed8be2)


- The email receipt layout will be the same as in the POS terminal.

task-3764071