### PR TITLE
[IMP] stock,mrp: permit reload on the traceability report

### DIFF
--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -19,6 +19,13 @@
             <field name="target">fullscreen</field>
         </record>
 
+        <record id="action_stock_report_production" model="ir.actions.client">
+            <field name="name">Traceability Report</field>
+            <field name="tag">stock_report_generic</field>
+            <field name="res_model">mrp.production</field>
+            <field name="context" eval="{'url': '/stock/output_format/stock?active_id=:active_id&amp;active_model=mrp.production', 'model': 'stock.traceability.report'}"/>
+        </record>
+
         <record id="mrp_production_view_activity" model="ir.ui.view">
             <field name="name">mrp.production.view.activity</field>
             <field name="model">mrp.production</field>
@@ -247,7 +254,7 @@
                         <button type="object" name="action_view_mo_delivery" class="oe_stat_button" icon="fa-truck"  groups="base.group_user" invisible="delivery_count == 0">
                             <field name="delivery_count" widget="statinfo" string="Transfers"/>
                         </button>
-                        <button name="%(stock.action_stock_report)d" icon="oi-arrow-up" class="oe_stat_button" string="Traceability" type="action" invisible="state != 'done'" groups="stock.group_production_lot">
+                        <button name="%(action_stock_report_production)d" icon="oi-arrow-up" class="oe_stat_button" string="Traceability" type="action" invisible="state != 'done'" groups="stock.group_production_lot">
                             <div class="o_stat_info">
                                 <span class="o_stat_text">Traceability</span>
                             </div>

--- a/addons/stock/data/stock_traceability_report_data.xml
+++ b/addons/stock/data/stock_traceability_report_data.xml
@@ -7,4 +7,18 @@
         <field name="context" eval="{'url': '/stock/output_format/stock?active_id=:active_id&amp;active_model=:active_model', 'model': 'stock.traceability.report'}" />
     </record>
 
+    <record id="action_stock_report_lot" model="ir.actions.client">
+        <field name="name">Traceability Report</field>
+        <field name="tag">stock_report_generic</field>
+        <field name="res_model">stock.lot</field>
+        <field name="context" eval="{'url': '/stock/output_format/stock?active_id=:active_id&amp;active_model=stock.lot', 'model': 'stock.traceability.report'}"/>
+    </record>
+
+    <record id="action_stock_report_picking" model="ir.actions.client">
+        <field name="name">Traceability Report</field>
+        <field name="tag">stock_report_generic</field>
+        <field name="res_model">stock.picking</field>
+        <field name="context" eval="{'url': '/stock/output_format/stock?active_id=:active_id&amp;active_model=stock.picking', 'model': 'stock.traceability.report'}"/>
+    </record>
+
 </odoo>

--- a/addons/stock/static/src/client_actions/stock_traceability_report_backend.js
+++ b/addons/stock/static/src/client_actions/stock_traceability_report_backend.js
@@ -59,7 +59,7 @@ export class TraceabilityReport extends Component {
         Object.assign(this.context, {
             active_id: active_id || this.props.action.params.active_id,
             auto_unfold: auto_unfold || false,
-            model: active_model || false,
+            model: active_model || this.props.action.res_model || false,
             lot_name: lot_name || false,
             ttype: ttype || false,
         });

--- a/addons/stock/views/stock_lot_views.xml
+++ b/addons/stock/views/stock_lot_views.xml
@@ -21,7 +21,7 @@
                                 <span class="o_stat_text">Location</span>
                             </div>
                         </button>
-                        <button name="%(action_stock_report)d" icon="oi-arrow-up" class="oe_stat_button" type="action">
+                        <button name="%(action_stock_report_lot)d" icon="oi-arrow-up" class="oe_stat_button" type="action">
                             <div class="o_stat_info">
                                 <span class="o_stat_text">Traceability</span>
                             </div>

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -157,7 +157,7 @@
                         <button name="action_see_packages" string="Packages" type="object"
                             class="oe_stat_button" icon="fa-cubes"
                             invisible="not has_packages"/>
-                        <button name="%(action_stock_report)d" icon="oi-arrow-up" class="oe_stat_button" type="action" invisible="state != 'done' or not has_tracking" groups="stock.group_production_lot">
+                        <button name="%(action_stock_report_picking)d" icon="oi-arrow-up" class="oe_stat_button" type="action" invisible="state != 'done' or not has_tracking" groups="stock.group_production_lot">
                             <div class="o_stat_info">
                                 <span class="o_stat_text">Traceability</span>
                             </div>


### PR DESCRIPTION
The traceability report relies on the `active_model` to know which data to fetch. This information is unfortunately lost when reloading the page, so no data will be found, and the user has to go back to the previous form then click the traceability button again.

Now that the traceability report is able to show the complete traceability of a lot/serial through different companies, it becomes cumbersome to have to go back to the previous form every time we update the companies we want to display.

task-3853055

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
