### PR TITLE
[FIX] product_expiry: scheduled_date can be false

### DIFF
--- a/addons/product_expiry/models/stock_move_line.py
+++ b/addons/product_expiry/models/stock_move_line.py
@@ -36,7 +36,8 @@ class StockMoveLine(models.Model):
             elif move_line.picking_type_use_create_lots:
                 if move_line.product_id.use_expiration_date:
                     if not move_line.expiration_date:
-                        move_line.expiration_date = move_line.picking_id.scheduled_date + datetime.timedelta(days=move_line.product_id.expiration_time)
+                        from_date = move_line.picking_id.scheduled_date or fields.Datetime.today()
+                        move_line.expiration_date = from_date + datetime.timedelta(days=move_line.product_id.expiration_time)
                 else:
                     move_line.expiration_date = False
 
@@ -54,7 +55,8 @@ class StockMoveLine(models.Model):
         res = super()._onchange_product_id()
         if self.picking_type_use_create_lots:
             if self.product_id.use_expiration_date:
-                self.expiration_date = self.picking_id.scheduled_date + datetime.timedelta(days=self.product_id.expiration_time)
+                from_date = self.picking_id.scheduled_date or fields.Datetime.today()
+                self.expiration_date = from_date + datetime.timedelta(days=self.product_id.expiration_time)
             else:
                 self.expiration_date = False
         return res


### PR DESCRIPTION
Current behaviour:
---
When scheduled_date is not set, we get a traceback

Steps to reproduce:
---
1. Create Product FNS storable
2. Create Product CMP storable
3. Create quant for 10 units of CMP
4. Set CMP tracking to 'Lot' and 'Use expiration date' to True
5. Create MO for 1 unit of FNS using 1 unit of CMP
6. Try to Confirm: Traceback

Cause of the issue:
---
Caused by: https://github.com/odoo/odoo/commit/f1d4a727a84672d974151f681e43768abd3ac7cc

opw-3981689

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
