### PR TITLE
[PERF] hr_timesheet: fix OOM in `/my/timesheets`

### DIFF
--- a/addons/hr_timesheet/controllers/portal.py
+++ b/addons/hr_timesheet/controllers/portal.py
@@ -150,7 +150,7 @@ class TimesheetCustomerPortal(CustomerPortal):
 
             grouped_timesheets = [(
                 timesheets,
-                sum(Timesheet_sudo.search(domain).mapped('unit_amount'))
+                Timesheet_sudo._read_group(domain, aggregates=['unit_amount:sum'])[0][0]
             )] if timesheets else []
             return timesheets, grouped_timesheets
 


### PR DESCRIPTION
## Description
As an internal user one has access to many timesheets as if from the backend.
If the group by option of the portal view `/my/timesheets` is set to `None`, on a large database with millions of timesheets, the computation for the aggregate of the `unit_amount` is really slow, and it faces an internal limitation of the ORM when the `mapped` hitting fields out of cache. The code path used to fetch the missing records `expands_ids` has a bad space complexity and with millions of records, this leads to an Memory Error (OOM).

## Benchmark
On a database with over 4+M of timesheets matching the domain:
|        | Before    | After |
|--------|-----------|-------|
| Timing | N/A (OOM) | 0.7s  |

## Reference
task-3977971

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
