### PR TITLE
[IMP] account, mail: prevent move creation when email lacks attachment

### DIFF
--- a/addons/account/data/mail_template_data.xml
+++ b/addons/account/data/mail_template_data.xml
@@ -135,5 +135,22 @@
             <field name="lang">{{ object.partner_id.lang }}</field>
             <field name="auto_delete" eval="True"/>
         </record>
+        <!-- Invoice mail gateway failed -->
+        <template id="email_template_mail_gateway_failed">
+<p>
+    Hi,
+    <br/><br/>
+    Your email has been discarded. the e-mail address you have used only accepts new invoices:
+    <ul>
+        <li>For new invoices, please ensure a PDF or electronic invoice file is attached</li>
+        <li>To add information to a previously sent invoice, reply to your "sent" email</li>
+    </ul>
+    For any other question, write to <t t-esc="company_email"/>.
+    <br/>
+    --
+    <br/>
+    <t t-esc="company_name"/>
+</p>
+        </template>
     </data>
 </odoo>

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -5106,6 +5106,18 @@ class AccountMove(models.Model):
         return ['&', ('move_type', '=', 'out_invoice'), ('state', '=', 'posted')]
 
     @api.model
+    def _routing_check_route(self, message, message_dict, route, raise_exception=True):
+        if route[0] == 'account.move' and len(message_dict['attachments']) < 1:
+            # Don't create the move if no attachment.
+            body = self.env['ir.qweb']._render('account.email_template_mail_gateway_failed', {
+                'company_email': self.env.company.email,
+                'company_name': self.env.company.name,
+            })
+            self._routing_create_bounce_email(message_dict['from'], body, message)
+            return ()
+        return super()._routing_check_route(message, message_dict, route, raise_exception=raise_exception)
+
+    @api.model
     def message_new(self, msg_dict, custom_values=None):
         # EXTENDS mail mail.thread
         # Add custom behavior when receiving a new invoice through the mail's gateway.

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -1200,7 +1200,8 @@ class MailThread(models.AbstractModel):
                 for alias in dest_aliases:
                     user_id = self._mail_find_user_for_gateway(email_from, alias=alias).id or self._uid
                     route = (alias.sudo().alias_model_id.model, alias.alias_force_thread_id, ast.literal_eval(alias.alias_defaults), user_id, alias)
-                    route = self._routing_check_route(message, message_dict, route, raise_exception=True)
+                    AliasModel = self.env[route[0]] if route[0] in self.env and hasattr(self.env[route[0]], '_routing_check_route') else self
+                    route = AliasModel._routing_check_route(message, message_dict, route, raise_exception=True)
                     if route:
                         _logger.info(
                             'Routing mail from %s to %s with Message-Id %s: direct alias match: %r',


### PR DESCRIPTION
Previously, when an email gateway was set up for a journal, Odoo would create a move whenever an email was received, regardless of whether it had any attachments. This commit changes that behavior. Now, if an email is received without any attachments, Odoo will not create a move. Instead, it will send an email back to the sender to inform them of the issue.

task-3964321