### PR TITLE
[IMP] account: Keep the payment amount after date change

### DIFF
--- a/addons/account/wizard/account_payment_register_views.xml
+++ b/addons/account/wizard/account_payment_register_views.xml
@@ -32,6 +32,7 @@
                     <field name="writeoff_is_exchange_account" invisible="1"/>
                     <field name="untrusted_bank_ids" invisible="1"/>
                     <field name="missing_account_partners" invisible="1"/>
+                    <field name="is_amount_forced_by_user" invisible="1"/>
 
                     <div role="alert" class="alert alert-info" invisible="not hide_writeoff_section">
                         <p><b>Early Payment Discount of <field name="payment_difference"/> has been applied.</b></p>


### PR DESCRIPTION
[IMP] account: Keep the payment amount after date change

Keep the payment amount after payment_date change

Solution: keep track of the payment_date changes and whenever the user change the payment_date and he has already changed
the amount on the wizard, We will keep the amount on the wizard as is and ignore recalculating the amount.

IMPORTANT: if the user doesn't change the amount and keep changing the payment date,
we must recalculate the amount again because the 'payment_date' is a dependency on '_compute_amount' function
and we don't want to ignore recalculating the amount if the user doesn't change the amount in the wizard.

Reason: Because changing the amount the user set after changing the date is bothering!

Task-3786331

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
