### PR TITLE
[IMP] mail, *: standardize `EmojiPicker` design

### DIFF
--- a/addons/html_editor/static/src/scss/html_editor.frontend.scss
+++ b/addons/html_editor/static/src/scss/html_editor.frontend.scss
@@ -238,3 +238,12 @@ body.editor_enable:not(.o_basic_theme) .odoo-editor-editable {
         calc(var(--box-border-bottom-right-radius, 0px) - max(var(--box-border-bottom-width, 0px), var(--box-border-right-width, 0px)))
         calc(var(--box-border-bottom-left-radius, 0px) - max(var(--box-border-bottom-width, 0px), var(--box-border-left-width, 0px)));
 }
+
+// Needed to prevent the emoji picker from inheriting theme colors
+.o-EmojiPicker {
+    --EmojiPicker-background-color: white;
+    --EmojiPicker-font-size: 1rem;
+    --EmojiPicker-emoji-font-size: 1.5rem;
+    --EmojiPicker-text-color: #{rgba(black, $o-opacity-muted)};
+    --EmojiPicker-input-color: black;
+}

--- a/addons/im_livechat/static/src/embed/common/emoji_picker.scss
+++ b/addons/im_livechat/static/src/embed/common/emoji_picker.scss
@@ -1,3 +1,0 @@
-.o-EmojiPicker {
-    font-size: 1.2em;
-}

--- a/addons/mail/static/tests/emoji/emoji.test.js
+++ b/addons/mail/static/tests/emoji/emoji.test.js
@@ -140,8 +140,8 @@ test("recent category (basic)", async () => {
     await click("button[title='Add Emojis']");
     await contains(".o-EmojiPicker-navbar [title='Frequently used']");
     await contains(".o-Emoji:text('😀')", {
-        after: ["span", { textContent: "Frequently used" }],
-        before: ["span", { textContent: "Smileys & Emotion" }],
+        after: ["small", { textContent: "Frequently used" }],
+        before: ["small", { textContent: "Smileys & Emotion" }],
     });
 });
 
