### PR TITLE
[FIX] mail: define emoji in template data with html code

### DIFF
--- a/addons/mail/data/mail_templates_mailgateway.xml
+++ b/addons/mail/data/mail_templates_mailgateway.xml
@@ -36,7 +36,7 @@
     <div t-foreach="attachments" t-as="attachment">
         <a t-attf-href="{{attachment.get_base_url()}}/web/content/{{attachment.id}}?download=1&amp;access_token={{attachment.access_token}}"
            style="font-size: 12px; color: #875A7B; text-decoration:none !important; text-decoration:none; font-weight: 400;">
-            📥 <t t-out="attachment.name"/>
+            &amp;#128229; <t t-out="attachment.name"/>
         </a>
     </div>
 </div>


### PR DESCRIPTION
Before this commit, the emoji displayed in the template data `mail.mail_attachment_links` is not correctly compiled by the lxml module for the computer with Apple chip.

This commit defines the emoji by using its html code instead of directly displaying the emoji in the template to correctly compile it when we start a fresh db on mac with Apple chip.
