### PR TITLE
[FIX] account: incorrect text alignment on product cell

### DIFF
--- a/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.xml
+++ b/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.xml
@@ -82,7 +82,7 @@
                         <Many2XAutocomplete t-props="Many2XAutocompleteProps"/>
                         <button t-if="hasExternalButton"
                                 aria-label="Internal link"
-                                class="btn btn-link text-action oi"
+                                class="btn btn-link text-action oi o_external_button"
                                 data-tooltip="Internal link"
                                 draggable="false"
                                 tabindex="-1"
@@ -92,7 +92,7 @@
                         />
                         <button t-if="hasBarcodeButton"
                                 aria-label="Scan barcode"
-                                class="btn ms-3 o_barcode"
+                                class="btn ms-3 o_barcode o_external_button"
                                 data-tooltip="Scan barcode"
                                 draggable="false"
                                 tabindex="-1"
@@ -101,7 +101,7 @@
                                 t-on-click="onBarcodeBtnClick"
                         />
                         <button t-if="columnIsProductAndLabel.value and !label"
-                                class="btn fa fa-bars text-start"
+                                class="btn fa fa-bars text-start o_external_button"
                                 data-tooltip="Click or press enter to add a description"
                                 id="labelVisibilityButtonId"
                                 type="button"


### PR DESCRIPTION
Description of the issue this commit addresses:

When on on invoice, focusing in on the product cell slightly lowers the text on the line, this means that the text is not aligned with other cells anymore. This is not wanted.

---

Steps to reproduce:

1-Install account
2-Open a new invoice
3-Add a product on a line
4-Focus in the cell of the product
5-Text is slightly lower than in other cells

---

Desired behavior after this commit is merged:

The text of the product cell is aligned with other cells

---

Note on the fix:

The bug happened because the buttons on the line were slightly taller than the text box. They are hidden when the focus is out the box so it would only be a problem when focusing in. The fix consists in making sure that the buttons are not taller than the text so they will not mess with the line height

---

no task-feedback

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
