### PR TITLE
[FIX] point_of_sale: Avoid transaction aborted errors when handling failed orders

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -2115,6 +2115,7 @@ class PosSession(models.Model):
         return str2bool(self.env['ir.config_parameter'].sudo().get_param('point_of_sale.capture_unprocessed_order', True))
 
     def _handle_order_process_fail(self, order: dict, exception: Exception, draft: bool):
+        self.env.cr.rollback()  # It would have rollback anyway as it was raising an exception
         if not self._is_capture_system_activated():
             return
 
@@ -2125,7 +2126,6 @@ class PosSession(models.Model):
             _logger.info("order '%s' was not captured as it is draft", order['data']['name'])
             return
 
-        self.env.cr.rollback()  # It would have rollback anyway as it was raising an exception
         self.sudo()._process_order_process_fail(order, exception, self.env.user.id)
         self.env.cr.commit()  # Make sure that our created records are stored
 

--- a/doc/cla/corporate/braintec.md
+++ b/doc/cla/corporate/braintec.md
@@ -18,3 +18,4 @@ Frédéric Garbely frederic.garbely@braintec.com https://github.com/BT-fgarbely
 Carlos Serra Toro carlos.serra@braintec.com https://github.com/BT-cserra
 Cristian Rodriguez Navarro cristian.rodriguez@braintec.com https://github.com/BT-crodriguez
 Olivier Jossen olivier.jossen@braintec.com https://github.com/BT-ojossen
+Simon Schmid simon.schmid@braintec.com https://github.com/BT-sschmid


### PR DESCRIPTION
POSSession._handle_order_process_fail is usally called on any Exceptions, also on DB-related exception which may abort the current transaction.
In this case, the call to _is_capture_system_activated raises with an TransactionAborted Error, which shadows the real traceback of the original
Exception.

This PR moves the Rollback to the top of the Method.
This is safe as the caller raises anyway.