### PR TITLE
[FIX] account: change logger exception to warning

### DIFF
--- a/addons/account/models/ir_attachment.py
+++ b/addons/account/models/ir_attachment.py
@@ -37,7 +37,7 @@ class IrAttachment(models.Model):
         try:
             xml_tree = etree.fromstring(content)
         except Exception as e:
-            _logger.exception("Error when converting the xml content to etree: %s", e)
+            _logger.warning("Error when converting the xml content to etree: %s", e)
             return []
 
         to_process = []


### PR DESCRIPTION
Currently, an exception is occurring when the user tries to upload an empty XML file in customer invoices.

Steps to produce:
1) Install `Accounting`
2) Try to upload an empty `XML` file in customer invoices. 
3) In the backend a logger exception is encountered.

Error:- 
```
ValueError: can only parse strings
  File "addons/account/models/ir_attachment.py", line 38, in _decode_edi_xml
    xml_tree = etree.fromstring(content)
  File "src/lxml/etree.pyx", line 3255, in lxml.etree.fromstring
  File "src/lxml/parser.pxi", line 1912, in lxml.etree._parseMemoryDocument
```

This causes noise in the sentry, So changing the exception to a warning can resolve this issue.

https://github.com/odoo/odoo/blob/14755d586a695df4c350f29e0c99c876c5811e4f/addons/account/models/ir_attachment.py#L40

sentry-4855416823

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
