### PR TITLE
[FIX] mail: fix non deterministic channel subscription test

### DIFF
--- a/addons/bus/static/tests/mock_server/mock_models/bus_bus.js
+++ b/addons/bus/static/tests/mock_server/mock_models/bus_bus.js
@@ -48,11 +48,8 @@ export class BusBus extends models.Model {
             const { channels } = data;
             this.channelsByUser[this.env?.uid] = channels;
         }
-        const callbackFn = registry
-            .category("mock_server_websocket_callbacks")
-            .get(event_name, null);
-        if (callbackFn) {
-            callbackFn(data);
+        for (const fn of registry.category("mock_server_websocket_callbacks").get(event_name, [])) {
+            fn(data);
         }
     }
 

--- a/addons/mail/static/tests/discuss/core/public_web/discuss.test.js
+++ b/addons/mail/static/tests/discuss/core/public_web/discuss.test.js
@@ -25,7 +25,8 @@ test("bus subscription updated when joining/leaving thread as non member", async
         name: "General",
     });
     await start();
-    await Promise.all([openDiscuss(channelId), waitForChannels([`discuss.channel_${channelId}`])]);
+    await openDiscuss(channelId);
+    await waitForChannels([`discuss.channel_${channelId}`]);
     await click("[title='Leave this channel']");
     await waitForChannels([`discuss.channel_${channelId}`], { operation: "delete" });
 });
@@ -37,7 +38,8 @@ test("bus subscription updated when joining locally pinned thread", async () => 
         name: "General",
     });
     await start();
-    await Promise.all([openDiscuss(channelId), waitForChannels([`discuss.channel_${channelId}`])]);
+    await openDiscuss(channelId);
+    await waitForChannels([`discuss.channel_${channelId}`]);
     await click("[title='Add Users']");
     await click(".o-discuss-ChannelInvitation-selectable", {
         text: "Mitchell Admin",


### PR DESCRIPTION
Before this PR, some bus subscription tests were occasionally failing.
These tests open Discuss and assert that bus subscriptions are
correctly handled in different scenarios, such as joining/leaving a
channel. To achieve this, they use the `waitForChannel` helper.
Sometimes, the subscription is made before calling `waitForChannel`,
which causes the test to fail.

This PR replaces the `waitForChannel` method by adding a step when
`bus_service.addChannel` is called. Since this setup can be done
before opening Discuss, we ensure that the subscription is not missed.

fixes runbot-61294,65319,61969