### PR TITLE
[FIX] point_of_sale/pos_restaurant: load pos data with noupdate

### DIFF
--- a/addons/point_of_sale/data/point_of_sale_onboarding.xml
+++ b/addons/point_of_sale/data/point_of_sale_onboarding.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<odoo noupdate="1">
     <!-- Resource: pos.category -->
     <record id="pos_category_miscellaneous" model="pos.category">
         <field name="name">Misc</field>

--- a/addons/point_of_sale/data/point_of_sale_onboarding_main_config.xml
+++ b/addons/point_of_sale/data/point_of_sale_onboarding_main_config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<odoo noupdate="1">
     <record model="pos.config" id="pos_config_main">
         <field name="iface_start_categ_id" ref="pos_category_desks" />
         <field name="start_category">True</field>

--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -2287,14 +2287,14 @@ class PosSession(models.Model):
     def _load_onboarding_data(self):
         if not self.env.user.has_group("point_of_sale.group_pos_user"):
             raise AccessDenied()
-        convert.convert_file(self.env, 'point_of_sale', 'data/point_of_sale_onboarding.xml', None, mode='init', kind='data')
+        convert.convert_file(self.env, 'point_of_sale', 'data/point_of_sale_onboarding.xml', None, mode='init', noupdate=True, kind='data')
         shop_config = self.env.ref('point_of_sale.pos_config_main', raise_if_not_found=False)
         if shop_config and shop_config.active:
             self._load_onboarding_main_config_data(shop_config)
 
     @api.model
     def _load_onboarding_main_config_data(self, shop_config):
-        convert.convert_file(self.env, 'point_of_sale', 'data/point_of_sale_onboarding_main_config.xml', None, mode='init', kind='data')
+        convert.convert_file(self.env, 'point_of_sale', 'data/point_of_sale_onboarding_main_config.xml', None, mode='init', noupdate=True, kind='data')
         if len(shop_config.session_ids.filtered(lambda s: s.state == 'opened')) == 0:
             self.env['pos.session'].create({
                 'config_id': shop_config.id,

--- a/addons/pos_restaurant/data/pos_restaurant_onboarding.xml
+++ b/addons/pos_restaurant/data/pos_restaurant_onboarding.xml
@@ -1,4 +1,4 @@
-<odoo>
+<odoo noupdate="1">
 
     <record id="drinks" model="pos.category">
         <field name="name">Drinks</field>

--- a/addons/pos_restaurant/data/pos_restaurant_onboarding_main_config.xml
+++ b/addons/pos_restaurant/data/pos_restaurant_onboarding_main_config.xml
@@ -1,4 +1,4 @@
-<odoo>
+<odoo noupdate="1">
      <!-- Pos Config -->
     <record model="pos.config" id="pos_config_main_restaurant">
         <field name="name">Restaurant</field>

--- a/addons/pos_restaurant/data/pos_restaurant_onboarding_open_session.xml
+++ b/addons/pos_restaurant/data/pos_restaurant_onboarding_open_session.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<odoo noupdate="1">
     <!-- Open Session -->
 
     <function model="ir.model.data" name="_update_xmlids">

--- a/addons/pos_restaurant/models/pos_session.py
+++ b/addons/pos_restaurant/models/pos_session.py
@@ -66,16 +66,16 @@ class PosSession(models.Model):
     @api.model
     def _load_onboarding_data(self):
         super()._load_onboarding_data()
-        convert.convert_file(self.env, 'pos_restaurant', 'data/pos_restaurant_onboarding.xml', None, mode='init', kind='data')
+        convert.convert_file(self.env, 'pos_restaurant', 'data/pos_restaurant_onboarding.xml', None, mode='init', noupdate=True, kind='data')
         restaurant_config = self.env.ref('pos_restaurant.pos_config_main_restaurant', raise_if_not_found=False)
         if restaurant_config:
-            convert.convert_file(self.env, 'pos_restaurant', 'data/pos_restaurant_onboarding_main_config.xml', None, mode='init', kind='data')
+            convert.convert_file(self.env, 'pos_restaurant', 'data/pos_restaurant_onboarding_main_config.xml', None, mode='init', noupdate=True, kind='data')
             if len(restaurant_config.session_ids.filtered(lambda s: s.state == 'opened')) == 0:
                 self.env['pos.session'].create({
                     'config_id': restaurant_config.id,
                     'user_id': self.env.ref('base.user_admin').id,
                 })
-            convert.convert_file(self.env, 'pos_restaurant', 'data/pos_restaurant_onboarding_open_session.xml', None, mode='init', kind='data')
+            convert.convert_file(self.env, 'pos_restaurant', 'data/pos_restaurant_onboarding_open_session.xml', None, mode='init', noupdate=True, kind='data')
 
     def _after_load_onboarding_data(self):
         super()._after_load_onboarding_data()


### PR DESCRIPTION
When demo data is loaded by user from UI, the same records are created as is done with loading demo data, ideally they should have same attributes but loading through python function doesn't result in same because noupdate flag is not set. And when ORM tries to remove these records it ends up causing an error.
similar:https://github.com/odoo/odoo/pull/162080
Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
