### PR TITLE
[16.0][FIX][WEBSITE] incompatibility between "Sales Price" and "Compare to price" product fields

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1162,7 +1162,7 @@
                 <span class="oe_price" style="white-space: nowrap;" t-esc="combination_info['price']" t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"/>
                 <span itemprop="price" style="display:none;" t-esc="combination_info['price']"/>
                 <span itemprop="priceCurrency" style="display:none;" t-esc="website.currency_id.name"/>
-                <span t-attf-class="text-danger oe_default_price ms-1 h5 {{'' if combination_info['has_discounted_price'] and not combination_info['compare_list_price'] else 'd-none'}}"
+                <span t-attf-class="text-danger ms-1 h5 {{'' if combination_info['has_discounted_price'] and not combination_info['compare_list_price'] else 'd-none'}}"
                     style="text-decoration: line-through; white-space: nowrap;"
                     t-esc="combination_info['list_price']"
                     t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"


### PR DESCRIPTION
The product page of the website is displaying list_price and compare_list_price
 
Steps to reproduce:
1. Activate "Comparison price" and "Discount on lines" user groups.
![image](https://github.com/odoo/odoo/assets/1337928/0452b22b-b95a-4e0d-b164-76e17ffb5b93)

2. Configure _Discount policy_ field as **"Show public price & discount to the customer"** of a pricelist (i.e Public pricelist).

![image](https://github.com/odoo/odoo/assets/1337928/99180318-9972-4011-811c-cd1187bf7e27)

3. Set a price rule for a product (price lower than _Sales Price_ field)
![image](https://github.com/odoo/odoo/assets/1337928/48e15ff6-3e43-4178-9de7-22d5a24dc8c6)

4.  On product ("Customizable Desk") set _Compare to price_ field greater than _Sales Price_
![image](https://github.com/odoo/odoo/assets/1337928/e01b40d4-3fdd-4157-b335-daefa46dc8db)

5. Go to  website > product "Customizable Desk" page and see that both field are being displaying
![image](https://github.com/odoo/odoo/assets/1337928/c127b350-516d-40c6-8f38-44b9ee25d079)

---
My CLA is pending on https://github.com/odoo/odoo/pull/168142
