### PR TITLE
[FIX] base: fix get_filters

### DIFF
--- a/odoo/addons/base/models/ir_filters.py
+++ b/odoo/addons/base/models/ir_filters.py
@@ -67,7 +67,7 @@ class IrFilters(models.Model):
            same context (menu/view) as the given action."""
         action_condition = ('action_id', 'in', [action_id, False]) if action_id else ('action_id', '=', False)
         embedded_condition = ('embedded_action_id', '=', embedded_action_id) if embedded_action_id else ('embedded_action_id', '=', False)
-        embedded_parent_res_id_condition = ('embedded_parent_res_id', '=', embedded_parent_res_id) if embedded_action_id and embedded_parent_res_id else ('embedded_parent_res_id', '=', False)
+        embedded_parent_res_id_condition = ('embedded_parent_res_id', '=', embedded_parent_res_id) if embedded_action_id and embedded_parent_res_id else ('embedded_parent_res_id', 'in', [0, False])
 
         return [action_condition, embedded_condition, embedded_parent_res_id_condition]
 


### PR DESCRIPTION
This commit fixes a bug that was introduced by
https://github.com/odoo/odoo/pull/163184.

Bug Description:
When a favorite filter is created from the search bar without an active_id in the global context, the embedded_parent_res_id variable is assigned a False value. However, since embedded_parent_res_id is an integer, it defaults to 0 in the database. Consequently, when retrieving filters for the same action, the newly created favorite filter appears because the system searches for a False value for embedded_parent_res_id , but a 0 value is stored in the database.

Solution:
Modify the action_domain to fetch both False and 0 values.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
