### PR TITLE
[FIX] hr: deleting address violates bank account constraints

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -306,12 +306,13 @@ class HrEmployeePrivate(models.Model):
 
     def write(self, vals):
         if 'address_home_id' in vals:
+            address_home_id = vals['address_home_id']
             account_ids = vals.get('bank_account_id') or self.bank_account_id.ids
-            if account_ids:
-                self.env['res.partner.bank'].browse(account_ids).partner_id = vals['address_home_id']
+            if account_ids and address_home_id:
+                self.env['res.partner.bank'].browse(account_ids).partner_id = address_home_id
             self.message_unsubscribe(self.address_home_id.ids)
-            if vals['address_home_id']:
-                self._message_subscribe([vals['address_home_id']])
+            if address_home_id:
+                self._message_subscribe([address_home_id])
         if vals.get('user_id'):
             # Update the profile pictures with user, except if provided 
             vals.update(self._sync_user(self.env['res.users'].browse(vals['user_id']),

--- a/addons/hr/tests/test_hr_employee.py
+++ b/addons/hr/tests/test_hr_employee.py
@@ -69,3 +69,20 @@ class TestHrEmployee(TestHrCommon):
 
     def test_employee_has_same_avatar_as_corresponding_user(self):
         self.assertEqual(self.employee_without_image.avatar_1920, self.user_without_image.avatar_1920)
+
+    def test_unlink_address(self):
+        employee = self.employee_without_image
+        partner = self.env["res.partner"].create({
+            "name": "Mr. Bean",
+            "street": "12 Arbour Road",
+            "city": "London"
+        })
+        employee.address_home_id = partner.id
+        bank = self.env['res.partner.bank'].create({
+            "acc_number": "123",
+            "partner_id": partner.id
+        })
+        employee.bank_account_id = bank.id
+
+        employee.address_home_id = False
+        self.assertFalse(employee.address_home_id)


### PR DESCRIPTION
Issue
----

Deleting the private address of an employee fails if a bank account is set.

Steps
-----

- Go to an employee's form in the Employees app.
- Choose an employee -> Go to Private Information.
- Make sure an address and a bank account is set.
- Delete the address & save.
- An error is thrown.

Cause
-----

The code in the overridden `write` method sets the `res_bank.partner_id` to the `address_home_id` field (both are `res.partner`). If the `address_home_id` field is deleted, the method tries to write `False` to `res_bank.partner_id`, which fails as this field is required.

opw-3976098