### PR TITLE
[FIX] sale: remove wire transfer confirmation from `action_lock`

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -878,11 +878,6 @@ class SaleOrder(models.Model):
             )
 
     def action_done(self):
-        for order in self:
-            tx = order.sudo().transaction_ids._get_last()
-            if tx and tx.state == 'pending' and tx.provider_id.code == 'custom' and tx.provider_id.custom_mode == 'wire_transfer':
-                tx._set_done()
-                tx.write({'is_post_processed': True})
         self.write({'state': 'done'})
 
     def action_unlock(self):


### PR DESCRIPTION
Versions
--------
- 16.0+

Steps
-----
1. Enable lock SO on confirmation;
2. enable wire transfer as payment provider'
3. go to website;
4. buy a product using wire transfer;
5. confirm the generated SO in the back-end;
6. front-end says payment has been confirmed.

Issue
-----
The confirmation status of the SO doesn't reflect the confirmation status of the payment.

Cause
-----
The `action_lock` method looks at any relevant wire transfers that are pending, and confirms them.

Solution
--------
Decouple wire transfer confirmation from the locking of sale orders.

opw-3751481