### PR TITLE
[FIX] website: fix textarea placeholder not showing in form field

### DIFF
--- a/addons/website/views/snippets/s_website_form.xml
+++ b/addons/website/views/snippets/s_website_form.xml
@@ -76,8 +76,7 @@
                                 <span class="s_website_form_mark"> *</span>
                             </label>
                             <div class="col-sm">
-                                <textarea class="form-control s_website_form_input" name="description" required="1" id="oyeqnysxh10b" rows="3">
-                                </textarea>
+                                <textarea class="form-control s_website_form_input" name="description" required="1" id="oyeqnysxh10b" rows="3"></textarea>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
This commit fixes an issue in the default form snippet, where the
placeholder text for the "Your Question" field (a textarea) doesn't
appear (bug introduced in the commit [1]).

Steps to reproduce:

- Navigate to website in edit mode
- Drag & drop the "Form" snippet
- Click on the "Your question" field to activate the snippet options
- On the right panel, fill in the "Placeholder" field with anything
- --> Bug. The placeholder doesn't appear in the field as it should

This was caused by an empty line between the opening and closing
`<textarea>` tags in the template, which the browser interpreted as
default content. The empty line has been removed to ensure the
placeholder text is displayed correctly.

[1]: https://github.com/odoo/odoo/commit/b993399f8a2283cf8ab571f399cf5f0eaf81bfce

task-3665275