### PR TITLE
[FIX] web_editor: fix misalignment when printing document

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/base_style.scss
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/base_style.scss
@@ -13,15 +13,17 @@ $sizes: '', 'xs-', 'sm-', 'md-', 'lg-', 'xl-', 'xxl-';
     max-width: 100% !important;
     padding: 0 !important;
 }
-.o_text_columns > .row {
-    margin: 0 !important;
-    @each $size in $sizes {
-        @for $i from 1 through 12 {
-            & > .col-#{$size}#{$i}:first-of-type {
-                padding-left: 0;
-            }
-            & > .col-#{$size}#{$i}:last-of-type {
-                padding-right: 0;
+@media screen {
+    .o_text_columns > .row {
+        margin: 0 !important;
+        @each $size in $sizes {
+            @for $i from 1 through 12 {
+                & > .col-#{$size}#{$i}:first-of-type {
+                    padding-left: 0;
+                }
+                & > .col-#{$size}#{$i}:last-of-type {
+                    padding-right: 0;
+                }
             }
         }
     }


### PR DESCRIPTION
Currently, the editor uses the bootstrap grid system for the column layouts and the editor CSS rules changes the paddings and the margins of the columns. When the user prints a document, the columns can go one under the other but the paddings and margins set are still applied. As a result, the columns appear off-centered on printing devices.

To fix that issue, we will scope the CSS rules that adjust the paddings and margins of the columns to the screen devices. This way, the rules won't be applied when printing the document.

task-3664950

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
