### PR TITLE
[FIX] mrp_subcontracting: Fix component consumption on backorders

### DIFF
--- a/addons/mrp_subcontracting/models/stock_picking.py
+++ b/addons/mrp_subcontracting/models/stock_picking.py
@@ -71,6 +71,9 @@ class StockPicking(models.Model):
             # Create backorder MO for each move lines
             amounts = [move_line.qty_done for move_line in move.move_line_ids]
             len_amounts = len(amounts)
+            # _split_production can set the qty_done, but not split it.
+            # Remove the qty_done potentially set by a previous split to prevent any issue.
+            production.move_line_raw_ids.filtered(lambda l: l.state == 'assigned').write({'qty_done': 0})
             productions = production._split_productions({production: amounts}, set_consumed_qty=True)
             for production, move_line in zip(productions, move.move_line_ids):
                 if move_line.lot_id:


### PR DESCRIPTION
The method _split_production only handles 'draft' and 'confirmed' productions. Hence, if the qty_done is set on the move lines, it will not be split.

When validating a subcontracting receipt, the qty_done is set for both the initial and backorder picking using 'set_consumed_qty=True'. This does not create any issue for the first backorder, but does if you split it again.

As it is necessary for finished products tracked by serial number to have the qty_done set on all backorders, instead of cleaning the qty_done after the split, we do it before. The qty_done will then be correctly set by _split_production.

OPW-3838250
