### PR TITLE
[FIX] website: fix non-empty form snippet content

### DIFF
--- a/addons/website/views/snippets/s_website_form.xml
+++ b/addons/website/views/snippets/s_website_form.xml
@@ -76,8 +76,8 @@
                                 <span class="s_website_form_mark"> *</span>
                             </label>
                             <div class="col-sm">
-                                <textarea class="form-control s_website_form_input" name="description" required="1" id="oyeqnysxh10b" rows="3">
-                                </textarea>
+                                <textarea class="form-control s_website_form_input" name="description" required="1"
+                                          id="oyeqnysxh10b" rows="3"/>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
The 'Your Question' textarea had space in its default content

Steps to reproduce :
- Drop form snippet
- Save
- Click inside "Your Question"

task-3879975

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
