### PR TITLE
[FIX] l10n_ec_website_sale: allow edition of address with VAT

### DIFF
--- a/addons/l10n_ec_website_sale/__manifest__.py
+++ b/addons/l10n_ec_website_sale/__manifest__.py
@@ -18,6 +18,11 @@
     'demo': [
         'demo/website_demo.xml',
     ],
+    'assets': {
+        'web.assets_tests': [
+            'l10n_ec_website_sale/static/tests/tours/*.js',
+        ],
+    },
     'installable': True,
     'auto_install': True,
     'license': 'LGPL-3',

--- a/addons/l10n_ec_website_sale/models/website.py
+++ b/addons/l10n_ec_website_sale/models/website.py
@@ -1,0 +1,12 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class Website(models.Model):
+    _inherit = "website"
+
+    def _display_partner_b2b_fields(self):
+        """Ecuadorian localization must always display b2b fields"""
+        self.ensure_one()
+        return self.company_id.country_id.code == "EC" or super()._display_partner_b2b_fields()

--- a/addons/l10n_ec_website_sale/static/tests/tours/website_sale_checkout_address.js
+++ b/addons/l10n_ec_website_sale/static/tests/tours/website_sale_checkout_address.js
@@ -1,0 +1,27 @@
+/** @odoo-module **/
+
+import { registry } from "@web/core/registry";
+import tourUtils from "@website_sale/js/tours/tour_utils";
+
+registry.category("web_tour.tours").add("shop_checkout_address_ec", {
+    test: true,
+    url: "/shop",
+    steps: () => [
+        ...tourUtils.addToCart({ productName: "Test Product" }),
+        tourUtils.goToCart({ quantity: 1 }),
+        {
+            content: "Go to checkout",
+            trigger: "a:contains('Checkout')",
+        },
+        {
+            content: "Check that VAT field is present",
+            trigger: "label:contains('Identification Type')",
+            isCheck: true,
+        },
+        {
+            content: "Check that VAT field is present",
+            trigger: "label:contains('Identification Number')",
+            isCheck: true,
+        },
+    ],
+});

--- a/addons/l10n_ec_website_sale/tests/__init__.py
+++ b/addons/l10n_ec_website_sale/tests/__init__.py
@@ -1,5 +1,3 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import payment_method
-from . import sale_order
-from . import website
+from . import test_l10n_ec_website_sale

--- a/addons/l10n_ec_website_sale/tests/test_l10n_ec_website_sale.py
+++ b/addons/l10n_ec_website_sale/tests/test_l10n_ec_website_sale.py
@@ -1,0 +1,23 @@
+from odoo.tests.common import HttpCase, tagged
+from odoo.addons.l10n_ec_edi.tests.common import TestEcEdiCommon
+
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class TestUi(HttpCase, TestEcEdiCommon):
+
+    def test_checkout_address_ec(self):
+        self.env.ref('base.user_admin').write({
+            'company_id': self.env.company.id,
+            'company_ids': [(4, self.env.company.id)],
+        })
+        self.env.company = self.company_data['company']
+        self.env['product.product'].create({
+            'name': 'Test Product',
+            'sale_ok': True,
+            'website_published': True,
+        })
+        self.env['ir.config_parameter'].set_param('sale.automatic_invoice', True)
+        self.env['website'].get_current_website().company_id = self.env.company.id
+        user_admin = self.env.ref('base.user_admin')
+        user_admin.company_ids = user_admin.company_ids + self.env.company
+        self.start_tour('/shop', 'shop_checkout_address_ec', login='admin')


### PR DESCRIPTION
Steps to reproduce:
- Install `l10n_ec_website_sale`
- Go to website and select the website of the 'EC Company'
- Add a product and go to checkout
- Save the demo address
- Add an address

Issues:
When adding a new address VAT is not shown when logged in, however it's
required by some localization (Ecuador for instance).

opw-3921156