### PR TITLE
[16.0][IMP] hr_attendance: Show Extra hours information in kiosk only if the "Count Extra Hours" checkbox is selected

### DIFF
--- a/addons/hr_attendance/models/hr_employee.py
+++ b/addons/hr_attendance/models/hr_employee.py
@@ -169,6 +169,7 @@ class HrEmployee(models.Model):
         else:
             modified_attendance = employee._attendance_action_change()
         action_message['attendance'] = modified_attendance.read()[0]
+        action_message['show_total_overtime'] = employee.company_id.hr_attendance_overtime
         action_message['total_overtime'] = employee.total_overtime
         # Overtime have an unique constraint on the day, no need for limit=1
         action_message['overtime_today'] = self.env['hr.attendance.overtime'].sudo().search([

--- a/addons/hr_attendance/static/src/js/greeting_message.js
+++ b/addons/hr_attendance/static/src/js/greeting_message.js
@@ -55,6 +55,7 @@ var GreetingMessage = AbstractAction.extend({
         this.attendance.check_out_time = this.attendance.check_out && this.attendance.check_out.format(this.format_time);
 
         // extra hours amount displayed in the greeting message template.
+        this.show_total_overtime = action.show_total_overtime;
         this.total_overtime_float = action.total_overtime; // Used for comparison in template
         this.total_overtime = field_utils.format.float_time(this.total_overtime_float);
         this.today_overtime_float = action.overtime_today;

--- a/addons/hr_attendance/static/src/xml/attendance.xml
+++ b/addons/hr_attendance/static/src/xml/attendance.xml
@@ -159,12 +159,14 @@
                             Checked out at <b><t t-esc="widget.attendance.check_out_time"/></b>
                             <br/><b><t t-esc="widget.hours_today"/></b>
                         </div>
-                        <div t-att-class="'alert ' + (widget.today_overtime_float &gt;= 0 ? 'alert-success' : 'alert-danger') + ' h3 mx-3'" role="status">
-                            Extra hours today:
-                            <span t-esc="widget.today_overtime"/>
-                        </div>
-                        <t t-if="widget.total_overtime_float &gt; 0">
-                            Total extra hours: <span t-esc="widget.total_overtime"/>
+                        <t t-if="widget.show_total_overtime">
+                            <div t-att-class="'alert ' + (widget.today_overtime_float &gt;= 0 ? 'alert-success' : 'alert-danger') + ' h3 mx-3'" role="status">
+                                Extra hours today:
+                                <span t-esc="widget.today_overtime"/>
+                            </div>
+                            <t t-if="widget.total_overtime_float &gt; 0">
+                                Total extra hours: <span t-esc="widget.total_overtime"/>
+                            </t>
                         </t>
                         <h3 class="o_hr_attendance_random_message fst-italic mb24"/>
                         <div class="o_hr_attendance_warning_message mt24 alert alert-warning" style="display:none" role="alert"/>


### PR DESCRIPTION
Show Extra hours information in kiosk only if the "_Count Extra Hours_" checkbox is selected

**Count Extra Hours checked**
![horas-extra-activado](https://github.com/odoo/odoo/assets/4117568/6f0fae4d-860a-43ea-91fb-1466ba5bac71)

**Count Extra Hours unchecked**
![horas-extra-desactivado](https://github.com/odoo/odoo/assets/4117568/84615eb1-4979-404d-bc69-16f74b9e9ce1)

Ping @pedrobaeza 

@Tecnativa TT49624

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
