### PR TITLE
[IMP] website_sale: add title block for the alternative products

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1521,14 +1521,18 @@
                     data-name="Alternative Products" style="background-image: none;" t-att-data-filter-id="product._get_alternative_product_filter()"
                     data-template-key="website_sale.dynamic_filter_template_product_product_borderless_1" data-product-category-id="all" data-number-of-elements="4"
                     data-number-of-elements-small-devices="1" data-number-of-records="16" data-carousel-interval="5000" data-bs-original-title="" title="">
-                    <div class="container o_not_editable">
-                        <div class="css_non_editable_mode_hidden">
-                            <div class="missing_option_warning alert alert-info rounded-0 fade show d-none d-print-none">
-                                Your Dynamic Snippet will be displayed here...
-                                This message is displayed because youy did not provide both a filter and a template to use.
-                            </div>
+                    <div class="container">
+                        <div class="row s_nb_column_fixed">
+                            <section class="s_dynamic_snippet_title oe_unremovable oe_unmovable d-flex flex-column flex-md-row justify-content-between mb-lg-0 pb-3 pb-md-0">
+                                <div>
+                                    <h4>Alternative Products</h4>
+                                    <p class="lead">These other products might interest you</p>
+                                </div>
+                            </section>
                         </div>
-                        <div class="dynamic_snippet_template"></div>
+                        <div class="o_not_editable">
+                            <div class="dynamic_snippet_template"/>
+                        </div>
                     </div>
                 </section>
             </div>


### PR DESCRIPTION
Before this commit :

-There is no title block linked to the alternative product.
If we want to add the title block above the alternative product
we can only add that functionality using the additional
title block from web editior above the alternative product.

After these commit :

-Added a title block above the alternative product snippet.
-Added subtitle "These other products might interest you"
-so customer can edit the title for the altenative product
as per requirement.
-Remove the message because it does not reproduce when we install the eCommerce.
"This Dynamic Snippet will be displayed here...
This message appears because  you did not provide both a filter and a template
to use."

task-3571905