### PR TITLE
[FIX] stock: invalid res_model in the Forecasted Report actions

### DIFF
--- a/addons/stock/views/stock_forecasted.xml
+++ b/addons/stock/views/stock_forecasted.xml
@@ -4,13 +4,13 @@
     <record id="stock_forecasted_product_product_action" model="ir.actions.client">
         <field name="name">Forecasted Report</field>
         <field name="tag">stock_forecasted</field>
-        <field name="res_model" ref="product.model_product_product"/>
+        <field name="res_model">product.product</field>
     </record>
 
     <record id="stock_forecasted_product_template_action" model="ir.actions.client">
         <field name="name">Forecasted Report</field>
         <field name="tag">stock_forecasted</field>
-        <field name="res_model" ref="product.model_product_template"/>
+        <field name="res_model">product.template</field>
     </record>
 
 </odoo>


### PR DESCRIPTION
Steps to reproduce
==================

- Install mrp
- Enable debug mode
- Go to products
- Open the "Acoustics Bloc Screens" form
- Click on the "Forecasted" smart button
- Click on the debug icon > "View access rights"

A traceback occurs when evaluating the domain

Cause of the issue
==================

ir.actions.client is supposed to be a string but is an id in this case.

`ir.model.search([["model", "=", action.res_model]])` returns nothing. [0]

---

[0]: https://github.com/odoo/odoo/blob/c07181b20bf4f06b783136ffdb3b7a304be6b136/addons/web/static/src/webclient/actions/debug_items.js#L147

opw-3955762