### PR TITLE
[IMP] website_slides{_survey}, website_{forum|profile|slides}: prepare website_slides redesign

### DIFF
--- a/addons/test_website_slides_full/static/tests/tours/slides_certification_member.js
+++ b/addons/test_website_slides_full/static/tests/tours/slides_certification_member.js
@@ -59,7 +59,7 @@ var buyCertificationSteps = [{
     run: "click",
 }, {
     content: 'eLearning: go into bought course',
-    trigger: 'a:contains("DIY Furniture")',
+    trigger: 'a:contains("DIY Furniture - TEST")',
     run: "click",
 }, {
     content: 'eLearning: user should be enrolled',
@@ -153,7 +153,7 @@ var certificationCompletionSteps = [{
     run: "click",
 }, {
     content: 'eLearning: course should be completed',
-    trigger: '.o_wslides_course_card:contains("DIY Furniture") .badge:contains("Completed")',
+    trigger: '.o_wslides_course_card:contains("DIY Furniture - TEST") .badge:contains("Completed")',
 }];
 
 var profileSteps = [{

--- a/addons/website_forum/__manifest__.py
+++ b/addons/website_forum/__manifest__.py
@@ -75,6 +75,7 @@ Ask questions, get answers, no distractions
             'website_forum/static/src/scss/website_forum.scss',
             'website_forum/static/src/js/website_forum.js',
             'website_forum/static/src/js/website_forum.share.js',
+            'website_forum/static/src/js/website_profile.js',
             'website_forum/static/src/xml/public_templates.xml',
             'website_forum/static/src/xml/website_forum_tags_wrapper.xml',
             'website_forum/static/src/components/flag_mark_as_offensive/**/*',

--- a/addons/website_forum/static/src/js/website_profile.js
+++ b/addons/website_forum/static/src/js/website_profile.js
@@ -1,0 +1,37 @@
+import publicWidget from "@web/legacy/js/public/public_widget";
+
+publicWidget.registry.websiteProfileForumActivities = publicWidget.Widget.extend({
+    selector: '.o_wprofile_forum_activities',
+    read_events: {
+        'click #profile_extra_info_activities_filter li a': '_onSelectTab',
+    },
+
+    /**
+     * @override
+     */
+    start: function () {
+        this.formSelectorByTabRef = {
+            "#profile_extra_info_activities_tab_question": ".o_wprofile_forum_activities_search_question",
+            "#profile_extra_info_activities_tab_answer": ".o_wprofile_forum_activities_search_answer",
+        };
+        const activeTab = this.$el.data('active-tab');
+        this._selectTab(document.querySelector(`a[href="#profile_extra_info_activities_tab_${activeTab}"]`));
+    },
+
+    _onSelectTab: function (ev) {
+        this._selectTab(ev.target);
+    },
+
+    _selectTab: function(navLink) {
+        const selectedTabRef = navLink.getAttribute("href");
+        for (const [tabRef, formSelector] of Object.entries(this.formSelectorByTabRef)) {
+            const form = document.querySelector(formSelector);
+            if (tabRef === selectedTabRef) {
+                form.classList.remove("d-none");
+            } else {
+                form.classList.add("d-none");
+            }
+        }
+        document.querySelector(".profile_extra_info_activities_filter_label").textContent = navLink.text;
+    }
+});

--- a/addons/website_forum/views/forum_forum_templates_post.xml
+++ b/addons/website_forum/views/forum_forum_templates_post.xml
@@ -168,23 +168,19 @@
             t-attf-class="badge #{'ms-1' if not question_tag_first else ''} fw-normal o_tag o_color_#{question_tag.color}"
             t-field="question_tag.name"/>
     </div>
-    <div class="ms-auto d-flex">
-        <div>
-            <span t-if="question.child_count" class="small">
-                <t t-out="question.child_count or 0"/>
-                <span class="text-muted">
-                    <t t-if="question.child_count == 1">Reply</t>
-                    <t t-else="">Replies</t>
-                </span>
+    <div class="d-flex">
+        <div t-if="question.child_count" class="ms-2">
+            <span class="small" t-out="question.child_count or 0"/>
+            <span class="text-muted small">
+                <t t-if="question.child_count == 1">Reply</t>
+                <t t-else="">Replies</t>
             </span>
         </div>
-        <div class="mx-3">
-            <span t-if="question.views" class="small">
-                <t t-out="question.views or 0"/>
-                <span class="text-muted">
-                    <t t-if="question.views == 1">View</t>
-                    <t t-else="">Views</t>
-                </span>
+        <div class="ms-2">
+            <span class="small" t-out="question.views or 0"/>
+            <span class="text-muted small">
+                <t t-if="question.views == 1">View</t>
+                <t t-else="">Views</t>
             </span>
         </div>
     </div>

--- a/addons/website_forum/views/website_profile_templates.xml
+++ b/addons/website_forum/views/website_profile_templates.xml
@@ -52,13 +52,7 @@
         <xpath expr="//ul[@id='profile_extra_info_tablist']" position="inside">
             <t t-if="forum">
                 <li class="nav-item">
-                    <a role="tab" aria-controls="questions" href="#questions" class="nav-link o_wprofile_navlink" data-bs-toggle="tab"><t t-out="count_questions"/> Questions</a>
-                </li>
-                <li class="nav-item">
-                    <a role="tab" aria-controls="answers" href="#answers" class="nav-link o_wprofile_navlink" data-bs-toggle="tab"><t t-out="count_answers"/> Answers</a>
-                </li>
-                <li t-if="uid == user.id" class="nav-item">
-                    <a role="tab" aria-controls="activity" href="#activity" class="nav-link o_wprofile_navlink" data-bs-toggle="tab">Activity</a>
+                    <a role="tab" aria-controls="activities" href="#activities" t-attf-class="#{ 'active' if active_tab == 'activities' else '' } nav-link o_wprofile_navlink" data-bs-toggle="tab">Activities</a>
                 </li>
                 <li t-if="uid == user.id" class="nav-item">
                     <a role="tab" aria-controls="votes" href="#votes" class="nav-link o_wprofile_navlink" data-bs-toggle="tab">Votes</a>
@@ -68,100 +62,112 @@
         <xpath expr="//div[@id='profile_extra_info_tabcontent']" position="inside">
             <t t-if="forum">
                 <t t-set="is_profile" t-value="true"/>
-                <div role="tabpanel" class="o_wforum_profile_tab tab-pane" id="questions">
-                    <div class="mb-4">
-                        <h5 class="border-bottom pb-1 d-flex align-items-center justify-content-between">
-                            Questions
-                            <t t-if="count_questions &gt; 0" class="float-end" t-call="website.website_search_box_input">
-                                <t t-set="_form_classes" t-valuef="d-flex flex-row align-items-center flex-wrap float-end"/>
-                                <t t-set="search_type" t-valuef="forums"/>
-                                <t t-if="forum_id" t-set="action" t-value="'/forum/%s%s' % (forum_id, ('/tag/%s/questions' % slug(tag)) if tag else '')"/>
-                                <t t-else="" t-set="action" t-value="'/forum/all%s' % (('/tag/%s/questions' % slug(tag)) if tag else '')"/>
-                                <t t-set="display_description" t-value="true"/>
-                                <t t-set="display_detail" t-valuef="false"/>
-                                <t t-set="placeholder" t-valuef="Search Questions..."/>
-                                <input type="hidden" name="create_uid" t-att-value="user.id"/>
-                                <input t-if="filters" type="hidden" name="filters" t-att-value="filters"/>
-                                <input t-if="my_profile" type="hidden" name="my" t-att-value="mine"/>
-                                <input t-if="sorting" type="hidden" name="sorting" t-att-value="sorting"/>
-                            </t>
-                        </h5>
-                        <t t-call="website_forum.forum_filter_tag"/>
-                        <t t-if="questions">
-                            <div class="mb-1" t-foreach="questions" t-as="question">
-                                <t t-call="website_forum.display_post"/>
+                <t t-set="activities_active_tab" t-value="'answer' if activities_search_answer else 'question'"/>
+                <div role="tabpanel" t-attf-class="o_wforum_profile_tab tab-pane o_wprofile_forum_activities #{ 'show active' if active_tab == 'activities' else '' }" id="activities"
+                     t-att-data-active-tab="activities_active_tab">
+                    <h5 class="border-bottom pb-1 d-flex align-items-center justify-content-between">
+                        <div>Activities</div>
+                        <div class="d-flex">
+                            <form method="post" class="o_wprofile_forum_activities_search_question mx-1">
+                                <div class="input-group" role="search">
+                                    <input type="text" class="form-control" name="activities_search_question" t-att-value="activities_search_question" placeholder="Search Questions..."/>
+                                    <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
+                                    <button type="submit" class="btn btn-primary" aria-label="Search" title="Search">
+                                        <i class="fa fa-search"/>
+                                    </button>
+                                </div>
+                            </form>
+                            <form method="post" class="o_wprofile_forum_activities_search_answer d-none mx-1">
+                                <div class="input-group" role="search">
+                                    <input type="text" class="form-control" name="activities_search_answer" t-att-value="activities_search_answer" placeholder="Search Answers..."/>
+                                    <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
+                                    <button type="submit" class="btn btn-primary" aria-label="Search" title="Search">
+                                        <i class="fa fa-search"/>
+                                    </button>
+                                </div>
+                            </form>
+                            <div class="dropdown" id="profile_extra_info_activities_filter" role="tablist">
+                                <button class="btn btn-primary dropdown-toggle" type="button" id="profile_extra_info_activities_filter_button"
+                                        data-bs-toggle="dropdown" aria-expanded="false">
+                                    <i class="fa fa-filter"/>&amp;nbsp;<span class="profile_extra_info_activities_filter_label"><t t-out="count_questions"/> Questions</span>
+                                </button>
+                                <ul class="dropdown-menu" aria-labelledby="profile_extra_info_activities_filter_button">
+                                    <li><a role="tab" aria-controls="questions" href="#profile_extra_info_activities_tab_question" t-attf-class="#{ 'active' if activities_active_tab =='question' else '' } nav-link o_wprofile_navlink px-3" data-bs-toggle="tab" aria-selected="true"><t t-out="count_questions"/> Questions</a></li>
+                                    <li><a role="tab" aria-controls="answers" href="#profile_extra_info_activities_tab_answer" t-attf-class="#{ 'active' if activities_active_tab =='answer' else '' } nav-link o_wprofile_navlink px-3" data-bs-toggle="tab"><t t-out="count_answers"/> Answers</a></li>
+                                    <li t-if="uid == user.id"><a role="tab" aria-controls="activity" href="#profile_extra_info_activities_tab_activity" class="nav-link o_wprofile_navlink px-3" data-bs-toggle="tab">Activity</a></li>
+                                </ul>
                             </div>
-                        </t>
-                        <div t-elif="my_profile" class="text-muted">
-                            You have not posted any questions yet. <br />
-                            <a href="/forum/" class="btn btn-link px-0">
-                                <i class="oi oi-arrow-right d-inline-block"/> Go to Forums
-                            </a>
                         </div>
-                        <t t-else="">
-                            <div class="text-muted">This user hasn't posted any questions yet.<br/>
-                                <a href="/forum/" class="btn btn-link px-0">
-                                    <i class="oi oi-arrow-right d-inline-block"/> Go to Forums
-                                </a>
-                            </div>
-                        </t>
-                    </div>
-                    <t t-if="favourite">
-                        <div class="mb-4">
-                            <h5 class="border-bottom pb-1">Favourite Questions</h5>
-                            <div class="mb-1" t-foreach="favourite" t-as="question">
-                                <t t-call="website_forum.display_post">
-                                    <t t-set="hide_fav_icon" t-value="True"/>
+
+                    </h5>
+                    <t t-call="website_forum.forum_filter_tag"/>
+
+                    <div class="tab-content mt-2" id="profile_extra_info_tabcontent_activities">
+                        <div role="tabpanel" t-attf-class="#{ 'show active' if activities_active_tab =='question' else '' } o_wforum_profile_tab tab-pane" id="profile_extra_info_activities_tab_question">
+                            <div class="mb-4">
+                                <t t-if="questions">
+                                    <div class="mb-1" t-foreach="questions" t-as="question">
+                                        <t t-call="website_forum.display_post"/>
+                                    </div>
+                                </t>
+                                <div t-elif="my_profile" class="text-muted">
+                                    You have not posted any questions yet. <br />
+                                    <a href="/forum/" class="btn btn-link px-0">
+                                        <i class="oi oi-arrow-right d-inline-block"/> Go to Forums
+                                    </a>
+                                </div>
+                                <t t-else="">
+                                    <div class="text-muted">This user hasn't posted any questions yet.<br/>
+                                        <a href="/forum/" class="btn btn-link px-0">
+                                            <i class="oi oi-arrow-right d-inline-block"/> Go to Forums
+                                        </a>
+                                    </div>
                                 </t>
                             </div>
-                        </div>
-                    </t>
-                    <t t-if="followed">
-                        <div class="mb-4">
-                            <h5 class="border-bottom pb-1">Followed Questions</h5>
-                            <div class="mb-1" t-foreach="followed" t-as="question">
-                                <t t-call="website_forum.display_post"/>
-                            </div>
-                        </div>
-                    </t>
-                </div>
-                <div role="tabpanel" class="o_wforum_profile_tab tab-pane" id="answers">
-                    <div class="mb-4">
-                        <h5 class="border-bottom pb-1 d-flex align-items-center justify-content-between">
-                            Answers
-                            <t t-if="count_questions &gt; 0" class="float-end" t-call="website.website_search_box_input">
-                                <t t-set="_form_classes" t-valuef="d-flex flex-row align-items-center flex-wrap float-end"/>
-                                <t t-set="search_type" t-valuef="forums"/>
-                                <t t-if="forum_id" t-set="action" t-value="'/forum/%s%s' % (forum_id, '/tag/%s/questions' % slug(tag)) if tag else ''"/>
-                                <t t-else="" t-set="action" t-value="'/forum/all%s' % (('/tag/%s/questions' % slug(tag)) if tag else '')"/>
-                                <t t-set="display_description" t-value="true"/>
-                                <t t-set="display_detail" t-valuef="false"/>
-                                <t t-set="placeholder" t-valuef="Search Answers..."/>
-                                <input type="hidden" name="author" t-att-value="user.id"/>
-                                <input t-if="filters" type="hidden" name="filters" t-att-value="filters"/>
-                                <input t-if="my_profile" type="hidden" name="my" t-att-value="mine"/>
-                                <input t-if="sorting" type="hidden" name="sorting" t-att-value="sorting"/>
-                                <input type="hidden" name="include_answers" t-att-value="True"/>
+                            <t t-if="favourite">
+                                <div class="mb-4">
+                                    <h5 class="border-bottom pb-1">Favourite Questions</h5>
+                                    <div class="mb-1" t-foreach="favourite" t-as="question">
+                                        <t t-call="website_forum.display_post">
+                                            <t t-set="hide_fav_icon" t-value="True"/>
+                                        </t>
+                                    </div>
+                                </div>
                             </t>
-                        </h5>
-                        <t t-call="website_forum.forum_filter_tag"/>
-
-                        <t t-if="answers">
-                            <div class="mb-1" t-foreach="answers" t-as="answer">
-                                <t t-call="website_forum.display_post_answer"/>
-                            </div>
-                        </t>
-                        <div t-elif="my_profile" class="text-muted">
-                            You have not answered any questions yet. <br />
-                            <a href="/forum/" class="btn btn-link px-0">
-                                <i class="oi oi-arrow-right d-inline-block"/> Go to Forums
-                            </a>
+                            <t t-if="followed">
+                                <div class="mb-4">
+                                    <h5 class="border-bottom pb-1">Followed Questions</h5>
+                                    <div class="mb-1" t-foreach="followed" t-as="question">
+                                        <t t-call="website_forum.display_post"/>
+                                    </div>
+                                </div>
+                            </t>
                         </div>
-                        <div t-else="" class="text-muted">
-                            This user hasn't answered any questions yet. <br/>
-                            <a href="/forum/" class="btn btn-link px-0">
-                                <i class="oi oi-arrow-right d-inline-block"/> Go to Forums
-                            </a>
+                        <div role="tabpanel" t-attf-class="#{ 'show active' if activities_active_tab =='answer' else '' } o_wforum_profile_tab tab-pane" id="profile_extra_info_activities_tab_answer">
+                            <div class="mb-4">
+                                <t t-if="answers">
+                                    <div class="mb-1" t-foreach="answers" t-as="answer">
+                                        <t t-call="website_forum.display_post_answer"/>
+                                    </div>
+                                </t>
+                                <div t-elif="my_profile" class="text-muted">
+                                    You have not answered any questions yet. <br />
+                                    <a href="/forum/" class="btn btn-link px-0">
+                                        <i class="oi oi-arrow-right d-inline-block"/> Go to Forums
+                                    </a>
+                                </div>
+                                <div t-else="" class="text-muted">
+                                    This user hasn't answered any questions yet. <br/>
+                                    <a href="/forum/" class="btn btn-link px-0">
+                                        <i class="oi oi-arrow-right d-inline-block"/> Go to Forums
+                                    </a>
+                                </div>
+                            </div>
+                        </div>
+                        <div t-if="uid == user.id" role="tabpanel" class="o_wforum_profile_tab tab-pane" id="profile_extra_info_activities_tab_activity">
+                            <div class="mb-4">
+                                <t t-call="website_forum.display_activities"/>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -184,15 +190,6 @@
                         </h5>
                         <t t-call="website_forum.forum_filter_tag"/>
                         <t t-call="website_forum.user_votes"/>
-                    </div>
-                </div>
-                <div role="tabpanel" class="o_wforum_profile_tab tab-pane" id="activity" t-if="uid == user.id">
-                    <div class="mb-4">
-                        <h5 class="border-bottom pb-1 d-flex align-items-center justify-content-between" style="height:43px;">
-                            Activities
-                        </h5>
-                        <t t-call="website_forum.forum_filter_tag"/>
-                        <t t-call="website_forum.display_activities"/>
                     </div>
                 </div>
             </t>

--- a/addons/website_forum/views/website_profile_templates.xml
+++ b/addons/website_forum/views/website_profile_templates.xml
@@ -11,12 +11,25 @@
 
     <template id="user_profile_sub_nav" inherit_id="website_profile.user_profile_sub_nav">
         <xpath expr="//nav" position="before">
-            <div t-if="request.params.get('forum_origin')" class="o_wprofile_all_users_nav_btn_container col pe-0 flex-grow-0">
+            <div t-if="request.params.get('forum_origin') and not request.params.get('forum_id')"
+                 class="o_wprofile_all_users_nav_btn_container col pe-0 flex-grow-0">
                 <a t-att-href="(request.website.domain or '') + '/' + request.params.get('forum_origin').lstrip('/')"
                     class="o_wprofile_all_users_nav_btn btn text-nowrap">
                     <i class="oi oi-chevron-left small"/> Back
                 </a>
             </div>
+        </xpath>
+        <xpath expr="//nav[hasclass('o_wprofile_user_profile_sub_nav_desktop_nav')]//ol/li[1]" position="before">
+            <li t-if="request.params.get('forum_origin') and request.params.get('forum_id')" class="breadcrumb-item ">
+                <a t-att-href="(request.website.domain or '') + '/' + request.params.get('forum_origin').lstrip('/')"
+                   t-out="request.env['forum.forum'].browse([int(request.params.get('forum_id'))]).display_name"/>
+            </li>
+        </xpath>
+        <xpath expr="//div[hasclass('o_wprofile_user_profile_sub_nav_mobile_col')]//ul/a[1]" position="after">
+            <a t-if="request.params.get('forum_origin') and request.params.get('forum_id')" class="dropdown-item"
+               t-att-href="(request.website.domain or '') + '/' + request.params.get('forum_origin').lstrip('/')">
+                &#9492; <t t-out="request.env['forum.forum'].browse([int(request.params.get('forum_id'))]).display_name"/>
+            </a>
         </xpath>
     </template>
 

--- a/addons/website_profile/views/website_profile.xml
+++ b/addons/website_profile/views/website_profile.xml
@@ -6,10 +6,10 @@
             <div class="container">
                 <div class="row align-items-center justify-content-between">
                     <!-- Desktop Mode -->
-                    <nav aria-label="breadcrumb" class="col d-none d-md-flex">
+                    <nav aria-label="breadcrumb" class="col d-none d-md-flex o_wprofile_user_profile_sub_nav_desktop_nav">
                         <ol class="breadcrumb bg-transparent mb-0 ps-0 py-0">
                             <li t-attf-class="breadcrumb-item #{'active' if not view_user else ''}">
-                                <a href="/profile/users">Users</a>
+                                <a t-attf-href="/profile/users?{{ keep_query() }}">Users</a>
                             </li>
                             <li t-if="view_user" class="breadcrumb-item active">
                                 <a><t t-esc="view_user"/></a>

--- a/addons/website_slides/__manifest__.py
+++ b/addons/website_slides/__manifest__.py
@@ -49,6 +49,7 @@ Featuring
         'views/website_slides_templates_profile.xml',
         'views/website_slides_templates_utils.xml',
         'views/website_pages_views.xml',
+        'views/website_profile_templates.xml',
         'views/slide_channel_add.xml',
         'wizard/slide_channel_invite_views.xml',
         'data/gamification_data.xml',

--- a/addons/website_slides/data/mail_template_data.xml
+++ b/addons/website_slides/data/mail_template_data.xml
@@ -82,7 +82,7 @@
                         <p>Check out the other available courses.</p><br/>
 
                         <div style="padding: 16px 8px 16px 8px; text-align: center;">
-                            <a href="/slides/all" style="background-color: #875a7b; padding: 8px 16px 8px 16px; text-decoration: none; color: #fff; border-radius: 5px;">
+                            <a href="/slides" style="background-color: #875a7b; padding: 8px 16px 8px 16px; text-decoration: none; color: #fff; border-radius: 5px;">
                                 Explore courses
                             </a>
                         </div>

--- a/addons/website_slides/data/slide_channel_demo.xml
+++ b/addons/website_slides/data/slide_channel_demo.xml
@@ -13,8 +13,8 @@
         <field name="tag_ids" eval="[(5, 0),
                                      (4, ref('website_slides.slide_channel_tag_level_basic')),
                                      (4, ref('website_slides.slide_channel_tag_role_gardener')),
-                                     (4, ref('website_slides.slide_channel_tag_other_0')),
-                                     (4, ref('website_slides.slide_channel_tag_other_2'))]"/>
+                                     (4, ref('website_slides.slide_channel_tag_quiz')),
+                                     (4, ref('website_slides.slide_channel_tag_dog_friendly'))]"/>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/channel_demo_gardening.jpg"/>
         <field name="description">Learn the basics of gardening!</field>
         <field name="create_date" eval="DateTime.now() - relativedelta(days=8)"/>
@@ -32,7 +32,7 @@
         <field name="tag_ids" eval="[(5, 0),
                                      (4, ref('website_slides.slide_channel_tag_level_intermediate')),
                                      (4, ref('website_slides.slide_channel_tag_role_gardener')),
-                                     (4, ref('website_slides.slide_channel_tag_other_0'))]"/>
+                                     (4, ref('website_slides.slide_channel_tag_quiz'))]"/>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/channel_demo_gardening_2.jpg"/>
         <field name="description">Learn how to take care of your favorite trees. Learn when to plant, how to manage potted trees, ...</field>
         <field name="create_date" eval="DateTime.now() - relativedelta(days=7)"/>
