### PR TITLE
[FIX]purchase_stock: fix write of purchase.order.line to avoid error …

### DIFF
--- a/addons/purchase_stock/models/purchase.py
+++ b/addons/purchase_stock/models/purchase.py
@@ -393,7 +393,8 @@ class PurchaseOrderLine(models.Model):
         if values.get('date_planned'):
             new_date = fields.Datetime.to_datetime(values['date_planned'])
             self.filtered(lambda l: not l.display_type)._update_move_date_deadline(new_date)
-        lines = self.filtered(lambda l: l.order_id.state == 'purchase')
+        lines = self.filtered(lambda l: l.order_id.state == 'purchase'
+                                        and not l.display_type)
 
         if 'product_packaging_id' in values:
             self.move_ids.filtered(


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When change date_planned field of a confirmed PO, some times can  happen if there more than one line_section or line_note, these lines is seen as product_lines.

Current behavior before PR:
Before Assertion failure for round digits for precision digits on method https://github.com/odoo/odoo/blob/16.0/odoo/tools/float_utils.py#L25
So we can't change the date_planned values.


Desired behavior after PR is merged:
I can change the date_planned field


More Note:
I see the problem for version 14.0 15.0 e and 16.0


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
