### PR TITLE
[FIX] account: fix fixed taxes display on invoices

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -2135,6 +2135,7 @@ class AccountTax(models.Model):
                 'tax_group_base_amount_company_currency': company.currency_id.round(tax_detail['display_base_amount']),
                 'formatted_tax_group_amount': formatLang(self.env, tax_detail['tax_amount_currency'], currency_obj=currency),
                 'formatted_tax_group_base_amount': formatLang(self.env, tax_detail['display_base_amount_currency'], currency_obj=currency),
+                'display_formatted_tax_group_base_amount': not all(x['amount_type'] == 'fixed' for x in tax_detail['group_tax_details']),
             })
             encountered_base_amounts.add(tax_detail['display_base_amount_currency'])
 

--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -480,7 +480,7 @@ class AccountTestInvoicingCommon(TransactionCase):
 
     def assert_tax_totals(self, tax_totals, currency, expected_values):
         main_keys_to_ignore = {'formatted_amount_total', 'formatted_amount_untaxed'}
-        group_keys_to_ignore = {'group_key', 'formatted_tax_group_amount', 'formatted_tax_group_base_amount'}
+        group_keys_to_ignore = {'group_key', 'formatted_tax_group_amount', 'formatted_tax_group_base_amount', 'display_formatted_tax_group_base_amount'}
         subtotals_keys_to_ignore = {'formatted_amount'}
         comp_curr_keys = {'tax_group_amount_company_currency', 'tax_group_base_amount_company_currency', 'amount_company_currency'}
         to_compare = dict(tax_totals)

--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -355,8 +355,10 @@
                     <t t-else="">
                         <td>
                             <span t-out="amount_by_group['tax_group_name']">Tax 15%</span>
-                            <span> on </span>
-                            <span class="text-nowrap" t-out="amount_by_group['formatted_tax_group_base_amount']">27.00</span>
+                            <t t-if="amount_by_group['display_formatted_tax_group_base_amount']">
+                                <span> on </span>
+                                <span class="text-nowrap" t-out="amount_by_group['formatted_tax_group_base_amount']">27.00</span>
+                            </t>
                         </td>
                         <td class="text-end o_price_total">
                             <span class="text-nowrap" t-out="amount_by_group['formatted_tax_group_amount']">4.05</span>
@@ -391,11 +393,13 @@
                                 <t t-if="tax_totals['display_tax_base']">
                                     <td>
                                         <span t-out="amount_by_group['tax_group_name']">Tax 15%</span>
-                                        <span> on </span>
-                                        <span class="text-nowrap" t-out="amount_by_group['tax_group_base_amount_company_currency']"
-                                               t-options='{"widget": "monetary", "display_currency": o.company_currency_id}'>
-                                               27.00
-                                        </span>
+                                        <t t-if="amount_by_group['display_formatted_tax_group_base_amount']">
+                                            <span> on </span>
+                                            <span class="text-nowrap" t-out="amount_by_group['tax_group_base_amount_company_currency']"
+                                                   t-options='{"widget": "monetary", "display_currency": o.company_currency_id}'>
+                                                   27.00
+                                            </span>
+                                        </t>
                                     </td>
                                     <td class="text-end o_price_total">
                                         <span class="text-nowrap"


### PR DESCRIPTION
When printing an invoice including a fixed tax, we don't want the base amount to be displayed after said tax,
since the fixed computation doesn't take into account said amount.

Added a check to differenciate fixed taxes from other and adapt display accordingly.

see https://github.com/odoo/odoo/pull/168638

task-3964942