### PR TITLE
Saas 17.1 adapt requirements xdo

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,55 +2,68 @@
 # python3-* equivalent distributed in Ubuntu 22.04 and Debian 11
 Babel==2.9.1  # min version = 2.6.0 (Focal with security backports)
 chardet==4.0.0
-cryptography==3.4.8
+cryptography==3.4.8; python_version < '3.12'  # incompatibility between pyopenssl 19.0.0 and cryptography>=37.0.0
+cryptography==42.0.8 ; python_version >= '3.12'  # (Noble) min 41.0.7, pinning 42.0.8 for security fixes
 decorator==4.4.2
 docutils==0.17
 ebaysdk==2.1.5
 freezegun==1.1.0
 geoip2==2.9.0
-gevent==21.8.0 ; python_version == '3.10'  # (Jammy)
-gevent==22.10.2; python_version > '3.10'
-greenlet==1.1.2 ; python_version == '3.10'  # (Jammy)
-greenlet==2.0.2 ; python_version > '3.10'
+gevent==21.8.0 ; sys_platform != 'win32' and python_version == '3.10'  # (Jammy)
+gevent==22.10.2; sys_platform != 'win32' and python_version > '3.10' and python_version < '3.12'
+gevent==24.2.1 ; sys_platform != 'win32' and python_version >= '3.12'  # (Noble)
+greenlet==1.1.2 ; sys_platform != 'win32' and python_version == '3.10'  # (Jammy)
+greenlet==2.0.2 ; sys_platform != 'win32' and python_version > '3.10' and python_version < '3.12'
+greenlet==3.0.3 ; sys_platform != 'win32' and python_version >= '3.12'  # (Noble)
 idna==2.10  # requests 2.25.1 depends on idna<3 and >=2.5
 Jinja2==3.0.3 ; python_version <= '3.10'
 Jinja2==3.1.2 ; python_version > '3.10'
-libsass==0.20.1
+libsass==0.20.1 ; python_version < '3.12'
+libsass==0.22.0 ; python_version >= '3.12'  # (Noble) Mostly to have a wheel package
 lxml==4.8.0 ; python_version <= '3.10'
 lxml==4.9.3 ; python_version > '3.10' and python_version < '3.12' # min 4.9.2, pinning 4.9.3 because of missing wheels for darwin in 4.9.3
 lxml==5.2.1; python_version >= '3.12' # (Noble - removed html clean)
 lxml-html-clean; python_version >= '3.12' # (Noble - removed from lxml, unpinned for futur security patches)
 MarkupSafe==2.0.1 ; python_version <= '3.10'
-MarkupSafe==2.1.2 ; python_version > '3.10'
+MarkupSafe==2.1.2 ; python_version > '3.10' and python_version < '3.12'
+MarkupSafe==2.1.5 ; python_version >= '3.12'  # (Noble) Mostly to have a wheel package
 num2words==0.5.10
 ofxparse==0.21
 passlib==1.7.4 # min version = 1.7.2 (Focal with security backports)
-Pillow==9.0.1 ; python_version <= '3.10'  # min version = 7.0.0 (Focal with security backports)
-Pillow==9.4.0 ; python_version > '3.10'
+Pillow==9.0.1 ; python_version <= '3.10'
+Pillow==9.4.0 ; python_version > '3.10' and python_version < '3.12'
+Pillow==10.2.0 ; python_version >= '3.12'  # (Noble) Mostly to have a wheel package
 polib==1.1.1
 psutil==5.9.0 ; python_version <= '3.10' 
-psutil==5.9.4 ; python_version > '3.10' 
-psycopg2==2.9.2 ; sys_platform != 'win32' and python_version <= '3.10'
-psycopg2==2.9.5 ; python_version > '3.10' or sys_platform == 'win32'
-pyopenssl==21.0.0
+psutil==5.9.4 ; python_version > '3.10' and python_version < '3.12' 
+psutil==5.9.8 ; python_version >= '3.12' # (Noble) Mostly to have a wheel package
+psycopg2==2.9.2 ; python_version == '3.10' # (Jammy)
+psycopg2==2.9.5 ; python_version == '3.11'
+psycopg2==2.9.9 ; python_version >= '3.12' # (Noble) Mostly to have a wheel package
+pyopenssl==21.0.0 ; python_version < '3.12'
+pyopenssl==24.1.0 ; python_version >= '3.12' # (Noble) min 23.2.0, pinned for compatibility with cryptography==42.0.8 and security patches
 PyPDF2==1.26.0 ; python_version <= '3.10'
 PyPDF2==2.12.1 ; python_version > '3.10'
 pypiwin32 ; sys_platform == 'win32'
 pyserial==3.5
 python-dateutil==2.8.1
