### PR TITLE
[FIX] odoo: WIP

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -6406,7 +6406,7 @@ class BaseModel(metaclass=MetaModel):
         if origin is not None:
             origin = origin.id
         record = self.browse((NewId(origin, ref),))
-        record._update_cache(values, validate=False)
+        record._update_cache(values, validate=True if origin is not None else False)
 
         return record
 


### PR DESCRIPTION
I've encountered a bug in the `stock.move` view that affects the display and computation of move lines. Here's a detailed breakdown of the issue:

# Issue:
- When accessing `self.move_id.move_line_ids` to compute the quantity for a new move line, only the edited and new lines are visible, while the other lines are missing. This issue occurs when editing a stock move line in a stock move with multiple stock move lines.

# Steps To Reproduce:
- In Inventory, create a product and add some quantity on hand for it.
- Create a delivery operation with a demand of 5  and "Mark as Todo."
- Using the detail menu (three horizontal bars), separate the quantity into two lines and save.
- Again, using the detail menu, edit the quantity of one line and add a new line.
- Notice that `compute_quantity` of `stock.move.line` gets triggered when a new line is added. However, when debugging, `record.move_id.move_line_ids` only contains the edited stock move lines.

# Investigation:

**Root Cause**:
- The issue originates in the js file `odoo/addons/web/static/src/model/relational_model/static_list.js` within the `addNewRecord` method.
- The `addNewRecord` method calls `_createNewRecordDatapoint`.
- In `_createNewRecordDatapoint`, if `params.withoutParent` is false and `this.config.relationField` is true, it sets the `changes` for the parent model.
- `_createNewRecordDatapoint` then calls `_loadNewRecord`, which subsequently triggers the `onchange` method in Python via RPC.

**Python `onchange` Method**:
 - The `onchange` method processes the provided values and field specifications to update the model.
 - For a new record, `field_names` is empty, so it retrieves default values for missing fields and updates `values` accordingly.
 - It then creates a new record with these initial values. Since `self` is `False` (indicating a new record), the new record is initialized with mostly default values.


**Cache Update**:
- The `onchange` method calls `_update_cache` to update the new record's cache with the initial and changed values.
- During this process, when updating the `move_id` field (a `many2one` relation), it triggers another cache update for the parent `stock.move`.
- The `update_cache` method for `one2many` fields (like `move_line_ids`) processes a list of commands. Since `validate` is `False`, the IDs for existing move lines are not validated and effectively cleared.
- As a result, when the computation for `move_line_ids` is performed in `stock.move.line`, it only includes the newly created line and the edited line, while the other lines are excluded. This leads to an incomplete set of move lines being considered, causing incorrect quantity computations.
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
