### PR TITLE
[FIX] base: un-require `currency_field` in `ir.model.fields` form

### DIFF
--- a/odoo/addons/base/views/ir_model_views.xml
+++ b/odoo/addons/base/views/ir_model_views.xml
@@ -305,8 +305,7 @@
                                             readonly="ttype not in ['many2one', 'one2many', 'many2many']"/>
                                         <field name="currency_field"
                                             invisible="ttype != 'monetary'"
-                                            readonly="ttype != 'monetary'"
-                                            required="ttype == 'monetary'"/>
+                                            readonly="ttype != 'monetary'"/>
                                     </group>
                                 </group>
                                 <group string="HTML/Sanitization Properties">


### PR DESCRIPTION
Small fix on commit 71ab15e4 to remove the `required` attribute on `currency_field` in the form view, which makes it impossible to save the form if the field is not set and editing something unrelated on a monetary field, for ex. the field label or the translations.

The checks in the constraint `_check_currency_field()` added in the same commit should be enough to ensure the `currency_field` is set as needed.

Impacted branches:

`17.0` and `master`

Steps to reproduce:

 1. Go to the Technical menu -> Fields and select a monetary type field
 2. Try to update the Field Label or any field translation

Current behavior:

The editing is blocked by the required 'Currency field'.

Expected behavior:

Allow editing the form view or the related translations.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