@@ -54,8 +54,8 @@
                                      (4, ref('website_slides.slide_channel_tag_level_intermediate')),
                                      (4, ref('website_slides.slide_channel_tag_role_gardener')),
                                      (4, ref('website_slides.slide_channel_tag_role_carpenter')),
-                                     (4, ref('website_slides.slide_channel_tag_other_0')),
-                                     (4, ref('website_slides.slide_channel_tag_other_2'))]"/>
+                                     (4, ref('website_slides.slide_channel_tag_quiz')),
+                                     (4, ref('website_slides.slide_channel_tag_dog_friendly'))]"/>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/channel_demo_gardening_3.jpg"/>
         <field name="description">A lot of nice documentation: trees, wood, gardens. A gold mine for references.</field>
         <field name="create_date" eval="DateTime.now() - relativedelta(days=6)"/>
@@ -75,7 +75,7 @@
                                      (4, ref('website_slides.slide_channel_tag_role_gardener')),
                                      (4, ref('website_slides.slide_channel_tag_role_carpenter')),
                                      (4, ref('website_slides.slide_channel_tag_role_furniture')),
-                                     (4, ref('website_slides.slide_channel_tag_other_2'))]"/>
+                                     (4, ref('website_slides.slide_channel_tag_dog_friendly'))]"/>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/channel_demo_tree_1.jpg"/>
         <field name="description">Knowing which kind of wood to use depending on your application is important. In this course you
 will learn the basics of wood characteristics.</field>
