### PR TITLE
[REF] website, *: migrate from deprecated t-esc to t-out 

### DIFF
--- a/addons/test_website/data/test_website_data.xml
+++ b/addons/test_website/data/test_website_data.xml
@@ -132,8 +132,8 @@
 
         <!-- RECORDS FOR REDIRECT TESTS -->
         <template id="test_redirect_view">
-            <t t-esc="country.name"/>
-            <t t-if="not request.env.user._is_public()" t-esc="'Logged In'"/>
+            <t t-out="country.name"/>
+            <t t-if="not request.env.user._is_public()" t-out="'Logged In'"/>
             <!-- `href` is send through `url_for` for non editor users -->
             <a href="/test_website/country/andorra-1">I am a link</a>
         </template>

--- a/addons/website/data/website_demo.xml
+++ b/addons/website/data/website_demo.xml
@@ -19,34 +19,34 @@
                                         <div class="col-8">
                                             <h2>Badge</h2>
                                             <t t-foreach="bs_theme_colors" t-as="color">
-                                                <span t-attf-class="badge mb-1 text-bg-#{color[0]}"><t t-esc="color[1]"/></span>
+                                                <span t-attf-class="badge mb-1 text-bg-#{color[0]}"><t t-out="color[1]"/></span>
                                             </t>
                                             <h3 class="mt-2 h6">Link</h3>
                                             <t t-foreach="bs_theme_colors" t-as="color">
-                                                <a href="#" t-attf-class="badge mb-1 text-bg-#{color[0]}"><t t-esc="color[1]"/></a>
+                                                <a href="#" t-attf-class="badge mb-1 text-bg-#{color[0]}"><t t-out="color[1]"/></a>
                                             </t>
                                             <h3 class="mt-2 h6">Autosizing</h3>
                                             <div class="h3">
                                                 <t t-foreach="bs_theme_colors" t-as="color">
-                                                    <span t-attf-class="badge mb-1 text-bg-#{color[0]}"><t t-esc="color[1]"/></span>
+                                                    <span t-attf-class="badge mb-1 text-bg-#{color[0]}"><t t-out="color[1]"/></span>
                                                 </t>
                                             </div>
 
                                             <h2 class="mt-4">Button</h2>
                                             <t t-foreach="bs_theme_colors" t-as="color">
-                                                <button type="button" t-attf-class="btn mb-1 btn-#{color[0]}"><t t-esc="color[1]"/></button>
+                                                <button type="button" t-attf-class="btn mb-1 btn-#{color[0]}"><t t-out="color[1]"/></button>
                                             </t>
                                             <h6 class="mt-2">Outline</h6>
                                             <t t-foreach="bs_theme_colors" t-as="color">
-                                                <button type="button" t-attf-class="btn mb-1 btn-outline-#{color[0]}"><t t-esc="color[1]"/></button>
+                                                <button type="button" t-attf-class="btn mb-1 btn-outline-#{color[0]}"><t t-out="color[1]"/></button>
                                             </t>
                                             <h6 class="mt-2">Small</h6>
                                             <t t-foreach="bs_theme_colors" t-as="color">
-                                                <button type="button" t-attf-class="btn mb-1 btn-sm btn-#{color[0]}"><t t-esc="color[1]"/></button>
+                                                <button type="button" t-attf-class="btn mb-1 btn-sm btn-#{color[0]}"><t t-out="color[1]"/></button>
                                             </t>
                                             <h6 class="mt-2">Large</h6>
                                             <t t-foreach="bs_theme_colors" t-as="color">
-                                                <button type="button" t-attf-class="btn mb-1 btn-lg btn-#{color[0]}"><t t-esc="color[1]"/></button>
+                                                <button type="button" t-attf-class="btn mb-1 btn-lg btn-#{color[0]}"><t t-out="color[1]"/></button>
                                             </t>
                                             <h6 class="mt-2">Group</h6>
                                             <div class="btn-group" role="group" aria-label="Basic example">
@@ -314,7 +314,7 @@
                                             <div class="col-6">
                                                 <t t-foreach="bs_theme_colors" t-as="color">
                                                     <div t-attf-class="alert alert-#{color[0]}">
-                                                        This is a "<t t-esc="color[1]"/>" alert with a <a href="#" class="alert-link">link</a>.
+                                                        This is a "<t t-out="color[1]"/>" alert with a <a href="#" class="alert-link">link</a>.
                                                     </div>
                                                 </t>
                                             </div>
@@ -363,42 +363,42 @@
                                             <div class="row g-0">
                                                 <t t-foreach="odoo_theme_colors" t-as="color">
                                                     <div t-attf-class="col-auto bg-#{color[0]}">
-                                                        <div class="py-1 px-3"><t t-esc="color[1]"/></div>
+                                                        <div class="py-1 px-3"><t t-out="color[1]"/></div>
                                                     </div>
                                                 </t>
                                             </div>
                                             <div class="row g-0 mt-2">
                                                 <t t-foreach="bs_theme_colors" t-as="color">
                                                     <div t-attf-class="col-auto text-bg-#{color[0]}">
-                                                        <div class="py-1 px-3"><t t-esc="color[1]"/></div>
+                                                        <div class="py-1 px-3"><t t-out="color[1]"/></div>
                                                     </div>
                                                 </t>
                                             </div>
                                             <div class="row g-0 mt-2">
                                                 <t t-foreach="bs_gray_colors" t-as="color">
                                                     <div t-attf-class="col-auto bg-#{color[0]}">
-                                                        <div class="py-1 px-3"><t t-esc="color[1]"/></div>
+                                                        <div class="py-1 px-3"><t t-out="color[1]"/></div>
                                                     </div>
                                                 </t>
                                             </div>
                                             <div class="row g-0 mt-4">
                                                 <t t-foreach="odoo_theme_colors" t-as="color">
                                                     <div t-attf-class="col-auto text-#{color[0]}">
-                                                        <div class="py-1 px-3"><t t-esc="color[1]"/></div>
+                                                        <div class="py-1 px-3"><t t-out="color[1]"/></div>
                                                     </div>
                                                 </t>
                                             </div>
                                             <div class="row g-0 mt-2">
                                                 <t t-foreach="bs_theme_colors" t-as="color">
                                                     <div t-attf-class="col-auto text-#{color[0]}">
-                                                        <div class="py-1 px-3"><t t-esc="color[1]"/></div>
+                                                        <div class="py-1 px-3"><t t-out="color[1]"/></div>
                                                     </div>
                                                 </t>
                                             </div>
                                             <div class="row g-0 mt-2">
                                                 <t t-foreach="bs_gray_colors" t-as="color">
                                                     <div t-attf-class="col-auto text-#{color[0]}">
-                                                        <div class="py-1 px-3"><t t-esc="color[1]"/></div>
+                                                        <div class="py-1 px-3"><t t-out="color[1]"/></div>
                                                     </div>
                                                 </t>
                                             </div>
@@ -484,7 +484,7 @@
                                                             <div class="d-flex">
                                                                 <span t-attf-class="border p-3 me-1 bg-o-color-#{i}"></span>
                                                                 <div class="flex-grow-1 align-self-center">
-                                                                    <h5 class="m-0">o-color-<t t-esc="i"/></h5>
+                                                                    <h5 class="m-0">o-color-<t t-out="i"/></h5>
                                                                 </div>
                                                             </div>
                                                         </td>
@@ -495,7 +495,7 @@
                                                             <div class="d-flex">
                                                                 <span t-attf-class="border p-3 me-1 bg-#{i}"></span>
                                                                 <div class="flex-grow-1 align-self-center">
-                                                                    <h5 class="m-0" t-esc="i"></h5>
+                                                                    <h5 class="m-0" t-out="i"></h5>
                                                                 </div>
                                                             </div>
                                                         </td>
@@ -510,7 +510,7 @@
                                                 <div class="row">
                                                     <div class="col-7">
                                                         <h2>
-                                                            Preset <t t-esc="i"/>
+                                                            Preset <t t-out="i"/>
                                                         </h2>
                                                         <p>Paragraph text. Lorem <b>ipsum dolor sit amet</b>, consectetur adipiscing elit. <i>Integer posuere erat a ante</i>. <a class="o_translate_inline" href="#">Link text</a></p>
                                                         <p class="text-muted">Text muted. Lorem <b>ipsum dolor sit amet</b>, consectetur.</p>
@@ -540,7 +540,7 @@
                                                                 <p class="card-text">Paragraph. <a class="o_translate_inline" href="#">text link</a></p>
 
                                                                 <t t-foreach="['primary','secondary', 'info', 'warning', 'danger', 'success']" t-as="btn">
-                                                                    <a href="#" t-attf-class="mb-2 btn-sm btn btn-#{btn}" t-esc="'btn-' + btn"/>
+                                                                    <a href="#" t-attf-class="mb-2 btn-sm btn btn-#{btn}" t-out="'btn-' + btn"/>
                                                                 </t>
                                                             </div>
                                                         </div>
@@ -569,8 +569,8 @@
                                                     </div>
                                                     <div class="col-5 border-start">
                                                         <div t-foreach="['info', 'warning', 'danger', 'success']" t-as="btn">
-                                                            <a href="#" t-attf-class="mb-2 btn-block btn btn-#{btn}" t-esc="'btn-' + btn"/>
-                                                            <a href="#" t-attf-class="mb-3 btn-block btn btn-outline-#{btn}" t-esc="'btn-outline-' + btn"/>
+                                                            <a href="#" t-attf-class="mb-2 btn-block btn btn-#{btn}" t-out="'btn-' + btn"/>
+                                                            <a href="#" t-attf-class="mb-3 btn-block btn btn-outline-#{btn}" t-out="'btn-outline-' + btn"/>
                                                         </div>
                                                     </div>
                                                 </div>

--- a/addons/website/static/src/snippets/s_searchbar/000.xml
+++ b/addons/website/static/src/snippets/s_searchbar/000.xml
@@ -6,7 +6,7 @@
     class="o_dropdown_menu show position-absolute w-100">
     <t t-if="fuzzySearch and results.length">
         <span class="dropdown-item-text">
-            <span class="text-muted">No results found for '<t t-esc="search"/>'. Showing results for '<a href="#" class="s_searchbar_fuzzy_submit" t-esc="fuzzySearch"/>'.</span>
+            <span class="text-muted">No results found for '<t t-out="search"/>'. Showing results for '<a href="#" class="s_searchbar_fuzzy_submit" t-out="fuzzySearch"/>'.</span>
         </span>
     </t>
     <t t-elif="!results.length">

--- a/addons/website/static/src/xml/website.xml
+++ b/addons/website/static/src/xml/website.xml
@@ -5,14 +5,14 @@
                 <div class="modal-dialog">
                 <div class="modal-content">
                     <header class="modal-header" t-if="window_title">
-                        <h3 class="modal-title"><t t-esc="window_title"/></h3>
+                        <h3 class="modal-title"><t t-out="window_title"/></h3>
                         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                     </header>
                     <main class="modal-body">
                         <form role="form" t-att-id="id">
                             <div class="row mb0">
                                 <label for="page-name" class="col-md-3 col-form-label">
-                                    <t t-esc="field_name"/>
+                                    <t t-out="field_name"/>
                                 </label>
                                 <div class="col-md-9">
                                     <input t-if="field_type == 'input'" type="text" class="form-control" required="required"/>
@@ -23,8 +23,8 @@
                         </form>
                     </main>
                     <footer class="modal-footer">
-                        <button type="button" class="btn btn-primary btn-continue"><t t-esc="btn_primary_title"/></button>
-                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" aria-label="Cancel"><t t-esc="btn_secondary_title"/></button>
+                        <button type="button" class="btn btn-primary btn-continue"><t t-out="btn_primary_title"/></button>
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" aria-label="Cancel"><t t-out="btn_secondary_title"/></button>
                     </footer>
                 </div>
             </div>

--- a/addons/website/static/src/xml/website_form.xml
+++ b/addons/website/static/src/xml/website_form.xml
@@ -12,7 +12,7 @@
     <t t-name="website.s_website_form_status_error">
         <span id="s_website_form_result" class="me-2 small text-danger">
             <i class="fa fa-close me-1" role="img" aria-hidden="true" title="Error"/>
-            <t t-esc="message"/>
+            <t t-out="message"/>
         </span>
     </t>
 

--- a/addons/website/static/src/xml/website_form_editor.xml
+++ b/addons/website/static/src/xml/website_form_editor.xml
@@ -51,12 +51,12 @@
     </t>
 
     <t t-name="website.form_label_content">
-        <span class="s_website_form_label_content" t-esc="field.string"/>
+        <span class="s_website_form_label_content" t-out="field.string"/>
         <t t-if="field.required or field.modelRequired">
-            <span class="s_website_form_mark" t-if="field.formatInfo.requiredMark" t-esc="' ' + field.formatInfo.mark"/>
+            <span class="s_website_form_mark" t-if="field.formatInfo.requiredMark" t-out="' ' + field.formatInfo.mark"/>
         </t>
         <t t-else="">
-            <span class="s_website_form_mark" t-if="field.formatInfo.optionalMark" t-esc="' ' + field.formatInfo.mark"/>
+            <span class="s_website_form_mark" t-if="field.formatInfo.optionalMark" t-out="' ' + field.formatInfo.mark"/>
         </t>
     </t>
 
@@ -74,7 +74,7 @@
             not make sense to try and change it over there anyway).
         -->
         <div t-if="default_description" class="s_website_form_field_description small form-text text-muted" contenteditable="true">
-            <t t-esc="default_description"/>
+            <t t-out="default_description"/>
         </div>
     </t>
 
@@ -132,7 +132,7 @@
                 t-att-placeholder="field.placeholder"
                 t-att-id="field.id"
                 t-att-rows="field.rows || 3"
-                t-esc="field.value"
+                t-out="field.value"
             />
         </t>
     </t>
@@ -267,7 +267,7 @@
                     t-att-required="field.required || field.modelRequired || None"
                 />
                 <label class="form-check-label s_website_form_check_label" t-att-for="recordId">
-                    <t t-esc="record.display_name"/>
+                    <t t-out="record.display_name"/>
                 </label>
             </div>
         </div>
@@ -284,7 +284,7 @@
             <t t-call="website.form_field">
                 <select class="form-select s_website_form_input" t-att-name="field.name" t-att-required="field.required || field.modelRequired || None" t-att-id="field.id">
                     <t t-foreach="field.records" t-as="record" t-key="record_index">
-                        <option t-esc="record.display_name" t-att-id="field.id + record_index" t-att-value="record.id" t-att="{selected: record.selected and 'selected' or None}"/>
+                        <option t-out="record.display_name" t-att-id="field.id + record_index" t-att-value="record.id" t-att="{selected: record.selected and 'selected' or None}"/>
                     </t>
                 </select>
             </t>
@@ -338,7 +338,7 @@
                     t-att-required="field.required || field.modelRequired || None"
                 />
                 <label class="form-check-label s_website_form_check_label" t-att-for="recordId">
-                    <t t-esc="record.display_name"/>
+                    <t t-out="record.display_name"/>
                 </label>
             </div>
         </div>

--- a/addons/website/tests/test_http_endpoint.py
+++ b/addons/website/tests/test_http_endpoint.py
@@ -23,7 +23,7 @@ class TestHttpEndPoint(HttpCase):
             'inherit_id': homepage_view.id,
             'arch_db': """
                 <t t-call="website.layout" position="before">
-                    <t t-esc="website.env.registry.clear_cache('routing')"/>
+                    <t t-out="website.env.registry.clear_cache('routing')"/>
                 </t>
             """,
         })

--- a/addons/website/tests/test_page.py
+++ b/addons/website/tests/test_page.py
@@ -264,7 +264,7 @@ class WithContext(HttpCase):
     @mute_logger('odoo.http')
     def test_03_error_page_debug(self):
         with MockRequest(self.env, website=self.env['website'].browse(1)):
-            self.base_view.arch = self.base_view.arch.replace('I am a generic page', '<t t-esc="15/0"/>')
+            self.base_view.arch = self.base_view.arch.replace('I am a generic page', '<t t-out="15/0"/>')
 
             # first call, no debug, traceback should not be visible
             r = self.url_open(self.page.url)

--- a/addons/website/views/snippets/s_call_to_action.xml
+++ b/addons/website/views/snippets/s_call_to_action.xml
@@ -11,7 +11,7 @@
                 </div>
                 <div class="col-lg-3">
                     <p style="text-align: right;">
-                        <a t-att-href="cta_btn_href" class="btn btn-primary btn-lg o_translate_inline"><t t-esc="cta_btn_text">Contact us</t></a>
+                        <a t-att-href="cta_btn_href" class="btn btn-primary btn-lg o_translate_inline"><t t-out="cta_btn_text">Contact us</t></a>
                     </p>
                 </div>
             </div>

--- a/addons/website/views/snippets/s_cover.xml
+++ b/addons/website/views/snippets/s_cover.xml
@@ -9,7 +9,7 @@
             <h1 class="display-3" style="text-align: center;">Your journey starts here</h1>
             <p class="lead" style="text-align: center;">Write one or two paragraphs describing your product, services or a specific feature.<br/> To be successful your content needs to be useful to your readers.</p>
             <p style="text-align: center;">
-                <a t-att-href="cta_btn_href" class="btn btn-secondary mb-2 o_translate_inline"><t t-esc="cta_btn_text">Discover more</t></a>
+                <a t-att-href="cta_btn_href" class="btn btn-secondary mb-2 o_translate_inline"><t t-out="cta_btn_text">Discover more</t></a>
                 <t t-set="contact_us_label">Contact us</t>
                 <a href="/contactus" class="btn btn-outline-secondary mb-2 o_translate_inline"><t t-out="contact_us_label"/></a>
             </p>

--- a/addons/website/views/snippets/s_dynamic_snippet.xml
+++ b/addons/website/views/snippets/s_dynamic_snippet.xml
@@ -39,7 +39,7 @@
             <we-select string="Template" data-name="template_opt" data-attribute-name="templateKey" data-no-preview="true">
             </we-select>
             <we-select string="Fetched Elements" data-name="number_of_records_opt" data-attribute-name="numberOfRecords" data-no-preview="true">
-                <we-button t-foreach="range(1, 17)" t-as="value" t-att-data-select-data-attribute="value" t-esc="value"/>
+                <we-button t-foreach="range(1, 17)" t-as="value" t-att-data-select-data-attribute="value" t-out="value"/>
             </we-select>
             <t t-out="0"/>
         </div>

