### PR TITLE
[FIX] account_edi_proxy_client : demo id_client constraint

### DIFF
--- a/addons/account_edi_proxy_client/models/account_edi_proxy_user.py
+++ b/addons/account_edi_proxy_client/models/account_edi_proxy_user.py
@@ -174,7 +174,7 @@ class AccountEdiProxyClientUser(models.Model):
         )
         if edi_mode == 'demo':
             # simulate registration
-            response = {'id_client': f'demo{company.id}', 'refresh_token': 'demo'}
+            response = {'id_client': f'demo{company.id}{proxy_type}', 'refresh_token': 'demo'}
         else:
             try:
                 # b64encode returns a bytestring, we need it as a string


### PR DESCRIPTION
step:
-install l10n_it and account_peppol without demo data -setup a peppol demo account
-give your company a codigo fiscal
-settings > Italian Electronic Invoicing > check "Allow Odoo to process invoices"
-> constraint

This happens because when creating demo edi, the id_client is set as "demo{company_id}", but the id_client must be unique so when registering two edi services for the same company, there is a collision.

After this PR, we avoid the collision by adding the proxy_type to the demo id_client.

opw-3983974

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
