### PR TITLE
[FIX] sale: improvement on down payment SO item description

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -328,7 +328,9 @@ class SaleOrderLine(models.Model):
                 elif dp_state == 'cancel':
                     name = _("%(line_description)s (Canceled)", line_description=name)
                 else:
-                    invoice = line._get_invoice_lines().move_id
+                    invoice = line._get_invoice_lines().filtered(
+                        lambda aml: aml.quantity >= 0  # Original downpayment invoice
+                    ).move_id
                     if len(invoice) == 1 and invoice.payment_reference and invoice.invoice_date:
                         name = _(
                             "%(line_description)s (ref: %(reference)s on %(date)s)",


### PR DESCRIPTION
Steps to reproduce:
-create sales order for some product.
-create invoice for down payment.
-create regular invoice.

Issue:
-Description of down payment get modified after creating regular invoice.

Cause:
-Credit note is also taken in consideration in modifying name of invoices.

Fix:
-Applied filter to only take customer invoice

opw-3904918

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
