### PR TITLE
[FIX] website: prevent multi-level sub-menu creation

### DIFF
--- a/addons/website/models/website_menu.py
+++ b/addons/website/models/website_menu.py
@@ -66,6 +66,37 @@ class Menu(models.Model):
                 menu_name += f' [{menu.website_id.name}]'
             menu.display_name = menu_name
 
+    @api.constrains("parent_id", "child_id", "is_mega_menu", "mega_menu_content")
+    def _validate_parent_menu(self):
+        """
+        Ensure valid menu hierarchy and mega menu constraints.
+
+        Rules enforced:
+        - Menus must not exceed two levels of nesting.
+        - A mega menu must not have a parent or child.
+        - Menus with children cannot be added as a submenu under another menu.
+        """
+        for record in self:
+            parent_menu = record.parent_id.sudo() if record.parent_id else None
+
+            # Check hierarchy level
+            level = 0
+            current_menu = parent_menu
+            while current_menu:
+                level += 1
+                current_menu = current_menu.parent_id
+                if level > 2:
+                    raise UserError(_("Menus cannot have more than two levels of hierarchy."))
+
+            if parent_menu:
+                # Mega menu constraint
+                if parent_menu.is_mega_menu or (record.is_mega_menu and (parent_menu.parent_id or record.child_id)):
+                    raise UserError(_("A mega menu cannot have a parent or child menu."))
+
+                # Submenu structure constraint
+                if record.child_id and (parent_menu.parent_id or record.child_id.child_id):
+                    raise UserError(_("Menus with child menus cannot be added as a submenu."))
+
     @api.model_create_multi
     def create(self, vals_list):
         ''' In case a menu without a website_id is trying to be created, we duplicate

--- a/addons/website/tests/test_menu.py
+++ b/addons/website/tests/test_menu.py
@@ -9,6 +9,7 @@ from werkzeug.urls import url_parse
 
 from odoo.addons.website.tools import MockRequest
 from odoo.tests import common
+from odoo.exceptions import UserError
 
 
 class TestMenu(common.TransactionCase):
@@ -237,6 +238,49 @@ class TestMenu(common.TransactionCase):
         # anchor and query string are not messing with the slug url compare
         submenu.url = '/sub/slug-3'
         test_full_case(submenu)
+
+    def test_07_menu_hierarchy_validation(self):
+        Menu = self.env['website.menu']
+
+        # Validation 1: Parent menu validation
+        self.main_menu = Menu.create({
+            'name': 'Main',
+        })
+        self.child_menu_1 = Menu.create({
+            'name': 'Child1',
+        })
+        self.child_menu_1.parent_id = self.main_menu.id
+
+        # Attempt to assign a second child menu as a child of the first child menu,
+        # which should raise a UserError due to hierarchy restrictions.
+        self.child_menu_2 = Menu.create({
+            'name': 'Child2',
+        })
+        with self.assertRaises(UserError):
+            self.child_menu_2.parent_id = self.child_menu_1.id
+
+        # Validation 2: Mega menu validation
+        self.mega_menu = Menu.create({
+            'name': 'Mega menu',
+            'is_mega_menu': True,
+        })
+        self.another_menu = Menu.create({
+            'name': 'Sample_menu',
+        })
+
+        # Attempt to assign a parent to the mega menu and a child to it,
+        # which should both raise UserErrors due to mega menu restrictions.
+        with self.assertRaises(UserError):
+            self.mega_menu.parent_id = self.another_menu.id
+
+        with self.assertRaises(UserError):
+            self.another_menu.parent_id = self.mega_menu.id
+
+        # Validation 3: Child menu condition validation
+        # Attempt to assign another_menu as a parent of main_menu chain having Child1,
+        # which should raise a UserError because a main_menu had child.
+        with self.assertRaises(UserError):
+            self.main_menu.parent_id = self.another_menu.id
 
 
 class TestMenuHttp(common.HttpCase):

--- a/addons/website/tests/test_performance.py
+++ b/addons/website/tests/test_performance.py
@@ -254,13 +254,7 @@ class TestWebsitePerformance(UtilPerf):
         _, menu_aa = self._create_page_with_menu('/aa')
         _, menu_b = self._create_page_with_menu('/b')
         _, menu_bb = self._create_page_with_menu('/bb')
-        _, menu_bbb = self._create_page_with_menu('/bbb')
-        _, menu_bbbb = self._create_page_with_menu('/bbbb')
-        _, menu_bbbbb = self._create_page_with_menu('/bbbbb')
         self._create_page_with_menu('c')
-        menu_bbbbb.parent_id = menu_bbbb
-        menu_bbbb.parent_id = menu_bbb
-        menu_bbb.parent_id = menu_bb
         menu_bb.parent_id = menu_b
         menu_aa.parent_id = menu_a
 


### PR DESCRIPTION
Steps to Reproduce:
1. Go to the website.
2. Create a new menu (e.g., 'Test 1') using the 'Edit Menu' option and add it under another menu (e.g., 'Contact Us'), creating a sub-menu. 
3. Turn on the developer mode.
4. Go to Configuration -> Menus and add two menus (e.g., 'menu 1' and  'menu 2') under the new sub-menu (e.g., 'Test 1').
5. Notice that the two menus ('menu 1' and 'menu 2') are not visible on the website.

Description:
As per functional specifications, creation of multi-level sub-menus should not be allowed.

Key Changes:
raises a `UserError` if a menu exceeds the two-level hierarchy by checking the parent and grandparent levels.
- Implements mega menu restrictions:
    - A mega menu cannot have a parent menu.
    - A mega menu cannot have child menus.
    - Any menu cannot be a child of a mega menu.
- Prevents menus with child menus from being added as submenus to existing menus.

This ensures that the website menu structure adheres to the defined functional specifications, providing a consistent and predictable user experience.

task-3901371