### PR TITLE
[FIX] pos_restaurant: multiple time merge table got owl error

### DIFF
--- a/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.js
+++ b/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.js
@@ -381,14 +381,16 @@ export class FloorScreen extends Component {
                 Promise.reject(e);
             } finally {
                 this.pos.tableSyncing = false;
+                const orders = this.pos.getTableOrders(table.id);
+                if (orders.length > 0) {
+                    this.pos.set_order(orders[0]);
+                    this.pos.orderToTransferUuid = null;
+                    this.pos.showScreen(orders[0].get_screen_data().name);
+                } else {
+                    this.pos.add_new_order();
+                    this.pos.showScreen("ProductScreen");
+                }
             }
-        }
-        const orders = this.pos.getTableOrders(table.id);
-        if (orders.length > 0) {
-            this.pos.showScreen(orders[0].get_screen_data().name);
-        } else {
-            this.pos.add_new_order();
-            this.pos.showScreen("ProductScreen");
         }
     }
     unselectTables() {


### PR DESCRIPTION
Before this commit:
=====================
transfer/merge tables in the floor plan multiple times resulted in a blank screen and an Owl error.

Steps To Reproduced:
=====================
- Step 1: Open POS Restaurant 
- Step 2: Open any table and add product into cart
- Step 3: Open another table and add some product
- Step 4: Click on transfer/Merge button from POS terminal  
- Step 5: Select Merge from table view and select targeted table 
- Step 6: Repeat above step (Step 5) 

Screen become blank and owl error occurred 

After this commit:
===================
The Owl error has been resolved, ensuring the table merging and transferring process works smoothly without any issues.

task- 3938124

