### PR TITLE
[FIX] {*}_loyalty: not use rewards with no active product

### DIFF
--- a/addons/loyalty/models/loyalty_reward.py
+++ b/addons/loyalty/models/loyalty_reward.py
@@ -83,6 +83,7 @@ class LoyaltyReward(models.Model):
     multi_product = fields.Boolean(compute='_compute_multi_product')
     reward_product_ids = fields.Many2many(
         'product.product', string="Reward Products", compute='_compute_multi_product',
+        search='_search_reward_product_ids',
         help="These are the products that can be claimed with this rule.")
     reward_product_qty = fields.Integer(default=1)
     reward_product_uom_id = fields.Many2one('uom.uom', compute='_compute_reward_product_uom_id')
@@ -127,6 +128,22 @@ class LoyaltyReward(models.Model):
             domain = expression.AND([domain, ast.literal_eval(self.discount_product_domain)])
         return domain
 
+    @api.model
+    def _get_active_products_domain(self):
+        return [
+            '|',
+                ('reward_type', '!=', 'product'),
+                '&',
+                    ('reward_type', '=', 'product'),
+                    '|',
+                        '&',
+                            ('reward_product_tag_id', '=', False),
+                            ('reward_product_id.active', '=', True),
+                        '&',
+                            ('reward_product_tag_id', '!=', False),
+                            ('reward_product_ids.active', '=', True)
+        ]
+
     @api.depends('discount_product_domain')
     def _compute_reward_product_domain(self):
         compute_all_discount_product = self.env['ir.config_parameter'].sudo().get_param('loyalty.compute_all_discount_product_ids', 'enabled')
@@ -151,6 +168,15 @@ class LoyaltyReward(models.Model):
             products = reward.reward_product_id + reward.reward_product_tag_id.product_ids
             reward.multi_product = reward.reward_type == 'product' and len(products) > 1
             reward.reward_product_ids = reward.reward_type == 'product' and products or self.env['product.product']
+
+    def _search_reward_product_ids(self, operator, value):
+        if operator not in ('=', '!=', 'in'):
+            raise NotImplementedError("Unsupported search operator")
+        return [
+            '&', ('reward_type', '=', 'product'),
+            '|', ('reward_product_id', operator, value),
+            ('reward_product_tag_id.product_ids', operator, value)
+        ]
 
     @api.depends('reward_type', 'reward_product_id', 'discount_mode',
                  'discount', 'currency_id', 'discount_applicability', 'all_discount_product_ids')

--- a/addons/pos_loyalty/models/pos_session.py
+++ b/addons/pos_loyalty/models/pos_session.py
@@ -2,7 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import models
-from odoo.osv.expression import OR
+from odoo.osv.expression import AND
 import ast
 import json
 
@@ -39,9 +39,10 @@ class PosSession(models.Model):
         }
 
     def _loader_params_loyalty_reward(self):
