### PR TITLE
[IMP] sale: prevent to recompute price on sol

### DIFF
--- a/addons/repair/models/repair.py
+++ b/addons/repair/models/repair.py
@@ -644,7 +644,7 @@ class Repair(models.Model):
         for repair in self:
             add_moves = repair.move_ids.filtered(lambda m: m.repair_line_type == 'add' and m.sale_line_id)
             if repair.under_warranty:
-                add_moves.sale_line_id.write({'price_unit': 0.0})
+                add_moves.sale_line_id.write({'price_unit': 0.0, 'technical_price_unit': 0.0})
             else:
                 add_moves.sale_line_id._compute_price_unit()
 

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1168,6 +1168,7 @@ class SaleOrder(models.Model):
     def _recompute_prices(self):
         lines_to_recompute = self._get_update_prices_lines()
         lines_to_recompute.invalidate_recordset(['pricelist_item_id'])
+        lines_to_recompute.technical_price_unit = 0.0
         lines_to_recompute._compute_price_unit()
         # Special case: we want to overwrite the existing discount on _recompute_prices call
         # i.e. to make sure the discount is correctly reset

--- a/addons/sale/tests/test_sale_prices.py
+++ b/addons/sale/tests/test_sale_prices.py
@@ -523,6 +523,21 @@ class TestSalePrices(SaleCommon):
             "The SO amount without pricelist should be the same than with an empty pricelist"
         )
 
+    def test_manual_price_prevents_recompute(self):
+        sale_order_line = self.sale_order.order_line[0]
+        # Ensure initial price is set correctly
+        self.assertEqual(sale_order_line.price_unit, 20.0)
+
+        # Update the price manually and then change the quantity
+        with Form(sale_order_line) as line:
+            line.price_unit = 100.0
+            line.product_uom_qty = 10
+
+        self.assertEqual(
+            sale_order_line.price_unit, 100.0,
+            "Price should remain 100.0 after changing the quantity"
+        )
+
     # Taxes tests:
     # We do not rely on accounting common on purpose to avoid
     # all the useless setup not needed here.

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -592,6 +592,7 @@
                                 <field
                                     name="price_unit"
                                     readonly="qty_invoiced &gt; 0"/>
+                                <field name="technical_price_unit" column_invisible="1"/>
                                 <field
                                     name="tax_id"
                                     widget="many2many_tags"

--- a/addons/sale_management/models/sale_order_option.py
+++ b/addons/sale_management/models/sale_order_option.py
@@ -109,6 +109,7 @@ class SaleOrderOption(models.Model):
         return {
             'order_id': self.order_id.id,
             'price_unit': self.price_unit,
+            'technical_price_unit': self.price_unit,
             'name': self.name,
             'product_id': self.product_id.id,
             'product_uom_qty': self.quantity,


### PR DESCRIPTION
Before this commit:
When a user manually changes the price on a SOL and then modifies the quantity, the price will be recomputed, reverting it to the product's default price instead of retaining the user's manually inputed price.

After this commit:
Once user manually set the price of a product on a SOL, it will remain fixed and will not be recomputed when the quantity is modified.

Task: 3964654

Enterprise PR: https://github.com/odoo/enterprise/pull/69282

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
