### PR TITLE
[FIX] website_sale: unable to set product to add to cart button

### DIFF
--- a/addons/website_sale/static/src/snippets/s_add_to_cart/options.js
+++ b/addons/website_sale/static/src/snippets/s_add_to_cart/options.js
@@ -98,6 +98,7 @@ options.registry.AddToCart = options.Class.extend({
             domain: [
                 ["product_tmpl_id", "=", parseInt(productTemplateId)],
             ],
+            fields: ['id'],
         });
         this.$target[0].dataset.variants = response.map(variant => variant.id);
     },


### PR DESCRIPTION
Reading all fields of a product model can lead to access errors because
it may contain fields related to models that don't have read permissions.
Therefore, we should only read the id instead of everything to avoid errors

Step to reproduce:
- Install stock application.
- User (Editor and Designer) selects product for the snippet add to cart button.
-> Cannot select product due to access error.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
