### PR TITLE
[IMP] product: Fix memory error

### DIFF
--- a/addons/product/models/product_attribute.py
+++ b/addons/product/models/product_attribute.py
@@ -64,8 +64,16 @@ class ProductAttribute(models.Model):
 
     @api.depends('product_tmpl_ids')
     def _compute_number_related_products(self):
+        res = {
+            attribute.id: count
+            for attribute, count in self.env['product.template.attribute.line']._read_group(
+                domain=[('attribute_id', 'in', self.ids)],
+                groupby=['attribute_id'],
+                aggregates=['product_tmpl_id:count_distinct'],
+            )
+        }
         for pa in self:
-            pa.number_related_products = len(pa.product_tmpl_ids)
+            pa.number_related_products = res.get(pa.id, 0)
 
     @api.depends('attribute_line_ids.active', 'attribute_line_ids.product_tmpl_id')
     def _compute_products(self):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
 - During migration, the compute method `_compute_number_related_products` of model `product.attribute` is called and cause the `Memory Error` due to high number of records.
 - This method get the count of product_template_ids for particular product_attribute.

**Traceback:**
```python
 Traceback (most recent call last):
   File "/tmp/tmpal_p0o26/migrations/base/tests/test_mock_crawl.py", line 255, in crawl_menu
    self.mock_action(action_vals)
   File "/tmp/tmpal_p0o26/migrations/base/tests/test_mock_crawl.py", line 412, in mock_action
    mock_method(model, view, fields_list, domain, group_by)
   File "/tmp/tmpal_p0o26/migrations/base/tests/test_mock_crawl.py", line 441, in mock_view_form
    [data] = record.read(fields_list)
   File "/home/odoo/src/odoo/17.0/odoo/models.py", line 3540, in read
    return self._read_format(fnames=fields, load=load)
   File "/home/odoo/src/odoo/17.0/odoo/models.py", line 3751, in _read_format
    vals[name] = convert(record[name], record, use_display_name)
   File "/home/odoo/src/odoo/17.0/odoo/models.py", line 6603, in __getitem__
    return self._fields[key].__get__(self, self.env.registry[self._name])
   File "/home/odoo/src/odoo/17.0/odoo/fields.py", line 1207, in __get__
    self.compute_value(recs)
   File "/home/odoo/src/odoo/17.0/odoo/fields.py", line 1389, in compute_value
    records._compute_field_value(self)
   File "/home/odoo/src/odoo/17.0/odoo/models.py", line 4875, in _compute_field_value
    fields.determine(field.compute, self)
   File "/home/odoo/src/odoo/17.0/odoo/fields.py", line 102, in determine
    return needle(*args)
   File "/home/odoo/src/odoo/17.0/addons/product/models/product_attribute.py", line 68, in _compute_number_related_products
    pa.number_related_products = len(pa.product_tmpl_ids)
   File "/home/odoo/src/odoo/17.0/odoo/fields.py", line 2907, in __get__
    return super().__get__(records, owner)
   File "/home/odoo/src/odoo/17.0/odoo/fields.py", line 1156, in __get__
    return self.convert_to_record(value, record)
   File "/home/odoo/src/odoo/17.0/odoo/fields.py", line 4249, in convert_to_record
    corecords = corecords.filtered(Comodel._active_name).with_prefetch(prefetch_ids)
   File "/home/odoo/src/odoo/17.0/odoo/models.py", line 6110, in filtered
    return self.browse([rec.id for rec in self if func(rec)])
   File "/home/odoo/src/odoo/17.0/odoo/models.py", line 6110, in <listcomp>
    return self.browse([rec.id for rec in self if func(rec)])
   File "/home/odoo/src/odoo/17.0/odoo/models.py", line 6109, in <lambda>
    func = lambda rec: any(rec.mapped(name))
   File "/home/odoo/src/odoo/17.0/odoo/models.py", line 6087, in mapped
    recs = recs._fields[name].mapped(recs)
   File "/home/odoo/src/odoo/17.0/odoo/fields.py", line 1281, in mapped
    self.__get__(first(remaining), type(remaining))
   File "/home/odoo/src/odoo/17.0/odoo/fields.py", line 1182, in __get__
    recs._fetch_field(self)
   File "/home/odoo/src/odoo/17.0/odoo/models.py", line 3777, in _fetch_field
    self.fetch(fnames)
   File "/home/odoo/src/odoo/17.0/odoo/models.py", line 3827, in fetch
    fetched = self._fetch_query(query, fields_to_fetch)
   File "/home/odoo/src/odoo/17.0/odoo/models.py", line 3920, in _fetch_query
    rows = self.env.cr.fetchall()
 MemoryError
```

Current behavior before PR:
Before fix:
 - The standard compute method in version [17.0](https://github.com/odoo/odoo/blob/4b67a7bec2007d89dfa8d9ecc7a73d4fe86547a3/addons/product/models/product_attribute.py#L70C4-L73C104)

Desired behavior after PR is merged:

 - The data is fetched using _read_group method in compute method and solve the memory error.

Task Link: [3906977](https://www.odoo.com/odoo/70/tasks/3906977?cids=2)
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
