### PR TITLE
[REF] web_tour: remove extra_trigger

### DIFF
--- a/addons/account/static/src/js/tours/account.js
+++ b/addons/account/static/src/js/tours/account.js
@@ -32,8 +32,11 @@ registry.category("web_tour.tours").add('account_tour', {
     ...accountTourSteps.onboarding(),
     ...accountTourSteps.newInvoice(),
     {
+        trigger: "[name=move_type] [raw-value=out_invoice]",
+        auto: true,
+    },
+    {
         trigger: "div[name=partner_id] .o_input_dropdown",
-        extra_trigger: "[name=move_type] [raw-value=out_invoice]",
         content: markup(_t("Write a customer name to <b>create one</b> or <b>see suggestions</b>.")),
         position: "right",
         run: "click",
@@ -41,57 +44,87 @@ registry.category("web_tour.tours").add('account_tour', {
         trigger: "div[name=partner_id] input",
         run: "edit Test",
         auto: true,
-    }, {
+    }, 
+    {
+        trigger: "[name=move_type] [raw-value=out_invoice]",
+        auto: true,
+    },
+    {
         trigger: ".o_m2o_dropdown_option a:contains('Create')",
-        extra_trigger: "[name=move_type] [raw-value=out_invoice]",
         content: _t("Select first partner"),
         auto: true,
         run: "click",
-    }, {
+    }, 
+    {
+        trigger: "[name=move_type] [raw-value=out_invoice]",
+        auto: true,
+    },
+    {
         trigger: ".modal-content button.btn-primary",
-        extra_trigger: "[name=move_type] [raw-value=out_invoice]",
         content: markup(_t("Once everything is set, you are good to continue. You will be able to edit this later in the <b>Customers</b> menu.")),
         auto: true,
         run: "click",
-    }, {
+    }, 
+    {
+        trigger: "[name=move_type] [raw-value=out_invoice]",
+        auto: true,
+    },
+    {
         trigger: "div[name=invoice_line_ids] .o_field_x2many_list_row_add a",
-        extra_trigger: "[name=move_type] [raw-value=out_invoice]",
         content: _t("Add a line to your invoice"),
         run: "click",
-    }, {
+    },
+    {
+        trigger: "[name=move_type] [raw-value=out_invoice]",
+        auto: true,
+    },
+    {
         trigger: "div[name=invoice_line_ids] div[name=product_id] input",
-        extra_trigger: "[name=move_type] [raw-value=out_invoice]",
         content: _t("Fill in the details of the line."),
         position: "bottom",
         run: "edit Test",
-    }, {
+    },
+    {
+        trigger: "[name=move_type] [raw-value=out_invoice]",
+        auto: true,
+    },
+    {
         trigger: "div[name=invoice_line_ids] div[name=price_unit] input",
-        extra_trigger: "[name=move_type] [raw-value=out_invoice]",
         content: _t("Set a price"),
         position: "bottom",
         run: "edit 100",
     },
     ...stepUtils.saveForm(),
     {
+        trigger: "button.o_form_button_create",
+        auto: true,
+    },
+    {
         trigger: "button[name=action_post]",
-        extra_trigger: "button.o_form_button_create",
         content: _t("Once your invoice is ready, confirm it."),
         run: "click",
-    }, {
+    },
+    {
+        trigger: "[name=move_type] [raw-value=out_invoice]",
+        auto: true,
+    },
+    {
         trigger: "button[name=action_invoice_sent]",
-        extra_trigger: "[name=move_type] [raw-value=out_invoice]",
         content: _t("Send the invoice to the customer and check what he'll receive."),
         position: "bottom",
         run: "click",
-    }, {
+    },
+    {
+        trigger: "div.modal-dialog",
+        auto: true,
+    },
+    {
         trigger: "button[name=document_layout_save]",
-        extra_trigger: "div.modal-dialog",
         content: _t("Configure document layout."),
         run: "click",
     },
     {
         trigger: "div[name=partner_missing_email] a",
-        extra_trigger: "[name=move_type] [raw-value=out_invoice]",
         content: _t("Complete the partner data with email"),
         run: "click",
     }, {
@@ -106,14 +139,22 @@ registry.category("web_tour.tours").add('account_tour', {
         content: _t('Go back'),
         position: 'bottom',
         run: "click",
-    }, {
+    }, 
+    {
+        trigger: "[name=move_type] [raw-value=out_invoice], [name=move_type][raw-value=out_invoice]",
+        auto: true,
+    },
+    {
         trigger: "button[name=action_invoice_sent]",
-        extra_trigger: "[name=move_type] [raw-value=out_invoice], [name=move_type][raw-value=out_invoice]",
         content: _t("Send the invoice and check what the customer will receive."),
         run: "click",
-    }, {
+    }, 
+    {
+        trigger: "[name=move_type] [raw-value=out_invoice]",
+        auto: true,
+    },
+    {
         trigger: "button[name=action_send_and_print]",
-        extra_trigger: "[name=move_type] [raw-value=out_invoice]",
         content: _t("Let's send the invoice."),
         position: "top",
         run: "click",

--- a/addons/account/static/tests/tours/tax_group_tests.js
+++ b/addons/account/static/tests/tours/tax_group_tests.js
@@ -20,9 +20,11 @@ registry.category("web_tour.tours").add('account_tax_group', {
         run: "click",
     },
     {
+        trigger: ".o_breadcrumb .text-truncate:contains(Bills)",
+    },
+    {
         content: "Create new bill",
         trigger: '.o_control_panel_main_buttons .o_list_button_add',
-        extra_trigger: '.o_breadcrumb .text-truncate:contains("Bills")',
         run: "click",
     },
     // Set a vendor

--- a/addons/auth_totp/static/tests/totp_flow.js
+++ b/addons/auth_totp/static/tests/totp_flow.js
@@ -16,7 +16,6 @@ function openRoot() {
     }, {
         content: "wait for client reload",
         trigger: 'body:not(.wait)',
-        run() {}
     }];
 }
 function openUserProfileAtSecurityTab() {
@@ -80,9 +79,12 @@ registry.category("web_tour.tours").add('totp_tour_setup', {
     content: "Open totp wizard",
     trigger: 'button[name=action_totp_enable_wizard]',
     run: "click",
-}, {
+},
+{
+    trigger: "div:contains(enter your password)",
+},
+{
     content: "Check that we have to enter enhanced security mode and input password",
-    extra_trigger: 'div:contains("enter your password")',
     trigger: '[name=password] input',
     run: "edit demo",
 }, {
@@ -92,7 +94,6 @@ registry.category("web_tour.tours").add('totp_tour_setup', {
 }, {
     content: "Check the wizard has opened",
     trigger: 'li:contains("When requested to do so")',
-    run() {}
 }, {
     content: "Get secret from collapsed div",
     trigger: 'a:contains("Cannot scan it?")',
@@ -114,7 +115,6 @@ registry.category("web_tour.tours").add('totp_tour_setup', {
 }, {
     content: 'wait for rpc',
     trigger: 'body.got-token',
-    run() {}
 },
 ...openRoot(),
 ...openUserProfileAtSecurityTab(),
@@ -151,20 +151,17 @@ registry.category("web_tour.tours").add('totp_login_enabled', {
     content: "input code",
     trigger: 'input[name=totp_token]',
     async run(helpers) {
-        // TODO: if tours are ever async-aware the click should get moved out,
-        //       but currently there's no great way to make the tour wait until
-        //       we've retrieved and set the token: `:empty()` is aboutthe text
-        //       content of the HTML element, not the JS value property. We
-        //       could set a class but that's really no better than
-        //       procedurally clicking the button after we've set the input.
         const token = await rpc('/totphook');
         helpers.edit(token);
-        helpers.click('button:contains("Log in")');
     }
-}, {
+}, 
+{
+    trigger: `button:contains("Log in")`,
+    run: "click",
+},
+{
     content: "check we're logged in",
     trigger: ".o_user_menu .dropdown-toggle",
-    run() {}
 }]});
 
 registry.category("web_tour.tours").add('totp_login_device', {
@@ -200,9 +197,13 @@ registry.category("web_tour.tours").add('totp_login_device', {
     async run(helpers) {
         const token = await rpc('/totphook')
         helpers.edit(token);
-        helpers.click('button:contains("Log in")');
     }
-}, {
+},
+{
+    trigger: "button:contains(Log in)",
+    run: "click",
+},
+{
     content: "check we're logged in",
     trigger: ".o_user_menu .dropdown-toggle",
     run: 'click',
@@ -229,7 +230,6 @@ registry.category("web_tour.tours").add('totp_login_device', {
 },  {
     content: "check we're logged in without 2FA",
     trigger: ".o_user_menu .dropdown-toggle",
-    run() {}
 },
 // now go and disable two-factor authentication would be annoying to do in a separate tour
 // because we'd need to login & totp again as HttpCase.authenticate can't
@@ -239,9 +239,12 @@ registry.category("web_tour.tours").add('totp_login_device', {
     content: "Open totp wizard",
     trigger: 'button[name=action_totp_disable]',
     run: "click",
-}, {
+},
+{
+    trigger: "div:contains(enter your password)",
+},
+{
     content: "Check that we have to enter enhanced security mode and input password",
-    extra_trigger: 'div:contains("enter your password")',
     trigger: '[name=password] input',
     run: "edit demo",
 }, {
@@ -297,7 +300,6 @@ registry.category("web_tour.tours").add('totp_admin_disables', {
 }, {
     content: 'Wait for page',
     trigger: '.o_menu_brand:contains("Settings")',
-    run() {}
 }, {
     content: "Open Users menu",
     trigger: '[data-menu-xmlid="base.menu_users"]',
@@ -326,9 +328,12 @@ registry.category("web_tour.tours").add('totp_admin_disables', {
     content: "Select totp remover",
     trigger: 'span.dropdown-item:contains(Disable two-factor authentication)',
     run: "click",
-}, { // enhanced security yo
+},
+{
+    trigger: "div:contains(enter your password)",
+},
+{ // enhanced security yo
     content: "Check that we have to enter enhanced security mode & input password",
-    extra_trigger: 'div:contains("enter your password")',
     trigger: '[name=password] input',
     run: "edit admin",
 }, {

--- a/addons/crm/static/src/js/tours/crm.js
+++ b/addons/crm/static/src/js/tours/crm.js
@@ -22,9 +22,13 @@ registry.category("web_tour.tours").add('crm_tour', {
     position: 'bottom',
     edition: 'enterprise',
     run: "click",
-}, {
+},
+{
+    trigger: ".o_opportunity_kanban",
+    auto: true,
+},
+{
     trigger: '.o-kanban-button-new',
-    extra_trigger: '.o_opportunity_kanban',
     content: markup(_t("<b>Create your first opportunity.</b>")),
     position: 'bottom',
     run: "click",
@@ -43,22 +47,34 @@ registry.category("web_tour.tours").add('crm_tour', {
     content: markup(_t("Now, <b>add your Opportunity</b> to your Pipeline.")),
     position: "bottom",
     run: "click",
-}, {
+}, 
+{
+    trigger: ".o_opportunity_kanban",
+    auto: true,
+},
+{
     trigger: ".o_opportunity_kanban .o_kanban_group:first-child .o_kanban_record:last-of-type .oe_kanban_content",
-    extra_trigger: ".o_opportunity_kanban",
     content: markup(_t("<b>Drag &amp; drop opportunities</b> between columns as you progress in your sales cycle.")),
     position: "right",
     run: "drag_and_drop(.o_opportunity_kanban .o_kanban_group:eq(2))",
-}, {
+}, 
+{
+    trigger: ".o_opportunity_kanban",
+    auto: true,
+},
+{
     // Choose the element that is not going to be moved by the previous step.
     trigger: ".o_opportunity_kanban .o_kanban_group:nth-child(2) .o_kanban_record .o-mail-ActivityButton",
-    extra_trigger: ".o_opportunity_kanban",
     content: markup(_t("Looks like nothing is planned. :(<br><br><i>Tip: Schedule activities to keep track of everything you have to do!</i>")),
     position: "bottom",
     run: "click",
-}, {
+},
+{
+    trigger: ".o_opportunity_kanban",
+    auto: true,
+},
+{
     trigger: ".o-mail-ActivityListPopover button:contains(Schedule an activity)",
-    extra_trigger: ".o_opportunity_kanban",
     content: markup(_t("Let's <b>Schedule an Activity.</b>")),
     position: "bottom",
     width: 200,
@@ -74,9 +90,13 @@ registry.category("web_tour.tours").add('crm_tour', {
     content: markup(_t("Drag your opportunity to <b>Won</b> when you get the deal. Congrats!")),
     position: "bottom",
     run: "drag_and_drop(.o_opportunity_kanban .o_kanban_group:eq(3))",
-},  {
+},
+{
+    trigger: ".o_opportunity_kanban",
+    auto: true,
+},
+{
     trigger: ".o_kanban_record",
-    extra_trigger: ".o_opportunity_kanban",
     content: _t("Let’s have a look at an Opportunity."),
     position: "right",
     run: "click",

--- a/addons/crm/static/tests/tours/crm_email_and_phone_propagation.js
+++ b/addons/crm/static/tests/tours/crm_email_and_phone_propagation.js
@@ -16,9 +16,12 @@
             trigger: '.o_kanban_record .o_kanban_record_title span:contains(Test Lead Propagation)',
             content: 'Open the first lead',
             run: 'click',
-        }, {
+        },
+        {
+            trigger: ".o_form_editable .o_field_widget[name=email_from] input",
+        },
+        {
             trigger: '.o_form_button_save',
-            extra_trigger: '.o_form_editable .o_field_widget[name=email_from] input',
             content: 'Save the lead',
             run: 'click',
         },
@@ -37,15 +40,21 @@
             trigger: '.o_kanban_record .o_kanban_record_title span:contains(Test Lead Propagation)',
             content: 'Open the first lead',
             run: 'click',
-        }, {
+        },
+        {
+            trigger: ".o_form_editable .o_field_widget[name=phone] input",
+        },
+        {
             trigger: '.o_form_editable .o_field_widget[name=email_from] input',
-            extra_trigger: '.o_form_editable .o_field_widget[name=phone] input',
             content: 'Remove the email and the phone',
             run: "clear && clear .o_form_editable .o_field_widget[name=phone] input",
-        }, {
+        },
+        {
+            trigger: ".o_form_sheet_bg .fa-exclamation-triangle:not(.o_invisible_modifier)",
+        },
+        {
             trigger: '.o_back_button',
             // wait the warning message to be visible
-            extra_trigger: '.o_form_sheet_bg .fa-exclamation-triangle:not(.o_invisible_modifier)',
             content: 'Save the lead and exit to kanban',
             run: 'click',
         },{

--- a/addons/crm/static/tests/tours/crm_rainbowman.js
+++ b/addons/crm/static/tests/tours/crm_rainbowman.js
@@ -1,95 +1,119 @@
 /** @odoo-module **/
 
-    import { registry } from "@web/core/registry";
-    import { stepUtils } from '@web_tour/tour_service/tour_utils';
+import { registry } from "@web/core/registry";
+import { stepUtils } from "@web_tour/tour_service/tour_utils";
 
-    registry.category("web_tour.tours").add('crm_rainbowman', {
-        test: true,
-        url: "/web",
-        steps: () => [
+registry.category("web_tour.tours").add("crm_rainbowman", {
+    test: true,
+    url: "/web",
+    steps: () => [
         stepUtils.showAppsMenuItem(),
         {
             trigger: ".o_app[data-menu-xmlid='crm.crm_menu_root']",
             content: "open crm app",
             run: "click",
-        }, {
+        },
+        {
             trigger: ".o-kanban-button-new",
             content: "click create",
             run: "click",
-        }, {
+        },
+        {
             trigger: ".o_field_widget[name=name] input",
             content: "complete name",
             run: "edit Test Lead 1",
-        }, {
+        },
+        {
             trigger: ".o_field_widget[name=expected_revenue] input",
             content: "complete expected revenue",
             run: "edit 999999997",
-        }, {
+        },
+        {
             trigger: "button.o_kanban_add",
             content: "create lead",
             run: "click",
-        }, {
+        },
+        {
             trigger: ".o_kanban_record .o_kanban_record_title:contains('Test Lead 1')",
             content: "move to won stage",
             run: "drag_and_drop (.o_opportunity_kanban .o_kanban_group:eq(3))",
-        }, {
+        },
+        {
             trigger: ".o_reward_rainbow",
-            extra_trigger: ".o_reward_rainbow",
-        }, {
+        },
+        {
+            trigger: ".o_reward_rainbow",
+        },
+        {
             // This step and the following simulates the fact that after drag and drop,
             // from the previous steps, a click event is triggered on the window element,
             // which closes the currently shown .o_kanban_quick_create.
             trigger: ".o_kanban_renderer",
             run: "click",
-        }, {
+        },
+        {
             trigger: ".o_kanban_renderer:not(:has(.o_kanban_quick_create))",
-        }, {
+        },
+        {
             trigger: ".o-kanban-button-new",
             content: "create second lead",
             run: "click",
-        }, {
+        },
+        {
             trigger: ".o_field_widget[name=name] input",
             content: "complete name",
             run: "edit Test Lead 2",
-        }, {
+        },
+        {
             trigger: ".o_field_widget[name=expected_revenue] input",
             content: "complete expected revenue",
             run: "edit 999999998",
-        }, {
+        },
+        {
             trigger: "button.o_kanban_add",
             content: "create lead",
             run: "click",
-        }, {
+        },
+        {
             trigger: ".o_kanban_record .o_kanban_record_title:contains('Test Lead 2')",
-        }, {
+        },
+        {
             // move first test back to new stage to be able to test rainbowman a second time
             trigger: ".o_kanban_record .o_kanban_record_title:contains('Test Lead 1')",
             content: "move back to new stage",
-            run: "drag_and_drop .o_opportunity_kanban .o_kanban_group:eq(0) "
-        }, {
+            run: "drag_and_drop .o_opportunity_kanban .o_kanban_group:eq(0) ",
+        },
+        {
             trigger: ".o_kanban_record .o_kanban_record_title:contains('Test Lead 2')",
             content: "click on second lead",
             run: "click",
-        }, {
+        },
+        {
             trigger: ".o_statusbar_status button[data-value='4']",
             content: "move lead to won stage",
             run: "click",
         },
         ...stepUtils.saveForm(),
         {
+            trigger: ".o_reward_rainbow",
+        },
+        {
             trigger: ".o_statusbar_status button[data-value='1']",
-            extra_trigger: ".o_reward_rainbow",
             content: "move lead to previous stage & rainbowman appears",
             run: "click",
-        }, {
+        },
+        {
             trigger: "button[name=action_set_won_rainbowman]",
             content: "click button mark won",
             run: "click",
         },
         ...stepUtils.saveForm(),
         {
+            trigger: ".o_reward_rainbow",
+        },
+        {
             trigger: ".o_menu_brand",
-            extra_trigger: ".o_reward_rainbow",
             content: "last rainbowman appears",
-        }
-    ]});
+        },
+    ],
+});

--- a/addons/event/static/src/js/tours/event_tour.js
+++ b/addons/event/static/src/js/tours/event_tour.js
@@ -23,9 +23,12 @@ registry.category("web_tour.tours").add('event_tour', {
     content: markup(_t("Ready to <b>organize events</b> in a few minutes? Let's get started!")),
     edition: 'community',
     run: "click",
-}, {
+},
+{
+    trigger: ".o_event_kanban_view",
+},
+{
     trigger: '.o-kanban-button-new',
-    extra_trigger: '.o_event_kanban_view',
     content: markup(_t("Let's create your first <b>event</b>.")),
     position: 'bottom',
     width: 175,
@@ -61,9 +64,12 @@ registry.category("web_tour.tours").add('event_tour', {
     content: _t("Now that your event is ready, click here to move it to another stage."),
     position: 'bottom',
     run: "click",
-}, {
+},
+{
+    trigger: `.o_event_form_view div[name="stage_id"]`,
+},
+{
     trigger: 'ol.breadcrumb li.breadcrumb-item:first',
-    extra_trigger: '.o_event_form_view div[name="stage_id"]',
     content: markup(_t("Use the <b>breadcrumbs</b> to go back to your kanban overview.")),
     position: 'bottom',
     run: 'click',

--- a/addons/event_sale/static/tests/tours/event_configurator_ui.js
+++ b/addons/event_sale/static/tests/tours/event_configurator_ui.js
@@ -14,9 +14,12 @@ registry.category("web_tour.tours").add('event_configurator_tour', {
     trigger: '.o_app[data-menu-xmlid="sale.sale_menu_root"]',
     edition: 'enterprise',
     run: "click",
-}, {
+},
+{
+    trigger: ".o_sale_order",
+},
+{
     trigger: ".o_list_button_add",
-    extra_trigger: ".o_sale_order",
     run: "click",
 }, {
     trigger: "a:contains('Add a product')",

--- a/addons/hr_expense/static/src/js/tours/hr_expense.js
+++ b/addons/hr_expense/static/src/js/tours/hr_expense.js
@@ -21,29 +21,41 @@ registry.category("web_tour.tours").add('hr_expense_tour' , {
     position: 'bottom',
     edition: 'enterprise',
     run: "click",
-}, {
+},
+{
+    trigger: ".o_button_upload_expense",
+},
+{
     trigger: '.o_list_button_add',
-    extra_trigger: '.o_button_upload_expense',
     content: _t("It all begins here - let's go!"),
     position: 'bottom',
     mobile: false,
     run: "click",
-}, {
+},
+{
+    trigger: ".o_button_upload_expense",
+},
+{
     trigger: '.o-kanban-button-new',
-    extra_trigger: '.o_button_upload_expense',
     content: _t("It all begins here - let's go!"),
     position: 'bottom',
     mobile: true,
     run: "click",
-}, {
+},
+{
+    trigger: ".o_hr_expense_form_view_view",
+},
+{
     trigger: '.o_field_widget[name="product_id"] .o_input_dropdown',
-    extra_trigger: '.o_hr_expense_form_view_view',
     content: _t("Enter a name then choose a category and configure the amount of your expense."),
     position: 'bottom',
     run: "click",
-}, {
+},
+{
+    trigger: ".o_hr_expense_form_view_view",
+},
+{
     trigger: '.o_form_status_indicator_dirty .o_form_button_save',
-    extra_trigger: '.o_hr_expense_form_view_view',
     content: markup(_t("Ready? You can save it manually or discard modifications from here. You don't <em>need to save</em> - Odoo will save eveyrthing for you when you navigate.")),
     position: 'bottom',
     run: "click",
@@ -70,8 +82,10 @@ registry.category("web_tour.tours").add('hr_expense_tour' , {
 },
 stepUtils.openBurgerMenu(),
 {
+    trigger: ".o_main_navbar",
+},
+{
     trigger: "[data-menu-xmlid='hr_expense.menu_hr_expense_report']",
-    extra_trigger: '.o_main_navbar',
     content: _t("Let's check out where you can manage all your employees expenses"),
     position: "bottom",
     run: "click",

--- a/addons/hr_holidays/static/src/tours/hr_holidays_tour.js
+++ b/addons/hr_holidays/static/src/tours/hr_holidays_tour.js
@@ -39,8 +39,10 @@ registry.category("web_tour.tours").add("hr_holidays_tour", {
             run: "click",
         },
         {
+            trigger: `.o_field_widget[name='holiday_status_id'] input:value("${leaveType}")`,
+        },
+        {
             trigger: "input[data-field=request_date_from]",
-            extra_trigger: `.o_field_widget[name='holiday_status_id'] input:value("${leaveType}")`,
             content: _t(
                 "You can select the period you need to take off, from start date to end date"
             ),
@@ -80,13 +82,10 @@ registry.category("web_tour.tours").add("hr_holidays_tour", {
             run: "click",
         },
         {
-            trigger: "table.o_list_table",
-            content: _t("Select the request you just created"),
             position: "bottom",
-            run: function (actions) {
-                const rows = this.anchor.querySelectorAll("tr.o_data_row");
-                actions.click(rows[0]);
-            },
+            content: _t("Select the request you just created"),
+            trigger: "table.o_list_table tr.o_data_row:eq(0)",
+            run: "click",
         },
         {
             trigger: 'button[name="action_approve"]',

--- a/addons/lunch/static/tests/tours/order_lunch.js
+++ b/addons/lunch/static/tests/tours/order_lunch.js
@@ -19,15 +19,19 @@ registry.category("web_tour.tours").add('order_lunch_tour', {
     run: "click",
 },
 {
+    trigger: ".o_search_panel_filter_value .form-check-input:checked",
+},
+{
     trigger: "div[role=article]",
-    extra_trigger: '.o_search_panel_filter_value .form-check-input:checked',
     content: _t("Click on a product you want to order and is available."),
     position: 'bottom',
     run: "click",
 },
 {
+    trigger: `button[name="add_to_cart"]`,
+},
+{
     trigger: 'textarea[name="note"]',
-    extra_trigger: 'button[name="add_to_cart"]',
     content: _t("Add additionnal information about your order."),
     position: 'bottom',
     run: "edit allergy to peanuts",

--- a/addons/mail/static/tests/tours/discuss_channel_public_tour.js
+++ b/addons/mail/static/tests/tours/discuss_channel_public_tour.js
@@ -47,9 +47,11 @@ registry.category("web_tour.tours").add("discuss_channel_public_tour.js", {
             },
         },
         {
+            trigger: ".o-mail-AttachmentCard:not(.o-isUploading)", // waiting the attachment to be uploaded
+        },
+        {
             content: "Check the earlier provided attachment is listed",
             trigger: '.o-mail-AttachmentCard[title="text.txt"]',
-            extra_trigger: ".o-mail-AttachmentCard:not(.o-isUploading)", // waiting the attachment to be uploaded
         },
         {
             content: "Send message",
@@ -93,10 +95,11 @@ registry.category("web_tour.tours").add("discuss_channel_public_tour.js", {
             },
         },
         {
+            trigger: ".o-mail-Message .o-mail-Composer .o-mail-AttachmentCard:not(.o-isUploading)", // waiting the attachment to be uploaded
+        },
+        {
             content: "Check the earlier provided extra attachment is listed",
             trigger: '.o-mail-Message .o-mail-Composer .o-mail-AttachmentCard[title="extra.txt"]',
-            extra_trigger:
-                ".o-mail-Message .o-mail-Composer .o-mail-AttachmentCard:not(.o-isUploading)", // waiting the attachment to be uploaded
         },
         {
             content: "Save edited message",

--- a/addons/mail/static/tests/tours/discuss_channel_tour.js
+++ b/addons/mail/static/tests/tours/discuss_channel_tour.js
@@ -25,8 +25,11 @@ registry.category("web_tour.tours").add("discuss_channel_tour", {
             run: `edit SomeChannel_${new Date().getTime()}`,
         },
         {
+            trigger: ".o-discuss-ChannelSelector-suggestion",
+            auto: true,
+        },
+        {
             trigger: ".o-discuss-ChannelSelector-list",
-            extra_trigger: ".o-discuss-ChannelSelector-suggestion",
             content: markup(_t("<p>Create a public or private channel.</p>")),
             position: "right",
             run() {

--- a/addons/mail/static/tests/tours/mail_activity_schedule_from_chatter.js
+++ b/addons/mail/static/tests/tours/mail_activity_schedule_from_chatter.js
@@ -19,7 +19,9 @@ registry.category("web_tour.tours").add("mail_activity_schedule_from_chatter", {
             trigger: "input[id*='activity_type_id']:value('Call')",
         },
         {
-            extra_trigger: "button:contains('Schedule')",
+            trigger: "button:contains('Schedule')",
+        },
+        {
             trigger: "input[id*='activity_type_id']",
             run: "click",
         },

--- a/addons/mail/static/tests/tours/mail_composer_test_tour.js
+++ b/addons/mail/static/tests/tours/mail_composer_test_tour.js
@@ -46,9 +46,11 @@ registry.category("web_tour.tours").add("mail/static/tests/tours/mail_composer_t
             },
         },
         {
+            trigger: ".o-mail-AttachmentCard:not(.o-isUploading)", // waiting the attachment to be uploaded
+        },
+        {
             content: "Open full composer",
             trigger: "button[aria-label='Full composer']",
-            extra_trigger: ".o-mail-AttachmentCard:not(.o-isUploading)", // waiting the attachment to be uploaded
             run: "click",
         },
         {

--- a/addons/mail/static/tests/tours/user_modify_own_profile_tour.js
+++ b/addons/mail/static/tests/tours/user_modify_own_profile_tour.js
@@ -20,9 +20,11 @@ registry.category("web_tour.tours").add("mail/static/tests/tours/user_modify_own
             run: "edit updatedemail@example.com",
         },
         {
+            trigger: "body.modal-open",
+        },
+        {
             content: "Save the form",
             trigger: 'button[name="preference_save"]',
-            extra_trigger: "body.modal-open",
         },
         {
             content: "Wait until the modal is closed",

--- a/addons/mass_mailing/static/src/js/tours/mass_mailing_tour.js
+++ b/addons/mass_mailing/static/src/js/tours/mass_mailing_tour.js
@@ -24,9 +24,13 @@
         content: _t("Let's try the Email Marketing app."),
         edition: 'community',
         run: "click",
-    }, {
+    },
+    {
+        trigger: ".o_mass_mailing_mailing_tree",
+        auto: true,
+    },
+    {
         trigger: '.o_list_button_add',
-        extra_trigger: '.o_mass_mailing_mailing_tree',
         content: markup(_t("Start by creating your first <b>Mailing</b>.")),
         position: 'bottom',
         run: "click",

--- a/addons/mass_mailing/static/tests/tours/mailing_editor_theme.js
+++ b/addons/mass_mailing/static/tests/tours/mailing_editor_theme.js
@@ -35,16 +35,19 @@ registry.category("web_tour.tours").add('mailing_editor_theme', {
             run: "click",
         },
         {
+            trigger: ":iframe .o_mail_theme_selector_new",
+        },
+        {
             content: "Pick the basic theme",
             trigger: ':iframe #basic',
-            extra_trigger: ':iframe .o_mail_theme_selector_new',
             run: "click",
+        },
+        {
+            trigger: ":iframe html:not(:has(.o_mail_theme_selector_new))",
         },
         {
             content: "Make sure the snippets menu is hidden",
             trigger: 'html:has(#oe_snippets.d-none)',
-            extra_trigger: ':iframe html:not(:has(.o_mail_theme_selector_new))',
-            run: () => null, // no click, just check
         },
         ...stepUtils.saveForm(),
         {
@@ -53,9 +56,11 @@ registry.category("web_tour.tours").add('mailing_editor_theme', {
             run: "click",
         },
         {
+            trigger: ":iframe .o_mail_theme_selector_new",
+        },
+        {
             content: "Fill in Subject",
             trigger: '#subject_0',
-            extra_trigger: ':iframe .o_mail_theme_selector_new',
             run: "edit Test Newsletter Theme",
         },
         {
@@ -76,7 +81,6 @@ registry.category("web_tour.tours").add('mailing_editor_theme', {
         {
             content: "Make sure the snippets menu is displayed",
             trigger: '#oe_snippets',
-            run: () => null, // no click, just check
         },
         ...stepUtils.discardForm(),
         {
@@ -87,7 +91,6 @@ registry.category("web_tour.tours").add('mailing_editor_theme', {
         {
             content: "Make sure the snippets menu is hidden",
             trigger: 'html:has(#oe_snippets.d-none)',
-            run: () => null,
         },
         {
             content: "Add some content to be selected afterwards",
@@ -104,7 +107,6 @@ registry.category("web_tour.tours").add('mailing_editor_theme', {
         {
             content: "Make sure the floating toolbar is visible",
             trigger: '#toolbar.oe-floating[style*="visible"]',
-            run: () => null,
         },
         {
             content: "Open the color picker",
@@ -124,7 +126,6 @@ registry.category("web_tour.tours").add('mailing_editor_theme', {
         {
             content: "Check that color was applied",
             trigger: ':iframe p font.text-o-color-1',
-            run: () => null,
         },
         ...stepUtils.saveForm(),
         {
@@ -140,7 +141,6 @@ registry.category("web_tour.tours").add('mailing_editor_theme', {
         {
             content: "Make sure the snippets menu is hidden",
             trigger: 'html:has(#oe_snippets.d-none)',
-            run: () => null,
         },
         {
             content: "Select content",
@@ -152,7 +152,6 @@ registry.category("web_tour.tours").add('mailing_editor_theme', {
         {
             content: "Make sure the floating toolbar is visible",
             trigger: '#toolbar.oe-floating[style*="visible"]',
-            run: () => null,
         },
         ...stepUtils.discardForm(),
     ]

--- a/addons/mass_mailing/static/tests/tours/mailing_portal_unsubscribe_from_list.js
+++ b/addons/mass_mailing/static/tests/tours/mailing_portal_unsubscribe_from_list.js
@@ -6,44 +6,53 @@ import { registry } from "@web/core/registry";
  * Tour: unsubscribe from a mailing done on lists (aka playing with opt-out flag
  * instead of directly blocking emails).
  */
-registry.category("web_tour.tours").add('mailing_portal_unsubscribe_from_list', {
+registry.category("web_tour.tours").add("mailing_portal_unsubscribe_from_list", {
     test: true,
     steps: () => [
         {
             content: "Confirmation unsubscribe is done",
-            trigger: "div#o_mailing_subscription_info span:contains('You are no longer part of the List1, List2 mailing list')",
+            trigger:
+                "div#o_mailing_subscription_info span:contains('You are no longer part of the List1, List2 mailing list')",
             run: "click",
-        }, {
+        },
+        {
             content: "Feedback textarea not displayed (see data)",
             trigger: "div#o_mailing_portal_subscription:not(textarea)",
             run: "click",
-        }, {
+        },
+        {
             content: "Choose 'Other' reason",
             trigger: "fieldset label:contains('Other')",
             run: "click",
-        }, {
+        },
+        {
             content: "Write feedback reason",
             trigger: "textarea[name='feedback']",
             run: "edit My feedback",
-        }, {
+        },
+        {
             content: "Hit Send",
             trigger: "button#button_feedback",
             run: "click",
-        }, {
+        },
+        {
             content: "Confirmation feedback is sent",
-            trigger: "div#o_mailing_subscription_feedback_info span:contains('Sent. Thanks you for your feedback!')",
+            trigger:
+                "div#o_mailing_subscription_feedback_info span:contains('Sent. Thanks you for your feedback!')",
             run: "click",
-        }, {
+        },
+        {
             content: "Now exclude me",
             trigger: "div#button_blocklist_add",
             run: "click",
-        }, {
+        },
+        {
             content: "Confirmation exclusion is done",
-            trigger: "div#o_mailing_subscription_update_info span:contains('Email added to our blocklist')",
+            trigger:
+                "div#o_mailing_subscription_update_info span:contains('Email added to our blocklist')",
         },
     ],
 });
-
 
 /*
  * Tour: unsubscribe from a mailing done on lists (aka playing with opt-out flag
@@ -51,132 +60,181 @@ registry.category("web_tour.tours").add('mailing_portal_unsubscribe_from_list', 
  * blocklist addition / removal. This is mainly an extended version of the tour
  * hereabove, easing debug and splitting checks.
  */
-registry.category("web_tour.tours").add('mailing_portal_unsubscribe_from_list_with_update', {
+registry.category("web_tour.tours").add("mailing_portal_unsubscribe_from_list_with_update", {
     test: true,
     steps: () => [
         {
             content: "Confirmation unsubscribe is done",
-            trigger: "div#o_mailing_subscription_info span:contains('You are no longer part of the List1, List2 mailing list')",
+            trigger:
+                "div#o_mailing_subscription_info span:contains('You are no longer part of the List1, List2 mailing list')",
             run: "click",
-        }, {
+        },
+        {
             content: "List1 is present, just opt-outed",
-            trigger: "ul#o_mailing_subscription_form_lists li.list-group-item:contains('List1') span:contains('Not subscribed')",
+            trigger:
+                "ul#o_mailing_subscription_form_lists li.list-group-item:contains('List1') span:contains('Not subscribed')",
             run: "click",
-        }, {
+        },
+        {
             content: "List3 is present, opt-outed (test starting data)",
-            trigger: "ul#o_mailing_subscription_form_lists li.list-group-item:contains('List3') span:contains('Not subscribed')",
+            trigger:
+                "ul#o_mailing_subscription_form_lists li.list-group-item:contains('List3') span:contains('Not subscribed')",
             run: "click",
-        }, {
+        },
+        {
             content: "List2 is proposed (not member -> proposal to join)",
-            trigger: "ul#o_mailing_subscription_form_lists_additional li.list-group-item:contains('List2')",
+            trigger:
+                "ul#o_mailing_subscription_form_lists_additional li.list-group-item:contains('List2')",
             run: "click",
-        }, {
+        },
+        {
             content: "List4 is not proposed (not member but not private)",
-            trigger: "ul#o_mailing_subscription_form_lists_additional:not(:has(li.list-group-item:contains('List4')))",
+            trigger:
+                "ul#o_mailing_subscription_form_lists_additional:not(:has(li.list-group-item:contains('List4')))",
             run: "click",
-        }, {
+        },
+        {
             content: "Feedback textarea not displayed (see data)",
             trigger: "div#o_mailing_portal_subscription:not(textarea)",
             run: "click",
-        }, {
+        },
+        {
             content: "Choose 'Other' reason",
             trigger: "fieldset label:contains('Other')",
             run: "click",
-        }, {
+        },
+        {
             content: "Write feedback reason",
             trigger: "textarea[name='feedback']",
             run: "edit My feedback",
-        }, {
+        },
+        {
             content: "Hit Send",
             trigger: "button#button_feedback",
             run: "click",
-        }, {
+        },
+        {
             content: "Confirmation feedback is sent",
-            trigger: "div#o_mailing_subscription_feedback_info span:contains('Sent. Thanks you for your feedback!')",
+            trigger:
+                "div#o_mailing_subscription_feedback_info span:contains('Sent. Thanks you for your feedback!')",
             run: "click",
-        }, {
+        },
+        {
             content: "Now exclude me",
             trigger: "div#button_blocklist_add",
             run: "click",
-        }, {
+        },
+        {
             content: "Confirmation exclusion is done",
-            trigger: "div#o_mailing_subscription_update_info span:contains('Email added to our blocklist')",
+            trigger:
+                "div#o_mailing_subscription_update_info span:contains('Email added to our blocklist')",
             run: "click",
-        }, {
+        },
+        {
             content: "This should disable the 'Update my subscriptions' (Apply changes) button",
             trigger: "div#o_mailing_subscription_blocklist:not(button#button_form_send)",
-        }, {
+        },
+        {
             content: "Revert exclusion list",
             trigger: "div#button_blocklist_remove",
             run: "click",
-        }, {
+        },
+        {
             content: "Confirmation exclusion list is removed",
-            trigger: "div#o_mailing_subscription_update_info span:contains('Email removed from our blocklist')",
+            trigger:
+                "div#o_mailing_subscription_update_info span:contains('Email removed from our blocklist')",
             run: "click",
-        },  {
+        },
+        {
             content: "'Update my subscriptions' button usable again",
             trigger: "button#button_form_send:not([disabled])",
-        }, {
+        },
+        {
             content: "Choose the mailing list 3 to come back",
             trigger: "ul#o_mailing_subscription_form_lists input[title='List3']",
             run: "click",
-        }, {
+        },
+        {
             content: "Add list 2",
             trigger: "ul#o_mailing_subscription_form_lists_additional input[title='List2']",
             run: "click",
-        }, {
+        },
+        {
             content: "Update subscription",
             trigger: "button#button_form_send",
             run: "click",
-        }, {
+        },
+        {
             content: "Confirmation changes are done",
             trigger: "div#o_mailing_subscription_update_info span:contains('Membership updated')",
             run: "click",
-        }, {
+        },
+        {
             content: "List 3 is noted as subscribed again",
-            trigger: "ul#o_mailing_subscription_form_lists li.list-group-item:contains('List3') span:contains('Subscribed')",
+            trigger:
+                "ul#o_mailing_subscription_form_lists li.list-group-item:contains('List3') span:contains('Subscribed')",
             run: "click",
-        }, {
+        },
+        {
             content: "List 2 has joined the subscriptions",
-            trigger: "ul#o_mailing_subscription_form_lists li.list-group-item:contains('List2') span:contains('Subscribed')",
+            trigger:
+                "ul#o_mailing_subscription_form_lists li.list-group-item:contains('List2') span:contains('Subscribed')",
             run: "click",
-        }, {
+        },
+        {
             content: "No list in proposals",
-            trigger: "div#o_mailing_subscription_form_manage:not(:has(ul#o_mailing_subscription_form_lists_additional))",
+            trigger:
+                "div#o_mailing_subscription_form_manage:not(:has(ul#o_mailing_subscription_form_lists_additional))",
             run: "click",
-        }, {
-            content: "Feedback area is not displayed (nothing opt-out or no blocklist done, no feedback required)",
+        },
+        {
+            trigger: "div#o_mailing_portal_subscription:not(fieldset)",
+        },
+        {
+            content:
+                "Feedback area is not displayed (nothing opt-out or no blocklist done, no feedback required)",
             trigger: "div#o_mailing_portal_subscription:not(textarea)",
-            extra_trigger: "div#o_mailing_portal_subscription:not(fieldset)",
             run: "click",
-        }, {
+        },
+        {
             content: "Now exclude me (again)",
             trigger: "div#button_blocklist_add",
             run: "click",
-        }, {
+        },
+        {
             content: "Confirmation exclusion is done",
-            trigger: "div#o_mailing_subscription_update_info span:contains('Email added to our blocklist')",
+            trigger:
+                "div#o_mailing_subscription_update_info span:contains('Email added to our blocklist')",
             run: "click",
-        }, {
+        },
+        {
             content: "Should display warning about mailing lists",
-            trigger: "div#o_mailing_subscription_form_blocklisted p:contains('You will not receive any news from those mailing lists you are a member of')",
+            trigger:
+                "div#o_mailing_subscription_form_blocklisted p:contains('You will not receive any news from those mailing lists you are a member of')",
             run: "click",
-        }, {
+        },
+        {
+            trigger: "div#o_mailing_subscription_form_blocklisted li strong:contains('List3')",
+        },
+        {
             content: "Warning should contain reference to memberships",
             trigger: "div#o_mailing_subscription_form_blocklisted li strong:contains('List2')",
-            extra_trigger: "div#o_mailing_subscription_form_blocklisted li strong:contains('List3')",
             run: "click",
-        }, {
+        },
+        {
             content: "Give a reason for blocklist (first one)",
             trigger: "fieldset input.o_mailing_subscription_opt_out_reason:first",
             run: "click",
-        }, {
+        },
+        {
             content: "Hit Send",
             trigger: "button#button_feedback",
             run: "click",
-        }, {
+        },
+        {
             content: "Confirmation feedback is sent",
-            trigger: "div#o_mailing_subscription_feedback_info span:contains('Sent. Thanks you for your feedback!')",
-        }
+            trigger:
+                "div#o_mailing_subscription_feedback_info span:contains('Sent. Thanks you for your feedback!')",
+        },
     ],
 });

--- a/addons/mass_mailing/static/tests/tours/mailing_portal_unsubscribe_from_my.js
+++ b/addons/mass_mailing/static/tests/tours/mailing_portal_unsubscribe_from_my.js
@@ -6,121 +6,166 @@ import { registry } from "@web/core/registry";
  * Tour: use 'my' portal page of mailing to manage mailing lists subscription
  * as well as manage blocklist (add / remove my own email from block list).
  */
-registry.category("web_tour.tours").add('mailing_portal_unsubscribe_from_my', {
+registry.category("web_tour.tours").add("mailing_portal_unsubscribe_from_my", {
     test: true,
     steps: () => [
-       {
+        {
             content: "List1 is present, opt-in member",
-            trigger: "ul#o_mailing_subscription_form_lists li.list-group-item:contains('List1') span:contains('Subscribed')",
+            trigger:
+                "ul#o_mailing_subscription_form_lists li.list-group-item:contains('List1') span:contains('Subscribed')",
             run: "click",
-        }, {
+        },
+        {
             content: "List3 is present, opt-outed (test starting data)",
-            trigger: "ul#o_mailing_subscription_form_lists li.list-group-item:contains('List3') span:contains('Not subscribed')",
+            trigger:
+                "ul#o_mailing_subscription_form_lists li.list-group-item:contains('List3') span:contains('Not subscribed')",
             run: "click",
-        }, {
+        },
+        {
             content: "List2 is proposed (not member -> proposal to join)",
-            trigger: "ul#o_mailing_subscription_form_lists_additional li.list-group-item:contains('List2')",
+            trigger:
+                "ul#o_mailing_subscription_form_lists_additional li.list-group-item:contains('List2')",
             run: "click",
-        }, {
+        },
+        {
             content: "List4 is not proposed (not member but not private)",
-            trigger: "ul#o_mailing_subscription_form_lists_additional:not(:has(li.list-group-item:contains('List4')))",
+            trigger:
+                "ul#o_mailing_subscription_form_lists_additional:not(:has(li.list-group-item:contains('List4')))",
             run: "click",
-        }, {
+        },
+        {
+            trigger: "div#o_mailing_portal_subscription:not(fieldset)",
+        },
+        {
             content: "Feedback area is not displayed (nothing done, no feedback required)",
             trigger: "div#o_mailing_portal_subscription:not(textarea)",
-            extra_trigger: "div#o_mailing_portal_subscription:not(fieldset)",
             run: "click",
-        }, {
+        },
+        {
             content: "List3: come back (choose to opt-in instead of opt-out)",
             trigger: "ul#o_mailing_subscription_form_lists input[title='List3']",
             run: "click",
-        }, {
+        },
+        {
             content: "List2: join (opt-in, not already member)",
             trigger: "ul#o_mailing_subscription_form_lists_additional input[title='List2']",
             run: "click",
-        }, {
+        },
+        {
             content: "List1: opt-out",
             trigger: "ul#o_mailing_subscription_form_lists input[title='List1']",
             run: "click",
-        }, {
+        },
+        {
             content: "Update subscription",
             trigger: "button#button_form_send",
             run: "click",
-        }, {
+        },
+        {
             content: "Confirmation changes are done",
             trigger: "div#o_mailing_subscription_update_info span:contains('Membership updated')",
             run: "click",
-        }, {
-            content: "Should make feedback reasons choice appear (feedback still not displayed, linked to reasons)",
+        },
+        {
+            trigger: "div#o_mailing_portal_subscription:not(textarea)",
+        },
+        {
+            content:
+                "Should make feedback reasons choice appear (feedback still not displayed, linked to reasons)",
             trigger: "div#o_mailing_portal_subscription fieldset",
-            extra_trigger: "div#o_mailing_portal_subscription:not(textarea)",
             run: "click",
-        }, {
+        },
+        {
             content: "Choose first reason, which should not display feedback (see data)",
             trigger: "fieldset input.o_mailing_subscription_opt_out_reason:first",
             run: "click",
-        }, {
+        },
+        {
             content: "Feedback textarea not displayed (see data)",
             trigger: "div#o_mailing_portal_subscription:not(textarea)",
             run: "click",
-        }, {
+        },
+        {
             content: "Choose 'Other' reason",
             trigger: "fieldset label:contains('Other')",
             run: "click",
-        }, {
+        },
+        {
             content: "This should display the Feedback area",
             trigger: "div#o_mailing_portal_subscription textarea",
-        }, {
+        },
+        {
             content: "Write feedback reason",
             trigger: "textarea[name='feedback']",
             run: "edit My feedback",
-        }, {
+        },
+        {
             content: "Hit Send",
             trigger: "button#button_feedback",
             run: "click",
-        }, {
+        },
+        {
             content: "Confirmation feedback is sent",
-            trigger: "div#o_mailing_subscription_feedback_info span:contains('Sent. Thanks you for your feedback!')",
+            trigger:
+                "div#o_mailing_subscription_feedback_info span:contains('Sent. Thanks you for your feedback!')",
             run: "click",
-        }, {
+        },
+        {
+            trigger: "textarea[disabled]",
+            allowDisabled: true,
+        },
+        {
             content: "Once sent feedback area is readonly",
             trigger: "fieldset input.o_mailing_subscription_opt_out_reason[disabled]",
-            extra_trigger: "textarea[disabled]",
             allowDisabled: true,
-        }, {
+        },
+        {
             content: "Now exclude me",
             trigger: "div#button_blocklist_add",
             run: "click",
-        }, {
+        },
+        {
             content: "Confirmation exclusion is done",
-            trigger: "div#o_mailing_subscription_update_info span:contains('Email added to our blocklist')",
+            trigger:
+                "div#o_mailing_subscription_update_info span:contains('Email added to our blocklist')",
             run: "click",
-        }, {
+        },
+        {
             content: "This should disable the 'Update my subscriptions' (Apply changes) button",
             trigger: "div#o_mailing_subscription_blocklist:not(button#button_form_send)",
-        }, {
+        },
+        {
             content: "This should enabled Feedback again",
             trigger: "div#o_mailing_portal_subscription textarea",
-        }, {
+        },
+        {
             content: "Display warning about mailing lists",
-            trigger: "div#o_mailing_subscription_form_blocklisted p:contains('You will not receive any news from those mailing lists you are a member of')",
+            trigger:
+                "div#o_mailing_subscription_form_blocklisted p:contains('You will not receive any news from those mailing lists you are a member of')",
             run: "click",
-        }, {
+        },
+        {
+            trigger: "div#o_mailing_subscription_form_blocklisted li strong:contains('List3')",
+        },
+        {
             content: "Warning should contain reference to memberships",
             trigger: "div#o_mailing_subscription_form_blocklisted li strong:contains('List2')",
-            extra_trigger: "div#o_mailing_subscription_form_blocklisted li strong:contains('List3')",
             run: "click",
-        }, {
+        },
+        {
             content: "Give a reason for blocklist (first one)",
             trigger: "fieldset input.o_mailing_subscription_opt_out_reason:first",
             run: "click",
-        }, {
+        },
+        {
             content: "Hit Send",
             trigger: "button#button_feedback",
             run: "click",
-        }, {
+        },
+        {
             content: "Confirmation feedback is sent",
-            trigger: "div#o_mailing_subscription_feedback_info span:contains('Sent. Thanks you for your feedback!')",
-        }
+            trigger:
+                "div#o_mailing_subscription_feedback_info span:contains('Sent. Thanks you for your feedback!')",
+        },
     ],
 });

--- a/addons/pos_loyalty/static/tests/tours/utils/pos_loyalty_util.js
+++ b/addons/pos_loyalty/static/tests/tours/utils/pos_loyalty_util.js
@@ -33,9 +33,11 @@ export function claimReward(rewardName) {
     return [
         ProductScreen.clickControlButton("Reward"),
         {
-            content: "select reward",
             // There should be description because a program always has a name.
-            extra_trigger: ".selection-item span:nth-child(2)",
+            trigger: ".selection-item span:nth-child(2)",
+        },
+        {
+            content: "select reward",
             trigger: `.selection-item:contains("${rewardName}")`,
             run: "click",
         },

--- a/addons/project/static/tests/tours/project_burndown_chart_tour.js
+++ b/addons/project/static/tests/tours/project_burndown_chart_tour.js
@@ -17,10 +17,13 @@ registry.category("web_tour.tours").add('burndown_chart_tour', {
     content: `Open "Burndown Chart Test" project's "Burndown Chart" view`,
     trigger: '.o_kanban_manage_reporting div[role="menuitem"] a:contains("Burndown Chart")',
     run: "click",
-}, {
+},
+{
+    trigger: ".o_graph_renderer",
+},
+{
     content: 'The sort buttons are not rendered',
     trigger: '.o_graph_renderer:not(:has(.btn-group[role=toolbar][aria-label="Sort graph"]))',
-    extra_trigger: '.o_graph_renderer',
     run: "click",
 }, {
     content: 'Remove the project search "Burndown Chart Test"',

--- a/addons/project/static/tests/tours/project_tags_filter_tour_tests.js
+++ b/addons/project/static/tests/tours/project_tags_filter_tour_tests.js
@@ -6,8 +6,8 @@ import { stepUtils } from "@web_tour/tour_service/tour_utils";
 function changeFilter(filterName) {
     return [
         {
-            trigger: '.o_control_panel_actions .o_searchview_dropdown_toggler',
-            content: 'open searchview menu',
+            trigger: ".o_control_panel_actions .o_searchview_dropdown_toggler",
+            content: "open searchview menu",
             run: "click",
         },
         {
@@ -15,35 +15,54 @@ function changeFilter(filterName) {
             run: "click",
         },
         {
-            trigger: '.o_control_panel_actions .o_searchview_dropdown_toggler',
-            content: 'close searchview menu',
+            trigger: ".o_control_panel_actions .o_searchview_dropdown_toggler",
+            content: "close searchview menu",
             run: "click",
         },
     ];
 }
 
-registry.category("web_tour.tours").add('project_tags_filter_tour',
-    {
-        test: true,
-        url: '/web',
-        steps: () => [stepUtils.showAppsMenuItem(),{
-    trigger: '.o_app[data-menu-xmlid="project.menu_main_pm"]',
-    run: "click",
-},
-...changeFilter("Corkscrew tail tag filter"),
-{
-    trigger: '.o_kanban_group:has(.o_kanban_header:has(span:contains("pig"))) .o_kanban_record:has(span:contains("Pigs"))',
-    extra_trigger: '.o_kanban_group:has(.o_kanban_header:has(span:contains("goat"))):not(:has(.o_kanban_record))',
-    content: 'check that the corkscrew tail filter has taken effect',
-}, ...changeFilter("horned tag filter"),
-{
-    trigger: '.o_kanban_group:has(.o_kanban_header:has(span:contains("goat"))) .o_kanban_record:has(span:contains("Goats"))',
-    extra_trigger: '.o_kanban_group:has(.o_kanban_header:has(span:contains("pig"))):not(:has(.o_kanban_record))',
-    content: 'check that the horned filter has taken effect',
-}, ...changeFilter("4 Legged tag filter"),
-{
-    trigger: '.o_kanban_group:has(.o_kanban_header:has(span:contains("goat"))) .o_kanban_record:has(span:contains("Goats"))',
-    extra_trigger: '.o_kanban_group:has(.o_kanban_header:has(span:contains("pig"))) .o_kanban_record:has(span:contains("Pigs"))',
-    content: 'check that the 4 legged filter has taken effect',
-},
-]});
+registry.category("web_tour.tours").add("project_tags_filter_tour", {
+    test: true,
+    url: "/web",
+    steps: () => [
+        stepUtils.showAppsMenuItem(),
+        {
+            trigger: '.o_app[data-menu-xmlid="project.menu_main_pm"]',
+            run: "click",
+        },
+        ...changeFilter("Corkscrew tail tag filter"),
+        {
+            trigger:
+                '.o_kanban_group:has(.o_kanban_header:has(span:contains("goat"))):not(:has(.o_kanban_record))',
+            content: "check that the corkscrew tail filter has taken effect",
+        },
+        {
+            trigger:
+                '.o_kanban_group:has(.o_kanban_header:has(span:contains("pig"))) .o_kanban_record:has(span:contains("Pigs"))',
+            content: "check that the corkscrew tail filter has taken effect",
+        },
+        ...changeFilter("horned tag filter"),
+        {
+            trigger:
+                '.o_kanban_group:has(.o_kanban_header:has(span:contains("pig"))):not(:has(.o_kanban_record))',
+            content: "check that the horned filter has taken effect",
+        },
+        {
+            trigger:
+                '.o_kanban_group:has(.o_kanban_header:has(span:contains("goat"))) .o_kanban_record:has(span:contains("Goats"))',
+            content: "check that the horned filter has taken effect",
+        },
+        ...changeFilter("4 Legged tag filter"),
+        {
+            trigger:
+                '.o_kanban_group:has(.o_kanban_header:has(span:contains("pig"))) .o_kanban_record:has(span:contains("Pigs"))',
+            content: "check that the 4 legged filter has taken effect",
+        },
+        {
+            trigger:
+                '.o_kanban_group:has(.o_kanban_header:has(span:contains("goat"))) .o_kanban_record:has(span:contains("Goats"))',
+            content: "check that the 4 legged filter has taken effect",
+        },
+    ],
+});

--- a/addons/project/static/tests/tours/project_task_history.js
+++ b/addons/project/static/tests/tours/project_task_history.js
@@ -36,10 +36,13 @@ registry.category("web_tour.tours").add("project_task_history_tour", {
         content: "Open the project app",
         trigger: ".o_app[data-menu-xmlid='project.menu_main_pm']",
         run: "click",
-    }, {
+    },
+    {
+        trigger: ".o_kanban_view",
+    },
+    {
         content: "Open Test History Project",
         trigger: "div span.o_text_overflow[title='Test History Project']",
-        extra_trigger: ".o_kanban_view",
         run: "click",
     }, {
         content: "Open Test History Task",
@@ -55,20 +58,29 @@ registry.category("web_tour.tours").add("project_task_history_tour", {
         content: "Go back to kanban view of tasks. this step is added because it takes some time to save the changes, so it's a sort of timeout to wait a bit for the save",
         trigger: ".o_back_button a",
         run: "click",
-    }, {
+    },
+    {
+        trigger: ".o_kanban_view",
+    },
+    {
         content: "Open Test History Task",
         trigger: "div strong.o_kanban_record_title:contains('Test History Task')",
-        extra_trigger: ".o_kanban_view",
         run: "click",
-    }, {
+    },
+    {
+        trigger: ".o_form_view",
+    },
+    {
         content: "Open History Dialog",
         trigger: ".o_cp_action_menus i.fa-cog",
-        extra_trigger: ".o_form_view",
         run: "click",
-    }, {
+    },
+    {
+        trigger: ".dropdown-menu",
+    },
+    {
         content: "Open History Dialog",
         trigger: ".o_menu_item i.fa-history",
-        extra_trigger: ".dropdown-menu",
         run: "click",
     }, {
         content: "Verify that 4 revisions are displayed (default empty description after the creation of the task + 3 edits)",

--- a/addons/project/static/tests/tours/project_tour.js
+++ b/addons/project/static/tests/tours/project_tour.js
@@ -10,9 +10,12 @@ registry.category("web_tour.tours").add('project_test_tour', {
     stepUtils.showAppsMenuItem(), {
         trigger: '.o_app[data-menu-xmlid="project.menu_main_pm"]',
         run: "click",
-    }, {
+    }, 
+    {
+        trigger: '.o_project_kanban',
+    },
+    {
         trigger: '.o-kanban-button-new',
-        extra_trigger: '.o_project_kanban',
         width: 200,
         run: "click",
     }, {
@@ -29,21 +32,30 @@ registry.category("web_tour.tours").add('project_test_tour', {
         trigger: ".o_kanban_project_tasks .o_column_quick_create .o_kanban_add",
         auto: true,
         run: "click",
-    }, {
+    }, 
+    {
+        trigger: ".o_kanban_group",
+    },
+    {
         trigger: ".o_kanban_project_tasks .o_column_quick_create .input-group input",
-        extra_trigger: '.o_kanban_group',
         run: "edit Done",
     }, {
         trigger: ".o_kanban_project_tasks .o_column_quick_create .o_kanban_add",
         auto: true,
         run: "click",
-    }, {
+    }, 
+    {
+        trigger: ".o_kanban_group:eq(0)",
+    },
+    {
         trigger: '.o-kanban-button-new',
-        extra_trigger: '.o_kanban_group:eq(0)',
         run: "click",
-    }, {
+    }, 
+    {
+        trigger: ".o_kanban_project_tasks",
+    },
+    {
         trigger: '.o_kanban_quick_create div.o_field_char[name=display_name] input',
-        extra_trigger: '.o_kanban_project_tasks',
         run: "edit New task",
     }, {
         trigger: '.o_kanban_quick_create .o_kanban_add',
@@ -72,23 +84,32 @@ registry.category("web_tour.tours").add('project_test_tour', {
         trigger: ".o_kanban_record .oe_kanban_content .o_widget_subtask_counter .subtask_list_button",
         content: 'open sub-tasks from kanban card',
         run: "click",
-    }, {
+    }, 
+    {
+        trigger: ".o_widget_subtask_kanban_list .subtask_list",
+    },
+    {
         trigger: ".o_kanban_record .o_widget_subtask_kanban_list .subtask_create",
-        extra_trigger: ".o_widget_subtask_kanban_list .subtask_list",
         content: 'Create a new sub-task',
         run: "click",
-    }, {
+    }, 
+    {
+        trigger: ".subtask_create_input",
+    },
+    {
         trigger: ".o_kanban_record .o_widget_subtask_kanban_list .subtask_create_input input",
-        extra_trigger: ".subtask_create_input",
         content: 'Give the sub-task a name',
         run: "edit newer subtask && click .o_kanban_renderer",
     }, {
         trigger: ".o_kanban_record .o_widget_subtask_kanban_list .subtask_list_row:first-child .o_field_project_task_state_selection button",
         content: 'Change the subtask state',
         run: "click",
-    }, {
+    }, 
+    {
+        trigger: ".dropdown-menu",
+    },
+    {
         trigger: ".dropdown-menu span.text-danger",
-        extra_trigger: ".dropdown-menu",
         content: 'Mark the task as Canceled',
         run: "click",
     }, {
@@ -120,9 +141,12 @@ registry.category("web_tour.tours").add('project_test_tour', {
         trigger: '.o_field_subtasks_one2many div[name="name"] input',
         content: 'Set subtask name',
         run: "edit new subtask",
-    }, {
+    }, 
+    {
+        trigger: '.o_field_many2many_tags_avatar .o_m2m_avatar',
+    },
+    {
         trigger: 'button[special="save"]',
-        extra_trigger: '.o_field_many2many_tags_avatar .o_m2m_avatar',
         content: 'Save task',
         run: "click",
     },

--- a/addons/project_todo/static/tests/tours/project_todo_main_functions.js
+++ b/addons/project_todo/static/tests/tours/project_todo_main_functions.js
@@ -14,71 +14,104 @@ registry.category("web_tour.tours").add('project_todo_main_functions', {
     trigger: ".o_project_task_kanban_view .o_column_quick_create .o_kanban_add_column",
     content: "Create a personal stage from the To-do kanban view",
     run: "click",
-}, {
+}, 
+{
+    trigger: ".o_kanban_group",
+},
+{
     trigger: ".o_project_task_kanban_view .o_column_quick_create .o_kanban_header input",
-    extra_trigger: '.o_kanban_group',
     content: "Create a personal stage from the To-do kanban view",
     run: "edit Stage 1",
 }, {
     trigger: ".o_project_task_kanban_view .o_column_quick_create .o_kanban_add",
     content: "Save the personal stage",
     run: "click",
-}, {
+}, 
+{
+    trigger: ".o_kanban_group",
+},
+{
     trigger: ".o_project_task_kanban_view .o_column_quick_create .o_kanban_header input",
-    extra_trigger: '.o_kanban_group',
     content: "Create a second personal stage from the To-do kanban view",
     run: "edit Stage 2",
 }, {
     trigger: ".o_project_task_kanban_view .o_column_quick_create .o_kanban_add",
     content: "Save the personal stage",
     run: "click",
-}, {
+}, 
+{
+    trigger: ".o_kanban_group:eq(1)",
+},
+{
     trigger: '.o-kanban-button-new',
-    extra_trigger: '.o_kanban_group:eq(1)',
     content: "Create a task in the first stage",
     run: "click",
-}, {
+}, 
+{
+    trigger: ".o_project_task_kanban_view",
+},
+{
     trigger: '.o_kanban_quick_create div.o_field_char[name=name] input',
-    extra_trigger: '.o_project_task_kanban_view',
     content: "Create a personal task from the To-do kanban view",
     run: "edit Personal Task 1",
-}, {
+}, 
+{
+    trigger: ".o_project_task_kanban_view",
+},
+{
     trigger: '.o_kanban_quick_create .o_kanban_add',
-    extra_trigger: '.o_project_task_kanban_view',
     content: "Save the personal task",
     run: "click",
-}, {
+}, 
+{
+    trigger: ".o_project_task_kanban_view",
+},
+{
     trigger: ".o_kanban_record .oe_kanban_content",
-    extra_trigger: '.o_project_task_kanban_view',
     content: "Drag &amp; drop the card to change the personal task from personal stage.",
     run: "drag_and_drop(.o_kanban_group:eq(1))",
-}, {
+}, 
+{
+    trigger: ".o_project_task_kanban_view",
+},
+{
     trigger: ".o_kanban_record:first",//:contains(Send message)
-    extra_trigger: '.o_project_task_kanban_view',
     content: "Open the first todo record",
     run: "click",
-}, {
+}, 
+{
+    trigger: ".o_todo_form_view",
+},
+{
     trigger: ".o-mail-Chatter-topbar button.o-mail-Chatter-sendMessage",
-    extra_trigger: '.o_todo_form_view',
     content: "A 'send message' button should be present in the chatter",
     run: "click",
-}, {
+}, 
+{
+    trigger: ".o_todo_form_view",
+},
+{
     trigger: ".o-mail-Chatter-topbar button.o-mail-Chatter-logNote",
-    extra_trigger: '.o_todo_form_view',
     content: "A 'log note' button should be present in the chatter",
     run: "click",
-}, {
+}, 
+{
+    trigger: ".o_todo_form_view",
+},
+{
     trigger: ".o-mail-Chatter-topbar button.o-mail-Chatter-activity",
-    extra_trigger: '.o_todo_form_view',
     content: "An 'Activities' button should be present in the chatter",
     run: "click",
 }, {
     trigger: "button[name=action_schedule_activities]",
     content: "Schedule an activity",
     run: "click",
-}, {
+}, 
+{
+    trigger: ".o_todo_form_view",
+},
+{
     trigger: ".o_field_widget[name='user_ids'] input",
-    extra_trigger: '.o_todo_form_view',
     content: "Assign a responsible to your task",
     run(helpers) {
         this.anchor.click();
@@ -95,9 +128,12 @@ registry.category("web_tour.tours").add('project_todo_main_functions', {
     trigger: '.o_breadcrumb .o_todo_done_button',
     content: 'Mark the task as done directly from the breadcrumb',
     run: "click",
-}, {
+}, 
+{
+    trigger: ".o_todo_form_view .o_form_dirty",
+},
+{
     trigger: ".o_form_button_save",
-    extra_trigger: '.o_todo_form_view .o_form_dirty',
     content: "Save the record",
     run: "click",
 }, {

--- a/addons/purchase/static/src/js/tours/purchase.js
+++ b/addons/purchase/static/src/js/tours/purchase.js
@@ -5,6 +5,7 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
 
 import PurchaseAdditionalTourSteps from "@purchase/js/tours/purchase_steps";
+import { queryFirst } from "@odoo/hoot-dom";
 
 registry.category("web_tour.tours").add("purchase_tour", {
     url: "/web",
@@ -30,15 +31,21 @@ registry.category("web_tour.tours").add("purchase_tour", {
             run: "click",
         },
         {
+            trigger: ".o_purchase_order",
+            auto: true,
+        },
+        {
             trigger: ".o_list_button_add",
-            extra_trigger: ".o_purchase_order",
             content: _t("Let's create your first request for quotation."),
             position: "bottom",
             run: "click",
         },
         {
+            trigger: ".o_purchase_order",
+            auto: true,
+        },
+        {
             trigger: ".o_form_editable .o_field_many2one[name='partner_id'] input",
-            extra_trigger: ".o_purchase_order",
             content: _t("Search a vendor name, or create one on the fly."),
             position: "bottom",
             run: "edit Agrolait",
@@ -50,24 +57,30 @@ registry.category("web_tour.tours").add("purchase_tour", {
             run: "click",
         },
         {
+            trigger: ".o_field_many2one[name='partner_id'] .o_external_button",
+            auto: true,
+        },
+        {
             trigger: ".o_field_x2many_list_row_add > a",
-            extra_trigger: ".o_field_many2one[name='partner_id'] .o_external_button",
             content: _t("Add some products or services to your quotation."),
             position: "bottom",
             run: "click",
         },
         {
+            trigger: ".o_purchase_order",
+            auto: true,
+        },
+        {
             trigger: ".o_field_widget[name=product_id], .o_field_widget[name=product_template_id]",
-            extra_trigger: ".o_purchase_order",
             content: _t("Select a product, or create a new one on the fly."),
             position: "right",
             run: function (actions) {
                 const input = this.anchor.querySelector("input");
                 actions.edit("DESK0001", input || this.anchor);
-                var $descriptionElement = $('.o_form_editable textarea[name="name"]');
+                const descriptionElement = queryFirst('.o_form_editable textarea[name="name"]');
                 // when description changes, we know the product has been created
-                $descriptionElement.change(function () {
-                    $descriptionElement.addClass("product_creation_success");
+                descriptionElement.addEventListener("change", () => {
+                    descriptionElement.classList.add("product_creation_success");
                 });
             },
         },
@@ -81,8 +94,11 @@ registry.category("web_tour.tours").add("purchase_tour", {
             auto: true,
         },
         {
+            trigger: ".o_purchase_order",
+            auto: true,
+        },
+        {
             trigger: ".o_form_editable input[name='product_qty'] ",
-            extra_trigger: ".o_purchase_order",
             content: _t("Indicate the product quantity you want to order."),
             position: "right",
             run: "edit 12.0",
@@ -93,27 +109,25 @@ registry.category("web_tour.tours").add("purchase_tour", {
             ".o_statusbar_buttons .o_arrow_button_current[name='action_rfq_send']"
         ),
         {
-            trigger: ".modal-content",
-            auto: true,
-            run: function (actions) {
-                // Check in case user must add email to vendor
-                var $input = $(".modal-content input[name='email']");
-                if ($input.length) {
-                    actions.edit("agrolait@example.com", $input);
-                    actions.click($(".modal-footer button"));
-                }
-            },
+            trigger: ".modal-content input[name='email']",
+            run: "edit agrolait@example.com",
         },
         {
             trigger: ".modal-footer button[name='action_send_mail']",
-            extra_trigger: ".modal-footer button[name='action_send_mail']",
+            auto: true,
+        },
+        {
+            trigger: ".modal-footer button[name='action_send_mail']",
             content: _t("Send the request for quotation to your vendor."),
             position: "left",
             run: "click",
         },
         {
+            trigger: ".o_purchase_order",
+            auto: true,
+        },
+        {
             trigger: ".o_field_widget [name=price_unit]",
-            extra_trigger: ".o_purchase_order",
             content: _t(
                 "Once you get the price from the vendor, you can complete the purchase order with the right price."
             ),

--- a/addons/sale/static/src/js/tours/sale.js
+++ b/addons/sale/static/src/js/tours/sale.js
@@ -18,37 +18,53 @@ registry.category("web_tour.tours").add("sale_tour", {
             position: "right",
             edition: "community",
             run: "click",
-        }, {
+        },
+        {
             trigger: ".o_app[data-menu-xmlid='sale.sale_menu_root']",
             content: _t("Let’s create a beautiful quotation in a few clicks ."),
             position: "bottom",
             edition: "enterprise",
             run: "click",
-        }, {
+        },
+        {
+            trigger: ".o_sale_order",
+            auto: true,
+        },
+        {
             trigger: "button.o_list_button_add",
-            extra_trigger: ".o_sale_order",
             content: _t("Build your first quotation right here!"),
             position: "bottom",
             run: "click",
-        }, {
+        },
+        {
+            trigger: ".o_sale_order",
+            auto: true,
+        },
+        {
             trigger: ".o_field_res_partner_many2one[name='partner_id'] input",
-            extra_trigger: ".o_sale_order",
             content: _t("Search a customer name, or create one on the fly."),
             position: "right",
             run: "edit Agrolait",
-        }, {
+        },
+        {
             trigger: ".ui-menu-item > a:contains('Agrolait')",
             auto: true,
             in_modal: false,
             run: "click",
-        }, {
+        },
+        {
             trigger: ".o_field_x2many_list_row_add > a",
             content: _t("Click here to add some products or services to your quotation."),
             position: "bottom",
             run: "click",
-        }, {
-            trigger: ".o_field_widget[name='product_id'], .o_field_widget[name='product_template_id']",
-            extra_trigger: ".o_sale_order",
+        },
+        {
+            trigger: ".o_sale_order",
+            auto: true,
+        },
+        {
+            trigger:
+                ".o_field_widget[name='product_id'], .o_field_widget[name='product_template_id']",
             content: _t("Select a product, or create a new one on the fly."),
             position: "right",
             run: function (actions) {
@@ -64,21 +80,28 @@ registry.category("web_tour.tours").add("sale_tour", {
                     });
                 }
             },
-            id: "product_selection_step"
-        }, {
+            id: "product_selection_step",
+        },
+        {
             trigger: "a:contains('DESK0001')",
             auto: true,
             run: "click",
-        }, {
+        },
+        {
             trigger: ".o_field_text[name='name'] textarea:value(DESK0001)",
             auto: true,
-        }, {
+        },
+        {
+            trigger: ".oi-arrow-right", // Wait for product creation
+            auto: true,
+        },
+        {
             trigger: ".o_field_widget[name='price_unit'] input",
-            extra_trigger: ".oi-arrow-right",  // Wait for product creation
             content: _t("add the price of your product."),
             position: "right",
             run: "edit 10.0 && click .o_selected_row",
-        }, {
+        },
+        {
             trigger: ".o_field_monetary[name='price_subtotal']:contains(10.00)",
             auto: true,
             run: "click",
@@ -90,7 +113,6 @@ registry.category("web_tour.tours").add("sale_tour", {
         ),
         {
             trigger: ".modal-footer button[name='document_layout_save']",
-            extra_trigger: ".modal-footer button[name='document_layout_save']",
             content: _t("let's continue"),
             position: "bottom",
             skip_trigger: ".modal-footer button[name='action_send_mail']",
@@ -98,7 +120,6 @@ registry.category("web_tour.tours").add("sale_tour", {
         },
         {
             trigger: ".modal-footer button[name='action_send_mail']",
-            extra_trigger: ".modal-footer button[name='action_send_mail']",
             content: _t("Go ahead and send the quotation."),
             position: "bottom",
             run: "click",
@@ -107,6 +128,6 @@ registry.category("web_tour.tours").add("sale_tour", {
             trigger: "body:not(.modal-open)",
             auto: true,
             run: "click",
-        }
+        },
     ],
 });

--- a/addons/sale_project/static/tests/tours/project_create_sol_tour.js
+++ b/addons/sale_project/static/tests/tours/project_create_sol_tour.js
@@ -26,9 +26,12 @@ registry.category("web_tour.tours").add('project_create_sol_tour', {
         content: "Select the customer in the autocomplete dropdown",
         auto: true,
         run: "click",
-    }, {
+    }, 
+    {
+        trigger: 'div.o_notebook_headers',
+    },
+    {
         trigger: 'a.nav-link[name="settings"]',
-        extra_trigger: 'div.o_notebook_headers',
         content: 'Click on Settings tab to configure this project.',
         run: "click",
     }, {

--- a/addons/stock/static/tests/tours/stock_picking_tour.js
+++ b/addons/stock/static/tests/tours/stock_picking_tour.js
@@ -361,7 +361,9 @@ registry.category("web_tour.tours").add('test_add_new_line', {
     test: true,
     steps: () => [
         {
-            extra_trigger: '.o_form_editable',
+            trigger: ".o_form_editable",
+        },
+        {
             trigger: '.o_field_x2many_list_row_add > a',
             run: "click",
         },

--- a/addons/stock/static/tests/tours/stock_report_tests.js
+++ b/addons/stock/static/tests/tours/stock_report_tests.js
@@ -5,9 +5,11 @@
     registry.category("web_tour.tours").add('test_stock_route_diagram_report', {
         test: true,
         steps: () => [
+        {
+            trigger: ".o_breadcrumb",
+        },
     {
         trigger: '.o_kanban_record',
-        extra_trigger: '.o_breadcrumb',
         run: "click",
     },
     {

--- a/addons/survey/static/src/js/tours/survey_tour.js
+++ b/addons/survey/static/src/js/tours/survey_tour.js
@@ -27,21 +27,33 @@ registry.category("web_tour.tours").add('survey_tour', {
     content: _t("Let's get started!"),
     position: 'bottom',
     run: "click",
-}, {
+}, 
+{
+    trigger: '.js_question-wrapper span:contains("How frequently")',
+    auto: true,
+},
+{
     trigger: 'button[type=submit]',
-    extra_trigger: '.js_question-wrapper span:contains("How frequently")',
     content: _t("Whenever you pick an answer, Odoo saves it for you."),
     position: 'bottom',
     run: "click",
-}, {
+}, 
+{
+    trigger: '.js_question-wrapper span:contains("How many")',
+    auto: true,
+},
+{
     trigger: 'button[type=submit]',
-    extra_trigger: '.js_question-wrapper span:contains("How many")',
     content: _t("Only a single question left!"),
     position: 'bottom',
     run: "click",
-}, {
+}, 
+{
+    trigger: '.js_question-wrapper span:contains("How likely")',
+    auto: true,
+},
+{
     trigger: 'button[value=finish]',
-    extra_trigger: '.js_question-wrapper span:contains("How likely")',
     content: _t("Now that you are done, submit your form."),
     position: 'bottom',
     run: "click",

--- a/addons/survey/static/tests/tours/survey_chained_conditional_questions.js
+++ b/addons/survey/static/tests/tours/survey_chained_conditional_questions.js
@@ -16,10 +16,13 @@ registry.category("web_tour.tours").add('test_survey_chained_conditional_questio
         content: 'Answer Q1 with Answer 1',
         trigger: 'div.js_question-wrapper:contains("Q1") label:contains("Answer 1")',
         run: "click",
-    }, {
+    }, 
+    {
+        trigger: 'div.js_question-wrapper:contains("Q4")',
+    },
+    {
         content: 'Answer Q2 with Answer 1',
         trigger: 'div.js_question-wrapper:contains("Q2") label:contains("Answer 1")',
-        extra_trigger: 'div.js_question-wrapper:contains("Q4")',
         run: "click",
     }, {
         content: 'Answer Q3 with Answer 1',

--- a/addons/survey/static/tests/tours/survey_roaming_mandatory_questions.js
+++ b/addons/survey/static/tests/tours/survey_roaming_mandatory_questions.js
@@ -13,9 +13,12 @@ registry.category('web_tour.tours').add('test_survey_roaming_mandatory_questions
         content: 'Skip question Q1',
         trigger: 'button.btn:contains("Continue")',
         run: "click",
-    }, {
+    }, 
+    {
+        trigger: 'div.js_question-wrapper:contains("Q2")',
+    },
+    {
         content: 'Skip question Q2',
-        extra_trigger: 'div.js_question-wrapper:contains("Q2")',
         trigger: 'button.btn:contains("Continue")',
         run: "click",
     }, {

--- a/addons/test_sale_product_configurators/static/tests/tours/product_attribute_with_multi_type.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_attribute_with_multi_type.js
@@ -11,10 +11,13 @@ registry.category("web_tour.tours").add("product_attribute_multi_type", {
         content: "navigate to the sale app",
         trigger: '.o_app[data-menu-xmlid="sale.sale_menu_root"]',
         run: "click",
-    }, {
+    }, 
+    {
+        trigger: ".o_sale_order",
+    },
+    {
         content: "create a new order",
         trigger: '.o_list_button_add',
-        extra_trigger: ".o_sale_order",
         run: "click",
     }, {
         content: "search the partner",

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_custom_value_update_tour.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_custom_value_update_tour.js
@@ -10,9 +10,12 @@ registry.category("web_tour.tours").add('sale_product_configurator_custom_value_
     steps: () => [stepUtils.showAppsMenuItem(), {
     trigger: '.o_app[data-menu-xmlid="sale.sale_menu_root"]',
     run: "click",
-}, {
+}, 
+{
+    trigger: ".o_sale_order",
+},
+{
     trigger: '.o_list_button_add',
-    extra_trigger: '.o_sale_order',
     run: "click",
 }, {
     trigger: '.o_required_modifier[name=partner_id] input',

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_ui.js
@@ -13,9 +13,12 @@ registry.category("web_tour.tours").add('sale_product_configurator_tour', {
     steps: () => [stepUtils.showAppsMenuItem(), {
     trigger: '.o_app[data-menu-xmlid="sale.sale_menu_root"]',
     run: "click",
-}, {
+}, 
+{
+    trigger: ".o_sale_order",
+},
+{
     trigger: '.o_list_button_add',
-    extra_trigger: '.o_sale_order',
     run: "click",
 }, {
     trigger: '.o_required_modifier[name=partner_id] input',
@@ -50,9 +53,12 @@ registry.category("web_tour.tours").add('sale_product_configurator_tour', {
 }, {
     trigger: 'label[style="background-color:#FFFFFF"] input',
     run: "click",
-}, {
+}, 
+{
+    trigger: ".modal-footer",
+},
+{
     trigger: '.btn-primary:not(:disabled):contains("Confirm")',
-    extra_trigger: '.modal-footer',
 }, {
     trigger: 'span:contains("Aluminium"):eq(1)',
     run: "click",

--- a/addons/test_website/static/tests/tours/custom_snippets.js
+++ b/addons/test_website/static/tests/tours/custom_snippets.js
@@ -56,9 +56,11 @@ wTourUtils.registerWebsitePreviewTour('test_custom_snippet', {
         },
     },
     {
+        trigger: ".oe_snippet[name='Custom Banner'] .oe_snippet_thumbnail:not(.o_we_already_dragging)",
+    },
+    {
         content: "rename custom snippet",
         trigger: ".oe_snippet[name='Custom Banner'] we-button.o_rename_btn",
-        extra_trigger: ".oe_snippet[name='Custom Banner'] .oe_snippet_thumbnail:not(.o_we_already_dragging)",
         run: "click",
     },
     {
@@ -87,9 +89,11 @@ wTourUtils.registerWebsitePreviewTour('test_custom_snippet', {
         },
     },
     {
+        trigger: ".oe_snippet[name='Bruce Banner'] .oe_snippet_thumbnail:not(.o_we_already_dragging)",
+    },
+    {
         content: "delete custom snippet",
         trigger: ".oe_snippet[name='Bruce Banner'] we-button.o_delete_btn",
-        extra_trigger: ".oe_snippet[name='Bruce Banner'] .oe_snippet_thumbnail:not(.o_we_already_dragging)",
         run: "click",
     },
     {

--- a/addons/test_website/static/tests/tours/image_upload_progress.js
+++ b/addons/test_website/static/tests/tours/image_upload_progress.js
@@ -48,10 +48,13 @@ const setupSteps = [{
     content: "drop a snippet",
     trigger: "#oe_snippets .oe_snippet[name='Text - Image'] .oe_snippet_thumbnail:not(.o_we_already_dragging)",
     run: "drag_and_drop :iframe #wrap",
-}, {
+}, 
+{
+    trigger: "body.editor_has_snippets",
+},
+{
     content: "drop a snippet",
     trigger: "#oe_snippets .oe_snippet[name='Image Gallery'] .oe_snippet_thumbnail:not(.o_we_already_dragging)",
-    extra_trigger: "body.editor_has_snippets",
     run: "drag_and_drop :iframe #wrap",
 }];
 
@@ -222,10 +225,13 @@ wTourUtils.registerWebsitePreviewTour('test_image_upload_progress_unsplash', {
         content: "click on unsplash result", // note that unsplash is mocked
         trigger: "img[alt~=fox]",
         run: "click",
-    }, {
+    }, 
+    {
+        trigger: ".o_notification_close",
+    },
+    {
         content: "check that the upload progress bar is correctly shown",
         // ensure it is there so we are sure next step actually test something
-        extra_trigger: '.o_notification_close',
         trigger: ".o_we_progressbar:contains('fox'):contains('File has been uploaded')",
         in_modal: false,
     }, {

--- a/addons/test_website/static/tests/tours/page_manager.js
+++ b/addons/test_website/static/tests/tours/page_manager.js
@@ -49,9 +49,12 @@ registry.category("web_tour.tours").add('test_website_page_manager', {
     content: "Click on Kanban View",
     trigger: '.o_cp_switch_buttons .o_kanban',
     run: "click",
-}, {
+}, 
+{
+    trigger: ".o_kanban_renderer",
+},
+{
     content: "Click on List View",
-    extra_trigger: '.o_kanban_renderer',
     trigger: '.o_cp_switch_buttons .o_list',
     run: "click",
 }, {

--- a/addons/test_website/static/tests/tours/reset_views.js
+++ b/addons/test_website/static/tests/tours/reset_views.js
@@ -9,14 +9,16 @@ var BROKEN_STEP = {
     // to properly wait for the page to be saved & reloaded in order to fix the
     // race condition of a tour ending on a side-effect (with the possible
     // exception of somehow telling the harness / browser to do it)
-    trigger: 'body',
+    trigger: "body",
 };
-wTourUtils.registerWebsitePreviewTour('test_reset_page_view_complete_flow_part1', {
-    test: true,
-    url: '/test_page_view',
-    // 1. Edit the page through Edit Mode, it will COW the view
-    edition: true,
-},
+wTourUtils.registerWebsitePreviewTour(
+    "test_reset_page_view_complete_flow_part1",
+    {
+        test: true,
+        url: "/test_page_view",
+        // 1. Edit the page through Edit Mode, it will COW the view
+        edition: true,
+    },
     () => [
         {
             content: "drop a snippet",
@@ -40,23 +42,29 @@ wTourUtils.registerWebsitePreviewTour('test_reset_page_view_complete_flow_part1'
             content: "add a broken t-field in page DOM",
             trigger: 'div.ace_line .ace_xml:contains("placeholder")',
             run: function () {
-                ace.edit(document.querySelector('#resource-editor div')).getSession().insert({row: 4, column: 1}, '<t t-field="not.exist"/>\n');
+                ace.edit(document.querySelector("#resource-editor div"))
+                    .getSession()
+                    .insert({ row: 4, column: 1 }, '<t t-field="not.exist"/>\n');
             },
         },
         {
+            trigger: '.ace_content:contains("not.exist")',
+        },
+        {
             content: "save the html editor",
-            extra_trigger: '.ace_content:contains("not.exist")',
             trigger: ".o_resource_editor button:contains(Save)",
             run: "click",
         },
-        BROKEN_STEP
+        BROKEN_STEP,
     ]
 );
 
-wTourUtils.registerWebsitePreviewTour('test_reset_page_view_complete_flow_part2', {
-    test: true,
-    url: '/test_page_view',
-},
+wTourUtils.registerWebsitePreviewTour(
+    "test_reset_page_view_complete_flow_part2",
+    {
+        test: true,
+        url: "/test_page_view",
+    },
     () => [
         {
             content: "check that the view got fixed",
@@ -64,7 +72,7 @@ wTourUtils.registerWebsitePreviewTour('test_reset_page_view_complete_flow_part2'
         },
         {
             content: "check that the inherited COW view is still there (created during edit mode)",
-            trigger: ':iframe #oe_structure_test_website_page .s_cover',
+            trigger: ":iframe #oe_structure_test_website_page .s_cover",
         },
         //4. Now break the inherited view created when dropping a snippet
         {
@@ -79,19 +87,21 @@ wTourUtils.registerWebsitePreviewTour('test_reset_page_view_complete_flow_part2'
         },
         {
             content: "select oe_structure view",
-            trigger: '.o_resource_editor_title .o_select_menu_toggler',
+            trigger: ".o_resource_editor_title .o_select_menu_toggler",
             run: "click",
         },
         {
             content: "select oe_structure view",
-            trigger: '.o_select_menu_menu .o_select_menu_item:contains(Test Page View)',
+            trigger: ".o_select_menu_menu .o_select_menu_item:contains(Test Page View)",
             run: "click",
         },
         {
             content: "add a broken t-field in page DOM",
             trigger: 'div.ace_line .ace_xml:contains("oe_structure_test_website_page")',
             run: function () {
-                ace.edit(document.querySelector('#resource-editor div')).getSession().insert({row: 4, column: 1}, '<t t-field="not.exist"/>\n');
+                ace.edit(document.querySelector("#resource-editor div"))
+                    .getSession()
+                    .insert({ row: 4, column: 1 }, '<t t-field="not.exist"/>\n');
             },
         },
         {
@@ -99,6 +109,6 @@ wTourUtils.registerWebsitePreviewTour('test_reset_page_view_complete_flow_part2'
             trigger: ".o_resource_editor button:contains(Save)",
             run: "click",
         },
-        BROKEN_STEP
+        BROKEN_STEP,
     ]
 );

--- a/addons/test_website/static/tests/tours/website_controller_page.js
+++ b/addons/test_website/static/tests/tours/website_controller_page.js
@@ -34,8 +34,10 @@ wTourUtils.registerWebsitePreviewTour('website_controller_page_listing_layout', 
         run: "click",
     },
     {
+        trigger: "#oe_snippets .o_we_customize_panel",
+    },
+    {
         content: "open 'Layout' selector",
-        extra_trigger: '#oe_snippets .o_we_customize_panel',
         trigger: '[data-name="default_listing_layout"] we-toggler',
         run: "click",
     },

--- a/addons/website/static/tests/tours/automatic_editor.js
+++ b/addons/website/static/tests/tours/automatic_editor.js
@@ -31,8 +31,10 @@ wTourUtils.registerWebsitePreviewTour('automatic_editor_on_new_website', {
         run: "click",
     },
     {
+        trigger: '.modal div[name="lang_ids"] .rounded-pill .o_tag_badge_text:contains(Parseltongue)',
+    },
+    {
         content: "load parseltongue",
-        extra_trigger: '.modal div[name="lang_ids"] .rounded-pill .o_tag_badge_text:contains(Parseltongue)',
         trigger: '.modal-footer button[name=lang_install]',
         run: "click",
     },
@@ -93,9 +95,11 @@ wTourUtils.registerWebsitePreviewTour('automatic_editor_on_new_website', {
         run: "click",
     },
     {
+        trigger: ".o_menu_systray .o_user_menu",
+    },
+    {
         content: "Check that the homepage is loaded",
         trigger: ".o_website_preview[data-view-xmlid='website.homepage']",
-        extra_trigger: ".o_menu_systray .o_user_menu",
         timeout: 30000,
     },
 ]);

--- a/addons/website/static/tests/tours/drop_404_ir_attachment_url.js
+++ b/addons/website/static/tests/tours/drop_404_ir_attachment_url.js
@@ -15,10 +15,13 @@ wTourUtils.registerWebsitePreviewTour('drop_404_ir_attachment_url', {
         content: 'Click on the snippet image',
         trigger: ':iframe .s_404_snippet img',
         run: "click",
-    }, {
+    },
+    {
+        trigger: ".snippet-option-ReplaceMedia",
+    },
+    {
         content: 'Once the image UI appears, check the image has no size (404)',
         trigger: ':iframe .s_404_snippet img',
-        extra_trigger: '.snippet-option-ReplaceMedia',
         run: function () {
             const imgEl = this.anchor;
             if (!imgEl.complete

--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_redirect.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_redirect.js
@@ -40,9 +40,11 @@ registry.category("web_tour.tours").add("website_livechat.chatbot_redirect", {
             run: "click",
         },
         {
-            trigger: ".o-livechat-root:shadow .o-mail-Message:last:contains('Tadam')",
-            extra_trigger:
+            trigger:
                 ".o-livechat-root:shadow .o-mail-Message:contains('Go to the /chatbot-redirect page')",
+        },
+        {
+            trigger: ".o-livechat-root:shadow .o-mail-Message:last:contains('Tadam')",
             run() {
                 const url = new URL(location.href);
                 if (url.pathname !== "/chatbot-redirect") {

--- a/addons/website_sale/static/src/js/tours/tour_utils.js
+++ b/addons/website_sale/static/src/js/tours/tour_utils.js
@@ -126,7 +126,6 @@ function pay() {
     return {
         content: 'Pay',
         //Either there are multiple payment methods, and one is checked, either there is only one, and therefore there are no radio inputs
-        // extra_trigger: '#payment_method input:checked,#payment_method:not(:has("input:radio:visible"))',
         trigger: 'button[name="o_payment_submit_button"]:visible:not(:disabled)', 
         run: "click",
     };

--- a/addons/website_sale/static/tests/tours/website_free_delivery.js
+++ b/addons/website_sale/static/tests/tours/website_free_delivery.js
@@ -3,25 +3,30 @@
 import { registry } from "@web/core/registry";
 import tourUtils from "@website_sale/js/tours/tour_utils";
 
-registry.category("web_tour.tours").add('check_free_delivery', {
+registry.category("web_tour.tours").add("check_free_delivery", {
     test: true,
-    url: '/shop',
+    url: "/shop",
     steps: () => [
         // Part 1: Check free delivery
-        ...tourUtils.addToCart({productName: "Office Chair Black TEST"}),
-        tourUtils.goToCart({quantity: 1}),
+        ...tourUtils.addToCart({ productName: "Office Chair Black TEST" }),
+        tourUtils.goToCart({ quantity: 1 }),
         tourUtils.goToCheckout(),
         {
+            trigger: "#o_delivery_methods label:contains(/^Delivery Now Free Over 10$/)",
+        },
+        {
             content: "Check Free Delivery value to be zero",
-            extra_trigger: "#o_delivery_methods label:contains(/^Delivery Now Free Over 10$/)",
             trigger: "#o_delivery_methods span:contains('0.0')",
             run: "click",
         },
         // Part 2: check multiple delivery & price loaded asynchronously
         {
+            trigger: '#o_delivery_methods input[name="o_delivery_radio"]:checked',
+        },
+        {
             content: "Ensure price was loaded asynchronously",
-            extra_trigger: '#o_delivery_methods input[name="o_delivery_radio"]:checked',
-            trigger: '#o_delivery_methods [name="o_delivery_method"]:contains("20.0"):contains("The Poste")',
+            trigger:
+                '#o_delivery_methods [name="o_delivery_method"]:contains("20.0"):contains("The Poste")',
         },
         tourUtils.confirmOrder(),
         {
@@ -32,8 +37,8 @@ registry.category("web_tour.tours").add('check_free_delivery', {
         tourUtils.pay(),
         {
             content: "Confirmation page should be shown",
-            trigger: '#oe_structure_website_sale_confirmation_1',
+            trigger: "#oe_structure_website_sale_confirmation_1",
             allowInvisible: true,
-        }
+        },
     ],
 });

--- a/addons/website_sale/static/tests/tours/website_sale_cart_notification.js
+++ b/addons/website_sale/static/tests/tours/website_sale_cart_notification.js
@@ -42,14 +42,18 @@ registry.category("web_tour.tours").add('website_sale_cart_notification', {
             run: "click",
         },
         {
+            trigger: "#product_detail",
+        },
+        {
             content: "change quantity",
-            extra_trigger: '#product_detail',
             trigger: '#product_detail form[action^="/shop/cart/update"] input[name=add_qty]',
             run: "edit 3",
         },
         {
+            trigger: "#product_detail",
+        },
+        {
             content: "click on add to cart",
-            extra_trigger: '#product_detail',
             trigger: '#product_detail form[action^="/shop/cart/update"] #add_to_cart',
             run: "click",
         },

--- a/addons/website_sale/static/tests/tours/website_sale_complete_flow_backend.js
+++ b/addons/website_sale/static/tests/tours/website_sale_complete_flow_backend.js
@@ -13,8 +13,10 @@ wTourUtils.registerWebsitePreviewTour('website_sale_tour_backend', {
             run: "click",
         },
         {
+            trigger: "#oe_snippets .o_we_customize_panel",
+        },
+        {
             content: "Enable Extra step",
-            extra_trigger: '#oe_snippets .o_we_customize_panel',
             trigger: '[data-customize-website-views="website_sale.extra_info"] we-checkbox',
             run: "click",
         },

--- a/addons/website_sale/static/tests/tours/website_sale_shop_dynamic_variants.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_dynamic_variants.js
@@ -23,8 +23,10 @@ registry.category("web_tour.tours").add('tour_shop_dynamic_variants', {
         trigger: '.oe_price .oe_currency_value:contains("0.00")',
     },
     {
+        trigger: 'body:has(input[type="hidden"][name="product_id"][value="0"])',
+    },
+    {
         content: "click add to cart",
-        extra_trigger: 'body:has(input[type="hidden"][name="product_id"][value="0"])',
         trigger: '#add_to_cart',
         run: "click",
     },

--- a/addons/website_sale/static/tests/tours/website_sale_shop_list_view_b2c.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_list_view_b2c.js
@@ -20,9 +20,11 @@ wTourUtils.registerWebsitePreviewTour('shop_list_view_b2c', {
             run: "click",
         },
         {
+            trigger: ":iframe #product_details",
+        },
+        {
             content: "check products list is disabled initially (when on /product page)",
             trigger: ':iframe body:not(:has(.js_product_change))',
-            extra_trigger: ':iframe #product_details',
         },
         ...wTourUtils.clickOnEditAndWaitEditMode(),
         {
@@ -31,8 +33,10 @@ wTourUtils.registerWebsitePreviewTour('shop_list_view_b2c', {
             run: "click",
         },
         {
+            trigger: "#oe_snippets .o_we_customize_panel",
+        },
+        {
             content: "open 'Variants' selector",
-            extra_trigger: '#oe_snippets .o_we_customize_panel',
             trigger: '[data-name="variants_opt"] we-toggler',
             run: "click",
         },

--- a/addons/website_sale/static/tests/tours/website_sale_shop_mail.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_mail.js
@@ -23,14 +23,16 @@ registry.category("web_tour.tours").add('shop_mail', {
         run: "click",
     },
     {
+        trigger: '.o_statusbar_status .o_arrow_button_current:contains("Sales Order")',
+        allowDisabled: true,
+    },
+    {
         content: "click send by email",
         trigger: '.btn[name="action_quotation_send"]',
-        extra_trigger: '.o_statusbar_status .o_arrow_button_current:contains("Sales Order")',
         run: "click",
     },
     {
         trigger: ".modal-footer button[name='document_layout_save']",
-        extra_trigger: ".modal-footer button[name='document_layout_save']",
         content: "let's continue",
         position: "bottom",
         skip_trigger: ".modal-footer button[name='action_send_mail']",
@@ -48,9 +50,11 @@ registry.category("web_tour.tours").add('shop_mail', {
         run: "click",
     },
     {
+        trigger: '.o_badge_text:contains("Azure")',
+    },
+    {
         content: "click Send email",
         trigger: '.btn[name="action_send_mail"]',
-        extra_trigger: '.o_badge_text:contains("Azure")',
         run: "click",
     },
     {

--- a/addons/website_sale/static/tests/tours/website_sale_variants_modal_window.js
+++ b/addons/website_sale/static/tests/tours/website_sale_variants_modal_window.js
@@ -42,8 +42,10 @@
             run: "click",
         },
         {
+            trigger: ".oe_advanced_configurator_modal",
+        },
+        {
             content: "Go through the modal window of the product configurator",
-            extra_trigger: '.oe_advanced_configurator_modal',
             trigger: 'button span:contains(Proceed to Checkout)',
             run: 'click'
         },

--- a/addons/website_sale_comparison/static/tests/tours/website_sale_comparison.js
+++ b/addons/website_sale_comparison/static/tests/tours/website_sale_comparison.js
@@ -27,13 +27,17 @@
         run: "click",
     },
     {
+        trigger: ".comparator-popover",
+    },
+    {
         content: "check popover is now open and compare button contains two products",
-        extra_trigger: '.comparator-popover',
         trigger: ' .o_product_circle:contains(2)',
     },
     {
+        trigger: '.o_product_row:contains("Warranty")',
+    },
+    {
         content: "check products name are correct in the comparelist",
-        extra_trigger: '.o_product_row:contains("Warranty")',
         trigger: '.o_product_row:contains("Conference Chair")',
     },
     // test form product page
@@ -43,8 +47,10 @@
         run: "click",
     },
     {
+        trigger: "#product_details",
+    },
+    {
         content: "check compare button is still there and contains 2 products",
-        extra_trigger: '#product_details',
         trigger: '.o_product_circle:contains(2)',
     },
     {
@@ -57,8 +63,10 @@
         run: "click",
     },
     {
+        trigger: ".comparator-popover",
+    },
+    {
         content: "check the comparelist is now open and contains 3rd product with correct variant",
-        extra_trigger: '.comparator-popover',
         trigger: '.o_product_row:contains("Customizable Desk (Steel, White)")',
     },
     {
@@ -70,14 +78,18 @@
         },
     },
     {
+        trigger: 'img[class*="product_detail_img"]:not([data-image-to-change])',
+    },
+    {
         content: "click on compare button to add in comparison list when variant changed",
-        extra_trigger: 'img[class*="product_detail_img"]:not([data-image-to-change])',
         trigger: '.o_add_compare_dyn',
         run: "click",
     },
     {
+        trigger: '.o_product_circle:contains(4)',
+    },
+    {
         content: "comparelist contains 4th product with correct variant",
-        extra_trigger: '.o_product_circle:contains(4)',
         trigger: '.o_product_row:contains("Customizable Desk (Steel, Black)")',
         allowInvisible: true, //trigger is not visible .o_product_panel_content => display: none;
     },
@@ -91,8 +103,10 @@
         run: "click",
     },
     {
+        trigger: 'body:not(:has(.carousel-indicators))', // there is 1 image on the custom variant
+    },
+    {
         content: "click on compare button to add in comparison list when variant changed",
-        extra_trigger: 'body:not(:has(.carousel-indicators))', // there is 1 image on the custom variant
         trigger: '.o_add_compare_dyn',
         run: "click",
     },
@@ -132,8 +146,10 @@
         trigger: '#o_comparelist_table:not(:contains("Customizable Desk (Steel, Black)"))',
     },
     {
+        trigger: 'body:has(.o_product_row:contains("Warranty") .o_remove)',
+    },
+    {
         content: "open compare menu",
-        extra_trigger: 'body:has(.o_product_row:contains("Warranty") .o_remove)',
         trigger: '.o_product_panel_header',
         run: "click",
     },

--- a/addons/website_sale_loyalty/static/tests/tours/test_apply_discount_code.js
+++ b/addons/website_sale_loyalty/static/tests/tours/test_apply_discount_code.js
@@ -8,8 +8,10 @@ registry.category("web_tour.tours").add('apply_discount_code_program_multi_rewar
     url: '/shop?search=Super%20Chair',
     steps: () => [
         {
+            trigger: ".oe_search_found",
+        },
+        {
             content: 'select Super Chair',
-            extra_trigger: '.oe_search_found',
             trigger: '.oe_product_cart a:contains("Super Chair")',
             run: "click",
         },
@@ -20,8 +22,10 @@ registry.category("web_tour.tours").add('apply_discount_code_program_multi_rewar
         },
         tourUtils.goToCart(),
         {
+            trigger: 'form[name="coupon_code"]',
+        },
+        {
             content: 'insert discount code',
-            extra_trigger: 'form[name="coupon_code"]',
             trigger: 'form[name="coupon_code"] input[name="promo"]',
             run: "edit 12345",
         },
@@ -45,8 +49,10 @@ registry.category("web_tour.tours").add('apply_discount_code_program_multi_rewar
         },
         // Try to reapply the same promo code
         {
+            trigger: 'form[name="coupon_code"]',
+        },
+        {
             content: 'insert discount code',
-            extra_trigger: 'form[name="coupon_code"]',
             trigger: 'form[name="coupon_code"] input[name="promo"]',
             run: "edit 12345",
         },

--- a/addons/website_sale_loyalty/static/tests/tours/test_gift_card_tour.js
+++ b/addons/website_sale_loyalty/static/tests/tours/test_gift_card_tour.js
@@ -26,8 +26,10 @@ registry.category("web_tour.tours").add('shop_sale_gift_card', {
             run: "click",
         },
         {
+            trigger: 'form[name="coupon_code"]',
+        },
+        {
             content: 'insert gift card code',
-            extra_trigger: 'form[name="coupon_code"]',
             trigger: 'form[name="coupon_code"] input[name="promo"]',
             run: "edit 10PERCENT",
         },


### PR DESCRIPTION
In order to simplify the towers API, it was decided to remove the extra_trigger key from the step structure.
To check that an element is in the DOM, simply create a step with a trigger.

task-3974087