### PR TITLE
[IMP] account,l10n_{ch,din_5008}: invoice pdf generation time

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -48,7 +48,7 @@
                         </div>
                     </t>
                 </div>
-                <div class="clearfix">
+                <div class="clearfix invoice_main">
                     <div class="page mb-4">
                         <t t-set="layout_document_title">
                             <span t-if="not proforma"></span>

--- a/addons/l10n_ch/models/ir_actions_report.py
+++ b/addons/l10n_ch/models/ir_actions_report.py
@@ -35,63 +35,37 @@ class IrActionsReport(models.Model):
         report = self._get_report(report_ref)
         if self._is_invoice_report(report_ref):
             invoices = self.env[report.model].browse(res_ids)
+
             # Determine which invoices need a QR.
-            qr_inv_ids = []
-            for invoice in invoices:
-                # avoid duplicating existing streams
-                if report.attachment_use and report.retrieve_attachment(invoice):
-                    continue
-                if invoice.l10n_ch_is_qr_valid:
-                    qr_inv_ids.append(invoice.id)
-            # Render the additional reports.
-            streams_to_append = {}
+            qr_inv_ids = invoices.filtered('l10n_ch_is_qr_valid').ids
+
             if qr_inv_ids:
                 qr_res = self._render_qweb_pdf_prepare_streams(
                     'l10n_ch.l10n_ch_qr_report',
-                    {
-                        **data,
-                        'skip_headers': False,
-                    },
+                    data,
                     res_ids=qr_inv_ids,
                 )
-                header = self.env.ref('l10n_ch.l10n_ch_qr_header', raise_if_not_found=False)
-                if header:
-                    # Make a separated rendering to get the a page containing the company header. Then, merge the qr bill with it.
 
-                    header_res = self._render_qweb_pdf_prepare_streams(
-                        'l10n_ch.l10n_ch_qr_header',
-                        {
-                            **data,
-                            'skip_headers': True,
-                        },
-                        res_ids=qr_inv_ids,
-                    )
+                for invoice_id, stream in qr_res.items():
+                    qr_pdf = OdooPdfFileReader(stream['stream'], strict=False)
+                    res_pdf = OdooPdfFileReader(res[invoice_id]['stream'], strict=False)
 
-                    for invoice_id, stream in qr_res.items():
-                        qr_pdf = OdooPdfFileReader(stream['stream'], strict=False)
-                        header_pdf = OdooPdfFileReader(header_res[invoice_id]['stream'], strict=False)
+                    last_page = res_pdf.getPage(-1)
+                    last_page.mergePage(qr_pdf.getPage(0))
 
-                        page = header_pdf.getPage(0)
-                        page.mergePage(qr_pdf.getPage(0))
+                    output_pdf = OdooPdfFileWriter()
 
-                        output_pdf = OdooPdfFileWriter()
-                        output_pdf.addPage(page)
-                        new_pdf_stream = io.BytesIO()
-                        output_pdf.write(new_pdf_stream)
-                        streams_to_append[invoice_id] = {'stream': new_pdf_stream}
-                else:
-                    for invoice_id, stream in qr_res.items():
-                        streams_to_append[invoice_id] = stream
+                    # Add all pages from the original PDF except the last one
+                    for page_num in range(res_pdf.getNumPages() - 1):
+                        output_pdf.addPage(res_pdf.getPage(page_num))
 
-            # Add to results
-            for invoice_id, additional_stream in streams_to_append.items():
-                invoice_stream = res[invoice_id]['stream']
-                writer = OdooPdfFileWriter()
-                writer.appendPagesFromReader(OdooPdfFileReader(invoice_stream, strict=False))
-                writer.appendPagesFromReader(OdooPdfFileReader(additional_stream['stream'], strict=False))
-                new_pdf_stream = io.BytesIO()
-                writer.write(new_pdf_stream)
-                res[invoice_id]['stream'] = new_pdf_stream
-                invoice_stream.close()
-                additional_stream['stream'].close()
+                    output_pdf.addPage(last_page)  # Add the modified last page (with the QR code merged)
+
+                    new_pdf_stream = io.BytesIO()
+                    output_pdf.write(new_pdf_stream)
+                    new_pdf_stream.seek(0)
+                    res[invoice_id]['stream'].close()
+                    res[invoice_id]['stream'] = new_pdf_stream
+                    stream['stream'].close()
+
         return res

