### PR TITLE
[FIX] core: warn when using unsupported python version

### DIFF
--- a/odoo/__init__.py
+++ b/odoo/__init__.py
@@ -17,6 +17,7 @@ __path__ = [
 
 import sys
 MIN_PY_VERSION = (3, 7)
+MAX_PY_VERSION = (3, 12)
 assert sys.version_info > MIN_PY_VERSION, f"Outdated python version detected, Odoo requires Python >= {'.'.join(map(str, MIN_PY_VERSION))} to run."
 
 #----------------------------------------------------------

--- a/odoo/cli/server.py
+++ b/odoo/cli/server.py
@@ -66,6 +66,11 @@ def report_configuration():
     port = config['db_port'] or os.environ.get('PGPORT', 'default')
     user = config['db_user'] or os.environ.get('PGUSER', 'default')
     _logger.info('database: %s@%s:%s', user, host, port)
+    if sys.version_info[:2] > odoo.MAX_PY_VERSION:
+        _logger.warning("Python %s is not officially supported, please use Python %s instead",
+            '.'.join(map(str, sys.version_info[:2])),
+            '.'.join(map(str, odoo.MAX_PY_VERSION))
+        )
 
 def rm_pid_file(main_pid):
     config = odoo.tools.config


### PR DESCRIPTION
People tend to install every new shiny release of Python but fail to realise that it usually takes a month or two before Odoo is made compatible with that shiny new version. In the meantime there is a surge of issues / tickets with bugs related to the new python version, wasting time of a lot of people (at least mine).

Hardcode the officially maximum supported python version and emit a warning when the current python is more recent than that. We'll change the variable the next time we support a new python version.