### PR TITLE
[FIX] sales_team: default team filtered by user company

### DIFF
--- a/addons/sales_team/models/crm_team.py
+++ b/addons/sales_team/models/crm_team.py
@@ -64,6 +64,8 @@ class CrmTeam(models.Model):
             filtered_teams = teams.filtered_domain(domain)
             if default_team and default_team in filtered_teams:
                 team = default_team
+            elif user and user.company_id and len(filtered_teams) > 1:
+                team = filtered_teams.filtered(lambda team: team.company_id == user.company_id)[:1]
             else:
                 team = filtered_teams[:1]
 


### PR DESCRIPTION
# WIP
improvement of  the heuristic used for the sales team assignment

# Reproduction
Setup in 15.0
1. Install appointment_crm,website_appointment
2. Have two companies: C1 and C2
3. Have a user: Admin
	1. with C2 as his default company
	2. with C1 and C2 as his "Allowed companies"
	3. is an Employee in C2
4. Have two sales teams, with Admin as Team Leader:
	1. S1 (in C1)
	2. S2 (in C2)
	3. Ensure that S1 has higher sequence than S2 (bring S1 to the top of the sales team list)
5. Create an appointment A2 (belonging to C2) with:
	1. Create Opportunities checked
	2. with Admin as Employee
	3. Some Availability
	4. Publish it
6. Schedule an appointment A2 as public user (from incognito)
7. Sub-optimal behavior: Created opportunity is assigned to a C1, even tho:
	1. Admin is an equal member of both sales teams
	2. Admins's default company is C2 (even tho its staff user default company is C2)

## What is my fix changing?
In the situation as above, i.e when we have couple of teams that we can assign the lead to:
Instead of assigning it to the first one from the list
We assign it to the first one from the list that has the same default company as the user


opw-3862550

https://github.com/odoo/odoo/assets/33809926/dc0b0cb2-f559-4975-91d7-03fa81acab48

