### PR TITLE
[FIX] account: no multiline on invoice note

### DIFF
--- a/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.xml
+++ b/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.xml
@@ -51,7 +51,7 @@
                     </t>
                 </t>
                 <t t-else="">
-                    <t t-if="isSection">
+                    <t t-if="props.isSection">
                         <input
                             class="o_input text-wrap border-0 fst-italic"
                             placeholder="Enter a description"
@@ -122,7 +122,7 @@
                     </t>
                 </t>
                 <t t-else="">
-                    <t t-if="isSection">
+                    <t t-if="props.isSection">
                         <input
                             class="o_input text-wrap border-0 fst-italic"
                             type="text"


### PR DESCRIPTION
Description of the issue this commit addresses:

With the new merged product and label system on invoices, notes on invoices can't take multiple line anymore. This is not wanted.

---

Steps to reproduce:

1 - Install account
2 - Create a new invoice
3 - Add a note line
4 - Write text that should overflow the line/press enter.
5 - Instead of adding a line, first characters disappear to let last be shown

---

Desired behavior after this commit is merged:

Note on invoice lines should be able to be on multiple lines.

---

Note on the fix:

The error happened because the condition to use either an \<input\> for a section or a <textarea> for a section was mistaken. The note's <textarea> is inside the else of the section's \<input\> which's condition is "isSection". Problem is that isSection is a method and not an attribute so it would always return true. The attribute containing whether we are in a note line or not is props.isSection

---

no task-feedback

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