@@ -111,8 +111,7 @@ will learn the basics of wood characteristics.</field>
         <field name="tag_ids" eval="[(5, 0),
                                      (4, ref('website_slides.slide_channel_tag_level_intermediate')),
                                      (4, ref('website_slides.slide_channel_tag_role_furniture')),
-                                     (4, ref('website_slides.slide_channel_tag_other_0')),
-                                     (4, ref('website_slides.slide_channel_tag_other_1'))]"/>
+                                     (4, ref('website_slides.slide_channel_tag_quiz'))]"/>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/channel_demo_furniture_2.jpg"/>
         <field name="description">All you need to know about furniture creation.</field>
         <field name="create_date" eval="DateTime.now() - relativedelta(days=3)"/>
@@ -131,8 +130,7 @@ will learn the basics of wood characteristics.</field>
         <field name="tag_ids" eval="[(5, 0),
                                  (4, ref('website_slides.slide_channel_tag_level_advanced')),
                                  (4, ref('website_slides.slide_channel_tag_role_carpenter')),
-                                 (4, ref('website_slides.slide_channel_tag_role_furniture')),
-                                 (4, ref('website_slides.slide_channel_tag_other_1'))]"/>
+                                 (4, ref('website_slides.slide_channel_tag_role_furniture'))]"/>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/channel_demo_furniture_3.jpg"/>
         <field name="description">So much amazing certification.</field>
         <field name="create_date" eval="DateTime.now() - relativedelta(days=2)"/>

--- a/addons/website_slides/data/slide_channel_tag_demo.xml
+++ b/addons/website_slides/data/slide_channel_tag_demo.xml
@@ -20,16 +20,11 @@
         <field name="group_id" ref="website_slides.slide_channel_tag_group_role"/>
     </record>
 
-    <record id="slide_channel_tag_other_0" model="slide.channel.tag">
+    <record id="slide_channel_tag_quiz" model="slide.channel.tag">
         <field name="name">Quiz</field>
         <field name="group_id" ref="website_slides.slide_channel_tag_group_data_other"/>
     </record>
