### PR TITLE
[FIX] pos_self_order: traceback when create language

### DIFF
--- a/addons/pos_self_order/views/res_config_settings_views.xml
+++ b/addons/pos_self_order/views/res_config_settings_views.xml
@@ -44,11 +44,11 @@
                         <div class="content-group mt-3">
                             <div class="row">
                                 <label for="pos_self_ordering_default_language_id" class="col-lg-3" string="Default"/>
-                                <field name="pos_self_ordering_default_language_id" />
+                                <field name="pos_self_ordering_default_language_id" options="{'no_create': True}"/>
                             </div>
                             <div class="row">
                                 <label for="pos_self_ordering_available_language_ids" class="col-lg-3" string="Available"/>
-                                <field name="pos_self_ordering_available_language_ids" widget="many2many_tags"/>
+                                <field name="pos_self_ordering_available_language_ids" widget="many2many_tags" options="{'no_create': True}"/>
                             </div>
                         </div>
                         <div>


### PR DESCRIPTION
Add an option to restrict users from creating language on mobile self-order & kiosk mode.

task - 3980908