### PR TITLE
[FIX] stock: fix put tracked products in pack issues

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -915,8 +915,8 @@ class StockMoveLine(models.Model):
 
     def action_put_in_pack(self):
         for picking in self.picking_id:
-            picking.action_put_in_pack()
-        return self.picking_id.action_detailed_operations()
+            picking.with_context(move_lines_to_pack_ids=self.ids).action_put_in_pack()
+        return True
 
     def _get_revert_inventory_move_values(self):
         self.ensure_one()

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -1517,6 +1517,8 @@ class Picking(models.Model):
         move_line_ids = quantity_move_line_ids.filtered(lambda ml: ml.picked)
         if not move_line_ids:
             move_line_ids = quantity_move_line_ids
+        if self.env.context.get('move_lines_to_pack_ids', False):
+            move_line_ids = move_line_ids.filtered(lambda ml: ml.id in self.env.context['move_lines_to_pack_ids'])
         return move_line_ids
 
     def action_put_in_pack(self):


### PR DESCRIPTION
Steps to reproduce:
- Create a serial number tracked product.
- Activate "Packages" setting from the "Inventory" app configuration.
- Create a receipt order with a stock move of that product.
- Mark it as to-do and generate serial numbers.
- Click on "Detailed Operations" smart button.
- Select some of the move lines and click on "Put in Pack".

Expected behavior:
- Only the selected move lines are put in a package.

Current behavior:
- All of the move lines are put in a package.

Task-3857396

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
