### PR TITLE
[FIX] web: make shadow DOM specific overlays visible

### DIFF
--- a/addons/web/static/src/core/overlay/overlay_container.js
+++ b/addons/web/static/src/core/overlay/overlay_container.js
@@ -1,4 +1,4 @@
-import { Component, useRef } from "@odoo/owl";
+import { Component, useEffect, useRef, useState } from "@odoo/owl";
 import { sortBy } from "@web/core/utils/arrays";
 import { ErrorHandler, WithEnv } from "@web/core/utils/components";
 
@@ -9,6 +9,13 @@ export class OverlayContainer extends Component {
 
     setup() {
         this.root = useRef("root");
+        this.state = useState({ rootEl: null });
+        useEffect(
+            () => {
+                this.state.rootEl = this.root.el;
+            },
+            () => [this.root.el]
+        );
     }
 
     get sortedOverlays() {
@@ -16,7 +23,7 @@ export class OverlayContainer extends Component {
     }
 
     isVisible(overlay) {
-        return overlay.rootId === this.root.el?.getRootNode()?.host?.id;
+        return overlay.rootId === this.state.rootEl?.getRootNode()?.host?.id;
     }
 
     handleError(overlay, error) {


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/154349

PR above allowed to define shadow DOM-specific overlays, which is desirable for apps that need to work in a shadow DOM like livechat from visitor's perspective.

The reason for shadow DOM is to use exactly same style and behaviour of livechat like in Discuss as internal users. The shadow DOM has to sustain its good working by itself, so it also needs to deploy some required main components like overlay container. In website, there's also an overlay container, and since they share the same stateful service (overlay_service), we do not want to display the overlay twice.

So PR above solved the issue by allowing to make overlay with a provided `rootId`, which when set it contains the `id` attribute of the root node of the overlay that has to manage the overlay. This allows to clearly determine which overlay container is responsible to display the appropriate overlay.

Code above was however buggy: it relies on `isVisible(overlay)`, whose computation requires `rootRef.el`. Refs' el are not determined on the 1st rendering of the overlay service. This is not a problem when the overlay container is 1st mounted without any overlay, but if it's being registered with some overlays, mounting the overlay container afterwards results in the non-showing of the overlay. The `rootRef` is important to find out the "global" root node id, i.e. the shadow DOM root id.

This commit fixes the issue by rendering again overlay container after mount when there are some pre-registered overlays.