### PR TITLE
[IMP] website_sale: Add _onChangeState to be inheritable

### DIFF
--- a/addons/l10n_pe_website_sale/static/src/js/website_sale.js
+++ b/addons/l10n_pe_website_sale/static/src/js/website_sale.js
@@ -3,7 +3,6 @@ import {WebsiteSale} from "@website_sale/js/website_sale";
 
 WebsiteSale.include({
     events: Object.assign({}, WebsiteSale.prototype.events, {
-        "change select[name='state_id']": "_onChangeState",
         "change select[name='city_id']": "_onChangeCity",
     }),
     start: function () {
@@ -40,17 +39,20 @@ WebsiteSale.include({
             }
         });
     },
-    _onChangeState: function () {
-        if (this.isPeruvianCompany) {
-            if (this.elementState.value === "" && this.elemenCountry.value !== '') {
-                this.elementState.options[1].selected = true;
+    _onChangeState: function (ev) {
+        return this._super.apply(this, arguments).then(() => {
+            let selectedCountry = this.elemenCountry.options[this.elemenCountry.selectedIndex].getAttribute("code");
+            if (this.isPeruvianCompany && selectedCountry === "PE") {
+                if (this.elementState.value === "" && this.elemenCountry.value !== '') {
+                    this.elementState.options[1].selected = true;
+                }
+                const state = this.elementState.value;
+                const rpcRoute = `/shop/state_infos/${state}`;
+                return this.autoFormat.length
+                    ? this._changeOption(state, rpcRoute, "cities", this.elementCities).then(() => this._onChangeCity())
+                    : undefined;
             }
-            const state = this.elementState.value;
-            const rpcRoute = `/shop/state_infos/${state}`;
-            return this.autoFormat.length
-                ? this._changeOption(state, rpcRoute, "cities", this.elementCities).then(() => this._onChangeCity())
-                : undefined;
-        }
+        });
     },
     _onChangeCity: function () {
         if (this.isPeruvianCompany) {

--- a/addons/website_sale/static/src/js/website_sale.js
+++ b/addons/website_sale/static/src/js/website_sale.js
@@ -41,6 +41,7 @@ export const WebsiteSale = publicWidget.Widget.extend(VariantMixin, cartHandlerM
         'mousemove .o_wsale_filmstip_wrapper': '_onMouseMove',
         'click .o_wsale_filmstip_wrapper' : '_onClickHandler',
         'submit': '_onClickConfirmOrder',
+        "change select[name='state_id']": "_onChangeState",
     }),
 
     /**
@@ -636,6 +637,13 @@ export const WebsiteSale = publicWidget.Widget.extend(VariantMixin, cartHandlerM
             return;
         }
         return this._changeCountry();
+    },
+    /**
+     * @private
+     * @param {Event} ev
+     */
+    _onChangeState: function (ev) {
+        return Promise.resolve();
     },
     /**
      * @private


### PR DESCRIPTION
Make _onChangeState to be inheritable by adding it to website_sale.js and returning a promise.

Adapt the _onChangeState in PE localization for the inheritance by calling _super method and returning a promise.

related: https://github.com/odoo/enterprise/pull/64786

task-2856566

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
