### PR TITLE
[FIX] charts: fix padding computation

### DIFF
--- a/addons/spreadsheet/static/src/chart/odoo_chart/odoo_bar_chart.js
+++ b/addons/spreadsheet/static/src/chart/odoo_chart/odoo_bar_chart.js
@@ -68,7 +68,7 @@ function getBarConfiguration(chart, labels, locale) {
     config.options.plugins = config.options.plugins || {};
     config.options.plugins.legend = legend;
     config.options.layout = {
-        padding: { left: 20, right: 20, top: chart.title ? 10 : 25, bottom: 10 },
+        padding: { left: 20, right: 20, top: chart.title.text ? 10 : 25, bottom: 10 },
     };
     config.options.scales = {
         x: {

--- a/addons/spreadsheet/static/src/chart/odoo_chart/odoo_line_chart.js
+++ b/addons/spreadsheet/static/src/chart/odoo_chart/odoo_line_chart.js
@@ -104,7 +104,7 @@ function getLineConfiguration(chart, labels, locale) {
     config.options.plugins = config.options.plugins || {};
     config.options.plugins.legend = legend;
     config.options.layout = {
-        padding: { left: 20, right: 20, top: chart.title ? 10 : 25, bottom: 10 },
+        padding: { left: 20, right: 20, top: chart.title.text ? 10 : 25, bottom: 10 },
     };
     config.options.scales = {
         x: {

--- a/addons/spreadsheet/static/src/chart/odoo_chart/odoo_pie_chart.js
+++ b/addons/spreadsheet/static/src/chart/odoo_chart/odoo_pie_chart.js
@@ -51,7 +51,7 @@ function getPieConfiguration(chart, labels, locale) {
     config.options.plugins = config.options.plugins || {};
     config.options.plugins.legend = legend;
     config.options.layout = {
-        padding: { left: 20, right: 20, top: chart.title ? 10 : 25, bottom: 10 },
+        padding: { left: 20, right: 20, top: chart.title.text ? 10 : 25, bottom: 10 },
     };
     config.options.plugins.tooltip = {
         callbacks: {


### PR DESCRIPTION
## Description

Since the chart design refactoring, the value of the title is now stored in an object as chart.title.text, instead of the previous chart.title. During the introduction of the design customization, the computation of the padding hasn't been updated, considering now that the title is alsway defined, which is not the case. This PR aims to thix this behavior by changing the condition used in the padding computation.

## Related Tasks/PR:
- Task: 0
- https://github.com/odoo/o-spreadsheet/pull/4385

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
