### PR TITLE
[FIX] account_check_printing: checks to print on account journal dashboard

### DIFF
--- a/addons/account_check_printing/models/account_journal.py
+++ b/addons/account_check_printing/models/account_journal.py
@@ -84,7 +84,7 @@ class AccountJournal(models.Model):
         return dashboard_data
 
     def action_checks_to_print(self):
-        payment_method_line = self.outbound_payment_method_line_ids.filtered(lambda l: l.code == 'check_printing')
+        payment_method_line_id = self.outbound_payment_method_line_ids.filtered(lambda l: l.code == 'check_printing')[:1].id
         return {
             'name': _('Checks to Print'),
             'type': 'ir.actions.act_window',
@@ -96,6 +96,6 @@ class AccountJournal(models.Model):
                 journal_id=self.id,
                 default_journal_id=self.id,
                 default_payment_type='outbound',
-                default_payment_method_line_id=payment_method_line.id,
+                default_payment_method_line_id=payment_method_line_id,
             ),
         }


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
There is a bug with traceback on accounting dashboard when is clicked "Checks to print" on bank journal with more than one outgoing payment with "Checks" Payment Method.

**Steps to reproduce:**

1) With a database in v16 onwards, install the account_check_printing module.

2) Go to "Accounting / Configuration / Accounting / Journals" and create a new journal bank with more than one outgoing payment with "Checks" Payment Method.

3) Go to "Accounting / Vendor / Payments" and create a new payment with journal created on step 1 and "Checks" payment method and confirm.

4) Go to "Accounting" and on "Accounting dashboard" click on "Check to print" on Journal created on step 1 and then a bug with traceback is raised.

**Current behavior before PR:**
There is a bug with traceback on accounting dashboard when is clicked "Checks to print" on bank journal with more than one outgoing payment with "Checks" Payment Method.

**Desired behavior after PR is merged:**
There is not a bug with traceback on accounting dashboard when is clicked "Checks to print" on bank journal with more than one outgoing payment with "Checks" Payment Method.

**Video/Screenshot link:**
https://drive.google.com/file/d/1r6A3uMkFv2nIDZ1HYJLgj6e18pNH1P67/view

Ticket Adhoc side: 75606
Task latam: 1217

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
