### PR TITLE
[IMP] base: Add limit to filtered()

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -2897,7 +2897,7 @@ class AccountMoveLine(models.Model):
 
             # To know which rate to use for the adjustment, get the rate used by the most recent cash basis move
             last_caba_move = max(cash_basis_moves, key=lambda m: m.date) if cash_basis_moves else self.env['account.move']
-            currency_line = last_caba_move.line_ids.filtered(lambda x: x.currency_id == currency)[:1]
+            currency_line = last_caba_move.line_ids.filtered(lambda x: x.currency_id == currency, limit=1)
             currency_rate = currency_line.balance / currency_line.amount_currency if currency_line.amount_currency else 1.0
 
             existing_line_vals_list = move_vals['line_ids']

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -724,7 +724,7 @@ class AccountEdiXmlUBL20(models.AbstractModel):
                 # If we found taxes with the correct amount, look for a tax line using it, and correct it as needed.
                 if taxes:
                     tax_total = float(amount.text)
-                    tax_line = invoice.line_ids.filtered(lambda line: line.tax_line_id in taxes)[:1]
+                    tax_line = invoice.line_ids.filtered(lambda line: line.tax_line_id in taxes, limit=1)
                     if tax_line:
                         sign = -1 if invoice.is_inbound(include_receipts=True) else 1
                         tax_line_amount = abs(tax_line.amount_currency)

--- a/addons/account_peppol/wizard/peppol_registration.py
+++ b/addons/account_peppol/wizard/peppol_registration.py
@@ -82,7 +82,7 @@ class PeppolRegistration(models.TransientModel):
     @api.depends('company_id.account_edi_proxy_client_ids')
     def _compute_edi_user_id(self):
         for wizard in self:
-            wizard.edi_user_id = wizard.company_id.account_edi_proxy_client_ids.filtered(lambda u: u.proxy_type == 'peppol')[:1]
+            wizard.edi_user_id = wizard.company_id.account_edi_proxy_client_ids.filtered(lambda u: u.proxy_type == 'peppol', limit=1)
 
     @api.depends('peppol_eas', 'peppol_endpoint')
     def _compute_peppol_warnings(self):

--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -1047,7 +1047,7 @@ class Meeting(models.Model):
         self.ensure_one()
         now = fields.datetime.now()
         sorted_alarms = self.alarm_ids.sorted("duration_minutes")
-        triggered_alarms = sorted_alarms.filtered(lambda alarm: alarm.id in events_by_alarm)[0]
+        triggered_alarms = sorted_alarms.filtered(lambda alarm: alarm.id in events_by_alarm, limit=1)
         event_has_future_alarms = sorted_alarms[0] != triggered_alarms
         next_date = None
         if self.recurrence_id.trigger_id and self.recurrence_id.trigger_id.call_at <= now:

--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -1219,7 +1219,7 @@ class Lead(models.Model):
     def action_reschedule_meeting(self):
         self.ensure_one()
         action = self.action_schedule_meeting(smart_calendar=False)
-        next_activity = self.activity_ids.filtered(lambda activity: activity.user_id == self.env.user)[:1]
+        next_activity = self.activity_ids.filtered(lambda activity: activity.user_id == self.env.user, limit=1)
         if next_activity.calendar_event_id:
             action['context']['initial_date'] = next_activity.calendar_event_id.start
         return action
@@ -1239,7 +1239,7 @@ class Lead(models.Model):
 
     def action_snooze(self):
         self.ensure_one()
-        my_next_activity = self.activity_ids.filtered(lambda activity: activity.user_id == self.env.user)[:1]
+        my_next_activity = self.activity_ids.filtered(lambda activity: activity.user_id == self.env.user, limit=1)
         my_next_activity.action_snooze()
         return True
 

--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -548,7 +548,7 @@ class HrExpense(models.Model):
 
         product = self.env['product.product'].search([('can_be_expensed', '=', True)])
         if product:
-            product = product.filtered(lambda p: p.default_code == "EXP_GEN")[:1] or product[0]
+            product = product.filtered(lambda p: p.default_code == "EXP_GEN", limit=1) or product[0]
         else:
             raise UserError(_("You need to have at least one category that can be expensed in your database to proceed!"))
 

