### PR TITLE
[IMP] web_editor: translate content with a LLM

### DIFF
--- a/addons/mass_mailing/static/src/scss/mass_mailing.wysiwyg.scss
+++ b/addons/mass_mailing/static/src/scss/mass_mailing.wysiwyg.scss
@@ -61,6 +61,14 @@
         transform: translateX(0);
 
         > .o_we_customize_panel .oe-toolbar {
+            grid-template-areas:
+                "typo typo style style colors"
+                "size align list list link"
+                "ai translate translate . ."
+                "options options options options options"
+                "options2 options2 options2 options2 options2"
+                "options3 options3 options3 options3 options3";
+
             #style.dropup, #font-size.dropup {
                 > .dropdown-menu {
                     overflow-y: scroll;

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -3204,6 +3204,11 @@ export class OdooEditor extends EventTarget {
                     ? 'block'
                     : 'none';
             }
+
+            const translateDropdown = this.toolbar.querySelector('#translate');
+            if (translateDropdown) {
+                translateDropdown.style.display = sel.isCollapsed ? 'none' : '';
+            }
         }
         this.updateColorpickerLabels();
         const listUIClasses = {UL: 'fa-list-ul', OL: 'fa-list-ol', CL: 'fa-tasks'};

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/style.scss
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/style.scss
@@ -259,8 +259,10 @@
             padding: 5px;
         }
     }
-    #style .dropdown-menu {
-        text-align: left;
+    #style, #translate {
+        .dropdown-menu {
+            text-align: left;
+        }
     }
 }
 

--- a/addons/web_editor/static/src/js/editor/toolbar.js
+++ b/addons/web_editor/static/src/js/editor/toolbar.js
@@ -6,8 +6,13 @@ import { ColorPalette } from "@web_editor/js/wysiwyg/widgets/color_palette";
 import {
     Component,
     onMounted,
+    onWillStart,
     useRef,
+    useState,
 } from "@odoo/owl";
+
+import { useService } from "@web/core/utils/hooks";
+import { loadLanguages } from "@web/core/l10n/translation";
 
 export class Toolbar extends Component {
     static template = 'web_editor.toolbar';
@@ -83,6 +88,8 @@ export class Toolbar extends Component {
     }
 
     setup() {
+        this.orm = useService("orm");
+        this.state = useState({ languages : [] });
         onMounted(() => {
             for (const [colorType, ref] of Object.entries(this.colorDropdownRef)) {
                 const dropdown = ref.el;
@@ -97,6 +104,11 @@ export class Toolbar extends Component {
                 });
                 $dropdown.on('hide.bs.dropdown', (ev) => this.props.onColorpaletteDropdownHide(ev));
             }
+        });
+        onWillStart(() => {
+            loadLanguages(this.orm).then(res => {
+                this.state.languages = res;
+            });
         });
     }
 

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/chatgpt_translate_dialog.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/chatgpt_translate_dialog.js
@@ -1,0 +1,59 @@
+import { useState } from "@odoo/owl";
+import { ChatGPTDialog } from '@web_editor/js/wysiwyg/widgets/chatgpt_dialog';
+
+export class ChatGPTTranslateDialog extends ChatGPTDialog {
+    static template = 'web_editor.ChatGPTTranslateDialog';
+    static props = {
+        ...super.props,
+        originalText: String,
+        language: String,
+    };
+
+    setup() {
+        super.setup();
+        this.state = useState({
+            ...this.state,
+            conversationHistory: [{
+                role: 'system',
+                content: 'You are a translation assistant. You goal is to translate text while maintaining the original format and' +
+                    'respecting specific instructions. \n' +
+                    'Instructions: \n' +
+                    '- You must respect the format (wrapping the translated text between <generated_text> and </generated_text>)\n' +
+                    '- Do not write HTML.'
+            }],
+            messages: [],
+            translationInProgress: true,
+        });
+        this._translate();
+    }
+
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
+    async _translate() {
+        const prompt = `Translate <generated_text>${this.props.originalText}</generated_text> to ${this.props.language}`;
+        const messageId = new Date().getTime();
+        const conversation = { role: 'user', content: prompt };
+        this.state.conversationHistory.push(conversation);
+        this._generate(prompt, (content, isError) => {
+            let translatedText = content.replace(/^[\s\S]*<generated_text>/, '').replace(/<\/generated_text>[\s\S]*$/, '');
+            if (!this.formatContent(translatedText).length) {
+                isError = true;
+                translatedText = "You didn't select any text.";
+            }
+            this.state.translationInProgress = false;
+            if (!isError) {
+                // There was no error, add the response to the history.
+                this.state.conversationHistory.push({ role: 'assistant', content });
+            }
+            this.state.messages.push({
+                author: 'assistant',
+                text: translatedText,
+                id: messageId,
+                isError,
+            });
+            this.state.selectedMessageId = messageId;
+        });
+    }
+}

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/chatgpt_translate_dialog.xml
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/chatgpt_translate_dialog.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-name="web_editor.ChatGPTTranslateDialog">
+        <Dialog size="'lg'" title="'Translate with AI'">
+            <div t-if="state.translationInProgress" class="d-flex">
+                <img src="/web/static/img/spin.svg" alt="Loading..." class="me-2"
+                    style="filter:invert(1); opacity: 0.5; width: 30px; height: 30px;" />
+                <p class="m-0 text-muted align-self-center">
+                    <em>Translating...</em>
+                </p>
+            </div>
+            <t t-else="">
+                <t t-set="message" t-value="state.messages[0]" />
+                <div t-att-data-message-id="message.id"
+                    t-att-class="message.isError ? 'o-message-error border-danger bg-danger p-2' : ''"
+                    class="o-chatgpt-translated">
+                    <t t-out="formatContent(message.text)" />
+                </div>
+            </t>
+            <!-- FOOTER -->
+            <t t-set-slot="footer">
+                <button class="btn btn-primary"
+                    t-att-disabled="state.translationInProgress || state.messages[0].isError"
+                    t-on-click="_confirm">Insert</button>
+                <button class="btn btn-secondary" t-on-click="_cancel">Cancel</button>
+            </t>
+        </Dialog>
+    </t>
+</templates>

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -14,6 +14,7 @@ import { LinkPopoverWidget } from '@web_editor/js/wysiwyg/widgets/link_popover_w
 import { AltDialog } from '@web_editor/js/wysiwyg/widgets/alt_dialog';
 import { ChatGPTPromptDialog } from '@web_editor/js/wysiwyg/widgets/chatgpt_prompt_dialog';
 import { ChatGPTAlternativesDialog } from '@web_editor/js/wysiwyg/widgets/chatgpt_alternatives_dialog';
