### PR TITLE
[FIX] sale_timesheet: Missing parentheses on _is_updatable_timesheet function call

### DIFF
--- a/addons/sale_timesheet/models/account.py
+++ b/addons/sale_timesheet/models/account.py
@@ -176,4 +176,4 @@ class AccountAnalyticLine(models.Model):
         return round(sol.product_uom._compute_quantity(sol.product_uom_qty, to_uom, raise_if_failure=False), 2)
 
     def _is_updatable_timesheet(self):
-        return super()._is_updatable_timesheet and self._is_not_billed()
+        return super()._is_updatable_timesheet() and self._is_not_billed()


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Missing parentheses on the function call which is causing errors when adding manual timesheets to project tasks. Adding the parentheses will allow this call to access the _is_updatable_timesheet function in hr_timesheet, which will return True

Current behavior before PR:
User Error throw when trying to generate timesheet record directly onto a task.

Desired behavior after PR is merged:
No error thrown when 



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
