### PR TITLE
[FIX] website_slides: fix compute_name

### DIFF
--- a/addons/website_slides/models/slide_slide_resource.py
+++ b/addons/website_slides/models/slide_slide_resource.py
@@ -41,9 +41,9 @@ class SlideResource(models.Model):
             if to_update:
                 new_name = _("Resource")
                 if resource.resource_type == 'file' and (resource.data or resource.file_name):
-                    new_name = self.file_name
+                    new_name = resource.file_name
                 elif resource.resource_type == 'url':
-                    new_name = self.link
+                    new_name = resource.link
                 resource.name = new_name
 
     @api.constrains('data')


### PR DESCRIPTION
This commit fixes an issue introduced in 63285ce when merging `slide.slide.link` and `slide.slide.resource`.

When a user would edit multiple resources at once, the compute done for the name would crash.
This is caused by a read done on `self` instead a for loop, which causes a crash if `self` is a recordset.

To fix this, the read on self is replaced by resource which would be a record inside of the recordset.

task-3988760

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
