### PR TITLE
[FIX] hr_attendance : fix onboarding screen

### DIFF
--- a/addons/hr_attendance/static/src/views/attendance_helper_view.js
+++ b/addons/hr_attendance/static/src/views/attendance_helper_view.js
@@ -1,0 +1,26 @@
+import { useService } from "@web/core/utils/hooks";
+
+import { Component, onWillStart, useState } from "@odoo/owl";
+
+export class AttendanceActionHelper extends Component {
+    static template = "hr_attendance.AttendanceActionHelper";
+    static props = ["noContentHelp"];
+    setup() {
+        this.orm = useService("orm");
+        this.actionService = useService("action");
+        this.state = useState({
+            hasDemoData: false,
+        });
+        onWillStart(async () => {
+            this.state.hasDemoData = await this.orm.call("hr.attendance", "hasDemoData", []);
+        });
+    }
+
+    loadAttendanceScenario() {
+        this.actionService.doAction("hr_attendance.action_load_demo_data");
+    }
+
+    LoadTryKiosk() {
+        this.actionService.doAction("hr_attendance.action_try_kiosk");
+    }
+};

--- a/addons/hr_attendance/static/src/views/attendance_helper_view.js
+++ b/addons/hr_attendance/static/src/views/attendance_helper_view.js
@@ -12,7 +12,7 @@ export class AttendanceActionHelper extends Component {
             hasDemoData: false,
         });
         onWillStart(async () => {
-            this.state.hasDemoData = await this.orm.call("hr.attendance", "hasDemoData", []);
+            this.state.hasDemoData = await this.orm.call("hr.attendance", "has_demo_data", []);
         });
     }
 

--- a/addons/hr_attendance/static/src/views/attendance_helper_view.xml
+++ b/addons/hr_attendance/static/src/views/attendance_helper_view.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <t t-name="hr_attendance.AttendanceActionHelper">
+        <div class="o_view_nocontent">
+            <div class="o_nocontent_help">
+                <p class="oe_view_nocontent_attendance">
+                    <h3 class="py-2">
+                        Ready to track attendances ?
+                    </h3>
+                    <div class="d-flex align py-2">
+                        <div class="mx-5" >
+                            <img src="/hr_attendance/static/img/mock-tablet.png" height="180" class="mb-2"/>
+                            <div class="row justify-content-center mt-1">
+                                <a type="object" class="btn btn-primary d-block col-6" t-on-click="() => this.LoadTryKiosk()">
+                                    Try the kiosk
+                                </a>
+                            </div>
+                        </div>
+                        <div class="mx-5" >
+                            <img src="/hr_attendance/static/img/attendance_dot.gif" height="180" class="mb-2"/>
+                            <h3 class="mt-2"><em>Try the top
+                                <i class="fa fa-circle text-danger" role="img" aria-label="Attendance"/>
+                                icon (e.g for work from home)</em></h3>
+                        </div>
+                    </div>
+                    <t t-if="!state.hasDemoData">
+                        <div class="d-flex gap-3 align-items-center or-separator">
+                            <hr class="flex-grow-1"/>
+                            or
+                            <hr class="flex-grow-1"/>
+                        </div>
+                        <div class="px-2 py-2">
+                            <h3 class="m-2 py-2">
+                                Try the backend and reporting:
+                            </h3>
+                            <div class="row justify-content-center">
+                                <a type="object" class="btn btn-secondary d-block col-2" t-on-click="() => this.loadAttendanceScenario()">
+                                    Load sample data
+                                </a>
+                            </div>
+                        </div>
+                    </t>
+                </p>
+            </div>
+        </div>
+    </t>
+</odoo>

--- a/addons/hr_attendance/static/src/views/attendance_list_view.js
+++ b/addons/hr_attendance/static/src/views/attendance_list_view.js
@@ -1,0 +1,26 @@
+import { registry } from "@web/core/registry";
+
+import { listView } from "@web/views/list/list_view";
+import { ListRenderer } from "@web/views/list/list_renderer";
+import { AttendanceActionHelper } from "@hr_attendance/views/attendance_helper_view";
+
+export class AttendanceListRenderer extends ListRenderer {
+    static template = "hr_attendance.AttendanceListRenderer";
+    static components = {
+        ...AttendanceListRenderer.components,
+        AttendanceActionHelper,
+    };
+
+    /** @override **/
+    get showNoContentHelper() {
+        // Rows's length need to be lower than 6 to avoid nocontent overlapping
+        return super.showNoContentHelper && this.props.list.count < 6 ;
+    }
+};
+
+export const attendanceListView = {
+    ...listView,
+    Renderer: AttendanceListRenderer,
+};
+
+registry.category("views").add("attendance_list_view", attendanceListView);

--- a/addons/hr_attendance/static/src/views/attendance_list_view.xml
+++ b/addons/hr_attendance/static/src/views/attendance_list_view.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <t t-name="hr_attendance.AttendanceListRenderer" t-inherit="web.ListRenderer" t-inherit-mode="primary">
+        <t t-call="web.ActionHelper" position="replace">
+            <t t-if="showNoContentHelper">
+                <AttendanceActionHelper noContentHelp="props.noContentHelp"/>
+            </t>
+        </t>
+    </t>
+</odoo>

