### PR TITLE
[IMP] website_{forum|slide_forum}: embed forum

### DIFF
--- a/addons/website_forum/controllers/website_forum.py
+++ b/addons/website_forum/controllers/website_forum.py
@@ -23,6 +23,18 @@ class WebsiteForum(WebsiteProfile):
     _post_per_page = 10
     _user_per_page = 30
 
+    @staticmethod
+    def routes_with_embed(routes):
+        """ Returns the routes and their embed equivalent if it applies. """
+        if isinstance(routes, str):
+            routes = [routes]
+        res = []
+        for route in routes:
+            res.append(route)
+            if route.startswith('/forum/'):
+                res.append('/forum/embed/' + route[len('/forum/'):])
+        return res
+
     def _prepare_user_values(self, **kwargs):
         values = super(WebsiteForum, self)._prepare_user_values(**kwargs)
         values['forum_welcome_message'] = request.cookies.get('forum_welcome_message', False)
@@ -104,14 +116,7 @@ class WebsiteForum(WebsiteProfile):
             'tag': str(tag.id) if tag else None,
         }
 
-    @http.route(['/forum/all',
-                 '/forum/all/page/<int:page>',
-                 '/forum/<model("forum.forum"):forum>',
-                 '/forum/<model("forum.forum"):forum>/page/<int:page>',
-                 '''/forum/<model("forum.forum"):forum>/tag/<model("forum.tag"):tag>/questions''',
-                 '''/forum/<model("forum.forum"):forum>/tag/<model("forum.tag"):tag>/questions/page/<int:page>''',
-                 ], type='http', auth="public", website=True, sitemap=sitemap_forum, readonly=True)
-    def questions(self, forum=None, tag=None, page=1, filters='all', my=None, sorting=None, search='', create_uid=False, include_answers=False, **post):
+    def _prepare_question_values(self, forum=None, tag=None, page=1, filters='all', my=None, sorting=None, search='', create_uid=False, include_answers=False, **post):
         Post = request.env['forum.post']
 
         author = request.env['res.users'].browse(int(create_uid))
@@ -148,11 +153,11 @@ class WebsiteForum(WebsiteProfile):
         question_ids = question_ids[(page - 1) * self._post_per_page:page * self._post_per_page]
 
         if not forum:
-            url = '/forum/all'
+            url = self._get_embed_url('/forum/all')
         elif tag:
-            url = f'/forum/{slug(forum)}/tag/{slug(tag)}/questions'
+            url = self._get_embed_url(f'/forum/{slug(forum)}/tag/{slug(tag)}/questions')
         else:
-            url = f'/forum/{slug(forum)}'
+            url = self._get_embed_url(f'/forum/{slug(forum)}')
 
         url_args = {'sorting': sorting}
 
@@ -164,8 +169,7 @@ class WebsiteForum(WebsiteProfile):
             url=url, total=question_count, page=page, step=self._post_per_page,
             scope=5, url_args=url_args))
 
-        values = self._prepare_user_values(forum=forum, searches=post)
-        values.update({
+        values = {
             'author': author,
             'edit_in_backend': True,
             'question_ids': question_ids,
@@ -178,27 +182,40 @@ class WebsiteForum(WebsiteProfile):
             'sorting': sorting,
             'search': fuzzy_search_term or search,
             'original_search': fuzzy_search_term and search,
-        })
+        }
 
         if forum or tag:
             values['main_object'] = tag or forum
+        return values
 
-        return request.render("website_forum.forum_index", values)
+    @http.route(routes_with_embed(['/forum/all',
+                                   '/forum/all/page/<int:page>',
+                                   '/forum/<model("forum.forum"):forum>',
+                                   '/forum/<model("forum.forum"):forum>/page/<int:page>',
+                                   '''/forum/<model("forum.forum"):forum>/tag/<model("forum.tag"):tag>/questions''',
+                                   '''/forum/<model("forum.forum"):forum>/tag/<model("forum.tag"):tag>/questions/page/<int:page>''',
+                                   ]), type='http', auth="public", website=True, sitemap=sitemap_forum, readonly=True)
+    def questions(self, forum=None, tag=None, page=1, filters='all', my=None, sorting=None, search='', create_uid=False, include_answers=False, **post):
+        values = self._prepare_user_values(forum=forum, searches=post)
+        values.update(self._prepare_question_values(
+            forum=forum, tag=tag, page=page, filters=filters,
+            my=my, sorting=sorting, search=search, create_uid=create_uid, include_answers=include_answers, **post))
+        return request.render("website_forum.forum_index", self._add_embed_values(values))
 
     @http.route(['''/forum/<model("forum.forum"):forum>/faq'''], type='http', auth="public", website=True, sitemap=True, readonly=True)
     def forum_faq(self, forum, **post):
         values = self._prepare_user_values(forum=forum, searches=dict(), header={'is_guidelines': True}, **post)
-        return request.render("website_forum.faq", values)
+        return request.render("website_forum.faq", self._add_embed_values(values))
 
     @http.route(['/forum/<model("forum.forum"):forum>/faq/karma'], type='http', auth="public", website=True, sitemap=False, readonly=True)
     def forum_faq_karma(self, forum, **post):
         values = self._prepare_user_values(forum=forum, header={'is_guidelines': True, 'is_karma': True}, **post)
-        return request.render("website_forum.faq_karma", values)
+        return request.render("website_forum.faq_karma", self._add_embed_values(values))
 
     # Tags
     # --------------------------------------------------
 
-    @http.route('/forum/get_tags', type='http', auth="public", methods=['GET'], website=True, sitemap=False, readonly=True)
+    @http.route(routes_with_embed('/forum/get_tags'), type='http', auth="public", methods=['GET'], website=True, sitemap=False, readonly=True)
     def tag_read(self, forum_id, query='', limit=25, **post):
         data = request.env['forum.tag'].search_read(
             domain=[('forum_id', '=', int(forum_id)), ('name', '=ilike', (query or '') + "%")],
@@ -210,9 +227,10 @@ class WebsiteForum(WebsiteProfile):
             headers=[("Content-Type", "application/json")]
         )
 
