### PR TITLE
[FIX] pos_self_order: product info button visibility in self order

### DIFF
--- a/addons/pos_self_order/models/product_product.py
+++ b/addons/pos_self_order/models/product_product.py
@@ -44,6 +44,12 @@ class ProductProduct(models.Model):
         params += ['self_order_available']
         return params
 
+    @api.model
+    def _load_pos_self_data_fields(self, config_id):
+        params = super()._load_pos_self_data_fields(config_id)
+        params += ['description_self_order']
+        return params
+
     def _get_name(self) -> str:
         """
         Returns the name of the product without the code.

--- a/addons/pos_self_order/static/src/app/components/product_card/product_card.js
+++ b/addons/pos_self_order/static/src/app/components/product_card/product_card.js
@@ -127,4 +127,11 @@ export class ProductCard extends Component {
             },
         });
     }
+
+    get isHtmlEmpty() {
+        const div = Object.assign(document.createElement("div"), {
+            innerHTML: this.props.product.description_self_order,
+        });
+        return div.innerText.trim() === "";
+    }
 }

--- a/addons/pos_self_order/static/src/app/components/product_card/product_card.xml
+++ b/addons/pos_self_order/static/src/app/components/product_card/product_card.xml
@@ -6,7 +6,7 @@
             t-att-title="props.product.display_name"
             t-on-click="() => this.selectProduct()"
             t-ref="selfProductCard">
-            <div t-if="props.product.description_self_order" class="product-information-tag" t-on-click.prevent.stop="showProductInfo">
+            <div t-if="!this.isHtmlEmpty" class="product-information-tag" t-on-click.prevent.stop="showProductInfo">
                 <i class="product-information-tag-logo fa fa-info fs-4" role="img" aria-label="Product Information" title="Product Information" />
             </div>
             <div


### PR DESCRIPTION
Before this commit:
==========
- The product info button was not visible on the self order and kiosk product card even after adding self order description.

After this commit:
==========
- Now, the product info button is visible on the product card in self order and kiosk.

task-3972473