### PR TITLE
[FIX] mail: missing notif in systray

### DIFF
--- a/addons/im_livechat/models/mail_message.py
+++ b/addons/im_livechat/models/mail_message.py
@@ -21,7 +21,13 @@ class MailMessage(models.Model):
         for message in self:
             message.parent_body = message.parent_id.body if message.parent_id else False
 
-    def _message_format(self, format_reply=True, msg_vals=None, for_current_user=False):
+    def _message_format(
+        self,
+        format_reply=True,
+        msg_vals=None,
+        for_current_user=False,
+        follower_by_message_user=None,
+    ):
         """Override to remove email_from and to return the livechat username if applicable.
         A third param is added to the author_id tuple in this case to be able to differentiate it
         from the normal name in client code.
@@ -31,7 +37,12 @@ class MailMessage(models.Model):
         This allows the frontend display to include the additional features
         (e.g: Show additional buttons with the available answers for this step). """
 
-        vals_list = super()._message_format(format_reply=format_reply, msg_vals=msg_vals, for_current_user=for_current_user)
+        vals_list = super()._message_format(
+            format_reply=format_reply,
+            msg_vals=msg_vals,
+            for_current_user=for_current_user,
+            follower_by_message_user=follower_by_message_user,
+        )
         for vals in vals_list:
             message_sudo = self.browse(vals['id']).sudo().with_prefetch(self.ids)
             discuss_channel = self.env['discuss.channel'].browse(message_sudo.res_id) if message_sudo.model == 'discuss.channel' else self.env['discuss.channel']

--- a/addons/mail/controllers/mailbox.py
+++ b/addons/mail/controllers/mailbox.py
@@ -7,10 +7,13 @@ from odoo.http import request
 class MailboxController(http.Controller):
     @http.route("/mail/inbox/messages", methods=["POST"], type="json", auth="user")
     def discuss_inbox_messages(self, search_term=None, before=None, after=None, limit=30, around=None):
-        partner_id = request.env.user.partner_id.id
         domain = [("needaction", "=", True)]
         res = request.env["mail.message"]._message_fetch(domain, search_term=search_term, before=before, after=after, around=around, limit=limit)
-        return {**res, "messages": res["messages"]._message_format_personalize(partner_id)}
+        messages = res.pop("messages")
+        follower_by_message_user = request.env.user.sudo(False)._get_follower_by_message_user(messages)
+        return {**res, "messages": messages._message_format(
+            for_current_user=True, follower_by_message_user=follower_by_message_user
+        )}
 
     @http.route("/mail/history/messages", methods=["POST"], type="json", auth="user")
     def discuss_history_messages(self, search_term=None, before=None, after=None, limit=30, around=None):

--- a/addons/mail/static/src/core/web/mail_core_web_service.js
+++ b/addons/mail/static/src/core/web/mail_core_web_service.js
@@ -37,7 +37,7 @@ export class MailCoreWeb {
                 inbox.counter++;
             }
             inbox.messages.add(message);
-            if (notifId > message.thread.message_needaction_counter_bus_id) {
+            if (notifId > message.thread?.message_needaction_counter_bus_id) {
                 message.thread.message_needaction_counter++;
             }
         });

--- a/addons/mail/static/tests/legacy/helpers/mock_server/models/mail_message.js
+++ b/addons/mail/static/tests/legacy/helpers/mock_server/models/mail_message.js
@@ -337,34 +337,6 @@ patch(MockServer.prototype, {
         });
     },
     /**
-     * Simulate `_message_format_personalize` on `mail.message` for the current partner.
-     *
-     * @private
-     * @returns {integer[]} ids
-     * @returns {Object[]}
-     */
-    _mockMailMessageFormatPersonalize(ids) {
-        const messages = this._mockMailMessageMessageFormat(ids);
-        messages.forEach((message) => {
-            if (message.model && message.res_id) {
-                const follower = this.getRecords("mail.followers", [
-                    ["res_model", "=", message.model],
-                    ["res_id", "=", message.res_id],
-                    ["partner_id", "=", this.pyEnv.currentPartnerId],
-                ]);
-                if (follower.length !== 0) {
-                    const follower_id = follower[0].id;
-                    message.thread.selfFollower = {
-                        id: follower_id,
-                        is_active: true,
-                        partner: { id: this.pyEnv.currentPartnerId, type: "partner" },
-                    };
-                }
-            }
-        });
-        return messages;
-    },
-    /**
      * Simulates `_message_notification_format` on `mail.message`.
      *
      * @private

--- a/addons/mail/static/tests/mock_server/mock_models/mail_message.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_message.js
@@ -58,7 +58,12 @@ export class MailMessage extends models.ServerModel {
     }
 
     /** @param {number[]} ids */
