### PR TITLE
[FIX] spreadsheet: export From/To filter when sharing

### DIFF
--- a/addons/spreadsheet/static/src/global_filters/plugins/global_filters_ui_plugin.js
+++ b/addons/spreadsheet/static/src/global_filters/plugins/global_filters_ui_plugin.js
@@ -558,6 +558,9 @@ export class GlobalFiltersUIPlugin extends spreadsheet.UIPlugin {
                 numberOfCols = Math.max(numberOfCols, Number(colIndex) + 2);
                 for (const rowIndex in result[colIndex]) {
                     const cell = result[colIndex][rowIndex];
+                    if (cell.value === undefined) {
+                        continue;
+                    }
                     const xc = toXC(Number(colIndex) + 1, Number(rowIndex) + filterRowIndex);
                     cells[xc] = { content: cell.value.toString() };
                     if (cell.format) {

--- a/addons/spreadsheet/static/src/helpers/model.js
+++ b/addons/spreadsheet/static/src/helpers/model.js
@@ -6,7 +6,11 @@ import { _t } from "@web/core/l10n/translation";
 import { loadBundle } from "@web/core/assets";
 
 const { formatValue, isDefined, toCartesian } = helpers;
-import { isMarkdownViewUrl, isMarkdownIrMenuIdUrl, isIrMenuXmlUrl } from "@spreadsheet/ir_ui_menu/odoo_menu_link_cell";
+import {
+    isMarkdownViewUrl,
+    isMarkdownIrMenuIdUrl,
+    isIrMenuXmlUrl,
+} from "@spreadsheet/ir_ui_menu/odoo_menu_link_cell";
 
 export async function fetchSpreadsheetModel(env, resModel, resId) {
     const { data, revisions } = await env.services.orm.call(resModel, "join_spreadsheet_session", [
@@ -44,7 +48,11 @@ export async function waitForDataLoaded(model) {
 
 function containsLinkToOdoo(link) {
     if (link && link.url) {
-        return isMarkdownViewUrl(link.url) || isIrMenuXmlUrl(link.url) || isMarkdownIrMenuIdUrl(link.url);
+        return (
+            isMarkdownViewUrl(link.url) ||
+            isIrMenuXmlUrl(link.url) ||
+            isMarkdownIrMenuIdUrl(link.url)
+        );
     }
 }
 
@@ -99,6 +107,7 @@ function exportGlobalFiltersToSheet(model, data) {
             .flat()
             .filter(isDefined)
             .map(({ value, format }) => formatValue(value, { format, locale }))
+            .filter(isDefined)
             .join(", ");
     }
 }


### PR DESCRIPTION
Steps to reproduce:
- insert a pivot in a spreadsheet
- create a From/To global filter
- leave the filter values empty
- click on the Share button

=> boom because of `cell.value.toString()`
`cannot read toString of undefined`

opw-3971278

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
