### PR TITLE
[PERF] point_of_sale: improve frontend PERF

### DIFF
--- a/addons/point_of_sale/static/src/app/models/product_product.js
+++ b/addons/point_of_sale/static/src/app/models/product_product.js
@@ -1,7 +1,6 @@
 /** @odoo-module */
 import { registry } from "@web/core/registry";
 import { Base } from "./related_models";
-import { deserializeDate } from "@web/core/l10n/dates";
 import { _t } from "@web/core/l10n/translation";
 import { roundPrecision } from "@web/core/utils/numbers";
 
@@ -98,12 +97,31 @@ export class ProductProduct extends Base {
         return current;
     }
 
-    isPricelistItemUsable(item, date) {
-        return (
-            (!item.categ_id || this.parentCategories.includes(item.categ_id.id)) &&
-            (!item.date_start || deserializeDate(item.date_start) <= date) &&
-            (!item.date_end || deserializeDate(item.date_end) >= date)
-        );
+    getApplicablePricelistRules(pricelistRules) {
+        const applicableRules = {};
+        for (const pricelistId in pricelistRules) {
+            if (pricelistRules[pricelistId].productItems[this.id]) {
+                applicableRules[pricelistId] = pricelistRules[pricelistId].productItems[this.id];
+                continue;
+            }
+            const productTmplId = this.raw.product_tmpl_id;
+            if (pricelistRules[pricelistId].productTmlpItems[productTmplId]) {
+                applicableRules[pricelistId] =
+                    pricelistRules[pricelistId].productTmlpItems[productTmplId];
+                continue;
+            }
+            for (const category of this.parentCategories) {
+                if (pricelistRules[pricelistId].categoryItems[category]) {
+                    applicableRules[pricelistId] =
+                        pricelistRules[pricelistId].categoryItems[category];
+                    break;
+                }
+            }
+            if (!applicableRules[pricelistId]) {
+                applicableRules[pricelistId] = pricelistRules[pricelistId].globalItems;
+            }
+        }
+        return applicableRules;
     }
 
     // Port of _get_product_price on product.pricelist.

--- a/addons/point_of_sale/static/src/app/models/related_models.js
+++ b/addons/point_of_sale/static/src/app/models/related_models.js
@@ -123,11 +123,10 @@ function processModelDefs(modelDefs) {
 }
 
 export class Base {
-    constructor({ models, records, model, raw }) {
+    constructor({ models, records, model }) {
         this.models = models;
         this.records = records;
         this.model = model;
-        this._raw = raw;
     }
     /**
      * Called during instantiation when the instance is fully-populated with field values.
@@ -165,19 +164,15 @@ export class Base {
 
         return serializedData;
     }
-    get raw() {
-        if (this.id in this._raw) {
-            return this._raw[this.id];
-        }
-
-        return {};
-    }
     _getCacheSet(fieldName) {
         const cacheName = `_${fieldName}`;
         if (!(cacheName in this)) {
             this[cacheName] = new Set();
         }
         return this[cacheName];
+    }
+    get raw() {
+        return this._raw ?? {};
     }
 }
 
@@ -300,11 +295,10 @@ export function createRelatedModels(modelDefs, modelClasses = {}, indexes = {}) 
         }
 
         const Model = modelClasses[model] || Base;
-        const record = reactive(
-            new Model({ models, records, model: models[model], raw: baseData[model] })
-        );
+        const record = reactive(new Model({ models, records, model: models[model] }));
         const id = vals["id"];
         record.id = id;
+        record._raw = baseData[model][id];
         records[model][id] = record;
 
         const indexRecord = (key, keyVal, many) => {


### PR DESCRIPTION
Add raw data directly to each records themselves, instead of storing
them in a separate object. This way, we avoid having verify if the
raw data exists in the main object, we can directly access it.

This commit also include a backport of https://github.com/odoo/odoo/pull/168466, commit message:

Before this commit, loading the POS took a long time when there were
more than 1000 products and pricelists. The reason was that the
`computeProductPricelistCache` function had a time complexity of
O(n^2 * m) due to nested loops over products and pricelist items, and
several calls to the raw function which is O(n) itself.

This commit optimizes the `computeProductPricelistCache` function by
performing a single loop over pricelist items and another over
products. This change improves the loading speed from 10 minutes to
10 seconds with 1000 products and pricelist items.