### PR TITLE
[IMP] web, account: show stat buttons inside (payment) dialog

### DIFF
--- a/addons/account/views/account_payment_view.xml
+++ b/addons/account/views/account_payment_view.xml
@@ -198,7 +198,7 @@
                         <field name="available_journal_ids" invisible="1"/>
                         <field name="currency_id" invisible="1"/>
 
-                        <div class="oe_button_box" name="button_box">
+                        <div class="oe_button_box" name="button_box" show_in_dialog="1">
                             <!-- Invoice stat button -->
                             <button name="button_open_invoices" type="object"
                                     class="oe_stat_button" icon="fa-bars"

--- a/addons/web/static/src/views/form/form_compiler.js
+++ b/addons/web/static/src/views/form/form_compiler.js
@@ -128,7 +128,9 @@ export class FormCompiler extends ViewCompiler {
 
         el.classList.remove("oe_button_box");
         const buttonBox = createElement("ButtonBox");
-        buttonBox.setAttribute("t-if", "!__comp__.env.inDialog");
+        if (el.getAttribute("show_in_dialog") !== "1") {
+            buttonBox.setAttribute("t-if", "!__comp__.env.inDialog");
+        }
         let slotId = 0;
         let hasContent = false;
         for (const child of el.children) {
@@ -655,8 +657,13 @@ export class FormCompiler extends ViewCompiler {
             }
             if (compiled.nodeName === "ButtonBox") {
                 // in form views with a sheet, the button box is moved to the
-                // control panel, and in dialogs, there's no button box
-                continue;
+                // control panel, we only display it in dialogs
+                let isVisibleExpr = `(__comp__.env.inDialog and ${child.getAttribute("show_in_dialog") === "1"})`;
+                if (compiled.hasAttribute("t-if")) {
+                    const formerTif = compiled.getAttribute("t-if");
+                    isVisibleExpr = `( ${formerTif} ) and ${isVisibleExpr}`;
+                }
+                compiled.setAttribute("t-if", isVisibleExpr);
             }
             if (getTag(child, true) === "field") {
                 compiled.setAttribute("showTooltip", true);


### PR DESCRIPTION
Stat buttons were excluded from dialogs with commit [1] because in some flows, it was creating issues in the user flow, particularly in cases involving intermediary records that were not yet saved yet.

But in accounting, there is a case where not having those buttons is making the UX bad and make people waste time.
This is the case for the batch payments form view, which has a o2m to payments, which when clicked will open a form view of the payment. We want the stat buttons on this modal.

[1]: https://github.com/odoo/odoo/commit/473e629a099bfd4b5334951a54df48e37c8612c7

task-3973116
