### PR TITLE
[FIX] project: fix project sharing view inheritance

### DIFF
--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -54,14 +54,14 @@
             <field name="priority">999</field>
             <field name="arch" type="xml">
                 <field name="stage_id" position="after">
-                    <field name="project_id" string="Project"/>
+                    <field name="project_id" string="Project" groups="base.group_user"/>
                 </field>
                 <field name="partner_id" position="after">
                     <field name="company_id" groups="base.group_multi_company"/>
-                    <filter string="My Tasks" name="my_tasks" domain="[('user_ids', 'in', uid)]"/>
+                    <filter string="My Tasks" name="my_tasks" domain="[('user_ids', 'in', uid)]" groups="base.group_user"/>
                 </field>
                 <filter name="stage" position="after">
-                    <filter string="Project" name="project" context="{'group_by': 'project_id'}"/>
+                    <filter string="Project" name="project" context="{'group_by': 'project_id'}" groups="base.group_user"/>
                 </filter>
             </field>
         </record>


### PR DESCRIPTION
The project sharing search view is inheriting the wrong base search view (instead of inheriting `view_task_search_form_project_base`, it should be inheriting `view_task_search_form_base`), which causes some fields and filters to be visible in project sharing when they shouldn't.

This commit makes those fields and filters invisible for portal users.

Task-3978479