--- a/addons/website/views/snippets/s_mega_menu_big_icons_subtitles.xml
+++ b/addons/website/views/snippets/s_mega_menu_big_icons_subtitles.xml
@@ -73,8 +73,8 @@
         <div class="d-flex align-items-center">
             <i t-attf-class="fa rounded rounded-circle me-3 #{_icon_classes}"/>
             <div class="flex-grow-1">
-                <h4 class="mt-0 mb-0" t-esc="_title"/>
-                <span class="small"><t t-esc="_text"/></span>
+                <h4 class="mt-0 mb-0" t-out="_title"/>
+                <span class="small"><t t-out="_text"/></span>
             </div>
         </div>
     </a>

--- a/addons/website/views/snippets/s_mega_menu_cards.xml
+++ b/addons/website/views/snippets/s_mega_menu_cards.xml
@@ -57,8 +57,8 @@
     <div class="col-12 col-lg-3" data-name="Menu Item">
         <a href="#" class="nav-link rounded text-wrap text-center p-3">
             <img t-att-src="_img_src" class="mb-3 rounded shadow img-fluid" alt=""/>
-            <h4 t-esc="_title"/>
-            <span class="mb-0 small"><t t-esc="_text"/></span>
+            <h4 t-out="_title"/>
+            <span class="mb-0 small"><t t-out="_text"/></span>
         </a>
     </div>
 </template>

--- a/addons/website/views/snippets/s_mega_menu_images_subtitles.xml
+++ b/addons/website/views/snippets/s_mega_menu_images_subtitles.xml
@@ -61,8 +61,8 @@
         <div class="d-flex">
             <img t-att-src="_img_src" class="me-3 rounded shadow" alt=""/>
             <div class="flex-grow-1">
-                <h4 class="mt-0 mb-0" t-esc="_title"/>
-                <span class="small"><t t-esc="_text"/></span>
+                <h4 class="mt-0 mb-0" t-out="_title"/>
+                <span class="small"><t t-out="_text"/></span>
             </div>
         </div>
     </a>

--- a/addons/website/views/snippets/s_mega_menu_menu_image_menu.xml
+++ b/addons/website/views/snippets/s_mega_menu_menu_image_menu.xml
@@ -12,7 +12,7 @@
                             <t t-set="text">Menu Item %s</t>
                             <t t-set="text" t-value="text % (i + 1)"/>
                             <a href="#" class="nav-link" data-name="Menu Item"
-                                t-esc="text"/>
+                                t-out="text"/>
                         </t>
                     </nav>
                 </div>
@@ -26,7 +26,7 @@
                             <t t-set="text">Menu Item %s</t>
                             <t t-set="text" t-value="text % (i + 1)"/>
                             <a href="#" class="nav-link" data-name="Menu Item"
-                                t-esc="text"/>
+                                t-out="text"/>
                         </t>
                     </nav>
                 </div>

--- a/addons/website/views/snippets/s_mega_menu_multi_menus.xml
+++ b/addons/website/views/snippets/s_mega_menu_multi_menus.xml
@@ -11,13 +11,13 @@
                 <t t-set="menu4_title">Last Menu</t>
                 <t t-foreach="[menu1_title, menu2_title, menu3_title, menu4_title]" t-as="menu_title">
                     <div class="col-12 col-lg-3 py-2 text-center">
-                        <h4 t-esc="menu_title"/>
+                        <h4 t-out="menu_title"/>
                         <nav class="nav flex-column">
                             <t t-foreach="3" t-as="i">
                                 <t t-set="text">Menu Item %s</t>
                                 <t t-set="text" t-value="text % (i + 1)"/>
                                 <a href="#" class="nav-link" data-name="Menu Item"
-                                   t-esc="text"/>
+                                   t-out="text"/>
                             </t>
                         </nav>
                     </div>

--- a/addons/website/views/snippets/s_mega_menu_thumbnails.xml
+++ b/addons/website/views/snippets/s_mega_menu_thumbnails.xml
@@ -98,7 +98,7 @@
             <br/>
             <span class="d-block p-2 small">
                 <b>
-                    <t t-esc="_text"/>
+                    <t t-out="_text"/>
                 </b>
             </span>
         </a>

--- a/addons/website/views/snippets/s_striped_center_top.xml
+++ b/addons/website/views/snippets/s_striped_center_top.xml
@@ -11,7 +11,7 @@
                     <p class="lead" style="text-align: center;">We deliver seamless, innovative solutions that not only meet your needs but exceed expectations, driving meaningful results and lasting success.</p>
                     <p><br /></p>
                     <p style="text-align: center;">
-                        <a t-att-href="cta_btn_href" class="btn btn-primary btn-lg o_translate_inline"><t t-esc="cta_btn_text">Get started</t></a>
+                        <a t-att-href="cta_btn_href" class="btn btn-primary btn-lg o_translate_inline"><t t-out="cta_btn_text">Get started</t></a>
                     </p>
                 </div>
                 <div class="col-lg-10 offset-lg-1 pb24" style="text-align: center;">

--- a/addons/website/views/snippets/s_text_cover.xml
+++ b/addons/website/views/snippets/s_text_cover.xml
@@ -8,7 +8,7 @@
                 <div class="o_grid_item g-height-9 g-col-lg-5 col-lg-5 o_cc o_cc1" style="z-index: 1; grid-area: 2 / 3 / 11 / 8; --grid-item-padding-x: 24px; --grid-item-padding-y: 24px;">
                     <h1 class="display-3">Sell Online. <br/>Easily.</h1>
                     <p class="lead"><br/>Sell online easily with a user-friendly platform that streamlines all the steps, including setup, inventory management, and payment processing.<br/></p>
-                    <a t-att-href="cta_btn_href" class="btn btn-lg btn-primary"><t t-esc="cta_btn_text">Contact us</t></a>
+                    <a t-att-href="cta_btn_href" class="btn btn-lg btn-primary"><t t-out="cta_btn_text">Contact us</t></a>
                 </div>
                 <div class="o_grid_item g-height-11 g-col-lg-6 col-lg-6 o_cc o_cc1 oe_img_bg o_not_editable d-none d-lg-block o_snippet_mobile_invisible" style="grid-area: 1 / 7 / 12 / 13; --grid-item-padding-x: 0px; --grid-item-padding-y: 0px; background-image: url('/web/image/website.s_text_cover_default_image');"/>
             </div>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -1396,7 +1396,7 @@
                        data-select-class="o_header_standard"
                        data-customize-website-views="website.header_visibility_standard"
                        data-img="/website/static/src/img/snippets_options/header_effect_standard.png">
-                <span t-esc='header_effect_standard_label'/>
+                <span t-out='header_effect_standard_label'/>
             </we-button>
             <we-button id="option_header_effect_scroll"
                        t-att-data-select-label="header_effect_scroll_label"
@@ -1406,7 +1406,7 @@
                        data-select-class=""
                        data-customize-website-views=""
                        data-img="/website/static/src/img/snippets_options/header_effect_scroll.png">
-                <span t-esc='header_effect_scroll_label'/>
+                <span t-out='header_effect_scroll_label'/>
             </we-button>
             <we-button id="option_header_effect_fixed"
                        t-att-data-select-label="header_effect_fixed_label"
@@ -1416,7 +1416,7 @@
                        data-select-class="o_header_fixed"
                        data-customize-website-views="website.header_visibility_fixed"
                        data-img="/website/static/src/img/snippets_options/header_effect_fixed.png">
-                <span t-esc='header_effect_fixed_label'/>
+                <span t-out='header_effect_fixed_label'/>
             </we-button>
             <we-button id="option_header_effect_disappears"
                        t-att-data-select-label="header_effect_disappears_label"
@@ -1426,7 +1426,7 @@
                        data-select-class="o_header_disappears"
                        data-customize-website-views="website.header_visibility_disappears"
                        data-img="/website/static/src/img/snippets_options/header_effect_disappears.png">
-                <span t-esc="header_effect_disappears_label" />
+                <span t-out="header_effect_disappears_label" />
             </we-button>
             <we-button id="option_header_effect_fade_out"
                        t-att-data-select-label="header_effect_fadeout_label"
@@ -1436,7 +1436,7 @@
                        data-select-class="o_header_fade_out"
                        data-customize-website-views="website.header_visibility_fade_out"
                        data-img="/website/static/src/img/snippets_options/header_effect_fade_out.png">
-               <span t-esc='header_effect_fadeout_label'/>
+               <span t-out='header_effect_fadeout_label'/>
             </we-button>
         </we-select>
     </div>

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -261,7 +261,7 @@
                     'analytics_storage': 'denied',
                 });
                 gtag('js', new Date());
