### PR TITLE
[FIX] web: fix colorpicker position in iframe

### DIFF
--- a/addons/web/static/lib/popper/popper.js
+++ b/addons/web/static/lib/popper/popper.js
@@ -23,7 +23,7 @@
 
   function isElement(node) {
     var OwnElement = getWindow(node).Element;
-    return node instanceof OwnElement || node instanceof Element;
+    return node instanceof OwnElement || node.nodeType === Node.ELEMENT_NODE;
   }
 
   function isHTMLElement(node) {


### PR DESCRIPTION
Issue:
======
Half of the colorpicker isn't visible in the sidebar toolbar.

Steps to reproduce the issue:
=============================
- Go to mass mailing and choose any template with a button.
- Click on the button, make it a link.
- Choose style as custom in the sidebar
- Click on the circles for text color or fill color
- Colorpicker is not position correctly.

Origin of the issue:
====================
Explained in this commit: https://github.com/odoo/odoo/commit/88c16966b6b2d29d464ac3b43cc4998d3f4fe0e2

Before:
======
![before_colorpicker](https://github.com/odoo/odoo/assets/61123610/f7089635-9cfe-4279-b684-6c7695219142)


After:
====
![after_colorpicker](https://github.com/odoo/odoo/assets/61123610/3625b04c-fa7c-40fc-8217-50f04b69cddf)


opw-3984170