### PR TITLE
[IMP] account, l10n_it_edi_global_discount: Allow global discount from negative line

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -1598,6 +1598,103 @@ class AccountTax(models.Model):
             line_taxes = line_taxes.filtered(lambda tax: tax.company_id == company_id)
         return self._fix_tax_included_price(price, prod_taxes, line_taxes)
 
+    @api.model
+    def _dispatch_negative_lines(self, base_lines, sorting_criteria=None, additional_dispatching_method=None):
+        """
+        This method tries to dispatch the amount of negative lines on positive ones with the same tax, resulting in
+        a discount for these positive lines.
+
+        :param base_lines: A list of python dictionaries created using the '_convert_to_tax_base_line_dict' method.
+        :param sorting_criteria: Optional list of criteria to sort the candidate for a negative line
+        :param additional_dispatching_method: Optional method to transfer additional information (like tax amounts).
+                                              It takes as arguments:
+                                                  - neg_base_line: the negative line being dispatched
+                                                  - candidate: the positive line that will get discounted by neg_base_line
+                                                  - discount_to_distribute: the amount being transferred
+                                                  - is_zero: if the neg_base_line is nulled by the candidate
+
+        :return: A dictionary in the following form:
+            {
+                'result_lines': Remaining list of positive lines, with their potential increased discount
+                'orphan_negative_lines': A list of remaining negative lines that failed to be distributed
+                'nulled_candidate_lines': list of previously positive lines that have been nulled (with the discount)
+            }
+        """
+        results = {
+            'result_lines': [],
+            'orphan_negative_lines': [],
+            'nulled_candidate_lines': [],
+        }
+        for line in base_lines:
+            line['discount_amount'] = line['discount_amount_before_dispatching']
+
+            if line['currency'].compare_amounts(line['gross_price_subtotal'], 0) < 0.0:
+                results['orphan_negative_lines'].append(line)
+            else:
+                results['result_lines'].append(line)
+
+        for neg_base_line in list(results['orphan_negative_lines']):
+            candidates = [
+                candidate
+                for candidate in results['result_lines']
+                if (
+                    neg_base_line['currency'] == candidate['currency']
+                    and neg_base_line['partner'] == candidate['partner']
+                    and neg_base_line['taxes'] == candidate['taxes']
+                )
+            ]
+
+            sorting_criteria = sorting_criteria or self._get_negative_lines_sorting_candidate_criteria()
+            sorted_candidates = sorted(candidates, key=lambda candidate: tuple(method(candidate, neg_base_line) for method in sorting_criteria))
+
+            # Dispatch.
+            for candidate in sorted_candidates:
+                net_price_subtotal = neg_base_line['gross_price_subtotal'] - neg_base_line['discount_amount']
+                other_net_price_subtotal = candidate['gross_price_subtotal'] - candidate['discount_amount']
+                discount_to_distribute = min(other_net_price_subtotal, -net_price_subtotal)
+
+                candidate['discount_amount'] += discount_to_distribute
+                neg_base_line['discount_amount'] -= discount_to_distribute
+
+                remaining_to_distribute = neg_base_line['gross_price_subtotal'] - neg_base_line['discount_amount']
+                is_zero = neg_base_line['currency'].is_zero(remaining_to_distribute)
+
+                if additional_dispatching_method:
+                    additional_dispatching_method(neg_base_line=neg_base_line, candidate=candidate, discount_to_distribute=discount_to_distribute, is_zero=is_zero)
+
+                # Check if there is something left on the other line.
+                remaining_amount = candidate['discount_amount'] - candidate['gross_price_subtotal']
+                if candidate['currency'].is_zero(remaining_amount):
+                    results['result_lines'].remove(candidate)
+                    results['nulled_candidate_lines'].append(candidate)
+
+                if is_zero:
+                    results['orphan_negative_lines'].remove(neg_base_line)
+                    break
+
+        return results
+
+    @api.model
+    def _get_negative_lines_sorting_candidate_criteria(self):
+        # Ordering by priority:
+        # - same product
+        # - same amount
+        # - biggest amount
+        def same_product(candidate, negative_line):
+            return (
+                not candidate['product']
+                or not negative_line['product']
+                or candidate['product'] != negative_line['product']
+            )
+
+        def same_price_subtotal(candidate, negative_line):
+            return candidate['currency'].compare_amounts(candidate['price_subtotal'], -negative_line['price_subtotal']) != 0
+
+        def biggest_amount(candidate, negative_line):
+            return -candidate['price_subtotal']
+
+        return [same_product, same_price_subtotal, biggest_amount]
+
 
 class AccountTaxRepartitionLine(models.Model):
     _name = "account.tax.repartition.line"