-    _message_format(ids, for_current_user = false) {
+    _message_format(ids, for_current_user = false, follower_by_message_user) {
+        const kwargs = getKwArgs(arguments, "ids", "for_current_user", "follower_by_message_user");
+        ids = kwargs.ids;
+        for_current_user = kwargs.for_current_user;
+        follower_by_message_user = kwargs.follower_by_message_user;
+
         /** @type {import("mock_models").IrAttachment} */
         const IrAttachment = this.env["ir.attachment"];
         /** @type {import("mock_models").MailGuest} */
@@ -204,6 +209,18 @@ export class MailMessage extends models.ServerModel {
                 const formattedTrackingValues =
                     MailTrackingValue._tracking_value_format(trackingValues);
                 response["trackingValues"] = formattedTrackingValues;
+                if (follower_by_message_user) {
+                    const follower = follower_by_message_user.get(
+                        `${message.id}-${this.env.user.id}`
+                    );
+                    if (follower) {
+                        response.thread.selfFollower = {
+                            id: follower.id,
+                            is_active: true,
+                            partner: { id: follower.partner_id, type: "partner" },
+                        };
+                    }
+                }
             }
             return response;
         });
@@ -439,31 +456,6 @@ export class MailMessage extends models.ServerModel {
         messages.length = Math.min(messages.length, limit);
         res.messages = messages;
         return res;
-    }
-
-    /** @param {number[]} ids */
-    _message_format_personalize(ids) {
-        /** @type {import("mock_models").MailFollowers} */
-        const MailFollowers = this.env["mail.followers"];
-
-        const messages = this._message_format(ids, true);
-        messages.forEach((message) => {
-            if (message.model && message.res_id) {
-                const follower = MailFollowers._filter([
-                    ["res_model", "=", message.model],
-                    ["res_id", "=", message.res_id],
-                    ["partner_id", "=", this.env.user.partner_id],
-                ]);
-                if (follower.length !== 0) {
-                    message.thread.selfFollower = {
-                        id: follower[0].id,
-                        is_active: true,
-                        partner: { id: this.env.user.partner_id, type: "partner" },
-                    };
-                }
-            }
-        });
-        return messages;
     }
 
     /**

--- a/addons/mail/static/tests/mock_server/mock_models/mail_thread.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_thread.js
@@ -445,10 +445,20 @@ export class MailThread extends models.ServerModel {
                 if (partner.user_ids.length > 0) {
                     const [user] = ResUsers.search_read([["id", "=", partner.user_ids[0]]]);
                     if (user.notification_type === "inbox") {
+                        const follower_by_message_user = ResUsers._get_follower_by_message_user(
+                            [user.id],
+                            [message]
+                        );
                         notifications.push([
                             partner,
                             "mail.message/inbox",
-                            MailMessage._message_format_personalize([message_id])[0],
+                            MailMessage._message_format(
+                                [message.id],
+                                makeKwArgs({
+                                    for_current_user: true,
+                                    follower_by_message_user,
+                                })
+                            ),
                         ]);
                     }
                 }

--- a/addons/mail/static/tests/mock_server/mock_models/res_users.js
+++ b/addons/mail/static/tests/mock_server/mock_models/res_users.js
@@ -191,4 +191,27 @@ export class ResUsers extends webModels.ResUsers {
         }
         return Object.values(userActivitiesByModelName);
     }
+
+    _get_follower_by_message_user(ids, messages) {
+        /** @type {import("mock_models").MailFollowers} */
+        const MailFollowers = this.env["mail.followers"];
+        /** @type {import("mock_models").ResUsers} */
+        const ResUsers = this.env["res.users"];
+
+        const res = new Map();
+        const users = ResUsers._filter([["id", "in", ids]]);
+        for (const user of users) {
+            for (const message of messages) {
+                const [follower] = MailFollowers._filter([
+                    ["res_model", "=", message.model],
+                    ["res_id", "=", message.res_id],
+                    ["partner_id", "=", user.partner_id],
+                ]);
+                if (follower) {
+                    res.set(`${message.id}-${user.id}`, follower);
+                }
+            }
+        }
+        return res;
+    }
 }

