### PR TITLE
[FIX] im_livechat: crash when thread name contains non-ASCII

### DIFF
--- a/addons/im_livechat/static/src/embed/common/autopopup_service.js
+++ b/addons/im_livechat/static/src/embed/common/autopopup_service.js
@@ -1,12 +1,12 @@
 /* @odoo-module */
 
+import { expirableStorage } from "@im_livechat/embed/common/expirable_storage";
 import { SESSION_STATE } from "@im_livechat/embed/common/livechat_service";
 import { browser } from "@web/core/browser/browser";
-import { cookie } from "@web/core/browser/cookie";
 import { registry } from "@web/core/registry";
 
 export class AutopopupService {
-    static COOKIE = "im_livechat_auto_popup";
+    static STORAGE_KEY = "im_livechat_auto_popup";
 
     /**
      * @param {import("@web/env").OdooEnv} env
@@ -38,7 +38,7 @@ export class AutopopupService {
             if (this.allowAutoPopup && livechatService.state === SESSION_STATE.NONE) {
                 browser.setTimeout(async () => {
                     if (!this.storeService.ChatWindow.get({ thread: livechatService.thread })) {
-                        cookie.set(AutopopupService.COOKIE, JSON.stringify(false));
+                        expirableStorage.setItem(AutopopupService.STORAGE_KEY, false);
                         livechatService.open();
                     }
                 }, livechatService.rule.auto_popup_timer * 1000);
@@ -48,7 +48,7 @@ export class AutopopupService {
 
     get allowAutoPopup() {
         return Boolean(
-            JSON.parse(cookie.get(AutopopupService.COOKIE) ?? "true") !== false &&
+            !expirableStorage.getItem(AutopopupService.STORAGE_KEY) &&
                 !this.ui.isSmall &&
                 this.livechatService.rule?.action === "auto_popup" &&
                 (this.livechatService.available || this.chatbotService.available)

--- a/addons/im_livechat/static/src/embed/common/expirable_storage.js
+++ b/addons/im_livechat/static/src/embed/common/expirable_storage.js
@@ -1,0 +1,55 @@
+/* @odoo-module */
+
+import { browser } from "@web/core/browser/browser";
+
+const BASE_STORAGE_KEY = "EXPIRABLE_STORAGE";
+const CLEAR_INTERVAL = 24 * 60 * 60 * 1000; // 24 hours in milliseconds
+
+function cleanupExpirableStorage() {
+    const now = Date.now();
+    // Next line is for testing compatibility as for..in is not supported by
+    // the `MockStorage` class.
+    const keys = browser.localStorage.items?.keys() ?? Object.keys(browser.localStorage);
+    for (const key of keys) {
+        if (key.startsWith(BASE_STORAGE_KEY)) {
+            const item = JSON.parse(browser.localStorage.getItem(key));
+            if (item.expires && item.expires < now) {
+                browser.localStorage.removeItem(key);
+            }
+        }
+    }
+}
+
+export const expirableStorage = {
+    /** @param {string} key */
+    getItem(key) {
+        cleanupExpirableStorage();
+        const item = browser.localStorage.getItem(`${BASE_STORAGE_KEY}_${key}`);
+        if (item) {
+            return JSON.parse(item).value;
+        }
+        return null;
+    },
+    /**
+     * @param {string} key
+     * @param {string} value
+     * @param {number} ttl Number of seconds after which the item should expire.
+     */
+    setItem(key, value, ttl) {
+        let expires;
+        if (ttl) {
+            expires = Date.now() + ttl * 1000;
+        }
+        browser.localStorage.setItem(
+            `${BASE_STORAGE_KEY}_${key}`,
+            JSON.stringify({ value, expires })
+        );
+    },
+    /** @param {string} key */
+    removeItem(key) {
+        browser.localStorage.removeItem(`${BASE_STORAGE_KEY}_${key}`);
+    },
+};
+
+cleanupExpirableStorage();
+setInterval(cleanupExpirableStorage, CLEAR_INTERVAL);

--- a/addons/im_livechat/static/tests/embed/expirable_storage_test.js
+++ b/addons/im_livechat/static/tests/embed/expirable_storage_test.js
@@ -1,0 +1,15 @@
+/* @odoo-module */
+
+import { expirableStorage } from "@im_livechat/embed/common/expirable_storage";
+import { patchDate } from "@web/../tests/helpers/utils";
+
+QUnit.test("value is removed from expirable storage after expiration", async () => {
+    patchDate(2023, 1, 1, 0, 0, 0);
+    const ONE_DAY = 60 * 60 * 24;
+    expirableStorage.setItem("foo", "bar", ONE_DAY);
+    expect(expirableStorage.getItem("foo")).toBe("bar");
+    patchDate(2023, 1, 1, 23, 0, 0);
+    expect(expirableStorage.getItem("foo")).toBe("bar");
+    patchDate(2023, 1, 2, 0, 0, 1);
+    expect(expirableStorage.getItem("foo")).toBe(null);
+});


### PR DESCRIPTION
The live chat uses cookies to save data about the ongoing conversation, such as the thread name. When this information contains non-ASCII characters, the behavior of the cookie is not consistent across browsers.

Safari does not store it properly, and trying to parse it later on results in a crash.

Until version 17 ([1]), the fix relied on encoding the data using the `encodeURIComponent` method. However, cookie size is limited to 4096 bytes and this limit can be reached.

Starting with version 17.3, the live chat does not use cookies anymore ([2]). This PR backport this behavior to fix the issue.

opw-3968341

[1]: https://github.com/odoo/odoo/pull/168524
[2]: https://github.com/odoo/odoo/pull/167495