### PR TITLE
[IMP] base: move slug on ir.http to remove wrong import

### DIFF
--- a/addons/html_editor/controllers/main.py
+++ b/addons/html_editor/controllers/main.py
@@ -13,7 +13,6 @@ from odoo.addons.html_editor.tools import get_video_url_data
 from odoo.exceptions import UserError, MissingError, AccessError
 from odoo.http import request
 from odoo.tools.mimetypes import guess_mimetype
-from odoo.addons.http_routing.models.ir_http import slug, unslug
 from odoo.tools.misc import file_open
 from odoo.addons.iap.tools import iap_tools
 
@@ -436,6 +435,7 @@ class HTML_Editor(http.Controller):
         if response.status_code != requests.codes.ok:
             raise Exception(_("ERROR: couldn't get download urls from media library."))
 
+        slug = request.env['ir.http']._slug
         for id, url in response.json().items():
             req = requests.get(url)
             name = '_'.join([media[id]['query'], url.split('/')[-1]])
@@ -467,6 +467,7 @@ class HTML_Editor(http.Controller):
         """
         svg = None
         if module == 'illustration':
+            unslug = request.env['ir.http']._unslug
             attachment = request.env['ir.attachment'].sudo().browse(unslug(filename)[1])
             if (not attachment.exists()
                     or attachment.type != 'binary'

--- a/addons/html_editor/tests/test_controller.py
+++ b/addons/html_editor/tests/test_controller.py
@@ -8,8 +8,6 @@ import odoo.tests
 from odoo.tests.common import HttpCase, new_test_user
 from odoo.tools.json import scriptsafe as json_safe
 
-from odoo.addons.http_routing.models.ir_http import slug
-
 
 @odoo.tests.tagged('-at_install', 'post_install')
 class TestController(HttpCase):
@@ -78,6 +76,7 @@ class TestController(HttpCase):
                 'res_id': 0,
             })
             # Shape illustration with slug.
+            slug = self.env['ir.http']._slug
             url = '/html_editor/shape/illustration/%s' % slug(attachment)
             palette = 'c1=%233AADAA&c2=%237C6576&&c3=%23F6F6F6&&c4=%23FFFFFF&&c5=%23383E45'
             attachment['url'] = '%s?%s' % (url, palette)

--- a/addons/http_routing/models/ir_http.py
+++ b/addons/http_routing/models/ir_http.py
@@ -1,12 +1,11 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import contextlib
 import logging
 import os
 import re
 import traceback
-import threading
 import unicodedata
+import typing
 import werkzeug.exceptions
 import werkzeug.routing
 import werkzeug.urls
@@ -25,276 +24,27 @@ from odoo.addons.base.models.ir_http import RequestUID
 from odoo.addons.base.models.ir_qweb import keep_query, QWebException
 from odoo.addons.base.models.res_lang import LangData
 from odoo.exceptions import AccessError, MissingError
-from odoo.http import request, HTTPRequest, Response
+from odoo.http import request, Response
 from odoo.osv import expression
 from odoo.tools import ustr, pycompat
 
 _logger = logging.getLogger(__name__)
 
-# ------------------------------------------------------------
-# Slug API
-# ------------------------------------------------------------
 
-def _guess_mimetype(ext=False, default='text/html'):
-    exts = {
-        '.css': 'text/css',
-        '.less': 'text/less',
-        '.scss': 'text/scss',
-        '.js': 'text/javascript',
-        '.xml': 'text/xml',
-        '.csv': 'text/csv',
-        '.html': 'text/html',
-    }
-    return ext is not False and exts.get(ext, default) or exts
-
-
-def slugify_one(s, max_length=0):
-    """ Transform a string to a slug that can be used in a url path.
-        This method will first try to do the job with python-slugify if present.
-        Otherwise it will process string by stripping leading and ending spaces,
-        converting unicode chars to ascii, lowering all chars and replacing spaces
-        and underscore with hyphen "-".
-        :param s: str
-        :param max_length: int
-        :rtype: str
-    """
-    s = ustr(s)
-    if slugify_lib:
-        # There are 2 different libraries only python-slugify is supported
-        try:
-            return slugify_lib.slugify(s, max_length=max_length)
-        except TypeError:
-            pass
-    uni = unicodedata.normalize('NFKD', s).encode('ascii', 'ignore').decode('ascii')
-    slug_str = re.sub(r'[\W_]', ' ', uni).strip().lower()
-    slug_str = re.sub(r'[-\s]+', '-', slug_str)
-    return slug_str[:max_length] if max_length > 0 else slug_str
-
-
-def slugify(s, max_length=0, path=False):
-    if not path:
-        return slugify_one(s, max_length=max_length)
-    else:
-        res = []
-        for u in s.split('/'):
-            if slugify_one(u, max_length=max_length) != '':
-                res.append(slugify_one(u, max_length=max_length))
-        # check if supported extension
-        path_no_ext, ext = os.path.splitext(s)
-        if ext and ext in _guess_mimetype():
-            res[-1] = slugify_one(path_no_ext) + ext
-        return '/'.join(res)
-
-
-def slug(value):
-    try:
-        if not value.id:
-            raise ValueError("Cannot slug non-existent record %s" % value)
-        identifier, name = value.id, getattr(value, 'seo_name', False) or value.display_name
-    except AttributeError:
-        # assume name_search result tuple
-        identifier, name = value
-    slugname = slugify(name or '').strip().strip('-')
-    if not slugname:
-        return str(identifier)
-    return f"{slugname}-{identifier}"
-
+# see also mimetypes module: https://docs.python.org/3/library/mimetypes.html and odoo.tools.mimetypes
+EXTENSION_TO_WEB_MIMETYPES = {
+    '.css': 'text/css',
+    '.less': 'text/less',
+    '.scss': 'text/scss',
+    '.js': 'text/javascript',
+    '.xml': 'text/xml',
+    '.csv': 'text/csv',
+    '.html': 'text/html',
+}
 
 # NOTE: the second pattern is used for the ModelConverter, do not use nor flags nor groups
 _UNSLUG_RE = re.compile(r'(?:(\w{1,2}|\w[A-Za-z0-9-_]+?\w)-)?(-?\d+)(?=$|\/|#|\?)')
 _UNSLUG_ROUTE_PATTERN = r'(?:(?:\w{1,2}|\w[A-Za-z0-9-_]+?\w)-)?(?:-?\d+)(?=$|\/|#|\?)'
-
-
-def unslug(s):
-    """ Extract slug and id from a string.
-        Always return a 2-tuple (str|None, int|None)
-    """
-    m = _UNSLUG_RE.match(s)
-    if not m:
-        return None, None
-    return m.group(1), int(m.group(2))
-
-
-def unslug_url(s):
-    """ From /blog/my-super-blog-1" to "blog/1" """
-    parts = s.split('/')
-    if parts:
-        unslug_val = unslug(parts[-1])
-        if unslug_val[1]:
-            parts[-1] = str(unslug_val[1])
-            return '/'.join(parts)
-    return s
-
-
-# ------------------------------------------------------------
-# Language tools
-# ------------------------------------------------------------
-
-
-def url_localized(url=None, lang_code=None, canonical_domain=None, prefetch_langs=False, force_default_lang=False):
-    """ Returns the given URL adapted for the given lang, meaning that:
-    1. It will have the lang suffixed to it
-    2. The model converter parts will be translated
-
-    If it is not possible to rebuild a path, use the current one instead.
-    `url_quote_plus` is applied on the returned path.
-
-    It will also force the canonical domain is requested.
-    Eg:
-    - `_get_url_localized(lang_fr, '/shop/my-phone-14')` will return
-        `/fr/shop/mon-telephone-14`
-    - `_get_url_localized(lang_fr, '/shop/my-phone-14', True)` will return
-        `<base_url>/fr/shop/mon-telephone-14`
-    """
-    if not lang_code:
-        lang = request.lang
-    else:
-        lang = request.env['res.lang']._get_data(code=lang_code)
-
-    if not url:
-        qs = keep_query()
-        url = request.httprequest.path + ('?%s' % qs if qs else '')
-
-    # '/shop/furn-0269-chaise-de-bureau-noire-17?' to
-    # '/shop/furn-0269-chaise-de-bureau-noire-17', otherwise -> 404
-    url, sep, qs = url.partition('?')
-
-    try:
-        # Re-match the controller where the request path routes.
-        rule, args = request.env['ir.http']._match(url)
-        for key, val in list(args.items()):
-            if isinstance(val, models.BaseModel):
-                if isinstance(val._uid, RequestUID):
-                    args[key] = val = val.with_user(request.uid)
-                if val.env.context.get('lang') != lang.code:
-                    args[key] = val = val.with_context(lang=lang.code)
-                if prefetch_langs:
-                    args[key] = val = val.with_context(prefetch_langs=True)
-        router = http.root.get_db_router(request.db).bind('')
-        path = router.build(rule.endpoint, args)
-    except (NotFound, AccessError, MissingError):
-        # The build method returns a quoted URL so convert in this case for consistency.
-        path = werkzeug.urls.url_quote_plus(url, safe='/')
-    if force_default_lang or lang != request.env['ir.http']._get_default_lang():
-        path = f'/{lang.url_code}{path if path != "/" else ""}'
-
-    if canonical_domain:
-        # canonical URLs should not have qs
-        return werkzeug.urls.url_join(canonical_domain, path)
-
-    return path + sep + qs
-
-
-def url_lang(path_or_uri, lang_code=None):
-    ''' Given a relative URL, make it absolute and add the required lang or
-        remove useless lang.
-        Nothing will be done for absolute or invalid URL.
-        If there is only one language installed, the lang will not be handled
-        unless forced with `lang` parameter.
-
-        :param lang_code: Must be the lang `code`. It could also be something
-                          else, such as `'[lang]'` (used for url_return).
-    '''
-    Lang = request.env['res.lang']
-    location = pycompat.to_text(path_or_uri).strip()
-    force_lang = lang_code is not None
-    try:
-        url = werkzeug.urls.url_parse(location)
-    except ValueError:
-        # e.g. Invalid IPv6 URL, `werkzeug.urls.url_parse('http://]')`
-        url = False
-    # relative URL with either a path or a force_lang
-    if url and not url.netloc and not url.scheme and (url.path or force_lang):
-        location = werkzeug.urls.url_join(request.httprequest.path, location)
-        lang_url_codes = [info.url_code for info in Lang._get_frontend().values()]
-        lang_code = pycompat.to_text(lang_code or request.context['lang'])
-        lang_url_code = Lang._get_data(code=lang_code).url_code
-        lang_url_code = lang_url_code if lang_url_code in lang_url_codes else lang_code
-        if (len(lang_url_codes) > 1 or force_lang) and is_multilang_url(location, lang_url_codes):
-            loc, sep, qs = location.partition('?')
-            ps = loc.split(u'/')
-            default_lg = request.env['ir.http']._get_default_lang()
-            if ps[1] in lang_url_codes:
-                # Replace the language only if we explicitly provide a language to url_for
-                if force_lang:
-                    ps[1] = lang_url_code
-                # Remove the default language unless it's explicitly provided
-                elif ps[1] == default_lg.url_code:
-                    ps.pop(1)
-            # Insert the context language or the provided language
-            elif lang_url_code != default_lg.url_code or force_lang:
-                ps.insert(1, lang_url_code)
-                # Remove the last empty string to avoid trailing / after joining
-                if ps[-1] == '':
-                    ps.pop(-1)
-
-            location = u'/'.join(ps) + sep + qs
-    return location
-
-
-def url_for(url_from, lang_code=None):
-    ''' Return the url with the rewriting applied.
-        Nothing will be done for absolute URL, invalid URL, or short URL from 1 char.
-
-        :param url_from: The URL to convert.
-        :param lang_code: Must be the lang `code`. It could also be something
-                          else, such as `'[lang]'` (used for url_return).
-    '''
-    path, _, qs = (url_from or '').partition('?')
-    routing = getattr(request, 'website_routing', None)  # not modular, but not overridable
-    if (
-        path
-        # don't try to match route if we know that no rewrite has been loaded.
-        and request.env['ir.http']._rewrite_len(routing)
-        and (
-            len(path) > 1
-            and path.startswith('/')
-            and '/static/' not in path
-            and not path.startswith('/web/')
-        )
-    ):
-        url_from, _ = request.env['ir.http'].url_rewrite(path)
-        url_from = url_from if not qs else url_from + '?%s' % qs
-
-    return url_lang(url_from, lang_code=lang_code)
-
-
-def is_multilang_url(local_url, lang_url_codes=None):
-    ''' Check if the given URL content is supposed to be translated.
-        To be considered as translatable, the URL should either:
-        1. Match a POST (non-GET actually) controller that is `website=True` and
-           either `multilang` specified to True or if not specified, with `type='http'`.
-        2. If not matching 1., everything not under /static/ or /web/ will be translatable
-    '''
-    if not lang_url_codes:
-        lang_url_codes = [lg.url_code for lg in request.env['res.lang']._get_frontend().values()]
-    spath = local_url.split('/')
-    # if a language is already in the path, remove it
-    if spath[1] in lang_url_codes:
-        spath.pop(1)
-        local_url = '/'.join(spath)
-
-    url = local_url.partition('#')[0].split('?')
-    path = url[0]
-
-    # Consider /static/ and /web/ files as non-multilang
-    if '/static/' in path or path.startswith('/web/'):
-        return False
-
-    query_string = url[1] if len(url) > 1 else None
-
-    # Try to match an endpoint in werkzeug's routing table
-    try:
-        _, func = request.env['ir.http'].url_rewrite(path, query_args=query_string)
-
-        # /page/xxx has no endpoint/func but is multilang
-        return (not func or (
-            func.routing.get('website', False)
-            and func.routing.get('multilang', func.routing['type'] == 'http')
-        ))
-    except Exception as exception:
-        _logger.warning(exception)
-        return False
 
 
 class ModelConverter(ir_http.ModelConverter):
@@ -304,20 +54,12 @@ class ModelConverter(ir_http.ModelConverter):
         self.domain = domain
         self.regex = _UNSLUG_ROUTE_PATTERN
 
-    def to_url(self, value):
-        return slug(value)
-
-    def to_python(self, value):
-        matching = _UNSLUG_RE.match(value)
-        _uid = RequestUID(value=value, match=matching, converter=self)
-        record_id = int(matching.group(2))
-        env = api.Environment(request.cr, _uid, request.context)
-
-        if record_id < 0:
+    def to_python(self, value) -> models.BaseModel:
+        record = super().to_python(value)
+        if record.id < 0 and not record.browse(record.id).exists():
             # limited support for negative IDs due to our slug pattern, assume abs() if not found
-            if not env[self.model].browse(record_id).exists():
-                record_id = abs(record_id)
-        return env[self.model].with_context(_converter_value=value).browse(record_id)
+            record = record.browse(abs(record.id))
+        return record.with_context(_converter_value=value)
 
 
 class IrHttp(models.AbstractModel):
@@ -325,8 +67,85 @@ class IrHttp(models.AbstractModel):
 
     rerouting_limit = 10
 
