### PR TITLE
[FIX] stock: incorrect suggested quantity for sml

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -142,9 +142,8 @@ class StockMoveLine(models.Model):
         for record in self:
             if not record.quant_id or record.quantity:
                 continue
-            origin_move = record.move_id._origin
-            if float_compare(record.move_id.product_qty, origin_move.quantity, precision_rounding=record.move_id.product_uom.rounding) > 0:
-                record.quantity = max(0, min(record.quant_id.available_quantity, record.move_id.product_qty - origin_move.quantity))
+            if float_compare(record.move_id.product_qty, record.quantity, precision_rounding=record.move_id.product_uom.rounding) > 0:
+                record.quantity = max(0, min(record.quant_id.available_quantity, record.move_id.product_qty - record.move_id.quantity))
             else:
                 record.quantity = max(0, record.quant_id.available_quantity)
 


### PR DESCRIPTION
Use case:
- LOT A 20 units in stock
- LOT B 20 units in stock
- Do an outgoing picking for 10 units
- Reserve
- Remove the `stock.move.line`
- Add a new line of B

Current behavior:
Line is prefilled for 20 units

Expected:
Line only takes the 10 units missing

It's due to commit [1] enforcing the computation
on the origin move and not the current situation

[1] commit 383d4eb98ba4bfbcb384b3d1ee27393da00226e7

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
