### PR TITLE
[FIX] hr_holidays: use `resource_calendar` tz for leave defaults

### DIFF
--- a/addons/hr_holidays/tests/test_leave_requests.py
+++ b/addons/hr_holidays/tests/test_leave_requests.py
@@ -453,7 +453,7 @@ class TestLeaveRequests(TestHrHolidaysCommon):
         self.assertEqual(leave1.number_of_hours_display, 24)
 
     def _test_leave_with_tz(self, tz, local_date_from, local_date_to, number_of_days):
-        self.user_employee.tz = tz
+        self.user_employee.resource_calendar_id.tz = tz
         tz = timezone(tz)
 
         # We use new instead of create to avoid the leaves generated for the


### PR DESCRIPTION
Versions
--------
- 17.0+

Steps
-----
1. Set user timezone from Europe/Brussels to US/Samoa;
2. ensure work schedule timezone is still Europe/Brussels;
3. force refresh;
4. create a leave for current day;
5. set user timezone to Europe/Brussels;
6. force refresh;
7. create another leave for current day.

Issue
-----
You are able to register 2x the time off, as the hours don't overlap.

Cause
-----
The defaults get calculated based on the user timezone, while the leave itself uses the resource calendar timezone.

Solution
--------
If available, use the resource calendar timezone to calculate the defaults.

Use context added by 50652f265ca69f79f2ebd48435a2ba507118f1c8 to calculate duration using this timezone.

opw-3775826