### PR TITLE
[FIX] mail: fix channel members without persona

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -1103,11 +1103,11 @@ class Channel(models.Model):
             target = current_partner or current_guest
             if self.channel_type in self._types_allowing_seen_infos():
                 target = self
+            persona_fields = {"partner": {"id": True, "name": True}, "guest": {"id": True, "name": True}}
             self.env['bus.bus']._sendone(target, 'mail.record/insert', {
-                'ChannelMember': {
-                    'id': member.id,
-                    'seen_message_id': {'id': last_message.id} if last_message else None,
-                }
+                'ChannelMember': member._discuss_channel_member_format(fields={
+                    "id": True, "channel": {}, "persona": persona_fields, "seen_message_id": True
+                })[member]
             })
 
     def _types_allowing_seen_infos(self):

--- a/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
+++ b/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
@@ -1038,11 +1038,20 @@ export class DiscussChannel extends models.ServerModel {
             if (this._types_allowing_seen_infos().includes(channel.channel_type)) {
                 target = channel;
             }
+            const personaFields = {
+                partner: { id: true, name: true },
+                guest: { id: true, name: true },
+            };
             BusBus._sendone(target, "mail.record/insert", {
-                ChannelMember: {
-                    id: memberOfCurrentUser?.id,
-                    seen_message_id: message_id ? { id: message_id } : null,
-                },
+                ChannelMember: DiscussChannelMember._discuss_channel_member_format(
+                    [memberOfCurrentUser.id],
+                    {
+                        id: true,
+                        channel: {},
+                        persona: personaFields,
+                        seen_message_id: true,
+                    }
+                )[0],
             });
         }
     }

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -221,13 +221,18 @@ class TestChannelInternals(MailCommon, HttpCase):
                     "payload": {
                         "ChannelMember": {
                             "id": member.id,
-                            "new_message_separator": msg_1.id + 1,
                             "thread": {
                                 "id": chat.id,
+                                "model": "discuss.channel",
                                 "message_unread_counter": 0,
                                 "message_unread_counter_bus_id": last_bus_id + 1,
-                                "model": "discuss.channel",
                             },
+                            "persona": {
+                                "id": self.user_admin.partner_id.id,
+                                "name": self.user_admin.partner_id.name,
+                                "type": "partner",
+                            },
+                            "new_message_separator": msg_1.id + 1,
                             "syncUnread": False,
                         },
                     },
@@ -237,6 +242,15 @@ class TestChannelInternals(MailCommon, HttpCase):
                     "payload": {
                         "ChannelMember": {
                             "id": member.id,
+                            "thread": {
+                                "id": chat.id,
+                                "model": "discuss.channel",
+                            },
+                            "persona": {
+                                "id": self.user_admin.partner_id.id,
+                                "name": self.user_admin.partner_id.name,
+                                "type": "partner",
+                            },
                             "seen_message_id": {"id": msg_1.id},
                         },
                     },


### PR DESCRIPTION
Marking a message as (un)read results in a notification being sent
to update the new message separator and the message unread counter.
This notification is an update of the user channel member. This
notification does not contain any information about the member persona.

However, the code assumes the persona is always provided. As a result,
errors can occur. This commit fixes this issue by providing the persona
in the notification payload.

Steps to reproduce:
- Connect as admin
- Go to the live chat session history
- Click on a chat you are not a member of (chats between demo and visitor,
for example)
- Send a message on the channel
- An error occurs