### PR TITLE
[IMP] portal: vertically center contact name

### DIFF
--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -432,7 +432,7 @@
             <div class="d-flex gap-2">
                 <img class="o_avatar o_portal_contact_img rounded" t-att-src="_contactAvatar" alt="Contact"/>
                 <div>
-                    <span class="d-block lh-1 mb-1" t-out="_contactName"/>
+                    <span t-attf-class="d-block lh-1 mb-1 {{ 'pt-1' if not _contactLink else '' }}" t-out="_contactName"/>
                     <a t-if="_contactLink" href="#discussion" class="d-flex align-items-center gap-2 small lh-1">Send message</a>
                 </div>
             </div>


### PR DESCRIPTION
In portal, the name of the contact is not vertically centered relative to the contact's avatar. This PR will change it so that it is.

task-3973629