### PR TITLE
[FIX] im_livechat: auto-move up livechat icon at website bottom 

### DIFF
--- a/addons/im_livechat/static/src/embed/common/livechat_button.js
+++ b/addons/im_livechat/static/src/embed/common/livechat_button.js
@@ -1,6 +1,6 @@
 /* @odoo-module */
 
-import { Component, useRef, useState } from "@odoo/owl";
+import { Component, useExternalListener, useRef, useState } from "@odoo/owl";
 import { makeDraggableHook } from "@web/core/utils/draggable_hook_builder_owl";
 
 import { useService } from "@web/core/utils/hooks";
@@ -52,16 +52,30 @@ export class LivechatButton extends Component {
             animateNotification: !(
                 this.livechatService.thread || this.livechatService.shouldRestoreSession
             ),
+            hasAlreadyMovedOnce: false,
         });
         useMovable({
             cursor: "grabbing",
             ref: this.ref,
             elements: ".o-livechat-LivechatButton",
             onDrop: ({ top, left }) => {
+                this.state.hasAlreadyMovedOnce = true;
                 this.position.left = `${left}px`;
                 this.position.top = `${top}px`;
             },
         });
+        useExternalListener(document.body, "scroll", this._onScroll, { capture: true });
+    }
+
+    _onScroll(ev) {
+        if (!this.ref.el || this.state.hasAlreadyMovedOnce) {
+            return;
+        }
+        const container = ev.target;
+        this.position.top =
+            container.scrollHeight - container.scrollTop === container.clientHeight
+                ? `calc(93% - ${LIVECHAT_BUTTON_SIZE}px)`
+                : `calc(97% - ${LIVECHAT_BUTTON_SIZE}px)`;
     }
 
     onClick() {


### PR DESCRIPTION
Previously, the floating icon wasn't an OWL component and has been
refactored into an OWL component. When refactored he lost the auto
move up top logic that came with the css classes 'o_bottom_fixed_element'
and 'o_bottom_fixed_element_move_up'

This commit reintroduce this auto move up behavior by default within the
OWL component by listening to the scroll event of the document and
identifying whenever we reach the end of the document. It is useful
so we ensure the users can click all links potentially present in the
footer. If the icon is dragged and moved elsewhere, we prevent this
smart behavior from happening until next refresh of the state.

Commit introducing the drag & drop feature :
https://github.com/odoo/odoo/commit/d9f07235484

Commit of the OWL refactoring :
https://github.com/odoo/odoo/commit/20c1772d

Steps to reproduce :

- Install LiveChat
- Toggle Mobile display
- Scroll down to the bottom of page
-> The livechat floating icon doesn't go up as it was before

task-3946855

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
