### PR TITLE
[FIX] base: handle error when adding div in view's architecture

### DIFF
--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -297,7 +297,7 @@ _HTML_PARSER = etree.HTMLParser(encoding='utf8')
 def parse_html(text):
     try:
         parse = html.fragment_fromstring(text, parser=_HTML_PARSER)
-    except TypeError as e:
+    except (etree.ParserError, TypeError) as e:
         raise UserError(_("Error while parsing view:\n\n%s") % e) from e
     return parse
 


### PR DESCRIPTION
Currently, When the user adds a wrong ``div(eg: </div>)`` in a view's architecture and tries to save the view, then an error occurs.

Steps to reproduce:
- Go to Settings > Technical > Views > open a view
- In View Architecture add ``closing div(eg: </div>)`` after any ``div``
- Then save manually, the error will occur.

Traceback: 
`` ParserError: Multiple elements found (div, div)``

To solve this issue, the error has been handled using a try-except block in the ``parse_html`` method.

sentry-4147547360

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
