### PR TITLE
[I18N] base: improve in Spanish/Español translations

### DIFF
--- a/odoo/addons/base/i18n/es_MX.po
+++ b/odoo/addons/base/i18n/es_MX.po
@@ -34334,7 +34334,7 @@ msgstr "Subcampo \"%s\" desconocido"
 #: code:addons/base/models/ir_fields.py:0
 #, python-format
 msgid "Unknown value '%s' for boolean field '%%(field)s'"
-msgstr "Valor desconocido '%s' para campo booleano '%%(campo)s'"
+msgstr "Valor desconocido '%s' para campo booleano '%%(field)s'"
 
 #. module: base
 #. odoo-python


### PR DESCRIPTION
In Spanish (MX) / Español (MX) Language

The Translation of ``Valor desconocido '%s' para campo booleano '%%(campo)s'`` is done wrong in ``es_MX.po`` file of the base module. ﻿﻿which leads to a traceback

Traceback : ``KeyError 'campo'``

In the above-translated term, we mistakenly translated ``field`` to ``campo``. We should not translate ``field`` because it contains dynamic values.

sentry-5454184338

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
