### PR TITLE
[IMP] mrp, (purchase_)stock: replenish mixin improvements

### DIFF
--- a/addons/mrp/models/stock_orderpoint.py
+++ b/addons/mrp/models/stock_orderpoint.py
@@ -10,9 +10,7 @@ from dateutil.relativedelta import relativedelta
 class StockWarehouseOrderpoint(models.Model):
     _inherit = 'stock.warehouse.orderpoint'
 
-    show_bom = fields.Boolean('Show BoM column', compute='_compute_show_bom')
     bom_id = fields.Many2one(
-        'mrp.bom', string='Bill of Materials', check_company=True,
         domain="[('type', '=', 'normal'), '&', '|', ('company_id', '=', company_id), ('company_id', '=', False), '|', ('product_id', '=', product_id), '&', ('product_id', '=', False), ('product_tmpl_id', '=', product_tmpl_id)]")
     manufacturing_visibility_days = fields.Float(default=0.0, help="Visibility Days applied on the manufacturing routes.")
 
@@ -39,14 +37,6 @@ class StockWarehouseOrderpoint(models.Model):
                 }
             }
         return super()._get_replenishment_order_notification()
-
-    @api.depends('route_id')
-    def _compute_show_bom(self):
-        manufacture_route = []
-        for res in self.env['stock.rule'].search_read([('action', '=', 'manufacture')], ['route_id']):
-            manufacture_route.append(res['route_id'][0])
-        for orderpoint in self:
-            orderpoint.show_bom = orderpoint.route_id.id in manufacture_route
 
     def _compute_visibility_days(self):
         res = super()._compute_visibility_days()

--- a/addons/mrp/models/stock_replenish_mixin.py
+++ b/addons/mrp/models/stock_replenish_mixin.py
@@ -6,14 +6,20 @@ from odoo import api, fields, models
 class ProductReplenishMixin(models.AbstractModel):
     _inherit = 'stock.replenish.mixin'
 
-    bom_id = fields.Many2one('mrp.bom', string="Bill of Material", compute='_compute_bom',
-                             store=True, readonly=False, check_company=True)
+    bom_id = fields.Many2one('mrp.bom', string="Bill of Material", check_company=True)
     show_bom = fields.Boolean(compute='_compute_show_bom')
 
-    @api.depends('product_id')
-    def _compute_bom(self):
-        for rec in self:
-            rec.bom_id = self.env['mrp.bom']._bom_find(rec.product_id)[rec.product_id]
+    def default_get(self, fields):
+        res = super().default_get(fields)
+        if res.get('product_id'):
+            product_id = self.env['product.product'].browse(res['product_id'])
+            res['bom_id'] = self.env['mrp.bom']._bom_find(product_id)[product_id].id
+        return res
+
+    # @api.depends('product_id')
+    # def _compute_bom(self):
+    #     for rec in self:
+    #         rec.bom_id = self.env['mrp.bom']._bom_find(rec.product_id)[rec.product_id]
 
     @api.depends('route_id')
     def _compute_show_bom(self):

--- a/addons/mrp/models/stock_replenish_mixin.py
+++ b/addons/mrp/models/stock_replenish_mixin.py
@@ -16,11 +16,6 @@ class ProductReplenishMixin(models.AbstractModel):
             res['bom_id'] = self.env['mrp.bom']._bom_find(product_id)[product_id].id
         return res
 
-    # @api.depends('product_id')
-    # def _compute_bom(self):
-    #     for rec in self:
-    #         rec.bom_id = self.env['mrp.bom']._bom_find(rec.product_id)[rec.product_id]
-
     @api.depends('route_id')
     def _compute_show_bom(self):
         for rec in self:

--- a/addons/mrp/models/stock_replenish_mixin.py
+++ b/addons/mrp/models/stock_replenish_mixin.py
@@ -6,8 +6,14 @@ from odoo import api, fields, models
 class ProductReplenishMixin(models.AbstractModel):
     _inherit = 'stock.replenish.mixin'
 
-    bom_id = fields.Many2one('mrp.bom', string="Bill of Material")
+    bom_id = fields.Many2one('mrp.bom', string="Bill of Material", compute='_compute_bom',
+                             store=True, readonly=False, check_company=True)
     show_bom = fields.Boolean(compute='_compute_show_bom')
+
+    @api.depends('product_id')
+    def _compute_bom(self):
+        for rec in self:
+            rec.bom_id = self.env['mrp.bom']._bom_find(rec.product_id)[rec.product_id]
 
     @api.depends('route_id')
     def _compute_show_bom(self):

