### PR TITLE
[FIX] website_slides: fix quiz comment display

### DIFF
--- a/addons/website_slides/static/src/xml/slide_quiz_create.xml
+++ b/addons/website_slides/static/src/xml/slide_quiz_create.xml
@@ -60,8 +60,8 @@
                     <i class="o_wslides_js_quiz_icon o_wslides_js_quiz_add_answer fa fa-lg fa-plus-circle col-auto p-md-2 py-2 px-1 text-muted" title="Add an answer below this one" />
                     <i class="o_wslides_js_quiz_icon o_wslides_js_quiz_remove_answer fa fa-lg fa-trash-o col-auto p-md-2 py-2 px-1 text-muted" title="Remove this answer" />
                 </div>
-                <div class="o_wslides_js_quiz_answer_comment row align-items-center d-none">
-                    <input type="text" class="form-control col-8 offset-1 mt-1" placeholder="This is the correct answer, congratulations"
+                <div class="o_wslides_js_quiz_answer_comment row col-8 offset-1 p-0 align-items-center flex-nowrap d-none">
+                    <input type="text" class="form-control mt-1 ms-2" placeholder="This is the correct answer, congratulations"
                         t-attf-value="#{answer ? answer.comment : ''}" />
                     <i class="o_wslides_js_quiz_icon o_wslides_js_quiz_remove_answer_comment fa fa-lg fa-trash-o p-2 text-muted" title="Remove the answer comment" />
                 </div>


### PR DESCRIPTION
Purpose
=======
Fix the display of the quiz comment line:
- the trash icon is displayed under the line instead of next to it.
- the comment input is too large and should be aligned with the answers inputs.

Specification
=============
The comment input is too large because the "form-control" class has a "width: 100%"
style that overwrites the "width: 66.66666667%" one applied by the "col-8" class.

The good fix would be to create a new parent for the input and apply the "col-8" class
to limit its width accordingly while still keeping the good row gutters and margins.
However as changing the xml structure is not recommended in stable, the fix is to add
the "col-8" on the current "row" parent and forcing the trash icon to be next to by
using the "flex-nowrap" class.

Task-3986982

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
