### PR TITLE
[FIX] mail: fix channel members without persona

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -1051,6 +1051,10 @@ class Channel(models.Model):
         })
         member_basic_info = {
             "id": member.id,
+            "persona": {
+                "id": member.partner_id.id if member.partner_id else member.guest_id.id,
+                "type": "partner" if member.partner_id else "guest",
+            },
             "lastSeenMessage": {"id": last_message.id} if last_message else False,
         }
         member_self_info = {

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -217,6 +217,10 @@ class TestChannelInternals(MailCommon):
                     "payload": {
                         "ChannelMember": {
                             "id": member.id,
+                            "persona": {
+                                "id": self.user_admin.partner_id.id,
+                                "type": "partner",
+                            },
                             "lastSeenMessage": {"id": msg_1.id},
                         },
                     },
@@ -226,6 +230,10 @@ class TestChannelInternals(MailCommon):
                     "payload": {
                         "ChannelMember": {
                             "id": member.id,
+                            "persona": {
+                                "id": self.user_admin.partner_id.id,
+                                "type": "partner",
+                            },
                             "lastSeenMessage": {"id": msg_1.id},
                             "thread": {
                                 "id": chat.id,


### PR DESCRIPTION
Marking a message as (un)read results in a notification being sent to update the new message separator and the message unread counter. This notification is an update of the user channel member. This notification does not contain any information about the member persona.

However, the code assumes the persona is always provided. As a result, errors can occur. This commit fixes this issue by providing the persona in the notification payload.

Steps to reproduce the issue:
- Send a chat request to a website visitor
- Send a message to the visitor
- Navigate to another page with the visitor
- Send a message from the visitor
- An error occurs