### PR TITLE
[FIX] mrp: update qty in MO's of tracked product

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1396,6 +1396,18 @@ class MrpProduction(models.Model):
         self._set_lot_producing()
         if self.product_id.tracking == 'serial':
             self._set_qty_producing()
+            if self.warehouse_id.manufacture_steps != 'mrp_one_step':
+                is_waiting = self.picking_ids.filtered(
+                    lambda p: p.picking_type_id == self.warehouse_id.pbm_type_id
+                    and p.state not in ('done', 'cancel')
+                )
+                if is_waiting:
+                    moves_to_reset = self.move_raw_ids.filtered(
+                        lambda move: not (move.manual_consumption and move.picked)
+                        and move.product_id.type == 'product'
+                    )
+                    moves_to_reset.picked = False
+                    moves_to_reset.quantity = 0.0
         if self.picking_type_id.auto_print_generated_mrp_lot:
             return self._autoprint_generated_lot(self.lot_producing_id)
 

--- a/addons/mrp/tests/test_consume_component.py
+++ b/addons/mrp/tests/test_consume_component.py
@@ -384,3 +384,54 @@ class TestConsumeComponent(TestConsumeComponentCommon):
         testUnit(self.mo_lot_tmpl)
         testUnit(self.mo_serial_tmpl, 1)
         testUnit(self.mo_serial_tmpl, 2)
+
+    def test_tracked_production_2_steps_manufacturing(self):
+        """
+        Create an MO for a product tracked by SN in 2-steps manufacturing with tracked compoenents.
+        Assign a SN to the final product using the auto generation, then validate the pbm picking.
+        This test checks that the tracking of components is updated on the MO.
+        """
+        warehouse = self.env.ref('stock.warehouse0')
+        warehouse.manufacture_steps = 'pbm'
+        bom = self.bom_serial
+        bom.product_id = self.produced_serial
+        components = self.bom_serial.bom_line_ids.mapped('product_id')
+        lot_1 = self.env['stock.lot'].create({
+            'name': 'lot_1',
+            'product_id': components[1].id,
+            'company_id': self.env.company.id,
+        })
+        lot_2 = self.env['stock.lot'].create({
+            'name': 'SN01',
+            'product_id': components[2].id,
+            'company_id': self.env.company.id,
+        })
+        self.env['stock.quant']._update_available_quantity(components[0], self.env.ref('stock.warehouse0').lot_stock_id, 3)
+        self.env['stock.quant']._update_available_quantity(components[1], self.env.ref('stock.warehouse0').lot_stock_id, 2, lot_id=lot_1)
+        self.env['stock.quant']._update_available_quantity(components[2], self.env.ref('stock.warehouse0').lot_stock_id, 1, lot_id=lot_2)
+        mo = self.env['mrp.production'].create({
+            'product_id': bom.product_id.id,
+            'product_qty': 1,
+            'bom_id': bom.id,
+        })
+        mo.action_confirm()
+        self.assertRecordValues(mo.picking_ids.move_ids, [
+            {'quantity': 3.0, 'picked': False, 'lot_ids': []},
+            {'quantity': 2.0, 'picked': False, 'lot_ids': lot_1.ids},
+            {'quantity': 1.0, 'picked': False, 'lot_ids': lot_2.ids},
+        ])
+        mo.action_generate_serial()
+        self.assertRecordValues(mo.move_raw_ids, [
+            {'should_consume_qty': 3.0, 'quantity': 0.0, 'picked': False, 'lot_ids': []},
+            {'should_consume_qty': 2.0, 'quantity': 0.0, 'picked': False, 'lot_ids': []},
+            {'should_consume_qty': 1.0, 'quantity': 0.0, 'picked': False, 'lot_ids': []},
+        ])
+        self.assertTrue(mo.lot_producing_id)
+        mo.picking_ids.button_validate()
+        self.assertRecordValues(mo.move_raw_ids, [
+            {'quantity': 3.0, 'picked': False, 'lot_ids': []},
+            {'quantity': 2.0, 'picked': False, 'lot_ids': lot_1.ids},
+            {'quantity': 1.0, 'picked': False, 'lot_ids': lot_2.ids},
+        ])
+        mo.move_raw_ids.picked = True
+        mo.button_mark_done()


