### PR TITLE
[FIX] product: improve UX on form view of product

### DIFF
--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -90,7 +90,7 @@
                                             options="{'currency_field': 'currency_id', 'field_digits': True}"/>
                                             <span name="uom_span" groups="uom.group_uom">per
                                                 <field name="uom_id"
-                                                    class="oe_inline"
+                                                    class="oe_inline" style="max-width:136px"
                                                     options="{'no_create': True}"/>
                                             </span>
                                     </div>
@@ -446,7 +446,7 @@
                     <field name="product_tmpl_id" class="oe_inline" readonly="1" invisible="1" required="id"/>
                 </field>
                 <xpath expr="//div[hasclass('oe_title')]" position="inside">
-                    <field name="product_template_variant_value_ids" widget="many2many_tags" readonly="1" groups="product.group_product_variant"/>
+                    <field name="product_template_variant_value_ids" widget="many2many_tags" readonly="1" invisible="not product_template_variant_value_ids" groups="product.group_product_variant"/>
                 </xpath>
                 <field name="product_tag_ids" position="attributes">
                     <attribute name="options">{'no_open': True}</attribute>

--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -614,6 +614,13 @@
             display: inline-block;
             text-align: right;
             border: none;  // usefull for textarea
+            visibility: hidden;
+    }
+
+    div {
+        div:focus-within > span.o_field_translate, div:hover > span.o_field_translate {
+            visibility: visible !important;
+        }
     }
 
     input, textarea {

--- a/addons/web/static/tests/views/fields/char_field.test.js
+++ b/addons/web/static/tests/views/fields/char_field.test.js
@@ -266,6 +266,7 @@ test("char field translatable", async () => {
         }
     });
     expect("[name=name] input").toHaveClass("o_field_translate");
+    await contains("[name=name] input").click();
     expect(".o_field_char .btn.o_field_translate").toHaveCount(1, {
         message: "should have a translate button",
     });
@@ -353,6 +354,7 @@ test("translation dialog should close if field is not there anymore", async () =
         }
     });
     expect("[name=name] input").toHaveClass("o_field_translate");
+    await contains("[name=name] input").click();
     await contains(".o_field_char .btn.o_field_translate").click();
     expect(".modal").toHaveCount(1, {
         message: "a translate modal should be visible",

--- a/addons/web/static/tests/views/fields/html_field.test.js
+++ b/addons/web/static/tests/views/fields/html_field.test.js
@@ -1,5 +1,6 @@
 import {
     clickSave,
+    contains,
     defineModels,
     fields,
     models,
@@ -204,6 +205,7 @@ test("field html translatable", async () => {
     });
 
     expect("[name=txt] textarea").toHaveClass("o_field_translate");
+    await contains("[name=txt] textarea").click();
     expect(".o_field_html .btn.o_field_translate").toHaveCount(1, {
         message: "should have a translate button",
     });

--- a/addons/web/static/tests/views/fields/text_field.test.js
+++ b/addons/web/static/tests/views/fields/text_field.test.js
@@ -129,6 +129,7 @@ test("is translatable", async () => {
         arch: `<form><sheet><group><field name="description"/></group></sheet></form>`,
     });
     expect(".o_field_text textarea").toHaveClass("o_field_translate");
+    await contains(".o_field_text textarea").click()
     expect(".o_field_text .btn.o_field_translate").toHaveCount(1);
     await contains(".o_field_text .btn.o_field_translate").click();
     expect(".modal").toHaveCount(1);

--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -7531,6 +7531,7 @@ test(`translation dialog with right context and domain`, async () => {
         arch: `<form><field name="name"/></form>`,
         resId: 1,
     });
+    await contains(".o_field_translate").click();
     await contains(`.o_field_translate.btn-link`).click();
     expect([
         `translate args [[1],"name"]`,
@@ -7563,6 +7564,7 @@ test(`save new record before opening translate dialog`, async () => {
     expect(["get_views", "onchange"]).toVerifySteps();
     expect(`.o_form_editable`).toHaveCount(1);
 
+    await contains(`.o_field_translate`).click();
     await contains(`.o_field_translate.btn-link`).click();
     expect(["web_save", "get_field_translations"]).toVerifySteps();
     expect(`.modal`).toHaveCount(1);
@@ -7618,6 +7620,7 @@ test(`translate event correctly handled with multiple controllers`, async () => 
     expect(`.o_dialog`).toHaveCount(1);
 
     await contains(`[name="product_id"] .o_external_button`, { visible: false }).click();
+    await contains(`.o_field_translate`).click();
     expect(`.o_dialog:eq(1) span.o_field_translate`).toHaveCount(1);
 
     await contains(`.o_dialog:eq(1) span.o_field_translate`).click();


### PR DESCRIPTION
An empty line was rendered even if no tags of variants were put on
a product.
And the UoM on the form view of the products is on 2 lines.
The length of the size was limited (as UoM don't need to be that long).

While checking this view, it was noticed that the button to change 
the name in other languages (when you have
several activated) can be quite invasive.
We decided to render it only on hover/focus (everywhere).
task-3979068


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