-python-ldap==3.4.0 ; sys_platform != 'win32'  # min version = 3.2.0 (Focal with security backports)
+python-ldap==3.4.0 ; sys_platform != 'win32' and python_version < '3.12' # min version = 3.2.0 (Focal with security backports)
+python-ldap==3.4.4 ; sys_platform != 'win32' and python_version >= '3.12'  # (Noble) Mostly to have a wheel package
 python-stdnum==1.17
 pytz  # no version pinning to avoid OS perturbations
 pyusb==1.2.1
 qrcode==7.3.1
 reportlab==3.6.8 ; python_version <= '3.10'
-reportlab==3.6.12 ; python_version > '3.10'
-requests==2.25.1 # versions < 2.25 aren't compatible w/ urllib3 1.26. Bullseye = 2.25.1. min version = 2.22.0 (Focal)
+reportlab==3.6.12 ; python_version > '3.10' and python_version < '3.12'
+reportlab==4.1.0 ; python_version >= '3.12' # (Noble) Mostly to have a wheel package
+requests==2.25.1 ;  python_version < '3.12' # versions < 2.25 aren't compatible w/ urllib3 1.26. Bullseye = 2.25.1. min version = 2.22.0 (Focal)
+requests==2.31.0 ; python_version >= '3.12' # (Noble) 
 rjsmin==1.1.0
-urllib3==1.26.5 # indirect / min version = 1.25.8 (Focal with security backports)
+urllib3==1.26.5 ; python_version < '3.12' # indirect / min version = 1.25.8 (Focal with security backports)
+urllib3==2.0.7  ; python_version >= '3.12'  # (Noble) Compatibility with cryptography
 vobject==0.9.6.1
 Werkzeug==2.0.2
 xlrd==1.2.0
 XlsxWriter==3.0.2
-xlwt==1.3.*
+xlwt==1.3.0
 zeep==4.1.0

--- a/setup/requirements-check.py
+++ b/setup/requirements-check.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+
 """
 Checks versions from the requirements files against distribution-provided
 versions, taking distribution's Python version in account e.g. if checking
@@ -7,42 +8,84 @@ requirements.
 
 * only shows requirements for which at least one release diverges from the
   matching requirements version
-* empty cells mean that specific release matches its requirement (happens when
+* empty or green cells mean that specific release matches its requirement (happens when
   checking multiple releases: one of the other releases may mismatch the its
   requirements necessating showing the row)
 
-Only handles the subset of requirements files we're currently using:
-* no version spec or strict equality
-* no extras
-* only sys_platform and python_version environment markers
+This script was heavily reworked but is not in a final version:
+TODO:
+- add legends
+- better management of cache
+- add meta info on cells (mainly to genearte a better html report)
+    - warn/ko reason
+    - wheel + link
+    - original debian package name + link
+    ...
+
 """
 
 import argparse
 import gzip
 import itertools
 import json
-import operator
+import os
 import re
-import string
+import shutil
+import tempfile
+
+import pkg_resources
+
+try:
+    import ansitoimg
+except ImportError:
+    ansitoimg = None
 
 from abc import ABC, abstractmethod
 from pathlib import Path
-from urllib.request import urlopen
-from sys import stdout, stderr
-from typing import Dict, List, Set, Optional, Any, Tuple
+from sys import stderr, stdout
+from typing import Dict, List, Optional, Tuple
+from urllib.request import HTTPError
+from urllib.request import urlopen as _urlopen
+
+from pip._internal.index.package_finder import (
+    LinkEvaluator,  # noqa: PLC2701
+    canonicalize_name,  # noqa: PLC2701
+)
+from pip._internal.models.link import Link  # noqa: PLC2701
+from pip._internal.models.target_python import TargetPython  # noqa: PLC2701
+from pip._vendor.packaging.markers import Marker
+from pip._vendor.packaging.tags import mac_platforms  # noqa: PLC2701
 
 Version = Tuple[int, ...]
