### PR TITLE
[FIX] hr_fleet: switch cars from employee's partner to user's partner

### DIFF
--- a/addons/hr_fleet/models/employee.py
+++ b/addons/hr_fleet/models/employee.py
@@ -77,7 +77,7 @@ class Employee(models.Model):
 
     def _sync_user(self, user, employee_has_image=False):
         if self.work_contact_id and self.work_contact_id != user.partner_id:
-            cars = self.env['fleet.vehicle'].search(['|', ('future_driver_id', '=', self.work_contact_id.id), ('driver_id', '=', self.work_contact_id.id)])
+            cars = self.env['fleet.vehicle'].search(['|', ('future_driver_id', '=', self.work_contact_id.id), ('driver_id', '=', self.work_contact_id.id), ('company_id', '=', self.company_id.id)])
             for car in cars:
                 if car.future_driver_id == self.work_contact_id:
                     car.future_driver_id = user.partner_id

--- a/addons/hr_fleet/models/employee.py
+++ b/addons/hr_fleet/models/employee.py
@@ -58,8 +58,9 @@ class Employee(models.Model):
         if car_ids:
             raise ValidationError(_('Cannot remove address from employees with linked cars.'))
 
-
     def write(self, vals):
+        if 'user_id' in vals:
+            self._sync_employee_cars(self.env['res.users'].browse(vals['user_id']))
         res = super().write(vals)
         #Update car partner when it is changed on the employee
         if 'work_contact_id' in vals:
@@ -75,7 +76,7 @@ class Employee(models.Model):
             vehicles._compute_mobility_card()
         return res
 
-    def _sync_user(self, user, employee_has_image=False):
+    def _sync_employee_cars(self, user):
         if self.work_contact_id and self.work_contact_id != user.partner_id:
             cars = self.env['fleet.vehicle'].search(['|', ('future_driver_id', '=', self.work_contact_id.id), ('driver_id', '=', self.work_contact_id.id), ('company_id', '=', self.company_id.id)])
             for car in cars:
@@ -83,7 +84,6 @@ class Employee(models.Model):
                     car.future_driver_id = user.partner_id
                 if car.driver_id == self.work_contact_id:
                     car.driver_id = user.partner_id
-        return super()._sync_user(user, employee_has_image)
 
 
 class EmployeePublic(models.Model):

--- a/addons/hr_fleet/models/employee.py
+++ b/addons/hr_fleet/models/employee.py
@@ -76,13 +76,15 @@ class Employee(models.Model):
         return res
 
     def _sync_user(self, user, employee_has_image=False):
-        cars = self.env['fleet.vehicle'].search(['|', ('future_driver_id', '=', self.work_contact_id.id), ('driver_id', '=', self.work_contact_id.id)])
-        for car in cars:
-            if car.future_driver_id == self.work_contact_id:
-                car.future_driver_id = user.partner_id
-            if car.driver_id == self.work_contact_id:
-                car.driver_id = user.partner_id
+        if self.work_contact_id and self.work_contact_id != user.partner_id:
+            cars = self.env['fleet.vehicle'].search(['|', ('future_driver_id', '=', self.work_contact_id.id), ('driver_id', '=', self.work_contact_id.id)])
+            for car in cars:
+                if car.future_driver_id == self.work_contact_id:
+                    car.future_driver_id = user.partner_id
+                if car.driver_id == self.work_contact_id:
+                    car.driver_id = user.partner_id
         return super()._sync_user(user, employee_has_image)
+
 
 class EmployeePublic(models.Model):
     _inherit = 'hr.employee.public'

--- a/addons/hr_fleet/tests/test_hr_fleet_driver.py
+++ b/addons/hr_fleet/tests/test_hr_fleet_driver.py
@@ -34,6 +34,11 @@ class TestHrFleetDriver(common.TransactionCase):
             "plan_to_change_car": False
         })
 
+        cls.car2 = cls.env["fleet.vehicle"].create({
+            "model_id": cls.model.id,
+            "plan_to_change_car": False
+        })
+
     def test_driver_sync_with_employee(self):
         """
         If an employee has a car and their partner has changed, the update should be synced with the fleet
@@ -43,3 +48,18 @@ class TestHrFleetDriver(common.TransactionCase):
         self.assertEqual(self.test_employee.work_contact_id, self.test_user.partner_id)
         self.car.action_accept_driver_change()
         self.assertEqual(self.car.driver_id, self.test_user.partner_id)
+
+    def test_driver_sync_with_employee_without_contact(self):
+        """
+        When we create an employee with a user_id, he doesn't have a
+        work_contact_id and we don't want to assign him all unassigned
+        cars.
+        """
+        self.assertEqual(self.car2.future_driver_id.id, False)
+        self.assertEqual(self.car2.driver_id.id, False)
+        self.env['hr.employee'].create({
+            'name': 'Test Employee 2',
+            'user_id': self.test_user.id,
+        })
+        self.assertEqual(self.car2.future_driver_id.id, False)
+        self.assertEqual(self.car2.driver_id.id, False)


### PR DESCRIPTION
When we link a user on an existing employee, we look at the vehicle linked to the existing employee's partner, to re-assign it to the linked user's partner that will become the new work_contact_id.

The main issues are the following:
- When we create an employee and assign a user on it, it will set the user's partner on all vehicle without driver or futur driver
- When we select the user in the form, it will save the changes on the car, even if the form is not saved, because the function is called in an onchange.

Side issue:
- Whatever is the company of the employee, it'll search through all vehicles if you have activated multiple companies.

Bugs introduced in https://github.com/odoo/odoo/pull/157057

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
