### PR TITLE
[IMP] l10n_hu_edi: Partner feedbacks + bugfixes

### DIFF
--- a/addons/l10n_hu_edi/__manifest__.py
+++ b/addons/l10n_hu_edi/__manifest__.py
@@ -7,7 +7,7 @@
     'countries': ['hu'],
     'author': 'DO Tech (OdooTech Zrt.), BDSC Business Consulting Kft. & Odoo S.A.',
     'description': """
-* Submit e-invoices to the NAV (Hungarian Tax Agency) as part of the invoicing process.
+* Electronically report invoices to the NAV (Hungarian Tax Agency) when issuing physical (paper) invoices.
 * Perform the Tax Audit Export (Adóhatósági Ellenőrzési Adatszolgáltatás) in NAV 3.0 format.
     """,
     'website': 'https://www.odootech.hu',

--- a/addons/l10n_hu_edi/i18n/hu.po
+++ b/addons/l10n_hu_edi/i18n/hu.po
@@ -150,6 +150,17 @@ msgid "Account Move Send"
 msgstr "Bizonylat küldés"
 
 #. module: l10n_hu_edi
+#. odoo-python
+#: code:addons/l10n_hu_edi/models/account_move.py:0
+#, python-format
+msgid ""
+"All advance invoices must be paid and sent to NAV before the final invoice "
+"is issued."
+msgstr ""
+"A végszámla kiállítása előtt az összes előleg számlának kifizetettnek kell "
+"lennie."
+
+#. module: l10n_hu_edi
 #: model:ir.model.fields,field_description:l10n_hu_edi.field_l10n_hu_edi_cancellation__code
 msgid "Annulment Code"
 msgstr "Technikai érvénytelenítési kód"
@@ -1481,6 +1492,13 @@ msgstr "VTSZ - Vámtarifaszám"
 #, python-format
 msgid "View Company/ies"
 msgstr "Vállalat(ok) megtekintése"
+
+#. module: l10n_hu_edi
+#. odoo-python
+#: code:addons/l10n_hu_edi/models/account_move.py:0
+#, python-format
+msgid "View advance invoice(s)"
+msgstr "Előlegszámla(k) megtekintése"
 
 #. module: l10n_hu_edi
 #. odoo-python

--- a/addons/l10n_hu_edi/i18n/hu.po
+++ b/addons/l10n_hu_edi/i18n/hu.po
@@ -171,6 +171,11 @@ msgid "Annulment Reason"
 msgstr "Technikai érvénytelenítés indoklása"
 
 #. module: l10n_hu_edi
+#: model_terms:ir.ui.view,arch_db:l10n_hu_edi.res_config_settings_form_inherit_l10n_hu_edi
+msgid "Authentication with NAV 3.0 successful."
+msgstr "A NAV 3.0-val történő hitelesítés sikeres."
+
+#. module: l10n_hu_edi
 #: model_terms:ir.ui.view,arch_db:l10n_hu_edi.report_invoice_document
 msgid "Bank Account:"
 msgstr "Bankszámla:"
@@ -337,6 +342,17 @@ msgstr ""
 #, python-format
 msgid "Could not parse time of previous transaction"
 msgstr "Nem sikerült értelmezni az előző tranzakció idejét"
+
+#. module: l10n_hu_edi
+#. odoo-python
+#: code:addons/l10n_hu_edi/__init__.py:0
+#, python-format
+msgid ""
+"Could not set NAV tax types on taxes because some taxes from l10n_hu are missing.\n"
+"You should set the type manually or reload the CoA before sending invoices to NAV."
+msgstr ""
+"Nem sikerült beállítani a NAV adótípusait az adókra, mert néhány adó hiányzik a l10n_hu-ból.\n"
+"A típusokat kézzel kell beállítani, vagy újra kell tölteni a CoA-t, mielőtt a számlákat elküldi a NAV-nak."
 
 #. module: l10n_hu_edi
 #: model:ir.model.fields,field_description:l10n_hu_edi.field_l10n_hu_edi_cancellation__create_uid
@@ -700,6 +716,17 @@ msgid "Invoice upload time"
 msgstr "Számla beküldés ideje"
 
 #. module: l10n_hu_edi
+#. odoo-python
+#: code:addons/l10n_hu_edi/wizard/account_move_send.py:0
+#, python-format
+msgid ""
+"Invoices issued in Hungary must, with few exceptions, be reported to the "
+"NAV's Online-Invoice system!"
+msgstr ""
+"Magyarországon a kiállított számlákat, néhány kivételtől eltekintve, "
+"kötelező jelenteni az adóhatóság online számla rendszerébe!"
+
+#. module: l10n_hu_edi
 #: model:ir.model,name:l10n_hu_edi.model_account_move
 msgid "Journal Entry"
 msgstr "Könyvelési tétel"
@@ -767,6 +794,11 @@ msgstr "L10N Hu Edi Beavatkozható hibák"
 #: model:ir.model.fields,field_description:l10n_hu_edi.field_account_move_send__l10n_hu_edi_enable_nav_30
 msgid "L10N Hu Edi Enable Nav 30"
 msgstr "L10N Hu Edi Nav 30 engedélyezése"
+
+#. module: l10n_hu_edi
+#: model:ir.model.fields,field_description:l10n_hu_edi.field_res_config_settings__l10n_hu_edi_is_active
+msgid "L10N Hu Edi Is Active"
+msgstr ""
 
 #. module: l10n_hu_edi
 #: model:ir.model.fields,field_description:l10n_hu_edi.field_l10n_hu_edi_cancellation__write_uid
@@ -1027,9 +1059,9 @@ msgstr "Darab"
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_move.py:0
 #, python-format
-msgid "Please create an ATK (outside the scope of the VAT Act) type of tax!"
+msgid "Please create a sales tax with type ATK (outside the scope of the VAT Act)."
 msgstr ""
