### PR TITLE
[FIX] web: prevent crash when DnD property without group

### DIFF
--- a/addons/web/static/src/views/fields/properties/properties_field.js
+++ b/addons/web/static/src/views/fields/properties/properties_field.js
@@ -30,7 +30,11 @@ export class PropertiesField extends Component {
     static props = {
         ...standardFieldProps,
         context: { type: Object, optional: true },
-        columns: { type: Number, optional: true },
+        columns: {
+            type: Number,
+            optional: true,
+            validate: (columns) => [1, 2].includes(columns),
+        },
         showAddButton: { type: Boolean, optional: true },
     };
 
@@ -137,7 +141,12 @@ export class PropertiesField extends Component {
                     const group = this.groupedPropertiesList.find(
                         (group) => group.name === groupName
                     );
-                    to = group.elements.length ? group.elements.at(-1).name : groupName;
+                    if (!group) {
+                        to = null;
+                        moveBefore = false;
+                    } else {
+                        to = group.elements.length ? group.elements.at(-1).name : groupName;
+                    }
                 }
                 await this.onPropertyMoveTo(from, to, moveBefore);
             },
@@ -405,7 +414,9 @@ export class PropertiesField extends Component {
             const newSeparators = [];
             for (let col = 0; col < this.renderedColumnsCount; ++col) {
                 const separatorIndex = columnSize * col + newSeparators.length;
-                if (propertiesValues[separatorIndex].type === "separator") {
+
+                if (propertiesValues[separatorIndex]?.type === "separator") {
+                    newSeparators.push(propertiesValues[separatorIndex].name);
                     continue;
                 }
                 const newSeparator = {
@@ -417,7 +428,7 @@ export class PropertiesField extends Component {
                 propertiesValues.splice(separatorIndex, 0, newSeparator);
             }
             this._unfoldSeparators(newSeparators, true);
-            toPropertyName = toPropertyName || propertiesValues[0].name;
+            toPropertyName = toPropertyName || propertiesValues.at(-1).name;
 
             // indexes might have changed
             fromIndex = propertiesValues.findIndex((property) => property.name === propertyName);

--- a/addons/web/static/tests/views/fields/properties_field_tests.js
+++ b/addons/web/static/tests/views/fields/properties_field_tests.js
@@ -4,6 +4,7 @@ import {
     click,
     clickDiscard,
     clickSave,
+    drag,
     dragAndDrop,
     editInput,
     editSelect,
@@ -144,6 +145,10 @@ function getLocalStorageFold() {
         "fake.model,1337":
             JSON.parse(window.localStorage.getItem("properties.fold,fake.model,1337")) || [],
     };
+}
+
+function getPropertyHandleElement(propertyName) {
+    return target.querySelector(`*[property-name='${propertyName}'] .oi-draggable`);
 }
 
 QUnit.module("Fields", (hooks) => {
@@ -2729,5 +2734,86 @@ QUnit.module("Fields", (hooks) => {
             target.querySelector(".o_property_field .o_property_field_value input").value,
             "0"
         );
+    });
+
+    QUnit.test(
+        "properties: moving single property to 2nd group in auto split mode",
+        async function (assert) {
+            await makePropertiesGroupView([false]);
+
+            const { moveTo, drop } = await drag(getPropertyHandleElement("property_1"));
+
+            const secondGroup = target.querySelector(".o_property_group:last-of-type");
+            await moveTo(secondGroup, "bottom");
+            await drop(target, "bottom-right");
+
+            assert.deepEqual(getGroups(), [
+                [["GROUP 1", "property_gen_2"]],
+                [
+                    ["GROUP 2", "property_gen_3"],
+                    ["Property 1", "property_1"],
+                ],
+            ]);
+        }
+    );
+
+    QUnit.test("properties: moving single property to 1st group", async function (assert) {
+        await makePropertiesGroupView([true, true, false]);
+
+        await dragAndDrop(
+            getPropertyHandleElement("property_3"),
+            getPropertyHandleElement("property_1")
+        );
+
+        assert.deepEqual(getGroups(), [
+            [
+                ["SEPARATOR 1", "property_1"],
+                ["Property 3", "property_3"],
+            ],
+            [["SEPARATOR 2", "property_2"]],
+        ]);
+    });
+
+    QUnit.test("properties: split, moving property from 2nd group to 1st", async function (assert) {
+        await makePropertiesGroupView([true, false, false]);
+
+        await dragAndDrop(
+            getPropertyHandleElement("property_3"),
+            getPropertyHandleElement("property_2"),
+            "top"
+        );
+
+        assert.deepEqual(getGroups(), [
+            [
+                ["SEPARATOR 1", "property_1"],
+                ["Property 3", "property_3"],
+                ["Property 2", "property_2"],
+            ],
+            [["GROUP 2", "property_gen_2"]],
+        ]);
+    });
+
+    QUnit.test("properties: split, moving property from 1st group to 2nd", async function (assert) {
+        await makePropertiesGroupView([true, false, false, false, false, false]);
+
+        await dragAndDrop(
+            getPropertyHandleElement("property_3"),
+            getPropertyHandleElement("property_6"),
+            "top"
+        );
+
+        assert.deepEqual(getGroups(), [
+            [
+                ["SEPARATOR 1", "property_1"],
+                ["Property 2", "property_2"],
+                ["Property 4", "property_4"],
+            ],
+            [
+                ["GROUP 2", "property_gen_2"],
+                ["Property 5", "property_5"],
+                ["Property 3", "property_3"],
+                ["Property 6", "property_6"],
+            ],
+        ]);
     });
 });


### PR DESCRIPTION
Steps to reproduce
==================

- Install crm
- Add a single property
- Drag and drop it to the second group

=> TypeError: Cannot read properties of undefined (reading 'elements')

Cause of the issue
==================

A properties field is composed of a list of property stored in a JSON
object.

A property can either be a separator, or any other type, char, bool, ...

The properties field has a columns props.

If we either have no separator, or we have only one and it is at the
first position, we enter the split mode. This means that properties are
displayed across the available columns.

If we move a property in a group, it means we wan't that property to
stay in that group. When we're in split mode, we need to add the least
amount of new separators so that we get the expected layout.

In some cases, it wasn't possible to get the actual group where we dropped
a property.

This can happen for example when the target was inside an empty group
with a default invisible separator (it has no name).

In some cases also, the behavior wasn't simply what was expected.

opw-3961445