### PR TITLE
[FIX] hr_attendance: Fix group expand

### DIFF
--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -594,7 +594,8 @@ class HrAttendance(models.Model):
         }
 
     def _read_group_employee_id(self, resources, domain):
-        employee_domain = [
-            ('company_id', 'in', self.env.context.get('allowed_company_ids', [])),
-        ]
-        return self.env['hr.employee'].search(employee_domain)
+        user_domain = self.env.context.get('user_domain')
+        if not user_domain:
+            return self.env['hr.employee'].search([('company_id', 'in', self.env.context.get('allowed_company_ids', []))])
+        else:
+            return resources


### PR DESCRIPTION
The current state of _read_group_employee_id ignores the user domain and thus filtering To fix this we apply the domain in the case a user_domain is used in the gantt view