### PR TITLE
Master base improve config parameter cwg

### DIFF
--- a/addons/auth_totp_mail/tests/test_auth_signup.py
+++ b/addons/auth_totp_mail/tests/test_auth_signup.py
@@ -11,7 +11,7 @@ class TestAuthSignupFlowWith2faEnforced(HttpCaseWithUserPortal, HttpCaseWithUser
 
     def setUp(self):
         super().setUp()
-        self.env['res.config.settings'].create(
+        a = self.env['res.config.settings'].create(
             {
                 # Activate free signup
                 'auth_signup_uninvited': 'b2c',
@@ -19,7 +19,8 @@ class TestAuthSignupFlowWith2faEnforced(HttpCaseWithUserPortal, HttpCaseWithUser
                 'auth_totp_enforce': True,
                 'auth_totp_policy': 'all_required',
             }
-        ).execute()
+        )
+        a.execute()
 
     def test_signup_with_2fa_enforced(self):
         """

--- a/addons/sales_team/tests/test_sales_team_membership.py
+++ b/addons/sales_team/tests/test_sales_team_membership.py
@@ -31,6 +31,7 @@ class TestMembership(TestSalesCommon):
         self.assertTrue(self.new_team.with_user(self.env.user).is_membership_multi)
 
         self.env['ir.config_parameter'].sudo().set_param('sales_team.membership_multi', False)
+        self.env.invalidate_all()  # is_membership_multi isn't promised to be recomputed, explict invalidation is needed
         self.assertFalse(self.sales_team_1.with_user(self.env.user).is_membership_multi)
         self.assertFalse(self.new_team.with_user(self.env.user).is_membership_multi)
 

--- a/odoo/addons/base/data/neutralize.sql
+++ b/odoo/addons/base/data/neutralize.sql
@@ -18,10 +18,10 @@ UPDATE ir_cron
 );
 
 -- neutralization flag for the database
-INSERT INTO ir_config_parameter (key, value)
-VALUES ('database.is_neutralized', true)
+INSERT INTO ir_config_parameter (key, value, type)
+VALUES ('database.is_neutralized', 'true', 'str')
     ON CONFLICT (key) DO
-       UPDATE SET value = true;
+       UPDATE SET value = 'true', type = 'str';
 
 -- deactivate webhooks
 UPDATE ir_act_server

--- a/odoo/addons/base/models/ir_config_parameter.py
+++ b/odoo/addons/base/models/ir_config_parameter.py
@@ -103,16 +103,16 @@ class IrConfig_Parameter(models.Model):
     @api.model
     def set(self, key, value, type_=None):
         old_value = self._get(key)
-        if old_value is not None and (
+        if old_value is not None and type_ is None and (
             value == old_value or
-            value == False and old_value == '' and (type_ == 'str' or type_ is None)  # spical optimization for res.config.settings.set_values() for char fields
+            value == False and old_value == ''  # spical optimization for res.config.settings.set_values() for char fields
         ):
             return
         param = self.search_fetch([('key', '=', key)], ['type'])
         type_ = type_ or param.type or 'str'
         value = str(self._convert_to_type(value, type_))
         if param:
-            if value == param.value:  # spical optimization for str2bool e.g. 'yes', 'no'...
+            if value == param.value and 'type' == param.type:  # spical optimization for str2bool e.g. 'yes', 'no'...
                 return
             param.write({'value': value, 'type': type_})
         else:

--- a/odoo/addons/base/models/res_config.py
+++ b/odoo/addons/base/models/res_config.py
@@ -5,6 +5,7 @@ from ast import literal_eval
 
 from odoo import api, models, _
 from odoo.exceptions import AccessError, RedirectWarning, UserError
+from odoo.tools import SQL
 
 _logger = logging.getLogger(__name__)
 
@@ -148,6 +149,38 @@ class ResConfigSettings(models.TransientModel):
     _name = 'res.config.settings'
     _description = 'Config Settings'
 
+    def init(self):
+        module = self.env.context.get('module')
+        if not module:
+            return
+        config_parameters = []
+        for field in self._fields.values():
+            if module in field._modules and getattr(field, 'config_parameter', None):
+                value = False
+                if field.default:
+                    value = field.default(self)
+
+                if field.type in ('char', 'selection', 'datetime'):
+                    type_ = 'str'
+                elif field.type == 'boolean':
+                    type_ = 'bool'
+                elif field.type in ('integer', 'many2one'):
+                    type_ = 'int'
+                elif field.type == 'float':
+                    type_ = 'float'
+                else:
+                    raise ValueError(f'Invalid type {field.type} for field {field.name} with config_parameter')
+
+                value = str(self.env['ir.config_parameter']._convert_to_type(value, type_))
+                config_parameters.append((field.config_parameter, value, type_))
+        if config_parameters:
+            self.env.cr.execute(SQL("""
+            INSERT INTO ir_config_parameter ("key", "value", "type")
+            VALUES %s
+            ON CONFLICT ("key")
+            DO NOTHING
+            """, SQL(", ").join(config_parameters)))
+
     def _valid_field_parameter(self, field, name):
         return (
             name in ('default_model', 'config_parameter')
@@ -263,30 +296,11 @@ class ResConfigSettings(models.TransientModel):
         WARNING_MESSAGE = "Error when converting value %r of field %s for ir.config.parameter %r"
         for name, icp in classified['config']:
             field = self._fields[name]
-            value = IrConfigParameter.get_param(icp, field.default(self) if field.default else False)
-            if value is not False:
-                if field.type == 'many2one':
-                    try:
-                        # Special case when value is the id of a deleted record, we do not want to
-                        # block the settings screen
-                        value = self.env[field.comodel_name].browse(int(value)).exists().id
-                    except (ValueError, TypeError):
-                        _logger.warning(WARNING_MESSAGE, value, field, icp)
-                        value = False
-                elif field.type == 'integer':
-                    try:
-                        value = int(value)
-                    except (ValueError, TypeError):
-                        _logger.warning(WARNING_MESSAGE, value, field, icp)
-                        value = 0
-                elif field.type == 'float':
-                    try:
-                        value = float(value)
-                    except (ValueError, TypeError):
-                        _logger.warning(WARNING_MESSAGE, value, field, icp)
-                        value = 0.0
-                elif field.type == 'boolean':
-                    value = bool(value)
+            value = IrConfigParameter.get(icp)
+            if field.type == 'many2one':
+                # Special case when value is the id of a deleted record, we do not want to
+                # block the settings screen
+                value = self.env[field.comodel_name].browse(value).exists().id
             res[name] = value
 
         res.update(self.get_values())
@@ -330,21 +344,16 @@ class ResConfigSettings(models.TransientModel):
         for name, icp in classified['config']:
             field = self._fields[name]
             value = self[name]
-            current_value = IrConfigParameter.get_param(icp)
 
             if field.type == 'char':
                 # storing developer keys as ir.config_parameter may lead to nasty
                 # bugs when users leave spaces around them
-                value = (value or "").strip() or False
-            elif field.type in ('integer', 'float'):
-                value = repr(value) if value else False
+                value = (value or "").strip() or False  # TODO double check since it leads to fallback to default
             elif field.type == 'many2one':
                 # value is a (possibly empty) recordset
                 value = value.id
 
-            if current_value == str(value) or current_value == value:
-                continue
-            IrConfigParameter.set_param(icp, value)
+            IrConfigParameter.set(icp, value)
 
     def execute(self):
         """

--- a/odoo/addons/base/security/base_groups.xml
+++ b/odoo/addons/base/security/base_groups.xml
@@ -106,6 +106,7 @@
         <record id="default_template_user_config" model="ir.config_parameter">
             <field name="key">base.template_portal_user_id</field>
             <field name="value" ref="template_portal_user_id"/>
+            <field name="type">int</field>
         </record>
 
     </data>

--- a/odoo/addons/base/tests/test_config_parameter.py
+++ b/odoo/addons/base/tests/test_config_parameter.py
@@ -19,3 +19,89 @@ class TestIrConfigParameter(TransactionCase):
             new_key = f"{key}_updated"
             with self.assertRaises(ValidationError):
                 config_parameter.write({'key': new_key})
+
+    def test_get_set_param(self):
+        key = 'base._test_ir_config_parameter'
+        ICP = self.env['ir.config_parameter']
+
+        self.assertEqual(ICP.get_param(key), False)
+
+        test_values = [
+            (True, 'True'),
+            (False, False),
+            (1, '1'),
+            (0, '0'),
+            ('True', 'True'),
+            ('False', 'False'),
+            (1.0, '1.0'),
+            (1 / 3, str(1 / 3)),
+            (0.0, '0.0'),
+            ({}, '{}'),
+            ({'key': 'value'}, str({'key': 'value'})),
+            ([], '[]'),
+            ([1, 2, 3], '[1, 2, 3]'),
+            ("value", 'value'),
+            (None, False),
+            ('', False),
+        ]
+
+        for set_value, get_value in test_values:
+            ICP.set_param(key, set_value)
+            self.assertEqual(ICP.get_param(key), get_value)
+
+    def test_get_set(self):
+        key = 'base._test_ir_config_parameter'
+        ICP = self.env['ir.config_parameter']
+
+        self.assertEqual(ICP.get(key), None)
+        self.assertEqual(ICP.get_param(key), False)
+
+        # value_type, set_value, get_value, get_param_value
+        test_values = [
+            ('bool', True, True, 'True'),
+            ('bool', False, False, False),
+            ('bool', '', False, False),
+            ('int', 1, 1, '1'),
+            ('int', 0, 0, False),
+            ('int', False, False, False),
+            ('int', '', 0, False),
+            ('int', 3.6, 3, '3'),
+            ('str', 'True', 'True', 'True'),
+            ('str', 'False', 'False', 'False'),
+            ('float', 1.0, 1.0, '1.0'),
+            ('float', 1 / 3, 1 / 3, str(1 / 3)),  # todo imp float cmp
+            ('float', 0.0, 0.0, False),
+            ('float', False, False, False),
+            ('str', {}, '{}', '{}'),
+            ('str', {'key': 'value'}, str({'key': 'value'}), str({'key': 'value'})),
+            ('str', [], '[]', '[]'),
+            ('str', [1, 2, 3], '[1, 2, 3]', '[1, 2, 3]'),
+            ('str', 'value', 'value', 'value'),
+            ('str', None, '', False),
+            ('str', False, '', False),
+            ('str', '', '', False)
+        ]
+
+        for num, (value_type, set_value, get_value, get_param_value) in enumerate(test_values):
+            key_ = f'{key}_{num}'
+            ICP.set(key_, set_value, value_type)
+            if value_type == 'bool':
+                self.assertIs(ICP.get(key_), get_value)
+                self.assertEqual(ICP.get_param(key_), get_param_value)
+            elif value_type == 'int':
+                value = ICP.get(key_)
+                self.assertEqual(type(value).__name__, 'int')
+                self.assertEqual(ICP.get_param(key_), get_param_value)
+                self.assertEqual(value, get_value)
+            elif value_type == 'float':
+                value = ICP.get(key_)
+                self.assertEqual(type(value).__name__, 'float')
+                self.assertEqual(value, get_value)
+                self.assertEqual(ICP.get_param(key_), get_param_value)
+            elif value_type == 'str':
+                value = ICP.get(key_)
+                self.assertEqual(type(value).__name__, 'str')
+                self.assertEqual(value, get_value)
+                self.assertEqual(ICP.get_param(key_), get_param_value)
+            else:
+                raise ValueError(f"Invalid value_type: {value_type}")

--- a/odoo/addons/test_orm/models/__init__.py
+++ b/odoo/addons/test_orm/models/__init__.py
@@ -2,4 +2,5 @@ from . import (
     test_orm,
     test_performance,
     test_unity_read,
+    test_config,
 )

--- a/odoo/addons/test_orm/models/test_config.py
+++ b/odoo/addons/test_orm/models/test_config.py
@@ -1,0 +1,55 @@
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = 'res.config.settings'
+
+    test_boolean_field = fields.Boolean(
+        string='Test Boolean Field',
+        config_parameter='test_orm.test_boolean_field',
+        help='A test boolean field for configuration settings'
+    )
+
+    test_integer_field = fields.Integer(
+        string='Test Integer Field',
+        config_parameter='test_orm.test_integer_field',
+        help='A test integer field for configuration settings'
+    )
+
+    test_float_field = fields.Float(
+        string='Test Float Field',
+        digits=(10, 2),
+        config_parameter='test_orm.test_float_field',
+        help='A test float field for configuration settings'
+    )
+
+    test_char_field = fields.Char(
+        string='Test Char Field',
+        config_parameter='test_orm.test_char_field',
+        help='A test char field for configuration settings'
+    )
+
+    test_selection_field = fields.Selection(
+        string='Test Selection Field',
+        selection=[
+            ('option1', 'Option 1'),
+            ('option2', 'Option 2'),
+            ('option3', 'Option 3'),
+        ],
+        config_parameter='test_orm.test_selection_field',
+        help='A test selection field for configuration settings'
+    )
+
+    test_many2one_field = fields.Many2one(
+        string='Test Many2one Field',
+        comodel_name='res.partner',
+        config_parameter='test_orm.test_many2one_field',
+        help='A test many2one field for configuration settings'
+    )
+
+
+    test_datetime_field = fields.Datetime(
+        string='Test Datetime Field',
+        config_parameter='test_orm.test_datetime_field',
+        help='A test datetime field for configuration settings'
+    )

--- a/odoo/addons/test_orm/models/test_config.py
+++ b/odoo/addons/test_orm/models/test_config.py
@@ -47,7 +47,6 @@ class ResConfigSettings(models.TransientModel):
         help='A test many2one field for configuration settings'
     )
 
-
     test_datetime_field = fields.Datetime(
         string='Test Datetime Field',
         config_parameter='test_orm.test_datetime_field',

--- a/odoo/addons/test_orm/tests/__init__.py
+++ b/odoo/addons/test_orm/tests/__init__.py
@@ -2,6 +2,7 @@ from . import (
     test_attributes,
     test_autovacuum,
     test_company_checks,
+    test_config_settings,
     test_domain,
     test_fields,
     test_indexed_translation,

--- a/odoo/addons/test_orm/tests/test_config_settings.py
+++ b/odoo/addons/test_orm/tests/test_config_settings.py
@@ -1,0 +1,242 @@
+from datetime import datetime
+
+from odoo.tests.common import TransactionCase
+from odoo.fields import Datetime
+from freezegun import freeze_time
+
+# the res_config_write_value for res_config_setting_values to simulate a never customized setting
+DEFAULT_SETTING = object()
+
+class TestConfigSettings(TransactionCase):
+    """Test res.config.settings functionality
+    
+    res.config.settings
+    """
+
+    def _test_field(self, field_name, res_config_setting_values, get_param_values):
+        ResConfigSettings = self.env['res.config.settings']
+        IrConfigParameter = self.env['ir.config_parameter']
+        config_parameter = ResConfigSettings._fields[field_name].config_parameter
+
+        res_config_write_value, res_config_get_value = res_config_setting_values
+
+        # res.config.settings: set_values
+        if res_config_write_value is DEFAULT_SETTING:
+            self.env['ir.config_parameter'].search([('key', '=', config_parameter)]).unlink()
+        else:
+            self.config_settings = ResConfigSettings.create({})
+            self.config_settings[field_name] = res_config_write_value
+            self.config_settings.set_values()
+
+        # res.config.settings: get_values
+        new_config = ResConfigSettings.create({})
+        if res_config_get_value is False:
+            self.assertIs(new_config[field_name], False)
+        else:
+            self.assertEqual(new_config[field_name], res_config_get_value)
+
+        # ir.config_parameter: get_param
+        for get_param_default, get_param_value in get_param_values:
+            if get_param_value is False:
+                self.assertIs(IrConfigParameter.get_param(config_parameter, get_param_default), False)
+            else:
+                self.assertEqual(IrConfigParameter.get_param(config_parameter, get_param_default), get_param_value)
+
+    def test_boolean_field(self):
+        # [(res_config_write_value, res_config_get_value), [(get_param_default, get_param_value), ...]]
+        test_values = [
+            ([DEFAULT_SETTING, False], [('False', 'False'), (False, False)]),
+            ([False, False], [('False', 'False'), (False, False)]),
+            ([True, True], [('False', 'True'), (False, 'True')]),
+        ]
+
+        for res_config_setting_values, get_param_values in test_values:
+            self._test_field('test_boolean_field', res_config_setting_values, get_param_values)
+
+        # technically possible, but developer will easily notice the behavior doesn't suit for the business
+        field = self.env['res.config.settings']._fields['test_boolean_field']
+        old_default = field.default
+        self.addCleanup(setattr, field, 'default', old_default)
+        field.default = lambda x: True
+
+        # [(res_config_write_value, res_config_get_value), [(get_param_default, get_param_value), ...]]
+        test_values = [
+            ([DEFAULT_SETTING, True], [('True', 'True'), (True, True)]),
+            ([False, True], [('True', 'True'), (True, True)]),  # strange behavior
+            ([True, True], [('True', 'True'), (True, 'True')]),
+        ]
+        for res_config_setting_values, get_param_values in test_values:
+            self._test_field('test_boolean_field', res_config_setting_values, get_param_values)
+
+    def test_integer_field(self):
+        # [(res_config_write_value, res_config_get_value), [(get_param_default, get_param_value), ...]]
+        test_values = [
+            ([DEFAULT_SETTING, 0], [(0, 0), ('0', '0'), (False, False)]),
+            ([0, 0], [(0, 0), ('0', '0'), (False, False)]),
+            ([1, 1], [(0, '1'), ('0', '1'), (False, '1')]),
+        ]
+        for res_config_setting_values, get_param_values in test_values:
+            self._test_field('test_integer_field', res_config_setting_values, get_param_values)
+        
+        field = self.env['res.config.settings']._fields['test_integer_field']
+        old_default = field.default
+        self.addCleanup(setattr, field, 'default', old_default)
+        field.default = lambda x: 100
+
+        # [(res_config_write_value, res_config_get_value), [(get_param_default, get_param_value), ...]]
+        test_values = [
+            ([DEFAULT_SETTING, 100], [(100, 100), ('100', '100')]),
+            ([0, 100], [(100, 100), ('100', '100')]),
+            ([1, 1], [(100, '1'), ('100', '1')]),
+        ]
+        for res_config_setting_values, get_param_values in test_values:
+            self._test_field('test_integer_field', res_config_setting_values, get_param_values)
+
+    def test_float_field(self):
+        # [(res_config_write_value, res_config_get_value), [(get_param_default, get_param_value), ...]]
+        test_values = [
+            ([DEFAULT_SETTING, 0], [(False, False), (0.0, 0.0), ('0.0', '0.0')]),
+            ([0, 0], [(False, False), (0.0, 0.0), ('0.0', '0.0')]),
+            ([1, 1], [(False, '1.0'), (0.0, '1.0'), ('0.0', '1.0')]),
+            ([3.1415926, 3.14], [(False, '3.14'), (0.0, '3.14'), ('0.0', '3.14')]),
+        ]
+        for res_config_setting_values, get_param_values in test_values: 
+            self._test_field('test_float_field', res_config_setting_values, get_param_values)
+
+        field = self.env['res.config.settings']._fields['test_float_field']
+        old_default = field.default
+        self.addCleanup(setattr, field, 'default', old_default)
+        field.default = lambda x: 100.0
+
+        # [(res_config_write_value, res_config_get_value), [(get_param_default, get_param_value), ...]]
+        test_values = [
+            ([DEFAULT_SETTING, 100.0], [(100.0, 100.0), ('100.0', '100.0')]),
+            ([0, 100.0], [(100.0, 100.0), ('100.0', '100.0')]),
+            ([1, 1], [(100.0, '1.0'), ('100.0', '1.0')]),
+            ([3.1415926, 3.14], [(100.0, '3.14'), ('100.0', '3.14')]),
+        ]
+        for res_config_setting_values, get_param_values in test_values:
+            self._test_field('test_float_field', res_config_setting_values, get_param_values)
+
+    def test_char_field(self):
+        # [(res_config_write_value, res_config_get_value), [(get_param_default, get_param_value), ...]]
+        test_values = [
+            ([DEFAULT_SETTING, False], [(False, False), ('', '')]),
+            (['', False], [(False, False), ('', '')]),
+            ([False, False], [(False, False), ('', '')]),
+            (['value', 'value'], [(False, 'value'), ('', 'value')]),
+        ]
+        for res_config_setting_values, get_param_values in test_values:
+            self._test_field('test_char_field', res_config_setting_values, get_param_values)
+
+        field = self.env['res.config.settings']._fields['test_char_field']
+        old_default = field.default
+        self.addCleanup(setattr, field, 'default', old_default)
+        field.default = lambda x: ''
+
+        # [(res_config_write_value, res_config_get_value), [(get_param_default, get_param_value), ...]]
+        test_values = [
+            ([DEFAULT_SETTING, ''], [(False, False), ('', '')]),
+            (['', ''], [(False, False), ('', '')]),
+            ([False, ''], [(False, False), ('', '')]),
+            (['value', 'value'], [(False, 'value'), ('', 'value')]),
+        ]
+        for res_config_setting_values, get_param_values in test_values:
+            self._test_field('test_char_field', res_config_setting_values, get_param_values)
+
+        field.default = lambda x: 'default'
+
+        # [(res_config_write_value, res_config_get_value), [(get_param_default, get_param_value), ...]]
+        test_values = [
+            ([DEFAULT_SETTING, 'default'], [('default', 'default'), ('default', 'default')]),
+            (['', 'default'], [('default', 'default'), ('default', 'default')]),
+            ([False, 'default'], [('default', 'default'), ('default', 'default')]),
+            (['value', 'value'], [('default', 'value'), ('default', 'value')]),
+        ]
+        for res_config_setting_values, get_param_values in test_values:
+            self._test_field('test_char_field', res_config_setting_values, get_param_values)
+
+    def test_selection_field(self):
+        # [(res_config_write_value, res_config_get_value), [(get_param_default, get_param_value), ...]]
+        test_values = [
+            ([DEFAULT_SETTING, False], [(False, False)]),
+            ([False, False], [(False, False)]),
+            (['option2', 'option2'], [(False, 'option2')]),
+        ]
+        for res_config_setting_values, get_param_values in test_values:
+            self._test_field('test_selection_field', res_config_setting_values, get_param_values)
+
+        field = self.env['res.config.settings']._fields['test_selection_field']
+        old_default = field.default
+        self.addCleanup(setattr, field, 'default', old_default)
+        field.default = lambda x: 'option1'
+
+        # [(res_config_write_value, res_config_get_value), [(get_param_default, get_param_value), ...]]
+        test_values = [
+            ([DEFAULT_SETTING, 'option1'], [('option1', 'option1')]),
+            ([False, 'option1'], [('option1', 'option1')]),
+            (['option2', 'option2'], [('option1', 'option2')]),
+        ]
+        for res_config_setting_values, get_param_values in test_values:
+            self._test_field('test_selection_field', res_config_setting_values, get_param_values)
+
+    def test_many2one_field(self):
+        """Test many2one field functionality"""
+        falsy_partner = self.env['res.partner']
+        partner = self.env['res.partner'].create({'name': 'Test Partner'})
+
+        # [(res_config_write_value, res_config_get_value), [(get_param_default, get_param_value), ...]]
+        test_values = [
+            ([DEFAULT_SETTING, falsy_partner], [(False, False)]),
+            ([False, falsy_partner], [(False, False)]),
+            ([falsy_partner, falsy_partner], [(False, False)]),
+            ([partner.id, partner], [(False, str(partner.id))]),
+            ([partner, partner], [(False, str(partner.id))]),
+        ]
+        for res_config_setting_values, get_param_values in test_values:
+            self._test_field('test_many2one_field', res_config_setting_values, get_param_values)
+
+    @freeze_time(datetime(2024, 12, 31, 12, 0, 0))
+    def test_datetime_field(self):
+        test_datetime = datetime(2022, 1, 1, 12, 0, 0)
+
+        # [(res_config_write_value, res_config_get_value), [(get_param_default, get_param_value), ...]]
+        test_values = [
+            ([DEFAULT_SETTING, False], [(False, False)]),
+            ([False, False], [(False, False)]),
+            ([test_datetime, test_datetime], [(False, str(test_datetime))]),
+            ([str(test_datetime), test_datetime], [(False, str(test_datetime))]),
+        ]
+        for res_config_setting_values, get_param_values in test_values:
+            self._test_field('test_datetime_field', res_config_setting_values, get_param_values)
+        
+        # static default
+        field = self.env['res.config.settings']._fields['test_datetime_field']
+        old_default = field.default
+        self.addCleanup(setattr, field, 'default', old_default)
+        default_datetime = datetime(2023, 7, 7, 12, 0, 0)
+        field.default = lambda x: default_datetime
+
+        # [(res_config_write_value, res_config_set_value), [(get_param_default, get_param_value), ...]]
+        test_values = [
+            ([DEFAULT_SETTING, default_datetime], [(default_datetime, default_datetime)]),
+            ([False, default_datetime], [(default_datetime, default_datetime)]),
+            ([test_datetime, test_datetime], [(default_datetime, str(test_datetime))]),
+            ([str(test_datetime), test_datetime], [(default_datetime, str(test_datetime))]),
+        ]
+        for res_config_setting_values, get_param_values in test_values:
+            self._test_field('test_datetime_field', res_config_setting_values, get_param_values)
+        
+        # dynamic default
+        field.default = Datetime.now
+        now = datetime(2024, 12, 31, 12, 0, 0)
+
+        # [(res_config_write_value, res_config_get_value), [(get_param_default, get_param_value), ...]]
+        test_values = [
+            ([DEFAULT_SETTING, now], [(now, now)]),
+            ([False, now], [(now, now)]),
+            ([test_datetime, test_datetime], [(now, str(test_datetime))]),
+            ([str(test_datetime), test_datetime], [(now, str(test_datetime))]),
+        ]
+        for res_config_setting_values, get_param_values in test_values:
+            self._test_field('test_datetime_field', res_config_setting_values, get_param_values)

--- a/odoo/orm/environments.py
+++ b/odoo/orm/environments.py
@@ -145,6 +145,9 @@ class Environment(Mapping[str, "BaseModel"]):
         su = (user is None and self.su) if su is None else su
         return Environment(cr, uid, context, su)
 
+    def config(self, key) -> str | bool | int | float | None:
+        return self['ir.config_parameter'].get(key)
+
     @typing.overload
     def ref(self, xml_id: str, raise_if_not_found: typing.Literal[True] = True) -> BaseModel:
         ...


### PR DESCRIPTION
[IMP] base: improve config parameter
There are different ways to modify the ir.config_parameter
1. set_param(key, value)
2. import from xml
```
	<record id="xml_id" model="ir.config_parameter">
        <field name="key">key_name</field>
        <field name="value">value</field>
    </record>
    <function model="ir.config_parameter" name="set_param" eval="('key_name', 'value')"/>
```
4. ['res.config.settings'].create({"key": value}).execute()
5. change 'res.config.settings' from UI

Tricky use case 1
If the ir.config_parameter is set by 2:
when the user set it to a falsy value (`False`, `""`), the database will remove
it as well as its ir.model.data. So if we hope the config won't be changed after
upgrade, the record tag in must have both `noupdate="1"` and `forcecreate="0"`

Tricky use case 2
In the ir.config.settings, if a field has both config_parameter and truthy
default attributes, the developers have to promise all use cases for get_param
for the key must have the same default value. The get_param(key, default) will
return `str` if config has a truthy value, and default otherwise. So the return
type is unknown and the developer must call str2bool/int/float to manually
convert the type. `bool(get_param(key, True))` which is always truthy, is a very
intuitive but wrong code.

Tricky use case 3
In the ir.config.settings if a boolean field has both config_parameter and
default=True attributes, the developer must be very careful about
`set_param(key, value)`
`set_param(key, False)` means fallback the config to the default,
`str2bool(get_param(key, 'True'))` will return `True`
`set_param(key, 'False')` means set the value to 'False',
`str2bool(get_param(key, 'True'))` will return `False`
From the UI of settings, there is no way to set it the ir.config_parameter to
`'False'`

For compatibility
the old set_param, and get_param is still usable in most cases, but when set
it to a falsy value, the record as well as its ir.model.data will be kept

New apis
get:
usually get has ``default`` when undefined. But for configuration, using different
default values at different places is tricky and bug prone.

the ir.config_parameter can be set by res.config.settings' fields with attribute
config_parameter. These fields can be Boolean/Char/Text/Integer/Float. So it
would be more intuitive, easier-to-use and less error-prone to directly `get`
their values as their record format (bool/str/int/float) instead of always str

The 'ir.config_parameter' must be defined before use.
1. explicitly define them in the data.xml
2. implicitly define them in the 'res.config.settings' with config_parameter


https://github.com/odoo/upgrade/pull/8212