### PR TITLE
[IMP] stock,mrp,product: print only barcodes coded in code 128 format

### DIFF
--- a/odoo/addons/base/models/ir_qweb_fields.py
+++ b/odoo/addons/base/models/ir_qweb_fields.py
@@ -734,6 +734,8 @@ class BarcodeConverter(models.AbstractModel):
     def value_to_html(self, value, options=None):
         if not value:
             return ''
+        if not bool(re.match(r'^[\x00-\x7F]+$', value)):
+            return nl2br(value)
         barcode_symbology = options.get('symbology', 'Code128')
         barcode = self.env['ir.actions.report'].barcode(
             barcode_symbology,


### PR DESCRIPTION
Before this commit
==================
Barcodes are only readable if they are coded in code 128 format.
However, the barcode field currently accepts practically any character.

After this commit
=================
This commit prevents printing the barcode image when generating a barcode not
coded in code 128 format. Instead, the report displays only the barcode's value.

TaskId: 3634187