### PR TITLE
[FIX] l10n_gcc_invoice: duplicate product name display

### DIFF
--- a/addons/l10n_gcc_invoice/views/report_invoice.xml
+++ b/addons/l10n_gcc_invoice/views/report_invoice.xml
@@ -281,27 +281,14 @@
                                         <span t-field="line.product_uom_id" groups="uom.group_uom"/>
                                     </td>
                                     <td name="account_invoice_line_name" class="text-end">
-                                        <t t-if="line.product_id">
-                                            <t t-set="arabic_name" t-value="line.with_context(lang=line.env['res.lang']._get_code('ar_001')).product_id.display_name"/>
-                                            <t t-set="english_name" t-value="line.with_context(lang='en_US').product_id.display_name"/>
-
-                                            <span t-out="line.with_context(lang=line.env['res.lang']._get_code('ar_001')).product_id.name"
-                                                  t-options="{'widget': 'text'}"/>
-
-                                            <t t-if="arabic_name != english_name">
-                                                <br/>
-                                                <span t-field="line.product_id.display_name"
-                                                      t-options="{'widget': 'text'}"/>
-                                            </t>
-
-                                            <t t-if="line.name != english_name and line.name != arabic_name">
-                                                <br/>
-                                                <span t-field="line.name" t-options="{'widget': 'text'}"/>
-                                            </t>
-                                        </t>
-                                        <t t-else="">
-                                            <span t-field="line.name" t-options="{'widget': 'text'}"/>
-                                        </t>
+                                        <t t-set="line_name" t-value="
+                                            line.with_context(lang=o.partner_id.lang).product_id.display_name
+                                                if line.product_id and line.name in (
+                                                line.with_context(lang=line.env['res.lang']._get_code('ar_001')).product_id.display_name,
+                                                line.with_context(lang='en_US').product_id.display_name
+                                            ) else line.name
+                                        "/>
+                                        <span t-out="line_name" t-options="{'widget': 'text'}"/>
                                     </td>
 
                                 </t>


### PR DESCRIPTION
Problem: The arabic_english_invoice report displays product name twice since the description includes the product name by default.

Solution:The report should only display the description if the description is not the same as the products' name. Otherwise, the report should display the products' name in the same language as the customer.

Steps to Reproduce on Runbot:

Install sale, l10n_sa, l10n_gcc_invoice
Switch to SA Company
Create a product with sales description
Create an invoice with the product from step 3
Print the invoice report
Observe the product name is displayed twice
If Arabic is enabled as a language, the product name will be displayed three times, with the 3rd being in Arabic.
Ticket link
opw-3768196




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
