### PR TITLE
[FIX] resource: remove rounding factor

### DIFF
--- a/addons/resource/models/resource_calendar.py
+++ b/addons/resource/models/resource_calendar.py
@@ -19,7 +19,7 @@ from odoo.osv import expression
 from odoo.tools.float_utils import float_round
 
 from odoo.tools import date_utils, float_utils
-from .utils import Intervals, float_to_time, make_aware, datetime_to_string, string_to_datetime, ROUNDING_FACTOR
+from .utils import Intervals, float_to_time, make_aware, datetime_to_string, string_to_datetime
 
 
 class ResourceCalendar(models.Model):
@@ -500,7 +500,7 @@ class ResourceCalendar(models.Model):
 
         return {
             # Round the number of days to the closest 16th of a day.
-            'days': sum(float_utils.round(ROUNDING_FACTOR * day_days[day]) / ROUNDING_FACTOR for day in day_days),
+            'days': float_round(sum(day_days[day] for day in day_days), precision_rounding=0.01),
             'hours': sum(day_hours.values()),
         }
 
@@ -515,10 +515,10 @@ class ResourceCalendar(models.Model):
             day_hours[start.date()] += (stop - start).total_seconds() / 3600
 
         # compute number of days as quarters
-        days = sum(
-            float_utils.round(ROUNDING_FACTOR * day_hours[day] / day_total[day]) / ROUNDING_FACTOR if day_total[day] else 0
+        days = float_round(sum(
+            day_hours[day] / day_total[day] if day_total[day] else 0
             for day in day_hours
-        )
+        ), precision_rounding=0.01)
         return {
             'days': days,
             'hours': sum(day_hours.values()),

--- a/addons/test_resource/tests/test_resource.py
+++ b/addons/test_resource/tests/test_resource.py
@@ -711,7 +711,7 @@ class TestResMixin(TestResourceCommon):
             datetime_tz(2018, 4, 6, 16, 0, 0, tzinfo=self.john.tz),
         )[self.jean.id]
         # still showing as 5 days because of rounding, but we see only 39 hours
-        self.assertEqual(data, {'days': 4.875, 'hours': 39})
+        self.assertEqual(data, {'days': 4.88, 'hours': 39})
 
         # Looking at John's calendar
 
@@ -721,7 +721,7 @@ class TestResMixin(TestResourceCommon):
             datetime_tz(2018, 4, 2, 0, 0, 0, tzinfo=self.jean.tz),
             datetime_tz(2018, 4, 6, 23, 0, 0, tzinfo=self.jean.tz),
         )[self.john.id]
-        self.assertEqual(data, {'days': 1.4375, 'hours': 13})
+        self.assertEqual(data, {'days': 1.42, 'hours': 13})
 
         # Viewing it as Patel
         # Views from 2018/04/01 11:00:00 to 2018/04/06 10:00:00
@@ -729,7 +729,7 @@ class TestResMixin(TestResourceCommon):
             datetime_tz(2018, 4, 2, 0, 0, 0, tzinfo=self.patel.tz),
             datetime_tz(2018, 4, 6, 23, 0, 0, tzinfo=self.patel.tz),
         )[self.john.id]
-        self.assertEqual(data, {'days': 1.1875, 'hours': 10})
+        self.assertEqual(data, {'days': 1.17, 'hours': 10})
 
         # Viewing it as John
         data = self.john._get_work_days_data_batch(
@@ -875,7 +875,7 @@ class TestResMixin(TestResourceCommon):
             datetime_tz(2018, 4, 9, 0, 0, 0, tzinfo=self.john.tz),
             datetime_tz(2018, 4, 13, 23, 59, 59, tzinfo=self.john.tz),
         )[self.john.id]
-        self.assertEqual(data, {'days': 0.9375, 'hours': 10})
+        self.assertEqual(data, {'days': 0.96, 'hours': 10})
 
         # half days
         leave = self.env['resource.calendar.leaves'].create({


### PR DESCRIPTION
Issue:
------
The use case in which certain employees, who work part-time over several days (and not part-time with full days with one or more days off), want to take leaves distributed via allocations given in days is unfortunately not taken into account.

For example:
- monday morning: duration = 0.4
- monday afternoon: duration = 0.4

allocation duration = round(0.8 * 16) / 16 = round(12.8) / 16 = 13 / 16 = 0.8125 ~= 0.81

Note:
It's strange to round up to the sixteenth of an 8-hour day. It makes sense to have half-hour intervals, but it is does not work correctly with calendars that differ from the standard 8-hour calendar.

opw-3957459