-"Kérem, hozzon létre egy ATK (az ÁFA törvény hatályán kívüli) típusú adót!"
+"Kérem, hozzon létre egy ATK típusú forgalmi adót (az ÁFA törvény hatályán kívüli)."
 
 #. module: l10n_hu_edi
 #. odoo-python

--- a/addons/l10n_hu_edi/i18n/l10n_hu_edi.pot
+++ b/addons/l10n_hu_edi/i18n/l10n_hu_edi.pot
@@ -151,6 +151,11 @@ msgid "Annulment Reason"
 msgstr ""
 
 #. module: l10n_hu_edi
+#: model_terms:ir.ui.view,arch_db:l10n_hu_edi.res_config_settings_form_inherit_l10n_hu_edi
+msgid "Authentication with NAV 3.0 successful."
+msgstr ""
+
+#. module: l10n_hu_edi
 #: model_terms:ir.ui.view,arch_db:l10n_hu_edi.report_invoice_document
 msgid "Bank Account:"
 msgstr ""
@@ -305,6 +310,15 @@ msgstr ""
 #: code:addons/l10n_hu_edi/models/l10n_hu_edi_connection.py:0
 #, python-format
 msgid "Could not parse time of previous transaction"
+msgstr ""
+
+#. module: l10n_hu_edi
+#. odoo-python
+#: code:addons/l10n_hu_edi/__init__.py:0
+#, python-format
+msgid ""
+"Could not set NAV tax types on taxes because some taxes from l10n_hu are missing.\n"
+"You should set the type manually or reload the CoA before sending invoices to NAV."
 msgstr ""
 
 #. module: l10n_hu_edi
@@ -652,6 +666,15 @@ msgid "Invoice upload time"
 msgstr ""
 
 #. module: l10n_hu_edi
+#. odoo-python
+#: code:addons/l10n_hu_edi/wizard/account_move_send.py:0
+#, python-format
+msgid ""
+"Invoices issued in Hungary must, with few exceptions, be reported to the "
+"NAV's Online-Invoice system!"
+msgstr ""
+
+#. module: l10n_hu_edi
 #: model:ir.model,name:l10n_hu_edi.model_account_move
 msgid "Journal Entry"
 msgstr ""
@@ -718,6 +741,11 @@ msgstr ""
 #. module: l10n_hu_edi
 #: model:ir.model.fields,field_description:l10n_hu_edi.field_account_move_send__l10n_hu_edi_enable_nav_30
 msgid "L10N Hu Edi Enable Nav 30"
+msgstr ""
+
+#. module: l10n_hu_edi
+#: model:ir.model.fields,field_description:l10n_hu_edi.field_res_config_settings__l10n_hu_edi_is_active
+msgid "L10N Hu Edi Is Active"
 msgstr ""
 
 #. module: l10n_hu_edi
@@ -975,7 +1003,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_move.py:0
 #, python-format
-msgid "Please create an ATK (outside the scope of the VAT Act) type of tax!"
+msgid "Please create a sales tax with type ATK (outside the scope of the VAT Act)."
 msgstr ""
 
 #. module: l10n_hu_edi

--- a/addons/l10n_hu_edi/i18n/l10n_hu_edi.pot
+++ b/addons/l10n_hu_edi/i18n/l10n_hu_edi.pot
@@ -132,6 +132,15 @@ msgid "Account Move Send"
 msgstr ""
 
 #. module: l10n_hu_edi
+#. odoo-python
+#: code:addons/l10n_hu_edi/models/account_move.py:0
+#, python-format
+msgid ""
+"All advance invoices must be paid and sent to NAV before the final invoice "
+"is issued."
+msgstr ""
+
+#. module: l10n_hu_edi
 #: model:ir.model.fields,field_description:l10n_hu_edi.field_l10n_hu_edi_cancellation__code
 msgid "Annulment Code"
 msgstr ""
@@ -1395,6 +1404,13 @@ msgstr ""
 #: code:addons/l10n_hu_edi/models/account_move.py:0
 #, python-format
 msgid "View Company/ies"
+msgstr ""
+
+#. module: l10n_hu_edi
+#. odoo-python
+#: code:addons/l10n_hu_edi/models/account_move.py:0
+#, python-format
+msgid "View advance invoice(s)"
 msgstr ""
 
 #. module: l10n_hu_edi

