### PR TITLE
[FIX] hr_expense: record caba taxes on final account

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -548,7 +548,10 @@ Or send your receipts at <a href="mailto:%(email)s?subject=Lunch%%20with%%20cust
             move_line_values = []
             unit_amount = expense.unit_amount or expense.total_amount
             quantity = expense.quantity if expense.unit_amount else 1
-            taxes = expense.tax_ids.with_context(round=True).compute_all(unit_amount, expense.currency_id,quantity,expense.product_id)
+            taxes = expense.tax_ids.with_context(
+                round=True,
+                caba_no_transition_account=expense.payment_mode == 'company_account',
+            ).compute_all(unit_amount, expense.currency_id, quantity, expense.product_id)
             total_amount = 0.0
             total_amount_currency = 0.0
             partner_id = expense.employee_id.sudo().address_home_id.commercial_partner_id.id

--- a/addons/hr_expense/tests/test_expenses.py
+++ b/addons/hr_expense/tests/test_expenses.py
@@ -3,7 +3,7 @@
 from odoo.addons.hr_expense.tests.common import TestExpenseCommon
 from odoo.tests import tagged, Form
 from odoo.tools.misc import formatLang, format_date
-from odoo import fields
+from odoo import fields, Command
 
 
 @tagged('-at_install', 'post_install')
@@ -578,3 +578,37 @@ class TestExpenses(TestExpenseCommon):
         expenses.date = False
         sheet_name = expenses._get_default_expense_sheet_values()['default_name']
         self.assertFalse(sheet_name, "The report name should be empty if one of the expenses doesn't have a date")
+
+    def test_expense_by_company_with_caba_tax(self):
+        """When using cash basis tax in an expense paid by the company, the transition account should not be used."""
+
+        caba_transition_account = self.env['account.account'].create({
+            'name': 'Cash Basis Tax Transition Account',
+            'user_type_id': self.env.ref('account.data_account_type_current_assets').id,
+            'code': '131001',
+        })
+        caba_tax = self.env['account.tax'].create({
+            'name': 'Cash Basis Tax',
+            'tax_exigibility': 'on_payment',
+            'amount': 15,
+            'cash_basis_transition_account_id': caba_transition_account.id,
+        })
+
+        expense_sheet = self.env['hr.expense.sheet'].create({
+            'name': 'Company Cash Basis Expense Report',
+            'employee_id': self.expense_employee.id,
+            'payment_mode': 'company_account',
+            'state': 'approve',
+            'expense_line_ids': [Command.create({
+                'name': 'Company Cash Basis Expense',
+                'product_id': self.product_b.id,
+                'payment_mode': 'company_account',
+                'unit_amount': 20.0,
+                'employee_id': self.expense_employee.id,
+                'tax_ids': [Command.set(caba_tax.ids)],
+            })]
+        })
+
+        moves = expense_sheet.action_sheet_move_create()
+        tax_lines = moves[expense_sheet.id].line_ids.filtered(lambda line: line.tax_line_id == caba_tax)
+        self.assertNotEqual(tax_lines.account_id, caba_transition_account, "The tax should not be on the transition account")


### PR DESCRIPTION
### Steps to reproduce the issue:

1. Create a Tax Based On Payment with a Cash Basis Transition Account
2. Create an Expense Paid By Company and add previously created Tax
3. Create the report, submit it, approve it then Post Journal Entries
4. Go to the Journal Entry (until you see the Journal Items)
5. The Journal Item of the Tax is recorded on the Cash Basis Transition Account but no Caba Entry is created

### Explanation:

When using the company to pay the expense, the payment is immediate. When the employee took care of the payment, a Bill and a Caba Entry are created because the company still needs to reimburse the employee.

### Suggested fix:

Adding a Caba Entry is not necessary since there is no need to record the transaction in a transitional account, sending the transaction in the final Account would also match the use case when using Taxes Based On Invoice.
`account_id` is selected between the `cash_basis_transition_account_id` of the tax and the `account_id` of the repartition line depending on the values of `tax_exigibility` and `caba_no_transition_account`.
https://github.com/odoo/odoo/blob/0c0f0b58aa49cff1efafcc1d4c5a9091e99f2ff4/addons/account/models/account_tax.py#L640-L642 The latter is a context key and is only used in this check, meaning it is most likely harmless to add it in the context of the method.

opw-3946362