-    @http.route(['/forum/<model("forum.forum"):forum>/tag',
-                 '/forum/<model("forum.forum"):forum>/tag/<string:tag_char>',
-                 ], type='http', auth="public", website=True, sitemap=False, readonly=True)
+    @http.route(routes_with_embed([
+        '/forum/<model("forum.forum"):forum>/tag',
+        '/forum/<model("forum.forum"):forum>/tag/<string:tag_char>',
+    ]), type='http', auth="public", website=True, sitemap=False, readonly=True)
     def tags(self, forum, tag_char='', filters='all', search='', **post):
         """Render a list of tags matching filters and search parameters.
 
@@ -266,12 +284,12 @@ class WebsiteForum(WebsiteProfile):
             'search_count': len(tags) if search else None,
             'tags': tags,
         })
-        return request.render("website_forum.forum_index_tags", values)
+        return request.render("website_forum.forum_index_tags", self._add_embed_values(values))
 
     # Questions
     # --------------------------------------------------
 
-    @http.route('/forum/get_url_title', type='jsonrpc', auth="user", methods=['POST'], website=True)
+    @http.route(routes_with_embed('/forum/get_url_title'), type='jsonrpc', auth="user", methods=['POST'], website=True)
     def get_url_title(self, **kwargs):
         try:
             req = requests.get(kwargs.get('url'))
@@ -281,12 +299,12 @@ class WebsiteForum(WebsiteProfile):
         except IOError:
             return False
 
-    @http.route(['''/forum/<model("forum.forum"):forum>/question/<model("forum.post", "[('forum_id','=',forum.id),('parent_id','=',False),('can_view', '=', True)]"):question>'''],
+    @http.route(routes_with_embed('''/forum/<model("forum.forum"):forum>/question/<model("forum.post", "[('forum_id','=',forum.id),('parent_id','=',False),('can_view', '=', True)]"):question>'''),
                 type='http', auth="public", website=True, sitemap=False)
     def old_question(self, forum, question, **post):
         # Compatibility pre-v14
         slug = request.env['ir.http']._slug
-        return request.redirect("/forum/%s/%s" % (slug(forum), slug(question)), code=301)
+        return request.redirect(self._get_embed_url("/forum/%s/%s" % (slug(forum), slug(question))), code=301)
 
     def sitemap_forum_post(env, rule, qs):
         ForumPost = env['forum.post']
@@ -314,7 +332,7 @@ class WebsiteForum(WebsiteProfile):
         })
         return values
 
-    @http.route(['''/forum/<model("forum.forum"):forum>/<model("forum.post"):question>'''],
+    @http.route(routes_with_embed('/forum/<model("forum.forum"):forum>/<model("forum.post"):question>'),
                 type='http', auth="public", website=True, sitemap=sitemap_forum_post)
     def question(self, forum, question, **post):
         if not forum.active:
@@ -331,15 +349,15 @@ class WebsiteForum(WebsiteProfile):
 
         if question.parent_id:
             slug = request.env['ir.http']._slug
-            redirect_url = "/forum/%s/%s" % (slug(forum), slug(question.parent_id))
+            redirect_url = self._get_embed_url("/forum/%s/%s" % (slug(forum), slug(question.parent_id)))
             return request.redirect(redirect_url, 301)
         values = self._prepare_question_template_vals(forum, post, question)
         # increment view counter
         question.sudo()._set_viewed()
 
-        return request.render("website_forum.post_description_full", values)
+        return request.render("website_forum.post_description_full", self._add_embed_values(values))
 
-    @http.route('/forum/<model("forum.forum"):forum>/question/<model("forum.post"):question>/toggle_favourite', type='jsonrpc', auth="user", methods=['POST'], website=True)
+    @http.route(routes_with_embed('/forum/<model("forum.forum"):forum>/question/<model("forum.post"):question>/toggle_favourite'), type='jsonrpc', auth="user", methods=['POST'], website=True)
     def question_toggle_favorite(self, forum, question, **post):
         favourite = not question.user_favourite
         question.sudo().favourite_ids = [(favourite and 4 or 3, request.uid)]
@@ -350,7 +368,7 @@ class WebsiteForum(WebsiteProfile):
             question.sudo().message_subscribe(request.env.user.partner_id.ids)
         return favourite
 
-    @http.route('/forum/<model("forum.forum"):forum>/question/<model("forum.post"):question>/ask_for_close', type='http', auth="user", methods=['POST'], website=True)
+    @http.route(routes_with_embed('/forum/<model("forum.forum"):forum>/question/<model("forum.post"):question>/ask_for_close'), type='http', auth="user", methods=['POST'], website=True)
     def question_ask_for_close(self, forum, question, **post):
         reasons = request.env['forum.post.reason'].search([('reason_type', '=', 'basic')])
 
@@ -360,9 +378,9 @@ class WebsiteForum(WebsiteProfile):
             'forum': forum,
             'reasons': reasons,
         })
-        return request.render("website_forum.close_post", values)
+        return request.render("website_forum.close_post", self._add_embed_values(values))
 
-    @http.route('/forum/<model("forum.forum"):forum>/question/<model("forum.post"):question>/edit_answer', type='http', auth="user", website=True)
+    @http.route(routes_with_embed('/forum/<model("forum.forum"):forum>/question/<model("forum.post"):question>/edit_answer'), type='http', auth="user", website=True)
     def question_edit_answer(self, forum, question, **kwargs):
         for record in question.child_ids:
             if record.create_uid.id == request.uid:
@@ -371,57 +389,59 @@ class WebsiteForum(WebsiteProfile):
         else:
             raise werkzeug.exceptions.NotFound()
         slug = request.env['ir.http']._slug
-        return request.redirect(f'/forum/{slug(forum)}/post/{slug(answer)}/edit')
+        return request.redirect(self._get_embed_url(f'/forum/{slug(forum)}/post/{slug(answer)}/edit'))
 
-    @http.route('/forum/<model("forum.forum"):forum>/question/<model("forum.post"):question>/close', type='http', auth="user", methods=['POST'], website=True)
+    @http.route(routes_with_embed('/forum/<model("forum.forum"):forum>/question/<model("forum.post"):question>/close'), type='http', auth="user", methods=['POST'], website=True)
     def question_close(self, forum, question, **post):
         question.close(reason_id=int(post.get('reason_id', False)))
         slug = request.env['ir.http']._slug
-        return request.redirect("/forum/%s/%s" % (slug(forum), slug(question)))
+        return request.redirect(self._get_embed_url("/forum/%s/%s" % (slug(forum), slug(question))))
 
-    @http.route('/forum/<model("forum.forum"):forum>/question/<model("forum.post"):question>/reopen', type='http', auth="user", methods=['POST'], website=True)
+    @http.route(routes_with_embed('/forum/<model("forum.forum"):forum>/question/<model("forum.post"):question>/reopen'), type='http', auth="user", methods=['POST'], website=True)
     def question_reopen(self, forum, question, **kwarg):
         question.reopen()
         slug = request.env['ir.http']._slug
-        return request.redirect("/forum/%s/%s" % (slug(forum), slug(question)))
+        return request.redirect(self._get_embed_url("/forum/%s/%s" % (slug(forum), slug(question))))
 
-    @http.route('/forum/<model("forum.forum"):forum>/question/<model("forum.post"):question>/delete', type='http', auth="user", methods=['POST'], website=True)
+    @http.route(routes_with_embed('/forum/<model("forum.forum"):forum>/question/<model("forum.post"):question>/delete'), type='http', auth="user", methods=['POST'], website=True)
     def question_delete(self, forum, question, **kwarg):
         question.active = False
         slug = request.env['ir.http']._slug
-        return request.redirect("/forum/%s" % slug(forum))
+        return request.redirect(self._get_embed_url("/forum/%s" % slug(forum)))
 
-    @http.route('/forum/<model("forum.forum"):forum>/question/<model("forum.post"):question>/undelete', type='http', auth="user", methods=['POST'], website=True)
+    @http.route(routes_with_embed('/forum/<model("forum.forum"):forum>/question/<model("forum.post"):question>/undelete'), type='http', auth="user", methods=['POST'], website=True)
     def question_undelete(self, forum, question, **kwarg):
         question.active = True
         slug = request.env['ir.http']._slug
-        return request.redirect("/forum/%s/%s" % (slug(forum), slug(question)))
+        return request.redirect(self._get_embed_url("/forum/%s/%s" % (slug(forum), slug(question))))
 
     # Post
     # --------------------------------------------------
-    @http.route(['/forum/<model("forum.forum"):forum>/ask'], type='http', auth="user", website=True)
+    @http.route(routes_with_embed('/forum/<model("forum.forum"):forum>/ask'), type='http', auth="user", website=True)
     def forum_post(self, forum, **post):
         user = request.env.user
         if not user.email or not tools.single_email_re.match(user.email):
             slug = request.env['ir.http']._slug
-            return request.redirect("/forum/%s/user/%s/edit?email_required=1" % (slug(forum), request.session.uid))
+            return request.redirect(self._get_embed_url("/forum/%s/user/%s/edit?email_required=1" % (slug(forum), request.session.uid)))
         values = self._prepare_user_values(forum=forum, searches={}, new_question=True)
-        return request.render("website_forum.new_question", values)
+        return request.render("website_forum.new_question", self._add_embed_values(values))
 
-    @http.route(['/forum/<model("forum.forum"):forum>/new',
-                 '/forum/<model("forum.forum"):forum>/<model("forum.post"):post_parent>/reply'],
+    @http.route(routes_with_embed([
+        '/forum/<model("forum.forum"):forum>/new',
+        '/forum/<model("forum.forum"):forum>/<model("forum.post"):post_parent>/reply',
+    ]),
                 type='http', auth="user", methods=['POST'], website=True)
     def post_create(self, forum, post_parent=None, **post):
         if post.get('content', '') == '<p><br></p>':
-            return request.render('http_routing.http_error', {
+            return request.render('http_routing.http_error', self._add_embed_values({
                 'status_code': _('Bad Request'),
                 'status_message': post_parent and _('Reply should not be empty.') or _('Question should not be empty.')
-            })
+            }))
 
         post_tag_ids = forum._tag_to_write_vals(post.get('post_tags', ''))
         slug = request.env['ir.http']._slug
         if forum.has_pending_post:
-            return request.redirect("/forum/%s/ask" % slug(forum))
+            return request.redirect(self._get_embed_url("/forum/%s/ask" % slug(forum)))
 
         new_question = request.env['forum.post'].create({
             'forum_id': forum.id,
@@ -433,9 +453,9 @@ class WebsiteForum(WebsiteProfile):
         if post_parent:
             post_parent._update_last_activity()
         slug = request.env['ir.http']._slug
-        return request.redirect(f'/forum/{slug(forum)}/{slug(post_parent) if post_parent else new_question.id}')
+        return request.redirect(self._get_embed_url(f'/forum/{slug(forum)}/{slug(post_parent) if post_parent else new_question.id}'))
 
-    @http.route('/forum/<model("forum.forum"):forum>/post/<model("forum.post"):post>/comment', type='http', auth="user", methods=['POST'], website=True)
+    @http.route(routes_with_embed('/forum/<model("forum.forum"):forum>/post/<model("forum.post"):post>/comment'), type='http', auth="user", methods=['POST'], website=True)
     def post_comment(self, forum, post, **kwargs):
         question = post.parent_id or post
         if kwargs.get('comment') and post.forum_id.id == forum.id:
@@ -447,9 +467,9 @@ class WebsiteForum(WebsiteProfile):
                 subtype_xmlid='mail.mt_comment')
             question._update_last_activity()
         slug = request.env['ir.http']._slug
-        return request.redirect(f'/forum/{slug(forum)}/{slug(question)}')
+        return request.redirect(self._get_embed_url(f'/forum/{slug(forum)}/{slug(question)}'))
 
-    @http.route('/forum/<model("forum.forum"):forum>/post/<model("forum.post"):post>/toggle_correct', type='jsonrpc', auth="user", website=True)
+    @http.route(routes_with_embed('/forum/<model("forum.forum"):forum>/post/<model("forum.post"):post>/toggle_correct'), type='jsonrpc', auth="user", website=True)
     def post_toggle_correct(self, forum, post, **kwargs):
         if post.parent_id is False:
             return request.redirect('/')
@@ -461,16 +481,16 @@ class WebsiteForum(WebsiteProfile):
         post.is_correct = not post.is_correct
         return post.is_correct
 
-    @http.route('/forum/<model("forum.forum"):forum>/post/<model("forum.post"):post>/delete', type='http', auth="user", methods=['POST'], website=True)
+    @http.route(routes_with_embed('/forum/<model("forum.forum"):forum>/post/<model("forum.post"):post>/delete'), type='http', auth="user", methods=['POST'], website=True)
     def post_delete(self, forum, post, **kwargs):
         question = post.parent_id
         post.unlink()
         slug = request.env['ir.http']._slug
         if question:
-            request.redirect("/forum/%s/%s" % (slug(forum), slug(question)))
-        return request.redirect("/forum/%s" % slug(forum))
+            request.redirect(self._get_embed_url("/forum/%s/%s" % (slug(forum), slug(question))))
+        return request.redirect(self._get_embed_url("/forum/%s" % slug(forum)))
 
-    @http.route('/forum/<model("forum.forum"):forum>/post/<model("forum.post"):post>/edit', type='http', auth="user", website=True)
+    @http.route(routes_with_embed('/forum/<model("forum.forum"):forum>/post/<model("forum.post"):post>/edit'), type='http', auth="user", website=True)
     def post_edit(self, forum, post, **kwargs):
         tags = [dict(id=tag.id, name=tag.name) for tag in post.tag_ids]
         tags = json.dumps(tags)
@@ -483,9 +503,9 @@ class WebsiteForum(WebsiteProfile):
             'searches': kwargs,
             'content': post.name,
         })
-        return request.render("website_forum.edit_post", values)
+        return request.render("website_forum.edit_post", self._add_embed_values(values))
 
-    @http.route('/forum/<model("forum.forum"):forum>/post/<model("forum.post"):post>/save', type='http', auth="user", methods=['POST'], website=True)
+    @http.route(routes_with_embed('/forum/<model("forum.forum"):forum>/post/<model("forum.post"):post>/save'), type='http', auth="user", methods=['POST'], website=True)
     def post_save(self, forum, post, **kwargs):
         vals = {
             'content': kwargs.get('content'),
@@ -503,19 +523,19 @@ class WebsiteForum(WebsiteProfile):
         post.write(vals)
         question = post.parent_id if post.parent_id else post
         slug = request.env['ir.http']._slug
-        return request.redirect("/forum/%s/%s" % (slug(forum), slug(question)))
+        return request.redirect(self._get_embed_url("/forum/%s/%s" % (slug(forum), slug(question))))
 
     #  JSON utilities
     # --------------------------------------------------
 
-    @http.route('/forum/<model("forum.forum"):forum>/post/<model("forum.post"):post>/upvote', type='jsonrpc', auth="user", website=True)
+    @http.route(routes_with_embed('/forum/<model("forum.forum"):forum>/post/<model("forum.post"):post>/upvote'), type='jsonrpc', auth="user", website=True)
     def post_upvote(self, forum, post, **kwargs):
         if request.uid == post.create_uid.id:
             return {'error': 'own_post'}
         upvote = True if not post.user_vote > 0 else False
         return post.vote(upvote=upvote)
 
-    @http.route('/forum/<model("forum.forum"):forum>/post/<model("forum.post"):post>/downvote', type='jsonrpc', auth="user", website=True)
+    @http.route(routes_with_embed('/forum/<model("forum.forum"):forum>/post/<model("forum.post"):post>/downvote'), type='jsonrpc', auth="user", website=True)
     def post_downvote(self, forum, post, **kwargs):
         if request.uid == post.create_uid.id:
             return {'error': 'own_post'}
@@ -582,7 +602,7 @@ class WebsiteForum(WebsiteProfile):
 
         return request.render("website_forum.moderation_queue", values)
 
-    @http.route('/forum/<model("forum.forum"):forum>/closed_posts', type='http', auth="user", website=True)
+    @http.route(routes_with_embed('/forum/<model("forum.forum"):forum>/closed_posts'), type='http', auth="user", website=True)
     def closed_posts(self, forum, **kwargs):
         if request.env.user.karma < forum.karma_moderate:
             raise werkzeug.exceptions.NotFound()
@@ -597,7 +617,7 @@ class WebsiteForum(WebsiteProfile):
             'queue_type': 'close',
         })
 
-        return request.render("website_forum.moderation_queue", values)
+        return request.render("website_forum.moderation_queue", self._add_embed_values(values))
 
     @http.route('/forum/<model("forum.forum"):forum>/post/<model("forum.post"):post>/validate', type='http', auth="user", website=True)
     def post_accept(self, forum, post, **kwargs):
@@ -618,7 +638,7 @@ class WebsiteForum(WebsiteProfile):
         post._refuse()
         return self.question_ask_for_close(forum, post)
 
-    @http.route('/forum/<model("forum.forum"):forum>/post/<model("forum.post"):post>/flag', type='jsonrpc', auth="user", website=True)
+    @http.route(routes_with_embed('/forum/<model("forum.forum"):forum>/post/<model("forum.post"):post>/flag'), type='jsonrpc', auth="user", website=True)
     def post_flag(self, forum, post, **kwargs):
         return post._flag()[0]
 
@@ -648,7 +668,7 @@ class WebsiteForum(WebsiteProfile):
 
     # User
     # --------------------------------------------------
-    @http.route(['/forum/<model("forum.forum"):forum>/partner/<int:partner_id>'], type='http', auth="public", website=True)
+    @http.route('/forum/<model("forum.forum"):forum>/partner/<int:partner_id>', type='http', auth="public", website=True)
     def open_partner(self, forum, partner_id=0, **post):
         slug = request.env['ir.http']._slug
         if partner_id:
@@ -660,7 +680,7 @@ class WebsiteForum(WebsiteProfile):
     # Profile
     # -----------------------------------
 
-    @http.route(['/forum/user/<int:user_id>'], type='http', auth="public", website=True)
+    @http.route('/forum/user/<int:user_id>', type='http', auth="public", website=True)
     def view_user_forum_profile(self, user_id, forum_id='', forum_origin='/forum', **post):
         forum_origin_query = f'?forum_origin={forum_origin}&forum_id={forum_id}' if forum_id else ''
         return request.redirect(f'/profile/user/{user_id}{forum_origin_query}')
@@ -777,24 +797,54 @@ class WebsiteForum(WebsiteProfile):
     # Messaging
     # --------------------------------------------------
 
-    @http.route('/forum/<model("forum.forum"):forum>/post/<model("forum.post"):post>/comment/<model("mail.message"):comment>/convert_to_answer', type='http', auth="user", methods=['POST'], website=True)
+    @http.route(routes_with_embed('/forum/<model("forum.forum"):forum>/post/<model("forum.post"):post>/comment/<model("mail.message"):comment>/convert_to_answer'), type='http', auth="user", methods=['POST'], website=True)
     def convert_comment_to_answer(self, forum, post, comment, **kwarg):
         post = request.env['forum.post'].convert_comment_to_answer(comment.id)
         slug = request.env['ir.http']._slug
         if not post:
-            return request.redirect("/forum/%s" % slug(forum))
+            return request.redirect(self._get_embed_url("/forum/%s" % slug(forum)))
         question = post.parent_id if post.parent_id else post
-        return request.redirect("/forum/%s/%s" % (slug(forum), request.env['ir.http']._slug(question)))
+        return request.redirect(self._get_embed_url("/forum/%s/%s" % (slug(forum), request.env['ir.http']._slug(question))))
 
-    @http.route('/forum/<model("forum.forum"):forum>/post/<model("forum.post"):post>/convert_to_comment', type='http', auth="user", methods=['POST'], website=True)
+    @http.route(routes_with_embed('/forum/<model("forum.forum"):forum>/post/<model("forum.post"):post>/convert_to_comment'), type='http', auth="user", methods=['POST'], website=True)
     def convert_answer_to_comment(self, forum, post, **kwarg):
         question = post.parent_id
         new_msg = post.convert_answer_to_comment()
         slug = request.env['ir.http']._slug
         if not new_msg:
-            return request.redirect("/forum/%s" % slug(forum))
-        return request.redirect("/forum/%s/%s" % (slug(forum), request.env['ir.http']._slug(question)))
+            return request.redirect(self._get_embed_url("/forum/%s" % slug(forum)))
+        return request.redirect(self._get_embed_url("/forum/%s/%s" % (slug(forum), request.env['ir.http']._slug(question))))
 
-    @http.route('/forum/<model("forum.forum"):forum>/post/<model("forum.post"):post>/comment/<model("mail.message"):comment>/delete', type='jsonrpc', auth="user", website=True)
+    @http.route(routes_with_embed('/forum/<model("forum.forum"):forum>/post/<model("forum.post"):post>/comment/<model("mail.message"):comment>/delete'), type='jsonrpc', auth="user", website=True)
     def delete_comment(self, forum, post, comment, **kwarg):
         return post.unlink_comment(comment.id)[0]
+
+    # Utility functions for the embedded forum version
+    # --------------------------------------------------
+    @staticmethod
+    def _is_embed():
+        return request.httprequest.path.startswith('/forum/embed/')
+
+    @staticmethod
+    def _base_url():
+        return '/forum/embed' if WebsiteForum._is_embed() else '/forum'
+
+    @staticmethod
+    def _add_embed_values(values):
+        if not WebsiteForum._is_embed():
+            values.update({'forum_base_path': '/forum'})
+        else:
+            values.update({
+                'forum_embed': True,
+                'forum_base_path': '/forum/embed',
+                'no_footer': True,
+                'no_header': True,
+                'no_livechat': True,
+            })
+        return values
+
+    @staticmethod
+    def _get_embed_url(url):
+        if url.startswith('/forum/') and WebsiteForum._is_embed():
+            return '/forum/embed/' + url[len('/forum/'):]
+        return url

--- a/addons/website_forum/static/src/scss/website_forum.scss
+++ b/addons/website_forum/static/src/scss/website_forum.scss
@@ -303,3 +303,10 @@ $-forum-sidebar-width: map-get($container-max-widths, sm) / 2;
 .o_wforum_background_gradient {
     background-image: linear-gradient(0deg, rgba($body-bg, .75) 30%, rgba($body-bg, 0) 100%);
 }
+
+// Remove website backend and editor buttons for the embedded version
+.o_forum_embed {
+    .o_frontend_to_backend_nav {
+        display: none !important;
+    }
+}

--- a/addons/website_forum/static/src/xml/public_templates.xml
+++ b/addons/website_forum/static/src/xml/public_templates.xml
@@ -54,7 +54,7 @@
     <t t-name="website_forum.social_message_answer">
         <p>By sharing you answer, you will get additional <b>karma points</b> if your
         answer is selected as the right one. See what you can do with karma
-        <a href="/forum/help-1/faq" target="_blank">here</a>.</p>
+        <a t-attf-href="#{forum_base_path or '/forum'}/help-1/faq" target="_blank">here</a>.</p>
     </t>
     <t t-name="website_forum.social_message_default">
         <p>Share this content to increase your chances to be featured on the front page and attract more visitors.</p>

--- a/addons/website_forum/static/tests/tours/website_forum_question.js
+++ b/addons/website_forum/static/tests/tours/website_forum_question.js
@@ -1,8 +1,6 @@
 import { registry } from "@web/core/registry";
 
-registry.category("web_tour.tours").add('forum_question', {
-    url: '/forum/help-1',
-    steps: () => [
+const getTourForumQuestionSteps = (checkURL) => [
     {
         content: "Ask the question in this forum by clicking on the button.",
         trigger: '.o_wforum_ask_btn',
@@ -12,6 +10,7 @@ registry.category("web_tour.tours").add('forum_question', {
         trigger: 'input[name=post_name]',
         run: "edit First Question Title",
     },
+    checkURL,
     {
         trigger: "#wrap:not(:has(input[name=post_name]:value('')))",
     },
@@ -39,9 +38,6 @@ registry.category("web_tour.tours").add('forum_question', {
         content: "Click to post your question.",
         trigger: 'button:contains("Post")',
         run: "click",
-    }, {
-        content: "This page contain new created question.",
-        trigger: '#wrap:has(.fa-star)',
     },
     {
         trigger: ".o_wforum_question:contains(marc demo)",
@@ -51,6 +47,11 @@ registry.category("web_tour.tours").add('forum_question', {
         trigger: ".modal:contains(thanks for posting!) .modal-header button.btn-close",
         run: "click",
     },
+    {
+        content: "This page contain new created question.",
+        trigger: '.o_wforum_post_content:contains("First Question")',
+    },
+    checkURL,
     {
         content: "Check that the code still exists as it was written.",
         trigger: 'div.o_wforum_post_content:contains("First Question <p>code here</p>")',
@@ -69,6 +70,7 @@ registry.category("web_tour.tours").add('forum_question', {
         content: "Check that the content is the same",
         trigger: 'div.odoo-editor-editable p:contains("First Question <p>code here</p>")',
     },
+    checkURL,
     {
         content: "Save changes",
         trigger: 'button:contains("Save Changes")',
@@ -85,6 +87,7 @@ registry.category("web_tour.tours").add('forum_question', {
         trigger: '.note-editable p',
         run: "editor First Answer",
     },
+    checkURL,
     {
         trigger: ".note-editable:not(:has(br))",
     },
@@ -100,5 +103,34 @@ registry.category("web_tour.tours").add('forum_question', {
     }, {
         content: "Congratulations! You just created and post your first question and answer.",
         trigger: '.o_wforum_validate_toggler',
-    }]
+    },
+    checkURL,
+];
+
+registry.category("web_tour.tours").add("forum_question", {
+    steps: () =>
+        getTourForumQuestionSteps({
+            content: "We are still on the non-embedded forum.",
+            trigger: ".website_forum",
+            run: () => {
+                if (window.location.pathname.startsWith("/forum/embed/")) {
+                    console.error("We have switched to the embedded forum.");
+                }
+            },
+        }),
+    url: "/forum/help-1",
+});
+
+registry.category("web_tour.tours").add("forum_question_embed", {
+    steps: () =>
+        getTourForumQuestionSteps({
+            content: "We are still on the embedded forum.",
+            trigger: ".website_forum",
+            run: () => {
+                if (!window.location.pathname.startsWith("/forum/embed/")) {
+                    console.error("We have left the embedded forum.");
+                }
+            },
+        }),
+    url: "/forum/embed/help-1",
 });

--- a/addons/website_forum/tests/test_forum_controller.py
+++ b/addons/website_forum/tests/test_forum_controller.py
@@ -1,12 +1,17 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import re
+from werkzeug import urls
+
+from odoo import http
 from odoo.addons.website.tools import MockRequest
 from odoo.addons.website_forum.controllers.website_forum import WebsiteForum
 from odoo.addons.website_forum.tests.common import KARMA, TestForumCommon
+from odoo.tests import HttpCase
 
 
-class TestForumController(TestForumCommon):
+class TestForumController(TestForumCommon, HttpCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -16,6 +21,7 @@ class TestForumController(TestForumCommon):
             'name': f'Forum {idx + 2}',
             'karma_ask': cls.minimum_karma_allowing_to_post,
             'website_id': website.id,
+            'welcome_message': 'Welcome',
         } for idx, website in enumerate(
             (cls.base_website, cls.base_website, cls.base_website, cls.website_2, cls.website_2))])
         cls.forum_1, cls.forum_2, cls.forum_3, cls.forum_1_website_2, cls.forum_2_website_2 = cls.forums
@@ -25,11 +31,12 @@ class TestForumController(TestForumCommon):
         """ Get user other forums limited to the forums of the test (self.forums). """
         return self.forums & self.controller._prepare_user_values(forum=forum).get('my_other_forums')
 
-    def forum_post(self, user, forum):
+    def forum_post(self, user, forum, tags=None):
         return self.env['forum.post'].with_user(user).create({
             'content': 'A post ...',
             'forum_id': forum.id,
             'name': 'Post...',
+            'tag_ids': tags and tags.mapped('id'),
         })
 
     def test_prepare_user_values_my_other_forum(self):
@@ -61,3 +68,125 @@ class TestForumController(TestForumCommon):
                     self.assertEqual(self._get_my_other_forums(self.forum_2_website_2), self.forum_1_website_2)
                     employee_2_website_2_forum_2_post.favourite_ids += self.env.user
                     self.assertEqual(self._get_my_other_forums(self.forum_1_website_2), self.forum_2_website_2)
+
+    def _extract_link_and_form_urls(self, url, post_data=None):
+        """ Extract URLs from links and form action of the html fetched from the URL along with the final URL. """
+        if post_data is not None:
+            post_data = {**post_data, 'csrf_token': http.Request.csrf_token(self)}
+        response = self.url_open(url, post_data, allow_redirects=True)
+        self.assertEqual(response.status_code, 200, f'Get {url} must succeed')
+        html = response.text
+        urls = {match[0] or match[1]
+                  for match in re.findall(r'<a[^>]*\shref="([^"]+)"|<form[^>]*\saction="([^"]+)"', html)}
+        urls.add(response.url)  # Add the URL of the page as well
+        return urls
+
+    @staticmethod
+    def _get_not_starting_with(urls, prefixes):
+        """ Returns all the given urls not starting by prefixes. """
+        return {url
+                for url in urls
+                if not any(url.startswith(prefix) for prefix in prefixes)}
+
+    def test_embed_forum(self):
+        """ Test embedded forum confinement.
+
+        Concretely, we check that all embed links/actions target the embedded forum
+        and that all links/actions of the non-embedded forum targets the non-embedded forum.
+        """
+        self.forum.karma_ask = 0
+        tag_important = self.env['forum.tag'].create({
+            'forum_id': self.forum_1.id,
+            'name': 'important',
+        })
+        post = self.forum_post(self.user_admin, self.forum_1, tag_important)
+        post_no_answer = self.forum_post(self.user_admin, self.forum_1, tag_important)
+        post_answer = self.forum_post(self.user_admin, self.forum_1, tag_important)
+        post.child_ids = post_answer
+        # Embedded forum can only have links to itself or external sites (ex.: for sharing).
+        authorized_prefixes = ['/forum/embed', '#', '?', 'http']
+
+        # Not logged
+        not_logged_urls = [
+            f'{self.forum_1.id}',
+            f'{self.forum_1.id}/{post.id}',
+            f'{self.forum_1.id}/page/1',
+            f'{self.forum_1.id}/tag/{tag_important.id}/questions',
+            f'{self.forum_1.id}/tag/{tag_important.id}/questions/page/1',
+            f'{self.forum_1.id}/tag',
+            f'{self.forum_1.id}/tag/i',
+            f'{self.forum_1.id}/question/{post.id}',
+            f'{self.forum_1.id}/{post.id}',
+            f'{self.forum_1.id}?search=Test&order=name+asc&filters=all&sorting=last_activity_date+desc',
+            f'{self.forum_1.id}?filters=unsolved&search=&sorting=last_activity_date+desc',
+            f'{self.forum_1.id}?filters=solved&search=&sorting=last_activity_date+desc',
+        ]
+        for url_part in not_logged_urls:
+            url = f'/forum/embed/{url_part}'
+            links = self._extract_link_and_form_urls(url)
+            self.assertTrue(links, f"{url}: there is at least one URL")
+            # Login links are authorized as long as they redirect to the embedded forum
+            login_links = {link for link in links if link.startswith('/web/login')}
+            for login_link in login_links:
+                query_params = urls.url_parse(login_link).decode_query()
+                self.assertTrue({
+                    key for key, value in query_params.items()
+                    if key == 'redirect' and value.startswith('/forum/embed')
+                }, f"{url}: all login URLs redirect to the embedded forum")
+            links = links.difference(login_links)
+            # Other links must starts with /forum/embed or be 100% relative
+            self.assertFalse(
+                self._get_not_starting_with(links, authorized_prefixes),
+                f"{url}: the form and links URL must be 100% relative or starts with /forum/embed")
+            # Non embedded forum must not contain embed URLs
+            self.assertFalse(
+                any(link for link in self._extract_link_and_form_urls(f'/forum/{url_part}')
+                    if link.startswith('/forum/embed')),
+                f"{url}: non embed forum doesn't contains embed URL."
+            )
+
+        # Logged
+        self.authenticate('admin', 'admin')
+        post_to_delete = self.forum_post(self.user_admin, self.forum_1, tag_important)
+        comment = post.with_context(mail_create_nosubscribe=True).message_post(
+            body='comment', message_type='comment', subtype_xmlid='mail.mt_comment')
+        logged_urls = [
+            *([(up, None) for up in not_logged_urls]),
+            (f'{self.forum_1.id}/post/{post.id}/edit', None),
+            (f'{self.forum_1.id}/question/{post.id}/edit_answer', None),
+            (f'{self.forum_1.id}/ask', None),
+            (f'{self.forum_1.id}/new', {'post_name': 'Test', 'content': '<p>test post</p>'}),
+            (f'{self.forum_1.id}/{post_no_answer.id}/reply', {'content': '<p>test answer</p>'}),
+            (f'{self.forum_1.id}/post/{post.id}/save', {'post_name': 'Test', 'content': '<p>test mod</p>'}),
+            (f'{self.forum_1.id}/question/{post.id}/ask_for_close', {}),
+            (f'{self.forum_1.id}/question/{post.id}/close', {'post_id': post.id}),
+            (f'{self.forum_1.id}/question/{post.id}/reopen', {}),
+            (f'{self.forum_1.id}/post/{post.id}/comment', {'post_id': post.id, 'comment': 'comment'}),
+            (f'{self.forum_1.id}/post/{post.id}/comment/{comment.id}/convert_to_answer', {}),
+        ]
+        for url_part, post_data in [
+            *logged_urls,
+            (f'{self.forum_1.id}/question/{post_to_delete.id}/delete', {}),
+        ]:
+            url = f'/forum/embed/{url_part}'
+            self.assertEqual(
+                self._get_not_starting_with(self._extract_link_and_form_urls(url, post_data), authorized_prefixes),
+                {'/web'},  # backend
+                f"{url}: the form and links URL must be 100% relative or starts with /forum/embed (except /web)")
+        # Recreate/unlink some objects to redo the action on the non-embedded version
+        post_no_answer.child_ids.unlink()  # to reply again
+        post_to_delete = self.forum_post(self.user_admin, self.forum_1, tag_important)
+        comment = post.with_context(mail_create_nosubscribe=True).message_post(
+            body='comment', message_type='comment', subtype_xmlid='mail.mt_comment')
+        # Non embedded forum must not contain embed URLs
+        for url_part, post_data in [
+            *logged_urls,
+            (f'{self.forum_1.id}/question/{post_to_delete.id}/delete', {}),
+            (f'{self.forum_1.id}/post/{post.id}/comment/{comment.id}/convert_to_answer', {}),
+        ]:
+            url = f'/forum/{url_part}'
+            self.assertFalse(
+                any(link for link in self._extract_link_and_form_urls(url, post_data)
+                    if link.startswith('/forum/embed')),
+                f"{url}: non embed forum doesn't contains embed URL."
+            )

--- a/addons/website_forum/tests/test_forum_tours.py
+++ b/addons/website_forum/tests/test_forum_tours.py
@@ -26,3 +26,9 @@ class TestUi(HttpCaseGamification):
         demo = self.user_demo
         demo.karma = forum.karma_post + 1
         self.start_tour("/", 'forum_question', login="demo")
+
+    def test_03_demo_question_embed(self):
+        forum = self.env.ref('website_forum.forum_help')
+        demo = self.user_demo
+        demo.karma = forum.karma_post + 1
+        self.start_tour("/", 'forum_question_embed', login="demo")

--- a/addons/website_forum/tests/test_sitemap.py
+++ b/addons/website_forum/tests/test_sitemap.py
@@ -29,3 +29,6 @@ class TestWebsiteControllers(TestForumCommon):
 
         locs = website._enumerate_pages(query_string='/forum/%s' % self.env['ir.http']._slug(self.forum))
         self.assertEqual(next(iter(locs))['lastmod'].strftime("%Y-%m-%d"), datetime)
+
+        self.assertFalse([*website._enumerate_pages(query_string='/forum/embed')],
+                         "Sitemap must not contains forum embed links")

--- a/addons/website_forum/views/forum_forum_templates.xml
+++ b/addons/website_forum/views/forum_forum_templates.xml
@@ -46,7 +46,7 @@
         <t t-if="question_count == 0 or original_search" t-call="website_forum.no_results_message">
             <t t-set="record_name_plural">posts</t>
             <t t-set="_forum_slug" t-value="slug(forum) if forum else 'all'"/>
-            <t t-set="go_back_url" t-valuef="/forum/#{_forum_slug}/"/>
+            <t t-set="go_back_url" t-valuef="#{forum_base_path or '/forum'}/#{_forum_slug}/"/>
         </t>
         <t t-call="website.pager"/>
     </t>
@@ -60,10 +60,10 @@
         <div t-if="forum and forum.has_pending_post" class="alert border" role="alert">
             <b>You already have a pending post.</b><br/>
             <p>Please wait for a moderator to validate your previous post before continuing.</p>
-            <a t-attf-href="/forum/#{ slug(forum) }" title="All Topics"><i class="fa fa-angle-left me-2"/>Back to All Posts</a>
+            <a t-attf-href="#{ forum_base_path or '/forum' }/#{ slug(forum) }" title="All Topics"><i class="fa fa-angle-left me-2"/>Back to All Posts</a>
         </div>
 
-        <form t-else="" t-attf-action="/forum/#{slug(forum)}/new" method="post" role="form" class="tag_text js_website_submit_form js_wforum_submit_form o_wforum_readable mt-lg-3">
+        <form t-else="" t-attf-action="#{ forum_base_path or '/forum' }/#{slug(forum)}/new" method="post" role="form" class="tag_text js_website_submit_form js_wforum_submit_form o_wforum_readable mt-lg-3">
             <div class="row mb-3">
                 <label class="form-label col-lg-2" for="content">Title</label>
                 <div class="col">
@@ -125,7 +125,7 @@
                     <button type="submit" t-attf-class="o_wforum_submit_post #{ 'oe_social_share_call' if forum.allow_share else '' } btn btn-primary #{ 'karma_required' if user.karma &lt; forum.karma_ask else ''}"
                     t-att-data-karma="forum.karma_ask"
                     data-hashtags="#question" data-social-target-type="question">Post Your Question</button>
-                    <a class="btn btn-link" title="Back to Question" t-attf-href="/forum/#{ slug(forum) }">Discard</a>
+                    <a class="btn btn-link" title="Back to Question" t-attf-href="#{ forum_base_path or '/forum' }/#{ slug(forum) }">Discard</a>
                 </div>
             </div>
         </form>
@@ -154,7 +154,7 @@
             </article>
         </div>
 
-        <form t-attf-action="/forum/#{slug(forum)}/post/#{slug(post)}/save" method="post" role="form" class="tag_text js_website_submit_form js_wforum_submit_form o_wforum_readable">
+        <form t-attf-action="#{forum_base_path or '/forum'}/#{slug(forum)}/post/#{slug(post)}/save" method="post" role="form" class="tag_text js_website_submit_form js_wforum_submit_form o_wforum_readable">
             <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
             <div t-if="not is_answer" class="row mb-3">
                 <label class="form-label col-lg-2" for="post_name">Title</label>
@@ -218,7 +218,7 @@
             <div class="row mb-5">
                 <div class="col offset-lg-2">
                     <button type="submit" class="o_wforum_submit_post btn btn-primary">Save Changes</button>
-                    <a class="btn btn-link" title="Back to Question" t-attf-href="/forum/#{ slug(forum) }/#{ slug(post)}">
+                    <a class="btn btn-link" title="Back to Question" t-attf-href="#{forum_base_path or '/forum'}/#{ slug(forum) }/#{ slug(post)}">
                         Discard
                     </a>
                 </div>
@@ -236,7 +236,7 @@
                 <ul class="pagination overflow-auto mt0 mb0">
                     <t t-foreach="pager_tag_chars" t-as="tuple_char">
                         <li t-if="tuple_char_index &lt; 11" t-attf-class="page-item #{ 'active' if active_char_tag == tuple_char[1] else '' }">
-                            <a t-attf-href="/forum/#{ slug(forum) }/tag/#{ quote_plus(tuple_char[1] )}?#{ keep_query('filters', 'search') }"
+                            <a t-attf-href="#{forum_base_path or '/forum'}/#{ slug(forum) }/tag/#{ quote_plus(tuple_char[1] )}?#{ keep_query('filters', 'search') }"
                                class="page-link">
                                 <t t-out="tuple_char[0]"/>
                             </a>
@@ -249,7 +249,7 @@
                 <select name="filter" class="form-select w-auto" onchange="location = this.value;">
                     <t t-foreach="pager_tag_chars" t-as="tuple_char">
                         <option t-if="active_char_tag == tuple_char[1]" selected="selected" value="" t-out="tuple_char[0]"/>
-                        <option t-else="" t-attf-value="/forum/#{slug(forum)}/tag/#{quote_plus(tuple_char[1]) + '?' + keep_query('filters')}"
+                        <option t-else="" t-attf-value="#{forum_base_path or '/forum'}/#{slug(forum)}/tag/#{quote_plus(tuple_char[1]) + '?' + keep_query('filters')}"
                                 t-out="tuple_char[0]"
                         />
                     </t>
@@ -269,7 +269,7 @@
                         <t t-set="follow_btn_classes" t-value="'opacity-50'"/>
                     </t>
                     <a t-attf-class="#{ 'disabled' if len(tag.post_ids) == 0  else '' } o_js_forum_tag_link btn-link #{ '' if tag.message_is_follower else 'text-muted' }"
-                       t-attf-href="/forum/#{ slug(forum) }/tag/#{ slug(tag) }/questions?#{ keep_query(filters='tag') }">
+                       t-attf-href="#{forum_base_path or '/forum'}/#{ slug(forum) }/tag/#{ slug(tag) }/questions?#{ keep_query(filters='tag') }">
                         <t t-out="tag.name"/>&amp;nbsp;
                         <span class="small">(<t t-out="tag.posts_count"/>)</span>
                     </a>
@@ -278,7 +278,7 @@
         </div>
         <t t-else="">
             <t t-set="tag_filter" t-value="keep_query('filters').split('=')[1] if keep_query('filters') else ''"/>
-            <t t-set="go_back_url" t-valuef="/forum/#{ slug(forum) }/tag"/>
+            <t t-set="go_back_url" t-valuef="#{forum_base_path or '/forum'}/#{ slug(forum) }/tag"/>
             <t t-set="record_name_plural">tags</t>
             <t t-call="website_forum.no_results_message">
                 <t t-if="tag_filter and tag_filter != 'all'" t-set="result_msg">

--- a/addons/website_forum/views/forum_forum_templates_forum_all.xml
+++ b/addons/website_forum/views/forum_forum_templates_forum_all.xml
@@ -35,7 +35,7 @@
     <t t-foreach="sorted_forums" t-as="forum">
         <t t-set="has_desc" t-value="forum.description"/>
         <div t-attf-class="#{col_class}">
-            <a t-attf-href="/forum/#{slug(forum)}"
+            <a t-attf-href="#{forum_base_path or '/forum'}/#{slug(forum)}"
                 class="card oe_img_bg h-100 justify-content-end shadow-sm border-0 p-3 pt-5 text-reset text-decoration-none transition-base"
                 t-attf-style="background-image: url('#{website.image_url(forum, 'image_1920') if forum.image_1920 else ''}')"
             >
@@ -55,7 +55,7 @@
                         <span class="badge bg-dark me-1">Last post:</span>
                         <object>
                             <a
-                                t-attf-href="/forum/#{slug(forum)}/#{slug(forum.last_post_id)}"
+                                t-attf-href="#{forum_base_path or '/forum'}/#{slug(forum)}/#{slug(forum.last_post_id)}"
                                 t-out="forum.last_post_id.name"
                             />
                         </object>

--- a/addons/website_forum/views/forum_forum_templates_layout.xml
+++ b/addons/website_forum/views/forum_forum_templates_layout.xml
@@ -31,11 +31,12 @@
             <div class="flex-grow-1">
                 <div class="o_wforum_breadcrumb_root_single row g-0">
                     <div t-if="breadcrumb_kind == 'base'" class="col-10">
-                        <a class="btn btn-link px-0 pb-2 fs-5" t-attf-href="/forum/#{ _forum_slug }">
+                        <a t-if="not forum_embed" class="btn btn-link px-0 pb-2 fs-5" t-attf-href="#{ forum_base_path or '/forum' }/#{ _forum_slug }">
                             <i class="d-inline-block fa fa-angle-left me-1 small"/><t t-out="_forum_name"/>
                         </a>
+                        <span t-else="" class="btn btn-link px-0 pb-2 fs-5" t-out="_forum_name"/>
                     </div>
-                    <div class="d-lg-none col-2 text-end">
+                    <div t-if="not forum_embed" class="d-lg-none col-2 text-end">
                         <button class="btn position-relative ms-auto fs-5" data-bs-toggle="offcanvas" data-bs-target="#o_wforum_offcanvas">
                             <i class="fa fa-navicon"/>
                         </button>
@@ -53,7 +54,7 @@
                             </t>
                         </span>
                         <a t-elif="uid" type="button" aria-label="Favorite"
-                            t-attf-data-href="/forum/#{slug(question.forum_id)}/question/#{slug(question)}/toggle_favourite"
+                            t-attf-data-href="#{forum_base_path or '/forum'}/#{slug(question.forum_id)}/question/#{slug(question)}/toggle_favourite"
                             t-attf-class="o_wforum_favourite_toggle btn btn-lg #{ 'opacity-50' if not question.user_favourite else '' } opacity-hover-100 p-0">
                             <i t-attf-class="position-relative fa #{'o_wforum_gold fa-star ' if question.user_favourite else 'fa-star-o '}"
                                 data-bs-toggle="tooltip"
@@ -81,7 +82,8 @@
         </t>
         <ol t-else="" class="breadcrumb col-10 col-lg flex-grow-1 flex-nowrap my-0 p-0 fs-5">
             <li class="o_wforum_breadcrumb_root breadcrumb-item text-nowrap text-truncatet">
-                <a t-attf-href="/forum/#{ _forum_slug }" t-out="_forum_name"/>
+                <a t-if="not forum_embed" t-attf-href="#{ forum_base_path or '/forum' }/#{ _forum_slug }" t-out="_forum_name"/>
+                <span t-else="" t-out="_forum_name"/>
             </li>
             <li t-if="queue_type" class="breadcrumb-item text-nowrap d-none d-lg-flex">
                 <span>Moderation</span>
@@ -91,7 +93,7 @@
             </li>
         </ol>
         <t t-if="_page_name != 'single_question'">
-            <div class="d-lg-none text-end">
+            <div t-if="not forum_embed" class="d-lg-none text-end">
                 <button class="btn position-relative ms-auto fs-5" data-bs-toggle="offcanvas" data-bs-target="#o_wforum_offcanvas">
                     <i class="fa fa-navicon"/>
                 </button>
@@ -99,7 +101,7 @@
             <div t-if="tag or tags or search or question_count or page_name or website_forum_action" t-attf-class="d-flex justify-content-lg-end gap-2 flex-grow-1 flex-wrap flex-md-nowrap w-100 w-lg-auto #{'mw-xl-75' if search else 'mw-xl-50'}">
                 <span t-if="tag and not tags" class="btn btn-light rounded ps-2">
                     <span t-if="tag"><i class="fa fa-tag me-1 opacity-50"/><t t-out="tag.name"></t></span>
-                    <a t-attf-href="#{ url_for('/forum') }/#{ _forum_slug }?#{ keep_query('search', 'sorting', 'my', 'create_uid') }"
+                    <a t-attf-href="#{ forum_base_path or '/forum' }/#{ _forum_slug }?#{ keep_query('search', 'sorting', 'my', 'create_uid') }"
                        class="p-1 text-decoration-none text-reset opacity-50"><i class="oi oi-close d-inline-block"/></a>
                 </span>
                 <span t-if="search" class="btn btn-light rounded ps-2">
@@ -163,11 +165,11 @@
                 <t t-if="question_count or tags" t-call="website.website_search_box_input">
                     <t t-if="_page_name == 'tags'">
                         <t t-set="search_type" t-value="'forum_tags_only'"/>
-                        <t t-set="action" t-value="'/forum/%s/tag' % (_forum_slug)"/>
+                        <t t-set="action" t-value="'%s/%s/tag' % (forum_base_path or '/forum', _forum_slug)"/>
                     </t>
                     <t t-else="">
                         <t t-set="search_type" t-value="'forums'"/>
-                        <t t-set="action" t-value="'/forum/%s' % (_forum_slug)"/>
+                        <t t-set="action" t-value="'%s/%s' % (forum_base_path or '/forum', _forum_slug)"/>
                     </t>
                     <t t-set="display_description" t-valuef="true"/>
                     <t t-set="display_detail" t-valuef="true"/>
@@ -185,10 +187,10 @@
                         data-bs-toggle="popover"
                         t-att-data-bs-title="popover_title"
                         t-att-data-bs-content="popover_content">
-                        <a class="o_wforum_ask_btn disabled btn btn-primary w-100 w-md-auto mb-3 mb-md-0" t-attf-href="/forum/#{ slug(forum) }/ask">New Post</a>
+                        <a class="o_wforum_ask_btn disabled btn btn-primary w-100 w-md-auto mb-3 mb-md-0" t-attf-href="#{forum_base_path or '/forum'}/#{ slug(forum) }/ask">New Post</a>
                     </div>
                     <a t-elif="uid and forum" role="button" type="button" t-attf-class="o_wforum_ask_btn btn btn-primary w-100 w-md-auto #{ 'karma_required' if user.karma &lt; forum.karma_ask else '' }"
-                        t-att-data-karma="forum.karma_ask" t-attf-href="/forum/#{slug(forum)}/ask">New Post</a>
+                        t-att-data-karma="forum.karma_ask" t-attf-href="#{forum_base_path or '/forum'}/#{slug(forum)}/ask">New Post</a>
                 </t>
                 <button t-if="website_forum_action and not queue_type == 'close' and posts_ids" type="button" class="o_wforum_btn_filter_tool btn btn-secondary"
                     data-bs-toggle="modal" data-bs-target="#markAllAsSpam">
@@ -211,15 +213,15 @@
         </t>
         <t t-else="">
             <div class="oe_structure" id="oe_structure_website_forum_header_1"/>
-            <div id="wrap" t-attf-class="o_wforum_wrapper position-relative container row mx-auto px-0 #{ 'h-100' if forum_welcome_message else ''} #{website_forum_action}">
+            <div id="wrap" t-attf-class="o_wforum_wrapper position-relative #{'container-fluid px-4' if forum_embed else 'container px-0'} row mx-auto #{ 'h-100' if forum_welcome_message else ''} #{website_forum_action}">
                 <t t-set="_forum_slug" t-value="slug(forum) if forum else 'all'"/>
-                <t t-set="_forum_path" t-value="url_for('/forum') + '/' + _forum_slug"/>
-                <t t-call="website_forum.user_sidebar"/>
-                <t t-call="website_forum.user_sidebar_mobile"/>
-                <div class="o_wforum_content_wrapper col-lg-9">
+                <t t-set="_forum_path" t-value="(forum_base_path or '/forum') + '/' + _forum_slug"/>
+                <t t-if="not forum_embed" t-call="website_forum.user_sidebar"/>
+                <t t-if="not forum_embed" t-call="website_forum.user_sidebar_mobile"/>
+                <div t-attf-class="o_wforum_content_wrapper #{'col-lg-12' if forum_embed else 'col-lg-9'}">
                     <div class="o_wprofile_email_validation_container d-flex flex-column justify-content-center mb-3 mb-lg-5 pt-2 pt-lg-3">
                         <t t-call="website_profile.email_validation_banner">
-                            <t t-set="redirect_url" t-value="'/forum/%s' % forum.id if forum else '/forum/all/'"/>
+                            <t t-set="redirect_url" t-value="'%s/%s' % (forum_base_path or '/forum', forum.id) if forum else '%s/all/' % forum_base_path"/>
                             <t t-set="additional_validation_email_message"> and join this Forum</t>
                             <t t-set="additional_validated_email_message"> You may now participate in our forums.</t>
                         </t>
@@ -240,7 +242,7 @@
             <t t-call="website_forum.user_sidebar_body"/>
         </div>
         <div t-if="forum" class="o_wforum_sidebar_footer mt-3 px-3 pb-2 text-center">
-            <a class="btn btn-sm btn-link" t-attf-href="/forum/#{slug(forum)}/faq">
+            <a class="btn btn-sm btn-link" t-attf-href="#{forum_base_path or '/forum'}/#{slug(forum)}/faq">
                 <i class="fa fa-info-circle fa-fw"/> About this forum
             </a>
         </div>
@@ -273,7 +275,7 @@
         </div>
     </div>
     <div t-if="uid" class="o_wforum_sidebar_section mt-4 mb-2">
-        <a t-attf-href="/forum/user/#{ uid }?forum_id=#{ forum.id if forum else '' }&amp;forum_origin=#{ request.httprequest.path }"
+        <a t-attf-href="#{forum_base_path or '/forum'}/user/#{ uid }?forum_id=#{ forum.id if forum else '' }&amp;forum_origin=#{ request.httprequest.path }"
             class="btn w-100 py-1 text-start d-flex align-items-center" data-bs-toggle="tooltip" data-trigger="hover"
             title="My profile">
             <img class="o_wforum_avatar rounded-circle o_object_fit_cover" t-att-src="request.website.image_url(user, 'avatar_128', '60x60')" alt="Avatar"/>
@@ -313,18 +315,18 @@
             <i class="fa fa-shield fa-fw opacity-50"/> Badges
         </a>
     </div>
-    <div t-if="forum and user.karma>=forum.karma_moderate" class="o_wforum_sidebar_section pt-3">
+    <div t-if="forum and user.karma>=forum.karma_moderate and not forum_embed" class="o_wforum_sidebar_section pt-3">
         <!-- Moderation Tools -->
         <div class="px-3 pb-1 fw-bold">Moderation tools</div>
-        <a t-attf-class="nav-link my-1 py-1 #{ 'rounded text-bg-light disabled' if queue_type == 'validation' else 'text-reset'}" t-attf-href="/forum/#{_forum_slug}/validation_queue">
+        <a t-attf-class="nav-link my-1 py-1 #{ 'rounded text-bg-light disabled' if queue_type == 'validation' else 'text-reset'}" t-attf-href="#{forum_base_path or '/forum'}/#{_forum_slug}/validation_queue">
             <i t-attf-class="fa fa-check-square-o fa-fw #{ 'opacity-50' if queue_type != 'validation' else ''}"/> To Validate
             <span id="count_posts_queue_validation" t-attf-class="badge #{ 'text-bg-warning' if forum.count_posts_waiting_validation > 0 else 'd-none'}" t-out="forum.count_posts_waiting_validation"/>
         </a>
-        <a t-attf-class="nav-link my-1 py-1 #{'rounded text-bg-light disabled' if queue_type == 'offensive' or queue_type == 'flagged' else 'text-reset'}" t-attf-href="/forum/#{_forum_slug}/flagged_queue">
+        <a t-attf-class="nav-link my-1 py-1 #{'rounded text-bg-light disabled' if queue_type == 'offensive' or queue_type == 'flagged' else 'text-reset'}" t-attf-href="#{forum_base_path or '/forum'}/#{_forum_slug}/flagged_queue">
             <i t-attf-class="fa fa-flag fa-fw #{ 'opacity-50' if queue_type != 'flagged' else ''}"/> Flagged
             <span id="count_posts_queue_flagged" t-attf-class="badge #{ 'text-bg-danger' if forum.count_flagged_posts > 0 else 'd-none'}" t-out="forum.count_flagged_posts"/>
         </a>
-        <a t-attf-class="nav-link my-1 py-1 #{ 'rounded text-bg-light disabled' if queue_type == 'close' else 'text-reset'}" t-attf-href="/forum/#{_forum_slug}/closed_posts">
+        <a t-attf-class="nav-link my-1 py-1 #{ 'rounded text-bg-light disabled' if queue_type == 'close' else 'text-reset'}" t-attf-href="#{forum_base_path or '/forum'}/#{_forum_slug}/closed_posts">
             <i t-attf-class="fa fa-window-close fa-fw #{ 'opacity-50' if queue_type != 'close' else '' }"/> Closed
         </a>
     </div>
@@ -344,7 +346,7 @@
     <div t-if="my_other_forums" class="o_wforum_sidebar_section pt-3">
         <div class="px-3 pb-1 fw-bold">My forums</div>
         <t t-foreach="my_other_forums.sorted(lambda f: f.name.casefold())" t-as="my_forum">
-            <a class="nav-link my-1 py-1 text-reset" t-attf-href="/forum/#{slug(my_forum)}">
+            <a class="nav-link my-1 py-1 text-reset" t-attf-href="#{forum_base_path or '/forum'}/#{slug(my_forum)}">
                 <i class="fa fa-file-o fa-fw opacity-50"/>
                 <t t-out="my_forum.name"/>
             </a>
@@ -354,7 +356,7 @@
 
 <template id="header_welcome_message" inherit_id="website_forum.header" name="Forum Welcome Message (oe_structure_forum_top)">
     <xpath expr="//*[hasclass('oe_structure')][@id='oe_structure_website_forum_header_1']" position="replace">
-        <div t-if="forum" class="oe_structure oe_empty" id="oe_structure_website_forum_header_1">
+        <div t-if="forum and not forum_embed" class="oe_structure oe_empty" id="oe_structure_website_forum_header_1">
             <section t-if="editable or (is_public_user and not forum_welcome_message)" t-attf-class="s_cover parallax s_parallax_is_fixed bg-black-50 pt48 pb48 #{'css_non_editable_mode_hidden' if editable else 'forum_intro'}" data-scroll-background-ratio="1" data-snippet="s_cover">
                 <span t-if="forum.image_1920" class="s_parallax_bg oe_img_bg" t-attf-style="background-image: url('#{request.website.image_url(forum, 'image_1920')}'); background-position: center;"/>
                 <div t-if="forum.image_1920" class="o_we_bg_filter bg-black-50"/>
@@ -375,7 +377,7 @@
         <t t-set="_no_results_title">You've Completely Caught&amp;nbsp;Up!</t>
         <t t-set="result_msg">Go enjoy a cup of coffee.</t>
         <t t-set="record_name_plural">posts</t>
-        <t t-set="go_back_url" t-valuef="/forum/#{ slug(forum) }/"/>
+        <t t-set="go_back_url" t-valuef="#{ forum_base_path or '/forum' }/#{ slug(forum) }/"/>
     </t>
     <t t-else="" t-set="_no_results_title">Oops!</t>
     <div t-attf-class="#{ 'o_caught_up_alert' if queue_type else '' } row g-0 justify-content-center #{ 'd-none' if hide_alert else '' }">
@@ -413,7 +415,7 @@
             </div>
             <span t-elif="forum and forum.total_posts == 0">Because there are no posts in this forum yet.</span>
             <div class="mt-3">
-                <a t-if="uid and forum and forum.total_posts == 0" role="button" type="button" class="o_forum_ask_btn btn btn-primary ms-2" t-attf-href="/forum/#{_forum_slug}/ask">Start by creating a post</a>
+                <a t-if="uid and forum and forum.total_posts == 0" role="button" type="button" class="o_forum_ask_btn btn btn-primary ms-2" t-attf-href="#{forum_base_path or '/forum'}/#{_forum_slug}/ask">Start by creating a post</a>
                 <a t-else="" role="button" type="button" class="btn btn-primary mt-2" t-att-href="go_back_url">Go back to the list of <t t-out="record_name_plural"/></a>
             </div>
         </div>

--- a/addons/website_forum/views/forum_forum_templates_moderation.xml
+++ b/addons/website_forum/views/forum_forum_templates_moderation.xml
@@ -25,7 +25,7 @@
             users having a high karma can see offensive posts to moderate
             them.
         </div>
-        <form t-attf-action="/forum/#{ slug(forum) }/#{'post' if offensive else 'question'}/#{slug(question)}/#{'mark_as_offensive' if offensive else 'close'}" method="post" role="form" class="js_website_submit_form">
+        <form t-attf-action="#{ forum_base_path or '/forum' }/#{ slug(forum) }/#{'post' if offensive else 'question'}/#{slug(question)}/#{'mark_as_offensive' if offensive else 'close'}" method="post" role="form" class="js_website_submit_form">
             <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
             <input name="post_id" t-att-value="question.id" type="hidden"/>
             <div class="row g-0 mb-3">
@@ -46,7 +46,7 @@
                         <t t-if="offensive">Mark as offensive</t>
                         <t t-if="not offensive">Close post</t>
                     </button>
-                    <a role="button" class="btn btn-link ms-2" t-attf-href="/forum/#{ slug(forum) }/#{ slug(question) }">Discard</a>
+                    <a role="button" class="btn btn-link ms-2" t-attf-href="#{ forum_base_path or '/forum' }/#{ slug(forum) }/#{ slug(question) }">Discard</a>
                 </div>
             </div>
         </form>
@@ -146,7 +146,7 @@
                         <b t-else="">Question:</b>
                     </h6>
                     <div class="col d-flex align-items-center justify-content-between">
-                        <a t-attf-href="/forum/#{slug(question.forum_id)}/#{slug(question)}#{ ('/#answer-%s' % answer.id) if answer else '' }"
+                        <a t-attf-href="#{forum_base_path or '/forum'}/#{slug(question.forum_id)}/#{slug(question)}#{ ('/#answer-%s' % answer.id) if answer else '' }"
                             t-attf-title="Read: #{question.name}"
                             t-attf-class="text-reset"
                             t-out="question.name"/>
@@ -194,11 +194,11 @@
                             </small>
                         </div>
                     </div>
-                    <t t-set="post_url" t-valuef="/forum/#{ slug(forum) }/post/#{ slug(question) }"/>
+                    <t t-set="post_url" t-valuef="#{forum_base_path or '/forum'}/#{ slug(forum) }/post/#{ slug(question) }"/>
                     <div class="col-sm-3 o_wforum_validation_queue">
                         <div class="text-center d-flex flex-row gap-2 flex-lg-column align-items-stretch mt-2 mt-lg-0">
                             <t t-if="queue_type == 'close'" t-call="website_forum.link_button">
-                                <t t-set="url" t-valuef="/forum/#{ slug(forum) }/question/#{ slug(question) }/reopen"/>
+                                <t t-set="url" t-valuef="#{forum_base_path or '/forum'}/#{ slug(forum) }/question/#{ slug(question) }/reopen"/>
                                 <t t-set="label">Reopen</t>
                                 <t t-set="icon" t-value="'fa fa-folder-open'"/>
                                 <t t-set="karma" t-value="question.karma_close if not question.can_close else 0"/>

--- a/addons/website_forum/views/forum_forum_templates_post.xml
+++ b/addons/website_forum/views/forum_forum_templates_post.xml
@@ -16,7 +16,7 @@
                 aria-label="You're following this post"
                 data-bs-toggle="tooltip"
                 class="fa fa-bell"/>
-            <a t-attf-href="/forum/#{slug(question.forum_id)}/#{slug(question)}#{ ('/#answer-%s' % answer.id) if answer else '' }"
+            <a t-attf-href="#{forum_base_path or '/forum'}/#{slug(question.forum_id)}/#{slug(question)}#{ ('/#answer-%s' % answer.id) if answer else '' }"
                 t-attf-title="Read: #{question.name}"
                 t-attf-class="stretched-link text-body #{_link_classes}">
                 <span t-out="question.name" t-if="question.name"/>
@@ -35,9 +35,9 @@
 
             <!-- Toggle Tags on click -->
             <t t-if="tag and tag.name == question_tag.name" t-set="click_action"
-                t-value="'/forum/' + slug(question_tag.forum_id) + '?' + keep_query( 'search', 'sorting', 'my', 'create_uid',)"/>
+                t-valuef="#{forum_base_path or '/forum'}/#{slug(question_tag.forum_id)}?#{keep_query( 'search', 'sorting', 'my', 'create_uid',)}"/>
             <t t-else="" t-set="click_action"
-                t-value="'/forum/' + slug(question_tag.forum_id) + '/tag/' + slug(question_tag) + '/questions?' + keep_query( 'search', 'sorting', 'my', 'create_uid', filters='tag')"/>
+                t-valuef="#{forum_base_path or '/forum'}/#{slug(question_tag.forum_id)}/tag/#{slug(question_tag)}/questions?#{keep_query( 'search', 'sorting', 'my', 'create_uid', filters='tag')}"/>
 
             <a t-att-href="click_action"
                 t-attf-class="badge position-relative z-1 fw-normal o_tag o_color_#{question_tag.color}"
@@ -100,7 +100,7 @@
             </div>
         </td>
         <td class="o_wforum_reply_count order-3 d-flex d-lg-table-cell flex-column text-end text-lg-center">
-            <a t-if="question.child_count" class="text-reset" t-attf-href="/forum/#{ slug(question.forum_id) }/#{ slug(question) }">
+            <a t-if="question.child_count" class="text-reset" t-attf-href="#{ forum_base_path or '/forum' }/#{ slug(question.forum_id) }/#{ slug(question) }">
                 <i class="fa fa-reply me-1 d-lg-none" />
                 <t t-out="question.child_count"/>
             </a>
@@ -138,7 +138,7 @@
     <t t-if="request.params.get('nocontent')">
         <p class="alert alert-danger" role="alert">You cannot post an empty answer</p>
     </t>
-    <form t-attf-action="/forum/#{ slug(forum) }/#{slug(question)}/reply" method="post" class="js_website_submit_form js_wforum_submit_form d-flex flex-column" role="form">
+    <form t-attf-action="#{ forum_base_path or '/forum' }/#{ slug(forum) }/#{slug(question)}/reply" method="post" class="js_website_submit_form js_wforum_submit_form d-flex flex-column" role="form">
         <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
         <input type="hidden" name="karma" t-att-value="user.karma" id="karma"/>
         <textarea name="content" t-attf-id="content-#{str(question.id)}" class="form-control o_wysiwyg_loader" required="required" minlength="50" t-att-data-karma="forum.karma_editor"/>
@@ -164,7 +164,7 @@
 <template id="post_stats">
     <div t-if="question.tag_ids" class="o_wforum_index_entry_tags ms-0">
         <a  t-foreach="question.tag_ids" t-as="question_tag"
-            t-attf-href="/forum/#{slug(question_tag.forum_id)}/tag/#{slug(question_tag)}/questions?#{keep_query(filters='tag')}"
+            t-attf-href="#{forum_base_path or '/forum'}/#{slug(question_tag.forum_id)}/tag/#{slug(question_tag)}/questions?#{keep_query(filters='tag')}"
             t-attf-class="badge #{'ms-1' if not question_tag_first else ''} fw-normal o_tag o_color_#{question_tag.color}"
             t-field="question_tag.name"/>
     </div>
@@ -198,13 +198,13 @@
     <t t-call="website_forum.header">
         <div class="mw-xl-75 mw-xxl-100">
             <!-- Post Status Messages -->
-            <div t-if="forum and question.state == 'pending' and user.karma >= forum.karma_moderate and question.active" class="alert alert-info text-center" role="status" >
+            <div t-if="forum and question.state == 'pending' and user.karma >= forum.karma_moderate and question.active and not forum_embed" class="alert alert-info text-center" role="status" >
                 <p>This post is currently awaiting moderation and is not published yet.<br/>
                     As a moderator you can either <b>Accept</b> or <b>Reject</b> this post.</p>
                 <div>
-                    <a role="button" t-attf-href="/forum/#{slug(forum)}/post/#{slug(question)}/validate" type="button" class="btn btn-success">
+                    <a role="button" t-attf-href="#{forum_base_path or '/forum'}/#{slug(forum)}/post/#{slug(question)}/validate" type="button" class="btn btn-success">
                         <i class="fa fa-check fa-fw me-1"/>Accept</a>
-                    <a role="button" t-attf-href="/forum/#{slug(forum)}/post/#{slug(question)}/refuse" type="button" class="btn btn-danger">
+                    <a role="button" t-attf-href="#{forum_base_path or '/forum'}/#{slug(forum)}/post/#{slug(question)}/refuse" type="button" class="btn btn-danger">
                         <i class="fa fa-times fa-fw me-1"/>Reject</a>
                 </div>
             </div>
@@ -217,13 +217,13 @@
             </div>
             <div t-attf-class="alert alert-danger o_wforum_flag_alert #{'d-none ' if question.state != 'flagged' else ''}text-center" >
                 <h5>This question has been flagged</h5>
-                <span t-if="question.can_moderate">As a moderator, you can either validate or reject this answer.</span>
+                <span t-if="question.can_moderate and not forum_embed">As a moderator, you can either validate or reject this answer.</span>
                 <t t-call="website_forum.link_button">
-                    <t t-set="url" t-value="'/forum/' + slug(forum) + '/post/' + slug(question) + '/flag'"/>
+                    <t t-set="url" t-valuef="#{forum_base_path or '/forum'}/#{slug(forum)}/post/#{slug(question)}/flag"/>
                     <t t-set="form_method" t-value="'GET'"/>
                     <t t-set="karma" t-value="question.forum_id.karma_flag if not question.can_flag else 0"/>
                     <t t-set="classes" t-valuef="o_wforum_flag"/>
-                    <t t-set="flag_validator" t-value="question.can_moderate"/>
+                    <t t-set="flag_validator" t-value="question.can_moderate and not forum_embed"/>
                     <t t-set="object" t-value="question"/>
                 </t>
             </div>
@@ -231,13 +231,13 @@
                     The question has been closed<t t-if="question.closed_reason_id"> for reason: <b><i t-out="question.closed_reason_id.name"/></b></t>
                     <t t-if="question.closed_uid">
                         <br/>by
-                        <a t-attf-href="/forum/#{ slug(forum) }/user/#{ question.closed_uid.id }"
+                        <a t-attf-href="#{forum_base_path or '/forum'}/#{ slug(forum) }/user/#{ question.closed_uid.id }"
                            t-out="question.closed_uid.name"/>
                     </t>
                     on <span t-field="question.closed_date"/>
                 <div t-if="user.karma > question.karma_close" class="mt-3 text-center">
                     <t t-call="website_forum.link_button">
-                        <t t-set="url" t-value="'/forum/' + slug(forum) + '/question/' + slug(question) + '/reopen'"/>
+                        <t t-set="url" t-valuef="#{forum_base_path or '/forum'}/#{slug(forum)}/question/#{slug(question)}/reopen"/>
                         <t t-set="label">Reopen</t>
                         <t t-set="icon" t-value="'fa-folder-open'"/>
                         <t t-set="karma" t-value="question.karma_close if not question.can_close else 0"/>
@@ -339,7 +339,7 @@
                         <p><b class="d-block ">This answer has been flagged</b>
                             As a moderator, you can either validate or reject this answer.</p>
                         <t t-call="website_forum.link_button">
-                            <t t-set="url" t-valuef="/forum/#{ slug(forum) }/post/#{ slug(post_id) }/flag"/>
+                            <t t-set="url" t-valuef="#{forum_base_path or '/forum'}/#{ slug(forum) }/post/#{ slug(post_id) }/flag"/>
                             <t t-set="form_method" t-value="'GET'"/>
                             <t t-set="karma" t-value="post_id.forum_id.karma_flag if not post_id.can_flag else 0"/>
                             <t t-set="classes" t-valuef="o_wforum_flag"/>
@@ -379,7 +379,7 @@
                                 t-att-title="helper_no_karma if not post_id.can_accept else (helper_decline if answer.is_correct else (helper_accept if not answer.is_correct else (helper_own_post if answer.is_correct and answer.create_uid.id == uid else '')))"
                                 data-bs-toggle="tooltip"
                                 t-attf-data-target="#answer-#{post_id.id}"
-                                t-attf-data-href="/forum/#{ slug(question.forum_id) }/post/#{ slug(answer) }/toggle_correct">
+                                t-attf-data-href="#{forum_base_path or '/forum'}/#{ slug(question.forum_id) }/post/#{ slug(answer) }/toggle_correct">
                                 <i t-attf-class="fa fa-lg #{ 'fa-check-circle text-success' if answer.is_correct else 'fa-check-circle-o' }"/>
                             </a>
                         </t>
@@ -404,7 +404,7 @@
                         </t>
                         <div class="d-flex ms-auto me-2" t-if="post_id == answer and post_id.create_uid.id == uid">
                             <a class="btn btn-sm btn-outline-primary"
-                                t-attf-href="/forum/#{slug(forum)}/question/#{slug(question)}/edit_answer">
+                                t-attf-href="#{forum_base_path or '/forum'}/#{slug(forum)}/question/#{slug(question)}/edit_answer">
                                 <i class="fa fa-pencil"/>
                                 Edit<span class="d-none d-lg-inline"> your answer</span>
                             </a>
@@ -460,7 +460,7 @@
     <div class="dropdown-menu dropdown-menu-end" aria-labelledby="dropdownMenuLink">
         <t t-if="post_id == question">
             <t t-if="post_id.state == 'close'" t-call="website_forum.link_button">
-                <t t-set="url" t-value="'/forum/' + slug(forum) +'/question/' + slug(post_id) + '/reopen'"/>
+                <t t-set="url" t-valuef="#{forum_base_path or '/forum'}/#{slug(forum)}/question/#{slug(post_id)}/reopen"/>
                 <t t-set="label">Reopen</t>
                 <t t-set="inDropdown" t-value="True"/>
                 <t t-set="icon" t-value="'fa-undo fa-fw'"/>
@@ -468,7 +468,7 @@
             </t>
         </t>
         <t t-call="website_forum.link_button">
-            <t t-set="url" t-value="'/forum/' + slug(forum) +'/post/' + slug(post_id) + '/edit'"/>
+            <t t-set="url" t-valuef="#{forum_base_path or '/forum'}/#{slug(forum)}/post/#{slug(post_id)}/edit"/>
             <t t-set="label">Edit</t>
             <t t-set="inDropdown" t-value="True"/>
             <t t-set="icon" t-value="'fa-pencil fa-fw'"/>
@@ -476,21 +476,21 @@
         </t>
         <t t-if="post_id == question">
             <t t-if="post_id.state != 'close'" t-call="website_forum.link_button">
-                <t t-set="url" t-value="'/forum/' + slug(forum) +'/question/' + slug(post_id) + '/ask_for_close'"/>
+                <t t-set="url" t-valuef="#{forum_base_path or '/forum'}/#{slug(forum)}/question/#{slug(post_id)}/ask_for_close"/>
                 <t t-set="label">Close</t>
                 <t t-set="inDropdown" t-value="True"/>
                 <t t-set="icon" t-value="'fa-times fa-fw'"/>
                 <t t-set="karma" t-value="post_id.karma_close if not post_id.can_close else 0"/>
             </t>
             <t t-if="not post_id.active and post_id.state != 'offensive'" t-call="website_forum.link_button">
-                <t t-set="url" t-value="'/forum/' + slug(forum) +'/question/' + slug(post_id) + '/undelete'"/>
+                <t t-set="url" t-valuef="#{forum_base_path or '/forum'}/#{slug(forum)}/question/#{slug(post_id)}/undelete"/>
                 <t t-set="label">Undelete</t>
                 <t t-set="inDropdown" t-value="True"/>
                 <t t-set="icon" t-value="'fa-upload fa-fw'"/>
                 <t t-set="karma" t-value="post_id.karma_unlink if not post_id.can_unlink else 0"/>
             </t>
             <t t-if="not post_id.active and post_id.state == 'offensive'" t-call="website_forum.link_button">
-                <t t-set="url" t-value="'/forum/' + slug(forum) +'/post/' + slug(post_id) + '/validate'"/>
+                <t t-set="url" t-valuef="#{forum_base_path or '/forum'}/#{slug(forum)}/post/#{slug(post_id)}/validate"/>
                 <t t-set="label">Validate</t>
                 <t t-set="inDropdown" t-value="True"/>
                 <t t-set="icon" t-value="'fa-check fa-fw'"/>
@@ -498,21 +498,21 @@
             </t>
         </t>
         <t t-else="" t-call="website_forum.link_button">
-            <t t-set="url" t-valuef="/forum/#{slug(forum)}/post/#{slug(post_id)}/convert_to_comment"/>
+            <t t-set="url" t-valuef="#{forum_base_path or '/forum'}/#{slug(forum)}/post/#{slug(post_id)}/convert_to_comment"/>
             <t t-set="label">Convert to Comment</t>
             <t t-set="inDropdown" t-value="True"/>
             <t t-set="icon" t-valuef="fa-comment fa-fw"/>
             <t t-set="karma" t-value="post_id.karma_comment_convert if not post_id.can_comment_convert else 0"/>
         </t>
         <t t-if="post_id.active" t-call="website_forum.link_button">
-            <t t-set="url" t-value="'/forum/' + slug(forum) +'/question/' + slug(post_id) + '/delete'"/>
+            <t t-set="url" t-valuef="#{forum_base_path or '/forum'}/#{slug(forum)}/question/#{slug(post_id)}/delete"/>
             <t t-set="label">Delete</t>
             <t t-set="inDropdown" t-value="True"/>
             <t t-set="icon" t-value="'fa-trash-o fa-fw'"/>
             <t t-set="karma" t-value="post_id.karma_unlink if not post_id.can_unlink else 0"/>
         </t>
-        <t t-if="post_id.active and post_id.state != 'flagged'" t-call="website_forum.link_button">
-            <t t-set="url" t-value="'/forum/' + slug(forum) +'/post/' + slug(post_id) + '/flag'"/>
+        <t t-if="post_id.active and post_id.state != 'flagged' and not forum_embed" t-call="website_forum.link_button">
+            <t t-set="url" t-valuef="#{forum_base_path or '/forum'}/#{slug(forum)}/post/#{slug(post_id)}/flag"/>
             <t t-set="label">Flag</t>
             <t t-set="inDropdown" t-value="True"/>
             <t t-set="icon" t-value="'fa-flag-o' if not post_id.can_flag else 'fa-flag'"/>
@@ -528,7 +528,7 @@
     <div class="o_wforum_post_comments_container d-flex flex-column gap-2 rounded">
         <div class="css_editable_mode_hidden o_wforum_readable">
             <form t-att-id="_collapse_uid" class="oe_comment_grey js_website_submit_form js_wforum_submit_form collapse rounded o_cc2 p-2"
-                t-attf-action="/forum/#{slug(forum)}/post/#{slug(object)}/comment" method="POST">
+                t-attf-action="#{forum_base_path or '/forum'}/#{slug(forum)}/post/#{slug(object)}/comment" method="POST">
                     <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
                     <input name="post_id" t-att-value="object.id" type="hidden"/>
                     <div class="d-flex gap-1 w-100">
@@ -570,7 +570,7 @@
                         <i class="fa fa-ellipsis-h"/>
                     </a>
                     <div class="dropdown-menu">
-                        <t t-set="comment_url" t-valuef="/forum/#{ slug(forum) }/post/#{ slug(object) }/comment/#{ slug(message) }"/>
+                        <t t-set="comment_url" t-valuef="#{ forum_base_path or '/forum' }/#{ slug(forum) }/post/#{ slug(object) }/comment/#{ slug(message) }"/>
                         <t t-call="website_forum.link_button">
                             <t t-set="url" t-valuef="#{ comment_url }/delete"/>
                             <t t-set="label">Delete</t>
@@ -623,7 +623,7 @@
     <div class="o_wforum_sign_up_cta alert alert-info mt-4">
        <h6 class="alert-heading">Enjoying the discussion? Don't just read, join in!</h6>
        <p>Create an account today to enjoy exclusive features and engage with our awesome community!</p>
-       <a class="btn btn-primary me-2" t-att-href="'/web/login?redirect=forum/%s/%s' % (slug(forum), slug(question))">Sign up</a>
+       <a class="btn btn-primary me-2" t-att-href="'/web/login?redirect=%s/%s/%s' % (forum_base_path or '/forum', slug(forum), slug(question))">Sign up</a>
     </div>
 </template>
     </data>

--- a/addons/website_forum/views/forum_forum_templates_tools.xml
+++ b/addons/website_forum/views/forum_forum_templates_tools.xml
@@ -9,7 +9,7 @@
     <a href="#" t-att-data-post-id="object.id" t-attf-data-action="validate" t-attf-class="o_wforum_flag_validator flag_validator btn btn-success #{'' if object.state == 'flagged' else 'd-none'} my-2 me-2" title="Validate" data-bs-toggle="tooltip" data-bs-placement="top">
         <i class="fa fa-check"/> Accept
     </a>
-    <a href="#" t-attf-data-action="/forum/#{object.id}/ask_for_mark_as_offensive" t-attf-class="o_wforum_flag_mark_as_offensive flag_validator #{'' if object.state == 'flagged' else 'd-none'} btn btn-danger my-2 me-2" title="Mark as Offensive"  data-bs-toggle="tooltip" data-bs-placement="top">
+    <a href="#" t-attf-data-action="#{forum_base_path or '/forum'}/#{object.id}/ask_for_mark_as_offensive" t-attf-class="o_wforum_flag_mark_as_offensive flag_validator #{'' if object.state == 'flagged' else 'd-none'} btn btn-danger my-2 me-2" title="Mark as Offensive"  data-bs-toggle="tooltip" data-bs-placement="top">
         <i class="fa fa-times"/> Reject
     </a>
 </template>
@@ -104,7 +104,7 @@
     <t t-set="can_upvote" t-value="post.can_upvote"/>
     <t t-set="can_downvote" t-value="post.can_downvote"/>
     <div t-attf-class="vote d-inline-flex align-items-center gap-2 ms-n2 #{classes} text-muted text-center">
-        <button type="button" t-attf-data-href="/forum/#{slug(forum)}/post/#{slug(post)}/upvote"
+        <button type="button" t-attf-data-href="#{forum_base_path or '/forum'}/#{slug(forum)}/post/#{slug(post)}/upvote"
             t-attf-class="btn vote_up py-0 px-2 #{ 'text-success' if own_vote == 1 else '' } #{ 'karma_required text-reset opacity-50' if not can_upvote else ''}#{ ' text-300' if post.create_uid.id == uid else ''}"
             t-att-disabled="own_vote == 1 and 'disabled'"
             t-att-data-karma="forum.karma_upvote"
@@ -114,7 +114,7 @@
         </button>
         <small t-attf-class="vote_count #{ 'text-success' if own_vote == 1 else 'text-danger' if own_vote == -1 else ('text-muted opacity-75' if post.vote_count == 0 and not own_vote else '') }"
             t-out="post.vote_count"/>
-        <button type="button" t-attf-data-href="/forum/#{slug(forum)}/post/#{slug(post)}/downvote"
+        <button type="button" t-attf-data-href="#{forum_base_path or '/forum'}/#{slug(forum)}/post/#{slug(post)}/downvote"
             t-attf-class="btn vote_down py-0 px-2 #{ 'text-danger' if own_vote == -1 else ''} #{'karma_required text-reset opacity-50' if not can_downvote else '' }#{' text-300' if post.create_uid.id == uid else '' }"
             t-att-disabled="own_vote == -1 and 'disabled'"
             t-att-data-karma="forum.karma_downvote"
@@ -144,8 +144,8 @@
          t-att-data-bs-content="bio_popover_data"
          data-bs-placement="top">
         <t t-set="user_profile_url" t-value="False"/>
-        <t t-if="'forum_id' in object and (object.create_uid.id == request.session.uid or object.create_uid.sudo().website_published)">
-            <t t-set="user_profile_url" t-valuef="/forum/user/#{ object.create_uid.id }?forum_id=#{ object.forum_id.id }&amp;forum_origin=#{ request.httprequest.path }"/>
+        <t t-if="not forum_embed and 'forum_id' in object and (object.create_uid.id == request.session.uid or object.create_uid.sudo().website_published)">
+            <t t-set="user_profile_url" t-valuef="#{forum_base_path or '/forum'}/user/#{ object.create_uid.id }?forum_id=#{ object.forum_id.id }&amp;forum_origin=#{ request.httprequest.path }"/>
         </t>
         <a t-if="show_image" t-att-href="user_profile_url or '#'" t-attf-class="o_wforum_author_pic position-relative #{ 'pe-none' if not user_profile_url else '' }">
             <img t-attf-class="o_wforum_avatar rounded-circle o_object_fit_cover #{'me-2' if show_name or show_date or show_karma else '' } #{_image_classes}" t-att-src="website.image_url(object.create_uid, 'avatar_128', '60x60')" alt="Avatar"/>

--- a/addons/website_slides_forum/views/forum_forum_templates.xml
+++ b/addons/website_slides_forum/views/forum_forum_templates.xml
@@ -15,6 +15,12 @@
             </t>
         </xpath>
     </template>
+
+    <template id="back_to_course">
+        <a t-if="not forum_embed" t-attf-href="/slides/#{slug(forum.slide_channel_id)}#{'/' + slug(category) if category else ''}" t-out="forum.name"/>
+        <span t-else="" t-out="forum.name"/>
+    </template>
+
     <template name="Replace Breadcrumb Root" id="website_slides_forum_breadcrumb" inherit_id="website_forum.forum_model_nav" active="True">
         <xpath expr="//nav[@id='o_wforum_nav']" position="before">
             <t t-if="forum and forum.slide_channel_id" t-set="breadcrumb_kind" t-value="'slides'"/>
@@ -22,17 +28,17 @@
         <xpath expr="//div[hasclass('o_wforum_breadcrumb_root_single')]" position="inside">
             <ol t-if="breadcrumb_kind == 'slides'" class="breadcrumb order-first col-10 col-lg flex-grow-1 flex-nowrap my-0 p-0 fs-5">
                 <li class="breadcrumb-item">
-                    <a t-attf-href="/slides/#{slug(forum.slide_channel_id)}#{'/' + slug(category) if category else ''}" t-out="forum.name"/>
+                    <t t-call="website_slides_forum.back_to_course"/>
                 </li>
                 <li class="breadcrumb-item text-nowrap">
-                    <a t-attf-href="/forum/#{ slug(forum) }">Forum</a>
+                    <a t-attf-href="#{ forum_base_path or '/forum' }/#{ slug(forum) }">Forum</a>
                 </li>
             </ol>
         </xpath>
         <xpath expr="//div[hasclass('o_wforum_breadcrumb_root_list_or_edit')]" position="inside">
             <ol t-if="breadcrumb_kind == 'slides'" class="breadcrumb order-first col-10 col-lg flex-grow-1 flex-nowrap my-0 p-0 fs-5">
                 <li class="breadcrumb-item text-nowrap">
-                    <a t-attf-href="/slides/#{slug(forum.slide_channel_id)}#{'/' + slug(category) if category else ''}" t-out="forum.name"/>
+                   <t t-call="website_slides_forum.back_to_course"/>
                 </li>
                 <li class="breadcrumb-item text-nowrap">
                     <strong>Forum</strong>

--- a/addons/website_slides_forum/views/website_slides_templates.xml
+++ b/addons/website_slides_forum/views/website_slides_templates.xml
@@ -3,10 +3,19 @@
     <template id='course_main' inherit_id="website_slides.course_main">
         <!-- Channel main template: add link to forum -->
         <xpath expr="//li[hasclass('o_wslides_course_header_nav_review')]" position="after">
-            <li class="nav-item" t-if="not invite_preview and (channel.is_member or channel.visibility == 'public') and channel.forum_id">
-                <a t-att-href="'/forum/%s' % (slug(channel.forum_id))"
-                    t-att-class="'nav-link'" target="new">Forum</a>
+            <li class="nav-item" role="presentation" t-if="not invite_preview and (channel.is_member or channel.visibility == 'public') and channel.forum_id">
+                <a href="#forum" t-att-aria-selected="'true' if active_tab == 'forum' else 'false'"
+                   t-att-class="'nav-link %s' % ('active' if active_tab == 'forum' else '')"
+                   id="forum-tab" data-bs-toggle="pill" role="tab" aria-controls="forum">
+                    Forum
+                </a>
             </li>
+        </xpath>
+        <xpath expr="//div[@id='home']" position="after">
+            <div t-att-class="'tab-pane fade %s' % ('show active' if active_tab == 'forum' else '')" id="forum" role="tabpanel" aria-labelledby="forum-tab"
+                 t-if="not invite_preview and (channel.is_member or channel.visibility == 'public') and channel.forum_id">
+                <iframe class="w-100 vh-100 border rounded" frameborder="0" t-attf-src="/forum/embed/#{slug(channel.forum_id)}"/>
+            </div>
         </xpath>
     </template>
 


### PR DESCRIPTION
[IMP] website_{forum|slide_forum}: embed forum

We improve the integration of the forum in the course by using an iframe instead of opening it in a new window. This new embedded version allows to embed a given forum in an iframe and ensure that no action performed on that iframe (links and forms) won't make the user leave that given forum.

Currently, we use that feature for the course forum to allow the user to use the course forum without leaving the course but it could be used in the future, for example, to share a forum to embed it in another website.

Technically, most of the forum URL (beginning with "/forum") have an embed counter part (beginning with /forum/embed"). We first considered using a parameter instead of changing the URL but it was not easy to keep that
parameter for every click the user can do (for example, we had to tweak the ir_qweb keep_query or add that parameter everywhere keep_query is used).

When the URL starts with /forum/embed, the header, the footer and the menu is removed and the links that target other apps are removed (ex.: breadcrumb that target the related course). The template have been modified with conditional statement using the variable "forum_embed" (which is only True when the URL starts with "/forum/embed"). We have also changed every hard coded URL starting with "/forum" by using the dynamic value stored in the variable "forum_base_path". And finally, we also add in that case, the class o_forum_embed on the body to remove with css the button to navigate to the backend/to the website editor.

As the sitemap is generated by dedicated functions, adding the embed route doesn't change it as long as we avoid doing it on routes with the parameter sitemap=True (which is the case of only 2 routes that we don't convert for the
embedded version).

Notes:
- In the embedded view, we remove:
  - The welcome message as it can contain hard-coded links and because the forum can be introduced by the site which embed it.
  - The side menu as the embedded view is to display a given forum. Note that removing it, remove the faq and some "backend" feature like "moderation tools".
  - The possibility to flag a post.
- To avoid error where the "forum_base_path" is not defined, we use the expression "forum_base_path or '/forum'" everywhere /forum was used except in the mail where we keep /forum as we don't want to redirect to the embedded
version.

[IMP] website_forum: duplicate forum tour for testing embed version

We duplicate the forum tour to test the embed version.

Technical note: we modify the step "This page contain new created question." because it was actually testing an icon in the menu (the star in front of the favorites menu rather than checking the post was displayed) which is not
present in the embed version.

[IMP] website_forum: test embedded forum

We ensure that there are no embed forum URL in the sitemap and we test the embedded forum confinement i.e. that when we are on the embedded version, we stay on it by clicking on the actions/links of the pages and that there are no actions/links to the embedded forum in the non-embedded version.

Task-3974177