### PR TITLE
[FIX] calendar: prevent error while drag & drop calendar event

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -626,7 +626,7 @@ class Meeting(models.Model):
     def write(self, values):
         detached_events = self.env['calendar.event']
         recurrence_update_setting = values.pop('recurrence_update', None)
-        update_recurrence = recurrence_update_setting in ('all_events', 'future_events') and len(self) == 1
+        update_recurrence = recurrence_update_setting in ('all_events', 'future_events') and len(self) == 1 and self.recurrence_id
         break_recurrence = values.get('recurrency') is False
 
         if any(vals in self._get_recurrent_fields() for vals in values) and not (update_recurrence or values.get('recurrency')):


### PR DESCRIPTION
This error occurs when the user drag & drop the newly created calendar event and select ``This and Following events`` in ``Edit Recurrent event``

Steps to reproduce:
- Install ``Calendar`` module
- Create a new event from the Calendar view
- Edit event -> Enable ``Recurrent``
- Now click on any day from ``Repeat on`` and remove the day which is selected by 
  default (eg: if Tuesday is the default then select Monday and unselect Tuesday)
- Save and Unarchive it and go back to the calendar view
- Now drag & drop the newly created event to anywhere and select 
  ``This and Following events`` in ``Edit Recurrent event``

Traceback: 
``ValueError: not enough values to unpack (expected 1, got 0)``

The error on line [1] occurs because ``recurrence_id`` is not found in ``self``. This issue stems from a change made in commit [2], where ``recurrency`` was set to ``True``. Consequently, when an event is archived, ``recurrency`` remains ``True``, but the event lacks a ``recurrence_id``. This absence of ``recurrence_id`` in ``self`` at line [1] triggers an error. However, before this commit, the expected behavior was that when an event is archived, ``recurrency`` should be set to ``False``.

This commit will fix the error by passing ``false`` for ``update_recurrence`` when ``recurrence_id`` is not present.

[1]: https://github.com/odoo/odoo/blob/d7cfef9c51461a595f3f46c7b91e5c56241d4af3/addons/calendar/models/calendar_event.py#L1196
[2]: https://github.com/odoo/odoo/commit/48e3f725a2506ca63336a131661542cacc6f1ab5

sentry-5462902179

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
