### PR TITLE
[FIX] sale_loyalty: discounts applied on reward lines

### DIFF
--- a/addons/sale_loyalty/models/sale_order.py
+++ b/addons/sale_loyalty/models/sale_order.py
@@ -165,8 +165,9 @@ class SaleOrder(models.Model):
             # Ignore lines from this reward
             if not line.product_uom_qty or not line.price_unit:
                 continue
+            discounted_price_unit = line.price_unit * (1 - (line.discount or 0.0) / 100.0)
             tax_data = line.tax_id.compute_all(
-                line.price_unit,
+                discounted_price_unit,
                 quantity=line.product_uom_qty,
                 product=line.product_id,
                 partner=line.order_partner_id,


### PR DESCRIPTION
Introduced by 09f31597163a3251e58bb7b08939301574e1f65a

Steps to reproduce:
1. Activate user's permission **"Discount on line"**

2. Configure a pricelist with _discount_policy_ as **"Show public price & discount to the customer"** and set _selectable_ `True`.

3. Configure a price rule for a given product (e.g. Storage Box)

Storage box _Sales Price_ is set on 10$ and I set a price rule in 5$ so its like a 50% of discount in that product

4. Go to website shop + select configured pricelist + add to cart "Storage box" + Go to cart page

5. Apply a loyalty program (ie: discount code program type) configure as its reward's applicability on "Order".

6. Claim that discount code on cart page.

Reward product price is 1$ when it should be 2$
