### PR TITLE
[FIX] point_of_sale : Set order date on receipt not current date

### DIFF
--- a/addons/point_of_sale/static/src/app/store/models.js
+++ b/addons/point_of_sale/static/src/app/store/models.js
@@ -1607,7 +1607,6 @@ export class Order extends PosModel {
         const paymentlines = this.paymentlines
             .filter((p) => !p.is_change)
             .map((p) => p.export_for_printing());
-        this.receiptDate ||= formatDateTime(luxon.DateTime.now());
         return {
             orderlines: this.orderlines.map((l) => omit(l.getDisplayData(), "internalNote")),
             paymentlines,
@@ -1622,7 +1621,7 @@ export class Order extends PosModel {
             name: this.get_name(),
             invoice_id: null, //TODO
             cashier: this.cashier?.name,
-            date: this.receiptDate,
+            date: formatDateTime(this.date_order),
             pos_qr_code:
                 this.pos.company.point_of_sale_use_ticket_qr_code &&
                 (this.finalized || ["paid", "done", "invoiced"].includes(this.state)) &&


### PR DESCRIPTION
**Steps to reproduce:**
	- Install Point of Sale module
	- Create an order through the PoS day and time X
	- Re-print the receipt/ticket another day

**Current behavior before PR:**
When reprint an order's receipt in a day different than the order creation date you will have the current date at the end of the receipt. This is happening because when exporting the data of the order to print the receipt we are setting the date to be printed equals to the receipt date which is the current time.
https://github.com/odoo/odoo/blob/17.0/addons/point_of_sale/static/src/app/store/models.js#L1610 https://github.com/odoo/odoo/blob/17.0/addons/point_of_sale/static/src/app/store/models.js#L1625

**Desired behavior after PR is merged:**
We are now passing the order date instead of the receipt date.

opw-3979454