### PR TITLE
[FIX] account_peppol: fix demo mode registration

### DIFF
--- a/addons/account_peppol/models/res_config_settings.py
+++ b/addons/account_peppol/models/res_config_settings.py
@@ -14,6 +14,7 @@ class ResConfigSettings(models.TransientModel):
         string='EDI user',
         compute='_compute_account_peppol_edi_user',
     )
+    account_peppol_edi_mode = fields.Selection(related='account_peppol_edi_user.edi_mode')
     account_peppol_contact_email = fields.Char(related='company_id.account_peppol_contact_email', readonly=False)
     account_peppol_eas = fields.Selection(related='company_id.peppol_eas', readonly=False)
     account_peppol_edi_identification = fields.Char(related='account_peppol_edi_user.edi_identification')

--- a/addons/account_peppol/static/src/components/res_config_settings_buttons/res_config_settings_buttons.js
+++ b/addons/account_peppol/static/src/components/res_config_settings_buttons/res_config_settings_buttons.js
@@ -41,7 +41,7 @@ class PeppolSettingsButtons extends Component {
     }
 
     get ediMode() {
-        return this.props.record.data.edi_mode;
+        return this.props.record.data.edi_mode || this.props.record.data.account_peppol_edi_mode;
     }
 
     get modeConstraint() {
@@ -62,13 +62,10 @@ class PeppolSettingsButtons extends Component {
     }
 
     get deregisterUserButtonLabel() {
-        const modes = {
-            demo: _t("Switch to Live"),
-        }
         if (['not_registered', 'in_verification'].includes(this.proxyState)) {
             return _t("Discard");
         }
-        return this.modeConstraint !== "demo" && modes[this.ediMode] || _t("Deregister");
+        return _t("Deregister");
     }
 
     async _callConfigMethod(methodName) {

--- a/addons/account_peppol/tools/demo_utils.py
+++ b/addons/account_peppol/tools/demo_utils.py
@@ -98,17 +98,15 @@ def _mock_user_creation(func, self, *args, **kwargs):
 
 def _mock_receiver_registration(func, self, *args, **kwargs):
     self.account_peppol_proxy_state = 'receiver'
-    return self._action_send_notification(
+    return self.env['peppol.registration']._action_send_notification(
         *_get_notification_message(self.account_peppol_proxy_state)
     )
 
 
 def _mock_check_verification_code(func, self, *args, **kwargs):
-    self.account_peppol_proxy_state = 'sender'
+    self.button_peppol_sender_registration()
     self.verification_code = False
-    if self.smp_registration:
-        return self.button_peppol_smp_registration()
-    return self._action_send_notification(
+    return self.env['peppol.registration']._action_send_notification(
         *_get_notification_message(self.account_peppol_proxy_state)
     )
 

--- a/addons/account_peppol/views/account_journal_dashboard_views.xml
+++ b/addons/account_peppol/views/account_journal_dashboard_views.xml
@@ -11,7 +11,7 @@
                     <field name="account_peppol_proxy_state" invisible="1"/>
                 </xpath>
 
-                <xpath expr="//t[@id='account.JournalBodySalePurchase']//div" position="inside">
+                <xpath expr="//t[@id='account.JournalBodySalePurchase']" position="inside">
                     <t t-if="['sender', 'smp_registration', 'receiver'].includes(record.account_peppol_proxy_state.raw_value)">
                         <t t-if="journal_type == 'sale'">
                             <div class="w-100">

--- a/addons/account_peppol/views/res_config_settings_views.xml
+++ b/addons/account_peppol/views/res_config_settings_views.xml
@@ -89,12 +89,12 @@
                             </div>
 
                             <!-- All action buttons -->
-                            <div invisible="account_peppol_proxy_state != 'receiver' or (account_peppol_edi_user and account_peppol_edi_user.edi_mode == 'demo')">
-                                  <button string="Configure Peppol Services"
-                                          name="button_account_peppol_configure_services"
-                                          type="object"
-                                          class="btn-link mt-3 mb-3"
-                                          icon="oi-arrow-right"/>
+                            <div invisible="account_peppol_proxy_state != 'receiver' or account_peppol_edi_mode == 'demo'">
+                                <button string="Configure Peppol Services"
+                                        name="button_account_peppol_configure_services"
+                                        type="object"
+                                        class="btn-link mt-3 mb-3"
+                                        icon="oi-arrow-right"/>
                             </div>
                             <div class="d-flex gap-1 action_buttons" colspan="3">
                                 <div class="mt-3"


### PR DESCRIPTION
The registration flow changed and the demo mode mocking was not adjusted properly, skipping the step of creating an edi user. Additionally, we need to hide Peppol Services button in demo mode by adding a non-stored `account_peppol_edi_mode` field.

task-3971063




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
