### PR TITLE
[FIX] phone_validation: phone numbers in brazil

### DIFF
--- a/addons/phone_validation/lib/phonenumbers_patch/__init__.py
+++ b/addons/phone_validation/lib/phonenumbers_patch/__init__.py
@@ -57,3 +57,21 @@ else:
     if parse_version(phonenumbers.__version__) < parse_version('8.12.39'):
         # https://github.com/daviddrysdale/python-phonenumbers/blob/v8.13.36/python/phonenumbers/data/region_CO.py
         phonenumbers.phonemetadata.PhoneMetadata.register_region_loader('CO', _local_load_region)
+
+    # MONKEY PATCHING phonemetadata to fix Brazilian phonenumbers following 2016 changes
+    def _hook_load_region(code):
+        if parse_version(phonenumbers.__version__) < parse_version('8.13.39'):
+            # https://github.com/daviddrysdale/python-phonenumbers/blob/v8.13.39/python/phonenumbers/data/region_BR.py
+            _local_load_region(code)
+        else:
+            phonenumbers.data._load_region(code)
+        _region_metadata = phonenumbers.PhoneMetadata._region_metadata
+        if 'BR' in _region_metadata:
+            _region_metadata['BR'].intl_number_format.append(
+                phonenumbers.phonemetadata.NumberFormat(
+                    pattern='(\\d{2})(\\d{4})(\\d{4})',
+                    format='\\1 9\\2-\\3',
+                    leading_digits_pattern=['(?:[14689][1-9]|2[12478]|3[1-578]|5[13-5]|7[13-579][689])'],
+                )
+            )
+    phonenumbers.phonemetadata.PhoneMetadata.register_region_loader('BR', _hook_load_region)

