### PR TITLE
[FIX] sale_pdf_quote_builder: error when doc inside quote & type url

### DIFF
--- a/addons/sale_pdf_quote_builder/i18n/sale_pdf_quote_builder.pot
+++ b/addons/sale_pdf_quote_builder/i18n/sale_pdf_quote_builder.pot
@@ -96,6 +96,13 @@ msgid "Only PDF documents can be attached inside a quote."
 msgstr ""
 
 #. module: sale_pdf_quote_builder
+#. odoo-python
+#: code:addons/sale_pdf_quote_builder/models/product_document.py:0
+#, python-format
+msgid "When attached inside a quote, the document must be a file, not a URL."
+msgstr ""
+
+#. module: sale_pdf_quote_builder
 #: model_terms:ir.ui.view,arch_db:sale_pdf_quote_builder.sale_order_template_form
 msgid "PDF Quote Builder"
 msgstr ""

--- a/addons/sale_pdf_quote_builder/models/product_document.py
+++ b/addons/sale_pdf_quote_builder/models/product_document.py
@@ -24,9 +24,13 @@ class ProductDocument(models.Model):
              "header pages and the quote table. ",
     )
 
-    @api.constrains('attached_on', 'datas')
+    @api.constrains('attached_on', 'datas', 'type')
     def _check_attached_on_and_datas_compatibility(self):
         for doc in self.filtered(lambda doc: doc.attached_on == 'inside'):
+            if doc.type != 'binary':
+                raise ValidationError(_(
+                    "When attached inside a quote, the document must be a file, not a URL."
+                ))
             if doc.datas and not doc.mimetype.endswith('pdf'):
                 raise ValidationError(_("Only PDF documents can be attached inside a quote."))
             utils._ensure_document_not_encrypted(base64.b64decode(doc.datas))


### PR DESCRIPTION
**Steps:**
- Go to Sales > Products > Products > Any Product
- Click Documents smart button > Create New
- Type = URL
- Name = Something
- URL = Something
- Sales Visibility = Inside Quote
- Save > Error

**Issue:**
- For the type 'url' and sales visibility 'Inside quote', the record will never get the correct mimetype of the url document, resulting into the false condition everytime as pdf quote builder specifically checks for mimetype 'pdf'.

**Fix:**
- If the sale visibility is 'Inside quote', the type should always be File and not URL. If not the case, warning or validation error will be raised.

**Affected Version:** 17 ~ master
**opw:** 3964066