### PR TITLE
[FIX] mrp: dont traceback on zero production overview report

### DIFF
--- a/addons/mrp/report/mrp_report_mo_overview.py
+++ b/addons/mrp/report/mrp_report_mo_overview.py
@@ -101,7 +101,7 @@ class ReportMoOverview(models.AbstractModel):
             'unit_real_cost': unit_real_cost,
         }
         if production_done:
-            production_qty = summary.get('quantity', 1.0)
+            production_qty = summary.get('quantity') or 1.0
             extras['total_mo_cost_components'] = sum(compo.get('summary', {}).get('mo_cost', 0.0) for compo in components)
             extras['total_real_cost_components'] = sum(compo.get('summary', {}).get('real_cost', 0.0) for compo in components)
             extras['total_mo_cost_components_decorator'] = self._get_comparison_decorator(extras['total_real_cost_components'], extras['total_mo_cost_components'], currency.rounding)


### PR DESCRIPTION
Steps
---
* create MO
* confirm > produce all
* unlock > set produced quantity to 0
* click 'Overview' => Traceback (zero div)

Fix
---
set overview fields that do not make sense when the final production quantity is 0 to `False`, so they are left blank on the report

opw-3958811