### PR TITLE
[FIX] repair: allow the repair of consumable kit products

### DIFF
--- a/addons/mrp_repair/tests/test_tracability.py
+++ b/addons/mrp_repair/tests/test_tracability.py
@@ -295,3 +295,18 @@ class TestRepairTraceability(TestMrpCommon):
         self.assertRecordValues(mo.move_raw_ids.move_line_ids, [
             {'product_id': component.id, 'lot_id': sn_lot.id, 'quantity': 1.0, 'state': 'done'},
         ])
+
+    def test_repair_with_consumable_kit(self):
+        """Test that a consumable kit can be repaired."""
+        self.assertEqual(self.bom_2.type, 'phantom')
+        kit_product = self.bom_2.product_id
+        kit_product.type = 'consu'
+        self.assertEqual(kit_product.type, 'consu')
+        ro = self.env['repair.order'].create({
+            'product_id': kit_product.id,
+            'picking_type_id': self.warehouse_1.repair_type_id.id,
+        })
+        ro.action_validate()
+        ro.action_repair_start()
+        ro.action_repair_end()
+        self.assertEqual(ro.state, 'done')

--- a/addons/repair/models/stock_move.py
+++ b/addons/repair/models/stock_move.py
@@ -73,14 +73,16 @@ class StockMove(models.Model):
             move.origin = move.name
             move.picking_type_id = move.repair_id.picking_type_id.id
             repair_moves |= move
-
-            if move.state == 'draft' and move.repair_id.state in ('confirmed', 'under_repair'):
-                move._check_company()
-                move._adjust_procure_method()
-                move._action_confirm()
-                move._trigger_scheduler()
-        repair_moves._create_repair_sale_order_line()
-        return moves
+        no_repair_moves = moves - repair_moves
+        draft_repair_moves = repair_moves.filtered(lambda m: m.state == 'draft' and m.repair_id.state in ('confirmed', 'under_repair'))
+        other_repair_moves = repair_moves - draft_repair_moves
+        draft_repair_moves._check_company()
+        draft_repair_moves._adjust_procure_method()
+        res = draft_repair_moves._action_confirm()
+        res._trigger_scheduler()
+        confirmed_repair_moves = (res | other_repair_moves)
+        confirmed_repair_moves._create_repair_sale_order_line()
+        return (confirmed_repair_moves | no_repair_moves)
 
     def write(self, vals):
         res = super().write(vals)
@@ -90,7 +92,7 @@ class StockMove(models.Model):
             if not move.repair_id:
                 continue
             # checks vals update
-            if 'repair_line_type' in vals or 'picking_type_id' in vals and move.product_id != move.repair_id.product_id:
+            if 'repair_line_type' in vals or 'picking_type_id' in vals and move.repair_line_type:
                 move.location_id, move.location_dest_id = move._get_repair_locations(move.repair_line_type)
             if not move.sale_line_id and 'sale_line_id' not in vals and move.repair_line_type == 'add':
                 moves_to_create_so_line |= move


### PR DESCRIPTION
**Steps to reproduce the bug:**
- Create a consumable product “Kit 1” with the following BoM:
    - component: X1

- Create a repair order to repair one unit of Kit 1:
    - Don’t add any part
    - confirm and Start the repair
    - try to end the repair

**Problem:**
A traceback is triggered:
“raise ValueError("Expected singleton: %s" % self)
Value Error: Expected singleton: stock.location()
“

When the "action_repair_end" is called, a move is created with the kit
product, and then we attempt to confirm it:
https://github.com/odoo/odoo/blob/eaa6e1a08c3d2cdcb558689523e5bd332978f5e4/addons/repair/models/stock_move.py#L80

Since the product is a kit, it is exploded into two moves with products
“X1” and “X2”. We then try to assign them a “repair” picking_type_id:

https://github.com/odoo/odoo/blob/eaa6e1a08c3d2cdcb558689523e5bd332978f5e4/addons/repair/models/stock_move.py#L74

So, the write method is used and since the “picking_type_id” is in the
vals, and the product in the move (X1) is not the same as the one in the
repair order, we consider this product a “Part” of the repair.
Therefore, we try to use its location_id and location_dest_id, which we
fetch based on the “repair_line_type” that will be False because it is
not a part of the repair but rather the product to be repaired:

https://github.com/odoo/odoo/blob/eaa6e1a08c3d2cdcb558689523e5bd332978f5e4/addons/repair/models/stock_move.py#L93-L94

The first error is triggered during the “should_by_pass” check because
there is no location set in the move:
https://github.com/odoo/odoo/blob/c7b947364d34cc6ccfb1eb7a2c16b6bba226d8e7/addons/stock/models/stock_move.py#L1051-L1052

If we fix this error, we will still encounter an error because both
moves will be confirmed. However, we will return to the first loop to
continue calling the “_trigger_scheduler” function for the first move
with the “Kit” product, which will be already deleted because it was
exploded, resulting in a user error:

“odoo.exceptions.MissingError: Record does not exist or has been deleted.
(Record: stock.move(253,), User: 1)
“

opw-[3942297](https://www.odoo.com/web#id=3942297&view_type=form&model=project.task)