### PR TITLE
[FIX] pos_self_order_sale: make optional products available on mobile menu

### DIFF
--- a/addons/pos_self_order_sale/static/src/app/pages/cart_page/cart_page.xml
+++ b/addons/pos_self_order_sale/static/src/app/pages/cart_page/cart_page.xml
@@ -6,7 +6,7 @@
                 <h2 class="mb-5">Want to add something ?</h2>
                 <div class="upsale-product row justify-content-between justify-content-md-start row-cols-sm-2 row-cols-md-4 row-cols-lg-4 row-cols-xl-5 row-cols-xxl-6">
                     <t t-foreach="optionalProducts" t-as="product" t-key="product.id">
-                        <ProductCard product="product" />
+                        <ProductCard product="product" isAvailable="product.pos_categ_ids.some(categ => selfOrder.isCategoryAvailable(categ.id))"/>
                     </t>
                 </div>
             </div>


### PR DESCRIPTION
To reproduce the bug follow the instructions:
- Have pos and sales app installed
- Go to pos app setting and enable is a Restorant setting
- Back to the dashboard you should have a new shop called Restorant
- Go to the products from and create a product ('pencil' for instance), make it available in pos and in self-order and assign to it a category
- Add another product ('paper') with the same options in pos side and assign to it the same category, then add the first product ('pencil') to its optional product in sales section
- Back to pos dashboard open a sessing in Restorant shop then go back again to the dashboard
- Click on the tree dots on the top right of the Restorant shop block and click on the mobile view
- Create a new order adding 'paper' to the command then go to checkout

Now the optional product 'pencil' should be shown but it's unavailable.

A feature was added in Odoo 17.1 and newer for the availibility of the product on the point of sale app. It filter the product based on the availability hours of its categories. This brought changes to ProductCard component witch (you can check product_list_page) in pos_self_order modul for that. The thing is that these change wasn't made is pos_self_order_sale modul witch made the product always shown as unavailable.

### **opw-3977238**