### PR TITLE
[FIX] base: reset parent_id when type is company

### DIFF
--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -404,6 +404,12 @@ class Partner(models.Model):
         if self.parent_id:
             self.lang = self.parent_id.lang or self.env.context.get('default_lang') or self.env.lang
 
+    @api.onchange('is_company')
+    def _onchange_is_company_for_parent_id(self):
+        # When switching a contact from individual to a company, the parent_id should be reset.
+        if self.is_company:
+            self.parent_id = False
+
     @api.onchange('country_id')
     def _onchange_country_id(self):
         if self.country_id and self.country_id != self.state_id.country_id:


### PR DESCRIPTION
To reproduce:
1- Create a new contact "Entity A" and set the type as Company.
2- Create a new contact "Entity B" and set the type as an Individual and the "Company Name" (parent_id) field to Entity A.
3- Switch the contact type to Company.

Result: the parent_id is still shown pointing to Entity A, and the user is unable to change some fields like the tax ID.

Solution: when a contact's type is switched to Company, reset the parent_id field.

task-3976041