-    <record id="slide_channel_tag_other_1" model="slide.channel.tag">
-        <field name="name">Certification</field>
-        <field name="color">7</field>
-        <field name="group_id" ref="website_slides.slide_channel_tag_group_data_other"/>
-    </record>
-    <record id="slide_channel_tag_other_2" model="slide.channel.tag">
+    <record id="slide_channel_tag_dog_friendly" model="slide.channel.tag">
         <field name="name">Dog Friendly</field>
         <field name="group_id" ref="website_slides.slide_channel_tag_group_data_other"/>
     </record>

--- a/addons/website_slides/views/slide_snippets.xml
+++ b/addons/website_slides/views/slide_snippets.xml
@@ -4,7 +4,7 @@
 <!-- Snippets and options -->
 <template id="slide_searchbar_input_snippet_options" inherit_id="website.searchbar_input_snippet_options" name="slide search bar snippet options">
     <xpath expr="//div[@data-js='SearchBar']/we-select[@data-name='scope_opt']" position="inside">
-        <we-button data-set-search-type="slides" data-select-data-attribute="slides" data-name="search_slides_opt" data-form-action="/slides/all">Courses</we-button>
+        <we-button data-set-search-type="slides" data-select-data-attribute="slides" data-name="search_slides_opt" data-form-action="/slides">Courses</we-button>
     </xpath>
     <xpath expr="//div[@data-js='SearchBar']/we-select[@data-name='order_opt']" position="inside">
         <we-button data-set-order-by="slide_last_update asc" data-select-data-attribute="slide_last_update asc" data-dependencies="search_slides_opt" data-name="order_slide_last_update_asc_opt">Date (old to new)</we-button>

--- a/addons/website_slides/views/website_profile_templates.xml
+++ b/addons/website_slides/views/website_profile_templates.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo><data>
+    <template id="user_profile_sub_nav" inherit_id="website_profile.user_profile_sub_nav">
+        <xpath expr="//nav[hasclass('o_wprofile_user_profile_sub_nav_desktop_nav')]//ol/li[1]" position="before">
+            <li t-if="request.params.get('slides_origin')" class="breadcrumb-item ">
+                <a t-att-href="(request.website.domain or '') + '/' + request.params.get('slides_origin').lstrip('/')">
+                    All Courses
+                </a>
+            </li>
+        </xpath>
+        <xpath expr="//div[hasclass('o_wprofile_user_profile_sub_nav_mobile_col')]//ul/a[1]" position="after">
+            <a t-if="request.params.get('slides_origin')" class="dropdown-item"
+               t-att-href="(request.website.domain or '') + '/' + request.params.get('slides_origin').lstrip('/')">
+                &#9492; All Courses
+            </a>
+        </xpath>
+    </template>
+</data></odoo>

--- a/addons/website_slides/views/website_slides_templates_course.xml
+++ b/addons/website_slides/views/website_slides_templates_course.xml
@@ -46,7 +46,7 @@
                         <t t-set="_input_classes" t-valuef="border-0 rounded-0 bg-transparent"/>
                         <t t-set="_submit_classes" t-valuef="btn-link rounded-0 pe-1"/>
                         <t t-set="search_type" t-valuef="slides"/>
-                        <t t-set="action" t-valuef="/slides/all"/>
+                        <t t-set="action" t-valuef="/slides"/>
                         <t t-set="display_description" t-valuef="true"/>
                         <t t-set="display_detail" t-valuef="false"/>
                         <t t-set="placeholder">Search courses</t>

--- a/addons/website_slides/views/website_slides_templates_homepage.xml
+++ b/addons/website_slides/views/website_slides_templates_homepage.xml
@@ -1,48 +1,113 @@
 <?xml version="1.0" ?>
 <odoo><data>
 
-<!-- Channels home template -->
-<template id='courses_home' name="Odoo Courses Homepage">
-    <t t-set="body_classname" t-value="'o_wslides_body'"/>
-    <t t-call="website.layout">
-        <div id="wrap" class="wrap o_wslides_wrap">
-            <div class="oe_structure oe_empty">
-            <section class="s_banner overflow-hidden" style="background-color:(0, 0, 0, 0); background-image: url(&quot;/website_slides/static/src/img/banner_default.svg&quot;); background-size: cover; background-position: 55% 65%" data-snippet="s_banner">
-                <div class="container align-items-center d-flex mb-5 mt-lg-5 pt-lg-4 pb-lg-1">
-                    <div class="text-white">
-                        <h1 class="display-3 mb-0">Reach new heights</h1>
-                        <h2 class="mb-4">Start your online course today!</h2>
-                        <div class="row mt-1 mb-3">
-                            <div class="col">
-                                <p>Skill up and have an impact! Your business career starts here.<br/>Time to start a course.</p>
+<template id="courses_home_side_bar">
+    <div class="container o_wslides_home_main">
+        <div class="row">
+            <t t-set="has_side_column" t-value="is_view_active('website_slides.toggle_leaderboard')"/>
+            <t t-if="is_public_user">
+                <div t-if="has_side_column">
+                    <div class="row">
+                        <div class="col-12 col-md-5 col-lg-12">
+                            <div class="ps-md-5 ps-lg-0">
+                                <t t-call="website_slides.slides_home_users_small"/>
                             </div>
                         </div>
                     </div>
                 </div>
-            </section>
-            </div>
-            <div class="container mt16 o_wslides_home_nav position-relative">
-                <nav class="navbar navbar-expand-lg navbar-light shadow-sm">
-                    <t t-call="website.website_search_box_input">
-                        <t t-set="_form_classes" t-valuef="o_wslides_nav_navbar_right order-lg-3"/>
-                        <t t-set="search_type" t-valuef="slides"/>
-                        <t t-set="action" t-valuef="/slides/all"/>
-                        <t t-set="display_description" t-valuef="true"/>
-                        <t t-set="display_detail" t-valuef="false"/>
-                        <t t-set="placeholder">Search courses</t>
-                        <input type="hidden" name="prevent_redirect" value="True"/>
-                    </t>
-                    <button class="navbar-toggler px-2 order-1" type="button"
-                        data-bs-toggle="collapse" data-bs-target="#navbarSlidesHomepage"
-                        aria-controls="navbarSlidesHomepage" aria-expanded="false" aria-label="Toggle navigation">
-                        <span class="navbar-toggler-icon"/>
-                    </button>
-                    <div class="collapse navbar-collapse order-2" id="navbarSlidesHomepage">
-                        <div class="navbar-nav pt-3 pt-lg-0">
-                            <a class="nav-link nav-link me-md-2 o_wslides_home_all_slides" href="/slides/all"><i class="fa fa-graduation-cap me-1"/>All courses</a>
+            </t>
+            <div t-else="">
+                <t t-set="has_side_column" t-value="True"/>
+                <div class="o_wslides_home_aside_loggedin card p-3 p-lg-0 mb-4">
+                    <div class="o_wslides_home_aside_title">
+                        <div class="d-flex align-items-center">
+                            <t t-call="website_slides.slides_misc_user_image">
+                                <t t-set="img_class" t-value="'rounded-circle me-1'"/>
+                                <t t-set="img_style" t-value="'width: 22px; height: 22px;'"/>
+                            </t>
+                            <h5 t-esc="user.name" class="d-flex flex-grow-1 mb-0"/>
+                            <a class="d-none d-lg-block" t-att-href="'/profile/user/%s' % user.id">View</a>
+                            <a class="d-lg-none btn btn-sm bg-white border" href="#" data-bs-toggle="collapse" data-bs-target="#o_wslides_home_aside_content">More info</a>
+                        </div>
+                        <hr class="d-none d-lg-block mt-2 mb-2 mb-1"/>
+                    </div>
+                    <div id="o_wslides_home_aside_content" class="collapse d-lg-block">
+                        <div class="row g-0 mb-5 mt-3 mt-lg-0">
+                            <div class="col-12 col-sm-6 col-lg-12">
+                                <t t-call="website_slides.slides_home_user_profile_small"/>
+                            </div>
+                            <div class="col-12 col-sm-6 col-lg-12 ps-md-5 ps-lg-0 mt-lg-4">
+                                <t t-call="website_slides.slides_home_user_achievements_small"/>
+                            </div>
+                            <div class="col-12 col-md-7 col-lg-12 ps-md-5 ps-lg-0 mt-lg-4 mb-3">
+                                <t t-call="website_slides.slides_home_achievements_small"/>
+                            </div>
+                            <div class="col-12 col-sm-6 col-lg-12 ps-md-5 ps-lg-0 mt-lg-4">
+                                <t t-call="website_slides.slides_home_users_small"/>
+                            </div>
                         </div>
                     </div>
