### PR TITLE
[IMP] {test_}mass_mailing{_sms}: delivered SMS not counted in Sent SMS

### DIFF
--- a/addons/mass_mailing_sms/models/sms_tracker.py
+++ b/addons/mass_mailing_sms/models/sms_tracker.py
@@ -47,9 +47,11 @@ class SmsTracker(models.Model):
                 'trace_status': trace_status,
                 'failure_type': failure_type,
                 'failure_reason': failure_reason,
-                **{'sent_datetime': fields.Datetime.now() if trace_status == 'pending' else {}},
             }
             traces.write(traces_values)
+            traces.filtered(
+                lambda t: t.trace_status not in ['outgoing', 'process', 'error', 'cancel'] and not t.sent_datetime
+            ).sent_datetime = self.env.cr.now()
         return traces
 
     def _update_sms_mailings(self, trace_status, traces):

--- a/addons/test_mass_mailing/tests/test_mailing_statistics_sms.py
+++ b/addons/test_mass_mailing/tests/test_mailing_statistics_sms.py
@@ -73,3 +73,18 @@ class TestMailingStatistics(TestMassSMSCommon):
         kpi_click_values = body_html.xpath('//table//tr[contains(@style,"color: #888888")]/td[contains(@style,"width: 30%")]/text()')
         first_link_value = int(kpi_click_values[0].strip().split()[1].strip('()'))
         self.assertEqual(first_link_value, mailing.clicked)
+
+    @users('user_marketing')
+    @mute_logger('odoo.addons.mass_mailing_sms.models.mailing_mailing', 'odoo.addons.mail.models.mail_mail', 'odoo.addons.mail.models.mail_thread')
+    def test_sent_delivered_sms(self):
+        """ Test that if we get delivered trace status first instead of sent from
+            providers for some reasons, the statistics for sent SMS will be correct. """
+        mailing = self.env['mailing.mailing'].browse(self.mailing_sms.ids)
+        target_records = self.env['mail.test.sms'].browse(self.records.ids)
+        mailing.write({'mailing_domain': [('id', 'in', target_records.ids)], 'user_id': self.user_marketing_2.id})
+        mailing.action_put_in_queue()
+        with self.mockSMSGateway(force_delivered=True):
+            mailing.action_send_sms()
+
+        self.assertEqual(mailing.delivered, 10)
+        self.assertEqual(mailing.sent, 10)


### PR DESCRIPTION
## Before this PR:

Sometimes Delivered SMS Text Messages are not counted as Sent SMS, thus causes
confusion among users.

## Technical:

Sometimes we got 'Delivered' Status first instead of getting 'Sent' Status from
3rd party providers (IAP).  Because of this 'sent_datetime' is not Set and return False.

Sent SMS in tooltip as well in other views(i.e., traces list) are counted
if Sent On(sent_datetime) has a value. 

## After this PR:

'sent_datetime' will be set if SMS status is not in '**Outgoing**', '**Processing**',
'**Exception**' , '**Canceled**', thus counted as Sent SMS.
This will also solve any potential future issue if we can't get any delivery status from
3rd party providers for some reasons (i.e., Delivered) but we can get click/open,...
status directly from recipient.

https://github.com/odoo/odoo/assets/157007055/a28f6c3c-883d-4f09-a591-25dfe35e029d

Task-3972519