### PR TITLE
[IMP] account_debit_note: Introduce Dedicated Sequence for Debit Notes

### DIFF
--- a/addons/account_debit_note/__manifest__.py
+++ b/addons/account_debit_note/__manifest__.py
@@ -16,6 +16,7 @@ The wizard used is similar as the one for the credit note.
     'data': [
         'wizard/account_debit_note_view.xml',
         'views/account_move_view.xml',
+        'views/account_journal_views.xml',
         'security/ir.model.access.csv',
     ],
     'installable': True,

--- a/addons/account_debit_note/models/__init__.py
+++ b/addons/account_debit_note/models/__init__.py
@@ -2,3 +2,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import account_move
+from . import account_journal

--- a/addons/account_debit_note/models/account_journal.py
+++ b/addons/account_debit_note/models/account_journal.py
@@ -1,0 +1,18 @@
+from odoo import api, fields, models
+
+
+class AccountJournal(models.Model):
+    _inherit = "account.journal"
+
+    debit_sequence = fields.Boolean(
+        string="Dedicated Debit Note Sequence",
+        compute="_compute_debit_sequence",
+        readonly=False, store=True,
+        help="Check this box if you don't want to share the same sequence for invoices "
+        "and debit notes made from this journal",
+    )
+
+    @api.depends("type")
+    def _compute_debit_sequence(self):
+        for journal in self:
+            journal.debit_sequence = journal.type in ("sale", "purchase")

--- a/addons/account_debit_note/models/account_move.py
+++ b/addons/account_debit_note/models/account_move.py
@@ -32,3 +32,19 @@ class AccountMove(models.Model):
     def action_debit_note(self):
         action = self.env.ref('account_debit_note.action_view_account_move_debit')._get_action_dict()
         return action
+
+    def _get_last_sequence_domain(self, relaxed=False):
+        where_string, param = super()._get_last_sequence_domain(relaxed)
+        if self.journal_id.debit_sequence:
+            where_string += " AND debit_origin_id IS " + ("NOT NULL" if self.debit_origin_id else "NULL")
+        return where_string, param
+
+    def _get_starting_sequence(self):
+        starting_sequence = super()._get_starting_sequence()
+        if (
+            self.journal_id.debit_sequence
+            and self.debit_origin_id
+            and self.move_type in ("in_invoice", "out_invoice")
+        ):
+            starting_sequence = "D" + starting_sequence
+        return starting_sequence

--- a/addons/account_debit_note/views/account_journal_views.xml
+++ b/addons/account_debit_note/views/account_journal_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_account_journal_form_inherit_debit_note" model="ir.ui.view">
+        <field name="name">account.journal.form.inherit.debit.note</field>
+        <field name="model">account.journal</field>
+        <field name="inherit_id" ref="account.view_account_journal_form"/>
+        <field name="arch" type="xml">
+            <field name="refund_sequence" position="after">
+               <field name="debit_sequence" invisible="type not in ('sale', 'purchase')"/>
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/addons/l10n_latam_invoice_document/models/account_journal.py
+++ b/addons/l10n_latam_invoice_document/models/account_journal.py
@@ -36,9 +36,16 @@ class AccountJournal(models.Model):
                 raise ValidationError(_(
                     'You can not modify the field "Use Documents?" if there are validated invoices in this journal!'))
 
-    @api.onchange('type', 'l10n_latam_use_documents')
-    def _onchange_type(self):
-        res = super()._onchange_type()
-        if self.l10n_latam_use_documents:
-            self.refund_sequence = False
-        return res
+    @api.depends('type', 'l10n_latam_use_documents')
+    def _compute_debit_sequence(self):
+        super()._compute_debit_sequence()
+        for journal in self:
+            if journal.l10n_latam_use_documents:
+                journal.debit_sequence = False
+
+    @api.depends('type', 'l10n_latam_use_documents')
+    def _compute_refund_sequence(self):
+        super()._compute_refund_sequence()
+        for journal in self:
+            if journal.l10n_latam_use_documents:
+                journal.refund_sequence = False


### PR DESCRIPTION
- Before this PR, there was no dedicated sequence available for debit notes. It was considered as an invoice only.

- After this PR, a specific sequence for the Debit note is now available.

**task**-3906389