--- a/addons/hr_attendance/tests/__init__.py
+++ b/addons/hr_attendance/tests/__init__.py
@@ -3,3 +3,4 @@
 from . import test_hr_attendance_constraints
 from . import test_hr_attendance_overtime
 from . import test_hr_attendance_process
+from . import test_hr_attendance_domain_translation

--- a/addons/hr_attendance/tests/test_hr_attendance_domain_translation.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_domain_translation.py
@@ -1,0 +1,53 @@
+import time
+
+from odoo.tests.common import tagged, TransactionCase
+
+
+@tagged('attendance_searchbar_user_domain')
+class TestHrAttendanceDomainTranslation(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.hr_attendance = cls.env['hr.attendance']
+        cls.hr_employee = cls.env['hr.employee']
+        cls.employee_musa, employee_tecna = cls.hr_employee.create([{'name': 'Musa'}, {'name': 'Tecna'}])
+        cls.hr_attendance.create({
+            'employee_id': employee_tecna.id,
+            'check_in': time.strftime('%Y-%m-10 10:00'),
+        })
+
+    def test_searchbar_with_user_domain(self):
+        companies_ids = self.env['res.company'].search([]).ids
+
+        # Checks that this domain returns no attendance
+        self.assertEqual(
+            self.hr_attendance.search([
+                '&',
+                    ('check_out', "!=", False),
+                    '|',
+                        ('employee_id', 'ilike', 'Musa'),
+                        ('employee_id', 'ilike', 'Flora')
+            ]),
+            self.hr_attendance
+        )
+
+        # Ensure that if an employee is searched with the search bar even if he doesn't have any attendance,
+        # he will be returned.
+        self.assertEqual(
+            self.hr_attendance.with_context(
+                allowed_company_ids=companies_ids,
+                user_domain=[
+                    '|',
+                        ('employee_id', 'ilike', 'Musa'),
+                        ('employee_id', 'ilike', 'Flora')
+                ])._read_group_employee_id(self.hr_employee, [
+                    '&',
+                        ('check_out', "!=", False),
+                        '|',
+                            ('employee_id', 'ilike', 'Musa'),
+                            ('employee_id', 'ilike', 'Flora')
+                    ]),
+            self.employee_musa
+        )

--- a/addons/hr_attendance/views/hr_attendance_view.xml
+++ b/addons/hr_attendance/views/hr_attendance_view.xml
@@ -7,7 +7,7 @@
         <field name="name">hr.attendance.tree</field>
         <field name="model">hr.attendance</field>
         <field name="arch" type="xml">
-            <tree string="Employee attendances" decoration-success="color == 10" decoration-danger="color == 1" sample="1" duplicate="false">
+            <tree string="Employee attendances" decoration-success="color == 10" decoration-danger="color == 1" sample="1" duplicate="false" js_class="attendance_list_view">
                 <field name="employee_id" widget="many2one_avatar_user"/>
                 <field name="check_in"/>
                 <field name="check_out" options="{}"/>
@@ -258,41 +258,7 @@
             }
         </field>
         <field name="search_view_id" ref="hr_attendance_view_filter"/>
-        <field name="help" type="html">
-            <p class="oe_view_nocontent_attendance">
-                Ready to track attendances ?
-                <div class="d-flex align">
-                    <div class="mx-5" >
-                        <img src="/hr_attendance/static/img/mock-tablet.png" height="180" class="mb-2"/>
-                        <div class="row justify-content-center mt-1">
-                            <a type="action" class="btn btn-primary d-block col-6" name="%(action_try_kiosk)d">
-                                Try the kiosk
-                            </a>
-                        </div>
-                    </div>
-                    <div class="mx-5" >
-                        <img src="/hr_attendance/static/img/attendance_dot.gif" height="180" class="mb-2"/>
-                        <p class="mt-2"><em>Try the top
-                            <i class="fa fa-circle text-danger" role="img" aria-label="Attendance"/>
-                            icon (e.g for work from home)</em></p>
-                    </div>
-                </div>
-                <div class="d-flex gap-3 align-items-center or-separator">
-                    <hr class="flex-grow-1"/>
-                    or
-                    <hr class="flex-grow-1"/>
-                </div>
-                <div class="px-2 py-2">
-                    <div class="m-2">
-                        Try the backend and reporting:
-                    </div>
-                    <div class="row justify-content-center">
-                        <a type="action" class="btn btn-secondary d-block col-2" name="%(action_load_demo_data)d">
-                            Load sample data
-                        </a>
-                    </div>
-                </div>
-            </p>
+        <field name="help">
         </field>
     </record>
 


### PR DESCRIPTION
STEP TO REPRODUCE:
==================

    ISSUE 1:
    ========
        0- Create a database without demodata
        1- Go on Attendance Application
        2- Click on Load demo data
        3- Write in "gegegege" in search bar for employee
        4 - Click again on Load demo data
    An error will be raised. To fix that if the demo data have been already launched this button will be hide.

    ISSUE 2:
    ========
    To have this issue, today's month need to have less than 31 days.
        0- Create a database without demodata
        1- Go on Attendance Application
        2- Click on Load demo data
    An error about month's number will be raised.

task-3983778

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
