### PR TITLE
[FIX] web: allow to sign with 4k resolution

### DIFF
--- a/addons/web/static/src/core/signature/name_and_signature.js
+++ b/addons/web/static/src/core/signature/name_and_signature.js
@@ -245,7 +245,13 @@ export class NameAndSignature extends Component {
      */
     async printImage(imgSrc) {
         this.clear();
-        await this.fromDataURL(imgSrc);
+        // Force the width and height to the canvas size to prevent shrinking
+        // high DPI screens (devicePixelRatio > 1)
+        const options = {
+            width: this.signatureRef.el.width,
+            height: this.signatureRef.el.height,
+        };
+        await this.fromDataURL(imgSrc, options);
     }
 
     /**

--- a/addons/web/static/src/core/signature/name_and_signature.js
+++ b/addons/web/static/src/core/signature/name_and_signature.js
@@ -250,6 +250,7 @@ export class NameAndSignature extends Component {
         const options = {
             width: this.signatureRef.el.width,
             height: this.signatureRef.el.height,
+            yOffset: 30,
         };
         await this.fromDataURL(imgSrc, options);
     }

--- a/addons/web/static/src/core/signature/name_and_signature.scss
+++ b/addons/web/static/src/core/signature/name_and_signature.scss
@@ -6,7 +6,7 @@
 .o_signature_stroke {
     position: absolute;
     border-top: #D1D0CE solid 2px;
-    bottom: 33%;
+    bottom: 20%;
     width: 72%;
     left: 14%;
 }


### PR DESCRIPTION
Before this commit, when a 4K screen was used with devicePixelRatio > 1, the signature svg size was divided by the devicePixelRatio value.

We would have small automatic signature shrinked.

taskid: 3971056



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
