### PR TITLE
[FIX] hr_expense: delete draft move when canceling

### DIFF
--- a/addons/project_sale_expense/tests/test_project_profitability.py
+++ b/addons/project_sale_expense/tests/test_project_profitability.py
@@ -199,7 +199,7 @@ class TestProjectSaleExpenseProfitability(TestProjectProfitabilityCommon, TestPr
             {'id': 'expenses', 'sequence': expense_sequence, 'billed': expense.currency_id.round(billed), 'to_bill': 0.0},
         )
 
-        expense_sheet._do_refuse('Test Cancel Expense')
+        expense_sheet.action_reset_expense_sheets()
         expense_profitability = project._get_expenses_profitability_items(False)
         self.assertDictEqual(
             expense_profitability.get('revenues', {}),
@@ -243,7 +243,7 @@ class TestProjectSaleExpenseProfitability(TestProjectProfitabilityCommon, TestPr
             {'id': 'expenses', 'sequence': expense_sequence, 'billed': expense.currency_id.round(-expense_foreign.untaxed_amount_currency * 0.2), 'to_bill': 0.0},
         )
 
-        expense_sheet_foreign._do_refuse('Test Cancel Expense')
+        expense_sheet_foreign.action_reset_expense_sheets()
         expense_profitability = project._get_expenses_profitability_items(False)
         self.assertDictEqual(
             expense_profitability.get('revenues', {}),


### PR DESCRIPTION
In f8928001f6bd7e7f0777ed1557535a0e57b6ed6d, the case of refusing an expense was not taken into account, this make sure no draft move gets left behind that gets paid by accident

task-id: 3955524

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
