### PR TITLE
[IMP] web,project,web_tour: make client more accessible

### DIFF
--- a/addons/project/static/src/components/project_task_state_selection/project_task_state_selection.xml
+++ b/addons/project/static/src/components/project_task_state_selection/project_task_state_selection.xml
@@ -85,14 +85,14 @@
             <attribute name="t-att-class">getTogglerClass(currentValue)</attribute>
         </xpath>
         <!-- Dropdown divider -->
-        <xpath expr="//DropdownItem" position="before">
+        <xpath expr="//CheckboxItem" position="before">
             <div t-if="option[0] == '1_canceled' and (currentValue != '04_waiting_normal' or this.env.isSmall)" role="separator" class="dropdown-divider"/>
         </xpath>
         <!-- Approval mode dropdown button (class)-->
-        <xpath expr="//DropdownItem/span[1]" position="attributes">
+        <xpath expr="//CheckboxItem/span[1]" position="attributes">
             <attribute name="t-attf-class" separator=" " add="{{ stateIcon(option[0]) }}" remove="o_status"></attribute>
         </xpath>
-        <xpath expr="//DropdownItem/span[2]" position="attributes">
+        <xpath expr="//CheckboxItem/span[2]" position="attributes">
             <attribute name="t-attf-class">{{ statusColor(option[0]) }}</attribute>
         </xpath>
     </t>

--- a/addons/web/static/src/search/cog_menu/cog_menu.js
+++ b/addons/web/static/src/search/cog_menu/cog_menu.js
@@ -1,7 +1,7 @@
 import { registry } from "@web/core/registry";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { ActionMenus } from "@web/search/action_menus/action_menus";
-
+import { _t } from "@web/core/l10n/translation";
 import { onWillStart, onWillUpdateProps } from "@odoo/owl";
 
 const cogMenuRegistry = registry.category("cogMenu");
@@ -72,5 +72,9 @@ export class CogMenu extends ActionMenus {
             }
             return (item1.sequence || 0) - (item2.sequence || 0);
         });
+    }
+
+    getPrintItemAriaLabel(item) {
+        return _t("Print report: %s", item.description);
     }
 }

--- a/addons/web/static/src/search/cog_menu/cog_menu.xml
+++ b/addons/web/static/src/search/cog_menu/cog_menu.xml
@@ -5,7 +5,7 @@
         <div t-if="hasItems" class="o_cp_action_menus d-flex align-items-center gap-1" t-att-class="{'pe-2': !env.isSmall}">
             <div class="lh-1">
                 <Dropdown menuClass="'lh-base'" beforeOpen.bind="loadPrintItems">
-                    <button class="d-print-none btn" t-att-class="env.isSmall ? 'btn-secondary' : 'lh-sm p-0 border-0'" data-hotkey="u" data-tooltip="Actions">
+                    <button class="d-print-none btn" t-att-class="env.isSmall ? 'btn-secondary' : 'lh-sm p-0 border-0'" data-hotkey="u" data-tooltip="Actions" aria-label="Actions menu">
                         <i class="fa fa-cog"/>
                     </button>
 
@@ -21,6 +21,7 @@
                                         t-as="item"
                                         t-key="item.key"
                                         class="'o_menu_item'"
+                                        attrs="{ 'aria-label': this.getPrintItemAriaLabel(item) }"
                                         onSelected="() => this.onItemSelected(item)"
                                     >
                                         <t t-esc="item.description"/>
@@ -28,7 +29,7 @@
                                 </t>
                             </Dropdown>
 
-                            <DropdownItem t-else="" class="'o_menu_item'" onSelected="() => this.onItemSelected(state.printItems[0])">
+                            <DropdownItem t-else="" class="'o_menu_item'" attrs="{ 'aria-label': this.getPrintItemAriaLabel(state.printItems[0]) }" onSelected="() => this.onItemSelected(state.printItems[0])">
                                 <i class="fa fa-print me-1"/> <t t-out="state.printItems[0].description"/>
                             </DropdownItem>
                         </t>

--- a/addons/web/static/src/search/control_panel/control_panel.xml
+++ b/addons/web/static/src/search/control_panel/control_panel.xml
@@ -114,6 +114,7 @@
                                     t-attf-class="o_{{view.type}} {{view.active ? 'active' : ''}}"
                                     t-att-data-tooltip="view.name"
                                     t-on-click="() => this.switchView(view.type)"