--- a/addons/hr_expense/models/hr_expense_sheet.py
+++ b/addons/hr_expense/models/hr_expense_sheet.py
@@ -315,8 +315,9 @@ class HrExpenseSheet(models.Model):
                 expenses = sheet.expense_line_ids
                 expenses_mma_checksums = expenses.message_main_attachment_id.mapped('checksum')
                 sheet.message_main_attachment_id = attachments.filtered(
-                    lambda att: att.checksum in expenses_mma_checksums
-                )[:1] or attachments[:1]
+                    lambda att: att.checksum in expenses_mma_checksums,
+                    limit=1,
+                ) or attachments[:1]
 
     @api.depends('expense_line_ids.currency_id', 'company_currency_id')
     def _compute_currency_id(self):

--- a/addons/l10n_es_edi_sii/models/account_edi_format.py
+++ b/addons/l10n_es_edi_sii/models/account_edi_format.py
@@ -105,7 +105,7 @@ class AccountEdiFormat(models.Model):
             taxes = line.tax_ids.flatten_taxes_hierarchy()
             recargo_tax = [t for t in taxes if t.l10n_es_type == 'recargo']
             if recargo_tax and taxes:
-                recargo_main_tax = taxes.filtered(lambda x: x.l10n_es_type in ('sujeto', 'sujeto_isp'))[:1]
+                recargo_main_tax = taxes.filtered(lambda x: x.l10n_es_type in ('sujeto', 'sujeto_isp'), limit=1)
                 if not recargo_tax_details.get(recargo_main_tax):
                     recargo_tax_details[recargo_main_tax] = [
                         x for x in tax_details['tax_details'].values()

--- a/addons/mass_mailing_sms/controllers/main.py
+++ b/addons/mass_mailing_sms/controllers/main.py
@@ -53,7 +53,7 @@ class MailingSMSController(http.Controller):
         )
         tocheck_number = sanitized or sms_number
 
-        trace = check_res['trace'].filtered(lambda r: r.sms_number == tocheck_number)[:1] if tocheck_number else False
+        trace = check_res['trace'].filtered(lambda r: r.sms_number == tocheck_number, limit=1) if tocheck_number else False
         # compute opt-out / blacklist information
         lists_optout = request.env['mailing.list'].sudo()
         lists_optin = request.env['mailing.list'].sudo()

--- a/addons/microsoft_calendar/models/calendar.py
+++ b/addons/microsoft_calendar/models/calendar.py
@@ -522,7 +522,7 @@ class Meeting(models.Model):
             values['location'] = {'displayName': self.location or ''}
 
         if 'alarm_ids' in fields_to_sync:
-            alarm_id = self.alarm_ids.filtered(lambda a: a.alarm_type == 'notification')[:1]
+            alarm_id = self.alarm_ids.filtered(lambda a: a.alarm_type == 'notification', limit=1)
             values['isReminderOn'] = bool(alarm_id)
             values['reminderMinutesBeforeStart'] = alarm_id.duration_minutes
 

--- a/addons/mrp_subcontracting/models/mrp_production.py
+++ b/addons/mrp_subcontracting/models/mrp_production.py
@@ -42,7 +42,7 @@ class MrpProduction(models.Model):
                 move = production._get_move_raw_values(product_id, qty, product_id.uom_id)
                 move['additional'] = True
                 production.move_raw_ids = [(0, 0, move)]
-                production.move_raw_ids.filtered(lambda m: m.product_id == product_id)[:1].move_line_ids = lines
+                production.move_raw_ids.filtered(lambda m: m.product_id == product_id, limit=1).move_line_ids = lines
 
     def write(self, vals):
         if self.env.user._is_portal() and not self.env.su:

--- a/addons/mrp_subcontracting/models/stock_move.py
+++ b/addons/mrp_subcontracting/models/stock_move.py
@@ -84,11 +84,11 @@ class StockMove(models.Model):
 
     def _auto_record_components(self, qty):
         self.ensure_one()
