### PR TITLE
[FIX] account: filter out draft/cancelled in Dashboard > Bank > Payments

### DIFF
--- a/addons/account/views/account_payment_view.xml
+++ b/addons/account/views/account_payment_view.xml
@@ -118,7 +118,7 @@
                     <filter string="Posted" name="state_posted" domain="[('state', '=', 'posted')]"/>
                     <separator/>
                     <filter string="Sent" name="state_sent" domain="[('is_move_sent', '=', True)]"/>
-                    <filter string="No Bank Matching" name="unmatched" domain="[('is_matched', '=', False)]"/>
+                    <filter string="No Bank Matching" name="unmatched" domain="[('is_matched', '=', False), ('state', '=', 'posted')]"/>
                     <filter string="Reconciled" name="reconciled" domain="[('is_reconciled', '=', True)]"/>
                     <separator/>
                     <filter string="Payment Date" name="date" date="date"/>


### PR DESCRIPTION
Problem
---
In the accounting dashboard, when going to Bank > Payments draft and cancelled payments are not filtered out by default. This makes the amount displayed on the kanban card inconsistent with the sum of the payments that are shown by default.

opw-3978180