### PR TITLE
[FIX] payment_stripe: fix mandate parameters validation

### DIFF
--- a/addons/payment_stripe/const.py
+++ b/addons/payment_stripe/const.py
@@ -43,6 +43,21 @@ PAYMENT_METHODS_TOKENIZATION_SUPPORT = {
     'zip': False,
 }
 
+INDIAN_MANDATES_SUPPORTED_CURRENCIES = [
+    'USD',
+    'EUR',
+    'GBP',
+    'SGD',
+    'CAD',
+    'CHF',
+    'SEK',
+    'AED',
+    'JPY',
+    'NOK',
+    'MYR',
+    'HKD',
+]
+
 # Mapping of transaction states to Stripe objects ({Payment,Setup}Intent, Refund) statuses.
 # For each object's exhaustive status list, see:
 # https://stripe.com/docs/api/payment_intents/object#payment_intent_object-status


### PR DESCRIPTION
Since early June 2024, on new individual accounts, Stripe validates Indian mandate parameters even if they are irrelevant (e.g. mandates are not needed and won't be created). This prevents payments not compatible with Indian mandates from being made, like those made with MXN currency.

With this fix, mandate parameters will be sent only if the payment's currency is supported by Indian mandates.

Note: Accounts created before June 2024 or accounts linked to a platform created before June 2024 that have already used mandates are not affected by this bug. 

opw-3946505
