### PR TITLE
[FIX] bus: do not rely on session language when dispatching bus notif.

### DIFF
--- a/addons/bus/websocket.py
+++ b/addons/bus/websocket.py
@@ -637,7 +637,7 @@ class Websocket:
         if not session:
             raise SessionExpiredException()
         with acquire_cursor(session.db) as cr:
-            env = api.Environment(cr, session.uid, session.context)
+            env = api.Environment(cr, session.uid, dict(session.context, lang=None))
             if session.uid is not None and not check_session(session, env):
                 raise SessionExpiredException()
             # Mark the notification request as processed.


### PR DESCRIPTION
Use case:

On a database that has only the "English (US)" (`en_US`) language
installed,

1. A visitor having set his browser prefered language to `fr_FR` browse
  the website, open the livechat and ask a question.
2. A livechat operator pick-up and respond
3. The visitor never see the reponse

On the server we see an error:
```odoo.addons.bus.websocket: Invalid language code: fr_FR```

That crash prevent sending the operator response back to the guest
(website visitor).

As we don't need the language at all to dispatch bus notification,
set it to `None`.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
