### PR TITLE
[IMP] project: copy the top bar shared actions when duplicating the project

### DIFF
--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -409,6 +409,15 @@ class Project(models.Model):
         new_projects = super(Project, self.with_context(mail_auto_subscribe_no_notify=True, mail_create_nosubscribe=True)).copy(default=default)
         if 'milestone_mapping' not in self.env.context:
             self = self.with_context(milestone_mapping={})
+        actions_per_project = dict(self.env['ir.embedded.actions']._read_group(
+            domain=[
+                ('parent_res_id', 'in', self.ids),
+                ('parent_res_model', '=', 'project.project'),
+                ('user_id', '=', False),
+            ],
+            groupby=['parent_res_id'],
+            aggregates=['id:recordset'],
+        ))
         for old_project, new_project in zip(self, new_projects):
             for follower in old_project.message_follower_ids:
                 new_project.message_subscribe(partner_ids=follower.partner_id.ids, subtype_ids=follower.subtype_ids.ids)
@@ -418,6 +427,12 @@ class Project(models.Model):
                 old_project.map_tasks(new_project.id)
             if not old_project.active:
                 new_project.with_context(active_test=False).tasks.active = True
+            # Copy the shared embedded actions in the new project
+            shared_embedded_actions = actions_per_project.get(old_project.id)
+            if shared_embedded_actions:
+                copy_shared_embedded_actions = shared_embedded_actions.copy({'parent_res_id': new_project.id})
+                for original_action, copied_action in zip(shared_embedded_actions, copy_shared_embedded_actions):
+                    copied_action.filter_ids = original_action.filter_ids.copy({'embedded_parent_res_id': new_project.id})
         return new_projects
 
     @api.model


### PR DESCRIPTION
We want to copy the shared top bar actions of the project so that the user can use them in case the project is duplicated, or when an SO confirmation generates a project based on a project template for instance.

task-3794997

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
