### PR TITLE
[FIX] hr_expense: mandatory plan not matching product category

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -1416,6 +1416,7 @@ class HrExpenseSheet(models.Model):
         for line in self.expense_line_ids:
             line._validate_distribution(**{
                 'account': line.account_id.id,
+                'product': line.product_id.id,
                 'business_domain': 'expense',
                 'company_id': line.company_id.id,
             })


### PR DESCRIPTION
Create an analytic plan [TEST] with default optional availability 
Add an applicability line with:
- Domain: Expense
- Product Category: [CATEG]
- Applicability: Mandatory 

Create an expense with an expense product having categoy [CATEG]
Create Report, submit and approve

Issue: No message is raised, the action should have been blocked by the mandatory applicability

opw-3955683
