### PR TITLE
[REF] web_tour: remove skip_trigger

### DIFF
--- a/addons/sale/static/src/js/tours/sale.js
+++ b/addons/sale/static/src/js/tours/sale.js
@@ -4,6 +4,7 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
 import { markup } from "@odoo/owl";
+import { click, queryFirst } from "@odoo/hoot-dom";
 
 registry.category("web_tour.tours").add("sale_tour", {
     url: "/web",
@@ -89,12 +90,17 @@ registry.category("web_tour.tours").add("sale_tour", {
             ".o_statusbar_buttons button[name='action_quotation_send']",
         ),
         {
-            trigger: ".modal-footer button[name='document_layout_save']",
-            extra_trigger: ".modal-footer button[name='document_layout_save']",
+            trigger: ".modal-footer",
             content: _t("let's continue"),
             position: "bottom",
-            skip_trigger: ".modal-footer button[name='action_send_mail']",
-            run: "click",
+            run() {
+                const el =
+                    queryFirst(`.modal-footer button[name='action_send_mail']`) ||
+                    queryFirst(`.modal-footer button[name='document_layout_save']`);
+                if (el) {
+                    click(el);
+                }
+            },
         },
         {
             trigger: ".modal-footer button[name='action_send_mail']",

--- a/addons/web_tour/static/src/tour_service/tour_service.js
+++ b/addons/web_tour/static/src/tour_service/tour_service.js
@@ -35,7 +35,6 @@ import { callWithUnloadCheck } from "./tour_utils";
  * @property {HootSelector} trigger The node on which the action will be executed.
  * @property {HootSelector} [extra_trigger] Required (extra) node for the step to be executed.
  * @property {HootSelector} [alt_trigger] An alternative node to the trigger (trigger or alt_trigger).
- * @property {HootSelector} [skip_trigger] If node is present in the DOM, it bypasses the step.
  * @property {string} [content] Description of the step.
  * @property {"top" | "botton" | "left" | "right"} [position] The position where the UI helper is shown.
  * @property {"community" | "enterprise"} [edition]

--- a/addons/website_sale/static/tests/tours/website_sale_shop_mail.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_mail.js
@@ -1,5 +1,6 @@
 /** @odoo-module **/
 
+import { click, queryFirst } from "@odoo/hoot-dom";
 import { registry } from "@web/core/registry";
 import tourUtils from "@website_sale/js/tours/tour_utils";
 
@@ -29,12 +30,17 @@ registry.category("web_tour.tours").add('shop_mail', {
         run: "click",
     },
     {
-        trigger: ".modal-footer button[name='document_layout_save']",
-        extra_trigger: ".modal-footer button[name='document_layout_save']",
+        trigger: ".modal-footer",
         content: "let's continue",
         position: "bottom",
-        skip_trigger: ".modal-footer button[name='action_send_mail']",
-        run: "click",
+        run() {
+            const el =
+                queryFirst(`.modal-footer button[name='action_send_mail']`) ||
+                queryFirst(`.modal-footer button[name='document_layout_save']`);
+            if (el) {
+                click(el);
+            }
+        },
     },
     {
         content: "Open recipients dropdown",

--- a/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
+++ b/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
@@ -5,7 +5,7 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
 
 import { markup } from "@odoo/owl";
-import { queryFirst } from "@odoo/hoot-dom";
+import { queryFirst, click } from "@odoo/hoot-dom";
 
 registry.category("web_tour.tours").add('main_flow_tour', {
     test: true,
@@ -683,12 +683,17 @@ stepUtils.autoExpandMoreButtons('.o_form_saved'),
 },
 ...stepUtils.statusbarButtonsSteps('Send by Email', _t("Try to send it to email"), ".o_statusbar_status .dropdown-toggle:contains('Quotation')"),
 {
-    trigger: ".modal-footer button[name='document_layout_save']",
-    extra_trigger: ".modal-footer button[name='document_layout_save']",
+    trigger: ".modal-footer",
     content: _t("let's continue"),
     position: "bottom",
-    skip_trigger: ".modal-footer button[name='action_send_mail']",
-    run: "click",
+    run() {
+        const el =
+            queryFirst(`.modal-footer button[name='action_send_mail']`) ||
+            queryFirst(`.modal-footer button[name='document_layout_save']`);
+        if (el) {
+            click(el);
+        }
+    },
 }, {
     trigger: ".o_field_widget[name=email] input",
     content: _t("Enter an email address"),


### PR DESCRIPTION
In this commit, we remove the skip_trigger key from a tour step because
it is rarely used in the codebase.
This helps simplify the tours API.

task~3974087