### PR TITLE
[FIX] website_sale: Fix traceback on delivery test setup

### DIFF
--- a/addons/website_sale/tests/test_delivery_ui.py
+++ b/addons/website_sale/tests/test_delivery_ui.py
@@ -13,12 +13,6 @@ class TestUi(odoo.tests.HttpCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        transfer_provider = cls.env.ref('payment.payment_provider_transfer')
-        transfer_provider.write({
-            'state': 'enabled',
-            'is_published': True,
-        })
-        transfer_provider._transfer_ensure_pending_msg_is_set()
 
         # Avoid Shipping/Billing address page
         cls.env.ref('base.partner_admin').write({
@@ -61,6 +55,14 @@ class TestUi(odoo.tests.HttpCase):
     def test_01_free_delivery_when_exceed_threshold(self):
         if self.env['ir.module.module']._get('payment_custom').state != 'installed':
             self.skipTest("Transfer provider is not installed")
+
+        transfer_provider = self.env.ref('payment.payment_provider_transfer')
+        transfer_provider.write({
+            'state': 'enabled',
+            'is_published': True,
+        })
+        transfer_provider._transfer_ensure_pending_msg_is_set()
+
         self.env['delivery.price.rule'].create([{
             'carrier_id': self.carrier.id,
             'max_value': 5,
@@ -83,6 +85,14 @@ class TestUi(odoo.tests.HttpCase):
     def test_pay_button_disabled_when_carrier_has_error(self):
         if self.env['ir.module.module']._get('payment_custom').state != 'installed':
             self.skipTest("Transfer provider is not installed")
+
+        transfer_provider = self.env.ref('payment.payment_provider_transfer')
+        transfer_provider.write({
+            'state': 'enabled',
+            'is_published': True,
+        })
+        transfer_provider._transfer_ensure_pending_msg_is_set()
+
         Monetary = self.env['ir.qweb.field.monetary']
         usd_currency = self.env.ref('base.USD')
         with patch.object(WebsiteSaleDelivery, '_get_rate',


### PR DESCRIPTION
Since Commit 4c58d82c7e582c11eb967b6ed7c918a6da3ebd23 refactored `test_delivery_ui`, the check for the `payment_custom` module was moved to individual tests, however, the new `setUpClass` function now uses code that requires `payment_custom` and fails when the server tries to run tests.

Solution:
Move the initialization of `transfer_provider` to the individual tests instead of within the setup function.

opw-3957075
