### PR TITLE
[IMP] mrp: permit to reshuffle operations

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -942,22 +942,6 @@ class MrpProduction(models.Model):
                 vals['move_raw_ids'] = [(0, 0, move_vals) for move_vals in production.move_raw_ids.filtered(lambda m: m.product_qty != 0.0).copy_data()]
         return vals_list
 
-    def copy(self, default=None):
-        new_productions = super().copy(default)
-        for old_production, new_production in zip(self, new_productions):
-            if old_production.workorder_ids.blocked_by_workorder_ids:
-                workorders_mapping = {}
-                for original, copied in zip(old_production.workorder_ids, new_production.workorder_ids.sorted()):
-                    workorders_mapping[original] = copied
-                for workorder in old_production.workorder_ids:
-                    if workorder.blocked_by_workorder_ids:
-                        copied_workorder = workorders_mapping[workorder]
-                        dependencies = []
-                        for dependency in workorder.blocked_by_workorder_ids:
-                            dependencies.append(Command.link(workorders_mapping[dependency].id))
-                        copied_workorder.blocked_by_workorder_ids = dependencies
-        return new_productions
-
     def action_generate_bom(self):
         """ Generates a new Bill of Material based on the Manufacturing Order's product, components,
         workorders and by-products, and assigns it to the MO. Returns a new BoM's form view action.

--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1448,11 +1448,8 @@ class MrpProduction(models.Model):
         last_workorder_per_bom = defaultdict(lambda: self.env['mrp.workorder'])
         self.allow_workorder_dependencies = self.bom_id.allow_operation_dependencies
 
-        def workorder_order(wo):
-            return (wo.operation_id.bom_id, wo.operation_id.sequence)
-
         if self.allow_workorder_dependencies:
-            for workorder in self.workorder_ids.sorted(workorder_order):
+            for workorder in self.workorder_ids.sorted():
                 workorder.blocked_by_workorder_ids = [Command.link(workorder_per_operation[operation_id].id)
                                                       for operation_id in
                                                       workorder.operation_id.blocked_by_operation_ids
@@ -1461,8 +1458,8 @@ class MrpProduction(models.Model):
                     last_workorder_per_bom[workorder.operation_id.bom_id] = workorder
         else:
             previous_workorder = False
-            for workorder in self.workorder_ids.sorted(workorder_order):
-                if previous_workorder and previous_workorder.operation_id.bom_id == workorder.operation_id.bom_id:
+            for workorder in self.workorder_ids.sorted():
+                if previous_workorder:
                     workorder.blocked_by_workorder_ids = [Command.link(previous_workorder.id)]
                 previous_workorder = workorder
                 last_workorder_per_bom[workorder.operation_id.bom_id] = workorder

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -282,6 +282,7 @@
                             <field name="use_create_components_lots" invisible="1"/>
                             <field name="show_lot_ids" invisible="1"/>
                             <field name="product_tracking" invisible="1"/>
+                            <field name="allow_workorder_dependencies" invisible="1"/>
                             <field name="product_id" context="{'default_is_storable': True}" readonly="state != 'draft'" default_focus="1" placeholder="Product to build..."/>
                             <field name="product_tmpl_id" invisible="1"/>
                             <field name="forecasted_issue" invisible="1"/>

--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -111,6 +111,9 @@
             <xpath expr="//field[@name='show_json_popover']" position='before'>
                 <button name="action_open_wizard" type="object" icon="fa-external-link" class="oe_edit_only" title="Open Work Order" context="{'default_workcenter_id': workcenter_id}"/>
             </xpath>
+            <xpath expr="//field[@name='name']" position='before'>
+                <field name="sequence" widget="handle" column_invisible="parent.state != 'draft'"/>
+            </xpath>
         </field>
     </record>
 

--- a/addons/stock/static/src/views/list/auto_column_width_list_renderer.js
+++ b/addons/stock/static/src/views/list/auto_column_width_list_renderer.js
@@ -1,8 +1,17 @@
 /** @odoo-module **/
 
 import { ListRenderer } from "@web/views/list/list_renderer";
+import { useEffect } from "@odoo/owl";
 
 export class AutoColumnWidthListRenderer extends ListRenderer {
     static props = [...ListRenderer.props];
-    static useMagicColumnWidths = false;
+    setup() {
+        super.setup();
+        useEffect(
+            () => {
+                this.keepColumnWidths = false;
+            },
+            () => [this.columns]
+        );
+    }
 }


### PR DESCRIPTION
Enterprise PR: https://github.com/odoo/enterprise/pull/64770

This commit adds a sequence on mrp.workorder. This sequence can be
changed when the production order is in draft state.

When dependencies setting is enabled, the blocked by field will be
visible on the operation tree view and changing the sequence will not
change anything about blocking operations.
When dependencies setting is disabled, changing the sequence will
impact the linear dependencies between operations when the production
order is confirmed.

task-3848797