### PR TITLE
[IMP] hr_contract: change the kanban_state values

### DIFF
--- a/addons/hr_contract/models/hr_contract.py
+++ b/addons/hr_contract/models/hr_contract.py
@@ -63,9 +63,9 @@ class Contract(models.Model):
             * red = Shows a warning on the employees kanban view
     """
     kanban_state = fields.Selection([
-        ('normal', 'Grey'),
-        ('done', 'Green'),
-        ('blocked', 'Red')
+        ('normal', 'Ongoing'),
+        ('done', 'Ready'),
+        ('blocked', 'Warning')
     ], string='Kanban State', default='normal', tracking=True, copy=False)
     currency_id = fields.Many2one(string="Currency", related='company_id.currency_id', readonly=True)
     permit_no = fields.Char('Work Permit No', related="employee_id.permit_no", readonly=False)


### PR DESCRIPTION
This commit changes the values of the `kanban_state` selection field in `hr_contract`. 
Grey --> Ongoing
Green --> Ready
Red --> Warning

task-3976568
