### PR TITLE
[FIX] hr_timesheet: resolve access right error on creating new subtask on portal

### DIFF
--- a/addons/hr_timesheet/models/hr_timesheet.py
+++ b/addons/hr_timesheet/models/hr_timesheet.py
@@ -446,3 +446,13 @@ class AccountAnalyticLine(models.Model):
                 'res_id': uom_hours.id,
                 'noupdate': True,
             })
+
+    def action_open_timesheet_view_portal(self):
+        self.ensure_one()
+        return {
+            'type': 'ir.actions.act_window',
+            'res_id': self.id,
+            'res_model': 'account.analytic.line',
+            'views': [(self.env.ref('hr_timesheet.timesheet_view_form_portal_user').id, 'form')],
+            'context': self._context,
+        }

--- a/addons/hr_timesheet/views/project_task_sharing_views.xml
+++ b/addons/hr_timesheet/views/project_task_sharing_views.xml
@@ -52,7 +52,7 @@
                             <field name="name"/>
                             <field name="unit_amount" widget="timesheet_uom" decoration-danger="unit_amount &gt; 24"/>
                         </tree>
-                        <kanban class="o_kanban_mobile">
+                        <kanban class="o_kanban_mobile" action="action_open_timesheet_view_portal" type="object">
                             <field name="date"/>
                             <field name="employee_id"/>
                             <field name="name"/>


### PR DESCRIPTION
- saas-17.4

issue 2:
###  Steps to Reproduce:
   - Install the hr_timesheet module.
   - Create a portal user.
   - Create a project, task, and sub-task (with timesheet entries).
   - Share the project with the portal user.
   - Log in as the portal user.
   - Open the shared project and navigate to the task.
   - Open timesheet.

### Issue:
   When a portal user tries to open the timesheet of a shared project task from a mobile device,
   an error occurs.

### Cause:
   The portal user does not have access to the analytic account, which triggers this error.  The form view for analytic.line 
   in the analytic module includes analyti_account_id.

### Solution:
   In this commit, we have used the `timesheet_view_form_portal_user` form view. This view  does not include 
   analytic_account_id, which prevents the access error from occurring.

task-4369891
