### PR TITLE
[FIX] spreadsheet: Fix Odoo graph data name

### DIFF
--- a/addons/spreadsheet/static/src/chart/plugins/odoo_chart_core_plugin.js
+++ b/addons/spreadsheet/static/src/chart/plugins/odoo_chart_core_plugin.js
@@ -109,7 +109,7 @@ export class OdooChartCorePlugin extends OdooCorePlugin {
      */
     getOdooChartDisplayName(chartId) {
         return `(#${this.getOdooChartIds().indexOf(chartId) + 1}) ${
-            this.getters.getChart(chartId).title
+            this.getters.getChart(chartId).title.text
         }`;
     }
 

--- a/addons/spreadsheet/static/tests/utils/data.js
+++ b/addons/spreadsheet/static/tests/utils/data.js
@@ -54,7 +54,7 @@ export function getBasicListArch() {
 
 export function getBasicGraphArch() {
     return /* xml */ `
-        <graph>
+        <graph string="PartnerGraph">
             <field name="bar" />
         </graph>
     `;


### PR DESCRIPTION
Since the recent chart options refactoring, the title of the chart is not longer a string but an object with different style-related keys and the title string is set in the key `text`. The getter `getOdooChartDIsplayName` was not adapted to this change.

task-3978637

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
