### PR TITLE
[FIX] web: ignore null value monetory fields

### DIFF
--- a/addons/web/static/src/views/fields/formatters.js
+++ b/addons/web/static/src/views/fields/formatters.js
@@ -280,7 +280,7 @@ export function formatX2many(value) {
 export function formatMonetary(value, options = {}) {
     // Monetary fields want to display nothing when the value is unset.
     // You wouldn't want a value of 0 euro if nothing has been provided.
-    if (value === false) {
+    if (value === false || value === null) {
         return "";
     }
 


### PR DESCRIPTION
The issue:
if we have a monetary field that has a value of null, this will cause a traceback

The Fix:
ignore the field and treat it as it has a false value

opw-3975866