+    # ------------------------------------------------------------
+    # Slug tools
+    # ------------------------------------------------------------
+
     @classmethod
-    def _get_converters(cls):
+    def _slugify_one(cls, value: str, max_length: int = 0) -> str:
+        """ Transform a string to a slug that can be used in a url path.
+            This method will first try to do the job with python-slugify if present.
+            Otherwise it will process string by stripping leading and ending spaces,
+            converting unicode chars to ascii, lowering all chars and replacing spaces
+            and underscore with hyphen "-".
+            :param s: str
+            :param max_length: int
+            :rtype: str
+        """
+        value = ustr(value)
+        if slugify_lib:
+            # There are 2 different libraries only python-slugify is supported
+            try:
+                return slugify_lib.slugify(value, max_length=max_length)
+            except TypeError:
+                pass
+        uni = unicodedata.normalize('NFKD', value).encode('ascii', 'ignore').decode('ascii')
+        slug_str = re.sub(r'[\W_]+', '-', uni).strip('-').lower()
+        return slug_str[:max_length] if max_length > 0 else slug_str
+
+    @classmethod
+    def _slugify(cls, value: str, max_length: int = 0, path: bool = False) -> str:
+        if not path:
+            return cls._slugify_one(value, max_length=max_length)
+        else:
+            res = []
+            for u in value.split('/'):
+                s = cls._slugify_one(u, max_length=max_length)
+                if s:
+                    res.append(s)
+            # check if supported extension
+            path_no_ext, ext = os.path.splitext(value)
+            if ext in EXTENSION_TO_WEB_MIMETYPES:
+                res[-1] = cls._slugify_one(path_no_ext) + ext
+            return '/'.join(res)
+
+    @classmethod
+    def _slug(cls, value: models.BaseModel | tuple[int, str]) -> str:
+        try:
+            identifier, name = value.id, value.display_name
+        except AttributeError:
+            # assume name_search result tuple
+            identifier, name = value
+        if not identifier:
+            raise ValueError("Cannot slug non-existent record %s" % value)
+        slugname = cls._slugify(name or '')
+        if not slugname:
+            return str(identifier)
+        return f"{slugname}-{identifier}"
+
+    @classmethod
+    def _unslug(cls, value: str) -> tuple[str | None, int] | tuple[None, None]:
+        """ Extract slug and id from a string.
+            Always return a 2-tuple (str|None, int|None)
+        """
+        m = _UNSLUG_RE.match(value)
+        if not m:
+            return None, None
+        return m.group(1), int(m.group(2))
+
+    @classmethod
+    def _unslug_url(cls, value: str) -> str:
+        """ From /blog/my-super-blog-1" to "blog/1" """
+        parts = value.split('/')
+        if parts:
+            unslug_val = cls._unslug(parts[-1])
+            if unslug_val[1]:
+                parts[-1] = str(unslug_val[1])
+                return '/'.join(parts)
+        return value
+
+    @classmethod
+    def _get_converters(cls) -> dict[str, type]:
         """ Get the converters list for custom url pattern werkzeug need to
             match Rule. This override adds the website ones.
         """
@@ -334,6 +153,164 @@ class IrHttp(models.AbstractModel):
             super(IrHttp, cls)._get_converters(),
             model=ModelConverter,
         )
+
+    # ------------------------------------------------------------
+    # Language tools
+    # ------------------------------------------------------------
+
+    @classmethod
+    def _url_localized(cls,
+            url: str | None = None,
+            lang_code: str | None = None,
+            canonical_domain: str | tuple[str, str, str, str, str] | None = None,
+            prefetch_langs: bool = False, force_default_lang: bool = False) -> str:
+        """ Returns the given URL adapted for the given lang, meaning that:
+        1. It will have the lang suffixed to it
+        2. The model converter parts will be translated
+
+        If it is not possible to rebuild a path, use the current one instead.
+        `url_quote_plus` is applied on the returned path.
+
+        It will also force the canonical domain is requested.
+        Eg:
+        - `_get_url_localized(lang_fr, '/shop/my-phone-14')` will return
+            `/fr/shop/mon-telephone-14`
+        - `_get_url_localized(lang_fr, '/shop/my-phone-14', True)` will return
+            `<base_url>/fr/shop/mon-telephone-14`
+        """
+        if not lang_code:
+            lang = request.lang
+        else:
+            lang = request.env['res.lang']._get_data(code=lang_code)
+
+        if not url:
+            qs = keep_query()
+            url = request.httprequest.path + ('?%s' % qs if qs else '')
+
+        # '/shop/furn-0269-chaise-de-bureau-noire-17?' to
+        # '/shop/furn-0269-chaise-de-bureau-noire-17', otherwise -> 404
+        url, sep, qs = url.partition('?')
+
+        try:
+            # Re-match the controller where the request path routes.
+            rule, args = request.env['ir.http']._match(url)
+            for key, val in list(args.items()):
+                if isinstance(val, models.BaseModel):
+                    if isinstance(val._uid, RequestUID):
+                        args[key] = val = val.with_user(request.uid)
+                    if val.env.context.get('lang') != lang.code:
+                        args[key] = val = val.with_context(lang=lang.code)
+                    if prefetch_langs:
+                        args[key] = val = val.with_context(prefetch_langs=True)
+            router = http.root.get_db_router(request.db).bind('')
+            path = router.build(rule.endpoint, args)
+        except (NotFound, AccessError, MissingError):
+            # The build method returns a quoted URL so convert in this case for consistency.
+            path = werkzeug.urls.url_quote_plus(url, safe='/')
+        if force_default_lang or lang != request.env['ir.http']._get_default_lang():
+            path = f'/{lang.url_code}{path if path != "/" else ""}'
+
+        if canonical_domain:
+            # canonical URLs should not have qs
+            return werkzeug.urls.url_join(canonical_domain, path)
+
+        return path + sep + qs
+
+    @classmethod
+    def _url_lang(cls, path_or_uri: str, lang_code: str | None = None) -> str:
+        ''' Given a relative URL, make it absolute and add the required lang or
+            remove useless lang.
+            Nothing will be done for absolute or invalid URL.
+            If there is only one language installed, the lang will not be handled
+            unless forced with `lang` parameter.
+
+            :param lang_code: Must be the lang `code`. It could also be something
+                              else, such as `'[lang]'` (used for url_return).
+        '''
+        Lang = request.env['res.lang']
+        location = pycompat.to_text(path_or_uri).strip()
+        force_lang = lang_code is not None
+        try:
+            url = werkzeug.urls.url_parse(location)
+        except ValueError:
+            # e.g. Invalid IPv6 URL, `werkzeug.urls.url_parse('http://]')`
+            url = False
+        # relative URL with either a path or a force_lang
+        if url and not url.netloc and not url.scheme and (url.path or force_lang):
+            location = werkzeug.urls.url_join(request.httprequest.path, location)
+            lang_url_codes = [info.url_code for info in Lang._get_frontend().values()]
+            lang_code = pycompat.to_text(lang_code or request.context['lang'])
+            lang_url_code = Lang._get_data(code=lang_code).url_code
+            lang_url_code = lang_url_code if lang_url_code in lang_url_codes else lang_code
+            if (len(lang_url_codes) > 1 or force_lang) and cls._is_multilang_url(location, lang_url_codes):
+                loc, sep, qs = location.partition('?')
+                ps = loc.split('/')
+                default_lg = request.env['ir.http']._get_default_lang()
+                if ps[1] in lang_url_codes:
+                    # Replace the language only if we explicitly provide a language to url_for
+                    if force_lang:
+                        ps[1] = lang_url_code
+                    # Remove the default language unless it's explicitly provided
+                    elif ps[1] == default_lg.url_code:
+                        ps.pop(1)
+                # Insert the context language or the provided language
+                elif lang_url_code != default_lg.url_code or force_lang:
+                    ps.insert(1, lang_url_code)
+                    # Remove the last empty string to avoid trailing / after joining
+                    if not ps[-1]:
+                        ps.pop(-1)
+
+                location = '/'.join(ps) + sep + qs
+        return location
+
+    @classmethod
+    def _url_for(cls, url_from: str, lang_code: str | None = None) -> str:
+        ''' Return the url with the rewriting applied.
+            Nothing will be done for absolute URL, invalid URL, or short URL from 1 char.
+
+            :param url_from: The URL to convert.
+            :param lang_code: Must be the lang `code`. It could also be something
+                              else, such as `'[lang]'` (used for url_return).
+        '''
+        return cls._url_lang(url_from, lang_code=lang_code)
+
+    @classmethod
+    def _is_multilang_url(cls, local_url: str, lang_url_codes: list[str] | None = None) -> bool:
+        ''' Check if the given URL content is supposed to be translated.
+            To be considered as translatable, the URL should either:
+            1. Match a POST (non-GET actually) controller that is `website=True` and
+            either `multilang` specified to True or if not specified, with `type='http'`.
+            2. If not matching 1., everything not under /static/ or /web/ will be translatable
+        '''
+        if not lang_url_codes:
+            lang_url_codes = [lg.url_code for lg in request.env['res.lang']._get_frontend().values()]
+        spath = local_url.split('/')
+        # if a language is already in the path, remove it
+        if spath[1] in lang_url_codes:
+            spath.pop(1)
+            local_url = '/'.join(spath)
+
+        url = local_url.partition('#')[0].split('?')
+        path = url[0]
+
+        # Consider /static/ and /web/ files as non-multilang
+        if '/static/' in path or path.startswith('/web/'):
+            return False
+
+        query_string = url[1] if len(url) > 1 else None
+
+        # Try to match an endpoint in werkzeug's routing table
+        try:
+            _, func = request.env['ir.http'].url_rewrite(path, query_args=query_string)
+
+            # /page/xxx has no endpoint/func but is multilang
+            return (not func or (
+                func.routing.get('website', False)
+                and func.routing.get('multilang', func.routing['type'] == 'http')
+            ))
+        except Exception as exception:  # noqa: BLE001
+            _logger.warning(exception)
+            return False
 
     @classmethod
     def _get_default_lang(cls) -> LangData:
@@ -343,7 +320,7 @@ class IrHttp(models.AbstractModel):
         return next(iter(request.env['res.lang']._get_active_by('code').values()))
 
     @api.model
-    def get_frontend_session_info(self):
+    def get_frontend_session_info(self) -> dict:
         session_info = super(IrHttp, self).get_frontend_session_info()
 
         IrHttpModel = request.env['ir.http'].sudo()
@@ -361,7 +338,7 @@ class IrHttp(models.AbstractModel):
         return session_info
 
     @api.model
-    def get_translation_frontend_modules(self):
+    def get_translation_frontend_modules(self) -> list[str]:
         Modules = request.env['ir.module.module'].sudo()
         extra_modules_domain = self._get_translation_frontend_modules_domain()
         extra_modules_name = self._get_translation_frontend_modules_name()
@@ -373,21 +350,21 @@ class IrHttp(models.AbstractModel):
         return extra_modules_name
 
     @classmethod
-    def _get_translation_frontend_modules_domain(cls):
+    def _get_translation_frontend_modules_domain(cls) -> list[tuple[str, str, typing.Any]]:
         """ Return a domain to list the domain adding web-translations and
             dynamic resources that may be used frontend views
         """
         return []
 
     @classmethod
-    def _get_translation_frontend_modules_name(cls):
+    def _get_translation_frontend_modules_name(cls) -> list[str]:
         """ Return a list of module name where web-translations and
             dynamic resources may be used in frontend views
         """
         return ['web']
 
     @api.model
-    def get_nearest_lang(self, lang_code):
+    def get_nearest_lang(self, lang_code: str) -> str:
         """ Try to find a similar lang. Eg: fr_BE and fr_FR
             :param lang_code: the lang `code` (en_US)
         """
@@ -400,6 +377,10 @@ class IrHttp(models.AbstractModel):
 
         short = lang_code.partition('_')[0]
         return next((code for code in frontend_langs if code.startswith(short)), None)
+
+    # ------------------------------------------------------------
+    # Routing and diplatch
+    # ------------------------------------------------------------
 
     @classmethod
     def _match(cls, path):
@@ -602,6 +583,10 @@ class IrHttp(models.AbstractModel):
         if request.httprequest.cookies.get('frontend_lang') != request.lang.code:
             request.future_response.set_cookie('frontend_lang', request.lang.code)
 
+    # ------------------------------------------------------------
+    # Exception
+    # ------------------------------------------------------------
+
     @classmethod
     def _get_exception_code_values(cls, exception):
         """ Return a tuple with the error code following by the values matching the exception"""
@@ -685,6 +670,10 @@ class IrHttp(models.AbstractModel):
         cls._post_dispatch(response)
         return response
 
+    # ------------------------------------------------------------
+    # Rewrite
+    # ------------------------------------------------------------
+
     @api.model
     @tools.ormcache('path', 'query_args', cache='routing.rewrites')
     def url_rewrite(self, path, query_args=None):
@@ -702,6 +691,3 @@ class IrHttp(models.AbstractModel):
         except werkzeug.exceptions.NotFound:
             new_url = path
         return new_url or path, endpoint and endpoint[0]
-
-    def _rewrite_len(self, website_id):
-        return 0

--- a/addons/http_routing/models/ir_qweb.py
+++ b/addons/http_routing/models/ir_qweb.py
@@ -3,7 +3,6 @@
 import logging
 from odoo import models
 from odoo.http import request
