### PR TITLE
[REF] web_tour: remove shadow_dom attribute

### DIFF
--- a/addons/im_livechat/static/tests/tours/im_livechat_channel_creation_tour.js
+++ b/addons/im_livechat/static/tests/tours/im_livechat_channel_creation_tour.js
@@ -2,35 +2,33 @@ import { registry } from "@web/core/registry";
 
 const requestChatSteps = [
     {
-        trigger: ".o-livechat-LivechatButton",
+        trigger: ".o-livechat-root:shadow .o-livechat-LivechatButton",
         run: "click",
     },
     {
-        trigger: ".o-mail-ChatWindow",
+        trigger: ".o-livechat-root:shadow .o-mail-ChatWindow",
     },
 ];
 
 registry.category("web_tour.tours").add("im_livechat_request_chat", {
     test: true,
     steps: () => requestChatSteps,
-    shadow_dom: ".o-livechat-root",
 });
 
 registry.category("web_tour.tours").add("im_livechat_request_chat_and_send_message", {
     test: true,
-    shadow_dom: ".o-livechat-root",
     steps: () => [
         ...requestChatSteps,
         {
-            trigger: ".o-mail-Composer-input",
+            trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
             run: "edit Hello, I need help please !",
         },
         {
-            trigger: ".o-mail-Composer-input",
+            trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
             run: "press Enter",
         },
         {
-            trigger: ".o-mail-Message:contains('Hello, I need help')",
+            trigger: ".o-livechat-root:shadow .o-mail-Message:contains('Hello, I need help')",
         },
     ],
 });