-def parse_version(vstring: str) -> Optional[Version]:
-    if not vstring:
-        return None
-    return tuple(map(int, vstring.split('.')))
 
 # shared beween debian and ubuntu
 SPECIAL = {
     'pytz': 'tz',
     'libsass': 'libsass-python',
 }
-def unfuck(s: str) -> str:
+SUPPORTED_FORMATS = ('txt', 'ansi', 'svg', 'html', 'json')
+PLATFORM_CODES = ('linux', 'win32', 'darwin')
+PLATFORM_NAMES = ('Linux', 'Win', 'OSX')
+
+
+def urlopen(url):
+    file_name = "".join(c if c.isalnum() else '_' for c in url)
+    os.makedirs('/tmp/package_versions_cache/', exist_ok=True)
+    file_path = f'/tmp/package_versions_cache/{file_name}'
+    if not os.path.isfile(file_path):
+        response = _urlopen(url)
+        with open(file_path, 'wb') as fw:
+            fw.write(response.read())
+    return open(file_path, 'rb')   # noqa: SIM115
+
+
+def parse_version(vstring: str) -> Optional[Version]:
+    if not vstring:
+        return None
+    return tuple(map(int, vstring.split('.')))
+
+
+def cleanup_debian_version(s: str) -> str:
     """ Try to strip the garbage from the version string, just remove everything
     following the first `+`, `~` or `-`
     """
