### PR TITLE
[FIX] web: fix traceback on qweb profiling views

### DIFF
--- a/addons/web/static/src/core/debug/profiling/profiling_qweb.js
+++ b/addons/web/static/src/core/debug/profiling/profiling_qweb.js
@@ -299,7 +299,7 @@ export class ProfilingQwebView extends Component {
             query: query,
         });
         const div = new DOMParser().parseFromString(xml, "text/html").querySelector("div");
-        node.insertBefore(div, node.firstChild);
+        node.appendChild(div);
     }
     _renderInfo(delays, querys, displayDetail, groups, node) {
         const xml = renderToString("web.ProfilingQwebView.info", {
@@ -309,7 +309,7 @@ export class ProfilingQwebView extends Component {
             groups: groups,
         });
         const div = new DOMParser().parseFromString(xml, "text/html").querySelector("div");
-        node.insertBefore(div, node.firstChild);
+        node.appendChild(div);
     }
 
     //--------------------------------------------------------------------------


### PR DESCRIPTION
With the update of ace to 1.32.3, the lib is formatting her cells by getting them with hardcoded position in a array (here: 0, 1 and 2). On our side we are adding our o_info as first element, so the lib returns a traceback because her elements are shifted.

After this commit, our info node is added after the lib nodes to not shift the all bunch.

runbot issue 55085



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