+                                    t-att-aria-label="view.name + ' View'"
                                 >
                                     <i t-att-class="view.icon" />
                                 </button>

--- a/addons/web/static/src/search/layout.xml
+++ b/addons/web/static/src/search/layout.xml
@@ -6,10 +6,10 @@
             <t t-slot="layout-buttons"/>
         </t>
         <t t-component="components.ControlPanel" slots="controlPanelSlots" t-if="props.display.controlPanel" display="props.display.controlPanel"/>
-        <div t-ref="content" class="o_content" t-attf-class="{{props.className}}" t-att-class="{ 'o_component_with_search_panel': props.display.searchPanel }">
+        <main t-ref="content" class="o_content" t-attf-class="{{props.className}}" t-att-class="{ 'o_component_with_search_panel': props.display.searchPanel }">
             <t t-component="components.SearchPanel" t-if="props.display.searchPanel"/>
             <t t-slot="default" contentRef="contentRef" />
-        </div>
+        </main>
     </t>
 
 </templates>

--- a/addons/web/static/src/views/fields/state_selection/state_selection_field.js
+++ b/addons/web/static/src/views/fields/state_selection/state_selection_field.js
@@ -1,7 +1,7 @@
 import { Component } from "@odoo/owl";
 import { useCommand } from "@web/core/commands/command_hook";
 import { Dropdown } from "@web/core/dropdown/dropdown";
