### PR TITLE
[16.0][FIX] point_of_sale: incorrect totals on discount

### DIFF
--- a/addons/point_of_sale/report/pos_order_report.py
+++ b/addons/point_of_sale/report/pos_order_report.py
@@ -45,7 +45,7 @@ class PosOrderReport(models.Model):
                 s.date_order AS date,
                 SUM(l.qty) AS product_qty,
                 SUM(l.qty * l.price_unit / CASE COALESCE(s.currency_rate, 0) WHEN 0 THEN 1.0 ELSE s.currency_rate END) AS price_sub_total,
-                SUM(ROUND((l.price_subtotal_incl) * (100 - l.discount) / 100 / CASE COALESCE(s.currency_rate, 0) WHEN 0 THEN 1.0 ELSE s.currency_rate END, cu.decimal_places)) AS price_total,
+                SUM(ROUND((l.price_subtotal_incl) / CASE COALESCE(s.currency_rate, 0) WHEN 0 THEN 1.0 ELSE s.currency_rate END, cu.decimal_places)) AS price_total,
                 SUM((l.qty * l.price_unit) * (l.discount / 100) / CASE COALESCE(s.currency_rate, 0) WHEN 0 THEN 1.0 ELSE s.currency_rate END) AS total_discount,
                 CASE
                     WHEN SUM(l.qty * u.factor) = 0 THEN NULL

--- a/addons/point_of_sale/tests/test_report_pos_order.py
+++ b/addons/point_of_sale/tests/test_report_pos_order.py
@@ -11,7 +11,38 @@ class TestReportPoSOrder(TestPoSCommon):
         super(TestReportPoSOrder, self).setUp()
         self.config = self.basic_config
 
-    def test_report_pos_order(self):
+    def test_report_pos_order_0(self):
+        """Test the margin and price_total of a PoS Order with no taxes."""
+        product1 = self.create_product('Product 1', self.categ_basic, 150)
+
+        self.open_new_session()
+        session = self.pos_session
+        self.env['pos.order'].create({
+            'session_id': session.id,
+            'lines': [
+                (0, 0, {
+                    'name': "OL/0001",
+                    'product_id': product1.id,
+                    'price_unit': 150,
+                    'discount': 0,
+                    'qty': 1.0,
+                    'price_subtotal': 150,
+                    'price_subtotal_incl': 150,
+                })
+            ],
+            'amount_total': 150.0,
+            'amount_tax': 0.0,
+            'amount_paid': 0.0,
+            'amount_return': 0.0,
+        })
+        # PoS Orders have negative IDs to avoid conflict, so reports[0] will correspond to the newest order
+        reports = self.env['report.pos.order'].sudo().search([('product_id', '=', product1.id)], order='id')
+
+        self.assertEqual(reports[0].margin, 150)
+        self.assertEqual(reports[0].price_total, 150)
+
+    def test_report_pos_order_1(self):
+        """Test the margin and price_total of a PoS Order with taxes."""
 
         product1 = self.create_product('Product 1', self.categ_basic, 150, self.taxes['tax10'].id)
 
@@ -40,3 +71,36 @@ class TestReportPoSOrder(TestPoSCommon):
 
         self.assertEqual(reports[0].margin, 150)
         self.assertEqual(reports[0].price_total, 165)
+
+    def test_report_pos_order_2(self):
+        """Test the margin and price_total of a PoS Order with discount and no taxes"""
+
+        product1 = self.create_product('Product 1', self.categ_basic, 150)
+
+        self.open_new_session()
+        session = self.pos_session
+
+        self.env['pos.order'].create({
+            'session_id': session.id,
+            'lines': [
+                (0, 0, {
+                    'name': "OL/0001",
+                    'product_id': product1.id,
+                    'price_unit': 150,
+                    'discount': 10,
+                    'qty': 1.0,
+                    'price_subtotal': 135,
+                    'price_subtotal_incl': 135,
+                })
+            ],
+            'amount_total': 135.0,
+            'amount_tax': 0.0,
+            'amount_paid': 0.0,
+            'amount_return': 0.0,
+        })
+
+        # PoS Orders have negative IDs to avoid conflict, so reports[0] will correspond to the newest order
+        reports = self.env['report.pos.order'].sudo().search([('product_id', '=', product1.id)], order='id')
+
+        self.assertEqual(reports[0].margin, 135)
+        self.assertEqual(reports[0].price_total, 135)


### PR DESCRIPTION
This fixes a bug introduced in 96638eb, where lines with discount apply it twice.

Description of the issue/feature this PR addresses: https://github.com/odoo/odoo/issues/168115

Current behavior before PR: discount is applied twice on `report.pos.order`

Desired behavior after PR is merged: both cases (current one and the fixed in https://github.com/odoo/odoo/pull/162883) are computed right




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
