### PR TITLE
[FIX] auth_password_policy: traceback on change password

### DIFF
--- a/addons/auth_password_policy/models/res_users.py
+++ b/addons/auth_password_policy/models/res_users.py
@@ -27,7 +27,7 @@ class ResUsers(models.Model):
             if not password:
                 continue
             if len(password) < minlength:
-                failures.append(_("Your password must contain at least %(minimal_length)d characters and only has %(current_count)d.", minlength, len(password)))
+                failures.append(_("Your password must contain at least %(minimal_length)d characters and only has %(current_count)d.", minimal_length=minlength, current_count=len(password)))
 
         if failures:
             raise UserError(u'\n\n '.join(failures))


### PR DESCRIPTION
Before this PR:

Attempting to change a password to a length shorter than the minimum
requirement resulted in a traceback due to a syntax error in the validation
message in commit [1].

After this PR:

Setting a password shorter than the minimum length now throws a UserError.

[1]: https://github.com/odoo/odoo/commit/c1f277a7d04d9d6035413e315556b41a44d0b5b2

task-3930129