### PR TITLE
[IMP] web: calendar scroll to current hour

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.js
+++ b/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.js
@@ -8,6 +8,7 @@ import { CalendarCommonPopover } from "./calendar_common_popover";
 import { makeWeekColumn } from "./calendar_common_week_column";
 
 import { Component } from "@odoo/owl";
+import { useBus } from "@web/core/utils/hooks";
 
 const SCALE_TO_FC_VIEW = {
     day: "timeGridDay",
@@ -61,6 +62,9 @@ export class CalendarCommonRenderer extends Component {
         this.fc = useFullCalendar("fullCalendar", this.options);
         this.click = useClickHandler(this.onClick, this.onDblClick);
         this.popover = useCalendarPopover(this.constructor.components.Popover);
+        useBus(this.props.model.bus, "SCROLL_TO_CURRENT_HOUR", () =>
+            this.fc.api.scrollToTime(`${luxon.DateTime.local().hour - 2}:00:00`)
+        );
     }
 
     get options() {

--- a/addons/web/static/src/views/calendar/calendar_controller.js
+++ b/addons/web/static/src/views/calendar/calendar_controller.js
@@ -377,6 +377,9 @@ export class CalendarController extends Component {
                 break;
             case "today":
                 date = luxon.DateTime.local().startOf("day");
+                if (date.ts === this.date.startOf("day").ts) {
+                    this.model.bus.trigger("SCROLL_TO_CURRENT_HOUR", false);
+                }
                 break;
         }
         await this.model.load({ date });

--- a/addons/web/static/src/views/calendar/calendar_model.js
+++ b/addons/web/static/src/views/calendar/calendar_model.js
@@ -44,8 +44,8 @@ export class CalendarModel extends Model {
         if (!this.meta.date) {
             this.meta.date =
                 params.context && params.context.initial_date
-                    ? deserializeDateTime(params.context.initial_date)
-                    : luxon.DateTime.local();
+                    ? deserializeDateTime(params.context.initial_date).startOf("day")
+                    : luxon.DateTime.local().startOf("day");
         }
         // Prevent picking a scale that is not supported by the view
         if (!this.meta.scales.includes(this.meta.scale)) {
@@ -846,7 +846,9 @@ export class CalendarModel extends Model {
             recordId: null,
             value: "all",
             label: isUserOrPartner ? _t("Everybody's calendars") : _t("Everything"),
-            active: previousAllFilter ? previousAllFilter.active : this.meta.allFilter[sectionLabel] || false,
+            active: previousAllFilter
+                ? previousAllFilter.active
+                : this.meta.allFilter[sectionLabel] || false,
             canRemove: false,
             colorIndex: null,
             hasAvatar: false,

--- a/addons/web/static/tests/views/calendar/calendar_test_helpers.js
+++ b/addons/web/static/tests/views/calendar/calendar_test_helpers.js
@@ -1,5 +1,6 @@
 import { drag, hover, queryFirst, queryRect } from "@odoo/hoot-dom";
 import { animationFrame, runAllTimers } from "@odoo/hoot-mock";
+import { EventBus } from "@odoo/owl";
 import { contains } from "@web/../tests/web_test_helpers";
 
 import { createElement } from "@web/core/utils/xml";
@@ -171,6 +172,7 @@ export const FAKE_FIELDS = {
 };
 
 export const FAKE_MODEL = {
+    bus: new EventBus(),
     canCreate: true,
     canDelete: true,
     canEdit: true,

--- a/addons/web/static/tests/views/calendar/calendar_view.test.js
+++ b/addons/web/static/tests/views/calendar/calendar_view.test.js
@@ -3861,3 +3861,19 @@ test(`Retaining the 'all' filter value on re-rendering`, async () => {
     await getService("action").switchView("calendar");
     expect(`.o_calendar_filter_item[data-value='all'] input`).toBeChecked();
 });
+
+test(`scroll to current hour when clicking on today`, async () => {
+    mockDate("2016-12-12T01:00:00", 1);
+    await mountView({
+        resModel: "event",
+        type: "calendar",
+        arch: `<calendar event_open_popup="1" date_start="start" date_stop="stop" all_day="is_all_day" mode="week"/>`,
+    });
+    // Default scroll time should be 6am no matter the current hour
+    expect(queryLast(".fc-scroller").scrollTop).toBeWithin(210, 230);
+    await contains(".o_calendar_button_today").click();
+    expect(queryLast(".fc-scroller").scrollTop).toBe(0);
+    mockDate("2016-12-12T20:00:00", 1);
+    await contains(".o_calendar_button_today").click();
+    expect(queryLast(".fc-scroller").scrollTop).toBeWithin(360, 380);
+});


### PR DESCRIPTION
This commit adds a functionality to the calendar which allows to scroll to the current hour when the user clicks on the today button while the current day is already in the views

task-3629959
