### PR TITLE
[FIX] tools: added Image validation in html2plaintext

### DIFF
--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -380,6 +380,15 @@ def html2plaintext(html, body_id=None, encoding='utf-8'):
             link.text = '%s [%s]' % (link.text, i)
             url_index.append(url)
 
+    for img in tree.findall('.//img'):
+        src = img.get('src')
+        if src:
+            i += 1
+            img.tag = 'span'
+            img_name = re.search(r'[^/]+(?=\.[a-zA-Z]+(?:\?|$))', src)
+            img.text = '%s [%s]' % (img_name.group(0) if img_name else 'Image', i)
+            url_index.append(src)
+
     html = ustr(etree.tostring(tree, encoding=encoding))
     # \r char is converted into &#13;, must remove it
     html = html.replace('&#13;', '')


### PR DESCRIPTION
**Steps to reproduce:**
- Open "Configure Document Layout" in settings.
- Add only an image in the company_details section.

**Issue:**

- The customer added only an image to company_details in their production version 15.2. However, after migrating to version 17, the image appears in company_details but does not show up in the document preview. In version 15.2, there were some changes to company details that caused this issue https://github.com/odoo/odoo/pull/122438. 
- Due to these changes, company_details is processed with the html2plaintext() function, which removes all the tags from company_details and only links and text will remain.
- This function does not recognize the image element and removes it along with other elements. I have prepared a fix that recognizes the image element from company_details and prevents it from getting discarded.
- Video reference from RunBot version 17: https://drive.google.com/file/d/1Ml62xIV1mhwKwU8KRHdc-qfTFCZhEqY0/view?usp=sharing
- I have also added a test case for html2plaintext function in test_html2plaintext function by backporting this method from 
master.

OPW : [3945490](https://www.odoo.com/odoo/my-tasks/3945490?cids=2)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
