### PR TITLE
[IMP] stock, *: Back2Basics stock improvements

### DIFF
--- a/addons/purchase_stock/models/purchase_order.py
+++ b/addons/purchase_stock/models/purchase_order.py
@@ -266,7 +266,7 @@ class PurchaseOrder(models.Model):
         self.ensure_one()
         result = self.env["ir.actions.actions"]._for_xml_id('stock.action_picking_tree_all')
         # override the context to get rid of the default filtering on operation type
-        result['context'] = {'default_partner_id': self.partner_id.id, 'default_origin': self.name, 'default_picking_type_id': self.picking_type_id.id}
+        result['context'] = {'default_partner_id': self.partner_id.id, 'default_picking_type_id': self.picking_type_id.id}
         # choose the view_mode accordingly
         if not pickings or len(pickings) > 1:
             result['domain'] = [('id', 'in', pickings.ids)]

--- a/addons/stock/views/stock_lot_views.xml
+++ b/addons/stock/views/stock_lot_views.xml
@@ -69,12 +69,12 @@
                 <field name="name" decoration-bf="1"/>
                 <field name="product_id" readonly="1"/>
                 <field name="ref" optional="hide"/>
-                <field name="create_date" optional="show"/>
-                <field name="company_id" groups="base.group_multi_company"/>
+                <field name="create_date" optional="hide"/>
+                <field name="company_id" optional="hide" groups="base.group_multi_company"/>
                 <field name="partner_ids" optional="hide" widget="many2many_tags" string="Transfer to"/>
                 <field name="activity_ids" widget="list_activity" optional="show"/>
                 <field name="lot_properties" optional="hide"/>
-                <field name="product_qty" optional="hide"/>
+                <field name="product_qty" optional="show"/>
             </list>
         </field>
     </record>


### PR DESCRIPTION
*: purchase_stock

With this commit:
----------------------------------------
- Made the On Hand Quantity optionally visible in the Lots/Serials list view.
- Removed the default Source Document assignment when creating transfers from
  the PO-linked transfer list view.

These improvements enhance the better visibility of lot/serial data,
and a simplified transfer creation flow without misleading default
Source Document values.

Task ID: 3850457