### PR TITLE
[FIX] stock: reserved quantity in scrap

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -615,7 +615,7 @@ class StockMoveLine(models.Model):
             return 0, False
         if action == "available":
             available_qty, in_date = self.env['stock.quant']._update_available_quantity(self.product_id, location, quantity, lot_id=lot, package_id=package, owner_id=owner, in_date=in_date)
-        elif action == "reserved" and not self.move_id._should_bypass_reservation():
+        elif action == "reserved" and not self.move_id._should_bypass_reservation(location):
             self.env['stock.quant']._update_reserved_quantity(self.product_id, location, quantity, lot_id=lot, package_id=package, owner_id=owner)
         if available_qty < 0 and lot:
             # see if we can compensate the negative quants with some untracked quants


### PR DESCRIPTION
Usecase:
- Create a sublocation of input with scrap checked
- Use warehouse 2 steps
- Do a delivery for 10 units
- Scrap 2 to the sublocation of input
- Validate the 8 units remaining (backorder doens't change anything)
- Return 2 units
- Edit the stock.move.line to take them from the sublocation of input
- Validate

Current behaviour:
The quant in input's sublocation has -2 reserved quantity

Expected Behaviour:
The quant is deleted

It happens because the `_synchronize_quant` method do a check but it's on the move. However in our case, the `stock.move` still have input as location and it's not a scrap, so it doesn't skip the quant update. We should force the location of the `stock.move.line` to ensure the check is done on the correct sublocation.

opw-mri

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
