### PR TITLE
[IMP] l10n_in_pos: HSN summary visibility

### DIFF
--- a/addons/l10n_in_pos/static/src/overrides/components/pos_receipt.xml
+++ b/addons/l10n_in_pos/static/src/overrides/components/pos_receipt.xml
@@ -29,25 +29,25 @@
         <xpath expr="//div[@class='before-footer']" position="after">
             <br/>
             <t t-set="l10n_in_hsn_summary" t-value="props.data?.l10n_in_hsn_summary"/>
-            <table t-if="l10n_in_hsn_summary and props.data.headerData.company.country_id?.code === 'IN'" style="width:100%;">
-                <tr>
-                    <th class="text-center fw-bolder" colspan="6">--- HSN Summary ---</th>
+            <table t-if="l10n_in_hsn_summary and props.data.headerData.company.country_id?.code === 'IN' and l10n_in_hsn_summary.items.length > 0" style="width:100%;">
+              <tr>
+                    <th class="text-center fw-bolder" colspan="6">HSN Summary</th>
                 </tr>
                 <tr>
                     <th class="text-center">HSN Code</th>
                     <th class="text-center">Rate%</th>
                     <th class="text-center">CGST</th>
                     <th class="text-center">SGST</th>
-                    <th class="text-center">IGST</th>
-                    <th class="text-center">CESS</th>
+                    <th class="text-center" t-if="l10n_in_hsn_summary.has_igst">IGST</th>
+                    <th class="text-center" t-if="l10n_in_hsn_summary.has_cess">CESS</th>
                 </tr>
                 <tr t-foreach="l10n_in_hsn_summary.items" t-as="item" t-key="item_index">
                     <td class="text-center" t-out="item.l10n_in_hsn_code"/>
                     <td class="text-center"><t t-out="item.rate"/> %</td>
                     <td class="text-center" t-out="item.tax_amount_cgst"/>
                     <td class="text-center" t-out="item.tax_amount_sgst"/>
-                    <td class="text-center" t-out="item.tax_amount_igst"/>
-                    <td class="text-center" t-out="item.tax_amount_cess"/>
+                    <td class="text-center" t-if="l10n_in_hsn_summary.has_igst" t-out="item.tax_amount_igst"/>
+                    <td class="text-center" t-if="l10n_in_hsn_summary.has_cess" t-out="item.tax_amount_cess"/>
                 </tr>
             </table>
         </xpath>


### PR DESCRIPTION
- show HSN Summary section only when it's applicable
- show IGST & CESS columns only when it's applicable
- edit the title to be just plain "HSN Summary"

task-3965118