### PR TITLE
[IMP] account: replace last by previous

### DIFF
--- a/addons/account/data/account_reports_data.xml
+++ b/addons/account/data/account_reports_data.xml
@@ -7,7 +7,7 @@
             <field name="name">Generic Tax report</field>
             <field name="filter_multi_company">tax_units</field>
             <field name="filter_fiscal_position" eval="1"/>
-            <field name="default_opening_date_filter">last_tax_period</field>
+            <field name="default_opening_date_filter">previous_tax_period</field>
             <field name="only_tax_exigible" eval="True"/>
             <field name="column_ids">
                 <record id="generic_tax_report_column_net" model="account.report.column">

--- a/addons/account/models/account_report.py
+++ b/addons/account/models/account_report.py
@@ -65,13 +65,13 @@ class AccountReport(models.Model):
             ('this_quarter', "This Quarter"),
             ('this_month', "This Month"),
             ('today', "Today"),
-            ('last_month', "Last Month"),
-            ('last_quarter', "Last Quarter"),
-            ('last_year', "Last Year"),
+            ('previous_month', "Last Month"),
+            ('previous_quarter', "Last Quarter"),
+            ('previous_year', "Last Year"),
             ('this_tax_period', "This Tax Period"),
-            ('last_tax_period', "Last Tax Period"),
+            ('previous_tax_period', "Last Tax Period"),
         ],
-        compute=lambda x: x._compute_report_option_filter('default_opening_date_filter', 'last_month'),
+        compute=lambda x: x._compute_report_option_filter('default_opening_date_filter', 'previous_month'),
         readonly=False, store=True, depends=['root_report_id', 'section_main_report_ids'],
     )
 


### PR DESCRIPTION
In this commit: https://github.com/odoo/enterprise/pull/63743/commits/82ca4e785b8e17f496277c225ebca7b3d9192831 we allowed future date in the date filter. By doing so we refactored a bit the way previous period work. The last period was not relevent anymore. So we renamed last into previous and by default if no period is given we go back from 1 month/quarter/year.

task: 3961087

enterprise pr: https://github.com/odoo/enterprise/pull/63743


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
