### PR TITLE
[FIX] pos_hr: show cash in out button for admin

### DIFF
--- a/addons/point_of_sale/static/tests/tours/utils/dialog_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/dialog_util.js
@@ -20,6 +20,14 @@ export function cancel() {
         run: "click",
     };
 }
+export function discard() {
+    return {
+        content: "discard dialog",
+        trigger: `.modal-footer button:contains("Discard")`,
+        in_modal: true,
+        run: "click",
+    };
+}
 export function is({ title } = {}) {
     let trigger = ".modal-content";
     if (title) {

--- a/addons/pos_hr/static/src/overrides/components/navbar/navbar.js
+++ b/addons/pos_hr/static/src/overrides/components/navbar/navbar.js
@@ -7,8 +7,7 @@ patch(Navbar.prototype, {
             return super.showCashMoveButton;
         }
 
-        const { cashier } = this.pos;
-        return super.showCashMoveButton && (!cashier || cashier._role == "manager");
+        return super.showCashMoveButton && this.employeeIsAdmin();
     },
     employeeIsAdmin() {
         if (!this.pos.config.module_pos_hr) {

--- a/addons/pos_hr/static/tests/tours/pos_hr_tour.js
+++ b/addons/pos_hr/static/tests/tours/pos_hr_tour.js
@@ -77,6 +77,10 @@ registry.category("web_tour.tours").add("PosHrTour", {
             TicketScreen.nthRowContains(4, "Mitchell Admin", false),
 
             // Close register should be accessible by the admin user.
+            Chrome.clickMenuOption("Cash In/Out"),
+            Dialog.discard(),
+
+            // Close register should be accessible by the admin user.
             Chrome.clickMenuOption("Close Register"),
             Dialog.is("Closing Register"),
         ].flat(),

--- a/addons/pos_hr/tests/test_frontend.py
+++ b/addons/pos_hr/tests/test_frontend.py
@@ -53,5 +53,10 @@ class TestPosHrHttpCommon(TestPointOfSaleHttpCommon):
 @tagged("post_install", "-at_install")
 class TestUi(TestPosHrHttpCommon):
     def test_01_pos_hr_tour(self):
+        self.pos_admin.write({
+            "groups_id": [
+                (4, self.env.ref('account.group_account_invoice').id)
+            ]
+        })
         self.main_pos_config.with_user(self.pos_admin).open_ui()
         self.start_pos_tour("PosHrTour", login="pos_admin")


### PR DESCRIPTION
### Steps to reproduce
- install **point_of_sale** module
- Go to **Configuration** > **Settings** > **PoS Interface** and enable Log in with Employees
- Open a PoS session with the admin as the Cashier
- Click on the menu on the upper right corner, the (Cash in/out) option is not visible

### Investigation
- In `showCashMoveButton`, There's no check if the current cashier is the logged in user (admin)
