### PR TITLE
[IMP] l10n_pl: Credit note can't be more than the invoice total amount

### DIFF
--- a/addons/l10n_pl/i18n/l10n_pl.pot
+++ b/addons/l10n_pl/i18n/l10n_pl.pot
@@ -196,6 +196,13 @@ msgid "Created on"
 msgstr ""
 
 #. module: l10n_pl
+#. odoo-python
+#: code:addons/l10n_pl/models/account_move.py:0
+#, python-format
+msgid "Credit notes can't have a total amount greater than the invoice's"
+msgstr ""
+
+#. module: l10n_pl
 #: model:ir.model.fields,field_description:l10n_pl.field_l10n_pl_l10n_pl_tax_office__name
 msgid "Description"
 msgstr ""

--- a/addons/l10n_pl/i18n/pl.po
+++ b/addons/l10n_pl/i18n/pl.po
@@ -197,6 +197,13 @@ msgid "Created on"
 msgstr "Data utworzenia"
 
 #. module: l10n_pl
+#. odoo-python
+#: code:addons/l10n_pl/models/account_move.py:0
+#, python-format
+msgid "Credit notes can't have a total amount greater than the invoice's"
+msgstr "Noty kredytowe nie mogą mieć łącznej kwoty większej niż kwota faktury"
+
+#. module: l10n_pl
 #: model:ir.model.fields,field_description:l10n_pl.field_l10n_pl_l10n_pl_tax_office__name
 msgid "Description"
 msgstr "Opis"

--- a/addons/l10n_pl/models/account_move.py
+++ b/addons/l10n_pl/models/account_move.py
@@ -1,4 +1,5 @@
-from odoo import api, fields, models
+from odoo import fields, models, _
+from odoo.exceptions import ValidationError
 
 
 class AccountMove(models.Model):
@@ -16,3 +17,11 @@ class AccountMove(models.Model):
         string='B_MPV_Prowizja',
         help="Supply of agency and other services pertaining to the transfer of a single-purpose voucher",
     )
+
+    def action_post(self):
+        "Validation to avoid having credit notes with more than the invoice"
+        for record in self:
+            if record.company_id.account_fiscal_country_id.code == 'PL' and record.reversed_entry_id and\
+                record.reversed_entry_id.amount_total < record.amount_total and record.move_type != 'entry':
+                raise ValidationError(_("Credit notes can't have a total amount greater than the invoice's"))
+        return super().action_post()


### PR DESCRIPTION
[IMP] l10n_pl: Credit note can't be more than the invoice total amount

Polish law don't allow to have credit note with an amount higher than the invoice

Solution: Don't allow to post a credit note if the total is higher than the invoice

task-id#3965527

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr