### PR TITLE
[FIX] account: tax scope spacing in autocomplete

### DIFF
--- a/addons/account/static/src/components/tax_autocomplete/tax_autocomplete.scss
+++ b/addons/account/static/src/components/tax_autocomplete/tax_autocomplete.scss
@@ -1,4 +1,5 @@
 .tax_autocomplete_grid {
     display: grid;
     grid-template-columns: minmax(auto, 1fr) minmax(auto, 1fr);
+    gap: 1em;
 }


### PR DESCRIPTION
Description of the issue this commit addresses:

In some instances where the tax name and tax scope name take perfectly the space available in the tax widget's autocomplete, there is no space in between those two which make it seem like a single piece of text. This happens when the longest tax name also has the longest tax_scope. This is not wanted.

---

Steps to reproduce:

(Luckily, a perfect example is available in demo data)
1-Install l10n_be
2-Create a vendor bill
3-Add a line and open the tax cell's autocomplete
4-21% M.Cocont and Merchandise are joined

---

Desired behavior after this commit is merged:

In such scenarios, a space should be forced between the tax name and the scope.

---

Note on the fix:

Since there is always a tax name but not always a tax scope, I decided to add a left margin on the tax_scope.

---

no task-feedback

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
