### PR TITLE
[FIX] stock: show lots at company-less locations

### DIFF
--- a/addons/stock/views/stock_lot_views.xml
+++ b/addons/stock/views/stock_lot_views.xml
@@ -145,7 +145,7 @@
                           (0, 0, {'view_mode': 'form', 'view_id': ref('view_production_lot_form')})]"/>
         <field name="search_view_id" ref="search_product_lot_filter"/>
         <field name="context">{'search_default_group_by_product': 1, 'display_complete': True}</field>
-        <field name="domain">['|', ('location_id', '=', False), ('location_id.company_id', 'in', allowed_company_ids)]</field>
+        <field name="domain">['|', ('location_id', '=', False), ('location_id.company_id', 'in', allowed_company_ids + [False])]</field>
         <field name="help" type="html">
           <p class="o_view_nocontent_smiling_face">
             Add a lot/serial number
@@ -166,7 +166,7 @@
                           (0, 0, {'view_mode': 'form', 'view_id': ref('view_production_lot_form')})]"/>
         <field name="search_view_id" ref="search_product_lot_filter"/>
         <field name="context">{'search_default_group_by_product': 1, 'display_complete': True, 'default_company_id': allowed_company_ids[0]}</field>
-        <field name="domain">['|', ('location_id', '=', False), ('location_id.company_id', 'in', allowed_company_ids)]</field>
+        <field name="domain">['|', ('location_id', '=', False), ('location_id.company_id', 'in', allowed_company_ids + [False])]</field>
         <field name="help" type="html">
           <p class="o_view_nocontent_smiling_face">
             Add a lot/serial number


### PR DESCRIPTION
Problem
---
After shipping them to customers, lots do not appear in the `Inventory > Products > Lots/Serial Number` view

Steps
---
* enable stock locations in setting
* create a product tracked by unique serial
* make an inventory adjustment so we have at least 1 of it
* create sale order for this product, confirm it
* go to corresponding delivery, validate it
* go to `Inventory > Products > Lots/Serial Number` => the lot is not there

opw-3969556