### PR TITLE
[FIX] core: fix second onchange on X2many

### DIFF
--- a/addons/base_automation/models/base_automation.py
+++ b/addons/base_automation/models/base_automation.py
@@ -684,16 +684,12 @@ class BaseAutomation(models.Model):
             # this is a create: all fields are considered modified
             return True
 
-        # Note: old_vals are in the format of read()
+        # note: old_vals are in the record format
         old_vals = self._context['old_values'].get(record.id, {})
 
         def differ(name):
-            field = record._fields[name]
-            return (
-                name in old_vals and
-                field.convert_to_cache(record[name], record, validate=False) !=
-                field.convert_to_cache(old_vals[name], record, validate=False)
-            )
+            return name in old_vals and record[name] != old_vals[name]
+
         return any(differ(field.name) for field in self_sudo.trigger_field_ids)
 
     def _register_hook(self):
@@ -738,8 +734,8 @@ class BaseAutomation(models.Model):
                 pre = {a: a._filter_pre(records) for a in automations}
                 # read old values before the update
                 old_values = {
-                    old_vals.pop('id'): old_vals
-                    for old_vals in (records.read(list(vals)) if vals else [])
+                    record.id: {field_name: record[field_name] for field_name in vals}
+                    for record in records
                 }
                 # call original method
                 write.origin(self.with_env(automations.env), vals, **kw)
@@ -758,8 +754,8 @@ class BaseAutomation(models.Model):
             #
             def _compute_field_value(self, field):
                 # determine fields that may trigger an automation
-                stored_fields = [f for f in self.pool.field_computed[field] if f.store]
-                if not any(stored_fields):
+                stored_fnames = [f.name for f in self.pool.field_computed[field] if f.store]
+                if not stored_fnames:
                     return _compute_field_value.origin(self, field)
                 # retrieve the action rules to possibly execute
                 automations = self.env['base.automation']._get_actions(self, WRITE_TRIGGERS)
@@ -771,8 +767,8 @@ class BaseAutomation(models.Model):
                 pre = {a: a._filter_pre(records) for a in automations}
                 # read old values before the update
                 old_values = {
-                    old_vals.pop('id'): old_vals
-                    for old_vals in (records.read([f.name for f in stored_fields]))
+                    record.id: {fname: record[fname] for fname in stored_fnames}
+                    for record in records
                 }
                 # call original method
                 _compute_field_value.origin(self, field)

--- a/addons/stock/static/tests/tours/stock_picking_tour.js
+++ b/addons/stock/static/tests/tours/stock_picking_tour.js
@@ -156,3 +156,19 @@ registry.category("web_tour.tours").add('test_edit_existing_line', {
         },
     ]
 });
+
+registry.category("web_tour.tours").add('test_onchange_twice_lot_ids', {
+    test: true,
+    steps: () => [
+        { trigger: ".o_optional_columns_dropdown_toggle" },
+        { trigger: ".dropdown-item:contains('Serial Numbers')"},
+        { trigger: ".o_data_cell.o_many2many_tags_cell"},
+        { trigger: ".oi-close:first"},
+        { trigger: ".oi-close:first"},
+        { trigger: ".o_form_button_save"},
+        {
+            trigger: ".o_form_renderer.o_form_saved",
+            isCheck: true,
+        },
+    ]
+});

--- a/odoo/addons/test_new_api/tests/test_onchange.py
+++ b/odoo/addons/test_new_api/tests/test_onchange.py
@@ -1295,3 +1295,23 @@ class TestComputeOnchange2(common.TransactionCase):
                 self.assertEqual(message_form.has_important_sibling, True)
                 message_form.body = 'Required Body'
             self.assertEqual(len(discussion_form.messages), 1)
+
+    def test_new_one2many_traversing_many2one_second_onchange(self):
+        discussion = self.env['test_new_api.discussion'].create({
+            'name': 'Required field',
+            'messages': [Command.create({'body': 'Msg1: Existing', 'important': True})],
+            'participants': [Command.set(self.env.user.ids)],
+        })
+
+        with Form(discussion, 'test_new_api.discussion_form_2') as discussion_form:
+            self.assertEqual(len(discussion_form.messages), 1)
+            with discussion_form.messages.new() as message_form:
+                # check that Msg1 is visible in the one2many during onchange()
+                self.assertEqual(message_form.has_important_sibling, True)
+                message_form.body = 'Msg2: New'
+
+            self.assertEqual(len(discussion_form.messages), 2)
+            with discussion_form.messages.new() as message_form:
+                # check that Msg1 is visible in the one2many during onchange()
+                self.assertEqual(message_form.has_important_sibling, True)
+                message_form.body = 'Msg3: New'

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -4203,8 +4203,9 @@ class _RelationalMulti(_Relational):
                 browse = lambda it: comodel.browse((it and NewId(it),))
             else:
                 browse = comodel.browse
-            # determine the value ids
-            ids = OrderedSet(record[self.name]._ids if validate else ())
+            # determine the value ids: in case of a real record or a new record
+            # with origin, take its current value
+            ids = OrderedSet(record[self.name]._ids if record._origin else ())
             # modify ids with the commands
             for command in value:
                 if isinstance(command, (tuple, list)):


### PR DESCRIPTION
### [FIX] core: fix _RelationalMulti.convert_to_cache()

Since e0297bdac4eac165a79680de3b1139c2f554d5f5, we have tried to manage sibling dependencies in onchange, but we still have a bug: We already have a record N with a record R1 inside its one2many, when we create a new line R2, during the first onchange() on the one2many comodel, the cache of the N.one2many correctly contains R1 and the current new record R2. But at the onchange on a second line R3, N.one2many will only contain R2 + R3 and R1 won't be in it.

This happens because of the _RelationalMulti.convert_to_cache() uses the 'validate' attribute as a way to know if we need to avoid using the default value for new record without origin (see test_40_new_defaults).

Example of the stack:

From onchange: `record._update_cache(changed_values)`
From _update_to_cache, validate=True, field=Many2one, value=dict: `value = field.convert_to_cache(value, self, v
alidate)`
From convert_to_cache: `id_ = comodel.new(value, origin=origin).id`
From new: `record._update_cache(values, validate=False)`
From _update_to_cache, validate=False, field=move_line_ids, value=commands: `value = field.convert_to_cache(value, self, validate)`
From convert_to_cache: `ids = OrderedSet(record[self.name]._ids if validate else ())`

Instead check if it is a new record without origin to know if we need to bypass the default value or take the real/origin values from the cache and apply the commands to it.

### [FIX] base_automation: fix usage of convert_to_cache()

In the previous commit, we changed the behavior of convert_to_cache() for X2many fields when validate=False. The base_automation was relying on this to compare old and new values of X2many because the old values were in read format and the new values were in record format.

Instead of relying on read(), use the record format for old values and compare the record values. There are some minor changes:
- We now fetch less data because the read() fetch display_name of many2one and if vals is empty will actually fetch all fields for no reason.
- The order of X2many generated by command values doesn't matter anymore, but it shouldn't anyway, because we only want to trigger the base automation when the set of records changes. (Add a test ?)

### [FIX] tests: better simulate M2M in server side Form

Since e4b66668e0ff3d5444ef7fc7b79e6226c513e2c0, the webclient sends LINK and UNLINK commands for many2many values, but the Form test class only used SET commands. Try to mimic the web client more closely.