### PR TITLE
[FIX] base : disallow phone number flex on reports

### DIFF
--- a/odoo/addons/base/views/ir_qweb_widget_templates.xml
+++ b/odoo/addons/base/views/ir_qweb_widget_templates.xml
@@ -36,10 +36,10 @@
                     </div>
                 </span>
             </div>
-            <div class="d-flex align-items-center gap-1" t-if="phone and 'phone' in fields">
+            <div class="align-items-center gap-1" t-if="phone and 'phone' in fields">
                 <i t-if="not options.get('no_marker') or options.get('phone_icons')" class='fa fa-phone fa-fw' role="img" aria-label="Phone" title="Phone"/> <span class="o_force_ltr" itemprop="telephone" t-esc="phone"/>
             </div>
-            <div class="d-flex align-items-center gap-1" t-if="mobile and 'mobile' in fields">
+            <div class="align-items-center gap-1" t-if="mobile and 'mobile' in fields">
                 <i t-if="not options.get('no_marker') or options.get('phone_icons')" class='fa fa-mobile fa-fw' role="img" aria-label="Mobile" title="Mobile"/> <span class="o_force_ltr" itemprop="telephone" t-esc="mobile"/>
             </div>
             <div class="d-flex align-items-center gap-1" t-if="website and 'website' in fields">


### PR DESCRIPTION
Before this PR it would happend that the last two digits of a phone number would go on the line below.

After the PR, the phone number is always written in one line

opw-3954932
