### PR TITLE
[FIX] project: fix form with html expander

### DIFF
--- a/addons/project/static/src/views/form_with_html_expander/form_renderer_with_html_expander.js
+++ b/addons/project/static/src/views/form_with_html_expander/form_renderer_with_html_expander.js
@@ -14,19 +14,34 @@ export class FormRendererWithHtmlExpander extends FormRenderer {
                 if (el && size === 6) {
                     const descriptionField = el.querySelector(this.htmlFieldQuerySelector);
                     if (descriptionField) {
+                        const containerEL = descriptionField.closest(
+                            this.getHTMLFieldContainerQuerySelector
+                        );
                         const editor = descriptionField.querySelector('.note-editable');
                         const elementToResize = editor || descriptionField;
-                        const { bottom, height } = elementToResize.getBoundingClientRect();
-                        const minHeight = document.documentElement.clientHeight - bottom - height;
+                        const { top, bottom } = elementToResize.getBoundingClientRect();
+                        const { bottom: containerBottom } = containerEL.getBoundingClientRect();
+                        const { paddingTop, paddingBottom } = window.getComputedStyle(containerEL);
+                        const nonEditableHeight =
+                            containerBottom -
+                            bottom +
+                            parseInt(paddingTop) +
+                            parseInt(paddingBottom);
+                        const minHeight =
+                            document.documentElement.clientHeight - top - nonEditableHeight;
                         elementToResize.style.minHeight = `${minHeight}px`;
                     }
                 }
             },
-            () => [ref.el, this.ui.size, this.props.record.mode],
+            () => [ref.el, this.ui.size, this.props.record.resId]
         );
     }
 
     get htmlFieldQuerySelector() {
         return '.oe_form_field.oe_form_field_html';
+    }
+
+    get getHTMLFieldContainerQuerySelector() {
+        return ".o_form_sheet";
     }
 }


### PR DESCRIPTION
Before this commit, since the design changes, the form with html expander no longer works.

This commit adapts the code to expand the html field as before to take the remaining height unused by the form view when we first load the form view of `project`.

task-3258533
