### PR TITLE
[FIX] web_editor, website: fix text options display in translation mode

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -2711,6 +2711,15 @@ var SnippetsMenu = Widget.extend({
             // we create editors for invisible elements when translating them,
             // we only want to toggle their visibility when the related sidebar
             // buttons are clicked).
+            const translationEditors = this.snippetEditors.filter(editor => {
+                return this._allowInTranslationMode(editor.$target);
+            });
+            // Before returning, we need to clean editors if their snippets are
+            // allowed in the translation mode.
+            for (const editor of translationEditors) {
+                await editor.cleanForSave();
+                editor.destroy();
+            }
             return;
         }
         const exec = previewMode

--- a/addons/website/static/tests/tours/translate_text_options.js
+++ b/addons/website/static/tests/tours/translate_text_options.js
@@ -1,0 +1,105 @@
+/** @odoo-module **/
+
+import wTourUtils from "@website/js/tours/tour_utils";
+
+const selectText = (selector) => {
+    return {
+        content: "Select some text content",
+        trigger: `iframe ${selector}`,
+        run() {
+            const iframeDOC = document.querySelector(".o_iframe").contentDocument;
+            const range = iframeDOC.createRange();
+            const selection = iframeDOC.getSelection();
+            range.selectNodeContents(this.$anchor[0]);
+            selection.removeAllRanges();
+            selection.addRange(range);
+            this.$anchor[0].click();
+        },
+    };
+};
+
+wTourUtils.registerWebsitePreviewTour(
+    "translate_text_options",
+    {
+        url: "/",
+        test: true,
+        edition: true,
+    },
+    () => [
+        wTourUtils.dragNDrop({
+            id: "s_text_block",
+            name: "Text",
+        }),
+        {
+            content: "Select the first text block in the snippet",
+            trigger: "iframe #wrap .s_text_block p:first",
+            run: "dblclick",
+        },
+        {
+            content: "Click on the 'Animate Text' button to activate the option",
+            trigger: "div.o_we_animate_text",
+        },
+        {
+            content: "Select the second text block in the snippet",
+            trigger: "iframe #wrap .s_text_block p:last",
+            run: "dblclick",
+        },
+        {
+            content: "Click on the 'Highlight Effects' button to activate the option",
+            trigger: "div.o_we_text_highlight",
+        },
+        ...wTourUtils.clickOnSave(),
+        {
+            content: "Change the language to French",
+            trigger: 'iframe .js_language_selector .js_change_lang[data-url_code="fr"]',
+        },
+        {
+            content: "Enable translation",
+            trigger: ".o_translate_website_container a",
+        },
+        {
+            content: "Close the dialog",
+            trigger: ".modal-footer .btn-secondary",
+        },
+        // Select the highlighted text content.
+        selectText("#wrap .s_text_block p:last .o_text_highlight"),
+        {
+            content: "Check that the highlight options were displayed",
+            trigger: "#toolbar we-select[data-name=text_highlight_opt]",
+            isCheck: true,
+        },
+        ...wTourUtils.selectElementInWeSelectWidget("text_highlight_opt", "Jagged"),
+        // Select the animated text content.
+        selectText("#wrap .s_text_block p:first .o_animated_text"),
+        {
+            content:
+                "Check that the animation options are displayed and highlight options are no longer visible",
+            trigger:
+                "#toolbar:not(:has(.snippet-option-TextHighlight)) .snippet-option-WebsiteAnimate",
+            isCheck: true,
+        },
+        // Select a text content without any option.
+        selectText("footer .s_text_block p:first span"),
+        {
+            content: "Check that all text options are removed",
+            trigger:
+                "#toolbar:not(:has(.snippet-option-TextHighlight, .snippet-option-WebsiteAnimate))",
+            isCheck: true,
+        },
+        // Select the highlighted text content again.
+        selectText("#wrap .s_text_block p:last .o_text_highlight"),
+        {
+            content: "Check that only the highlight options are displayed",
+            trigger:
+                "#toolbar:not(:has(.snippet-option-WebsiteAnimate)) .snippet-option-TextHighlight",
+            isCheck: true,
+        },
+        ...wTourUtils.clickOnSave(),
+        {
+            content: "Check that the highlight effect was correctly translated",
+            trigger:
+                "iframe .s_text_block .o_text_highlight:has(.o_text_highlight_item:has(.o_text_highlight_path_jagged))",
+            isCheck: true,
+        },
+    ]
+);

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -182,6 +182,18 @@ class TestUiTranslate(odoo.tests.HttpCase):
         self.assertNotEqual(new_menu.name, 'value pa-GB', msg="The new menu should not have its value edited, only its translation")
         self.assertEqual(new_menu.with_context(lang=parseltongue.code).name, 'value pa-GB', msg="The new translation should be set")
 
+    def test_translate_text_options(self):
+        lang_en = self.env.ref('base.lang_en')
+        lang_fr = self.env.ref('base.lang_fr')
+        self.env['res.lang']._activate_lang(lang_fr.code)
+        default_website = self.env.ref('website.default_website')
+        default_website.write({
+            'default_lang_id': lang_en.id,
+            'language_ids': [(6, 0, (lang_en + lang_fr).ids)],
+        })
+
+        self.start_tour(self.env['website'].get_client_action_url('/'), 'translate_text_options', login='admin')
+
     def test_snippet_translation(self):
         ResLang = self.env['res.lang']
         parseltongue, fake_user_lang = ResLang.create([{


### PR DESCRIPTION
Steps to reproduce :

- Add a second language in your website settings.
- Drop a "Text" block in a new page.
- Add a highlight to some text > Save.
- Switch to the translation mode.
- Select the highlighted text > The text highlight options are shown.
- Select a text without any option > The highlight options remain
displayed.

Starting from [1], we allow using text options (text animations & text
highlights) in the translation mode, mainly by allowing the creation of
snippet editors if the target is a text option snippet.

Another fix (from [2]) was added later to exceptionally authorize the
editor's creation for "invisible" elements in translate mode, with a
small adaptation on `_activateSnippet()` to prevent activating invisible
snippets when their related sidebar buttons are clicked.

This code unintentionally leads to keeping the old editors created for a
text snippet when switching to another one in the DOM.

To fix this behaviour, we still need to ensure existing editors are
destroyed so we only create the ones we need in translate mode.

[1]: https://github.com/odoo/odoo/commit/3a149e36f7e6deaf156a7ee35e654aad61cf2e5d
[2]: https://github.com/odoo/odoo/commit/67efd1d98072f36caf9c473e97984631eb6bc8a3

task-3975683