--- a/addons/l10n_hu_edi/models/account_move.py
+++ b/addons/l10n_hu_edi/models/account_move.py
@@ -265,8 +265,8 @@ class AccountMove(models.Model):
     def _l10n_hu_get_currency_rate(self):
         """ Get the invoice currency / HUF rate.
 
-        If the company currency is HUF, we estimate this based on the invoice lines,
-        using a MMSE estimator.
+        If the company currency is HUF, we estimate this based on the invoice lines
+        (or if this is not an invoice, based on the AMLs), using a MMSE estimator.
 
         If the company currency is not HUF (e.g. Hungarian companies that do their accounting in euro),
         we get the rate from the currency rates.
@@ -274,7 +274,7 @@ class AccountMove(models.Model):
         if self.currency_id.name == 'HUF':
             return 1
         if self.company_id.currency_id.name == 'HUF':
-            squared_amount_currency = sum(line.amount_currency ** 2 for line in self.invoice_line_ids)
+            squared_amount_currency = sum(line.amount_currency ** 2 for line in (self.invoice_line_ids or self.line_ids))
             squared_balance = sum(line.balance ** 2 for line in self.invoice_line_ids)
             return math.sqrt(squared_balance / squared_amount_currency)
         return self.env['res.currency']._get_conversion_rate(
@@ -317,6 +317,9 @@ class AccountMove(models.Model):
     def _l10n_hu_edi_check_invoices(self):
         errors = []
         hu_vat_regex = re.compile(r'\d{8}-[1-5]-\d{2}')
+
+        # This contains all the advance invoices that correspond to final invoices in `self`.
+        advance_invoices = self.filtered(lambda m: not m._is_downpayment()).invoice_line_ids._get_downpayment_lines().mapped('move_id')
 
         checks = {
             'company_vat_missing': {
@@ -389,6 +392,17 @@ class AccountMove(models.Model):
                 ]),
                 'message': _('The following invoices appear to be earlier in the chain, but have not yet been sent. Please send them first.'),
                 'action_text': _('View invoice(s)'),
+            },
+            'invoice_advance_not_paid': {
+                'records': advance_invoices.filtered(
+                    lambda m: (
+                        m.payment_state not in ['in_payment', 'paid', 'partial']
+                        or m.l10n_hu_edi_state in [False, 'rejected', 'cancelled']
+                            and m not in self  # It's okay to send an advance and a final invoice together, as we sort by id before sending.
+                    )
+                ),
+                'message': _('All advance invoices must be paid and sent to NAV before the final invoice is issued.'),
+                'action_text': _('View advance invoice(s)'),
             },
             'invoice_line_not_one_vat_tax': {
                 'records': self.filtered(
@@ -859,20 +873,24 @@ class AccountMove(models.Model):
             }
 
             if 'is_downpayment' in line and line.is_downpayment:
-                advance_invoices = line._get_downpayment_lines().mapped('move_id').filtered(lambda m: m.state == 'posted') - self
+                # Advance and final invoices.
+                line_values['advanceIndicator'] = True
 
-                # Advance invoices case 1: this is an advance invoice
-                if not advance_invoices:
-                    line_values['advanceIndicator'] = True
+                if not self._is_downpayment():
+                    # This is a final invoice that deducts one or more advance invoices.
+                    # In this case, we add a reference to the *last-paid* advance invoice (NAV only allows us to report one) if one exists,
+                    # otherwise we don't add anything.
 
-                # Advance invoices case 2: this is a final invoice that deducts an advance invoice
-                else:
-                    line_values.update({
-                        'advanceIndicator': True,
-                        'advanceOriginalInvoice': advance_invoices[0].name,
-                        'advancePaymentDate': advance_invoices[0].invoice_date,
-                        'advanceExchangeRate': advance_invoices[0]._l10n_hu_get_currency_rate(),
-                    })
+                    advance_invoices = line._get_downpayment_lines().mapped('move_id').filtered(lambda m: m.state == 'posted')
+                    reconciled_moves = advance_invoices._get_reconciled_amls().move_id
+                    last_reconciled_payment = reconciled_moves.filtered(lambda m: m.payment_id or m.statement_line_id).sorted('date', reverse=True)[:1]
+
+                    if last_reconciled_payment:
+                        line_values.update({
+                            'advanceOriginalInvoice': advance_invoices.filtered(lambda m: last_reconciled_payment in m._get_reconciled_amls().move_id)[0].name,
+                            'advancePaymentDate': last_reconciled_payment.date,
+                            'advanceExchangeRate': last_reconciled_payment._l10n_hu_get_currency_rate(),
+                        })
 
             if line.display_type == 'product':
                 vat_tax = line.tax_ids.filtered(lambda t: t.l10n_hu_tax_type)

--- a/addons/l10n_hu_edi/models/account_move.py
+++ b/addons/l10n_hu_edi/models/account_move.py
@@ -918,9 +918,16 @@ class AccountMove(models.Model):
                 })
 
             elif line.display_type == 'rounding':
-                atk_tax = self.env['account.tax'].search([('l10n_hu_tax_type', '=', 'ATK'), ('company_id', '=', self.company_id.id)], limit=1)
+                atk_tax = self.env['account.tax'].search(
+                    [
+                        ('type_tax_use', '=', 'sale'),
+                        ('l10n_hu_tax_type', '=', 'ATK'),
+                        ('company_id', '=', self.company_id.id),
+                    ],
+                    limit=1,
+                )
                 if not atk_tax:
-                    raise UserError(_('Please create an ATK (outside the scope of the VAT Act) type of tax!'))
+                    raise UserError(_('Please create a sales tax with type ATK (outside the scope of the VAT Act).'))
 
                 amount_huf = line.balance if self.company_id.currency_id == currency_huf else currency_huf.round(line.amount_currency * currency_rate)
                 line_values.update({

--- a/addons/l10n_hu_edi/models/l10n_hu_edi_connection.py
+++ b/addons/l10n_hu_edi/models/l10n_hu_edi_connection.py
@@ -421,19 +421,13 @@ class L10nHuEdiConnection:
     # === Helpers: Response parsing === #
 
     def _parse_error_response(self, response_xml):
-        if response_xml.tag == '{http://schemas.nav.gov.hu/OSA/3.0/api}GeneralErrorResponse':
-            errors = []
+        error_code = response_xml.findtext('common:result/common:errorCode', namespaces=XML_NAMESPACES)
+        message = response_xml.findtext('common:result/common:message', namespaces=XML_NAMESPACES)
+        if error_code:
+            errors = [f'{error_code}: {message}']
             for message_xml in response_xml.iterfind('api:technicalValidationMessages', namespaces=XML_NAMESPACES):
                 message = message_xml.findtext('api:message', namespaces=XML_NAMESPACES)
                 error_code = message_xml.findtext('api:validationErrorCode', namespaces=XML_NAMESPACES)
                 errors.append(f'{error_code}: {message}')
+
             raise L10nHuEdiConnectionError(errors)
-
-        if response_xml.tag == '{http://schemas.nav.gov.hu/OSA/3.0/api}GeneralExceptionResponse':
-            message = response_xml.findtext('api:message', namespaces=XML_NAMESPACES)
-            code = response_xml.findtext('api:errorCode', namespaces=XML_NAMESPACES)
-            raise L10nHuEdiConnectionError(f'{code}: {message}')
-
-        func_code = response_xml.findtext('common:result/common:funcCode', namespaces=XML_NAMESPACES)
-        if func_code != 'OK':
-            raise L10nHuEdiConnectionError(_('NAV replied with non-OK funcCode: %s', func_code))

--- a/addons/l10n_hu_edi/models/res_company.py
+++ b/addons/l10n_hu_edi/models/res_company.py
@@ -101,13 +101,12 @@ class ResCompany(models.Model):
             for company in self:
                 if not company.vat:
                     raise UserError(_('NAV Credentials: Please set the hungarian vat number on the company first!'))
-                if self.l10n_hu_edi_server_mode != 'demo':
-                    try:
-                        connection.do_token_exchange(company._l10n_hu_edi_get_credentials_dict())
-                    except L10nHuEdiConnectionError as e:
-                        raise UserError(
-                            _('Incorrect NAV Credentials! Check that your company VAT number is set correctly. \nError details: %s', e)
-                        ) from e
+                try:
+                    connection.do_token_exchange(company._l10n_hu_edi_get_credentials_dict())
+                except L10nHuEdiConnectionError as e:
+                    raise UserError(
+                        _('Incorrect NAV Credentials! Check that your company VAT number is set correctly. \nError details: %s', e)
+                    ) from e
 
     def _l10n_hu_edi_recover_transactions(self, connection):
         """ Recover transactions that are in force but for some reason are not matched to the company's

