### PR TITLE
[FIX] pos_restaurant: confirm input on enter

### DIFF
--- a/addons/point_of_sale/static/src/app/utils/input_popups/text_input_popup.js
+++ b/addons/point_of_sale/static/src/app/utils/input_popups/text_input_popup.js
@@ -27,6 +27,7 @@ export class TextInputPopup extends Component {
     }
     onMounted() {
         this.inputRef.el.focus();
+        this.inputRef.el.select();
     }
     confirm() {
         this.props.getPayload(this.state.inputValue);
@@ -46,6 +47,12 @@ export class TextInputPopup extends Component {
             this.state.inputValue = lines.join("\n");
             this.state.inputValue += (lines.length > 0 ? "\n" : "") + button.label;
             button.isSelected = true;
+        }
+    }
+
+    onKeydown(ev) {
+        if (this.props.rows === 1 && ev.key.toUpperCase() === "ENTER") {
+            this.confirm();
         }
     }
 }

--- a/addons/point_of_sale/static/src/app/utils/input_popups/text_input_popup.xml
+++ b/addons/point_of_sale/static/src/app/utils/input_popups/text_input_popup.xml
@@ -8,7 +8,7 @@
                     <t t-esc="button.label"/>
                 </button>
             </t>
-            <textarea t-att-rows="props.rows" class="form-control form-control-lg mx-auto" type="text" t-model="state.inputValue" t-ref="input" t-att-placeholder="props.placeholder"/>
+            <textarea t-att-rows="props.rows" class="form-control form-control-lg mx-auto" type="text" t-model="state.inputValue" t-ref="input" t-att-placeholder="props.placeholder" t-on-keydown="onKeydown" />
             <t t-set-slot="footer">
                 <button class="btn btn-primary o-default-button" t-on-click="confirm">Apply</button>
                 <button class="btn btn-secondary o-default-button" t-on-click="close">Discard</button>

--- a/addons/pos_restaurant/static/tests/tours/floor_screen_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/floor_screen_tour.js
@@ -58,7 +58,8 @@ registry.category("web_tour.tours").add("FloorScreenTour", {
             FloorScreen.clickEditButton("Rename"),
 
             TextInputPopup.inputText("100"),
-            Dialog.confirm(),
+            // pressing enter should confirm the text input popup
+            { trigger: "textarea", run: "press Enter", in_modal: true },
             FloorScreen.clickTable("100"),
             FloorScreen.selectedTableIs("100"),
 


### PR DESCRIPTION
When creating a new floor, the text popup allows multiple line input which isn't a good UX. In this commit, we introduce a props to the `TextInputPopup` dialog that allows confirmation of the input when pressing the `enter` key. We activate this option to the creation/renaming of (new) floor, renaming a table, and setting a note to a free order.