+import { ChatGPTTranslateDialog } from "@web_editor/js/wysiwyg/widgets/chatgpt_translate_dialog";
 import { ImageCrop } from '@web_editor/js/wysiwyg/widgets/image_crop';
 
 import * as wysiwygUtils from "@web_editor/js/common/wysiwyg_utils";
@@ -1518,9 +1519,11 @@ export class Wysiwyg extends Component {
     /**
      * Open one of the ChatGPTDialogs to generate or modify content.
      *
-     * @param {'prompt'|'alternatives'} [mode='prompt']
+     * @param {'prompt'|'alternatives'|'translate'} [mode='prompt']
+     * @param {object} options
+     * @param {String} [options.language]
      */
-    openChatGPTDialog(mode = 'prompt') {
+    openChatGPTDialog(mode = 'prompt', options={}) {
         const restore = preserveCursor(this.odooEditor.document);
         const params = {
             insert: content => {
@@ -1561,12 +1564,15 @@ export class Wysiwyg extends Component {
                 }
             },
         };
-        if (mode === 'alternatives') {
+        if (mode === 'alternatives' || mode === 'translate') {
             params.originalText = this.odooEditor.document.getSelection().toString() || '';
+        }
+        if (mode === 'translate') {
+            params.language = options.language;
         }
         this.odooEditor.document.getSelection().collapseToEnd();
         this.env.services.dialog.add(
-            mode === 'prompt' ? ChatGPTPromptDialog : ChatGPTAlternativesDialog,
+            mode === 'prompt' ? ChatGPTPromptDialog : mode === 'translate' ? ChatGPTTranslateDialog : ChatGPTAlternativesDialog,
             params,
             { onClose: restore },
         );
@@ -1913,10 +1919,17 @@ export class Wysiwyg extends Component {
                 return;
             }
             this.showImageFullscreen(this.lastMediaClicked.src);
-    })
+        });
         $toolbar.find('#media-insert, #media-replace, #media-description').click(openTools);
         $toolbar.find('#create-link').click(openTools);
         $toolbar.find('#open-chatgpt').click(openTools);
