### PR TITLE
[FIX] mail,im_livechat: exclude bots from HasEveryoneSeen

### DIFF
--- a/addons/im_livechat/static/src/embed/common/thread_model_patch.js
+++ b/addons/im_livechat/static/src/embed/common/thread_model_patch.js
@@ -38,6 +38,10 @@ patch(Thread.prototype, {
         return this.newestMessage?.isSelfAuthored;
     },
 
+    get membersThatCanSeen() {
+        return super.membersThatCanSeen.filter(({ persona }) => !persona.is_bot);
+    },
+
     get avatarUrl() {
         if (this.channel_type === "livechat") {
             return this.operator.avatarUrl;

--- a/addons/mail/static/src/core/common/channel_member_model.js
+++ b/addons/mail/static/src/core/common/channel_member_model.js
@@ -89,6 +89,13 @@ export class ChannelMember extends Record {
     get memberSince() {
         return this.create_date ? deserializeDateTime(this.create_date) : undefined;
     }
+
+    /**
+     * @param {import("models").Message} message
+     */
+    hasSeen(message) {
+        return this.persona.eq(message.author) || this.seen_message_id?.id >= message.id;
+    }
 }
 
 ChannelMember.register();

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -48,16 +48,7 @@ export class Message extends Record {
     hasEveryoneSeen = Record.attr(false, {
         /** @this {import("models").Message} */
         compute() {
-            if (!this.thread) {
-                return false;
-            }
-            const otherDidNotSee = this.thread.channelMembers.filter((member) => {
-                return (
-                    member.persona.notEq(this.author) &&
-                    (!member.seen_message_id || member.seen_message_id.id < this.id)
-                );
-            });
-            return otherDidNotSee.length === 0;
+            return this.thread?.membersThatCanSeen.every((m) => m.hasSeen(this));
         },
     });
     isMessagePreviousToLastSelfMessageSeenByEveryone = Record.attr(false, {
@@ -80,13 +71,9 @@ export class Message extends Record {
     hasSomeoneSeen = Record.attr(false, {
         /** @this {import("models").Message} */
         compute() {
-            if (!this.thread) {
-                return false;
-            }
-            const otherSeen = this.thread.channelMembers.filter(
-                (m) => m.persona.notEq(this.author) && m.seen_message_id?.id >= this.id
-            );
-            return otherSeen.length > 0;
+            return this.thread?.membersThatCanSeen
+                .filter(({ persona }) => !persona.eq(this.author))
+                .some((m) => m.hasSeen(this));
         },
     });
     hasSomeoneFetched = Record.attr(false, {

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -89,6 +89,14 @@ export class Thread extends Record {
         onDelete: (r) => r.delete(),
         sort: (m1, m2) => m1.id - m2.id,
     });
+    /**
+     * To be overridden.
+     * The purpose is to exclude technical channelMembers like bots and avoid
+     * "wrong" seen message indicator
+     */
+    get membersThatCanSeen() {
+        return this.channelMembers;
+    }
     typingMembers = Record.many("ChannelMember", { inverse: "threadAsTyping" });
     otherTypingMembers = Record.many("ChannelMember", {
         /** @this {import("models").Thread} */


### PR DESCRIPTION
Before this PR, if a livechat channel had a bot in the channel members, a message could not be marked as seen by everyone because the bot would never read it.

This PR removes the bots from the computing of HasEveryoneSeen allowing the message to be marked properly.
