### PR TITLE
[FIX] handle webp to png implicit conversion (Safari and more)

### DIFF
--- a/addons/web/static/src/core/utils/image_processing.js
+++ b/addons/web/static/src/core/utils/image_processing.js
@@ -1,0 +1,162 @@
+/** @odoo-module **/
+
+const IMAGE_MIMETYPE_FILE_EXTENSIONS = {
+    "image/bmp": ["bmp"],
+    "image/cgm": ["cgm"],
+    "image/g3fax": ["g3"],
+    "image/gif": ["gif"],
+    "image/ief": ["ief"],
+    "image/jp2": ["jp2"],
+    "image/jpeg": ["jpg", "jpeg", "jpe"],
+    "image/pict": ["pict", "pic", "pct"],
+    "image/png": ["png"],
+    "image/prs.btif": ["btif"],
+    "image/svg+xml": ["svg", "svgz"],
+    "image/tiff": ["tiff", "tif"],
+    "image/vnd.adobe.photoshop": ["psd"],
+    "image/vnd.djvu": ["djvu", "djv"],
+    "image/vnd.dwg": ["dwg"],
+    "image/vnd.dxf": ["dxf"],
+    "image/vnd.fastbidsheet": ["fbs"],
+    "image/vnd.fpx": ["fpx"],
+    "image/vnd.fst": ["fst"],
+    "image/vnd.fujixerox.edmics-mmr": ["mmr"],
+    "image/vnd.fujixerox.edmics-rlc": ["rlc"],
+    "image/vnd.ms-modi": ["mdi"],
+    "image/vnd.net-fpx": ["npx"],
+    "image/vnd.wap.wbmp": ["wbmp"],
+    "image/vnd.xiff": ["xif"],
+    "image/webp": ["webp"],
+    "image/x-cmu-raster": ["ras"],
+    "image/x-cmx": ["cmx"],
+    "image/x-freehand": ["fh", "fhc", "fh4", "fh5", "fh7"],
+    "image/x-icon": ["ico"],
+    "image/x-macpaint": ["pntg", "pnt", "mac"],
+    "image/x-pcx": ["pcx"],
+    "image/x-portable-anymap": ["pnm"],
+    "image/x-portable-bitmap": ["pbm"],
+    "image/x-portable-graymap": ["pgm"],
+    "image/x-portable-pixmap": ["ppm"],
+    "image/x-quicktime": ["qtif", "qti"],
+    "image/x-rgb": ["rgb"],
+    "image/x-xbitmap": ["xbm"],
+    "image/x-xpixmap": ["xpm"],
+    "image/x-xwindowdump": ["xwd"],
+};
+const IMAGE_FILE_EXTENSION_MIMETYPE = Object.fromEntries(
+    Object.entries(IMAGE_MIMETYPE_FILE_EXTENSIONS)
+        .map(([mimetype, extensions]) => extensions.map((extension) => [extension, mimetype]))
+        .flat()
+);
+
+/**
+ * The return data of {@link convertCanvasToDataURL}.
+ *
+ * @typedef {Object} ConvertedCanvasImageData
+ * @property {string} dataURL The resulting data url from
+ * {@link HTMLCanvasElement#toDataURL}.
+ * @property {string} mimetype The actual output mimetype.
+ * @property {string} base64Part The base64 part of the data url for
+ * convenience.
+ * @property {string} defaultFileExtension The base64 part of the data url for
+ * convenience.
+ */
+
+/**
+ * Used to handle implicit mimetype conversions, which is when a browser doesn't
+ * support a mimetype as an argument of {@link HTMLCanvasElement#toDataURL} and
+ * returns a PNG instead. It returns both the dataURL and its mimetype. It also
+ * returns pre-processed data about the output image for convenience.
+ *
+ * See {@link https://caniuse.com/mdn-api_htmlcanvaselement_todataurl_type_parameter_webp}.
+ *
+ * @param {HTMLCanvasElement} canvas
+ * @param {string} [mimetype] See {@link HTMLCanvasElement#toDataURL}.
+ * @param {number} [quality] See {@link HTMLCanvasElement#toDataURL}.
+ * @returns {ConvertedCanvasImageData}
+ */
+export function convertCanvasToDataURL(canvas, mimetype, quality) {
+    const dataURL = canvas.toDataURL(mimetype, quality);
+    const actualMimetype = extractMimetypeFromDataURL(dataURL);
+    return {
+        dataURL,
+        mimetype: actualMimetype,
+        base64Part: extractBase64PartFromDataURL(dataURL),
+        defaultFileExtension: getDefaultFileExtensionForMimetype(actualMimetype),
+    };
+}
+
+/**
+ * Check whether the current browser has {@link HTMLCanvasElement#toDataURL}
+ * with `image/webp` mimetype capability.
+ *
+ * The result is memoized since the browser cannot gain or lose that capability
+ * during a continuous session.
+ *
+ * @returns {boolean}
+ */
+export function canExportCanvasAsWebp() {
+    if (typeof canExportCanvasAsWebp._canExportCanvasAsWebp === "undefined") {
+        const dummyCanvas = document.createElement("canvas");
+        dummyCanvas.width = 1;
+        dummyCanvas.height = 1;
+        const dataURL = dummyCanvas.toDataURL("image/webp");
+        dummyCanvas.remove();
+        canExportCanvasAsWebp._canExportCanvasAsWebp =
+            extractMimetypeFromDataURL(dataURL) === "image/webp";
+    }
+    return canExportCanvasAsWebp._canExportCanvasAsWebp;
+}
+
+/**
+ * @param dataURL
+ * @return {string} The image mimetype stored in {@link dataURL}.
+ */
+export function extractMimetypeFromDataURL(dataURL) {
+    return dataURL.split(":")[1].split(";")[0];
+}
+
+/**
+ * @param {string} dataURL
+ * @return {string} The base64 part of {@link dataURL}, without the extra
+ * starting and ending format bits. This can be useful to optimize storage.
+ */
+export function extractBase64PartFromDataURL(dataURL) {
+    return dataURL.split(",")[1];
+}
+
+/**
+ * Map mimetype -> file extension.
+ * Only supports image mimetypes.
+ *
+ * @example "image/jpeg" => "jpeg"
+ *
+ * @param {string} mimetype
+ * @return {string}
+ * @throws Error An error for unknown mimetypes.
+ */
+export function getDefaultFileExtensionForMimetype(mimetype) {
+    const extensions = IMAGE_MIMETYPE_FILE_EXTENSIONS[mimetype];
+    if (!extensions) {
+        throw new Error(`No extension mapping for mimetype ${mimetype}`);
+    }
+    return extensions?.[0];
+}
+
+/**
+ * Map file extension -> mimetype.
+ * Only supports image extensions.
+ *
+ * @example "jpg" => "image/jpeg"
+ *
+ * @param {string} extension
+ * @return {string}
+ * @throws Error An error for unknown file extensions.
+ */
+export function getMimetypeForFileExtension(extension) {
+    const mimetype = IMAGE_FILE_EXTENSION_MIMETYPE[extension];
+    if (!mimetype) {
+        throw new Error(`No mimetype mapping for extension ${extension}`);
+    }
+    return mimetype;
+}

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -32,6 +32,7 @@ import {
     getDataURLBinarySize,
 } from "@web_editor/js/editor/image_processing";
 import * as OdooEditorLib from "@web_editor/js/editor/odoo-editor/src/OdooEditor";
