### PR TITLE
[FIX] payment: multiple payment confirmation mails send

### DIFF
--- a/addons/sale/models/payment_transaction.py
+++ b/addons/sale/models/payment_transaction.py
@@ -92,10 +92,10 @@ class PaymentTransaction(models.Model):
 
     def _set_authorized(self, state_message=None, **kwargs):
         """ Override of payment to confirm the quotations automatically. """
-        super()._set_authorized(state_message=state_message, **kwargs)
-        confirmed_orders = self._check_amount_and_confirm_order()
+        txs_to_process = super()._set_authorized(state_message=state_message, **kwargs)
+        confirmed_orders = txs_to_process._check_amount_and_confirm_order()
         confirmed_orders._send_order_confirmation_mail()
-        (self.sale_order_ids - confirmed_orders)._send_payment_succeeded_for_order_mail()
+        (txs_to_process.sale_order_ids - confirmed_orders)._send_payment_succeeded_for_order_mail()
 
     def _log_message_on_linked_documents(self, message):
         """ Override of payment to log a message on the sales orders linked to the transaction.


### PR DESCRIPTION
Due to Stripe sending multiple confirmations regarding authorized payment, multiple mails were send to customer that their payment was succesful, now only transactions that were not processed yet result in mail sending.

opw-3967807

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
