### PR TITLE
[FIX] hr_holidays: fixed bool attribute error

### DIFF
--- a/addons/hr_holidays/models/hr_employee.py
+++ b/addons/hr_holidays/models/hr_employee.py
@@ -579,7 +579,7 @@ class HrEmployee(models.Model):
                     virtual_remaining = 0
                     additional_leaves_duration = 0
                     for allocation in consumed_content:
-                        latest_accrual_bonus += allocation._get_future_leaves_on(date_to_simulate)
+                        latest_accrual_bonus += allocation and allocation._get_future_leaves_on(date_to_simulate)
                         date_accrual_bonus += consumed_content[allocation]['accrual_bonus']
                         virtual_remaining += consumed_content[allocation]['virtual_remaining_leaves']
                     for leave in content['to_recheck_leaves']:


### PR DESCRIPTION
`to_recheck_leaves` stores every leave that is not yet taken into account by the "allocation_leaves_consumed" dictionary. now for some leave type, it's allocation contain
False value as key  of this `allocation_leaves_consumed` dictionary.
because when leave_type with requires_allocation
Is not yes then we pass leave type data with False as allocation.
see:
https://github.com/odoo/odoo/blob/7363d568df6e82119eed1cec55b3ae67a3816a1a/addons/hr_holidays/models/hr_employee.py#L565

and this will create issue when we try to calculate `latest_accrual_bonus` value by iterating  consumed_content which call `_get_future_leaves_on` function but as we got allocation as False will get error :

```
 File "/home/odoo/src/odoo/17.0/addons/hr_holidays/models/hr_employee.py", line 105, in _compute_allocation_remaining_display
    leaves_taken = self._get_consumed_leaves(allocations.holiday_status_id)[0]
   File "/home/odoo/src/odoo/17.0/addons/hr_holidays/models/hr_employee.py", line 582, in _get_consumed_leaves
    latest_accrual_bonus += allocation._get_future_leaves_on(date_to_simulate)
 AttributeError: 'bool' object has no attribute '_get_future_leaves_on'
```

Generated during upgrade.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
