### PR TITLE
[FIX] mail: message highlight in chatter

### DIFF
--- a/addons/mail/static/src/chatter/web/chatter_patch.js
+++ b/addons/mail/static/src/chatter/web/chatter_patch.js
@@ -69,6 +69,7 @@ Object.assign(Chatter.defaultProps, {
  */
 patch(Chatter.prototype, {
     setup() {
+        this.messageHighlight = useMessageHighlight();
         super.setup(...arguments);
         this.orm = useService("orm");
         this.mailPopoutService = useService("mail.popout");
@@ -83,7 +84,6 @@ patch(Chatter.prototype, {
         this.attachmentUploader = useAttachmentUploader(
             this.store.Thread.insert({ model: this.props.threadModel, id: this.props.threadId })
         );
-        this.messageHighlight = useMessageHighlight();
         this.unfollowHover = useHover("unfollow");
         this.followerListDropdown = useDropdownState();
         /** @type {number|null} */

--- a/addons/mail/static/tests/chatter/web/chatter_search.test.js
+++ b/addons/mail/static/tests/chatter/web/chatter_search.test.js
@@ -72,6 +72,8 @@ test("Search in chatter", async () => {
     await insertText(".o_searchview_input", "empty");
     triggerHotkey("Enter");
     await contains(".o-mail-Chatter-search .o-mail-Message");
+    await click(".o-mail-MessageCard-jump");
+    await contains(".o-mail-Message.o-highlighted .o-mail-Message-content", { text: "not empty" });
 });
 
 test("Close button should close the search panel", async () => {


### PR DESCRIPTION
Before this PR:

Chatter passes `messageHighlight` in it's childEnv by fetching it using a getter. This getter is overridden in it's patch. But in the patch the `messageHighlight` is set after calling `super.setup`. So, when the getter is called `messageHighlight` is never set. So, `messageHighlight` never gets passed down to it's child.

After this PR:

We set `messageHighlight` before calling `super.setup`.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
