### PR TITLE
[FIX] product: readonly boolean_favorite field was editable

### DIFF
--- a/addons/product/__manifest__.py
+++ b/addons/product/__manifest__.py
@@ -64,6 +64,7 @@ Print product labels with barcode.
             'product/static/src/product_catalog/**/*.js',
             'product/static/src/product_catalog/**/*.xml',
             'product/static/src/product_catalog/**/*.scss',
+            'product/static/src/scss/product_form.scss',
         ],
         'web.report_assets_common': [
             'product/static/src/scss/report_label_sheet.scss',

--- a/addons/product/static/src/scss/product_form.scss
+++ b/addons/product/static/src/scss/product_form.scss
@@ -1,0 +1,3 @@
+.oe_title .o_favorite i.fa {
+    font-size: inherit;
+}

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -49,7 +49,7 @@
                         <label for="name" string="Product Name"/>
                         <h1>
                             <div class="d-flex">
-                                <field name="is_favorite" widget="boolean_favorite" class="me-3" nolabel="1"/>
+                                <field name="is_favorite" widget="boolean_favorite" class="me-3" nolabel="1" readonly="1"/>
                                 <field class="text-break" name="name" options="{'line_breaks': False}" widget="text" placeholder="e.g. Cheese Burger"/>
                             </div>
                         </h1>
@@ -562,7 +562,12 @@ action = {
                                 <div class="o_kanban_record_top flex-column m-0"
                                      t-attf-id="product-{{record.id.raw_value}}">
                                     <div class="d-flex">
-                                        <field style="margin-top: 2px;" class="me-1" name="is_favorite" widget="boolean_favorite" nolabel="1"/>
+                                        <field style="margin-top: 2px;"
+                                            class="me-1"
+                                            name="is_favorite"
+                                            widget="boolean_favorite"
+                                            nolabel="1"
+                                            readonly="1"/>
                                         <h4 class="text-reset">
                                             <strong class="o_kanban_record_title"><field name="name"/></strong>
                                         </h4>

--- a/addons/web/static/src/views/fields/boolean_favorite/boolean_favorite_field.js
+++ b/addons/web/static/src/views/fields/boolean_favorite/boolean_favorite_field.js
@@ -16,7 +16,20 @@ export class BooleanFavoriteField extends Component {
         noLabel: false,
     };
 
+    get iconClass() {
+        return this.props.record.data[this.props.name] ? "fa fa-star me-1" : "fa fa-star-o me-1";
+    }
+
+    get label() {
+        return this.props.record.data[this.props.name]
+            ? _t("Remove from Favorites")
+            : _t("Add to Favorites");
+    }
+
     async update() {
+        if (this.props.readonly) {
+            return;
+        }
         const changes = { [this.props.name]: !this.props.record.data[this.props.name] };
         await this.props.record.update(changes, { save: this.props.autosave });
     }
@@ -38,9 +51,10 @@ export const booleanFavoriteField = {
             ),
         },
     ],
-    extractProps: ({ attrs, options }) => ({
+    extractProps: ({ attrs, options }, dynamicInfo) => ({
         noLabel: archParseBoolean(attrs.nolabel),
         autosave: "autosave" in options ? Boolean(options.autosave) : true,
+        readonly: dynamicInfo.readonly,
     }),
 };
 

--- a/addons/web/static/src/views/fields/boolean_favorite/boolean_favorite_field.xml
+++ b/addons/web/static/src/views/fields/boolean_favorite/boolean_favorite_field.xml
@@ -3,15 +3,9 @@
 
     <t t-name="web.BooleanFavoriteField">
         <div class="o_favorite" t-on-click.prevent.stop="update">
-            <a href="#">
-                <t t-if="props.record.data[props.name]">
-                    <i class="fa fa-star me-1" role="img" title="Remove from Favorites" aria-label="Remove from Favorites"/>
-                    <t t-if="!props.noLabel">Remove from Favorites</t>
-                </t>
-                <t t-else="">
-                    <i class="fa fa-star-o me-1" role="img" title="Add to Favorites" aria-label="Add to Favorites"/>
-                    <t t-if="!props.noLabel">Add to Favorites</t>
-                </t>
+            <a href="#" t-att-class="{'pe-none' : props.readonly}">
+                <i t-att-class="iconClass" role="img" t-att-title="label" t-att-aria-label="label"/>
+                <t t-if="!props.readonly and !props.noLabel" t-esc="label"/>
             </a>
         </div>
     </t>


### PR DESCRIPTION
added readonly behaviour to the boolean_favorite widget

opw-3933386

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