--- a/addons/l10n_ch/report/swissqr_report.xml
+++ b/addons/l10n_ch/report/swissqr_report.xml
@@ -24,22 +24,6 @@
             <field name="paperformat_id" ref="l10n_ch.paperformat_euro_no_margin"/>
         </record>
 
-        <record id="l10n_ch_qr_header" model="ir.actions.report">
-            <field name="name">QR-bill Header</field>
-            <field name="model">account.move</field>
-            <field name="report_type">qweb-pdf</field>
-            <field name="report_name">l10n_ch.qr_report_header</field>
-            <field name="report_file">l10n_ch.qr_report_header</field>
-        </record>
-
-        <template id="l10n_ch_header_template">
-            <t t-call="web.external_layout">
-                <!--The following elements are necessary for the header to be displayed correctly.-->
-                <br/>
-                <p>&amp;nbsp;</p>
-            </t>
-        </template>
-
         <template id="l10n_ch_swissqr_template">
             <div class="article" t-att-data-oe-model="o._name" t-att-data-oe-id="o.id">
                 <t t-set="o" t-value="o.with_context(lang=lang)"/>
@@ -239,16 +223,6 @@
                 <t t-foreach="docs" t-as="o">
                     <t t-set="lang" t-value="o.partner_id.lang"/>
                     <t t-call="l10n_ch.l10n_ch_swissqr_template" t-lang="lang"/>
-                </t>
-            </t>
-        </template>
-
-        <template id="l10n_ch.qr_report_header">
-            <t t-call="web.html_container">
-                <t t-foreach="docs" t-as="invoice">
-                    <t t-set="o" t-value="invoice"/>
-                    <t t-set="lang" t-value="o.partner_id.lang"/>
-                    <t t-call="l10n_ch.l10n_ch_header_template" t-lang="lang"/>
                 </t>
             </t>
         </template>

--- a/addons/l10n_ch/views/account_invoice.xml
+++ b/addons/l10n_ch/views/account_invoice.xml
@@ -4,5 +4,11 @@
         <xpath expr="//t[@t-set='show_qr']" position="attributes">
             <attribute name="t-value" add="and o.qr_code_method != 'ch_qr'" separator=" "/>
         </xpath>
+        <xpath expr="//div[hasclass('invoice_main')]" position="after">
+            <div t-if="o.l10n_ch_is_qr_valid">
+                <div style="page-break-after: always"/>
+                <br/>
+            </div>
+        </xpath>
     </template>
 </odoo>

--- a/addons/l10n_din5008/report/din5008_report.xml
+++ b/addons/l10n_din5008/report/din5008_report.xml
@@ -48,7 +48,7 @@
                            '/base/static/img/demo_logo_report.png' if company.layout_background == 'Demo logo' else ''}});"
                      t-att-data-oe-model="o and o._name"
                      t-att-data-oe-id="o and o.id">
-                    <table class="din_company_info table-borderless" t-if="not skip_headers">
+                    <table class="din_company_info table-borderless">
                         <tr>
                             <td>
                                 <div class="address">
@@ -95,7 +95,7 @@
                             <t t-out="din5008_address_block"/>
                         </t>
                     </table>
-                    <h2 t-if="not skip_headers">
+                    <h2>
                         <span t-if="not o and not docs">Invoice</span>
                         <span t-else="">
                             <t t-set="o" t-value="docs[0]" t-if="not o" />


### PR DESCRIPTION
For l10n_ch (Switzerland), this commit improves the invoice pdf generation time by reducing the number of call made to the function _run_wkhtmltopdf(), from 3 calls to 2. This is made possible by adding an empty page, but still containing the header, to the generic invoice template. Then the Swiss QR code, if exists, is merged onto this last added page.

task-3964501

**Flame graph and time for generating 1 invoice with a Swiss company for a Swiss customer (with QR code then)**
Before this commit:
![image](https://github.com/odoo/odoo/assets/115461192/180de8f1-6867-405e-9e5b-e57f7396f308)

After this commit:
![image](https://github.com/odoo/odoo/assets/115461192/7b58fcee-6449-4692-8374-6fba51351485)

Conclusion: Approximately from 9.6 seconds to 7 seconds, => ≈27% faster (test done locally on laptop)



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
