### PR TITLE
[FIX] sale_management: fix sequencing of optional product

### DIFF
--- a/addons/sale_management/models/sale_order_option.py
+++ b/addons/sale_management/models/sale_order_option.py
@@ -115,6 +115,7 @@ class SaleOrderOption(models.Model):
             'product_uom_qty': self.quantity,
             'product_uom': self.uom_id.id,
             'discount': self.discount,
+            'sequence': max(self.order_id.order_line.mapped('sequence'), default=0) + 1
         }
 
     @api.depends('line_id', 'order_id.order_line', 'product_id')


### PR DESCRIPTION
Steps:
- Create a quotation template with 2+ products and optional products.
- Create a new quotation using the template.
- Add an optional product from the template.

Issue:
- Optional product is not added at the end of the quotation.

Cause:
- Optional product sequence defaults to 10 instead of continuing the sequence.

Fix:
- Adjust the sequence of added optional products in add_order_button to be the max sequence + 1.

opw-3932966
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
