### PR TITLE
[PERF] base,website: avoid assets invalidation in multiwebsite

### DIFF
--- a/addons/website/models/ir_qweb.py
+++ b/addons/website/models/ir_qweb.py
@@ -114,6 +114,13 @@ class IrQWeb(models.AbstractModel):
     def _get_asset_bundle(self, xmlid, files, env=None, css=True, js=True):
         return AssetsBundleMultiWebsite(xmlid, files, env=env)
 
+    def _get_asset_nodes(self, bundle, css=True, js=True, debug=False, async_load=False, defer_load=False, lazy_load=False, media=None):
+        website = self.env['website'].get_current_website(fallback=False)
+        self_website = self
+        if website:
+            self_website = self.with_context(website_id=website.id)
+        return super(IrQWeb, self_website)._get_asset_nodes(bundle, css=css, js=js, debug=debug, async_load=async_load, defer_load=defer_load, lazy_load=lazy_load, media=media)
+
     def _post_processing_att(self, tagName, atts):
         if atts.get('data-no-post-process'):
             return atts

--- a/addons/website/tests/test_assets.py
+++ b/addons/website/tests/test_assets.py
@@ -65,3 +65,35 @@ class TestWebsiteAssets(odoo.tests.HttpCase):
         check_asset()
         self.url_open(domain_1 + '/web')
         check_asset()
+
+    def test_02_multi_domain_assets_generation(self):
+        # Create an additional website to ensure it works in multi-website setup
+        website2 = self.env['website'].create({'name': 'Second Website'})
+
+        self.authenticate('admin', 'admin')
+        # Edit one of the website to force assets to be different
+        self.env['web_editor.assets'].with_context(website_id=1).make_scss_customization(
+            '/website/static/src/scss/options/colors/user_color_palette.scss',
+            {"o-cc1-bg": "'400'"},
+        )
+
+        def get_backend_asset_attach():
+            return self.env['ir.attachment'].search([('name', '=', 'web.assets_backend.min.js')])
+
+        self.url_open('/website/force/1')
+        self.url_open('/web')
+        asset_website1 = get_backend_asset_attach().filtered(lambda r: r.website_id.id == 1)
+        self.assertIn(1, get_backend_asset_attach().mapped('website_id').ids)
+        self.url_open('/website/force/%s' % website2.id)
+        self.url_open('/web')
+        asset_website2 = get_backend_asset_attach().filtered(lambda r: r.website_id.id == website2.id)
+        self.assertIn(1, get_backend_asset_attach().mapped('website_id').ids)
+        self.assertIn(website2.id, get_backend_asset_attach().mapped('website_id').ids)
+        self.url_open('/website/force/1')
+        self.url_open('/web')
+        self.assertIn(1, get_backend_asset_attach().mapped('website_id').ids)
+        self.assertIn(website2.id, get_backend_asset_attach().mapped('website_id').ids)
+        self.url_open('/website/force/%s' % website2.id)
+        self.url_open('/web')
+        self.assertEqual(asset_website1, get_backend_asset_attach().filtered(lambda r: r.website_id.id == 1))
+        self.assertEqual(asset_website2, get_backend_asset_attach().filtered(lambda r: r.website_id.id == website2.id))

--- a/odoo/addons/base/models/assetsbundle.py
+++ b/odoo/addons/base/models/assetsbundle.py
@@ -280,6 +280,7 @@ class AssetsBundle(object):
         # avoid to invalidate cache if it's already empty (mainly useful for test)
 
         if attachments:
+            _logger.info('Deleting ir.attachment %s (from bundle %s)', attachments.ids, self.name)
             self._unlink_attachments(attachments)
             # force bundle invalidation on other workers
             self.env['ir.qweb'].clear_caches()
@@ -319,6 +320,8 @@ class AssetsBundle(object):
          """, [SUPERUSER_ID, url_pattern])
 
         attachment_ids = [r[0] for r in self.env.cr.fetchall()]
+        if not attachment_ids:
+            _logger.info('Failed to find attachment for assets %s', url_pattern)
         return self.env['ir.attachment'].sudo().browse(attachment_ids)
 
     def add_post_rollback(self):


### PR DESCRIPTION
When 2 different users navigate a different website while being connected, it sets force_website_id on their session.
Getting the web.assets_backend when going to /web would then depend on the theme installed on the forced website. The 2 users will invalidate the assets backend of each other, invalidating the cache.
    
Generating the backend assets should not depend on the website as used in get_current_website but it does due to tours from themes being in website.assets_editor which is included in web.assets_backend
    
Similar issue to this: https://github.com/odoo/odoo/pull/118526 but for another corner case
    
To avoid this, we use get_current_website to add the website_id in the context so it is coherent everywhere. This will create multiple web.assets_backend (one per website and only if they have different themes) and will prevent the unwanted unlink of the previous assets.

opw-3603541