### PR TITLE
[FIX] spreadsheet: disable "SEE_RECORDS" for spreadsheet pivot

### DIFF
--- a/addons/spreadsheet/static/src/pivot/pivot_actions.js
+++ b/addons/spreadsheet/static/src/pivot/pivot_actions.js
@@ -44,6 +44,7 @@ export const SEE_RECORDS_PIVOT = async (position, env) => {
 export const SEE_RECORDS_PIVOT_VISIBLE = (position, getters) => {
     const cell = getters.getCorrespondingFormulaCell(position);
     const evaluatedCell = getters.getEvaluatedCell(position);
+    const pivotId = getters.getPivotIdFromPosition(position);
     const argsDomain = getters.getPivotDomainArgsFromPosition(position)?.domainArgs;
     return (
         evaluatedCell.type !== "empty" &&
@@ -52,7 +53,8 @@ export const SEE_RECORDS_PIVOT_VISIBLE = (position, getters) => {
         argsDomain !== undefined &&
         cell &&
         cell.isFormula &&
-        getNumberOfPivotFunctions(cell.compiledFormula.tokens) === 1
+        getNumberOfPivotFunctions(cell.compiledFormula.tokens) === 1 &&
+        getters.getPivotCoreDefinition(pivotId).type === "ODOO"
     );
 };
 

--- a/addons/spreadsheet/static/tests/pivots/pivot_see_records_test.js
+++ b/addons/spreadsheet/static/tests/pivots/pivot_see_records_test.js
@@ -209,6 +209,34 @@ QUnit.test("Cannot see records of pivot formula without value", async function (
     assert.notOk(action.isVisible(env));
 });
 
+QUnit.test("Cannot see records of spreadsheet pivot", async function (assert) {
+    const { model, env } = await createSpreadsheetWithPivot();
+    setCellContent(model, "A11", "A");
+    setCellContent(model, "A12", "1");
+    setCellContent(model, "B11", "B");
+    setCellContent(model, "B12", "2");
+
+    model.dispatch("ADD_PIVOT", {
+        pivotId: "2",
+        pivot: {
+            type: "SPREADSHEET",
+            columns: [{ name: "A", order: "asc" }],
+            rows: [],
+            measures: [{ name: "B", aggregator: "sum" }],
+            name: "Pivot2",
+            dataSet: {
+                sheetId: model.getters.getActiveSheetId(),
+                zone: { top: 10, bottom: 11, left: 0, right: 1 },
+            },
+        },
+    });
+    setCellContent(model, "A13", `=PIVOT("2")`);
+    assert.strictEqual(getCellValue(model, "B15"), 2);
+    selectCell(model, "B15");
+    const action = await getActionMenu(cellMenuRegistry, ["pivot_see_records"], env);
+    assert.notOk(action.isVisible(env));
+});
+
 QUnit.test("See records is not visible on an empty cell", async function (assert) {
     const { env, model } = await createSpreadsheetWithPivot();
     assert.strictEqual(getCell(model, "A21"), undefined);


### PR DESCRIPTION
Steps to reproduce:
- insert a pivot based on a range in the spreadsheet
- right click on any pivot value
- click on "See records" => Traceback

This commit disable "SEE_RECORDS" for pivots of type "SPREADSHEET" as it does not make sense.

Task: 3987066

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
