### PR TITLE
[FIX] web_editor: fix display options of unsplash images

### DIFF
--- a/addons/web_editor/static/src/js/editor/image_processing.js
+++ b/addons/web_editor/static/src/js/editor/image_processing.js
@@ -474,6 +474,17 @@ async function loadImageInfo(img, rpc, attachmentSrc = '') {
         img.dataset.originalId = original.id;
         img.dataset.originalSrc = original.image_src;
         img.dataset.mimetype = original.mimetype;
+    } else {
+        const { original } = await rpc({
+            route: '/web_editor/get_image_info',
+            params: { src: decodeURI(relativeSrc) },
+        });
+
+        if (original && original.image_src) {
+            img.dataset.originalId = original.id;
+            img.dataset.originalSrc = original.image_src;
+            img.dataset.mimetype = original.mimetype;
+        }
     }
 }
 


### PR DESCRIPTION
The problem is that since ﻿[﻿https://github.com/odoo/odoo/commit/89c14783846288a2de53f6258a93440e02550b13﻿](https://github.com/odoo/odoo/commit/89c14783846288a2de53f6258a93440e02550b13)﻿ and then ﻿[﻿https://github.com/odoo/odoo/commit/96324fe8443647a078756c98f9629af274ff38a5﻿](https://github.com/odoo/odoo/commit/96324fe8443647a078756c98f9629af274ff38a5)﻿, "new URL()" is used in "loadImageInfo()". Due to it, a URL encoded version of the URL is sent as 'src' to the /web_editor/get_image_info route to search for the wanted attachment.

This commit comes with a simple approach which is trying the get the image attachment just as before and if we don't match anything, we try with the decoded version of the URL.

Steps to reproduce :

- Add a "Text-Image" snippet on the website.
- Double click to replace the image.
- Search for 'new car' and replace the image by an unsplash one (jpeg). -> The image options (shape, filter, quality...) are not shown.

task-3984743

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
