### PR TITLE
[FIX] point_of_sale: onboarding fixes

### DIFF
--- a/addons/point_of_sale/data/demo_data.xml
+++ b/addons/point_of_sale/data/demo_data.xml
@@ -4,5 +4,6 @@
         <function model="pos.config" name="load_onboarding_furniture_scenario" />
         <function model="pos.config" name="load_onboarding_clothes_scenario" />
         <function model="pos.config" name="load_onboarding_bakery_scenario" />
+        <function model="pos.config" name="hide_predefined_scenarios" />
     </data>
 </odoo>

--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -996,11 +996,13 @@ class PosConfig(models.Model):
             self._check_company_domain(self.env.company)
         ))
         has_chart_template = bool(self.env.company.chart_template)
+        main_company = self.env.ref('base.main_company', raise_if_not_found=False)
         return {
             "has_pos_config": has_pos_config,
             "has_chart_template": has_chart_template,
             "is_restaurant_installed": bool(self.env['ir.module.module'].search_count([('name', '=', 'pos_restaurant'), ('state', '=', 'installed')])),
             "show_predefined_scenarios": self.env.company.point_of_sale_show_predefined_scenarios,
+            "is_main_company": main_company and self.env.company.id == main_company.id or False
         }
 
     @api.model

--- a/addons/point_of_sale/static/src/backend/pos_kanban_view/pos_kanban_view.js
+++ b/addons/point_of_sale/static/src/backend/pos_kanban_view/pos_kanban_view.js
@@ -24,6 +24,7 @@ export class PosKanbanController extends KanbanController {
             has_chart_template: true,
             is_restaurant_installed: true,
             show_predefined_scenarios: true,
+            is_main_company: true,
         };
         onWillStart(() => updatePosKanbanViewState(this.orm, this.initialPosState));
     }
@@ -45,7 +46,10 @@ export class PosKanbanRenderer extends KanbanRenderer {
                     const result = await this.orm.call("pos.config", "install_pos_restaurant");
                     isInstalledWithDemo = result.installed_with_demo;
                 }
-                if (!isInstalledWithDemo) {
+                if (
+                    !isInstalledWithDemo ||
+                    (isInstalledWithDemo && !this.posState.is_main_company)
+                ) {
                     await this.orm.call("pos.config", functionName);
                     await this.orm.call("pos.config", "hide_predefined_scenarios");
                 }

--- a/addons/point_of_sale/static/src/backend/pos_kanban_view/pos_kanban_view.xml
+++ b/addons/point_of_sale/static/src/backend/pos_kanban_view/pos_kanban_view.xml
@@ -55,15 +55,15 @@
     </t>
 
     <t t-name="point_of_sale.ScenarioCard">
-        <div class="col-md-4">
+        <div class="col-lg-4">
             <div class="card mb-3 rounded-3 scenario-card" style="max-width: 540px;" t-on-click="() => this.loadScenario.call(item)">
                 <div class="row g-0">
-                    <div class="col-md-4">
+                    <div class="col-lg-4">
                         <div class="img-container m-2 d-flex align-items-center justify-content-center">
                             <img t-attf-src="/point_of_sale/static/img/{{item.iconFile}}" class="scenario-img" />
                         </div>
                     </div>
-                    <div class="col-md-8">
+                    <div class="col-lg-8">
                         <div class="card-body text-start p-3 m-2">
                             <h3 class="card-title fw-bolder" t-esc="item.name"/>
                             <p class="card-text text-large" t-esc="item.description"/>


### PR DESCRIPTION
1. When installing point_of_sale with demo, we should immediately hide the scenario options because all the scenarios are already installed.
2. When in a differenct company in demo mode, selecting a restaurant scenario when pos_restaurant is not yet installed should not only install the pos_restaurant module but also create the select scenario config.

