### PR TITLE
[FIX] base: field condition of ir.default is not show

### DIFF
--- a/odoo/addons/base/views/ir_default_views.xml
+++ b/odoo/addons/base/views/ir_default_views.xml
@@ -11,6 +11,7 @@
                     <group name="field_value">
                         <field name="field_id"/>
                         <field name="json_value"/>
+                        <field name="condition"/>
                     </group>
                     <group name="user_company_details">
                         <field name="user_id"/>
@@ -29,6 +30,7 @@
             <tree string="User-defined Defaults">
                 <field name="field_id"/>
                 <field name="json_value"/>
+                <field name="condition" optional="hide"/>
                 <field name="user_id"/>
                 <field name="company_id" groups="base.group_multi_company"/>
             </tree>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
The field condition is used but it is not show in any view.


@xmo-odoo @rco-odoo 



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
