### PR TITLE
[FIX] sale_timesheet: timesheet revenue for fixed price product

### DIFF
--- a/addons/sale_timesheet/report/timesheets_analysis_report.py
+++ b/addons/sale_timesheet/report/timesheets_analysis_report.py
@@ -40,7 +40,7 @@ class TimesheetsAnalysisReport(models.Model):
                 WHEN A.order_id IS NULL OR T.service_type in ('manual', 'milestones')
                 THEN 0
                 WHEN T.invoice_policy = 'order' AND SOL.qty_delivered != 0
-                THEN (SOL.price_total / SOL.qty_delivered) * (A.unit_amount * sol_product_uom.factor / a_product_uom.factor)
+                THEN (SOL.price_subtotal / SOL.qty_delivered) * (A.unit_amount * sol_product_uom.factor / a_product_uom.factor)
                 ELSE A.unit_amount * SOL.price_unit * sol_product_uom.factor / a_product_uom.factor
             END AS timesheet_revenues,
             CASE WHEN A.order_id IS NULL THEN 0 ELSE A.unit_amount END AS billable_time

--- a/addons/sale_timesheet/tests/test_sale_timesheet_report.py
+++ b/addons/sale_timesheet/tests/test_sale_timesheet_report.py
@@ -1,5 +1,6 @@
 from odoo.addons.sale_timesheet.tests.common import TestCommonSaleTimesheet
 from odoo.tests import tagged
+from odoo import Command
 
 
 @tagged('post_install', '-at_install')
@@ -28,6 +29,7 @@ class TestSaleTimesheetReport(TestCommonSaleTimesheet):
             'product_uom_qty': 3,
             'order_id': sale_order.id,
             'price_unit': 10.0,
+            'tax_id': [Command.set(self.tax_sale_a.ids)],
         })
         sale_order.action_confirm()
         task = self.env['project.task'].search([('sale_line_id', '=', so_line.id)])


### PR DESCRIPTION
Create a [TEST] Product with:
- Invoicing Policy: Prepaid/Fixed Price product
- Create on Order: Project & Task
- Unit of Measure: Days

Create a Sales Order with [TEST] prod and a tax
Add a timesheet line on the recorded hours
Go in Timesheet > Reporting > By Project
Add the measure Timesheet Revenues

Issue: Revenues are tax included, but should be tax excluded
This occurs because we are computing the revenue using the
sale order line price total

opw-3864227