--- a/addons/l10n_hu_edi/models/res_config_settings.py
+++ b/addons/l10n_hu_edi/models/res_config_settings.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models
+from odoo import fields, models, api
 
 
 class ResConfigSettings(models.TransientModel):
@@ -31,7 +31,10 @@ class ResConfigSettings(models.TransientModel):
         readonly=False,
     )
 
-    def set_values(self):
-        super().set_values()
-        if self.company_id.l10n_hu_edi_server_mode:
-            self.company_id._l10n_hu_edi_test_credentials()
+    @api.model_create_multi
+    def create(self, vals_list):
+        records = super().create(vals_list)
+        for record in records:
+            if record.company_id.l10n_hu_edi_server_mode in ['production', 'test']:
+                record.company_id._l10n_hu_edi_test_credentials()
+        return records

--- a/addons/l10n_hu_edi/models/res_config_settings.py
+++ b/addons/l10n_hu_edi/models/res_config_settings.py
@@ -30,6 +30,15 @@ class ResConfigSettings(models.TransientModel):
         related='company_id.l10n_hu_edi_replacement_key',
         readonly=False,
     )
+    # Technical field to control display of the "Authentication with NAV 3.0 successful" banner
+    l10n_hu_edi_is_active = fields.Boolean(
+        compute='_compute_l10n_hu_edi_is_active',
+    )
+
+    @api.depends('company_id.l10n_hu_edi_server_mode')
+    def _compute_l10n_hu_edi_is_active(self):
+        for record in self:
+            record.l10n_hu_edi_is_active = record.company_id.l10n_hu_edi_server_mode in ['production', 'test']
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/l10n_hu_edi/tests/common.py
+++ b/addons/l10n_hu_edi/tests/common.py
@@ -124,14 +124,13 @@ class L10nHuEdiTestCommon(AccountTestInvoicingCommon):
     @classmethod
     def write_edi_credentials(cls):
         # Set up test EDI user
-        with mock.patch.object(type(cls.env['res.company']), '_l10n_hu_edi_test_credentials', autospec=True):
-            return cls.company_data['company'].write({
-                'l10n_hu_edi_server_mode': 'test',
-                'l10n_hu_edi_username': 'this',
-                'l10n_hu_edi_password': 'that',
-                'l10n_hu_edi_signature_key': 'some_key',
-                'l10n_hu_edi_replacement_key': 'abcdefghijklmnop',
-            })
+        return cls.company_data['company'].write({
+            'l10n_hu_edi_server_mode': 'test',
+            'l10n_hu_edi_username': 'this',
+            'l10n_hu_edi_password': 'that',
+            'l10n_hu_edi_signature_key': 'some_key',
+            'l10n_hu_edi_replacement_key': 'abcdefghijklmnop',
+        })
 
     def create_invoice_simple(self):
         """ Create a really basic invoice - just one line. """

--- a/addons/l10n_hu_edi/tests/common.py
+++ b/addons/l10n_hu_edi/tests/common.py
@@ -153,7 +153,7 @@ class L10nHuEdiTestCommon(AccountTestInvoicingCommon):
         })
 
     def create_advance_invoice(self):
-        """ Create a sale order, an advance invoice and a final invoice. """
+        """ Create a sale order and an advance invoice. """
         self.product_a.invoice_policy = 'order'
         pricelist_huf = self.env['product.pricelist'].create({
             'name': 'HUF pricelist',
@@ -174,28 +174,34 @@ class L10nHuEdiTestCommon(AccountTestInvoicingCommon):
         })
         sale_order.action_confirm()
 
