### PR TITLE
[FIX] website_hr_recruitment: update partner_phone on job application submission

### DIFF
--- a/addons/website_hr_recruitment/data/config_data.xml
+++ b/addons/website_hr_recruitment/data/config_data.xml
@@ -24,7 +24,7 @@
                 'description',
                 'email_from',
                 'partner_name',
-                'partner_mobile',
+                'partner_phone',
                 'job_id',
                 'department_id',
                 'linkedin_profile',

--- a/addons/website_hr_recruitment/static/src/js/website_hr_recruitment_editor.js
+++ b/addons/website_hr_recruitment/static/src/js/website_hr_recruitment_editor.js
@@ -20,7 +20,7 @@ FormEditorRegistry.add('apply_job', {
         type: 'char',
         required: true,
         fillWith: 'phone',
-        name: 'partner_mobile',
+        name: 'partner_phone',
         string: _t('Phone Number'),
     }, {
         type: 'char',

--- a/addons/website_hr_recruitment/static/tests/tours/website_hr_recruitment.js
+++ b/addons/website_hr_recruitment/static/tests/tours/website_hr_recruitment.js
@@ -20,7 +20,7 @@
             run: `text ${application.email}`,
         }, {
             content: "Complete phone number",
-            trigger: "input[name=partner_mobile]",
+            trigger: "input[name=partner_phone]",
             run: `text ${application.phone}`,
         }, {
             content: "Complete LinkedIn profile",

--- a/addons/website_hr_recruitment/tests/test_website_hr_recruitment.py
+++ b/addons/website_hr_recruitment/tests/test_website_hr_recruitment.py
@@ -32,14 +32,14 @@ class TestWebsiteHrRecruitmentForm(odoo.tests.HttpCase):
         guru_applicant = capt.records[0]
         self.assertEqual(guru_applicant.partner_name, 'John Smith')
         self.assertEqual(guru_applicant.email_from, 'john@smith.com')
-        self.assertEqual(guru_applicant.partner_mobile, '118.218')
+        self.assertEqual(guru_applicant.partner_phone, '118.218')
         self.assertEqual(html2plaintext(guru_applicant.description), '### [GURU] HR RECRUITMENT TEST DATA ###')
         self.assertEqual(guru_applicant.job_id, job_guru)
 
         internship_applicant = capt.records[1]
         self.assertEqual(internship_applicant.partner_name, 'Jack Doe')
         self.assertEqual(internship_applicant.email_from, 'jack@doe.com')
-        self.assertEqual(internship_applicant.partner_mobile, '118.712')
+        self.assertEqual(internship_applicant.partner_phone, '118.712')
         self.assertEqual(html2plaintext(internship_applicant.description), '### HR [INTERN] RECRUITMENT TEST DATA ###')
         self.assertEqual(internship_applicant.job_id, job_intern)
 

--- a/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
+++ b/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
@@ -231,7 +231,7 @@
                                             <div class="col-sm">
                                                 <input id="recruitment3" type="tel"
                                                     class="form-control s_website_form_input"
-                                                    name="partner_mobile" required=""
+                                                    name="partner_phone" required=""
                                                     data-fill-with="phone"/>
                                             </div>
                                         </div>


### PR DESCRIPTION
For a logged user, when applying to a job position, the phone number is filled with phone but updates mobile on submission (instead of phone field)

Steps to reproduce:
1.Navigate to jobs > /jobs in the url.
2.Log as an existing user > the phone number is pre filled in the job form based on the user's phone field (can be seen in the contact view). 3.Change the phone number in the job form.
4.Apply to the job position > click on the "i'm feeling lucky" button. 5.Navigate to contact > search for the user
6.The given phone number will overwrite the mobile field of the user view

Cause:
partner_mobile field was been used.

Solution:
use partner_phone field from hr_applicant model

opw-3964062