### PR TITLE
[FIX] stock: avoid max qty in 0-0 reordering rules

### DIFF
--- a/addons/mrp/tests/test_bom.py
+++ b/addons/mrp/tests/test_bom.py
@@ -1313,7 +1313,7 @@ class TestBoM(TestMrpCommon):
         orderpoint = self.env['stock.warehouse.orderpoint'].search([('product_id', '=', product_gram.id)])
         self.assertEqual(orderpoint.route_id.id, manufacturing_route_id)
         self.assertEqual(orderpoint.qty_multiple, 2000.0)
-        self.assertEqual(orderpoint.qty_to_order, 2000.0)
+        self.assertEqual(orderpoint.qty_to_order, 4000.0)
 
     def test_bom_generated_from_mo(self):
         """ Creates a Manufacturing Order without BoM, then uses it to generate a new BoM.

--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -286,7 +286,10 @@ class StockWarehouseOrderpoint(models.Model):
                 remainder = orderpoint.qty_multiple > 0.0 and qty_to_order % orderpoint.qty_multiple or 0.0
                 if (float_compare(remainder, 0.0, precision_rounding=rounding) > 0
                         and float_compare(orderpoint.qty_multiple - remainder, 0.0, precision_rounding=rounding) > 0):
-                    qty_to_order -= remainder
+                    if float_is_zero(orderpoint.product_max_qty, precision_rounding=rounding):
+                        qty_to_order += orderpoint.qty_multiple - remainder
+                    else:
+                        qty_to_order -= remainder
             orderpoint.qty_to_order = qty_to_order
 
     def _get_qty_multiple_to_order(self):


### PR DESCRIPTION
### Steps to reproduce:

- Create a storable product with a vendor and using the buy route.
- Create a reordering rule for that product: - min: 0.0 - max: 0.0 - multiple: 5.0
- Case 1: Create an SO for 4 units
- Case 2: Create an SO for 9 units

### Expected behavior:

Case 1: A PO is created for 5 units.
Case 2:  A PO is created for 10 units.

### Current behavior:

Case 1: No PO is created.
Case 2: A PO is created for 5 units.

### Cause of the issue:

Since saas-17.2 (commit https://github.com/odoo/odoo/commit/e5d39368ee84238081c7a6b7f116e481a83f46e7) the max quantity of orderpoints has a meaning of storing capacity. As such the remainder quantity of a procuremnt can not exceed the max quantity of the orderpoint because of these lines: https://github.com/odoo/odoo/blob/c8985212fb4c937b814aaf7fe2ddca992b01735c/addons/stock/models/stock_orderpoint.py#L287-L289
However, the max quantity of 0 is usually interpreted as "to satisfy the demand" and should not be considered as a maximal storing capacity.

opw-3961033
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