-                </nav>
+                </div>
+            </div>
+        </div>
+    </div>
+</template>
+
+<template id="courses_my">
+    <div t-if="channels_my" class="container">
+        <div class="o_wslides_home_content_section mb-4">
+            <div t-foreach="channels_my" t-as="channel">
+                <div class="row">
+                    <div class="col-6">
+                        <a t-if="channel.is_member and not channel.completed" t-attf-href="/slides/#{slug(channel)}"
+                           t-out="channel.name"/>
+                        <span t-else="" t-field="channel.name"/>
+                        <span t-if="not channel.is_published" class="badge text-bg-danger">Unpublished</span>
+                    </div>
+                    <div class="col-4 d-flex justify-content-between align-items-center">
+                        <t t-if="channel.is_member and channel.completed">
+                            <div class="badge rounded-pill text-bg-success pull-right"><i class="fa fa-check"/> Completed</div>
+                        </t>
+                        <t t-elif="channel.is_member and channel.channel_type != 'documentation'">
+                            <div class="d-none d-md-block flex-grow-1">
+                                <div class="progress me-3" style="height: 6px">
+                                    <div class="progress-bar" role="progressbar" t-att-aria-valuenow="channel.completion" aria-valuemin="0" aria-valuemax="100" t-attf-style="width:#{channel.completion}%;" aria-label="Progress bar"/>
+                                </div>
+                            </div>
+                            <div>
+                                <t t-out="channel.completion"/> %
+                            </div>
+                        </t>
+                        <div t-else=""><b t-esc="channel.total_slides"/> steps</div>
+                        <div class="ms-4 text-muted">
+                            <t t-out="'{:.1f}'.format(channel.total_time).rstrip('.0')"/> hours
+                        </div>
+                    </div>
+                    <div class="col-2 d-flex flex-row-reverse">
+                        <a t-if="channel.is_member and not channel.completed" class="d-flex align-items-center" t-attf-href="/slides/#{slug(channel)}">
+                            <div class="d-none d-md-block me-2">Continue</div><i class="oi oi-arrow-right me-1"/>
+                        </a>
+                    </div>
+                </div>
+                <div t-if="not channel_last" class="row mx-1 mt-2">
+                    <hr/>
+                </div>
+            </div>
+        </div>
+    </div>
+</template>
+
+<!-- Channels home template -->
+<template id='courses_home' name="Odoo Courses Homepage">
+    <t t-set="body_classname" t-value="'o_wslides_body'"/>
+    <t t-set="has_side_column" t-value="not is_public_user or is_view_active('website_slides.toggle_leaderboard')"/>
+    <t t-call="website.layout">
+        <div id="wrap" class="wrap o_wslides_wrap">
+<div class="container-fluid mt-2">
+    <div class="row">
+        <div t-attf-class="#{'col-12 col-lg-9 order-2 order-lg-1' if has_side_column else 'col-12'}">
+            <div t-if="invite_error_msg" role="alert" class="o_not_editable alert alert-danger text-center" t-esc="invite_error_msg"/>
+            <div class="container o_wslides_home_nav">
                 <div class="o_wprofile_email_validation_container">
                     <t t-call="website_profile.email_validation_banner">
                         <t t-set="redirect_url" t-value="'/slides'"/>
@@ -53,280 +118,148 @@
                     </t>
                 </div>
             </div>
-
-            <div class="container o_wslides_home_main">
-                <div class="row">
-                    <t t-set="has_side_column" t-value="is_view_active('website_slides.toggle_leaderboard')"/>
-                    <t t-if="is_public_user">
-                        <div t-if="has_side_column" class="col-lg-3 order-3 order-lg-2">
-                            <div class="row">
-                                <div class="col-12 col-md-5 col-lg-12">
-                                    <div class="ps-md-5 ps-lg-0">
-                                        <t t-call="website_slides.slides_home_users_small"/>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </t>
-                    <div t-else="" class="col-lg-3 order-lg-2">
-                        <t t-set="has_side_column" t-value="True"/>
-                        <div class="o_wslides_home_aside_loggedin card p-3 p-lg-0 mb-4">
-                            <div class="o_wslides_home_aside_title">
-                                <div class="d-flex align-items-center">
-                                    <t t-call="website_slides.slides_misc_user_image">
-                                        <t t-set="img_class" t-value="'rounded-circle me-1'"/>
-                                        <t t-set="img_style" t-value="'width: 22px; height: 22px;'"/>
-                                    </t>
-                                    <h5 t-esc="user.name" class="d-flex flex-grow-1 mb-0"/>
-                                    <a class="d-none d-lg-block" t-att-href="'/profile/user/%s' % user.id">View</a>
-                                    <a class="d-lg-none btn btn-sm bg-white border" href="#" data-bs-toggle="collapse" data-bs-target="#o_wslides_home_aside_content">More info</a>
-                                </div>
-                                <hr class="d-none d-lg-block mt-2 mb-2 mb-1"/>
-                            </div>
-                            <div id="o_wslides_home_aside_content" class="collapse d-lg-block">
-                                <div class="row g-0 mb-5 mt-3 mt-lg-0">
-                                    <div class="col-12 col-sm-6 col-lg-12">
-                                        <t t-call="website_slides.slides_home_user_profile_small"/>
-                                    </div>
-                                    <div class="col-12 col-sm-6 col-lg-12 ps-md-5 ps-lg-0 mt-lg-4">
-                                        <t t-call="website_slides.slides_home_user_achievements_small"/>
-                                    </div>
-                                    <div class="col-12 col-md-7 col-lg-12 ps-md-5 ps-lg-0 mt-lg-4 mb-3">
-                                        <t t-call="website_slides.slides_home_achievements_small"/>
-                                    </div>
-                                    <div class="col-12 col-sm-6 col-lg-12 ps-md-5 ps-lg-0 mt-lg-4">
-                                        <t t-call="website_slides.slides_home_users_small"/>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <div t-att-class="'col-lg-9 pe-lg-5 order-lg-1' if has_side_column else 'col-lg pr-lg'">
-                        <div t-if="invite_error_msg" role="alert" class="o_not_editable alert alert-danger text-center" t-esc="invite_error_msg"/>
-                        <div class="o_wslides_home_content_section mb-3"
-                            t-if="not channels_popular">
-                            <p class="h2">No Course created yet.</p>
-                            <p groups="website_slides.group_website_slides_officer">Click on "New" in the top-right corner to write your first course.</p>
-                        </div>
-                        <t t-if="channels_my">
-                            <t t-set="void_count" t-value="3 - len(channels_my[:3])"/>
-                            <div class="o_wslides_home_content_section mb-3">
-                                <div class="row o_wslides_home_content_section_title align-items-center">
-                                    <div class="col">
-                                        <a href="/slides/all?my=1" class="float-end">View all</a>
-                                        <h5 class="m-0">My courses</h5>
-                                        <hr class="mt-2 mb-2"/>
-                                    </div>
-                                </div>
-                                <div class="row mx-n2 mt8">
-                                    <t t-foreach="channels_my[:3]" t-as="channel">
-                                        <div class="col-md-4 col-sm-6 px-2 col-xs-12 d-flex">
-                                            <t t-call="website_slides.course_card"/>
-                                        </div>
-                                    </t>
-                                </div>
-                            </div>
-                        </t>
-                        <div class="o_wslides_home_content_section mb-3"
-                            t-if="channels_popular">
-                            <div class="row o_wslides_home_content_section_title align-items-center">
-                                <div class="col">
-                                    <a href="slides/all" class="float-end">View all</a>
-                                    <h5 class="m-0">Most popular courses</h5>
-                                    <hr class="mt-2 mb-2"/>
-                                </div>
-                            </div>
-                            <div class="row mx-n2 mt8">
-                                <t t-foreach="channels_popular[:3]" t-as="channel">
-                                    <div class="col-md-4 col-sm-6 px-2 col-xs-12 d-flex">
-                                        <t t-call="website_slides.course_card"/>
-                                    </div>
-                                </t>
-                            </div>
-                        </div>
-                        <div class="o_wslides_home_content_section mb-3"
-                            t-if="channels_newest">
-                            <div class="row o_wslides_home_content_section_title align-items-center">
-                                <div class="col">
-                                    <a href="slides/all" class="float-end">View all</a>
-                                    <h5 class="m-0">Newest courses</h5>
-                                    <hr class="mt-2 mb-2"/>
-                                </div>
-                            </div>
-                            <div class="row mx-n2 mt8">
-                                <t t-foreach="channels_newest[:3]" t-as="channel">
-                                    <div class="col-md-4 col-sm-6 px-2 col-xs-12 d-flex">
-                                        <t t-call="website_slides.course_card"/>
-                                    </div>
-                                </t>
-                            </div>
-                        </div>
-                    </div>
-                </div>
+            <t t-call="website_slides.courses_search_bar"/>
+            <div class="container o_wslides_home_content_section mb-3"
+                t-if="not has_channel">
+                <p class="h2">No Course created yet.</p>
+                <p groups="website_slides.group_website_slides_officer">Click on "New" in the top-right corner to write your first course.</p>
             </div>
-            <t t-call="website_slides.courses_footer"></t>
+            <t t-if="search_my" t-call="website_slides.courses_my"/>
+            <t t-call="website_slides.courses_search_results"/>
+        </div>
+        <div t-if="has_side_column" class="col-12 col-lg-3 order-1 order-lg-2 mt-1">
+            <t t-call="website_slides.courses_home_side_bar"/>
+        </div>
+    </div>
+</div>
+<t t-call="website_slides.courses_footer"></t>
         </div>
     </t>
 </template>
 
