### PR TITLE
[FIX] resource, hr_contract: update leave calendar on resource change

### DIFF
--- a/addons/hr_contract/models/__init__.py
+++ b/addons/hr_contract/models/__init__.py
@@ -6,4 +6,5 @@ from . import hr_employee_public
 from . import hr_contract
 from . import res_users
 from . import resource
+from . import resource_calendar_leaves
 from . import hr_contract_type

--- a/addons/hr_contract/models/resource_calendar_leaves.py
+++ b/addons/hr_contract/models/resource_calendar_leaves.py
@@ -1,0 +1,43 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from collections import defaultdict
+from datetime import datetime
+from pytz import timezone, utc
+
+from odoo import models
+
+
+class ResourceCalendarLeaves(models.Model):
+    _inherit = 'resource.calendar.leaves'
+
+    def _compute_calendar_id(self):
+        def date2datetime(date, tz):
+            dt = datetime.fromordinal(date.toordinal())
+            return tz.localize(dt).astimezone(utc).replace(tzinfo=None)
+
+        contracts = self.env['hr.contract'].search([
+            ('state', '=', 'open'),
+            ('employee_id.resource_id', 'in', self.resource_id.ids),
+        ])
+
+        CalendarLeaves = self.env['resource.calendar.leaves']
+        leaves_by_resource_id = defaultdict(lambda: CalendarLeaves, {False: CalendarLeaves})
+        for leave in self:
+            leaves_by_resource_id[leave.resource_id.id] += leave
+        # pass leaves without resource_id to super
+        remaining = leaves_by_resource_id.pop(False)
+
+        for resource_id, leaves in leaves_by_resource_id.items():
+            contract = contracts.filtered_domain([('employee_id.resource_id', '=', resource_id)])
+            if not contract:
+                remaining += leaves
+                continue
+            tz = timezone(contract.resource_calendar_id.tz or 'UTC')
+            start_dt = date2datetime(contract.date_start, tz)
+            end_dt = date2datetime(contract.date_end, tz) if contract.date_end else datetime.max
+            # only modify leaves that fall under the active contract
+            leaves.filtered(
+                lambda leave: start_dt <= leave.date_from < end_dt
+            ).calendar_id = contract.resource_calendar_id
+
+        super(ResourceCalendarLeaves, remaining)._compute_calendar_id()

--- a/addons/hr_contract/tests/test_contract.py
+++ b/addons/hr_contract/tests/test_contract.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from datetime import datetime, date
@@ -106,3 +105,48 @@ class TestHrContracts(TestContractCommon):
         contract = self.create_contract('open', 'normal', date(2018, 1, 1), date(2018, 1, 2))
         duplicate_employee = self.employee.copy()
         self.assertNotEqual(duplicate_employee.contract_id, contract)
+
+    def test_contract_calendar_update(self):
+        """
+        Ensure the employee's working schedule updates after modifying them on
+        their contract, as well as well as the working schedule linked to the
+        employee's leaves iff they're after the contract's start date.
+        """
+        contract1 = self.create_contract('close', 'done', date(2024, 1, 1), date(2024, 5, 31))
+        contract2 = self.create_contract('open', 'normal', date(2024, 6, 1))
+
+        calendar1 = contract1.resource_calendar_id
+        calendar2 = self.env['resource.calendar'].create({'name': 'Test Schedule'})
+
+        leave1 = self.env['resource.calendar.leaves'].create({
+            'name': 'Sick day',
+            'resource_id': self.employee.resource_id.id,
+            'calendar_id': calendar1.id,
+            'date_from': datetime(2024, 5, 2, 8, 0),
+            'date_to': datetime(2024, 5, 2, 17, 0),
+        })
+        leave2 = self.env['resource.calendar.leaves'].create({
+            'name': 'Sick again',
+            'resource_id': self.employee.resource_id.id,
+            'calendar_id': calendar1.id,
+            'date_from': datetime(2024, 7, 5, 8, 0),
+            'date_to': datetime(2024, 7, 5, 17, 0),
+        })
+
+        contract2.resource_calendar_id = calendar2
+
+        self.assertEqual(
+            self.employee.resource_calendar_id,
+            calendar2,
+            "Employee calendar should update",
+        )
+        self.assertEqual(
+            leave1.calendar_id,
+            calendar1,
+            "Leave under previous calendar should not update",
+        )
+        self.assertEqual(
+            leave2.calendar_id,
+            calendar2,
+            "Leave under active contract should update",
+        )

