### PR TITLE
[FIX] pos_coupon: Ensure activePromoProgramIds correct initialization

### DIFF
--- a/addons/pos_coupon/static/src/js/coupon.js
+++ b/addons/pos_coupon/static/src/js/coupon.js
@@ -362,7 +362,7 @@ odoo.define('pos_coupon.pos', function (require) {
                  */
                 this.bookedCouponCodes = {};
             }
-            if (!this.activePromoProgramIds) {
+            if (!(this.activePromoProgramIds && this.activePromoProgramIds.length)) {
                 /**
                  * This field contains the ids of automatically/manually activated
                  * promo programs.


### PR DESCRIPTION
Before this commit, if you add a rewarded product in 2 steps promo program will not be applied

Now, we Ensure activePromoProgramIds correct initialization

Step to reproduce:
  - Create a coupon automatically applied
  - Settup the a PoS that uses floors setups and add the promotion program just created
  - Open a new session and add just 1 item of the rewarded
  - Go back to floors screen
  - Enter to the Order again
  - Add a new item of the rewarded product

You can see the promotion program it's not applied
VIDEO DEMO
https://www.youtube.com/watch?v=M4bjAXxgDuY

Closes https://github.com/odoo/odoo/issues/169166

Support Ticket

OPW-3988506


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