@@ -194,12 +194,12 @@ test("emoji usage amount orders frequent emojis", async () => {
     await click(".o-EmojiPicker-content .o-Emoji:text('👽')");
     await click("button[title='Add Emojis']");
     await contains(".o-Emoji:text('👽')", {
-        after: ["span", { textContent: "Frequently used" }],
+        after: ["small", { textContent: "Frequently used" }],
         before: [
             ".o-Emoji:text('😀')",
             {
-                after: ["span", { textContent: "Frequently used" }],
-                before: ["span", { textContent: "Smileys & Emotion" }],
+                after: ["small", { textContent: "Frequently used" }],
+                before: ["small", { textContent: "Smileys & Emotion" }],
             },
         ],
     });

--- a/addons/web/static/src/core/emoji_picker/emoji_picker.scss
+++ b/addons/web/static/src/core/emoji_picker/emoji_picker.scss
@@ -1,6 +1,12 @@
-.popover .o-EmojiPicker {
-    width: 300px;
-    height: 365px;
+.popover {
+    &:has(.o-EmojiPicker) {
+        max-width: calc(300px + 2 * var(--popover-border-width)) !important;
+    }
+
+    .o-EmojiPicker {
+        width: 300px;
+        height: 365px;
+    }
 }
 
 .o-EmojiPicker-content {
@@ -11,16 +17,16 @@
 .o-EmojiPicker {
     --EmojiPicker-active: #{rgba($o-action, .15)};
 
+    background-color: var(--EmojiPicker-background-color, $gray-100);
+
     .o-Emoji {
         padding-left: map-get($spacers, 1);
         padding-right: map-get($spacers, 1);
-        font-size: 0.8rem;
+        font-size: var(--EmojiPicker-emoji-font-size, $h2-font-size);
         aspect-ratio: 1;
-        &:hover {
-            background-color: var(--EmojiPicker-active) !important;
-        }
-        &.o-active {
-            background-color: var(--EmojiPicker-active) !important;
+
+        &:hover, &.o-active {
+            background-color: var(--EmojiPicker-active);
         }
     }
 
@@ -40,8 +46,24 @@
         }
     }
 
-    .o-EmojiPicker-sectionIcon {
-        filter: grayscale(1);
+    .o-EmojiPicker-section {
+        background-color: var(--EmojiPicker-background-color, $gray-100);
+
+        .o-EmojiPicker-sectionIcon {
+            filter: grayscale(1);
+        }
+    }
+
+    .o-EmojiPicker-sectionIcon + small,
+    .o-EmojiPicker-empty + span,
+    .o-EmojiPicker-search input:focus + .oi-search {
+        color: var(--EmojiPicker-text-color, $text-muted);
+    }
+
+    .o-EmojiPicker-sectionIcon,
+    .o-EmojiPicker-navbar-icon,
+    .o-EmojiPicker-empty + span {
+        font-size: var(--EmojiPicker-font-size, $h5-font-size);
     }
 
     .o-EmojiPicker-empty {
@@ -57,13 +79,20 @@
 
 .o-EmojiPicker-search {
     input {
+        font-size: var(--EmojiPicker-font-size, $input-font-size);
+
+        &, &:focus {
+            background-color: var(--EmojiPicker-background-color, $o-view-background-color);
+            color: var(--EmojiPicker-input-color, $input-color);
+        }
+
         &::placeholder {
             opacity: var(--EmojiPicker-placeholderOpacity, 50%);
+            color: var(--EmojiPicker-text-color, $input-placeholder-color);
         }
-        &:not(:focus) {
-            & + .oi-search {
-                color: $text-muted;
-            }
+
+        & + .oi-search {
+            color: var(--EmojiPicker-text-color, $body-color);
         }
     }
 }

--- a/addons/web/static/src/core/emoji_picker/emoji_picker.xml
+++ b/addons/web/static/src/core/emoji_picker/emoji_picker.xml
@@ -2,10 +2,10 @@
 <templates xml:space="preserve">
 
 <t t-name="web.EmojiPicker">
-    <div class="o-EmojiPicker bg-100 d-flex flex-column justify-content-center rounded-3" t-att-class="{ 'align-items-center': emojis.length === 0, 'h-100': props.mobile }" t-attf-class="{{props.class}}" t-on-click="onClick" t-on-keydown="onKeydown">
+    <div class="o-EmojiPicker d-flex flex-column justify-content-center rounded-3" t-att-class="{ 'align-items-center': emojis.length === 0, 'h-100': props.mobile }" t-attf-class="{{props.class}}" t-on-click="onClick" t-on-keydown="onKeydown">
         <t t-if="emojis.length === 0">
             <span class="o-EmojiPicker-empty">😵‍💫</span>
-            <span class="fs-5 text-muted">Failed to load emojis...</span>
+            <span>Failed to load emojis...</span>
         </t>
         <t t-else="">
             <div class="o-EmojiPicker-search d-flex align-items-center mx-2 mt-2 rounded">
@@ -22,7 +22,7 @@
             <div class="o-EmojiPicker-content overflow-auto d-flex flex-grow-1 w-100 flex-wrap align-items-center user-select-none mt-1" t-att-class="emojisFromSearch.length === 0 ? 'flex-column justify-content-center' : 'align-content-start'" t-ref="emoji-grid" t-on-scroll="highlightActiveCategory">
                 <t t-if="searchTerm and emojisFromSearch.length === 0" class="d-flex flex-column">
                     <span class="o-EmojiPicker-empty">😢</span>
-                    <span class="fs-5 text-muted">No emoji matches your search</span>
+                    <span>No emoji matches your search</span>
                 </t>
                 <t t-if="recentEmojis.length > 0">
                     <t t-if="!searchTerm" t-call="web.EmojiPicker.section">
@@ -73,13 +73,13 @@
 </t>
 
 <t t-name="web.EmojiPicker.tab">
-    <span class="o-Emoji text-center fs-5 rounded-3 cursor-pointer d-flex align-items-center align-self-stretch" t-att-class="{'o-active': category.sortId === state.categoryId}" t-att-title="category.name" t-att-data-id="category.sortId" t-on-click="() => this.selectCategory(category.sortId)">
+    <span class="o-EmojiPicker-navbar-icon o-Emoji text-center rounded-3 cursor-pointer d-flex align-items-center align-self-stretch" t-att-class="{'o-active': category.sortId === state.categoryId}" t-att-title="category.name" t-att-data-id="category.sortId" t-on-click="() => this.selectCategory(category.sortId)">
         <span t-esc="category.title"/>
     </span>
 </t>
 
 <t t-name="web.EmojiPicker.tabNext">
-    <span class="o-Emoji text-center fs-5 rounded-3 cursor-pointer d-flex align-items-center align-self-stretch" title="To previous categories" t-on-click="onClickToNextCategories">
+    <span class="o-EmojiPicker-navbar-icon o-Emoji text-center rounded-3 cursor-pointer d-flex align-items-center align-self-stretch" title="To previous categories" t-on-click="onClickToNextCategories">
         <span class="position-relative">
             <i class="oi oi-chevron-right fa-fw smaller opacity-0"/>
             <i class="oi oi-chevron-right fa-fw smaller position-absolute opacity-75" style="left: 3px; transform: translateY(75%);"/>
@@ -89,7 +89,7 @@
 </t>
 
 <t t-name="web.EmojiPicker.tabPrev">
-    <span class="o-Emoji text-center fs-5 rounded-3 cursor-pointer d-flex align-items-center align-self-stretch" title="To next categories" t-on-click="onClickToPreviousCategories">
+    <span class="o-EmojiPicker-navbar-icon o-Emoji text-center rounded-3 cursor-pointer d-flex align-items-center align-self-stretch" title="To next categories" t-on-click="onClickToPreviousCategories">
         <span class="position-relative">
             <i class="oi oi-chevron-left fa-fw smaller opacity-0"/>
             <i class="oi oi-chevron-left fa-fw smaller position-absolute opacity-75" style="left: 3px; transform: translateY(75%);"/>
@@ -99,18 +99,18 @@
 </t>
 
 <t t-name="web.EmojiPicker.tabEmpty">
-    <span class="o-Emoji text-center fs-5 rounded-3 cursor-pointer d-flex align-items-center align-self-stretch opacity-0">
+    <span class="o-EmojiPicker-navbar-icon o-Emoji text-center rounded-3 cursor-pointer d-flex align-items-center align-self-stretch opacity-0">
         <span>🫥</span>
     </span>
 </t>
 
 <t t-name="web.EmojiPicker.section">
-    <span class="w-100 fs-7 px-2 py-1 position-sticky top-0 bg-100 align-self-stretch" t-att-data-category="category.sortId"><span class="o-EmojiPicker-sectionIcon fs-5 opacity-50" t-esc="category.title"/><span class="ms-2 text-muted text-uppercase fs-7 opacity-50" t-esc="category.displayName"/></span>
-    <span class="o-EmojiPicker-category opacity-100 fs-7 py-2" t-att-data-category="category.sortId"/>
+    <span class="o-EmojiPicker-section w-100 fs-7 px-2 py-1 position-sticky top-0 align-self-stretch" t-att-data-category="category.sortId"><span class="o-EmojiPicker-sectionIcon opacity-50" t-esc="category.title"/><small class="ms-2 text-uppercase opacity-50" t-esc="category.displayName"/></span>
+    <span class="o-EmojiPicker-category opacity-100 py-2" t-att-data-category="category.sortId"/>
 </t>
 
 <t t-name="web.EmojiPicker.emoji">
-    <span class="o-Emoji cursor-pointer d-flex justify-content-center rounded-3 align-items-center align-self-stretch" t-att-class="{ 'o-active': state.activeEmojiIndex === itemIndex, 'fs-2': !ui.isSmall, 'fs-1': ui.isSmall }" t-att-title="emoji.name" t-att-data-codepoints="emoji.codepoints" t-att-data-index="itemIndex" t-att-data-category="inRecent ? recentCategory.sortId : categories.find(c => c.name === emoji.category).sortId" t-on-click="selectEmoji" t-on-mouseenter="(ev) => this.onMouseenterEmoji(ev, emoji)" t-on-mouseleave="(ev) => this.onMouseleaveEmoji(ev, emoji)">
+    <span class="o-Emoji cursor-pointer d-flex justify-content-center rounded-3 align-items-center align-self-stretch" t-att-class="{ 'o-active': state.activeEmojiIndex === itemIndex }" t-att-title="emoji.name" t-att-data-codepoints="emoji.codepoints" t-att-data-index="itemIndex" t-att-data-category="inRecent ? recentCategory.sortId : categories.find(c => c.name === emoji.category).sortId" t-on-click="selectEmoji" t-on-mouseenter="(ev) => this.onMouseenterEmoji(ev, emoji)" t-on-mouseleave="(ev) => this.onMouseleaveEmoji(ev, emoji)">
         <span t-esc="emoji.codepoints"/>
     </span>
 </t>


### PR DESCRIPTION
*: im_livechat, web, html_editor

task-3679384

------------------------
Standardizes the `EmojiPicker` design to ensure visual consistency between the frontend and backend.

Prior to this PR, this component relied on environment-specific overrides which caused the font-size to render differently in the backend vs. the frontend. This change removes the related utility classes in favor of manual overrides to enforce a single source of truth for the design.

- Removed environment-specific `font-size` classes;
- Removed environment-specific `background/text color` classes;
- Implemented CSS variables with SCSS variables fallbacks for the styling.

This commit also fixes an issue related to Commit [^1] which enforced a `width` of `300px` on the `.o-EmojiPicker` child of the popover while our standard popover have a `max-width` of `276px`, causing a visual issue with the borders of the picker being cut. To fix this, we simply set the `--popover-max-width` to `300px`, the value previously defined and also apply a class on the popover element to scope the style inside.

| Master | This PR |
|--------|--------|
| <img width="362" height="440" alt="image" src="https://github.com/user-attachments/assets/803051f4-d5d7-4702-8f05-b2833c04da38" /> | <img width="326" height="387" alt="image" src="https://github.com/user-attachments/assets/9f7c8d0a-aa4c-43f7-833e-5a195663ca18" /> |

[^1]: https://github.com/odoo/odoo/commit/cc919f3b59ef18bd95edf42eb354a627c4041b68