### PR TITLE
[FIX] l10n_gcc_invoice: force RTL Arabic partner

### DIFF
--- a/addons/l10n_gcc_invoice/models/__init__.py
+++ b/addons/l10n_gcc_invoice/models/__init__.py
@@ -2,3 +2,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import account_move
+from . import product

--- a/addons/l10n_gcc_invoice/models/product.py
+++ b/addons/l10n_gcc_invoice/models/product.py
@@ -1,0 +1,23 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import re
+
+from odoo import models
+
+
+class ProductProduct(models.Model):
+    _inherit = 'product.product'
+
+    def _compute_display_name(self):
+        """ In a string consisting of space-delimited substrings, force a double-space between
+        substrings where (when looking right to left) the first substring ends with a numeral and
+        the second begins with an Arabic character.
+        """
+        def repl(match_occurrence):
+            # group(1): (\d) == numeral
+            # group(3): ([\u0600-\u06FF]) == Arabic character
+            return f'{match_occurrence.group(1)}  {match_occurrence.group(3)}'
+
+        super()._compute_display_name()
+        for product in self:
+            product.display_name = re.sub(r'(\d)(\s)([\u0600-\u06FF])', repl, product.display_name)

--- a/addons/l10n_gcc_invoice/views/report_invoice.xml
+++ b/addons/l10n_gcc_invoice/views/report_invoice.xml
@@ -280,15 +280,9 @@
                                         <span t-field="line.quantity"/>
                                         <span t-field="line.product_uom_id" groups="uom.group_uom"/>
                                     </td>
-                                    <td name="account_invoice_line_name" class="text-end">
-                                        <t t-set="line_name" t-value="
-                                            line.with_context(lang=o.partner_id.lang).product_id.display_name
-                                                if line.product_id and line.name in (
-                                                line.with_context(lang='ar_001').product_id.display_name,
-                                                line.with_context(lang='en_US').product_id.display_name
-                                            ) else line.name
-                                        "/>
-                                        <span t-out="line_name" t-options="{'widget': 'text'}"/>
+                                    <td name="account_invoice_line_name">
+                                        <t t-set="line_name" t-value="line.with_context(lang=o.partner_id.lang).product_id.display_name or line.name"/>
+                                        <span t-out="line_name" t-options="{'widget': 'text'}" t-att-dir="o.env['res.lang']._lang_get_direction(o.partner_id.lang)"/>
                                     </td>
 
                                 </t>


### PR DESCRIPTION
**Current behavior:**
Lines in an invoice may display a product name incorrectly if
they mix arabic/latin characters.

**Expected behavior:**
These types of product names should respect the RTL syntax if
being sent to an Arabic lang partner.

**Steps to reproduce:**
*Ensure the rtlcss node package is installed and in PATH*

1. Create a Saudi company / switch to a demo one, switch to
     Arabic language

2. Create a product with the name:
   `دفتر سلكي بهوية الهيئة A4 - شد 50 ورقة`

3. Create an invoice to a partner with Arabic set as their lang

4. Confirm the invoice -> print it

5. The product name on the PDF has a mal-ordered name

**Cause of the issue:**
The right-to-left rule of the Arabic language is not getting
enforced.

There is a secondary bug where certain whitespace-delimited
substrings get displayed in a broken, overlapping way. From my
no-comprehensive testing, it seems to only happen when there is
a sequence in the string where you have some substring ending in
a numeral (0-9) followed by a single-space, then another
substring that begins with an Arabic alphabet character.

**Fix:**
When printing an invoice with an arabic partner:
1. Use right-aligned text instead of left

2. Pad single-space breaks between substrings in a product name
     where the first substring ends with a numeral and the
     second begins with an alpha char.

3. Add explicit `dir="rtl"` attribute to the display node

opw-3971541