+        domain_products = self.env['loyalty.reward']._get_active_products_domain()
         return {
             'search_params': {
-                'domain': [('program_id', 'in', self.config_id._get_program_ids().ids)],
+                'domain': AND([[('program_id', 'in', self.config_id._get_program_ids().ids)], domain_products]),
                 'fields': ['description', 'program_id', 'reward_type', 'required_points', 'clear_wallet', 'currency_id',
                     'discount', 'discount_mode', 'discount_applicability', 'all_discount_product_ids', 'is_global_discount',
                     'discount_max_amount', 'discount_line_product_id',

--- a/addons/pos_loyalty/static/src/tours/PosLoyaltyTour.js
+++ b/addons/pos_loyalty/static/src/tours/PosLoyaltyTour.js
@@ -399,3 +399,30 @@ PosLoyalty.check.orderTotalIs('90'),
 PosLoyalty.check.pointsAwardedAre("90"),
 PosLoyalty.exec.finalizeOrder("Cash", "90"),
 Tour.register("PosLoyaltyPointsGlobalDiscountProgramNoDomain", { test: true, url: "/pos/web" }, getSteps());
+
+startSteps();
+
+ProductScreen.do.clickHomeCategory();
+ProductScreen.do.confirmOpeningPopup();
+
+ProductScreen.do.clickPartnerButton();
+ProductScreen.do.clickCustomer("partner_a");
+
+ProductScreen.do.clickDisplayedProduct('Test Product A');
+PosLoyalty.check.checkNoClaimableRewards();
+ProductScreen.check.selectedOrderlineHas('Test Product A', '1.00', '100.00');
+PosLoyalty.exec.finalizeOrder("Cash", "100");
+
+Tour.register('PosLoyaltyArchivedRewardProductsInactive', {test: true, url: '/pos/web'}, getSteps());
+
+startSteps();
+
+ProductScreen.do.clickPartnerButton();
+ProductScreen.do.clickCustomer("partner_a");
+
+ProductScreen.do.clickDisplayedProduct('Test Product A');
+PosLoyalty.check.isRewardButtonHighlighted(true);
+ProductScreen.check.selectedOrderlineHas('Test Product A', '1.00', '100.00');
+PosLoyalty.exec.finalizeOrder("Cash", "100");
+
+Tour.register('PosLoyaltyArchivedRewardProductsActive', {test: true, url: '/pos/web'}, getSteps());

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -1916,6 +1916,67 @@ class TestUi(TestPointOfSaleHttpCommon):
         )
         self.assertEqual(loyalty_card.points, 100)
 
+    def test_archived_reward_products(self):
+        """
+        Check that a loyalty_reward with no active reward product is not loaded.
+        In the case where the reward is based on reward_product_tag_id we also check
+        the case where at least one reward is  active.
+        """
+        self.env['loyalty.program'].search([]).write({'active': False})
+        free_product_tag = self.env['product.tag'].create({'name': 'Free Product'})
+
+        self.product_a.write({
+            'name': 'Test Product A',
+            'type': 'product',
+            'list_price': 100,
+            'available_in_pos': True,
+            'taxes_id': False,
+        })
+
+        self.product_b.write({'product_tag_ids': [(4, free_product_tag.id)]})
+        product_c = self.env['product.product'].create(
+            {
+                'name': 'Free Product C',
+                'list_price': 1,
+                'available_in_pos': True,
+                'taxes_id': False,
+                'product_tag_ids': [(4, free_product_tag.id)],
+            }
+        )
+
+        LoyaltyProgram = self.env['loyalty.program']
+        loyalty_program = LoyaltyProgram.create(LoyaltyProgram._get_template_values()['loyalty'])
+        loyalty_program_tag = LoyaltyProgram.create(LoyaltyProgram._get_template_values()['loyalty'])
+
+        loyalty_program.reward_ids.write({
+            'reward_type': 'product',
+            'required_points': 1,
+            'reward_product_id': self.product_b,
+        })
+
+        loyalty_program_tag.reward_ids.write({
+            'reward_type': 'product',
+            'required_points': 1,
+            'reward_product_tag_id': free_product_tag.id,
+        })
+
+        self.product_b.active = False
+        product_c.active = False
+
+        self.main_pos_config.open_ui()
+        self.start_tour(
+            "/pos/web?config_id=%d" % self.main_pos_config.id,
+            "PosLoyaltyArchivedRewardProductsInactive",
+            login="accountman",
+        )
+
+        product_c.active = True
+        self.start_tour(
+            "/pos/web?config_id=%d" % self.main_pos_config.id,
+            "PosLoyaltyArchivedRewardProductsActive",
+            login="accountman",
+        )
+
     def test_gift_card_rewards_using_taxes(self):
         """
         Check the gift card value when the reward has taxes


### PR DESCRIPTION
*loyalty, pos_loyalty, sale_loyalty

Currently, archived products that are used in loyalty programs may cause the POS shop to crash.

Steps to reproduce:
-------------------
* Go to the **Point of Sale** App
* Go to the products
* Look for the product `Simple Pen`
* Archive the product
* Add some product to the order
* Add a customer that has loyalty points (`Azure Interior`)

> Observations: Blank screen. Error in the console: Cannot read properties of undefined (reading 'id') at Proxy._computeUnclaimedFreeProductQty

> Doing an equivalent flow in sales, when you select `Promotions`, an error message appears saying: Invalid Operation. Invalid product to claim.

Why the fix:
------------
When loading the `loyalty.rewards` to the pos session we check if there is at least one active product. If there is none, we don't load the reward.

Explanation of the domain:
* We only filter in the case where the `reward_type` is `product`.
* Second condition:
  * We cannot have a condition like `('reward_product_id', '!=', False)`
  We could have a setting with both `reward_product_id` and `reward_product_ids` being set. In this condition it would skip the check on `reward_product_ids`
  * We connot have a condition like `('reward_product_ids', '!=', False)` as `reward_product_ids` is always at least an empty set, thus it will always be '`True`'
  * We put the condition on `reward_product_tag_id`. When there is one set the computation of `reward_product_ids` is triggered. `reward_product_ids` will always include `reward_product_id`. When there is no tag set, we will always, at least, have a `reward_product_id`.

opw-[3968140](https://www.odoo.com/web#id=3968140&view_type=form&model=project.task)