### PR TITLE
[FIX] account: Adding company default tax for bill and invoice.

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -897,6 +897,11 @@ class AccountMoveLine(models.Model):
         if self.company_id and tax_ids:
             tax_ids = tax_ids._filter_taxes_by_company(self.company_id)
 
+        if not tax_ids and self.move_id.is_sale_document(include_receipts=True):
+            tax_ids = self.move_id.company_id.account_sale_tax_id
+        elif not tax_ids and self.move_id.is_purchase_document(include_receipts=True):
+            tax_ids = self.move_id.company_id.account_purchase_tax_id
+
         if tax_ids and self.move_id.fiscal_position_id:
             tax_ids = self.move_id.fiscal_position_id.map_tax(tax_ids)
 

--- a/addons/account/tests/test_account_journal_dashboard.py
+++ b/addons/account/tests/test_account_journal_dashboard.py
@@ -107,7 +107,7 @@ class TestAccountJournalDashboard(AccountTestInvoicingCommon):
             'partner_id': self.partner_a.id,
             'currency_id': currency.id,
             'invoice_line_ids': [
-                (0, 0, {'name': 'test', 'price_unit': 200})
+                (0, 0, {'name': 'test', 'price_unit': 200, 'tax_ids': None})
             ],
         })
         invoice.action_post()


### PR DESCRIPTION
Company default tax was removed from odoo 17 when the code was rewritten. This feature was available in Odoo 16. This code reimplements this feature for Odoo 17 if no tax is set on bill or invoice. This will also give a default tax on bills with only text lines.