--- a/addons/phone_validation/lib/phonenumbers_patch/region_BR.py
+++ b/addons/phone_validation/lib/phonenumbers_patch/region_BR.py
@@ -1,0 +1,26 @@
+"""Auto-generated file, do not edit by hand. BR metadata"""
+from ..phonemetadata import NumberFormat, PhoneNumberDesc, PhoneMetadata
+
+PHONE_METADATA_BR = PhoneMetadata(id='BR', country_code=55, international_prefix='00(?:1[245]|2[1-35]|31|4[13]|[56]5|99)',
+    general_desc=PhoneNumberDesc(national_number_pattern='(?:[1-46-9]\\d\\d|5(?:[0-46-9]\\d|5[0-46-9]))\\d{8}|[1-9]\\d{9}|[3589]\\d{8}|[34]\\d{7}', possible_length=(8, 9, 10, 11)),
+    fixed_line=PhoneNumberDesc(national_number_pattern='(?:[14689][1-9]|2[12478]|3[1-578]|5[13-5]|7[13-579])[2-5]\\d{7}', example_number='1123456789', possible_length=(10,), possible_length_local_only=(8,)),
+    mobile=PhoneNumberDesc(national_number_pattern='(?:[14689][1-9]|2[12478]|3[1-578]|5[13-5]|7[13-579])(?:7|9\\d)\\d{7}', example_number='11961234567', possible_length=(10, 11), possible_length_local_only=(8, 9)),
+    toll_free=PhoneNumberDesc(national_number_pattern='800\\d{6,7}', example_number='800123456', possible_length=(9, 10)),
+    premium_rate=PhoneNumberDesc(national_number_pattern='300\\d{6}|[59]00\\d{6,7}', example_number='300123456', possible_length=(9, 10)),
+    shared_cost=PhoneNumberDesc(national_number_pattern='(?:30[03]\\d{3}|4(?:0(?:0\\d|20)|370))\\d{4}|300\\d{5}', example_number='40041234', possible_length=(8, 10)),
+    no_international_dialling=PhoneNumberDesc(national_number_pattern='30(?:0\\d{5,7}|3\\d{7})|40(?:0\\d|20)\\d{4}|800\\d{6,7}', possible_length=(8, 9, 10)),
+    national_prefix='0',
+    national_prefix_for_parsing='(?:0|90)(?:(1[245]|2[1-35]|31|4[13]|[56]5|99)(\\d{10,11}))?',
+    national_prefix_transform_rule='\\2',
+    number_format=[NumberFormat(pattern='(\\d{3,6})', format='\\1', leading_digits_pattern=['1(?:1[25-8]|2[357-9]|3[02-68]|4[12568]|5|6[0-8]|8[015]|9[0-47-9])|321|610']),
+        NumberFormat(pattern='(\\d{4})(\\d{4})', format='\\1-\\2', leading_digits_pattern=['300|4(?:0[02]|37)', '4(?:02|37)0|[34]00']),
+        NumberFormat(pattern='(\\d{4})(\\d{4})', format='\\1-\\2', leading_digits_pattern=['[2-57]', '[2357]|4(?:[0-24-9]|3(?:[0-689]|7[1-9]))']),
+        NumberFormat(pattern='(\\d{3})(\\d{2,3})(\\d{4})', format='\\1 \\2 \\3', leading_digits_pattern=['(?:[358]|90)0'], national_prefix_formatting_rule='0\\1'),
+        NumberFormat(pattern='(\\d{5})(\\d{4})', format='\\1-\\2', leading_digits_pattern=['9']),
+        NumberFormat(pattern='(\\d{2})(\\d{4})(\\d{4})', format='\\1 \\2-\\3', leading_digits_pattern=['(?:[14689][1-9]|2[12478]|3[1-578]|5[13-5]|7[13-579])[2-57]'], national_prefix_formatting_rule='(\\1)', domestic_carrier_code_formatting_rule='0 $CC (\\1)'),
+        NumberFormat(pattern='(\\d{2})(\\d{5})(\\d{4})', format='\\1 \\2-\\3', leading_digits_pattern=['[16][1-9]|[2-57-9]'], national_prefix_formatting_rule='(\\1)', domestic_carrier_code_formatting_rule='0 $CC (\\1)')],
+    intl_number_format=[NumberFormat(pattern='(\\d{4})(\\d{4})', format='\\1-\\2', leading_digits_pattern=['300|4(?:0[02]|37)', '4(?:02|37)0|[34]00']),
+        NumberFormat(pattern='(\\d{3})(\\d{2,3})(\\d{4})', format='\\1 \\2 \\3', leading_digits_pattern=['(?:[358]|90)0']),
+        NumberFormat(pattern='(\\d{2})(\\d{4})(\\d{4})', format='\\1 \\2-\\3', leading_digits_pattern=['(?:[14689][1-9]|2[12478]|3[1-578]|5[13-5]|7[13-579])[2-57]']),
+        NumberFormat(pattern='(\\d{2})(\\d{5})(\\d{4})', format='\\1 \\2-\\3', leading_digits_pattern=['[16][1-9]|[2-57-9]'])],
+    mobile_number_portable_region=True)

--- a/addons/phone_validation/tests/test_phonenumbers.py
+++ b/addons/phone_validation/tests/test_phonenumbers.py
@@ -21,3 +21,19 @@ class TestPhonenumbers(BaseCase):
                 phone_validation.phone_format('0456998877', None, '32', force_format='E164'),
                 '+32456998877'
             )
+
+    def test_phone_format_e164_brazil(self):
+        """ In the new brazilian phone numbers system, phone numbers add a '9'
+            in front of the last 8 digits of mobile numbers.
+            Phonenumbers metadata is patched in odoo, however, when E164 is selected,
+            phone numbers aren't formatted, thus patched metadata not being applied.
+            See format_number in phonenumbers "Early exit for E164 case"
+        """
+        for number, expected_number in [
+            ('11 6123 4560', '+5511961234560'),  # mobile number, must have 9 added
+            ('+55 11 6123 4561', '+5511961234561'),  # mobile number, must have 9 added
+            ('11 2345 6789', '+551123456789'),  # landline, must NOT have 9 added
+            ('+55 11 2345 6798', '+551123456798'),  # landline, must NOT have 9 added
+        ]:
+            res = phone_validation.phone_format(number, 'BR', '55', force_format='E164')
+            self.assertEqual(res, expected_number)

