### PR TITLE
[IMP] base: automatically translate currency unit and subunit labels 

### DIFF
--- a/odoo/addons/base/models/res_currency.py
+++ b/odoo/addons/base/models/res_currency.py
@@ -44,8 +44,8 @@ class Currency(models.Model):
     position = fields.Selection([('after', 'After Amount'), ('before', 'Before Amount')], default='after',
         string='Symbol Position', help="Determines where the currency symbol should be placed after or before the amount.")
     date = fields.Date(compute='_compute_date')
-    currency_unit_label = fields.Char(string="Currency Unit")
-    currency_subunit_label = fields.Char(string="Currency Subunit")
+    currency_unit_label = fields.Char(string="Currency Unit", translate=True)
+    currency_subunit_label = fields.Char(string="Currency Subunit", translate=True)
     is_current_company_currency = fields.Boolean(compute='_compute_is_current_company_currency')
 
     _sql_constraints = [

--- a/odoo/addons/test_new_api/tests/test_new_fields.py
+++ b/odoo/addons/test_new_api/tests/test_new_fields.py
@@ -4242,8 +4242,9 @@ class TestFieldParametersValidation(TransactionCase):
 def select(model, *fnames):
     """ Return the expected query string to SELECT the given columns. """
     table = model._table
+    model_fields = model._fields
     terms = ", ".join(
-        f'"{table}"."{fname}"'
+        f'"{table}"."{fname}"' if not model_fields[fname].translate else f'"{table}"."{fname}"->>%s'
         for fname in ['id'] + list(fnames)
     )
     return f'SELECT {terms} FROM "{table}" WHERE ("{table}"."id" IN %s)'


### PR DESCRIPTION
Noticed currencies where translated in transifex, like Riyal to ريال and Halala to هللة, but could not make it to the client as the translate attribute was not set.

Cause:
Currency labels are stored as char in the db, so no translation options available.

Solution:
Set translate=True to the labels fields to store those value as json.

opw-3976417
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
