### PR TITLE
[IMP] core: improve performance of Field.__get__()

### DIFF
--- a/odoo/addons/test_performance/models/models.py
+++ b/odoo/addons/test_performance/models/models.py
@@ -101,3 +101,9 @@ class Test_PerformanceSimpleMinded(models.Model):
     parent_id = fields.Many2one('test_performance.simple.minded')
 
     child_ids = fields.One2many('test_performance.simple.minded', 'parent_id')
+
+    simple_compute = fields.Char(compute='_compute_simple_compute')
+
+    def _compute_simple_compute(self):
+        for rec in self:
+            rec.simple_compute = rec.name

--- a/odoo/addons/test_performance/tests/test_timeit.py
+++ b/odoo/addons/test_performance/tests/test_timeit.py
@@ -139,6 +139,13 @@ class TestPerformanceTimeit(TransactionCase):
         self.launch_perf("records.name = 'ok'", self.parent_0_child)
         self.launch_perf_set("records.name = records[0].name")
 
+    def test_perf_field_set_compute(self):
+        field = self.Model._fields['simple_compute']
+        self.launch_perf_set(
+            "field.compute_value(records); records.invalidate_model(['simple_compute'])", 
+            ctx={'field': field},
+        )
+
     def test_perf_field_set_flush(self):
         self.launch_perf("records.flush_recordset()", self.parent_0_child)
         self.launch_perf("records.write({'name': 'ok'}); records.flush_recordset()", self.parent_0_child)

--- a/odoo/orm/environments.py
+++ b/odoo/orm/environments.py
@@ -563,11 +563,12 @@ class Cache:
     the values that should be in the database must be in a context where all
     the field's context keys are ``None``.
     """
-    __slots__ = ('_data', '_dirty', '_patches')
+    __slots__ = ('_data', '_data_get', '_dirty', '_patches')
 
     def __init__(self):
         # {field: {record_id: value}, field: {context_key: {record_id: value}}}
         self._data = defaultdict(dict)
+        self._data_get = self._data.get
 
         # {field: set[id]} stores the fields and ids that are changed in the
         # cache, but not yet written in the database; their changed values are
@@ -626,7 +627,7 @@ class Cache:
 
     def contains_field(self, field):
         """ Return whether ``field`` has a value for at least one record. """
-        cache = self._data.get(field)
+        cache = self._data_get(field)
         if not cache:
             return False
         # 'cache' keys are tuples if 'field' is context-dependent, record ids otherwise
@@ -947,7 +948,7 @@ class Cache:
                 if ids is None:
                     self._data.pop(field, None)
                     continue
-                cache = self._data.get(field)
+                cache = self._data_get(field)
                 if not cache:
                     continue
                 caches = cache.values() if isinstance(next(iter(cache)), tuple) else [cache]

--- a/odoo/orm/fields.py
+++ b/odoo/orm/fields.py
@@ -1157,28 +1157,40 @@ class Field(MetaField('DummyField', (object,), {}), typing.Generic[T]):
 
     def __get__(self, record: BaseModel, owner=None) -> T:
         """ return the value of field ``self`` on ``record`` """
-        if record is None:
-            return self         # the field is accessed through the owner class
-
-        if not record._ids:
-            # null record -> return the null value for this field
-            value = self.convert_to_cache(False, record, validate=False)
-            return self.convert_to_record(value, record)
-
-        env = record.env
-
-        # only a single record may be accessed
-        record.ensure_one()
+        # This part is specifically write to be fastest as possible
+        try:
+            id_, = record._ids
+        except ValueError:
+            if not record._ids:
+                # null record -> return the null value for this field
+                value = self.convert_to_cache(False, record, validate=False)
+                return self.convert_to_record(value, record)
+            # only a single record may be accessed
+            raise ValueError(f"Expected singleton: {self}") from None
+        except AttributeError:
+            if record is None:
+                return self         # the field is accessed through the owner class
+            raise
 
         if self.compute and self.store:
             # process pending computations
             self.recompute(record)
 
-        try:
-            value = env.cache.get(record, self)
-            return self.convert_to_record(value, record)
-        except KeyError:
-            pass
+        # it breaks the cache abstraction
+        env = record.env
+        if field_cache := env.cache._data_get(self):
+            try:
+                if self in record.pool.field_depends_context:
+                    field_cache = field_cache[env.cache_key(self)]
+
+                cache_value = field_cache[id_]
+                if self.translate and cache_value is not None:
+                    lang = (env.lang or 'en_US') if self.translate is True else env._lang
+                    cache_value = cache_value[lang]
+            except KeyError:
+                pass
+            else:
+                return self.convert_to_record(cache_value, record)
         # behavior in case of cache miss:
         #
         #   on a real record:
@@ -1198,7 +1210,7 @@ class Field(MetaField('DummyField', (object,), {}), typing.Generic[T]):
         #       not stored and computed -> compute
         #       not stored and not computed -> default
         #
-        if self.store and record.id:
+        if self.store and id_:
             # real record: fetch from database
             recs = self._in_cache_without(record, PREFETCH_MAX)
             try:
@@ -1243,7 +1255,7 @@ class Field(MetaField('DummyField', (object,), {}), typing.Generic[T]):
 
                 value = env.cache.get(record, self)
 
-        elif self.type == 'many2one' and self.delegate and not record.id:
+        elif self.type == 'many2one' and self.delegate and not id_:
             # parent record of a new record: new record, with the same
             # values as record for the corresponding inherited fields
             def is_inherited_field(name):

--- a/odoo/orm/identifiers.py
+++ b/odoo/orm/identifiers.py
@@ -5,11 +5,12 @@ class NewId:
     """ Pseudo-ids for new records, encapsulating an optional origin id (actual
         record id) and an optional reference (any value).
     """
-    __slots__ = ['origin', 'ref']
+    __slots__ = 'origin', 'ref' , '__hash'
 
     def __init__(self, origin=None, ref=None):
         self.origin = origin
         self.ref = ref
+        self.__hash = None
 
     def __bool__(self):
         return False
@@ -21,7 +22,9 @@ class NewId:
         )
 
     def __hash__(self):
-        return hash(self.origin or self.ref or id(self))
+        if self.__hash is None:
+            self.__hash = hash(self.origin or self.ref or id(self))
+        return self.__hash
 
     def __repr__(self):
         return (


### PR DESCRIPTION
Specialize Field.__get__() (breaks the cache abstraction) in order to reduce the performance penalty of Odoo's field cache as much as possible.
Also add _data_get to the Cache class to avoid huge number of __getattribute__().

Performance improvements: Before `self.login` took 405 ns ± 0.437 ns (with the previous optimization), now it takes 292 ns ± 0.375 ns.

We think it is worth it to break the abstraction of cache in this particular case because it is one of the most used method of Odoo.

