### PR TITLE
[FIX] mail, mass_mailing: don't load duplicate attachments

### DIFF
--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -1286,7 +1286,7 @@ class MassMailing(models.Model):
         root = lxml.html.fromstring(html_content)
         did_modify_body = False
 
-        conversion_info = []  # list of tuples (image: base64 image, node: lxml node, old_url: string or None))
+        conversion_info = []  # list of tuples (image: base64 image, node: lxml node, old_url: string or None, original_id))
         with requests.Session() as session:
             for node in root.iter(lxml.etree.Element, lxml.etree.Comment):
                 if node.tag == 'img':
@@ -1294,12 +1294,12 @@ class MassMailing(models.Model):
                     match = image_re.match(node.attrib.get('src', ''))
                     if match:
                         image = match.group(2).encode()  # base64 image as bytes
-                        conversion_info.append((image, node, None))
+                        conversion_info.append((image, node, None, int(node.attrib.get('data-original-id') or "0")))
                 elif 'base64' in (node.attrib.get('style') or ''):
                     # Convert base64 images in inline styles to attachments.
                     for match in re.findall(r'data:image/[A-Za-z]+;base64,.+?(?=&\#34;|\"|\'|&quot;|\))', node.attrib.get('style')):
                         image = re.sub(r'data:image/[A-Za-z]+;base64,', '', match).encode()  # base64 image as bytes
-                        conversion_info.append((image, node, match))
+                        conversion_info.append((image, node, match, int(node.attrib.get('data-original-id') or "0")))
                 elif mso_re.match(node.text or ''):
                     # Convert base64 images (in img tags or inline styles) in mso comments to attachments.
                     base64_in_element_regex = re.compile(r"""
@@ -1307,7 +1307,7 @@ class MassMailing(models.Model):
                     """, re.VERBOSE)
                     for match in re.findall(base64_in_element_regex, node.text):
                         image = re.sub(r'data:image/[A-Za-z]+;base64,', '', match).encode()  # base64 image as bytes
-                        conversion_info.append((image, node, match))
+                        conversion_info.append((image, node, match, int(node.attrib.get('data-original-id') or "0")))
                     # Crop VML images.
                     for match in re.findall(r'<v:image[^>]*>', node.text):
                         url = re.search(r'src=\s*\"([^\"]+)\"', match)[1]
@@ -1329,11 +1329,11 @@ class MassMailing(models.Model):
                             else:
                                 image_processor = tools.ImageProcess(image)
                                 image = image_processor.crop_resize(target_width, target_height, 0, 0)
-                                conversion_info.append((base64.b64encode(image.source), node, url))
+                                conversion_info.append((base64.b64encode(image.source), node, url, int(node.attrib.get('data-original-id') or "0")))
 
         # Apply the changes.
-        urls = self._create_attachments_from_inline_images([image for (image, _, _) in conversion_info])
-        for ((image, node, old_url), new_url) in zip(conversion_info, urls):
+        urls = self._create_attachments_from_inline_images([(image, original_id) for (image, _, _, original_id) in conversion_info])
+        for ((image, node, old_url, original_id), new_url) in zip(conversion_info, urls):
             did_modify_body = True
             if node.tag == 'img':
                 node.attrib['src'] = new_url
@@ -1356,27 +1356,47 @@ class MassMailing(models.Model):
             ('res_id', '=', self.id),
         ]).mapped(lambda record: (record.checksum, record)))
 
-        attachments, vals_for_attachs = [], []
+        attachments, vals_for_attachs, checksums = [], [], []
+        checksums_set, checksum_original_id, new_attachment_by_checksum = set(), {}, {}
         next_img_id = len(existing_attachments)
-        for b64image in b64images:
+        for (b64image, original_id) in b64images:
             checksum = IrAttachment._compute_checksum(base64.b64decode(b64image))
+            checksums.append(checksum)
             existing_attach = existing_attachments.get(checksum)
             # Existing_attach can be None, in which case it acts as placeholder
             # for attachment to be created.
             attachments.append(existing_attach)
-            if not existing_attach:
+            if original_id:
+                checksum_original_id[checksum] = original_id
+            if not existing_attach and not checksum in checksums_set:
+                # We create only one attachment per checksum
                 vals_for_attachs.append({
                     'datas': b64image,
                     'name': f"image_mailing_{self.id}_{next_img_id}",
                     'type': 'binary',
                     'res_id': self.id,
-                    'res_model': 'mailing.mailing'
+                    'res_model': 'mailing.mailing',
+                    'checksum': checksum,
                 })
+                checksums_set.add(checksum)
                 next_img_id += 1
+        for vals in vals_for_attachs:
+            if vals['checksum'] in checksum_original_id:
+                vals['original_id'] = checksum_original_id[vals['checksum']]
+            del vals['checksum']
 
         new_attachments = iter(IrAttachment.create(vals_for_attachs))
+        checksum_iter = iter(checksums)
         # Replace None entries by newly created attachments.
