### PR TITLE
[FIX] account: Ignore `default_account_id` When Inverting Analytic Distribution

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1223,7 +1223,10 @@ class AccountMoveLine(models.Model):
             line.id for line in self if line.parent_state == "posted"
         ])
         lines_to_modify.analytic_line_ids.unlink()
-        lines_to_modify._create_analytic_lines()
+
+        context = dict(self.env.context)
+        context.pop('default_account_id', None)
+        lines_to_modify.with_context(context)._create_analytic_lines()
 
     @api.onchange('account_id')
     def _inverse_account_id(self):


### PR DESCRIPTION
When you access the journal items list view with a `search_default_account_id` and try to modify the account on a line that has an analytic distribution, a validation error occurs.

### Steps to Reproduce

1. Install `account_accountant`.
2. Create an invoice with a line that has an analytic account and an account A.
3. Open the trial balance and access the journal items of account A using the three-dots menu.
4. Select the line from the invoice you created.
5. Attempt to change its account.

You will encounter the following validation error:

```
The operation cannot be completed: another model requires the record being deleted. If possible, archive it instead.

Model: Analytic Line (account.analytic.line)
Constraint: account_analytic_line_account_id_fkey
```

### Cause

When accessing the journal items from the Trial Balance report, the `search_default_account_id` context key is automatically applied to filter the accounts you selected. However, using `search_default_` with a relational field also creates a `default_` context key for that field. Here, `default_account_id` is added to the context.

When changing the account on a move line that has analytic accounts, the system deletes the existing related analytic items and creates new ones. Analytic items have an `account_id` field. Due to the `default_account_id` context key intended for the journal items, the same key is erroneously applied to the newly created analytic item, leading to a validation error because of a foreign key constraint.

### Fix

I was thinking about cleaning the context but after discussing with JOL, we decided to only get rid of the problematic default key.

opw-3958980