### PR TITLE
[FIX] pos_mercado_pago: Force PDV visibility

### DIFF
--- a/addons/pos_mercado_pago/views/pos_payment_method_views.xml
+++ b/addons/pos_mercado_pago/views/pos_payment_method_views.xml
@@ -10,7 +10,7 @@
                 <field name="mp_bearer_token" placeholder="APP_USR-..." invisible="use_payment_terminal != 'mercado_pago'" required="use_payment_terminal == 'mercado_pago'"/>
                 <field name="mp_webhook_secret_key" placeholder="c2f3662..." invisible="use_payment_terminal != 'mercado_pago'" required="use_payment_terminal == 'mercado_pago'"/>
                 <field name="mp_id_point_smart" placeholder="1494126963" invisible="use_payment_terminal != 'mercado_pago'" required="use_payment_terminal == 'mercado_pago'"/>
-                <button string="Force PDV" type="object" name="force_pdv" groups="base.group_no_one" class="oe_highlight"/>
+                <button string="Force PDV" type="object" name="force_pdv" groups="base.group_no_one" class="oe_highlight" invisible="use_payment_terminal != 'mercado_pago'" required="use_payment_terminal == 'mercado_pago'"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Currently the "Force PDV" button for mercado pago is visible in debug mode no matter if you select "mercado_pago" as the payment provider or not.

This PR makes it so that it is only visible if 'mercado_pago' is selected as a payment provider

![image](https://github.com/odoo/odoo/assets/36443074/1c8e0c3f-7d21-4ae6-b93e-d0fad7fd472f)
![image](https://github.com/odoo/odoo/assets/36443074/7025c358-9e77-4238-a9e4-ce44eb69c419)

task-3988847
