### PR TITLE
[FIX] point_of_sale: repeat failed call only for connection error

### DIFF
--- a/addons/point_of_sale/static/src/app/models/data_service.js
+++ b/addons/point_of_sale/static/src/app/models/data_service.js
@@ -119,7 +119,6 @@ export class PosData extends Reactive {
         options = [],
     }) {
         this.network.loading = true;
-
         try {
             let result = true;
 
@@ -167,7 +166,8 @@ export class PosData extends Reactive {
             this.setOnline();
             return result;
         } catch (error) {
-            if (queue) {
+            const skipError = error.constructor.name != "ConnectionLostError";
+            if (queue && !skipError) {
                 this.network.unsyncData.push({ type, model, ids, values });
             }
 
@@ -184,7 +184,6 @@ export class PosData extends Reactive {
         await this.mutex.exec(async () => {
             while (this.network.unsyncData.length > 0) {
                 const result = await this.execute(this.network.unsyncData[0]);
-
                 if (result) {
                     this.network.unsyncData.shift();
                 } else {

--- a/addons/point_of_sale/static/tests/unit/pos_app_tests.js
+++ b/addons/point_of_sale/static/tests/unit/pos_app_tests.js
@@ -1,4 +1,5 @@
 /** @odoo-module */
+/* global posmodel */
 import { Chrome } from "@point_of_sale/app/pos_app";
 import { getFixture, mount } from "@web/../tests/helpers/utils";
 import { makeTestEnv } from "@web/../tests/helpers/mock_env";
@@ -10,6 +11,7 @@ import { EventBus } from "@odoo/owl";
 import { uiService } from "@web/core/ui/ui_service";
 import { dialogService } from "@web/core/dialog/dialog_service";
 import { PosDataService } from "@point_of_sale/app/models/data_service";
+import { RPCError } from "@web/core/network/rpc";
 
 const mockContextualUtilsService = {
     dependencies: ["pos", "localization"],
@@ -98,7 +100,15 @@ export class MockPosData {
                         },
                     ],
                 },
-                "res.partner": { fields: {}, records: [] },
+                "res.partner": {
+                    fields: {
+                        vat: {
+                            string: "VAT",
+                            type: "string",
+                        },
+                    },
+                    records: [],
+                },
                 "stock.picking.type": { fields: {}, records: [] },
                 "pos.config": {
                     fields: {
@@ -161,4 +171,37 @@ QUnit.test("mount the Chrome", async (assert) => {
     });
     assert.containsOnce(fixture, ".pos");
     assert.verifySteps(["disable loader"]);
+});
+
+QUnit.test("test unsynch data error filtering", async (assert) => {
+    const serverData = new MockPosData().data;
+    const fixture = getFixture();
+    assert.verifySteps([]);
+    const testEnv = await makeTestEnv({
+        serverData,
+        async mockRPC(route, args) {
+            if (route === "/web/dataset/call_kw/res.partner/create") {
+                const error = new RPCError();
+                error.exceptionName = "odoo.exceptions.ValidationError";
+                error.code = 200;
+                throw error;
+            }
+        },
+    });
+    await mount(Chrome, fixture, {
+        env: testEnv,
+        test: true,
+        props: { disableLoader: () => {} },
+    });
+    const partner_data = {
+        name: "Test 1",
+        vat: "BE40301926",
+    };
+    try {
+        await posmodel.data.create("res.partner", [partner_data]);
+    } catch {
+        assert.step("create failed");
+        assert.equal(posmodel.data.network.unsyncData.length, 0);
+    }
+    assert.verifySteps(["create failed"]);
 });


### PR DESCRIPTION
When trying to create a partner with a wrong tax id, the create would fail. But with the new data_service, the create would be repeated to try to create the record again.

Steps to reproduce:
-------------------
* Open PoS session and create a partner from PoS, you can select belgium as country and BE40301926 as tax id
* You will get an error saying the tax id is wrong
* Now try to put a correct tax id like BE403019261

> Observation: You still get the error

Why the fix:
------------
When trying to create the record we end up here https://github.com/odoo/odoo/blob/28b7d698be8255f933ba5314e44e7059746fc234/addons/point_of_sale/static/src/app/models/data_service.js#L161-L164 because the server returns an error. And later on we will try to redo all the failed actions in `async syncData()`. But it will fail again as the values are still wrong.
To fix this we check that the error is not an RPCError before adding it to the queue.

opw-3943486
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
