### PR TITLE
[FIX] hr_holidays: apply multicompany security to report

### DIFF
--- a/addons/hr_holidays/security/hr_holidays_security.xml
+++ b/addons/hr_holidays/security/hr_holidays_security.xml
@@ -252,6 +252,12 @@
         <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
     </record>
 
+    <record id="hr_leave_report_rule_multi_company" model="ir.rule">
+        <field name="name">Time Off Report: multi company global rule</field>
+        <field name="model_id" ref="model_hr_leave_report"/>
+        <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
+    </record>
+
     <record id="hr_leave_report_rule_group_user" model="ir.rule">
         <field name="name">Time Off Summary / Report: Internal User</field>
         <field name="model_id" ref="model_hr_leave_report"/>


### PR DESCRIPTION
Steps to reproduce:
- Install "Time Off" and `l10n_be`
- "Time Off" -> "Reporting" -> "by Type"
- Unselect the company with the time off

Issues:
All the time off will be shown, company selection will not be taken into account. This is due to a missing security rules.

opw-3954393