### PR TITLE
[FIX] website_slides,portal[_rating]: empty message not displayed

### DIFF
--- a/addons/portal/controllers/mail.py
+++ b/addons/portal/controllers/mail.py
@@ -196,6 +196,10 @@ class PortalChatter(http.Controller):
             }
         }
 
+    def _get_void_portal_messages_domain(self):
+        """Return a domain to filter out void messages."""
+        return ["|", ("body", "!=", ""), ("attachment_ids", "!=", False)]
+
     @http.route('/mail/chatter_fetch', type='json', auth='public', website=True)
     def portal_message_fetch(self, res_model, res_id, domain=False, limit=10, offset=0, **kw):
         # Only search into website_message_ids, so apply the same domain to perform only one search
@@ -206,7 +210,8 @@ class PortalChatter(http.Controller):
         domain = expression.AND([
             self._setup_portal_message_fetch_extra_domain(kw),
             field_domain,
-            [('res_id', '=', res_id), '|', ('body', '!=', ''), ('attachment_ids', '!=', False)]
+            [("res_id", "=", res_id)],
+            self._get_void_portal_messages_domain(),
         ])
 
         # Check access

--- a/addons/portal_rating/controllers/portal_chatter.py
+++ b/addons/portal_rating/controllers/portal_chatter.py
@@ -35,6 +35,13 @@ class PortalChatter(mail.PortalChatter):
         result.update(self._portal_rating_stats(res_model, res_id, **kwargs))
         return result
 
+    def _get_void_portal_messages_domain(self):
+        """Override the domain to include messages with ratings."""
+        domain = super()._get_void_portal_messages_domain()
+        if request.env.context.get("rating_include"):
+            return expression.OR([domain, [("rating_ids", "!=", False)]])
+        return domain
+
     @http.route()
     def portal_message_fetch(self, res_model, res_id, domain=False, limit=False, offset=False, **kw):
         # add 'rating_include' in context, to fetch them in portal_message_format

--- a/addons/test_mail_full/tests/__init__.py
+++ b/addons/test_mail_full/tests/__init__.py
@@ -6,5 +6,6 @@ from . import test_mail_performance
 from . import test_mail_thread_internals
 from . import test_mass_mailing
 from . import test_portal
+from . import test_portal_rating
 from . import test_rating
 from . import test_res_users

--- a/addons/test_mail_full/tests/test_portal_rating.py
+++ b/addons/test_mail_full/tests/test_portal_rating.py
@@ -1,0 +1,70 @@
+import json
+
+from odoo.tests import tagged
+from odoo.tests.common import HttpCase
+
+
+@tagged("-at_install", "post_install", "portal")
+class TestPortalRatingControllers(HttpCase):
+    def setUp(self):
+        super().setUp()
+        self.partner_1 = self.env["res.partner"].create({"name": "Test Partner Portal"})
+
+        self.portal_record = self.env["mail.test.portal"].create(
+            {
+                "name": "Test Portal Record",
+                "partner_id": self.partner_1.id,
+            }
+        )
+
+    def test_portal_message_fetch_with_ratings(self):
+        """Test retrieving chatter messages with ratings through the portal controller"""
+
+        if not self.env["ir.module.module"].search(
+            [("name", "=", "portal_rating"), ("state", "=", "installed")]
+        ):
+            self.skipTest(
+                "This test requires the installation of the `Portal Rating` module"
+            )
+
+        self.authenticate(None, None)
+        message_fetch_url = "/mail/chatter_fetch"
+        payload = {
+            "jsonrpc": "2.0",
+            "method": "call",
+            "id": 0,
+            "params": {
+                "res_model": "mail.test.portal",
+                "res_id": self.portal_record.id,
+                "token": self.portal_record.access_token,
+            },
+        }
+
+        def get_chatter_message_count():
+            res = self.url_open(
+                url=message_fetch_url,
+                data=json.dumps(payload),
+                headers={"Content-Type": "application/json"},
+            )
+            return res.json().get("result", {}).get("message_count", 0)
+
+        self.assertEqual(get_chatter_message_count(), 0)
+
+        params = [
+            {"body": ""},
+            {"body": "", "rating_value": 5},
+            {"body": "test 2", "rating_value": 5},
+        ]
+
+        for param in params:
+            self.portal_record.message_post(
+                body=param["body"],
+                author_id=self.partner_1.id,
+                message_type="comment",
+                subtype_id=self.env.ref("mail.mt_comment").id,
+                rating_value=param.get("rating_value", None),
+            )
+
+        self.assertEqual(get_chatter_message_count(), 1)
+        payload["params"]["rating_include"] = True
+        self.assertEqual(get_chatter_message_count(), 2)

--- a/addons/website_slides/controllers/mail.py
+++ b/addons/website_slides/controllers/mail.py
@@ -63,7 +63,7 @@ class SlidesPortalChatter(PortalChatter):
 
         # fetch and update mail.message
         message_id = int(message_id)
-        message_body = plaintext2html(message)
+        message_body = plaintext2html(message) if message else message
         subtype_comment_id = request.env['ir.model.data']._xmlid_to_res_id('mail.mt_comment')
         domain = [
             ('model', '=', res_model),


### PR DESCRIPTION
Steps to reproduce:
-------------------
- Install `eLearning` module
- Create a course and publish it
- Go to the course page in the portal
- Click on `Add review` button
- Add a rating without message
- Click on `Reviews` tab

Issue:
------

1. Message not displayed.
2. If we click on `Edit review` button, the message is displayed.

Cause:
------

1. We retrieve only messages that have a body or an attachment.
2. When editing the message, we don't check if the message has a body, but still use `plaintext2html` on it, who add `<p></p>` to the body.

Solution:
---------

1. Add a condition to check if the message has ratings.
2. Don't use `plaintext2html` if the message has no body.

opw-3925752