-                gtag('config', '<t t-esc="website.google_analytics_key"/>');
+                gtag('config', '<t t-out="website.google_analytics_key"/>');
                 function allConsentsGranted() {
                     gtag('consent', 'update', {
                         'ad_storage': 'granted',
@@ -316,7 +316,7 @@
             <div class="o_frontend_to_backend_buttons d-flex">
                 <a href="#" title="Go to your Odoo Apps" class="o_frontend_to_backend_apps_btn fa fa-th d-flex align-items-center justify-content-center text-decoration-none" data-bs-toggle="dropdown"/>
                 <div class="dropdown-menu o_frontend_to_backend_apps_menu" role="menu">
-                    <a role="menuitem" class="dropdown-item" t-esc="menu['name']"
+                    <a role="menuitem" class="dropdown-item" t-out="menu['name']"
                        t-as="menu" t-foreach="env['ir.ui.menu'].with_context(force_action=True).load_menus_root()['children']"
                        t-attf-href="/odoo/action-#{menu['action'] and menu['action'].split(',')[1] or ''}"/>
                 </div>
@@ -1751,7 +1751,7 @@
                                 <li><a href="#">Legal</a></li>
                                 <t t-set="configurator_footer_links" t-value="[]"/>
                                 <li t-foreach="configurator_footer_links" t-as="link">
-                                    <a t-att-href="link['href']" t-esc="link['text']"/>
+                                    <a t-att-href="link['href']" t-out="link['text']"/>
                                 </li>
                                 <li><a href="/contactus">Contact us</a></li>
                             </ul>
@@ -1884,7 +1884,7 @@
                                 <li class="list-item py-1"><a href="#">Blog</a></li>
                                 <t t-set="configurator_footer_links" t-value="[]"/>
                                 <li t-foreach="configurator_footer_links" t-as="link" class="list-item py-1">
-                                    <a t-att-href="link['href']" t-esc="link['text']"/>
+                                    <a t-att-href="link['href']" t-out="link['text']"/>
                                 </li>
                             </ul>
                         </div>
@@ -1943,7 +1943,7 @@
                                 <li class="list-inline-item"><a href="#">Services</a></li>
                                 <t t-set="configurator_footer_links" t-value="[]"/>
                                 <li t-foreach="configurator_footer_links" t-as="link" class="list-inline-item">
-                                    <a t-att-href="link['href']" t-esc="link['text']"/>
+                                    <a t-att-href="link['href']" t-out="link['text']"/>
                                 </li>
                             </ul>
                         </div>
@@ -2112,7 +2112,7 @@
                                 <li><a href="/contactus">Contact us</a></li>
                                 <t t-set="configurator_footer_links" t-value="[]"/>
                                 <li t-foreach="configurator_footer_links" t-as="link">
-                                    <a t-att-href="link['href']" t-esc="link['text']"/>
+                                    <a t-att-href="link['href']" t-out="link['text']"/>
                                 </li>
                             </ul>
                         </div>
@@ -2448,11 +2448,11 @@
     <xpath expr="//div[@id='wrap']" position="inside">
         <div class="oe_structure">
             <section class="container">
-                <h1><t t-esc="res_company.name"/>
+                <h1><t t-out="res_company.name"/>
                     <small groups='base.group_no_one'>Odoo Version <t t-out="version.get('server_version')"/></small>
                 </h1>
                 <p>
-                    Information about the <t t-esc="res_company.name"/> instance of Odoo, the <a class="o_translate_inline" target="_blank" href="https://www.odoo.com">Open Source ERP</a>.
+                    Information about the <t t-out="res_company.name"/> instance of Odoo, the <a class="o_translate_inline" target="_blank" href="https://www.odoo.com">Open Source ERP</a>.
                 </p>
 
                 <div class="alert alert-warning alert-dismissable mt16" groups="website.group_website_restricted_editor" role="status">
@@ -2667,13 +2667,13 @@
         <div class="container" t-if="view and editable">
             <div class="alert alert-danger" role="alert">
                 <h4>Template fallback</h4>
-                <p>An error occurred while rendering the template <code t-esc="qweb_exception.name"/>.</p>
+                <p>An error occurred while rendering the template <code t-out="qweb_exception.name"/>.</p>
                 <p>If this error is caused by a change of yours in the templates, you have the possibility to reset the template to its <strong>factory settings</strong>.</p>
                 <form action="#" method="post" id="reset_templates_form">
                     <ul>
                         <li>
                             <label>
-                                <t t-esc="view.name"/>
+                                <t t-out="view.name"/>
                             </label>
                         </li>
                     </ul>
@@ -2696,10 +2696,10 @@ Allow: <t t-out="allowed_route"/>
 </t>
 <t t-if="website.domain and not website._is_indexable_url(url_root)">
 Disallow: /
-Sitemap: <t t-esc="website.domain"/>/sitemap.xml
+Sitemap: <t t-out="website.domain"/>/sitemap.xml
 </t>
 <t t-else="">
-Sitemap: <t t-esc="url_root"/>sitemap.xml
+Sitemap: <t t-out="url_root"/>sitemap.xml
 
 
 ##############
@@ -2713,10 +2713,10 @@ Sitemap: <t t-esc="url_root"/>sitemap.xml
 
 <template id="sitemap_locs">
     <url t-foreach="locs" t-as="page">
-        <loc><t t-esc="url_root"/><t t-esc="page['loc']"/></loc><t t-if="page.get('lastmod', False)">
-        <lastmod t-esc="page['lastmod']"/></t><t t-if="page.get('priority', False)">
-        <priority t-esc="page['priority']"/></t><t t-if="page.get('changefreq', False)">
-        <changefreq t-esc="page['changefreq']"/></t>
+        <loc><t t-out="url_root"/><t t-out="page['loc']"/></loc><t t-if="page.get('lastmod', False)">
+        <lastmod t-out="page['lastmod']"/></t><t t-if="page.get('priority', False)">
+        <priority t-out="page['priority']"/></t><t t-if="page.get('changefreq', False)">
+        <changefreq t-out="page['changefreq']"/></t>
     </url>
 </template>
 
@@ -2729,7 +2729,7 @@ Sitemap: <t t-esc="url_root"/>sitemap.xml
 <template id="sitemap_index_xml"><t t-translation="off">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 <sitemapindex t-attf-xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <sitemap t-translation="off" t-foreach="pages" t-as="page">
-    <loc><t t-esc="url_root"/>sitemap-<t t-esc="page"/>.xml</loc>
+    <loc><t t-out="url_root"/>sitemap-<t t-out="page"/>.xml</loc>
   </sitemap>
 </sitemapindex>
 </t>
@@ -2749,7 +2749,7 @@ Sitemap: <t t-esc="url_root"/>sitemap.xml
 </template>
 
 <template id="search_text_with_highlight" name="Website Searchbox item highlight">
-    <span t-foreach="enumerate(parts)" t-as="part" t-att-class="'text-primary-emphasis' if part[0] % 2 else None" t-esc="part[1]"/>
+    <span t-foreach="enumerate(parts)" t-as="part" t-att-class="'text-primary-emphasis' if part[0] % 2 else None" t-out="part[1]"/>
 </template>
 
 <template id="list_website_public_pages" name="Website Pages">
@@ -2765,20 +2765,20 @@ Sitemap: <t t-esc="url_root"/>sitemap.xml
                 <h1 class="mt16 h3-fs">Pages</h1>
                 <t t-if="not pages">
                     <div t-if="search" class="alert alert-warning mt8" role="alert">
-                        Your search '<t t-esc="search" />' did not match any pages.
+                        Your search '<t t-out="search" />' did not match any pages.
                     </div>
                     <div t-else="" class="alert alert-warning mt8" role="alert">
                         There are currently no pages for this website.
                     </div>
                 </t>
                 <div t-elif="original_search" class="alert alert-warning mt8" role="alert">
-                    No results found for '<span t-esc="original_search"/>'. Showing results for '<span t-esc="search"/>'.
+                    No results found for '<span t-out="original_search"/>'. Showing results for '<span t-out="search"/>'.
                 </div>
                 <div t-if="pages" class="table-responsive">
                     <table class="table table-hover">
                         <tbody>
                             <tr t-foreach="pages" t-as="page">
-                                <td><a t-att-href="page.url"><t t-esc="page.name"/></a></td>
+                                <td><a t-att-href="page.url"><t t-out="page.name"/></a></td>
                             </tr>
                         </tbody>
                     </table>
@@ -2804,7 +2804,7 @@ Sitemap: <t t-esc="url_root"/>sitemap.xml
                 <t t-if="not results">
                     <div class="alert alert-warning mt8" role="alert">
                         <t t-if="search">
-                            Your search '<t t-esc="search" />' did not match anything.
+                            Your search '<t t-out="search" />' did not match anything.
                         </t>
                         <t t-else="">
                             Specify a search term.
@@ -2813,8 +2813,8 @@ Sitemap: <t t-esc="url_root"/>sitemap.xml
                 </t>
                 <t t-elif="fuzzy_search">
                     <div class="alert alert-warning mt8" role="alert">
-                        Your search '<t t-esc="search" />' did not match anything.
-                        Results are displayed for '<t t-esc="fuzzy_search"/>'.
+                        Your search '<t t-out="search" />' did not match anything.
+                        Results are displayed for '<t t-out="fuzzy_search"/>'.
                     </div>
                 </t>
                 <div t-if="results" class="table-responsive">

--- a/addons/website/views/website_views.xml
+++ b/addons/website/views/website_views.xml
@@ -277,10 +277,10 @@
                             </div>
                             <div class="o_theme_preview_bottom mt-2 mb-3 px-2">
                                 <small t-if="record.summary.value" class="text-uppercase text-muted">
-                                    <b><t t-esc="record.summary.value.split(',')[0]"/></b>
+                                    <b><t t-out="record.summary.value.split(',')[0]"/></b>
                                 </small>
                                 <h3 t-if="record.display_name.value">
-                                    <b><t t-esc="record.display_name.value.replace('Theme', '').replace('theme', '')"/></b>
+                                    <b><t t-out="record.display_name.value.replace('Theme', '').replace('theme', '')"/></b>
                                 </h3>
                             </div>
                         </div>

--- a/addons/website_blog/data/mail_templates.xml
+++ b/addons/website_blog/data/mail_templates.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo><data noupdate="1">
     <template id="blog_post_template_new_post">
-        <p>A new post <t t-esc="post.name" /> has been published on the <t t-esc="object.name" /> blog. Click here to access the blog :</p>
+        <p>A new post <t t-out="post.name" /> has been published on the <t t-out="object.name" /> blog. Click here to access the blog :</p>
         <p style="margin-left: 30px; margin-top: 10 px; margin-bottom: 10px;">
             <a t-attf-href="/blog/#{slug(object)}/#{slug(post)}"
                 style="padding: 5px 10px; font-size: 12px; line-height: 18px; color: #FFFFFF; border-color:#875A7B; text-decoration: none; display: inline-block; margin-bottom: 0px; font-weight: 400; text-align: center; vertical-align: middle; cursor: pointer;background-color: #875A7B; border: 1px solid #875A7B; border-radius:3px">

--- a/addons/website_blog/views/website_blog_components.xml
+++ b/addons/website_blog/views/website_blog_components.xml
@@ -99,15 +99,15 @@
 ============================================================================ -->
 <template id="tags_list" name="Tags List">
     <t t-if="tags">
-        <div t-if="not hide_title and categ_title" class="text-muted mb-1 h6" t-esc="categ_title"/>
+        <div t-if="not hide_title and categ_title" class="text-muted mb-1 h6" t-out="categ_title"/>
         <t t-foreach="tags" t-as="tag">
             <t t-if="tag.post_ids">
                 <span t-if="dismissibleBtn and tag.id in active_tag_ids" t-attf-class="align-items-baseline d-inline-flex ps-2 rounded mb-2 o_filter_tag #{'o_color_%s' % tag.color}">
                     <i class="fa fa-tag me-2"/>
-                    <t t-esc="tag.name"/>
+                    <t t-out="tag.name"/>
                     <a t-attf-href="#{blog_url(tag=tags_list(active_tag_ids, tag.id))}" class="btn border-0 py-1 post_link text-reset" t-att-rel="len(active_tag_ids) and 'nofollow'">&#215;</a>
                 </span>
-                <a t-elif="showInactive" t-attf-href="#{blog_url(tag=tags_list(active_tag_ids, tag.id))}" t-attf-class="badge mb-2 mw-100 text-truncate text-decoration-none o_tag o_color_#{tag.color} post_link" t-att-rel="len(active_tag_ids) and 'nofollow'" t-esc="tag.name"/>
+                <a t-elif="showInactive" t-attf-href="#{blog_url(tag=tags_list(active_tag_ids, tag.id))}" t-attf-class="badge mb-2 mw-100 text-truncate text-decoration-none o_tag o_color_#{tag.color} post_link" t-att-rel="len(active_tag_ids) and 'nofollow'" t-out="tag.name"/>
             </t>
         </t>
     </t>
@@ -126,8 +126,8 @@
             <option t-foreach="nav_list[year]" t-as="months"
                     t-att="[('selected' if date_begin and (months['date_begin'] == date_begin) else 'unselected' ) , 'true' ]"
                     t-attf-value="#{blog_url(date_begin=months['date_begin'], date_end=months['date_end'], tag=tag)}">
-                <t t-esc="months['month']"/>
-                <t t-esc="year"/>
+                <t t-out="months['month']"/>
+                <t t-out="year"/>
             </option>
         </optgroup>
     </select>
@@ -143,7 +143,7 @@
              t-options='{"widget": "image", "class": "rounded-circle " + "o_wblog_author_avatar me-1" if hide_date else  "o_wblog_author_avatar_date me-2"}' />
         <div t-att-class="not hide_date and 'small fw-bold'" style="line-height:1">
             <span t-if="editable" t-field="blog_post.author_id" t-options='{ "widget": "contact", "fields": ["name"]}'/>
-            <span t-else="" t-esc="blog_post.author_name"/>
+            <span t-else="" t-out="blog_post.author_name"/>
             <small t-if="not hide_date" t-field="blog_post.post_date" t-options="{'format': 'long', 'date_only': 'true'}"/>
         </div>
     </div>
@@ -327,7 +327,7 @@ Display a sidebar beside the post content.
             <t t-if="blog_post.tag_ids">
                 <div class="h5">
                     <t t-foreach="blog_post.tag_ids" t-as="one_tag">
-                        <a t-attf-class="badge post_link text-decoration-none o_tag o_color_#{one_tag.color}" t-attf-href="#{blog_url(tag=slug(one_tag))}" t-esc="one_tag.name"/>
+                        <a t-attf-class="badge post_link text-decoration-none o_tag o_color_#{one_tag.color}" t-attf-href="#{blog_url(tag=slug(one_tag))}" t-out="one_tag.name"/>
                     </t>
                 </div>
             </t>

--- a/addons/website_blog/views/website_blog_posts_loop.xml
+++ b/addons/website_blog/views/website_blog_posts_loop.xml
@@ -23,12 +23,12 @@ according to the enabled options.
                     <a t-attf-class="btn #{state == 'published' and 'btn-success' or 'btn-default bg-white border'}"
                        t-attf-href="#{state == 'published' and blog_url(state='') or blog_url(state='published')}">
                         <i t-attf-class="fa me-1 #{state == 'published' and 'fa-check-square-o' or 'fa-square-o'}"/>
-                        Published (<t t-esc="state_info['published']" />)
+                        Published (<t t-out="state_info['published']" />)
                     </a>
                     <a t-attf-class="btn #{state == 'unpublished' and 'btn-success' or 'btn-default bg-white border'}"
                        t-attf-href="#{state == 'unpublished' and blog_url(state='') or blog_url(state='unpublished')}">
                         <i t-attf-class="fa me-1 #{state == 'unpublished' and 'fa-check-square-o' or 'fa-square-o'}"/>
-                        Unpublished (<t t-esc="state_info['unpublished']" />)
+                        Unpublished (<t t-out="state_info['unpublished']" />)
                     </a>
                 </div>
                 <div class="pt-1 fst-italic small">This box will not be visible to your visitors</div>
@@ -39,13 +39,13 @@ according to the enabled options.
             <!-- Filters -->
             <div t-if="tag or date_begin or search" class="col-12 mb-3">
                 <div t-if="posts" class="h4 mb-3">
-                    <t t-esc="search_count"/>
+                    <t t-out="search_count"/>
                     <t t-if="search_count &lt; 2">Article</t>
                     <t t-else="">Articles</t>
                 </div>
                 <span t-if="search" class="align-items-baseline border d-inline-flex ps-2 rounded mb-2">
                     <i class="fa fa-search me-2 text-muted"/>
-                    <t t-esc="search"/>
+                    <t t-out="search"/>
                     <a t-att-href="blog_url(search=False, tag=tag)" class="btn border-0 py-1 post_link">&#215;</a>
                 </span>
                 <t t-if="tag">
@@ -65,7 +65,7 @@ according to the enabled options.
                 </t>
                 <span t-if="date_begin" class="align-items-baseline border d-inline-flex ps-2 rounded mb-2">
                     <i class="fa fa-calendar-o me-2 text-muted"/>
-                    <t t-esc="date_begin" t-options="{'widget': 'date', 'format': 'MMM yyyy'}"></t>
+                    <t t-out="date_begin" t-options="{'widget': 'date', 'format': 'MMM yyyy'}"></t>
                     <a t-attf-href="#{blog_url(date_begin=False, date_end=False, tag=tag)}" class="btn border-0 py-1">&#215;</a>
                 </span>
                 <hr class="mt-2"/>
@@ -74,7 +74,7 @@ according to the enabled options.
             <!-- No blog post yet -->
             <div t-if="not posts" class="col">
                 <t t-set="no_results_str">No results for "%s".</t>
-                <h2 t-if="search" t-esc="no_results_str % search" class="fw-bold"/>
+                <h2 t-if="search" t-out="no_results_str % search" class="fw-bold"/>
                 <h2 t-else="">No blog post yet.</h2>
                 <div class="alert alert-info" groups="website.group_website_designer">
                     Click on "<b>New</b>" in the top-right corner to write your first blog post.
@@ -167,8 +167,8 @@ according to the enabled options.
         <div t-attf-class="d-flex flex-wrap align-items-center justify-content-between mx-n2 #{opt_blog_list_view and 'flex-grow-0 w-auto mw-100' or 'flex-grow-1' }">
             <time t-field="blog_post.post_date" class="text-nowrap fw-bold px-2" t-options="{'widget': 'datetime', 'date_only': 'true', 'format': 'medium'}"/>
             <div t-if="is_view_active('website_blog.opt_posts_loop_show_stats')" class="px-2">
-                <b class="text-nowrap" title="Comments"><i class="fa fa-comment text-muted me-1"/><t t-esc="len(blog_post.message_ids)"/></b>
-                <b class="text-nowrap ps-2" title="Views"><i class="fa fa-eye text-muted me-1"/><t t-esc="blog_post.visits"/></b>
+                <b class="text-nowrap" title="Comments"><i class="fa fa-comment text-muted me-1"/><t t-out="len(blog_post.message_ids)"/></b>
+                <b class="text-nowrap ps-2" title="Views"><i class="fa fa-eye text-muted me-1"/><t t-out="blog_post.visits"/></b>
             </div>
             <b t-if="posts_list_show_parent_blog" class="text-nowrap text-truncate px-2">
                 <i class="fa fa-folder-open text-muted"/>
@@ -213,7 +213,7 @@ according to the enabled options.
             <a t-attf-href="#{blog_url(tag=tags_list(active_tag_ids, one_tag.id))}"
                t-attf-class="badge mb-2 me-1 text-truncate o_tag o_color_#{one_tag.color} post_link"
                t-att-rel="len(active_tag_ids) and 'nofollow'"
-               t-esc="one_tag.name"/>
+               t-out="one_tag.name"/>
         </t>
     </div>
     </t>

--- a/addons/website_blog/views/website_blog_templates.xml
+++ b/addons/website_blog/views/website_blog_templates.xml
@@ -61,7 +61,7 @@ list of filtered posts (by date or tag).
         <section id="o_wblog_index_content" t-att-class="opt_blog_cards_design and 'o_wblog_page_cards_bg'">
             <div class="container py-4">
                 <div t-if="original_search and posts" class="alert alert-warning mt8">
-                    No results found for '<span t-esc="original_search"/>'. Showing results for '<span t-esc="search"/>'.
+                    No results found for '<span t-out="original_search"/>'. Showing results for '<span t-out="search"/>'.
                 </div>
                 <div t-attf-class="row #{opt_blog_sidebar_show and 'justify-content-between' or 'justify-content-center'}">
                     <div id="o_wblog_posts_loop_container" t-attf-class="col #{'o_container_small mx-0' if opt_blog_list_view else ''}">
@@ -247,7 +247,7 @@ list of filtered posts (by date or tag).
         <div t-if="len(blogs) > 1">in <a t-attf-href="#{blog_url(blog=blog_post.blog_id)}"><b t-field="blog.name"/></a></div>
         <div t-if="len(blog_post.tag_ids) > 0">#
             <t t-foreach="blog_post.tag_ids" t-as="one_tag">
-                <a t-attf-class="badge me-1 o_tag o_color_#{one_tag.color} post_link" t-attf-href="#{blog_url(tag=slug(one_tag), date_begin=False, date_end=False)}" t-esc="one_tag.name"/>
+                <a t-attf-class="badge me-1 o_tag o_color_#{one_tag.color} post_link" t-attf-href="#{blog_url(tag=slug(one_tag), date_begin=False, date_end=False)}" t-out="one_tag.name"/>
             </t>
         </div>
     </div>
@@ -406,17 +406,17 @@ list of filtered posts (by date or tag).
 <!-- Atom Feed -->
 <template id="blog_feed">&lt;?xml version="1.0" encoding="utf-8"?&gt;
 <feed t-att-xmlns="'http://www.w3.org/2005/Atom'">
-    <title t-esc="blog.name"/>
+    <title t-out="blog.name"/>
     <link t-att-href="'%s/blog/%s' % (base_url ,blog.id)"/>
-    <id t-esc="'%s/blog/%s' % (base_url, blog.id)"/>
-    <updated t-esc="str(posts[0].post_date).replace(' ', 'T') + 'Z' if posts else ''"/>
+    <id t-out="'%s/blog/%s' % (base_url, blog.id)"/>
+    <updated t-out="str(posts[0].post_date).replace(' ', 'T') + 'Z' if posts else ''"/>
     <entry t-foreach="posts" t-as="post">
-        <title t-esc="post.name"/>
+        <title t-out="post.name"/>
         <link t-att-href="'%s%s' % (base_url, post.website_url)"/>
-        <id t-esc="'%s%s' % (base_url, post.website_url)"/>
-        <author><name t-esc="post.sudo().author_id.name"/></author>
-        <summary t-esc="html2plaintext(post.teaser)"/>
-        <updated t-esc="str(post.post_date).replace(' ', 'T') + 'Z'"/>
+        <id t-out="'%s%s' % (base_url, post.website_url)"/>
+        <author><name t-out="post.sudo().author_id.name"/></author>
+        <summary t-out="html2plaintext(post.teaser)"/>
+        <updated t-out="str(post.post_date).replace(' ', 'T') + 'Z'"/>
     </entry>
 </feed>
 </template>

--- a/addons/website_crm_partner_assign/data/crm_lead_merge_template.xml
+++ b/addons/website_crm_partner_assign/data/crm_lead_merge_template.xml
@@ -19,7 +19,7 @@
     </xpath>
     <xpath expr="//div[@name='address']/*[last()]" position="after">
         <div name="partner_geolocation" t-if="lead.partner_latitude or lead.partner_longitude">
-            Geolocation: <t t-esc="lead.partner_latitude"/> latitude, <t t-esc="lead.partner_longitude"/> longitude
+            Geolocation: <t t-out="lead.partner_latitude"/> latitude, <t t-out="lead.partner_longitude"/> longitude
         </div>
     </xpath>
 </template>

--- a/addons/website_crm_partner_assign/views/website_crm_partner_assign_templates.xml
+++ b/addons/website_crm_partner_assign/views/website_crm_partner_assign_templates.xml
@@ -497,13 +497,13 @@
                         <td><span t-field="opp.email_from"/></td>
                         <td><span t-field="opp.phone"/></td>
                         <td>
-                            <span t-if="opp.company_currency" class="text-nowrap" t-esc="opp.expected_revenue" t-options="{'widget': 'monetary', 'display_currency': opp.company_currency}"/>
-                            <span t-else="" class="text-nowrap" t-esc="opp.expected_revenue"/>
+                            <span t-if="opp.company_currency" class="text-nowrap" t-out="opp.expected_revenue" t-options="{'widget': 'monetary', 'display_currency': opp.company_currency}"/>
+                            <span t-else="" class="text-nowrap" t-out="opp.expected_revenue"/>
                             <span> at </span>
                             <span t-field="opp.probability" />%
                         </td>
                         <td>
-                            <span class="badge text-bg-info" title="Current stage of the opportunity" t-esc="opp.stage_id.name" />
+                            <span class="badge text-bg-info" title="Current stage of the opportunity" t-out="opp.stage_id.name" />
                         </td>
                     </tr>
                 </tbody>
@@ -576,7 +576,7 @@
                         <th class="ps-0 pb-0">Tags</th>
                         <td class="w-100 pb-0 text-wrap">
                              <t t-foreach="lead.tag_ids" t-as="tag">
-                                <span class="badge text-bg-info" t-esc="tag.name" />
+                                <span class="badge text-bg-info" t-out="tag.name" />
                             </t>
                         </td>
                     </tr>
@@ -796,7 +796,7 @@
                                         <div class="row align-items-center">
                                             <div class="col-auto flex-grow-1">
                                                 <div class="input-group">
-                                                    <div class="input-group-text"><span class="text-nowrap" t-esc="opportunity.company_currency.symbol"/></div>
+                                                    <div class="input-group-text"><span class="text-nowrap" t-out="opportunity.company_currency.symbol"/></div>
                                                     <input type="text" name="expected_revenue" class="form-control expected_revenue" t-att-value="opportunity.expected_revenue" placeholder="Planned Revenue"/>
                                                 </div>
                                             </div>
@@ -838,7 +838,7 @@
                                             <div class="col-md-7">
                                                 <label>Expected Closing:</label>
                                                 <div class="input-group date" id="exp_closing_div">
-                                                    <t t-set='date_formatted'><t t-options='{"widget": "date"}' t-esc="opportunity.date_deadline"/></t>
+                                                    <t t-set='date_formatted'><t t-options='{"widget": "date"}' t-out="opportunity.date_deadline"/></t>
                                                     <input type="text" data-widget="datetime-picker" data-widget-type="date" name="date_deadline" t-att-value="date_formatted" class="datetimepicker-input form-control date_deadline" t-att-name="prefix"/>
                                                     <span class="input-group-text o_input_group_date_icon">
                                                         <span class="fa fa-calendar" role="img" aria-label="Calendar"></span>
@@ -856,14 +856,14 @@
                                                         <option t-att-data="activity_type.id" t-att-selected="activity_type.id == user_activity.activity_type_id.id"
                                                             t-att-name="activity_type.name" t-att-delay_count="activity_type.delay_count"
                                                             t-att-delay_unit="activity_type.delay_unit" t-att-summary="activity_type.summary">
-                                                        <t t-esc="activity_type.name"/></option>
+                                                        <t t-out="activity_type.name"/></option>
                                                     </t>
                                                 </select>
                                             </div>
                                             <div class="col-md-7">
                                                 <label class="col-form-label" for="activity_date_deadline">Next Activity Date</label>
                                                 <div class="input-group date" id="next_activity_div" >
-                                                    <t t-set='date_formatted'><t t-options='{"widget": "date"}' t-esc="user_activity.date_deadline"/></t>
+                                                    <t t-set='date_formatted'><t t-options='{"widget": "date"}' t-out="user_activity.date_deadline"/></t>
                                                     <input type="text" data-widget="datetime-picker" data-widget-type="date" name="activity_date_deadline" t-att-value="date_formatted" class="form-control activity_date_deadline datetimepicker-input" t-att-name="prefix"/>
                                                     <span class="input-group-text o_input_group_date_icon">
                                                         <span class="fa fa-calendar" role="img" aria-label="Calendar" title="Calendar"></span>
@@ -874,7 +874,7 @@
                                     </div>
                                     <div class="mb-3">
                                         <label class="col-form-label" for="activity_summary">Details Next Activity</label>
-                                        <textarea rows="6" name="activity_summary" class="form-control activity_summary"><t t-esc="user_activity.summary"/></textarea>
+                                        <textarea rows="6" name="activity_summary" class="form-control activity_summary"><t t-out="user_activity.summary"/></textarea>
                                     </div>
                                 </main>
                                 <footer class="modal-footer">
@@ -932,7 +932,7 @@
                                                     <option>States...</option>
                                                     <t t-foreach="states or []" t-as="state">
                                                         <option class="state" t-att-value="state.id" t-att-country="state.country_id.id" t-att-selected="state.id == opportunity.state_id.id">
-                                                            <t t-esc="state.name"/>
+                                                            <t t-out="state.name"/>
                                                         </option>
                                                     </t>
                                                 </select>
@@ -947,7 +947,7 @@
                                             <option>Countries...</option>
                                             <t t-foreach="countries or []" t-as="country">
                                                 <option t-att-value="country.id" t-att-selected="country.id == opportunity.country_id.id">
-                                                    <t t-esc="country.name"/>
+                                                    <t t-out="country.name"/>
                                                 </option>
                                             </t>
                                         </select>

--- a/addons/website_forum/data/mail_templates.xml
+++ b/addons/website_forum/data/mail_templates.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo><data noupdate="1">
     <template id="forum_post_template_new_answer">
-        <p>A new answer on <t t-esc="object.name"/> has been posted. Click here to access the post :</p>
+        <p>A new answer on <t t-out="object.name"/> has been posted. Click here to access the post :</p>
         <p style="margin-left: 30px; margin-top: 10 px; margin-bottom: 10px;">
             <a t-attf-href="/forum/#{slug(object.forum_id)}/#{slug(object)}"
                 t-attf-style="padding: 5px 10px; font-size: 12px; line-height: 18px; color: {{object.forum_id.website_id.get_current_website().company_id.email_primary_color or '#FFFFFF'}}; text-decoration: none; display: inline-block; margin-bottom: 0px; font-weight: 400; text-align: center; vertical-align: middle; cursor: pointer; background-color: {{object.forum_id.website_id.get_current_website().company_id.email_secondary_color or '#875A7B'}}; border-radius:3px">
@@ -11,7 +11,7 @@
     </template>
 
     <template id="forum_post_template_new_question">
-        <p>A new question <b t-esc="object.name" /> on <t t-esc="object.forum_id.name"/> has been posted. Click here to access the question :</p>
+        <p>A new question <b t-out="object.name" /> on <t t-out="object.forum_id.name"/> has been posted. Click here to access the question :</p>
         <p style="margin-left: 30px; margin-top: 10 px; margin-bottom: 10px;">
             <a t-attf-href="/forum/#{slug(object.forum_id)}/#{slug(object)}"
                 t-attf-style="padding: 5px 10px; font-size: 12px; line-height: 18px; color: {{object.forum_id.website_id.get_current_website().company_id.email_primary_color or '#FFFFFF'}}; text-decoration: none; display: inline-block; margin-bottom: 0px; font-weight: 400; text-align: center; vertical-align: middle; cursor: pointer; background-color: {{object.forum_id.website_id.get_current_website().company_id.email_secondary_color or '#875A7B'}}; border-radius:3px">
@@ -21,7 +21,7 @@
     </template>
 
     <template id="forum_post_template_validation">
-        <p>A new question <b t-esc="object.name" /> on <t t-esc="object.forum_id.name"/> has been posted and require your validation. Click here to access the question :</p>
+        <p>A new question <b t-out="object.name" /> on <t t-out="object.forum_id.name"/> has been posted and require your validation. Click here to access the question :</p>
         <p style="margin-left: 30px; margin-top: 10 px; margin-bottom: 10px;">
             <a t-attf-href="/forum/#{slug(object.forum_id)}/#{slug(object)}"
                 t-attf-style="padding: 5px 10px; font-size: 12px; line-height: 18px; color: {{object.forum_id.website_id.get_current_website().company_id.email_primary_color or '#FFFFFF'}}; text-decoration: none; display: inline-block; margin-bottom: 0px; font-weight: 400; text-align: center; vertical-align: middle; cursor: pointer; background-color: {{object.forum_id.website_id.get_current_website().company_id.email_secondary_color or '#875A7B'}}; border-radius:3px">

--- a/addons/website_forum/static/src/xml/public_templates.xml
+++ b/addons/website_forum/static/src/xml/public_templates.xml
@@ -37,8 +37,8 @@
                     <div class="form-check">
                         <input type="checkbox" class="form-check-input" t-attf-id="post_#{post.id}" t-att-value='post.id' checked='checked'/>
                         <label class="form-check-label" t-attf-for="post_#{post.id}">
-                            <b><t t-esc="post.name" /></b>
-                            <p class='text-muted'><t t-esc="post.content" /></p>
+                            <b><t t-out="post.name" /></b>
+                            <p class='text-muted'><t t-out="post.content" /></p>
                         </label>
                     </div>
                 </div>

--- a/addons/website_forum/views/base_contact_templates.xml
+++ b/addons/website_forum/views/base_contact_templates.xml
@@ -11,16 +11,16 @@
                             <span t-field="object.website" class="o_forum_tooltip_line"/>
                         </a>
                 </div>
-                <b class="mt-4"><i class="fa fa-diamond text-secondary"/> <t t-esc="object.karma"/></b>
+                <b class="mt-4"><i class="fa fa-diamond text-secondary"/> <t t-out="object.karma"/></b>
                 <div t-if="options.get('badges')" style="display: inline-block">
-                    <t t-esc="separator"/>
+                    <t t-out="separator"/>
                     <b>|</b>
                     <span class="fa fa-trophy o-text-gold ms-2" role="img" aria-label="Gold badge" title="Gold badge"/>
-                    <t t-esc="object.gold_badge"/>
+                    <t t-out="object.gold_badge"/>
                     <span class="fa fa-trophy o-text-silver ms-2" role="img" aria-label="Silver badge" title="Silver badge"/>
-                    <t t-esc="object.silver_badge"/>
+                    <t t-out="object.silver_badge"/>
                     <span class="fa fa-trophy o-text-bronze ms-2" role="img" aria-label="Bronze badge" title="Bronze badge"/>
-                    <t t-esc="object.bronze_badge"/>
+                    <t t-out="object.bronze_badge"/>
                 </div>
                 <t t-out="0"/>
                 <div t-if="options.get('UserBio')" class="mt-2">

--- a/addons/website_links/views/website_links_graphs.xml
+++ b/addons/website_links/views/website_links_graphs.xml
@@ -7,21 +7,21 @@
                         <div class="mt8">
                             <ol class="breadcrumb">
                                 <li class="breadcrumb-item"><a href="/r">Link Tracker</a></li>
-                                <li class="breadcrumb-item active truncate_text"><t t-esc="title"/></li>
+                                <li class="breadcrumb-item active truncate_text"><t t-out="title"/></li>
                             </ol>
                         </div>
 
                         <input type="hidden" id="code" t-att-value="code" />
                         <input type="hidden" id="link_id" t-att-value="id" />
 
-                        <h1 class="o_page_header mt0 text-truncate"><t t-esc="title"/></h1>
+                        <h1 class="o_page_header mt0 text-truncate"><t t-out="title"/></h1>
 
                         <div class="row">
                             <div class="col-md-2">
                                 <p><strong>Original URL</strong></p>
                             </div>
                             <div class="col-md-10">
-                                <p class="truncate_text mw-100" t-att-title="url"><a t-att-href="url"><t t-esc="url"/></a></p>
+                                <p class="truncate_text mw-100" t-att-title="url"><a t-att-href="url"><t t-out="url"/></a></p>
                             </div>
                         </div>
 
@@ -31,7 +31,7 @@
                             </div>
                             <div class="col-md-10">
                                 <p>
-                                    <span class="o_website_links_short_url" id="short_url"><span id="short-url-host"><t t-esc="short_url_host"/></span><span id="o_website_links_code"><t t-esc="code"/></span></span>
+                                    <span class="o_website_links_short_url" id="short_url"><span id="short-url-host"><t t-out="short_url_host"/></span><span id="o_website_links_code"><t t-out="code"/></span></span>
                                     <span class="o_website_links_edit_tools">
                                         <a role="button" class="o_website_links_ok_edit btn btn-sm btn-primary o_translate_inline" href="#">ok</a> or
                                         <a class="o_website_links_cancel_edit o_translate_inline" href="#">cancel</a>
@@ -49,7 +49,7 @@
                             </div>
                             <div class="col-md-10 d-flex flex-nowrap align-items-start gap-1">
                                 <p class="truncate_text" t-att-title="redirected_url">
-                                    <t t-esc="redirected_url"/>
+                                    <t t-out="redirected_url"/>
                                 </p>
                                 <a class="copy-to-clipboard btn btn-sm btn-primary" t-att-data-clipboard-text="redirected_url"><i class="fa fa-copy me-2"/>Copy</a>
                             </div>
@@ -59,7 +59,7 @@
                                 <p><strong>Campaign</strong></p>
                             </div>
                             <div class="col-md-10">
-                                <p><t t-esc="campaign_id[1]"/></p>
+                                <p><t t-out="campaign_id[1]"/></p>
                             </div>
                         </div>
                         <div t-if="medium_id" class="row">
@@ -67,7 +67,7 @@
                                 <p><strong>Medium</strong></p>
                             </div>
                             <div class="col-md-10">
-                                <p><t t-esc="medium_id[1]"/></p>
+                                <p><t t-out="medium_id[1]"/></p>
                             </div>
                         </div>
                         <div t-if="source_id" class="row">
@@ -75,7 +75,7 @@
                                 <p><strong>Source</strong></p>
                             </div>
                             <div class="col-md-10">
-                                <p><t t-esc="source_id[1]"/></p>
+                                <p><t t-out="source_id[1]"/></p>
                             </div>
                         </div>
                         <div t-if="label" class="row" >

--- a/addons/website_mass_mailing/views/snippets_templates.xml
+++ b/addons/website_mass_mailing/views/snippets_templates.xml
@@ -214,7 +214,7 @@ database, without the s_newsletter_list class. See fixNewsletterListClass.
                                                 <input type="checkbox" class="s_website_form_input form-check-input" name="list_ids"
                                                     t-attf-id="mailing_list_#{record.id}" t-att-value="record.id" required="1"/>
                                                 <label class="form-check-label s_website_form_check_label" t-attf-for="mailing_list_#{record.id}">
-                                                    <t t-esc="record.name"/>
+                                                    <t t-out="record.name"/>
                                                 </label>
                                             </div>
                                         </div>

--- a/addons/website_payment/static/src/snippets/s_donation/options.xml
+++ b/addons/website_payment/static/src/snippets/s_donation/options.xml
@@ -7,7 +7,7 @@
                         type="button"
                         contenteditable="false"
                         t-att-data-donation-value="prefilled_button_value"
-                        t-esc="prefilled_button_value"/>
+                        t-out="prefilled_button_value"/>
             </t>
             <span t-if="custom_input" class="s_donation_btn s_donation_custom_btn btn btn-outline-primary btn-lg mb-2 me-1">
                 <input id="s_donation_amount_input" type="number" t-att-min="minimum_amount" class="" placeholder="Custom Amount" aria-label="Amount"/>
@@ -21,8 +21,8 @@
                     <button class="s_donation_btn btn btn-outline-primary btn-lg me-3"
                             type="button"
                             t-att-data-donation-value="prefilled_button.value"
-                            t-esc="prefilled_button.value"/>
-                    <p class="s_donation_description mt-2 my-sm-auto text-muted fst-italic" t-esc="prefilled_button.description"></p>
+                            t-out="prefilled_button.value"/>
+                    <p class="s_donation_description mt-2 my-sm-auto text-muted fst-italic" t-out="prefilled_button.description"></p>
                 </div>
             </t>
             <div t-if="custom_input" class="d-sm-flex align-items-center my-3">

--- a/addons/website_profile/views/website_profile.xml
+++ b/addons/website_profile/views/website_profile.xml
@@ -12,7 +12,7 @@
                                 <a href="/profile/users">Users</a>
                             </li>
                             <li t-if="view_user" class="breadcrumb-item active">
-                                <a><t t-esc="view_user"/></a>
+                                <a><t t-out="view_user"/></a>
                             </li>
                         </ol>
                     </nav>
@@ -39,7 +39,7 @@
                                 <ul class="dropdown-menu">
                                     <a class="dropdown-item" t-att-href="home_url or '/'">Home</a>
                                     <a class="dropdown-item" href="/profile/users">&#9492; Users</a>
-                                    <a t-if="view_user" class="dropdown-item">&#9492; <t t-esc="view_user"/></a>
+                                    <a t-if="view_user" class="dropdown-item">&#9492; <t t-out="view_user"/></a>
                                 </ul>
                             </div>
 
@@ -81,7 +81,7 @@
     <template id="user_profile_header" name="Profile Page Header">
         <div class="o_wprofile_header o_wprofile_gradient position-relative text-white">
             <t t-call="website_profile.user_profile_sub_nav">
-                <t t-set="view_user"><t t-esc="user.name"/></t>
+                <t t-set="view_user"><t t-out="user.name"/></t>
             </t>
 
             <div class="container pb-3 pb-md-0 pt-2 pt-md-5">
@@ -158,7 +158,7 @@
                                     </tr>
                                     <tr t-if="user.badge_ids">
                                         <th><small class="fw-bold">Badges</small></th>
-                                        <td t-esc="len(user.badge_ids.filtered(lambda b: b.badge_id.website_published))"/>
+                                        <td t-out="len(user.badge_ids.filtered(lambda b: b.badge_id.website_published))"/>
                                     </tr>
                                 </tbody>
                             </table>
@@ -304,7 +304,7 @@
                 <nav t-if="request.params.get('url_origin') and request.params.get('name_origin')" aria-label="breadcrumb">
                     <ol class="breadcrumb p-0 bg-white">
                         <li class="breadcrumb-item">
-                            <a t-att-href="(request.website.domain or '') + '/' + request.params.get('url_origin').lstrip('/')" t-esc="request.params.get('name_origin')"/>
+                            <a t-att-href="(request.website.domain or '') + '/' + request.params.get('url_origin').lstrip('/')" t-out="request.params.get('name_origin')"/>
                         </li>
                         <li class="breadcrumb-item">Badges</li>
                     </ol>
@@ -312,7 +312,7 @@
                 <div class="row justify-content-between" t-if="ranks">
                     <div class="col-12 col-md-6 col-lg-5">
                         <h1>Ranks</h1>
-                        <p class="lead mb-4">Keep learning with <t t-esc="website.company_id.name"/>. Collect points on the forum or on the eLearning platform. Those points will make you reach new ranks.</p>
+                        <p class="lead mb-4">Keep learning with <t t-out="website.company_id.name"/>. Collect points on the forum or on the eLearning platform. Those points will make you reach new ranks.</p>
                         <h5>How do I earn badges?</h5>
                         <p>When you finish a course or reach milestones, you're awarded badges.</p>
                         <h5>How do I score more points?</h5>
@@ -363,7 +363,7 @@
                     <span t-field="badge.description"/>
                 </div>
                 <div class="col-3 text-end">
-                    <b t-esc="badge.granted_users_count"/>
+                    <b t-out="badge.granted_users_count"/>
                     <i class="text-muted"> awarded users</i>
                 </div>
             </div>
@@ -461,7 +461,7 @@
                 </table>
             </div>
             <t t-if='search and not users'>
-                <div class='alert alert-warning'>No user found for <strong><t t-esc="search"/></strong>. Try another search.</div>
+                <div class='alert alert-warning'>No user found for <strong><t t-out="search"/></strong>. Try another search.</div>
             </t>
             <div class="d-flex justify-content-center">
                 <t t-call="website_profile.pager_nobox"/>
@@ -478,37 +478,37 @@
                          t-att-src="'/profile/avatar/%s?field=avatar_256%s' % (user['id'], '&amp;res_model=%s&amp;res_id=%s' % (record._name, record.id) if record else '')"/>
                     <img class="position-absolute" t-attf-src="/website_profile/static/src/img/rank_#{user_index + 1}.svg" alt="User rank" style="bottom: 0; right: -10px"/>
                 </div>
-                <h3 class="mt-2 mb-0" t-esc="user['name']"></h3>
+                <h3 class="mt-2 mb-0" t-out="user['name']"></h3>
                 <span class="badge text-bg-danger fw-normal" t-if="not user['website_published']">Unpublished</span>
-                <strong class="text-muted" t-esc="user['rank']"/>
+                <strong class="text-muted" t-out="user['rank']"/>
                 <div class="h3 my-2" t-if="user['karma_gain']">
                     <span t-attf-class="badge #{ 'text-bg-success' if user['karma_gain'] > 0 else 'text-bg-warning'}">
-                        <t t-if="user['karma_gain'] > 0">+ </t><t t-esc="user['karma_gain']"/> XP
+                        <t t-if="user['karma_gain'] > 0">+ </t><t t-out="user['karma_gain']"/> XP
                     </span>
                 </div>
             </div>
             <div class="row mx-0 o_wprofile_top3_card_footer text-nowrap">
-                <div class="col py-3"><b t-esc="user['karma']"/> <span class="text-muted">XP</span></div>
-                <div class="col py-3"><b t-esc="user['badge_count']"/> <span class="text-muted">Badges</span></div>
+                <div class="col py-3"><b t-out="user['karma']"/> <span class="text-muted">XP</span></div>
+                <div class="col py-3"><b t-out="user['badge_count']"/> <span class="text-muted">Badges</span></div>
             </div>
         </div>
     </template>
 
     <template id="all_user_card" name="All User Card">
         <td class="align-middle text-end text-muted" style="width: 0">
-            <span t-esc="user['position']"/>
+            <span t-out="user['position']"/>
         </td>
         <td class="align-middle d-none d-sm-table-cell">
             <img class="object-fit-cover rounded-circle o_wprofile_img_small" width="30" height="30" t-att-src="'/profile/avatar/%s?field=avatar_128%s' % (user['id'], '&amp;res_model=%s&amp;res_id=%s' % (record._name, record.id) if record else '')"/>
         </td>
         <td class="align-middle w-md-75">
-            <span class="fw-bold" t-esc="user['name']"/><br/>
-            <span class="text-muted fw-bold" t-esc="user['rank']"></span>
+            <span class="fw-bold" t-out="user['name']"/><br/>
+            <span class="text-muted fw-bold" t-out="user['rank']"></span>
         </td>
         <td class="align-middle text-nowrap">
             <t t-if="user['karma_gain']">
                 <span t-attf-class="badge d-inline #{ 'text-bg-success' if user['karma_gain'] > 0 else 'text-bg-warning'}">
-                    <t t-if="user['karma_gain'] > 0">+ </t><t t-esc="user['karma_gain']"/> XP
+                    <t t-if="user['karma_gain'] > 0">+ </t><t t-out="user['karma_gain']"/> XP
                 </span>
                 <span class="text-muted ps-2 pe-3">
                     <t t-if="group_by == 'week'">this week</t>
@@ -521,10 +521,10 @@
             <span t-if="not user['website_published']" class="badge text-bg-danger fw-normal m-1">Unpublished</span>
         </td>
         <td class="align-middle fw-bold text-end text-nowrap">
-            <b t-esc="user['karma']"/> <span class="text-muted small fw-bold">XP</span>
+            <b t-out="user['karma']"/> <span class="text-muted small fw-bold">XP</span>
         </td>
         <td class="align-middle fw-bold text-end pe-3 text-nowrap all_user_badge_count">
-            <b t-esc="user['badge_count']"/> <span class="text-muted small fw-bold">Badges</span>
+            <b t-out="user['badge_count']"/> <span class="text-muted small fw-bold">Badges</span>
         </td>
     </template>
 
@@ -561,7 +561,7 @@
         <div t-elif="not validation_email_sent and not is_public_user and user.karma == 0" t-att-class="send_alert_classes" role="alert">
             <button type="button" class="btn-close validation_email_close" data-bs-dismiss="alert" aria-label="Close"/>
             Your Account has not yet been verified.<br/>
-            Click <a class="send_validation_email alert-link" href="#" t-att-data-redirect_url="redirect_url"><u>here</u></a> to receive a verification email<t t-esc="additional_validation_email_message"/>!
+            Click <a class="send_validation_email alert-link" href="#" t-att-data-redirect_url="redirect_url"><u>here</u></a> to receive a verification email<t t-out="additional_validation_email_message"/>!
         </div>
         <div t-elif="validation_email_sent and not validation_email_done" t-att-class="done_alert_classes">
             <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
@@ -572,7 +572,7 @@
         <div t-if="validation_email_done" t-att-class="done_alert_classes" role="status">
             <button type="button" class="btn-close validated_email_close" data-bs-dismiss="alert" aria-label="Close"/>
             <span id="email_validated_message">Congratulations! Your email has just been validated.</span>
-            <span t-esc="additional_validated_email_message"/>
+            <span t-out="additional_validated_email_message"/>
         </div>
     </template>
 

--- a/addons/website_sale/data/product_snippet_template_data.xml
+++ b/addons/website_sale/data/product_snippet_template_data.xml
@@ -126,7 +126,7 @@
 
         <template id="price_dynamic_filter_template_product_product" name="Dynamic Product Filter Price">
             <t t-if="not data.get('prevent_zero_price_sale') and not data.get('is_sample')">
-                <span t-esc="data['price']"
+                <span t-out="data['price']"
                       class="mb-0 fw-bold"
                       name="product_price"
                       t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"/>
@@ -136,7 +136,7 @@
                     style="white-space: nowrap;"
                 >
                     <small
-                        t-esc="data['list_price']"
+                        t-out="data['list_price']"
                         t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"
                     />
                 </del>

--- a/addons/website_sale/views/snippets/snippets.xml
+++ b/addons/website_sale/views/snippets/snippets.xml
@@ -319,7 +319,7 @@
                     t-as="query_and_label"
                 >
                     <we-button t-att-data-set-default-sort="query_and_label[0]">
-                        <t t-esc="query_and_label[1]"/>
+                        <t t-out="query_and_label[1]"/>
                     </we-button>
                 </t>
             </we-select>

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -17,7 +17,7 @@
                 <a href="/shop/cart" t-attf-class="#{_link_class}" aria-label="eCommerce cart">
                     <div t-attf-class="#{_icon_wrap_class}">
                         <i t-if="_icon" class="fa fa-shopping-cart fa-stack"/>
-                        <sup t-attf-class="my_cart_quantity badge bg-primary #{_badge_class} #{'d-none' if (website_sale_cart_quantity == 0) else ''}" t-esc="website_sale_cart_quantity" t-att-data-order-id="request.session.get('sale_order_id', '')"/>
+                        <sup t-attf-class="my_cart_quantity badge bg-primary #{_badge_class} #{'d-none' if (website_sale_cart_quantity == 0) else ''}" t-out="website_sale_cart_quantity" t-att-data-order-id="request.session.get('sale_order_id', '')"/>
                     </div>
                     <span t-if="_text" t-attf-class="#{_text_class}">My Cart</span>
                 </a>
@@ -80,7 +80,7 @@
                                     <li t-foreach="ecommerce_categories" t-as="category">
                                         <a
                                             t-att-href="'/shop/category/' + str(category['id'])"
-                                            t-esc="category['name']"
+                                            t-out="category['name']"
                                         />
                                     </li>
                                     <t t-if="not ecommerce_categories">
@@ -436,7 +436,7 @@
                     data-bs-toggle="dropdown"
                 >
                     <small class="d-none d-md-inline opacity-75"><t t-out="pricelist_label"/>:</small>
-                    <span class="d-none d-md-inline" t-esc="pricelist and pricelist.name or ' - '" />
+                    <span class="d-none d-md-inline" t-out="pricelist and pricelist.name or ' - '" />
                     <span class="d-md-none"><t t-out="pricelist_label"/></span>
                 </a>
                 <div class="dropdown-menu" role="menu">
@@ -451,7 +451,7 @@
                             <span
                                 class="switcher_pricelist"
                                 t-att-data-pl_id="pl.id"
-                                t-esc="pl.name"
+                                t-out="pl.name"
                             />
                         </a>
                     </t>
@@ -620,7 +620,7 @@
                                     <t t-if="search and category">
                                         <span class="text-muted">Searching</span>
                                         <span class="badge text-bg-info fw-normal base-fs">
-                                            <t t-esc="search"/>
+                                            <t t-out="search"/>
                                             <a
                                                 title="Clear search for this category"
                                                 t-att-href="keep(search=0)"
@@ -631,7 +631,7 @@
                                         </span>
                                         <span class="text-muted">in</span>
                                         <span class="badge text-bg-primary fw-normal base-fs">
-                                            <t t-esc="category.name"/>
+                                            <t t-out="category.name"/>
                                             <a
                                                 title="Search globally"
                                                 t-att-href="keep(shop_path, search=search)"
@@ -641,9 +641,9 @@
                                         </span>
                                     </t>
                                     <span t-elif="search">
-                                        <span class="text-muted">Search results for </span>'<strong t-esc="search"/>' <small t-if="search_count" class="text-muted"> (<t t-esc="search_count"/>)</small>
+                                        <span class="text-muted">Search results for </span>'<strong t-out="search"/>' <small t-if="search_count" class="text-muted"> (<t t-out="search_count"/>)</small>
                                     </span>
-                                    <t t-elif="category" t-esc="category.name"/>
+                                    <t t-elif="category" t-out="category.name"/>
                                 </h1>
                                 <h1 class="h4-fs" t-if="not category and not search">
                                     All products
@@ -651,7 +651,7 @@
                                 <t t-if="category">
                                     <t t-set='editor_msg'>
                                         Drag building blocks here to customize the header for
-                                        "<t t-esc='category.name'/>" category.
+                                        "<t t-out='category.name'/>" category.
                                     </t>
                                     <div
                                         id="category_header"
@@ -714,7 +714,7 @@
                                     </button>
                                 </div>
                                 <div t-if="original_search and products" class="alert alert-warning mt8">
-                                    No results found for '<span t-esc="original_search"/>'. Showing results for '<span t-esc="search"/>'.
+                                    No results found for '<span t-out="original_search"/>'. Showing results for '<span t-out="search"/>'.
                                 </div>
                             </header>
 
@@ -785,7 +785,7 @@
                                 </t>
                                 <t t-else="">
                                     <h3 class="mt8">No results</h3>
-                                    <p>No results for "<strong t-esc='search'/>"<t t-if="category"> in category "<strong t-esc="category.display_name"/>"</t>.</p>
+                                    <p>No results for "<strong t-out='search'/>"<t t-if="category"> in category "<strong t-out="category.display_name"/>"</t>.</p>
                                     <a
                                         t-if="category"
                                         t-att-href="keep(shop_path, search=search)"
@@ -809,7 +809,7 @@
                             <t t-if="category">
                                 <t t-set='footer_editor_message'>
                                     Drag building blocks here to customize the footer for
-                                    "<t t-esc='category.name'/>" category.
+                                    "<t t-out='category.name'/>" category.
                                 </t>
                                 <div
                                     class="mb16"
@@ -1853,7 +1853,7 @@
     <template id="base_unit_price" name="Product Base unit price">
         <span
             class="o_base_unit_price"
-            t-esc="base_unit_price"
+            t-out="base_unit_price"
             t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"
         />
          / <span class="oe_custom_base_unit" t-field="product.base_unit_name"/>
@@ -2547,7 +2547,7 @@
                       t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"/>
                 <span t-attf-class="text-muted oe_default_price ms-1 h5 {{'' if combination_info['has_discounted_price'] else 'd-none'}}"
                       style="text-decoration: line-through; white-space: nowrap;"
-                      t-esc="combination_info['list_price']"
+                      t-out="combination_info['list_price']"
                       t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"
                       name="product_list_price"
                 />
@@ -2558,7 +2558,7 @@
                     class="text-muted ms-1 h5 oe_compare_list_price"
                 >
                     <bdi dir="inherit">
-                    <span t-esc="combination_info['compare_list_price']"
+                    <span t-out="combination_info['compare_list_price']"
                           t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"/>
                     </bdi>
                 </del>
@@ -2708,7 +2708,7 @@
         </div>
         <t t-if='website_sale_order'>
             <div t-if='website_sale_order._get_shop_warning(clear=False)' class="alert alert-warning js_cart_lines" role="alert">
-                <strong>Warning!</strong> <t t-esc='website_sale_order._get_shop_warning()'/>
+                <strong>Warning!</strong> <t t-out='website_sale_order._get_shop_warning()'/>
             </div>
         </t>
         <div id="cart_products"
@@ -3204,13 +3204,13 @@
                                     <del
                                         name="suggested_product_list_price"
                                         t-attf-class="me-2 text-nowrap text-muted {{'' if combination_info['has_discounted_price'] else 'd-none'}}"
-                                        t-esc="combination_info['list_price']"
+                                        t-out="combination_info['list_price']"
                                         t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"
                                     />
                                     <span
                                         name="suggested_product_price"
                                         class="text-nowrap"
-                                        t-esc="combination_info['price']"
+                                        t-out="combination_info['price']"
                                         t-options="{'widget': 'monetary','display_currency': website.currency_id}"
                                     />
                                 </h6>
@@ -3569,9 +3569,9 @@
                 <t t-foreach="errors" t-as="error">
                     <div class="alert alert-danger" t-if="error" role="alert">
                         <h4>
-                            <t t-esc="error[0]" />
+                            <t t-out="error[0]" />
                         </h4>
-                        <t t-esc="error[1]" />
+                        <t t-out="error[1]" />
                     </div>
                 </t>
             </div>
@@ -3842,7 +3842,7 @@
             <t t-if='website_sale_order'>
                 <t t-set='warning' t-value='website_sale_order._get_shop_warning(clear=False)' />
                 <div t-if='warning' class="alert alert-warning" role="alert">
-                    <strong>Warning!</strong> <t t-esc='website_sale_order._get_shop_warning()'/>
+                    <strong>Warning!</strong> <t t-out='website_sale_order._get_shop_warning()'/>
                 </div>
             </t>
         </div>
@@ -4052,12 +4052,12 @@
                         <span t-else="">Your payment has been authorized.</span>
                     </t>
                     <t t-if="tx_sudo.state == 'error'">
-                        <span t-esc="tx_sudo.state_message"/>
+                        <span t-out="tx_sudo.state_message"/>
                     </t>
                 </div>
                 <t t-if="tx_sudo.provider_code == 'custom'">
                     <div id="order_reference" t-if="order.reference" class="mt-2">
-                        <b>Communication: </b><span t-esc='order.reference'/>
+                        <b>Communication: </b><span t-out='order.reference'/>
                     </div>
                     <div t-if="tx_sudo.provider_id.sudo().qr_code">
                         <t t-set="qr_code" t-value="tx_sudo.company_id.partner_id.bank_ids[:1].build_qr_code_base64(order.amount_total,tx_sudo.reference, None, tx_sudo.currency_id, tx_sudo.partner_id)"/>
@@ -4354,9 +4354,9 @@
                 <hr/>
                 <p class="text-muted">
                     <t t-foreach='website.shop_extra_field_ids' t-as='field' t-if='product[field.name]'>
-                        <b><t t-esc='field.label'/>: </b>
+                        <b><t t-out='field.label'/>: </b>
                         <t t-if='field.field_id.ttype != "binary"'>
-                            <span t-esc='product[field.name]' t-options="{'widget': field.field_id.ttype}"/>
+                            <span t-out='product[field.name]' t-options="{'widget': field.field_id.ttype}"/>
                         </t>
                         <t t-else=''>
                             <a target='_blank' t-attf-href='/web/content/product.template/#{product.id}/#{field.name}?download=1'>

--- a/addons/website_sale_comparison/views/website_sale_comparison_template.xml
+++ b/addons/website_sale_comparison/views/website_sale_comparison_template.xml
@@ -240,7 +240,7 @@
                                         <t t-set="combination_info" t-value="product._get_combination_info_variant()"/>
                                         <div class='product_summary'>
                                             <a class="o_product_comparison_table" t-att-href="product.website_url">
-                                                <span t-esc="combination_info['display_name']"></span><br/>
+                                                <span t-out="combination_info['display_name']"></span><br/>
                                             </a>
                                             <span class="o_comparison_price" t-if="not combination_info['prevent_zero_price_sale']">
                                                 <strong>Price:</strong>
@@ -249,7 +249,7 @@
                                                 <del t-if="combination_info.get('compare_list_price') and (combination_info['compare_list_price'] &gt; combination_info['price'])"
                                                      t-attf-class="text-muted mr8"
                                                      style="white-space: nowrap;"
-                                                     t-esc="combination_info['compare_list_price']"
+                                                     t-out="combination_info['compare_list_price']"
                                                      t-options="{'widget': 'monetary', 'display_currency': website.currency_id}" />
                                                 <del t-else=""
                                                      t-attf-class="text-muted mr8 {{'' if combination_info['has_discounted_price'] else 'd-none'}}"

--- a/addons/website_sale_loyalty/views/website_sale_templates.xml
+++ b/addons/website_sale_loyalty/views/website_sale_templates.xml
@@ -19,13 +19,13 @@
                         </t>
                         <t t-if="website_sale_order.get_promo_code_error(delete=False)">
                             <div class="alert alert-danger text-start small" role="alert">
-                                <t t-esc="website_sale_order.get_promo_code_error()"/>
+                                <t t-out="website_sale_order.get_promo_code_error()"/>
                             </div>
                         </t>
                         <t t-if="website_sale_order">
                             <t t-if="website_sale_order.get_promo_code_success_message(delete=False)">
                                 <div class="alert alert-success text-start small" role="alert">
-                                    You have successfully applied the following code: <strong t-esc="website_sale_order.get_promo_code_success_message()"/>
+                                    You have successfully applied the following code: <strong t-out="website_sale_order.get_promo_code_success_message()"/>
                                 </div>
                             </t>
                             <t t-foreach="website_sale_order._get_claimable_and_showable_rewards().items()" t-as="coupon_reward">
@@ -77,13 +77,13 @@
                                                         <div class="d-md-block small">
                                                             <span t-if="coupon and not coupon.program_id.is_nominative">
                                                                 Code:
-                                                                <t t-esc="coupon.code[-4:].rjust(14, '&#8902;')"/>
+                                                                <t t-out="coupon.code[-4:].rjust(14, '&#8902;')"/>
                                                             </span>
                                                             <t t-if="coupon.expiration_date">
                                                                 <br/>
                                                                 <span>
                                                                     Expired Date:
-                                                                    <t t-esc="coupon.expiration_date"/>
+                                                                    <t t-out="coupon.expiration_date"/>
                                                                 </span>
                                                             </t>
                                                         </div>

--- a/addons/website_sale_slides/views/website_sale_templates.xml
+++ b/addons/website_sale_slides/views/website_sale_templates.xml
@@ -49,7 +49,7 @@
         <div t-if="line.product_id.channel_ids"
              t-foreach="line.product_id.channel_ids.filtered(lambda course: course.enroll == 'payment')"
              t-as="course"
-             t-esc="course.name"/>
+             t-out="course.name"/>
     </xpath>
 </template>
 

--- a/addons/website_sale_slides/views/website_slides_templates.xml
+++ b/addons/website_sale_slides/views/website_slides_templates.xml
@@ -130,13 +130,13 @@
             <div class="css_editable_mode_hidden">
                 <!-- real price -->
                 <div t-attf-class="oe_price fw-bold text-nowrap my-2 #{'h4' if len(str(product_info['price'])) > 10 else 'h2'}"
-                     t-esc="product_info['price']"
+                     t-out="product_info['price']"
                      t-options="{'widget': 'monetary', 'display_currency': product_info['currency']}"/>
-                <span itemprop="price" style="display:none;" t-esc="product_info['price']"/>
-                <span itemprop="priceCurrency" style="display:none;" t-esc="product_info['currency'].name"/>
+                <span itemprop="price" style="display:none;" t-out="product_info['price']"/>
+                <span itemprop="priceCurrency" style="display:none;" t-out="product_info['currency'].name"/>
                 <!-- original discounted price, if any -->
                 <del t-att-class="'text-600 text-nowrap oe_default_price %s' % ('' if product_info['has_discounted_price'] else 'd-none')"
-                     t-esc="product_info['list_price']"
+                     t-out="product_info['list_price']"
                      t-options="{'widget': 'monetary', 'display_currency': product_info['currency']}"/>
             </div>
             <div class="css_non_editable_mode_hidden decimal_precision oe_price fw-bold text-nowrap h2 my-2"

--- a/addons/website_sale_stock/data/template_email.xml
+++ b/addons/website_sale_stock/data/template_email.xml
@@ -10,7 +10,7 @@
                 </a>
             </div>
             <div style="display: flex; flex-direction: row; align-items: center; justify-content: center; width: 100%;">
-                <p t-esc="product.name"/>
+                <p t-out="product.name"/>
                 <p t-if="product.product_template_attribute_value_ids"
                    style="margin-left: 0.5em;">
                     (<t
@@ -18,7 +18,7 @@
                     />)
                 </p>
             </div>
-            <p t-esc="product.description_sale"/>
+            <p t-out="product.description_sale"/>
             <div style="display: flex; justify-content: center; width: 100%;">
                 <a t-attf-href="#{product.website_url}" t-attf-style="background-color: {{product.website_id.get_current_website().company_id.email_secondary_color or '#875A7B'}}; padding: 8px 16px 8px 16px; text-decoration: none; color: {{product.website_id.get_current_website().company_id.email_primary_color or '#FFFFFF'}}; border-radius: 5px; font-size:13px;">
                     Order Now

--- a/addons/website_sale_stock/static/src/xml/website_sale_stock_product_availability.xml
+++ b/addons/website_sale_stock/static/src/xml/website_sale_stock_product_availability.xml
@@ -55,7 +55,7 @@
                 t-attf-class="availability_message_#{product_template} badge text-bg-warning"
             >
                 <i class="fa fa-circle text-warning me-2" role="presentation"/>
-                <t t-esc="formatQuantity(free_qty)"/> <t t-esc="uom_name" /> in stock
+                <t t-out="formatQuantity(free_qty)"/> <t t-out="uom_name" /> in stock
                 <span
                     id="already_in_cart_message"
                     t-if="!allow_out_of_stock_order and show_availability and cart_qty"
@@ -65,7 +65,7 @@
                         You already added all the available product in your cart
                     </t>
                     <t t-else="">
-                        (<t t-esc="cart_qty" /> in your cart)
+                        (<t t-out="cart_qty" /> in your cart)
                     </t>
                 </span>
             </div>

--- a/addons/website_slides/data/mail_templates.xml
+++ b/addons/website_slides/data/mail_templates.xml
@@ -11,9 +11,9 @@
         <td align="center" style="min-width: 590px;">
             <table border="0" cellpadding="0" cellspacing="0" width="100%" style="background-color: white; padding: 0; border-collapse:separate;">
                 <tr><td valign="middle">
-                    <span style="font-size: 10px;">Your <t t-esc="model_description or 'document'"/></span><br/>
+                    <span style="font-size: 10px;">Your <t t-out="model_description or 'document'"/></span><br/>
                     <span style="font-size: 20px; font-weight: bold;">
-                        <t t-esc="(record_name or message.record_name or '').replace('/','-')"/>
+                        <t t-out="(record_name or message.record_name or '').replace('/','-')"/>
                     </span>
                 </td><td valign="middle" align="right" t-if="company and not company.uses_default_logo">
                     <img t-att-src="'/logo.png?company=%s' % company.id" style="padding: 0px; margin: 0px; height: 48px;" t-att-alt="'%s' % company.name"/>
@@ -47,15 +47,15 @@
     <tr>
         <td align="center" style="min-width: 590px; padding: 0 8px 0 8px; font-size:11px;">
             <hr width="100%" style="background-color:rgb(204,204,204);border:medium none;clear:both;display:block;font-size:0px;min-height:1px;line-height:0; margin: 16px 0px 4px 0px;"/>
-            <b t-esc="company.name"/><br/>
+            <b t-out="company.name"/><br/>
             <div style="color: #999999;">
-                <t t-esc="company.phone"/>
+                <t t-out="company.phone"/>
                 <t t-if="company.email"> |
-                    <a t-att-href="'mailto:%s' % company.email" style="text-decoration:none; color: #999999;"><t t-esc="company.email"/></a>
+                    <a t-att-href="'mailto:%s' % company.email" style="text-decoration:none; color: #999999;"><t t-out="company.email"/></a>
                 </t>
                 <t t-if="company.website"> |
                     <a t-att-href="'%s' % company.website" style="text-decoration:none; color: #999999;">
-                        <t t-esc="company.website"/>
+                        <t t-out="company.website"/>
                     </a>
                 </t>
             </div>

--- a/addons/website_slides/static/src/xml/slide_course_join.xml
+++ b/addons/website_slides/static/src/xml/slide_course_join.xml
@@ -6,8 +6,8 @@
                 class="btn btn-primary o_wslides_js_course_join_link text-uppercase fw-bold"
                 title="Join the Course" aria-label="Join the Course"
                 href="#">
-                <t t-if="widget.channel.channelEnroll == 'public'" t-esc="widget.joinMessage"/>
-                <t t-if="widget.channel.channelEnroll == 'invite' and widget.isMemberOrInvited" t-esc="widget.joinMessage"/>
+                <t t-if="widget.channel.channelEnroll == 'public'" t-out="widget.joinMessage"/>
+                <t t-if="widget.channel.channelEnroll == 'invite' and widget.isMemberOrInvited" t-out="widget.joinMessage"/>
             </a>
         </div>
     </t>

--- a/addons/website_slides/static/src/xml/slide_quiz.xml
+++ b/addons/website_slides/static/src/xml/slide_quiz.xml
@@ -8,7 +8,7 @@
                      t-attf-class="o_wslides_js_lesson_quiz_question mt-5 mb-4 #{widget.slide.completed ? 'completed-disabled' : ''}"
                      t-att-data-question-id="question.id" t-att-data-title="question.question">
                     <div class="h4">
-                        <small class="text-muted"><span t-esc="question_index+1"/>. </small> <span t-esc="question.question"/>
+                        <small class="text-muted"><span t-out="question_index+1"/>. </small> <span t-out="question.question"/>
                     </div>
                     <div class="list-group">
                         <t t-foreach="question.answer_ids" t-as="answer" t-key="answer_index">
@@ -25,7 +25,7 @@
                                     <i class="fa fa-times-circle text-danger d-none"></i>
                                     <i t-att-class="'fa fa-check-circle text-success' + (widget.slide.completed &amp;&amp; answer.is_correct ? '' :  ' d-none')"></i>
                                 </label>
-                                <span t-esc="answer.text_value"/>
+                                <span t-out="answer.text_value"/>
                             </a>
                             <t t-if="widget.slide.completed and answer.is_correct" t-set="correct_answer_comment" t-value="answer.comment"/>
                         </t>
@@ -70,7 +70,7 @@
                         </b>
                         <span class="my-0 h4">
                             <span title="Succeed and gain karma" aria-label="Succeed and gain karma" class="badge bg-warning fw-bold ms-3">
-                                + <t t-esc="widget.quiz.quizKarmaGain"/> XP
+                                + <t t-out="widget.quiz.quizKarmaGain"/> XP
                             </span>
                         </span>
                     </div>
@@ -87,7 +87,7 @@
                         </b>
                         <span class="my-0 h4">
                             <span title="Succeed and gain karma" aria-label="Succeed and gain karma" class="badge bg-warning fw-bold ms-3">
-                                + <t t-esc="widget.quiz.quizKarmaGain"/> XP
+                                + <t t-out="widget.quiz.quizKarmaGain"/> XP
                             </span>
                         </span>
                         <div class="o_wslides_join_course_widget float-end"/>
@@ -105,7 +105,7 @@
                     <b t-else="" class="my-0 h5">Done!</b>
                     <span class="my-0 h5" style="line-height: 1">
                         <span role="button" title="Succeed and gain karma" class="badge bg-warning fw-bold ms-3">
-                            + <t t-if="!widget.slide.completed" t-esc="widget.quiz.quizKarmaGain"/><t t-else="" t-esc="widget.quiz.quizKarmaWon"/> XP
+                            + <t t-if="!widget.slide.completed" t-out="widget.quiz.quizKarmaGain"/><t t-else="" t-esc="widget.quiz.quizKarmaWon"/> XP
                         </span>
                     </span>
                     <div class="ms-3 d-none text-danger o_wslides_js_quiz_submit_error">
@@ -127,7 +127,7 @@
                     <span>Need help? Review related content:</span>
                     <ul>
                         <li t-foreach="widget.quiz.slideResources" t-as="resource" t-key="resource_index">
-                            <a t-att-href="resource.link or resource.download_url" t-esc="resource.display_name"/>
+                            <a t-att-href="resource.link or resource.download_url" t-out="resource.display_name"/>
                         </li>
                     </ul>
                 </div>

--- a/addons/website_slides/static/src/xml/slide_quiz_create.xml
+++ b/addons/website_slides/static/src/xml/slide_quiz_create.xml
@@ -6,7 +6,7 @@
             <form class="mb-3">
                 <div class="o_wslides_quiz_question row align-items-center me-0 mb-2">
                     <div class="input-group">
-                        <span class="input-group-text o_wslides_quiz_question_sequence"><t t-esc="widget.sequence"/></span>
+                        <span class="input-group-text o_wslides_quiz_question_sequence"><t t-out="widget.sequence"/></span>
                         <input type="text" name="question-name" class="form-control col-11" placeholder='e.g. "Which animal cannot fly?"'
                             t-att-value="widget.question.text"/>
                     </div>

--- a/addons/website_slides/views/website_slides_templates_course.xml
+++ b/addons/website_slides/views/website_slides_templates_course.xml
@@ -14,15 +14,15 @@
                         </li>
                         <t t-set="breadcrumb_class" t-value="'breadcrumb-item text-truncate %s' % ('fw-bold' if not slide else '')" />
                         <li t-att-class="'breadcrumb-item text-truncate %s' % ('fw-bold' if not search_category and not search_tag and not search_slide_category and not slide else '')">
-                            <a t-if="invite_preview" t-attf-href="/slides/#{channel.id}?#{keep_query('invite_hash', 'invite_partner_id')}" class="text-truncate d-block"><span t-esc="channel.name" t-att-title="channel.name"/></a>
-                            <a t-else="" t-att-href="'/slides/%s' % slug(channel)" class="text-truncate d-block"><span t-esc="channel.name" t-att-title="channel.name"/></a>
+                            <a t-if="invite_preview" t-attf-href="/slides/#{channel.id}?#{keep_query('invite_hash', 'invite_partner_id')}" class="text-truncate d-block"><span t-out="channel.name" t-att-title="channel.name"/></a>
+                            <a t-else="" t-att-href="'/slides/%s' % slug(channel)" class="text-truncate d-block"><span t-out="channel.name" t-att-title="channel.name"/></a>
                         </li>
                         <li t-att-class="breadcrumb_class" t-if="search_category">
-                            <a t-if="invite_preview" t-attf-href="/slides/#{channel.id}/category/#{search_category.id}?#{keep_query('invite_hash', 'invite_partner_id')}" aria-current='page'><span t-esc="search_category.name" t-att-title="search_category.name"/></a>
-                            <a t-else="" t-attf-href="/slides/#{slug(channel)}/category/#{slug(search_category)}" aria-current='page'><span t-esc="search_category.name" t-att-title="search_category.name"/></a>
+                            <a t-if="invite_preview" t-attf-href="/slides/#{channel.id}/category/#{search_category.id}?#{keep_query('invite_hash', 'invite_partner_id')}" aria-current='page'><span t-out="search_category.name" t-att-title="search_category.name"/></a>
+                            <a t-else="" t-attf-href="/slides/#{slug(channel)}/category/#{slug(search_category)}" aria-current='page'><span t-out="search_category.name" t-att-title="search_category.name"/></a>
                         </li>
                         <li t-att-class="breadcrumb_class" t-if="search_tag">
-                            <a t-att-href="'/slides/%s/tag/%s' % (slug(channel), slug(search_tag))" aria-current='page'><span t-esc="search_tag.name" t-att-title="search_tag.name"/></a>
+                            <a t-att-href="'/slides/%s/tag/%s' % (slug(channel), slug(search_tag))" aria-current='page'><span t-out="search_tag.name" t-att-title="search_tag.name"/></a>
                         </li>
                         <li t-att-class="breadcrumb_class" t-if="search_uncategorized">
                             <a t-if="invite_preview" t-attf-href="/slides/#{channel.id}?uncategorized=1&amp;#{keep_query('invite_hash', 'invite_partner_id')}" aria-current='page' title="Uncategorized">Uncategorized</a>
@@ -30,11 +30,11 @@
                         </li>
                         <li t-att-class="breadcrumb_class" t-if="search_slide_category">
                             <a t-att-href="'/slides/%s?slide_category=%s' % (slug(channel), search_slide_category)" aria-current='page'>
-                                <span t-esc="slide_categories.get('search_slide_category', '-')" t-att-title="slide_categories.get('search_slide_category', '-')"/>
+                                <span t-out="slide_categories.get('search_slide_category', '-')" t-att-title="slide_categories.get('search_slide_category', '-')"/>
                             </a>
                         </li>
                         <li t-if="slide" class="breadcrumb-item text-truncate fw-bold">
-                            <a t-att-href="'/slides/slide/%s' % slug(slide)"><span t-esc="slide.name" t-att-title="slide.name"/></a>
+                            <a t-att-href="'/slides/slide/%s' % slug(slide)"><span t-out="slide.name" t-att-title="slide.name"/></a>
                         </li>
                     </ol>
                 </nav>
@@ -65,24 +65,24 @@
                                 <t t-set="dropdown_class" t-value="'dropdown-item %s' % ('active' if not slide else '')"/>
                                 <a t-attf-class="dropdown-item #{'active' if not search_category and not search_tag and not search_slide_category else ''}"
                                     t-attf-href="/slides/#{channel.id if invite_preview else slug(channel)}?#{keep_query('invite_hash', 'invite_partner_id') if invite_preview else ''}">
-                                    &#9492;<span class="ms-1" t-esc="channel.name"/>
+                                    &#9492;<span class="ms-1" t-out="channel.name"/>
                                 </a>
                                 <a t-att-class="dropdown_class" aria-current="page" t-if="search_category"
                                     t-attf-href="/slides/#{channel.id if invite_preview else slug(channel)}/category/#{search_category.id if invite_preview else slug(search_category)}?#{keep_query('invite_hash', 'invite_partner_id') if invite_preview else ''}">
-                                    &#9492;<span class="ms-1" t-esc="search_category.name"/>
+                                    &#9492;<span class="ms-1" t-out="search_category.name"/>
                                 </a>
                                 <a t-att-class="dropdown_class" aria-current="page" t-if="search_tag" t-att-href="'/slides/%s/tag/%s' % (slug(channel), slug(search_tag))">
-                                    &#9492;<span class="ms-1" t-esc="search_tag.name"/>
+                                    &#9492;<span class="ms-1" t-out="search_tag.name"/>
                                 </a>
                                 <a t-att-class="dropdown_class" aria-current="page" t-if="search_uncategorized"
                                     t-attf-href="/slides/#{channel.id if invite_preview else slug(channel)}?uncategorized=1&amp;#{keep_query('invite_hash', 'invite_partner_id') if invite_preview else ''}">
                                     &#9492;<span class="ms-1">Uncategorized</span>
                                 </a>
                                 <a t-att-class="dropdown_class" aria-current="page" t-if="search_slide_category" t-att-href="'/slides/%s?slide_category=%s' % (slug(channel), search_slide_category)">
-                                    &#9492;<span class="ms-1" t-esc="slide_categories.get('search_slide_category', '-')"/>
+                                    &#9492;<span class="ms-1" t-out="slide_categories.get('search_slide_category', '-')"/>
                                 </a>
                                  <a t-if="slide" class="dropdown-item active" t-att-href="'/slides/slide/%s' % (slug(slide))">
-                                    &#9492;<span class="ms-1" t-esc="slide.name"/>
+                                    &#9492;<span class="ms-1" t-out="slide.name"/>
                                 </a>
                             </div>
                         </div>
@@ -187,7 +187,7 @@
                                     <a t-att-class="'nav-link %s' % ('active' if active_tab == 'review' else '')"
                                         id="review-tab" data-bs-toggle="pill" href="#review" role="tab" aria-controls="review"
                                         t-att-aria-selected="'true' if active_tab == 'review' else 'false'">
-                                        Reviews<t t-if="rating_count"> (<t t-esc="rating_count"/>)</t>
+                                        Reviews<t t-if="rating_count"> (<t t-out="rating_count"/>)</t>
                                     </a>
                                 </li>
                             </ul>
@@ -211,7 +211,7 @@
                                          class="mb-1 pt-1">
                                         <t t-if="channel_frontend_tags">
                                             <t t-foreach="channel_frontend_tags" t-as="channel_tag">
-                                                <span t-attf-class="badge o_wslides_channel_tag #{'o_color_'+str(channel_tag.color)}" t-esc="channel_tag.name"/>
+                                                <span t-attf-class="badge o_wslides_channel_tag #{'o_color_'+str(channel_tag.color)}" t-out="channel_tag.name"/>
                                             </t>
                                         </t>
                                         <a t-if="channel.can_upload"
@@ -258,19 +258,19 @@
             <table class="table table-sm mt-3">
                 <tr t-if="channel.user_id">
                     <th class="border-top-0">Responsible</th>
-                    <td class="border-top-0 text-break"><span t-esc="channel.user_id.display_name"/></td>
+                    <td class="border-top-0 text-break"><span t-out="channel.user_id.display_name"/></td>
                 </tr>
                 <tr>
                     <th class="border-top-0">Last Update</th>
-                    <td class="border-top-0"><t t-esc="channel.slide_last_update" t-options="{'widget': 'date'}"/></td>
+                    <td class="border-top-0"><t t-out="channel.slide_last_update" t-options="{'widget': 'date'}"/></td>
                 </tr>
                 <tr t-if="channel.total_time">
                     <th class="border-top-0">Completion Time</th>
-                    <td class="border-top-0"><t class="fw-bold" t-esc="channel.total_time" t-options="{'widget': 'duration', 'unit': 'hour', 'round': 'minute'}"/></td>
+                    <td class="border-top-0"><t class="fw-bold" t-out="channel.total_time" t-options="{'widget': 'duration', 'unit': 'hour', 'round': 'minute'}"/></td>
                 </tr>
                 <tr>
                     <th>Members</th>
-                    <td><t t-esc="channel.members_count"/></td>
+                    <td><t t-out="channel.members_count"/></td>
                 </tr>
             </table>
 
@@ -417,7 +417,7 @@
                         <div class="progress-bar" role="progressbar" t-attf-style="width: #{channel.completion}%" t-att-aria-valuenow="channel.completion" aria-valuemin="0" aria-valuemax="100" aria-label="Progress bar"></div>
                     </div>
                     <div class="ms-3 small">
-                        <span class="o_wslides_progress_percentage" t-esc="channel.completion"/> %
+                        <span class="o_wslides_progress_percentage" t-out="channel.completion"/> %
                     </div>
                 </div>
             </div>
@@ -599,7 +599,7 @@
                 <span t-field="slide.name"/>
             </a>
             <span t-else="">
-                <span t-esc="slide.name"/>
+                <span t-out="slide.name"/>
             </span>
         </div>
 
@@ -618,7 +618,7 @@
             </span>
             <span t-if="slide.question_ids" t-att-class="'badge fw-bold m-1 %s' % ('text-bg-success' if channel_progress[slide.id].get('completed') else 'text-bg-warning')">
                 <i t-attf-class="fa fa-fw #{'fa-check' if channel_progress[slide.id].get('completed') else 'fa-flag'}"/>
-                <t t-esc="channel_progress[slide.id].get('quiz_karma_won', 0) if channel_progress[slide.id].get('completed') else channel_progress[slide.id].get('quiz_karma_gain', 0)"/> xp
+                <t t-out="channel_progress[slide.id].get('quiz_karma_won', 0) if channel_progress[slide.id].get('completed') else channel_progress[slide.id].get('quiz_karma_gain', 0)"/> xp
             </span>
             <span class="badge text-bg-danger fw-normal m-1" t-if="not slide.website_published">Unpublished</span>
         </div>
@@ -658,7 +658,7 @@
                     <div class="o_wslides_desc_truncate_10 mt-3" t-field="slide_promoted.description"/>
                     <div t-if="slide_promoted.tag_ids" class="mt-2 pt-1">
                         <t t-foreach="slide_promoted.tag_ids" t-as="tag">
-                            <h4 t-if="invite_preview" class="badge text-bg-info" t-esc="tag.name"/>
+                            <h4 t-if="invite_preview" class="badge text-bg-info" t-out="tag.name"/>
                             <a t-else="" t-attf-href="/slides/#{slug(slide_promoted.channel_id)}/tag/#{slug(tag)}" class="badge text-bg-primary" t-esc="tag.name"/>
                         </t>
                     </div>
@@ -695,8 +695,8 @@
                                         <li t-if="search_category['nbr_%s' % slide_category_key] > 0" class="nav-item">
                                             <a t-att-href="'/slides/%s/category/%s?%s' % (slug(channel), slug(search_category), keep_query(slide_category=slide_category_key))"
                                                t-att-class="'nav-link d-flex align-items-center justify-content-between me-1 %s' % ('active' if search_slide_category == slide_category_key else '')">
-                                               <t t-esc="slide_categories[slide_category_key]"/>
-                                               <span t-attf-class="badge ms-1 #{'text-bg-info' if search_slide_category == slide_category_key else 'bg-400'}" t-esc="search_category['nbr_%s' % slide_category_key]"/>
+                                               <t t-out="slide_categories[slide_category_key]"/>
+                                               <span t-attf-class="badge ms-1 #{'text-bg-info' if search_slide_category == slide_category_key else 'bg-400'}" t-out="search_category['nbr_%s' % slide_category_key]"/>
                                             </a>
                                         </li>
                                     </t>
@@ -704,8 +704,8 @@
                                         <li t-if="channel['nbr_%s' % slide_category_key] > 0" class="nav-item">
                                             <a t-att-href="'/slides/%s?%s' % (slug(channel), keep_query(slide_category=slide_category_key))"
                                                t-att-class="'nav-link d-flex align-items-center justify-content-between me-1 %s' % ('active' if search_slide_category == slide_category_key else '')">
-                                               <t t-esc="slide_categories[slide_category_key]"/>
-                                               <span t-attf-class="badge ms-1 #{'text-bg-info' if search_slide_category == slide_category_key else 'bg-400'}" t-esc="channel['nbr_%s' % slide_category_key]"/>
+                                               <t t-out="slide_categories[slide_category_key]"/>
+                                               <span t-attf-class="badge ms-1 #{'text-bg-info' if search_slide_category == slide_category_key else 'bg-400'}" t-out="channel['nbr_%s' % slide_category_key]"/>
                                             </a>
                                         </li>
                                     </t>
@@ -763,7 +763,7 @@
             <div class="mb-2 pt-1 text-start col">
                 <t t-if="channel_frontend_tags">
                     <t t-foreach="channel_frontend_tags" t-as="channel_tag">
-                        <span t-attf-class="badge o_wslides_channel_tag #{'o_color_'+str(channel_tag.color)}" t-esc="channel_tag.name"/>
+                        <span t-attf-class="badge o_wslides_channel_tag #{'o_color_'+str(channel_tag.color)}" t-out="channel_tag.name"/>
                     </t>
                 </t>
                 <a t-if="channel.can_upload"
@@ -807,7 +807,7 @@
                 <t t-set="search_results_number" t-value="search_results_number + category['total_slides']"/>
             </t>
             <div t-if="search_results_number == 0" class="alert alert-info mt-4 mb-5 text-center">
-                No content was found using your search <span class="fw-bold" t-esc="search"/>.
+                No content was found using your search <span class="fw-bold" t-out="search"/>.
             </div>
         </t>
 
@@ -815,11 +815,11 @@
             <div class="mb-2" t-if="(category['slides'] or channel.can_publish) and (search_category and search_category.id == category['id'] or not search_category)">
                 <t t-set="is_empty_editable" t-value="not category['slides'] and channel.can_publish"/>
                 <div class="d-flex align-items-center justify-content-between border-bottom pb-2 mb-3" t-if="category['id'] and query_string != '?search_uncategorized=1'">
-                    <h5 t-attf-class="m-0 #{'text-muted' if is_empty_editable else ''}"><t t-esc="category['name']"/></h5>
+                    <h5 t-attf-class="m-0 #{'text-muted' if is_empty_editable else ''}"><t t-out="category['name']"/></h5>
                     <a t-if="category['id'] and not is_empty_editable" t-attf-href="/slides/#{channel.id}/category/#{category['id']}?#{keep_query('invite_hash', 'invite_partner_id') if invite_preview else ''}">View all</a>
                 </div>
                 <div class="d-flex align-items-center justify-content-between border-bottom pb-2 mb-3" t-if="not category['id'] and len(category['slides']) > 0">
-                    <h5 t-if="len(category_data) > 1" t-attf-class="m-0 #{'text-muted' if is_empty_editable else ''}"><t t-esc="category['name']"/></h5>
+                    <h5 t-if="len(category_data) > 1" t-attf-class="m-0 #{'text-muted' if is_empty_editable else ''}"><t t-out="category['name']"/></h5>
                     <a t-attf-href="/slides/#{channel.id}?uncategorized=1&amp;#{keep_query('invite_hash', 'invite_partner_id') if invite_preview else ''}">View all</a>
                 </div>
                 <div class="row mx-n2">
@@ -854,8 +854,8 @@
         <i t-if="channel_progress[slide.id].get('completed')" class="position-absolute py-1 px-2 h5 fa fa-check-circle text-primary" style="right:0; top:0;"/>
 
         <div class="card-body d-flex flex-column px-3">
-            <a t-if="can_access" class="card-title h5 o_wslides_desc_truncate_2" t-attf-href="/slides/slide/#{slug(slide)}#{query_string}" t-esc="slide.name"/>
-            <span t-else="" class="card-title h5 o_wslides_desc_truncate_2 text-muted" t-esc="slide.name"/>
+            <a t-if="can_access" class="card-title h5 o_wslides_desc_truncate_2" t-attf-href="/slides/slide/#{slug(slide)}#{query_string}" t-out="slide.name"/>
+            <span t-else="" class="card-title h5 o_wslides_desc_truncate_2 text-muted" t-out="slide.name"/>
             <div class="text-muted o_wslides_desc_truncate_2 mb-2" t-if="slide.is_preview or (not slide.is_published and user.has_group('website_slides.group_website_slides_officer'))">
                 <span t-if="slide.is_preview" class="badge text-bg-info">Preview</span>
                 <span t-if="not slide.is_published and channel.can_publish" class="badge text-bg-danger">Unpublished</span>
@@ -865,8 +865,8 @@
             </div>
             <div class="text-muted o_wslides_desc_truncate_2 my-2">
                 <t t-foreach="slide.tag_ids" t-as="tag">
-                    <h4 t-if="invite_preview" class="badge text-bg-info" t-esc="tag.name"/>
-                    <a t-else="" t-attf-href="/slides/#{slug(slide.channel_id)}/tag/#{slug(tag)}" class="badge text-bg-primary" t-esc="tag.name"/>
+                    <h4 t-if="invite_preview" class="badge text-bg-info" t-out="tag.name"/>
+                    <a t-else="" t-attf-href="/slides/#{slug(slide.channel_id)}/tag/#{slug(tag)}" class="badge text-bg-primary" t-out="tag.name"/>
                 </t>
             </div>
             <span t-if="channel.is_member and channel_progress[slide.id].get('completed')" class="badge text-bg-success align-self-start"><i class="fa fa-check me-1"/>Completed</span>

--- a/addons/website_slides/views/website_slides_templates_homepage.xml
+++ b/addons/website_slides/views/website_slides_templates_homepage.xml
@@ -77,7 +77,7 @@
                                         <t t-set="img_class" t-value="'rounded-circle me-1'"/>
                                         <t t-set="img_style" t-value="'width: 22px; height: 22px;'"/>
                                     </t>
-                                    <h5 t-esc="user.name" class="d-flex flex-grow-1 mb-0"/>
+                                    <h5 t-out="user.name" class="d-flex flex-grow-1 mb-0"/>
                                     <a class="d-none d-lg-block" t-att-href="'/profile/user/%s' % user.id">View</a>
                                     <a class="d-lg-none btn btn-sm bg-white border" href="#" data-bs-toggle="collapse" data-bs-target="#o_wslides_home_aside_content">More info</a>
                                 </div>
@@ -102,7 +102,7 @@
                         </div>
                     </div>
                     <div t-att-class="'col-lg-9 pe-lg-5 order-lg-1' if has_side_column else 'col-lg pr-lg'">
-                        <div t-if="invite_error_msg" role="alert" class="o_not_editable alert alert-danger text-center" t-esc="invite_error_msg"/>
+                        <div t-if="invite_error_msg" role="alert" class="o_not_editable alert alert-danger text-center" t-out="invite_error_msg"/>
                         <div class="o_wslides_home_content_section mb-3"
                             t-if="not channels_popular">
                             <p class="h2">No Course created yet.</p>
@@ -234,12 +234,12 @@
                                         t-att-data-bs-target="'#navToogleTagGroup%s' % tag_group.id"
                                         role="button" data-bs-toggle="dropdown"
                                         aria-haspopup="true" aria-expanded="false"
-                                        t-esc="tag_group.name"/>
+                                        t-out="tag_group.name"/>
                                     <div class="dropdown-menu" t-att-id="'navToogleTagGroup%s' % tag_group.id">
                                         <t t-foreach="group_frontend_tags" t-as="tag">
                                             <span t-att-class="'post_link cursor-pointer dropdown-item %s' % ('active' if tag in search_tags else '')"
                                                 t-att-data-post="slide_query_url(tag=slugify_tags(search_tags.ids, toggle_tag_id=tag.id), my=search_my, search=search_term, slide_category=search_slide_category, prevent_redirect=True)"
-                                                t-esc="tag.name"/>
+                                                t-out="tag.name"/>
                                         </t>
                                     </div>
                                 </li>
@@ -285,7 +285,7 @@
                 <t t-if="search_term">
                       <span class="align-items-baseline border d-inline-flex ps-2 rounded mb-2">
                       <i class="fa fa-tag me-2 text-muted"/>
-                      <t t-esc="search_term"/>
+                      <t t-out="search_term"/>
                       <span t-att-data-post="slide_query_url(tag=slugify_tags(search_tags.ids), my=search_my, slide_category=search_slide_category, prevent_redirect=True)"
                          class="post_link cursor-pointer btn border-0 py-1">&#215;</span>
                     </span>
@@ -293,7 +293,7 @@
                 <t t-foreach="search_tags" t-as="tag">
                     <span class="align-items-baseline border d-inline-flex ps-2 rounded mb-2">
                         <i class="fa fa-tag me-2 text-muted"/>
-                        <t t-esc="tag.display_name"/>
+                        <t t-out="tag.display_name"/>
                         <span t-att-data-post='slide_query_url(tag=slugify_tags(search_tags.ids, tag.id), my=search_my, search=search_term, slide_category=search_slide_category, prevent_redirect=True)'
                             class="post_link cursor-pointer btn border-0 py-1">&#215;</span>
                     </span>
@@ -305,14 +305,14 @@
                     <p groups="website_slides.group_website_slides_officer">Click on "New" in the top-right corner to write your first course.</p>
                 </div>
                 <div t-elif="search_term and not channels" class="alert alert-info mb-5">
-                    No course was found matching your search <code><t t-esc="search_term"/></code>.
+                    No course was found matching your search <code><t t-out="search_term"/></code>.
                 </div>
                 <div t-elif="not channels" class="alert alert-info mb-5">
                     No course was found matching your search.
                 </div>
                 <t t-else="">
                     <div t-if="original_search" class="alert alert-warning mb-5">
-                        No results found for '<span t-esc="original_search"/>'. Showing results for '<span t-esc="search_term"/>'.
+                        No results found for '<span t-out="original_search"/>'. Showing results for '<span t-out="search_term"/>'.
                     </div>
                     <div class="row mx-n2">
                         <t t-foreach="channels" t-as="channel">
@@ -351,11 +351,11 @@
                     <t t-foreach="channel_frontend_tags" t-as="tag">
                         <t t-if="search_tags">
                             <span t-att-data-post="slide_query_url(tag=slugify_tags(search_tags.ids, toggle_tag_id=tag.id), my=search_my, search=search_term, slide_category=search_slide_category, prevent_redirect=True)"
-                                t-attf-class="post_link cursor-pointer badge o_badge_clickable #{'o_color_'+str(tag.color) if tag in search_tags else 'o_wslides_channel_tag o_color_0'}" t-esc="tag.name"/>
+                                t-attf-class="post_link cursor-pointer badge o_badge_clickable #{'o_color_'+str(tag.color) if tag in search_tags else 'o_wslides_channel_tag o_color_0'}" t-out="tag.name"/>
                         </t>
                         <t t-else="">
                             <span t-att-data-post="slide_query_url(tag=slugify_tags(search_tags.ids, toggle_tag_id=tag.id), my=search_my, search=search_term, slide_category=search_slide_category, prevent_redirect=True)"
-                                t-attf-class="post_link cursor-pointer badge o_badge_clickable o_wslides_channel_tag #{'o_color_'+str(tag.color)}" t-esc="tag.name"/>
+                                t-attf-class="post_link cursor-pointer badge o_badge_clickable o_wslides_channel_tag #{'o_color_'+str(tag.color)}" t-out="tag.name"/>
                         </t>
                     </t>
                 </div>
@@ -363,7 +363,7 @@
         </div>
         <div class="card-footer bg-white text-600 px-3">
             <div class="d-flex justify-content-between align-items-center">
-                <small t-if="channel.total_time" class="fw-bold" t-esc="channel.total_time" t-options="{'widget': 'duration', 'unit': 'hour', 'round': 'minute'}"/>
+                <small t-if="channel.total_time" class="fw-bold" t-out="channel.total_time" t-options="{'widget': 'duration', 'unit': 'hour', 'round': 'minute'}"/>
                 <div class="d-flex flex-grow-1 justify-content-end">
                     <t t-if="channel.is_member and channel.completed">
                         <span class="badge text-bg-success pull-right"><i class="fa fa-check"/> Completed</span>
@@ -371,7 +371,7 @@
                     <div t-elif="channel.is_member and channel.channel_type != 'documentation'" class="progress w-50" style="height: 6px">
                         <div class="progress-bar" role="progressbar" t-att-aria-valuenow="channel.completion" aria-valuemin="0" aria-valuemax="100" t-attf-style="width:#{channel.completion}%;" aria-label="Progress bar"/>
                     </div>
-                    <small t-else=""><b t-esc="channel.total_slides"/> steps</small>
+                    <small t-else=""><b t-out="channel.total_slides"/> steps</small>
                 </div>
             </div>
         </div>
@@ -421,7 +421,7 @@
             <t t-set="user" t-value="achievement.user_id"/>
         </t>
         <div style="line-height: 1.3">
-            <span class="fw-bold" t-esc="achievement.user_id.name"/> achieved <span class="fw-bold" t-esc="achievement.badge_id.name"/>
+            <span class="fw-bold" t-out="achievement.user_id.name"/> achieved <span class="fw-bold" t-out="achievement.badge_id.name"/>
         </div>
     </div>
 </template>
@@ -459,14 +459,14 @@
 
 <template id='user_quickkarma_card' name="User QuickKarma Card">
     <div class="d-flex mb-3 align-items-center">
-        <b class="me-2 text-muted" t-esc="counter"/>
+        <b class="me-2 text-muted" t-out="counter"/>
         <t t-call="website_slides.slides_misc_user_image"/>
         <div style="line-height:1.3">
-            <span class="fw-bold" t-esc="user.name"/>
+            <span class="fw-bold" t-out="user.name"/>
             <div class="d-flex align-items-center">
-                <t t-esc="user.rank_id.name"/>
+                <t t-out="user.rank_id.name"/>
                 <span class="text-500 mx-2">&#8226;</span>
-                <span class="badge text-bg-success"><t t-esc="user.karma"/> xp</span>
+                <span class="badge text-bg-success"><t t-out="user.karma"/> xp</span>
             </div>
         </div>
     </div>
@@ -506,8 +506,8 @@
                     t-options="{'widget': 'image', 'preview_image': 'image_128', 'class': 'me-2', 'style': 'max-height: 36px'}"/>
                 <img t-else="" t-attf-src="'/website_profile/static/src/img/badge_%s.svg' % (challenge.reward_id.level)" t-att-alt="challenge.reward_id.name" style="max-height: 36px" class="me-2"/>
                 <div class="flex-grow-1">
-                    <b class="text_small_caps" t-esc="challenge.reward_id.name"/><br/>
-                    <span class="text-muted" t-esc="challenge.reward_id.description"/>
+                    <b class="text_small_caps" t-out="challenge.reward_id.name"/><br/>
+                    <span class="text-muted" t-out="challenge.reward_id.description"/>
                 </div>
                 <i t-if="challenge_done" class="fa fa-check h5 text-success" aria-label="Done" title="Done" role="img"></i>
             </div>

--- a/addons/website_slides/views/website_slides_templates_lesson.xml
+++ b/addons/website_slides/views/website_slides_templates_lesson.xml
@@ -24,7 +24,7 @@
                                 </h1>
                                 <div t-if="slide.channel_id.channel_type == 'documentation'" class="mb-3 small">
                                     <span class="fw-normal">Last update:</span>
-                                    <t t-esc="slide.date_published" t-options="{'widget': 'date'}"/>
+                                    <t t-out="slide.date_published" t-options="{'widget': 'date'}"/>
                                 </div>
                                 <div t-else="" t-attf-class="o_wslides_channel_completion_progressbar #{'d-none' if slide.channel_id.completed else 'd-flex'} align-items-center pb-3">
                                     <div class="progress w-50 bg-black-25" style="height: 10px;">
@@ -34,7 +34,7 @@
                                         </div>
                                     </div>
                                     <i class="fa fa-trophy m-0 ms-2 p-0 text-black-50"></i>
-                                    <small class="ms-2 text-white-50"><span class="o_wslides_progress_percentage" t-esc="slide.channel_id.completion"/> %</small>
+                                    <small class="ms-2 text-white-50"><span class="o_wslides_progress_percentage" t-out="slide.channel_id.completion"/> %</small>
                                 </div>
                             </div>
                             <div t-attf-class="o_wslides_channel_completion_completed col-12 col-sm-3 #{'d-none' if not slide.channel_id.completed else ''}">
@@ -101,9 +101,9 @@
     <a class="list-group-item list-group-item-action d-flex align-items-start px-2" t-att-href="'/slides/slide/%s' % (slug(aside_slide))">
         <div class="me-1 border o_wslides_background_image_aside_card" t-attf-style="background-image: url(#{website.image_url(aside_slide, 'image_256')});"/>
         <div class="overflow-hidden d-flex flex-column justify-content-start">
-            <h6 t-esc="aside_slide.name" class="o_wslides_desc_truncate_2 mb-1" style="line-height: 1.15"/>
+            <h6 t-out="aside_slide.name" class="o_wslides_desc_truncate_2 mb-1" style="line-height: 1.15"/>
             <small class="text-600">
-                <t t-esc="aside_slide.total_views"/> Views &#8226; <timeago class="timeago" t-att-datetime="aside_slide.create_date"></timeago>
+                <t t-out="aside_slide.total_views"/> Views &#8226; <timeago class="timeago" t-att-datetime="aside_slide.create_date"></timeago>
             </small>
         </div>
     </a>
@@ -165,10 +165,10 @@
                         <a t-att-href="'/slides/slide/%s' % (slug(aside_slide)) if can_access else '#'"
                             t-attf-class="d-flex text-decoration-none mw-100 overflow-hidden #{'text-muted' if not can_access else ''}">
                             <div class="o_wslides_lesson_link_name text-truncate" t-att-title="aside_slide.name">
-                                <span t-esc="aside_slide.name"/>
+                                <span t-out="aside_slide.name"/>
                                 <span class="align-items-end" t-if="aside_slide.question_ids">
                                     <span t-att-class="'badge rounded-pill %s' % ('text-bg-success' if channel_progress[aside_slide.id].get('completed') else 'text-bg-info')">
-                                        <t t-esc="channel_progress[aside_slide.id].get('quiz_karma_won') if channel_progress[aside_slide.id].get('completed') else channel_progress[aside_slide.id].get('quiz_karma_gain')"/> xp
+                                        <t t-out="channel_progress[aside_slide.id].get('quiz_karma_won') if channel_progress[aside_slide.id].get('completed') else channel_progress[aside_slide.id].get('quiz_karma_gain')"/> xp
                                     </span>
                                 </span>
                             </div>
@@ -230,12 +230,12 @@
                 <span t-if="slide_completed">
                     <i class="fa fa-check-circle"/>
                     <t t-if="quiz_karma_won">
-                        <t t-esc="quiz_karma_won" />
+                        <t t-out="quiz_karma_won" />
                         <span>XP</span>
                     </t>
                 </span>
                 <t t-else="">
-                    <span t-esc="quiz_karma_gain"/>
+                    <span t-out="quiz_karma_gain"/>
                     <span>XP</span>
                 </t>
             </span>
@@ -290,7 +290,7 @@
     </div>
     <div t-if="slide.tag_ids" class="pb-2">
         <t t-foreach="slide.tag_ids" t-as="tag">
-            <a t-att-href="'/slides/%s/tag/%s' % (slug(slide.channel_id), slug(tag))" class="badge text-bg-info" t-esc="tag.name"/>
+            <a t-att-href="'/slides/%s/tag/%s' % (slug(slide.channel_id), slug(tag))" class="badge text-bg-info" t-out="tag.name"/>
         </t>
     </div>
     <div class="oe_structure oe_empty" id="oe_structure_website_slides_lesson_top_1" data-editor-message.translate="BUILDING BLOCKS DROPPED HERE WILL BE SHOWN ACROSS ALL LESSONS"/>
@@ -321,7 +321,7 @@
             </li>
             <li class="nav-item" role="presentation">
                 <a href="#discuss" aria-controls="discuss" t-att-class="'nav-link active' if comments else 'nav-link'" role="tab" data-bs-toggle="tab">
-                    <i class="fa fa-comments"></i> Comments (<span t-esc="slide.comments_count"/>)
+                    <i class="fa fa-comments"></i> Comments (<span t-out="slide.comments_count"/>)
                 </a>
             </li>
             <li class="nav-item" role="presentation" groups="base.group_user">
@@ -388,15 +388,15 @@
                                     <th colspan="2" class="border-top-0">Views</th>
                                 </tr>
                                 <tr class="border-top-0">
-                                    <th class="border-top-0"><span t-esc="slide.total_views"/></th>
+                                    <th class="border-top-0"><span t-out="slide.total_views"/></th>
                                     <td class="border-top-0 w-100">Total Views</td>
                                 </tr>
                                 <tr>
-                                    <th><span t-esc="slide.slide_views"/></th>
+                                    <th><span t-out="slide.slide_views"/></th>
                                     <td>Members Views</td>
                                 </tr>
                                 <tr>
-                                    <th><span t-esc="slide.public_views"/></th>
+                                    <th><span t-out="slide.public_views"/></th>
                                     <td>Public Views</td>
                                 </tr>
                             </tbody>
@@ -425,7 +425,7 @@
                     <span class="text-muted fw-bold col-4 col-md-3">External sources</span>
                     <div class="text-muted me-auto border-start ps-3 col-8 col-md-9">
                         <t t-foreach="links" t-as="link">
-                            <a t-att-href="link.link" t-esc="link.name"/><br />
+                            <a t-att-href="link.link" t-out="link.name"/><br />
                         </t>
                     </div>
                 </div>
@@ -436,7 +436,7 @@
                     </span>
                     <div class="text-muted me-auto border-start ps-3 col-8 col-md-9">
                         <t t-foreach="slide.slide_resource_ids" t-as="resource" t-if="resource.resource_type == 'file' and resource.data">
-                            <a t-att-href="resource.download_url" t-esc="resource.name"/><br />
+                            <a t-att-href="resource.download_url" t-out="resource.name"/><br />
                         </t>
                     </div>
                 </div>
@@ -499,10 +499,10 @@
             <div class="h4">
                 <small class="text-muted">
                     <i class="o_wslides_js_quiz_icon o_wslides_js_quiz_sequence_handler fa fa-bars me-1 text-muted" t-if="slide.channel_id.can_upload and not slide_completed" />
-                    <t t-if="question_index != NoneType"><span class="o_wslides_quiz_question_sequence" t-esc="question_index+1"/>.</t>
-                    <t t-else=""><span class="o_wslides_quiz_question_sequence" t-esc="question['sequence']"/>.</t>
+                    <t t-if="question_index != NoneType"><span class="o_wslides_quiz_question_sequence" t-out="question_index+1"/>.</t>
+                    <t t-else=""><span class="o_wslides_quiz_question_sequence" t-out="question['sequence']"/>.</t>
                 </small>
-                <span t-esc="question['question']"/>
+                <span t-out="question['question']"/>
             </div>
             <div class="ms-auto o_wslides_js_quiz_edit_del" t-if="slide.channel_id.can_upload and not slide_completed" >
                 <i class="o_wslides_js_quiz_icon o_wslides_js_quiz_edit_question fa fa-pencil-square-o p-1 text-muted"></i>
@@ -524,7 +524,7 @@
                         <i class="fa fa-times-circle text-danger d-none"></i>
                         <i t-att-class="'fa fa-check-circle text-success %s' % ('d-none' if not (slide_completed and answer['is_correct']) else '')"></i>
                     </label>
-                    <span t-esc="answer['text_value']"/>
+                    <span t-out="answer['text_value']"/>
                 </a>
                 <t t-if="slide_completed and answer['is_correct']" t-set="correct_answer_comment" t-value="answer['comment']"/>
             </t>

--- a/addons/website_slides/views/website_slides_templates_lesson_embed.xml
+++ b/addons/website_slides/views/website_slides_templates_lesson_embed.xml
@@ -8,7 +8,7 @@
         <template id="embed_slide" name="Embedded Slide Page">
             <html>
                 <head>
-                    <title><t t-esc="slide.name"/></title>
+                    <title><t t-out="slide.name"/></title>
                     <t t-call-assets="website_slides.slide_embed_assets"/>
                     <script type="module" src="/web/static/lib/pdfjs/build/pdf.js"/>
                     <script type="module" src="/web/static/lib/pdfjs/build/pdf.worker.js"/>
@@ -61,7 +61,7 @@
                                                 <div class="card-body">
                                                     <h6 class="card-title">
                                                         <a t-att-href="suggest_slide.website_absolute_url" target="_new">
-                                                            <t t-esc="suggest_slide.name"/>
+                                                            <t t-out="suggest_slide.name"/>
                                                         </a>
                                                     </h6>
                                                     <div class="oe_slides_suggestion_caption"/>

--- a/addons/website_slides/views/website_slides_templates_lesson_fullscreen.xml
+++ b/addons/website_slides/views/website_slides_templates_lesson_fullscreen.xml
@@ -72,7 +72,7 @@
                                         <div class="progress-bar" role="progressbar" t-attf-style="width: #{slide.channel_id.completion}%" t-att-aria-valuenow="slide.channel_id.completion" aria-valuemin="0" aria-valuemax="100" aria-label="Progress bar"></div>
                                     </div>
                                     <div class="ms-3 small">
-                                        <span class="o_wslides_progress_percentage" t-esc="slide.channel_id.completion"/> %
+                                        <span class="o_wslides_progress_percentage" t-out="slide.channel_id.completion"/> %
                                     </div>
                                 </div>
                             </div>
@@ -141,24 +141,24 @@
                             <div class="d-flex">
                                 <t t-if="is_member" t-call="website_slides.slide_sidebar_done_button"/>
                                 <i t-else="" t-attf-class="fa #{slide.slide_icon_class} me-2"/>
-                                <div class="o_wslides_fs_slide_name text-truncate" t-esc="slide.name"/>
+                                <div class="o_wslides_fs_slide_name text-truncate" t-out="slide.name"/>
                             </div>
                         </a>
                         <span t-else="" class="d-block" href="#">
                             <div class="d-flex">
                                 <t t-if="is_member" t-call="website_slides.slide_sidebar_done_button"/>
                                 <i t-else="" t-attf-class="fa #{slide.slide_icon_class} me-2 text-600"/>
-                                <div class="o_wslides_fs_slide_name text-600 text-truncate" t-esc="slide.name"/>
+                                <div class="o_wslides_fs_slide_name text-600 text-truncate" t-out="slide.name"/>
                             </div>
                         </span>
                         <ul class="list-unstyled w-100 small fw-light" t-if="slide.sudo().slide_resource_ids or (slide.question_ids and not slide.slide_category =='quiz')" >
                             <t t-if="can_access_channel" t-foreach="slide.slide_resource_ids" t-as="resource">
                                 <li class="ps-1 mb-1">
                                     <a t-if="resource.resource_type == 'url'" class="o_wslides_fs_slide_link" t-att-href="resource.link" target="_blank">
-                                        <i class="fa fa-link me-2"/><span t-esc="resource.name"/>
+                                        <i class="fa fa-link me-2"/><span t-out="resource.name"/>
                                     </a>
                                     <a t-else="" class="o_wslides_fs_slide_link ps-0" t-att-href="resource.download_url">
-                                        <i class="fa fa-download me-2"/><span t-esc="resource.name"/>
+                                        <i class="fa fa-download me-2"/><span t-out="resource.name"/>
                                     </a>
                                 </li>
                             </t>

--- a/addons/website_slides/views/website_slides_templates_profile.xml
+++ b/addons/website_slides/views/website_slides_templates_profile.xml
@@ -57,7 +57,7 @@
 
                             <div class="overflow-hidden mb-1" style="height:24px">
                                 <t t-foreach="course.channel_id.tag_ids.filtered(lambda tag: tag.color)" t-as="tag">
-                                    <a t-att-href="'/slides/all/tag/%s' % slug(tag)" onclick="event.stopPropagation()" t-attf-class="badge o_wslides_channel_tag post_link #{'o_color_'+str(tag.color)}" t-esc="tag.name"/>
+                                    <a t-att-href="'/slides/all/tag/%s' % slug(tag)" onclick="event.stopPropagation()" t-attf-class="badge o_wslides_channel_tag post_link #{'o_color_'+str(tag.color)}" t-out="tag.name"/>
                                 </t>
                             </div>
 
@@ -65,7 +65,7 @@
                                 <div class="progress flex-grow-1" style="height:0.5em">
                                     <div class="progress-bar bg-primary" t-att-style="'width: '+ str(course.completion)+'%'"/>
                                 </div>
-                                <small class="fw-bold ps-2"><span t-esc="course.completion"/> %</small>
+                                <small class="fw-bold ps-2"><span t-out="course.completion"/> %</small>
                             </div>
                         </div>
                     </div>

--- a/addons/website_slides/views/website_slides_templates_utils.xml
+++ b/addons/website_slides/views/website_slides_templates_utils.xml
@@ -70,7 +70,7 @@
         <div>
             <textarea class="form-control slide_embed_code" readonly="readonly" onClick="this.select();" t-attf-id="wslides_share_embed_id_{{record.id}}">
                 <!-- Use the external embedding URL here, see python controller '_slide_embed' method for more details. -->
-                <t t-esc="slide.embed_code_external"/>
+                <t t-out="slide.embed_code_external"/>
             </textarea>
             <button t-att-id="'share_embed_clipboard_button_id_%s' % record.id" class="btn btn-sm btn-primary o_embed_clipboard_button float-end mt-1 p-2" >
                 <i class="fa fa-clipboard"/> Copy Embed Code

--- a/addons/website_slides_survey/views/website_profile.xml
+++ b/addons/website_slides_survey/views/website_profile.xml
@@ -70,9 +70,9 @@
                         <div class="card-body o_wprofile_slides_course_card_body p-0 d-flex" t-attf-onclick="location.href='/slides/#{slug(certificate.slide_id.channel_id)}';">
                             <div class="ps-5 pe-4 rounded-start" t-attf-style="background-image: url(#{website.image_url(certificate.slide_id, 'image_128')}); background-position: center"/>
                             <div class="p-2 w-100">
-                                <h5 class="mt-0 mb-1" t-esc="certificate.survey_id.title"/>
+                                <h5 class="mt-0 mb-1" t-out="certificate.survey_id.title"/>
                                 <div t-if="user.id == uid">
-                                    <small class="fw-bold">Score: <span t-esc="certificate.scoring_percentage"/> %</small>
+                                    <small class="fw-bold">Score: <span t-out="certificate.scoring_percentage"/> %</small>
                                     <div class="float-end">
                                         <a role="button" class="float-end" t-att-href="'/survey/%s/get_certification' % certificate.survey_id.id">
                                             <i class="fa fa-download" aria-label="Download certification" title="Download Certification"/>
@@ -111,14 +111,14 @@
 
     <template id="top3_user_card" inherit_id="website_profile.top3_user_card">
         <xpath expr="//div[hasclass('o_wprofile_top3_card_footer')]//div[last()]" position="after">
-            <div class="col py-3"><b t-esc="user['certification_count']"/> <span class="text-muted">Certifications</span></div>
+            <div class="col py-3"><b t-out="user['certification_count']"/> <span class="text-muted">Certifications</span></div>
         </xpath>
     </template>
 
     <template id="all_user_card" inherit_id="website_profile.all_user_card">
         <xpath expr="//td[hasclass('all_user_badge_count')]" position="after">
             <td class="align-middle text-end pe-3 text-nowrap all_user_certification_count">
-                <b t-esc="user['certification_count']"/> <span class="text-muted small fw-bold">Certifications</span>
+                <b t-out="user['certification_count']"/> <span class="text-muted small fw-bold">Certifications</span>
             </td>
         </xpath>
     </template>
@@ -143,7 +143,7 @@
                                 <span t-field="badge.description"/>
                             </div>
                             <div class="col-3 text-end">
-                                <b t-esc="badge.granted_users_count"/>
+                                <b t-out="badge.granted_users_count"/>
                                 <i class="text-muted"> awarded users</i>
                             </div>
                         </div>


### PR DESCRIPTION
\*: test_website, website_\*,

This commit updates all instances of the deprecated t-esc attribute
within the website modules to use the recommended t-out attribute. 
The JavaScript side remains untouched.

See also : 
- https://github.com/odoo/design-themes/pull/804
- https://github.com/odoo/enterprise/pull/65501

task-3573251
