### PR TITLE
[FIX] web: fallback to zx if BarcodeDetector fails

### DIFF
--- a/addons/web/i18n/web.pot
+++ b/addons/web/i18n/web.pot
@@ -1413,6 +1413,13 @@ msgid "Bar Chart"
 msgstr ""
 
 #. module: web
+#. odoo-javascript
+#: code:addons/web/static/src/webclient/barcode/barcode_scanner.js:0
+#, python-format
+msgid "BarcodeDetector not set"
+msgstr ""
+
+#. module: web
 #: model:ir.model,name:web.model_base
 msgid "Base"
 msgstr ""
@@ -3033,6 +3040,13 @@ msgstr ""
 #: code:addons/web/static/src/core/tree_editor/tree_editor_value_editors.js:0
 #, python-format
 msgid "False"
+msgstr ""
+
+#. module: web
+#. odoo-javascript
+#: code:addons/web/static/src/webclient/barcode/barcode_scanner.js:0
+#, python-format
+msgid "Failed to initialize BarcodeScanner: "
 msgstr ""
 
 #. module: web
@@ -7279,6 +7293,13 @@ msgstr ""
 msgid ""
 "Try to add some records, or make sure that there is no\n"
 "                    active filter in the search bar."
+msgstr ""
+
+#. module: web
+#. odoo-javascript
+#: code:addons/web/static/src/webclient/barcode/barcode_scanner.js:0
+#, python-format
+msgid "Trying again with ZX library."
 msgstr ""
 
 #. module: web


### PR DESCRIPTION
**Current behavior:**
When using a BarcodeScanner compatible browser/device combo, if construction fails, we don't try to fallback to the zx detector.

**Expected behavior:**
We try both BarcodeDetector implementations.

**Steps to reproduce:**
1. On a combatible device/browser, open the Barcode app

2. In DevTools, put a breakpoint in `onWillStart()` of the BarcodeDialog class

3. Click the scan button on the main menu of Barcode

4. Before the detector class is instantiated, over-write the `formats` argument so a TypeError is raised, e.g., contains unknown or empty (https://developer.mozilla.org/en-US/docs/Web/API/BarcodeDetector/BarcodeDetector#exceptions)

5. See trace back

**Cause of the issue:**
See https://developer.mozilla.org/en-US/docs/Web/API/BarcodeDetector/BarcodeDetector#exceptions

**Fix:**
Fallback to the zx detector, which can handle some argument vals which BarcodeDetector can't.

opw-3893160