### PR TITLE
[FIX] mrp: is_kits Multicompany

### DIFF
--- a/addons/mrp/models/product.py
+++ b/addons/mrp/models/product.py
@@ -5,7 +5,7 @@ import collections
 from datetime import timedelta
 from itertools import groupby
 import operator as py_operator
-from odoo import fields, models, _
+from odoo import api, fields, models, _
 from odoo.tools.float_utils import float_round, float_is_zero
 
 
@@ -38,8 +38,9 @@ class ProductTemplate(models.Model):
         for product in self:
             product.bom_count = self.env['mrp.bom'].search_count(['|', ('product_tmpl_id', '=', product.id), ('byproduct_ids.product_id.product_tmpl_id', '=', product.id)])
 
+    @api.depends_context('company')
     def _compute_is_kits(self):
-        domain = [('product_tmpl_id', 'in', self.ids), ('type', '=', 'phantom')]
+        domain = [('product_tmpl_id', 'in', self.ids), ('type', '=', 'phantom'), '|', ('company_id', '=', False), ('company_id', '=', self.env.company.id)]
         bom_mapping = self.env['mrp.bom'].search_read(domain, ['product_tmpl_id'])
         kits_ids = set(b['product_tmpl_id'][0] for b in bom_mapping)
         for template in self:
@@ -118,8 +119,11 @@ class ProductProduct(models.Model):
         for product in self:
             product.bom_count = self.env['mrp.bom'].search_count(['|', '|', ('byproduct_ids.product_id', '=', product.id), ('product_id', '=', product.id), '&', ('product_id', '=', False), ('product_tmpl_id', '=', product.product_tmpl_id.id)])
 
+    @api.depends_context('company')
     def _compute_is_kits(self):
-        domain = ['&', ('type', '=', 'phantom'),
+        domain = ['&', '&', ('type', '=', 'phantom'),
+                       '|', ('company_id', '=', False),
+                            ('company_id', '=', self.env.company.id),
                        '|', ('product_id', 'in', self.ids),
                             '&', ('product_id', '=', False),
                                  ('product_tmpl_id', 'in', self.product_tmpl_id.ids)]

--- a/addons/mrp/tests/test_multicompany.py
+++ b/addons/mrp/tests/test_multicompany.py
@@ -174,6 +174,32 @@ class TestMrpMulticompany(common.TransactionCase):
         with self.assertRaises(UserError):
             mo.button_mark_done()
 
+    def test_is_kit_in_multi_company_env(self):
+        """ Check that is_kits is company dependant """
+        product1, product2 = self.env['product.product'].create([{'name': 'Kit Kat'}, {'name': 'twix'}])
+        self.env['mrp.bom'].create([{
+            'product_id': product1.id,
+            'product_tmpl_id': product1.product_tmpl_id.id,
+            'company_id': self.company_a.id,
+            'type': 'phantom',
+        }, {
+            'product_id': product2.id,
+            'product_tmpl_id': product2.product_tmpl_id.id,
+            'company_id': False,
+            'type': 'phantom',
+        }])
+        template1 = product1.product_tmpl_id
+        template2 = product2.product_tmpl_id
+
+        self.assertTrue(product1.with_company(self.company_a).is_kits)
+        self.assertTrue(template1.with_company(self.company_a).is_kits)
+        self.assertFalse(product1.with_company(self.company_b).is_kits)
+        self.assertFalse(template1.with_company(self.company_b).is_kits)
+
+        self.assertTrue(product2.with_company(self.company_a).is_kits)
+        self.assertTrue(template2.with_company(self.company_a).is_kits)
+        self.assertTrue(product2.with_company(self.company_b).is_kits)
+        self.assertTrue(template2.with_company(self.company_b).is_kits)
 
     def test_partner_1(self):
         """ On a product without company, as a user of Company B, check it is not possible to use a


### PR DESCRIPTION
Steps to reproduce:
- Create a product that is a kit in company A and not in company B
- Try updating quantity on hand in company B

Bug:
since [1] it's not possible to update kit quantites directly but is_kits is not company dependant

Fix:
is_kits depends on the selected companies

opw-3946361
[1]:https://github.com/odoo/odoo/pull/161124/files
