### PR TITLE
[IMP] portal: /my/counters performances

### DIFF
--- a/addons/portal/controllers/portal.py
+++ b/addons/portal/controllers/portal.py
@@ -169,7 +169,12 @@ class CustomerPortal(Controller):
 
     @route(['/my/counters'], type='json', auth="user", website=True)
     def counters(self, counters, **kw):
-        return self._prepare_home_portal_values(counters)
+        cache = (request.session.portal_counters or {}).copy()
+        res = self._prepare_home_portal_values(counters)
+        cache.update({k: bool(v) for k, v in res.items() if k.endswith('_count')})
+        if cache != request.session.portal_counters:
+            request.session.portal_counters = cache
+        return res
 
     @route(['/my', '/my/home'], type='http', auth="user", website=True)
     def home(self, **kw):

--- a/addons/portal/static/src/js/portal.js
+++ b/addons/portal/static/src/js/portal.js
@@ -80,10 +80,10 @@ export const PortalHomeCounters = publicWidget.Widget.extend({
      * @private
      */
     async _updateCounters(elem) {
-        const numberRpc = 3;
         const needed = Object.values(this.el.querySelectorAll('[data-placeholder_count]'))
                                 .map(documentsCounterEl => documentsCounterEl.dataset['placeholder_count']);
-        const counterByRpc = Math.ceil(needed.length / numberRpc);  // max counter, last can be less
+        const numberRpc = Math.min(Math.ceil(needed.length / 5), 3); // max 3 rpc, up to 5 counters by rpc ideally
+        const counterByRpc = Math.ceil(needed.length / numberRpc);
         const countersAlwaysDisplayed = this._getCountersAlwaysDisplayed();
 
         const proms = [...Array(Math.min(numberRpc, needed.length)).keys()].map(async i => {

--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -222,7 +222,6 @@
             <div class="o_portal_my_home">
                 <div class="oe_structure" id="oe_structure_portal_my_home_1"/>
                 <div class="o_portal_docs row g-2">
-                    <div class="o_portal_doc_spinner spinner-border text-o-color-2 align-self-center mt-5"/>
                     <div t-if="portal_alert_category_enable" class="o_portal_category row g-2 mt-3" id="portal_alert_category"/>
                     <div t-if="portal_client_category_enable" class="o_portal_category row g-2 mt-3" id="portal_client_category"/>
                     <div t-if="portal_service_category_enable" class="o_portal_category row g-2 mt-3" id="portal_service_category"/>
@@ -237,6 +236,7 @@
                             <t t-set="config_card" t-value="True"/>
                         </t>
                     </div>
+                    <div class="o_portal_doc_spinner spinner-border text-o-color-2 align-self-center mt-5"/>
                 </div>
             </div>
             <div class="oe_structure" id="oe_structure_portal_my_home_2"/>
@@ -244,7 +244,8 @@
     </template>
 
     <template id="portal_docs_entry" name="My Portal Docs Entry">
-        <div t-att-class="'o_portal_index_card ' +  ('' if config_card else 'd-none ') + ('col-12 order-0' if show_count else 'col-md-6 order-2')">
+        <t t-set="force_show" t-value="placeholder_count and request.session.get('portal_counters', {}).get(placeholder_count) and not show_count"/>
+        <div t-att-class="'o_portal_index_card ' +  ('' if force_show or config_card else 'd-none ') + ('col-12 order-0' if show_count else 'col-md-6 order-2')">
             <a t-att-href="url" t-att-title="title" t-attf-class="d-flex justify-content-start gap-2 gap-md-3 align-items-center py-3 pe-2 px-md-3 h-100 rounded text-decoration-none text-reset #{bg_color if bg_color else 'text-bg-light'}">
                 <div t-if="icon" class="o_portal_icon align-self-start">
                     <img t-attf-src="#{icon}"/>
@@ -252,7 +253,7 @@
                 <div>
                     <h5 t-attf-class="mt-0 mb-1 #{'d-flex gap-2' if placeholder_count or count else ''}">
                         <t t-out="count"/>
-                        <span t-if="placeholder_count" t-att-class="'' if show_count else 'd-none'" t-att-data-placeholder_count="placeholder_count"/>
+                        <span t-if="placeholder_count and not force_show" t-att-class="'' if show_count else 'd-none'" t-att-data-placeholder_count="placeholder_count"/>
                         <span t-out="title"/>
                     </h5>
                     <p class="m-0 text-600">


### PR DESCRIPTION
The counters are primarily used as boolean to determine whether or not
to display the card. Therefore, as soon as you have one record, we can
show the card without needing to recheck it later. In the worst-case
scenario, you might see a card pointing to an empty list view.
This approach helps us avoid recalculating whether there is a record for
this card on each refresh.

The approach is to cache the counter in the session as soon as there are
more than 0 records. This way, if there are no invoices but a sale order
is validated, the invoice counter will be recomputed, and you will see
the invoice card the next time. For the duration of the same session, we
won't recompute it and will always display the invoice card.
We only re-request the computation if the counter in the session was 0
or if we need to show the counter, as in this case, we want to display
the most precise number.

This approach will also avoid flickering when the view is updated.
Since we already know the count, we can display the card immediately
without waiting for the RPC callback. To further reduce flickering, we
have moved the spinner to the bottom, preventing the content from
shifting upwards once the loader disappears.

On another note, we've updated the policy for the parallel RPC requests
made to /my/counter. Instead of splitting the counter into 3 RPC calls,
we now allow 5 counters per RPC, with a maximum of three RPCs.

An update of the view portal.portal_docs_entry is required to benefit
from this cache for /my/counter,
