### PR TITLE
[FIX] stock: prevent an errors when open a routes diagram

### DIFF
--- a/addons/stock/report/report_stock_rule.py
+++ b/addons/stock/report/report_stock_rule.py
@@ -57,12 +57,14 @@ class ReportStockRule(models.AbstractModel):
                     res = []
                     for x in range(len(locations_names)):
                         res.append([])
-                    idx = locations_names.index(rule_loc['destination'].display_name)
-                    tpl = (rule, 'destination', route_color, )
-                    res[idx] = tpl
-                    idx = locations_names.index(rule_loc['source'].display_name)
-                    tpl = (rule, 'origin', route_color, )
-                    res[idx] = tpl
+                    if rule_loc['destination']:
+                        idx = locations_names.index(rule_loc['destination'].display_name)
+                        tpl = (rule, 'destination', route_color, )
+                        res[idx] = tpl
+                    if rule_loc['source']:
+                        idx = locations_names.index(rule_loc['source'].display_name)
+                        tpl = (rule, 'origin', route_color, )
+                        res[idx] = tpl
                     route_lines.append(res)
         return {
             'docs': product,


### PR DESCRIPTION
Currently, the error is generated when the user opens a routes diagram in product view without 'Production Location'.

Steps to reproduce:

- Install the 'stock' and 'mrp' modules.
- Go to inventory > configuration > settings > enable Multi-Step Routes.
- Open product > inventory and enable 'Manufacture' in routes and set 'Production Location' as empty value.
- Now try to open a 'View Diagram'.

Traceback on sentry:
```
ValueError: False is not in list
  File "odoo/http.py", line 2254, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1829, in _serve_db
    return self._transactioning(_serve_ir_http, readonly=ro)
  File "odoo/http.py", line 1849, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1827, in _serve_ir_http
    return self._serve_ir_http(rule, args)
  File "odoo/http.py", line 1834, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1972, in dispatch
    return self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 220, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 740, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/report.py", line 39, in report_routes
    html = report.with_context(context)._render_qweb_html(reportname, docids, data=data)[0]
  File "home/odoo/src/enterprise/saas-17.2/web_studio/models/ir_actions_report.py", line 24, in _render_qweb_html
    return super(IrActionsReport, self)._render_qweb_html(report_ref, docids, data)
  File "odoo/addons/base/models/ir_actions_report.py", line 933, in _render_qweb_html
    data = self._get_rendering_context(report, docids, data)
  File "home/odoo/src/enterprise/saas-17.2/web_studio/models/ir_actions_report.py", line 44, in _get_rendering_context
    ctx = super()._get_rendering_context(report, docids, data)
  File "addons/stock/models/ir_actions_report.py", line 8, in _get_rendering_context
    data = super()._get_rendering_context(report, docids, data)
  File "addons/account/models/ir_actions_report.py", line 80, in _get_rendering_context
    data = super()._get_rendering_context(report, docids, data)
  File "odoo/addons/base/models/ir_actions_report.py", line 948, in _get_rendering_context
    data.update(report_model._get_report_values(docids, data=data))
  File "addons/stock/report/report_stock_rule.py", line 60, in _get_report_values
    idx = locations_names.index(rule_loc['destination'].display_name)
```

The issue arises when the user tries to open a routes diagram without 'Production Location'  because the system tries to get an index of location destination and location source at [1], Which is not available.

To resolve the issue, we add a condition of location destination and location source at [1], To ensure that route lines can not append without location destination or location source.

link [1]: https://github.com/odoo/odoo/blob/0ae818cca87bd8433a0783797309771125772d86/addons/stock/report/report_stock_rule.py#L60-L63

sentry-5049873238

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
