### PR TITLE
[FIX] stock: incorrect quantity in the past

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -177,8 +177,8 @@ class Product(models.Model):
             # Calculate the moves that were done before now to calculate back in time (as most questions will be recent ones)
             domain_move_in_done = [('state', '=', 'done'), ('date', '>', to_date)] + domain_move_in_done
             domain_move_out_done = [('state', '=', 'done'), ('date', '>', to_date)] + domain_move_out_done
-            moves_in_res_past = {product.id: product_qty for product, product_qty in Move._read_group(domain_move_in_done, ['product_id'], ['product_qty:sum'])}
-            moves_out_res_past = {product.id: product_qty for product, product_qty in Move._read_group(domain_move_out_done, ['product_id'], ['product_qty:sum'])}
+            moves_in_res_past = {product.id: product_qty for product, product_qty in Move._read_group(domain_move_in_done, ['product_id'], ['quantity:sum'])}
+            moves_out_res_past = {product.id: product_qty for product, product_qty in Move._read_group(domain_move_out_done, ['product_id'], ['quantity:sum'])}
 
         res = dict()
         for product in self.with_context(prefetch_fields=False):

--- a/addons/stock/tests/test_move.py
+++ b/addons/stock/tests/test_move.py
@@ -2138,6 +2138,42 @@ class StockMove(TransactionCase):
         move_partial._action_assign()
         self.assertEqual(move_partial.state, 'assigned')
 
+    def test_past_quantity(self):
+        """Test the quantity is correct when looking in the past."""
+        # make some stock
+        self.env["stock.quant"].create({
+            "product_id": self.product.id,
+            "location_id": self.stock_location.id,
+            "inventory_quantity": 3.0,
+        }).action_apply_inventory()
+        product_in_past = self.product.with_context(to_date=fields.Date.add(fields.Date.today(), days=-7))
+        self.assertAlmostEqual(self.product.qty_available, 3.0)
+        self.assertAlmostEqual(product_in_past.qty_available, 0)
+
+        # Make a move with a demand of 2, but confirms only 1
+        move_partial = self.env["stock.move"].create({
+            "name": "test_partial",
+            "location_id": self.stock_location.id,
+            "location_dest_id": self.customer_location.id,
+            "product_id": self.product.id,
+            "product_uom": self.uom_unit.id,
+            "product_uom_qty": 2.0,
+        })
+        move_partial._action_confirm()
+        move_partial._action_assign()
+        self.assertEqual(len(move_partial.move_line_ids), 1)
+
+        move_partial.move_line_ids[0].quantity = 1
+        move_partial.picked = True
+        move_partial._action_done(cancel_backorder=True)
+        self.assertEqual(move_partial.state, "done")
+        self.assertAlmostEqual(move_partial.product_qty, 2)
+        self.assertAlmostEqual(move_partial.quantity, 1)
+
+        # Check the quantity in the past is still 0
+        self.assertAlmostEqual(self.product.qty_available, 2.0)
+        self.assertAlmostEqual(product_in_past.qty_available, 0)
+
     def test_product_tree_views(self):
         """Test to make sure that there are no ACLs errors in users with basic permissions."""
         self.env["stock.quant"]._update_available_quantity(self.product, self.stock_location, 3.0)


### PR DESCRIPTION
### Steps to reproduce:
1. Create a storable product and set the quantity on hand to 100 units
2. Create a delivery of 20 units and mark as to-do
3. In the detailed operations, change the quantity to 10 units
4. Validate the transfer without backorder
5. Go to Inventory > Reporting > Locations
6. Click on Inventory at Date, and select a date one month in the past
7. The on hand quantity for the product is 10

### Before this commit:
When viewing a product's quantity in the past, the value was based on the `product_qty` of the done stock moves. However, this is the demand, and it is not always equals to the quantity that moved.

### After this commit:
Use the quantity of the done stock move lines, which reflect better what really moved in the past.

opw-3946354