### PR TITLE
[16.0][IMP] rating: Use with_company() in the rating controller

### DIFF
--- a/addons/rating/controllers/main.py
+++ b/addons/rating/controllers/main.py
@@ -30,7 +30,15 @@ class Rating(http.Controller):
         rating, _record_sudo = self._get_rating_and_record(token)
 
         lang = rating.partner_id.lang or get_lang(request.env).code
-        return request.env['ir.ui.view'].with_context(lang=lang)._render_template('rating.rating_external_page_submit', {
+        # Apply .sudo() to avoid error if public_user does not have this allowed company
+        view_model = request.env['ir.ui.view'].sudo()
+        if (
+            rating.resource_ref
+            and "company_id" in rating.resource_ref._fields
+            and rating.resource_ref.company_id
+        ):
+            view_model = view_model.with_company(rating.resource_ref.company_id)
+        return view_model.with_context(lang=lang)._render_template('rating.rating_external_page_submit', {
             'rating': rating,
             'token': token,
             'rate_names': {
@@ -57,7 +65,15 @@ class Rating(http.Controller):
             )
 
         lang = rating.partner_id.lang or get_lang(request.env).code
-        return request.env['ir.ui.view'].with_context(lang=lang)._render_template('rating.rating_external_page_view', {
+        # Apply .sudo() to avoid error if public_user does not have this allowed company
+        view_model = request.env['ir.ui.view'].sudo()
+        if (
+            rating.resource_ref
+            and "company_id" in rating.resource_ref._fields
+            and rating.resource_ref.company_id
+        ):
+            view_model = view_model.with_company(rating.resource_ref.company_id)
+        return view_model.with_context(lang=lang)._render_template('rating.rating_external_page_view', {
             'web_base_url': rating.get_base_url(),
             'rating': rating,
         })

--- a/addons/rating/tests/test_controller.py
+++ b/addons/rating/tests/test_controller.py
@@ -23,3 +23,21 @@ class TestControllersRoute(HttpCase):
         url = '/rate/%s/submit_feedback' % access_token
         req = self.url_open(url)
         self.assertEqual(req.status_code, 200, "Response should = OK")
+
+    def test_controller_rating_multi_company(self):
+        extra_company = self.env["res.company"].create({"name": "Extra company"})
+        partner = self.env["res.partner"].create({
+            "name": "Test partner",
+            "company_id": extra_company.id,
+        })
+        rating_test = self.env['rating.rating'].with_user(self.user).create({
+            'res_model_id': self.env['ir.model'].sudo().search([('model', '=', 'res.partner')], limit=1).id,
+            'res_model': 'res.partner',
+            'res_id': partner.id,
+            'rating': 3
+        })
+        self.authenticate(None, None)
+        access_token = rating_test.access_token
+        url = '/rate/%s/submit_feedback' % access_token
+        req = self.url_open(url)
+        self.assertIn("Extra company", str(req.content))


### PR DESCRIPTION
FWP from 15.0: https://github.com/odoo/odoo/pull/159100

If we use multi-company and create a rating related to a record that has a company_id set, that company must be used for the header to be correct (e.g. company logo).

**Example use case**:
- Create Company A and set a logo
- Create Company B and set a logo
- Creates a project linked to Company B
- Create a New and Done stage linked to the previous project.
- Go to Project > Configuration and activate Customer Ratings
- Set a rating template (Task: Rating Request) to the Done stage.
- Create a task linked to Company B and a customer.
- Change task to the Done stage.
- Click on the satisfaction icon in the email sent to the customer.

Current behavior before PR
- The correct logo (company B) is displayed.

@Tecnativa TT48498

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr