### PR TITLE
[FIX] Maintenance: Fix Required Check

### DIFF
--- a/addons/maintenance/views/maintenance_views.xml
+++ b/addons/maintenance/views/maintenance_views.xml
@@ -123,9 +123,9 @@
                             </div>
                             <label for="repeat_interval" invisible="not recurring_maintenance"/>
                             <div class="d-flex" invisible="not recurring_maintenance">
-                                <field name="repeat_interval" required="True" class="me-2" style="max-width: 2rem !important;" />
-                                <field name="repeat_unit" required="True" class="me-2" style="max-width: 4rem !important;" />
-                                <field name="repeat_type" required="True" class="me-2" style="max-width: 15rem !important;" />
+                                <field name="repeat_interval" required="recurring_maintenance" class="me-2" style="max-width: 2rem !important;" />
+                                <field name="repeat_unit" required="recurring_maintenance" class="me-2" style="max-width: 4rem !important;" />
+                                <field name="repeat_type" required="recurring_maintenance" class="me-2" style="max-width: 15rem !important;" />
                                 <field name="repeat_until" invisible="repeat_type != 'until'" required="repeat_type == 'until'" class="me-2" />
                             </div>
                             <field name="priority" widget="priority"/>


### PR DESCRIPTION
**Cause:** In version 17.0, new fields (repeat_unit, repeat_type, repeat_until) [ref](https://github.com/odoo/odoo/blob/d7cfef9c51461a595f3f46c7b91e5c56241d4af3/addons/maintenance/models/maintenance.py#L265) were introduced in the maintenance module. These fields are set as required in the view 'maintenance.hr_equipment_request_view_form', but they are only visible if the request is a recurrent maintenance request, which causes a validation error when changing the status.

**Solution:** Change the required condition 'True' to recurring_maintenance == True, as the field is only visible for recurring maintenance requests. Making it required for all cases is not feasible.

**Note:** This is not a bug in the general version of 17.0; it is introduced after an upgrade from version 16.0 to 17.0.

for more detail:  odoo/upgrade#6147

**opw-3983692**

**Current behavior before PR:**
 when migrating from 16.0 to 17.0, getting validation error on changing the state of maintenance request
![image](https://github.com/odoo/odoo/assets/145324071/5af78939-933e-41a6-8ab5-f4ba5f69984d)


**Desired behavior after PR is merged:**
able to change the state of maintenance request
![image](https://github.com/odoo/odoo/assets/145324071/e72de3f3-6787-4761-9151-3f7f2fdbd78b)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
