### PR TITLE
[FIX] point_of_sale: fix traceback when the user changes the product type

### DIFF
--- a/addons/point_of_sale/models/product.py
+++ b/addons/point_of_sale/models/product.py
@@ -72,6 +72,7 @@ class ProductTemplate(models.Model):
     def _onchange_type(self):
         if self.type == "combo" and self.attribute_line_ids:
             raise UserError(_("Combo products cannot contains variants or attributes"))
+        return super()._onchange_type()
 
 class ProductProduct(models.Model):
     _inherit = 'product.product'


### PR DESCRIPTION
Currently, a traceback occurs when the user changes the type of a product.

Steps to reproduce:-
1) Install sale, POS
2) Create a confirmed sale order with a product
2) Now change the product type for the above created `SO` product

Error:- 
```
TypeError: 'NoneType' object does not support item assignment
```

In the [1] commit there is no return type, So it by default returns None. 
Because of no return type, the value of `res` would be `None` at [2].

It leads to a traceback when assigning a value to `res`, which is a `NoneType` at [3]. 

[1]
https://github.com/odoo/odoo/commit/d9c5d163f251f59829b00decae94044941ee44e4

[2]
https://github.com/odoo/odoo/blob/a142a51faa8ab8cce9c9ae4a14e15646c2118f5e/addons/sale/models/product_template.py#L95

[3]
https://github.com/odoo/odoo/blob/a142a51faa8ab8cce9c9ae4a14e15646c2118f5e/addons/sale/models/product_template.py#L97

sentry-5488262774