--- a/addons/phone_validation/tests/test_phonenumbers_patch.py
+++ b/addons/phone_validation/tests/test_phonenumbers_patch.py
@@ -78,6 +78,22 @@ class TestPhonenumbersPatch(BaseCase):
                     self.assertEqual(parsed_phone.number_of_leading_zeros, parse_test_line.gt_number_of_leading_zeros,
                         "Parsed country code number differs from expected country code")
 
+    def test_region_BR_monkey_patch(self):
+        """ Test Brazil phone numbers patch for added 9 in mobile numbers
+        It should not be added for fixed lines numbers"""
+        if not phonenumbers:
+            self.skipTest('Cannot test without phonenumbers module installed.')
+
+        # Mobile number => 9 should be added
+        parsed = phonenumbers.parse('11 6123 4567', region="BR")
+        formatted = phonenumbers.format_number(parsed, phonenumbers.PhoneNumberFormat.INTERNATIONAL)
+        self.assertEqual(formatted, '+55 11 96123-4567')
+
+        # Fixed line => 9 should not be added
+        parsed = phonenumbers.parse('11 2345 6789', region="BR")
+        formatted = phonenumbers.format_number(parsed, phonenumbers.PhoneNumberFormat.INTERNATIONAL)
+        self.assertEqual(formatted, '+55 11 2345-6789')
+
     def test_region_CI_monkey_patch(self):
         """Makes sure that patch for Ivory Coast phone numbers work"""
         parse_test_lines_CI=(

--- a/addons/phone_validation/tools/phone_validation.py
+++ b/addons/phone_validation/tools/phone_validation.py
@@ -22,7 +22,12 @@ try:
         if not phonenumbers.is_possible_number(phone_nbr):
             raise UserError(_('Impossible number %s: probably invalid number of digits.', number))
         if not phonenumbers.is_valid_number(phone_nbr):
-            raise UserError(_('Invalid number %s: probably incorrect prefix.', number))
+            # Force format with international to force metadata to apply
+            formatted_intl = phonenumbers.format_number(phone_nbr, phonenumbers.PhoneNumberFormat.INTERNATIONAL)
+            phone_nbr_intl = phonenumbers.parse(formatted_intl, region=country_code or None, keep_raw_input=True)
+            if not phonenumbers.is_valid_number(phone_nbr_intl):
+                raise UserError(_('Invalid number %s: probably incorrect prefix.', number))
+            return phone_nbr_intl
 
         return phone_nbr
 


### PR DESCRIPTION
Current behaviour:
---
Brazilian phone numbers are not managed correctly following the 2016 changes in Brazil.
(Adding a 9 to mobile phone numbers)

Cause of the issue:
---
Phonenumbers metadata were patched to add 9 in mobile numbers, however, when E164 is selected, 
phone numbers aren't formatted, thus patched metadata not being applied.
See format_number in phonenumbers "Early exit for E164 case"

Fix:
---
Backport of: https://github.com/odoo/odoo/commit/53885e41867653ad45ca3aef55886c280240b76a 
In phone_validation, before formatting, phone_parse is called, https://github.com/odoo/odoo/blob/bdfb802293d9a3eebb378a15ed65f48b7c3182b2/addons/phone_validation/tools/phone_validation.py#L72 
old brazilian mobile numbers would be invalid, and raise an error. https://github.com/odoo/odoo/blob/bdfb802293d9a3eebb378a15ed65f48b7c3182b2/addons/phone_validation/tools/phone_validation.py#L51 
Now if the number is invalid, we force format in international, to force apply patched metadata, before re-trying to parse.

opw-3861847

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
