### PR TITLE
[FIX] sale_coupon: no fixed tax in percent reward

### DIFF
--- a/addons/sale_coupon/models/sale_order.py
+++ b/addons/sale_coupon/models/sale_order.py
@@ -242,9 +242,9 @@ class SaleOrder(models.Model):
             if line:
                 discount_line_amount = min(line.price_reduce * (program.discount_percentage / 100), amount_total)
                 if discount_line_amount:
-                    taxes = self.fiscal_position_id.map_tax(line.tax_id)
+                    taxes = self.fiscal_position_id.map_tax(line.tax_id).filtered(lambda t: t.amount_type != 'fixed')
 
-                    reward_dict[line.tax_id] = {
+                    reward_dict[taxes] = {
                         'name': _("Discount: %s", program.name),
                         'product_id': program.discount_line_product_id.id,
                         'price_unit': - discount_line_amount if discount_line_amount > 0 else 0,
@@ -266,12 +266,11 @@ class SaleOrder(models.Model):
 
                 if discount_line_amount:
 
-                    if line.tax_id in reward_dict:
-                        reward_dict[line.tax_id]['price_unit'] -= discount_line_amount
+                    taxes = self.fiscal_position_id.map_tax(line.tax_id).filtered(lambda t: t.amount_type != 'fixed')
+                    if taxes in reward_dict:
+                        reward_dict[taxes]['price_unit'] -= discount_line_amount
                     else:
-                        taxes = self.fiscal_position_id.map_tax(line.tax_id)
-
-                        reward_dict[line.tax_id] = {
+                        reward_dict[taxes] = {
                             'name': _(
                                 "Discount: %(program)s - On product with following taxes: %(taxes)s",
                                 program=program.name,


### PR DESCRIPTION
This commit contains two fixes.

The first is a backport of the fix in task-3580170. Namely, remove fixed taxes from percentage reward lines. For more details, see odoo/odoo#145567

The second is a fix of the first. Some context: reward lines are created and updated from dictionaries indexed on recordsets of taxes. The assumption that each reward line has a different tax set is used for example in `_update_existing_reward_lines` to match updated values with existing reward lines.

Removing fixed taxes broke that assumption because the keys were not adapted accordingly. This commit ensures the dictionaries for reward lines have keys that match the taxes of the reward lines themselves.

Quick reproduction of the issue (full details in the task):
1. Create a promotions program with a percentage reward
2. Create a sale order with a line that has a variable tax and another line that has the same variable tax and also a fixed tax.
3. When updating the promotions program (click on "PROMOTIONS" button), two reward lines are created instead of a single one. The last reward line overrides the first's price_unit. The rewards are incorrect (in some cases such as duplicating a SO the reward lines are "correct" until clicking on the "PROMOTIONS" button again, but there's still two lines instead of one)

After this commit, there's a single line per tax set and the amounts are correct, while always ignoring fixed taxes.

Task-[3990438](https://www.odoo.com/odoo/all-tasks/3990438)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