-from odoo.addons.http_routing.models.ir_http import slug, unslug_url, url_for, url_localized
 
 _logger = logging.getLogger(__name__)
 BAD_REQUEST = """Missing request.is_frontend attribute.
@@ -36,8 +35,8 @@ class IrQweb(models.AbstractModel):
 
     def _prepare_environment(self, values):
         irQweb = super()._prepare_environment(values)
-        values['slug'] = slug
-        values['unslug_url'] = unslug_url
+        values['slug'] = self.env['ir.http']._slug
+        values['unslug_url'] = self.env['ir.http']._unslug_url
 
         if not irQweb.env.context.get('minimal_qcontext') and request:
             if not hasattr(request, 'is_frontend'):
@@ -48,6 +47,6 @@ class IrQweb(models.AbstractModel):
         return irQweb
 
     def _prepare_frontend_environment(self, values):
-        values['url_for'] = url_for
-        values['url_localized'] = url_localized
+        values['url_for'] = self.env['ir.http']._url_for
+        values['url_localized'] = self.env['ir.http']._url_localized
         return self

--- a/addons/mail/models/mail_render_mixin.py
+++ b/addons/mail/models/mail_render_mixin.py
@@ -13,7 +13,6 @@ from werkzeug import urls
 
 from odoo import _, api, fields, models, tools
 from odoo.addons.base.models.ir_qweb import QWebException
-from odoo.addons.http_routing.models.ir_http import slug
 from odoo.exceptions import UserError, AccessError
 from odoo.tools.mail import is_html_empty, prepend_html_content
 from odoo.tools.rendering_tools import convert_inline_template_to_qweb, parse_inline_template, render_inline_template, template_env_globals
@@ -268,7 +267,7 @@ class MailRenderMixin(models.AbstractModel):
             'format_amount': lambda amount, currency, lang_code=False: tools.format_amount(self.env, amount, currency, lang_code),
             'format_duration': lambda value: tools.format_duration(value),
             'is_html_empty': is_html_empty,
-            'slug': slug,
+            'slug': self.env['ir.http']._slug,
             'user': self.env.user,
         }
         render_context.update(copy.copy(template_env_globals))

--- a/addons/mail_group/controllers/portal.py
+++ b/addons/mail_group/controllers/portal.py
@@ -5,7 +5,6 @@ import babel.dates
 import werkzeug
 
 from odoo import http, fields, tools, models
-from odoo.addons.http_routing.models.ir_http import slug
 from odoo.addons.portal.controllers.portal import pager as portal_pager
 from odoo.exceptions import AccessError
 from odoo.http import request, Response
@@ -119,7 +118,7 @@ class PortalMailGroup(http.Controller):
             offset=(page - 1) * self._thread_per_page).sudo()
 
         pager = portal_pager(
-            url=f'/groups/{slug(group)}',
+            url=f'/groups/{request.env["ir.http"]._slug(group)}',
             total=GroupMessage.search_count(domain),
             page=page,
             step=self._thread_per_page,

--- a/addons/mail_group/models/mail_group.py
+++ b/addons/mail_group/models/mail_group.py
@@ -12,7 +12,6 @@ from markupsafe import Markup
 from werkzeug import urls
 
 from odoo import _, api, fields, models, tools
-from odoo.addons.http_routing.models.ir_http import slug
 from odoo.addons.mail.tools.alias_error import AliasError
 from odoo.exceptions import ValidationError, UserError
 from odoo.osv import expression
@@ -430,7 +429,7 @@ class MailGroup(models.Model):
 
                 headers = {
                     ** self._notify_by_email_get_headers(),
-                    'List-Archive': f'<{base_url}/groups/{slug(self)}>',
+                    'List-Archive': f'<{base_url}/groups/{self.env["ir.http"]._slug(self)}>',
                     'List-Subscribe': f'<{base_url}/groups?email={email_url_encoded}>',
                     'List-Unsubscribe': f'<{unsubscribe_url}>',
                     'List-Unsubscribe-Post': 'List-Unsubscribe=One-Click',
@@ -450,7 +449,7 @@ class MailGroup(models.Model):
                 # Add the footer (member specific) in the body
                 template_values = {
                     'mailto': f'{self.alias_email}',
-                    'group_url': f'{base_url}/groups/{slug(self)}',
+                    'group_url': f'{base_url}/groups/{self.env["ir.http"]._slug(self)}',
                     'unsub_label': f'{base_url}/groups?unsubscribe',
                     'unsub_url':  unsubscribe_url,
                 }

--- a/addons/portal/__init__.py
+++ b/addons/portal/__init__.py
@@ -4,10 +4,10 @@
 # Updating mako environement in order to be able to use slug
 try:
     from odoo.tools.rendering_tools import template_env_globals
-    from odoo.addons.http_routing.models.ir_http import slug
+    from odoo.http import request
 
     template_env_globals.update({
-        'slug': slug
+        'slug': lambda value: request.env['ir.http']._slug(value)  # noqa: PLW0108
     })
 except ImportError:
     pass

--- a/addons/test_website/tests/test_redirect.py
+++ b/addons/test_website/tests/test_redirect.py
@@ -3,7 +3,6 @@
 import odoo
 from odoo.tests import HttpCase, tagged
 from odoo.tools import mute_logger
-from odoo.addons.http_routing.models.ir_http import slug
 
 from unittest.mock import patch
 from urllib.parse import urlparse
@@ -38,7 +37,7 @@ class TestRedirect(HttpCase):
                 - Correct & working redirect as logged in user
                 - Correct replace of url_for() URLs in DOM
         """
-        url = '/test_website/country/' + slug(country_ad)
+        url = '/test_website/country/' + self.env['ir.http']._slug(country_ad)
         redirect_url = url.replace('test_website', 'redirected')
 
         # [Public User] Open the original url and check redirect OK
@@ -180,7 +179,7 @@ class TestRedirect(HttpCase):
             'name': '301 test record',
             'is_published': True,
         })
-        url_rec1 = '/test_website/200/' + slug(rec1)
+        url_rec1 = '/test_website/200/' + self.env['ir.http']._slug(rec1)
         r = self.url_open(url_rec1)
         self.assertEqual(r.status_code, 200)
 
@@ -202,7 +201,7 @@ class TestRedirect(HttpCase):
         # 4. Accessing unpublished record with redirect to another published
         # record: expecting redirect to that record
         rec2 = rec1.copy({'is_published': True})
-        url_rec2 = '/test_website/200/' + slug(rec2)
+        url_rec2 = '/test_website/200/' + self.env['ir.http']._slug(rec2)
         redirect.url_to = url_rec2
         r = self.url_open(url_rec1)
         self.assertEqual(r.status_code, 200)
@@ -243,7 +242,7 @@ class TestRedirect(HttpCase):
             'name': '301 test record',
             'is_published': True,
         })
-        url_rec1 = f"/test_countries_308/{slug(rec1)}"
+        url_rec1 = f"/test_countries_308/{self.env['ir.http']._slug(rec1)}"
 
         resp = self.url_open("/test_countries_308", allow_redirects=False)
         self.assertEqual(resp.status_code, 308)

--- a/addons/test_website/tests/test_website_controller_page.py
+++ b/addons/test_website/tests/test_website_controller_page.py
@@ -1,5 +1,4 @@
 from lxml import html
-from odoo.addons.http_routing.models.ir_http import slug
 
 from odoo.tools import mute_logger
 from odoo.exceptions import AccessError
@@ -115,6 +114,7 @@ class TestWebsiteControllerPage(HttpCase):
     def test_expose_model(self):
         self.authenticate(None, None)
 
+        slug = self.env['ir.http']._slug
         response = self.url_open(f"/model/{self.listing_controller_page.name_slugified}")
         tree = html.fromstring(response.content.decode())
         rec_nodes = tree.xpath("//a[@class='test_record_listing']")
@@ -143,6 +143,7 @@ class TestWebsiteControllerPage(HttpCase):
     def test_search_listing(self):
         self.authenticate(None, None)
 
+        slug = self.env['ir.http']._slug
         response = self.url_open(f"/model/{self.listing_controller_page.name_slugified}?search=1")
         tree = html.fromstring(response.content.decode())
         rec_nodes = tree.xpath("//a[@class='test_record_listing']")

--- a/addons/web_editor/tests/test_controller.py
+++ b/addons/web_editor/tests/test_controller.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import binascii
 import json
 
@@ -10,8 +9,6 @@ from PIL import Image
 from odoo.tests.common import HttpCase, new_test_user, tagged
 from odoo.tools.json import scriptsafe as json_safe
 from odoo.tools.misc import file_open
-
-from odoo.addons.http_routing.models.ir_http import slug
 
 
 @tagged('-at_install', 'post_install')
@@ -81,6 +78,7 @@ class TestController(HttpCase):
             'res_id': 0,
         })
         # Shape illustration with slug.
+        slug = self.env['ir.http']._slug
         url = '/web_editor/shape/illustration/%s' % slug(attachment)
         palette = 'c1=%233AADAA&c2=%237C6576&&c3=%23F6F6F6&&c4=%23FFFFFF&&c5=%23383E45'
         attachment['url'] = '%s?%s' % (url, palette)

--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -25,7 +25,7 @@ from odoo.http import request, SessionExpiredException
 from odoo.osv import expression
 from odoo.tools import OrderedSet, escape_psql, html_escape as escape
 from odoo.addons.base.models.ir_qweb import QWebException
-from odoo.addons.http_routing.models.ir_http import slug, slugify, _guess_mimetype
+from odoo.addons.http_routing.models.ir_http import EXTENSION_TO_WEB_MIMETYPES
 from odoo.addons.portal.controllers.portal import pager as portal_pager
 from odoo.addons.portal.controllers.web import Home
 from odoo.addons.web.controllers.binary import Binary
@@ -50,6 +50,7 @@ class QueryURL:
         path = ''
         for key, value in self.args.items():
             kw.setdefault(key, value)
+        slug = request.env['ir.http']._slug
         path_args = OrderedSet(path_args or []) | self.path_args
         paths, fragments = {}, []
         for key, value in kw.items():
@@ -634,7 +635,7 @@ class Website(Home):
     def pagenew(self, path="", add_menu=False, template=False, redirect=False, **kwargs):
         # for supported mimetype, get correct default template
         _, ext = os.path.splitext(path)
-        ext_special_case = ext and ext in _guess_mimetype() and ext != '.html'
+        ext_special_case = ext != '.html' and ext in EXTENSION_TO_WEB_MIMETYPES
 
         if not template and ext_special_case:
             default_templ = 'website.default_%s' % ext.lstrip('.')
@@ -777,8 +778,8 @@ class Website(Home):
         res['has_social_default_image'] = request.website.has_social_default_image
 
         if res_model not in ('website.page', 'ir.ui.view') and 'seo_name' in record:  # allow custom slugify
-            res['seo_name_default'] = slugify(record.display_name)  # default slug, if seo_name become empty
-            res['seo_name'] = record.seo_name and slugify(record.seo_name) or ''
+            res['seo_name_default'] = request.env['ir.http']._slugify(record.display_name)  # default slug, if seo_name become empty
+            res['seo_name'] = record.seo_name and request.env['ir.http']._slugify(record.seo_name) or ''
 
         return res
 

--- a/addons/website/controllers/model_page.py
+++ b/addons/website/controllers/model_page.py
@@ -2,7 +2,6 @@ import ast
 
 import werkzeug
 
-from odoo.addons.http_routing.models.ir_http import slug, unslug
 from odoo.http import Controller, request, route
 from odoo.osv.expression import AND, OR
 
@@ -49,12 +48,12 @@ class ModelPageController(Controller):
         domains = [rec_domain]
 
         if record_slug:
-            _, res_id = unslug(record_slug)
+            _, res_id = request.env['ir.http']._unslug(record_slug)
             record = Model.browse(res_id).filtered_domain(AND(domains))
             # We check for slug matching because we are not entirely sure
             # that we end up seeing record for the right model
             # i.e. in case of a redirect when a "single" page doesn't match the listing
