### PR TITLE
[FIX] web: avoid datetime_picker to overflow on the left

### DIFF
--- a/addons/web/static/src/core/datetime/datetime_picker.scss
+++ b/addons/web/static/src/core/datetime/datetime_picker.scss
@@ -134,9 +134,12 @@
     }
 
     .o_cell_md {
-        padding: 0.4rem;
-        width: var(--DateTimePicker__Cell-size-md);
-        height: var(--DateTimePicker__Cell-size-md);
+        aspect-ratio: 1;
+        @include media-breakpoint-up(md) {
+            padding: 0.4rem;
+            width: var(--DateTimePicker__Cell-size-md);
+            height: var(--DateTimePicker__Cell-size-md);
+        }
     }
 
     .o_cell_lg {


### PR DESCRIPTION
Backport of odoo/odoo@7aca17cf6d6f8487ebba615bc4f2e6bde5e0c4a1

This commit force the datetime_picker's cells to have the same aspect ratio without any specific width or height on small screen.
So the datetime_picker can take the all width space available and be always responsive as each cells share the same width and the same height to respect the aspect ratio.

We backport this commit so on small screen the date picker has a smaller width and doesn't overflow anymore.

Steps to reproduce (Small screen/Mobile):
* Open CRM
* Click on a lead
* Click on Expected Closing => Bug the date picker overflow on the left

opw-3957058

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
