### PR TITLE
[FIX] mass_mailing: fetch only traces related to mass mailing

### DIFF
--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -735,8 +735,11 @@ class MassMailing(models.Model):
 
     def _action_view_documents_filtered(self, view_filter):
         def _fetch_trace_res_ids(trace_domain):
-            result = self.env['mailing.trace'].search_read(
-                domain=trace_domain, fields=['res_id'])
+            trace_domain = expression.AND([
+                trace_domain,
+                [('mass_mailing_id', '=', self.id)],
+            ])
+            result = self.env['mailing.trace'].search_read(domain=trace_domain, fields=['res_id'])
             return [line['res_id'] for line in result]
 
         model_name = self.env['ir.model']._get(self.mailing_model_real).display_name

--- a/addons/mass_mailing/tests/test_mailing_internals.py
+++ b/addons/mass_mailing/tests/test_mailing_internals.py
@@ -689,3 +689,27 @@ class TestMailingScheduleDateWizard(MassMailCommon):
         self.assertEqual(mailing.schedule_date, datetime(2021, 4, 30, 9, 0))
         self.assertEqual(mailing.schedule_type, 'scheduled')
         self.assertEqual(mailing.state, 'in_queue')
+
+
+class TestMassMailingActions(MassMailCommon):
+    def test_mailing_action_open(self):
+        mass_mailings = self.env['mailing.mailing'].create([
+            {'subject': 'First subject'},
+            {'subject': 'Second subject'}
+        ])
+        # Create two traces: one linked to the created mass.mailing and one not (action should open only the first)
+        self.env["mailing.trace"].create([{
+                "trace_status": "open",
+                "mass_mailing_id": mass_mailings[0].id,
+                "model": "res.partner",
+                "res_id": self.partner_admin.id,
+            }, {
+                "trace_status": "open",
+                "mass_mailing_id": mass_mailings[1].id,
+                "model": "res.partner",
+                "res_id": self.partner_employee.id,
+            }
+        ])
+        results = mass_mailings[0].action_view_opened()
+        results_partner = self.env["res.partner"].search(results['domain'])
+        self.assertEqual(results_partner, self.partner_admin, "Trace leaked from mass_mailing_2 to mass_mailing_1")


### PR DESCRIPTION
Previously, the action to retrieve traces fetched all records irrespective of their relationship with the specific Mass Mailing. This commit refines the retrieval process to only include traces associated with the corresponding Mass Mailing.

[Reproduce]
- Install mass_mailing
- Open Email Marketing, Create new mass_mailing with Recipients set to "Contact"
- Send to all
- Select "Opened" (or any of the others control panel actions)
- BUG: list is not empty, it should! (same for the other control traces)

Generalization: Note that in the steps above we used Recipients set to "Contact" it will render buggy behavior with any recipients, however in this way we have existing contact traces that show up

opw-3959467