### PR TITLE
[FIX] onboarding: fix a typo in the translation file to swedich

### DIFF
--- a/addons/onboarding/i18n/sv.po
+++ b/addons/onboarding/i18n/sv.po
@@ -446,4 +446,4 @@ msgstr "o_onboarding_confetti"
 #. module: onboarding
 #: model_terms:ir.ui.view,arch_db:onboarding.onboarding_panel
 msgid "onboarding.onboarding.step"
-msgstr "onboarding.onboarding.steg"
+msgstr "onboarding.onboarding.step"


### PR DESCRIPTION
An error occured trying to access new invoice in Accounting app, it was caused by a simple typo.

opw-3981302
