### PR TITLE
[FIX] point_of_sale: add id to date div in order receipt

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
@@ -136,7 +136,7 @@
             <div class="pos-receipt-order-data">
                 <p>Odoo Point of Sale</p>
                 <div t-esc="props.data.name" />
-                <div t-esc="props.data.date" />
+                <div id="order-date" t-esc="props.data.date" />
             </div>
         </div>
     </t>


### PR DESCRIPTION
This only adds an id to the div containing the date in the order receipt so that it can be xpath easily in the enterprise PR.

Enterprise PR: odoo/enterprise#63966

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