+        $toolbar.on('click', '#translate .lang', (e) => {
+            e.preventDefault();
+            e.stopImmediatePropagation();
+            e.stopPropagation();
+            const language = e.target.dataset.value;
+            this.openChatGPTDialog('translate', { language });
+        });
         $toolbar.find('#image-shape div, #fa-spin').click(e => {
             if (!this.lastMediaClicked) {
                 return;

--- a/addons/web_editor/static/src/scss/wysiwyg.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg.scss
@@ -298,10 +298,6 @@ $o-we-zindex: $o-we-overlay-zindex + 1 !default;
             min-width: 0;
         }
 
-        &:not(.colorpicker-menu) > li:last-child {
-            margin-bottom: 1em;
-        }
-
         &.colorpicker-menu {
             margin-top: 0;
             min-width: 222px !important;
@@ -769,7 +765,9 @@ textarea.o_codeview {
 button.o-message-insert {
     line-height: 1;
 }
-.o-chatgpt-message > div > *:last-child, .o-chatgpt-alternative > *:last-child {
+.o-chatgpt-message > div > *:last-child,
+.o-chatgpt-alternative > *:last-child,
+.o-chatgpt-translated > *:last-child {
     margin-bottom: 0;
 }
 .o-message-error {

--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -506,11 +506,13 @@
                 "typo typo style style colors"
                 "size align list list link"
                 "ai animate animate hilight hilight"
+                "translate translate . . ."
                 "options options options options options"
                 "options2 options2 options2 options2 options2"
                 "options3 options3 options3 options3 options3";
             grid-template-columns: 1fr 1fr 1fr 1fr 1fr;
             grid-template-rows:
+                minmax($o-we-sidebar-content-field-height, auto)
                 minmax($o-we-sidebar-content-field-height, auto)
                 minmax($o-we-sidebar-content-field-height, auto)
                 minmax($o-we-sidebar-content-field-height, auto)
@@ -761,6 +763,9 @@
 
             #chatgpt {
                 grid-area: ai;
+            }
+            #translate {
+                grid-area: translate;
             }
             #animate {
                 grid-area: animate;

--- a/addons/web_editor/static/src/xml/editor.xml
+++ b/addons/web_editor/static/src/xml/editor.xml
@@ -225,6 +225,22 @@
                     <span class="fa fa-magic fa-fw"></span>
                 </div>
             </div>
+            <div id="translate" t-attf-class="btn-group {{ props.dropDirection }}">
+                <div t-if="state.languages.length === 1" class="btn lang" title="Translate with AI" t-att-data-value="state.languages[0][1]">
+                    Translate
+                </div>
+                <t t-elif="state.languages.length > 1">
+                    <button type="button" class="btn dropdown-toggle"
+                        data-bs-toggle="dropdown" data-bs-original-title="Translate with AI" tabindex="-1" aria-expanded="false">
+                        <span title="Translate with AI">Translate</span>
+                    </button>
+                    <ul class="dropdown-menu">
+                        <t t-foreach="state.languages" t-as="language" t-key="language[0]">
+                            <li><a class="dropdown-item lang" t-att-data-value="language[1]" href="#">to <t t-out="language[1]" /></a></li>
+                        </t>
+                    </ul>
+                </t>
+            </div>
 
             <div  t-if="props.showImageShape" id="image-shape" class="btn-group">
                 <div id="rounded" title="Shape: Rounded" class="fa fa-square fa-fw btn editor-ignore"></div>

--- a/addons/web_editor/static/tests/test_utils.js
+++ b/addons/web_editor/static/tests/test_utils.js
@@ -105,6 +105,9 @@ patch(MockServer.prototype, {
                 return SNIPPETS_TEMPLATE;
             }
         }
+        if (args.model === "res.lang" && args.method === "get_installed") {
+            return [["en_US", "English"]];
+        }
         return super._performRPC(...arguments);
     },
 });


### PR DESCRIPTION
Description of the issue this PR addresses:

This PR introduces a new feature in web editor allowing users to translate content using ChatGPT. The translation functionality is accessible via a dialog that can be opened from a dropdown in the toolbar.

The translate button is visible only if multiple languages are installed, and the dropdown lists only the languages that are currently installed. The user can select one of the active languages to translate the text, which can be replaced with the selected content.

Use Cases:

1. Email Writing
2. Barcode lookup where product descriptions in various languages are received and need to be published in a specific language.

task-3961141