-        context = {
+        downpayment = self.env['sale.advance.payment.inv'].with_context({
             'active_model': 'sale.order',
             'active_ids': [sale_order.id],
             'active_id': sale_order.id,
             'default_journal_id': self.company_data['default_journal_sale'].id,
-        }
-
-        downpayment_1 = self.env['sale.advance.payment.inv'].with_context(context).create({
+        }).create({
             'advance_payment_method': 'fixed',
             'fixed_amount': 6350.0,
             'deposit_account_id': self.company_data['default_account_revenue'].id,
         })
-        downpayment_1.create_invoices()
-        advance_invoice = sale_order.invoice_ids
+        downpayment.create_invoices()
+        return sale_order, sale_order.invoice_ids
 
-        downpayment_2 = self.env['sale.advance.payment.inv'].with_context(context).create({
+    def create_final_invoice(self, sale_order):
+        """ Create a final invoice for a sale order """
+        advance_invoice = sale_order.invoice_ids
+        final_payment = self.env['sale.advance.payment.inv'].with_context({
+            'active_model': 'sale.order',
+            'active_ids': [sale_order.id],
+            'active_id': sale_order.id,
+            'default_journal_id': self.company_data['default_journal_sale'].id,
+        }).create({
             'advance_payment_method': 'delivered',
         })
-        downpayment_2.create_invoices()
+        final_payment.create_invoices()
         final_invoice = sale_order.invoice_ids - advance_invoice
 
-        return advance_invoice, final_invoice
+        return final_invoice
 
     def create_invoice_complex_huf(self):
         """ Create a complex invoice in HUF, with cash rounding. """

--- a/addons/l10n_hu_edi/tests/common.py
+++ b/addons/l10n_hu_edi/tests/common.py
@@ -4,7 +4,6 @@ from odoo import Command
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 
 import datetime
-from unittest import mock
 
 
 class L10nHuEdiTestCommon(AccountTestInvoicingCommon):
@@ -293,6 +292,7 @@ class L10nHuEdiTestCommon(AccountTestInvoicingCommon):
         invoice = self.create_invoice_simple()
         invoice.action_post()
         send_and_print = self.create_send_and_print(invoice, l10n_hu_edi_enable_nav_30=True)
+        self.assertRecordValues(send_and_print, [{'l10n_hu_edi_actionable_errors': {}}])
         send_and_print.action_send_and_print()
         cancel_wizard = self.env['l10n_hu_edi.cancellation'].with_context({"default_invoice_id": invoice.id}).create({
             'code': 'ERRATIC_DATA',

--- a/addons/l10n_hu_edi/tests/invoice_xmls/invoice_advance.xml
+++ b/addons/l10n_hu_edi/tests/invoice_xmls/invoice_advance.xml
@@ -5,7 +5,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://schemas.nav.gov.hu/OSA/3.0/data invoiceData.xsd">
     <invoiceNumber>INV/2024/00001</invoiceNumber>
-    <invoiceIssueDate>2024-02-01</invoiceIssueDate>
+    <invoiceIssueDate>2024-01-01</invoiceIssueDate>
     <completenessIndicator>false</completenessIndicator>
     <invoiceMain>
         <invoice>
@@ -48,11 +48,11 @@
                 </customerInfo>
                 <invoiceDetail>
                     <invoiceCategory>NORMAL</invoiceCategory>
-                    <invoiceDeliveryDate>2024-02-01</invoiceDeliveryDate>
+                    <invoiceDeliveryDate>2024-01-01</invoiceDeliveryDate>
                     <smallBusinessIndicator>false</smallBusinessIndicator>
                     <currencyCode>HUF</currencyCode>
                     <exchangeRate>1.000000</exchangeRate>
-                    <paymentDate>2024-02-01</paymentDate>
+                    <paymentDate>2024-01-01</paymentDate>
                     <cashAccountingIndicator>false</cashAccountingIndicator>
                     <invoiceAppearance>PAPER</invoiceAppearance>
                 </invoiceDetail>

--- a/addons/l10n_hu_edi/tests/invoice_xmls/invoice_final.xml
+++ b/addons/l10n_hu_edi/tests/invoice_xmls/invoice_final.xml
@@ -92,13 +92,13 @@
                         <advanceIndicator>true</advanceIndicator>
                         <advancePaymentData>
                             <advanceOriginalInvoice>INV/2024/00001</advanceOriginalInvoice>
-                            <advancePaymentDate>2024-02-01</advancePaymentDate>
+                            <advancePaymentDate>2024-01-15</advancePaymentDate>
                             <advanceExchangeRate>1.000000</advanceExchangeRate>
                         </advancePaymentData>
                     </advanceData>
                     <lineExpressionIndicator>true</lineExpressionIndicator>
                     <lineNatureIndicator>SERVICE</lineNatureIndicator>
-                    <lineDescription>Down Payment: 02/01/2024 (Draft)</lineDescription>
+                    <lineDescription>Down payment (ref: INV/2024/00001 on 01/01/2024)</lineDescription>
                     <quantity>-1.0</quantity>
                     <unitOfMeasure>PIECE</unitOfMeasure>
                     <unitPrice>5000.000000</unitPrice>

--- a/addons/l10n_hu_edi/tests/test_flows_live.py
+++ b/addons/l10n_hu_edi/tests/test_flows_live.py
@@ -57,13 +57,16 @@ class L10nHuEdiTestFlowsLive(L10nHuEdiTestCommon, TestAccountMoveSendCommon):
         if 'sale_line_ids' not in self.env['account.move.line']:
             self.skipTest('Sale module not installed, skipping advance invoice tests.')
 
-        advance_invoice, final_invoice = self.create_advance_invoice()
+        sale_order, advance_invoice = self.create_advance_invoice()
         with self.set_invoice_name(advance_invoice, 'INV/2024/'):
             advance_invoice.action_post()
             send_and_print = self.create_send_and_print(advance_invoice, l10n_hu_edi_enable_nav_30=True)
             send_and_print.action_send_and_print()
             self.assertRecordValues(advance_invoice, [{'l10n_hu_edi_state': 'confirmed', 'l10n_hu_invoice_chain_index': -1}])
 
+        self.env['account.payment.register'].with_context(active_ids=advance_invoice.ids, active_model='account.move').create({})._create_payments()
+
+        final_invoice = self.create_final_invoice(sale_order)
         with self.set_invoice_name(final_invoice, 'INV/2024/'):
             final_invoice.action_post()
             send_and_print = self.create_send_and_print(final_invoice, l10n_hu_edi_enable_nav_30=True)

--- a/addons/l10n_hu_edi/tests/test_flows_live.py
+++ b/addons/l10n_hu_edi/tests/test_flows_live.py
@@ -35,6 +35,7 @@ class L10nHuEdiTestFlowsLive(L10nHuEdiTestCommon, TestAccountMoveSendCommon):
         with self.set_invoice_name(invoice, 'INV/2024/'):
             invoice.action_post()
             send_and_print = self.create_send_and_print(invoice, l10n_hu_edi_enable_nav_30=True)
+            self.assertRecordValues(send_and_print, [{'l10n_hu_edi_actionable_errors': {}}])
             send_and_print.action_send_and_print()
             self.assertRecordValues(invoice, [{'l10n_hu_edi_state': 'confirmed', 'l10n_hu_invoice_chain_index': -1}])
 
@@ -42,6 +43,7 @@ class L10nHuEdiTestFlowsLive(L10nHuEdiTestCommon, TestAccountMoveSendCommon):
         with self.set_invoice_name(credit_note, 'RINV/2024/'):
             credit_note.action_post()
             send_and_print = self.create_send_and_print(credit_note, l10n_hu_edi_enable_nav_30=True)
+            self.assertRecordValues(send_and_print, [{'l10n_hu_edi_actionable_errors': {}}])
             send_and_print.action_send_and_print()
             self.assertRecordValues(credit_note, [{'l10n_hu_edi_state': 'confirmed', 'l10n_hu_invoice_chain_index': 1}])
 
@@ -61,6 +63,7 @@ class L10nHuEdiTestFlowsLive(L10nHuEdiTestCommon, TestAccountMoveSendCommon):
         with self.set_invoice_name(advance_invoice, 'INV/2024/'):
             advance_invoice.action_post()
             send_and_print = self.create_send_and_print(advance_invoice, l10n_hu_edi_enable_nav_30=True)
+            self.assertRecordValues(send_and_print, [{'l10n_hu_edi_actionable_errors': {}}])
             send_and_print.action_send_and_print()
             self.assertRecordValues(advance_invoice, [{'l10n_hu_edi_state': 'confirmed', 'l10n_hu_invoice_chain_index': -1}])
 
@@ -70,6 +73,7 @@ class L10nHuEdiTestFlowsLive(L10nHuEdiTestCommon, TestAccountMoveSendCommon):
         with self.set_invoice_name(final_invoice, 'INV/2024/'):
             final_invoice.action_post()
             send_and_print = self.create_send_and_print(final_invoice, l10n_hu_edi_enable_nav_30=True)
+            self.assertRecordValues(send_and_print, [{'l10n_hu_edi_actionable_errors': {}}])
             send_and_print.action_send_and_print()
             self.assertRecordValues(final_invoice, [{'l10n_hu_edi_state': 'confirmed', 'l10n_hu_invoice_chain_index': -1}])
 
@@ -78,6 +82,7 @@ class L10nHuEdiTestFlowsLive(L10nHuEdiTestCommon, TestAccountMoveSendCommon):
         with self.set_invoice_name(invoice, 'INV/2024/'):
             invoice.action_post()
             send_and_print = self.create_send_and_print(invoice, l10n_hu_edi_enable_nav_30=True)
+            self.assertRecordValues(send_and_print, [{'l10n_hu_edi_actionable_errors': {}}])
             send_and_print.action_send_and_print()
             self.assertRecordValues(invoice, [{'l10n_hu_edi_state': 'confirmed', 'l10n_hu_invoice_chain_index': -1}])
 
@@ -86,6 +91,7 @@ class L10nHuEdiTestFlowsLive(L10nHuEdiTestCommon, TestAccountMoveSendCommon):
         with self.set_invoice_name(invoice, 'INV/2024/'):
             invoice.action_post()
             send_and_print = self.create_send_and_print(invoice, l10n_hu_edi_enable_nav_30=True)
+            self.assertRecordValues(send_and_print, [{'l10n_hu_edi_actionable_errors': {}}])
             send_and_print.action_send_and_print()
             self.assertRecordValues(invoice, [{'l10n_hu_edi_state': 'confirmed', 'l10n_hu_invoice_chain_index': -1}])
 
@@ -94,6 +100,7 @@ class L10nHuEdiTestFlowsLive(L10nHuEdiTestCommon, TestAccountMoveSendCommon):
         invoice.action_post()
 
         send_and_print = self.create_send_and_print(invoice, l10n_hu_edi_enable_nav_30=True)
+        self.assertRecordValues(send_and_print, [{'l10n_hu_edi_actionable_errors': {}}])
         with self.patch_call_nav_endpoint('manageInvoice', make_request=False), contextlib.suppress(UserError):
             send_and_print.action_send_and_print()
 
@@ -110,6 +117,7 @@ class L10nHuEdiTestFlowsLive(L10nHuEdiTestCommon, TestAccountMoveSendCommon):
         with self.set_invoice_name(invoice, 'INV/2024/'):
             invoice.action_post()
             send_and_print = self.create_send_and_print(invoice, l10n_hu_edi_enable_nav_30=True)
+            self.assertRecordValues(send_and_print, [{'l10n_hu_edi_actionable_errors': {}}])
             with self.patch_call_nav_endpoint('manageInvoice'), contextlib.suppress(UserError):
                 send_and_print.action_send_and_print()
 

--- a/addons/l10n_hu_edi/tests/test_flows_mocked.py
+++ b/addons/l10n_hu_edi/tests/test_flows_mocked.py
@@ -26,12 +26,14 @@ class L10nHuEdiTestFlowsMocked(L10nHuEdiTestCommon, TestAccountMoveSendCommon):
             invoice = self.create_invoice_simple()
             invoice.action_post()
             send_and_print = self.create_send_and_print(invoice, l10n_hu_edi_enable_nav_30=True)
+            self.assertRecordValues(send_and_print, [{'l10n_hu_edi_actionable_errors': {}}])
             send_and_print.action_send_and_print()
             self.assertRecordValues(invoice, [{'l10n_hu_edi_state': 'confirmed', 'l10n_hu_invoice_chain_index': -1}])
 
             credit_note = self.create_reversal(invoice)
             credit_note.action_post()
             send_and_print = self.create_send_and_print(credit_note, l10n_hu_edi_enable_nav_30=True)
+            self.assertRecordValues(send_and_print, [{'l10n_hu_edi_actionable_errors': {}}])
             send_and_print.action_send_and_print()
             self.assertRecordValues(credit_note, [{'l10n_hu_edi_state': 'confirmed', 'l10n_hu_invoice_chain_index': 1}])
 
@@ -43,6 +45,7 @@ class L10nHuEdiTestFlowsMocked(L10nHuEdiTestCommon, TestAccountMoveSendCommon):
             invoice = self.create_invoice_simple()
             invoice.action_post()
             send_and_print = self.create_send_and_print(invoice, l10n_hu_edi_enable_nav_30=True)
+            self.assertRecordValues(send_and_print, [{'l10n_hu_edi_actionable_errors': {}}])
             send_and_print.action_send_and_print()
             self.assertRecordValues(invoice, [{'l10n_hu_edi_state': 'confirmed_warning', 'l10n_hu_invoice_chain_index': -1}])
 
@@ -54,6 +57,7 @@ class L10nHuEdiTestFlowsMocked(L10nHuEdiTestCommon, TestAccountMoveSendCommon):
             invoice = self.create_invoice_simple()
             invoice.action_post()
             send_and_print = self.create_send_and_print(invoice, l10n_hu_edi_enable_nav_30=True)
+            self.assertRecordValues(send_and_print, [{'l10n_hu_edi_actionable_errors': {}}])
             with contextlib.suppress(UserError):
                 send_and_print.action_send_and_print()
             self.assertRecordValues(invoice, [{'l10n_hu_edi_state': 'rejected', 'l10n_hu_invoice_chain_index': 0}])
@@ -65,6 +69,7 @@ class L10nHuEdiTestFlowsMocked(L10nHuEdiTestCommon, TestAccountMoveSendCommon):
             invoice.action_post()
 
             send_and_print = self.create_send_and_print(invoice, l10n_hu_edi_enable_nav_30=True)
+            self.assertRecordValues(send_and_print, [{'l10n_hu_edi_actionable_errors': {}}])
             send_and_print.action_send_and_print()
             self.assertRecordValues(invoice, [{'l10n_hu_edi_state': 'send_timeout', 'l10n_hu_invoice_chain_index': -1}])
 
@@ -85,6 +90,7 @@ class L10nHuEdiTestFlowsMocked(L10nHuEdiTestCommon, TestAccountMoveSendCommon):
             invoice.action_post()
 
             send_and_print = self.create_send_and_print(invoice, l10n_hu_edi_enable_nav_30=True)
+            self.assertRecordValues(send_and_print, [{'l10n_hu_edi_actionable_errors': {}}])
             send_and_print.action_send_and_print()
             self.assertRecordValues(invoice, [{'l10n_hu_edi_state': 'send_timeout', 'l10n_hu_invoice_chain_index': -1}])
 
@@ -145,10 +151,12 @@ class L10nHuEdiTestFlowsMocked(L10nHuEdiTestCommon, TestAccountMoveSendCommon):
                 credit_note = invoice.reversal_move_id
 
                 send_and_print = self.create_send_and_print(credit_note, l10n_hu_edi_enable_nav_30=True)
+                self.assertRecordValues(send_and_print, [{'l10n_hu_edi_actionable_errors': {}}])
                 send_and_print.action_send_and_print()
                 self.assertRecordValues(credit_note, [{'l10n_hu_edi_state': 'confirmed', 'l10n_hu_invoice_chain_index': 1}])
 
                 send_and_print = self.create_send_and_print(new_invoice, l10n_hu_edi_enable_nav_30=True)
+                self.assertRecordValues(send_and_print, [{'l10n_hu_edi_actionable_errors': {}}])
                 send_and_print.action_send_and_print()
                 self.assertRecordValues(new_invoice, [{'l10n_hu_edi_state': 'confirmed', 'l10n_hu_invoice_chain_index': 2}])
 
@@ -167,14 +175,17 @@ class L10nHuEdiTestFlowsMocked(L10nHuEdiTestCommon, TestAccountMoveSendCommon):
 
             with self.patch_post():
                 send_and_print = self.create_send_and_print(invoice, l10n_hu_edi_enable_nav_30=True)
+                self.assertRecordValues(send_and_print, [{'l10n_hu_edi_actionable_errors': {}}])
                 send_and_print.action_send_and_print()
                 self.assertRecordValues(invoice, [{'l10n_hu_edi_state': 'confirmed', 'l10n_hu_invoice_chain_index': -1}])
 
                 send_and_print = self.create_send_and_print(credit_note, l10n_hu_edi_enable_nav_30=True)
+                self.assertRecordValues(send_and_print, [{'l10n_hu_edi_actionable_errors': {}}])
                 send_and_print.action_send_and_print()
                 self.assertRecordValues(credit_note, [{'l10n_hu_edi_state': 'confirmed', 'l10n_hu_invoice_chain_index': 1}])
 
                 send_and_print = self.create_send_and_print(new_invoice, l10n_hu_edi_enable_nav_30=True)
+                self.assertRecordValues(send_and_print, [{'l10n_hu_edi_actionable_errors': {}}])
                 send_and_print.action_send_and_print()
                 self.assertRecordValues(new_invoice, [{'l10n_hu_edi_state': 'confirmed', 'l10n_hu_invoice_chain_index': 2}])
 

--- a/addons/l10n_hu_edi/views/account_tax_views.xml
+++ b/addons/l10n_hu_edi/views/account_tax_views.xml
@@ -7,7 +7,9 @@
         <field name="arch" type="xml">
             <field name="name" position="after">
                 <field name="l10n_hu_tax_type" invisible="country_code != 'HU'"/>
-                <field name="l10n_hu_tax_reason" invisible="country_code != 'HU'" required="country_code == 'HU' and l10n_hu_tax_type not in [False, 'VAT']"/>
+                <field name="l10n_hu_tax_reason"
+                       invisible="country_code != 'HU' or l10n_hu_tax_type == 'VAT'"
+                       required="country_code == 'HU' and l10n_hu_tax_type not in [False, 'VAT']"/>
             </field>
         </field>
     </record>

--- a/addons/l10n_hu_edi/views/res_config_settings_views.xml
+++ b/addons/l10n_hu_edi/views/res_config_settings_views.xml
@@ -14,6 +14,13 @@
                              help="Enter your e-invoicing credentials given by the Hungarian Authority."
                              name="l10n_hu_edi_nav_credentials">
                         <div class="row">
+                            <field name="l10n_hu_edi_is_active" invisible="1"/>
+                            <div class="alert alert-success text-center ms-3" role="alert"
+                                 invisible="not l10n_hu_edi_is_active">
+                                Authentication with NAV 3.0 successful.
+                            </div>
+                        </div>
+                        <div class="row">
                             <label string="Mode" for="l10n_hu_edi_server_mode" class="col-lg-3 o_light_label"/>
                             <field name="l10n_hu_edi_server_mode"/>
                         </div>

--- a/addons/l10n_hu_edi/wizard/account_move_send.py
+++ b/addons/l10n_hu_edi/wizard/account_move_send.py
@@ -1,7 +1,7 @@
 import time
 from datetime import timedelta
 
-from odoo import api, fields, models
+from odoo import api, fields, models, _
 from odoo.addons.l10n_hu_edi.models.l10n_hu_edi_connection import L10nHuEdiConnection
 
 
@@ -9,7 +9,7 @@ class AccountMoveSend(models.TransientModel):
     _inherit = 'account.move.send'
 
     l10n_hu_edi_actionable_errors = fields.Json(
-        compute='_compute_l10n_hu_edi_enable_nav_30'
+        compute='_compute_l10n_hu_edi_actionable_errors'
     )
     l10n_hu_edi_enable_nav_30 = fields.Boolean(
         compute='_compute_l10n_hu_edi_enable_nav_30'
@@ -36,18 +36,29 @@ class AccountMoveSend(models.TransientModel):
     def _compute_l10n_hu_edi_enable_nav_30(self):
         for wizard in self:
             enabled_moves = wizard.move_ids.filtered(lambda m: 'upload' in m._l10n_hu_edi_get_valid_actions())._origin
-            if wizard.mode in ('invoice_single', 'invoice_multi') and enabled_moves:
-                wizard.l10n_hu_edi_enable_nav_30 = True
-                wizard.l10n_hu_edi_actionable_errors = enabled_moves._l10n_hu_edi_check_invoices()
+            wizard.l10n_hu_edi_enable_nav_30 = wizard.mode in ('invoice_single', 'invoice_multi') and enabled_moves
 
-            else:
-                wizard.l10n_hu_edi_enable_nav_30 = False
-                wizard.l10n_hu_edi_actionable_errors = False
-
-    @api.depends('l10n_hu_edi_enable_nav_30', 'l10n_hu_edi_actionable_errors')
+    @api.depends('l10n_hu_edi_enable_nav_30')
     def _compute_l10n_hu_edi_checkbox_nav_30(self):
         for wizard in self:
             wizard.l10n_hu_edi_checkbox_nav_30 = wizard.l10n_hu_edi_enable_nav_30
+
+    @api.depends('l10n_hu_edi_enable_nav_30', 'l10n_hu_edi_checkbox_nav_30', 'move_ids')
+    def _compute_l10n_hu_edi_actionable_errors(self):
+        for wizard in self:
+            if wizard.l10n_hu_edi_enable_nav_30:
+                enabled_moves = wizard.move_ids.filtered(lambda m: 'upload' in m._l10n_hu_edi_get_valid_actions())._origin
+                actionable_errors = enabled_moves._l10n_hu_edi_check_invoices()
+
+                if enabled_moves and not wizard.l10n_hu_edi_checkbox_nav_30:
+                    actionable_errors['checkbox_not_ticked'] = {
+                        'message': _("Invoices issued in Hungary must, with few exceptions, be reported to the NAV's Online-Invoice system.")
+                    }
+
+                wizard.l10n_hu_edi_actionable_errors = actionable_errors
+
+            else:
+                wizard.l10n_hu_edi_actionable_errors = False
 
     # -------------------------------------------------------------------------
     # BUSINESS ACTIONS


### PR DESCRIPTION
#### Partner feedbacks

- Add small box notification in settings when NAV 3.0 authentication succeeds.
- Add warning if the user un-checks the 'NAV 3.0' checkbox in the Send & Print.
- Amend module manifest to clarify that we are electronically reporting paper invoices.
- Report the *date of payment*, not date of issue of advance invoices as `advancePaymentDate` when issuing the final invoice. In addition, advanceExchangeRate should be the HUF exchange rate used for the payment.
- Add a warning if not all advance invoices are paid when issuing the final invoice.
- Add more checks in tests that the invoice checks pass when opening the Send & Print wizard.
- Make the 'HU Tax Reason' field invisible if the tax has VAT type.

#### Bugfixes
- connection testing should be done on res.config.settings `create()`, not on `set_values()` because the related fields are written during the create, which is called in a prior transaction to the set_values. This ensures that if the connection cannot be established, the UserError causes the rollback of the transaction before the values are written to res_company.
- the parse_error_response method wasn't correctly parsing error results leading to empty error messages


Many thanks to:
- Eiler Attila (online-erp.hu)
- Geza Nagy (oregional.hu)

taskid: 3985127