### PR TITLE
[IMP] mail: modifying follower mail template

### DIFF
--- a/addons/mail/__manifest__.py
+++ b/addons/mail/__manifest__.py
@@ -119,6 +119,7 @@ For more specific needs, you may also assign custom-defined actions
         'views/mail_menus.xml',
         'views/res_company_views.xml',
         "data/mail_canned_response_data.xml",
+        'data/mail_templates_invite.xml',
     ],
     'demo': [
         'demo/discuss_channel_demo.xml',

--- a/addons/mail/data/mail_templates_email_layouts.xml
+++ b/addons/mail/data/mail_templates_email_layouts.xml
@@ -79,7 +79,7 @@
     <div t-if="email_add_signature and not is_html_empty(signature)" t-out="signature" style="font-size: 13px;"/>
 </t>
 <!-- FOOTER -->
-<div style="margin-top:32px;">
+<div style="margin-top:16px;">
     <hr width="100%" style="background-color:rgb(204,204,204);border:medium none;clear:both;display:block;font-size:0px;min-height:1px;line-height:0; margin: 16px 0px 4px 0px;"/>
     <b t-out="company.name" style="font-size:11px;"/><br/>
     <p style="color: #999999; margin-top:2px; font-size:11px;">

--- a/addons/mail/data/mail_templates_invite.xml
+++ b/addons/mail/data/mail_templates_invite.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <template id="mail_notification_invite" inherit_id="mail.mail_notification_layout" primary="True">
+            <xpath expr="//td[@t-if='subtitles']" position="before">
+                <t t-if="not has_button_access">
+                    <t t-set="subtitles" t-value="False" />
+                </t>
+            </xpath>
+            <xpath expr="//div[@t-out='message.body']" position="before">
+                <hr width="100%"
+    style="background-color:rgb(204,204,204);border:medium none;clear:both;display:block;font-size:0px;min-height:1px;line-height:0;margin: 10px 0px;"/>
+            </xpath>
+            <xpath expr="//div[@t-out='message.body']" position="replace">
+                <div style="font-size:13px;">
+                    <div>
+                        <t t-out='message.author_id.name'/> (<t t-out='message.author_id.email'/>) added you as a follower of this <t t-out="model_description"/>.
+                    </div>
+                    <br t-if="len(message.body) > 0"/>
+                    <div style="color:grey;">
+                        <t t-out="message.body"/>
+                    </div>
+                </div>
+            </xpath>
+            <xpath expr="//tr[td/p[@t-if='subtype_internal']]" position="replace"/>
+            <xpath expr="//span[@id='mail_unfollow']" position="replace"/>
+            <xpath expr="//div[@style='margin-top:16px;']/hr" position="before">
+                <span id="mail_unfollow" style="font-size: 13px;">
+                    Not interested by this? <a href="/mail/unfollow" style="text-decoration:none; color:#555555;">Unfollow</a>
+                </span>
+            </xpath>
+        </template>
+    </data>
+</odoo>

--- a/addons/mail/static/src/core/web/follower_list.js
+++ b/addons/mail/static/src/core/web/follower_list.js
@@ -35,11 +35,12 @@ export class FollowerList extends Component {
             res_model: "mail.wizard.invite",
             view_mode: "form",
             views: [[false, "form"]],
-            name: _t("Invite Follower"),
+            name: _t("Add followers to this document"),
             target: "new",
             context: {
                 default_res_model: this.props.thread.model,
                 default_res_id: this.props.thread.id,
+                dialog_size: "medium",
             },
         };
         this.action.doAction(action, {

--- a/addons/mail/static/src/scss/mail_invite_wizard.scss
+++ b/addons/mail/static/src/scss/mail_invite_wizard.scss
@@ -1,0 +1,3 @@
+.o_mail_extra_comments .note-editable {
+    min-height: 80px;
+}

--- a/addons/mail/wizard/mail_wizard_invite_views.xml
+++ b/addons/mail/wizard/mail_wizard_invite_views.xml
@@ -12,18 +12,21 @@
                         <field name="res_model" invisible="1"/>
                         <field name="res_id" invisible="1"/>
                         <field name="partner_ids" widget="many2many_tags_email"
-                                placeholder="Add contacts to notify..."
+                                placeholder="Add contacts"
                                 options="{'no_quick_create': True}"
                                 context="{'show_email': True, 'form_view_ref': 'base.view_partner_simple_form'}"/>
-                        <field name="notify"/>
-                        <field name="message" invisible="not notify"
-                               widget="html_mail"
-                               class="oe-bordered-editor"/>
+                        <field name="notify" widget="boolean_toggle"/>
                     </group>
+                    <field name="message"
+                           invisible="not notify"
+                           placeholder="Extra Comments ..."
+                           widget="html_mail"
+                           options="{'no-attachment': true}"
+                           class="o_mail_extra_comments border p-1 ps-1 pe-5"/>
                     <footer>
-                        <button string="Add Followers"
+                        <button string="Add and close"
                             name="add_followers" type="object" class="btn-primary" data-hotkey="q"/>
-                        <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x" />
+                        <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="x" />
                     </footer>
                 </form>
             </field>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Desired behavior after PR is merged:

This PR revamps the look of the mail template that's sent to
users when they are added as follower in a record.

Mail wizard now has a separate button to add and notify a follower.

Additionally, performance tests are modified to adapt with an extra
query call done for fetching `create_uid` of records while sending an invite.

Task - 3911767




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