--- a/addons/rating/models/mail_message.py
+++ b/addons/rating/models/mail_message.py
@@ -26,8 +26,19 @@ class MailMessage(models.Model):
         ])
         return [('id', 'in', ratings.mapped('message_id').ids)]
 
-    def _message_format(self, format_reply=True, msg_vals=None, for_current_user=False):
-        message_values = super()._message_format(format_reply=format_reply, msg_vals=msg_vals, for_current_user=for_current_user)
+    def _message_format(
+        self,
+        format_reply=True,
+        msg_vals=None,
+        for_current_user=False,
+        follower_by_message_user=None,
+    ):
+        message_values = super()._message_format(
+            format_reply=format_reply,
+            msg_vals=msg_vals,
+            for_current_user=for_current_user,
+            follower_by_message_user=follower_by_message_user,
+        )
         rating_mixin_messages = self.filtered(lambda message:
             message.model
             and message.res_id

--- a/addons/sms/models/mail_message.py
+++ b/addons/sms/models/mail_message.py
@@ -33,13 +33,24 @@ class MailMessage(models.Model):
             return ['&', ('notification_ids.notification_status', '=', 'exception'), ('notification_ids.notification_type', '=', 'sms')]
         raise NotImplementedError()
 
-    def _message_format(self, format_reply=True, msg_vals=None, for_current_user=False):
+    def _message_format(
+        self,
+        format_reply=True,
+        msg_vals=None,
+        for_current_user=False,
+        follower_by_message_user=None,
+    ):
         """ Override in order to retrieves data about SMS (recipient name and
             SMS status)
 
         TDE FIXME: clean the overall message_format thingy
         """
-        message_values = super()._message_format(format_reply=format_reply, msg_vals=msg_vals, for_current_user=for_current_user)
+        message_values = super()._message_format(
+            format_reply=format_reply,
+            msg_vals=msg_vals,
+            for_current_user=for_current_user,
+            follower_by_message_user=follower_by_message_user,
+        )
         all_sms_notifications = self.env['mail.notification'].sudo().search([
             ('mail_message_id', 'in', [r['id'] for r in message_values]),
             ('notification_type', '=', 'sms')

--- a/addons/test_mail/tests/test_mail_followers.py
+++ b/addons/test_mail/tests/test_mail_followers.py
@@ -860,11 +860,13 @@ class UnfollowFromInboxTest(MailCommon):
 
     def _fetch_inbox_message(self, message_id, user=None):
         """ Fetch the given message similarly to the controller. """
-        MailMessage = self.env['mail.message'].with_user(user) if user else self.env['mail.message']
-        partner_id = self.env.user.partner_id.id
+        messages = self.env['mail.message'].with_user(user) if user else self.env['mail.message']._message_fetch(domain=[('needaction', '=', True)])["messages"]
+        follower_by_message_user = self.env.user.sudo(False)._get_follower_by_message_user(messages)
         return list(filter(
             lambda m: m['id'] == message_id,
-            MailMessage._message_fetch(domain=[('needaction', '=', True)])["messages"]._message_format_personalize(partner_id)))
+            messages._message_format(
+                for_current_user=True, follower_by_message_user=follower_by_message_user
+        )))
 
     @users('employee')
     @mute_logger('odoo.models')


### PR DESCRIPTION
When handling notifications in Odoo and tagging the user on a SO/ task / whatever, the messaging counter is increased by 1 and the notification appears in the inbox, but not in the systray.

This is because the needaction is wrongly set with self, which is the user that is doing the action, not the user that should be notified.

This commit fixes the issue by correctly setting user when it comes to the personalized notify

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