-import { DropdownItem } from "@web/core/dropdown/dropdown_item";
+import { CheckboxItem } from "@web/core/dropdown/checkbox_item";
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { formatSelection } from "../formatters";
@@ -11,7 +11,7 @@ export class StateSelectionField extends Component {
     static template = "web.StateSelectionField";
     static components = {
         Dropdown,
-        DropdownItem,
+        CheckboxItem,
     };
     static props = {
         ...standardFieldProps,

--- a/addons/web/static/src/views/fields/state_selection/state_selection_field.xml
+++ b/addons/web/static/src/views/fields/state_selection/state_selection_field.xml
@@ -18,12 +18,12 @@
                 </button>
                 <t t-set-slot="content">
                     <t t-foreach="options" t-as="option" t-key="option[0]">
-                        <DropdownItem
+                        <CheckboxItem
                             class="`d-flex align-items-center ${option[0] === currentValue ? 'active' : ''}`"
-                            onSelected="() => this.updateRecord(option[0])">
+                            onSelected="() => this.updateRecord(option[0])" checked="option[0] === currentValue">
                                 <span t-attf-class="o_status ms-2 {{ statusColor(option[0]) }} "/>
                                 <span t-esc="option[1]"/>
-                        </DropdownItem>
+                        </CheckboxItem>
                     </t>
                 </t>
             </Dropdown>

--- a/addons/web/static/src/views/fields/statusbar/statusbar_field.js
+++ b/addons/web/static/src/views/fields/statusbar/statusbar_field.js
@@ -284,14 +284,14 @@ export class StatusBarField extends Component {
     /**
      * @param {StatusBarItem} item
      */
-    getItemTooltip(item) {
+    getItemAriaLabel(item) {
         if (item.isSelected) {
-            return _t("Current state");
+            return _t("Current state is %s", item.label);
         }
         if (this.props.isDisabled) {
-            return _t("Not active state");
+            return _t("Unselected state is %s", item.label);
         }
-        return _t("Not active state, click to change it");
+        return _t("Not active state, click to change it to %s", item.label);
     }
 
     getSortedItems() {

--- a/addons/web/static/src/views/fields/statusbar/statusbar_field.xml
+++ b/addons/web/static/src/views/fields/statusbar/statusbar_field.xml
@@ -40,7 +40,7 @@
                     }"
                     t-att-disabled="props.isDisabled || item.isSelected"
                     role="radio"
-                    t-att-aria-label="getItemTooltip(item)"
+                    t-att-aria-label="getItemAriaLabel(item)"
                     t-att-aria-checked="item.isSelected.toString()"
                     t-att-aria-current="item.isSelected and 'step'"
                     t-att-data-value="item.value"

--- a/addons/web/static/tests/search/control_panel.test.js
+++ b/addons/web/static/tests/search/control_panel.test.js
@@ -92,6 +92,23 @@ test.tags`desktop`("view switcher", async () => {
     expect.verifySteps(["kanban"]);
 });
 
+test.tags`desktop`("views aria labels", async () => {
+    await mountWithSearch(
+        ControlPanel,
+        { resModel: "foo" },
+        {
+            viewSwitcherEntries: [
+                { type: "list", active: true, icon: "oi-view-list", name: "List" },
+                { type: "kanban", icon: "oi-view-kanban", name: "Kanban" },
+            ],
+        }
+    );
+
+    const views = queryAll`.o_switch_view`;
+    expect(views[0]).toHaveAttribute("aria-label", "List View");
+    expect(views[1]).toHaveAttribute("aria-label", "Kanban View");
+});
+
 test.tags`mobile`("view switcher on mobile", async () => {
     await mountWithSearch(
         ControlPanel,

--- a/addons/web/static/tests/views/fields/state_selection_field.test.js
+++ b/addons/web/static/tests/views/fields/state_selection_field.test.js
@@ -123,6 +123,36 @@ test("StateSelectionField in form view", async () => {
     });
 });
 
+test("Check role attribute for dropdown items", async () => {
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        arch: /* xml */ `
+            <form>
+                <sheet>
+                    <group>
+                        <field name="selection" widget="state_selection"/>
+                    </group>
+                </sheet>
+            </form>
+        `,
+        resId: 1,
+    });
+
+    // Open the dropdown
+    click(".o_field_widget.o_field_state_selection .o_status");
+    await animationFrame();
+
+    // Assert that the dropdown is open
+    expect(".o-dropdown--menu").toHaveCount(1, { message: "there should be a dropdown" });
+
+    // Assert that each dropdown item has role="checkbox"
+    expect(queryFirst(".o-dropdown--menu .dropdown-item")).toHaveAttribute(
+        "role",
+        "menuitemcheckbox"
+    );
+});
+
 test("StateSelectionField with readonly modifier", async () => {
     await mountView({
         type: "form",

--- a/addons/web/static/tests/views/fields/statusbar_field.test.js
+++ b/addons/web/static/tests/views/fields/statusbar_field.test.js
@@ -381,7 +381,7 @@ test("statusbar: choose an item from the folded menu", async () => {
         `,
     });
 
-    expect("[aria-label='Current state']").toHaveText("aaa", {
+    expect("[aria-label='Current state is aaa']").toHaveText("aaa", {
         message: "default status is 'aaa'",
     });
 
@@ -394,7 +394,7 @@ test("statusbar: choose an item from the folded menu", async () => {
     await click(".o-dropdown--menu .dropdown-item");
     await animationFrame();
 
-    expect("[aria-label='Current state']").toHaveText("second record", {
+    expect("[aria-label='Current state is second record']").toHaveText("second record", {
         message: "status has changed to the selected dropdown item",
     });
 });

--- a/addons/web_tour/static/src/tour_service/tour_utils.js
+++ b/addons/web_tour/static/src/tour_service/tour_utils.js
@@ -237,7 +237,7 @@ export const stepUtils = {
                 isActive: ["auto"],
                 content: "wait for cancellation to complete",
                 trigger:
-                    ".o_view_controller.o_list_view, .o_form_view > div > div > .o_form_readonly, .o_form_view > div > div > .o_form_saved",
+                    ".o_view_controller.o_list_view, .o_form_view > div > main > .o_form_readonly, .o_form_view > div > main > .o_form_saved",
             },
         ];
     },


### PR DESCRIPTION
Improved accessibility for keyboard navigation and screen readers

- Added aria-labels:
  - 'Actions menu' to action menu cog item
  - Dynamic aria-label 'Print report: {report_name}' to print menu entry
  - {view_name view} to view mode buttons

- Converted state_selection to use CheckBoxItem instead of DropdownItem:
  - Improves audio narration to announce checked items properly.

- Updated main container landmarks:
  - Used `<main>` node instead of `<div>` in views layout.

Task: 3603393

enterprise :-https://github.com/odoo/enterprise/pull/71309

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
