### PR TITLE
[FIX] pos_restaurant: load missing partners when loading orders

### DIFF
--- a/addons/pos_restaurant/static/src/overrides/models/pos_store.js
+++ b/addons/pos_restaurant/static/src/overrides/models/pos_store.js
@@ -194,6 +194,7 @@ patch(PosStore.prototype, {
             await this._syncTableOrdersToServer(); // to prevent losing the transferred orders
             const ordersJsons = await this._getTableOrdersFromServer(tableIds); // get all orders
             await this._loadMissingProducts(ordersJsons);
+            await this._loadMissingPartners(ordersJsons);
             return ordersJsons;
         } else {
             return await super._getOrdersJson();


### PR DESCRIPTION
Before this commit, when orders were loaded, if a partner was missing, it wouldn't be loaded.

Steps to reproduce:
1. Create a new order and create a new customer related to this order
2. From another device, load the order. The order will appear but with no customer defined.

opw-3926662

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
