### PR TITLE
[FIX] stock: do not auto apply snoozed reordering rules

### DIFF
--- a/addons/sale_purchase_stock/tests/test_sale_purchase_stock_flow.py
+++ b/addons/sale_purchase_stock/tests/test_sale_purchase_stock_flow.py
@@ -142,3 +142,8 @@ class TestSalePurchaseStockFlow(TransactionCase):
         so_2.action_confirm()
         po = self.env['purchase.order'].search([('partner_id', '=', self.vendor.id), ('state', '!=', 'cancel')], limit=1)
         self.assertFalse(po)
+
+        # we run the scheduler
+        self.env['procurement.group'].run_scheduler()
+        po = self.env['purchase.order'].search([('partner_id', '=', self.vendor.id), ('state', '!=', 'cancel')], limit=1)
+        self.assertFalse(po)

--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -597,7 +597,7 @@ class ProcurementGroup(models.Model):
 
     @api.model
     def _get_orderpoint_domain(self, company_id=False):
-        domain = [('trigger', '=', 'auto'), ('product_id.active', '=', True)]
+        domain = [('trigger', '=', 'auto'), ('product_id.active', '=', True), '|', ('snoozed_until', '=', False), ('snoozed_until', '<=', fields.Date.today())]
         if company_id:
             domain += [('company_id', '=', company_id)]
         return domain


### PR DESCRIPTION
### Steps to reproduce:

- Create a storable product with a vendor (in the pruchase tab)
- Create a buy reordering rule with that vendor for that product
- Select the reordering rule line and snooze it for one day
- Create a sale order for that product
- Go to manufactoring > Planning > Run Scheduler and Run Scheduler

#### > the snoozed reordering rule is triggered

### Cause of the issue:

Running the scheduler will trigger the "_run_scheduler_tasks": https://github.com/odoo/odoo/blob/174cb193592f12c7f4167eb34642665778deb208/addons/stock/models/stock_rule.py#L548-L557 However, the snoozed orderpoints are not filtered out by the domain: https://github.com/odoo/odoo/blob/174cb193592f12c7f4167eb34642665778deb208/addons/stock/models/stock_rule.py#L599-L603

Followup of https://github.com/odoo/odoo/commit/515a53a2a442053392d36461feda17f131daf686

opw-3901613
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
