### PR TITLE
[FIX] project: translate default label_tasks

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -301,7 +301,7 @@ class Project(models.Model):
     is_favorite = fields.Boolean(compute='_compute_is_favorite', inverse='_inverse_is_favorite',
         string='Show Project on Dashboard',
         help="Whether this project should be displayed on your dashboard.")
-    label_tasks = fields.Char(string='Use Tasks as', default='Tasks', help="Label used for the tasks of the project.", translate=True)
+    label_tasks = fields.Char(string='Use Tasks as', default=lambda s: _('Tasks'), help="Label used for the tasks of the project.", translate=True)
     tasks = fields.One2many('project.task', 'project_id', string="Task Activities")
     resource_calendar_id = fields.Many2one(
         'resource.calendar', string='Working Time',


### PR DESCRIPTION
The field is translatable, but the default value wasn't being translated so new projects' tasks labels were always defaulting to English regardless of language.

opw-3976888

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
