### PR TITLE
[FIX] point_of_sale: convert the diff_amount to the company currency

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -950,7 +950,7 @@ class PosSession(models.Model):
     def _apply_diff_on_account_payment_move(self, account_payment, payment_method, diff_amount):
         source_vals, dest_vals = self._get_diff_vals(payment_method.id, diff_amount)
         outstanding_line = account_payment.move_id.line_ids.filtered(lambda line: line.account_id.id == source_vals['account_id'])
-        new_balance = outstanding_line.balance + diff_amount
+        new_balance = outstanding_line.balance + self._amount_converter(diff_amount, self.stop_at, False)
         new_balance_compare_to_zero = self.currency_id.compare_amounts(new_balance, 0)
         account_payment.move_id.write({
             'line_ids': [


### PR DESCRIPTION
Current behavior:
In the journal items of a PoS session, Debit and Credit mismatch for the bank

Steps to reproduce:
- Install "Point of Sale", "Accounting" apps
- Create a company and set the currency to something different than USD (eg. EUR)
- Set the company and go to Accounting settings and set the "Fiscal Localization" to "Configurable Chart Template"
- Go back to your company settings and set again the currency (for an unknown reason, it changes back to USD)
- Go to Accounting -> Currencies -> USD -> Add a rate line and set a rate different to 1 Unit per EUR (eg. 1.2)
- In Accounting, go to Journals -> Bank -> set the currency to USD -> do the same for Cash
- Add a Journal named "PoS" -> set its type to "Miscellaneous" -> set the short code to "POS" -> set the currency to USD
- Go to POS -> Payment Methods -> Create "Cash" -> set the journal "Cash (USD)" and the account "<some number> Account Receivable (PoS)"
- Create a "Bank" payment method -> set the journal "Bank (USD)" -> Set the Outstanding Account "<some number> Outstanding Receipts" -> set the Intermediary Account "<some number> Account Receivable (PoS)"
- Create a shop
- In the shop settings, set the default journal to "POS(USD)" then add "Cash" and "Bank to "Payment methods"
- Start a shop session and sell a product paid by bank
- Close the session ->  set the bank count to the price of 2 products
- Go to "Order" -> "Sessions" -> last session -> "Journal Items"
- The "PBNK" line doesn't have Debit and Credit equal

Cause:
The diff_amount used for the line calculation is in USD and not in the company currency

opw-3905691


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
