### PR TITLE
[FIX] payment: keep payment provider published status

### DIFF
--- a/addons/payment/views/payment_provider_views.xml
+++ b/addons/payment/views/payment_provider_views.xml
@@ -6,6 +6,8 @@
         <field name="model">payment.provider</field>
         <field name="arch" type="xml">
             <form string="Payment provider">
+                <!-- Prevent considering the field readonly and thus allow writing on it. -->
+                <field name="is_published" invisible="1"/>
                 <sheet>
                     <!-- === Stat Buttons === -->
                     <div class="oe_button_box" name="button_box"


### PR DESCRIPTION
Steps to reproduce
==================

- Website > Configuration > Payment Providers
- Enable a payment provider, and it will be published by default
- Save your changes
- Observed behavior: the status of the payment provider is Unpublished, even
- though it is published on the website
- When disabling the payment provider, the status will be changes to Published
- If you try to unpublish it, you'll get the message You cannot publish a disabled provider
- Expected behavior: it should be automatically published when enabled, and
- automatically unpublished when disabled. At the moment, the behavior from the
- front-end is okay, but the status of the publish button is wrong.

Cause of the issue
==================

Changes applied to readonly fields are not saved

https://github.com/odoo/odoo/blob/4f325ef620263c27e095eb49026a677ac617a0ee/addons/web/static/src/model/relational_model/record.js#L623-L630

Since https://github.com/odoo/odoo/pull/137031 ,
the field has been removed from the view. It is now considered readonly.

Solution
========

Add the field back to the view

opw-3908473