--- a/addons/resource/models/resource.py
+++ b/addons/resource/models/resource.py
@@ -1030,7 +1030,12 @@ class ResourceCalendarLeaves(models.Model):
     company_id = fields.Many2one(
         'res.company', string="Company", readonly=True, store=True,
         default=lambda self: self.env.company, compute='_compute_company_id')
-    calendar_id = fields.Many2one('resource.calendar', 'Working Hours', domain="[('company_id', 'in', [company_id, False])]", check_company=True, index=True)
+    calendar_id = fields.Many2one(
+        'resource.calendar', 'Working Hours',
+        compute='_compute_calendar_id', store=True, readonly=False,
+        domain="[('company_id', 'in', [company_id, False])]",
+        check_company=True, index=True,
+    )
     date_from = fields.Datetime('Start Date', required=True)
     date_to = fields.Datetime('End Date', required=True)
     resource_id = fields.Many2one(
@@ -1051,8 +1056,12 @@ class ResourceCalendarLeaves(models.Model):
 
     @api.onchange('resource_id')
     def onchange_resource(self):
-        if self.resource_id:
-            self.calendar_id = self.resource_id.calendar_id
+        pass
+
+    @api.depends('resource_id.calendar_id')
+    def _compute_calendar_id(self):
+        for leave in self.filtered('resource_id'):
+            leave.calendar_id = leave.resource_id.calendar_id
 
     def _copy_leave_vals(self):
         self.ensure_one()

--- a/addons/resource/tests/test_resource.py
+++ b/addons/resource/tests/test_resource.py
@@ -560,6 +560,28 @@ class TestCalendar(TestResourceCommon):
         self.assertEqual(pierre_intervals[0][0], datetime_tz(2020, 4, 3, 8, 0, 0, tzinfo=pierre.tz))
         self.assertEqual(pierre_intervals[0][1], datetime_tz(2020, 4, 3, 15, 0, 0, tzinfo=pierre.tz))
 
+    def test_resource_calendar_update(self):
+        holiday = self.env['resource.calendar.leaves'].create({
+            'name': 'May Day',
+            'calendar_id': self.calendar_jean.id,
+            'date_from': datetime_str(2024, 5, 1, 0, 0, 0, tzinfo=self.jean.tz),
+            'date_to': datetime_str(2024, 5, 1, 23, 59, 59, tzinfo=self.jean.tz),
+        })
+
+        # Jean takes a leave
+        leave = self.env['resource.calendar.leaves'].create({
+            'name': 'Jean is AFK',
+            'calendar_id': self.calendar_jean.id,
+            'resource_id': self.jean.resource_id.id,
+            'date_from': datetime_str(2024, 5, 10, 8, 0, 0, tzinfo=self.jean.tz),
+            'date_to': datetime_str(2024, 5, 10, 16, 0, 0, tzinfo=self.jean.tz),
+        })
+
+        # Jean changes working schedule to Jules'
+        self.jean.resource_calendar_id = self.calendar_jules
+        self.assertEqual(leave.calendar_id, self.calendar_jules, "leave calendar should be updated")
+        self.assertEqual(holiday.calendar_id, self.calendar_jean, "global leave shouldn't change")
+
 
 class TestResMixin(TestResourceCommon):
 


### PR DESCRIPTION
Versions
--------
- 15.0+

Steps
-----
1. Have an employee on a 40 hour/week work schedule;
2. for a past week, create a sick leave for monday & tuesday;
3. create 8 hour timesheets for the remaining weekdays;
4. switch the employee's work schedule to 35 hour/weeks;
4. navigate to the week with the leaves in Timesheets.

Issue
-----
The hours displayed next to the employee name shows -11:00, ignoring the the timesheets created by the leaves.

Cause
-----
`resource.calendar.leave` records have a `calendar_id` field which is inialized to the resource's calendar, and updates if the resource changes, but not when the resource's calendar changes.

As a consequence, the `_work_intervals_batch` method used for this calculation gets called on the employee's new calendar, which is no longer related to the calendar associated with their leaves.

Solution
--------
Replace the `onchange_resource` method with a compute method which updates the leave's field if the employee's calendar changes.

opw-3693131