### PR TITLE
[FIX] {sale, hr} _timesheet : Update project id in timesheet grid

### DIFF
--- a/addons/hr_timesheet/models/hr_timesheet.py
+++ b/addons/hr_timesheet/models/hr_timesheet.py
@@ -103,7 +103,7 @@ class AccountAnalyticLine(models.Model):
             if timesheet.project_id:
                 timesheet.partner_id = timesheet.task_id.partner_id or timesheet.project_id.partner_id
 
-    @api.depends('task_id')
+    @api.depends('task_id.project_id')
     def _compute_project_id(self):
         for line in self:
             if not line.task_id.project_id or line.project_id == line.task_id.project_id:
@@ -112,10 +112,7 @@ class AccountAnalyticLine(models.Model):
 
     @api.depends('project_id')
     def _compute_task_id(self):
-        for line in self:
-            if line.project_id and line.project_id == line.task_id.project_id:
-                continue
-            line.task_id = False
+        self.filtered(lambda t: not t.project_id).task_id = False
 
     @api.onchange('project_id')
     def _onchange_project_id(self):

--- a/addons/hr_timesheet/tests/test_timesheet.py
+++ b/addons/hr_timesheet/tests/test_timesheet.py
@@ -290,8 +290,8 @@ class TestTimesheet(TestCommonTimesheet):
 
         timesheet_count1 = Timesheet.search_count([('project_id', '=', self.project_customer.id)])
         timesheet_count2 = Timesheet.search_count([('project_id', '=', self.project_customer2.id)])
-        self.assertEqual(timesheet_count1, 3, "3 timesheets should be linked to Project1")
-        self.assertEqual(timesheet_count2, 0, "No timesheets should be linked to Project2")
+        self.assertEqual(timesheet_count1, 0, "0 timesheets should be linked to Project1")
+        self.assertEqual(timesheet_count2, 3, "3 timesheets should be linked to Project2")
         self.assertEqual(len(self.task1.timesheet_ids), 1, "The timesheet still should be linked to task1")
         self.assertEqual(len(task_child.timesheet_ids), 1, "The timesheet still should be linked to task_child")
         self.assertEqual(len(task_grandchild.timesheet_ids), 1, "The timesheet still should be linked to task_grandchild")
@@ -405,7 +405,7 @@ class TestTimesheet(TestCommonTimesheet):
             'project_id': second_project.id
         })
 
-        self.assertEqual(timesheet.project_id, project, 'The project_id of timesheet shouldn\'t have changed')
+        self.assertEqual(timesheet.project_id, second_project, 'The project_id of non-validated timesheet should have changed')
 
     def test_create_timesheet_employee_not_in_company(self):
         ''' ts.employee_id only if the user has an employee in the company or one employee for all companies.

--- a/addons/sale_timesheet/tests/test_sale_timesheet.py
+++ b/addons/sale_timesheet/tests/test_sale_timesheet.py
@@ -518,15 +518,15 @@ class TestSaleTimesheet(TestCommonSaleTimesheet):
         self.assertEqual(timesheet_count2, 1, "One timesheet in project_template")
         self.assertEqual(len(task.timesheet_ids), 1, "The timesheet should be linked to task")
 
-        # change project of task, it has no impact on timesheet. never.
+        # change project of task, non-validated timesheets will follow the project of task
         task.write({
             'project_id': self.project_global.id
         })
 
         timesheet_count1 = Timesheet.search_count([('project_id', '=', self.project_global.id)])
         timesheet_count2 = Timesheet.search_count([('project_id', '=', self.project_template.id)])
-        self.assertEqual(timesheet_count1, 0, "No timesheet in project_global")
-        self.assertEqual(timesheet_count2, 1, "One timesheet in project_template")
+        self.assertEqual(timesheet_count1, 1, "One timesheet in project_global")
+        self.assertEqual(timesheet_count2, 0, "0 timesheet in project_template")
         self.assertEqual(len(task.timesheet_ids), 1, "The timesheet still should be linked to task")
 
         # Create an invoice
@@ -550,16 +550,16 @@ class TestSaleTimesheet(TestCommonSaleTimesheet):
             'unit_amount': 6,
         })
 
-        self.assertEqual(Timesheet.search_count([('project_id', '=', self.project_global.id)]), 1, "1 timesheets in project_global")
+        self.assertEqual(Timesheet.search_count([('project_id', '=', self.project_global.id)]), 2, "2 timesheets in project_global")
 
-        # change project of task, it has no impact on timesheet. never.
+        # change project of task, only the timesheet not billed gets its project changed
         task.write({
             'project_id': self.project_template.id
         })
 
         timesheet_count1 = Timesheet.search_count([('project_id', '=', self.project_global.id)])
         timesheet_count2 = Timesheet.search_count([('project_id', '=', self.project_template.id)])
-        self.assertEqual(timesheet_count1, 1, "Still one timesheet in project_global")
+        self.assertEqual(timesheet_count1, 1, "One timesheet in project_global")
         self.assertEqual(timesheet_count2, 1, "One timesheet in project_template")
         self.assertEqual(len(task.timesheet_ids), 2, "The 2 timesheets still should be linked to task")
 


### PR DESCRIPTION
**Steps to reproduce:**
	- Install Timesheet, Project and Sale modules
	- Create a service product and set it to create a task when ordered
	- Create a quotation with this product
	- Navigate to the task and create a timesheet line for it
	- Check this line in Timesheet grid
	- Change the project of this task

**Current behavior before PR:**
When changing a task's project it won't reflect on the timesheet grid and you will still see the name of the old project. This is happening because the dependency of _compute_project_id is wrong. So we will not have 'account.analytic.line.project_id' in the trigger tree so it won't get recomputed therefore won't be updated in the database

**Desired behavior after PR is merged:**
By changing the dependency of the _compute_project_id to trigger it when the task's project gets changed. This was actually done in this commit https://github.com/odoo/odoo/pull/153281/commits/0e701ed0819d02965e267e24dd73aab13880ad2c but this was only commited in master not in V17.0 this is why we have this issue in 17.0 and 17.1 only.

opw-3944300