### PR TITLE
[FIX] purchase_stock: include discounts in AVCO stock valuation

### DIFF
--- a/addons/purchase_stock/models/stock_move.py
+++ b/addons/purchase_stock/models/stock_move.py
@@ -66,11 +66,13 @@ class StockMove(models.Model):
             for invoice_line in line.sudo().invoice_lines:
                 if invoice_line.move_id.state != 'posted':
                     continue
+                # Adjust unit price to account for discounts before adding taxes.
+                adjusted_unit_price = invoice_line.price_unit * (1 - (invoice_line.discount / 100)) if invoice_line.discount else invoice_line.price_unit
                 if invoice_line.tax_ids:
                     invoice_line_value = invoice_line.tax_ids.with_context(round=False).compute_all(
-                        invoice_line.price_unit, currency=invoice_line.currency_id, quantity=invoice_line.quantity)['total_void']
+                        adjusted_unit_price, currency=invoice_line.currency_id, quantity=invoice_line.quantity)['total_void']
                 else:
-                    invoice_line_value = invoice_line.price_unit * invoice_line.quantity
+                    invoice_line_value = adjusted_unit_price * invoice_line.quantity
                 total_invoiced_value += invoice_line.currency_id._convert(
                         invoice_line_value, order.currency_id, order.company_id, invoice_line.move_id.invoice_date, round=False)
                 invoiced_qty += invoice_line.product_uom_id._compute_quantity(invoice_line.quantity, line.product_id.uom_id)


### PR DESCRIPTION
## Issue:
- The stock valuation for discounted purchase orders is incorrectly based on the original unit price instead of the price.

## Steps To Reproduce:
- Create a storable product with AVCO costing method.
- In its purchase tab set control policy "On ordered quantities".
- Create RFQ for a product 10 qty with 10 unit price and add a 10% discount.
- Create a vendor bill and confirm it.
- Receive the product.
- See the valuation, it will show 100 instead of 90.

## Solution:
- I fixed the issue by updating the `_get_price_unit` method to consider discounts when calculating the invoiced value.
  
opw-3895448
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
