### PR TITLE
[IMP] project: remove unused js_class

### DIFF
--- a/addons/project/views/rating_rating_views.xml
+++ b/addons/project/views/rating_rating_views.xml
@@ -70,9 +70,6 @@
         <field name="mode">primary</field>
         <field name="priority">64</field>
         <field name="arch" type="xml">
-            <xpath expr="//pivot" position="attributes">
-                <attribute name="js_class">project_rating_pivot</attribute>
-            </xpath>
             <xpath expr="//field[@name='create_date']" position="attributes">
                 <attribute name="invisible">1</attribute>
             </xpath>
@@ -89,9 +86,6 @@
         <field name="mode">primary</field>
         <field name="priority">64</field>
         <field name="arch" type="xml">
-            <xpath expr="//graph" position="attributes">
-                <attribute name="js_class">project_rating_graph</attribute>
-            </xpath>
             <xpath expr="//field[@name='rating']" position="attributes">
                 <attribute name="string">Rating (1-5)</attribute>
             </xpath>


### PR DESCRIPTION
  We removed the js code in the below commit but forgot to remove the js_class.
  commit-https://github.com/odoo/odoo/pull/164490/commits/595d08a0632accbd236963add26ac1116f171b82

  task-3827128
