### PR TITLE
[FIX] web_editor,website: traceback on change of theme color and saving

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -4525,6 +4525,7 @@ const SnippetOptionWidget = Widget.extend({
                 // TODO the flag should be fetched through widget params somehow
                 return;
             }
+
             // Call widget option methods and update $target
             await this._select(previewMode, widget).catch(() => { });
 

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -4525,9 +4525,8 @@ const SnippetOptionWidget = Widget.extend({
                 // TODO the flag should be fetched through widget params somehow
                 return;
             }
-
             // Call widget option methods and update $target
-            await this._select(previewMode, widget);
+            await this._select(previewMode, widget).catch(() => { });
 
             // If it is not preview mode, the user selected the option for good
             // (so record the action)

--- a/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
+++ b/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
@@ -732,8 +732,8 @@ export class WysiwygAdapterComponent extends Wysiwyg {
         };
         Object.entries(bundles).forEach(([bundleName, bundleURLs]) => {
             const selector = `link[href*="${bundleName}"]`;
-            const $linksIframe = this.websiteService.contentWindow.$(selector);
-            if ($linksIframe.length) {
+            const $linksIframe = this.websiteService.contentWindow.$?.(selector);
+            if ($linksIframe?.length) {
                 $allLinksIframe = $allLinksIframe.add($linksIframe);
                 createLinksProms(bundleURLs, $linksIframe.last());
             }

--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -746,6 +746,9 @@ options.Class.include({
             }
             case 'customizeWebsiteVariable': {
                 const ownerDocument = this.$target[0].ownerDocument;
+                if (!ownerDocument.defaultView) {
+                    return;
+                }
                 const style = ownerDocument.defaultView.getComputedStyle(ownerDocument.documentElement);
                 let finalValue = weUtils.getCSSVariableValue(params.variable, style);
                 if (!params.colorNames) {
@@ -1344,6 +1347,9 @@ options.registry.OptionsTab = options.registry.WebsiteLevelColor.extend({
         // The bg-XXX classes have been updated (and could be updated by another
         // option like changing color palette) -> update the preview element.
         const ownerDocument = this.$target[0].ownerDocument;
+        if (!ownerDocument.defaultView) {
+            return;
+        }
         const style = ownerDocument.defaultView.getComputedStyle(ownerDocument.documentElement);
         const grayPreviewEls = this.$el.find(".o_we_gray_preview span");
         for (const e of grayPreviewEls) {


### PR DESCRIPTION
Previously, a traceback occurred when changing the theme color from the color palette and pressing the save button immediately. This PR resolves the issue by adding catch block to handle promise rejections and ensured the correct jquery context is used within the iframe.

task-3919146