### PR TITLE
[FIX] hw_*: Add possibility to access to the iot with the port 80

### DIFF
--- a/setup/win32/conf/nginx/nginx.conf
+++ b/setup/win32/conf/nginx/nginx.conf
@@ -16,4 +16,12 @@ http {
             proxy_pass http://127.0.0.1:8069;
         }
     }
+    server {
+        listen 80;
+        listen [::]:80;
+        location / {
+            proxy_read_timeout 600s;
+            proxy_pass http://127.0.0.1:8069;
+        }
+    }
 }


### PR DESCRIPTION
Currently it is only possible to access Windows IOT via port 8069 or 443. With this commit let's configure Nginx so that it also listens on port 80

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
