### PR TITLE
[FIX] website_editor: stop dragging custom snippets while editing title.

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -2759,7 +2759,7 @@ var SnippetsMenu = Widget.extend({
 
         const smoothScrollOptions = this._getScrollOptions({
             jQueryDraggableOptions: {
-                handle: '.oe_snippet_thumbnail:not(.o_we_already_dragging)',
+                handle: '.oe_snippet_thumbnail:not(.o_we_already_dragging):not(.o_snippet_no_drag)',
                 cancel: '.oe_snippet.o_disabled',
                 helper: function () {
                     const dragSnip = this.cloneNode(true);
@@ -3439,7 +3439,7 @@ var SnippetsMenu = Widget.extend({
         const $textInput = $input.find('input');
         $textInput.focus();
         $textInput.select();
-        $snippet.find('.oe_snippet_thumbnail').addClass('o_we_already_dragging'); // prevent drag
+        $snippet[0].querySelector('.oe_snippet_thumbnail').classList.add("o_snippet_no_drag"); // prevent drag
         $input.find('.o_we_confirm_btn').click(async () => {
             const name = $textInput.val();
             if (name !== snippetName) {
@@ -3455,9 +3455,11 @@ var SnippetsMenu = Widget.extend({
                     });
                 }, true);
             }
+            this.el.classList.remove("o_snippet_no_drag");
             await this._loadSnippetsTemplates(name !== snippetName);
         });
         $input.find('.o_we_cancel_btn').click(async () => {
+            this.el.classList.remove("o_snippet_no_drag");
             await this._loadSnippetsTemplates(false);
         });
     },


### PR DESCRIPTION
Issue:
While editing the title of a custom snippet, it should not be draggable. However, when another snippet is dragged and dropped from the snippets menu, the custom snippet becomes draggable again.

Steps to Reproduce the Bug:
1. Edit the name of a custom snippet.
2. Do not click on the "Confirm" button.
3. Notice that it is not possible to drag and drop the custom snippet (this is the expected behavior).
4. Drag and drop another snippet.
5. Observe that the custom snippet becomes draggable (this is the unwanted behavior).

This commit ensures that a custom snippet remains undraggable while the user is editing its title, even if another snippet is dragged and dropped.

task-3581814