### PR TITLE
[FIX] account: prevent change payment_state to paid

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -889,6 +889,7 @@ class AccountMove(models.Model):
         if stored_ids:
             self.env['account.partial.reconcile'].flush_model()
             self.env['account.payment'].flush_model(['is_matched'])
+            self._compute_amount()
 
             queries = []
             for source_field, counterpart_field in (('debit', 'credit'), ('credit', 'debit')):
@@ -953,6 +954,8 @@ class AccountMove(models.Model):
                                 new_pmt_state = invoice._get_invoice_in_payment_state()
 
                         else:
+                            # if currency.is_zero(invoice.amount_total) or reconciliation_vals:
+                            #     new_pmt_state = 'paid'
                             new_pmt_state = 'paid'
 
                             reverse_move_types = set()


### PR DESCRIPTION
Steps to reproduce:
[base_automation][debug]
- Create a new `automated action` 1) model: journal entry, action to do: update|execute python code, triger: on update|on creation & update, Before Update Domain: payment_state != paid 2) you don' need to write code or set an updated value
- create a new invoice
- register a payment -> the invoice is in payment
- reset to draft the payment

Issue:
The invoice is `paid`

Cause:
In base_automation we recompute the field impacted, in this case `payment_state` https://github.com/odoo/odoo/blob/f188bf734f56cf2ab045aff1060aa048ed6cf58c/addons/base_automation/models/base_automation.py#L444

and in the compute method since we unreconciled in https://github.com/odoo/odoo/blob/75ed210a547224d7b102afb5e40b611c4d42dc77/addons/account/models/account_move_line.py#L2515

The SQL query will not retrieve any information in the transaction and will set the field `payment_state` to `paid`. https://github.com/odoo/odoo/blob/75ed210a547224d7b102afb5e40b611c4d42dc77/addons/account/models/account_move.py#L938

Solution:
We allow the state to be set to paid if:
 - the amount_residual is 0 and that it is has reconcliations_vals => normal case
 - the amount_residual is 0 and that the amount_total is 0 => chould be considered as paid with no reconciliations vals such as in https://github.com/odoo/odoo/blob/9b357f6a8adca93c0759168d0e207cbee1d43b80/addons/account/tests/test_account_move_reconcile.py#L339

opw-3460455