--- a/addons/mrp/models/stock_warehouse.py
+++ b/addons/mrp/models/stock_warehouse.py
@@ -2,8 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models, _
-from odoo.exceptions import ValidationError, UserError
-from odoo.tools import split_every
+from odoo.exceptions import UserError
 
 
 class StockWarehouse(models.Model):
@@ -279,25 +278,3 @@ class StockWarehouse(models.Model):
             if warehouse.manufacture_pull_id and name:
                 warehouse.manufacture_pull_id.write({'name': warehouse.manufacture_pull_id.name.replace(warehouse.name, name, 1)})
         return res
-
-class Orderpoint(models.Model):
-    _inherit = "stock.warehouse.orderpoint"
-
-    @api.constrains('product_id')
-    def check_product_is_not_kit(self):
-        domain = [
-            '|', ('product_id', 'in', self.product_id.ids),
-                 '&', ('product_id', '=', False),
-                      ('product_tmpl_id', 'in', self.product_id.product_tmpl_id.ids),
-            ('type', '=', 'phantom'),
-        ]
-        if self.env['mrp.bom'].search_count(domain, limit=1):
-            raise ValidationError(_("A product with a kit-type bill of materials can not have a reordering rule."))
-
-    def _get_orderpoint_products(self):
-        non_kit_ids = []
-        for products in split_every(2000, super()._get_orderpoint_products().ids, self.env['product.product'].browse):
-            kit_ids = set(k.id for k in self.env['mrp.bom']._bom_find(products, bom_type='phantom').keys())
-            non_kit_ids.extend(id_ for id_ in products.ids if id_ not in kit_ids)
-            products.invalidate_recordset()
-        return self.env['product.product'].browse(non_kit_ids)

--- a/addons/purchase_stock/models/stock.py
+++ b/addons/purchase_stock/models/stock.py
@@ -89,10 +89,7 @@ class ReturnPicking(models.TransientModel):
 class Orderpoint(models.Model):
     _inherit = "stock.warehouse.orderpoint"
 
-    show_supplier = fields.Boolean('Show supplier column', compute='_compute_show_suppplier')
-    supplier_id = fields.Many2one(
-        'product.supplierinfo', string='Supplier', check_company=True,
-        domain="['|', ('product_id', '=', product_id), '&', ('product_id', '=', False), ('product_tmpl_id', '=', product_tmpl_id)]")
+    supplier_id = fields.Many2one(domain="['|', ('product_id', '=', product_id), '&', ('product_id', '=', False), ('product_tmpl_id', '=', product_tmpl_id)]")
     vendor_id = fields.Many2one(related='supplier_id.partner_id', string="Vendor", store=True)
     purchase_visibility_days = fields.Float(default=0.0, help="Visibility Days applied on the purchase routes.")
     product_supplier_id = fields.Many2one('res.partner', compute='_compute_product_supplier_id', store=True, string='Product Supplier')
@@ -131,14 +128,6 @@ class Orderpoint(models.Model):
             if 'buy' in orderpoint.rule_ids.mapped('action'):
                 orderpoint.days_to_order = orderpoint.company_id.days_to_purchase
         return res
