### PR TITLE
Add country to time off type

### DIFF
--- a/addons/hr_holidays/data/hr_holidays_data.xml
+++ b/addons/hr_holidays/data/hr_holidays_data.xml
@@ -264,6 +264,7 @@
             <field name="icon_id" ref="hr_holidays.icon_14"/>
             <field name="color">2</field>
             <field name="company_id" eval="False"/> <!-- Explicitely set to False for it to be available to all companies -->
+            <field name="country_id" eval="False"/> <!-- Explicitely set to False for it to be available to all countries -->
             <field name="sequence">1</field>
         </record>
 
@@ -277,6 +278,7 @@
             <field name="icon_id" ref="hr_holidays.icon_22"/>
             <field name="color">3</field>
             <field name="company_id" eval="False"/> <!-- Explicitely set to False for it to be available to all companies -->
+            <field name="country_id" eval="False"/> <!-- Explicitely set to False for it to be available to all countries -->
             <field name="sequence">2</field>
         </record>
 
@@ -293,6 +295,7 @@
             <field name="icon_id" ref="hr_holidays.icon_4"/>
             <field name="color">4</field>
             <field name="company_id" eval="False"/> <!-- Explicitely set to False for it to be available to all companies -->
+            <field name="country_id" eval="False"/> <!-- Explicitely set to False for it to be available to all countries -->
             <field name="sequence">4</field>
         </record>
 
@@ -309,6 +312,7 @@
             <field name="icon_id" ref="hr_holidays.icon_28"/>
             <field name="color">5</field>
             <field name="company_id" eval="False"/> <!-- Explicitely set to False for it to be available to all companies -->
+            <field name="country_id" eval="False"/> <!-- Explicitely set to False for it to be available to all countries -->
             <field name="sequence">3</field>
         </record>
     </data>

