### PR TITLE
[IMP] l10n_in_pos: introduce place of supply field

### DIFF
--- a/addons/l10n_in_pos/models/pos_order.py
+++ b/addons/l10n_in_pos/models/pos_order.py
@@ -7,6 +7,8 @@ from odoo import api, fields, models
 class PosOrder(models.Model):
     _inherit = 'pos.order'
 
+    l10n_in_state_id = fields.Many2one('res.country.state', string='Place of supply')
+
     def _prepare_invoice_vals(self):
         vals = super()._prepare_invoice_vals()
         if self.session_id.company_id.country_id.code == 'IN':
@@ -17,4 +19,6 @@ class PosOrder(models.Model):
             if not l10n_in_gst_treatment:
                 l10n_in_gst_treatment = partner.vat and 'regular' or 'consumer'
             vals['l10n_in_gst_treatment'] = l10n_in_gst_treatment
+            if self.l10n_in_state_id:
+                vals['l10n_in_state_id'] = self.l10n_in_state_id.id
         return vals

--- a/addons/l10n_in_pos/static/src/overrides/components/ship_later.js
+++ b/addons/l10n_in_pos/static/src/overrides/components/ship_later.js
@@ -1,0 +1,75 @@
+import { DatePickerPopup } from "@point_of_sale/app/utils/date_picker_popup/date_picker_popup";
+import { usePos } from "@point_of_sale/app/store/pos_hook";
+import { AutoComplete } from "@web/core/autocomplete/autocomplete";
+
+export class ShipLater extends DatePickerPopup {
+    static template = "l10n_in_pos.ShipLater";
+    static components = {
+        ...DatePickerPopup.components,
+        AutoComplete,
+    };
+    static props = {
+        ...DatePickerPopup.props,
+    };
+
+    setup() {
+        super.setup();
+        this.pos = usePos();
+        this.posData = this.getPlaceOfSupply;
+    }
+
+    loadOptionsSource(request) {
+        const inputValue = request?.toLowerCase();
+        const records = this.posData.map(({ id, name }) => [id, name]);
+        const filteredRecords = inputValue
+            ? records.filter(([_, name]) => name.toLowerCase().startsWith(inputValue))
+            : records;
+        return filteredRecords.map(this.mapRecordToOption);
+    }
+
+    mapRecordToOption([value, name]) {
+        return {
+            value,
+            label: name.split("\n")[0],
+            displayName: name,
+        };
+    }
+
+    get getPlaceOfSupply() {
+        const states = this.pos.models["res.country.state"].getAll();
+        const l10n_in_state = [];
+        for (const state of states) {
+            if (state.country_id.code == "IN") {
+                l10n_in_state.push({ id: state.id, name: state.name });
+            }
+        }
+        return l10n_in_state;
+    }
+
+    get sources() {
+        return [this.optionsSource];
+    }
+
+    get optionsSource() {
+        return {
+            options: this.loadOptionsSource.bind(this),
+        };
+    }
+
+    get defaultValue() {
+        return this.pos.company.state_id.name;
+    }
+
+    onSelect(option, params = {}) {
+        this.selectedStateId = this.pos.models["res.country.state"].get(option.value);
+        params.input.value = option.displayName;
+    }
+
+    confirm() {
+        this.props.getPayload(
+            this.state.shippingDate < this._today() ? this._today() : this.state.shippingDate,
+            this.selectedStateId ? this.selectedStateId : this.pos.company.state_id
+        );
+        this.props.close();
+    }
+}

--- a/addons/l10n_in_pos/static/src/overrides/components/ship_later.scss
+++ b/addons/l10n_in_pos/static/src/overrides/components/ship_later.scss
@@ -1,0 +1,4 @@
+.o-autocomplete--dropdown-menu {
+    overflow: auto !important;
+    max-height: 250px
+}

