### PR TITLE
[FIX] mail: make 'mark as read' test deterministic

### DIFF
--- a/addons/mail/static/tests/chat_window/chat_window.test.js
+++ b/addons/mail/static/tests/chat_window/chat_window.test.js
@@ -1095,7 +1095,9 @@ test("mark as read when opening chat window", async () => {
     await click(".o-mail-NotificationItem", { text: "bob" });
     await contains(".o-mail-ChatWindow .o-mail-ChatWindow-header", { text: "bob" });
     // composer is focused by default, we remove that focus
-    await contains(".o-mail-Composer-input", { setFocus: false });
+    await contains(".o-mail-Composer-input:focus");
+    document.querySelector(".o-mail-Composer-input").blur();
+    await contains(".o-mail-Composer-input:not(:focus");
     await withUser(bobUserId, () =>
         rpc("/mail/message/post", {
             post_data: {


### PR DESCRIPTION
The `mark as read when opening chat window` test is incorrect. It receives a message outside the thread focus to have one unread message, then opens the chat window to verify the message is read. The `setFocus` parameter of the `contains` helper is used to remove focus, but it can only focus an element, not blur it. This causes the test to pass only due to the delay between opening the chat window and the mark as read RPC. Properly blurring the composer fixes the issue.

fixes runbot-65485