### PR TITLE
[FIX] website_sale: singleton error in taxes computation

### DIFF
--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -294,11 +294,11 @@ class ProductTemplate(models.Model):
 
                 # Compare_list_price are never tax included
                 base_price = self._apply_taxes_to_price(
-                    base_price, currency, product_taxes, taxes, self,
+                    base_price, currency, product_taxes, taxes, template,
                 )
 
             price_reduce = self._apply_taxes_to_price(
-                price_reduce, currency, product_taxes, taxes, self,
+                price_reduce, currency, product_taxes, taxes, template,
             )
 
             template_price_vals = {


### PR DESCRIPTION
since 9338ac01745156abff2bf7606c2679f7c623bb81, we were erroneously giving all the templates whose price was computed to the taxes computation logic, when we should have been giving one template at a time (as we were looping on the templates here).


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