--- a/addons/l10n_in_pos/static/src/overrides/components/ship_later.xml
+++ b/addons/l10n_in_pos/static/src/overrides/components/ship_later.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-name="l10n_in_pos.ShipLater" t-inherit="point_of_sale.DatePickerPopup" t-inherit-mode="primary">
+        <xpath expr="//input" position="after">
+            <div class="o_input_dropdown form-control form-control-lg w-75 mx-auto my-2">
+                <AutoComplete
+                    value="defaultValue"
+                    placeholder="'Enter Place of supply'"
+                    sources="sources"
+                    onSelect.bind="onSelect"
+                    dropdown="true"
+                    autoSelect="true"
+                    autofocus="true"
+                />
+            </div>
+        </xpath>
+    </t>
+</templates>

--- a/addons/l10n_in_pos/static/src/overrides/models/payment_screen.js
+++ b/addons/l10n_in_pos/static/src/overrides/models/payment_screen.js
@@ -1,9 +1,11 @@
 /** @odoo-module */
 
 import { PaymentScreen } from "@point_of_sale/app/screens/payment_screen/payment_screen";
-
 import { patch } from "@web/core/utils/patch";
 import { companyStateDialog } from "@l10n_in_pos/company_state_dialog/company_state_dialog";
+import { _t } from "@web/core/l10n/translation";
+import { AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
+import { ShipLater } from "@l10n_in_pos/overrides/components/ship_later";
 
 patch(PaymentScreen.prototype, {
     toggleIsToInvoice() {
@@ -12,5 +14,42 @@ patch(PaymentScreen.prototype, {
             return;
         }
         return super.toggleIsToInvoice();
+    },
+    async toggleShippingDatePicker() {
+        if (this.pos.company.country_id?.code === "IN") {
+            if (!this.currentOrder.getShippingDate()) {
+                this.dialog.add(ShipLater, {
+                    title: _t("Select the shipping date"),
+                    getPayload: (shippingDate, stateId) => {
+                        this.currentOrder.setShippingDate(shippingDate);
+                        this.currentOrder.setPlaceOfSupply(stateId);
+                    },
+                });
+            } else {
+                this.currentOrder.setShippingDate(false);
+            }
+        } else {
+            return super.toggleShippingDatePicker();
+        }
+    },
+    async validateOrder(isForceValidate) {
+        if (this.pos.company.country_id?.code === "IN") {
+            if (!this.pos.config.ship_later || this.isValid) {
+                super.validateOrder(isForceValidate);
+            } else {
+                this.dialog.add(AlertDialog, {
+                    title: _t("Invoice Mandatory"),
+                    body: _t("For Inter State Shipping Invoice is Mandatory"),
+                });
+            }
+        } else {
+            super.validateOrder();
+        }
+    },
+    get isValid() {
+        return (
+            this.pos.company.state_id == this.currentOrder.l10n_in_state_id ||
+            this.currentOrder.to_invoice
+        );
     },
 });

--- a/addons/l10n_in_pos/static/src/overrides/models/pos_order.js
+++ b/addons/l10n_in_pos/static/src/overrides/models/pos_order.js
@@ -8,6 +8,13 @@ import {
 import { formatCurrency } from "@point_of_sale/app/models/utils/currency";
 
 patch(PosOrder.prototype, {
+    setup(vals) {
+        if (this.company.country_id?.code === "IN") {
+            this.l10n_in_state_id = this.config.company_id.state_id;
+        }
+        return super.setup(...arguments);
+    },
+
     export_for_printing(baseUrl, headerData) {
         const result = super.export_for_printing(...arguments);
         if (this.get_partner()) {
@@ -69,5 +76,9 @@ patch(PosOrder.prototype, {
             }
         }
         return hsnSummary;
+    },
+
+    setPlaceOfSupply(state) {
+        this.l10n_in_state_id = state;
     },
 });


### PR DESCRIPTION
Currently, when invoices are created from POS there is no option to add place of supply, also for inter-state shipping invoices should be mandatory.

This commit adds the option to select the place of supply if the ship later option is enabled, if ship later is not enabled the current company's state is considered for a place of supply in invoices.

If the chosen place of supply is different than the company state i.e for inter state shipping an alert message to select and generate invoices is shown.

Task-3916566
