### PR TITLE
[FIX] point_of_sale, pos_restaurant: remove ordering in kitchen when making a bill

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
@@ -34,12 +34,15 @@ export class ReceiptScreen extends Component {
             // to send in preparation it is automatically sent
             if (this.pos.orderPreparationCategories.size) {
                 try {
-                    await this.pos.sendOrderInPreparationUpdateLastChange(this.currentOrder);
+                    this.sendOrderToPreparationTools();
                 } catch (error) {
                     Promise.reject(error);
                 }
             }
         });
+    }
+    async sendOrderToPreparationTools() {
+        await this.pos.sendOrderInPreparationUpdateLastChange(this.currentOrder);
     }
     _addNewOrder() {
         this.pos.add_new_order();

--- a/addons/pos_restaurant/static/tests/tours/helpers/ProductScreenTourMethods.js
+++ b/addons/pos_restaurant/static/tests/tours/helpers/ProductScreenTourMethods.js
@@ -32,10 +32,6 @@ export function clickPrintBillButton() {
             content: "click print bill button",
             trigger: ".control-buttons .control-button.order-printbill",
         },
-        {
-            content: "Close printing error",
-            trigger: ".popup-error .cancel",
-        },
     ];
 }
 export function clickSubmitButton() {


### PR DESCRIPTION
Fix for version 17.0 only

Problem: In restaurant, when we make a bill, the order is made to the kitchen

Steps to reproduce:
- Install "Point of Sale" app and "pos_restaurant" module
- Open a restaurant session
- Select products for a table
- Click on "Bill"
- The order is now in the kitchen while it should not

Cause:
The full process for making an order is called with "sendOrderInPreparationUpdateLastChange" while it is not necessary to make a bill

Solution:
Remove the "sendOrderInPreparationUpdateLastChange" for the bill screen when pos_preparation_display is installed

opw-3938924

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
