### PR TITLE
[FIX] tools: classify \uFEFF as whitespace for translations

### DIFF
--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -171,6 +171,7 @@ TRANSLATED_ATTRS.update(
 
 avoid_pattern = re.compile(r"\s*<!DOCTYPE", re.IGNORECASE | re.MULTILINE | re.UNICODE)
 node_pattern = re.compile(r"<[^>]*>(.*)</[^<]*>", re.DOTALL | re.MULTILINE | re.UNICODE)
+space_pattern = re.compile(r"[\s\uFEFF]*")  # web_editor uses \uFEFF as ZWNBSP
 
 
 def translate_xml_node(node, callback, parse, serialize):
@@ -183,7 +184,7 @@ def translate_xml_node(node, callback, parse, serialize):
 
     def nonspace(text):
         """ Return whether ``text`` is a string with non-space characters. """
-        return bool(text) and not text.isspace()
+        return bool(text) and not space_pattern.fullmatch(text)
 
     def translatable(node):
         """ Return whether the given node can be translated as a whole. """


### PR DESCRIPTION
Versions
--------
- 15.0
- 16.0
- 17.0
- saas-17.1
- saas-17.2
- saas-17.3

Issue
-----
  Commit 9426ee54b927 introduced the \uFEFF character to web_editor as a zero-width non-breaking whitespace. When this gets added to a HTML node, and processed for translation, it throws an "empty document" error.

Cause
-----
When passed to the `get_text_content` function, the call to `html.fromstring('\uFEFF').text_content()` throws an error. \uFEFF is not technically classified as whitespace, so the `nonspace` function which attempts to prevent processing empty documents doesn't catch it.

Solution
--------
Instead of the `isspace` method, use a regex which matches on all whitespace as well as \uFEFF.

To be applied on stable versions while the origins of stray ZWNBSPs get tackled on master.

opw-3957259