### PR TITLE
[FIX] point_of_sale: fix price computation with fiscal position 

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -680,8 +680,8 @@ class PosGlobalState extends PosModel {
 
             if (mapped_included_taxes.length > 0) {
                 if (new_included_taxes.length > 0) {
-                    const price_without_taxes = this.compute_all(mapped_included_taxes, price, 1, this.currency.rounding, true).total_excluded
-                    return this.compute_all(new_included_taxes, price_without_taxes, 1, this.currency.rounding, false).total_included
+                    //If previous tax and new tax where both included in price. The price including tax is the same
+                    return price;
                 }
                 else{
                     return this.compute_all(mapped_included_taxes, price, 1, this.currency.rounding, true).total_excluded;

--- a/addons/point_of_sale/static/tests/tours/TicketScreen.tour.js
+++ b/addons/point_of_sale/static/tests/tours/TicketScreen.tour.js
@@ -189,4 +189,16 @@ odoo.define('point_of_sale.tour.TicketScreen', function (require) {
 
     Tour.register('LotRefundTour', { test: true, url: '/pos/ui' }, getSteps());
 
+    startSteps();
+
+    ProductScreen.do.confirmOpeningPopup();
+    ProductScreen.do.clickHomeCategory();
+    ProductScreen.do.clickDisplayedProduct("Test Product");
+    ProductScreen.check.checkTaxAmount("9.09");
+    ProductScreen.check.totalAmountIs("100.00");
+    ProductScreen.do.changeFiscalPosition("test fp");
+    ProductScreen.check.totalAmountIs("100.00");
+    ProductScreen.check.checkTaxAmount("4.76");
+
+    Tour.register("FiscalPositionTwoTaxIncluded", { test: true, url: "/pos/ui" }, getSteps());
 });

--- a/addons/point_of_sale/static/tests/tours/helpers/ProductScreenTourMethods.js
+++ b/addons/point_of_sale/static/tests/tours/helpers/ProductScreenTourMethods.js
@@ -362,6 +362,14 @@ odoo.define('point_of_sale.tour.ProductScreenTourMethods', function (require) {
                 },
             ];
         }
+        checkTaxAmount(number) {
+            return [
+                {
+                    content: `check order tax amount`,
+                    trigger: `.subentry:contains("${number}")`,
+                },
+            ];
+        }
     }
 
     class Execute {

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1062,3 +1062,45 @@ class TestUi(TestPointOfSaleHttpCommon):
         })
         self.main_pos_config.open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'ReceiptTrackingMethodTour', login="accountman")
+
+    def test_fiscal_position_two_tax_included(self):
+        """This tests make sure that if both tax in a fiscal position are tax included, the total price is still the same
+           but only the tax amount is modified"""
+
+        tax_1 = self.env['account.tax'].create({
+            'name': 'Tax 10%',
+            'amount': 10,
+            'price_include': True,
+            'amount_type': 'percent',
+            'type_tax_use': 'sale',
+        })
+
+        tax_2 = self.env['account.tax'].create({
+            'name': 'Tax 5%',
+            'amount': 5,
+            'price_include': True,
+            'amount_type': 'percent',
+            'type_tax_use': 'sale',
+        })
+
+        self.product = self.env['product.product'].create({
+            'name': 'Test Product',
+            'taxes_id': [(6, 0, [tax_1.id])],
+            'list_price': 100,
+            'available_in_pos': True,
+        })
+
+        fiscal_position = self.env['account.fiscal.position'].create({
+            'name': 'test fp',
+            'tax_ids': [(0, 0, {
+                'tax_src_id': tax_1.id,
+                'tax_dest_id': tax_2.id,
+            })],
+        })
+
+        self.main_pos_config.write({
+            'tax_regime_selection': True,
+            'fiscal_position_ids': [(6, 0, [fiscal_position.id])],
+        })
+        self.main_pos_config.open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'FiscalPositionTwoTaxIncluded', login="accountman")


### PR DESCRIPTION
Fiscal position using 2 taxes including in price are not working in PoS. If you use the fiscal position only the tax should change, not the total price, as both tax are included in price.

Steps to reproduce:
-------------------
* Create two taxes that are included in price
* Create a fiscal position matching those 2 taxes
* Create a product using the first tax
* Open PoS session, and add the product to the order
* Price should be for example 100€
* Now change the fiscal position to the one you created
> Observation: Price of the product changed when it shouldn't have

Why the fix:
------------
When computing the price of the product with a fiscal position, if the previous tax is included in price and the new one is also included in price, the price of the product shouldn't change. So instead of recomputing the price of the product with the new tax based on the previous tax excluded price. We just use the price of the product

opw-3952604
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
