### PR TITLE
[FIX] mail: discuss public channel guest notification settings

### DIFF
--- a/addons/mail/static/src/discuss/core/common/thread_actions.js
+++ b/addons/mail/static/src/discuss/core/common/thread_actions.js
@@ -14,7 +14,11 @@ import { usePopover } from "@web/core/popover/popover_hook";
 threadActionsRegistry
     .add("notification-settings", {
         condition(component) {
-            return component.thread?.model === "discuss.channel" && !component.props.chatWindow;
+            return (
+                component.thread?.model === "discuss.channel" &&
+                !component.props.chatWindow &&
+                component.store.self.type !== "guest"
+            );
         },
         setup(action) {
             const component = useComponent();


### PR DESCRIPTION
**Current behavior before PR:**

In discuss guest user view, notification settings button was visible, which used to throw a "Session Expired" error upon being clicked.

**Desired behavior after PR is merged:**

In discuss guest user view, notification settings button is removed.

**task:3975859**

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