-            if not record.exists() or record_slug != slug(record):
+            if not record.exists() or record_slug != request.env['ir.http']._slug(record):
                 raise werkzeug.exceptions.NotFound()
 
             listing = request.env["website.controller.page"].search(AND([
@@ -97,7 +96,7 @@ class ModelPageController(Controller):
         def record_to_url(record):
             if not single_record_page:
                 return None
-            return "/model/%s/%s" % (single_record_page.name_slugified, slug(record))
+            return "/model/%s/%s" % (single_record_page.name_slugified, request.env['ir.http']._slug(record))
 
         if searches["search"]:
             # _name_search doesn't take offset, we reimplement the logic that builds the name domain here

--- a/addons/website/models/ir_qweb.py
+++ b/addons/website/models/ir_qweb.py
@@ -10,7 +10,6 @@ from odoo import models
 from odoo.http import request
 from odoo.tools import lazy
 from odoo.addons.base.models.assetsbundle import AssetsBundle
-from odoo.addons.http_routing.models.ir_http import url_for
 from odoo.osv import expression
 from odoo.addons.website.models import ir_http
 from odoo.exceptions import AccessError
@@ -175,9 +174,9 @@ class IrQWeb(models.AbstractModel):
         name = self.URL_ATTRS.get(tagName)
         if request:
             if name and name in atts:
-                atts[name] = url_for(atts[name])
+                atts[name] = self.env['ir.http']._url_for(atts[name])
             # Adapt background-image URL in the same way as image src.
-            atts = self._adapt_style_background_image(atts, url_for)
+            atts = self._adapt_style_background_image(atts, self.env['ir.http']._url_for)
 
         if not website.cdn_activated:
             return atts

--- a/addons/website/models/mixins.py
+++ b/addons/website/models/mixins.py
@@ -7,7 +7,6 @@ import re
 from werkzeug.urls import url_join
 
 from odoo import api, fields, models, _
-from odoo.addons.http_routing.models.ir_http import url_for
 from odoo.addons.website.tools import text_from_html
 from odoo.http import request
 from odoo.osv import expression
@@ -56,7 +55,7 @@ class SeoMetadata(models.AbstractModel):
             'og:type': 'website',
             'og:title': title,
             'og:site_name': request.website.name,
-            'og:url': url_join(request.website.domain or request.httprequest.url_root, url_for(request.httprequest.path)),
+            'og:url': url_join(request.website.domain or request.httprequest.url_root, self.env['ir.http']._url_for(request.httprequest.path)),
             'og:image': request.website.image_url(request.website, img_field),
         }
         # Default meta for Twitter
@@ -91,8 +90,8 @@ class SeoMetadata(models.AbstractModel):
         if self.website_meta_description:
             opengraph_meta['og:description'] = self.website_meta_description
             twitter_meta['twitter:description'] = self.website_meta_description
-        opengraph_meta['og:image'] = url_join(root_url, url_for(self.website_meta_og_img or opengraph_meta['og:image']))
-        twitter_meta['twitter:image'] = url_join(root_url, url_for(self.website_meta_og_img or twitter_meta['twitter:image']))
+        opengraph_meta['og:image'] = url_join(root_url, self.env['ir.http']._url_for(self.website_meta_og_img or opengraph_meta['og:image']))
+        twitter_meta['twitter:image'] = url_join(root_url, self.env['ir.http']._url_for(self.website_meta_og_img or twitter_meta['twitter:image']))
         return {
             'opengraph_meta': opengraph_meta,
             'twitter_meta': twitter_meta,

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -16,7 +16,6 @@ from werkzeug import urls
 from werkzeug.exceptions import NotFound
 
 from odoo import api, fields, models, tools, release, registry
-from odoo.addons.http_routing.models.ir_http import slugify, url_for, url_localized
 from odoo.addons.website.models.ir_http import sitemap_qs2dom
 from odoo.addons.website.tools import similarity_score, text_from_html, get_base_domain
 from odoo.addons.portal.controllers.portal import pager
@@ -924,9 +923,9 @@ class Website(models.Model):
             template_module = namespace
         else:
             template_module, _ = template.split('.')
-        page_url = '/' + slugify(name, max_length=1024, path=True)
+        page_url = '/' + self.env['ir.http']._slugify(name, max_length=1024, path=True)
         page_url = self.get_unique_path(page_url)
-        page_key = slugify(name)
+        page_key = self.env['ir.http']._slugify(name)
         result = {'url': page_url}
 
         if not name:
@@ -1439,7 +1438,7 @@ class Website(models.Model):
         return pages
 
     def search_pages(self, needle=None, limit=None):
-        name = slugify(needle, max_length=50, path=True)
+        name = self.env['ir.http']._slugify(needle, max_length=50, path=True)
         res = []
         for page in self._enumerate_pages(query_string=name, force=True):
             res.append(page)
@@ -1453,8 +1452,8 @@ class Website(models.Model):
             Where icon can be a module name, or a path
         """
         suggested_controllers = [
-            (_('Homepage'), url_for('/'), 'website'),
-            (_('Contact Us'), url_for('/contactus'), 'website_crm'),
+            (_('Homepage'), self.env['ir.http']._url_for('/'), 'website'),
+            (_('Contact Us'), self.env['ir.http']._url_for('/contactus'), 'website_crm'),
         ]
         return suggested_controllers
 
@@ -1509,7 +1508,7 @@ class Website(models.Model):
         if mode_edit:
             # If the user gets on a translated page (e.g /fr) the editor will
             # never start. Forcing the default language fixes this issue.
-            path = url_for(path, self.default_lang_id.url_code)
+            path = self.env['ir.http']._url_for(path, self.default_lang_id.url_code)
         return self.get_client_action(path, mode_edit)
 
     def _is_canonical_url(self):
@@ -1519,7 +1518,7 @@ class Website(models.Model):
         # the language in the path. It is important to also test the domain of
         # the current URL.
         current_url = request.httprequest.url_root[:-1] + request.httprequest.environ['REQUEST_URI']
-        canonical_url = url_localized(lang_code=request.lang.code, canonical_domain=self.get_base_url())
+        canonical_url = self.env['ir.http']._url_localized(lang_code=request.lang.code, canonical_domain=self.get_base_url())
         # A request path with quotable characters (such as ",") is never
         # canonical because request.httprequest.base_url is always unquoted,
         # and canonical url is always quoted, so it is never possible to tell

--- a/addons/website/models/website_controller_page.py
+++ b/addons/website/models/website_controller_page.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from odoo.addons.http_routing.models.ir_http import slugify
 from odoo import api, fields, models
 
 
@@ -46,7 +45,7 @@ class WebsiteControllerPage(models.Model):
         for rec in self:
             if not rec.model_id or not rec.page_type:
                 continue
-            rec.name_slugified = slugify(rec.page_name or '')
+            rec.name_slugified = self.env['ir.http']._slugify(rec.page_name or '')
 
     def unlink(self):
         # When a website_controller_page is deleted, the ORM does not delete its

--- a/addons/website/models/website_menu.py
+++ b/addons/website/models/website_menu.py
@@ -7,7 +7,6 @@ import werkzeug.urls
 from werkzeug.urls import url_parse
 
 from odoo import api, fields, models, _
-from odoo.addons.http_routing.models.ir_http import unslug_url
 from odoo.exceptions import UserError
 from odoo.fields import Command
 from odoo.http import request
@@ -210,6 +209,7 @@ class Menu(models.Model):
                 return False
 
             menu_url = url_parse(menu_url)
+            unslug_url = self.env['ir.http']._unslug_url
             if unslug_url(menu_url.path) == unslug_url(request_url.path):
                 if not (
                     set(menu_url.decode_query().items(multi=True))

--- a/addons/website/models/website_page.py
+++ b/addons/website/models/website_page.py
@@ -3,7 +3,6 @@
 
 import re
 
-from odoo.addons.http_routing.models.ir_http import slugify
 from odoo.addons.website.tools import text_from_html
 from odoo import api, fields, models
 from odoo.osv import expression
@@ -132,7 +131,7 @@ class Page(models.Model):
         page = self.browse(int(page_id))
         copy_param = dict(name=page_name or page.name, website_id=self.env['website'].get_current_website().id)
         if page_name:
-            url = '/' + slugify(page_name, max_length=1024, path=True)
+            url = '/' + self.env['ir.http']._slugify(page_name, max_length=1024, path=True)
             copy_param['url'] = self.env['website'].get_unique_path(url)
 
         new_page = page.copy(copy_param)
@@ -176,7 +175,7 @@ class Page(models.Model):
                     redirect_old_url = url.get('redirect_old_url')
                     redirect_type = url.get('redirect_type')
                     url = url.get('url')
-                url = '/' + slugify(url, max_length=1024, path=True)
+                url = '/' + self.env['ir.http']._slugify(url, max_length=1024, path=True)
                 if page.url != url:
                     url = self.env['website'].with_context(website_id=website_id).get_unique_path(url)
                     page.menu_ids.write({'url': url})
@@ -198,7 +197,7 @@ class Page(models.Model):
 
             # If name has changed, check for key uniqueness
             if 'name' in vals and page.name != vals['name']:
-                vals['key'] = self.env['website'].with_context(website_id=website_id).get_unique_key(slugify(vals['name']))
+                vals['key'] = self.env['website'].with_context(website_id=website_id).get_unique_key(self.env['ir.http']._slugify(vals['name']))
             if 'visibility' in vals:
                 if vals['visibility'] != 'restricted_group':
                     vals['groups_id'] = False

--- a/addons/website/tests/test_converter.py
+++ b/addons/website/tests/test_converter.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+import threading
 
-from odoo.addons.http_routing.models.ir_http import slugify, unslug
 from odoo.tests.common import BaseCase
+from odoo.modules.registry import Registry
 
 
-class TestUnslug(BaseCase):
+class TestSlugUnslug(BaseCase):
 
     def test_unslug(self):
         tests = {
@@ -29,8 +30,24 @@ class TestUnslug(BaseCase):
             'foo-1#anchor': ('foo', 1),
         }
 
+        unslug = Registry(threading.current_thread().dbname)['ir.http']._unslug
+
         for slug, expected in tests.items():
             self.assertEqual(unslug(slug), expected, "%r case failed" % slug)
+
+    def test_slug(self):
+        tests = {
+            'foo-1': (1, 'foo'),
+            'foo-bar-1': (1, 'foo-bar'),
+            'foo--1': (-1, 'foo'),
+            '1-2': (2, '1'),
+        }
+
+        slug = Registry(threading.current_thread().dbname)['ir.http']._slug
+
+        for expected, value in tests.items():
+            self.assertEqual(slug(value), expected, "%r case failed" % (value,))
+
 
 class TestTitleToSlug(BaseCase):
     """
@@ -38,50 +55,54 @@ class TestTitleToSlug(BaseCase):
     See website/models/website.py slugify method
     """
 
+    def _slugify(self, value):
+        _slugify = Registry(threading.current_thread().dbname)['ir.http']._slugify
+        return _slugify(value)
+
     def test_spaces(self):
         self.assertEqual(
             "spaces",
-            slugify(u"   spaces   ")
+            self._slugify("   spaces   ")
         )
 
     def test_unicode(self):
         self.assertEqual(
             "heterogeneite",
-            slugify(u"hétérogénéité")
+            self._slugify("hétérogénéité")
         )
 
     def test_underscore(self):
         self.assertEqual(
             "one-two",
-            slugify(u"one_two")
+            self._slugify("one_two")
         )
 
     def test_caps(self):
         self.assertEqual(
             "camelcase",
-            slugify(u"CamelCase")
+            self._slugify("CamelCase")
         )
 
     def test_special_chars(self):
         self.assertEqual(
             "o-d-o-o",
-            slugify(r"o!#d{|\o/@~o&%^?")
+            self._slugify(r"o!#d{|\o/@~o&%^?")
         )
 
     def test_str_to_unicode(self):
         self.assertEqual(
             "espana",
-            slugify("España")
+            self._slugify("España")
         )
 
     def test_numbers(self):
         self.assertEqual(
             "article-1",
-            slugify(u"Article 1")
+            self._slugify("Article 1")
         )
 
     def test_all(self):
         self.assertEqual(
             "do-you-know-martine-a-la-plage",
-            slugify(u"Do YOU know 'Martine à la plage' ?")
+            self._slugify("Do YOU know 'Martine à la plage' ?")
         )

--- a/addons/website/tests/test_lang_url.py
+++ b/addons/website/tests/test_lang_url.py
@@ -5,7 +5,6 @@ import json
 import lxml.html
 from urllib.parse import urlparse
 
-from odoo.addons.http_routing.models.ir_http import url_for
 from odoo.addons.website.tools import MockRequest
 from odoo.tests import HttpCase, tagged
 
@@ -24,7 +23,7 @@ class TestLangUrl(HttpCase):
 
     def test_01_url_lang(self):
         with MockRequest(self.env, website=self.website):
-            self.assertEqual(url_for('', '[lang]'), '/[lang]/mockrequest', "`[lang]` is used to be replaced in the url_return after installing a language, it should not be replaced or removed.")
+            self.assertEqual(self.env['ir.http']._url_for('', '[lang]'), '/[lang]/mockrequest', "`[lang]` is used to be replaced in the url_return after installing a language, it should not be replaced or removed.")
 
     def test_02_url_redirect(self):
         url = '/fr_WHATEVER/contactus'

--- a/addons/website_blog/controllers/main.py
+++ b/addons/website_blog/controllers/main.py
@@ -8,7 +8,6 @@ import babel.dates
 from collections import defaultdict
 
 from odoo import http, fields, tools, models
-from odoo.addons.http_routing.models.ir_http import slug, unslug
 from odoo.addons.website.controllers.main import QueryURL
 from odoo.http import request
 from odoo.tools import html2plaintext
@@ -27,7 +26,7 @@ class WebsiteBlog(http.Controller):
         else:
             tag_ids.append(current_tag)
         tag_ids = request.env['blog.tag'].browse(tag_ids)
-        return ','.join(slug(tag) for tag in tag_ids)
+        return ','.join(request.env['ir.http']._slug(tag) for tag in tag_ids)
 
     def nav_list(self, blog=None):
         dom = blog and [('blog_id', '=', blog.id)] or []
@@ -79,11 +78,11 @@ class WebsiteBlog(http.Controller):
 
         if date_begin and date_end:
             domain += [("post_date", ">=", date_begin), ("post_date", "<=", date_end)]
-        active_tag_ids = tags and [unslug(tag)[1] for tag in tags.split(',')] or []
+        active_tag_ids = tags and [request.env['ir.http']._unslug(tag)[1] for tag in tags.split(',')] or []
         active_tags = BlogTag
         if active_tag_ids:
             active_tags = BlogTag.browse(active_tag_ids).exists()
-            fixed_tag_slug = ",".join(slug(t) for t in active_tags)
+            fixed_tag_slug = ",".join(request.env['ir.http']._slug(t) for t in active_tags)
             if fixed_tag_slug != tags:
                 path = request.httprequest.full_path
                 new_url = path.replace("/tag/%s" % tags, fixed_tag_slug and "/tag/%s" % fixed_tag_slug or "", 1)
@@ -185,7 +184,7 @@ class WebsiteBlog(http.Controller):
         blogs = tools.lazy(lambda: Blog.search(request.website.website_domain(), order="create_date asc, id asc"))
 
         if not blog and len(blogs) == 1:
-            url = QueryURL('/blog/%s' % slug(blogs[0]), search=search, **opt)()
+            url = QueryURL('/blog/%s' % request.env['ir.http']._slug(blogs[0]), search=search, **opt)()
             return request.redirect(url, code=302)
 
         date_begin, date_end = opt.get('date_begin'), opt.get('date_end')
@@ -224,7 +223,7 @@ class WebsiteBlog(http.Controller):
     ], type='http', auth="public", website=True, sitemap=False)
     def old_blog_post(self, blog, blog_post, **post):
         # Compatibility pre-v14
-        return request.redirect("/blog/%s/%s" % (slug(blog), slug(blog_post)), code=301)
+        return request.redirect("/blog/%s/%s" % (request.env['ir.http']._slug(blog), request.env['ir.http']._slug(blog_post)), code=301)
 
     @http.route([
         '''/blog/<model("blog.blog"):blog>/<model("blog.post", "[('blog_id','=',blog.id)]"):blog_post>''',
@@ -255,7 +254,7 @@ class WebsiteBlog(http.Controller):
         blog_url = QueryURL('', ['blog', 'tag'], blog=blog_post.blog_id, tag=tag, date_begin=date_begin, date_end=date_end)
 
         if not blog_post.blog_id.id == blog.id:
-            return request.redirect("/blog/%s/%s" % (slug(blog_post.blog_id), slug(blog_post)), code=301)
+            return request.redirect("/blog/%s/%s" % (request.env['ir.http']._slug(blog_post.blog_id), request.env['ir.http']._slug(blog_post)), code=301)
 
         tags = request.env['blog.tag'].search([])
 
@@ -267,7 +266,7 @@ class WebsiteBlog(http.Controller):
         all_post = BlogPost.search(blog_post_domain)
 
         if blog_post not in all_post:
-            return request.redirect("/blog/%s" % (slug(blog_post.blog_id)))
+            return request.redirect("/blog/%s" % (request.env['ir.http']._slug(blog_post.blog_id)))
 
         # should always return at least the current post
         all_post_ids = all_post.ids

--- a/addons/website_blog/models/website.py
+++ b/addons/website_blog/models/website.py
@@ -2,7 +2,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import models, _
-from odoo.addons.http_routing.models.ir_http import url_for
 
 
 class Website(models.Model):
@@ -10,7 +9,7 @@ class Website(models.Model):
 
     def get_suggested_controllers(self):
         suggested_controllers = super(Website, self).get_suggested_controllers()
-        suggested_controllers.append((_('Blog'), url_for('/blog'), 'website_blog'))
+        suggested_controllers.append((_('Blog'), self.env['ir.http']._url_for('/blog'), 'website_blog'))
         return suggested_controllers
 
     def configurator_set_menu_links(self, menu_company, module_data):

--- a/addons/website_blog/models/website_blog.py
+++ b/addons/website_blog/models/website_blog.py
@@ -5,7 +5,6 @@ from datetime import datetime
 import random
 
 from odoo import api, models, fields, _
-from odoo.addons.http_routing.models.ir_http import slug, unslug
 from odoo.addons.website.tools import text_from_html
 from odoo.tools.json import scriptsafe as json_scriptsafe
 from odoo.tools.translate import html_translate
@@ -161,7 +160,7 @@ class BlogPost(models.Model):
     def _compute_website_url(self):
         super(BlogPost, self)._compute_website_url()
         for blog_post in self:
-            blog_post.website_url = "/blog/%s/%s" % (slug(blog_post.blog_id), slug(blog_post))
+            blog_post.website_url = "/blog/%s/%s" % (self.env['ir.http']._slug(blog_post.blog_id), self.env['ir.http']._slug(blog_post))
 
     def _default_content(self):
         return '''
@@ -329,9 +328,9 @@ class BlogPost(models.Model):
         state = options.get('state')
         domain = [website.website_domain()]
         if blog:
-            domain.append([('blog_id', '=', unslug(blog)[1])])
+            domain.append([('blog_id', '=', self.env['ir.http']._unslug(blog)[1])])
         if tags:
-            active_tag_ids = [unslug(tag)[1] for tag in tags.split(',')] or []
+            active_tag_ids = [self.env['ir.http']._unslug(tag)[1] for tag in tags.split(',')] or []
             if active_tag_ids:
                 domain.append([('tag_ids', 'in', active_tag_ids)])
         if date_begin and date_end:

--- a/addons/website_crm_partner_assign/models/res_partner_grade.py
+++ b/addons/website_crm_partner_assign/models/res_partner_grade.py
@@ -2,7 +2,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import fields, models
-from odoo.addons.http_routing.models.ir_http import slug
 
 
 class ResPartnerGrade(models.Model):
@@ -20,7 +19,7 @@ class ResPartnerGrade(models.Model):
     def _compute_website_url(self):
         super(ResPartnerGrade, self)._compute_website_url()
         for grade in self:
-            grade.website_url = "/partners/grade/%s" % (slug(grade))
+            grade.website_url = "/partners/grade/%s" % (self.env['ir.http']._slug(grade))
 
     def _default_is_published(self):
         return True

--- a/addons/website_crm_partner_assign/models/website.py
+++ b/addons/website_crm_partner_assign/models/website.py
@@ -2,7 +2,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import models, _
-from odoo.addons.http_routing.models.ir_http import url_for
 
 
 class Website(models.Model):
@@ -10,5 +9,5 @@ class Website(models.Model):
 
     def get_suggested_controllers(self):
         suggested_controllers = super(Website, self).get_suggested_controllers()
-        suggested_controllers.append((_('Resellers'), url_for('/partners'), 'website_crm_partner_assign'))
+        suggested_controllers.append((_('Resellers'), self.env['ir.http']._url_for('/partners'), 'website_crm_partner_assign'))
         return suggested_controllers

--- a/addons/website_customer/models/website.py
+++ b/addons/website_customer/models/website.py
@@ -2,7 +2,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import models, _
-from odoo.addons.http_routing.models.ir_http import url_for
 
 
 class Website(models.Model):
@@ -10,5 +9,5 @@ class Website(models.Model):
 
     def get_suggested_controllers(self):
         suggested_controllers = super(Website, self).get_suggested_controllers()
-        suggested_controllers.append((_('References'), url_for('/customers'), 'website_customer'))
+        suggested_controllers.append((_('References'), self.env['ir.http']._url_for('/customers'), 'website_customer'))
         return suggested_controllers

--- a/addons/website_event/models/event_event.py
+++ b/addons/website_event/models/event_event.py
@@ -9,7 +9,6 @@ import werkzeug.urls
 from pytz import utc, timezone
 
 from odoo import api, fields, models, _
-from odoo.addons.http_routing.models.ir_http import slug
 from odoo.exceptions import UserError, ValidationError
 from odoo.osv import expression
 from odoo.tools.misc import get_lang, format_date
@@ -233,7 +232,7 @@ class Event(models.Model):
         super(Event, self)._compute_website_url()
         for event in self:
             if event.id:  # avoid to perform a slug on a not yet saved record in case of an onchange.
-                event.website_url = '/event/%s' % slug(event)
+                event.website_url = '/event/%s' % self.env['ir.http']._slug(event)
 
     # -------------------------------------------------------------------------
     # CONSTRAINT METHODS
@@ -345,8 +344,8 @@ class Event(models.Model):
         return [
             (_('Introduction'), False, 'website_event.template_intro', 1, 'introduction'),
             (_('Location'), False, 'website_event.template_location', 50, 'location'),
-            (_('Info'), '/event/%s/register' % slug(self), False, 100, 'register'),
-            (_('Community'), '/event/%s/community' % slug(self), False, 80, 'community'),
+            (_('Info'), '/event/%s/register' % self.env['ir.http']._slug(self), False, 100, 'register'),
+            (_('Community'), '/event/%s/community' % self.env['ir.http']._slug(self), False, 80, 'community'),
         ]
 
     def _update_website_menus(self, menus_update_by_field=None):
@@ -422,7 +421,7 @@ class Event(models.Model):
                 add_menu=False, ispage=False)
             view_id = page_result['view_id']
             view = self.env["ir.ui.view"].browse(view_id)
-            url = f"/event/{slug(self)}/page/{view.key.split('.')[-1]}"  # url contains starting "/"
+            url = f"/event/{self.env['ir.http']._slug(self)}/page/{view.key.split('.')[-1]}"  # url contains starting "/"
 
         website_menu = self.env['website.menu'].sudo().create({
             'name': name,

--- a/addons/website_event/models/website.py
+++ b/addons/website_event/models/website.py
@@ -2,14 +2,13 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import models, _
-from odoo.addons.http_routing.models.ir_http import url_for
 
 class Website(models.Model):
     _inherit = "website"
 
     def get_suggested_controllers(self):
         suggested_controllers = super(Website, self).get_suggested_controllers()
-        suggested_controllers.append((_('Events'), url_for('/event'), 'website_event'))
+        suggested_controllers.append((_('Events'), self.env['ir.http']._url_for('/event'), 'website_event'))
         return suggested_controllers
 
     def get_cta_data(self, website_purpose, website_type):

--- a/addons/website_event_booth/models/event_event.py
+++ b/addons/website_event_booth/models/event_event.py
@@ -2,7 +2,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models, _
-from odoo.addons.http_routing.models.ir_http import slug
 
 
 class Event(models.Model):
@@ -51,5 +50,5 @@ class Event(models.Model):
     def _get_website_menu_entries(self):
         self.ensure_one()
         return super(Event, self)._get_website_menu_entries() + [
-            (_('Get A Booth'), '/event/%s/booth' % slug(self), False, 90, 'booth')
+            (_('Get A Booth'), '/event/%s/booth' % self.env['ir.http']._slug(self), False, 90, 'booth')
         ]

--- a/addons/website_event_exhibitor/models/event_event.py
+++ b/addons/website_event_exhibitor/models/event_event.py
@@ -2,7 +2,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models, _
-from odoo.addons.http_routing.models.ir_http import slug
 
 
 class EventEvent(models.Model):
@@ -59,5 +58,5 @@ class EventEvent(models.Model):
     def _get_website_menu_entries(self):
         self.ensure_one()
         return super(EventEvent, self)._get_website_menu_entries() + [
-            (_('Exhibitors'), '/event/%s/exhibitors' % slug(self), False, 60, 'exhibitor')
+            (_('Exhibitors'), '/event/%s/exhibitors' % self.env['ir.http']._slug(self), False, 60, 'exhibitor')
         ]

--- a/addons/website_event_exhibitor/models/event_sponsor.py
+++ b/addons/website_event_exhibitor/models/event_sponsor.py
@@ -5,7 +5,6 @@ from datetime import datetime, timedelta
 from pytz import timezone, utc
 
 from odoo import api, fields, models, _
-from odoo.addons.http_routing.models.ir_http import slug
 from odoo.addons.resource.models.utils import float_to_time
 from odoo.tools import is_html_empty
 from odoo.tools.translate import html_translate
@@ -192,7 +191,7 @@ class Sponsor(models.Model):
         for sponsor in self:
             if sponsor.id:  # avoid to perform a slug on a not yet saved record in case of an onchange.
                 base_url = sponsor.event_id.get_base_url()
-                sponsor.website_url = '%s/event/%s/exhibitor/%s' % (base_url, slug(sponsor.event_id), slug(sponsor))
+                sponsor.website_url = '%s/event/%s/exhibitor/%s' % (base_url, self.env["ir.http"]._slug(sponsor.event_id), self.env["ir.http"]._slug(sponsor))
 
     # ------------------------------------------------------------
     # CRUD
@@ -228,7 +227,7 @@ class Sponsor(models.Model):
         """ Overridden to use a relative URL instead of an absolute when website_id is False. """
         if self.event_id.website_id:
             return super().open_website_url()
-        return self.env['website'].get_client_action(f'/event/{slug(self.event_id)}/exhibitor/{slug(self)}')
+        return self.env['website'].get_client_action(f'/event/{self.env["ir.http"]._slug(self.event_id)}/exhibitor/{self.env["ir.http"]._slug(self)}')
 
     # ------------------------------------------------------------
     # MESSAGING

--- a/addons/website_event_meet/controllers/community.py
+++ b/addons/website_event_meet/controllers/community.py
@@ -6,7 +6,6 @@ from werkzeug.exceptions import Forbidden, NotFound
 
 from odoo import exceptions, http
 from odoo.http import request
-from odoo.addons.http_routing.models.ir_http import slug
 from odoo.addons.website_event.controllers.community import EventCommunityController
 from odoo.osv import expression
 
@@ -101,7 +100,7 @@ class WebsiteEventMeetController(EventCommunityController):
         })
         _logger.info("New meeting room (%s) created by %s (uid %s)" % (name, request.httprequest.remote_addr, request.env.uid))
 
-        return request.redirect(f"/event/{slug(event)}/meeting_room/{slug(meeting_room)}")
+        return request.redirect(f"/event/{request.env['ir.http']._slug(event)}/meeting_room/{request.env['ir.http']._slug(meeting_room)}")
 
     @http.route(["/event/active_langs"], type="json", auth="public")
     def active_langs(self):

--- a/addons/website_event_meet/models/event_meeting_room.py
+++ b/addons/website_event_meet/models/event_meeting_room.py
@@ -4,7 +4,6 @@
 import datetime
 
 from odoo import api, fields, models
-from odoo.addons.http_routing.models.ir_http import slug
 
 
 class EventMeetingRoom(models.Model):
@@ -34,7 +33,7 @@ class EventMeetingRoom(models.Model):
         for meeting_room in self:
             if meeting_room.id:
                 base_url = meeting_room.event_id.get_base_url()
-                meeting_room.website_url = '%s/event/%s/meeting_room/%s' % (base_url, slug(meeting_room.event_id), slug(meeting_room))
+                meeting_room.website_url = '%s/event/%s/meeting_room/%s' % (base_url, self.env["ir.http"]._slug(meeting_room.event_id), self.env["ir.http"]._slug(meeting_room))
 
     @api.model_create_multi
     def create(self, values_list):
@@ -57,4 +56,4 @@ class EventMeetingRoom(models.Model):
         """ Overridden to use a relative URL instead of an absolute when website_id is False. """
         if self.event_id.website_id:
             return super().open_website_url()
-        return self.env['website'].get_client_action(f'/event/{slug(self.event_id)}/meeting_room/{slug(self)}')
+        return self.env['website'].get_client_action(f'/event/{self.env["ir.http"]._slug(self.event_id)}/meeting_room/{self.env["ir.http"]._slug(self)}')

--- a/addons/website_event_track/controllers/event_track.py
+++ b/addons/website_event_track/controllers/event_track.py
@@ -15,7 +15,6 @@ import operator
 import pytz
 
 from odoo import exceptions, http, fields, tools, _
-from odoo.addons.http_routing.models.ir_http import slug
 from odoo.http import request
 from odoo.osv import expression
 from odoo.tools import is_html_empty, plaintext2html
@@ -76,6 +75,7 @@ class EventTrackController(http.Controller):
             # We replaced those with POST to avoid that, but it's not sufficient as bots "remember" crawled pages for a while
             # This permanent redirect is placed to instruct the bots that this page is no longer valid
             # TODO: remove in a few stable versions (v19?), including the "prevent_redirect" param in templates
+            slug = request.env['ir.http']._slug
             return request.redirect(f'/event/{slug(event)}/track', code=301)
 
         return request.render(

--- a/addons/website_event_track/controllers/webmanifest.py
+++ b/addons/website_event_track/controllers/webmanifest.py
@@ -5,7 +5,6 @@ import json
 import pytz
 
 from odoo import http
-from odoo.addons.http_routing.models.ir_http import url_for
 from odoo.http import request
 from odoo.tools import ustr
 from odoo.tools.misc import file_open
@@ -25,8 +24,8 @@ class TrackManifest(http.Controller):
             'name': website.events_app_name,
             'short_name': website.events_app_name,
             'description': _('%s Online Events Application') % website.company_id.name,
-            'scope': url_for('/event'),
-            'start_url': url_for('/event'),
+            'scope': request.env['ir.http']._url_for('/event'),
+            'start_url': request.env['ir.http']._url_for('/event'),
             'display': 'standalone',
             'background_color': '#ffffff',
             'theme_color': '#875A7B',
@@ -56,7 +55,7 @@ class TrackManifest(http.Controller):
         body = body.replace('__ODOO_CDN_URL__', js_cdn_url)
         response = request.make_response(body, [
             ('Content-Type', 'text/javascript'),
-            ('Service-Worker-Allowed', url_for('/event')),
+            ('Service-Worker-Allowed', request.env['ir.http']._url_for('/event')),
         ])
         return response
 

--- a/addons/website_event_track/models/event_event.py
+++ b/addons/website_event_track/models/event_event.py
@@ -2,7 +2,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models, _
-from odoo.addons.http_routing.models.ir_http import slug
 
 
 class Event(models.Model):
@@ -85,7 +84,7 @@ class Event(models.Model):
     def _get_website_menu_entries(self):
         self.ensure_one()
         return super(Event, self)._get_website_menu_entries() + [
-            (_('Talks'), '/event/%s/track' % slug(self), False, 10, 'track'),
-            (_('Agenda'), '/event/%s/agenda' % slug(self), False, 70, 'track'),
-            (_('Talk Proposals'), '/event/%s/track_proposal' % slug(self), False, 15, 'track_proposal')
+            (_('Talks'), '/event/%s/track' % self.env['ir.http']._slug(self), False, 10, 'track'),
+            (_('Agenda'), '/event/%s/agenda' % self.env['ir.http']._slug(self), False, 70, 'track'),
+            (_('Talk Proposals'), '/event/%s/track_proposal' % self.env['ir.http']._slug(self), False, 15, 'track_proposal')
         ]

--- a/addons/website_event_track/models/event_track.py
+++ b/addons/website_event_track/models/event_track.py
@@ -6,7 +6,6 @@ from pytz import utc
 from random import randint
 
 from odoo import api, fields, models, tools
-from odoo.addons.http_routing.models.ir_http import slug
 from odoo.osv import expression
 from odoo.tools.mail import is_html_empty
 from odoo.tools.translate import _, html_translate
@@ -156,7 +155,7 @@ class Track(models.Model):
         super(Track, self)._compute_website_url()
         for track in self:
             if track.id:
-                track.website_url = '/event/%s/track/%s' % (slug(track.event_id), slug(track))
+                track.website_url = '/event/%s/track/%s' % (self.env['ir.http']._slug(track.event_id), self.env['ir.http']._slug(track))
 
     # STAGES
 

--- a/addons/website_event_track_quiz/controllers/community.py
+++ b/addons/website_event_track_quiz/controllers/community.py
@@ -4,7 +4,6 @@
 import math
 
 from odoo import http
-from odoo.addons.http_routing.models.ir_http import slug
 from odoo.addons.website_event.controllers.community import EventCommunityController
 from odoo.http import request
 
@@ -39,7 +38,7 @@ class WebsiteEventTrackQuizCommunityController(EventCommunityController):
         user_count = len(values['visitors'])
         if user_count:
             page_count = math.ceil(user_count / self._visitors_per_page)
-            url = '/event/%s/community/leaderboard/results' % (slug(event))
+            url = '/event/%s/community/leaderboard/results' % (request.env['ir.http']._slug(event))
             if values.get('current_visitor_position') and not page:
                 values['scroll_to_position'] = True
                 page = math.ceil(values['current_visitor_position'] / self._visitors_per_page)

--- a/addons/website_forum/controllers/website_forum.py
+++ b/addons/website_forum/controllers/website_forum.py
@@ -10,7 +10,6 @@ import werkzeug.urls
 import werkzeug.wrappers
 
 from odoo import _, http, tools
-from odoo.addons.http_routing.models.ir_http import slug
 from odoo.addons.website.models.ir_http import sitemap_qs2dom
 from odoo.addons.website_profile.controllers.main import WebsiteProfile
 from odoo.exceptions import AccessError, UserError
@@ -72,6 +71,7 @@ class WebsiteForum(WebsiteProfile):
         domain = request.website.website_domain()
         forums = request.env['forum.forum'].search(domain)
         if len(forums) == 1:
+            slug = request.env['ir.http']._slug
             return request.redirect('/forum/%s' % slug(forums[0]), code=302)
 
         return request.render("website_forum.forum_all", {
@@ -82,6 +82,7 @@ class WebsiteForum(WebsiteProfile):
         Forum = env['forum.forum']
         dom = sitemap_qs2dom(qs, '/forum', Forum._rec_name)
         dom += env['website'].get_current_website().website_domain()
+        slug = env['ir.http']._slug
         for f in Forum.search(dom):
             loc = '/forum/%s' % slug(f)
             if not qs or qs.lower() in loc:
@@ -140,6 +141,8 @@ class WebsiteForum(WebsiteProfile):
             **post
         )
 
+        slug = request.env['ir.http']._slug
+
         if tag and request.httprequest.method == 'GET' and not post.get('prevent_redirect'):
             # Previously, the tags were searched using GET, which caused issues with crawlers (too many hits)
             # We replaced those with POST to avoid that, but it's not sufficient as bots "remember" crawled pages for a while
@@ -154,8 +157,10 @@ class WebsiteForum(WebsiteProfile):
 
         if not forum:
             url = '/forum/all'
+        elif tag:
+            url = f'/forum/{slug(forum)}/tag/{slug(tag)}/questions'
         else:
-            url = f"/forum/{slug(forum)}{f'/tag/{slug(tag)}/questions' if tag else ''}"
+            url = f'/forum/{slug(forum)}'
 
         url_args = {'sorting': sorting}
 
@@ -235,6 +240,7 @@ class WebsiteForum(WebsiteProfile):
             # We replaced those with POST to avoid that, but it's not sufficient as bots "remember" crawled pages for a while
             # This permanent redirect is placed to instruct the bots that this page is no longer valid
             # TODO: remove in a few stable versions (v19?), including the "prevent_redirect" param in templates
+            slug = request.env['ir.http']._slug
             return request.redirect(f'/forum/{slug(forum)}/tag', code=301)
 
         domain = [('forum_id', '=', forum.id), ('posts_count', '=' if filters == "unused" else '>', 0)]
@@ -295,6 +301,7 @@ class WebsiteForum(WebsiteProfile):
                 type='http', auth="public", website=True, sitemap=False)
     def old_question(self, forum, question, **post):
         # Compatibility pre-v14
+        slug = request.env['ir.http']._slug
         return request.redirect("/forum/%s/%s" % (slug(forum), slug(question)), code=301)
 
     def sitemap_forum_post(env, rule, qs):
@@ -303,6 +310,7 @@ class WebsiteForum(WebsiteProfile):
             env['website'].get_current_website().website_domain(),
             [('parent_id', '=', False), ('can_view', '=', True)],
         ])
+        slug = env['ir.http']._slug
         for forum_post in ForumPost.search(dom):
             loc = '/forum/%s/%s' % (slug(forum_post.forum_id), slug(forum_post))
             if not qs or qs.lower() in loc:
@@ -338,6 +346,7 @@ class WebsiteForum(WebsiteProfile):
             raise werkzeug.exceptions.NotFound()
 
         if question.parent_id:
+            slug = request.env['ir.http']._slug
             redirect_url = "/forum/%s/%s" % (slug(forum), slug(question.parent_id))
             return request.redirect(redirect_url, 301)
         values = self._prepare_question_template_vals(forum, post, question)
@@ -379,26 +388,31 @@ class WebsiteForum(WebsiteProfile):
                 break
         else:
             raise werkzeug.exceptions.NotFound()
+        slug = request.env['ir.http']._slug
         return request.redirect(f'/forum/{slug(forum)}/post/{slug(answer)}/edit')
 
     @http.route('/forum/<model("forum.forum"):forum>/question/<model("forum.post"):question>/close', type='http', auth="user", methods=['POST'], website=True)
     def question_close(self, forum, question, **post):
         question.close(reason_id=int(post.get('reason_id', False)))
+        slug = request.env['ir.http']._slug
         return request.redirect("/forum/%s/%s" % (slug(forum), slug(question)))
 
     @http.route('/forum/<model("forum.forum"):forum>/question/<model("forum.post"):question>/reopen', type='http', auth="user", methods=['POST'], website=True)
     def question_reopen(self, forum, question, **kwarg):
         question.reopen()
+        slug = request.env['ir.http']._slug
         return request.redirect("/forum/%s/%s" % (slug(forum), slug(question)))
 
     @http.route('/forum/<model("forum.forum"):forum>/question/<model("forum.post"):question>/delete', type='http', auth="user", methods=['POST'], website=True)
     def question_delete(self, forum, question, **kwarg):
         question.active = False
+        slug = request.env['ir.http']._slug
         return request.redirect("/forum/%s" % slug(forum))
 
     @http.route('/forum/<model("forum.forum"):forum>/question/<model("forum.post"):question>/undelete', type='http', auth="user", methods=['POST'], website=True)
     def question_undelete(self, forum, question, **kwarg):
         question.active = True
+        slug = request.env['ir.http']._slug
         return request.redirect("/forum/%s/%s" % (slug(forum), slug(question)))
 
     # Post
@@ -407,6 +421,7 @@ class WebsiteForum(WebsiteProfile):
     def forum_post(self, forum, **post):
         user = request.env.user
         if not user.email or not tools.single_email_re.match(user.email):
+            slug = request.env['ir.http']._slug
             return request.redirect("/forum/%s/user/%s/edit?email_required=1" % (slug(forum), request.session.uid))
         values = self._prepare_user_values(forum=forum, searches={}, new_question=True)
         return request.render("website_forum.new_question", values)
@@ -422,6 +437,7 @@ class WebsiteForum(WebsiteProfile):
             })
 
         post_tag_ids = forum._tag_to_write_vals(post.get('post_tags', ''))
+        slug = request.env['ir.http']._slug
         if forum.has_pending_post:
             return request.redirect("/forum/%s/ask" % slug(forum))
 
@@ -434,6 +450,7 @@ class WebsiteForum(WebsiteProfile):
         })
         if post_parent:
             post_parent._update_last_activity()
+        slug = request.env['ir.http']._slug
         return request.redirect(f'/forum/{slug(forum)}/{slug(post_parent) if post_parent else new_question.id}')
 
     @http.route('/forum/<model("forum.forum"):forum>/post/<model("forum.post"):post>/comment', type='http', auth="user", methods=['POST'], website=True)
@@ -447,6 +464,7 @@ class WebsiteForum(WebsiteProfile):
                 message_type='comment',
                 subtype_xmlid='mail.mt_comment')
             question._update_last_activity()
+        slug = request.env['ir.http']._slug
         return request.redirect(f'/forum/{slug(forum)}/{slug(question)}')
 
     @http.route('/forum/<model("forum.forum"):forum>/post/<model("forum.post"):post>/toggle_correct', type='json', auth="public", website=True)
@@ -467,6 +485,7 @@ class WebsiteForum(WebsiteProfile):
     def post_delete(self, forum, post, **kwargs):
         question = post.parent_id
         post.unlink()
+        slug = request.env['ir.http']._slug
         if question:
             request.redirect("/forum/%s/%s" % (slug(forum), slug(question)))
         return request.redirect("/forum/%s" % slug(forum))
@@ -503,6 +522,7 @@ class WebsiteForum(WebsiteProfile):
         vals['tag_ids'] = forum._tag_to_write_vals(kwargs.get('post_tags', ''))
         post.write(vals)
         question = post.parent_id if post.parent_id else post
+        slug = request.env['ir.http']._slug
         return request.redirect("/forum/%s/%s" % (slug(forum), slug(question)))
 
     #  JSON utilities
@@ -605,6 +625,7 @@ class WebsiteForum(WebsiteProfile):
 
     @http.route('/forum/<model("forum.forum"):forum>/post/<model("forum.post"):post>/validate', type='http', auth="user", website=True)
     def post_accept(self, forum, post, **kwargs):
+        slug = request.env['ir.http']._slug
         if post.state == 'flagged':
             url = f'/forum/{slug(forum)}/flagged_queue'
         elif post.state == 'offensive':
@@ -644,6 +665,7 @@ class WebsiteForum(WebsiteProfile):
     @http.route('/forum/<model("forum.forum"):forum>/post/<model("forum.post"):post>/mark_as_offensive', type='http', auth="user", methods=["POST"], website=True)
     def post_mark_as_offensive(self, forum, post, **kwargs):
         post._mark_as_offensive(reason_id=int(kwargs.get('reason_id', False)))
+        slug = request.env['ir.http']._slug
         if post.parent_id:
             url = f'/forum/{slug(forum)}/{post.parent_id.id}/#answer-{post.id}'
         else:
@@ -654,11 +676,12 @@ class WebsiteForum(WebsiteProfile):
     # --------------------------------------------------
     @http.route(['/forum/<model("forum.forum"):forum>/partner/<int:partner_id>'], type='http', auth="public", website=True)
     def open_partner(self, forum, partner_id=0, **post):
+        slug = request.env['ir.http']._slug
         if partner_id:
             partner = request.env['res.partner'].sudo().search([('id', '=', partner_id)])
             if partner and partner.user_ids:
                 return request.redirect(f'/forum/{slug(forum)}/user/{partner.user_ids[0].id}')
-        return request.redirect('/forum/' + slug(forum))
+        return request.redirect('/forum/' + request.env['ir.http']._slug(forum))
 
     # Profile
     # -----------------------------------
@@ -783,18 +806,20 @@ class WebsiteForum(WebsiteProfile):
     @http.route('/forum/<model("forum.forum"):forum>/post/<model("forum.post"):post>/comment/<model("mail.message"):comment>/convert_to_answer', type='http', auth="user", methods=['POST'], website=True)
     def convert_comment_to_answer(self, forum, post, comment, **kwarg):
         post = request.env['forum.post'].convert_comment_to_answer(comment.id)
+        slug = request.env['ir.http']._slug
         if not post:
             return request.redirect("/forum/%s" % slug(forum))
         question = post.parent_id if post.parent_id else post
-        return request.redirect("/forum/%s/%s" % (slug(forum), slug(question)))
+        return request.redirect("/forum/%s/%s" % (slug(forum), request.env['ir.http']._slug(question)))
 
     @http.route('/forum/<model("forum.forum"):forum>/post/<model("forum.post"):post>/convert_to_comment', type='http', auth="user", methods=['POST'], website=True)
     def convert_answer_to_comment(self, forum, post, **kwarg):
         question = post.parent_id
         new_msg = post.convert_answer_to_comment()
+        slug = request.env['ir.http']._slug
         if not new_msg:
             return request.redirect("/forum/%s" % slug(forum))
-        return request.redirect("/forum/%s/%s" % (slug(forum), slug(question)))
+        return request.redirect("/forum/%s/%s" % (slug(forum), request.env['ir.http']._slug(question)))
 
     @http.route('/forum/<model("forum.forum"):forum>/post/<model("forum.post"):post>/comment/<model("mail.message"):comment>/delete', type='json', auth="user", website=True)
     def delete_comment(self, forum, post, comment, **kwarg):

--- a/addons/website_forum/models/forum_forum.py
+++ b/addons/website_forum/models/forum_forum.py
@@ -8,7 +8,6 @@ from operator import itemgetter
 from markupsafe import Markup
 
 from odoo import _, api, fields, models
-from odoo.addons.http_routing.models.ir_http import slug
 from odoo.tools.translate import html_translate
 
 MOST_USED_TAGS_COUNT = 5  # Number of tags to track as "most used" to display on frontend
@@ -243,7 +242,7 @@ class Forum(models.Model):
     def _compute_website_url(self):
         if not self.id:
             return False
-        return f'/forum/{slug(self)}'
+        return f'/forum/{self.env["ir.http"]._slug(self)}'
 
     # ----------------------------------------------------------------------
     # CRUD

--- a/addons/website_forum/models/forum_post.py
+++ b/addons/website_forum/models/forum_post.py
@@ -7,7 +7,6 @@ import re
 from datetime import datetime
 
 from odoo import api, fields, models, tools, _
-from odoo.addons.http_routing.models.ir_http import slug, unslug
 from odoo.exceptions import UserError, ValidationError, AccessError
 from odoo.osv import expression
 from odoo.tools import sql, SQL
@@ -177,7 +176,7 @@ class Post(models.Model):
         self.website_url = False
         for post in self.filtered(lambda post: post.id):
             anchor = f'#answer_{post.id}' if post.parent_id else ''
-            post.website_url = f'/forum/{slug(post.forum_id)}/{slug(post)}{anchor}'
+            post.website_url = f'/forum/{self.env["ir.http"]._slug(post.forum_id)}/{self.env["ir.http"]._slug(post)}{anchor}'
 
     @api.depends('vote_count', 'forum_id.relevancy_post_vote', 'forum_id.relevancy_time_decay')
     def _compute_relevancy(self):
@@ -871,10 +870,10 @@ class Post(models.Model):
             domain = expression.AND([domain, [('parent_id', '=', False)]])
         forum = options.get('forum')
         if forum:
-            domain = expression.AND([domain, [('forum_id', '=', unslug(forum)[1])]])
+            domain = expression.AND([domain, [('forum_id', '=', self.env['ir.http']._unslug(forum)[1])]])
         tags = options.get('tag')
         if tags:
-            domain = expression.AND([domain, [('tag_ids', 'in', [unslug(tag)[1] for tag in tags.split(',')])]])
+            domain = expression.AND([domain, [('tag_ids', 'in', [self.env['ir.http']._unslug(tag)[1] for tag in tags.split(',')])]])
         filters = options.get('filters')
         if filters == 'unanswered':
             domain = expression.AND([domain, [('child_ids', '=', False)]])

--- a/addons/website_forum/models/forum_tag.py
+++ b/addons/website_forum/models/forum_tag.py
@@ -2,7 +2,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models, _
-from odoo.addons.http_routing.models.ir_http import slug, unslug
 from odoo.exceptions import AccessError
 
 
@@ -35,7 +34,7 @@ class Tags(models.Model):
     @api.depends("forum_id", "forum_id.name", "name")
     def _compute_website_url(self):
         for tag in self:
-            tag.website_url = f'/forum/{slug(tag.forum_id)}/tag/{slug(tag)}/questions'
+            tag.website_url = f'/forum/{self.env["ir.http"]._slug(tag.forum_id)}/tag/{self.env["ir.http"]._slug(tag)}/questions'
 
     @api.model_create_multi
     def create(self, vals_list):
@@ -59,7 +58,7 @@ class Tags(models.Model):
         }
         base_domain = []
         if forum := options.get("forum"):
-            forum_ids = (unslug(forum)[1],) if isinstance(forum, str) else forum.ids
+            forum_ids = (self.env['ir.http']._unslug(forum)[1],) if isinstance(forum, str) else forum.ids
             search_domain = options.get("domain")
             base_domain = [search_domain if search_domain is not None else [('forum_id', 'in', forum_ids)]]
         return {

--- a/addons/website_forum/models/website.py
+++ b/addons/website_forum/models/website.py
@@ -2,7 +2,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import models, fields, api, _
-from odoo.addons.http_routing.models.ir_http import url_for
 
 
 class Website(models.Model):
@@ -18,7 +17,7 @@ class Website(models.Model):
 
     def get_suggested_controllers(self):
         suggested_controllers = super(Website, self).get_suggested_controllers()
-        suggested_controllers.append((_('Forum'), url_for('/forum'), 'website_forum'))
+        suggested_controllers.append((_('Forum'), self.env['ir.http']._url_for('/forum'), 'website_forum'))
         return suggested_controllers
 
     def configurator_get_footer_links(self):

--- a/addons/website_forum/tests/test_sitemap.py
+++ b/addons/website_forum/tests/test_sitemap.py
@@ -3,7 +3,6 @@
 from freezegun import freeze_time
 from unittest.mock import patch
 
-from odoo.addons.http_routing.models.ir_http import slug
 from odoo.addons.website_forum.tests.common import TestForumCommon
 from odoo.tests import tagged
 
@@ -20,7 +19,7 @@ class TestWebsiteControllers(TestForumCommon):
             self.post.name = "RenameIt"  # update write_date
             self.post._update_last_activity()  # update last_activity_date
 
-        locs = website._enumerate_pages(query_string='/forum/%s' % slug(self.forum))
+        locs = website._enumerate_pages(query_string='/forum/%s' % self.env['ir.http']._slug(self.forum))
         self.assertEqual(next(iter(locs))['lastmod'].strftime("%Y-%m-%d"), datetime)
 
         # Edit post content the 2024-01-01
@@ -28,5 +27,5 @@ class TestWebsiteControllers(TestForumCommon):
         with freeze_time(datetime), patch.object(self.env.cr, 'now', lambda: datetime):
             self.post.content = "I am a bird"  # update write_date
 
-        locs = website._enumerate_pages(query_string='/forum/%s' % slug(self.forum))
+        locs = website._enumerate_pages(query_string='/forum/%s' % self.env['ir.http']._slug(self.forum))
         self.assertEqual(next(iter(locs))['lastmod'].strftime("%Y-%m-%d"), datetime)

--- a/addons/website_hr_recruitment/controllers/main.py
+++ b/addons/website_hr_recruitment/controllers/main.py
@@ -7,7 +7,6 @@ from operator import itemgetter
 from werkzeug.urls import url_encode
 
 from odoo import http, _
-from odoo.addons.http_routing.models.ir_http import slug
 from odoo.addons.website.controllers.form import WebsiteForm
 from odoo.osv.expression import AND
 from odoo.http import request
@@ -220,11 +219,11 @@ class WebsiteHrRecruitment(WebsiteForm):
         job = request.env['hr.job'].with_context(rendering_bundle=True).create({
             'name': _('Job Title'),
         })
-        return f"/jobs/{slug(job)}"
+        return f"/jobs/{request.env['ir.http']._slug(job)}"
 
     @http.route('''/jobs/detail/<model("hr.job"):job>''', type='http', auth="public", website=True, sitemap=True)
     def jobs_detail(self, job, **kwargs):
-        redirect_url = f"/jobs/{slug(job)}"
+        redirect_url = f"/jobs/{request.env['ir.http']._slug(job)}"
         return request.redirect(redirect_url, code=301)
 
     @http.route('''/jobs/<model("hr.job"):job>''', type='http', auth="public", website=True, sitemap=True)

--- a/addons/website_hr_recruitment/models/hr_job.py
+++ b/addons/website_hr_recruitment/models/hr_job.py
@@ -3,7 +3,6 @@
 from werkzeug.urls import url_join
 
 from odoo import fields, models, api
-from odoo.addons.http_routing.models.ir_http import slug
 from odoo.tools import mute_logger
 from odoo.tools.translate import html_translate
 
@@ -73,7 +72,7 @@ class Job(models.Model):
     def _compute_website_url(self):
         super(Job, self)._compute_website_url()
         for job in self:
-            job.website_url = f'/jobs/{slug(job)}'
+            job.website_url = f'/jobs/{self.env["ir.http"]._slug(job)}'
 
     def set_open(self):
         self.write({'website_published': False})

--- a/addons/website_hr_recruitment/models/website.py
+++ b/addons/website_hr_recruitment/models/website.py
@@ -2,7 +2,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import models, _
-from odoo.addons.http_routing.models.ir_http import url_for
 
 
 class Website(models.Model):
@@ -10,7 +9,7 @@ class Website(models.Model):
 
     def get_suggested_controllers(self):
         suggested_controllers = super(Website, self).get_suggested_controllers()
-        suggested_controllers.append((_('Jobs'), url_for('/jobs'), 'website_hr_recruitment'))
+        suggested_controllers.append((_('Jobs'), self.env['ir.http']._url_for('/jobs'), 'website_hr_recruitment'))
         return suggested_controllers
 
     def _search_get_details(self, search_type, order, options):

--- a/addons/website_livechat/models/im_livechat.py
+++ b/addons/website_livechat/models/im_livechat.py
@@ -2,7 +2,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, models, fields
-from odoo.addons.http_routing.models.ir_http import slug
 from odoo.tools.translate import html_translate
 
 
@@ -14,7 +13,7 @@ class ImLivechatChannel(models.Model):
     def _compute_website_url(self):
         super(ImLivechatChannel, self)._compute_website_url()
         for channel in self:
-            channel.website_url = "/livechat/channel/%s" % (slug(channel),)
+            channel.website_url = "/livechat/channel/%s" % (self.env['ir.http']._slug(channel),)
 
     website_description = fields.Html(
         "Website description", default=False, translate=html_translate,

--- a/addons/website_livechat/models/website.py
+++ b/addons/website_livechat/models/website.py
@@ -2,7 +2,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import fields, models, _, Command
-from odoo.addons.http_routing.models.ir_http import url_for
 from odoo.addons.mail.models.discuss.mail_guest import add_guest_to_context
 
 
@@ -71,5 +70,5 @@ class Website(models.Model):
 
     def get_suggested_controllers(self):
         suggested_controllers = super(Website, self).get_suggested_controllers()
-        suggested_controllers.append((_('Live Support'), url_for('/livechat'), 'website_livechat'))
+        suggested_controllers.append((_('Live Support'), self.env['ir.http']._url_for('/livechat'), 'website_livechat'))
         return suggested_controllers

--- a/addons/website_mail_group/models/mail_group.py
+++ b/addons/website_mail_group/models/mail_group.py
@@ -2,7 +2,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import models
-from odoo.addons.http_routing.models.ir_http import slug
 
 
 class MailGroup(models.Model):
@@ -14,5 +13,5 @@ class MailGroup(models.Model):
         return {
             'type': 'ir.actions.act_url',
             'target': 'self',
-            'url': '/groups/%s' % slug(self),
+            'url': '/groups/%s' % self.env['ir.http']._slug(self),
         }

--- a/addons/website_membership/controllers/main.py
+++ b/addons/website_membership/controllers/main.py
@@ -7,7 +7,6 @@ from odoo import fields
 
 from odoo import http
 from odoo.http import request
-from odoo.addons.http_routing.models.ir_http import unslug, slug
 from odoo.tools.translate import _
 
 
@@ -164,12 +163,12 @@ class WebsiteMembership(http.Controller):
     @http.route(['/members/<partner_id>'], type='http', auth="public", website=True)
     def partners_detail(self, partner_id, **post):
         current_slug = partner_id
-        _, partner_id = unslug(partner_id)
+        _, partner_id = request.env['ir.http']._unslug(partner_id)
         if partner_id:
             partner = request.env['res.partner'].sudo().browse(partner_id)
             if partner.exists() and partner.website_published:  # TODO should be done with access rules
-                if slug(partner) != current_slug:
-                    return request.redirect('/members/%s' % slug(partner))
+                if request.env['ir.http']._slug(partner) != current_slug:
+                    return request.redirect('/members/%s' % request.env['ir.http']._slug(partner))
                 values = {}
                 values['main_object'] = values['partner'] = partner
                 return request.render("website_membership.partner", values)

--- a/addons/website_membership/models/website.py
+++ b/addons/website_membership/models/website.py
@@ -2,7 +2,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import models, _
-from odoo.addons.http_routing.models.ir_http import url_for
 
 
 class Website(models.Model):
@@ -10,5 +9,5 @@ class Website(models.Model):
 
     def get_suggested_controllers(self):
         suggested_controllers = super(Website, self).get_suggested_controllers()
-        suggested_controllers.append((_('Members'), url_for('/members'), 'website_membership'))
+        suggested_controllers.append((_('Members'), self.env['ir.http']._url_for('/members'), 'website_membership'))
         return suggested_controllers

--- a/addons/website_partner/controllers/main.py
+++ b/addons/website_partner/controllers/main.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from odoo import http
-from odoo.addons.http_routing.models.ir_http import unslug, slug
 from odoo.http import request
 
 
@@ -11,13 +10,14 @@ class WebsitePartnerPage(http.Controller):
     @http.route(['/partners/<partner_id>'], type='http', auth="public", website=True)
     def partners_detail(self, partner_id, **post):
         current_slug = partner_id
-        _, partner_id = unslug(partner_id)
+        _, partner_id = request.env['ir.http']._unslug(partner_id)
         if partner_id:
             partner_sudo = request.env['res.partner'].sudo().browse(partner_id)
             is_website_restricted_editor = request.env.user.has_group('website.group_website_restricted_editor')
             if partner_sudo.exists() and (partner_sudo.website_published or is_website_restricted_editor):
-                if slug(partner_sudo) != current_slug:
-                    return request.redirect('/partners/%s' % slug(partner_sudo))
+                partner_slug = request.env['ir.http']._slug(partner_sudo)
+                if partner_slug != current_slug:
+                    return request.redirect('/partners/%s' % partner_slug)
                 values = {
                     'main_object': partner_sudo,
                     'partner': partner_sudo,

--- a/addons/website_partner/models/res_partner.py
+++ b/addons/website_partner/models/res_partner.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from odoo import api, fields, models
-from odoo.addons.http_routing.models.ir_http import slug
 from odoo.tools.translate import html_translate
 
 
@@ -15,4 +14,4 @@ class WebsiteResPartner(models.Model):
     def _compute_website_url(self):
         super(WebsiteResPartner, self)._compute_website_url()
         for partner in self:
-            partner.website_url = "/partners/%s" % slug(partner)
+            partner.website_url = "/partners/%s" % self.env['ir.http']._slug(partner)

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -16,7 +16,6 @@ from odoo.osv import expression
 from odoo.tools import clean_context, float_round, groupby, lazy, single_email_re, str2bool, SQL
 from odoo.tools.json import scriptsafe as json_scriptsafe
 
-from odoo.addons.http_routing.models.ir_http import slug
 from odoo.addons.payment import utils as payment_utils
 from odoo.addons.payment.controllers import portal as payment_portal
 from odoo.addons.portal.controllers.portal import _build_url_w_params
@@ -152,7 +151,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
         dom = sitemap_qs2dom(qs, '/shop/category', Category._rec_name)
         dom += env['website'].get_current_website().website_domain()
         for cat in Category.search(dom):
-            loc = '/shop/category/%s' % slug(cat)
+            loc = '/shop/category/%s' % env['ir.http']._slug(cat)
             if not qs or qs.lower() in loc:
                 yield {'loc': loc}
 
@@ -350,7 +349,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
         categs = lazy(lambda: Category.search(categs_domain))
 
         if category:
-            url = "/shop/category/%s" % slug(category)
+            url = "/shop/category/%s" % request.env['ir.http']._slug(category)
 
         pager = website.pager(url=url, total=product_count, page=page, step=ppg, scope=5, url_args=post)
         offset = pager['offset']
@@ -457,7 +456,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
     @route(['/shop/product/<model("product.template"):product>'], type='http', auth="public", website=True, sitemap=False)
     def old_product(self, product, category='', search='', **kwargs):
         # Compatibility pre-v14
-        return request.redirect(_build_url_w_params("/shop/%s" % slug(product), request.params), code=301)
+        return request.redirect(_build_url_w_params("/shop/%s" % request.env['ir.http']._slug(product), request.params), code=301)
 
     @route(['/shop/product/extra-images'], type='json', auth='user', website=True)
     def add_product_images(self, images, product_product_id, product_template_id, combination_ids=None):

--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -7,7 +7,6 @@ from odoo.osv import expression
 from odoo.tools import float_is_zero, is_html_empty
 from odoo.tools.translate import html_translate
 
-from odoo.addons.http_routing.models.ir_http import slug, unslug
 from odoo.addons.website.models import ir_http
 
 _logger = logging.getLogger(__name__)
@@ -174,7 +173,7 @@ class ProductTemplate(models.Model):
         super()._compute_website_url()
         for product in self:
             if product.id:
-                product.website_url = "/shop/%s" % slug(product)
+                product.website_url = "/shop/%s" % self.env['ir.http']._slug(product)
 
     #=== CRUD METHODS ===#
 
@@ -740,7 +739,7 @@ class ProductTemplate(models.Model):
         max_price = options.get('max_price')
         attrib_values = options.get('attrib_values')
         if category:
-            domains.append([('public_categ_ids', 'child_of', unslug(category)[1])])
+            domains.append([('public_categ_ids', 'child_of', self.env['ir.http']._unslug(category)[1])])
         if tags:
             if isinstance(tags, str):
                 tags = tags.split(',')
@@ -803,7 +802,7 @@ class ProductTemplate(models.Model):
             if with_category and categ_ids:
                 data['category'] = self.env['ir.ui.view'].sudo()._render_template(
                     "website_sale.product_category_extra_link",
-                    {'categories': categ_ids, 'slug': slug}
+                    {'categories': categ_ids, 'slug': self.env['ir.http']._slug}
                 )
         return results_data
 

--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -5,8 +5,6 @@ from odoo.exceptions import UserError
 from odoo.http import request
 from odoo.osv import expression
 
-from odoo.addons.http_routing.models.ir_http import url_for
-
 
 class Website(models.Model):
     _inherit = 'website'
@@ -526,7 +524,7 @@ class Website(models.Model):
 
     def get_suggested_controllers(self):
         suggested_controllers = super().get_suggested_controllers()
-        suggested_controllers.append((_('eCommerce'), url_for('/shop'), 'website_sale'))
+        suggested_controllers.append((_('eCommerce'), self.env['ir.http']._url_for('/shop'), 'website_sale'))
         return suggested_controllers
 
     def _search_get_details(self, search_type, order, options):

--- a/addons/website_slides/controllers/main.py
+++ b/addons/website_slides/controllers/main.py
@@ -11,7 +11,6 @@ import math
 import werkzeug
 
 from odoo import fields, http, tools, _
-from odoo.addons.http_routing.models.ir_http import slug, unslug
 from odoo.addons.website.controllers.main import QueryURL
 from odoo.addons.website.models.ir_http import sitemap_qs2dom
 from odoo.addons.website_profile.controllers.main import WebsiteProfile
@@ -43,7 +42,7 @@ class WebsiteSlides(WebsiteProfile):
         dom = sitemap_qs2dom(qs=qs, route='/slides/', field=Channel._rec_name)
         dom += env['website'].get_current_website().website_domain()
         for channel in Channel.search(dom):
-            loc = '/slides/%s' % slug(channel)
+            loc = '/slides/%s' % env['ir.http']._slug(channel)
             if not qs or qs.lower() in loc:
                 yield {'loc': loc}
 
@@ -288,7 +287,7 @@ class WebsiteSlides(WebsiteProfile):
             tag_ids.remove(toggle_tag_id)
         elif toggle_tag_id:
             tag_ids.append(toggle_tag_id)
-        return ','.join(slug(tag) for tag in request.env['slide.channel.tag'].browse(tag_ids))
+        return ','.join(request.env['ir.http']._slug(tag) for tag in request.env['slide.channel.tag'].browse(tag_ids))
 
     def _channel_search_tags_ids(self, search_tags):
         """ Input: %5B4%5D """
@@ -304,7 +303,7 @@ class WebsiteSlides(WebsiteProfile):
         """ Input: hotels-1,adventure-2 """
         ChannelTag = request.env['slide.channel.tag']
         try:
-            tag_ids = list(filter(None, [unslug(tag)[1] for tag in (search_tags or '').split(',')]))
+            tag_ids = list(filter(None, [request.env['ir.http']._unslug(tag)[1] for tag in (search_tags or '').split(',')]))
         except Exception:
             return ChannelTag
         # perform a search to filter on existing / valid tags implicitly
@@ -733,7 +732,7 @@ class WebsiteSlides(WebsiteProfile):
 
     @staticmethod
     def _redirect_to_channel(channel):
-        return request.redirect(f"/slides/{slug(channel)}")
+        return request.redirect(f"/slides/{request.env['ir.http']._slug(channel)}")
 
     def _slide_channel_prepare_review_values(self, channel):
         values = {
@@ -928,7 +927,7 @@ class WebsiteSlides(WebsiteProfile):
         tag = self._create_or_get_channel_tag(tag_id, group_id)
         tag.write({'channel_ids': [(4, channel.id, 0)]})
 
-        return {'url': "/slides/%s" % (slug(channel))}
+        return {'url': "/slides/%s" % (request.env['ir.http']._slug(channel))}
 
     @http.route(['/slides/channel/send_share_email'], type='json', auth='user', website=True)
     def slide_channel_send_share_email(self, channel_id, emails):
@@ -1061,7 +1060,7 @@ class WebsiteSlides(WebsiteProfile):
         next_slide = None
         if next_slide_id:
             next_slide = self._fetch_slide(next_slide_id).get('slide', None)
-        return request.redirect("/slides/slide/%s" % (slug(next_slide) if next_slide else slug(slide)))
+        return request.redirect("/slides/slide/%s" % (request.env['ir.http']._slug(next_slide) if next_slide else request.env['ir.http']._slug(slide)))
 
     @http.route('/slides/slide/set_completed', website=True, type="json", auth="public")
     def slide_set_completed(self, slide_id):
@@ -1081,7 +1080,7 @@ class WebsiteSlides(WebsiteProfile):
                 website=True, type='http', auth='user', handle_params_access_error=handle_wslide_error)
     def slide_set_uncompleted_and_redirect(self, slide):
         self._slide_mark_uncompleted(slide)
-        return request.redirect(f'/slides/slide/{slug(slide)}')
+        return request.redirect(f'/slides/slide/{request.env["ir.http"]._slug(slide)}')
 
     @http.route('/slides/slide/set_uncompleted', website=True, type='json', auth='public')
     def slide_set_uncompleted(self, slide_id):
@@ -1343,7 +1342,7 @@ class WebsiteSlides(WebsiteProfile):
 
         request.env['slide.slide'].create(self._get_new_slide_category_values(channel, name))
 
-        return request.redirect("/slides/%s" % (slug(channel)))
+        return request.redirect("/slides/%s" % (request.env['ir.http']._slug(channel)))
 
     # --------------------------------------------------
     # SLIDE.UPLOAD
@@ -1476,7 +1475,7 @@ class WebsiteSlides(WebsiteProfile):
         elif slide.slide_category == 'quiz':
             redirect_url += "?quiz_quick_create"
         elif channel.channel_type == "training":
-            redirect_url = "/slides/%s" % (slug(channel))
+            redirect_url = "/slides/%s" % (request.env['ir.http']._slug(channel))
         return {
             'url': redirect_url,
             'channel_type': channel.channel_type,

--- a/addons/website_slides/models/slide_channel.py
+++ b/addons/website_slides/models/slide_channel.py
@@ -10,7 +10,6 @@ from dateutil.relativedelta import relativedelta
 from markupsafe import Markup
 
 from odoo import api, fields, models, tools, _
-from odoo.addons.http_routing.models.ir_http import slug, unslug
 from odoo.exceptions import AccessError, UserError
 from odoo.osv import expression
 from odoo.tools import is_html_empty
@@ -661,7 +660,7 @@ class Channel(models.Model):
         for channel in self:
             if channel.id:  # avoid to perform a slug on a not yet saved record in case of an onchange.
                 base_url = channel.get_base_url()
-                channel.website_url = '%s/slides/%s' % (base_url, slug(channel))
+                channel.website_url = '%s/slides/%s' % (base_url, self.env['ir.http']._slug(channel))
 
     @api.depends('can_publish', 'is_member', 'karma_review', 'karma_slide_comment', 'karma_slide_vote')
     @api.depends_context('uid')
@@ -1163,7 +1162,7 @@ class Channel(models.Model):
                 continue
             category_data.append({
                 'category': category, 'id': category.id,
-                'name': category.name, 'slug_name': slug(category),
+                'name': category.name, 'slug_name': self.env['ir.http']._slug(category),
                 'total_slides': len(category_slides),
                 'slides': category_slides[(offset or 0):(limit + offset or len(category_slides))],
             })
@@ -1231,7 +1230,7 @@ class Channel(models.Model):
         if search_tags:
             ChannelTag = self.env['slide.channel.tag']
             try:
-                tag_ids = list(filter(None, [unslug(tag)[1] for tag in search_tags.split(',')]))
+                tag_ids = list(filter(None, [self.env['ir.http']._unslug(tag)[1] for tag in search_tags.split(',')]))
                 tags = ChannelTag.search([('id', 'in', tag_ids)]) if tag_ids else ChannelTag
             except Exception:
                 tags = ChannelTag
@@ -1273,4 +1272,4 @@ class Channel(models.Model):
         """ Overridden to use a relative URL instead of an absolute when website_id is False. """
         if self.website_id:
             return super().open_website_url()
-        return self.env['website'].get_client_action(f'/slides/{slug(self)}')
+        return self.env['website'].get_client_action(f'/slides/{self.env["ir.http"]._slug(self)}')

--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -14,7 +14,6 @@ from markupsafe import Markup
 from werkzeug import urls
 
 from odoo import api, fields, models, _
-from odoo.addons.http_routing.models.ir_http import slug, url_for
 from odoo.exceptions import RedirectWarning, UserError, AccessError
 from odoo.http import request
 from odoo.tools import html2plaintext, sql
@@ -490,8 +489,8 @@ class Slide(models.Model):
             elif slide.slide_category in ['infographic', 'document'] and slide.source_type == 'external' and slide.google_drive_id:
                 embed_code = Markup('<iframe src="//drive.google.com/file/d/%s/preview" allowFullScreen="true" frameborder="0" aria-label="%s"></iframe>') % (slide.google_drive_id, _('Google Drive'))
             elif slide.slide_category == 'document' and slide.source_type == 'local_file':
-                slide_url = base_url + url_for('/slides/embed/%s?page=1' % slide.id)
-                slide_url_external = base_url + url_for('/slides/embed_external/%s?page=1' % slide.id)
+                slide_url = base_url + self.env['ir.http']._url_for('/slides/embed/%s?page=1' % slide.id)
+                slide_url_external = base_url + self.env['ir.http']._url_for('/slides/embed_external/%s?page=1' % slide.id)
                 base_embed_code = Markup('<iframe src="%s" class="o_wslides_iframe_viewer" allowFullScreen="true" height="%s" width="%s" frameborder="0" aria-label="%s"></iframe>')
                 iframe_aria_label = _('Embed code')
                 embed_code = base_embed_code % (slide_url, 315, 420, iframe_aria_label)
@@ -596,7 +595,7 @@ class Slide(models.Model):
         for slide in self:
             if slide.id:  # avoid to perform a slug on a not yet saved record in case of an onchange.
                 base_url = slide.channel_id.get_base_url()
-                slide.website_url = '%s/slides/slide/%s' % (base_url, slug(slide))
+                slide.website_url = '%s/slides/slide/%s' % (base_url, self.env['ir.http']._slug(slide))
 
     @api.depends('is_published')
     def _compute_website_share_url(self):
@@ -1399,4 +1398,4 @@ class Slide(models.Model):
         """ Overridden to use a relative URL instead of an absolute when website_id is False. """
         if self.website_id:
             return super().open_website_url()
-        return self.env['website'].get_client_action(f'/slides/slide/{slug(self)}')
+        return self.env['website'].get_client_action(f'/slides/slide/{self.env["ir.http"]._slug(self)}')

--- a/addons/website_slides/models/website.py
+++ b/addons/website_slides/models/website.py
@@ -2,7 +2,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import fields, models, _
-from odoo.addons.http_routing.models.ir_http import url_for
 
 
 class Website(models.Model):
@@ -12,7 +11,7 @@ class Website(models.Model):
 
     def get_suggested_controllers(self):
         suggested_controllers = super(Website, self).get_suggested_controllers()
-        suggested_controllers.append((_('Courses'), url_for('/slides'), 'website_slides'))
+        suggested_controllers.append((_('Courses'), self.env['ir.http']._url_for('/slides'), 'website_slides'))
         return suggested_controllers
 
     def _search_get_details(self, search_type, order, options):

--- a/addons/website_slides/tests/test_attendee.py
+++ b/addons/website_slides/tests/test_attendee.py
@@ -4,7 +4,6 @@
 from odoo import fields
 from odoo.addons.mail.tests.common import mail_new_test_user
 from odoo.addons.base.tests.common import HttpCaseWithUserPortal
-from odoo.addons.http_routing.models.ir_http import slug
 from odoo.addons.website_slides.tests import common
 from odoo.tests import tagged, users
 
@@ -311,14 +310,14 @@ class TestAttendeeCase(HttpCaseWithUserPortal):
         self.authenticate("user_emp", "user_emp")
         res = self.url_open(invite_url_emp)
         self.assertEqual(res.status_code, 200)
-        self.assertTrue(f'slides/{slug(self.channel)}' in res.url, "Should redirect the logged attendee to the course page")
+        self.assertTrue(f'slides/{self.env["ir.http"]._slug(self.channel)}' in res.url, "Should redirect the logged attendee to the course page")
 
         # Logged user is not an attendee of the course, and has no rights to see it.
         self.channel_partner_emp.sudo().unlink()
         self.channel.visibility = 'members'
         res = self.url_open(invite_url_emp)
         self.assertEqual(res.status_code, 200)
-        self.assertFalse(f'slides/{slug(self.channel)}' in res.url, "Should not redirect the logged attendee to the course page")
+        self.assertFalse(f'slides/{self.env["ir.http"]._slug(self.channel)}' in res.url, "Should not redirect the logged attendee to the course page")
 
     def test_direct_invite_link_members_visibility_as_archived(self):
         ''' Check that archived attendees are not given access to the course with the link, whatever their status.'''

--- a/addons/website_slides_survey/controllers/slides.py
+++ b/addons/website_slides_survey/controllers/slides.py
@@ -7,7 +7,6 @@ import werkzeug.exceptions
 
 from odoo import _
 from odoo import http
-from odoo.addons.http_routing.models.ir_http import slug
 from odoo.exceptions import AccessError
 from odoo.http import request
 from odoo.osv import expression
@@ -77,7 +76,8 @@ class WebsiteSlidesSurvey(WebsiteSlides):
 
         if post['slide_category'] == "certification":
             # Set the url to redirect the user to the survey
-            result['url'] = '/slides/slide/%s?fullscreen=1' % (slug(request.env['slide.slide'].browse(result['slide_id']))),
+            slide = request.env['slide.slide'].browse(result['slide_id'])
+            result['url'] = f'/slides/slide/{request.env["ir.http"]._slug(slide)}?fullscreen=1'
 
         return result
 


### PR DESCRIPTION
Addons such as mail use the http_routing slug method without depending
on it. The links sent do not correspond to what the server should
receive. The slug and unslug methods are moved to ir.http in order to
be used everywhere with behavior corresponding to the installed addons.

The method imported from `http_routing` are moved on `ir.http`:

- `slugify_one` => `_slugify_one`
- `slugify` => `_slugify`
- `unslug_url` => `_unslug_url`
- `url_localized` => `_url_localized`
- `url_lang` => `_url_lang`
- `url_for` => `_url_for`
- `is_multilang_url` => `_is_multilang_url`

The method imported from `http_routing` are moved on `ir.http` and splitted into `base`, `http_routing` and `website` addons:

- `slug` => `_slug`
    declared in base: use id for basic routing (to use mail without website for example)
    ovewrited in http_routing: to use name-id
    ovewrited in website: to use website_seo-id
- `unslug` => `_unslug`
    declared in base: use id in basic routing
    ovewrited in http_routing: to extract and compare id from name-id
    ovewrited in website: to extract and compare id from website_seo-id


The method `_rewrite_len` declared in `http_routing` is updated to remove a `getattr(request, 'website_routing', None)` from `url_lang` method. The method was not modular before this commit. The getattr was used to overcome this problem.
The method `_rewrite_len(self, website_id)` are moved in `website`.

`_guess_mimetype` is replaced into dictionary `EXTENSION_TO_WEB_MIMETYPES`


Example:

```
from odoo.addons.http_routing.models.ir_http import slug
... f'/example/{slug(group)}'
```

will be replaced by

```
... f'/example/{self.env["ir.http"]._slug(group)}'
```