### PR TITLE
[IMP] pos_razorpay: hide unnecessary fields in the payment view

### DIFF
--- a/addons/pos_razorpay/views/pos_payment_views.xml
+++ b/addons/pos_razorpay/views/pos_payment_views.xml
@@ -6,13 +6,16 @@
         <field name="inherit_id" ref="point_of_sale.view_pos_payment_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='transaction_id']" position='after'>
-                <field name="razorpay_authcode" invisible="not razorpay_authcode"/>
-                <field name="razorpay_issuer_card_no" invisible="not razorpay_issuer_card_no"/>
+                <field name="razorpay_authcode" invisible="not razorpay_authcode or razorpay_payment_method != 'CARD'"/>
+                <field name="razorpay_issuer_card_no" invisible="not razorpay_issuer_card_no or razorpay_payment_method != 'CARD'"/>
                 <field name="razorpay_issuer_bank" invisible="not razorpay_issuer_bank"/>
                 <field name="razorpay_payment_method" invisible="not razorpay_payment_method"/>
                 <field name="razorpay_reference_no" invisible="not razorpay_reference_no"/>
-                <field name="razorpay_card_scheme" invisible="not razorpay_card_scheme"/>
-                <field name="razorpay_card_owner_name" invisible="not razorpay_card_owner_name"/>
+                <field name="razorpay_card_scheme" invisible="not razorpay_card_scheme or razorpay_payment_method != 'CARD'"/>
+                <field name="razorpay_card_owner_name" invisible="not razorpay_card_owner_name or razorpay_payment_method != 'CARD'"/>
+            </xpath>
+            <xpath expr="//field[@name='card_type']" position='attributes'>
+                <attribute name="invisible">not card_type or razorpay_payment_method != 'CARD'</attribute>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Before this commit:
==========
- The POS payment form view included unnecessary fields for payment methods other than 'CARD'.

After this commit:
==========
- The POS payment form view encompasses only essential fields for a specific payment method.

task-3981087