### PR DESCRIPTION
Issue 1:
---

### Steps to reproduce:

- Create a storable product P tracked by SN
- Create a consumable (or a storable with 5 units on hand) product
  COMP 1 and a storable product COMP 2 (without units on hand)
- Create a BOM for P with an operation op 1 and two component lines:
    - 1 x COMP 1 consumed in op 1
    - 1 x COMP 2 consumed in op 1
- Create and confirm an MO for 5 units of P
- Go to the shopfloor and click on register production.
**> the qty is updated to 1 on COMP 2 but to 5/1 on COMP 1**

As such, if you click on the 5/1, 5 units of COMP 1 will be consumed to produce only one unit of P

### Cause of the issue:

When you confirm the MO, since Comp 1 is a consumable its quantity is automatically set to 5.0 because reservation are bypassed. On the other hand, since Comp 2 is a storable without on hand qty, its quantity stays at 0.0. When you click on register production, or on the plus sign will trigger a call of the "_set_qty_producing" method. This call will update the qty_producing of the final product:
https://github.com/odoo/odoo/blob/f86c68ec8340a59407ea9c51dd0ba942f9b4429c/addons/mrp/models/mrp_production.py#L1214-L1218
However, the update of the qty consumed by the raw move will be bypassed because of these lines:
https://github.com/odoo/odoo/blob/f86c68ec8340a59407ea9c51dd0ba942f9b4429c/addons/mrp/models/mrp_production.py#L1225-L1226
https://github.com/odoo/enterprise/blob/0646022d7726a0cc183b191ca5be4e4bb4368f93/mrp_workorder/models/stock_move.py#L10-L13
And the quantity will therefore not be updated by these lines:
https://github.com/odoo/odoo/blob/f86c68ec8340a59407ea9c51dd0ba942f9b4429c/addons/mrp/models/mrp_production.py#L1228-L1231
However, as the quantity is not set to 0, it will be displayed as "quantity/should_consume_qty" and clicking on the raw move line will not update the quantity so 5 units will be marked as consumed ("picked").

Issue 2
---
### Steps to reproduce:

- Enable Multi-Step routes in the settings
- Go Inventory >  Configuration > Warehouse Management > Warehouses
- Enable 2-step manufacturing on your Warehouse
- Create 2 storable products:
    - product P: tracked by SN
    - product COMP: tracked by lot
- Update the "on hand qty" of COMP by creating a lot with 10 units
- Create and confirm a manufacturing order for 1 unit of P
- Assign a serial number to the final product
- Validate the transfer of components from stock to preproduction (The lot is automatically used on this transfer as it is available)

### Expected behavior:

Since the lot of COMP was used in the transfer from stock to preproduction it should be displayed on the raw move of the MO.

### Current behavior:

The raw move is not updated.

Note: if the transfer is validated before we assign a serial number to the final product, the lot of the component is correctly updated.

### Cause of the issue:

When the 'action_generate_serial' is triggered in order to assign a SN to the final product P, the '_set_qty_producing' is called in order adapt the quantities of the MO (produce only one unit and consume accordingly):
https://github.com/odoo/odoo/blob/37c67ba6d2bef0bdca715619f117c3124ef5d334/addons/mrp/models/mrp_production.py#L1397-L1398
https://github.com/odoo/odoo/blob/37c67ba6d2bef0bdca715619f117c3124ef5d334/addons/mrp/models/mrp_production.py#L1215-L1231
Now, changing the quantity of the stock move of the component to a positive quantity will trigger the inverse method '_set_quantity' of that field to adapt reservation by creating a stock.move.line. Therefore, validating the transfer of components from stock to pre-production will not update the lot of components on the raw move because the computed need will be at 0 here:
https://github.com/odoo/odoo/blob/3097ea49705a1b6319be9677152d65ebe3ce515b/addons/stock/models/stock_move.py#L1689-L1697
and the '_update_reserved_quantity' call will therefore be empty.

Issue 1: opw-3887580 and opw-3863572

Issue 2: opw-3925894

Enterprise: https://github.com/odoo/enterprise/pull/63912
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
