### PR TITLE
[WIP][IMP] account,l10n_hu_edi: Multi-EDI PoC

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -253,7 +253,16 @@ class AccountMove(models.Model):
     made_sequence_hole = fields.Boolean(compute='_compute_made_sequence_hole')
     show_name_warning = fields.Boolean(store=False)
     type_name = fields.Char('Type Name', compute='_compute_type_name')
-    country_code = fields.Char(related='company_id.account_fiscal_country_id.code', readonly=True)
+    country_code = fields.Char(compute='_compute_country_code')
+
+    @api.depends('company_id', 'fiscal_position_id')
+    def _compute_country_code(self):
+        for move in self:
+            if move.fiscal_position_id.foreign_vat:
+                move.country_code = move.fiscal_position_id.country_id.code
+            else:
+                move.country_code = move.company_id.account_fiscal_country_id.code
+
     attachment_ids = fields.One2many('ir.attachment', 'res_id', domain=[('res_model', '=', 'account.move')], string='Attachments')
 
     # === Hash Fields === #

--- a/addons/account/models/res_config_settings.py
+++ b/addons/account/models/res_config_settings.py
@@ -136,6 +136,7 @@ class ResConfigSettings(models.TransientModel):
         related='company_id.account_cash_basis_base_account_id',
         domain=[('deprecated', '=', False)])
     account_fiscal_country_id = fields.Many2one(string="Fiscal Country Code", related="company_id.account_fiscal_country_id", readonly=False, store=False)
+    multi_vat_foreign_country_ids = fields.Many2many(string="Foreign VAT Countries", related="company_id.multi_vat_foreign_country_ids", readonly=False, store=False)
 
     qr_code = fields.Boolean(string='Display SEPA QR-code', related='company_id.qr_code', readonly=False)
     invoice_is_download = fields.Boolean(string='Download', related='company_id.invoice_is_download', readonly=False)

--- a/addons/l10n_hu_edi/models/account_move.py
+++ b/addons/l10n_hu_edi/models/account_move.py
@@ -327,7 +327,7 @@ class AccountMove(models.Model):
             'company_vat_invalid': {
                 'records': self.company_id.filtered(
                     lambda c: (
-                        (c.vat and not hu_vat_regex.fullmatch(c.vat))
+                        (c.account_fiscal_country_id.code == 'HU' and c.vat and not hu_vat_regex.fullmatch(c.vat))
                         or (c.l10n_hu_group_vat and not hu_vat_regex.fullmatch(c.l10n_hu_group_vat))
                     )
                 ),
@@ -339,10 +339,15 @@ class AccountMove(models.Model):
                 'message': _('Please set company Country, Zip, City and Street!'),
                 'action_text': _('View Company/ies'),
             },
-            'company_not_huf': {
-                'records': self.company_id.filtered(lambda c: c.currency_id.name != 'HUF'),
-                'message': _('Please use HUF as company currency!'),
-                'action_text': _('View Company/ies'),
+            'fiscal_position_vat_invalid': {
+                'records': self.fiscal_position_id.filtered(
+                    lambda p: (
+                        p.country_id.code == 'HU'
+                        and not hu_vat_regex.fullmatch(p.foreign_vat)
+                    )
+                ),
+                'message': _('Please enter the Hungarian VAT number in 12345678-1-12 format!'),
+                'action_text': _('View Fiscal Position(s)'),
             },
             'partner_vat_missing': {
                 'records': self.partner_id.commercial_partner_id.filtered(

--- a/addons/l10n_hu_edi/views/res_company_views.xml
+++ b/addons/l10n_hu_edi/views/res_company_views.xml
@@ -7,8 +7,9 @@
         <field name="inherit_id" ref="account.view_company_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='company_registry']" position="after">
+                <field name="multi_vat_foreign_country_ids" invisible="1"/>
                 <field name="account_fiscal_country_id" invisible="1"/>
-                <field name="l10n_hu_group_vat" invisible="account_fiscal_country_id != %(base.hu)d"/>
+                <field name="l10n_hu_group_vat" invisible="%(base.hu)d not in (multi_vat_foreign_country_ids + [account_fiscal_country_id])"/>
             </xpath>
         </field>
     </record>

--- a/addons/l10n_hu_edi/views/res_config_settings_views.xml
+++ b/addons/l10n_hu_edi/views/res_config_settings_views.xml
@@ -6,8 +6,10 @@
         <field name="inherit_id" ref="account.res_config_settings_view_form"/>
         <field name="arch" type="xml">
             <xpath expr="//block[@id='invoicing_settings']" position="after">
+                <field name="multi_vat_foreign_country_ids" invisible="1"/>
+                <field name="account_fiscal_country_id" invisible="1"/>
                 <block title="Hungarian Electronic Invoicing"
-                       invisible="country_code != 'HU'"
+                       invisible="%(base.hu)d not in (multi_vat_foreign_country_ids + [account_fiscal_country_id])"
                        groups="account.group_account_manager"
                        name="l10n_hu_edi_settings">
                     <setting company_dependent="1" string="NAV Credentials"


### PR DESCRIPTION
This is a PoC to see what changes would be needed to trigger the
Hungarian EDI on invoices issued in Hungary by a foreign company.

The proposed flow requires the following configuration:
- Create a fiscal position for Hungary, and insert the Hungarian VAT
  number in the 'Foreign VAT' field.
- Click on the button to load Hungarian taxes.
- This should make the Hungarian EDI configuration appear in the
  Accounting settings. Enter the NAV credentials there.
- Then, create an invoice that uses the Hungarian fiscal position.
- Now the NAV 3.0 option appears in the Send and Print wizard, and
  lets you issue invoices with the NAV using your Hungarian VAT number.

taskid: 3989516