### PR TITLE
[PERF] base: add missing index on `call_at`

### DIFF
--- a/odoo/addons/base/models/ir_cron.py
+++ b/odoo/addons/base/models/ir_cron.py
@@ -548,7 +548,7 @@ class ir_cron_trigger(models.Model):
     _allow_sudo_commands = False
 
     cron_id = fields.Many2one("ir.cron", index=True)
-    call_at = fields.Datetime()
+    call_at = fields.Datetime(index=True)
 
     @api.autovacuum
     def _gc_cron_triggers(self):


### PR DESCRIPTION
## Description
`call_at` is a criteria used in the call `_get_all_ready_jobs` that can be frequently called on large database with many cron workers. This leads to very frequent Seq.Scan on the table, that may actually have a non-negligible number of records due to routines like the cron `ir_cron_campaign_execute_activities` which creates many triggers.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
