### PR TITLE
[REV] product: truncate product name if too long

### DIFF
--- a/addons/product/static/src/scss/report_label_sheet.scss
+++ b/addons/product/static/src/scss/report_label_sheet.scss
@@ -72,8 +72,8 @@
         padding:0;
         line-height:1;
         font-size:55%;
-        overflow:visible;
-        white-space:normal;
-        word-wrap: break-word;
+        overflow:hidden;
+        white-space:nowrap;
+        text-overflow: ellipsis;
     }
 }


### PR DESCRIPTION
Current behaviour:
---
Product name can overflow from the label box

Expected behaviour:
---
Truncate the name if it's too long

Steps to reproduce:
---
1. Go to Inventory > Products > Lots/Serial Numbers
2. Open one Serial Number > open its product
3. Rename product with long name
4. Go back to Lots/Serial Numbers
5. Select the Serial Number with renamed product
6. Click on Print > PDF
7. Barcode is out of the box

Cause of the issue:
---
Caused by: https://github.com/odoo/odoo/commit/a5924bfe11cd9324e2ba056e0ac1d449aed730c8

Fix:
---
Reverting: https://github.com/odoo/odoo/commit/a5924bfe11cd9324e2ba056e0ac1d449aed730c8

opw-3819349

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
