### PR TITLE
[PERF] point_of_sale: remove index

### DIFF
--- a/addons/point_of_sale/static/src/app/models/data_service.js
+++ b/addons/point_of_sale/static/src/app/models/data_service.js
@@ -214,14 +214,15 @@ export class PosData extends Reactive {
             };
         }
 
-        const { models, records, indexedRecords } = createRelatedModels(
+        // const { models, records, indexedRecords } = createRelatedModels(
+        const { models, records } = createRelatedModels(
             relations,
             modelClasses,
             this.opts.databaseIndex
         );
 
         this.records = records;
-        this.indexedRecords = indexedRecords;
+        // this.indexedRecords = indexedRecords;
         this.fields = fields;
         this.relations = relations;
         this.models = models;

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1070,7 +1070,6 @@ export class PosStore extends Reactive {
         if (!this.selectedOrderUuid) {
             return undefined;
         }
-
         return this.models["pos.order"].getBy("uuid", this.selectedOrderUuid);
     }
     get selectedOrder() {

--- a/addons/point_of_sale/static/tests/tours/large_db_tour.js
+++ b/addons/point_of_sale/static/tests/tours/large_db_tour.js
@@ -1,0 +1,21 @@
+/* global posmodel */
+import * as Dialog from "@point_of_sale/../tests/tours/utils/dialog_util";
+import { run } from "@point_of_sale/../tests/tours/utils/common";
+import { registry } from "@web/core/registry";
+import { TourError } from "@web_tour/tour_service/tour_utils";
+
+registry.category("web_tour.tours").add("LargeDBTour", {
+    test: true,
+    steps: () =>
+        [
+            Dialog.confirm("Open session"),
+            run(() => {
+                const time = performance.getEntriesByName("first-contentful-paint")[0].startTime;
+                throw new TourError(
+                    `time was ${time}, for a db with ${
+                        posmodel.models["product.product"].getAll().length
+                    } products`
+                );
+            }),
+        ].flat(),
+});

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -106,7 +106,7 @@ class TestPointOfSaleHttpCommon(AccountTestInvoicingHttpCommon):
 
         cls.tip = env.ref('point_of_sale.product_product_tip')
 
-        pos_desk_misc_test = env['pos.category'].create({
+        cls.pos_desk_misc_test = env['pos.category'].create({
             'name': 'Misc test',
         })
         pos_cat_chair_test = env['pos.category'].create({
@@ -124,7 +124,7 @@ class TestPointOfSaleHttpCommon(AccountTestInvoicingHttpCommon):
             'taxes_id': False,
             'weight': 0.01,
             'to_weight': True,
-            'pos_categ_ids': [(4, pos_desk_misc_test.id)],
+            'pos_categ_ids': [(4, cls.pos_desk_misc_test.id)],
         })
         cls.wall_shelf = env['product.product'].create({
             'name': 'Wall Shelf Unit',
@@ -1261,6 +1261,19 @@ class TestUi(TestPointOfSaleHttpCommon):
 
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'RefundFewQuantities', login="pos_user")
+
+    # This test is meant to only be run manually
+    # def test_large_db(self):
+    #     NUM_OF_PRODUCTS = 10000
+    #     self.env['product.product'].create([{
+    #         "name": f"Product {i}",
+    #         "available_in_pos": True,
+    #         'pos_categ_ids': [(4, self.pos_desk_misc_test.id)],
+    #     } for i in range(NUM_OF_PRODUCTS)])
+    #     self.main_pos_config.with_user(self.pos_user).open_ui()
+    #     self.start_pos_tour('LargeDBTour')
+
+
 
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):

--- a/addons/point_of_sale/views/pos_assets_index.xml
+++ b/addons/point_of_sale/views/pos_assets_index.xml
@@ -34,10 +34,8 @@
                 'pos_config_id': pos_config_id,
                 'access_token': access_token,
                 'debug': debug,
-            })"/>;
-            // Prevent the menu_service to load anything. In an ideal world, POS assets would only contain
-            // what is genuinely necessary, and not the whole backend.
-            odoo.loadMenusPromise = Promise.resolve();
+            })
+            "/>;
         </script>
 
         <t t-call="web.conditional_assets_tests">


### PR DESCRIPTION
In this commit we remove the concept of indexing from the related
models. It turns out that they slow down the pos more than they help
it.

As a result, for a pos config with 10k products, the `first-contentful-paint` time
halved. ( from ~35s to ~17s ).

Task: 3987554



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
