### PR TITLE
[FIX] l10n_in_*: handle zero distance on ewaybill

### DIFF
--- a/addons/l10n_in_edi_ewaybill/tests/__init__.py
+++ b/addons/l10n_in_edi_ewaybill/tests/__init__.py
@@ -2,3 +2,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_edi_ewaybill_json
+from . import test_edi_ewaybill_distance

--- a/addons/l10n_in_edi_ewaybill/tests/test_edi_ewaybill_distance.py
+++ b/addons/l10n_in_edi_ewaybill/tests/test_edi_ewaybill_distance.py
@@ -1,0 +1,46 @@
+from contextlib import contextmanager
+from unittest.mock import patch
+
+from odoo.addons.l10n_in_edi.tests.test_edi_json import TestEdiJson
+from odoo.addons.l10n_in_edi_ewaybill.models.account_edi_format import AccountEdiFormat
+from odoo.tests import tagged
+
+
+@tagged("post_install_l10n", "post_install", "-at_install")
+class TestEdiEwaybillJson(TestEdiJson):
+
+    @contextmanager
+    def mockEwaybillGateway(self):
+
+        def _l10n_in_edi_ewaybill_generate(self, company, json_payload={}):
+            return {
+                "status_cd": "1",
+                "status_desc": "EWAYBILL request succeeds",
+                "data": {
+                    "ewayBillNo": 123456789012,
+                    "ewayBillDate": "11/06/2024 06:37:15 AM",
+                    "validUpto": "12/06/2024 06:37:15 AM",
+                    "alert": ", Distance between these two pincodes is 118, ",
+                }
+            }
+
+        with patch.object(AccountEdiFormat, "_l10n_in_edi_ewaybill_generate", side_effect=_l10n_in_edi_ewaybill_generate):
+            yield
+
+    def test_edi_distance(self):
+        self.invoice.write(
+            {
+                "l10n_in_type_id": self.env.ref(
+                    "l10n_in_edi_ewaybill.type_tax_invoice_sub_type_supply"
+                ),
+                "l10n_in_distance": 0,
+                "l10n_in_mode": "1",
+                "l10n_in_vehicle_no": "GJ11AA1234",
+                "l10n_in_vehicle_type": "R",
+            }
+        )
+        with self.mockEwaybillGateway():
+            self.invoice.l10n_in_edi_ewaybill_send()
+            self.invoice.action_process_edi_web_services(with_commit=False)
+        expected_distance = 118
+        self.assertEqual(self.invoice.l10n_in_distance, expected_distance)

--- a/addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py
+++ b/addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py
@@ -391,6 +391,12 @@ class Ewaybill(models.Model):
         self._write_successfully_response({'state': 'cancel'})
         self._cr.commit()
 
+    def _l10n_in_ewaybill_stock_handle_zero_distance_alert_if_present(self, response):
+        if self.distance == 0 and (alert := response.get('data').get('alert')):
+            pattern = r", Distance between these two pincodes is \d+, "
+            if re.fullmatch(pattern, alert) and (dist := int(re.search(r'\d+', alert).group())) > 0:
+                self.distance = dist
+
     def _generate_ewaybill_direct(self):
         ewb_api = EWayBillApi(self.company_id)
         generate_json = self._ewaybill_generate_direct_json()
@@ -402,7 +408,7 @@ class Ewaybill(models.Model):
             return False
         self._handle_internal_warning_if_present(response)  # In case of error 604
         response_data = response.get("data")
-        self._write_successfully_response({
+        response_values = {
             'name': response_data.get("ewayBillNo"),
             'state': 'generated',
             'ewaybill_date': self._indian_timezone_to_odoo_utc(
@@ -411,7 +417,9 @@ class Ewaybill(models.Model):
             'ewaybill_expiry_date': self._indian_timezone_to_odoo_utc(
                 response_data.get('validUpto')
             ),
-        })
+        }
+        self._l10n_in_ewaybill_stock_handle_zero_distance_alert_if_present(response)
+        self._write_successfully_response(response_values)
         self._cr.commit()
 
     @api.model

--- a/addons/l10n_in_ewaybill_stock/tests/test_ewaybill_stock.py
+++ b/addons/l10n_in_ewaybill_stock/tests/test_ewaybill_stock.py
@@ -108,7 +108,10 @@ class TestStockEwaybill(AccountTestInvoicingCommon):
         self.assertDictEqual(ewaybill._ewaybill_generate_direct_json(), expected_json)
 
     @freeze_time('2024-04-26')
-    def test_ewaybill_stock_sub_type_other(self):
+    def test_ewaybill_stock_test_2(self):
+        """
+        Ewaybill challan type other test with description
+        """
         delivery_picking = self._create_stock_picking()
         ewaybill = self.env['l10n.in.ewaybill'].create({
             'picking_id': delivery_picking.id,
@@ -165,3 +168,33 @@ class TestStockEwaybill(AccountTestInvoicingCommon):
           'totInvValue': 2625.0
         }
         self.assertDictEqual(ewaybill._ewaybill_generate_direct_json(), expected_json)
+
+    @freeze_time('2024-04-26')
+    def test_ewaybill_stock_test_3(self):
+        """
+        Ewaybill Zero distance test
+        """
+        delivery_picking = self._create_stock_picking()
+        ewaybill = self.env['l10n.in.ewaybill'].create({
+            'type_id': self.env.ref('l10n_in_ewaybill_stock.type_delivery_challan_sub_others').id,
+            'type_description': "Other reasons",
+            'picking_id': delivery_picking.id,
+            'transporter_id': self.partner_a.id,
+            'mode': '2',
+            'distance': 0,
+            'transportation_doc_no': 123456789,
+            'transportation_doc_date': '2024-04-26'
+        })
+        expected_distance = 118
+        response = {
+            'status_cd': '1',
+            'status_desc': 'EWAYBILL request succeeds',
+            'data': {
+                'ewayBillNo': 123456789012,
+                'ewayBillDate': '26/02/2024 12:09:43 PM',
+                'validUpto': '27/02/2024 12:09:43 PM',
+                "alert": ", Distance between these two pincodes is 118, "
+            }
+        }
+        ewaybill._l10n_in_ewaybill_stock_handle_zero_distance_alert_if_present(response)
+        self.assertEqual(ewaybill.distance, expected_distance)


### PR DESCRIPTION
**Before this PR**:
While creating the E-way bill, when sending a request with the distance set to "Zero," the government portal updates the distance based on their own database and sends it back in the response as an alert in the format " , Distance between these two pincodes is \d+, ". However, the Odoo system did not update the distance field with this value.

**After this PR**:
The Odoo system now correctly parses the alert from the government portal response and updates the distance field on the E-way bill with the computed distance.

**task**-3961833

