### PR TITLE
[IMP] l10n_cz: Fill accounting date with 'taxable_supply_date'

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -672,10 +672,14 @@ class AccountMoveLine(models.Model):
                     from_currency=line.company_currency_id,
                     to_currency=line.currency_id,
                     company=line.company_id,
-                    date=line.move_id.invoice_date or line.move_id.date or fields.Date.context_today(line),
+                    date=line._get_rate_date(),
                 )
             else:
                 line.currency_rate = 1
+
+    def _get_rate_date(self):
+        self.ensure_one()
+        return self.move_id.invoice_date or self.move_id.date or fields.Date.context_today(self)
 
     @api.depends('currency_id', 'company_currency_id')
     def _compute_same_currency(self):

--- a/addons/l10n_cz/models/__init__.py
+++ b/addons/l10n_cz/models/__init__.py
@@ -2,3 +2,4 @@
 from . import template_cz
 from . import res_company
 from . import account_move
+from . import account_move_line

--- a/addons/l10n_cz/models/account_move.py
+++ b/addons/l10n_cz/models/account_move.py
@@ -1,8 +1,15 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from odoo import models, fields
+from odoo import models, fields, api
 
 
 class AccountMove(models.Model):
     _inherit = 'account.move'
 
-    taxable_supply_date = fields.Date()
+    taxable_supply_date = fields.Date(default=fields.Date.today())
+
+    @api.depends('taxable_supply_date')
+    def _compute_date(self):
+        super()._compute_date()
+        for move in self:
+            if move.country_code == 'CZ' and move.taxable_supply_date and move.state == 'draft':
+                move.date = move.taxable_supply_date

--- a/addons/l10n_cz/models/account_move_line.py
+++ b/addons/l10n_cz/models/account_move_line.py
@@ -1,0 +1,13 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import models, fields
+
+
+class AccountMoveLine(models.Model):
+    _inherit = "account.move.line"
+
+    def _get_rate_date(self):
+        # EXTENDS 'account'
+        self.ensure_one()
+        if self.move_id.country_code == 'CZ':
+            return self.move_id.taxable_supply_date or self.move_id.date or fields.Date.context_today(self)
+        return super()._get_rate_date()

--- a/addons/l10n_cz/tests/__init__.py
+++ b/addons/l10n_cz/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_moves

--- a/addons/l10n_cz/tests/test_moves.py
+++ b/addons/l10n_cz/tests/test_moves.py
@@ -1,0 +1,39 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.tests import tagged
+from odoo import fields, Command
+
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class TestAccountCZ(AccountTestInvoicingCommon):
+
+    @classmethod
+    def setUpClass(cls, chart_template_ref='cz'):
+        super().setUpClass(chart_template_ref=chart_template_ref)
+
+        cls.currency_usd = cls.env.ref('base.USD')
+        cls.invoice_a = cls.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'invoice_date': '2024-07-10',
+            'currency_id': cls.currency_usd.id,
+            'invoice_line_ids': [Command.create({
+                'quantity': 1.0,
+                'price_unit': 1000.0,
+            })],
+        })
+
+    def test_cz_out_invoice_onchange_accounting_date(self):
+        self.invoice_a.taxable_supply_date = '2024-03-31'
+        self.assertEqual(self.invoice_a.date, fields.Date.to_date('2024-03-31'))
+        self.assertEqual(self.invoice_a.invoice_line_ids[0].currency_rate, 1.0)
+
+        self.env['res.currency.rate'].create({
+            'name': '2024-04-28',
+            'rate': 0.042799058421,
+            'currency_id': self.currency_usd.id,
+        })
+
+        self.invoice_a.taxable_supply_date = '2024-05-31'
+        self.assertEqual(self.invoice_a.date, fields.Date.to_date('2024-05-31'))
+        self.assertEqual(self.invoice_a.invoice_line_ids[0].currency_rate, 0.042799058421)

--- a/addons/l10n_cz/views/account_move_views.xml
+++ b/addons/l10n_cz/views/account_move_views.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="account.view_move_form"/>
         <field name="arch" type="xml">
             <xpath expr="//div[@name='due_date']" position="after">
-                <field name="taxable_supply_date" invisible="country_code != 'CZ'"/>
+                <field name="taxable_supply_date" invisible="country_code != 'CZ'" readonly="state != 'draft'"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
[IMP] l10n_cz: Fill accounting date with 'taxable_supply_date'

In CZ, they need to use the taxable supply date as accounting date and rely on it when we are calculating the currency rate

1- Set default value for 'taxable_supply_date' as the invoice date and allow the user to modify it.
Also, fill the accounting date but using the taxable supply date as reference in place of invoice date.
2- Use taxable_supply_date/accounting date to compute the currency rate

task-id#3983749

enterprise-pr: https://github.com/odoo/enterprise/pull/67149

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr