### PR TITLE
[FIX] base: upgrade lxml to 4.9.3 for MacOS

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ Jinja2==2.11.3 ; python_version <= '3.10'  # min version = 2.10.1 (Focal - with 
 Jinja2==3.1.2 ; python_version > '3.10'
 libsass==0.20.1
 lxml==4.6.5 ; python_version <= '3.10'  # min version = 4.5.0 (Focal - with security backports)
-lxml==4.9.2 ; python_version > '3.10' and python_version < '3.12'
+lxml==4.9.3 ; python_version > '3.10' and python_version < '3.12' # min 4.9.2, pinning 4.9.3 because of missing wheels for darwin in 4.9.3
 lxml==5.2.1; python_version >= '3.12' # (Noble - removed html clean)
 lxml-html-clean; python_version >= '3.12' # (Noble - removed from lxml, unpinned for futur security patches)
 MarkupSafe==1.1.1 ; python_version <= '3.10'


### PR DESCRIPTION
The current version of lxml (4.9.2) is breaking Odoo on MacOS. This commit upgrades lxml to 4.9.3 which prevents the issue.

With the current version, the following error is raised whenever we try to install any module that depends on Mail:
lxml.etree.XMLSyntaxError: Char 0x0 out of allowed range

This error is due to an emoji that got introduced here: 97ce0844ca0c3d531a7a2e2e47a867d89835b24e

Original PR: #165997 (opening a new PR because of inability to reopen closed PRs after force-pushing in the branch 🥴)