### PR TITLE
[FIX] l10n_fr_account: change auto-installing dependencies

### DIFF
--- a/addons/l10n_fr_account/__manifest__.py
+++ b/addons/l10n_fr_account/__manifest__.py
@@ -34,7 +34,7 @@ configuration of their taxes and fiscal positions manually.
         'account',
         'l10n_fr',
     ],
-    'auto_install': ['account', 'l10n_fr'],
+    'auto_install': ['account'],
     'data': [
         'data/account_chart_template_data.xml',
         'data/account_data.xml',


### PR DESCRIPTION
To reproduce the bug, follow these instructions:
- Change the company localization to France.
- Install the Invoicing or Accounting app.
- Check if the l10n_fr_account module is auto-installed.

The module won't get installed because the auto-install dependencies are ['account', 'l10n_fr'], and l10n_fr does not have an auto-install dependency, so the l10n_fr_account module won't get installed.

OPW-3898999