### PR TITLE
[FIX] resource: prevent attributeerror when opening hours is not selected

### DIFF
--- a/addons/resource/models/resource_resource.py
+++ b/addons/resource/models/resource_resource.py
@@ -144,6 +144,8 @@ class ResourceResource(models.Model):
             calendar_mapping[resource.calendar_id or resource.company_id.resource_calendar_id] |= resource
 
         for calendar, resources in calendar_mapping.items():
+            if not calendar:
+                continue
             resources_unavailable_intervals = calendar._unavailable_intervals_batch(start_datetime, end_datetime, resources, tz=timezone(calendar.tz))
             resource_mapping.update(resources_unavailable_intervals)
         return resource_mapping

--- a/addons/test_resource/tests/test_resource.py
+++ b/addons/test_resource/tests/test_resource.py
@@ -1401,3 +1401,13 @@ class TestResource(TestResourceCommon):
         })
         resource_hour = resource._get_hours_per_day(resource_attendance)
         self.assertEqual(resource_hour, 0.0)
+
+    def test_resource_without_calendar(self):
+        resource = self.env['resource.resource'].create({
+            'name': 'resource',
+            'calendar_id': False,
+        })
+
+        resource.company_id.resource_calendar_id = False
+        unavailabilities = resource._get_unavailable_intervals(datetime(2024, 7, 11), datetime(2024, 7, 12))
+        self.assertFalse(unavailabilities)


### PR DESCRIPTION
When User opens an appointment with resource that does not have Opening Hours,
a traceback will appear.

Steps to reproduce the error:
- Go to 'Appointments' > Configuration > Resources >
  Create a new Resource without opening hours (ex. court) > Save
- Create new Appointment > Availability on: resources > Resource: court > Save
- Click on Go to website or Preview

Traceback:
```
AttributeError: 'bool' object has no attribute 'upper'
  File "odoo/http.py", line 2232, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1807, in _serve_db
    return self._transactioning(_serve_ir_http, readonly=ro)
  File "odoo/http.py", line 1827, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1805, in _serve_ir_http
    return self._serve_ir_http(rule, args)
  File "odoo/http.py", line 1812, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1950, in dispatch
    return self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 220, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 740, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "home/odoo/src/enterprise/saas-17.2/appointment/controllers/appointment.py", line 210, in appointment_type_page
    return self._get_appointment_type_page_view(appointment_type, page_values, state, **kwargs)
  File "home/odoo/src/enterprise/saas-17.2/website_appointment/controllers/appointment.py", line 108, in _get_appointment_type_page_view
    return super()._get_appointment_type_page_view(appointment_type, page_values, state, **kwargs)
  File "home/odoo/src/enterprise/saas-17.2/appointment/controllers/appointment.py", line 228, in _get_appointment_type_page_view
    slots = appointment_type._get_appointment_slots(
  File "home/odoo/src/enterprise/saas-17.2/appointment/models/appointment_type.py", line 798, in _get_appointment_slots
    self._slots_fill_resources_availability(
  File "home/odoo/src/enterprise/saas-17.2/appointment/models/appointment_type.py", line 1183, in _slots_fill_resources_availability
    availability_values = self._slot_availability_prepare_resources_values(
  File "home/odoo/src/enterprise/saas-17.2/appointment/models/appointment_type.py", line 1369, in _slot_availability_prepare_resources_values
    resources_values.update(self._slot_availability_prepare_resources_leave_values(resources, start_dt_utc, end_dt_utc))
  File "home/odoo/src/enterprise/saas-17.2/appointment/models/appointment_type.py", line 1422, in _slot_availability_prepare_resources_leave_values
    unavailabilities = appointment_resources.sudo().resource_id._get_unavailable_intervals(start_dt_utc, end_dt_utc)
  File "addons/resource/models/resource_resource.py", line 152, in _get_unavailable_intervals
    resources_unavailable_intervals = calendar._unavailable_intervals_batch(start_datetime, end_datetime, resources, tz=timezone(calendar.tz))
  File "odoo/tools/_monkeypatches_pytz.py", line 129, in timezone
    return original_pytz_timezone(name)
  File "__init__.py", line 183, in timezone
    if zone.upper() == 'UTC':
```

https://github.com/odoo/odoo/blob/6cb52b4a02a7b3236c20863b177bfaadf474651d/addons/resource/models/resource_resource.py#L147 Here, when the user does not select Opening Hours in resource,
"calendar.tz" will be False.
So, it will lead to the above traceback.

sentry-5475389977

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
