### PR TITLE
[TEST] double onchange lot_ids

### DIFF
--- a/addons/stock/static/tests/tours/stock_picking_tour.js
+++ b/addons/stock/static/tests/tours/stock_picking_tour.js
@@ -156,3 +156,19 @@ registry.category("web_tour.tours").add('test_edit_existing_line', {
         },
     ]
 });
+
+registry.category("web_tour.tours").add('test_onchange_twice_lot_ids', {
+    test: true,
+    steps: () => [
+        { trigger: ".o_optional_columns_dropdown_toggle" },
+        { trigger: ".dropdown-item:contains('Serial Numbers')"},
+        { trigger: ".o_data_cell.o_many2many_tags_cell"},
+        { trigger: ".oi-close:first"},
+        { trigger: ".oi-close:first"},
+        { trigger: ".o_form_button_save"},
+        {
+            trigger: ".o_form_renderer.o_form_saved",
+            isCheck: true,
+        },
+    ]
+});

--- a/addons/stock/tests/test_picking_tours.py
+++ b/addons/stock/tests/test_picking_tours.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from odoo import Command
-from odoo.tests import HttpCase, tagged
+from odoo.tests import Form, HttpCase, tagged
 
 
 @tagged('-at_install', 'post_install')
@@ -118,3 +118,59 @@ class TestStockPickingTour(HttpCase):
 
         names = self.receipt.move_ids.move_line_ids.mapped('lot_name')
         self.assertEqual(names, ["one", "two"])
+
+    def test_onchange_serial_lot_ids(self):
+        """
+        Checks that onchange behaves correctly with respect to multiple unlinks
+        """
+        product_serial = self.env['product.product'].create({
+            'name': 'PSerial',
+            'type': 'product',
+            'tracking': 'serial',
+            'categ_id': self.env.ref('product.product_category_all').id,
+        })
+
+        lots = self.env['stock.lot'].create([
+            {
+            'name': 'SN01',
+            'product_id': product_serial.id,
+            'company_id': self.env.company.id,
+            },
+            {
+            'name': 'SN02',
+            'product_id': product_serial.id,
+            'company_id': self.env.company.id,
+            },
+            {
+            'name': 'SN03',
+            'product_id': product_serial.id,
+            'company_id': self.env.company.id,
+            },
+        ])
+        stock_location = self.env.ref('stock.stock_location_stock')
+        self.env['stock.quant']._update_available_quantity(product_serial, stock_location, 1, lot_id=lots[0])
+        self.env['stock.quant']._update_available_quantity(product_serial, stock_location, 1, lot_id=lots[1])
+        self.env['stock.quant']._update_available_quantity(product_serial, stock_location, 1, lot_id=lots[2])
+        picking = self.env['stock.picking'].create({
+            'location_id': stock_location.id,
+            'location_dest_id': self.ref('stock.stock_location_customers'),
+            'picking_type_id': self.ref('stock.picking_type_out'),
+            'move_ids': [Command.create({
+                'name': product_serial.name,
+                'product_id': product_serial.id,
+                'product_uom_qty': 3,
+                'product_uom': product_serial.uom_id.id,
+                'location_id': stock_location.id,
+                'location_dest_id': self.ref('stock.stock_location_customers'),
+            })]
+        })
+        picking.action_confirm()
+        with Form(picking) as picking_form:
+            with picking_form.move_ids_without_package.edit(0) as move_form:
+                move_form.quantity = 3.0
+                move_form.lot_ids = lots
+        picking = picking_form.save()
+
+        url = self._get_picking_url(picking.id)
+        self.start_tour(url, 'test_onchange_twice_lot_ids', login='admin', step_delay=100)
+        self.assertRecordValues(picking.move_ids, [{"quantity": 1, "lot_ids": lots[2].ids}])


### PR DESCRIPTION
Here is a little test to check the onchange for multiple unlinks

### Steps to reproduce:

- Create a storable product SP tracked by serial number
- Register 3 serial numbers SN01, SN02 and SN03 in stocks for that product (this can for instance be achieved by creating and validating a receipt where you assigned the serial numbers)
- Create a delivery order for these 3 units and mark as to do
- "Extend" the stock move of the picking to see the serial numbers, remove two of them of then and save

### Expected behavior:

The last serial number remains assigned to the stock move

### Current behavior:

The quantity set on the stock move is zero and hence saving the record will remove all associated stock move line and hence every remaining SN

Cause of the issue:

The "lot_ids" field of the stock.move model is a computed non-stored many2many field.

The first time we remove an SN, an onchange setting the "lot_ids" of the stock move is performed and correctly updates the new record both in terms of quantity and lots/stock.move.line.
On the other hand, the second time that we remove a serial number, the onchange tries to modify two times the SN linked to our move. Once by modifying the "lot_ids" of the "move_ids_without_package" of the picking with an "update" command and once more by modifying the dirrectly the "lot_ids" of stock move with two unlink (the previous one and the current one). However, the first of these update will incorrectly set the "lot_ids" to an empty value in the cache since, to not modify the "move_ids_without_package" directly on "real" record, a "new" picking will be created to update the cache:
https://github.com/odoo/odoo/blob/b11480e757ba35e0c616b84bf4dd801210de66f0/addons/web/models/models.py#L1030
However, during this call of the "new" method, the cache is updated again:
https://github.com/odoo/odoo/blob/c6ddaeaf2a6ae70df7f36a1cbc3a874d58ca0b88/odoo/models.py#L6436-L6437
but this time with the validate parameter equal to false ! During this call, the lot_ids of the the stock move of the "new"picking
will be updated using the ids provided by the "convert_to_cache" method here:
https://github.com/odoo/odoo/blob/c6ddaeaf2a6ae70df7f36a1cbc3a874d58ca0b88/odoo/models.py#L6003-L6004
However, the convert_to_cache method of multirelational field, clears all the ids of an unlink operation in case validate is set to false because of these lines:
https://github.com/odoo/odoo/blob/c6ddaeaf2a6ae70df7f36a1cbc3a874d58ca0b88/odoo/fields.py#L4207
https://github.com/odoo/odoo/blob/c6ddaeaf2a6ae70df7f36a1cbc3a874d58ca0b88/odoo/fields.py#L4220-L4221
As a result, the lot_ids of the stock_move is set to be empty in cache. Soon after the "_onchange_lot_ids" method is triggered to compute the quantity linked of products related to the stock.move:
https://github.com/odoo/odoo/blob/c6ddaeaf2a6ae70df7f36a1cbc3a874d58ca0b88/addons/stock/models/stock_move.py#L1121-L1123
Since the lot_ids is set to an empty record set in cache, this value is used and a quantity of 0 is set. As such, the stock move line linked to the move will be unlinked to the move when a save is performed.

### Note:

This flow use to work correctly as, before 17.0, the command set was used instead of unlink to perform the changes on the lot_ids. This has been changed by the following commit: https://github.com/odoo/odoo/commit/e4b66668e0ff3d5444ef7fc7b79e6226c513e2c0

opw-3897055
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
