### PR TITLE
[FIX] im_livechat: crash when thread name contains non-ASCII characters

### DIFF
--- a/addons/im_livechat/static/src/public_models/livechat_button_view.js
+++ b/addons/im_livechat/static/src/public_models/livechat_button_view.js
@@ -177,7 +177,7 @@ registerModel({
             if (this.isOpeningChat) {
                 return;
             }
-            const cookie = getCookie('im_livechat_session');
+            const cookie = decodeURIComponent(getCookie('im_livechat_session'));
             let def;
             this.update({ isOpeningChat: true });
             clearTimeout(this.autoOpenChatTimeout);

--- a/addons/im_livechat/static/src/public_models/public_livechat.js
+++ b/addons/im_livechat/static/src/public_models/public_livechat.js
@@ -6,7 +6,6 @@ import { registerModel } from '@mail/model/model_core';
 import { attr, one } from '@mail/model/model_field';
 import { clear } from '@mail/model/model_field_command';
 
-import { unaccent } from 'web.utils';
 import { deleteCookie, setCookie } from 'web.utils.cookies';
 
 registerModel({
@@ -44,7 +43,7 @@ registerModel({
             deleteCookie("im_livechat_session");
             setCookie(
                 "im_livechat_session",
-                unaccent(JSON.stringify(this.widget.toData()), true),
+                encodeURIComponent(JSON.stringify(this.widget.toData()), true),
                 60 * 60,
                 "required"
             );

--- a/addons/im_livechat/static/src/public_models/public_livechat_global.js
+++ b/addons/im_livechat/static/src/public_models/public_livechat_global.js
@@ -47,7 +47,7 @@ registerModel({
             await this._willStartChatbot();
         },
         async _willStart() {
-            const strCookie = getCookie('im_livechat_session');
+            const strCookie = decodeURIComponent(getCookie('im_livechat_session'));
             let isSessionCookieAvailable = Boolean(strCookie);
             let cookie = JSON.parse(strCookie || '{}');
             if (isSessionCookieAvailable && cookie.visitor_uid !== session.user_id) {
@@ -113,7 +113,7 @@ registerModel({
                     }),
                 });
             } else if (this.history !== null && this.history.length !== 0) {
-                const sessionCookie = getCookie('im_livechat_session');
+                const sessionCookie = decodeURIComponent(getCookie('im_livechat_session'));
                 if (sessionCookie) {
                     this.update({ sessionCookie });
                 }
@@ -146,7 +146,7 @@ registerModel({
         },
 
         getVisitorUserId() {
-            const cookie = JSON.parse(getCookie("im_livechat_session") || "{}");
+            const cookie = JSON.parse(decodeURIComponent(getCookie("im_livechat_session")) || "{}");
             if ("visitor_uid" in cookie) {
                 return cookie.visitor_uid;
             }
@@ -158,7 +158,7 @@ registerModel({
          * this will deactivate the mail_channel, notify operator that visitor has left the channel.
          */
         leaveSession() {
-            const cookie = getCookie('im_livechat_session');
+            const cookie = decodeURIComponent(getCookie('im_livechat_session'));
             if (cookie) {
                 const channel = JSON.parse(cookie);
                 if (channel.uuid) {

--- a/addons/im_livechat/static/src/services/public_livechat_service.js
+++ b/addons/im_livechat/static/src/services/public_livechat_service.js
@@ -4,10 +4,19 @@ import LivechatButton from '@im_livechat/legacy/widgets/livechat_button';
 
 import rootWidget from 'root.widget';
 
+import {getCookie, deleteCookie} from 'web.utils.cookies';
+
 export const publicLivechatService = {
     dependencies: ['messaging'],
     async start(env, { messaging: messagingService }) {
         const messaging = await messagingService.get();
+        try {
+            JSON.parse(decodeURIComponent(getCookie('im_livechat_session')));
+        } catch {
+            // Cookies are not supposed to contain non-ASCII characters.
+            // However, some were set in the past. Let's clean them up.
+            deleteCookie('im_livechat_session');
+        }
         return {
             mountLivechatButton() {
                 const livechatButton = new LivechatButton(rootWidget, messaging);

--- a/addons/website_livechat/models/website_visitor.py
+++ b/addons/website_livechat/models/website_visitor.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from datetime import datetime, timedelta
+from urllib.parse import unquote
 import json
 
 from odoo import api, Command, fields, models, _
@@ -111,7 +112,7 @@ class WebsiteVisitor(models.Model):
         visitor_id, upsert = super()._upsert_visitor(access_token, force_track_values=force_track_values)
         if upsert == 'inserted':
             visitor_sudo = self.sudo().browse(visitor_id)
-            mail_channel_uuid = json.loads(request.httprequest.cookies.get('im_livechat_session', '{}')).get('uuid')
+            mail_channel_uuid = json.loads(unquote(request.httprequest.cookies.get('im_livechat_session', '{}'))).get('uuid')
             if mail_channel_uuid:
                 mail_channel = request.env["mail.channel"].sudo().search([("uuid", "=", mail_channel_uuid)])
                 mail_channel.write({

--- a/addons/website_livechat/static/src/public_models/livechat_button_view.js
+++ b/addons/website_livechat/static/src/public_models/livechat_button_view.js
@@ -4,7 +4,6 @@ import { registerPatch } from '@mail/model/model_core';
 import { attr, one } from '@mail/model/model_field';
 import { clear } from '@mail/model/model_field_command';
 
-import {unaccent} from 'web.utils';
 import {setCookie} from 'web.utils.cookies';
 
 registerPatch({
@@ -46,7 +45,7 @@ registerPatch({
             this.widget._sendWelcomeMessage();
             this.messaging.publicLivechatGlobal.chatWindow.renderMessages();
             this.env.services.bus_service.addChannel(this.messaging.publicLivechatGlobal.publicLivechat.uuid);
-            setCookie('im_livechat_session', unaccent(JSON.stringify(this.messaging.publicLivechatGlobal.publicLivechat.widget.toData()), true), 60 * 60, 'required');
+            setCookie('im_livechat_session', encodeURIComponent(JSON.stringify(this.messaging.publicLivechatGlobal.publicLivechat.widget.toData()), true), 60 * 60, 'required');
             this.update({ isOpeningChat: false });
         },
     },

--- a/addons/website_livechat/static/src/public_models/public_livechat_global.js
+++ b/addons/website_livechat/static/src/public_models/public_livechat_global.js
@@ -49,7 +49,7 @@ registerPatch({
             }
             if (this.options.chat_request_session) {
                 this.options.chat_request_session.visitor_uid = this.getVisitorUserId();
-                setCookie('im_livechat_session', JSON.stringify(this.options.chat_request_session), 60 * 60, 'required');
+                setCookie('im_livechat_session', encodeURIComponent(JSON.stringify(this.options.chat_request_session)), 60 * 60, 'required');
             }
             return this._super();
         },


### PR DESCRIPTION
The live chat uses cookies to save data about the ongoing conversation such as the thread name. When those informations contain non-ASCII chars, the behavior of the cookie is not consistent across browsers.

Safari does not store it properly, and trying to parse it later on result in a crash.

This PR solves this issue by encoding the data using the `encodeURIComponent` method.

opw-3968341
