### PR TITLE
[FIX] point_of_sale: cannot change type to combo with variants

### DIFF
--- a/addons/point_of_sale/models/product.py
+++ b/addons/point_of_sale/models/product.py
@@ -68,6 +68,10 @@ class ProductTemplate(models.Model):
                     ])
         return res
 
+    @api.onchange('type')
+    def _onchange_type(self):
+        if self.type == "combo" and self.attribute_line_ids:
+            raise UserError(_("Combo products cannot contains variants or attributes"))
 
 class ProductProduct(models.Model):
     _inherit = 'product.product'


### PR DESCRIPTION
Current behavior:
If a product has some variants you shouldn't be able to change his type to combo

Steps to reproduce:
- Create a product, and add some variants to it
- Try to change his type to "Combo"
- You shouldn't be able to do it, as combo product shouldn't have variants

opw-3961311
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
