### PR TITLE
[FIX] l10n_es_edi_tbai: Handle All Sequence Number Formats

### DIFF
--- a/addons/l10n_es_edi_tbai/models/account_move.py
+++ b/addons/l10n_es_edi_tbai/models/account_move.py
@@ -128,7 +128,13 @@ class AccountMove(models.Model):
     def _get_l10n_es_tbai_sequence_and_number(self):
         """Get the TicketBAI sequence a number values for this invoice."""
         self.ensure_one()
-        sequence, number = self.name.rsplit('/', 1)  # NOTE non-decimal characters should not appear in the number
+
+        sequence = self.sequence_prefix.rstrip('/')
+
+        # NOTE non-decimal characters should not appear in the number
+        seq_length = self._get_sequence_format_param(self.name)[1]['seq_length']
+        number = f"{self.sequence_number:0{seq_length}d}"
+
         sequence = regex_sub(r"[^0-9A-Za-z.\_\-\/]", "", sequence)  # remove forbidden characters
         sequence = regex_sub(r"\s+", " ", sequence)  # no more than one consecutive whitespace allowed
         # NOTE (optional) not recommended to use chars out of ([0123456789ABCDEFGHJKLMNPQRSTUVXYZ.\_\-\/ ])

--- a/addons/l10n_es_edi_tbai/tests/test_edi_xml.py
+++ b/addons/l10n_es_edi_tbai/tests/test_edi_xml.py
@@ -43,6 +43,17 @@ class TestEdiTbaiXmls(TestEsEdiTbaiCommon):
             xml_expected = etree.fromstring(super().L10N_ES_TBAI_SAMPLE_XML_POST)
             self.assertXmlTreeEqual(xml_doc, xml_expected)
 
+    def test_xml_tree_post_generic_sequence(self):
+        """Test TBAI on moves whose sequence does not contain a '/'"""
+        with freeze_time(self.frozen_today):
+            invoice = self.out_invoice.copy({
+                'name': 'INV01',
+            })
+            xml_doc = self.edi_format._get_l10n_es_tbai_invoice_xml(invoice, cancel=False)[invoice]['xml_file']
+            xml_doc.remove(xml_doc.find("Signature", namespaces=NS_MAP))
+            xml_expected = etree.fromstring(super().L10N_ES_TBAI_SAMPLE_XML_POST)
+            self.assertXmlTreeEqual(xml_doc, xml_expected)
+
     def test_xml_tree_post_multicurrency(self):
         """Test of Customer Invoice XML. The invoice is not in company currency and has a line with a 100% discount"""
 


### PR DESCRIPTION
Currently, invoices cannot be sent to TicketBAI if the invoice sequence does not end with `/<sequence_number>`.

### Steps to Reproduce

* Install `l10n_es_edi_tbai`.
* Ensure your invoice has a sequence that does not contain a `/`.
* Attempt to send the invoice through TicketBAI.

A traceback error occurs:
`ValueError: not enough values to unpack (expected 2, got 1)`

### Cause

When parsing invoice sequence numbers for TicketBAI, the system splits the sequence number by the rightmost `/`. This fails when the sequence number does not contain a `/`.

opw-3952511