### PR TITLE
[FIX] product: fix traceback when the invoice date is false

### DIFF
--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -643,7 +643,7 @@ class ProductProduct(models.Model):
 
     def _get_filtered_sellers(self, partner_id=False, quantity=0.0, date=None, uom_id=False, params=False):
         self.ensure_one()
-        if date is None:
+        if not date:
             date = fields.Date.context_today(self)
         precision = self.env['decimal.precision'].precision_get('Product Unit of Measure')
 


### PR DESCRIPTION
This traceback occurs when the user created a refund bill with no invoice date 
and tries to add a product through the catalog.

To reproduce this issue:-

1) Install `purchase`
2) Create a new product and add a `vendor` with a `start` and `end` date
   in the `purchase page` of the product.
3) Now create a `refund bill` for the above-created vendor from the invoice 
4) Don't give the `bill date` and try to add a product from `Catalog` 
5) A traceback occurs.

Error:- 
```
TypeError: '>' not supported between instances of 'datetime.date' and 'bool'
```

As you can see `invoice_date` is not required when creating a refund bill. 
But here the `invoice_date` is used when selecting a product through catalog. https://github.com/odoo/odoo/blob/c8985212fb4c937b814aaf7fe2ddca992b01735c/addons/account/models/account_move.py#L2168-L2172

So the `invoice_date` value will be `False`. But here only the `None` case is handled for the date
in the `_select_seller` method
https://github.com/odoo/odoo/blob/c8985212fb4c937b814aaf7fe2ddca992b01735c/addons/product/models/product_product.py#L646-L647

which leads to the above traceback when a comparison is made between bool and DateTime.
https://github.com/odoo/odoo/blob/c8985212fb4c937b814aaf7fe2ddca992b01735c/addons/product/models/product_product.py#L659-L662

After applying this commit will resolve this issue by handling the False case also.

sentry-5475144539