### PR TITLE
[FIX] hr_recruitment_skills: fix computed field error on tree view with missing skills fields enabled column

### DIFF
--- a/addons/hr_recruitment_skills/models/hr_applicant.py
+++ b/addons/hr_recruitment_skills/models/hr_applicant.py
@@ -33,6 +33,7 @@ class HrApplicant(models.Model):
         job_id = self.env.context.get('active_id')
         if not job_id:
             self.matching_skill_ids = False
+            self.missing_skill_ids = False
             self.matching_score = 0
         else:
             for applicant in self:


### PR DESCRIPTION
In job applications view, if you add missing skills through studio, the fields computation throws an error
    
Steps to reproduce:
1.go to recruitment > applications > all applications > tree view
2.in studio > add missing skills field
3.the column will be added but an error on missing skill compute will appear
4.everytime you enter a "applications" tree view, an error will pop up for missing skill computation

Cause:
missing skill fields was not set during compute

Solution:
set missing skill during compute