### PR TITLE
[FIX] l10n_in: Display Place of Supply on Moves

### DIFF
--- a/addons/l10n_in/views/report_invoice.xml
+++ b/addons/l10n_in/views/report_invoice.xml
@@ -4,10 +4,14 @@
         <xpath expr="//address[@t-field='o.partner_id']" position="after">
             <span t-field="o.l10n_in_gstin" t-if="o.company_id.account_fiscal_country_id.code == 'IN'"/>
         </xpath>
-        <xpath expr="//t[@t-set='address']" position="inside">
-            <t t-if="o.company_id.account_fiscal_country_id.code == 'IN' and o.l10n_in_state_id" class="mt16">
-                Place of supply: <span t-esc="o.l10n_in_state_id.name"/>
-            </t>
+        <xpath expr="//div[@name='address_not_same_as_shipping']//t[@t-set='address']" position="inside">
+            <t t-call="l10n_in.place_of_supply"/>
+        </xpath>
+        <xpath expr="//div[@name='address_same_as_shipping']//t[@t-set='address']" position="inside">
+            <t t-call="l10n_in.place_of_supply"/>
+        </xpath>
+        <xpath expr="//div[@name='no_shipping']//t[@t-set='address']" position="inside">
+            <t t-call="l10n_in.place_of_supply"/>
         </xpath>
         <xpath expr="//div[@t-if='not is_html_empty(o.narration)']" position="before">
             <t t-if="o.company_id.account_fiscal_country_id.code == 'IN'">
@@ -62,6 +66,12 @@
                t-call="l10n_in.l10n_in_report_invoice_document_inherit"
                t-lang="lang"/>
         </xpath>
+    </template>
+
+    <template id="place_of_supply">
+        <div t-if="o.l10n_in_state_id">
+            Place of supply: <span t-out="o.l10n_in_state_id.name" />
+        </div>
     </template>
 
 </odoo>


### PR DESCRIPTION
- In Odoo v16 and above, the Place of Supply information was not displayed on the invoice report, unlike in previous versions.

- This PR rectifies the issue, ensuring that the Place of Supply is correctly printed on the invoice report, maintaining 
consistency with earlier versions.

**task**:3983822