### PR TITLE
[IMP] mrp_account: separate valuation journal items for MO labour costs

### DIFF
--- a/addons/mrp_account/__manifest__.py
+++ b/addons/mrp_account/__manifest__.py
@@ -25,6 +25,7 @@ If the automated inventory valuation is active, the necessary accounting entries
         "views/mrp_bom_views.xml",
         "views/mrp_production_views.xml",
         "views/analytic_account_views.xml",
+        "views/mrp_workcenter_views.xml",
         "report/report_mrp_templates.xml"
     ],
     'demo': [

--- a/addons/mrp_account/models/mrp_production.py
+++ b/addons/mrp_account/models/mrp_production.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from ast import literal_eval
+from collections import defaultdict
 
 from odoo import api, fields, models, _
 from odoo.tools import float_round
@@ -108,4 +109,45 @@ class MrpProduction(models.Model):
     def _get_backorder_mo_vals(self):
         res = super()._get_backorder_mo_vals()
         res['extra_cost'] = self.extra_cost
+        return res
+
+    def _post_labour(self):
+        for mo in self:
+            if mo.with_company(mo.company_id).product_id.valuation != 'real_time':
+                continue
+
+            product_accounts = mo.product_id.product_tmpl_id.get_product_accounts()
+            labour_amounts = defaultdict(float)
+            workorders = defaultdict(self.env['mrp.workorder'].browse)
+            for wo in mo.workorder_ids:
+                account = wo.workcenter_id.expense_account_id or product_accounts['expense']
+                labour_amounts[account] += wo._cal_cost()
+                workorders[account] |= wo
+            workcenter_cost = sum(labour_amounts.values())
+
+            if mo.company_id.currency_id.is_zero(workcenter_cost):
+                continue
+
+            desc = _('%s - Labour', mo.name)
+            account = self.env['account.account'].browse(mo.move_finished_ids[0]._get_src_account(product_accounts))
+            labour_amounts[account] -= workcenter_cost
+            account_move = self.env['account.move'].sudo().create({
+                'journal_id': product_accounts['stock_journal'].id,
+                'date': fields.Date.context_today(self),
+                'ref': desc,
+                'move_type': 'entry',
+                'line_ids': [(0, 0, {
+                    'name': desc,
+                    'ref': desc,
+                    'balance': amt,
+                    'account_id': acc.id,
+                }) for acc, amt in labour_amounts.items()]
+            })
+            account_move._post()
+            for line in account_move.line_ids[:-1]:
+                workorders[line.account_id].time_ids.write({'account_move_line_id': line.id})
+
+    def button_mark_done(self):
+        res = super().button_mark_done()
+        self._post_labour()
         return res

--- a/addons/mrp_account/models/mrp_workcenter.py
+++ b/addons/mrp_account/models/mrp_workcenter.py
@@ -9,6 +9,8 @@ class MrpWorkcenter(models.Model):
     _inherit = ['mrp.workcenter', 'analytic.mixin']
 
     costs_hour_account_ids = fields.Many2many('account.analytic.account', compute="_compute_costs_hour_account_ids", store=True)
+    expense_account_id = fields.Many2one('account.account', string="Expense Account", check_company=True,
+                                         help="The expense is accounted for when the manufacturing order is marked as done. If not set, it is the expense account of the final product that will be used instead.")
 
     @api.depends('analytic_distribution')
     def _compute_costs_hour_account_ids(self):
@@ -16,3 +18,10 @@ class MrpWorkcenter(models.Model):
             record.costs_hour_account_ids = bool(record.analytic_distribution) and self.env['account.analytic.account'].browse(
                 list({int(account_id) for ids in record.analytic_distribution for account_id in ids.split(",")})
             ).exists()
+
+
+class MrpWorkcenterProductivity(models.Model):
+    _name = 'mrp.workcenter.productivity'
+    _inherit = 'mrp.workcenter.productivity'
+
+    account_move_line_id = fields.Many2one('account.move.line')

--- a/addons/mrp_account/models/stock_move.py
+++ b/addons/mrp_account/models/stock_move.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+from collections import defaultdict
 
 from odoo import models
+from odoo.tools import float_round
 
 
 class StockMove(models.Model):
@@ -42,3 +44,36 @@ class StockMove(models.Model):
     def _is_production_consumed(self):
         self.ensure_one()
         return self.location_dest_id.usage == 'production' and self.location_id._should_be_valued()
+
+    def _generate_valuation_lines_data(self, partner_id, qty, debit_value, credit_value, debit_account_id, credit_account_id, svl_id, description):
+        rslt = super()._generate_valuation_lines_data(partner_id, qty, debit_value, credit_value, debit_account_id, credit_account_id, svl_id, description)
+
+        product_expense_account = self.product_id.product_tmpl_id.get_product_accounts()['expense']
+        labour_amounts = defaultdict(float)
+        for wo in self.production_id.workorder_ids:
+            account = wo.workcenter_id.expense_account_id or product_expense_account
+            labour_amounts[account] += wo._cal_cost()
+        workcenter_cost = sum(labour_amounts.values())
+
+        if self.company_id.currency_id.is_zero(workcenter_cost):
+            return rslt
+
+        cost_share = 1
+        if self.production_id.move_byproduct_ids:
+            if self.cost_share:
+                cost_share = self.cost_share / 100
+            else:
+                cost_share = float_round(1 - sum(self.production_id.move_byproduct_ids.mapped('cost_share')) / 100, precision_rounding=0.0001)
+        rslt['credit_line_vals']['balance'] += workcenter_cost * cost_share
+        for acc, amt in labour_amounts.items():
+            rslt['labour_credit_line_vals_' + acc.code] = {
+                'name': description,
+                'product_id': self.product_id.id,
+                'quantity': qty,
+                'product_uom_id': self.product_id.uom_id.id,
+                'ref': description,
+                'partner_id': partner_id,
+                'balance': -amt * cost_share,
+                'account_id': acc.id,
+            }
+        return rslt

--- a/addons/mrp_account/views/mrp_workcenter_views.xml
+++ b/addons/mrp_account/views/mrp_workcenter_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="mrp_workcenter_view_inherit" model="ir.ui.view">
+        <field name="name">mrp.workcenter.form.inherit</field>
+        <field name="model">mrp.workcenter</field>
+        <field name="inherit_id" ref="mrp.mrp_workcenter_view"/>
+        <field name="arch" type="xml">
+            <group name="costing" position="inside">
+                <field name="expense_account_id"/>
+            </group>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
When marking an MO as done, the valuation of the final product might be higher than the valuation of the individual components due to the hourly costs on the used workcenters and employees on the different workorders.

Before this commit, these differences would cumulate onto the production cost account.

After this commit, these labor costs will instead be put on the expense account linked to the relevant workcenters. If no expense account is set on a workcenter, the expense account linked to the final product will be used instead.

Finally, all of these labour costs will then be moved from the expense account back to the cost of production account in a separate 'labour' journal entry that is posted upon marking the MO as done.

task-3952309

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