-<!-- Channel all/main template -->
-<template id='courses_all' name="Odoo All Courses">
-    <t t-set="body_classname" t-value="'o_wslides_body'"/>
-    <t t-call="website.layout">
-        <div id="wrap" class="wrap o_wslides_wrap">
+<template id="courses_search_bar">
+    <div class="container o_wslides_home_nav">
+        <!-- Navbar dynamically composed using displayed channel tag groups. -->
+        <nav class="navbar navbar-expand-md navbar-light shadow-sm px-2 mb-4">
             <!-- Repeat structure for every section to allow customization through website editor. !-->
-            <div class="oe_structure oe_empty" t-if="search_my">
-                <section class="s_banner" data-snippet="s_banner"
-                         style="background-color:(0, 0, 0, 0); background-image: url(&quot;/website_slides/static/src/img/banner_default_all.svg&quot;); background-size: cover; background-position: 80% 20%">
-                    <div class="container py-5"><h1 class="display-3 mb-0 text-white">My Courses</h1></div>
-                </section>
+            <div class="oe_structure oe_empty fw-bold" t-if="search_my and channels_my">My Courses</div>
+            <div class="oe_structure oe_empty fw-bold" t-elif="search_slide_category == 'certification'">Certifications</div>
+            <div class="oe_structure oe_empty fw-bold" t-else="">Online Courses</div>
+            <!-- Clear filtering (mobile)-->
+            <div class="text-nowrap ms-auto d-md-none" t-if="search_slide_category or search_tags">
+                <a href="/slides" class="btn btn-info me-2" role="button" title="Clear filters">
+                    <i class="fa fa-eraser"/> Clear filters
+                </a>
             </div>
-            <div class="oe_structure oe_empty" t-elif="search_slide_category == 'certification'">
-               <section class="s_banner" data-snippet="s_banner"
-                        style="background-color:(0, 0, 0, 0); background-image: url(&quot;/website_slides/static/src/img/banner_default_all.svg&quot;); background-size: cover; background-position: 80% 20%">
-                    <div class="container py-5"><h1 class="display-3 mb-0 text-white">Certifications</h1></div>
-                </section>
-            </div>
-            <div class="oe_structure oe_empty" t-else="">
-                <section class="s_banner" data-snippet="s_banner"
-                         style="background-color:(0, 0, 0, 0); background-image: url(&quot;/website_slides/static/src/img/banner_default_all.svg&quot;); background-size: cover; background-position: 80% 20%">
-                    <div class="container py-5"><h1 class="display-3 mb-0 text-white">All Courses</h1></div>
-                </section>
-            </div>
-            <div class="container mt16 o_wslides_home_nav position-relative">
-                <!-- Navbar dynamically composed using displayed channel tag groups. -->
-                <nav class="navbar navbar-expand-md navbar-light shadow-sm ps-0">
-                    <div class="navbar-nav border-end">
-                        <a class="nav-link nav-item px-3" href="/slides"><i class="oi oi-chevron-left"/></a>
-                    </div>
-                    <!-- Clear filtering (mobile)-->
-                    <div class="text-nowrap ms-auto d-md-none" t-if="search_slide_category or search_my or search_tags">
-                        <a href="/slides/all" class="btn btn-info me-2" role="button" title="Clear filters">
-                            <i class="fa fa-eraser"/> Clear filters
-                        </a>
-                    </div>
-                    <t t-else="" t-call="website.website_search_box_input">
-                        <!-- Search box (mobile)-->
-                        <t t-set="_form_classes" t-valuef="o_wslides_nav_navbar_right d-md-none"/>
-                        <t t-set="search_type" t-valuef="slides"/>
-                        <!-- No action: remain on same URL -->
-                        <t t-set="display_description" t-valuef="true"/>
-                        <t t-set="display_detail" t-valuef="false"/>
-                        <t t-set="placeholder">Search courses</t>
-                        <t t-set="search" t-value="original_search or search_term"/>
-                        <input t-if="search_my" type="hidden" name="my" t-att-value="1"/>
-                        <input t-if="search_slide_category" type="hidden" name="slide_category" t-att-value="search_slide_category" />
-                        <input type="hidden" name="prevent_redirect" value="True"/>
-                    </t>
-                    <button class="navbar-toggler px-1" type="button"
-                        data-bs-toggle="collapse" data-bs-target="#navbarTagGroups"
-                        aria-controls="navbarTagGroups" aria-expanded="false" aria-label="Toggle navigation">
-                        <span class="navbar-toggler-icon small"/>
-                    </button>
-                    <div class="collapse navbar-collapse" id="navbarTagGroups">
-                        <t t-set="search_tag_groups" t-value="search_tags.mapped('group_id')"/>
-                        <ul class="navbar-nav flex-grow-1">
-                            <t t-foreach="tag_groups" t-as="tag_group">
-                                <t t-set="group_frontend_tags" t-value="tag_group.tag_ids.filtered(lambda tag: tag.color)"/>
-                                <li class="nav-item dropdown ml16" t-if="group_frontend_tags">
-                                    <a t-att-class="'nav-link dropdown-toggle %s' % ('active' if tag_group in search_tag_groups else '')"
-                                        href="/slides/all"
-                                        t-att-data-bs-target="'#navToogleTagGroup%s' % tag_group.id"
-                                        role="button" data-bs-toggle="dropdown"
-                                        aria-haspopup="true" aria-expanded="false"
-                                        t-esc="tag_group.name"/>
-                                    <div class="dropdown-menu" t-att-id="'navToogleTagGroup%s' % tag_group.id">
-                                        <t t-foreach="group_frontend_tags" t-as="tag">
-                                            <span t-att-class="'post_link cursor-pointer dropdown-item %s' % ('active' if tag in search_tags else '')"
-                                                t-att-data-post="slide_query_url(tag=slugify_tags(search_tags.ids, toggle_tag_id=tag.id), my=search_my, search=search_term, slide_category=search_slide_category, prevent_redirect=True)"
-                                                t-esc="tag.name"/>
-                                        </t>
-                                    </div>
-                                </li>
-                            </t>
-                        </ul>
-                        <!-- Clear filtering (desktop)-->
-                        <div class="ms-auto d-none d-md-flex" t-if="search_slide_category or search_my or search_tags">
-                            <a href="/slides/all" class="btn btn-info text-nowrap me-2" role="button" title="Clear filters">
-                                <i class="fa fa-eraser"/> Clear filters
-                            </a>
-                        </div>
-                        <!-- Search box (desktop) -->
-                        <t t-call="website.website_search_box_input">
-                            <t t-set="_form_classes" t-valuef="o_wslides_nav_navbar_right d-none d-md-flex"/>
-                            <t t-set="search_type" t-valuef="slides"/>
-                            <!-- No action: remain on same URL -->
-                            <t t-set="display_description" t-valuef="true"/>
-                            <t t-set="display_detail" t-valuef="false"/>
-                            <t t-set="placeholder">Search courses</t>
-                            <t t-set="search" t-value="original_search or search_term"/>
-                            <input t-if="search_my" type="hidden" name="my" t-att-value="1"/>
-                            <input t-if="search_slide_category" type="hidden" name="slide_category" t-att-value="search_slide_category" />
-                            <input type="hidden" name="prevent_redirect" value="True"/>
-                        </t>
-                    </div>
-                </nav>
-                <div class="o_wprofile_email_validation_container mb16 mt16">
-                    <t t-call="website_profile.email_validation_banner">
-                        <t t-set="redirect_url" t-value="'/slides'"/>
-                        <t t-set="additional_validation_email_message"> and join this Community</t>
-                        <t t-set="additional_validated_email_message"> You may now participate in our eLearning.</t>
-                    </t>
-                </div>
-                <!-- Display tags -->
-                <t t-if="search_my">
-                      <span class="align-items-baseline border d-inline-flex ps-2 rounded mb-2">
-                      <i class="fa fa-tag me-2 text-muted"/>
-                      My Courses
-                      <span t-att-data-post="slide_query_url(tag=slugify_tags(search_tags.ids), search=search_term, prevent_redirect=True)"
-                         class="post_link cursor-pointer btn border-0 py-1">&#215;</span>
-                    </span>
-                </t>
-                <t t-if="search_term">
-                      <span class="align-items-baseline border d-inline-flex ps-2 rounded mb-2">
-                      <i class="fa fa-tag me-2 text-muted"/>
-                      <t t-esc="search_term"/>
-                      <span t-att-data-post="slide_query_url(tag=slugify_tags(search_tags.ids), my=search_my, slide_category=search_slide_category, prevent_redirect=True)"
-                         class="post_link cursor-pointer btn border-0 py-1">&#215;</span>
-                    </span>
-                </t>
-                <t t-foreach="search_tags" t-as="tag">
-                    <span class="align-items-baseline border d-inline-flex ps-2 rounded mb-2">
-                        <i class="fa fa-tag me-2 text-muted"/>
-                        <t t-esc="tag.display_name"/>
-                        <span t-att-data-post='slide_query_url(tag=slugify_tags(search_tags.ids, tag.id), my=search_my, search=search_term, slide_category=search_slide_category, prevent_redirect=True)'
-                            class="post_link cursor-pointer btn border-0 py-1">&#215;</span>
-                    </span>
-                </t>
-            </div>
-            <div class="container o_wslides_home_main pb-5">
-                <div t-if="not channels and not search_term and not search_slide_category and not search_my and not search_tags">
-                    <p class="h2">No Course created yet.</p>
-                    <p groups="website_slides.group_website_slides_officer">Click on "New" in the top-right corner to write your first course.</p>
-                </div>
-                <div t-elif="search_term and not channels" class="alert alert-info mb-5">
-                    No course was found matching your search <code><t t-esc="search_term"/></code>.
-                </div>
-                <div t-elif="not channels" class="alert alert-info mb-5">
-                    No course was found matching your search.
-                </div>
-                <t t-else="">
-                    <div t-if="original_search" class="alert alert-warning mb-5">
-                        No results found for '<span t-esc="original_search"/>'. Showing results for '<span t-esc="search_term"/>'.
-                    </div>
-                    <div class="row mx-n2">
-                        <t t-foreach="channels" t-as="channel">
-                            <div class="col-12 col-sm-6 col-md-4 col-lg-3 px-2 d-flex">
-                                <t t-call="website_slides.course_card"/>
+            <t t-else="" t-call="website.website_search_box_input">
+                <!-- Search box (mobile)-->
+                <t t-set="_form_classes" t-valuef="o_wslides_nav_navbar_right d-md-none"/>
+                <t t-set="search_type" t-valuef="slides"/>
+                <!-- No action: remain on same URL -->
+                <t t-set="display_description" t-valuef="true"/>
+                <t t-set="display_detail" t-valuef="false"/>
+                <t t-set="placeholder">Search courses</t>
+                <t t-set="search" t-value="original_search or search_term"/>
+                <input type="hidden" name="my" t-attf-value="#{'1' if search_my else '0'}"/>
+                <input t-if="search_slide_category" type="hidden" name="slide_category" t-att-value="search_slide_category" />
+                <input type="hidden" name="prevent_redirect" value="True"/>
+            </t>
+            <button class="navbar-toggler px-1" type="button"
+                data-bs-toggle="collapse" data-bs-target="#navbarTagGroups"
+                aria-controls="navbarTagGroups" aria-expanded="false" aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon small"/>
+            </button>
+            <div class="collapse navbar-collapse" id="navbarTagGroups">
+                <t t-set="search_tag_groups" t-value="search_tags.mapped('group_id')"/>
+                <ul class="navbar-nav flex-grow-1">
+                    <t t-foreach="tag_groups" t-as="tag_group">
+                        <t t-set="group_frontend_tags" t-value="tag_group.tag_ids.filtered(lambda tag: tag.color)"/>
+                        <li class="nav-item dropdown ml16" t-if="group_frontend_tags">
+                            <a t-att-class="'nav-link dropdown-toggle %s' % ('active' if tag_group in search_tag_groups else '')"
+                                href="/slides"
+                                t-att-data-bs-target="'#navToogleTagGroup%s' % tag_group.id"
+                                role="button" data-bs-toggle="dropdown"
+                                aria-haspopup="true" aria-expanded="false"
+                                t-esc="tag_group.name"/>
+                            <div class="dropdown-menu" t-att-id="'navToogleTagGroup%s' % tag_group.id">
+                                <t t-foreach="group_frontend_tags" t-as="tag">
+                                    <span t-att-class="'post_link cursor-pointer dropdown-item %s' % ('active' if tag in search_tags else '')"
+                                          t-att-data-post="slide_query_url(tag=slugify_tags(search_tags.ids, toggle_tag_id=tag.id), my=search_my, search=search_term, slide_category=search_slide_category, prevent_redirect=True)"
+                                          t-esc="tag.name"/>
+                                </t>
                             </div>
