### PR TITLE
[FIX] website_sale: products snippets crash when samples displayed

### DIFF
--- a/addons/website_sale/data/product_snippet_template_data.xml
+++ b/addons/website_sale/data/product_snippet_template_data.xml
@@ -435,10 +435,10 @@
             </t>
         </template>
         <template id="price_dynamic_filter_template_product_product" name="Dynamic Product Filter Price">
-            <t t-if="data['prevent_zero_price_sale']">
+            <t t-if="data.get('prevent_zero_price_sale')">
                 <span t-field="website.prevent_zero_price_sale_text"/>
             </t>
-            <t t-else="">
+            <t t-elif="not data.get('is_sample')">
                 <span t-esc="data['price']"
                       class="fw-bold"
                       name="product_price"

--- a/addons/website_sale/models/website_snippet_filter.py
+++ b/addons/website_sale/models/website_snippet_filter.py
@@ -84,6 +84,10 @@ class WebsiteSnippetFilter(models.Model):
 
                     if records.env.context.get('add2cart_rerender'):
                         res_product['_add2cart_rerender'] = True
+                else:
+                    res_product.update({
+                        'is_sample': True,
+                    })
         return res_products
 
     @api.model


### PR DESCRIPTION
Introduced by f1df88e8d2092b0d4e9ce2bba155a5084edfe86f, sample data does not have 'prevent_zero_price_sale' value added a default value

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
