### PR TITLE
[FIX] portal: format number of due in days

### DIFF
--- a/addons/portal/static/src/js/portal_sidebar.js
+++ b/addons/portal/static/src/js/portal_sidebar.js
@@ -38,9 +38,9 @@ var PortalSidebar = publicWidget.Widget.extend({
                 } else if (diff > 0) {
                     // Workaround: force uniqueness of these two translations. We use %1d because the string
                     // with %d is already used in mail and mail's translations are not sent to the frontend.
-                    displayStr = _t('Due in %s days', Math.abs(diff).toFixed(1));
+                    displayStr = _t('Due in %s days', Math.abs(diff).toFixed());
                 } else {
-                    displayStr = _t('%s days overdue', Math.abs(diff).toFixed(1));
+                    displayStr = _t('%s days overdue', Math.abs(diff).toFixed());
                 }
                 $(el).text(displayStr);
         });


### PR DESCRIPTION
To reproduce the bug:
- Go to Accounting app -> Customers -> Invoices
- Click on an invoice or create a new one
- Click on the Preview button
- Chcek due in days. It has number after the decimal point.

This was caused to a miss understanding of the toFixed function. The parameter of the function represent the numbers needed after the digit. And by default its value is 0.

opw-3957112