### PR TITLE
[FIX] point_of_sale: customer screen using iot-connected display

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -808,6 +808,10 @@ class PosConfig(models.Model):
             return
         self._notify("UPDATE_CUSTOMER_DISPLAY", order)
 
+    def _get_display_device_ip(self):
+        self.ensure_one()
+        return self.proxy_ip
+
     def _get_customer_display_data(self):
         self.ensure_one()
         return {
@@ -816,7 +820,7 @@ class PosConfig(models.Model):
             'type': self.customer_display_type,
             'has_bg_img': bool(self.customer_display_bg_img),
             'company_id': self.company_id.id,
-            **({'proxy_ip': self.proxy_ip} if self.customer_display_type == 'proxy' else {}),
+            **({'proxy_ip': self._get_display_device_ip()} if self.customer_display_type == 'proxy' else {}),
         }
 
     @api.model

--- a/addons/point_of_sale/static/src/app/navbar/closing_popup/closing_popup.js
+++ b/addons/point_of_sale/static/src/app/navbar/closing_popup/closing_popup.js
@@ -147,7 +147,8 @@ export class ClosePosPopup extends Component {
     }
     async closeSession() {
         if (this.pos.config.customer_display_type === "proxy") {
-            fetch(`${deduceUrl(this.pos.config.proxy_ip)}/hw_proxy/customer_facing_display`, {
+            const proxyIP = this.pos.getDisplayDeviceIP();
+            fetch(`${deduceUrl(proxyIP)}/hw_proxy/customer_facing_display`, {
                 method: "POST",
                 headers: {
                     Accept: "application/json",

--- a/addons/point_of_sale/static/src/app/navbar/navbar.js
+++ b/addons/point_of_sale/static/src/app/navbar/navbar.js
@@ -113,7 +113,8 @@ export class Navbar extends Component {
         }
         if (this.pos.config.customer_display_type === "proxy") {
             this.notification.add("Connecting to the IoT Box");
-            fetch(`${deduceUrl(this.pos.config.proxy_ip)}/hw_proxy/customer_facing_display`, {
+            const proxyIP = this.pos.getDisplayDeviceIP();
+            fetch(`${deduceUrl(proxyIP)}/hw_proxy/customer_facing_display`, {
                 method: "POST",
                 headers: {
                     Accept: "application/json",

--- a/addons/point_of_sale/static/src/app/navbar/sale_details_button/sales_detail_report.xml
+++ b/addons/point_of_sale/static/src/app/navbar/sale_details_button/sales_detail_report.xml
@@ -52,7 +52,7 @@
                         <div class="responsive-price">
                             <t t-esc="line['product_name'].substr(0,20)" />
                             <span class="pos-receipt-right-align">
-                                <t t-esc="Math.round(line.qty * Math.pow(10, pos.models['decimal.precision'].find((dp) => dp.name === 'Product Unit of Measure')?.digits)) / Math.pow(10, pos.models['decimal.precision'].find((dp) => dp.name === 'Product Unit of Measure')?.digits)" />
+                                <t t-esc="Math.round(line.quantity * Math.pow(10, pos.models['decimal.precision'].find((dp) => dp.name === 'Product Unit of Measure')?.digits)) / Math.pow(10, pos.models['decimal.precision'].find((dp) => dp.name === 'Product Unit of Measure')?.digits)" />
                                 <t t-if="line.uom !== 'Units'">
                                     <t t-esc="line.uom" />
                                 </t>

--- a/addons/point_of_sale/static/src/app/pos_app.js
+++ b/addons/point_of_sale/static/src/app/pos_app.js
@@ -58,7 +58,8 @@ export class Chrome extends Component {
             ]);
         }
         if (this.pos.config.customer_display_type === "proxy") {
-            fetch(`${deduceUrl(this.pos.config.proxy_ip)}/hw_proxy/customer_facing_display`, {
+            const proxyIP = this.pos.getDisplayDeviceIP();
+            fetch(`${deduceUrl(proxyIP)}/hw_proxy/customer_facing_display`, {
                 method: "POST",
                 headers: {
                     Accept: "application/json",

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1632,6 +1632,10 @@ export class PosStore extends Reactive {
     redirectToBackend() {
         window.location = "/web#action=point_of_sale.action_client_pos_menu";
     }
+
+    getDisplayDeviceIP() {
+        return this.config.proxy_ip;
+    }
 }
 
 PosStore.prototype.electronic_payment_interfaces = {};


### PR DESCRIPTION
When selecting the option "IoT-connected display" for customer display, and pos_iot is installed, there is no way from the res.config.settings form to specify the `proxy_ip` field which is used to send the customer display information. Because of this, using IoT-connected display for customer screen doesn't work.

This commit introduces a way to infer the proxy_ip from the specify display device.

Related: https://github.com/odoo/enterprise/pull/64360