### PR TITLE
[FIX] web: list groupby button when group is False

### DIFF
--- a/addons/web/static/src/model/relational_model/relational_model.js
+++ b/addons/web/static/src/model/relational_model/relational_model.js
@@ -483,6 +483,10 @@ export class RelationalModel extends Model {
                 resIds: groupRecordResIds,
             }).then((records) => {
                 for (const group of groups) {
+                    if (!group.value) {
+                        group.values = { id: false };
+                        continue;
+                    }
                     group.values = records.find((r) => group.value && r.id === group.value);
                 }
             });

--- a/addons/web/static/src/views/list/list_renderer.xml
+++ b/addons/web/static/src/views/list/list_renderer.xml
@@ -179,7 +179,7 @@
                     <span t-attf-class="o_group_caret fa fa-fw {{group.isFolded ? 'fa-caret-right' : 'fa-caret-down' }} me-1"
                         t-attf-style="--o-list-group-level: {{getGroupLevel(group)}}"/>
                     <t t-esc="getGroupDisplayName(group)"/> (<t t-esc="group.count"/>)
-                    <div t-if="(groupByButtons[group.groupByField.name] and !group.isFolded)" class="o_group_buttons">
+                    <div t-if="(groupByButtons[group.groupByField.name] and !group.isFolded and group.record.resId)" class="o_group_buttons">
                         <t t-foreach="groupByButtons[group.groupByField.name]" t-as="button" t-key="button.id">
                             <t t-if="!evalInvisible(button.invisible, group.record)">
                                 <t t-if="button.clickParams.type === 'edit'">

--- a/addons/web/static/tests/views/list_view_tests.js
+++ b/addons/web/static/tests/views/list_view_tests.js
@@ -8346,6 +8346,30 @@ QUnit.module("Views", (hooks) => {
         assert.verifySteps(["button_method"]);
     });
 
+    QUnit.test("groupby node with a button when many2one is None", async function (assert) {
+        serverData.models.foo.fields.currency_id.sortable = true;
+        serverData.models.foo.records.forEach((rec) => (rec.currency_id = false));
+        await makeView({
+            type: "list",
+            resModel: "foo",
+            serverData,
+            arch: `
+                <tree default_group_by="currency_id">
+                    <field name="foo"/>
+                    <groupby name="currency_id">
+                        <field name="display_name" />
+                        <button string="Button 1" type="object" name="button_method"/>
+                    </groupby>
+                </tree>`,
+        });
+
+        assert.containsOnce(target, ".o_list_table_grouped");
+        assert.containsNone(target, ".o_group_header.o_group_open button");
+        await click(target, ".o_group_header:first-child");
+        assert.containsOnce(target, ".o_group_header.o_group_open");
+        assert.containsNone(target, ".o_group_header button");
+    });
+
     QUnit.test("groupby node with a button in inner groupbys", async function (assert) {
         await makeView({
             type: "list",


### PR DESCRIPTION
Have a list with some groupby buttons.
```
<tree>
  <groupby="m2o">
    <field name="display_name" />
    <button type="object" .... />
  </groupby>
</tree>
```

If the group's value (the m2o on which records are grouped) is false (the m2o of each record is non-required and empty) then there was a crash.

This commit fixes that and doesn't display those groupby buttons of there is no record to trigger the button on.

task-3986706

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
