### PR TITLE
[FIX] web: mock odoofin

### DIFF
--- a/addons/web/tests/test_click_everywhere.py
+++ b/addons/web/tests/test_click_everywhere.py
@@ -44,6 +44,7 @@ class TestMenusAdminLight(odoo.tests.HttpCase):
         if '/proxy_rpc_call/v1/get_favorite_institutions' in r.url:
             r = Response()
             r.status_code = 200
+            r.json = lambda: {'result': {}}
             return r
         return super()._request_handler(s, r, **kw)
 


### PR DESCRIPTION
Build Error: 66996
In a previous commit, the odoofin API call was mocked, but the json function was omitted
