### PR TITLE
[FIX] web_editor: consider borders when placing elements in grid mode

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -1091,6 +1091,10 @@ var SnippetEditor = Widget.extend({
                     this.dragState.columnWidth = parseFloat(this.$target[0].scrollWidth);
                     this.dragState.columnHeight = parseFloat(this.$target[0].scrollHeight);
                 }
+                // Taking the column borders into account.
+                const style = window.getComputedStyle(this.$target[0]);
+                this.dragState.columnWidth += parseFloat(style.borderLeft) + parseFloat(style.borderRight);
+                this.dragState.columnHeight += parseFloat(style.borderTop) + parseFloat(style.borderBottom);
             }
             // Storing the starting top position of the column.
             this.dragState.columnTop = this.$target[0].getBoundingClientRect().top;


### PR DESCRIPTION
There are some small issues when transforming a normal column into a grid item:

1) When borders are set on columns, these columns do not look good when they become grid items:

- In edit mode, drop the "Text-Image" snippet.
- Set the columns "Border" option to a rather big number (e.g. 50px).
- Toggle the grid mode. => The layout does not look good: the grid items are too small and not placed like how they were in normal mode (toggling the grid mode is supposed to place the items as close as possible as before the toggle).
- Drop the "Steps" snippet and set a border on a column.
- Drag the column and drop it in the "Text-Image" grid dropzone. => The content of the column overflows the grid area which does not look good.

This issue happens because when computing the grid areas, the border was not taken into account, resulting in grid items being too small (-> the width/height without the borders) and not having the right position (-> the starting position of the element "inside" the borders).

2) When a column becomes a grid item, its grid area is sometimes a bit too small to contain its content, making it overflow a bit:

- Drop the "Text-Image" snippet.
- In the first column, drop the "Rating" snippet and delete all the other content.
- Toggle the grid mode. => The "Rating" snippet overflows a bit the grid item (it is easier to see when using the browser inspector).

This overflow happens because when computing the grid areas, the grid padding was not taken into account, resulting in the content overflowing if it was barely fitting or if the grid padding was really big (e.g. when dropping a normal column in a grid mode "Big Boxes" snippet).

This commit fixes these issues by taking the borders and the grid padding into account in the grid areas computation when toggling the grid mode and when converting a normal column to a grid item when drag and dropping it.

task-3970022