### PR TITLE
Add new option to accrual plan milestone triggers

### DIFF
--- a/addons/hr_holidays/models/hr_leave_accrual_plan_level.py
+++ b/addons/hr_holidays/models/hr_leave_accrual_plan_level.py
@@ -108,6 +108,19 @@ class AccrualPlanLevel(models.Model):
     yearly_day = fields.Integer(default=1)
     yearly_day_display = fields.Selection(
         _get_selection_days, compute='_compute_days_display', inverse='_inverse_yearly_day_display')
+    accrual_date_ref = fields.Selection(
+        [('reference', 'Reference Date'),
+         ('allocation', 'Allocation Start Date')],
+        default="reference",
+        required=True,
+        string="Accrual Date Reference",
+        help="The accrual date could be a reference date i.e. 01/05 or relative to allocation start date i.e. 3 days after allocation start date")
+    allocation_date_offset = fields.Integer(default=0, required=True)
+    allocation_date_offset_type = fields.Selection(
+        [('day', 'Days'),
+         ('month', 'Months')],
+        default='day', required=True,
+        help="This field defines the unit of time that will be used for the offset from the allocation start date to define the accrual date")
     cap_accrued_time = fields.Boolean("Cap accrued time", default=True,
         help="When the field is checked the accrued time will be capped at the specified amount of time.")
     maximum_leave = fields.Float(
@@ -219,7 +232,7 @@ class AccrualPlanLevel(models.Model):
             else:
                 level.yearly_day = DAY_SELECT_VALUES.index(level.yearly_day_display) + 1
 
-    def _get_next_date(self, last_call):
+    def _get_next_date(self, last_call, allocation_start_date):
         """
         Returns the next date with the given last call
         """
@@ -257,16 +270,24 @@ class AccrualPlanLevel(models.Model):
             else:
                 return last_call + relativedelta(years=1, month=first_month, day=self.first_month_day)
         elif self.frequency == 'yearly':
-            month = MONTHS.index(self.yearly_month) + 1
-            date = last_call + relativedelta(month=month, day=self.yearly_day)
-            if last_call < date:
-                return date
+            if self.accrual_date_ref == "reference":
+                month = MONTHS.index(self.yearly_month) + 1
+                date = last_call + relativedelta(month=month, day=self.yearly_day)
+                if last_call < date:
+                    return date
+                else:
+                    return last_call + relativedelta(years=1, month=month, day=self.yearly_day)
             else:
-                return last_call + relativedelta(years=1, month=month, day=self.yearly_day)
+                month, day = self._get_accrual_month_day_from_allocation_date(allocation_start_date)
+                date = last_call + relativedelta(month=month, day=day)
+                if last_call < date:
+                    return date
+                else:
+                    return last_call + relativedelta(years=1, month=month, day=day)
         else:
             return False
 
-    def _get_previous_date(self, last_call):
+    def _get_previous_date(self, last_call, allocation_start_date):
         """
         Returns the date a potential previous call would have been at
         For example if you have a monthly level giving 16/02 would return 01/02
@@ -307,10 +328,22 @@ class AccrualPlanLevel(models.Model):
                 return last_call + relativedelta(years=-1, month=second_month, day=self.second_month_day)
         elif self.frequency == 'yearly':
             month = MONTHS.index(self.yearly_month) + 1
-            year_date = last_call + relativedelta(month=month, day=self.yearly_day)
+            day = self.yearly_day
+            if self.accrual_date_ref == 'allocation':
+                month, day = self._get_accrual_month_day_from_allocation_date(allocation_start_date)
+            year_date = last_call + relativedelta(month=month, day=day)
             if last_call >= year_date:
                 return year_date
-            else:
-                return last_call + relativedelta(years=-1, month=month, day=self.yearly_day)
+            return year_date + relativedelta(years=-1)
         else:
             return False
+
+    def _get_accrual_month_day_from_allocation_date(self, allocation_start_date):
+        days = 0
+        months = 0
+        if self.allocation_date_offset_type == 'day':
+            days = self.allocation_date_offset
+        else:
+            months = self.allocation_date_offset
+        accrual_date = allocation_start_date + relativedelta(months=months, days=days)
+        return accrual_date.month, accrual_date.day

--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -329,7 +329,8 @@ class HolidaysAllocation(models.Model):
         previous_level = level_ids[current_level_idx - 1]
         # If the next date from the current level's start date is before the last call of the previous level
         # return the previous level
-        if current_level._get_next_date(level_start_date) < previous_level._get_next_date(level_start_date):
+        if (current_level._get_next_date(level_start_date, self.date_from) <
+            previous_level._get_next_date(level_start_date, self.date_from)):
             return (previous_level, current_level_idx - 1)
         return (current_level, current_level_idx)
 
@@ -402,7 +403,7 @@ class HolidaysAllocation(models.Model):
                 if date_to < first_level_start_date:
                     continue
                 allocation.lastcall = max(allocation.lastcall, first_level_start_date)
-                allocation.nextcall = first_level._get_next_date(allocation.lastcall)
+                allocation.nextcall = first_level._get_next_date(allocation.lastcall, allocation.date_from)
                 # adjust nextcall for carryover
                 carryover_date = allocation._get_carryover_date(allocation.nextcall)
                 allocation.nextcall = min(carryover_date, allocation.nextcall)
@@ -423,12 +424,12 @@ class HolidaysAllocation(models.Model):
                     break
                 if current_level.cap_accrued_time:
                     current_level_maximum_leave = current_level.maximum_leave if current_level.added_value_type == "day" else current_level.maximum_leave / (allocation.employee_id.sudo().resource_id.calendar_id.hours_per_day or HOURS_PER_DAY)
-                nextcall = current_level._get_next_date(allocation.nextcall)
+                nextcall = current_level._get_next_date(allocation.nextcall, allocation.date_from)
                 # Since _get_previous_date returns the given date if it corresponds to a call date
                 # this will always return lastcall except possibly on the first call
                 # this is used to prorate the first number of days given to the employee
-                period_start = current_level._get_previous_date(allocation.lastcall)
-                period_end = current_level._get_next_date(allocation.lastcall)
+                period_start = current_level._get_previous_date(allocation.lastcall, allocation.date_from)
+                period_end = current_level._get_next_date(allocation.lastcall, allocation.date_from)
                 # There are 2 cases where nextcall could be closer than the normal period:
                 # 1. Passing from one level to another, if mode is set to 'immediately'
                 if current_level_idx < (len(level_ids) - 1) and allocation.accrual_plan_id.transition_mode == 'immediately':
@@ -461,7 +462,7 @@ class HolidaysAllocation(models.Model):
             if allocation.accrual_plan_id.accrued_gain_time == 'start':
                 # check that we are at the start of a period, not on a carry-over or level transition date
                 current_level = current_level or allocation.accrual_plan_id.level_ids[0]
-                period_start = current_level._get_previous_date(allocation.lastcall)
+                period_start = current_level._get_previous_date(allocation.lastcall, allocation.date_from)
                 if allocation.lastcall != period_start:
                     continue
                 if current_level.cap_accrued_time:
@@ -538,12 +539,12 @@ class HolidaysAllocation(models.Model):
                     allocation.lastcall = today
                     continue
                 allocation.lastcall = max(
-                    current_level._get_previous_date(today),
+                    current_level._get_previous_date(today, allocation.date_from),
                     allocation.date_from + get_timedelta(current_level.start_count, current_level.start_type)
                 )
             if current_level and not allocation.nextcall:
                 accrual_plan = allocation.accrual_plan_id
-                allocation.nextcall = current_level._get_next_date(allocation.lastcall)
+                allocation.nextcall = current_level._get_next_date(allocation.lastcall, allocation.date_from)
                 if current_level_idx < (len(accrual_plan.level_ids) - 1) and accrual_plan.transition_mode == 'immediately':
                     next_level = accrual_plan.level_ids[current_level_idx + 1]
                     next_level_start = allocation.date_from + get_timedelta(next_level.start_count, next_level.start_type)

--- a/addons/hr_holidays/tests/test_accrual_allocations.py
+++ b/addons/hr_holidays/tests/test_accrual_allocations.py
@@ -1845,3 +1845,175 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             })
 
             self.assertEqual(allocation.lastcall, datetime.date(2017, 12, 5))
+
+    def test_accrue_days_on_allocation_start_date(self):
+        """
+        Create an accrual plan with one milestone:
+            * Number of accrued days: 10 days
+            * Frequency: Yearly
+            * Accrue days on allocation start date.
+        Create an allocation:
+            * Start date: 25/05/2024
+            * Type: Accrual
+            * Accrual plan: Use the one defined above
+        On 25/05/2025: 10 days should be accrued.
+        """
+        accrual_plan = self.env['hr.leave.accrual.plan'].with_context(tracking_disable=True).create({
+            'name': 'Accrual Plan for Test',
+            'carryover_date': 'year_start',
+            'accrued_gain_time': 'end',
+            'level_ids': [(0, 0, {
+                'added_value': 10,
+                'added_value_type': 'day',
+                'frequency': 'yearly',
+                'start_count': 0,
+                'start_type': 'day',
+                'accrual_date_ref': 'allocation',
+                'allocation_date_offset': 0,
+                'allocation_date_offset_type': 'day',
+            })],
+        })
+        with freeze_time("2024-5-25"):
+            allocation = self.env['hr.leave.allocation'].with_context(tracking_disable=True).create({
+                'name': 'Accrual allocation for employee',
+                'employee_id': self.employee_emp.id,
+                'holiday_status_id': self.leave_type.id,
+                'allocation_type': 'accrual',
+                'accrual_plan_id': accrual_plan.id,
+                'number_of_days': 0,
+            })
+            allocation.action_validate()
+
+        with freeze_time("2025-5-25"):
+            allocation._update_accrual()
+        self.assertEqual(allocation.number_of_days, 10, "10 days are accrued on allocation start date")
+
+    def test_accrue_days_on_relative_date_to_allocation_start_date(self):
+        """
+        Create an accrual plan with one milestone:
+            * Number of accrued days: 10 days
+            * Frequency: Yearly
+            * Accrue days 10 days after allocation start date.
+        Create an allocation:
+            * Start date: 25/05/2024
+            * Type: Accrual
+            * Accrual plan: Use the one defined above
+        On 04/06/2025: 10 days + (10/365) * 10 = 10.27 days should be accrued.
+        """
+        accrual_plan = self.env['hr.leave.accrual.plan'].with_context(tracking_disable=True).create({
+            'name': 'Accrual Plan for Test',
+            'carryover_date': 'year_start',
+            'accrued_gain_time': 'end',
+            'level_ids': [(0, 0, {
+                'added_value': 10,
+                'added_value_type': 'day',
+                'frequency': 'yearly',
+                'start_count': 0,
+                'start_type': 'day',
+                'accrual_date_ref': 'allocation',
+                'allocation_date_offset': 10,
+                'allocation_date_offset_type': 'day',
+            })],
+        })
+        with freeze_time("2024-5-25"):
+            allocation = self.env['hr.leave.allocation'].with_context(tracking_disable=True).create({
+                'name': 'Accrual allocation for employee',
+                'employee_id': self.employee_emp.id,
+                'holiday_status_id': self.leave_type.id,
+                'allocation_type': 'accrual',
+                'accrual_plan_id': accrual_plan.id,
+                'number_of_days': 0,
+            })
+            allocation.action_validate()
+
+        with freeze_time("2025-6-04"):
+            allocation._update_accrual()
+        self.assertAlmostEqual(allocation.number_of_days, 10.27, 2, "10.27 days should be accrued")
+
+    def test_accrue_days_on_relative_date_to_allocation_start_date_2(self):
+        """
+        Create an accrual plan with one milestone:
+            * Number of accrued days: 10 days
+            * Frequency: Yearly
+            * Accrue days 2 months after allocation start date.
+            * Start level 2 months after allocation start date
+        Create an allocation:
+            * Start date: 25/05/2024
+            * Type: Accrual
+            * Accrual plan: Use the one defined above
+        On 25/07/2025: 10 days should be accrued.
+        """
+        accrual_plan = self.env['hr.leave.accrual.plan'].with_context(tracking_disable=True).create({
+            'name': 'Accrual Plan for Test',
+            'carryover_date': 'year_start',
+            'accrued_gain_time': 'end',
+            'level_ids': [(0, 0, {
+                'added_value': 10,
+                'added_value_type': 'day',
+                'frequency': 'yearly',
+                'start_count': 2,
+                'start_type': 'month',
+                'accrual_date_ref': 'allocation',
+                'allocation_date_offset': 2,
+                'allocation_date_offset_type': 'month',
+            })],
+        })
+        with freeze_time("2024-5-25"):
+            allocation = self.env['hr.leave.allocation'].with_context(tracking_disable=True).create({
+                'name': 'Accrual allocation for employee',
+                'employee_id': self.employee_emp.id,
+                'holiday_status_id': self.leave_type.id,
+                'allocation_type': 'accrual',
+                'accrual_plan_id': accrual_plan.id,
+                'number_of_days': 0,
+            })
+            allocation.action_validate()
+
+        with freeze_time("2025-7-25"):
+            allocation._update_accrual()
+        self.assertEqual(allocation.number_of_days, 10, "10 days should be accrued")
+
+    def test_accrue_days_on_relative_date_to_allocation_start_date_3(self):
+        """
+        Create an accrual plan with one milestone:
+            * Number of accrued days: 10 days
+            * Frequency: Yearly
+            * Accrue days 26 months after allocation start date.
+            * Start level 2 months after allocation start date
+        Setting the offset from allocation start date to 26 months (2 year + 2 months) should only
+        result in 2 months offset.
+        Create an allocation:
+            * Start date: 25/05/2024
+            * Type: Accrual
+            * Accrual plan: Use the one defined above
+        On 25/07/2025: 10 days should be accrued.
+        """
+        accrual_plan = self.env['hr.leave.accrual.plan'].with_context(tracking_disable=True).create({
+            'name': 'Accrual Plan for Test',
+            'carryover_date': 'year_start',
+            'accrued_gain_time': 'end',
+            'level_ids': [(0, 0, {
+                'added_value': 10,
+                'added_value_type': 'day',
+                'frequency': 'yearly',
+                'start_count': 2,
+                'start_type': 'month',
+                'accrual_date_ref': 'allocation',
+                'allocation_date_offset': 2,
+                'allocation_date_offset_type': 'month',
+            })],
+        })
+        with freeze_time("2024-5-25"):
+            allocation = self.env['hr.leave.allocation'].with_context(tracking_disable=True).create({
+                'name': 'Accrual allocation for employee',
+                'employee_id': self.employee_emp.id,
+                'holiday_status_id': self.leave_type.id,
+                'allocation_type': 'accrual',
+                'accrual_plan_id': accrual_plan.id,
+                'number_of_days': 0,
+            })
+            allocation.action_validate()
+
+        with freeze_time("2025-7-25"):
+            allocation._update_accrual()
+        self.assertEqual(allocation.number_of_days, 10, "10 days should be accrued")

--- a/addons/hr_holidays/views/hr_leave_accrual_views.xml
+++ b/addons/hr_holidays/views/hr_leave_accrual_views.xml
@@ -48,8 +48,18 @@
                         </div>
                         <div name="yearly" invisible="frequency != 'yearly'">
                             <field name="frequency" style="width: 4rem"/>
-                            <label for="yearly_day_display" string="on the" class="me-1"/>
-                            <field name="yearly_day_display" required="1" style="width: 4rem"/> of <field name="yearly_month" required="1" style="width: 5.4rem"/>
+                        </div>
+                        <div  invisible="frequency != 'yearly'" colspan="2">
+                            <label for="accrual_date_ref" string="Accrual date based on" class="me-2" style="width: 6rem" />
+                            <field name="accrual_date_ref" style="width: 10.5rem"/>
+                            <div name="accrual_reference_date" invisible="accrual_date_ref != 'reference'">
+                                <label for="yearly_day_display" string="Accrue days on the" class="me-1"/>
+                                <field name="yearly_day_display" required="1" style="width: 4rem"/> of <field name="yearly_month" required="1" style="width: 5.4rem"/>
+                            </div>
+                            <div name="allocation_date_offset" invisible="accrual_date_ref != 'allocation'">
+                                <label for="allocation_date_offset" string="Accrue days after" class="me-1"/>
+                                <field name="allocation_date_offset" required="1" style="width: 4rem"/> <field name="allocation_date_offset_type" required="1" style="white-space: nowrap;width: 5rem"/> from allocation start date
+                            </div>
                         </div>
                     </group>
                     <group name="maximum_leave">


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

* If we want, with a minimum effort, to have an automatic allocation providing accrue days based on seniority, we're missing the possibility that the allocation will trigger on a computed date instead of a fixed date.
* task-3965007


Current behavior before PR:

1. The only way to define an allocation that is triggered based on  the start date of the employee's contract is to define an accrual plan for each employee with the `Employee Accrue` set to the start date of the contract. The problem is that a new accrual plan would have to be defined for each employee based on their contract start date.

Desired behavior after PR is merged:

1. Now, there is an option to trigger an allocation based on the allocation start date. So, only one accrual plan is defined for all employees and for each employee, an allocation is created with the `allocation start date` set to the employee's contract start date.   


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
