### PR TITLE
[FIX] sale: use company from SOL when computing taxes

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -619,7 +619,9 @@ class SaleOrderLine(models.Model):
         Compute the amounts of the SO line.
         """
         for line in self:
-            tax_results = self.env['account.tax']._compute_taxes([line._convert_to_tax_base_line_dict()])
+            tax_results = self.env['account.tax'].with_company(line.company_id)._compute_taxes(
+                [line._convert_to_tax_base_line_dict()]
+            )
             totals = list(tax_results['totals'].values())[0]
             amount_untaxed = totals['amount_untaxed']
             amount_tax = totals['amount_tax']

--- a/addons/sale/tests/test_sale_order.py
+++ b/addons/sale/tests/test_sale_order.py
@@ -731,3 +731,58 @@ class TestSalesTeam(SaleCommon):
         order.action_update_taxes()
         self.assertEqual(order.amount_total, 252)
         self.assertEqual(order.amount_tax, 52)
+
+    def test_recompute_taxes_rounded_globally_multi_company_currency(self):
+        '''
+        Check that taxes computation are made in the currency of the company
+        configured on the SO lines.
+        '''
+        # create a currency with no decimal
+        currency_b = self.env['res.currency'].create({
+            'name': 'B',
+            'symbol': 'B',
+            'rounding': 1.000000,
+        })
+        # create a company with USD as currency (rounding == 0.01)
+        company_a = self.env['res.company'].create({
+            'name': 'Company A',
+            'country_id': self.env.ref('base.us').id,
+        })
+        # create a company with currency_b as currency
+        company_b = self.env['res.company'].create({
+            'name': 'Company B',
+            'tax_calculation_rounding_method': 'round_globally',
+            'currency_id': currency_b.id,
+        })
+        # set company_b as default company of current user
+        self.env.user.company_id = company_b
+        tax_a = self.env['account.tax'].create({
+            'name': 'Tax A',
+            'amount': 10,
+            'company_id': company_a.id,
+            'country_id': self.env.ref('base.us').id,
+        })
+        # create a SO from company_a
+        so = self.env['sale.order'].create({
+            'partner_id': self.partner.id,
+            'company_id': company_a.id,
+            'order_line': [
+                Command.create({
+                    'product_id': self.product.id,
+                    'product_uom_qty': 1,
+                    'price_unit': 123.4,
+                    'tax_id': tax_a.ids,
+                }),
+            ],
+        })
+        # edit the price unit
+        so.write({
+            'order_line': [
+                Command.update(so.order_line[0].id, {'price_unit': 123.5}),
+            ],
+        })
+        # call "flush_all" as it is done in "call_kw" method to test
+        # the tax values that have been recomputed after it
+        self.env.flush_all()
+        self.assertEqual(so.amount_tax, 12.35)
+        self.assertEqual(so.amount_total, 135.85)


### PR DESCRIPTION
**Steps to reproduce:**
- Install Sales & Accounting
- Create a second company with a different currency (e.g. AED) than the first one (e.g. USD)
- Configure the rounding factor of the currency of the second company to 1.000000
- Configure the default company of the current user to the second company
- Switch to the second company
- In Accounting settings, set "Rounding Method" to "Round Globally"
- Switch to the first company
- Create a SO:
  * Customer: [any]
  * Order Lines: [any line with a tax]
- Save the SO
- Edit the SO by changing the price unit of the product !!! Make sure that the tax amount has a decimal part
- Save the SO

**Issue:**
In the chatter, the note about the new value of the tracked field Total is different from the Total value shown in the SO. Also, in Customer Preview, the total to pay shown on the upper-left of the page is different than the total shown in the SO details.

**Cause:**
After save, the taxes are recomputed on the SO lines after a "flush_all" triggered by "call_kw" method.
The computed values are rounded depending on the rounding factor of the currency of the current company (i.e. self.env.company).
However, "allowed_company_ids" being absent in the context, the current company cannot be computed correctly and a fallback is made on the default company of the current user.
Unfortunately, the default company of the current user is different than the real current company, leading to a different currency having a different rounding factor.
In this case, the tax values are rounded to the unity, which is not correct.

**Solution:**
Specify the company configured on the SO line when computing its taxes.

opw-3814058



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
