### PR TITLE
[IMP] loading: signal changes on registry new

### DIFF
--- a/odoo/modules/registry.py
+++ b/odoo/modules/registry.py
@@ -137,6 +137,7 @@ class Registry(Mapping):
         registry.ready = True
         registry.registry_invalidated = bool(update_module)
         registry.new = registry.init = registry.registries = None
+        registry.signal_changes()
 
         _logger.info("Registry loaded in %.3fs", time.time() - t0)
         return registry


### PR DESCRIPTION
Installing a modules and running the post test in the same run will lead to a state where the registry_invalidated flag is set, because the registry loading did not clear the flag after install.

Actually, it makes sense to signal the change after installing a module. The schema may have changed, with new constraints, new default, but existing worker won't take that into account.

This issue already exist for server admin that need to restart manually all workers after a manual install.

The proposed solution will signal the changes after load_modules, just after comitting the new registry schema.

A possible issue with that may be to trigger a reload before the process is restarted, if the code changed. The assets and static resources may be reload immediately even if the python code is not reloaded yet. But this is already an issue now and it is unlikely to do that.
