### PR TITLE
[FIX] spreadsheet: undo a move_global_filter

### DIFF
--- a/addons/spreadsheet/static/src/global_filters/index.js
+++ b/addons/spreadsheet/static/src/global_filters/index.js
@@ -63,6 +63,15 @@ inverseCommandRegistry
                 filter: {},
             },
         ];
+    })
+    .add("MOVE_GLOBAL_FILTER", (cmd) => {
+        return [
+            {
+                type: "MOVE_GLOBAL_FILTER",
+                id: cmd.id,
+                delta: cmd.delta * -1,
+            },
+        ];
     });
 
 export { GlobalFiltersCorePlugin, GlobalFiltersUIPlugin };

--- a/addons/spreadsheet/static/tests/global_filters/global_filters_model_test.js
+++ b/addons/spreadsheet/static/tests/global_filters/global_filters_model_test.js
@@ -1143,6 +1143,24 @@ QUnit.module("spreadsheet > Global filters model", {}, () => {
         assert.equal(model.getters.getGlobalFilters()[0].label, "Arthouuuuuur");
     });
 
+    QUnit.test("Can undo-redo a MOVE_GLOBAL_FILTER", async function (assert) {
+        const model = await createModelWithDataSource();
+        addGlobalFilter(model, LAST_YEAR_GLOBAL_FILTER, {});
+        addGlobalFilter(model, THIS_YEAR_GLOBAL_FILTER, {});
+        addGlobalFilter(model, NEXT_YEAR_GLOBAL_FILTER, {});
+
+        const lastYearFilterId = LAST_YEAR_GLOBAL_FILTER.id;
+
+        moveGlobalFilter(model, lastYearFilterId, 1);
+        assert.deepEqual(model.getters.getGlobalFilters()[1].id, lastYearFilterId);
+
+        model.dispatch("REQUEST_UNDO");
+        assert.deepEqual(model.getters.getGlobalFilters()[0].id, lastYearFilterId);
+
+        model.dispatch("REQUEST_REDO");
+        assert.deepEqual(model.getters.getGlobalFilters()[1].id, lastYearFilterId);
+    });
+
     QUnit.test("pivot headers won't change when adding a filter ", async function (assert) {
         assert.expect(6);
         const { model } = await createSpreadsheetWithPivot({


### PR DESCRIPTION
Before this fix, undoing a command MOVE_GLOBAL_FILTER broke the history because the inverse command was missing from the inverse registry.

This fix adds the missing inverse command.

OWP: 3966053





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
