### PR TITLE
[FIX] stock: missing default picking destination

### DIFF
--- a/addons/stock/i18n/stock.pot
+++ b/addons/stock/i18n/stock.pot
@@ -2862,6 +2862,12 @@ msgstr ""
 
 #. module: stock
 #. odoo-python
+#: code:addons/stock/models/stock_move.py:0
+msgid "Edit Picking settings"
+msgstr ""
+
+#. module: stock
+#. odoo-python
 #: code:addons/stock/models/stock_orderpoint.py:0
 msgid "Edit Product"
 msgstr ""
@@ -8306,6 +8312,12 @@ msgstr ""
 #. odoo-python
 #: code:addons/stock/models/stock_move.py:0
 msgid "The deadline has been automatically updated due to a delay on %s."
+msgstr ""
+
+#. module: stock
+#. odoo-python
+#: code:addons/stock/models/stock_move.py:0
+msgid "The default destination of '%s' picking type must be set"
 msgstr ""
 
 #. module: stock


### PR DESCRIPTION
Steps to reproduce:
- Enable locations in Stock settings
- Edit delivry order picking type in Inventory overview
- Edit the form view and remove required from default_location_dest_id
- Set Default Destination Location to blank
- Create and confirm a new SO

Bug:
default_location_dest_id is only required on the frontend if not set an error is thrown when confirming an SO (impossible to create the move)

Fix:
-Stable: upgrade script has already been fixed https://github.com/odoo/upgrade/pull/5873 but it's better to still add a more userfreindly redirect for customers that upgraded before the PR was merged (particularly since it's still possible to mess it up as the field is not required on the backend)

-Matser: set the field as required on the backend aswell

opw-3970295
