### PR TITLE
[FIX] point_of_sale: fix duplicate order when sync_from_ui

### DIFF
--- a/addons/point_of_sale/static/src/app/models/data_service.js
+++ b/addons/point_of_sale/static/src/app/models/data_service.js
@@ -490,13 +490,14 @@ export class PosData extends Reactive {
             .map(([idx, values]) => values)
             .flat();
 
+        this.indexedDB.delete(recordModel, [record.uuid]);
+        const result = record.delete();
         for (const item of recordsToDelete) {
             this.indexedDB.delete(item.model.modelName, [item.uuid]);
             item.delete();
         }
 
-        this.indexedDB.delete(recordModel, [record.uuid]);
-        return record.delete();
+        return result;
     }
 
     deleteUnsyncData(uuid) {

--- a/addons/point_of_sale/static/src/app/models/related_models.js
+++ b/addons/point_of_sale/static/src/app/models/related_models.js
@@ -554,16 +554,17 @@ export function createRelatedModels(modelDefs, modelClasses = {}, indexes = {}) 
             }
         }
 
+        orderedRecords[model] = orderedRecords[model].filter((rec) => rec.id !== record.id);
+        delete records[model][id];
+
         for (const key of indexes[model] || []) {
             const keyVal = record[key];
             const finds = orderedRecords[model].find((rec) => rec[key] === keyVal);
 
-            if (finds === -1) {
+            if (!finds) {
                 delete indexedRecords[model][key][keyVal];
             }
         }
-        orderedRecords[model] = orderedRecords[model].filter((rec) => rec.id !== record.id);
-        delete records[model][id];
         models[model].triggerEvents("delete", id);
     }
 
@@ -757,6 +758,7 @@ export function createRelatedModels(modelDefs, modelClasses = {}, indexes = {}) 
     const models = mapObj(processedModelDefs, (model, fields) => createCRUD(model, fields));
 
     function replaceDataByKey(key, rawData) {
+        const newRecords = {};
         for (const model in rawData) {
             const uiState = {};
             const rawDataIdx = rawData[model].map((r) => r[key]);
@@ -778,7 +780,15 @@ export function createRelatedModels(modelDefs, modelClasses = {}, indexes = {}) 
                     record.uiState = uiState[record[key]];
                 }
             }
+
+            if (!newRecords[model]) {
+                newRecords[model] = [];
+            }
+
+            newRecords[model].push(...newRec[model]);
         }
+
+        return newRecords;
     }
 
     /**

--- a/addons/point_of_sale/static/src/app/models/utils/order_change.js
+++ b/addons/point_of_sale/static/src/app/models/utils/order_change.js
@@ -88,6 +88,8 @@ export const getOrderChanges = (order, skipped = false, orderPreparationCategori
                     attribute_value_ids: lineResume["attribute_value_ids"],
                     quantity: -lineResume["quantity"],
                 };
+                changeAbsCount += Math.abs(lineResume["quantity"]);
+                changesCount += lineResume["quantity"];
             } else {
                 changes[lineKey]["quantity"] -= lineResume["quantity"];
             }

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
@@ -30,6 +30,7 @@ export class ReceiptScreen extends Component {
         this.doPrint = useTrackedAsync(() => this.pos.printReceipt());
         onMounted(() => {
             const order = this.pos.get_order();
+            this.currentOrder.uiState.locked = true;
             this.pos.sendOrderInPreparation(order);
         });
     }

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -847,63 +847,48 @@ export class PosStore extends Reactive {
                 order.recomputeOrderData();
             }
 
-            const orderToDelete = [];
-            const { localOrders, serializedOrder } = orders.reduce(
-                (acc, curr) => {
-                    acc.localOrders.push(curr);
-                    acc.serializedOrder.push(curr.serialize({ orm: true }));
-                    return acc;
-                },
-                { localOrders: [], serializedOrder: [] }
-            );
+            const serializedOrder = orders.map((order) => order.serialize({ orm: true }));
+            const data = await this.data.call("pos.order", "sync_from_ui", [serializedOrder], {
+                context,
+            });
 
-            const data = await this.data.callRelated(
-                "pos.order",
-                "sync_from_ui",
-                [serializedOrder],
-                {
-                    context,
-                }
-            );
+            const modelToAdd = {};
+            const newData = {};
+            for (const [model, records] of Object.entries(data)) {
+                const modelKey = this.data.opts.databaseTable.find((dt) => dt.name === model)?.key;
 
-            const serverOrders = data["pos.order"];
-            for (const localO of localOrders) {
-                const serverO = serverOrders.find((o) => o.uuid === localO.uuid);
-                serverO.uiState = {
-                    ...localO.uiState,
-                    locked: serverO.finalized && typeof serverO.id === "number",
-                };
-                if (serverO && typeof localO.id === "string") {
-                    orderToDelete.push(localO);
+                if (!modelKey) {
+                    modelToAdd[model] = records;
+                    continue;
                 }
+
+                Object.assign(
+                    newData,
+                    this.models.replaceDataByKey(modelKey, { [model]: records })
+                );
             }
 
-            for (const serverO of serverOrders) {
-                if (serverO.state === "draft") {
-                    this.addPendingOrder([serverO.id]);
+            for (const order of [...orders, ...newData["pos.order"]]) {
+                if (!["invoiced", "paid", "done", "cancel"].includes(order.state)) {
+                    this.addPendingOrder([order.id]);
                 } else {
-                    this.removePendingOrder(serverO);
-                }
-
-                for (const line of serverO.lines) {
-                    const refundedOrderLine = line.refunded_orderline_id;
-
-                    if (refundedOrderLine) {
-                        const order = refundedOrderLine.order_id;
-                        delete order.uiState.lineToRefund[refundedOrderLine.uuid];
-                        refundedOrderLine.refunded_qty += Math.abs(line.qty);
-                    }
+                    this.removePendingOrder(order);
                 }
             }
 
-            for (const orderToDel of orderToDelete) {
-                this.removePendingOrder(orderToDel);
-                // We can force the delete because at this point we have serverO
-                this.data.localDeleteCascade(orderToDel, true);
+            for (const line of newData["pos.order.line"]) {
+                const refundedOrderLine = line.refunded_orderline_id;
+
+                if (refundedOrderLine) {
+                    const order = refundedOrderLine.order_id;
+                    delete order.uiState.lineToRefund[refundedOrderLine.uuid];
+                    refundedOrderLine.refunded_qty += Math.abs(line.qty);
+                }
             }
 
-            this.postSyncAllOrders(serverOrders);
-            return serverOrders;
+            this.models.loadData(modelToAdd);
+            this.postSyncAllOrders(newData["pos.order"]);
+            return newData["pos.order"];
         } catch (error) {
             if (options.throw) {
                 throw error;


### PR DESCRIPTION
When the user pay or send an order to the server, some indexes was not updated in related_models and the order was duplicated in the store.

This commit fix the issue by updating the indexes in related_models.

taskId: 3976728
Enterprise PR: https://github.com/odoo/enterprise/pull/64241
