### PR TITLE
[FIX] *_expense: update approval_state and forbids unrealistic case when refusing expense sheet

### DIFF
--- a/addons/hr_expense/i18n/hr_expense.pot
+++ b/addons/hr_expense/i18n/hr_expense.pot
@@ -2304,6 +2304,13 @@ msgstr ""
 
 #. module: hr_expense
 #. odoo-python
+#: code:addons/hr_expense/models/hr_expense_sheet.py:0
+#, python-format
+msgid "You cannot cancel an expense sheet linked to a journal entry"
+msgstr ""
+
+#. module: hr_expense
+#. odoo-python
 #: code:addons/hr_expense/models/hr_expense.py:0
 #, python-format
 msgid "You cannot delete a posted or approved expense."

--- a/addons/hr_expense/models/hr_expense_sheet.py
+++ b/addons/hr_expense/models/hr_expense_sheet.py
@@ -657,7 +657,9 @@ class HrExpenseSheet(models.Model):
         self.activity_update()
 
     def _do_refuse(self, reason):
-        self.write({'state': 'cancel'})
+        if self.account_move_ids:  # Todo: in 17.3+, edit it to allow draft entries
+            raise UserError(_("You cannot cancel an expense sheet linked to a journal entry"))
+        self.approval_state = 'cancel'
         subtype_id = self.env['ir.model.data']._xmlid_to_res_id('mail.mt_comment')
         for sheet in self:
             sheet.message_post_with_source(

--- a/addons/project_sale_expense/tests/test_project_profitability.py
+++ b/addons/project_sale_expense/tests/test_project_profitability.py
@@ -195,7 +195,7 @@ class TestProjectSaleExpenseProfitability(TestProjectProfitabilityCommon, TestPr
             {'id': 'expenses', 'sequence': expense_sequence, 'billed': expense.currency_id.round(billed), 'to_bill': 0.0},
         )
 
-        expense_sheet._do_refuse('Test Cancel Expense')
+        expense_sheet.action_reset_expense_sheets()
         expense_profitability = project._get_expenses_profitability_items(False)
         self.assertDictEqual(
             expense_profitability.get('revenues', {}),
@@ -239,7 +239,7 @@ class TestProjectSaleExpenseProfitability(TestProjectProfitabilityCommon, TestPr
             {'id': 'expenses', 'sequence': expense_sequence, 'billed': expense.currency_id.round(-expense_foreign.untaxed_amount_currency * 0.2), 'to_bill': 0.0},
         )
 
-        expense_sheet_foreign._do_refuse('Test Cancel Expense')
+        expense_sheet_foreign.action_reset_expense_sheets()
         expense_profitability = project._get_expenses_profitability_items(False)
         self.assertDictEqual(
             expense_profitability.get('revenues', {}),


### PR DESCRIPTION
 *= hr_expense, project_sale_expense

-STEP TO REPRODUCE: Create an expense sheet , submit then approve it as
well, go to Pg admin or update the view manually to see the field
`approval_state`. The `approval_state` is now approved.
After that try to refuse the sheet, `approval_state` still approved
while it should be consider `cancel` (Refuse)

-Solution is to forbids unrealistic case where we shouldn't allow user
to cancel when it linked to a journal entry and also update `approval_state` as well -> Therefore some test in
`test_project_profitability` need to adapt

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
