### PR TITLE
[FIX] product: barcode field to update on save

### DIFF
--- a/addons/product/views/product_template_views.xml
+++ b/addons/product/views/product_template_views.xml
@@ -43,8 +43,7 @@
             </xpath>
             <field name="categ_id" position="after">
                 <field name="default_code" invisible="product_variant_count &gt; 1"/>
-                <field name="valid_product_template_attribute_line_ids" invisible="1"/>
-                <field name="barcode" invisible="product_variant_count &gt; 1 or (product_variant_count == 0 and valid_product_template_attribute_line_ids)"/>
+                <field name="barcode" invisible="product_variant_count &gt; 1"/>
             </field>
 
             <div name="button_box" position="inside">


### PR DESCRIPTION
**Prior this commit:**
When a user adds an attribute to a product (even with a single value), the barcode field temporarily disappears from the form. It shows up again on saving.

**Post this commit:**
The invisibility condition for the barcode field has been updated. This prevents the barcode field from disappearing and maintains its visibility consistently.

Commit causing issue: https://github.com/odoo-dev/odoo/commit/459760c4220e80b5c67567a7af57c05959363742

**Affected Version:** 17.0 ~ master

**opw**-3901043