### PR TITLE
[FIX] l10n_pl: actually hide the tab if not polish company

### DIFF
--- a/addons/l10n_pl/views/account_move_views.xml
+++ b/addons/l10n_pl/views/account_move_views.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="account.view_move_form"/>
         <field name="arch" type="xml">
             <notebook position="inside">
-                <page id="pl_extra" string="PL Extra" name="page_pl_extra" invisible="move_type not in ('out_invoice', 'out_refund') and country_code != 'PL'">
+                <page id="pl_extra" string="PL Extra" name="page_pl_extra" invisible="move_type not in ('out_invoice', 'out_refund') or country_code != 'PL'">
                     <group>
                         <group>
                             <field name="l10n_pl_vat_b_spv_dostawa" readonly="state != 'draft'"/>


### PR DESCRIPTION
During a fw-port, an error was made and the "or" became an "and". 
This fixes it, to hide the tab if the move is not from a polish company.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
