### PR TITLE
[IMP] hr_holidays: remove draft state on hr_leave

### DIFF
--- a/addons/hr_holidays/models/hr_employee.py
+++ b/addons/hr_holidays/models/hr_employee.py
@@ -26,7 +26,6 @@ class HrEmployeeBase(models.AbstractModel):
              'Total based on all the time off types without overriding limit.')
     current_leave_state = fields.Selection(compute='_compute_leave_status', string="Current Time Off Status",
         selection=[
-            ('draft', 'New'),
             ('confirm', 'Waiting Approval'),
             ('refuse', 'Refused'),
             ('validate1', 'Waiting Second Approval'),
@@ -245,7 +244,7 @@ class HrEmployeeBase(models.AbstractModel):
                 hr_vals['manager_id'] = values['parent_id']
             if values.get('department_id') is not None:
                 hr_vals['department_id'] = values['department_id']
-            holidays = self.env['hr.leave'].sudo().search(['|', ('state', 'in', ['draft', 'confirm']), ('date_from', '>', today_date), ('employee_id', 'in', self.ids)])
+            holidays = self.env['hr.leave'].sudo().search(['|', ('state', '=', 'confirm'), ('date_from', '>', today_date), ('employee_id', 'in', self.ids)])
             holidays.write(hr_vals)
             allocations = self.env['hr.leave.allocation'].sudo().search([('state', 'in', ['draft', 'confirm']), ('employee_id', 'in', self.ids)])
             allocations.write(hr_vals)

--- a/addons/hr_holidays/models/resource.py
+++ b/addons/hr_holidays/models/resource.py
@@ -61,7 +61,7 @@ class CalendarLeaves(models.Model):
         previous_durations = leaves.mapped('number_of_days')
         previous_states = leaves.mapped('state')
         leaves.sudo().write({
-            'state': 'draft',
+            'state': 'confirm',
         })
         self.env.add_to_compute(self.env['hr.leave']._fields['number_of_days'], leaves)
         self.env.add_to_compute(self.env['hr.leave']._fields['duration_display'], leaves)

--- a/addons/hr_holidays/populate/hr_leave.py
+++ b/addons/hr_holidays/populate/hr_leave.py
@@ -59,8 +59,5 @@ class HolidaysRequest(models.Model):
             ('employee_id', populate.compute(compute_employee_id)),
             ('request_date_from', populate.compute(compute_request_date_from)),
             ('request_date_to', populate.compute(compute_request_date_to)),
-            ('state', populate.randomize([
-                'draft',
-                'confirm',
-            ])),
+            ('state', populate.constant('confirm')),
         ]

--- a/addons/hr_holidays/report/hr_leave_employee_type_report.py
+++ b/addons/hr_holidays/report/hr_leave_employee_type_report.py
@@ -22,7 +22,6 @@ class LeaveReport(models.Model):
         ('planned', 'Planned')
     ])
     state = fields.Selection([
-        ('draft', 'To Submit'),
         ('cancel', 'Cancelled'),
         ('confirm', 'To Approve'),
         ('refuse', 'Refused'),

--- a/addons/hr_holidays/report/hr_leave_report.py
+++ b/addons/hr_holidays/report/hr_leave_report.py
@@ -24,7 +24,6 @@ class LeaveReport(models.Model):
     department_id = fields.Many2one('hr.department', string='Department', readonly=True)
     holiday_status_id = fields.Many2one("hr.leave.type", string="Time Off Type", readonly=True)
     state = fields.Selection([
-        ('draft', 'To Submit'),
         ('cancel', 'Cancelled'),
         ('confirm', 'To Approve'),
         ('refuse', 'Refused'),

--- a/addons/hr_holidays/report/hr_leave_report_calendar.py
+++ b/addons/hr_holidays/report/hr_leave_report_calendar.py
@@ -21,7 +21,6 @@ class LeaveReportCalendar(models.Model):
     job_id = fields.Many2one('hr.job', readonly=True)
     company_id = fields.Many2one('res.company', readonly=True)
     state = fields.Selection([
-        ('draft', 'To Submit'),
         ('cancel', 'Cancelled'),
         ('confirm', 'To Approve'),
         ('refuse', 'Refused'),
@@ -41,7 +40,7 @@ class LeaveReportCalendar(models.Model):
     def init(self):
         tools.drop_view_if_exists(self._cr, 'hr_leave_report_calendar')
         self._cr.execute("""CREATE OR REPLACE VIEW hr_leave_report_calendar AS
-        (SELECT 
+        (SELECT
             hl.id AS id,
             hl.id AS leave_id,
             CONCAT(em.name, ': ', hl.duration_display) AS name,
@@ -73,7 +72,7 @@ class LeaveReportCalendar(models.Model):
                 ON co.id = em.company_id
             LEFT JOIN resource_calendar cc
                 ON cc.id = co.resource_calendar_id
-        WHERE 
+        WHERE
             hl.state IN ('confirm', 'validate', 'validate1', 'refuse')
         );
         """)

--- a/addons/hr_holidays/security/hr_holidays_security.xml
+++ b/addons/hr_holidays/security/hr_holidays_security.xml
@@ -60,7 +60,7 @@
     <record id="hr_leave_rule_employee_unlink" model="ir.rule">
         <field name="name">Time Off base.group_user unlink</field>
         <field name="model_id" ref="model_hr_leave"/>
-        <field name="domain_force">[('employee_id.user_id', '=', user.id), ('state', 'in', ['draft', 'confirm', 'validate1'])]</field>
+        <field name="domain_force">[('employee_id.user_id', '=', user.id), ('state', 'in', ['confirm', 'validate1'])]</field>
         <field name="perm_read" eval="False"/>
         <field name="perm_write" eval="False"/>
         <field name="perm_create" eval="False"/>

--- a/addons/hr_holidays/tests/test_holidays_flow.py
+++ b/addons/hr_holidays/tests/test_holidays_flow.py
@@ -191,12 +191,6 @@ class TestHolidaysFlow(TestHrHolidaysCommon):
             self.assertEqual(hol2.state, 'refuse',
                             'hr_holidays: hr_user should not be able to reset a refused leave request')
 
-            # HrManager resets the request
-            hol2_manager_group = hol2.with_user(self.user_hrmanager_id)
-            hol2_manager_group.action_draft()
-            self.assertEqual(hol2.state, 'draft',
-                            'hr_holidays: resetting should lead to draft state')
-
             employee_id = self.ref('hr.employee_admin')
             # cl can be of maximum 20 days for employee_admin
             hol3_status = holiday_status_paid_time_off.with_context(employee_id=employee_id)
@@ -212,10 +206,8 @@ class TestHolidaysFlow(TestHrHolidaysCommon):
             # I find a small mistake on my leave request to I click on "Refuse" button to correct a mistake.
             hol3.action_refuse()
             self.assertEqual(hol3.state, 'refuse', 'hr_holidays: refuse should lead to refuse state')
-            # I again set to draft and then confirm.
-            hol3.action_draft()
-            self.assertEqual(hol3.state, 'draft', 'hr_holidays: resetting should lead to draft state')
-            hol3.action_confirm()
+            # Reset to confirm.
+            hol3.action_reset_confirm()
             self.assertEqual(hol3.state, 'confirm', 'hr_holidays: confirming should lead to confirm state')
             # I validate the holiday request by clicking on "To Approve" button.
             hol3.action_validate()

--- a/addons/hr_holidays/tests/test_leave_requests.py
+++ b/addons/hr_holidays/tests/test_leave_requests.py
@@ -631,8 +631,8 @@ class TestLeaveRequests(TestHrHolidaysCommon):
                 'request_date_from': '2022-01-03',
                 'request_date_to': '2022-01-06',
             })
-            leave_draft = Leave.create(leave_vals)
-            leave_draft.action_refuse()
+            leave_confirm = Leave.create(leave_vals)
+            leave_confirm.action_refuse()
             leave_vals.update({
                 'request_date_from': '2022-01-03',
                 'request_date_to': '2022-01-06',

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -217,13 +217,12 @@
             <field name="can_cancel" invisible="1"/>
             <field name="has_mandatory_day" invisible="1"/>
             <header>
-                <button string="Confirm" name="action_confirm" type="object" class="oe_highlight" invisible="not id or state != 'draft'"/>
                 <button string="Approve" name="action_approve" type="object" class="oe_highlight" invisible="not can_approve or state != 'confirm'"/>
                 <button string="Validate" name="action_validate" invisible="state != 'validate1'" type="object" groups="hr_holidays.group_hr_holidays_user" class="oe_highlight"/>
                 <button string="Refuse" name="action_refuse" type="object" invisible="not can_approve or state not in ('confirm', 'validate1', 'validate')"/>
                 <button string="Cancel" name="action_cancel" type="object" invisible="state == 'cancel' or not can_cancel" />
-                <button string="Mark as Draft" name="action_draft" type="object"
-                        invisible="not can_reset or state not in ['confirm', 'refuse']"/>
+                <button string="Reset" name="action_reset_confirm" type="object"
+                        invisible="not can_reset or state not in ['cancel', 'refuse']"/>
                 <field name="state" widget="statusbar" statusbar_visible="confirm,validate,cancel"/>
             </header>
             <sheet>
@@ -268,24 +267,24 @@
                             <label for="request_date_from" invisible="not request_unit_half and not request_unit_hours" string="Date" />
                             <label for="request_date_from" invisible="request_unit_half or request_unit_hours" string="Dates" />
                             <div class="o_row" invisible="not request_unit_half and not request_unit_hours">
-                                <field name="request_date_from" class="oe_inline" string="Date" readonly="state not in ('draft', 'confirm')" />
-                                <field name="request_date_from_period" invisible="not request_unit_half" required="request_unit_half" readonly="state not in ('draft', 'confirm')"/>
+                                <field name="request_date_from" class="oe_inline" string="Date" readonly="state != 'confirm'" />
+                                <field name="request_date_from_period" invisible="not request_unit_half" required="request_unit_half" readonly="state != 'confirm'"/>
                             </div>
                             <!-- full days: show date start/end with daterange -->
                             <div class="o_row" invisible="request_unit_half or request_unit_hours">
                                 <field
                                     name="request_date_from"
                                     widget="daterange"
-                                    readonly="state not in ('draft', 'confirm')"
+                                    readonly="state != 'confirm'"
                                     required="not date_from or not date_to"
                                     options="{'end_date_field': 'request_date_to'}"/>
                                 <field name="request_date_to" invisible="1" />
                             </div>
                             <label for="request_unit_half" string="" invisible="leave_type_request_unit == 'day'"/>
                             <div class="o_row o_row_readonly oe_edit_only" style="margin-left: -2px;" invisible="leave_type_request_unit == 'day'">
-                                <field name="request_unit_half" class="oe_inline" invisible="leave_type_request_unit == 'day'" readonly="state not in ('draft', 'confirm')" />
+                                <field name="request_unit_half" class="oe_inline" invisible="leave_type_request_unit == 'day'" readonly="state != 'confirm'" />
                                 <label for="request_unit_half" invisible="leave_type_request_unit == 'day'" />
-                                <field name="request_unit_hours" invisible="leave_type_request_unit != 'hour'" readonly="state not in ('draft', 'confirm')" class="ms-5" />
+                                <field name="request_unit_hours" invisible="leave_type_request_unit != 'hour'" readonly="state != 'confirm'" class="ms-5" />
                                 <label for="request_unit_hours" invisible="leave_type_request_unit != 'hour'" />
                             </div>
                             <label for="request_hour_from" string="" invisible="not request_unit_hours"/>
@@ -295,7 +294,6 @@
                                 <label for="request_hour_to" string="To" />
                                 <field name="request_hour_to" invisible="not request_unit_hours" readonly="state == 'validate'" required="request_unit_hours" />
                             </div>
-
                             <field name="number_of_days" invisible="1"/>
                             <field name="number_of_hours" invisible="1"/>
                             <field name="duration_display" readonly="1"/>
@@ -304,11 +302,11 @@
                             <span >You can only take this time off in whole days, so if your schedule has half days, it won't be used efficiently.</span>
                         </div>
                         <group>
-                            <field name="name" readonly="state not in ('draft', 'confirm')" widget="text" placeholder="Add a description..." />
+                            <field name="name" readonly="state != 'confirm'" widget="text" placeholder="Add a description..." />
                             <field name="user_id" invisible="1" />
                             <field name="leave_type_support_document" invisible="1" />
-                            <label for="supported_attachment_ids" string="Supporting Document" invisible="not leave_type_support_document or state not in ('draft', 'confirm', 'validate1')" />
-                            <field name="supported_attachment_ids" widget="many2many_binary" nolabel="1" invisible="not leave_type_support_document or state not in ('draft', 'confirm', 'validate1')" />
+                            <label for="supported_attachment_ids" string="Supporting Document" invisible="not leave_type_support_document or state not in ('confirm', 'validate1')" />
+                            <field name="supported_attachment_ids" widget="many2many_binary" nolabel="1" invisible="not leave_type_support_document or state not in ('confirm', 'validate1')" />
                         </group>
                     </div>
                 </div>
@@ -470,7 +468,7 @@
                 <field name="date_from" readonly="state in ['cancel', 'refuse', 'validate', 'validate1']"/>
                 <field name="date_to" readonly="state in ['cancel', 'refuse', 'validate', 'validate1']"/>
                 <field name="duration_display" string="Duration"/>
-                <field name="state" widget="badge" decoration-info="state == 'draft'" decoration-warning="state in ('confirm','validate1')" decoration-success="state == 'validate'" decoration-danger="state == 'cancel'"/>
+                <field name="state" widget="badge" decoration-warning="state in ('confirm','validate1')" decoration-success="state == 'validate'" decoration-danger="state == 'cancel'"/>
                 <field name="active_employee" column_invisible="True"/>
                 <field name="user_id" column_invisible="True"/>
                 <field name="message_needaction" column_invisible="True"/>

--- a/addons/hr_holidays_attendance/models/hr_leave.py
+++ b/addons/hr_holidays_attendance/models/hr_leave.py
@@ -67,14 +67,14 @@ class HRLeave(models.Model):
                     'duration': -1 * duration,
                 })
 
-    def action_draft(self):
+    def action_reset_confirm(self):
         overtime_leaves = self.filtered('overtime_deductible')
         if any([l.employee_overtime < float_round(l.number_of_hours, 2) for l in overtime_leaves]):
             if self.employee_id.user_id.id == self.env.user.id:
                 raise ValidationError(_('You do not have enough extra hours to request this leave'))
             raise ValidationError(_('The employee does not have enough extra hours to request this leave.'))
 
-        res = super().action_draft()
+        res = super().action_reset_confirm()
         overtime_leaves.overtime_id.sudo().unlink()
         for leave in overtime_leaves:
             overtime = self.env['hr.attendance.overtime'].sudo().create({

--- a/addons/hr_holidays_attendance/tests/test_holidays_overtime.py
+++ b/addons/hr_holidays_attendance/tests/test_holidays_overtime.py
@@ -77,7 +77,7 @@ class TestHolidaysOvertime(TransactionCase):
                     'holiday_status_id': self.leave_type_no_alloc.id,
                     'request_date_from': datetime(2021, 1, 4),
                     'request_date_to': datetime(2021, 1, 4),
-                    'state': 'draft',
+                    'state': 'confirm',
                 })
 
             self.new_attendance(check_in=datetime(2021, 1, 2, 8), check_out=datetime(2021, 1, 2, 16))
@@ -122,7 +122,7 @@ class TestHolidaysOvertime(TransactionCase):
         self.assertFalse(leave.overtime_id.exists(), "Overtime should be deleted")
         self.assertEqual(self.employee.total_overtime, 8)
 
-        leave.action_draft()
+        leave.action_reset_confirm()
         self.assertTrue(leave.overtime_id.exists(), "Overtime should be created")
         self.assertEqual(self.employee.total_overtime, 0)
 

--- a/addons/hr_work_entry_holidays/models/hr_leave.py
+++ b/addons/hr_work_entry_holidays/models/hr_leave.py
@@ -121,11 +121,11 @@ class HrLeave(models.Model):
         with self.env['hr.work.entry']._error_checking(start=start, stop=stop, employee_ids=employee_ids):
             return super().create(vals_list)
 
-    def action_confirm(self):
+    def action_reset_confirm(self):
         start = min(self.mapped('date_from'), default=False)
         stop = max(self.mapped('date_to'), default=False)
         with self.env['hr.work.entry']._error_checking(start=start, stop=stop, employee_ids=self.employee_id.ids):
-            return super().action_confirm()
+            return super().action_reset_confirm()
 
     def _get_leaves_on_public_holiday(self):
         return super()._get_leaves_on_public_holiday().filtered(

--- a/addons/hr_work_entry_holidays/tests/test_leave.py
+++ b/addons/hr_work_entry_holidays/tests/test_leave.py
@@ -160,7 +160,7 @@ class TestWorkEntryLeave(TestWorkEntryHolidaysBase):
     def test_work_entry_generation_company_time_off(self):
         existing_leaves = self.env['hr.leave'].search([])
         existing_leaves.action_refuse()
-        existing_leaves.action_draft()
+        existing_leaves.action_reset_confirm()
         existing_leaves.unlink()
         start = date(2022, 8, 1)
         end = date(2022, 8, 31)

--- a/addons/hr_work_entry_holidays/tests/test_performance.py
+++ b/addons/hr_work_entry_holidays/tests/test_performance.py
@@ -32,7 +32,7 @@ class TestWorkEntryHolidaysPerformance(TestWorkEntryHolidaysBase):
         self.richard_emp.generate_work_entries(date(2018, 1, 1), date(2018, 1, 2))
         leave = self.create_leave(datetime(2018, 1, 1, 7, 0), datetime(2018, 1, 1, 18, 0))
 
-        with self.assertQueryCount(__system__=113, admin=114):  # com 96/97
+        with self.assertQueryCount(__system__=114, admin=115):  # com 96/97
             leave.action_validate()
         leave.action_refuse()
 
@@ -51,15 +51,6 @@ class TestWorkEntryHolidaysPerformance(TestWorkEntryHolidaysBase):
         with self.assertQueryCount(__system__=60, admin=60):
             leave = self.create_leave(datetime(2018, 1, 1, 7, 0), datetime(2018, 1, 1, 18, 0))
         leave.action_refuse()
-
-    @users('__system__', 'admin')
-    @warmup
-    def test_performance_leave_confirm(self):
-        leave = self.create_leave(datetime(2018, 1, 1, 7, 0), datetime(2018, 1, 1, 18, 0))
-        leave.action_draft()
-        with self.assertQueryCount(__system__=43, admin=42):
-            leave.action_confirm()
-        leave.state = 'refuse'
 
 
 @tagged('work_entry_perf')


### PR DESCRIPTION
The draft state is considered to be a superfluous state that doesn't
really add any value to the flow of time off. With this commit it is
removed.

task-3106305

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
