### PR TITLE
[FIX] base: missing error when load create a recordset

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -1129,6 +1129,8 @@ class BaseModel(metaclass=MetaModel):
                     info = data_list[0]['info']
                     messages.append(dict(info, type='error', message=_(u"Unknown database error: '%s'", e)))
                 return
+            except UserError as e:
+                messages.append(dict(data_list[0]['info'], type='error', message=str(e)))
             except Exception:
                 pass
 
@@ -1150,7 +1152,8 @@ class BaseModel(metaclass=MetaModel):
                     errors += 1
                 except UserError as e:
                     info = rec_data['info']
-                    messages.append(dict(info, type='error', message=str(e)))
+                    if dict(info, type='error', message=str(e)) not in messages:
+                        messages.append(dict(info, type='error', message=str(e)))
                     errors += 1
                 except Exception as e:
                     _logger.debug("Error while loading record", exc_info=True)


### PR DESCRIPTION
Summary
-----
In the method load in models.py, when there is an error when we try to create a recordset with at least 2 records, we try to create each record separately.
Only the errors caught by creating these single records are displayed which is confusing.

Steps to Reproduce
-----
    1. In Accounting > Configuration > Accounting > Chart of
    Accounts, create an account with the type "Off-Balanced Sheet"
    2. On the same page, import a Chart of Account (import journal
    items) by uploading a file which contains the following lines
    (example available on the ticket):
    [
        ['move_id','account_id','balance' 'journal_id','date'],
        [<move_name>,<account_code_1>,1,<journal_name>,2021-01-01],
        [<move_name>,<account_code_2>,-1,<journal_name>,2021-01-01]
    ]
        such that:
            - move_name cannot exist

             account_code_1 is the code of the created account at
            first step

             account_code_2 is not the code of an account with the
            type "Off-Balanced Sheet"
            - journal_name is the name of an existing journal
    3. Test or import the uploaded file and see the error which does
    not mention the "Off-Balanced Sheet" account.

Cause
-----
If a journal entry contains a line with an "Off
Balanced Sheet" account, then all the other lines must have an account with the same type.
So when we try to load the lines of the uploaded file, it raises a UserError which is caught (which is not added to the list 'messages'). Then we try to create the lines one by one which and that raises an error too because the balance is not null.
Only these errors are added to the list 'messages' which contains the displayed error messages.

Fix
-----
Add the first error to 'message', and ensure that the next errors are not already in 'messages'.

opw-3945687