### PR TITLE
[FIX] stock_account: fix UnboundLocalError on analytic account

### DIFF
--- a/addons/stock_account/models/analytic_account.py
+++ b/addons/stock_account/models/analytic_account.py
@@ -101,6 +101,8 @@ class AccountAnalyticAccount(models.Model):
                 existing_aal.unlink()
         # Create new lines from remaining distributions
         for accounts, percentage in distribution.items():
+            if not accounts:
+                continue
             account_field_values = {}
             for account in accounts:
                 new_amount = account.root_plan_id._calculate_distribution_amount(amount, percentage, total_percentages[plan], distribution_on_each_plan)


### PR DESCRIPTION
This fixes the syntax error on function _perform_analytic_distribution of the model AccountAnalyticAccount.

opw-3907439

Description of the issue/feature this PR addresses and current behavior before PR:

- The _perform_analytic_distribution function on model AccountAnalyticAccount has a syntax error causing a UnboundLocalError

Desired behavior after PR is merged:

- No UnboundLocalError

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