-        subcontracted_productions = self._get_subcontract_production()
-        production = subcontracted_productions.filtered(lambda p: not p._has_been_recorded())[-1:]
+        subcontracted_productions = self._get_subcontract_production()[::-1]
+        production = subcontracted_productions.filtered(lambda p: not p._has_been_recorded(), limit=1)
         if not production:
             # If new quantity is over the already recorded quantity and we have no open production, then create a new one for the missing quantity.
-            production = subcontracted_productions[-1:]
+            production = subcontracted_productions[:1]
             production = production.sudo().with_context(allow_more=True)._split_productions({production: [production.qty_producing, qty]})[-1:]
         qty = self.product_uom._compute_quantity(qty, production.product_uom_id)
 

--- a/addons/mrp_subcontracting/report/mrp_report_bom_structure.py
+++ b/addons/mrp_subcontracting/report/mrp_report_bom_structure.py
@@ -23,7 +23,7 @@ class ReportBomStructure(models.AbstractModel):
         res = super()._get_bom_data(bom, warehouse, product, line_qty, bom_line, level, parent_bom, parent_product, index, product_info, ignore_stock)
         if bom.type == 'subcontract' and not self.env.context.get('minimized', False):
             if not res['product']:
-                seller = bom.product_tmpl_id.seller_ids.filtered(lambda s: s.partner_id in bom.subcontractor_ids)[:1]
+                seller = bom.product_tmpl_id.seller_ids.filtered(lambda s: s.partner_id in bom.subcontractor_ids, limit=1)
             else:
                 seller = res['product']._select_seller(quantity=res['quantity'], uom_id=bom.product_uom_id, params={'subcontractor_ids': bom.subcontractor_ids})
             if seller:

--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -183,7 +183,7 @@ class PosOrder(models.Model):
         order.amount_paid = sum(order.payment_ids.mapped('amount'))
 
         if not draft and not float_is_zero(pos_order['amount_return'], prec_acc):
