### PR TITLE
[FIX] http: allow proxy-fix in wesg environ

### DIFF
--- a/odoo/http.py
+++ b/odoo/http.py
@@ -1210,7 +1210,7 @@ class HTTPRequest:
         self.environ = {
             key: value
             for key, value in self.__environ.items()
-            if not key.startswith(('werkzeug.', 'wsgi.')) or key in ['wsgi.url_scheme']
+            if not key.startswith(('werkzeug.', 'wsgi.')) or key in ['wsgi.url_scheme', 'werkzeug.proxy_fix.orig']
         }
 
     def __enter__(self):


### PR DESCRIPTION
(note for reviewer: I reset my branch on 15.0)

The `werkzeug.proxy_fix.orig` is set when running in --proxy-mode, it holds the original value of various headers before the ProxyFix class changed them according to the `X-Forwarded-` headers.

It is a dictionnary with the following entries:

    orig_remote_addr = environ_get("REMOTE_ADDR")
    orig_wsgi_url_scheme = environ_get("wsgi.url_scheme")
    orig_http_host = environ_get("HTTP_HOST")
    "werkzeug.proxy_fix.orig": {
        "REMOTE_ADDR": orig_remote_addr,
        "wsgi.url_scheme": orig_wsgi_url_scheme,
        "HTTP_HOST": orig_http_host,
        "SERVER_NAME": environ_get("SERVER_NAME"),
        "SERVER_PORT": environ_get("SERVER_PORT"),
        "SCRIPT_NAME": environ_get("SCRIPT_NAME"),
    }

All those sub-entries are already allow-listed by the Odoo's HTTPRequest class.

Accessing those values is handy when debugging the --proxy-mode, it allows to see at a glance if the proxy-mode was effective for this request: the `werkzeug.proxy_fix.orig` entry is present; or not: the entry is absent.