-        attachments = [(attach or next(new_attachments)) for attach in attachments]
+        for i in range(len(attachments)):
+            checksum = next(checksum_iter)
+            if attachments[i]:
+                continue
+            if checksum in new_attachment_by_checksum:
+                attachments[i] = new_attachment_by_checksum[checksum]
+            else:
+                attachments[i] = next(new_attachments)
+                new_attachment_by_checksum[checksum] = attachments[i]
 
         urls = []
         for attachment in attachments:

--- a/addons/mass_mailing/tests/test_mailing_internals.py
+++ b/addons/mass_mailing/tests/test_mailing_internals.py
@@ -123,10 +123,12 @@ class TestMassMailValues(MassMailCommon):
                                 <div style="color: red; background-image:url(data:image/jpg;base64,{BASE_64_STRING}15); display: block;"/>
                                 <div style="color: red; background-image: url(data:image/jpg;base64,{BASE_64_STRING}16); background: url('data:image/jpg;base64,{BASE_64_STRING}17'); display: block;"/>
                             <![endif]-->
+                            <img src="data:image/png;base64,{BASE_64_STRING}0">
                         </body></html>
                     """,
                 })
-        self.assertEqual(len(attachments), 18)
+        self.assertEqual(len(attachments), 19)
+        self.assertEqual(attachments[0]['id'], attachments[18]['id'])
         self.assertEqual(str(mailing.body_html), f"""
                         <html><body>
                             <img src="/web/image/{attachments[0]['id']}?access_token={attachments[0]['token']}">
@@ -149,6 +151,7 @@ class TestMassMailValues(MassMailCommon):
                                 <div style="color: red; background-image:url(/web/image/{attachments[15]['id']}?access_token={attachments[15]['token']}); display: block;"/>
                                 <div style="color: red; background-image: url(/web/image/{attachments[16]['id']}?access_token={attachments[16]['token']}); background: url('/web/image/{attachments[17]['id']}?access_token={attachments[17]['token']}'); display: block;"/>
                             <![endif]-->
+                            <img src="/web/image/{attachments[18]['id']}?access_token={attachments[18]['token']}">
                         </body></html>
         """.strip())
 
@@ -420,6 +423,61 @@ class TestMassMailValues(MassMailCommon):
         with self.assertRaises(IntegrityError):
             activity.write({'res_id': 0})
             self.env.flush_all()
+
+    def test_mailing_editor_created_attachments(self):
+        mailing = self.env['mailing.mailing'].create({
+            'name': 'TestMailing',
+            'subject': 'Test',
+            'mailing_type': 'mail',
+            'body_html': '<p>Hello</p>',
+            'mailing_model_id': self.env['ir.model']._get('res.partner').id,
+        })
+        blob_b64 = base64.b64encode(b'blob1')
+
+        # Created when uploading an image
+        original_svg_attachment = self.env['ir.attachment'].create({
+            "name": "test SVG",
+            "mimetype": "image/svg+xml",
+            "datas": blob_b64,
+            "public": True,
+            "res_model": "mailing.mailing",
+            "res_id": mailing.id,
+        })
+
+        # Created when saving the mass_mailing
+        png_duplicate_of_svg_attachment = self.env['ir.attachment'].create({
+            "name": "test SVG duplicate",
+            "mimetype": "image/png",
+            "datas": blob_b64,
+            "public": True,
+            "res_model": "mailing.mailing",
+            "res_id": mailing.id,
+            "original_id": original_svg_attachment.id
+        })
+
+        # Created by uploading new image
+        original_png_attachment = self.env['ir.attachment'].create({
+            "name": "test PNG",
+            "mimetype": "image/png",
+            "datas": blob_b64,
+            "public": True,
+            "res_model": "mailing.mailing",
+            "res_id": mailing.id,
+        })
+
+        # Created by modify_image in editor controller
+        self.env['ir.attachment'].create({
+            "name": "test PNG duplicate",
+            "mimetype": "image/png",
+            "datas": blob_b64,
+            "public": True,
+            "res_model": "mailing.mailing",
+            "res_id": mailing.id,
+            "original_id": original_png_attachment.id
+        })
+
+        mail_thread_attachments = mailing._get_mail_thread_data_attachments()
+        self.assertSetEqual(set(mail_thread_attachments.ids), {png_duplicate_of_svg_attachment.id, original_png_attachment.id})
 
 
 @tagged("mass_mailing", "utm")


### PR DESCRIPTION
Issue:
======
Duplicate attachmenets are loaded in chatter.

Steps to reproduce the issue:
=============================
- Go to massmailing, create a new email with a template with images.
- Replace the image by uploading a new one, save.
- The second and onward uploaded images have two attachments in the
  tab->chat->attachment.

Origin of the issue:
====================
In web_editor, optimized versions of the images are created. In the
chatter we load all attachments, original and optimized ones which looks
like we have duplicates.

For .svg images, we create duplicate .png versions in python side.

Spec for Images created from mass_mailing:
===========================================
- For SVG images we show only the png version.
- For non SVG images we show the original version.

Solution:
=========
- For SVG images: If the image doesn't have .png version which means
added directly in the chatter/attach we show it otherwise we show the
.png version.

- For non SVG images: We always show the image which doesn't have
  original_id or their original_id image isn't in the list of
  attachment.

task-3639914
opw-3589477