-                        </t>
+                        </li>
+                    </t>
+                </ul>
+                <!-- Clear filtering (desktop)-->
+                <div class="ms-auto d-none d-md-flex" t-if="search_slide_category or search_tags">
+                    <a href="/slides" class="btn btn-info text-nowrap me-2" role="button" title="Clear filters">
+                        <i class="fa fa-eraser"/> Clear filters
+                    </a>
+                </div>
+                <!-- Search box (desktop) -->
+                <t t-call="website.website_search_box_input">
+                    <t t-set="_form_classes" t-valuef="o_wslides_nav_navbar_right d-none d-md-flex"/>
+                    <t t-set="search_type" t-valuef="slides"/>
+                    <!-- No action: remain on same URL -->
+                    <t t-set="display_description" t-valuef="true"/>
+                    <t t-set="display_detail" t-valuef="false"/>
+                    <t t-set="placeholder">Search courses</t>
+                    <t t-set="search" t-value="original_search or search_term"/>
+                    <input type="hidden" name="my" t-attf-value="#{'1' if search_my else '0'}"/>
+                    <input t-if="search_slide_category" type="hidden" name="slide_category" t-att-value="search_slide_category" />
+                    <input type="hidden" name="prevent_redirect" value="True"/>
+                </t>
+            </div>
+        </nav>
+    </div>
+</template>
+
+<template id="courses_search_tags">
+    <t t-if="search_term">
+          <span class="align-items-baseline border d-inline-flex ps-2 rounded mb-2">
+          <i class="fa fa-tag me-2 text-muted"/>
+          <t t-esc="search_term"/>
+          <span t-att-data-post="slide_query_url(tag=slugify_tags(search_tags.ids), my=search_my, slide_category=search_slide_category, prevent_redirect=True)"
+                         class="post_link cursor-pointer btn border-0 py-1">&#215;</span>
+        </span>
+    </t>
+    <t t-foreach="search_tags" t-as="tag">
+        <span class="align-items-baseline border d-inline-flex ps-2 rounded mb-2">
+            <i class="fa fa-tag me-2 text-muted"/>
+            <t t-esc="tag.display_name"/>
+            <span t-att-data-post="slide_query_url(tag=slugify_tags(search_tags.ids, tag.id), my=search_my, search=search_term, slide_category=search_slide_category, prevent_redirect=True)"
+                         class="post_link cursor-pointer btn border-0 py-1">&#215;</span>
+        </span>
+    </t>
+</template>
+
+<template id="courses_search_results">
+    <div class="container o_wslides_home_main pb-5">
+        <t t-call="website_slides.courses_search_tags"/>
+        <div t-if="not channels and not search_term and not search_slide_category and not search_my and not search_tags">
+            <p class="h2">No Course created yet.</p>
+            <p groups="website_slides.group_website_slides_officer">Click on "New" in the top-right corner to write your first course.</p>
+        </div>
+        <div t-elif="search_term and not channels" class="alert alert-info mb-5">
+            No course was found matching your search <code><t t-esc="search_term"/></code>.
+        </div>
+        <div t-elif="not channels" class="alert alert-info mb-5">
+            No course was found matching your search.
+        </div>
+        <t t-else="">
+            <div t-if="original_search" class="alert alert-warning mb-5">
+                No results found for '<span t-esc="original_search"/>'. Showing results for '<span t-esc="search_term"/>'.
+            </div>
+            <div class="row mx-n2">
+                <t t-foreach="channels" t-as="channel">
+                    <div class="col-12 col-sm-6 col-md-4 col-lg-3 px-2 d-flex">
+                        <t t-call="website_slides.course_card"/>
                     </div>
                 </t>
             </div>
-
-            <t t-call="website_slides.courses_footer"></t>
-        </div>
-    </t>
+        </t>
+    </div>
 </template>
 
 <template id='courses_footer'>
@@ -352,11 +285,11 @@
                     <t t-foreach="channel_frontend_tags" t-as="tag">
                         <t t-if="search_tags">
                             <span t-att-data-post="slide_query_url(tag=slugify_tags(search_tags.ids, toggle_tag_id=tag.id), my=search_my, search=search_term, slide_category=search_slide_category, prevent_redirect=True)"
-                                t-attf-class="post_link cursor-pointer badge o_badge_clickable #{'text-bg-primary' if tag in search_tags else 'o_wslides_channel_tag o_color_0'}" t-esc="tag.name"/>
+                                  t-attf-class="post_link cursor-pointer badge o_badge_clickable #{'text-bg-primary' if tag in search_tags else 'o_wslides_channel_tag o_color_0'}" t-esc="tag.name"/>
                         </t>
                         <t t-else="">
                             <span t-att-data-post="slide_query_url(tag=slugify_tags(search_tags.ids, toggle_tag_id=tag.id), my=search_my, search=search_term, slide_category=search_slide_category, prevent_redirect=True)"
-                                t-attf-class="post_link cursor-pointer badge o_badge_clickable o_wslides_channel_tag #{'o_color_'+str(tag.color)}" t-esc="tag.name"/>
+                                  t-attf-class="post_link cursor-pointer badge o_badge_clickable o_wslides_channel_tag #{'o_color_'+str(tag.color)}" t-esc="tag.name"/>
                         </t>
                     </t>
                 </div>

