### PR TITLE
[FIX] account: tour test_01_account_tour step run

### DIFF
--- a/addons/account/static/src/js/tours/account.js
+++ b/addons/account/static/src/js/tours/account.js
@@ -18,6 +18,7 @@ export const accountTourSteps = {
             {
                 trigger: "button.o_list_button_add",
                 content: _t("Now, we'll create your first invoice"),
+                run: "click",
             },
         ];
     },


### PR DESCRIPTION
It is now mandatory to add a run step in the tour. The issue only arises in community, as an auto-install module in enterprise overrides it.

runbot-67024




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
