### PR TITLE
[FIX] mail: fix avatar card popover overflow

### DIFF
--- a/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.xml
+++ b/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.xml
@@ -17,13 +17,13 @@
                             <i t-elif="!user.im_status" class="fa fa-fw fa-question-circle" title="No IM status available"/>
                         </span>
                     </span>
-                    <div class="d-flex flex-column o_card_user_infos">
+                    <div class="d-flex flex-column o_card_user_infos overflow-hidden">
                         <span class="fw-bold" t-esc="user.name"/>
                         <t t-if="userInfoTemplate" t-call="{{userInfoTemplate}}"/>
-                        <a t-if="email" t-att-href="'mailto:'+email">
+                        <a t-if="email" t-att-href="'mailto:'+email" t-att-title="email" class="text-truncate">
                             <i class="fa fa-fw fa-envelope me-1"/><t t-esc="email"/>
                         </a>
-                        <a t-if="phone" t-att-href="'tel:'+phone">
+                        <a t-if="phone" t-att-href="'tel:'+phone" class="text-truncate">
                             <i class="fa fa-fw fa-phone me-1"/><t t-esc="phone"/>
                         </a>
                     </div>


### PR DESCRIPTION
This PR fixes an issue introduced in Commit[1] about
the avatar card popover overflowing in certain scenarios.

Since saas-17.1, we allow users to add skills within
the avatar card popover. Allowing the card to display such long labels
introduced an issue about long labels overflowing outside the popover,
due to a missing `overflow-hidden-class`.

To prevent such a behaviour, we add an `overflow-hidden` class to the
popover.

task-3924641

Commit[1] : dba8528
Backport of : https://github.com/odoo/odoo/pull/165172