--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -138,7 +138,6 @@ class HrLeave(models.Model):
         store=True, string="Time Off Type",
         required=True, readonly=False,
         domain="""[
-            ('company_id', 'in', [employee_company_id, False]),
             '|',
                 ('requires_allocation', '=', 'no'),
                 ('has_valid_allocation', '=', True),

--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -226,7 +226,7 @@ class HrLeaveType(models.Model):
 
     @api.constrains('requires_allocation')
     def check_allocation_requirement_edit_validity(self):
-        if self.env['hr.leave'].search_count([('holiday_status_id', 'in', self.ids)], limit=1):
+        if not self.env.context.get('install_mode') and self.env['hr.leave'].search_count([('holiday_status_id', 'in', self.ids)], limit=1):
             raise UserError(_("The allocation requirement of a time off type cannot be changed once leaves of that type have been taken. You should create a new time off type instead."))
 
     @api.depends('company_id')

--- a/addons/hr_holidays/security/hr_holidays_security.xml
+++ b/addons/hr_holidays/security/hr_holidays_security.xml
@@ -240,7 +240,14 @@
     <record id="hr_holidays_status_rule_multi_company" model="ir.rule">
         <field name="name">Time Off multi company rule</field>
         <field name="model_id" ref="model_hr_leave_type"/>
-        <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
+        <field name="domain_force">[
+            '|', 
+                ('company_id', 'in', company_ids),
+                '&amp;',
+                    ('company_id', '=', False),
+                    ('country_id', 'in', user.env.companies.country_id.ids + [False])
+        ]
+        </field>
     </record>
 
     <record id="hr_leave_accrual_plan_rule_multi_company" model="ir.rule">

--- a/addons/hr_holidays/static/src/tours/hr_leave_type_tour.js
+++ b/addons/hr_holidays/static/src/tours/hr_leave_type_tour.js
@@ -1,0 +1,194 @@
+/** @odoo-module **/
+
+import { registry } from "@web/core/registry";
+import { stepUtils } from "@web_tour/tour_service/tour_utils";
+
+const leaveType1 = "leave_type_1";
+const leaveType2 = "leave_type_2";
+const leaveType3 = "leave_type_3";
+const noRecords = "No Records";
+const company2 = "company_2";
+const firstLeaveDateFrom = "01/17/2022";
+const firstLeaveDateTo = "01/17/2022";
+const secondLeaveDateFrom = "01/18/2022";
+const secondLeaveDateTo = "01/18/2022";
+
+
+registry.category("web_tour.tours").add("hr_leave_type_tour", {
+    url: "/web",
+    test: true,
+    steps: () => [
+        stepUtils.showAppsMenuItem(),
+        {
+            trigger: '.o_app[data-menu-xmlid="hr_holidays.menu_hr_holidays_root"]',
+            content: "Open the time-off application",
+            tooltipPosition: "bottom",
+            run: "click",
+        },
+        {
+            trigger: 'button[data-menu-xmlid="hr_holidays.menu_hr_holidays_management"]',
+            content: "Open the management menu",
+            tooltipPosition: "bottom",
+            run: "click",
+        },
+        {
+            trigger: 'a[data-menu-xmlid="hr_holidays.menu_open_department_leave_approve"]',
+            content: "Choose Time Off from the menu",
+            tooltipPosition: "right",
+            run: "click",
+        },
+        {
+            trigger: "button.o_list_button_add",
+            content: "Create a new time-off request",
+            tooltipPosition: "bottom",
+            run: "click",
+        },
+        // Check if a time-off could be requested using leave_type_1 as company_1 is selected by default.
+        {
+            trigger: 'div[name="holiday_status_id"] input',
+            content: "Create a time-off using leave_type_1. Select it from the list",
+            tooltipPosition: "bottom",
+            run: `edit ${leaveType1}`,
+        },
+        {
+            isActive: ["auto"],
+            trigger: `.ui-autocomplete .ui-menu-item a:contains("${leaveType1}")`,
+            run: "click",
+        },
+        {
+            trigger: `.o_field_widget[name='holiday_status_id'] input:value("${leaveType1}")`,
+        },
+        // Check that a time-off cannot be requested using leave_type_2 as company_2 is not selected.
+        {
+            trigger: 'div[name="holiday_status_id"] input',
+            content: "Try to select leave_type_2 from the list. It shouldn't be present",
+            tooltipPosition: "bottom",
+            run: `edit ${leaveType2}`,
+        },
+        {
+            trigger: `.ui-autocomplete .ui-menu-item a:contains('${noRecords}')`,
+        },
+        // Check if a time-off could be requested using leave_type_3
+        {
+            trigger: 'div[name="holiday_status_id"] input',
+            content: "Select leave_type_3 from the list",
+            tooltipPosition: "bottom",
+            run: `edit ${leaveType3}`,
+        },
+        {
+            isActive: ["auto"],
+            trigger: `.ui-autocomplete .ui-menu-item a:contains("${leaveType3}")`,
+            run: "click",
+        },
+        {
+            trigger: `.o_field_widget[name='holiday_status_id'] input:value("${leaveType3}")`,
+        },
+        {
+            trigger: "input[data-field=request_date_from]",
+            content: "Select the start date of the leave",
+            tooltipPosition: "right",
+            run: `edit ${firstLeaveDateFrom}`,
+        },
+        {
+            trigger: "button.o_apply",
+            content: "Confirm date selection",
+            tooltipPosition: "bottom",
+            run: "click",
+        },
+        {
+            trigger: "input[data-field=request_date_to]",
+            content: "Select the end date of the leave",
+            tooltipPosition: "right",
+            run: `edit ${firstLeaveDateTo}`,
+        },
+        {
+            trigger: "button.o_apply",
+            content: "Confirm date selection",
+            tooltipPosition: "bottom",
+            run: "click",
+        },
+        {
+            trigger: 'button[name="action_approve"]',
+            content: "Approve the leave",
+            tooltipPosition: "bottom",
+            run: "click",
+        },
+        {
+            trigger: 'button[name="action_cancel"]',
+            content: "Make sure that the leave is approved by checking that the cancel button appears",
+        },
+        {
+            trigger: ".o_switch_company_menu button",
+            content: "Open the companies selection menu",
+            tooltipPosition: "bottom",
+            run: "click",
+        },
+        {
+            trigger: `.o_switch_company_item:contains("${company2}") [role=menuitemcheckbox]`,
+            content: "Select company_2",
+            tooltipPosition: "bottom",
+            run: "click",
+        },
+        {
+            trigger: ".o_switch_company_menu_buttons button:contains(Confirm)",
+            content: "Confirm the company selection",
+            tooltipPosition: "bottom",
+            run: "click",
+        },
+        {
+            trigger: "button.o_form_button_create",
+            content: "Create a new time-off request",
+            tooltipPosition: "bottom",
+            run: "click",
+        },
+        {
+            trigger: 'div[name="holiday_status_id"] input',
+            content: "Select leave_type_2 from the list. It should be available now because company_2 is selected",
+            tooltipPosition: "bottom",
+            run: `edit ${leaveType2}`,
+        },
+        {
+            isActive: ["auto"],
+            trigger: `.ui-autocomplete .ui-menu-item a:contains("${leaveType2}")`,
+            run: "click",
+        },
+        {
+            trigger: `.o_field_widget[name='holiday_status_id'] input:value("${leaveType2}")`,
+            tooltipPosition: "bottom",
+        },
+        {
+            trigger: "input[data-field=request_date_from]",
+            content: "Select the start date of the leave",
+            tooltipPosition: "right",
+            run: `edit ${secondLeaveDateFrom}`,
+        },
+        {
+            trigger: "button.o_apply",
+            content: "Confirm date selection",
+            tooltipPosition: "bottom",
+            run: "click",
+        },
+        {
+            trigger: "input[data-field=request_date_to]",
+            content: "Select the end date of the leave",
+            tooltipPosition: "right",
+            run: `edit ${secondLeaveDateTo}`,
+        },
+        {
+            trigger: "button.o_apply",
+            content: "Confirm date selection",
+            tooltipPosition: "bottom",
+            run: "click",
+        },
+        {
+            trigger: 'button[name="action_approve"]',
+            content: "Approve the leave",
+            tooltipPosition: "bottom",
+            run: "click",
+        },
+        {
+            trigger: 'button[name="action_cancel"]',
+            content: "Make sure that the leave is approved by checking that the cancel button appears",
+        },
+    ],
+});

--- a/addons/hr_holidays/static/src/tours/hr_leave_type_tour.js
+++ b/addons/hr_holidays/static/src/tours/hr_leave_type_tour.js
@@ -16,7 +16,6 @@ const secondLeaveDateTo = "01/18/2022";
 
 registry.category("web_tour.tours").add("hr_leave_type_tour", {
     url: "/web",
-    test: true,
     steps: () => [
         stepUtils.showAppsMenuItem(),
         {

--- a/addons/hr_holidays/tests/__init__.py
+++ b/addons/hr_holidays/tests/__init__.py
@@ -27,3 +27,4 @@ from . import test_dashboard
 from . import test_expiring_leaves
 from . import test_hr_departure_wizard
 from . import test_time_off_card_tour
+from . import test_hr_leave_type_tour

--- a/addons/hr_holidays/tests/common.py
+++ b/addons/hr_holidays/tests/common.py
@@ -16,6 +16,21 @@ class TestHrHolidaysCommon(common.TransactionCase):
         cls.company = cls.env['res.company'].create({'name': 'Test company'})
         cls.env.user.company_id = cls.company
 
+        # The available time off types are the ones whose:
+        # 1. Company is one of the selected companies.
+        # 2. Company is false but whose country is one the countries of the selected companies.
+        # 3. Company is false and country is false
+        # Thus, a time off type is defined to be available for `Test company`
+        # For example, the tour 'time_off_request_calendar_view' would succeed (false positive) without this leave type.
+        # However, the tour won't create a time-off request (as expected)because no time-off type is available to be selected on the leave
+        # This would cause the test case that uses the tour to fail.
+        cls.env['hr.leave.type'].create({
+            'name': 'Test Leave Type',
+            'requires_allocation': 'no',
+            'request_unit': 'day',
+            'company_id': cls.company.id,
+        })
+
         # Test users to use through the various tests
         cls.user_hruser = mail_new_test_user(cls.env, login='armande', groups='base.group_user,hr_holidays.group_hr_holidays_user')
         cls.user_hruser_id = cls.user_hruser.id

--- a/addons/hr_holidays/tests/test_hr_leave_type_tour.py
+++ b/addons/hr_holidays/tests/test_hr_leave_type_tour.py
@@ -1,0 +1,71 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from freezegun import freeze_time
+
+from odoo import Command
+from odoo.tests import HttpCase
+from odoo.tests.common import tagged
+
+from datetime import date
+
+
+@tagged('post_install', '-at_install')
+class TestHrLeaveTypeTour(HttpCase):
+    @freeze_time('01/17/2022')
+    def test_hr_leave_type_tour(self):
+        """
+        Test Time Off multi company rule defined in hr_holidays_security for hr_leave_type.
+        The available leave types are the ones whose:
+            - Company is one of the selected companies.
+            - Company is false but whose country is one the countries of the selected companies.
+            - Company is false and country is false
+
+        Define:
+            - 2 Companies: company_1 and company_2
+            - 3 Leave Types:
+                * leave_type_1 whose country is set to the country of company_1.
+                * leave_type_2 whose company is set to company_2.
+                * leave_type_3 whose country and company are both False.
+
+        leave_type_1 will be available if company_1 is one of the selected companies.
+        leave_type_2 will be available if company_2 is one of the selected companies.
+        leave_type_3 will always be available.
+        """
+        admin_user = self.env.ref('base.user_admin')
+        admin_employee = admin_user.employee_id
+        HRLeave = self.env['hr.leave']
+        date_from = date(2022, 1, 17)
+        date_to = date(2022, 1, 18)
+        leaves_on_freeze_date = HRLeave.search([
+            ('date_from', '>=', date_from),
+            ('date_to', "<=", date_to),
+            ('employee_id', '=', admin_employee.id)
+        ])
+        leaves_on_freeze_date.sudo().unlink()
+        company_1 = self.env.company
+        company_1.name = 'company_1'
+        company_2 = self.env['res.company'].create({'name': 'company_2'})
+        self.env["res.users"].browse(2).write({
+            "company_ids": [Command.clear(), Command.link(company_1.id), Command.link(company_2.id)]
+        })
+
+        leave_type = self.env['hr.leave.type'].with_user(admin_user)
+
+        leave_type.create({
+            'name': 'leave_type_1',
+            'requires_allocation': 'no',
+            'leave_validation_type': 'hr',
+            'country_id': company_1.country_id.id
+        })
+        leave_type.create({
+            'name': 'leave_type_2',
+            'requires_allocation': 'no',
+            'leave_validation_type': 'hr',
+            'company_id': company_2.id
+        })
+        leave_type.create({
+            'name': 'leave_type_3',
+            'requires_allocation': 'no',
+            'leave_validation_type': 'hr'
+        })
+        self.start_tour('/web', 'hr_leave_type_tour', login="admin", step_delay=500)

--- a/addons/hr_holidays/views/hr_leave_type_views.xml
+++ b/addons/hr_holidays/views/hr_leave_type_views.xml
@@ -10,6 +10,7 @@
                 <field name="create_calendar_meeting"/>
                 <separator/>
                 <filter string="Archived" name="inactive" domain="[('active','=',False)]"/>
+                <filter string="Country" name="country" context="{'group_by': 'country_id'}"/>
             </search>
         </field>
     </record>
@@ -72,18 +73,21 @@
                     </group>
                     <group>
                         <group name="configuration" id="configuration" string="Configuration">
-                            <field name="responsible_ids"
-                                widget="many2many_tags"
-                                placeholder="Nobody will be notified"
-                                invisible="leave_validation_type in ['no_validation', 'manager'] and (requires_allocation == 'no' or allocation_validation_type not in ['hr', 'both'])"/>
-                            <field name="request_unit"/>
-                            <field name="include_public_holidays_in_duration"/>
-                            <field name="show_on_dashboard"/>
-                            <field name="support_document" string="Allow To Attach Supporting Document" />
-                            <field name="time_type" required="1"/>
-                            <field name="company_id" groups="base.group_multi_company"/>
-                            <field name="country_id" invisible="1"/>
-                            <field name="country_code" invisible="1"/>
+                            <group>
+                                <field name="responsible_ids"
+                                    widget="many2many_tags"
+                                    placeholder="Nobody will be notified"
+                                    invisible="leave_validation_type in ['no_validation', 'manager'] and (requires_allocation == 'no' or allocation_validation_type not in ['hr', 'both'])"/>
+                                <field name="request_unit"/>
+                                <field name="include_public_holidays_in_duration"/>
+                                <field name="show_on_dashboard"/>
+                                <field name="support_document" string="Allow To Attach Supporting Document" />
+                                <field name="time_type" required="1"/>
+                                <field name="company_id" groups="base.group_multi_company" readonly="is_used"/>
+                                <field name="country_id" groups="base.group_multi_company" readonly="company_id or is_used"/>
+                                <field name="country_id" invisible="1"/>
+                                <field name="country_code" invisible="1"/>
+                            </group>
                         </group>
                         <group name="negative_cap" id="negative_cap"
                             string="Negative Cap"
@@ -136,7 +140,8 @@
                 <field name="allocation_validation_type" string="Allocation Approval"/>
                 <field name="employee_requests" optional="hide"/>
                 <field name="color" widget="color_picker" optional="hide"/>
-                <field name="company_id" groups="base.group_multi_company" optional="hide"/>
+                <field name="company_id" groups="base.group_multi_company" optional="show" readonly="is_used"/>
+                <field name="country_id" groups="base.group_multi_company" optional="show" readonly="company_id or is_used"/>
             </list>
         </field>
     </record>

--- a/addons/hr_holidays_attendance/data/hr_holidays_attendance_data.xml
+++ b/addons/hr_holidays_attendance/data/hr_holidays_attendance_data.xml
@@ -9,6 +9,7 @@
             <field name="overtime_deductible" eval="True"/>
             <field name="active" eval="True"/>
             <field name="company_id" eval="False"/>
+            <field name="country_id" eval="False"/>
             <field name="icon_id" ref="hr_holidays.icon_9"/>
             <field name="sequence">5</field>
         </record>

--- a/addons/hr_holidays_attendance/views/hr_leave_type_views.xml
+++ b/addons/hr_holidays_attendance/views/hr_leave_type_views.xml
@@ -5,8 +5,10 @@
         <field name="model">hr.leave.type</field>
         <field name="inherit_id" ref="hr_holidays.edit_holiday_status_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='request_unit']" position="after">
-                <field name="overtime_deductible"/>
+            <xpath expr="//group[@name='configuration']" position="inside">
+                <group>
+                        <field name="overtime_deductible"/>
+                </group>
             </xpath>
         </field>
     </record>

--- a/addons/l10n_fr_hr_holidays/data/l10n_fr_hr_holidays_demo.xml
+++ b/addons/l10n_fr_hr_holidays/data/l10n_fr_hr_holidays_demo.xml
@@ -45,6 +45,7 @@
     <record id="l10n_fr_holiday_status_cl" model="hr.leave.type">
         <field name="name">Paid Time Off</field>
         <field name="company_id" ref="base.demo_company_fr"/>
+        <field name="country_id" ref="base.fr"/>
         <field name="requires_allocation">yes</field>
         <field name="employee_requests">no</field>
         <field name="leave_validation_type">both</field>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
* It required to restrict time off types available to an employee when they request time off.
task-3978260

Current behavior before PR:
* Currently, when a time off is requested/allocated, you'll have the list of all time off types, cause there is no field "country" on the leave type. So, if you have "sick leave" in belgium, "sickness" in US and "sick holiday" in India, you'll see the three of them.

Desired behavior after PR is merged:
* These changes restrict the time off types available to an employee when a time off is requested/allocated. The available time off types would be the ones whose country is the same as:
    1. The country of the company of the employee(s) who requested the time off (Assuming that all
	the employees belong to the same company).
    2. The country of the company on the time off request/allocation if the mode is `by company`,
	`by department` or `by employee tag`.


* These changes also give the ability to search for time off types that have a specific country and group time
off types by country.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
