### PR TITLE
[FIX] sale: Translation for Down payment lines on sale order lines

### DIFF
--- a/addons/sale/i18n/sale.pot
+++ b/addons/sale/i18n/sale.pot
@@ -36,20 +36,6 @@ msgid "# of Sales Orders"
 msgstr ""
 
 #. module: sale
-#. odoo-python
-#: code:addons/sale/models/sale_order_line.py:0
-#, python-format
-msgid "%(line_description)s (Canceled)"
-msgstr ""
-
-#. module: sale
-#. odoo-python
-#: code:addons/sale/models/sale_order_line.py:0
-#, python-format
-msgid "%(line_description)s (Draft)"
-msgstr ""
-
-#. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.portal_my_orders
 msgid "&amp;nbsp;"
 msgstr ""
@@ -1496,9 +1482,17 @@ msgstr ""
 
 #. module: sale
 #. odoo-python
+#: code:addons/sale/models/sale_order_line.py:0
 #: code:addons/sale/wizard/sale_make_invoice_advance.py:0
 #, python-format
 msgid "Down Payment"
+msgstr ""
+
+#. module: sale
+#. odoo-python
+#: code:addons/sale/models/sale_order_line.py:0
+#, python-format
+msgid "Down Payment (Canceled)"
 msgstr ""
 
 #. module: sale
@@ -1518,6 +1512,7 @@ msgstr ""
 
 #. module: sale
 #. odoo-python
+#: code:addons/sale/models/sale_order_line.py:0
 #: code:addons/sale/wizard/sale_make_invoice_advance.py:0
 #, python-format
 msgid "Down Payment: %s (Draft)"

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -8,7 +8,7 @@ from odoo import api, fields, models, _
 from odoo.exceptions import UserError
 from odoo.fields import Command
 from odoo.osv import expression
-from odoo.tools import float_is_zero, float_compare, float_round
+from odoo.tools import float_is_zero, float_compare, float_round, format_date
 
 
 class SaleOrderLine(models.Model):
@@ -316,9 +316,11 @@ class SaleOrderLine(models.Model):
                 context = {'lang': lang}
                 dp_state = line._get_downpayment_state()
                 if dp_state == 'draft':
-                    name = _("%(line_description)s (Draft)", line_description=name)
+                    name = _('Down Payment: %s (Draft)', format_date(self.env, self.create_date.date()))
                 elif dp_state == 'cancel':
-                    name = _("%(line_description)s (Canceled)", line_description=name)
+                    name = _("Down Payment (Canceled)")
+                else:
+                    name = _("Down Payment")
                 del context
             line.name = name
 


### PR DESCRIPTION
Current behavior:
When a down payment is recorded for a sale order, the label uses the Down payment product's name which is not translated into customer's language.

Purpose of this PR:
To add a translatable string that can be used for the down payment lines' labels

Steps to Reproduce on Runbot:
1) Load 2 languages
2) Set a customer's language to be different than environment's 
3) Create a sale order for the customer and create a down payment. 
4) A Down payment product is created. The name will be in the language of the environment. 
5) When we confirm the down payment invoice, the down payment sale order line will not be translated in the customer's language and remain in the environment language.

Notes:
In saas-17.1 this issue is resolved by removing the creation of a Down Payment product and adding translatable strings for the down payment labels in the sale.pot file.

opw-3949119