### PR TITLE
[IMP] web: add model view in developer tools

### DIFF
--- a/addons/web/static/src/webclient/actions/debug_items.js
+++ b/addons/web/static/src/webclient/actions/debug_items.js
@@ -72,6 +72,26 @@ function viewFields({ action, env }) {
     };
 }
 
+function ViewModel({ action, env }) {
+    if (!action.res_model) {
+        return null;
+    }
+    const modelName = action.res_model
+    return {
+        type: "item",
+        description: _t("View Model: %s", modelName),
+        callback: async () => {
+            const modelId = (
+                await env.services.orm.search("ir.model", [["model", "=", modelName]], {
+                    limit: 1,
+                })
+            )[0];
+            editModelDebug(env, modelName, "ir.model", modelId);
+        },
+        sequence: 130,
+    };
+}
+
 function manageFilters({ action, env }) {
     if (!action.res_model) {
         return null;
@@ -96,7 +116,7 @@ function manageFilters({ action, env }) {
                 },
             });
         },
-        sequence: 130,
+        sequence: 140,
     };
 }
 
@@ -169,6 +189,7 @@ debugRegistry
     .add("actionSeparator", actionSeparator)
     .add("editAction", editAction)
     .add("viewFields", viewFields)
+    .add("ViewModel", ViewModel)
     .add("manageFilters", manageFilters)
     .add("accessSeparator", accessSeparator)
     .add("viewAccessRights", viewAccessRights)

--- a/addons/web/static/tests/core/debug/debug_manager.test.js
+++ b/addons/web/static/tests/core/debug/debug_manager.test.js
@@ -664,4 +664,34 @@ describe.tags("desktop")("DebugMenu", () => {
             ["partner", "m2o", 1, true, true, false],
         ]);
     });
+
+    test("display model view in developer tools", async () => {
+        serverState.debug = "1";
+        webModels.ResPartner._views.form = `<form><field name="name"/></form>`;
+        webModels.ResPartner._views.search = "<search/>";
+        webModels.ResPartner._records.push({ id: 88, name: "p1" });
+        webModels.IrModel._views.form = `
+            <form>
+                <field name="name"/>
+                <field name="model"/>
+            </form>`;
+        webModels.IrModel._views.search = "<search/>";
+
+        defineWebModels();
+        await mountWithCleanup(WebClient);
+        await getService("action").doAction({
+            name: "Partners",
+            res_model: "res.partner",
+            type: "ir.actions.act_window",
+            views: [[false, "form"]],
+        });
+
+        await contains(".o_debug_manager button").click();
+        expect(queryAll(".dropdown-menu .dropdown-item")[1]).toHaveText("View Model: res.partner");
+        await contains(".dropdown-menu .dropdown-item:contains('View Model:')").click();
+
+        expect(".breadcrumb-item").toHaveCount(1);
+        expect(".o_breadcrumb .active").toHaveCount(1);
+        expect(".o_breadcrumb .active").toHaveText("Partner");
+    });
 });


### PR DESCRIPTION
Specification:
- add the `Model View` option to the developer tools. By selecting the `Model View` option will be redirected to the corresponding model view.
- some debug items are only visible in debug mode, with assets like running unit tests and Point of Sale JS tests.

Task-3867703