### PR TITLE
[IMP] pos_loyalty: loyalty point ui/ux improvement

### DIFF
--- a/addons/point_of_sale/static/src/app/generic_components/order_widget/order_widget.xml
+++ b/addons/point_of_sale/static/src/app/generic_components/order_widget/order_widget.xml
@@ -8,14 +8,16 @@
                     <Orderline t-else="" line="line" />
                 </t>
             </div>
-            <div t-if="props.total or props.tax" class="order-summary w-100 py-2 px-3 bg-white text-end fw-bolder fs-2 lh-sm">
-                Total:
-                <span t-esc="props.total" class="total"/>
-                <div t-if="props.tax" class="fs-6 text-muted subentry">
-                    Taxes: <span t-esc="props.tax" class="tax"/>
+            <div class="order-summary d-flex justify-content-end w-100 py-2 px-3 bg-white">
+                <t t-slot="details"/>
+                <div t-if="props.total or props.tax" class="text-end fw-bolder fs-2 lh-sm">
+                    Total:
+                    <span t-esc="props.total" class="total"/>
+                    <div t-if="props.tax" class="fs-6 text-muted subentry">
+                        Taxes: <span t-esc="props.tax" class="tax"/>
+                    </div>
                 </div>
             </div>
-            <t t-slot="details"/>
         </t>
         <t t-else="">
             <CenteredIcon icon="'fa-shopping-cart fa-4x'" text="emptyCartText()"/>

--- a/addons/pos_loyalty/static/src/overrides/components/product_screen/order_summary/order_summary.xml
+++ b/addons/pos_loyalty/static/src/overrides/components/product_screen/order_summary/order_summary.xml
@@ -8,21 +8,12 @@
         </xpath>
         <xpath expr="//OrderWidget/t[@t-set-slot='details']" position="inside">
             <t t-foreach="pos.get_order()?.getLoyaltyPoints() or []" t-as="_loyaltyStat" t-key="_loyaltyStat.couponId">
-                <div t-if="_loyaltyStat.points.won || _loyaltyStat.points.spent" class="w-100 border-top mt-auto fw-bolder d-flex flex-column px-3 py-2 bg-200">
-                    <div t-esc="_loyaltyStat.points.name" class="loyalty-points-title text-center mb-1" />
-                    <div class="d-flex justify-content-around gap-2 mt-1">
-                        <div t-if='_loyaltyStat.points.won' class="loyalty-points-won d-flex flex-column align-items-center justify-content-center flex-grow-1 rounded bg-300 px-3 py-2" >
-                            <span class="text-muted">Points Won</span>
-                            <span class='value text-success '>+<t t-esc='_loyaltyStat.points.won'/></span>
-                        </div>
-                        <div t-if='_loyaltyStat.points.spent' class="loyalty-points-won d-flex flex-column align-items-center justify-content-center flex-grow-1 rounded bg-300 px-3 py-2" >
-                            <span class="text-muted">Points Spent</span>
-                            <span class='value text-danger'>-<t t-esc='_loyaltyStat.points.spent'/></span>
-                        </div>
-                        <div class="loyalty-points-total d-flex flex-column align-items-center justify-content-center flex-grow-1 rounded bg-300 px-3 py-2">
-                            <span class="text-muted">New Total</span>
-                            <span class='value text-primary'><t t-esc='_loyaltyStat.points.total'/></span>
-                        </div>
+                <div t-if="_loyaltyStat.points.won || _loyaltyStat.points.spent" class="w-50 d-flex flex-column flex-grow-1">
+                    <div t-esc="_loyaltyStat.points.name" class="loyalty-points-title text-start fw-bolder" />
+                    <div class="loyalty-points d-flex justify-content-left gap-2">
+                        <span class='loyalty-points-won text-success' t-if='_loyaltyStat.points.won'>+<t t-esc='_loyaltyStat.points.won'/></span>
+                        <span class='loyalty-points-spent text-danger' t-if='_loyaltyStat.points.spent'> -<t t-esc='_loyaltyStat.points.spent'/></span>
+                        <span class='loyalty-points-total text-primary'>= <t t-esc='_loyaltyStat.points.total'/></span>
                     </div>
                 </div>
             </t>

--- a/addons/pos_loyalty/static/tests/tours/utils/pos_loyalty_util.js
+++ b/addons/pos_loyalty/static/tests/tours/utils/pos_loyalty_util.js
@@ -95,7 +95,7 @@ export function pointsAwardedAre(points_str) {
     return [
         {
             content: "loyalty points awarded " + points_str,
-            trigger: '.loyalty-points-won .value:contains("' + points_str + '")',
+            trigger: '.loyalty-points-won:contains("' + points_str + '")',
             run: function () {}, // it's a check
         },
     ];


### PR DESCRIPTION
In this commit:
================
Improved the UI/UX for displaying loyalty points.
Replaced the loyalty points block in order lines with a simple text display.

task- 3978306


Before:
======
![image](https://github.com/odoo/odoo/assets/127721971/bac5ddeb-5a42-4693-bff1-7ab856f03dd0)


After:
=====

![image](https://github.com/odoo/odoo/assets/127721971/8517240e-5caa-4437-908f-6b615dbb8944)