-
-    @api.depends('route_id')
-    def _compute_show_suppplier(self):
-        buy_route = []
-        for res in self.env['stock.rule'].search_read([('action', '=', 'buy')], ['route_id']):
-            buy_route.append(res['route_id'][0])
-        for orderpoint in self:
-            orderpoint.show_supplier = orderpoint.route_id.id in buy_route
 
     def action_view_purchase(self):
         """ This function returns an action that display existing

--- a/addons/purchase_stock/models/stock_replenish_mixin.py
+++ b/addons/purchase_stock/models/stock_replenish_mixin.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models
+from odoo.osv.expression import AND
 
 
 class ProductReplenishMixin(models.AbstractModel):
@@ -30,10 +31,11 @@ class ProductReplenishMixin(models.AbstractModel):
                 res['supplier_id'] = product_tmpl_id.seller_ids[0].id
         return res
 
-    # @api.depends('product_id', 'route_id')
-    # def _compute_supplier(self):
-    #     for rec in self:
-    #         rec.supplier_id = rec.product_id.seller_ids[:1] if rec.show_vendor else False
+    def _get_route_domain(self, product_tmpl_id):
+        domain = super()._get_route_domain(product_tmpl_id)
+        if not product_tmpl_id.seller_ids:
+            domain = AND([domain, [('id', '!=', self.env.ref('purchase_stock.route_warehouse0_buy', raise_if_not_found=False).id)]])
+        return domain
 
     @api.depends('route_id')
     def _compute_show_vendor(self):

--- a/addons/purchase_stock/models/stock_replenish_mixin.py
+++ b/addons/purchase_stock/models/stock_replenish_mixin.py
@@ -6,7 +6,7 @@ from odoo import api, fields, models
 class ProductReplenishMixin(models.AbstractModel):
     _inherit = 'stock.replenish.mixin'
 
-    supplier_id = fields.Many2one('product.supplierinfo', string="Vendor", check_company=True)
+    supplier_id = fields.Many2one('product.supplierinfo', string="Supplier", check_company=True)
     show_vendor = fields.Boolean(compute='_compute_show_vendor')
 
     @api.model

--- a/addons/purchase_stock/models/stock_replenish_mixin.py
+++ b/addons/purchase_stock/models/stock_replenish_mixin.py
@@ -6,8 +6,34 @@ from odoo import api, fields, models
 class ProductReplenishMixin(models.AbstractModel):
     _inherit = 'stock.replenish.mixin'
 
-    supplier_id = fields.Many2one('product.supplierinfo', string="Vendor")
+    supplier_id = fields.Many2one('product.supplierinfo', string="Vendor", check_company=True)
     show_vendor = fields.Boolean(compute='_compute_show_vendor')
+
+    @api.model
+    def default_get(self, fields):
+        res = super().default_get(fields)
+        if res.get('product_id'):
+            product_id = self.env['product.product'].browse(res['product_id'])
+            product_tmpl_id = product_id.product_tmpl_id
+            company = product_tmpl_id.company_id or self.env.company
+            if 'warehouse_id' not in res:
+                res['warehouse_id'] = self.env['stock.warehouse'].search([
+                    *self.env['stock.warehouse']._check_company_domain(company),
+                ], limit=1).id
+            orderpoint = self.env['stock.warehouse.orderpoint'].search(
+                [('product_id', 'in', [product_tmpl_id.product_variant_id.id, product_id.id]),
+                 ("warehouse_id", "=", res['warehouse_id'])], limit=1)
+            res['supplier_id'] = False
+            if orderpoint:
+                res['supplier_id'] = orderpoint.supplier_id.id
+            elif product_tmpl_id.seller_ids:
+                res['supplier_id'] = product_tmpl_id.seller_ids[0].id
+        return res
+
+    # @api.depends('product_id', 'route_id')
+    # def _compute_supplier(self):
+    #     for rec in self:
+    #         rec.supplier_id = rec.product_id.seller_ids[:1] if rec.show_vendor else False
 
     @api.depends('route_id')
     def _compute_show_vendor(self):

--- a/addons/purchase_stock/models/stock_replenish_mixin.py
+++ b/addons/purchase_stock/models/stock_replenish_mixin.py
@@ -8,7 +8,7 @@ class ProductReplenishMixin(models.AbstractModel):
     _inherit = 'stock.replenish.mixin'
 
     supplier_id = fields.Many2one('product.supplierinfo', string="Supplier", check_company=True)
-    show_vendor = fields.Boolean(compute='_compute_show_vendor')
+    show_supplier = fields.Boolean(compute='_compute_show_supplier')
 
     @api.model
     def default_get(self, fields):
@@ -38,9 +38,9 @@ class ProductReplenishMixin(models.AbstractModel):
         return domain
 
     @api.depends('route_id')
-    def _compute_show_vendor(self):
+    def _compute_show_supplier(self):
         for rec in self:
-            rec.show_vendor = rec._get_show_vendor(rec.route_id)
+            rec.show_supplier = rec._get_show_supplier(rec.route_id)
 
-    def _get_show_vendor(self, route):
+    def _get_show_supplier(self, route):
         return any(r.action == 'buy' for r in route.rule_ids)

--- a/addons/purchase_stock/views/stock_views.xml
+++ b/addons/purchase_stock/views/stock_views.xml
@@ -31,8 +31,8 @@
             <field name="inherit_id" ref="stock.view_warehouse_orderpoint_tree_editable"/>
             <field name="arch" type="xml">
                 <xpath expr="//button[@name='action_stock_replenishment_info']" position="before">
-                    <field name="show_supplier" column_invisible="True"/>
-                    <field name="supplier_id" string="Vendor" optional="hidden" invisible="not show_supplier" options="{'no_create': True}"/>
+                    <field name="show_vendor" column_invisible="True"/>
+                    <field name="supplier_id" string="Vendor" optional="hidden" invisible="not show_vendor" options="{'no_create': True}"/>
                 </xpath>
             </field>
         </record>

--- a/addons/purchase_stock/views/stock_views.xml
+++ b/addons/purchase_stock/views/stock_views.xml
@@ -31,8 +31,8 @@
             <field name="inherit_id" ref="stock.view_warehouse_orderpoint_tree_editable"/>
             <field name="arch" type="xml">
                 <xpath expr="//button[@name='action_stock_replenishment_info']" position="before">
-                    <field name="show_vendor" column_invisible="True"/>
-                    <field name="supplier_id" string="Vendor" optional="hidden" invisible="not show_vendor" options="{'no_create': True}"/>
+                    <field name="show_supplier" column_invisible="True"/>
+                    <field name="supplier_id" string="Vendor" optional="hidden" invisible="not show_supplier" options="{'no_create': True}"/>
                 </xpath>
             </field>
         </record>

--- a/addons/purchase_stock/wizard/product_replenish.py
+++ b/addons/purchase_stock/wizard/product_replenish.py
@@ -2,7 +2,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import _, api, fields, models
-from odoo.osv.expression import AND
 
 
 class ProductReplenish(models.TransientModel):
@@ -66,9 +65,3 @@ class ProductReplenish(models.TransientModel):
         if bool(self.env['ir.config_parameter'].sudo().get_param('purchase.use_po_lead')):
             delay += self.env.company.po_lead
         return fields.Datetime.add(date, days=delay)
-
-    def _get_route_domain(self, product_tmpl_id):
-        domain = super()._get_route_domain(product_tmpl_id)
-        if not product_tmpl_id.seller_ids:
-            domain = AND([domain, [('id', '!=', self.env.ref('purchase_stock.route_warehouse0_buy', raise_if_not_found=False).id)]])
-        return domain

--- a/addons/purchase_stock/wizard/product_replenish.py
+++ b/addons/purchase_stock/wizard/product_replenish.py
@@ -8,25 +8,6 @@ from odoo.osv.expression import AND
 class ProductReplenish(models.TransientModel):
     _inherit = 'product.replenish'
 
-    @api.model
-    def default_get(self, fields):
-        res = super().default_get(fields)
-        if res.get('product_id'):
-            product_id = self.env['product.product'].browse(res['product_id'])
-            product_tmpl_id = product_id.product_tmpl_id
-            company = product_tmpl_id.company_id or self.env.company
-            if 'warehouse_id' not in res:
-                res['warehouse_id'] = self.env['stock.warehouse'].search([
-                    *self.env['stock.warehouse']._check_company_domain(company),
-                ], limit=1).id
-            orderpoint = self.env['stock.warehouse.orderpoint'].search([('product_id', 'in', [product_tmpl_id.product_variant_id.id, product_id.id]), ("warehouse_id", "=", res['warehouse_id'])], limit=1)
-            res['supplier_id'] = False
-            if orderpoint:
-                res['supplier_id'] = orderpoint.supplier_id.id
-            elif product_tmpl_id.seller_ids:
-                res['supplier_id'] = product_tmpl_id.seller_ids[0].id
-        return res
-
     @api.depends('route_id', 'supplier_id')
     def _compute_date_planned(self):
         super()._compute_date_planned()

--- a/addons/purchase_stock/wizard/product_replenish.py
+++ b/addons/purchase_stock/wizard/product_replenish.py
@@ -12,7 +12,7 @@ class ProductReplenish(models.TransientModel):
         super()._compute_date_planned()
         for rec in self:
             if rec.route_id.name == 'Buy':
-                rec.date_planned = rec._get_date_planned(rec.route_id, supplier=rec.supplier_id, show_vendor=rec.show_vendor)
+                rec.date_planned = rec._get_date_planned(rec.route_id, supplier=rec.supplier_id, show_supplier=rec.show_supplier)
 
     def _prepare_run_values(self):
         res = super()._prepare_run_values()
@@ -56,8 +56,8 @@ class ProductReplenish(models.TransientModel):
             return date
 
         supplier = kwargs.get('supplier')
-        show_vendor = kwargs.get('show_vendor')
-        if not show_vendor or not supplier:
+        show_supplier = kwargs.get('show_supplier')
+        if not show_supplier or not supplier:
             return date
 
         delay = supplier.delay + self.env.company.days_to_purchase

--- a/addons/purchase_stock/wizard/product_replenish_views.xml
+++ b/addons/purchase_stock/wizard/product_replenish_views.xml
@@ -6,10 +6,10 @@
         <field name="inherit_id" ref="stock.view_product_replenish"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='route_id']" position="after">
-                <label for="supplier_id" invisible="not show_vendor"/>
+                <label for="supplier_id" invisible="not show_supplier"/>
                 <div class="o_row">
-                    <field name="show_vendor" invisible="1"/>
-                    <field name="supplier_id" invisible="not show_vendor" required="show_vendor" domain="[('product_tmpl_id', '=', product_tmpl_id)]" options="{'no_open': 1, 'no_create': 1}"/>
+                    <field name="show_supplier" invisible="1"/>
+                    <field name="supplier_id" invisible="not show_supplier" required="show_supplier" domain="[('product_tmpl_id', '=', product_tmpl_id)]" options="{'no_open': 1, 'no_create': 1}"/>
                 </div>
             </xpath>
         </field>

--- a/addons/stock/models/__init__.py
+++ b/addons/stock/models/__init__.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+# Mixins
+from . import stock_replenish_mixin
+
+# Models
 from . import barcode
 from . import ir_actions_report
 from . import product_strategy
@@ -15,7 +19,6 @@ from . import stock_orderpoint
 from . import stock_lot
 from . import stock_picking
 from . import stock_quant
-from . import stock_replenish_mixin
 from . import stock_rule
 from . import stock_warehouse
 from . import stock_scrap

--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -20,6 +20,7 @@ _logger = logging.getLogger(__name__)
 class StockWarehouseOrderpoint(models.Model):
     """ Defines Minimum stock rules. """
     _name = "stock.warehouse.orderpoint"
+    _inherit = "stock.replenish.mixin"
     _description = "Minimum Inventory Rule"
     _check_company_auto = True
     _order = "location_id,company_id,id"
@@ -74,8 +75,6 @@ class StockWarehouseOrderpoint(models.Model):
 
     rule_ids = fields.Many2many('stock.rule', string='Rules used', compute='_compute_rules')
     lead_days_date = fields.Date(compute='_compute_lead_days')
-    route_id = fields.Many2one(
-        'stock.route', string='Route', domain="[('product_selectable', '=', True)]")
     qty_on_hand = fields.Float('On Hand', readonly=True, compute='_compute_qty', digits='Product Unit of Measure')
     qty_forecast = fields.Float('Forecast', readonly=True, compute='_compute_qty', digits='Product Unit of Measure')
     qty_to_order = fields.Float('To Order', compute='_compute_qty_to_order', inverse='_inverse_qty_to_order', search='_search_qty_to_order', digits='Product Unit of Measure')

--- a/addons/stock/models/stock_replenish_mixin.py
+++ b/addons/stock/models/stock_replenish_mixin.py
@@ -7,11 +7,37 @@ class ProductReplenishMixin(models.AbstractModel):
     _name = 'stock.replenish.mixin'
     _description = 'Product Replenish Mixin'
 
-    route_id = fields.Many2one(
-        'stock.route', string="Preferred Route",
-        help="Apply specific route for the replenishment instead of product's default routes.",
-        check_company=True)
+    route_id = fields.Many2one('stock.route', string="Preferred Route", check_company=True)
     allowed_route_ids = fields.Many2many('stock.route', compute='_compute_allowed_route_ids')
+
+    @api.model
+    def default_get(self, fields):
+        res = super().default_get(fields)
+        product_tmpl_id = self.env['product.template']
+        if self.env.context.get('default_product_id'):
+            product_id = self.env['product.product'].browse(self.env.context['default_product_id'])
+            product_tmpl_id = product_id.product_tmpl_id
+            if 'product_id' in fields:
+                res['product_tmpl_id'] = product_id.product_tmpl_id.id
+                res['product_id'] = product_id.id
+        elif self.env.context.get('default_product_tmpl_id'):
+            product_tmpl_id = self.env['product.template'].browse(self.env.context['default_product_tmpl_id'])
+            if 'product_id' in fields:
+                res['product_tmpl_id'] = product_tmpl_id.id
+                res['product_id'] = product_tmpl_id.product_variant_id.id
+                if len(product_tmpl_id.product_variant_ids) > 1:
+                    res['product_has_variants'] = True
+        if 'route_id' in fields and 'route_id' not in res and product_tmpl_id:
+            res['route_id'] = self.env['stock.route'].search(self._get_route_domain(product_tmpl_id), limit=1).id
+            if not res['route_id']:
+                if product_tmpl_id.route_ids:
+                    res['route_id'] = product_tmpl_id.route_ids.filtered(lambda r: r.company_id == self.env.company or not r.company_id)[0].id
+        return res
+
+    # @api.depends('product_id', 'product_id.route_ids')
+    # def _compute_route(self):
+    #     for rec in self:
+    #         rec.route_id = next((r for r in rec.product_id.route_ids if r.id in rec.allowed_route_ids.ids), False)
 
     # INHERITS in 'Drop Shipping', 'Dropship and Subcontracting Management' and 'Dropship and Subcontracting Management'
     @api.depends('product_id', 'product_tmpl_id')

--- a/addons/stock/wizard/product_replenish.py
+++ b/addons/stock/wizard/product_replenish.py
@@ -48,21 +48,8 @@ class ProductReplenish(models.TransientModel):
 
     @api.model
     def default_get(self, fields):
-        res = super(ProductReplenish, self).default_get(fields)
-        product_tmpl_id = self.env['product.template']
-        if self.env.context.get('default_product_id'):
-            product_id = self.env['product.product'].browse(self.env.context['default_product_id'])
-            product_tmpl_id = product_id.product_tmpl_id
-            if 'product_id' in fields:
-                res['product_tmpl_id'] = product_id.product_tmpl_id.id
-                res['product_id'] = product_id.id
-        elif self.env.context.get('default_product_tmpl_id'):
-            product_tmpl_id = self.env['product.template'].browse(self.env.context['default_product_tmpl_id'])
-            if 'product_id' in fields:
-                res['product_tmpl_id'] = product_tmpl_id.id
-                res['product_id'] = product_tmpl_id.product_variant_id.id
-                if len(product_tmpl_id.product_variant_ids) > 1:
-                    res['product_has_variants'] = True
+        res = super().default_get(fields)
+        product_tmpl_id = self.env['product.template'].browse(res.get('product_tmpl_id'))
         company = product_tmpl_id.company_id or self.env.company
         if 'product_uom_id' in fields:
             res['product_uom_id'] = product_tmpl_id.uom_id.id
@@ -71,11 +58,6 @@ class ProductReplenish(models.TransientModel):
         if 'warehouse_id' in fields and 'warehouse_id' not in res:
             warehouse = self.env['stock.warehouse'].search([('company_id', '=', company.id)], limit=1)
             res['warehouse_id'] = warehouse.id
-        if 'route_id' in fields and 'route_id' not in res and product_tmpl_id:
-            res['route_id'] = self.env['stock.route'].search(self._get_route_domain(product_tmpl_id), limit=1).id
-            if not res['route_id']:
-                if product_tmpl_id.route_ids:
-                    res['route_id'] = product_tmpl_id.route_ids.filtered(lambda r: r.company_id == self.env.company or not r.company_id)[0].id
         return res
 
     def _get_date_planned(self, route_id, **kwargs):

--- a/addons/stock/wizard/product_replenish.py
+++ b/addons/stock/wizard/product_replenish.py
@@ -5,7 +5,6 @@ import datetime
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
-from odoo.osv import expression
 from odoo.tools.misc import clean_context
 
 
@@ -146,11 +145,3 @@ class ProductReplenish(models.TransientModel):
                 'sticky': False,
             }
         }
-
-    def _get_route_domain(self, product_tmpl_id):
-        company = product_tmpl_id.company_id or self.env.company
-        domain = expression.AND([self._get_allowed_route_domain(), self.env['stock.route']._check_company_domain(company)])
-        domain = expression.AND([domain, [('id', 'not in', self.env['stock.warehouse'].search([]).crossdock_route_id.ids)]])
-        if product_tmpl_id.route_ids:
-            domain = expression.AND([domain, [('product_ids', '=', product_tmpl_id.id)]])
-        return domain


### PR DESCRIPTION
changes brought by this PR:
- move default_get logic for `route_id`, `supplier_id` and `bom_id` to the mixin
- add mixin to `stock.warehouse.orderpoint`
- cleanup `stock.warehouse.orderpoint` in mrp since its logic was on 2 different files
- use `show_supplier` instead of `show_vendor` to be coherent with `supplier_id`

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
