### PR TITLE
[16.0][FIX][POS] finalized order cannont be modified error

### DIFF
--- a/addons/pos_loyalty/static/src/js/Loyalty.js
+++ b/addons/pos_loyalty/static/src/js/Loyalty.js
@@ -223,7 +223,7 @@ const PosLoyaltyGlobalState = (PosGlobalState) => class PosLoyaltyGlobalState ex
         // When an order is selected, it doesn't always contain the reward lines.
         // And the list of active programs are not always correct. This is because
         // of the use of DropPrevious in _updateRewards.
-        if (order) {
+        if (order && !order.finalized) {
             order._updateRewards();
         }
         return result;

--- a/doc/cla/corporate/factorlibre.md
+++ b/doc/cla/corporate/factorlibre.md
@@ -17,3 +17,4 @@ Hugo Santos hugo.santos@factorlibre.com https://github.com/hugosantosred
 Jorge Martínez jorge.martinez@factorlibre.com https://github.com/jorgemartinez-factorlibre
 Adriana Saiz adriana.saiz@factorlibre.com https://github.com/AdrianaSaiz
 Pablo Calvo pablo.calvo@factorlibre.com https://github.com/Pablocce
+Juan Carlos Bonilla juancarlos.bonilla@factorlibre.com https://github.com/suker


### PR DESCRIPTION
This PR bugfix an error: "Error: Finalized Order cannot be modified" during a pos session.

Steps to reproduce:

1. Install `pos_loyalty` module
2. Use any loyalty program (in video I used a gift card) on a pos order
3.  Paid order but stay on "ReceiptScreen"
4. Click on "Orders" ("TicketButton")
5. Click on "New Order"
6. Click again on "Orders" and select paid order in status "Receipt"
7. "Error: Finalized Order cannot be modified" is shown

Video of steps: https://www.loom.com/share/6ea8c86ebd994ce0958f42b6eb12c5db

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