--- a/addons/website_slides/views/website_slides_templates_homepage.xml
+++ b/addons/website_slides/views/website_slides_templates_homepage.xml
@@ -26,7 +26,7 @@
                                 <t t-set="img_style" t-value="'width: 22px; height: 22px;'"/>
                             </t>
                             <h5 t-esc="user.name" class="d-flex flex-grow-1 mb-0"/>
-                            <a class="d-none d-lg-block" t-att-href="'/profile/user/%s' % user.id">View</a>
+                            <a class="d-none d-lg-block" t-att-href="'/profile/user/%s?slides_origin=%s' % (user.id, request.httprequest.path)">View</a>
                             <a class="d-lg-none btn btn-sm bg-white border" href="#" data-bs-toggle="collapse" data-bs-target="#o_wslides_home_aside_content">More info</a>
                         </div>
                         <hr class="d-none d-lg-block mt-2 mb-2 mb-1"/>

--- a/addons/website_slides/views/website_slides_templates_profile.xml
+++ b/addons/website_slides/views/website_slides_templates_profile.xml
@@ -25,7 +25,7 @@
                     </div>
                     <div t-else="" class="text-muted d-inline-block">No completed courses yet!</div>
                     <div t-if="request.env.user != user" class="text-end d-inline-block pull-right">
-                        <a href="/slides/all" class="btn btn-link btn-sm"><i class="oi oi-arrow-right me-1"/>All Courses</a>
+                        <a href="/slides?my=0" class="btn btn-link btn-sm"><i class="oi oi-arrow-right me-1"/>All Courses</a>
                     </div>
                 </div>
                 <div class="mb32">
@@ -57,7 +57,7 @@
 
                             <div class="overflow-hidden mb-1" style="height:24px">
                                 <t t-foreach="course.channel_id.tag_ids.filtered(lambda tag: tag.color)" t-as="tag">
-                                    <a t-att-href="'/slides/all/tag/%s' % slug(tag)" onclick="event.stopPropagation()" t-attf-class="badge o_wslides_channel_tag post_link #{'o_color_'+str(tag.color)}" t-esc="tag.name"/>
+                                    <a t-att-href="'/slides/tag/%s?my=0' % slug(tag)" onclick="event.stopPropagation()" t-attf-class="badge o_wslides_channel_tag post_link #{'o_color_'+str(tag.color)}" t-esc="tag.name"/>
                                 </t>
                             </div>
 

--- a/addons/website_slides_survey/views/website_profile.xml
+++ b/addons/website_slides_survey/views/website_profile.xml
@@ -35,7 +35,7 @@
                 <t t-if="not user_inputs">
                     <p t-if="certification_search_terms">No certification found for the given search term.</p>
                     <p t-else="">You have not taken any certification yet.</p>
-                    <a href="/slides/all?slide_category=certification">
+                    <a href="/slides?my=0&amp;slide_category=certification">
                         <i class="oi oi-arrow-right"/> See Certifications
                     </a>
                 </t>
@@ -96,7 +96,7 @@
          <t t-elif="my_profile">
             <div class="text-muted d-inline-block">
                 Certifications are exams that you successfully passed. <br />
-                <a href="/slides/all?slide_type=certification" class="btn-link">
+                <a href="/slides?my=0&amp;slide_type=certification" class="btn-link">
                     <i class="fa fa-arrow-right"></i> Get Certified
                 </a>
             </div>
@@ -104,7 +104,7 @@
         <t t-else="">
             <div class="text-muted d-inline-block">No certifications yet!</div>
             <div class="text-end d-inline-block pull-right">
-                <a href="/slides/all?slide_category=certification" class="btn btn-link btn-sm"><i class="oi oi-arrow-right me-1"/>All Certifications</a>
+                <a href="/slides?slide_category=certification" class="btn btn-link btn-sm"><i class="oi oi-arrow-right me-1"/>All Certifications</a>
             </div>
         </t>
     </template>

--- a/addons/website_slides_survey/views/website_profile.xml
+++ b/addons/website_slides_survey/views/website_profile.xml
@@ -21,9 +21,10 @@
             <div t-if="show_certification_tab" role="tabpanel" t-attf-class="tab-pane #{ 'show active' if active_tab == 'certification' else '' }" id="profile_tab_content_certification">
                 <h5 class="d-flex justify-content-between align-items-end border-bottom pb-1">
                     Certification Attempts
-                    <form method="get">
+                    <form method="post">
                         <div class="input-group" role="search">
                             <input type="text" class="form-control" name="certification_search" t-att-value="certification_search_terms or ''" placeholder="Search Attempts..."/>
+                            <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
                             <div class="input-group-append">
                                 <button type="submit" class="btn btn-primary" aria-label="Search" title="Search">
                                     <i class="fa fa-search"/>

--- a/addons/website_slides_survey/views/website_slides_templates_homepage.xml
+++ b/addons/website_slides_survey/views/website_slides_templates_homepage.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <data>
-        <template id="courses_home_inherit_survey" inherit_id="website_slides.courses_home">
-            <xpath expr="//a[hasclass('o_wslides_home_all_slides')]" position="after">
-                <a class="nav-link nav-link d-flex" href="/slides/all?slide_category=certification">
+        <template id="courses_search_bar_inherit_survey" inherit_id="website_slides.courses_search_bar">
+            <xpath expr="//div[@id='navbarTagGroups']" position="before">
+                <a t-if="search_slide_category != 'certification'" class="nav-link nav-link d-flex mx-3" href="/slides?my=0&amp;slide_category=certification">
                     <t t-call="website_slides_survey.o_wss_certification_icon"/>
                     <span class="ms-1">Certifications</span>
                 </a>

--- a/addons/website_slides_survey/views/website_slides_templates_homepage.xml
+++ b/addons/website_slides_survey/views/website_slides_templates_homepage.xml
@@ -3,7 +3,8 @@
     <data>
         <template id="courses_search_bar_inherit_survey" inherit_id="website_slides.courses_search_bar">
             <xpath expr="//div[@id='navbarTagGroups']" position="before">
-                <a t-if="search_slide_category != 'certification'" class="nav-link nav-link d-flex mx-3" href="/slides?my=0&amp;slide_category=certification">
+                <a t-if="search_slide_category != 'certification'" class="nav-link nav-link d-flex mx-3"
+                   t-att-href="slide_query_url(tag=slugify_tags(search_tags.ids), my=search_my, search=search_term, slide_category='certification')">
                     <t t-call="website_slides_survey.o_wss_certification_icon"/>
                     <span class="ms-1">Certifications</span>
                 </a>
@@ -15,6 +16,20 @@
                 <div t-if="channel.nbr_certification > 0" class="position-absolute py-1 px-2 h5" style="right:0; top:0">
                     <t t-call="website_slides_survey.o_wss_certification_icon"/>
                 </div>
+            </xpath>
+        </template>
+
+        <template id="courses_search_results_inherit_survey" inherit_id="website_slides.courses_search_results">
+            <xpath expr="//t[@t-call='website_slides.courses_search_tags']" position="before">
+                <t t-if="search_slide_category">
+                    <span class="align-items-baseline border d-inline-flex ps-2 rounded mb-2">
+                        <span class="align-items-center me-1">
+                            <t t-call="website_slides_survey.o_wss_certification_icon"/>
+                        </span>
+                        Certification
+                        <a t-att-href="slide_query_url(tag=slugify_tags(search_tags.ids), my=search_my, search=search_term)" class="btn border-0 py-1 post_link">&#215;</a>
+                    </span>
+                </t>
             </xpath>
         </template>
     </data>


### PR DESCRIPTION
[IMP] website_slides{_survey}: prepare website_slides redesign

We merge the page /slides/all into the home page /slides, allowing to search course on the home page while still displaying the ongoing course and progression. This commit reorganize the html code for the redesign; it is then not the final one.

Note that we remove the survey button previously added by the website_slide_survey in the elearning home page as we now have a full search on the home page which allow to select certification by selecting the corresponding tag.

Technical notes:
- In the tour "certification_member", we had to update the selector of the course from contains("DIY Furniture") to contains("DIY Furniture - TEST") because there is a very similar course (almost same name and content) in the demo data named "DIY Furniture". And with the changes, that was the course of the demo data that was selected instead of the course setup for the test.
- In the method _slides_channel_user_values, we don't improve channels_all that retrieve all channels of the website because we still need to know if there are course for which the user is not member of. An alternative would be to transform that query into 2 small queries (one to get user course and one to know if there are other course).

[IMP] website_{forum|profile|slides}: improve profile breadcrumb

We improve the website_profile breadcrumb by adding at the beginning of it, a link from where we come from in those 2 cases:
- coming from the forum, we add a link to the forum, labeled as the forum name
- coming from the elearning home page, we add a link to elearning home page

Technical note: this added detail in the breadcrumb is lost when loading a new page. For example, when updating the profile it relies on parameter that won't necessarily be transmitted.

[IMP] website_forum: merge multiple profile tabs in one

We merge the profile tabs questions, answers and activities into one.

Technical note: the boostrap tabs (questions, answers and activities) are controlled by a drop-down. But as the bootstrap drop-down has no label by default, we use a widget to set it. That same widget also display the corresponding search field (respectively either question search, answer search or nothing).

Task-3893028