### PR TITLE
[FIX] website: display description under item in pricelist

### DIFF
--- a/addons/website/views/snippets/s_product_catalog.xml
+++ b/addons/website/views/snippets/s_product_catalog.xml
@@ -47,7 +47,7 @@
 </template>
 
 <template id="s_product_catalog_dish">
-    <li class="s_product_catalog_dish" data-name="Product">
+    <li class="s_product_catalog_dish" data-name="Product" data-oe-protected="true">
         <p class="s_product_catalog_dish_title d-flex align-items-baseline pb-2">
             <span t-esc="name" class="s_product_catalog_dish_name s_product_catalog_dish_dot_leaders"/>
             <span t-esc="price" class="s_product_catalog_dish_price ms-auto ps-2"/>


### PR DESCRIPTION
Steps to reproduce:
- Install 'Website'
- Add a pricelist widget on the website
- Enable descriptions

Issues:
Description are shown above the item, the intended behaviour is to have it under. The problem comes from the sanitize function which modify the DOM.

https://github.com/odoo/odoo/blob/16.0/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/sanitize.js#L245-L267

This causes the `s_product_catalog_dish_title` to be moved under the `li` item with the class `oe-nested`, leaving the `li` `s_product_catalog_dish` empty above. This `li` will later be filled by the `toggleDescription` function which result in the incorrect layout.

https://github.com/odoo/odoo/blob/3e5b60247ff764505d1d781b2a28c9646b137b2b/addons/website/static/src/snippets/s_product_catalog/options.js#L21-L38

By enabling `data-oe-protected` we are making sure the list is not modified by the sanitizer.

As a side note this problem in 17.3 and master due to changes of the sanitizer.

opw-3949549