### PR TITLE
[FIX] mail: chatter accesses unmounted element on file upload

### DIFF
--- a/addons/mail/static/src/core/web/chatter.js
+++ b/addons/mail/static/src/core/web/chatter.js
@@ -384,7 +384,9 @@ export class Chatter extends Component {
             this.reloadParentView();
         }
         this.state.isAttachmentBoxOpened = true;
-        this.rootRef.el.scrollTop = 0;
+        if (this.rootRef.el) {
+            this.rootRef.el.scrollTop = 0;
+        }
         this.state.thread.scrollTop = "bottom";
     }
 


### PR DESCRIPTION
Issue
----

When uploading a file, the chatter is unmounted from the right side of the screen then remounted to the bottom as soon as the file is uploaded to preview. For multiple files, the `onUploaded` hook is called before the re-mounted chatter root element becomes accessible to the component. This results in dereferencing `null` in `onUploaded`.

Steps
-----

- Create a new bill.
- Upload multiple attachments. Make sure that:
  - There are no attachments when you upload.
  - The attachments are large enough so the second attachment is uploaded just after the first is previewed (and the chatter is unmounted from the right).

opw-3985584
