### PR TITLE
[FIX] account_peppol: fix peppol validity for restricted users

### DIFF
--- a/addons/account_peppol/models/res_partner.py
+++ b/addons/account_peppol/models/res_partner.py
@@ -72,7 +72,7 @@ class ResPartner(models.Model):
     def _get_participant_info(self, edi_identification):
         hash_participant = md5(edi_identification.lower().encode()).hexdigest()
         endpoint_participant = parse.quote_plus(f"iso6523-actorid-upis::{edi_identification}")
-        peppol_user = self.env.company.account_edi_proxy_client_ids.filtered(lambda user: user.proxy_type == 'peppol')
+        peppol_user = self.env.company.sudo().account_edi_proxy_client_ids.filtered(lambda user: user.proxy_type == 'peppol')
         edi_mode = peppol_user and peppol_user.edi_mode or self.env['ir.config_parameter'].sudo().get_param('account_peppol.edi.mode')
         sml_zone = 'acc.edelivery' if edi_mode == 'test' else 'edelivery'
         smp_url = f"http://B-{hash_participant}.iso6523-actorid-upis.{sml_zone}.tech.ec.europa.eu/{endpoint_participant}"

--- a/addons/account_peppol/tools/demo_utils.py
+++ b/addons/account_peppol/tools/demo_utils.py
@@ -155,7 +155,7 @@ def handle_demo(func, self, *args, **kwargs):
         return self.account_peppol_edi_mode == 'demo'
 
     def get_demo_mode_res_partner(self, args, kwargs):
-        peppol_user = self.env.company.account_edi_proxy_client_ids.filtered(lambda user: user.proxy_type == 'peppol')
+        peppol_user = self.env.company.sudo().account_edi_proxy_client_ids.filtered(lambda user: user.proxy_type == 'peppol')
         if peppol_user:
             return peppol_user.edi_mode == 'demo'
         return False


### PR DESCRIPTION
- Have `account_peppol` installed
- Log in as a user who has read-only accounting rights
- Open a customer that is located in Peppol-supported countries and has UBL format, peppol eas and endpoint filled in
- An error is displayed saying the user cannot see this partner record

`account_edi_proxy_client_ids` is restricted to full accounting rights, so we have to access it with sudo when checking the edi mode for computing the validity of the peppol participant on the network.

opw-3950933



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
