### PR TITLE
[FIX] mrp_account: adds business domain to bom check analytic

### DIFF
--- a/addons/mrp_account/models/mrp_bom.py
+++ b/addons/mrp_account/models/mrp_bom.py
@@ -40,11 +40,3 @@ class MrpBom(models.Model):
                     "product_categ_id": record.product_id.categ_id.id,
                     "company_id": record.company_id.id,
                 })
-
-    @api.constrains('analytic_distribution')
-    def _check_analytic(self):
-        for record in self:
-            record.with_context({'validate_analytic': True})._validate_distribution(**{
-                'product': record.product_id.id,
-                'company_id': record.company_id.id,
-            })

--- a/addons/mrp_account/models/mrp_workcenter.py
+++ b/addons/mrp_account/models/mrp_workcenter.py
@@ -16,10 +16,3 @@ class MrpWorkcenter(models.Model):
             record.costs_hour_account_ids = bool(record.analytic_distribution) and self.env['account.analytic.account'].browse(
                 list({int(account_id) for ids in record.analytic_distribution for account_id in ids.split(",")})
             ).exists()
-
-    @api.constrains('analytic_distribution')
-    def _check_analytic(self):
-        for record in self:
-            record.with_context({'validate_analytic': True})._validate_distribution(**{
-                'company_id': record.company_id.id,
-            })


### PR DESCRIPTION
Steps to reproduce:
-Go to analytic plans -> Projects -> Add a new line with a "Purchase Order" Domain and set Applicability to "Mandatory" -> Save
-Go to Bills oF Materials -> create a new one w/ any product -> Save

Issue:
-There will be an error "One or more lines require a 100% analytic distribution."

Cause:
When saving the BoM, it leads to a constraint check
https://github.com/odoo/odoo/blob/0217b88e481dc1d0d244b620ba527dec177edde1/addons/mrp_account/models/mrp_bom.py#L44-L50

In this method, we first try to find the relevant plans:
https://github.com/odoo/odoo/blob/d6bdb05771fd29a79f2e8087b92a438fec28afaa/addons/analytic/models/analytic_mixin.py#L103-L107

To do so, we take all existing plans, evaluate them with a score, and take the one with the higher score. Here is the issue: when evaluating *Projects*, since we didn't provide any business domain and since the plan has a company, we assign a 0.5 score to the plan instead of skipping it:
https://github.com/odoo/odoo/blob/f17b37b14cad8f353443586cc9c4ecaf86e476da/addons/analytic/models/analytic_plan.py#L310-L319
Which does not make sense as the business domain of *Project* is *Purchase Order* and here the user is dealing with a BoM...

As a result, back to `_validate_distribution`, we check the distribution for this plan and realize there isn't any, hence the error:
https://github.com/odoo/odoo/blob/d6bdb05771fd29a79f2e8087b92a438fec28afaa/addons/analytic/models/analytic_mixin.py#L115-L117

Solution:

BOM: We don't restrict anymore the creation of a BOM. Setting an analytic distribution is only a tool to facilitate the definition of the analytic distribution on the MO but the creation should not be constrained
Workcenter: we correct the flowing by specifying the business domain restricting the creation of a workcenter if any relevant rule is present