### PR TITLE
[FIX] website_sale: only set partner of SO to follower

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1177,7 +1177,7 @@ class WebsiteSale(http.Controller):
 
                 # TDE FIXME: don't ever do this
                 # -> TDE: you are the guy that did what we should never do in commit e6f038a
-                order.message_partner_ids = [(4, partner_id), (3, request.website.partner_id.id)]
+                order.message_partner_ids = [(4, order.partner_id.id), (3, request.website.partner_id.id)]
                 if not errors:
                     return request.redirect(kw.get('callback') or '/shop/confirm_order')
 


### PR DESCRIPTION
Steps:
- Install Ecom.
- Buy a product without login and set different address for billing and shipping.

Issue:
- SO email sent to both billing and shipping emails it should only be sent to billing (main address).

Cause:
- In Ecom address controller it set both shipping and billing partner record to follower of SO and because of that SO sent to both emails.

Fix:
- Only set main address partner to follower of SO so it'll only send email to Customer's main email like it do for normal Sales flow.

opw-3714686