### PR TITLE
 [FIX] product: add domain on ptav filter

### DIFF
--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -614,11 +614,11 @@ action = {
                 <searchpanel>
                     <field name="categ_id"
                            string="Product Category"
-                           icon="fa-th-list"
-                           enable_counters="1"/>
+                           icon="fa-th-list"/>
                     <field name="product_template_attribute_value_ids"
                            string="Attributes"
                            icon="fa-th-list"
+                           domain="[('ptav_active', '=', True), ('product_tmpl_id.active', '=', True)]"
                            enable_counters="1"
                            select="multi"/>
                 </searchpanel>


### PR DESCRIPTION
### [FIX] product: add domain on ptav filter
Steps:
- Install sale.
- If user using odoo for 3-4 for years then
user probably have more then 200 ptavs in db..

Issue:
- It'll display limit warning instead of filter
in most of cases.

Cause:
- Have larger number of ptavs.

Fix:
-  Add domain to only search active ptav and has
related active product.

opw-3827751