### PR TITLE
[FIX] web_editor, website: always save colorpicker's custom color

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -1242,6 +1242,7 @@ var SnippetsMenu = Widget.extend({
         'drag_and_drop_stop': '_onSnippetDragAndDropStop',
         'drag_and_drop_start': '_onSnippetDragAndDropStart',
         'get_snippet_versions': '_onGetSnippetVersions',
+        'get_bypass_confirm_save_prompt': '_onGetBypassConfirmSavePrompt',
         'find_snippet_template': '_onFindSnippetTemplate',
         'remove_snippet': '_onRemoveSnippet',
         'snippet_edition_request': '_onSnippetEditionRequest',
@@ -1314,6 +1315,7 @@ var SnippetsMenu = Widget.extend({
         this.loadingTimers = {};
         this.loadingElements = {};
         this._loadingEffectDisabled = false;
+        this._bypassConfirmSavePrompt = false;
     },
     /**
      * @override
@@ -3496,6 +3498,13 @@ var SnippetsMenu = Widget.extend({
         });
     },
     /**
+     * @private
+     * @param {OdooEvent} ev
+     */
+    _onGetBypassConfirmSavePrompt: function (ev) {
+        ev.data.onSuccess(this._bypassConfirmSavePrompt);
+    },
+    /**
      * UNUSED: used to be called when saving a custom snippet. We now save and
      * reload the page when saving a custom snippet so that all the DOM cleanup
      * mechanisms are run before saving. Kept for compatibility.
@@ -3545,6 +3554,15 @@ var SnippetsMenu = Widget.extend({
         }
         delete data._toMutex;
         ev.stopPropagation();
+
+        // Don't ask the user whether to save or not
+        // This also allows any side effect (mutexed snippet updates) to be started before our save request
+        const self = this;
+        this._bypassConfirmSavePrompt = true;
+
+        // Make sure all widgets are closed
+        this._closeWidgets();
+
         this._execWithLoadingEffect(() => {
             if (data.reloadEditor) {
                 data.reload = false;
@@ -3554,6 +3572,12 @@ var SnippetsMenu = Widget.extend({
                         await oldOnSuccess.call(this, ...arguments);
                     }
                     window.location.href = window.location.origin + window.location.pathname + '?enable_editor=1';
+                };
+
+                const oldOnError = data.onError;
+                data.onError = async function () {
+                    self._bypassConfirmSavePrompt = false;
+                    await oldOnError.call(this, ...arguments);
                 };
             }
             this.trigger_up('request_save', data);

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -4118,7 +4118,13 @@ const SnippetOptionWidget = Widget.extend({
         // the case, warn the user and potentially ask if he agrees to save its
         // current changes. If not, just do nothing.
         let requiresReload = false;
-        if (!ev.data.previewMode && !ev.data.isSimulatedEvent) {
+        let bypassConfirmSavePrompt = false;
+        this.trigger_up("get_bypass_confirm_save_prompt", {
+            onSuccess: (value) => {
+                bypassConfirmSavePrompt = value;
+            },
+        });
+        if (!ev.data.previewMode && !ev.data.isSimulatedEvent && !bypassConfirmSavePrompt) {
             const linkedWidgets = this._requestUserValueWidgets(...ev.data.triggerWidgetsNames);
             const widgets = [ev.data.widget].concat(linkedWidgets);
 

--- a/addons/website/static/tests/tours/website_style_edition.js
+++ b/addons/website/static/tests/tours/website_style_edition.js
@@ -4,6 +4,8 @@ odoo.define("website.tour.website_style_edition", function (require) {
 const tour = require("web_tour.tour");
 
 const TARGET_FONT_SIZE = 30;
+const TARGET_PRIMARY_COLOR_INPUT = "#ff0000";
+const TARGET_PRIMARY_COLOR_RESULT = "rgb(255, 0, 0)";
 
 tour.register("website_style_edition", {
     test: true,
@@ -28,6 +30,31 @@ tour.register("website_style_edition", {
         const style = window.getComputedStyle(this.$anchor[0]);
         if (style.fontSize !== `${TARGET_FONT_SIZE}px`) {
             console.error(`Expected the font-size to be equal to ${TARGET_FONT_SIZE}px but found ${style.fontSize} instead`);
+        }
+    },
+}, {
+    content: "Enter edit mode",
+    trigger: 'a[data-action=edit]',
+}, {
+    content: "Go to theme options",
+    trigger: '.o_we_customize_theme_btn',
+}, {
+    content: "Open primary color colorpicker",
+    trigger: '[data-color="o-color-1"]',
+}, {
+    content: "Pick custom color without closing the picker",
+    trigger: '[data-color="o-color-1"] .o_hex_input',
+    run: `text_blur ${TARGET_PRIMARY_COLOR_INPUT}`,
+}, {
+    content: "Save",
+    trigger: '[data-action="save"]',
+}, {
+    content: "Check the color was saved",
+    trigger: 'body:not(.editor_enable) .btn-primary',
+    run: function (actions) {
+        const style = window.getComputedStyle(this.$anchor[0]);
+        if (style.backgroundColor !== `${TARGET_PRIMARY_COLOR_RESULT}`) {
+            console.error(`Expected the primary color to be equal to ${TARGET_PRIMARY_COLOR_RESULT} but found ${style.backgroundColor} instead`);
         }
     },
 }]);


### PR DESCRIPTION
When selecting a custom color with the color picker, clicking on the
save button without closing the colorpicker popup first doesn't save
the new color.

Steps to reproduce:
- Open the website editor
- Under THEME, open the color picker for one of the colors at the top
- Without closing the color picker, change the color to a custom value
  using the color wheel, hexcode or rgba
- Click on the Save button in the top-right of the screen

Old behavior: the color is not saved
New behavior: the color is always saved

This commit closes all the widgets before saving when clicking on the
save button. It also prevents save and reload confirmation dialogs from
opening if we're about to save due to user intent anyway. This has the
benefit of starting side effects (mutexed snippet updates) immediately,
before the save request (the awaits are avoided).

task-3610071