### PR TITLE
[FIX] website_livechat: fix incorrect loop when sending chat request

### DIFF
--- a/addons/website_livechat/models/website_visitor.py
+++ b/addons/website_livechat/models/website_visitor.py
@@ -80,33 +80,35 @@ class WebsiteVisitor(models.Model):
                 'livechat_visitor_id': visitor.id,
                 'livechat_active': True,
             })
-            discuss_channels = self.env['discuss.channel'].create(discuss_channel_vals_list)
-            for channel in discuss_channels:
-                if not channel.livechat_visitor_id.partner_id:
-                    # sudo: mail.guest - creating a guest in a dedicated channel created from livechat
-                    guest = self.env["mail.guest"].sudo().create(
-                        {
-                            "country_id": country.id,
-                            "lang": get_lang(channel.env).code,
-                            "name": _("Visitor #%d", channel.livechat_visitor_id.id),
-                            "timezone": visitor.timezone,
-                        }
-                    )
-                    channel.add_members(guest_ids=guest.ids, post_joined_message=False)
-            # Open empty chatter to allow the operator to start chatting with the visitor.
-            channel_members = self.env['discuss.channel.member'].sudo().search([
-                ('partner_id', '=', self.env.user.partner_id.id),
-                ('channel_id', 'in', discuss_channels.ids),
-            ])
-            channel_members.write({
-                'fold_state': 'open',
-                'is_minimized': True,
-            })
-            discuss_channels_info = discuss_channels._channel_info()
-            notifications = []
-            for discuss_channel_info in discuss_channels_info:
-                notifications.append([operator.partner_id, 'website_livechat.send_chat_request', discuss_channel_info])
-            self.env['bus.bus']._sendmany(notifications)
+        discuss_channels = self.env['discuss.channel'].create(discuss_channel_vals_list)
+        if not discuss_channels:
+            return
+        for channel in discuss_channels:
+            if not channel.livechat_visitor_id.partner_id:
+                # sudo: mail.guest - creating a guest in a dedicated channel created from livechat
+                guest = self.env["mail.guest"].sudo().create(
+                    {
+                        "country_id": country.id,
+                        "lang": get_lang(channel.env).code,
+                        "name": _("Visitor #%d", channel.livechat_visitor_id.id),
+                        "timezone": visitor.timezone,
+                    }
+                )
+                channel.add_members(guest_ids=guest.ids, post_joined_message=False)
+        # Open empty chatter to allow the operator to start chatting with the visitor.
+        channel_members = self.env['discuss.channel.member'].sudo().search([
+            ('partner_id', '=', self.env.user.partner_id.id),
+            ('channel_id', 'in', discuss_channels.ids),
+        ])
+        channel_members.write({
+            'fold_state': 'open',
+            'is_minimized': True,
+        })
+        discuss_channels_info = discuss_channels._channel_info()
+        notifications = []
+        for discuss_channel_info in discuss_channels_info:
+            notifications.append([operator.partner_id, 'website_livechat.send_chat_request', discuss_channel_info])
+        self.env['bus.bus']._sendmany(notifications)
 
     def _merge_visitor(self, target):
         """ Copy sessions of the secondary visitors to the main partner visitor. """


### PR DESCRIPTION
Some part of the `action_send_chat_request` method has been wrongly indented in [1]. As a result, this block is executed as part of a loop while it should not. This PR put the block of code out of the loop.

[1]: https://github.com/odoo/odoo/pull/129770
