### PR TITLE
[FIX] pos_viva_wallet: Change the currency value to a string

### DIFF
--- a/addons/pos_viva_wallet/static/src/app/payment_viva_wallet.js
+++ b/addons/pos_viva_wallet/static/src/app/payment_viva_wallet.js
@@ -87,7 +87,7 @@ export class PaymentVivaWallet extends PaymentInterface {
             "terminalId": line.payment_method.viva_wallet_terminal_id,
             "cashRegisterId": this.pos.get_cashier().name,
             "amount": line.amount * 100,
-            "currencyCode": 978, // Viva wallet only uses EUR 978 need add a new field numeric_code in res.currency
+            "currencyCode": '978', // Viva wallet only uses EUR 978 need add a new field numeric_code in res.currency
             "merchantReference": line.sessionId + '/' + this.pos.pos_session.id,
             "customerTrns": customerTrns,
             "preauth": false,


### PR DESCRIPTION
Currently we send the currency code as an integer and this must be sent as a string

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