--- a/addons/l10n_it_edi/data/invoice_it_template.xml
+++ b/addons/l10n_it_edi/data/invoice_it_template.xml
@@ -22,6 +22,10 @@
                         <Tipo t-out="format_alphanumeric(line_dict['discount_type'])"/>
                         <Percentuale t-out="format_numbers(abs(line.discount))"/>
                     </ScontoMaggiorazione>
+                    <ScontoMaggiorazione t-if="line_dict['discount_amount'] != 0">
+                        <Tipo t-out="'SC'"/>
+                        <Importo t-out="format_numbers(abs(line_dict['discount_amount']))"/>
+                    </ScontoMaggiorazione>
                     <PrezzoTotale t-out="format_monetary(line_dict['subtotal_price'], currency)"/>
                     <AliquotaIVA t-if="vat_tax.amount_type == 'percent'" t-out="format_numbers(vat_tax.amount)"/>
                     <AliquotaIVA t-elif="vat_tax.amount_type != 'percent'" t-out="'0.00'"/>

--- a/addons/l10n_it_edi/models/account_move.py
+++ b/addons/l10n_it_edi/models/account_move.py
@@ -242,20 +242,34 @@ class AccountMove(models.Model):
         """
         invoice_lines = []
         lines = self.invoice_line_ids.filtered(lambda l: l.display_type not in ('line_note', 'line_section'))
-        for num, line in enumerate(lines):
-            sign = -1 if line.move_id.is_inbound() else 1
-            price_subtotal = (line.balance * sign) if convert_to_euros else line.price_subtotal
-            # The price_subtotal should be inverted when the line is a reverse charge refund.
-            if reverse_charge_refund:
-                price_subtotal = -price_subtotal
-
-            # Unit price
-            price_unit = 0
-            if line.quantity and line.discount != 100.0:
-                price_unit = price_subtotal / ((1 - (line.discount or 0.0) / 100.0) * abs(line.quantity))
+        base_lines = [invl._convert_to_tax_base_line_dict() for invl in lines]
+        inverse_factor = (-1 if reverse_charge_refund else 1)
+        for num, line in enumerate(base_lines):
+            line['sequence'] = num
+            line['price_subtotal'] = line['price_subtotal'] * inverse_factor
+            if line['discount'] != 100.0 and line['quantity']:
+                gross_price = line['price_subtotal'] / (1 - line['discount'] / 100.0)
+                line['discount_amount_before_dispatching'] = (gross_price - line['price_subtotal']) * inverse_factor
+                line['gross_price_subtotal'] = line['currency'].round(gross_price * inverse_factor)
+                line['price_unit'] = line['currency'].round(gross_price / abs(line['quantity']))
             else:
-                price_unit = line.price_unit
+                line['gross_price_subtotal'] = line['currency'].round(line['price_unit'] * line['quantity'])
+                line['discount_amount_before_dispatching'] = line['gross_price_subtotal']
 
+        template = self.env['ir.qweb']._load('l10n_it_edi.account_invoice_line_it_FatturaPA')[0]
+        flat_discount_element = template.find('.//ScontoMaggiorazione/Percentuale')
+        if flat_discount_element is not None:
+            dispatch_result = self.env['account.tax']._dispatch_negative_lines(base_lines)
+            if dispatch_result['orphan_negative_lines']:
+                raise UserError(_("You have negative lines that we can't dispatch on others. They need to have the same tax."))
+            base_lines = sorted(dispatch_result['result_lines'] + dispatch_result['nulled_candidate_lines'], key=lambda line: line['sequence'])
+        else:
+            # The template needs to be updated to be able to handle negative lines
+            if any(line['price_subtotal'] < 0 for line in base_lines):
+                raise UserError(_("To handle negative lines, we need you to update your module 'Italy - E-invoicing'"))
+
+        for num, line_dict in enumerate(base_lines):
+            line = line_dict['record']
             description = line.name
 
             # Down payment lines:
@@ -273,8 +287,9 @@ class AccountMove(models.Model):
                 'line': line,
                 'line_number': num + 1,
                 'description': description or 'NO NAME',
-                'unit_price': price_unit,
-                'subtotal_price': price_subtotal,
+                'subtotal_price': (line_dict['gross_price_subtotal'] - line_dict['discount_amount']) * inverse_factor,
+                'unit_price': line_dict['price_unit'],
+                'discount_amount': line_dict['discount_amount'] - line_dict['discount_amount_before_dispatching'],
                 'vat_tax': line.tax_ids.flatten_taxes_hierarchy().filtered(lambda t: t._l10n_it_filter_kind('vat') and t.amount >= 0),
                 'downpayment_moves': downpayment_moves,
                 'discount_type': (

--- a/addons/l10n_it_edi/tests/export_xmls/credit_note_negative_price.xml
+++ b/addons/l10n_it_edi/tests/export_xmls/credit_note_negative_price.xml
@@ -62,7 +62,7 @@
                 <Divisa>EUR</Divisa>
                 <Data>2022-03-24</Data>
                 <Numero>RINV/2022/00001</Numero>
-                <ImportoTotaleDocumento>799.49</ImportoTotaleDocumento>
+                <ImportoTotaleDocumento>854.49</ImportoTotaleDocumento>
             </DatiGeneraliDocumento>
             <DatiFattureCollegate>
                 <IdDocumento>___ignore___</IdDocumento>
@@ -75,35 +75,17 @@
                 <Descrizione>standard_line</Descrizione>
                 <Quantita>1.00</Quantita>
                 <PrezzoUnitario>800.400000</PrezzoUnitario>
-                <PrezzoTotale>800.40</PrezzoTotale>
+                <ScontoMaggiorazione>
+                    <Tipo>SC</Tipo>
+                    <Importo>100.00</Importo>
+                </ScontoMaggiorazione>
+                <PrezzoTotale>700.40</PrezzoTotale>
                 <AliquotaIVA>22.00</AliquotaIVA>
-            </DettaglioLinee>
-            <DettaglioLinee>
-                <NumeroLinea>2</NumeroLinea>
-                <Descrizione>negative_line</Descrizione>
-                <Quantita>1.00</Quantita>
-                <PrezzoUnitario>-100.000000</PrezzoUnitario>
-                <PrezzoTotale>-100.00</PrezzoTotale>
-                <AliquotaIVA>22.00</AliquotaIVA>
-            </DettaglioLinee>
-            <DettaglioLinee>
-                <NumeroLinea>3</NumeroLinea>
-                <Descrizione>negative_line_different_tax</Descrizione>
-                <Quantita>1.00</Quantita>
-                <PrezzoUnitario>-50.000000</PrezzoUnitario>
-                <PrezzoTotale>-50.00</PrezzoTotale>
-                <AliquotaIVA>10.00</AliquotaIVA>
             </DettaglioLinee>
             <DatiRiepilogo>
                 <AliquotaIVA>22.00</AliquotaIVA>
                 <ImponibileImporto>700.40</ImponibileImporto>
                 <Imposta>154.09</Imposta>
-                <EsigibilitaIVA>I</EsigibilitaIVA>
-            </DatiRiepilogo>
-            <DatiRiepilogo>
-                <AliquotaIVA>10.00</AliquotaIVA>
-                <ImponibileImporto>-50.00</ImponibileImporto>
-                <Imposta>-5.00</Imposta>
                 <EsigibilitaIVA>I</EsigibilitaIVA>
             </DatiRiepilogo>
         </DatiBeniServizi>

--- a/addons/l10n_it_edi/tests/export_xmls/invoice_negative_price.xml
+++ b/addons/l10n_it_edi/tests/export_xmls/invoice_negative_price.xml
@@ -62,7 +62,7 @@
                 <Divisa>EUR</Divisa>
                 <Data>2022-03-24</Data>
                 <Numero>INV/2022/00001</Numero>
-                <ImportoTotaleDocumento>799.49</ImportoTotaleDocumento>
+                <ImportoTotaleDocumento>854.49</ImportoTotaleDocumento>
             </DatiGeneraliDocumento>
         </DatiGenerali>
         <DatiBeniServizi>
@@ -71,35 +71,17 @@
                 <Descrizione>standard_line</Descrizione>
                 <Quantita>1.00</Quantita>
                 <PrezzoUnitario>800.400000</PrezzoUnitario>
-                <PrezzoTotale>800.40</PrezzoTotale>
+                <ScontoMaggiorazione>
+                    <Tipo>SC</Tipo>
+                    <Importo>100.00</Importo>
+                </ScontoMaggiorazione>
+                <PrezzoTotale>700.40</PrezzoTotale>
                 <AliquotaIVA>22.00</AliquotaIVA>
-            </DettaglioLinee>
-            <DettaglioLinee>
-                <NumeroLinea>2</NumeroLinea>
-                <Descrizione>negative_line</Descrizione>
-                <Quantita>1.00</Quantita>
-                <PrezzoUnitario>-100.000000</PrezzoUnitario>
-                <PrezzoTotale>-100.00</PrezzoTotale>
-                <AliquotaIVA>22.00</AliquotaIVA>
-            </DettaglioLinee>
-            <DettaglioLinee>
-                <NumeroLinea>3</NumeroLinea>
-                <Descrizione>negative_line_different_tax</Descrizione>
-                <Quantita>1.00</Quantita>
-                <PrezzoUnitario>-50.000000</PrezzoUnitario>
-                <PrezzoTotale>-50.00</PrezzoTotale>
-                <AliquotaIVA>10.00</AliquotaIVA>
             </DettaglioLinee>
             <DatiRiepilogo>
                 <AliquotaIVA>22.00</AliquotaIVA>
                 <ImponibileImporto>700.40</ImponibileImporto>
                 <Imposta>154.09</Imposta>
-                <EsigibilitaIVA>I</EsigibilitaIVA>
-            </DatiRiepilogo>
-            <DatiRiepilogo>
-                <AliquotaIVA>10.00</AliquotaIVA>
-                <ImponibileImporto>-50.00</ImponibileImporto>
-                <Imposta>-5.00</Imposta>
                 <EsigibilitaIVA>I</EsigibilitaIVA>
             </DatiRiepilogo>
         </DatiBeniServizi>
@@ -108,7 +90,7 @@
             <DettaglioPagamento>
                 <ModalitaPagamento>MP05</ModalitaPagamento>
                 <DataScadenzaPagamento>2022-03-24</DataScadenzaPagamento>
-                <ImportoPagamento>799.49</ImportoPagamento>
+                <ImportoPagamento>854.49</ImportoPagamento>
                 <CodicePagamento>INV/2022/00001</CodicePagamento>
             </DettaglioPagamento>
         </DatiPagamento>


### PR DESCRIPTION
SDI does not accept negative lines. But people use it to define flat global discount.
We reuse the logic from l10n_mx_edi, so we move it to account. 
It will now try to create a flat discount for other lines that have the same tax.

[Task link](https://www.odoo.com/odoo/project.task/3943357)
task-3943357



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
