### PR TITLE
[FIX] website_slides: fixed broken tour

### DIFF
--- a/addons/website_slides/static/src/js/tours/slides_tour.js
+++ b/addons/website_slides/static/src/js/tours/slides_tour.js
@@ -46,7 +46,7 @@ wTourUtils.registerWebsitePreviewTour('slides_tour', {
     position: 'bottom',
     width: 260,
 }, {
-    trigger: ':iframe a.btn-primary.o_wslides_js_slide_upload',
+    trigger: '.o_iframe[is-ready="true"]:iframe a.btn-primary.o_wslides_js_slide_upload',
     content: markup(_t("Your first section is created, now it's time to add lessons to your course. Click on <b>Add Content</b> to upload a document, create an article or link a video.")),
     position: 'bottom',
 }, {
@@ -100,11 +100,11 @@ wTourUtils.registerWebsitePreviewTour('slides_tour', {
     position: 'left',
     width: 170,
 }, {
-    trigger: ':iframe li.breadcrumb-item:nth-child(2)',
+    trigger: '.o_iframe[is-ready="true"]:iframe li.breadcrumb-item:nth-child(2)',
     content: markup(_t("Click on your <b>Course</b> to go back to the table of content.")),
     position: 'top',
 }, {
-    trigger: '.o_menu_systray_item a .o_switch',
+    trigger: '.o_menu_systray_item.o_website_publish_container a',
     content: markup(_t("Once you're done, don't forget to <b>Publish</b> your course.")),
     position: 'bottom',
 }, {


### PR DESCRIPTION
**Issue**
From v17.2, the website_slides tour is not working because of some changes in the tour library.
Commit from where I think the bug is coming https://github.com/odoo/odoo/commit/b334055c82c4350b4122e620ae76179a9fc4eaa2
and later due to the website design change another step was also failing
and that should be coming this commit https://github.com/odoo/odoo/commit/80e3f53550b7ed74ac18bb09ea542c9e77c9a61d

**Technical**
The "Add to content" is loading before our frame is ready due to this the
position of the pointer was wrong.

Due to the design change tour was not able to point the publish btn

**After this PR**
Now the tour is working properly.

Task-3960962