### PR TITLE
[FIX] product: fix columns truncated in stock, product attribute

### DIFF
--- a/addons/product/views/product_attribute_views.xml
+++ b/addons/product/views/product_attribute_views.xml
@@ -50,7 +50,7 @@
                                 <field name="sequence" widget="handle"/>
                                 <field name="name"/>
                                 <field name="display_type" column_invisible="True"/>
-                                <field name="is_custom"
+                                <field name="is_custom" width="120px"
                                        column_invisible="parent.display_type == 'multi'"/>
                                 <field name="html_color"
                                        widget="color"
@@ -61,7 +61,7 @@
                                        options="{'size': [70, 70]}"
                                        class="oe_avatar text-start float-none"
                                        column_invisible="parent.display_type != 'color'"/>
-                                <field name="default_extra_price"/>
+                                <field name="default_extra_price" width="160px"/>
                                 <button name="action_open_product_template_attribute_value"
                                         type="object"
                                         string="View products"


### PR DESCRIPTION
Before this commit, columns of `is_custom` and `default_extra_price` in the stock -> product attribute form view with empty records were being truncated and not displayed properly.

Steps to Reproduce:
- Open documents and navigate to actions in the configuration.
- Click on any action and add a rule for any many-to-many field.
- Try to add many-to-many values to that rule.

Observed Behavior:
The columns do not have proper widths causing the header text to be truncated and not properly visible.

Expected Behavior:
The columns should have appropriate widths, so that the header texts is properly visible.

After this commit, columns of `is_custom` and `default_extra_price` in the stock -> product attribute form view with empty records are given proper widths so that they are properly visible.

Task ID: 3858802

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
