### PR TITLE
[FIX] account: Fix missing rounding in tax_totals

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -2090,7 +2090,7 @@ class AccountTax(models.Model):
         amount_untaxed_currency = 0.0
         for base_line, tax_details_results in to_process:
             amount_untaxed += comp_curr.round(tax_details_results['total_excluded'] / base_line['rate'])
-            amount_untaxed_currency += tax_details_results['total_excluded']
+            amount_untaxed_currency += currency.round(tax_details_results['total_excluded'])
 
         def grouping_key_generator(base_line, tax_data):
             return {'tax_group': tax_data['tax'].tax_group_id}
@@ -2131,8 +2131,8 @@ class AccountTax(models.Model):
                 'tax_group_name': tax_group.name,
                 'tax_group_amount': tax_detail['tax_amount_currency'],
                 'tax_group_amount_company_currency': tax_detail['tax_amount'],
-                'tax_group_base_amount': tax_detail['display_base_amount_currency'],
-                'tax_group_base_amount_company_currency': tax_detail['display_base_amount'],
+                'tax_group_base_amount': currency.round(tax_detail['display_base_amount_currency']),
+                'tax_group_base_amount_company_currency': company.currency_id.round(tax_detail['display_base_amount']),
                 'formatted_tax_group_amount': formatLang(self.env, tax_detail['tax_amount_currency'], currency_obj=currency),
                 'formatted_tax_group_base_amount': formatLang(self.env, tax_detail['display_base_amount_currency'], currency_obj=currency),
             })

--- a/addons/account/tests/test_invoice_tax_totals.py
+++ b/addons/account/tests/test_invoice_tax_totals.py
@@ -751,6 +751,66 @@ class TestTaxTotals(AccountTestInvoicingCommon):
             'subtotals_order': ["Untaxed Amount"],
         })
 
+    def test_round_globally_price_included_tax(self):
+        self.env.company.tax_calculation_rounding_method = 'round_globally'
+        tax_1 = self.env['account.tax'].create({
+            'name': "tax_1",
+            'amount_type': 'fixed',
+            'tax_group_id': self.tax_group1.id,
+            'amount': 1.0,
+            'include_base_amount': True,
+            'price_include': True,
+        })
+        tax_21 = self.env['account.tax'].create({
+            'name': "tax_21",
+            'amount_type': 'percent',
+            'tax_group_id': self.tax_group2.id,
+            'amount': 21.0,
+            'price_include': True,
+        })
+        invoice = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'partner_id': self.partner_a.id,
+            'invoice_date': '2019-01-01',
+            'invoice_line_ids': [
+                Command.create({
+                    'name': f'line{i}',
+                    'display_type': 'product',
+                    'price_unit': 21.53,
+                    'tax_ids': [Command.set((tax_1 + tax_21).ids)],
+                })
+                for i in range(2)
+            ],
+        })
+        self.assert_document_tax_totals(invoice, {
+            'amount_total': 43.050000000000004,
+            'amount_untaxed': 33.58,
+            'display_tax_base': True,
+            'groups_by_subtotal': {
+                'Untaxed Amount': [
+                    {
+                        'tax_group_name': self.tax_group1.name,
+                        'tax_group_amount': 2,
+                        'tax_group_base_amount': 33.59,
+                        'tax_group_id': self.tax_group1.id,
+                    },
+                    {
+                        'tax_group_name': self.tax_group2.name,
+                        'tax_group_amount': 7.47,
+                        'tax_group_base_amount': 35.59,
+                        'tax_group_id': self.tax_group2.id,
+                    }
+                ]
+            },
+            'subtotals': [
+                {
+                    'name': "Untaxed Amount",
+                    'amount': 33.58,
+                }
+            ],
+            'subtotals_order': ["Untaxed Amount"],
+        })
+
     def test_cash_rounding_amount_total_rounded(self):
         tax_15 = self.env['account.tax'].create({
             'name': "tax_15",


### PR DESCRIPTION
Suppose 2 lines of 21.53 having:
t1: fixed tax of 1, incl in price, include base amount t2: 21% price included tax

The price_subtotal is computed as 21.53 / 1.21 - 1 = 16.79. So the untaxed amount of the invoice is 16.79 * 2 = 33.58. However, 33.59 is displayed on the invoice tax_totals.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