@@ -52,6 +95,85 @@ def unfuck(s: str) -> str:
         (?:~|\+|-|\.dfsg)
         .*
     ''', s, flags=re.VERBOSE)[1]
+
+
+class PipPackage:
+    def __init__(self, name):
+        self.name = name
+        infos = json.load(urlopen(f'https://pypi.org/pypi/{name}/json'))
+        self.info = infos['info']
+        self.last_serial = infos['last_serial']
+        self.releases = infos['releases']
+        self.urls = infos['urls']
+        self.vulnerabilities = infos['vulnerabilities']
+
+    def has_wheel_for(self, version, python_version, platform):
+        if version is None:
+            return (False, False, False)
+        py_version_info = python_version.split('.')
+        if len(py_version_info) == 2:
+            py_version_info = (py_version_info[0], py_version_info[1], 0)
+        releases = self.releases
+        has_wheel_for_version = False
+        has_any_wheel = False
+        has_wheel_in_another_version = False
+        platforms = None
+        if platform == 'darwin':
+            platforms = list(mac_platforms((15, 0), 'x86_64'))
+        elif platform == 'win32':
+            platforms = ['win32', 'win-amd64']
+        else:
+            assert platform == 'linux'
+
+        target_python = TargetPython(
+            platforms=platforms,
+            py_version_info=py_version_info,
+            abis=None,
+            implementation=None,
+        )
+        le = LinkEvaluator(
+            project_name=self.name,
+            canonical_name=canonicalize_name(self.name),
+            formats={"binary", "source"},
+            target_python=target_python,
+            allow_yanked=True,
+            ignore_requires_python=False,
+        )
+        for release in releases[version]:
+            if release['filename'].endswith('.whl'):
+                has_any_wheel = True
+            is_candidate, _result = le.evaluate_link(Link(
+                comes_from=None,
+                url=release['url'],
+                requires_python=release['requires_python'],
+                yanked_reason=release['yanked_reason'],
+            ))
+            if is_candidate:
+                if release['filename'].endswith('.whl'):
+                    has_wheel_for_version = has_wheel_in_another_version = True
+                break
+
+        if not has_wheel_for_version and has_any_wheel:
+            # TODO, we should prefer a version matching the one from a distro
+            for rel_version, rel in releases.items():
+                for release in rel:
+                    if not release['filename'].endswith('.whl'):
+                        continue
+                    if any(not s.isdigit() for s in rel_version.split('.')) or parse_version(rel_version) <= parse_version(version):
+                        continue
+                    is_candidate, _result = le.evaluate_link(Link(
+                        comes_from=None,
+                        url=release['url'],
+                        requires_python=release['requires_python'],
+                        yanked_reason=release['yanked_reason'],
+                    ))
+                    if is_candidate:
+                        has_wheel_in_another_version = True
+                        stderr.write(f'WARNING: Wheel found for {self.name} ({python_version} {platform}) in {rel_version}\n')
+                        return (has_wheel_for_version, has_any_wheel, has_wheel_in_another_version)
+
+        return (has_wheel_for_version, has_any_wheel, has_wheel_in_another_version)
+
 
 class Distribution(ABC):
     def __init__(self, release):
@@ -73,7 +195,9 @@ class Distribution(ABC):
                 if c.__name__.lower() == name
             )
         except StopIteration:
-            raise ValueError(f"Unknown distribution {name!r}")
+            msg = f"Unknown distribution {name!r}"
+            raise ValueError(msg)
+
 
 class Debian(Distribution):
     def get_version(self, package):
@@ -83,19 +207,29 @@ class Debian(Distribution):
         # try the python prefix first: some packages have a native of foreign $X and
         # either the bindings or a python equivalent at python-X, or just a name
         # collision
-        for prefix in ['python-', '']:
-            res = json.load(urlopen(f'https://sources.debian.org/api/src/{prefix}{package}'))
+        prefixes = ['python-', '']
+        if package.startswith('python'):
+            prefixes = ['']
+        for prefix in prefixes:
+            try:
+                res = json.load(urlopen(f'https://sources.debian.org/api/src/{prefix}{package}/'))
+            except HTTPError:
+                return 'failed'
             if res.get('error') is None:
                 break
         if res.get('error'):
             return
 
-        return next(
-            parse_version(unfuck(distr['version']))
-            for distr in res['versions']
-            if distr['area'] == 'main'
-            if self._release in distr['suites']
-        )
+        try:
+            return next(
+                parse_version(cleanup_debian_version(distr['version']))
+                for distr in res['versions']
+                if distr['area'] == 'main'
+                if self._release.lower() in distr['suites']
+            )
+        except StopIteration:
+            return
+
 
 class Ubuntu(Distribution):
     """ Ubuntu doesn't have an API, instead it has a huge text file
@@ -109,9 +243,9 @@ class Ubuntu(Distribution):
         # content-encoding (x-gzip) anyway
         data = gzip.open(
             urlopen(f'https://packages.ubuntu.com/source/{release}/allpackages?format=txt.gz'),
-            mode='rt', encoding='utf-8'
+            mode='rt', encoding='utf-8',
         )
-        for line in itertools.islice(data, 6, None): # first 6 lines is garbage header
+        for line in itertools.islice(data, 6, None):  # first 6 lines is garbage header
             # ignore the restricted, security, universe, multiverse tags
             m = re.match(r'(\S+) \(([^)]+)\)', line.strip())
             assert m, f"invalid line {line.strip()!r}"
@@ -122,165 +256,46 @@ class Ubuntu(Distribution):
         for prefix in ['python3-', 'python-', '']:
             v = self._packages.get(f'{prefix}{package}')
             if v:
-                return parse_version(unfuck(v))
+                return parse_version(cleanup_debian_version(v))
         return None
 
-class Markers:
-    """ Simplistic RD parser for requirements env markers.
 
-    Evaluation of the env markers is so basic it goes to brunch in uggs.
-    """
-    def __init__(self, s=None):
-        self.rules = False
-        if s is not None:
-            self.rules, rest = self._parse_marker(s)
-            assert not rest
-
-    def evaluate(self, context: Dict[str, Any]) -> bool:
-        if not self.rules:
-            return True
-        return self._eval(self.rules, context)
-
-    def _eval(self, rule, context):
-        if rule[0] == 'OR':
-            return self._eval(rule[1], context) or self._eval(rule[2], context)
-        elif rule[0] == 'AND':
-            return self._eval(rule[1], context) and self._eval(rule[2], context)
-        elif rule[0] == 'ENV':
-            return context[rule[1]]
-        elif rule[0] == 'LIT':
-            return rule[1]
-        else:
-            op, var1, var2 = rule
-            var1 = self._eval(var1, context)
-            var2 = self._eval(var2, context)
-
-            # NOTE: currently doesn't follow PEP440 version matching at all
-            if op == '==': return var1 == var2
-            elif op == '!=': return var1 != var2
-            elif op == '<': return var1 < var2
-            elif op == '<=': return var1 <= var2
-            elif op == '>': return var1 > var2
-            elif op == '>=': return var1 >= var2
-            else:
-                raise NotImplementedError(f"Operator {op!r}")
-
-    def _parse_marker(self, s):
-        return self._parse_or(s)
-
-    def _parse_or(self, s):
-        sub1, rest = self._parse_and(s)
-        expr, n = re.subn(r'^\s*or\b', '', rest, count=1)
-        if not n:
-            return sub1, rest
-        sub2, rest = self._parse_and(expr)
-        return ('OR', sub1, sub2), rest
-
-    def _parse_and(self, s):
-        sub1, rest = self._parse_expr(s)
-        expr, n = re.subn(r'\s*and\b', '', rest, count=1)
-        if not n:
-            return sub1, rest
-        sub2, rest = self._parse_expr(expr)
-        return ('AND', sub1, sub2), rest
-
-    def _parse_expr(self, s):
-        expr, n = re.subn(r'^\s*\(', '', s, count=1)
-        if n:
-            sub, rest = self.parse_marker(expr)
-            rest, n = re.subn(r'\s*\)', '', rest, count=1)
-            assert n, f"expected closing parenthesis, found {rest}"
-            return sub, rest
-
-        var1, rest = self._parse_var(s)
-        op, rest = self._parse_op(rest)
-        var2, rest = self._parse_var(rest)
-        return (op, var1, var2), rest
-
-    def _parse_op(self, s):
-        m = re.match(r'''
-            \s*
-            (<= | < | != | >= | > | ~= | ===? | in \b | not \s+ in \b)
-            (.*)
-        ''', s, re.VERBOSE)
-        assert m, f"no operator in {s!r}"
-        return m.groups()
-
-    def _parse_var(self, s):
-        python_str = re.escape(string.printable.translate(str.maketrans({
-            '"': '',
-            "'": '',
-            '\\': '',
-            '-': '',
-        })))
-        m = re.match(fr'''
-            \s*
-            (:?
-                # TODO: add more envvars
-                (?P<env>python_version | os_name | sys_platform)
-              | " (?P<dquote>['{python_str}-]*) "
-              | ' (?P<squote>["{python_str}-]*) '
-            )
-            (?P<rest>.*)
-        ''', s, re.VERBOSE)
-        assert m, f"failed to find marker var in {s}"
-        if m['env']:
-            return ('ENV', m['env']), m['rest']
-        return ('LIT', m['dquote'] or m['squote'] or ''), m['rest']
-
-def parse_spec(line: str) -> (str, (Optional[str], Optional[str]), Markers):
-    """ Parse a requirements specification (a line of requirements)
-
-    Returns the package name, a version spec (operator and comparator) possibly
-    None and a Markers object.
-
-    Not correctly supported:
-
-    * version matching, not all operators are implemented and those which are
-      almost certainly don't match PEP 440
-
-    Not supported:
-
-    * url requirements
-    * multi-versions spec
-    * extras
-    * continuations
-
-    Full grammar is at https://www.python.org/dev/peps/pep-0508/#complete-grammar
-    """
-    # weirdly a distribution name can apparently start with a number
-    name, rest = re.match(r'([\w\d](?:[._-]*[\w\d]+)*)\s*(.*)', line.strip()).groups()
-    # skipping extras
-    version_cmp = version = None
-    versionspec = re.match(r'''
-        (< | <= | != | == | >= | > | ~= | ===)
-        \s*
-        ([\w\d_.*+!-]+)
-        \s*
-        (.*)
-    ''', rest, re.VERBOSE)
-    if versionspec:
-        version_cmp, version, rest = versionspec.groups()
-    markers = Markers()
-    if rest[:1] == ';':
-        markers = Markers(rest[1:])
-
-    return name, (version_cmp, version), markers
-
-def parse_requirements(reqpath: Path) -> Dict[str, List[Tuple[str, Markers]]]:
+def parse_requirements(reqpath: Path) -> Dict[str, List[Tuple[str, Marker]]]:
     """ Parses a requirement file to a dict of {package: [(version, markers)]}
 
     The env markers express *whether* that specific dep applies.
     """
     reqs = {}
-    for line in reqpath.open('r', encoding='utf-8'):
-        if line.isspace() or line.startswith('#'):
-            continue
-
-        name, (op, version), markers = parse_spec(line)
-        assert op is None or op == '==', f"unexpected version comparator {op}"
-        reqs.setdefault(name, []).append((version, markers))
+    with reqpath.open('r', encoding='utf-8') as f:
+        for requirement in pkg_resources.parse_requirements(f):
+            version = None
+            if requirement.specs:
+                if len(requirement.specs) > 1:
+                    raise NotImplementedError('mutli spec not supported yet')
+                version = requirement.specs[0][1]
+            reqs.setdefault(requirement.name, []).append((version, requirement.marker))
     return reqs
+
+
+def ok(text):
+    return f'\033[92m{text}\033[39m'
+
+
+def em(text):
+    return f'\033[94m{text}\033[39m'
+
+
+def warn(text):
+    return f'\033[93m{text}\033[39m'
+
+
+def ko(text):
+    return f'\033[91m{text}\033[39m'
+
+
+def default(text):
+    return text
+
 
 def main(args):
     checkers = [
@@ -289,80 +304,171 @@ def main(args):
         for (distro, release) in [version.split(':')]
     ]
 
-    stderr.write(f"Fetch Python versions...\n")
+    stderr.write("Fetch Python versions...\n")
     pyvers = [
         '.'.join(map(str, checker.get_version('python3-defaults')[:2]))
         for checker in checkers
     ]
 
-    uniq = sorted(v for v in set(pyvers))
-    table = [
-        ['']
-        + [f'req {v}' for v in uniq]
-        + [f'{checker._release} ({version})' for checker, version in zip(checkers, pyvers)]
-    ]
+    uniq = sorted(set(pyvers), key=parse_version)
+    platforms = PLATFORM_NAMES if args.check_pypi else PLATFORM_NAMES[:1]
+    platform_codes = PLATFORM_CODES if args.check_pypi else PLATFORM_CODES[:1]
+    platform_headers = ['']
+    python_headers = ['']
+    table = [platform_headers, python_headers]
+    # requirements headers
+    for v in uniq:
+        for p in platforms:
+            platform_headers.append(p)
+            python_headers.append(v)
+
+    # distro headers
+    for checker, version in zip(checkers, pyvers):
+        platform_headers.append(checker._release[:5])
+        python_headers.append(version)
 
     reqs = parse_requirements((Path.cwd() / __file__).parent.parent / 'requirements.txt')
-    tot = len(reqs) * len(checkers)
+    if args.filter:
+        reqs = {r: o for r, o in reqs.items() if any(f in r for f in args.filter.split(','))}
 
-    def progress(n=iter(range(tot+1))):
-        stderr.write(f"\rFetch requirements: {next(n)} / {tot}")
-
-    progress()
     for req, options in reqs.items():
+        if args.check_pypi:
+            pip_infos = PipPackage(req)
         row = [req]
+        seps = [' || ']
         byver = {}
         for pyver in uniq:
             # FIXME: when multiple options apply, check which pip uses
             #        (first-matching. best-matching, latest, ...)
-            for version, markers in options:
-                if markers.evaluate({
-                    'python_version': pyver,
-                    'sys_platform': 'linux',
-                }):
-                    byver[pyver] = version
-                    break
-            row.append(byver.get(pyver) or '')
+            seps[-1] = ' || '
+            for platform in platform_codes:
+                platform_version = 'none'
+                for version, markers in options:
+                    if not markers or markers.evaluate({
+                        'python_version': pyver,
+                        'sys_platform': platform,
+                    }):
+                        if platform == 'linux':
+                            byver[pyver] = version
+                        platform_version = version
+                        break
+                deco = None
+                if args.check_pypi:
+                    if platform_version == 'none':
+                        deco = 'ok'
+                    else:
+                        has_wheel_for_version, has_any_wheel, has_wheel_in_another_version = pip_infos.has_wheel_for(platform_version, pyver, platform)
+                        if has_wheel_for_version:
+                            deco = 'ok'
+                        elif has_wheel_in_another_version:
+                            deco = 'ko'
+                        elif has_any_wheel:
+                            deco = 'warn'
+                    if deco in ("ok", None):
+                        if byver.get(pyver, 'none') != platform_version:
+                            deco = 'em'
+                req_ver = platform_version or 'any'
+                row.append((req_ver, deco))
+                seps.append(' | ')
+
+        seps[-1] = ' |#| '
         # this requirement doesn't apply, ignore
-        if not byver:
-            # normally the progressbar is updated when processing each
-            # requirement against each checker, if the requirement doesn't apply
-            # to any checker we still need to consider the requirement fetched /
-            # resolved for each checker or our tally is incorrect
-            for _ in checkers:
-                progress()
+        if not byver and not args.all:
             continue
 
-        mismatch = False
         for i, c in enumerate(checkers):
-            req_version = byver.get(pyvers[i], '')
-            check_version = '.'.join(map(str, c.get_version(req.lower()) or ['<missing>']))
-            progress()
+            req_version = byver.get(pyvers[i], 'none') or 'any'
+            check_version = '.'.join(map(str, c.get_version(req.lower()) or [])) or None
             if req_version != check_version:
-                row.append(check_version)
-                mismatch = True
+                deco = 'ko'
+                if req_version == 'none':
+                    deco = 'ok'
+                elif req_version == 'any':
+                    if check_version is None:
+                        deco = 'ok'
+                elif check_version is None:
+                    deco = 'ko'
+                elif parse_version(req_version) >= parse_version(check_version):
+                    deco = 'warn'
+                row.append((check_version or '</>', deco))
+            elif args.all:
+                row.append((check_version or '</>', 'ok'))
             else:
                 row.append('')
+            seps.append(' |#|  ')
+        table.append(row)
 
-        # only show row if one of the items diverges from requirement
-        if mismatch:
-            table.append(row)
+    seps[-1] = ' '  # remove last column separator
+
     stderr.write('\n')
 
     # evaluate width of columns
-    sizes = [0] * (len(checkers) + len(uniq) + 1)
+    sizes = [0] * len(table[0])
     for row in table:
         sizes = [
-            max(s, len(cell))
+            max(s, len(cell[0] if isinstance(cell, tuple) else cell))
             for s, cell in zip(sizes, row)
         ]
 
-    # format table
-    for row in table:
-        stdout.write('| ')
-        for cell, width in zip(row, sizes):
-            stdout.write(f'{cell:<{width}} | ')
-        stdout.write('\n')
+    output_format = 'ansi'
+    if args.format:
+        output_format = args.format
+        assert format in SUPPORTED_FORMATS
+    elif args.output:
+        output_format = 'txt'
+        ext = args.output.split('.')[-1]
+        if ext in SUPPORTED_FORMATS:
+            output_format = ext
+
+    if output_format == 'json':
+        output = json.dumps(table)
+    else:
+        output = ''
+        # format table
+        for row in table:
+            output += ' '
+            for cell, width, sep in zip(row, sizes, seps):
+                cell_content = cell
+                deco = default
+                if isinstance(cell, tuple):
+                    cell_content, level = cell
+                    if output_format == 'txt' or level is None:
+                        deco = default
+                    elif level == 'ok':
+                        deco = ok
+                    elif level == 'em':
+                        deco = em
+                    elif level == 'warn':
+                        deco = warn
+                    else:
+                        deco = ko
+                output += deco(f'{cell_content:<{width}}') + sep
+            output += '\n'
+
+    if output_format in ('svg', 'html'):
+        if not ansitoimg:
+            output_format = 'ansi'
+            stderr.write(f'Missing ansitoimg for {output_format} format, switching to ansi')
+        else:
+            convert = ansitoimg.ansiToSVG
+            if output_format == 'html':
+                convert = ansitoimg.ansiToHTML
+            with tempfile.NamedTemporaryFile() as tmp:
+                convert(output, tmp.name, width=(sum(sizes) + sum(len(sep) for sep in seps)), title='requirements-check.py')
+                output = tmp.read().decode()
+                # remove mac like bullets
+                output = output.replace('''<g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>''', "")  #
+
+    if args.output:
+        with open(args.output, 'w', encoding='utf8') as f:
+            f.write(output)
+    else:
+        stdout.write(output)
+
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
@@ -373,5 +479,30 @@ if __name__ == '__main__':
         'release', nargs='+',
         help="Release to check against, should use the format '{distro}:{release}' e.g. 'debian:sid'"
     )
+    parser.add_argument(
+        '-a', '--all', action="store_true",
+        help="Display all requirements even if it matches",
+    )
+    parser.add_argument(
+        '-o', '--output', help="output path",
+    )
+    parser.add_argument(
+        '-f', '--format', help=f"Supported format: {', '.join(SUPPORTED_FORMATS)}",
+    )
+    parser.add_argument(
+        '--update-cache', action="store_true",
+        help="Ignore the existing package version cache and update them",
+    )
+    parser.add_argument(
+        '--check-pypi', action="store_true",
+        help="Check wheel packages",
+    )
+    parser.add_argument(
+        '--filter',
+        help="Comma sepaated list of package to check",
+    )
+
     args = parser.parse_args()
+    if args.update_cache:
+        shutil.rmtree('/tmp/package_versions_cache/')
     main(args)


### PR DESCRIPTION
The main goal of this pr is to adapt the requirements to make it work in ubuntu Noble (right now, it will only work when using debian packages)

## FIX requirements_check.py
The first step is to adapt and fix the requirements_check in order to have an overview of the current state.
![old](https://github.com/odoo/odoo/assets/35262360/f54b6a8f-d80e-4aad-aac0-1bf36ade2cc2)



This is showing the difference between an installation from pip compared to the official packaged version in the distribution matching the same python version. Red usually means that the package in the corresponding version has a higher version than the pinned one. We expect to have almost the same version as the corresponding minimal supported python version. It is possible that some version are higher (yellow) for historical/security/compatibility reasons.

## Adapt requirements.txc

We don't need to fix all versions, but we want to adapt it to work in most cases, mainly we need to be able to install the requirements on ubuntu Noble. If a change is needed, the version of the requirement for 3.12 is pinned to match the version of the package in ubuntu Noble. 

### greenlet
The first change concern greenlet and gevent, the current version does not install on python 3.12

### Missing wheel
The second changes adapt all packages that did not have a wheel in 3.12. Some of them fail to build, and building them is slow. 

### Non compatible packages
Finally, some package are not compatible, leading to import error or requirements install errors

![out](https://github.com/odoo/odoo/assets/35262360/1a12d1fd-91b3-4694-a49c-4725f9e0354a)

Since the requirements versions are the same as the debian package version we  expect the build with requirements to be green similar to the PureNoble builds. 


### Fix win32 wheel

Building wheel on windows is painful because c++ builds tools are quite heavy and not included. 
Most of the version pinned in 3.12 will have a wheel on win32, except got gevent and greenlet. Since they are not required to run odoo, removing them for win32

### Simplify psycopg2 dependencies

Note that if most changes does only concern 3.12, an exception was made to simplify psycopg2 exceptions

Since there is no wheel package in psycopg 2.8.6, the pinned version was 2.9.5, an **exception** for windows (exception in blue)
But in Jammy, with python 3.10, the expected version is actually 2.9.2 (column is red) which has a wheel package sor windows
![image](https://github.com/odoo/odoo/assets/35262360/7c0df21b-8c9b-49e2-bd4e-4f112e239ffe)
We can fix both issues by pinning 2.9.2 for all python 3.10, not depending on the operating system.
![image](https://github.com/odoo/odoo/assets/35262360/ab558226-e1b7-4743-8ea0-2941ad1fd02f)

It also looks like we have a wheel package in windows 2.7.7 and python 3.7, so we could simplify even further, but I'm not sure if it was intended or a remaining from change history. Anyway, this will be clean in future version where minimal version is higher than 3.7.

Manual forwardport of #168296