### PR TITLE
[IMP] purchase: product description widget

### DIFF
--- a/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.js
+++ b/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.js
@@ -13,9 +13,15 @@ import { useProductAndLabelAutoresize } from "@account/core/utils/product_and_la
 import { X2ManyField, x2ManyField } from "@web/views/fields/x2many/x2many_field";
 
 export class ProductLabelSectionAndNoteListRender extends SectionAndNoteListRenderer {
+
+    setup() {
+        super.setup();
+        this.productColumns = ["product_id", "product_template_id"];
+    }
+
     getCellTitle(column, record) {
         // When using this list renderer, we don't want the product_id cell to have a tooltip with its label.
-        if (column.name === "product_id") {
+        if (this.productColumns.includes(column.name)) {
             return;
         }
         super.getCellTitle(column, record);
@@ -23,7 +29,7 @@ export class ProductLabelSectionAndNoteListRender extends SectionAndNoteListRend
 
     getActiveColumns(list) {
         let activeColumns = super.getActiveColumns(list);
-        const productCol = activeColumns.find((col) => col.name === "product_id");
+        const productCol = activeColumns.find((col) => this.productColumns.includes(col.name));
         const labelCol = activeColumns.find((col) => col.name === "name");
 
         if (productCol) {
@@ -33,7 +39,7 @@ export class ProductLabelSectionAndNoteListRender extends SectionAndNoteListRend
                 list.records.forEach((record) => (record.columnIsProductAndLabel = false));
             }
             activeColumns = activeColumns.filter((col) => col.name !== "name");
-            this.titleField = "product_id";
+            this.titleField = productCol.name;
         } else {
             this.titleField = "name";
         }
@@ -118,9 +124,9 @@ export class ProductLabelSectionAndNoteField extends Many2OneField {
         this.switchToLabel = false;
         this.columnIsProductAndLabel = useState({ value: this.props.record.columnIsProductAndLabel });
         this.labelNode = useRef("labelNodeRef");
-        useProductAndLabelAutoresize(this.labelNode, { targetParentName: "product_id" });
+        useProductAndLabelAutoresize(this.labelNode, { targetParentName: this.props.name });
         this.productNode = useRef("productNodeRef");
-        useProductAndLabelAutoresize(this.productNode, { targetParentName: "product_id" });
+        useProductAndLabelAutoresize(this.productNode, { targetParentName: this.props.name });
 
         useEffect(
             () => {
@@ -138,7 +144,7 @@ export class ProductLabelSectionAndNoteField extends Many2OneField {
     }
 
     get productName() {
-        return this.props.record.data.product_id[1];
+        return this.props.record.data[this.props.name][1];
     }
 
     get label() {
@@ -194,7 +200,12 @@ export class ProductLabelSectionAndNoteField extends Many2OneField {
     }
 
     updateLabel(value) {
-        this.props.record.update({ name: this.productName ? `${this.productName}\n${value}` : value });
+        this.props.record.update({
+          name:
+            this.productName && this.productName !== value
+              ? `${this.productName}\n${value}`
+              : value,
+        });
     }
 }
 

--- a/addons/purchase/views/portal_templates.xml
+++ b/addons/purchase/views/portal_templates.xml
@@ -357,7 +357,7 @@
 
                             <tr t-att-class="'fw-bold o_line_section' if line.display_type == 'line_section' else 'fst-italic text-break' if line.display_type == 'line_note' else ''">
                                 <t t-if="not line.display_type">
-                                    <td id="product_name">
+                                    <td id="product_name" class="d-flex">
                                         <img t-att-src="image_data_uri(resize_to_48(line.product_id.image_1024))" alt="Product" class="d-none d-lg-inline"/>
                                         <span t-field="line.name"/>
                                     </td>

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -207,7 +207,7 @@
                         <page string="Products" name="products">
                             <field name="tax_country_id" invisible="1"/>
                             <field name="order_line"
-                                widget="section_and_note_one2many"
+                                widget="product_label_section_and_note_field_o2m"
                                 mode="tree,kanban"
                                 context="{'default_state': 'draft'}"
                                 readonly="state in ('done', 'cancel')">
@@ -230,6 +230,7 @@
                                     <field name="sequence" widget="handle"/>
                                     <field
                                         name="product_id"
+                                        widget="product_label_section_and_note_field"
                                         readonly="state in ('purchase', 'to approve', 'done', 'cancel')"
                                         required="not display_type"
                                         context="{'partner_id':parent.partner_id, 'quantity':product_qty, 'company_id': parent.company_id}"

--- a/addons/purchase_product_matrix/static/src/js/purchase_product_field.js
+++ b/addons/purchase_product_matrix/static/src/js/purchase_product_field.js
@@ -2,12 +2,15 @@
 
 import { _t } from "@web/core/l10n/translation";
 import { registry } from '@web/core/registry';
-import { Many2OneField, many2OneField } from '@web/views/fields/many2one/many2one_field';
+import { many2OneField } from '@web/views/fields/many2one/many2one_field';
 import { ProductMatrixDialog } from "@product_matrix/js/product_matrix_dialog";
 import { useService } from "@web/core/utils/hooks";
 import { useRecordObserver } from "@web/model/relational_model/utils";
+import {
+    ProductLabelSectionAndNoteField
+} from "@account/components/product_label_section_and_note_field/product_label_section_and_note_field";
 
-export class PurchaseOrderLineProductField extends Many2OneField {
+export class PurchaseOrderLineProductField extends ProductLabelSectionAndNoteField {
     static template = "purchase.PurchaseProductField";
     setup() {
         super.setup();
@@ -45,7 +48,7 @@ export class PurchaseOrderLineProductField extends Many2OneField {
             if (this.props.record.data.product_id != result.product_id.id) {
                 this.props.record.update({
                     // TODO right name get (same problem as configurator)
-                    product_id: [result.product_id, 'whatever'],
+                    product_id: [result.product_id, result.product_name],
                 });
             }
         } else {

--- a/addons/purchase_product_matrix/static/src/js/purchase_product_field.xml
+++ b/addons/purchase_product_matrix/static/src/js/purchase_product_field.xml
@@ -2,18 +2,17 @@
 
 <templates xml:space="preserve">
 
-    <t t-name="purchase.PurchaseProductField" t-inherit="web.Many2OneField" t-inherit-mode="primary">
-        <xpath expr="//t[@t-if='hasExternalButton']" position="before">
-            <t t-if="isConfigurableTemplate">
-                <button
-                    type="button"
-                    class="btn btn-secondary fa fa-pencil"
-                    tabindex="-1"
-                    draggable="false"
-                    t-att-aria-label="configurationButtonHelp"
-                    t-att-data-tooltip="configurationButtonHelp"
-                    t-on-click="onEditConfiguration"/>
-            </t>
+    <t t-name="purchase.PurchaseProductField" t-inherit="account.ProductLabelSectionAndNoteField" t-inherit-mode="primary">
+        <xpath expr="//button[@t-if='hasExternalButton']" position="before">
+            <button
+                t-if="isConfigurableTemplate"
+                type="button"
+                class="btn btn-link fa fa-pencil"
+                tabindex="-1"
+                draggable="false"
+                t-att-aria-label="configurationButtonHelp"
+                t-att-data-tooltip="configurationButtonHelp"
+                t-on-click="onEditConfiguration"/>
         </xpath>
     </t>
 

--- a/addons/purchase_product_matrix/static/tests/tours/purchase_product_matrix_tour.js
+++ b/addons/purchase_product_matrix/static/tests/tours/purchase_product_matrix_tour.js
@@ -50,7 +50,7 @@ registry.category("web_tour.tours").add('purchase_matrix_tour', {
     trigger: ".o_form_status_indicator_buttons.invisible", // wait for save to be finished
 },
 {
-    trigger: 'span:contains("Matrix (PAV11, PAV22, PAV31)\nPA4: PAV41")',
+    trigger: '.o_field_pol_product_many2one',
     run: "click",
 }, {
     trigger: '[name=product_template_id] button.fa-pencil', // edit the matrix


### PR DESCRIPTION
This PR applies the new widget for product name and description introduced in #152869 on purchase order lines. This widget combines name and description in one single column for better readability. Also all report and portal views are updated to reflect the same look of `purchase.order` form view. So now all reports of `purchase.order` have the product name and description in one column, with the name on the top and the description below it. Users are also now not required to fill the description field as before.

Task-3930391