+import { canExportCanvasAsWebp } from "@web/core/utils/image_processing";
 import { pick } from "@web/core/utils/objects";
 import { _t } from "@web/core/l10n/translation";
 import {
@@ -6205,18 +6206,11 @@ const ImageHandlerOption = SnippetOptionWidget.extend({
     /**
      * @see this.selectClass for parameters
      */
-    selectFormat(previewMode, widgetValue, params) {
-        const values = widgetValue.split(' ');
+    async selectFormat(previewMode, widgetValue, params) {
+        const [resizeWidth, mimetype] = widgetValue.split(" ");
         const image = this._getImg();
-        image.dataset.resizeWidth = values[0];
-        if (image.dataset.shape) {
-            // If the image has a shape, modify its originalMimetype attribute.
-            image.dataset.originalMimetype = values[1];
-        } else {
-            // If the image does not have a shape, modify its mimetype
-            // attribute.
-            image.dataset.mimetype = values[1];
-        }
+        image.dataset.resizeWidth = resizeWidth;
+        this._setImageMimetype(image, mimetype);
         return this._applyOptions();
     },
     /**
@@ -6285,17 +6279,8 @@ const ImageHandlerOption = SnippetOptionWidget.extend({
         });
 
         switch (methodName) {
-            case "selectFormat": {
-                const currentImageMimetype = this._getImageMimetype(img);
-                const availableFormats = (await this._computeAvailableFormats()).map(
-                    ([value, [, targetFormat]]) => `${Math.round(value)} ${targetFormat}`
-                );
-                const currentFormatSize = img.naturalWidth.toString();
-                const currentFormat = `${currentFormatSize} ${currentImageMimetype}`;
-                return availableFormats.includes(currentFormat)
-                    ? currentFormat
-                    : availableFormats.find((format) => format.startsWith(currentFormatSize));
-            }
+            case 'selectFormat':
+                return this._getCurrentFormat(img);
             case 'setFilter':
                 return img.dataset.filter;
             case 'glFilter':
@@ -6324,9 +6309,16 @@ const ImageHandlerOption = SnippetOptionWidget.extend({
             return;
         }
         const $select = $(uiFragment).find('we-select[data-name=format_select_opt]');
-        (await this._computeAvailableFormats()).forEach(([value, [label, targetFormat]]) => {
-            $select.append(`<we-button data-select-format="${Math.round(value)} ${targetFormat}" class="o_we_badge_at_end">${label} <span class="badge rounded-pill text-bg-dark">${targetFormat.split('/')[1]}</span></we-button>`);
-        });
+        (await this._computeAvailableFormats()).forEach(
+            ([value, [label, targetFormat, isDisabled]]) => {
+                const selectFormat = `${Math.round(value)} ${targetFormat}`;
+                const unavailableOptionDependencies = isDisabled ? ' data-dependencies="fake"' : "";
+                const mimetypeBadge = targetFormat.split("/")[1];
+                $select.append(
+                    `<we-button data-select-format="${selectFormat}" class="o_we_badge_at_end"${unavailableOptionDependencies}>${label} <span class="badge rounded-pill text-bg-dark">${mimetypeBadge}</span></we-button>`
+                );
+            }
+        );
 
         if (!['image/jpeg', 'image/webp'].includes(this._getImageMimetype(img))) {
             const optQuality = uiFragment.querySelector('we-range[data-set-quality]');
@@ -6346,28 +6338,53 @@ const ImageHandlerOption = SnippetOptionWidget.extend({
             return [];
         }
         const img = this._getImg();
-        const original = await loadImage(this.originalSrc);
-        const maxWidth = img.dataset.width ? img.naturalWidth : original.naturalWidth;
-        const optimizedWidth = Math.min(maxWidth, this._computeMaxDisplayWidth());
+        const originalSize = await this._getOriginalSize();
+        const optimizedWidth = Math.min(originalSize, this._computeMaxDisplayWidth());
         this.optimizedWidth = optimizedWidth;
-        const widths = {
-            128: ['128px', 'image/webp'],
-            256: ['256px', 'image/webp'],
-            512: ['512px', 'image/webp'],
-            1024: ['1024px', 'image/webp'],
-            1920: ['1920px', 'image/webp'],
+        const optimizedMimetype = canExportCanvasAsWebp() ? "image/webp" : "image/jpeg";
+        const formatsByWidth = {
+            128: ["128px", optimizedMimetype],
+            256: ["256px", optimizedMimetype],
+            512: ["512px", optimizedMimetype],
+            1024: ["1024px", optimizedMimetype],
+            1920: ["1920px", optimizedMimetype],
         };
-        widths[img.naturalWidth] = [_t("%spx", img.naturalWidth), 'image/webp'];
-        widths[optimizedWidth] = [_t("%spx (Suggested)", optimizedWidth), 'image/webp'];
+        formatsByWidth[img.naturalWidth] = [_t("%spx", img.naturalWidth), optimizedMimetype];
+        formatsByWidth[optimizedWidth] = [
+            _t("%spx (Suggested)", optimizedWidth),
+            optimizedMimetype,
+        ];
         const mimetypeBeforeConversion = img.dataset.mimetypeBeforeConversion;
-        widths[maxWidth] = [_t("%spx (Original)", maxWidth), mimetypeBeforeConversion];
-        if (mimetypeBeforeConversion !== "image/webp") {
-            // Avoid a key collision by subtracting 0.1 - putting the webp
-            // above the original format one of the same size.
-            widths[maxWidth - 0.1] = [_t("%spx", maxWidth), 'image/webp'];
+        formatsByWidth[originalSize] = [
+            _t("%spx (Original)", originalSize),
+            mimetypeBeforeConversion,
+        ];
+        if (mimetypeBeforeConversion !== optimizedMimetype) {
+            // Avoid key collision and ensure the optimized format is above the
+            // original one of the same size.
+            formatsByWidth[originalSize - 0.1] = [_t("%spx", originalSize), optimizedMimetype];
         }
-        return Object.entries(widths)
-            .filter(([width]) => width <= maxWidth)
+
+        // If the currently selected format is unavailable, add it as an
+        // unselectable option.
+        // This handles cases such as:
+        // - Switching between a browser where webp is available and one where
+        //   webp is not
+        // - Changing the specs of the available formats, where some previously
+        //   used format cannot be selected anymore
+        // - External modification of the format
+        const currentFormat = this._getCurrentFormat(img);
+        const [selectedSize, selectedMimetype] = currentFormat?.split(" ") || [];
+        if (
+            selectedSize &&
+            selectedMimetype &&
+            (!formatsByWidth[selectedSize] || formatsByWidth[selectedSize][1] !== selectedMimetype)
+        ) {
+            formatsByWidth[selectedSize - 0.2] = [_t("%spx", selectedSize), selectedMimetype, true];
+        }
+
+        return Object.entries(formatsByWidth)
+            .filter(([width]) => width <= originalSize)
             .sort(([v1], [v2]) => v1 - v2);
     },
     /**
@@ -6394,9 +6411,12 @@ const ImageHandlerOption = SnippetOptionWidget.extend({
             delete img.dataset.mimetype;
             return;
         }
+        const targetMimetype = await this._getImageTargetMimetype();
         const { dataURL, mimetype } = await applyModifications(
             img,
-            { mimetype: this._getImageMimetype(img) },
+            {
+                mimetype: targetMimetype,
+            },
             true // TODO: remove in master
         );
         this._filesize = getDataURLBinarySize(dataURL) / 1024;
@@ -6438,12 +6458,12 @@ const ImageHandlerOption = SnippetOptionWidget.extend({
         await this._loadImageInfo();
         await this._rerenderXML();
         const img = this._getImg();
-        if (!['image/gif', 'image/svg+xml'].includes(img.dataset.mimetype)) {
+        if (
+            !["image/gif", "image/svg+xml"].includes(img.dataset.mimetype) ||
+            (img.dataset.shape && img.dataset.originalMimetype !== "image/gif")
+        ) {
             // Convert to recommended format and width.
-            img.dataset.mimetype = 'image/webp';
-            img.dataset.resizeWidth = this.optimizedWidth;
-        } else if (img.dataset.shape && img.dataset.originalMimetype !== "image/gif") {
-            img.dataset.originalMimetype = "image/webp";
+            this._setImageMimetype(img, canExportCanvasAsWebp() ? "image/webp" : "image/jpeg");
             img.dataset.resizeWidth = this.optimizedWidth;
         }
         await this._applyOptions();
@@ -6530,6 +6550,70 @@ const ImageHandlerOption = SnippetOptionWidget.extend({
             || params.optionsPossibleValues.setQuality
             || widgetName === 'format_select_opt';
     },
+    /**
+     * @param {HTMLImageElement} [image] Override image element.
+     * @return {string} The image's current width.
+     * @private
+     */
+    _getImageWidth(image = this._getImg()) {
+        return Math.trunc(
+            image.dataset.resizeWidth || image.dataset.width || image.naturalWidth
+        ).toString();
+    },
+    /**
+     * @return {Promise<number>} The image's original size.
+     * @private
+     */
+    async _getOriginalSize() {
+        const image = this._getImg();
+        const originalImage = await loadImage(this.originalSrc);
+        return image.dataset.width ? image.naturalWidth : originalImage.naturalWidth;
+    },
+    /**
+     * @param {HTMLImageElement} img
+     * @return {string} The image's current format (widget value).
+     * @private
+     */
+    _getCurrentFormat(img) {
+        return `${img.naturalWidth} ${this._getImageMimetype(img)}`;
+    },
+    /**
+     * Returns whether the format is the image's original format.
+     *
+     * @param {string} size
+     * @param {string} mimetype
+     * @param {HTMLImageElement} [image] Override image element.
+     * @return {Promise<boolean>}
+     * @private
+     */
+    async _isOriginalFormat(size, mimetype, image = this._getImg()) {
+        const originalMimetype = image.dataset.mimetypeBeforeConversion;
+        if (mimetype !== originalMimetype) {
+            return false;
+        }
+
+        const originalSize = await this._getOriginalSize();
+        return size.toString() === originalSize.toString();
+    },
+    /**
+     * Get the appropriate mimetype to applyModifications.
+     * Avoid implicit conversions.
+     * Only target available formats.
+     *
+     * @param {HTMLImageElement} [image] Override image element.
+     * @private
+     */
+    async _getImageTargetMimetype(image = this._getImg()) {
+        const currentSize = this._getImageWidth(image);
+        const currentMimetype = this._getImageMimetype(image);
+
+        const isOriginalFormat = await this._isOriginalFormat(currentSize, currentMimetype);
+        if (!isOriginalFormat && ["image/webp", "image/jpeg"].includes(currentMimetype)) {
+            return canExportCanvasAsWebp() ? "image/webp" : "image/jpeg";
+        } else {
+            return currentMimetype;
+        }
+    },
 });
 
 /**
@@ -6614,7 +6698,7 @@ registry.ImageTools = ImageHandlerOption.extend({
         await new Promise(resolve => {
             this.$target.one('image_cropper_destroyed', async () => {
                 if (isGif(this._getImageMimetype(img))) {
-                    img.dataset[img.dataset.shape ? 'originalMimetype' : 'mimetype'] = 'image/png';
+                    this._setImageMimetype(img, "image/png");
                 }
                 await this._reapplyCurrentShape();
                 resolve();
@@ -6678,6 +6762,7 @@ registry.ImageTools = ImageHandlerOption.extend({
         // temporarily into the body.
         const imageCropWrapperElement = document.createElement('div');
         document.body.append(imageCropWrapperElement);
+        img.dataset.targetMimetype = img.dataset.mimetypeBeforeConversion;
         const imageCropWrapper = await attachComponent(this, imageCropWrapperElement, ImageCrop, {
             rpc: this.rpc,
             activeOnStart: true,
@@ -6745,10 +6830,11 @@ registry.ImageTools = ImageHandlerOption.extend({
             }
         } else {
             // Re-applying the modifications and deleting the shapes
+            const targetMimetype = await this._getImageTargetMimetype();
             const { dataURL, mimetype } = await applyModifications(
                 img,
                 {
-                    mimetype: this._getImageMimetype(img),
+                    mimetype: targetMimetype,
                 },
                 true // TODO: remove in master
             );
@@ -7124,10 +7210,11 @@ registry.ImageTools = ImageHandlerOption.extend({
         // We will store the image in base64 inside the SVG.
         // applyModifications will return a dataURL with the current filters
         // and size options.
+        const targetMimetype = await this._getImageTargetMimetype(img);
         const { dataURL: imgDataURL, mimetype } = await applyModifications(
             img,
             {
-                mimetype: this._getImageMimetype(img),
+                mimetype: targetMimetype,
                 perspective: svg.dataset.imgPerspective || null,
                 imgAspectRatio: svg.dataset.imgAspectRatio || null,
                 svgAspectRatio: svgAspectRatio,

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -6177,6 +6177,13 @@ const ImageHandlerOption = SnippetOptionWidget.extend({
         // This does not update the target.
         await this._applyOptions(false);
     },
+    /**
+     * @override
+     */
+    async cleanForSave() {
+        const img = this._getImg();
+        delete img.dataset.width;
+    },
 
     //--------------------------------------------------------------------------
     // Public
@@ -6413,6 +6420,10 @@ const ImageHandlerOption = SnippetOptionWidget.extend({
 
         if (update) {
             img.classList.add('o_modified_image_to_save');
+            if (!img.dataset.width) {
+                // Save image original width.
+                img.dataset.width = await this._getOriginalSize();
+            }
             this._setImageMimetype(img, mimetype);
             const loadedImg = await loadImage(dataURL, img);
             this._applyImage(loadedImg);
@@ -6556,8 +6567,13 @@ const ImageHandlerOption = SnippetOptionWidget.extend({
      */
     async _getOriginalSize() {
         const image = this._getImg();
-        const originalImage = await loadImage(this.originalSrc);
-        return Math.round(image.dataset.width) || originalImage.naturalWidth;
+        const storedOriginalWidth = Math.round(image.dataset.width);
+        if (storedOriginalWidth) {
+            return storedOriginalWidth;
+        } else {
+            const originalImage = await loadImage(this.originalSrc);
+            return originalImage.naturalWidth;
+        }
     },
     /**
      * @param {HTMLImageElement} img

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -6567,7 +6567,7 @@ const ImageHandlerOption = SnippetOptionWidget.extend({
     async _getOriginalSize() {
         const image = this._getImg();
         const originalImage = await loadImage(this.originalSrc);
-        return image.dataset.width ? image.naturalWidth : originalImage.naturalWidth;
+        return Math.round(image.dataset.width) || originalImage.naturalWidth;
     },
     /**
      * @param {HTMLImageElement} img
@@ -6762,7 +6762,6 @@ registry.ImageTools = ImageHandlerOption.extend({
         // temporarily into the body.
         const imageCropWrapperElement = document.createElement('div');
         document.body.append(imageCropWrapperElement);
-        img.dataset.targetMimetype = img.dataset.mimetypeBeforeConversion;
         const imageCropWrapper = await attachComponent(this, imageCropWrapperElement, ImageCrop, {
             rpc: this.rpc,
             activeOnStart: true,
@@ -6776,6 +6775,11 @@ registry.ImageTools = ImageHandlerOption.extend({
         imageCropWrapperElement.remove();
 
         await this._reapplyCurrentShape();
+
+        // Reset to "Suggested" format
+        await this._computeAvailableFormats(); // Update this.optimizedWidth
+        const optimizedMimetype = canExportCanvasAsWebp() ? "image/webp" : "image/jpeg";
+        await this.selectFormat(false, `${this.optimizedWidth} ${optimizedMimetype}`);
     },
     /**
      * Resets the image rotation and translation

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/image_crop.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/image_crop.js
@@ -22,10 +22,12 @@ export class ImageCrop extends Component {
         activeOnStart: { type: Boolean, optional: true },
         media: { optional: true },
         mimetype: { type: String, optional: true },
+        mimetypeOutputAttribute: { type: String, optional: true },
     };
     static defaultProps = {
         activeOnStart: false,
         showCount: 0,
+        mimetypeOutputAttribute: "mimetype",
     };
     aspectRatios = {
         "0/0": {label: _t("Flexible"), value: 0},
@@ -80,6 +82,7 @@ export class ImageCrop extends Component {
             this.elRef.el.ownerDocument.removeEventListener('keydown', this._onDocumentKeydown, {capture: true});
         }
         this.media.setAttribute('src', this.initialSrc);
+        this.media.dataset[this.props.mimetypeOutputAttribute] = this.mimetype;
         this.$media.trigger('image_cropper_destroyed');
         this.state.active = false;
     }
@@ -199,7 +202,13 @@ export class ImageCrop extends Component {
             }
         });
         delete this.media.dataset.resizeWidth;
-        this.initialSrc = await applyModifications(this.media, {forceModification: true, mimetype: this.mimetype});
+        const { dataURL, mimetype } = await applyModifications(
+            this.media,
+            { forceModification: true, mimetype: this.mimetype },
+            true // TODO: remove in master
+        );
+        this.initialSrc = dataURL;
+        this.mimetype = mimetype;
         this.media.classList.toggle('o_we_image_cropped', cropped);
         this.$media.trigger('image_cropped');
         this._closeCropper();

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -20,6 +20,7 @@ import weUtils from "@web_editor/js/common/utils";
 import { isSelectionInSelectors, peek } from '@web_editor/js/editor/odoo-editor/src/utils/utils';
 import { PeerToPeer, RequestError } from "@web_editor/js/wysiwyg/PeerToPeer";
 import { uniqueId } from "@web/core/utils/functions";
+import { convertCanvasToDataURL } from "@web/core/utils/image_processing";
 import { groupBy } from "@web/core/utils/arrays";
 import { debounce } from "@web/core/utils/timing";
 import { registry } from "@web/core/registry";
@@ -3522,11 +3523,17 @@ export class Wysiwyg extends Component {
                 ctx.fillStyle = 'rgb(255, 255, 255)';
                 ctx.fillRect(0, 0, canvas.width, canvas.height);
                 ctx.drawImage(image, 0, 0, image.width, image.height, 0, 0, canvas.width, canvas.height);
-                altData[size] = {
-                    'image/jpeg': canvas.toDataURL('image/jpeg', 0.75).split(',')[1],
+
+                const generateAltData = (mimetype) => {
+                    const imageData = convertCanvasToDataURL(canvas, mimetype, 0.75);
+                    if (!altData[size]) {
+                        altData[size] = {};
+                    }
+                    altData[size][imageData.mimetype] = imageData.base64Part;
                 };
+                generateAltData("image/jpeg");
                 if (size !== originalSize) {
-                    altData[size]['image/webp'] = canvas.toDataURL('image/webp', 0.75).split(',')[1];
+                    generateAltData("image/webp");
                 }
             }
         }

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -20,7 +20,7 @@ import weUtils from "@web_editor/js/common/utils";
 import { isSelectionInSelectors, peek } from '@web_editor/js/editor/odoo-editor/src/utils/utils';
 import { PeerToPeer, RequestError } from "@web_editor/js/wysiwyg/PeerToPeer";
 import { uniqueId } from "@web/core/utils/functions";
-import { convertCanvasToDataURL } from "@web/core/utils/image_processing";
+import { canExportCanvasAsWebp, convertCanvasToDataURL } from "@web/core/utils/image_processing";
 import { groupBy } from "@web/core/utils/arrays";
 import { debounce } from "@web/core/utils/timing";
 import { registry } from "@web/core/registry";
@@ -3526,13 +3526,15 @@ export class Wysiwyg extends Component {
 
                 const generateAltData = (mimetype) => {
                     const imageData = convertCanvasToDataURL(canvas, mimetype, 0.75);
-                    if (!altData[size]) {
-                        altData[size] = {};
+                    if (imageData.mimetype === mimetype) {
+                        if (!altData[size]) {
+                            altData[size] = {};
+                        }
+                        altData[size][imageData.mimetype] = imageData.base64Part;
                     }
-                    altData[size][imageData.mimetype] = imageData.base64Part;
                 };
                 generateAltData("image/jpeg");
-                if (size !== originalSize) {
+                if (size !== originalSize && canExportCanvasAsWebp()) {
                     generateAltData("image/webp");
                 }
             }

--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -4,6 +4,7 @@ import { loadCSS } from "@web/core/assets";
 import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { Dialog } from "@web/core/dialog/dialog";
 import { useChildRef } from "@web/core/utils/hooks";
+import { canExportCanvasAsWebp } from "@web/core/utils/image_processing";
 import weUtils from "@web_editor/js/common/utils";
 import options from "@web_editor/js/editor/snippets.options";
 import { NavbarLinkPopoverWidget } from "@website/js/widgets/link_popover_widget";
@@ -2991,7 +2992,7 @@ options.registry.CoverProperties = options.Class.extend({
                     "image/gif",
                     "image/svg+xml",
                     "image/webp",
-                ].includes(originalMimetype)) {
+                ].includes(originalMimetype) && canExportCanvasAsWebp()) {
                     // Convert to webp but keep original width.
                     const { dataURL, mimetype } = await applyModifications(
                         imgEl,

--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -2986,17 +2986,22 @@ options.registry.CoverProperties = options.Class.extend({
                 const imgEl = document.createElement("img");
                 imgEl.src = widgetValue;
                 await loadImageInfo(imgEl, this.rpc);
-                if (imgEl.dataset.mimetype && ![
+                const originalMimetype = imgEl.dataset.mimetype;
+                if (originalMimetype && ![
                     "image/gif",
                     "image/svg+xml",
                     "image/webp",
-                ].includes(imgEl.dataset.mimetype)) {
+                ].includes(originalMimetype)) {
                     // Convert to webp but keep original width.
-                    imgEl.dataset.mimetype = "image/webp";
-                    const base64src = await applyModifications(imgEl, {
-                        mimetype: "image/webp",
-                    });
-                    widgetValue = base64src;
+                    const { dataURL, mimetype } = await applyModifications(
+                        imgEl,
+                        {
+                            mimetype: "image/webp",
+                        },
+                        true // TODO: remove in master
+                    );
+                    imgEl.dataset.mimetype = mimetype;
+                    widgetValue = dataURL;
                     this.$image[0].classList.add("o_b64_image_to_save");
                 }
             }

--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -493,6 +493,48 @@ function toggleMobilePreview(toggleOn) {
     }];
 }
 
+/**
+ * Waits for an HTMLImageElement to load. Skips waiting if already loaded.
+ *
+ * @param {string} selector The {@link HTMLImageElement} to wait for.
+ * @return {Array}
+ */
+function waitForImageToLoad(selector) {
+    if (selector) {
+        return [
+            {
+                content: "Wait for image to load",
+                trigger: selector,
+                async run() {
+                    const img = this.$anchor[0];
+                    await new Promise((resolve) => {
+                        if (img.complete) {
+                            resolve();
+                        } else {
+                            img.addEventListener("load", resolve);
+                        }
+                    });
+                },
+            },
+        ];
+    } else {
+        return waitForNextRenderFrame();
+    }
+}
+
+function waitForNextRenderFrame() {
+    return [
+        {
+            content: "Wait for next render frame",
+            trigger: "body",
+            async run() {
+                await new Promise((resolve) => window.requestAnimationFrame(resolve));
+                await new Promise((resolve) => setTimeout(resolve));
+            },
+        },
+    ];
+}
+
 export default {
     addMedia,
     assertCssVariable,
@@ -525,4 +567,6 @@ export default {
     selectSnippetColumn,
     switchWebsite,
     toggleMobilePreview,
+    waitForImageToLoad,
+    waitForNextRenderFrame,
 };

--- a/addons/website/static/src/snippets/s_image_gallery/options.js
+++ b/addons/website/static/src/snippets/s_image_gallery/options.js
@@ -1,5 +1,6 @@
 /** @odoo-module **/
 
+import { canExportCanvasAsWebp } from "@web/core/utils/image_processing";
 import { MediaDialog } from "@web_editor/components/media_dialog/media_dialog";
 import options from "@web_editor/js/editor/snippets.options";
 import wUtils from '@website/js/utils';
@@ -526,7 +527,7 @@ options.registry.GalleryImageList = options.registry.GalleryLayout.extend({
                                     "image/gif",
                                     "image/svg+xml",
                                     "image/webp",
-                                ].includes(originalMimetype)) {
+                                ].includes(originalMimetype) && canExportCanvasAsWebp()) {
                                     // Convert to webp but keep original width.
                                     applyModifications(
                                         imgEl,

--- a/addons/website/static/src/snippets/s_image_gallery/options.js
+++ b/addons/website/static/src/snippets/s_image_gallery/options.js
@@ -521,17 +521,22 @@ options.registry.GalleryImageList = options.registry.GalleryLayout.extend({
                         const imgEl = $img[0];
                         imagePromises.push(new Promise(resolve => {
                             loadImageInfo(imgEl, this.rpc).then(() => {
-                                if (imgEl.dataset.mimetype && ![
+                                const originalMimetype = imgEl.dataset.mimetype;
+                                if (originalMimetype && ![
                                     "image/gif",
                                     "image/svg+xml",
                                     "image/webp",
-                                ].includes(imgEl.dataset.mimetype)) {
+                                ].includes(originalMimetype)) {
                                     // Convert to webp but keep original width.
-                                    imgEl.dataset.mimetype = "image/webp";
-                                    applyModifications(imgEl, {
-                                        mimetype: "image/webp",
-                                    }).then(src => {
-                                        imgEl.src = src;
+                                    applyModifications(
+                                        imgEl,
+                                        {
+                                            mimetype: "image/webp",
+                                        },
+                                        true // TODO: remove in master
+                                    ).then(({ dataURL, mimetype }) => {
+                                        imgEl.dataset.mimetype = mimetype;
+                                        imgEl.src = dataURL;
                                         imgEl.classList.add("o_modified_image_to_save");
                                         resolve();
                                     });

--- a/addons/website/static/tests/tours/snippet_image_mimetype.js
+++ b/addons/website/static/tests/tours/snippet_image_mimetype.js
@@ -1,0 +1,637 @@
+/** @odoo-module */
+
+import {
+    canExportCanvasAsWebp,
+    convertCanvasToDataURL,
+    extractBase64PartFromDataURL,
+    extractMimetypeFromDataURL,
+} from "@web/core/utils/image_processing";
+import wTourUtils from "@website/js/tours/tour_utils";
+
+let originalToDataURL;
+export const mockCanvasToDataURLStep = {
+    content: "Mock HTMLCanvasElement.toDataURL",
+    trigger: "body",
+    run() {
+        originalToDataURL = HTMLCanvasElement.prototype.toDataURL;
+        HTMLCanvasElement.prototype.toDataURL = function (type, quality) {
+            return originalToDataURL.call(
+                this,
+                type === "image/webp" ? "image/png" : type,
+                quality
+            );
+        };
+        canExportCanvasAsWebp._canExportCanvasAsWebp = false;
+    },
+};
+export const unmockCanvasToDataURLStep = {
+    content: "Unmock HTMLCanvasElement.toDataURL",
+    trigger: "body",
+    run() {
+        HTMLCanvasElement.prototype.toDataURL = originalToDataURL;
+        originalToDataURL = undefined;
+        canExportCanvasAsWebp._canExportCanvasAsWebp = true;
+    },
+};
+
+export function uploadImageFromDialog(
+    mimetype,
+    filename,
+    data,
+    confirmChoice = true,
+    targetSelector = ".o_we_existing_attachments .o_we_attachment_selected img"
+) {
+    return [
+        {
+            content: "Upload an image",
+            trigger: ".o_upload_media_button",
+            async run() {
+                const imageData = Uint8Array.from([...atob(data)].map((c) => c.charCodeAt(0)));
+                const fileInput = document.querySelector(
+                    '.o_select_media_dialog input[type="file"]'
+                );
+                const file = new File([imageData], filename, { type: mimetype });
+                const transfer = new DataTransfer();
+                transfer.items.add(file);
+                fileInput.files = transfer.files;
+                fileInput.dispatchEvent(new Event("change"));
+            },
+        },
+        ...(confirmChoice
+            ? [
+                  ...wTourUtils.waitForImageToLoad(targetSelector),
+                  {
+                      content: "Confirm choice",
+                      trigger: '.o_select_media_dialog footer button:contains("Add")',
+                      extraTrigger: ".o_we_existing_attachments .o_we_attachment_selected",
+                  },
+              ]
+            : []),
+    ];
+}
+
+export const PNG_THAT_CONVERTS_TO_BIGGER_WEBP =
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQIW2NgAAIAAAUAAR4f7BQAAAAASUVORK5CYII=";
+const DUMMY_WEBP = "UklGRiwAAABXRUJQVlA4TB8AAAAv/8F/EAcQEREQCCT7e89QRP8z/vOf//znP//5z/8BAA==";
+
+export function generateTestImage(size, mimetype) {
+    const canvas = document.createElement("canvas");
+    canvas.width = size;
+    canvas.height = size;
+    return canvas.toDataURL(mimetype);
+}
+
+const selectTextImageSnippetImage = {
+    content: "Select image",
+    trigger: "iframe .s_text_image img",
+};
+const selectImageGallerySnippetImage = {
+    content: "Select image",
+    trigger: "iframe .s_image_gallery img",
+};
+
+function setOriginalImageFormat() {
+    return setImageFormat(undefined, true);
+}
+
+function setImageFormat(targetFormat, isOriginalFormat = false) {
+    const formatSelector = isOriginalFormat
+        ? "we-button:last-child"
+        : `we-button[data-select-format="${targetFormat}"]`;
+    return [
+        {
+            content: "Open format select",
+            trigger: 'we-select[data-name="format_select_opt"]',
+        },
+        {
+            content: `Select ${targetFormat || "original format"}`,
+            trigger: `we-select[data-name="format_select_opt"] ${formatSelector}`,
+        },
+    ];
+}
+
+function setImageShape() {
+    return [
+        {
+            content: "Open shape select",
+            trigger:
+                'we-customizeblock-options:has(we-title:contains("Image")) we-select[data-name="shape_img_opt"]',
+        },
+        {
+            content: "Select diamond shape",
+            trigger:
+                'we-customizeblock-options:has(we-title:contains("Image")) we-select[data-name="shape_img_opt"] we-button[data-select-label="Diamond"]',
+        },
+        {
+            content: "Wait for image update: svg wrap",
+            trigger: 'iframe .s_text_image img[src^="data:image/svg+xml;base64,"]',
+            isCheck: true,
+        },
+    ];
+}
+
+function removeImageShape(targetMimetype) {
+    return [
+        {
+            content: "Remove image shape",
+            trigger:
+                'we-customizeblock-options:has(we-title:contains("Image")) we-button[data-set-img-shape=""]',
+        },
+        {
+            content: `Wait for image update: mimetype ${targetMimetype}`,
+            trigger: `iframe .s_text_image img[src^="data:${targetMimetype};base64,"]`,
+            isCheck: true,
+        },
+    ];
+}
+
+function cropImage(targetMimetype) {
+    return [
+        {
+            content: "Open crop widget",
+            trigger:
+                'we-customizeblock-options:has(we-title:contains("Image")) we-button[data-crop="true"]',
+        },
+        {
+            content: "Choose 1/1 crop ratio",
+            trigger: '[data-action="ratio"][data-value="1/1"]',
+        },
+        {
+            content: "Apply",
+            trigger: '[data-action="apply"]',
+        },
+        {
+            content: `Wait for image update: aspect ratio to 1/1`,
+            trigger: `iframe .s_text_image img[data-aspect-ratio="1/1"]`,
+            isCheck: true,
+        },
+        {
+            content: `Wait for image update: mimetype ${targetMimetype}`,
+            trigger: `iframe .s_text_image img[src^="data:${targetMimetype};base64,"]`,
+            isCheck: true,
+        },
+    ];
+}
+
+function removeImageCrop(originalMimetype) {
+    return [
+        {
+            content: "Reset crop",
+            trigger:
+                'we-customizeblock-options:has(we-title:contains("Image")) we-button[data-reset-crop]',
+        },
+        {
+            content: `Wait for image update: reset aspect ratio to 0/0`,
+            trigger: `iframe .s_text_image img[data-aspect-ratio="0/0"]`,
+            isCheck: true,
+        },
+        {
+            content: `Wait for image update: mimetype ${originalMimetype}`,
+            trigger: `iframe .s_text_image img[src^="data:${originalMimetype};base64,"]`,
+            isCheck: true,
+        },
+    ];
+}
+
+function testImageMimetypeIs(
+    expectedBaseImageMimetype,
+    isSvgEmbedded = false,
+    trigger = "iframe .o_modified_image_to_save",
+    skipDataURLMimetypeCheck = false
+) {
+    const expectedMimetype = isSvgEmbedded ? "image/svg+xml" : expectedBaseImageMimetype;
+    const expectedSvgEmbeddedMimetype = isSvgEmbedded ? expectedBaseImageMimetype : undefined;
+    if (!skipDataURLMimetypeCheck) {
+        trigger += `[src^="data:${expectedMimetype};base64,"]`;
+    }
+    return [
+        {
+            content: `Image data-mimetype is ${expectedMimetype}`,
+            trigger: `${trigger}[data-mimetype="${expectedMimetype}"]`,
+            isCheck: true,
+        },
+        {
+            content: `Image data-original-mimetype is ${expectedSvgEmbeddedMimetype}`,
+            trigger: `${trigger}${
+                expectedSvgEmbeddedMimetype
+                    ? `[data-original-mimetype="${expectedSvgEmbeddedMimetype}"]`
+                    : ":not([data-original-mimetype])"
+            }`,
+            isCheck: true,
+        },
+        ...(skipDataURLMimetypeCheck
+            ? []
+            : [
+                  {
+                      content: `Image's actual mimetype is ${expectedBaseImageMimetype}`,
+                      trigger: trigger,
+                      run() {
+                          const dataURL = this.$anchor[0].src;
+                          let actualMimetype = extractMimetypeFromDataURL(dataURL);
+                          if (isSvgEmbedded) {
+                              if (actualMimetype !== "image/svg+xml") {
+                                  throw new Error(
+                                      `Image is not embedded in SVG (Got ${actualMimetype} - Expected: image/svg+xml)`
+                                  );
+                              }
+
+                              const svgText = atob(extractBase64PartFromDataURL(dataURL));
+                              const svg = new DOMParser().parseFromString(
+                                  svgText,
+                                  "image/svg+xml"
+                              ).documentElement;
+                              const embeddedDataURL = svg
+                                  .querySelector("image")
+                                  .getAttribute("xlink:href");
+                              actualMimetype = extractMimetypeFromDataURL(embeddedDataURL);
+                          }
+
+                          if (actualMimetype !== expectedBaseImageMimetype) {
+                              throw new Error(
+                                  `Base image dataURL is of the wrong mimetype: Got ${actualMimetype} - Expected: ${expectedBaseImageMimetype}`
+                              );
+                          }
+                      },
+                  },
+              ]),
+    ];
+}
+
+function testImageMimetypeBeforeAndAfterSave(
+    expectedMimetype,
+    mimetypeBeforeConversion,
+    selectImageStep,
+    isSvgEmbedded = false,
+    goBackToEditMode = true
+) {
+    const postSaveTrigger = `iframe img[data-mimetype-before-conversion="${mimetypeBeforeConversion}"]`;
+    return [
+        ...testImageMimetypeIs(expectedMimetype, isSvgEmbedded),
+        ...wTourUtils.clickOnSave(),
+        ...testImageMimetypeIs(expectedMimetype, isSvgEmbedded, postSaveTrigger, true),
+        ...(goBackToEditMode ? [...wTourUtils.clickOnEditAndWaitEditMode(), selectImageStep] : []),
+    ];
+}
+
+const testFormatSnippetOption = (expectedValue) => ({
+    content: `Format snippet option is set to ${expectedValue}`,
+    trigger: 'we-select[data-name="format_select_opt"] we-toggler',
+    run() {
+        const actualValue = this.$anchor[0].innerText;
+        if (actualValue !== expectedValue) {
+            throw new Error(
+                `Format snippet option is "${actualValue}" - Expected "${expectedValue}"`
+            );
+        }
+    },
+});
+
+function reloadMock(selectImageStep, mockStep = mockCanvasToDataURLStep) {
+    return [
+        ...wTourUtils.clickOnSave(),
+        mockStep,
+        ...wTourUtils.clickOnEditAndWaitEditMode(),
+        selectImageStep,
+    ];
+}
+
+function reloadUnmock(selectImageStep) {
+    return reloadMock(selectImageStep, unmockCanvasToDataURLStep);
+}
+
+function testImageSnippet(imageFormat, originalMimetype, formatMimetype) {
+    const testStepOnOff = (on, off, wrapOn = false, wrapOff = false) => {
+        const test = (fn, mimetype, wrap) => [
+            ...fn(wrap ? "image/svg+xml" : mimetype),
+            ...testImageMimetypeIs(mimetype, !!wrap),
+        ];
+        const testOn = (mimetype) => test(on, mimetype, wrapOn);
+        const testOff = (mimetype) => test(off, mimetype, wrapOff);
+        return [
+            ...setOriginalImageFormat(),
+            ...testOn(originalMimetype),
+            ...testOff(originalMimetype),
+
+            ...setImageFormat(imageFormat),
+            ...testOn(formatMimetype),
+            ...testOff(formatMimetype),
+
+            ...testOn(formatMimetype),
+            ...setOriginalImageFormat(),
+            ...testOff(originalMimetype),
+
+            ...testOn(originalMimetype),
+            ...setImageFormat(imageFormat),
+            ...testOff(formatMimetype),
+        ];
+    };
+    return [
+        selectTextImageSnippetImage,
+
+        ...setImageFormat(imageFormat),
+        ...testImageMimetypeBeforeAndAfterSave(
+            formatMimetype,
+            originalMimetype,
+            selectTextImageSnippetImage
+        ),
+
+        ...setOriginalImageFormat(),
+        ...testImageMimetypeBeforeAndAfterSave(
+            originalMimetype,
+            originalMimetype,
+            selectTextImageSnippetImage
+        ),
+
+        // Image shape
+        ...testStepOnOff(setImageShape, removeImageShape, true),
+
+        // Image crop
+        ...testStepOnOff(cropImage, removeImageCrop),
+
+        // Image crop while shape on
+        ...setImageShape(),
+        ...testStepOnOff(cropImage, removeImageCrop, true, true),
+        ...removeImageShape(formatMimetype),
+    ];
+}
+
+wTourUtils.registerWebsitePreviewTour(
+    "website_image_mimetype",
+    {
+        test: true,
+        url: "/",
+        edition: true,
+    },
+    () => [
+        wTourUtils.dragNDrop({
+            id: "s_text_image",
+            name: "Text - Image",
+        }),
+        ...testImageSnippet("128 image/webp", "image/jpeg", "image/webp"),
+    ]
+);
+
+wTourUtils.registerWebsitePreviewTour(
+    "website_image_mimetype_no_webp",
+    {
+        test: true,
+        url: "/",
+        edition: true,
+    },
+    () => [
+        mockCanvasToDataURLStep,
+        wTourUtils.dragNDrop({
+            id: "s_text_image",
+            name: "Text - Image",
+        }),
+        ...testImageSnippet("128 image/webp", "image/jpeg", "image/png"),
+    ]
+);
+
+wTourUtils.registerWebsitePreviewTour(
+    "website_image_mimetype_bigger_output",
+    {
+        test: true,
+        url: "/",
+        edition: true,
+    },
+    () => [
+        {
+            content: "Verify that the test png data produces a bigger webp as output",
+            trigger: "body",
+            run: () => {
+                const canvas = document.createElement("canvas");
+                const input = PNG_THAT_CONVERTS_TO_BIGGER_WEBP;
+                const defaultQualityUsedInCode = 0.75; // Should match {@link applyModifications}
+                const { dataURL: output } = convertCanvasToDataURL(
+                    canvas,
+                    "image/webp",
+                    defaultQualityUsedInCode
+                );
+                if (output.length <= input.length) {
+                    throw new Error(
+                        "Wrong test data: this png should produce a bigger output when converted to webp"
+                    );
+                }
+            },
+        },
+        wTourUtils.dragNDrop({
+            id: "s_text_image",
+            name: "Text - Image",
+        }),
+        {
+            ...selectTextImageSnippetImage,
+            run: "dblclick",
+        },
+        ...uploadImageFromDialog(
+            "image/png",
+            "o.png",
+            PNG_THAT_CONVERTS_TO_BIGGER_WEBP,
+            false,
+            selectTextImageSnippetImage.trigger
+        ),
+        ...testImageSnippet("1 image/webp", "image/png", "image/png"),
+    ]
+);
+
+function testImageGallerySnippet(
+    imageData,
+    originalMimetype,
+    targetMimetype,
+    waitForModifiedImage = true
+) {
+    return [
+        wTourUtils.dragNDrop({
+            id: "s_image_gallery",
+            name: "Image Gallery",
+        }),
+        selectImageGallerySnippetImage,
+        {
+            content: "Click on Images - Add button",
+            trigger: 'we-button[data-add-images="true"]',
+        },
+        ...uploadImageFromDialog(originalMimetype, "test_image", imageData),
+        {
+            content: "Navigate to last carousel image",
+            trigger: 'iframe [data-bs-slide-to="3"]',
+        },
+        ...(waitForModifiedImage
+            ? testImageMimetypeBeforeAndAfterSave(
+                  targetMimetype,
+                  originalMimetype,
+                  selectImageGallerySnippetImage,
+                  false,
+                  false
+              )
+            : testImageMimetypeIs(
+                  targetMimetype,
+                  false,
+                  `iframe .carousel-item.active img[src$="test_image"]`,
+                  true
+              )),
+    ];
+}
+
+wTourUtils.registerWebsitePreviewTour(
+    "website_image_mimetype_image_gallery",
+    {
+        test: true,
+        url: "/",
+        edition: true,
+    },
+    () => [
+        ...testImageGallerySnippet(
+            extractBase64PartFromDataURL(generateTestImage(1024, "image/jpeg")),
+            "image/jpeg",
+            "image/webp"
+        ),
+    ]
+);
+
+wTourUtils.registerWebsitePreviewTour(
+    "website_image_mimetype_image_gallery_no_webp",
+    {
+        test: true,
+        url: "/",
+        edition: true,
+    },
+    () => [
+        mockCanvasToDataURLStep,
+        ...testImageGallerySnippet(
+            extractBase64PartFromDataURL(generateTestImage(1024, "image/jpeg")),
+            "image/jpeg",
+            "image/png",
+            false
+        ),
+    ]
+);
+
+wTourUtils.registerWebsitePreviewTour(
+    "website_image_mimetype_image_gallery_bigger_output",
+    {
+        test: true,
+        url: "/",
+        edition: true,
+    },
+    () => [...testImageGallerySnippet(PNG_THAT_CONVERTS_TO_BIGGER_WEBP, "image/png", "image/png")]
+);
+
+wTourUtils.registerWebsitePreviewTour(
+    "website_image_mimetype_crop",
+    {
+        test: true,
+        url: "/",
+        edition: true,
+    },
+    () => [
+        wTourUtils.dragNDrop({
+            id: "s_text_image",
+            name: "Text - Image",
+        }),
+        selectTextImageSnippetImage,
+        ...setImageFormat("512 image/webp"),
+
+        // Webp -> no webp
+        ...cropImage("image/webp"),
+        ...testImageMimetypeIs("image/webp"),
+        mockCanvasToDataURLStep,
+        ...removeImageCrop("image/png"), // !isChanged && Original format is smaller
+        ...testImageMimetypeIs("image/png"),
+        testFormatSnippetOption("800px webp"),
+
+        // No webp -> webp
+        ...setImageFormat("512 image/webp"),
+        ...cropImage("image/png"),
+        ...testImageMimetypeIs("image/png"),
+        unmockCanvasToDataURLStep,
+        ...removeImageCrop("image/webp"),
+        ...testImageMimetypeIs("image/webp"),
+        testFormatSnippetOption("800px webp"),
+    ]
+);
+
+wTourUtils.registerWebsitePreviewTour(
+    "website_image_mimetype_shape",
+    {
+        test: true,
+        url: "/",
+        edition: true,
+    },
+    () => [
+        wTourUtils.dragNDrop({
+            id: "s_text_image",
+            name: "Text - Image",
+        }),
+        selectTextImageSnippetImage,
+        ...setOriginalImageFormat(),
+        ...testImageMimetypeIs("image/jpeg"),
+
+        ...setImageShape(),
+        ...testImageMimetypeIs("image/jpeg", true),
+        ...setImageFormat("512 image/webp"),
+        ...testImageMimetypeIs("image/webp", true),
+        testFormatSnippetOption("512px webp"),
+        ...removeImageShape("image/webp"),
+        ...testImageMimetypeIs("image/webp"),
+        testFormatSnippetOption("512px webp"),
+
+        // Webp browser -> no webp browser
+        ...setImageShape(),
+        ...setImageFormat("512 image/webp"),
+        ...testImageMimetypeIs("image/webp", true), // Wait for html update
+        ...reloadMock(selectTextImageSnippetImage),
+        testFormatSnippetOption("512px webp"),
+        ...removeImageShape("image/png"),
+        ...testImageMimetypeIs("image/png"),
+        testFormatSnippetOption("512px webp"),
+
+        // No webp browser -> webp browser
+        ...setImageShape(),
+        ...setImageFormat("512 image/webp"),
+        ...testImageMimetypeIs("image/png", true),
+        testFormatSnippetOption("512px webp"),
+        ...reloadUnmock(selectTextImageSnippetImage),
+        testFormatSnippetOption("512px webp"),
+        ...removeImageShape("image/webp"),
+        ...testImageMimetypeIs("image/webp"),
+        testFormatSnippetOption("512px webp"),
+
+        // Set shape webp -> no webp
+        ...reloadMock(selectTextImageSnippetImage),
+        ...setImageShape(),
+        ...testImageMimetypeIs("image/png", true),
+        testFormatSnippetOption("512px webp"),
+    ]
+);
+
+const wysiwygSteps = () => [
+    {
+        content: "Select logo",
+        trigger: 'iframe [data-oe-field="logo"] img',
+    },
+    {
+        content: "Replace image button",
+        trigger: 'we-button[data-replace-media="true"]',
+    },
+    ...uploadImageFromDialog("image/webp", "test.webp", DUMMY_WEBP, false),
+    ...setOriginalImageFormat(),
+    ...wTourUtils.clickOnSave(),
+];
+wTourUtils.registerWebsitePreviewTour(
+    "website_image_mimetype_wysiwyg",
+    {
+        test: true,
+        url: "/",
+        edition: true,
+    },
+    () => [...wysiwygSteps()]
+);
+wTourUtils.registerWebsitePreviewTour(
+    "website_image_mimetype_wysiwyg_no_webp",
+    {
+        test: true,
+        url: "/",
+        edition: true,
+    },
+    () => [mockCanvasToDataURLStep, ...wysiwygSteps()]
+);

--- a/addons/website/static/tests/tours/snippet_image_mimetype.js
+++ b/addons/website/static/tests/tours/snippet_image_mimetype.js
@@ -354,12 +354,12 @@ function testImageSnippet(imageFormat, originalMimetype, formatMimetype) {
         ...testStepOnOff(setImageShape, removeImageShape, true),
 
         // Image crop
-        ...testStepOnOff(cropImage, removeImageCrop, false, false, "image/jpeg"),
+        ...testStepOnOff(cropImage, removeImageCrop, false, false, formatMimetype),
 
         // Image crop while shape on
         ...setImageShape(),
-        ...testStepOnOff(cropImage, removeImageCrop, true, true, "image/jpeg"),
-        ...removeImageShape("image/jpeg"),
+        ...testStepOnOff(cropImage, removeImageCrop, true, true, formatMimetype),
+        ...removeImageShape(formatMimetype),
     ];
 }
 
@@ -545,16 +545,16 @@ wTourUtils.registerWebsitePreviewTour(
         mockCanvasToDataURLStep,
         ...removeImageCrop("image/jpeg"), // !isChanged && Original format is smaller
         ...testImageMimetypeIs("image/jpeg"),
-        testFormatSnippetOption("800px (Original) jpeg"),
+        testFormatSnippetOption("690px (Suggested) jpeg"),
         ...setImageFormat("512 image/jpeg"),
 
         // No webp -> webp
         ...cropImage("image/jpeg"),
         ...testImageMimetypeIs("image/jpeg"),
         unmockCanvasToDataURLStep,
-        ...removeImageCrop("image/jpeg"),
-        ...testImageMimetypeIs("image/jpeg"),
-        testFormatSnippetOption("800px (Original) jpeg"),
+        ...removeImageCrop("image/webp"),
+        ...testImageMimetypeIs("image/webp"),
+        testFormatSnippetOption("690px (Suggested) webp"),
     ]
 );
 

--- a/addons/website/tests/test_snippets.py
+++ b/addons/website/tests/test_snippets.py
@@ -129,3 +129,50 @@ class TestSnippets(HttpCase):
 
     def test_dropdowns_and_header_hide_on_scroll(self):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'dropdowns_and_header_hide_on_scroll', login='admin')
+
+    def test_image_mimetype(self):
+        self.start_tour('/', "website_image_mimetype", login='admin', timeout=90)
+
+    def test_image_mimetype_no_webp(self):
+        self.start_tour('/', "website_image_mimetype_no_webp", login='admin', timeout=90)
+
+    def test_image_mimetype_bigger_output(self):
+        self.start_tour('/', "website_image_mimetype_bigger_output", login='admin', timeout=90)
+
+    def test_image_mimetype_image_gallery(self):
+        self.start_tour('/', "website_image_mimetype_image_gallery", login='admin')
+
+    def test_image_mimetype_image_gallery_no_webp(self):
+        self.start_tour('/', "website_image_mimetype_image_gallery_no_webp", login='admin')
+
+    def test_image_mimetype_image_gallery_bigger_output(self):
+        self.start_tour('/', "website_image_mimetype_image_gallery_bigger_output", login='admin')
+
+    def test_image_mimetype_crop(self):
+        self.start_tour('/', "website_image_mimetype_crop", login='admin')
+
+    def test_image_mimetype_shape(self):
+        self.start_tour('/', "website_image_mimetype_shape", login='admin')
+
+    def assert_wysiwyg_logo_attachments(self, jpeg_count, webp_count):
+        jpegs = self.env['ir.attachment'].search([
+            ('res_model', '=', 'ir.attachment'),
+            ('name', '=', 'test.jpg'),
+        ])
+        webps = self.env['ir.attachment'].search([
+            ('res_model', '=', 'ir.attachment'),
+            ('name', '=', 'test.webp'),
+        ])
+        # Desktop + mobile logo
+        self.assertEqual(len(jpegs), jpeg_count,
+                         "Should have " + str(jpeg_count) + " alternative jpeg")
+        self.assertEqual(len(webps), webp_count,
+                         "Should have " + str(webp_count) + " alternative webp")
+
+    def test_image_mimetype_wysiwyg(self):
+        self.start_tour('/', "website_image_mimetype_wysiwyg", login='admin')
+        self.assert_wysiwyg_logo_attachments(3, 2)
+
+    def test_image_mimetype_wysiwyg_no_webp(self):
+        self.start_tour('/', "website_image_mimetype_wysiwyg_no_webp", login='admin')
+        self.assert_wysiwyg_logo_attachments(3, 0)

--- a/addons/website_event/static/tests/tours/website_event_cover_image_mimetype.js
+++ b/addons/website_event/static/tests/tours/website_event_cover_image_mimetype.js
@@ -1,0 +1,93 @@
+/** @odoo-module **/
+
+import {
+    extractBase64PartFromDataURL,
+    extractMimetypeFromDataURL,
+} from "@web/core/utils/image_processing";
+import {
+    generateTestImage,
+    mockCanvasToDataURLStep,
+    PNG_THAT_CONVERTS_TO_BIGGER_WEBP,
+    uploadImageFromDialog,
+} from "@website/../tests/tours/snippet_image_mimetype";
+import wTourUtils from "@website/js/tours/tour_utils";
+
+function testPngUploadImplicitConversion(testImageData, expectedMimetype) {
+    return [
+        {
+            content: "Click on the first event's cover",
+            trigger: "iframe .o_record_cover_component",
+        },
+        {
+            content: "Open add image dialog",
+            trigger: ".snippet-option-CoverProperties we-button[data-background].active",
+        },
+        ...uploadImageFromDialog(expectedMimetype, "fake_file", testImageData, false, undefined),
+        ...wTourUtils.clickOnSave(),
+        {
+            content: `Verify image mimetype is ${expectedMimetype}`,
+            trigger: "iframe .o_record_cover_component",
+            async run() {
+                const cover = this.$anchor[0];
+
+                async function convertToBase64(file) {
+                    return await new Promise((resolve, reject) => {
+                        const reader = new FileReader();
+                        reader.onload = () => resolve(reader.result);
+                        reader.onerror = reject;
+                        reader.readAsDataURL(file);
+                    });
+                }
+
+                const src = cover.style.backgroundImage.split('"')[1];
+                const imgBlob = await (await fetch(src)).blob();
+                const dataURL = await convertToBase64(imgBlob);
+                const mimetype = extractMimetypeFromDataURL(dataURL);
+                if (mimetype !== expectedMimetype) {
+                    console.error(`Wrong mimetype ${mimetype} - Expected ${expectedMimetype}`);
+                }
+            },
+        },
+    ];
+}
+
+wTourUtils.registerWebsitePreviewTour(
+    "website_event_cover_image_mimetype",
+    {
+        test: true,
+        edition: true,
+        url: "/event",
+    },
+    () => [
+        ...testPngUploadImplicitConversion(
+            extractBase64PartFromDataURL(generateTestImage(1024, "image/jpeg")),
+            "image/webp"
+        ),
+    ]
+);
+
+wTourUtils.registerWebsitePreviewTour(
+    "website_event_cover_image_mimetype_no_webp",
+    {
+        test: true,
+        edition: true,
+        url: "/event",
+    },
+    () => [
+        mockCanvasToDataURLStep,
+        ...testPngUploadImplicitConversion(
+            extractBase64PartFromDataURL(generateTestImage(1024, "image/jpeg")),
+            "image/png"
+        ),
+    ]
+);
+
+wTourUtils.registerWebsitePreviewTour(
+    "website_event_cover_image_mimetype_bigger_output",
+    {
+        test: true,
+        edition: true,
+        url: "/event",
+    },
+    () => [...testPngUploadImplicitConversion(PNG_THAT_CONVERTS_TO_BIGGER_WEBP, "image/png")]
+);

--- a/addons/website_event/static/tests/tours/website_event_cover_image_mimetype.js
+++ b/addons/website_event/static/tests/tours/website_event_cover_image_mimetype.js
@@ -77,7 +77,7 @@ wTourUtils.registerWebsitePreviewTour(
         mockCanvasToDataURLStep,
         ...testPngUploadImplicitConversion(
             extractBase64PartFromDataURL(generateTestImage(1024, "image/jpeg")),
-            "image/png"
+            "image/jpeg"
         ),
     ]
 );

--- a/addons/website_event/tests/test_website_event.py
+++ b/addons/website_event/tests/test_website_event.py
@@ -288,3 +288,16 @@ class TestWebsiteAccess(HttpCaseWithUserDemo, OnlineEventCase):
 
         with self.assertRaises(AccessError):
             self.env['res.partner'].browse(self.partner.id).read()
+
+
+@tagged('-at_install', 'post_install')
+class TestImageProcessing(HttpCase):
+
+    def test_cover_image_mimetype(self):
+        self.start_tour('/event', "website_event_cover_image_mimetype", login='admin')
+
+    def test_cover_image_mimetype_no_webp(self):
+        self.start_tour('/event', "website_event_cover_image_mimetype_no_webp", login='admin')
+
+    def test_cover_image_mimetype_bigger_output(self):
+        self.start_tour('/event', "website_event_cover_image_mimetype_bigger_output", login='admin')

--- a/addons/website_sale/static/src/js/website_sale.editor.js
+++ b/addons/website_sale/static/src/js/website_sale.editor.js
@@ -5,6 +5,7 @@ import { MediaDialog } from "@web_editor/components/media_dialog/media_dialog";
 import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { _t } from "@web/core/l10n/translation";
 import "@website/js/editor/snippets.options";
+import { convertCanvasToDataURL } from "@web/core/utils/image_processing";
 import { renderToElement } from "@web/core/utils/render";
 
 options.registry.WebsiteSaleGridLayout = options.Class.extend({
@@ -615,7 +616,7 @@ options.registry.WebsiteSaleProductPage = options.Class.extend({
         await new Promise(resolve => imgEl.addEventListener("load", resolve));
         const originalSize = Math.max(imgEl.width, imgEl.height);
         const smallerSizes = [1024, 512, 256, 128].filter(size => size < originalSize);
-        const webpName = attachment.name.replace(/\.(jpe?g|png)$/i, ".webp");
+        const fileBasename = attachment.name.replace(/\.(jpe?g|png)$/i, "");
         let referenceId = undefined;
         for (const size of [originalSize, ...smallerSizes]) {
             const ratio = size / originalSize;
@@ -626,23 +627,24 @@ options.registry.WebsiteSaleProductPage = options.Class.extend({
             ctx.fillStyle = "rgb(255, 255, 255)";
             ctx.fillRect(0, 0, canvas.width, canvas.height);
             ctx.drawImage(imgEl, 0, 0, imgEl.width, imgEl.height, 0, 0, canvas.width, canvas.height);
+            const imageData = convertCanvasToDataURL(canvas, "image/webp", 0.75);
             const [resizedId] = await this.orm.call("ir.attachment", "create_unique", [[{
-                name: webpName,
+                name: `${fileBasename}.${imageData.defaultFileExtension}`,
                 description: size === originalSize ? "" : `resize: ${size}`,
-                datas: canvas.toDataURL("image/webp", 0.75).split(",")[1],
+                datas: imageData.base64Part,
                 res_id: referenceId,
                 res_model: "ir.attachment",
-                mimetype: "image/webp",
+                mimetype: imageData.mimetype,
             }]]);
             if (size === originalSize) {
                 attachment.original_id = attachment.id;
                 attachment.id = resizedId;
                 attachment.image_src = `/web/image/${resizedId}-autowebp/${attachment.name}`;
-                attachment.mimetype = "image/webp";
+                attachment.mimetype = imageData.mimetype;
             }
             referenceId = referenceId || resizedId; // Keep track of original.
             await this.orm.call("ir.attachment", "create_unique", [[{
-                name: webpName.replace(/\.webp$/, ".jpg"),
+                name: `${fileBasename}.jpg`,
                 description: "format: jpeg",
                 datas: canvas.toDataURL("image/jpeg", 0.75).split(",")[1],
                 res_id: resizedId,

--- a/addons/website_sale/static/tests/tours/website_sale_add_image_mimetype.js
+++ b/addons/website_sale/static/tests/tours/website_sale_add_image_mimetype.js
@@ -1,0 +1,87 @@
+/** @odoo-module **/
+
+import { extractMimetypeFromDataURL } from "@web/core/utils/image_processing";
+import wTourUtils from "@website/js/tours/tour_utils";
+import {
+    mockCanvasToDataURLStep,
+    uploadImageFromDialog,
+} from "@website/../tests/tours/snippet_image_mimetype";
+
+const DUMMY_WEBP = "UklGRiwAAABXRUJQVlA4TB8AAAAv/8F/EAcQEREQCCT7e89QRP8z/vOf//znP//5z/8BAA==";
+
+function testWebpUploadImplicitConversion(expectedMimetype) {
+    return [
+        {
+            content: "Go to product page",
+            trigger: "iframe .oe_product_cart a",
+            run() {
+                this.$anchor[0].click(); // For some reason the default action doesn't work.
+            },
+        },
+        ...wTourUtils.clickOnEditAndWaitEditMode(),
+        {
+            content: "Click on the product image",
+            trigger: "iframe #o-carousel-product .product_detail_img",
+        },
+        {
+            content: "Open add image dialog",
+            trigger: 'we-button[data-add-images="true"]',
+        },
+        ...uploadImageFromDialog("image/webp", "fake_file.webp", DUMMY_WEBP),
+        {
+            content: "Go to last carousel image",
+            trigger: 'iframe [data-bs-target="#o-carousel-product"][data-bs-slide-to="1"]',
+        },
+        ...wTourUtils.waitForImageToLoad(
+            "iframe #o-carousel-product .carousel-item:nth-child(2) img"
+        ),
+        ...wTourUtils.clickOnSave(),
+        {
+            content: "Go to last carousel image",
+            trigger: 'iframe [data-bs-target="#o-carousel-product"][data-bs-slide-to="1"]',
+        },
+        {
+            content: `Verify image mimetype is ${expectedMimetype}`,
+            trigger: "iframe #o-carousel-product .carousel-item:nth-child(2) img",
+            async run() {
+                const img = this.$anchor[0];
+
+                async function convertToBase64(file) {
+                    return await new Promise((resolve, reject) => {
+                        const reader = new FileReader();
+                        reader.onload = () => resolve(reader.result);
+                        reader.onerror = reject;
+                        reader.readAsDataURL(file);
+                    });
+                }
+
+                const imgBlob = await (await fetch(img.src)).blob();
+                const dataURL = await convertToBase64(imgBlob);
+                const mimetype = extractMimetypeFromDataURL(dataURL);
+                if (mimetype !== expectedMimetype) {
+                    console.error(`Wrong mimetype ${mimetype} - Expected ${expectedMimetype}`);
+                }
+            },
+        },
+    ];
+}
+
+wTourUtils.registerWebsitePreviewTour(
+    "website_sale_add_image_mimetype",
+    {
+        test: true,
+        edition: false,
+        url: "/shop?search=customizable desk",
+    },
+    () => [...testWebpUploadImplicitConversion("image/webp")]
+);
+
+wTourUtils.registerWebsitePreviewTour(
+    "website_sale_add_image_mimetype_no_webp",
+    {
+        test: true,
+        edition: false,
+        url: "/shop?search=customizable desk",
+    },
+    () => [mockCanvasToDataURLStep, ...testWebpUploadImplicitConversion("image/png")]
+);

--- a/addons/website_sale/tests/test_website_editor.py
+++ b/addons/website_sale/tests/test_website_editor.py
@@ -252,3 +252,39 @@ class TestWebsiteSaleEditor(HttpCase):
             _logger.warning("This test relies on demo data. To be rewritten independently of demo data for accurate and reliable results.")
             return
         self.start_tour(self.env['website'].get_client_action_url('/shop'), 'website_sale_restricted_editor_ui', login='restricted')
+
+    def test_website_sale_add_image_mimetype(self):
+        if not loaded_demo_data(self.env):
+            _logger.warning("This test relies on demo data. To be rewritten independently of demo "
+                            "data for accurate and reliable results.")
+            return
+        self.start_tour(self.env['website'].get_client_action_url('/shop'),
+                        "website_sale_add_image_mimetype", login='admin')
+
+        attachments = self.env['ir.attachment'].search([
+            ('res_model', '=', 'ir.attachment'),
+            ('name', 'like', '%webp'),
+            ('description', 'not like', 'format: %'),
+        ])
+        self.assertEqual(len(attachments), 3, "Should have uploaded 3 attachments")
+        for attachment in attachments:
+            self.assertEqual(attachment.mimetype, "image/webp",
+                             "Attachment mimetype should be image/webp")
+
+    def test_website_sale_add_image_mimetype_no_webp(self):
+        if not loaded_demo_data(self.env):
+            _logger.warning("This test relies on demo data. To be rewritten independently of demo "
+                            "data for accurate and reliable results.")
+            return
+        self.start_tour(self.env['website'].get_client_action_url('/shop'),
+                        "website_sale_add_image_mimetype_no_webp", login='admin')
+
+        attachments = self.env['ir.attachment'].search([
+            ('res_model', '=', 'ir.attachment'),
+            ('name', 'like', '%webp'),
+            ('description', 'not like', 'format: %'),
+        ])
+        self.assertEqual(len(attachments), 3, "Should have uploaded 3 attachments")
+        for attachment in attachments:
+            self.assertEqual(attachment.mimetype, "image/png", "Attachment mimetype should be "
+                                                               "image/png")


### PR DESCRIPTION
Commits:

-----

[FIX] web: add image_processing utils

This commit adds new util functions to standardize client-side low-level
image processing and dataURL manipulation. These functions are made to
be basic, as simple as possible and thus reusable wherever needed.

See jsdoc in `image_processing.js`.

These are used in the next commit.

task-3847470

-----

[FIX] web, web_editor, *: store the correct image mimetype

*: website, website_event, website_sale

In some cases, `HTMLCanvasElement#toDataURL` returns a png instead of
the requested mimetype. Specifically, Safari doesn't support
`image/webp`. We call this an "implicit conversion".

Steps to reproduce (6 cases):
- Use Safari or an affected browser
- One of:
  - Image Field
    - In any regular page such as the Discuss home page, click on your
      user profile picture (top-right)
    - Click on Preferences
    - Change the profile picture to a webp image
  - Website
    - Insert a "Text - Image" snippet
    - Change the image format to one of the webp formats with a lower
      resolution
  - Website
    - Insert an "Image Gallery" snippet
    - Add a webp image
  - Website
    - Change the logo image
    - Select a webp format with a lower resolution than the original
  - Website/Events (website_event)
    - Change an event's cover image to a webp
  - Website/Shop (website_sale)
    - Change a product image's to a webp
- Save

Old behavior: the actual mimetype is `image/png` but it's saved as
`image/webp` and a .webp file extension
New behavior: it is correctly saved as `image/png` and a .png file
extension

To fix this, this commit handles all possible implicit conversions
through `convertCanvasToDataURL` and returns both the dataURL and the
actual mimetype in `applyModifications`. It then saves the output
mimetype and the correct file extension.

task-3847470

-----

[FIX] web_editor, website, *: avoid implicit conversions when possible

*: website_event

This commit deals with implicit conversion when converting to webp isn't
available:
- When trying to generate alternative webp attachments, don't
- In website, suggest jpeg alternatives instead of webp. When the
  current image's format isn't available on this browser, display it in
  the options but don't allow selecting it. When applying a
  modification, use its same-size counterpart (webp <=> jpeg) instead.

task-3847470

-----

[FIX] web_editor: select optimized width format on crop reset
    
When cropping an image, the selected format is lost. Ideally, resetting
the crop would restore the format selected before cropping. However,
before this PR, resetting the crop loses the format size but keeps the
right mimetype.

This commit selects the "Suggested" (optimized width) format when
resetting the crop. This behavior is expected to be changed in a future
task to instead go back to the format that was selected before cropping.

This commit also fixes the way the original size is computed. If the
current image has a data-width attribute, use its value instead of
the naturalWidth property, as the latter actually corresponds in some
cases to the "optimized width".

task-3847470