### PR TITLE
[IMP] mrp_workorder: mrp b2b

### DIFF
--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -216,7 +216,7 @@ class StockMove(models.Model):
     product_virtual_available = fields.Float('Product Forecasted Quantity', related='product_id.virtual_available', depends=['product_id'])
     description_bom_line = fields.Char('Kit', compute='_compute_description_bom_line')
     manual_consumption = fields.Boolean(
-        'Manual Consumption', compute='_compute_manual_consumption', store=True,
+        'Manual Consumption', compute='_compute_manual_consumption', store=True, readonly=False,
         help="When activated, then the registration of consumption for that component is recorded manually exclusively.\n"
              "If not activated, and any of the components consumption is edited manually on the manufacturing order, Odoo assumes manual consumption also.")
 
@@ -226,7 +226,7 @@ class StockMove(models.Model):
             # when computed for new_id in onchange, use value from _origin
             if move != move._origin:
                 move.manual_consumption = move._origin.manual_consumption
-            else:
+            elif not move.manual_consumption:
                 move.manual_consumption = move._is_manual_consumption()
 
     @api.depends('raw_material_production_id', 'raw_material_production_id.location_dest_id', 'production_id', 'production_id.location_dest_id')

--- a/addons/repair/views/repair_views.xml
+++ b/addons/repair/views/repair_views.xml
@@ -402,6 +402,10 @@
 
         <menuitem id="repair_menu_config" name="Configuration" parent="menu_repair_order" groups="stock.group_stock_manager"/>
 
-        <menuitem id="repair_menu_tag" name="Repair Orders Tags" parent="repair_menu_config" action="action_repair_order_tag"/>
+        <menuitem id="repair_menu_tag" name="Repair Orders Tags" parent="repair_menu_config" action="action_repair_order_tag" sequence="1"/>
+        <menuitem id="repair_menu_product_template" name="Products" action="stock.product_template_action_product"
+            parent="repair_menu_config" sequence="2"/>
+        <menuitem id="repair_menu_product_product" name="Product Variants" action="stock.stock_product_normal_action"
+            parent="repair_menu_config" sequence="3" groups="product.group_product_variant"/>
     </data>
 </odoo>

--- a/addons/stock/models/stock_scrap.py
+++ b/addons/stock/models/stock_scrap.py
@@ -53,6 +53,10 @@ class StockScrap(models.Model):
         string='Status', default="draft", readonly=True, tracking=True)
     date_done = fields.Datetime('Date', readonly=True)
     should_replenish = fields.Boolean(string='Replenish Quantities', help="Trigger replenishment for scrapped products")
+    scrap_reason_tag_ids = fields.Many2many(
+        comodel_name='stock.scrap.reason.tag',
+        string='Scrap Reason',
+    )
 
     @api.depends('product_id')
     def _compute_product_uom_id(self):
@@ -221,3 +225,17 @@ class StockScrap(models.Model):
                 'context': ctx,
                 'target': 'new'
             }
+
+
+class StockScrapReasonTag(models.Model):
+    _name = 'stock.scrap.reason.tag'
+    _description = 'Scrap Reason Tag'
+    _order = 'sequence, id'
+
+    name = fields.Char(string="Name", required=True, translate=True)
+    sequence = fields.Integer(default=10)
+    color = fields.Char(string="Color", default='#3C3C3C')
+
+    _sql_constraints = [
+        ('name_uniq', 'unique (name)', "Tag name already exists!"),
+    ]

--- a/addons/stock/security/ir.model.access.csv
+++ b/addons/stock/security/ir.model.access.csv
@@ -54,6 +54,8 @@ access_barcode_rule_stock_user,barcode.rule.stock.user,barcodes.model_barcode_ru
 access_barcode_rule_stock_manager,barcode.rule.stock.manager,barcodes.model_barcode_rule,stock.group_stock_manager,1,1,1,1
 access_stock_scrap_user,stock.scrap.user,model_stock_scrap,stock.group_stock_user,1,1,1,0
 access_stock_scrap_manager,stock.scrap.manager,model_stock_scrap,stock.group_stock_manager,1,1,1,1
+access_stock_scrap_reason_tag_user,stock.scrap.reason.tag.user,model_stock_scrap_reason_tag,stock.group_stock_user,1,1,1,0
+access_stock_scrap_reason_tag_manager,stock.scrap.reason.tag.manager,model_stock_scrap_reason_tag,stock.group_stock_manager,1,1,1,1
 access_product_attribute_manager,product.attribute manager,product.model_product_attribute,stock.group_stock_manager,1,1,1,1
 access_product_attribute_value_manager,product.attribute manager value,product.model_product_attribute_value,stock.group_stock_manager,1,1,1,1
 access_product_product_attribute_manager,product.product.attribute manager value,product.model_product_template_attribute_value,stock.group_stock_manager,1,1,1,1

--- a/addons/stock/views/stock_scrap_views.xml
+++ b/addons/stock/views/stock_scrap_views.xml
@@ -60,6 +60,7 @@
                                 </div>
                                 <field name="lot_id" context="{'default_product_id': product_id}" invisible="not product_id or tracking == 'none'" readonly="state == 'done'" required="tracking != 'none'" groups="stock.group_production_lot"/>
                                 <field name="should_replenish" readonly="state == 'done'"/>
+                                <field name="scrap_reason_tag_ids" widget="many2many_tags" options="{'no_create_edit': True}"/>
                             </group>
                             <group>
                                 <field name="company_id" invisible="1" readonly="state == 'done'"/>
@@ -160,6 +161,7 @@
                                 invisible="not product_id or tracking == 'none'"
                                 readonly="state == 'done'"
                                 required="tracking != 'none'"/>
+                            <field name="scrap_reason_tag_ids" widget="many2many_tags" options="{'no_create_edit': True}"/>
                         </group>
                         <group>
                             <field name="picking_id" invisible="1" readonly="state == 'done'"/>


### PR DESCRIPTION
This PR adds miscellaneous improvements:

#### Scrap:
A new field is added to `stock.scrap` model which is "Scrap Reasons". It is shown in the scrap order form as a `many2many_tags` field and new records of this model `stock.scrap.reason.tag` can only be created from scrap order form.

#### Repairs:
Two menu items are added to the "Configuration" menu in "Repairs" app: "Products" and "Product Variants". Their actions are the
exact same of the similar menu items in the "Inventory" app.

#### MPS:
Enable splitting a generated manufacturing order from a procurement if `batch_size` field is specified in the extra values of the procurement. It's mainly to be used by replenishments triggered by MPS. See enterprise PR for more details.

Enterprise PR: odoo/enterprise#64600

Task-3962134

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
