### PR TITLE
[FIX] website_sale: fix ribbon bg-color on product

### DIFF
--- a/addons/website_sale/models/product_ribbon.py
+++ b/addons/website_sale/models/product_ribbon.py
@@ -17,15 +17,3 @@ class ProductRibbon(models.Model):
     bg_color = fields.Char(string='Ribbon background color', required=False)
     text_color = fields.Char(string='Ribbon text color', required=False)
     html_class = fields.Char(string='Ribbon class', required=True, default='')
-
-    @api.model_create_multi
-    def create(self, vals_list):
-        for vals in vals_list:
-            if vals.get('bg_color') and not '!important' in vals['bg_color']:
-                vals['bg_color'] += ' !important'
-        return super().create(vals_list)
-
-    def write(self, data):
-        if data.get('bg_color') and not '!important' in data['bg_color']:
-            data['bg_color'] += ' !important'
-        return super().write(data)

--- a/addons/website_sale/static/src/js/website_sale.editor.js
+++ b/addons/website_sale/static/src/js/website_sale.editor.js
@@ -376,7 +376,8 @@ options.registry.WebsiteSaleProductsItem = options.Class.extend({
         $ribbons.removeClass(htmlClasses);
 
         $ribbons.addClass(ribbon.html_class || '');
-        $ribbons.attr('style', `background-color: ${ribbon.bg_color || ''} !important`);
+        $ribbons.attr('style',
+            `background-color: ${ribbon.bg_color ? `${ribbon.bg_color} !important` : 'inherit'}`);
         $ribbons.css('color', ribbon.text_color || '');
 
         if (!this.ribbons[ribbonId]) {


### PR DESCRIPTION
Steps to reproduce:
- Go to Shop page on website
- Enable edit mode
- Pick a product and create a new Badge/Ribbon
- Change the background color
- Bug -> the bg-color is not set.

Issue :
ribbon bg-color is not set on the product.

Cause :
The !important attribute has been duplicated in the CSS rule since [1]
and [2]. As a result, the background colour CSS rule for the ribbon is
broken due to having !important twice.

[1]: https://github.com/odoo/odoo/commit/c6f4929f65b899736c556f8f0bb7824883a6d893
[2]: https://github.com/odoo/odoo/commit/9ee115b58342b3e0dbc11081e7ff752c10f8bfa9

fix :
After removing the '!important' attribute from the create and write methods,
we only encounter the '!important' attribute once. As a result, the ribbon
background color is applied to the product.

opw-3964071