### PR TITLE
[FIX] website_slides: course content list weird icon border

### DIFF
--- a/addons/website_slides/static/src/xml/website_slides_sidebar.xml
+++ b/addons/website_slides/static/src/xml/website_slides_sidebar.xml
@@ -13,7 +13,7 @@
                 <i t-if="slideCompleted" class="o_wslides_slide_completed fa fa-check-circle fa-fw text-success fa-lg" t-att-data-slide-id="slideId" title="Mark as not done"/>
                 <i t-else="" t-attf-class="fa #{uncompletedIcon or 'fa-circle-thin'} fa-fw fa-lg" t-att-data-slide-id="slideId" title="Mark as done"/>
             </button>
-            <button class="o_wslides_button_complete btn btn-sm" t-else="" disabled="1">
+            <button class="o_wslides_button_complete btn btn-sm border-0" t-else="" disabled="1">
                 <i t-if="slideCompleted" class="o_wslides_slide_completed fa fa-check fa-fw text-success fa-lg" t-att-data-slide-id="slideId" title="Can not be marked as not done"/>
                 <i t-else="" t-attf-class="fa #{uncompletedIcon or 'fa-circle-thin'} fa-fw fa-lg" t-att-data-slide-id="slideId" title="Can not be marked as done"/>
             </button>

--- a/addons/website_slides/views/website_slides_templates_utils.xml
+++ b/addons/website_slides/views/website_slides_templates_utils.xml
@@ -152,7 +152,7 @@
             <i t-if="slide_completed" class="o_wslides_slide_completed fa fa-check-circle fa-fw text-success fa-lg" t-att-data-slide-id="slide.id" title="Mark as not done"/>
             <i t-else="" t-attf-class="fa #{uncompleted_icon} fa-fw fa-lg" t-att-data-slide-id="slide.id" title="Mark as done"/>
         </button>
-        <button class="o_wslides_button_complete o_wslides_button_uncompleted btn btn-sm" t-else="" disabled="1">
+        <button class="o_wslides_button_complete o_wslides_button_uncompleted btn btn-sm border-0" t-else="" disabled="1">
             <i t-if="slide_completed" class="o_wslides_slide_completed fa fa-check fa-fw text-success fa-lg" t-att-data-slide-id="slide.id" title="Can not be marked as not done"/>
             <i t-else="" t-attf-class="fa #{uncompleted_icon} fa-fw fa-lg" t-att-data-slide-id="slide.id" title="Can not be marked as done"/>
         </button>


### PR DESCRIPTION
## Issue

In Course List, After v17.3 +
There a topless border in icons where button is disabled.
Which looks weird and doesn't make sense as we don't need any border there.

## Technical

This issue came from this commit odoo@7d66dcb , where `disabled="1"` was added inside the button.
The default `btn.disabled` has button border in [bootstrap](https://github.com/odoo/odoo/blob/51af11c9180fe48ba3492ffd3402a22bde211318/addons/web/static/lib/bootstrap/dist/css/bootstrap.css#L3048-L3053) code.
That's why the border is appearing there.

## After this PR

There will be no borders where icon buttons are disabled.

Task-3975450
