### PR TITLE
[FIX] l10n_it_edi: duplicated hotkey action check

### DIFF
--- a/addons/l10n_it_edi/views/l10n_it_view.xml
+++ b/addons/l10n_it_edi/views/l10n_it_view.xml
@@ -133,7 +133,7 @@
                         type="object"
                         string="Check Sending"
                         class="oe_highlight"
-                        data-hotkey="c"
+                        data-hotkey="shift+K"
                         invisible="l10n_it_edi_state not in ('being_sent', 'processing', 'forward_attempt')"
                     />
                 </xpath>


### PR DESCRIPTION
The keyboard shortcut for the `Check Sending` action
was the same as the one used to create a new record.

Ticket [link](https://www.odoo.com/web#model=project.task&id=3970056)
opw-3970056