--- a/addons/web_tour/static/src/tour_service/tour_compilers.js
+++ b/addons/web_tour/static/src/tour_service/tour_compilers.js
@@ -33,21 +33,19 @@ import {
 
 /**
  * @param {string} selector - any valid Hoot selector
- * @param {string|undefined} shadowDOM - selector of the shadow root host
  * @param {boolean} inModal
  * @returns {Array<Element>}
  */
-function findTrigger(selector, shadowDOM, inModal) {
-    const target = shadowDOM ? document.querySelector(shadowDOM)?.shadowRoot : document;
+function findTrigger(selector, inModal) {
     let nodes;
     if (inModal !== false) {
-        const visibleModal = hoot.queryAll(".modal", { root: target, visible: true }).at(-1);
+        const visibleModal = hoot.queryAll(".modal", { visible: true }).at(-1);
         if (visibleModal) {
             nodes = hoot.queryAll(selector, { root: visibleModal });
         }
     }
     if (!nodes) {
-        nodes = hoot.queryAll(selector, { root: target });
+        nodes = hoot.queryAll(selector);
     }
     return nodes;
 }
@@ -62,7 +60,7 @@ function tryFindTrigger(tour, step, elKey) {
     const selector = step[elKey];
     const in_modal = elKey === "extra_trigger" ? false : step.in_modal;
     try {
-        const nodes = findTrigger(selector, step.shadow_dom, in_modal);
+        const nodes = findTrigger(selector, in_modal);
         //TODO : change _legacyIsVisible by isVisible (hoot lib)
         //Failed with tour test_snippet_popup_with_scrollbar_and_animations > snippet_popup_and_animations
         return !step.allowInvisible ? nodes.find(_legacyIsVisible) : nodes.at(0);

--- a/addons/web_tour/static/tests/tour_service_tests.js
+++ b/addons/web_tour/static/tests/tour_service_tests.js
@@ -118,7 +118,7 @@ QUnit.module("Tour service", (hooks) => {
         const env = await makeTestEnv({});
         const sortedTours = env.services.tour_service.getSortedTours();
         assert.strictEqual(sortedTours.length, 1);
-        assert.deepEqual(sortedTours[0].steps, [{ shadow_dom: undefined, trigger: "#2" }]);
+        assert.deepEqual(sortedTours[0].steps, [{ trigger: "#2" }]);
         assert.deepEqual(sortedTours[0].name, "homepage");
     });
 

--- a/addons/website_livechat/static/tests/tours/lazy_frontend_bus_tour.js
+++ b/addons/website_livechat/static/tests/tours/lazy_frontend_bus_tour.js
@@ -3,10 +3,9 @@ import { registry } from "@web/core/registry";
 registry.category("web_tour.tours").add("website_livechat.lazy_frontend_bus", {
     test: true,
     url: "/",
-    shadow_dom: ".o-livechat-root",
     steps: () => [
         {
-            trigger: ".o-livechat-LivechatButton",
+            trigger: ".o-livechat-root:shadow .o-livechat-LivechatButton",
             async run() {
                 await odoo.__WOWL_DEBUG__.root.env.services["mail.store"].isReady;
                 if (odoo.__WOWL_DEBUG__.root.env.services.bus_service.isActive) {
@@ -15,15 +14,15 @@ registry.category("web_tour.tours").add("website_livechat.lazy_frontend_bus", {
             },
         },
         {
-            trigger: ".o-livechat-LivechatButton",
+            trigger: ".o-livechat-root:shadow .o-livechat-LivechatButton",
             run: "click",
         },
         {
-            trigger: ".o-mail-Composer-input",
+            trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
             run: "edit Hello, I need help!",
         },
         {
-            trigger: ".o-mail-Composer-input",
+            trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
             run(helpers) {
                 if (odoo.__WOWL_DEBUG__.root.env.services.bus_service.isActive) {
                     throw new Error("Bus service should not start for temporary live chat");
@@ -32,7 +31,7 @@ registry.category("web_tour.tours").add("website_livechat.lazy_frontend_bus", {
             },
         },
         {
-            trigger: ".o-mail-Message:contains(Hello, I need help!)",
+            trigger: ".o-livechat-root:shadow .o-mail-Message:contains(Hello, I need help!)",
             run() {
                 if (!odoo.__WOWL_DEBUG__.root.env.services.bus_service.isActive) {
                     throw new Error("Bus service should start after first live chat message");

--- a/addons/website_livechat/static/tests/tours/website_livechat_as_portal.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_as_portal.js
@@ -2,22 +2,21 @@ import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("website_livechat_as_portal_tour", {
     test: true,
-    shadow_dom: ".o-livechat-root",
     steps: () => [
         {
-            trigger: ".o-livechat-LivechatButton",
+            trigger: ".o-livechat-root:shadow .o-livechat-LivechatButton",
             run: "click",
         },
         {
-            trigger: ".o-mail-Composer-input",
+            trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
             run: "edit Hello, I need help!",
         },
         {
-            trigger: ".o-mail-Composer-input",
+            trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
             run: "press Enter",
         },
         {
-            trigger: ".o-mail-Message:contains('Hello, I need help!')",
+            trigger: ".o-livechat-root:shadow .o-mail-Message:contains('Hello, I need help!')",
         },
     ],
 });

--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_after_reload.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_after_reload.js
@@ -1,11 +1,10 @@
 import { registry } from "@web/core/registry";
 import { endDiscussion } from "./website_livechat_common";
 
-const messagesContain = (text) => `.o-mail-Message:contains("${text}")`;
+const messagesContain = (text) => `.o-livechat-root:shadow .o-mail-Message:contains("${text}")`;
 
 registry.category("web_tour.tours").add("website_livechat_chatbot_after_reload_tour", {
     test: true,
-    shadow_dom: ".o-livechat-root",
     steps: () => [
         {
             trigger: messagesContain("Hello! I'm a bot!"),
@@ -18,7 +17,7 @@ registry.category("web_tour.tours").add("website_livechat_chatbot_after_reload_t
         },
         ...endDiscussion,
         {
-            trigger: ".o-livechat-LivechatButton",
+            trigger: ".o-livechat-root:shadow .o-livechat-LivechatButton",
             run: "click",
         },
         {

--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_flow.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_flow.js
@@ -1,11 +1,10 @@
 import { registry } from "@web/core/registry";
 import { contains } from "@web/../tests/utils";
 
-const messagesContain = (text) => `.o-mail-Message:contains("${text}")`;
+const messagesContain = (text) => `.o-livechat-root:shadow .o-mail-Message:contains("${text}")`;
 
 registry.category("web_tour.tours").add("website_livechat_chatbot_flow_tour", {
     test: true,
-    shadow_dom: ".o-livechat-root",
     steps: () => [
         {
             trigger: messagesContain("Hello! I'm a bot!"),
@@ -31,11 +30,11 @@ registry.category("web_tour.tours").add("website_livechat_chatbot_flow_tour", {
             },
         },
         {
-            trigger: 'li:contains("I want to buy the software")',
+            trigger: '.o-livechat-root:shadow li:contains("I want to buy the software")',
             run: "click",
         },
         {
-            trigger: ".o-mail-ChatWindow",
+            trigger: ".o-livechat-root:shadow .o-mail-ChatWindow",
             // check selected option is posted and reactions are available since
             // the thread has been persisted in the process
             async run() {
@@ -50,11 +49,11 @@ registry.category("web_tour.tours").add("website_livechat_chatbot_flow_tour", {
             trigger: messagesContain("Can you give us your email please?"),
         },
         {
-            trigger: ".o-mail-Composer-input ",
+            trigger: ".o-livechat-root:shadow .o-mail-Composer-input ",
             run: "edit No, you won't get my email!",
         },
         {
-            trigger: ".o-mail-Composer-input",
+            trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
             run: "press Enter",
         },
         {
@@ -64,11 +63,11 @@ registry.category("web_tour.tours").add("website_livechat_chatbot_flow_tour", {
             ),
         },
         {
-            trigger: ".o-mail-Composer-input",
+            trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
             run: "edit okfine@fakeemail.com",
         },
         {
-            trigger: ".o-mail-Composer-input",
+            trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
             run: "press Enter",
         },
         {
@@ -80,11 +79,11 @@ registry.category("web_tour.tours").add("website_livechat_chatbot_flow_tour", {
             trigger: messagesContain("Would you mind providing your website address?"),
         },
         {
-            trigger: ".o-mail-Composer-input",
+            trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
             run: "edit https://www.fakeaddress.com",
         },
         {
-            trigger: ".o-mail-Composer-input",
+            trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
             run: "press Enter",
         },
         {
@@ -92,27 +91,27 @@ registry.category("web_tour.tours").add("website_livechat_chatbot_flow_tour", {
             // should ask for feedback now
         },
         {
-            trigger: ".o-mail-Composer-input",
+            trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
             run: "edit Yes, actually, I'm glad you asked!",
         },
         {
-            trigger: ".o-mail-Composer-input",
+            trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
             run: "press Enter",
         },
         {
-            trigger: ".o-mail-Composer-input",
+            trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
             run: "edit I think it's outrageous that you ask for all my personal information!",
         },
         {
-            trigger: ".o-mail-Composer-input",
+            trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
             run: "press Enter",
         },
         {
-            trigger: ".o-mail-Composer-input",
+            trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
             run: "edit I will be sure to take this to your manager!",
         },
         {
-            trigger: ".o-mail-Composer-input",
+            trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
             run: "press Enter",
         },
         {
@@ -120,7 +119,8 @@ registry.category("web_tour.tours").add("website_livechat_chatbot_flow_tour", {
             trigger: messagesContain("Ok bye!"),
         },
         {
-            trigger: ".o-mail-ChatWindow-command[title='Restart Conversation']",
+            trigger:
+                ".o-livechat-root:shadow .o-mail-ChatWindow-command[title='Restart Conversation']",
             run: "click",
         },
         {
@@ -140,7 +140,7 @@ registry.category("web_tour.tours").add("website_livechat_chatbot_flow_tour", {
             trigger: messagesContain("How can I help you?"),
         },
         {
-            trigger: 'li:contains("Pricing Question")',
+            trigger: '.o-livechat-root:shadow li:contains("Pricing Question")',
             run: "click",
         },
         {
@@ -158,11 +158,11 @@ registry.category("web_tour.tours").add("website_livechat_chatbot_flow_tour", {
             trigger: messagesContain("Would you mind providing your website address?"),
         },
         {
-            trigger: ".o-mail-Composer-input",
+            trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
             run: "edit no",
         },
         {
-            trigger: ".o-mail-Composer-input",
+            trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
             run: "press Enter",
         },
         {
@@ -170,11 +170,11 @@ registry.category("web_tour.tours").add("website_livechat_chatbot_flow_tour", {
             trigger: messagesContain("Great, do you want to leave any feedback for us to improve?"),
         },
         {
-            trigger: ".o-mail-Composer-input",
+            trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
             run: "edit no, nothing so say",
         },
         {
-            trigger: ".o-mail-Composer-input",
+            trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
             run: "press Enter",
         },
         {
@@ -183,7 +183,8 @@ registry.category("web_tour.tours").add("website_livechat_chatbot_flow_tour", {
         },
         {
             // wait for chatbot script to finish.
-            trigger: ".o-mail-ChatWindow-command[title='Restart Conversation']",
+            trigger:
+                ".o-livechat-root:shadow .o-mail-ChatWindow-command[title='Restart Conversation']",
         },
     ],
 });

--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_redirect.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_redirect.js
@@ -3,24 +3,25 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("website_livechat.chatbot_redirect", {
-    shadow_dom: ".o-livechat-root",
     test: true,
     url: "/contactus",
     steps: () => [
         {
-            trigger: ".o-livechat-LivechatButton",
+            trigger: ".o-livechat-root:shadow .o-livechat-LivechatButton",
             run: "click",
         },
         {
-            trigger: ".o-mail-Message:contains(Hello, were do you want to go?)",
+            trigger:
+                ".o-livechat-root:shadow .o-mail-Message:contains(Hello, were do you want to go?)",
             run: "click",
         },
         {
-            trigger: "li:contains(Go to the #chatbot-redirect anchor)",
+            trigger: ".o-livechat-root:shadow li:contains(Go to the #chatbot-redirect anchor)",
             run: "click",
         },
         {
-            trigger: ".o-mail-Message:contains(Tadam, we are on the page you asked for!)",
+            trigger:
+                ".o-livechat-root:shadow .o-mail-Message:contains(Tadam, we are on the page you asked for!)",
             run() {
                 const url = new URL(location.href);
                 if (url.pathname !== "/contactus" || url.hash !== "#chatbot-redirect") {
@@ -31,16 +32,17 @@ registry.category("web_tour.tours").add("website_livechat.chatbot_redirect", {
             },
         },
         {
-            trigger: "button[title='Restart Conversation']",
+            trigger: ".o-livechat-root:shadow button[title='Restart Conversation']",
             run: "click",
         },
         {
-            trigger: "li:contains(Go to the /chatbot-redirect page)",
+            trigger: ".o-livechat-root:shadow li:contains(Go to the /chatbot-redirect page)",
             run: "click",
         },
         {
-            trigger:
-                ".o-mail-Message:contains('Go to the /chatbot-redirect page') + .o-mail-Message:contains('Tadam')",
+            trigger: ".o-livechat-root:shadow .o-mail-Message:last:contains('Tadam')",
+            extra_trigger:
+                ".o-livechat-root:shadow .o-mail-Message:contains('Go to the /chatbot-redirect page')",
             run() {
                 const url = new URL(location.href);
                 if (url.pathname !== "/chatbot-redirect") {

--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_test_page_tour.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_test_page_tour.js
@@ -1,10 +1,9 @@
 import { registry } from "@web/core/registry";
 import { contains } from "@web/../tests/utils";
 
-const messagesContain = (text) => `.o-mail-Message:contains("${text}")`;
+const messagesContain = (text) => `.o-livechat-root:shadow .o-mail-Message:contains("${text}")`;
 
 registry.category("web_tour.tours").add("website_livechat_chatbot_test_page_tour", {
-    shadow_dom: ".o-livechat-root",
     steps: () => [
         {
             trigger: messagesContain("Hello! I'm a bot!"),
@@ -26,7 +25,7 @@ registry.category("web_tour.tours").add("website_livechat_chatbot_test_page_tour
             run: "click",
         },
         {
-            trigger: 'li:contains("I want to buy the software")',
+            trigger: '.o-livechat-root:shadow li:contains("I want to buy the software")',
             run: "click",
         },
         {

--- a/addons/website_livechat/static/tests/tours/website_livechat_common.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_common.js
@@ -7,27 +7,27 @@ import { queryAll } from "@odoo/hoot-dom";
 export const start = [
     {
         content: "click on livechat widget",
-        trigger: ".o-livechat-LivechatButton",
+        trigger: ".o-livechat-root:shadow .o-livechat-LivechatButton",
         run: "click",
     },
     {
         content: "Say hello!",
-        trigger: ".o-mail-Composer-input",
+        trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
         run: "edit Hello Sir!",
     },
     {
         content: "Send the message",
-        trigger: ".o-mail-Composer-input",
+        trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
         run: "press Enter",
     },
     {
         content: "Verify your message has been typed",
-        trigger: ".o-mail-Message:contains('Hello Sir!')",
+        trigger: ".o-livechat-root:shadow .o-mail-Message:contains('Hello Sir!')",
         run: "click",
     },
     {
         content: "Verify there is no duplicates",
-        trigger: ".o-mail-Thread",
+        trigger: ".o-livechat-root:shadow .o-mail-Thread",
         run() {
             const el = queryAll(".o-mail-Message:contains('Hello Sir!')", { root: this.anchor });
             if (el.length === 1) {
@@ -38,14 +38,13 @@ export const start = [
     {
         content: "Is your message correctly sent ?",
         trigger: "body.no_duplicated_message",
-        shadow_dom: false,
     },
 ];
 
 export const endDiscussion = [
     {
         content: "Close the chat window",
-        trigger: ".o-mail-ChatWindow-command[title*=Close]",
+        trigger: ".o-livechat-root:shadow .o-mail-ChatWindow-command[title*=Close]",
         run: "click",
     },
 ];
@@ -53,41 +52,41 @@ export const endDiscussion = [
 export const feedback = [
     {
         content: "Patching Livechat",
-        trigger: "textarea[placeholder='Explain your note']",
+        trigger: ".o-livechat-root:shadow textarea[placeholder='Explain your note']",
         run: function () {
             document.body.classList.add("feedback_sent");
         },
     },
     {
         content: "Type a feedback",
-        trigger: "textarea[placeholder='Explain your note']",
+        trigger: ".o-livechat-root:shadow textarea[placeholder='Explain your note']",
         run: "edit ;-) This was really helpful. Thanks ;-)!",
     },
     {
         content: "Send the feedback",
-        trigger: "button:contains(Send):not(:disabled)",
+        trigger: ".o-livechat-root:shadow button:contains(Send):not(:disabled)",
         run: "click",
     },
     {
         content: "Thanks for your feedback",
-        trigger: "p:contains('Thank you for your feedback')",
+        trigger: ".o-livechat-root:shadow p:contains('Thank you for your feedback')",
     },
 ];
 
 export const transcript = [
     {
         content: "Type your email",
-        trigger: "input[placeholder='mail@example.com']",
+        trigger: ".o-livechat-root:shadow input[placeholder='mail@example.com']",
         run: "edit deboul@onner.com",
     },
     {
         content: "Send the conversation to your email address",
-        trigger: "button[data-action=sendTranscript]",
+        trigger: ".o-livechat-root:shadow button[data-action=sendTranscript]",
         run: "click",
     },
     {
         content: "Check conversation is sent",
-        trigger: ".form-text:contains(The conversation was sent)",
+        trigger: ".o-livechat-root:shadow .form-text:contains(The conversation was sent)",
         run: "click",
     },
 ];
@@ -95,12 +94,12 @@ export const transcript = [
 export const close = [
     {
         content: "Close the conversation with the x button",
-        trigger: ".o-mail-ChatWindow-command[title*=Close]",
+        trigger: ".o-livechat-root:shadow .o-mail-ChatWindow-command[title*=Close]",
         run: "click",
     },
     {
         content: "Check that the button is not displayed anymore",
-        trigger: ".o-mail-ChatWindowContainer",
+        trigger: ".o-livechat-root:shadow .o-mail-ChatWindowContainer",
         allowInvisible: true,
         run() {
             if (this.anchor.querySelectorAll(".o-livechat-livechatButton").length === 0) {
@@ -111,14 +110,13 @@ export const close = [
     {
         content: "Is the Test succeeded ?",
         trigger: "body.tour_success",
-        shadow_dom: false,
     },
 ];
 
 export const goodRating = [
     {
         content: "Choose Good Rating",
-        trigger: `img[src*=rating][alt="5"]`,
+        trigger: `.o-livechat-root:shadow img[src*=rating][alt="5"]`,
         run: "click",
     },
 ];
@@ -126,7 +124,7 @@ export const goodRating = [
 export const okRating = [
     {
         content: "Choose ok Rating",
-        trigger: `img[src*=rating][alt="3"]`,
+        trigger: `.o-livechat-root:shadow img[src*=rating][alt="3"]`,
         run: "click",
     },
 ];
@@ -134,7 +132,7 @@ export const okRating = [
 export const sadRating = [
     {
         content: "Choose bad Rating",
-        trigger: `img[src*=rating][alt="1"]`,
+        trigger: `.o-livechat-root:shadow img[src*=rating][alt="1"]`,
         run: "click",
     },
 ];

--- a/addons/website_livechat/static/tests/tours/website_livechat_rating.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_rating.js
@@ -13,41 +13,35 @@ import { registry } from "@web/core/registry";
 registry.category("web_tour.tours").add("website_livechat_complete_flow_tour", {
     test: true,
     url: "/",
-    shadow_dom: ".o-livechat-root",
     steps: () => [].concat(start, endDiscussion, okRating, feedback, transcript, close),
 });
 
 registry.category("web_tour.tours").add("website_livechat_happy_rating_tour", {
     test: true,
     url: "/",
-    shadow_dom: ".o-livechat-root",
     steps: () => [].concat(start, endDiscussion, goodRating, feedback),
 });
 
 registry.category("web_tour.tours").add("website_livechat_ok_rating_tour", {
     test: true,
     url: "/",
-    shadow_dom: ".o-livechat-root",
     steps: () => [].concat(start, endDiscussion, okRating, feedback),
 });
 
 registry.category("web_tour.tours").add("website_livechat_sad_rating_tour", {
     test: true,
     url: "/",
-    shadow_dom: ".o-livechat-root",
     steps: () => [].concat(start, endDiscussion, sadRating, feedback),
 });
 
 registry.category("web_tour.tours").add("website_livechat_no_rating_tour", {
     test: true,
     url: "/",
-    shadow_dom: ".o-livechat-root",
     steps: () => [].concat(start, endDiscussion, transcript, close),
 });
 
 registry.category("web_tour.tours").add("website_livechat_no_rating_no_close_tour", {
     test: true,
     url: "/",
-    shadow_dom: ".o-livechat-root",
     steps: () => [].concat(start),
 });

--- a/addons/website_livechat/static/tests/tours/website_livechat_request.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_request.js
@@ -5,22 +5,23 @@ import { registry } from "@web/core/registry";
 const chatRequest = [
     {
         content: "Answer the chat request!",
-        trigger: ".o-mail-Composer-input",
+        trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
         run: "edit Hi ! What a coincidence! I need your help indeed.",
     },
     {
         content: "Send the message",
-        trigger: ".o-mail-Composer-input",
+        trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
         run: "press Enter",
     },
     {
         content: "Verify your message has been typed",
-        trigger: ".o-mail-Message:contains('Hi ! What a coincidence! I need your help indeed.')",
+        trigger:
+            ".o-livechat-root:shadow .o-mail-Message:contains('Hi ! What a coincidence! I need your help indeed.')",
         run: "click",
     },
     {
         content: "Verify there is no duplicates",
-        trigger: ".o-mail-Thread",
+        trigger: ".o-livechat-root:shadow .o-mail-Thread",
         run() {
             if (
                 queryAll(
@@ -34,7 +35,6 @@ const chatRequest = [
     },
     {
         content: "Is your message correctly sent ?",
-        shadow_dom: false,
         trigger: "body.no_duplicated_message",
     },
 ];
@@ -42,13 +42,11 @@ const chatRequest = [
 registry.category("web_tour.tours").add("website_livechat_chat_request_part_1_no_close_tour", {
     test: true,
     url: "/",
-    shadow_dom: ".o-livechat-root",
     steps: () => [].concat(chatRequest),
 });
 
 registry.category("web_tour.tours").add("website_livechat_chat_request_part_2_end_session_tour", {
     test: true,
     url: "/",
-    shadow_dom: ".o-livechat-root",
     steps: () => [].concat(endDiscussion, okRating, feedback, transcript, close),
 });

--- a/addons/website_livechat/static/tests/tours/website_livechat_session_user_changes.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_session_user_changes.js
@@ -3,47 +3,41 @@ import { registry } from "@web/core/registry";
 registry.category("web_tour.tours").add("website_livechat_login_after_chat_start", {
     test: true,
     url: "/",
-    shadow_dom: ".o-livechat-root",
     steps: () => [
         {
-            trigger: ".o-livechat-LivechatButton",
+            trigger: ".o-livechat-root:shadow .o-livechat-LivechatButton",
             run: "click",
         },
         {
-            trigger: ".o-mail-Composer-input",
+            trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
             run: "edit Hello!",
         },
         {
-            trigger: ".o-mail-Composer-input",
+            trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
             run: "press Enter",
         },
         {
-            trigger: ".o-mail-Message-content:contains('Hello!')",
+            trigger: ".o-livechat-root:shadow .o-mail-Message-content:contains('Hello!')",
             run: "click",
         },
         {
             trigger: "a:contains(Sign in)",
             run: "click",
-            shadow_dom: false,
         },
         {
             trigger: "input[name='login']",
             run: "edit admin",
-            shadow_dom: false,
         },
         {
             trigger: "input[name='password']",
             run: "edit admin",
-            shadow_dom: false,
         },
         {
             trigger: "button:contains(Log in)",
             run: "click",
-            shadow_dom: false,
         },
         {
             trigger: ".o_main_navbar",
-            shadow_dom: false,
             run() {
                 window.location = "/";
             },
@@ -51,7 +45,7 @@ registry.category("web_tour.tours").add("website_livechat_login_after_chat_start
         {
             content:
                 "Livechat button is present since the old livechat session was linked to the public user, not the current user.",
-            trigger: ".o-livechat-LivechatButton",
+            trigger: ".o-livechat-root:shadow .o-livechat-LivechatButton",
         },
     ],
 });
@@ -59,38 +53,35 @@ registry.category("web_tour.tours").add("website_livechat_login_after_chat_start
 registry.category("web_tour.tours").add("website_livechat_logout_after_chat_start", {
     test: true,
     url: "/",
-    shadow_dom: ".o-livechat-root",
     steps: () => [
         {
-            trigger: ".o-livechat-LivechatButton",
+            trigger: ".o-livechat-root:shadow .o-livechat-LivechatButton",
             run: "click",
         },
         {
-            trigger: ".o-mail-Composer-input",
+            trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
             run: "edit Hello!",
         },
         {
-            trigger: ".o-mail-Composer-input",
+            trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
             run: "press Enter",
         },
         {
-            trigger: ".o-mail-Message-content:contains('Hello!')",
+            trigger: ".o-livechat-root:shadow .o-mail-Message-content:contains('Hello!')",
             run: "click",
         },
         {
             trigger: "header#top a:contains(Mitchell Admin)",
             run: "click",
-            shadow_dom: false,
         },
         {
             trigger: "a:contains(Logout)",
-            shadow_dom: false,
             run: "click",
         },
         {
             content:
                 "Livechat button is present since the old livechat session was linked to the logged user, not the public one.",
-            trigger: ".o-livechat-LivechatButton",
+            trigger: ".o-livechat-root:shadow .o-livechat-LivechatButton",
         },
     ],
 });

--- a/addons/website_livechat/static/tests/tours/website_livechat_user_known_after_reload.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_user_known_after_reload.js
@@ -1,29 +1,30 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("website_livechat_user_known_after_reload", {
-    shadow_dom: ".o-livechat-root",
     test: true,
     steps: () => [
         {
-            trigger: ".o-livechat-LivechatButton",
+            trigger: ".o-livechat-root:shadow .o-livechat-LivechatButton",
             run: "click",
         },
         {
-            trigger: ".o-mail-Composer-input",
+            trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
             run: "edit Hello, I need help!",
         },
         {
-            trigger: ".o-mail-Composer-input",
+            trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
             run: "press Enter",
         },
         {
-            trigger: ".o-mail-Message:contains('Hello, I need help!').o-selfAuthored ",
+            trigger:
+                ".o-livechat-root:shadow .o-mail-Message:contains('Hello, I need help!').o-selfAuthored ",
             run() {
                 window.location.reload();
             },
         },
         {
-            trigger: ".o-mail-Message:contains('Hello, I need help!').o-selfAuthored ",
+            trigger:
+                ".o-livechat-root:shadow .o-mail-Message:contains('Hello, I need help!').o-selfAuthored ",
         },
     ],
 });


### PR DESCRIPTION
In order to significantly simplify the turn step API, we are removing the "shadow_dom" attribute. Indeed, it is possible to select the trigger with a pseudo selector (from hoot) in a shadow_dom by adding ":shadow" to the trigger. From then on, this functionality no longer needs to be supported by the tour_compiler.

task~3974087
