### PR TITLE
[IMP] web: create the Phone component

### DIFF
--- a/addons/web/static/src/views/fields/phone/phone_field.js
+++ b/addons/web/static/src/views/fields/phone/phone_field.js
@@ -5,18 +5,24 @@ import { standardFieldProps } from "../standard_field_props";
 
 import { Component } from "@odoo/owl";
 
-export class PhoneField extends Component {
-    static template = "web.PhoneField";
+export class Phone extends Component {
+    static template = "web.Phone";
     static props = {
         ...standardFieldProps,
         placeholder: { type: String, optional: true },
     };
 
-    setup() {
-        useInputField({ getValue: () => this.props.record.data[this.props.name] || "" });
-    }
     get phoneHref() {
         return "tel:" + this.props.record.data[this.props.name].replace(/\s+/g, "");
+    }
+}
+
+export class PhoneField extends Phone {
+    static template = "web.PhoneField";
+
+    setup() {
+        super.setup();
+        useInputField({ getValue: () => this.props.record.data[this.props.name] || "" });
     }
 }
 

--- a/addons/web/static/src/views/fields/phone/phone_field.xml
+++ b/addons/web/static/src/views/fields/phone/phone_field.xml
@@ -1,22 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="web.PhoneField">
-        <div class="o_phone_content d-inline-flex w-100">
-            <t t-if="props.readonly">
-                <a t-if="props.record.data[props.name]" class="o_form_uri" target="_blank" t-att-href="phoneHref" t-esc="props.record.data[props.name]"/>
-            </t>
-            <t t-else="">
-                <input
-                    class="o_input"
-                    t-att-id="props.id"
-                    type="tel"
-                    autocomplete="off"
-                    t-att-placeholder="props.placeholder"
-                    t-ref="input"
-                />
-            </t>
+    <t t-name="web.Phone">
+        <div class="o_phone_content">
+            <a t-if="props.record.data[props.name]" class="btn btn-secondary"
+                target="_blank" t-att-href="phoneHref"><i class="fa fa-phone"></i>
+            </a>
         </div>
+    </t>
+
+    <t t-name="web.PhoneField" t-inherit="web.Phone" t-inherit-mode="primary">
+        <xpath expr="//div[hasclass('o_phone_content')]" position="replace">
+            <div class="o_phone_content d-inline-flex w-100">
+                <t t-if="props.readonly">
+                    <a t-if="props.record.data[props.name]" class="o_form_uri"
+                        target="_blank" t-att-href="phoneHref" t-out="props.record.data[props.name]"/>
+                </t>
+                <t t-else="">
+                    <input
+                        class="o_input"
+                        t-att-id="props.id"
+                        type="tel"
+                        autocomplete="off"
+                        t-att-placeholder="props.placeholder"
+                        t-ref="input"
+                    />
+                </t>
+            </div>
+        </xpath>
     </t>
 
     <t t-name="web.FormPhoneField" t-inherit="web.PhoneField" t-inherit-mode="primary">


### PR DESCRIPTION
The phone component is used in the PhoneField and the Gantt popover.

Technical:
  useInputField is used in the phone field, so we have not used the phone field in the
  Gantt popover because there will be no input.

task-3617833


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
