### PR TITLE
[FIX] account: Fix invoice creation from mail alias

### DIFF
--- a/addons/account/tests/test_account_incoming_supplier_invoice.py
+++ b/addons/account/tests/test_account_incoming_supplier_invoice.py
@@ -88,11 +88,13 @@ class TestAccountIncomingSupplierInvoice(AccountTestInvoicingCommon):
         with patch.object(type(self.env['ir.attachment']), '_decode_edi_pdf', decode_edi_pdf):
             yield xml_filename
 
-    def _assert_extend_with_attachments(self, expected_values, new=False):
-        attachments = self.env['ir.attachment'].browse([x.id for x in expected_values])
+    def _assert_extend_with_attachments(self, input_values, expected_values=None, new=False, **context):
+        if not expected_values:
+            expected_values = input_values
+        attachments = self.env['ir.attachment'].browse([x.id for x in input_values])
         nb_moves_before = self.env['account.move'].search_count([('company_id', '=', self.env.company.id)])
         results = self.env['account.move']\
-            .with_context(default_move_type='out_invoice', default_journal_id=self.company_data['default_journal_sale'].id)\
+            .with_context(**context, default_move_type='out_invoice', default_journal_id=self.company_data['default_journal_sale'].id)\
             ._extend_with_attachments(attachments, new=new)
         invoice_number = 0
         previous_invoice = None
@@ -206,16 +208,25 @@ class TestAccountIncomingSupplierInvoice(AccountTestInvoicingCommon):
             self._assert_extend_with_attachments({pdf1: 1, pdf2: 2}, new=True)
             self.assertEqual(decoded_files, {pdf1.name, pdf2.name})
         with self.with_success_decoder() as decoded_files:
+            self._assert_extend_with_attachments({pdf1: 1, pdf2: 2}, new=True, from_alias=True)
+            self.assertEqual(decoded_files, {pdf1.name, pdf2.name})
+        with self.with_success_decoder() as decoded_files:
             self._assert_extend_with_attachments({pdf1: 1, pdf2: 1, gif1: 1, gif2: 1}, new=False)
             self.assertEqual(decoded_files, {pdf1.name})
         with self.with_success_decoder() as decoded_files:
             self._assert_extend_with_attachments({pdf1: 1, pdf2: 2, gif1: 3, gif2: 4}, new=True)
             self.assertEqual(decoded_files, {pdf1.name, pdf2.name, gif1.name, gif2.name})
         with self.with_success_decoder() as decoded_files:
+            self._assert_extend_with_attachments({pdf1: 1, pdf2: 2, gif1: 3, gif2: 4}, expected_values={pdf1: 1, pdf2: 2}, new=True, from_alias=True)
+            self.assertEqual(decoded_files, {pdf1.name, pdf2.name})
+        with self.with_success_decoder() as decoded_files:
             self._assert_extend_with_attachments({pdf1: 1, xml1: 1}, new=False)
             self.assertEqual(decoded_files, {xml1.name})
         with self.with_success_decoder() as decoded_files:
             self._assert_extend_with_attachments({pdf1: 1, xml1: 1}, new=True)
+            self.assertEqual(decoded_files, {xml1.name})
+        with self.with_success_decoder() as decoded_files:
+            self._assert_extend_with_attachments({pdf1: 1, xml1: 1}, new=True, from_alias=True)
             self.assertEqual(decoded_files, {xml1.name})
         with self.with_success_decoder() as decoded_files:
             self._assert_extend_with_attachments({xml1: 1, xml2: 1}, new=False)
@@ -223,8 +234,14 @@ class TestAccountIncomingSupplierInvoice(AccountTestInvoicingCommon):
         with self.with_success_decoder() as decoded_files:
             self._assert_extend_with_attachments({xml1: 1, xml2: 2}, new=True)
             self.assertEqual(decoded_files, {xml1.name, xml2.name})
+        with self.with_success_decoder() as decoded_files:
+            self._assert_extend_with_attachments({xml1: 1, xml2: 2}, new=True, from_alias=True)
+            self.assertEqual(decoded_files, {xml1.name, xml2.name})
         with self.with_success_decoder(omit={pdf1.name}) as decoded_files:
             self._assert_extend_with_attachments({pdf1: 1, pdf2: 2}, new=True)
+            self.assertEqual(decoded_files, {pdf2.name})
+        with self.with_success_decoder(omit={pdf1.name}) as decoded_files:
+            self._assert_extend_with_attachments({pdf1: 1, pdf2: 2}, new=True, from_alias=True)
             self.assertEqual(decoded_files, {pdf2.name})
         with self.with_success_decoder() as decoded_files, self.with_simulated_embedded_xml(pdf1) as xml_filename:
             self._assert_extend_with_attachments({pdf1: 1, pdf2: 1}, new=False)
@@ -232,9 +249,15 @@ class TestAccountIncomingSupplierInvoice(AccountTestInvoicingCommon):
         with self.with_success_decoder() as decoded_files, self.with_simulated_embedded_xml(pdf1) as xml_filename:
             self._assert_extend_with_attachments({pdf1: 1, pdf2: 2}, new=True)
             self.assertEqual(decoded_files, {xml_filename, pdf2.name})
+        with self.with_success_decoder() as decoded_files, self.with_simulated_embedded_xml(pdf1) as xml_filename:
+            self._assert_extend_with_attachments({pdf1: 1, pdf2: 2}, new=True, from_alias=True)
+            self.assertEqual(decoded_files, {xml_filename, pdf2.name})
         with self.with_success_decoder() as decoded_files, self.with_simulated_embedded_xml(pdf1):
             self._assert_extend_with_attachments({pdf1: 1, xml1: 1}, new=False)
             self.assertEqual(decoded_files, {xml1.name})
         with self.with_success_decoder() as decoded_files, self.with_simulated_embedded_xml(pdf1):
             self._assert_extend_with_attachments({pdf1: 1, xml1: 1}, new=True)
+            self.assertEqual(decoded_files, {xml1.name})
+        with self.with_success_decoder() as decoded_files, self.with_simulated_embedded_xml(pdf1):
+            self._assert_extend_with_attachments({pdf1: 1, xml1: 1}, new=True, from_alias=True)
             self.assertEqual(decoded_files, {xml1.name})


### PR DESCRIPTION
Problem
---------
Currently, if an email containing a lot of images and documents reaches the mail alias, one invoice will be created for each attachment (image, PDF, XML, etc.) in the mail. This can pollute databases as, nowadays, many emails possess rogue images with link to Facebook, Twitter, branding, etc.

Objective
---------
Do not create an attachment for images in the mails from a mail alias.

Solution
---------
Filter out the binary file data that have not been yet extracted; this ensures that only rogue images are filtered out. The other file types will create new invoices like before.

epr-63997
task-3973973

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
