### PR TITLE
[FIX] stock: hide quants with different company lot

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -178,10 +178,11 @@ class StockQuant(models.Model):
 
     def _search(self, domain, *args, **kwargs):
         domain = [
-            line if not isinstance(line, (list, tuple)) or not line[0].startswith('lot_properties.')
+            line if not isinstance(line, (list, tuple)) or not (isinstance(line[0], str) and line[0].startswith('lot_properties.'))
             else ['lot_id', 'any', [line]]
             for line in domain
         ]
+        domain = expression.AND([['|', ('lot_id', '=', False), ('lot_id.company_id', 'in', self.env.companies.ids)], domain])
         return super()._search(domain, *args, **kwargs)
 
     @api.depends('inventory_quantity')


### PR DESCRIPTION
### Steps to reproduce:

With company 1:

- Create a storable product tracked by SN
- Create a SN for that product
- Create and validate a delivery order for a partner delivering that SN

#### > a quant is created in the company free location Partners/Customers

With company 2:

- Go to Inventory > Reporting > Locations
##### > the quant is displayed in this company

#### You can generate access errors by performing any of the following:
- Click on the quant and then on its lot
- Click on the wheel and export all
- Try to duplicate the quant

### Cause of the issue:

The stock.lot referring to your serial number belongs to company 1 and company 2 does not have access to it.

### Fix:

Quants referring to a SN that does not belong to their company should not be found.

opw-3962673
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
