### PR TITLE
[FIX] account: fix fixed taxes display on invoices

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -1237,6 +1237,7 @@ class AccountTax(models.Model):
                 'tax_group': tax_detail['tax_group'],
                 'base_amount': tax_detail['base_amount_currency'],
                 'tax_amount': tax_detail['tax_amount_currency'],
+                'hide_base_amount': all(x['tax_repartition_line'].tax_id.amount_type == 'fixed' for x in tax_detail['group_tax_details']),
             }
 
             # Handle a manual edition of tax lines.
@@ -1275,6 +1276,7 @@ class AccountTax(models.Model):
                 'tax_group_base_amount': tax_group_vals['base_amount'],
                 'formatted_tax_group_amount': formatLang(self.env, tax_group_vals['tax_amount'], currency_obj=currency),
                 'formatted_tax_group_base_amount': formatLang(self.env, tax_group_vals['base_amount'], currency_obj=currency),
+                'hide_base_amount': tax_group_vals['hide_base_amount'],
             })
 
         # ==== Build the final result ====

--- a/addons/account/tests/test_early_payment_discount.py
+++ b/addons/account/tests/test_early_payment_discount.py
@@ -517,6 +517,7 @@ class TestAccountEarlyPaymentDiscount(AccountTestInvoicingCommon):
                         {
                             'tax_group_amount': 90,
                             'tax_group_base_amount': 900,
+                            'hide_base_amount': False,
                         },
                     ],
                 },
@@ -699,6 +700,7 @@ class TestAccountEarlyPaymentDiscount(AccountTestInvoicingCommon):
                         {
                             'tax_group_amount': 20.58,
                             'tax_group_base_amount': 98,
+                            'hide_base_amount': False,
                         },
                     ],
                 },

--- a/addons/account/tests/test_invoice_tax_totals.py
+++ b/addons/account/tests/test_invoice_tax_totals.py
@@ -59,7 +59,7 @@ class TestTaxTotals(AccountTestInvoicingCommon):
 
     def assertTaxTotals(self, document, expected_values):
         main_keys_to_ignore = {'formatted_amount_total', 'formatted_amount_untaxed'}
-        group_keys_to_ignore = {'group_key', 'formatted_tax_group_amount', 'formatted_tax_group_base_amount'}
+        group_keys_to_ignore = {'group_key', 'formatted_tax_group_amount', 'formatted_tax_group_base_amount', 'hide_base_amount'}
         subtotals_keys_to_ignore = {'formatted_amount'}
 
         to_compare = document.tax_totals

--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -312,7 +312,7 @@
                     <t t-if="tax_totals['display_tax_base']">
                         <td>
                             <span t-esc="amount_by_group['tax_group_name']"/>
-                            <span class="text-nowrap"> on
+                            <span t-if="not amount_by_group['hide_base_amount']" class="text-nowrap"> on
                                 <t t-esc="amount_by_group['formatted_tax_group_base_amount']"/>
                             </span>
                         </td>


### PR DESCRIPTION
When printing an invoice including a fixed tax, we don't want the base amount to be displayed after said tax, since the fixed computation doesn't take into account said amount.

Added a check to differentiate fixed taxes from other and adapt display accordingly.

Since the function modified has been updated in 17.2, another PR will be necessary.

See https://github.com/odoo/odoo/pull/168634

task-3964942

