### PR TITLE
[FIX] analytic: Prevent unwated closing of analytic_distribution widget

### DIFF
--- a/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.js
+++ b/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.js
@@ -605,14 +605,23 @@ export class AnalyticDistribution extends Component {
     }
 
     onWindowClick(ev) {
-        //TODO: dragging the search more dialog should not close the popup either
-        const modal = document.querySelector('.modal:not(.o_inactive_modal)');
-        const clickedInSearchMoreDialog = modal && modal.querySelector('.o_list_view') && modal.contains(ev.target);
-        const clickedInKanbanSelectorDialog = modal && modal.querySelector('.o_kanban_view') && modal.contains(ev.target);
+        /*
+        Dropdown should be closed only if all these condition are true:
+            - dropdown is open
+            - click is outside widget element (widgetRef)
+            - there is no active modal containing a list/kanban view (search more modal)
+            - there is no popover (click is not in search modal's search bar menu)
+            - click is not targeting document dom element (drag and drop search more modal)
+        */
+
+        const selectors = [
+            ".o_popover",
+            ".modal:not(.o_inactive_modal)",
+        ];
         if (this.isDropdownOpen
             && !this.widgetRef.el.contains(ev.target)
-            && !clickedInSearchMoreDialog
-            && !clickedInKanbanSelectorDialog
+            && !ev.target.closest(selectors.join(","))
+            && !ev.target.isSameNode(document.documentElement)
            ) {
             this.forceCloseEditor();
         }


### PR DESCRIPTION
Steps:
- install 'purchase' and 'analytic'
- open purchase/RFQ
- create a new rfq
- add a new line in the subview list
- Toggle `Analytic Distribution` optional column
- Edit 'Analytic Distribution' col with the widget (`analytic_disribution`)
- Select first column to edit it (`Projects (100%)`)
- Click on `Search More` in the dropdown
- A new dialog is opened `Search: Projects`
- Go to filters and click `Add Custom Filter`
- Another modal is now opened `Add Custom Filter`
- Click on the first domain input
- After clicking on this input, the initial `analytic_distribution` drodown is closed
    - This is the cause of the problem
- Validate your domain
- Traceback `Component is destroyed`

The initial problem comes from `AnalyticDistribution` Component.

There's a listener on `click`on `document` to manage whether or not to close the widget.

There are several cases that prevent the widget from closing:
- having an active modal containing a list view or kanban view with the following selectors:
  - `'.o_modal:not(.o_inactive_modal) .o_list_view'`
  - `'.o_modal:not(.o_inactive_modal) .o_kanban_view'`.
- if the click occurred in the widget element
- if the dropdown is closed

However in many other cases we have undesired behavior (unwanted closing of the widget):
- a click on dialog that is open and not modal (as in the steps above)
- a click on a popover
- drag and drop an active modal to the side

This fix normally corrects the first three cases, but unfortunately I haven't found a way to correct the case of the palette command where the `ev.target` is at the point where the element selected in the palette points into the dom, especially as this is not currently the customer's problem.

Here's how the other cases are fixed:
instead of having a condition for each case
(as there used to be for modal list view and modal kanban view)

```js
        const modal = document.querySelector('.modal:not(.o_inactive_modal)');
        const clickedInSearchMoreDialog = modal && modal.querySelector('.o_list_view') && modal.contains(ev.target);
        const clickedInKanbanSelectorDialog = modal && modal.querySelector('.o_kanban_view') && modal.contains(ev.target);
```

I create a list of css selectors corresponding to the elements in which the `ev.target` must not be located in order to close. In particular, I include the two cases already handled by the code, as well as the new ones.

Instead of having the two previous conditions, I just have one selector in my list.

https://github.com/odoo/odoo/blob/4637514b4b1550014fc6affff1b0753ab9bc0f69/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.js#L611

So I add the `o_popover` and `o_dialog` selectors to correct my initial problem.

When dragging and dropping a modal, the `ev.target` is always equal to the document, so to prevent the `analytic_distribution` widget from closing in this case I check that it's not equal to `documentElement`.

https://github.com/odoo/odoo/blob/4637514b4b1550014fc6affff1b0753ab9bc0f69/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.js#L617

opw-3954404