### PR TITLE
[FIX] hr_holidays: Fix displaay of the dashboard date picker

### DIFF
--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -6,7 +6,7 @@ import logging
 import pytz
 
 from collections import defaultdict
-from datetime import time, datetime
+from datetime import date, datetime, time
 
 from odoo import api, fields, models
 from odoo.tools import format_date, frozendict
@@ -366,6 +366,20 @@ class HolidaysType(models.Model):
     # ------------------------------------------------------------
 
     @api.model
+    def has_accrual_allocation(self):
+        employee = self.env['hr.employee']._get_contextual_employee()
+        if not employee:
+            return False
+        return bool(self.env['hr.leave.allocation'].search_count([
+            ('employee_id', '=', employee.id),
+            ('state', '=', 'validate'),
+            ('allocation_type', '=', 'accrual'),
+            '|',
+            ('date_to', '>', date.today()),
+            ('date_to', '=', False),
+        ]))
+
+    @api.model
     def get_allocation_data_request(self, target_date=None):
         leave_types = self.search([
             '|',
@@ -414,7 +428,6 @@ class HolidaysType(models.Model):
                         'exceeding_duration': extra_data[employee][leave_type]['exceeding_duration'],
                         'request_unit': leave_type.request_unit,
                         'icon': leave_type.sudo().icon_id.url,
-                        'has_accrual_allocation': False,
                         'allows_negative': leave_type.allows_negative,
                         'max_allowed_negative': leave_type.max_allowed_negative,
                     },
@@ -442,8 +455,6 @@ class HolidaysType(models.Model):
                 for allocation, data in allocations_leaves_consumed[employee][leave_type].items():
                     # We only need the allocation that are valid at the given date
                     if allocation:
-                        if allocation.allocation_type == 'accrual':
-                            lt_info[1]['has_accrual_allocation'] = True
                         today = fields.Date.today()
                         if allocation.date_from <= today and (not allocation.date_to or allocation.date_to >= today):
                             # we get each allocation available now to indicate visually if

--- a/addons/hr_holidays/static/src/dashboard/time_off_dashboard.js
+++ b/addons/hr_holidays/static/src/dashboard/time_off_dashboard.js
@@ -21,6 +21,10 @@ export class TimeOffDashboard extends Component {
 
         onWillStart(async () => {
             await this.loadDashboardData();
+            this.hasAccrualAllocation = await this.orm.call(
+                "hr.leave.type",
+                "has_accrual_allocation"
+            );
         });
     }
 
@@ -49,10 +53,6 @@ export class TimeOffDashboard extends Component {
     resetDate() {
         this.state.date = luxon.DateTime.now();
         this.loadDashboardData();
-    }
-
-    has_accrual_allocation() {
-        return this.state.holidays.some((leave_type) => leave_type[1]["has_accrual_allocation"]);
     }
 }
 

--- a/addons/hr_holidays/static/src/dashboard/time_off_dashboard.xml
+++ b/addons/hr_holidays/static/src/dashboard/time_off_dashboard.xml
@@ -10,7 +10,7 @@
                 employeeId="props.employeeId"/>
         </t>
         <div class="o_timeoff_card p-0 d-flex justify-content-around">
-            <div class="row justify-content-center align-items-center border-bottom h-50 w-100 p-1" t-if="has_accrual_allocation()">
+            <div class="row justify-content-center align-items-center border-bottom h-50 w-100 p-1" t-if="hasAccrualAllocation">
                 Balance at the
                 <div class="p-1" style="max-width: 100px!important">
                     <DateTimeInput


### PR DESCRIPTION
Reproduce the issue:
- have an employee with one accrual allocation valid today
- the allocation ends at a certain date
- on his dashboard with the date picker, select a date after the allocation end
- the date picker disappears

Expected behaviour:
- The date picker should stay on the view

task-3984127