### PR TITLE
[FIX] point_of_sale: improve loading speed of POS

### DIFF
--- a/addons/point_of_sale/static/src/app/models/product_product.js
+++ b/addons/point_of_sale/static/src/app/models/product_product.js
@@ -1,7 +1,6 @@
 /** @odoo-module */
 import { registry } from "@web/core/registry";
 import { Base } from "./related_models";
-import { deserializeDate } from "@web/core/l10n/dates";
 import { _t } from "@web/core/l10n/translation";
 import { roundPrecision } from "@web/core/utils/numbers";
 
@@ -98,12 +97,31 @@ export class ProductProduct extends Base {
         return current;
     }
 
-    isPricelistItemUsable(item, date) {
-        return (
-            (!item.categ_id || this.parentCategories.includes(item.categ_id.id)) &&
-            (!item.date_start || deserializeDate(item.date_start) <= date) &&
-            (!item.date_end || deserializeDate(item.date_end) >= date)
-        );
+    getApplicablePricelistRules(pricelistRules) {
+        const applicableRules = {};
+        for (const pricelistId in pricelistRules) {
+            if (pricelistRules[pricelistId].productItems[this.id]) {
+                applicableRules[pricelistId] = pricelistRules[pricelistId].productItems[this.id];
+                continue;
+            }
+            const productTmplId = this.raw.product_tmpl_id;
+            if (pricelistRules[pricelistId].productTmlpItems[productTmplId]) {
+                applicableRules[pricelistId] =
+                    pricelistRules[pricelistId].productTmlpItems[productTmplId];
+                continue;
+            }
+            for (const category of this.parentCategories) {
+                if (pricelistRules[pricelistId].categoryItems[category]) {
+                    applicableRules[pricelistId] =
+                        pricelistRules[pricelistId].categoryItems[category];
+                    break;
+                }
+            }
+            if (!applicableRules[pricelistId]) {
+                applicableRules[pricelistId] = pricelistRules[pricelistId].globalItems;
+            }
+        }
+        return applicableRules;
     }
 
     // Port of _get_product_price on product.pricelist.

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -25,6 +25,7 @@ import { EditListPopup } from "@point_of_sale/app/store/select_lot_popup/select_
 import { ProductConfiguratorPopup } from "./product_configurator_popup/product_configurator_popup";
 import { ComboConfiguratorPopup } from "./combo_configurator_popup/combo_configurator_popup";
 import { makeAwaitable, ask } from "@point_of_sale/app/store/make_awaitable_dialog";
+import { deserializeDate } from "@web/core/l10n/dates";
 
 const { DateTime } = luxon;
 import { PartnerList } from "../screens/partner_list/partner_list";
@@ -305,30 +306,53 @@ export class PosStore extends Reactive {
             }
         }
 
-        for (const product of products) {
-            const applicableRules = {};
-
-            for (const item of pricelistItems) {
-                if (!applicableRules[item.pricelist_id.id]) {
-                    applicableRules[item.pricelist_id.id] = [];
-                }
-
-                if (!product.isPricelistItemUsable(item, date)) {
-                    continue;
-                }
-
-                if (item.raw.product_id && product.id === item.raw.product_id) {
-                    applicableRules[item.pricelist_id.id].push(item);
-                } else if (
-                    !item.raw.product_id &&
-                    item.raw.product_tmpl_id &&
-                    product.raw?.product_tmpl_id === item.raw.product_tmpl_id
-                ) {
-                    applicableRules[item.pricelist_id.id].push(item);
-                } else if (!item.raw.product_tmpl_id && !item.raw.product_id) {
-                    applicableRules[item.pricelist_id.id].push(item);
-                }
+        const pushItem = (targetArray, key, item) => {
+            if (!targetArray[key]) {
+                targetArray[key] = [];
             }
+            targetArray[key].push(item);
+        };
+
+        const pricelistRules = {};
+
+        for (const item of pricelistItems) {
+            if (
+                (item.date_start && deserializeDate(item.date_start) > date) ||
+                (item.date_end && deserializeDate(item.date_end) < date)
+            ) {
+                continue;
+            }
+            const pricelistId = item.pricelist_id.id;
+
+            if (!pricelistRules[pricelistId]) {
+                pricelistRules[pricelistId] = {
+                    productItems: {},
+                    productTmlpItems: {},
+                    categoryItems: {},
+                    globalItems: [],
+                };
+            }
+
+            const productId = item.raw.product_id;
+            if (productId) {
+                pushItem(pricelistRules[pricelistId].productItems, productId, item);
+                continue;
+            }
+            const productTmplId = item.raw.product_tmpl_id;
+            if (productTmplId) {
+                pushItem(pricelistRules[pricelistId].productTmlpItems, productTmplId, item);
+                continue;
+            }
+            const categId = item.raw.categ_id;
+            if (categId) {
+                pushItem(pricelistRules[pricelistId].categoryItems, categId, item);
+            } else {
+                pricelistRules[pricelistId].globalItems.push(item);
+            }
+        }
+
+        for (const product of products) {
+            const applicableRules = product.getApplicablePricelistRules(pricelistRules);
             for (const pricelistId in applicableRules) {
                 if (product.cachedPricelistRules[pricelistId]) {
                     const existingRuleIds = product.cachedPricelistRules[pricelistId].map(


### PR DESCRIPTION
Before this commit, loading the POS took a long time when there were more than 1000 products and pricelists. The reason was that the `computeProductPricelistCache` function had a time complexity of O(n^2 * m) due to nested loops over products and pricelist items, and several calls to the raw function which is O(n) itself.

This commit optimizes the `computeProductPricelistCache` function by performing a single loop over pricelist items and another over products. This change improves the loading speed from 10 minutes to 10 seconds with 1000 products and pricelist items.

opw-3978067

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
