### PR TITLE
[REF] web_tour: check tourStep structure 

### DIFF
--- a/addons/hr_expense/static/tests/tours/expense_form_tours.js
+++ b/addons/hr_expense/static/tests/tours/expense_form_tours.js
@@ -50,6 +50,5 @@ registry.category("web_tour.tours").add('create_expense_no_employee_access_tour'
     {
         content: "Check",
         trigger: '.o_app[data-menu-xmlid="hr_expense.menu_hr_expense_root"]',
-        isCheck: true,
     },
 ]});

--- a/addons/mail/static/tests/tours/discuss_channel_as_guest_tour.js
+++ b/addons/mail/static/tests/tours/discuss_channel_as_guest_tour.js
@@ -15,7 +15,6 @@ registry.category("web_tour.tours").add("discuss_channel_as_guest_tour.js", {
         {
             content: "Click join",
             trigger: "button[title='Join Channel']",
-            extraTrigger: ".o-mail-Thread",
             run: "click",
         },
         {

--- a/addons/mail/static/tests/tours/discuss_channel_public_tour.js
+++ b/addons/mail/static/tests/tours/discuss_channel_public_tour.js
@@ -6,7 +6,6 @@ registry.category("web_tour.tours").add("discuss_channel_public_tour.js", {
     steps: () => [
         {
             trigger: ".o-mail-DiscussPublic",
-            extraTrigger: ".o-mail-Thread",
         },
         {
             content: "Check that we are on channel page",
@@ -24,7 +23,6 @@ registry.category("web_tour.tours").add("discuss_channel_public_tour.js", {
                 }
                 document.body.classList.add("o_discuss_channel_public_modules_loaded");
             },
-            extraTrigger: ".o_discuss_channel_public_modules_loaded",
         },
         {
             content: "Wait for all modules loaded check in previous step",

--- a/addons/mass_mailing/static/tests/tours/mailing_portal_unsubscribe_from_document.js
+++ b/addons/mass_mailing/static/tests/tours/mailing_portal_unsubscribe_from_document.js
@@ -18,7 +18,7 @@ registry.category("web_tour.tours").add('mailing_portal_unsubscribe_from_documen
             trigger: "div#o_mailing_subscription_form_blocklisted:not(:has(p:contains('You will not receive any news from those mailing lists you are a member of')))",
             run: "click",
         }, {
-            contnet: "Warning will not receive anything anymore",
+            content: "Warning will not receive anything anymore",
             trigger: "div#o_mailing_subscription_form_blocklisted p:contains('You will not hear from us anymore.')",
             run: "click",
         }, {

--- a/addons/point_of_sale/static/tests/tours/utils/chrome_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/chrome_util.js
@@ -23,7 +23,6 @@ export function clickMenuDropdownOption(name) {
 export function isCashMoveButtonHidden() {
     return [
         {
-            extraTrigger: ".pos-topheader",
             trigger: ".pos-topheader:not(:contains(Cash In/Out))",
         },
     ];

--- a/addons/web_tour/static/src/tour_service/tour_compilers.js
+++ b/addons/web_tour/static/src/tour_service/tour_compilers.js
@@ -112,7 +112,7 @@ function describeWhyStepFailed(step) {
     } else if (!stepState.isVisible) {
         return "Element has been found but isn't displayed. (Use 'step.allowInvisible: true,' if you want to skip this check)";
     } else if (!stepState.isEnabled) {
-        return "Element has been found but is disabled. (If this step does not run action so that you only want to check that element is visible, you can use 'step.isCheck: true,')";
+        return "Element has been found but is disabled.";
     } else if (stepState.isBlocked) {
         return "Element has been found but DOM is blocked by UI.";
     } else if (!stepState.hasRun) {

--- a/addons/web_tour/static/src/tour_service/tour_service.js
+++ b/addons/web_tour/static/src/tour_service/tour_service.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { EventBus, markup, whenReady, reactive } from "@odoo/owl";
+import { EventBus, markup, whenReady, reactive, validate } from "@odoo/owl";
 import { browser } from "@web/core/browser/browser";
 import { _t } from "@web/core/l10n/translation";
 import { MacroEngine } from "@web/core/macro";
@@ -59,6 +59,45 @@ import { callWithUnloadCheck } from "./tour_utils";
  * @typedef {"manual" | "auto"} TourMode
  */
 
+/**
+ * Check properties of tourStep
+ * @param {TourStep} tourStep
+ */
+function checkTourStepKeyValues(tourStep) {
+    const stepschema = {
+        id: { type: String, optional: true },
+        trigger: { type: String },
+        extra_trigger: { type: String, optional: true },
+        alt_trigger: { type: String, optional: true },
+        skip_trigger: { type: String, optional: true },
+        content: { type: [String, Object], optional: true }, //allow object for _t && markup
+        position: { type: String, optional: true },
+        edition: { type: String, optional: true },
+        run: { type: [String, Function], optional: true },
+        allowInvisible: { type: Boolean, optional: true },
+        allowDisabled: { type: Boolean, optional: true },
+        auto: { type: Boolean, optional: true },
+        in_modal: { type: Boolean, optional: true },
+        width: { type: Number, optional: true },
+        timeout: { type: Number, optional: true },
+        consumeVisibleOnly: { type: Boolean, optional: true },
+        consumeEvent: { type: String, optional: true },
+        mobile: { type: Boolean, optional: true },
+        title: { type: String, optional: true },
+        shadow_dom: { type: Boolean, optional: true },
+        debugHelp: { type: String, optional: true },
+        noPrepend: { type: Boolean, optional: true },
+    };
+
+    try {
+        validate(tourStep, stepschema);
+        return true;
+    } catch (error) {
+        console.error(`Error for step ${JSON.stringify(tourStep, null, 4)}\n${error.message}`);
+        return false;
+    }
+}
+
 export const tourService = {
     // localization dependency to make sure translations used by tours are loaded
     dependencies: ["orm", "effect", "ui", "overlay", "localization"],
@@ -82,7 +121,7 @@ export const tourService = {
                         throw new Error(`tour.steps has to be a function that returns TourStep[]`);
                     }
                     if (!steps) {
-                        steps = tour.steps();
+                        steps = tour.steps().filter(checkTourStepKeyValues);
                     }
                     return steps;
                 },

--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -63,7 +63,6 @@ function selectColorPalette(position = "left") {
         content: markup(_t(`<b>Select</b> a Color Palette.`)),
         position: position,
         run: 'click',
-        location: position === 'left' ? '#oe_snippets' : undefined,
     };
 }
 
@@ -122,7 +121,6 @@ function selectNested(trigger, optionName, alt_trigger = null, optionTooltipLabe
         alt_trigger: alt_trigger == null ? undefined : `${option_block} ${alt_trigger}`,
         position: position,
         run: 'click',
-        location: position === 'left' ? '#oe_snippets' : undefined,
     };
 }
 

--- a/addons/website/static/tests/tours/edit_link_popover.js
+++ b/addons/website/static/tests/tours/edit_link_popover.js
@@ -138,7 +138,6 @@ wTourUtils.registerWebsitePreviewTour('edit_link_popover_1', {
     {
         content: "Check that the modal is closed",
         trigger: ":iframe html:not(.modal-body)",
-        isCheck:true,
     }
 ]);
 

--- a/addons/website/static/tests/tours/snippet_empty_parent_autoremove.js
+++ b/addons/website/static/tests/tours/snippet_empty_parent_autoremove.js
@@ -35,7 +35,6 @@ wTourUtils.registerWebsitePreviewTour('snippet_empty_parent_autoremove', {
     {
         content: "Check that #wrap is empty",
         trigger: ':iframe #wrap:empty',
-        isCheck:true,
     },
 
     // Cover: test that parallax, bg-filter and shape are not treated as content

--- a/addons/website_sale/static/tests/tours/website_sale_preconfigured_variant_price.js
+++ b/addons/website_sale/static/tests/tours/website_sale_preconfigured_variant_price.js
@@ -5,16 +5,16 @@ import { registry } from "@web/core/registry";
 registry.category("web_tour.tours").add('website_sale_product_configurator_optional_products_tour', {
     test: true,
     steps: () => [{
-    name: 'Click Aluminium Option',
+    content: 'Click Aluminium Option',
     trigger: 'ul.js_add_cart_variants span:contains("Aluminium")',
     extra_trigger: 'ul.js_add_cart_variants span:contains("Aluminium") ~ span.badge:contains("50.40")',
     run: "click",
 }, {
-    name: 'Add to cart',
+    content: 'Add to cart',
     trigger: '#add_to_cart',
     run: "click",
 }, {
-    name: 'Check that modal was opened with the correct variant price',
+    content: 'Check that modal was opened with the correct variant price',
     trigger: 'main.oe_advanced_configurator_modal',
     extra_trigger: 'main.oe_advanced_configurator_modal span:contains("800.40")',
 }]});

--- a/addons/website_sale/static/tests/tours/website_sale_shop_customize.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_customize.js
@@ -49,7 +49,7 @@ wTourUtils.registerWebsitePreviewTour('shop_customize', {
         },
         ...wTourUtils.clickOnSave(),
         {
-            context: "check variant price",
+            content: "check variant price",
             trigger: ':iframe .form-check:contains("Aluminium") .badge:contains("+") .oe_currency_value:contains("50.4")',
         },
         {

--- a/addons/website_sale/static/tests/tours/website_sale_shop_list_view_b2c.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_list_view_b2c.js
@@ -47,7 +47,7 @@ wTourUtils.registerWebsitePreviewTour('shop_list_view_b2c', {
             trigger: ':iframe .js_product_change',
         },
         {
-            context: "check variant price",
+            content: "check variant price",
             trigger: ':iframe .form-check:contains("Aluminium") .badge:contains("+") .oe_currency_value:contains("55.44")',
         },
         {

--- a/addons/website_sale/static/tests/tours/website_sale_shop_multi_checkbox.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_multi_checkbox.js
@@ -75,7 +75,6 @@ registry.category("web_tour.tours").add('tour_shop_multi_checkbox_single_value',
     {
         content: "check price",
         trigger: '.oe_currency_value:contains("750")',
-        isCheck: true,
     },
     {
         content: 'click on the first option to select it',
@@ -85,7 +84,6 @@ registry.category("web_tour.tours").add('tour_shop_multi_checkbox_single_value',
     {
         content: "check price of options is correct",
         trigger: '.oe_currency_value:contains("750")',
-        isCheck: true,
     },
     {
         content: "add to cart",
@@ -96,6 +94,5 @@ registry.category("web_tour.tours").add('tour_shop_multi_checkbox_single_value',
     {
         content: "check choice was correctly saved",
         trigger: '#cart_products div div.text-muted>span:contains("Toppings: cheese")',
-        isCheck: true,
     },
 ]});


### PR DESCRIPTION
In this commit, we add a check of the composition of a tour step (the
keys and values ​​of the object). Using an unauthorized key or a value 
that has the wrong type returns an error and ends the tour.

task~3974087

https://github.com/odoo/enterprise/pull/64327