### PR TITLE
[FIX] point_of_sale: fix report sale details total invoice

### DIFF
--- a/addons/point_of_sale/views/report_saledetails.xml
+++ b/addons/point_of_sale/views/report_saledetails.xml
@@ -356,10 +356,10 @@
                         <td style="background-color: #b1b1b1;"/>
                         <td class="text-end" style="background-color: #b1b1b1;"><strong>
                             <span t-if="currency['position']">
-                                <span t-out="invoice['total']" t-options="{'widget': 'float', 'precision': currency['precision']}">123.45</span><span t-out='currency["symbol"]'>$</span>
+                                <span t-out="invoiceTotal" t-options="{'widget': 'float', 'precision': currency['precision']}">123.45</span><span t-out='currency["symbol"]'>$</span>
                             </span>
                             <span t-else="">
-                                <span t-out='currency["symbol"]'>$</span><span t-out="invoice['total']" t-options="{'widget': 'float', 'precision': currency['precision']}">123.45</span>
+                                <span t-out='currency["symbol"]'>$</span><span t-out="invoiceTotal" t-options="{'widget': 'float', 'precision': currency['precision']}">123.45</span>
                             </span>
                         </strong></td>
                     </tr>


### PR DESCRIPTION
Current behavior:
When doing multiple orders with invoices, then generating the sale details report of the session. The total amount for the invoices would be incorrect. It would be the value of the last invoice

Steps to reproduce:
- Open PoS session
- Make at least 2 orders and invoice them
- Close the session
- Go in Order > Session, select the session you just closed
- Click on the little gear, and generate the sale details report
- Go to the invoices part of the report, the Total doesn't match the total of all the lines. It's the same value as the last line

opw-3930210
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