-            cash_payment_method = pos_session.payment_method_ids.filtered('is_cash_count')[:1]
+            cash_payment_method = pos_session.payment_method_ids.filtered('is_cash_count', limit=1)
             if not cash_payment_method:
                 raise UserError(_("No cash statement found for this session. Unable to record returned cash."))
             return_payment_vals = {

--- a/addons/point_of_sale/tests/common.py
+++ b/addons/point_of_sale/tests/common.py
@@ -554,7 +554,7 @@ class TestPoSCommon(ValuationReconciliationTestCommon):
         # 2. generate the payments
         total_amount_incl = sum(line[2]['price_subtotal_incl'] for line in order_lines)
         if payments is None:
-            default_cash_pm = self.config.payment_method_ids.filtered(lambda pm: pm.is_cash_count and not pm.split_transactions)[:1]
+            default_cash_pm = self.config.payment_method_ids.filtered(lambda pm: pm.is_cash_count and not pm.split_transactions, limit=1)
             if not default_cash_pm:
                 raise Exception('There should be a cash payment method set in the pos.config.')
             payments = [create_payment(default_cash_pm, total_amount_incl)]
@@ -646,7 +646,7 @@ class TestPoSCommon(ValuationReconciliationTestCommon):
             _logger.info('DONE: Call of before_closing_cb.')
         self._check_invoice_journal_entries(pos_session, orders_map, expected_values=args['journal_entries_before_closing'])
         _logger.info('DONE: Checks for journal entries before closing the session.')
-        cash_payment_method = pos_session.payment_method_ids.filtered('is_cash_count')[:1]
+        cash_payment_method = pos_session.payment_method_ids.filtered('is_cash_count', limit=1)
         total_cash_payment = sum(pos_session.mapped('order_ids.payment_ids').filtered(lambda payment: payment.payment_method_id.id == cash_payment_method.id).mapped('amount'))
         pos_session.post_closing_cash_details(total_cash_payment)
         pos_session.close_session_from_ui()

--- a/addons/pos_online_payment/models/pos_config.py
+++ b/addons/pos_online_payment/models/pos_config.py
@@ -23,4 +23,4 @@ class PosConfig(models.Model):
 
     def _get_cashier_online_payment_method(self):
         self.ensure_one()
-        return self.payment_method_ids.filtered('is_online_payment')[:1]
+        return self.payment_method_ids.filtered('is_online_payment', limit=1)

--- a/addons/product_images/wizard/product_fetch_image_wizard.py
+++ b/addons/product_images/wizard/product_fetch_image_wizard.py
@@ -175,8 +175,9 @@ class ProductFetchImageWizard(models.TransientModel):
             # p.image_fetch_pending needed for self.products_to_process's records that might already
             # have been processed but not yet removed from the list when called from
             # action_fetch_image.
-            lambda p: not p.image_1920 and p.barcode and p.image_fetch_pending
-        )[:limit]  # Apply the limit after the filter with self.products_to_process for more results
+            lambda p: not p.image_1920 and p.barcode and p.image_fetch_pending,
+            limit=limit,  # Apply the limit after the filter with self.products_to_process for more results
+        )
 
     def _process_products(self, products_to_process):
         """ Fetch an image from the Google Custom Search API for each product.

--- a/addons/purchase_stock/models/stock_rule.py
+++ b/addons/purchase_stock/models/stock_rule.py
@@ -68,8 +68,9 @@ class StockRule(models.Model):
             # Fall back on a supplier for which no price may be defined. Not ideal, but better than
             # blocking the user.
             supplier = supplier or procurement.product_id._prepare_sellers(False).filtered(
-                lambda s: not s.company_id or s.company_id == procurement.company_id
-            )[:1]
+                lambda s: not s.company_id or s.company_id == procurement.company_id,
+                limit=1,
+            )
 
             if not supplier:
                 msg = _('There is no matching vendor price to generate the purchase order for product %s (no vendor defined, minimum quantity not reached, dates not valid, ...). Go on the product form and complete the list of vendors.', procurement.product_id.display_name)

--- a/addons/resource/models/resource_calendar.py
+++ b/addons/resource/models/resource_calendar.py
@@ -139,9 +139,11 @@ class ResourceCalendar(models.Model):
     @api.constrains('attendance_ids')
     def _check_attendance_ids(self):
         for resource in self:
-            if (resource.two_weeks_calendar and
-                    resource.attendance_ids.filtered(lambda a: a.display_type == 'line_section') and
-                    not resource.attendance_ids.sorted('sequence')[0].display_type):
+            if (
+                resource.two_weeks_calendar
+                and any(a.display_type == 'line_section' for a in resource.attendance_ids)
+                and not resource.attendance_ids.sorted('sequence')[0].display_type
+            ):
                 raise ValidationError(_("In a calendar with 2 weeks mode, all periods need to be in the sections."))
 
     @api.depends('two_weeks_calendar')

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1468,7 +1468,7 @@ class SaleOrder(models.Model):
 
                 if not move.currency_id.is_zero(delta_amount):
                     receivable_line = move.line_ids.filtered(
-                        lambda aml: aml.account_id.account_type == 'asset_receivable')[:1]
+                        lambda aml: aml.account_id.account_type == 'asset_receivable', limit=1)
                     product_lines = move.line_ids.filtered(
                         lambda aml: aml.display_type == 'product' and aml.is_downpayment)
                     tax_lines = move.line_ids.filtered(

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -940,7 +940,7 @@ class SaleOrderLine(models.Model):
                     # remaining amount to invoice
                     amount = 0
                     for l in inv_lines:
-                        if len(l.tax_ids.filtered(lambda tax: tax.price_include)) > 0:
+                        if any(tax.price_include for tax in l.tax_ids):
                             amount += l.tax_ids.compute_all(l.currency_id._convert(l.price_unit, line.currency_id, line.company_id, l.date or fields.Date.today(), round=False) * l.quantity)['total_excluded']
                         else:
                             amount += l.currency_id._convert(l.price_unit, line.currency_id, line.company_id, l.date or fields.Date.today(), round=False) * l.quantity

--- a/addons/sale/wizard/sale_make_invoice_advance.py
+++ b/addons/sale/wizard/sale_make_invoice_advance.py
@@ -175,7 +175,7 @@ class SaleAdvancePaymentInv(models.TransientModel):
                 delta_amount = (invoice.amount_total - self.fixed_amount) * (1 if invoice.is_inbound() else -1)
                 if not order.currency_id.is_zero(delta_amount):
                     receivable_line = invoice.line_ids\
-                        .filtered(lambda aml: aml.account_id.account_type == 'asset_receivable')[:1]
+                        .filtered(lambda aml: aml.account_id.account_type == 'asset_receivable', limit=1)
                     product_lines = invoice.line_ids\
                         .filtered(lambda aml: aml.display_type == 'product')
                     tax_lines = invoice.line_ids\

--- a/addons/sale_loyalty_delivery/models/sale_order.py
+++ b/addons/sale_loyalty_delivery/models/sale_order.py
@@ -31,7 +31,7 @@ class SaleOrder(models.Model):
         return order_line.filtered(lambda line: not line.is_delivery)
 
     def _get_reward_values_free_shipping(self, reward, coupon, **kwargs):
-        delivery_line = self.order_line.filtered(lambda l: l.is_delivery)[:1]
+        delivery_line = self.order_line.filtered(lambda l: l.is_delivery, limit=1)
         taxes = delivery_line.product_id.taxes_id._filter_taxes_by_company(self.company_id)
         taxes = self.fiscal_position_id.map_tax(taxes)
         max_discount = reward.discount_max_amount or float('inf')

--- a/addons/stock/models/stock_package_level.py
+++ b/addons/stock/models/stock_package_level.py
@@ -67,7 +67,7 @@ class StockPackageLevel(models.Model):
                                 if float_is_zero(to_dispatch, precision_rounding=ml.product_id.uom_id.rounding):
                                     break
                         else:
-                            corresponding_move = package_level.move_ids.filtered(lambda m: m.product_id == quant.product_id)[:1]
+                            corresponding_move = package_level.move_ids.filtered(lambda m: m.product_id == quant.product_id, limit=1)
                             self.env['stock.move.line'].create({
                                 'location_id': package_level.location_id.id,
                                 'location_dest_id': package_level.location_dest_id.id,

--- a/addons/stock/wizard/product_replenish.py
+++ b/addons/stock/wizard/product_replenish.py
@@ -75,7 +75,7 @@ class ProductReplenish(models.TransientModel):
             res['route_id'] = self.env['stock.route'].search(self._get_route_domain(product_tmpl_id), limit=1).id
             if not res['route_id']:
                 if product_tmpl_id.route_ids:
-                    res['route_id'] = product_tmpl_id.route_ids.filtered(lambda r: r.company_id == self.env.company or not r.company_id)[0].id
+                    res['route_id'] = product_tmpl_id.route_ids.filtered(lambda r: r.company_id == self.env.company or not r.company_id, limit=1).id
         return res
 
     def _get_date_planned(self, route_id, **kwargs):

--- a/addons/web/controllers/webmanifest.py
+++ b/addons/web/controllers/webmanifest.py
@@ -25,11 +25,11 @@ class WebManifest(http.Controller):
                                                          ('module', 'in', module_names)])
         shortcuts = []
         for module in module_ids:
-            data = datas.filtered(lambda res: res.module == module.name)
+            data = datas.filtered(lambda res: res.module == module.name, limit=1)
             if data:
                 shortcuts.append({
                     'name': module.display_name,
-                    'url': '/odoo?menu_id=%s' % data.mapped('res_id')[0],
+                    'url': '/odoo?menu_id=%s' % data.res_id,
                     'description': module.summary,
                     'icons': [{
                         'sizes': '100x100',

--- a/addons/website_crm_partner_assign/controllers/main.py
+++ b/addons/website_crm_partner_assign/controllers/main.py
@@ -174,7 +174,7 @@ class WebsiteAccount(CustomerPortal):
         return request.render(
             "website_crm_partner_assign.portal_my_opportunity", {
                 'opportunity': opp,
-                'user_activity': opp.sudo().activity_ids.filtered(lambda activity: activity.user_id == request.env.user)[:1],
+                'user_activity': opp.sudo().activity_ids.filtered(lambda activity: activity.user_id == request.env.user, limit=1),
                 'stages': request.env['crm.stage'].search([
                     ('is_won', '!=', True), '|', ('team_id', '=', False), ('team_id', '=', opp.team_id.id)
                 ], order='sequence desc, name desc, id desc'),

--- a/addons/website_crm_partner_assign/models/crm_lead.py
+++ b/addons/website_crm_partner_assign/models/crm_lead.py
@@ -234,7 +234,7 @@ class CrmLead(models.Model):
             # will be modified by the portal form. If no activity exist we create a new one instead
             # that we assign to the portal user.
 
-            user_activity = lead.sudo().activity_ids.filtered(lambda activity: activity.user_id == self.env.user)[:1]
+            user_activity = lead.sudo().activity_ids.filtered(lambda activity: activity.user_id == self.env.user, limit=1)
             if values['activity_date_deadline']:
                 if user_activity:
                     user_activity.sudo().write({

--- a/addons/website_sale_loyalty/models/sale_order.py
+++ b/addons/website_sale_loyalty/models/sale_order.py
@@ -170,7 +170,7 @@ class SaleOrder(models.Model):
         self._update_programs_and_rewards()
 
     def _cart_update(self, product_id, line_id=None, add_qty=0, set_qty=0, **kwargs):
-        line = self.order_line.filtered(lambda sol: sol.product_id.id == product_id)[:1]
+        line = self.order_line.filtered(lambda sol: sol.product_id.id == product_id, limit=1)
         reward_id = line.reward_id
         if set_qty == 0 and line.coupon_id and reward_id and reward_id.reward_type == 'discount':
             # Force the deletion of the line even if it's a temporary record created by new()

--- a/addons/website_sale_loyalty/wizard/coupon_share.py
+++ b/addons/website_sale_loyalty/wizard/coupon_share.py
@@ -45,7 +45,7 @@ class CouponShare(models.TransientModel):
     @api.depends('coupon_id.code', 'program_id.rule_ids.code')
     def _compute_promo_code(self):
         for record in self:
-            record.promo_code = record.coupon_id.code or record.program_id.rule_ids.filtered('code')[:1].code
+            record.promo_code = record.coupon_id.code or record.program_id.rule_ids.filtered('code', limit=1).code
 
     @api.depends('website_id', 'redirect')
     @api.depends_context('use_short_link')

--- a/odoo/addons/base/tests/test_api.py
+++ b/odoo/addons/base/tests/test_api.py
@@ -611,6 +611,14 @@ class TestAPI(SavepointCaseWithUserDemo):
             ps.filtered('parent_id.employee')
         )
 
+        # check filtering on one2many.char
+        # that the function does not crash
+        ps.filtered('category_id.name')
+
+        # filter with a limit
+        limit = len(customers) // 2
+        self.assertEqual(ps.filtered('employee', limit=limit), ps.filtered('employee')[:limit])
+
     @mute_logger('odoo.models')
     def test_80_map(self):
         """ Check map on recordsets. """

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -6152,11 +6152,12 @@ class BaseModel(metaclass=MetaModel):
         else:
             return self._mapped_func(func)
 
-    def filtered(self, func):
+    def filtered(self, func, limit=None):
         """Return the records in ``self`` satisfying ``func``.
 
         :param func: a function or a dot-separated sequence of field names
         :type func: callable or str
+        :param limit: limit the number of results
         :return: recordset of records satisfying func, may be empty.
 
         .. code-block:: python3
@@ -6170,7 +6171,10 @@ class BaseModel(metaclass=MetaModel):
         if isinstance(func, str):
             name = func
             func = lambda rec: any(rec.mapped(name))
-        return self.browse([rec.id for rec in self if func(rec)])
+        filtered_ids = (rec.id for rec in self if func(rec))
+        if limit is not None:
+            filtered_ids = itertools.islice(filtered_ids, limit)
+        return self.browse(filtered_ids)
 
     def grouped(self, key):
         """Eagerly groups the records of ``self`` by the ``key``, returning a


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This simplifies code like `x.filtered('x')[:1] to ` `x.filtered('x', limit=1)` and stops filtering as soon as enough results are found. In case when the recordset is big, this avoids checking the remaining records.

Current behavior before PR:
`filtered` always was scanning the whole recordset.

Desired behavior after PR is merged:
When limit is provided, the iteration stops when we find enough arguments.

Enterprise adaptations: https://github.com/odoo/enterprise/pull/63991

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
