### PR TITLE
[FIX] web_tour: tour_utils helpers

### DIFF
--- a/addons/web_tour/static/src/tour_service/tour_utils.js
+++ b/addons/web_tour/static/src/tour_service/tour_utils.js
@@ -389,7 +389,7 @@ export const stepUtils = {
             extra_trigger: extra_trigger,
             auto: true,
             run: (actions) => {
-                const more = hoot.queryOne(".o-form-buttonbox .o_button_more");
+                const more = hoot.queryFirst(".o-form-buttonbox .o_button_more");
                 if (more) {
                     hoot.click(more);
                 }
@@ -451,7 +451,7 @@ export const stepUtils = {
                 trigger: ".o_statusbar_buttons",
                 extra_trigger: extraTrigger,
                 run: (actions) => {
-                    const node = hoot.queryOne(
+                    const node = hoot.queryFirst(
                         ".o_statusbar_buttons .btn.dropdown-toggle:contains(Action)"
                     );
                     if (node) {


### PR DESCRIPTION
This commit [1] introduces `queryOne` to find element nodes in DOM. But, if `queryOne` fails to find the element it throws error which breaks the tour which wasn't the case before this change was introduced. There might be some scenarios where it might not affect if the node is found or not, but because of `queryOne` the tour will fail.

So, to fix this we use `queryFirst` which doesn't throw error if it fails to find the node.

1: c0f3bdb928db5a119817710e260edfda9a2f40ac

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
