### PR TITLE
[IMP] hr_holidays: UX improvement

### DIFF
--- a/addons/hr_holidays/static/src/views/hooks.js
+++ b/addons/hr_holidays/static/src/views/hooks.js
@@ -28,7 +28,7 @@ export function useLeaveCancelWizard() {
     return (leaveId, callback) => {
         action.doAction(
             {
-                name: _t("Delete Confirmation"),
+                name: _t("Cancel Time Off"),
                 type: "ir.actions.act_window",
                 res_model: "hr.holidays.cancel.leave",
                 target: "new",

--- a/addons/hr_holidays/static/src/views/view_dialog/form_view_dialog.js
+++ b/addons/hr_holidays/static/src/views/view_dialog/form_view_dialog.js
@@ -50,15 +50,23 @@ export class TimeOffDialogFormController extends FormController {
     deleteRecord() {
         this.props.onRecordDeleted(this.record);
         this.props.onCancelLeave();
-        if (this.record.data.can_cancel) {
-            this.leaveCancelWizard(this.record.resId, () => {
-                this.props.onLeaveCancelled();
-            });
-        }
+    }
+
+    cancelRecord() {
+        this.deleteRecord();
+        this.leaveCancelWizard(this.record.resId, () => {
+            this.props.onLeaveCancelled();
+        });
+    }
+
+    get canCancel() {
+        return !this.model.root.isNew && this.record.data.can_cancel;
     }
 
     get canDelete() {
-        return !this.model.root.isNew && (this.record.data.can_cancel || this.record.data.state && !['validate', 'refuse', 'cancel'].includes(this.record.data.state));
+        return !this.canCancel
+            && this.record.data.state
+            && !['validate', 'refuse', 'cancel'].includes(this.record.data.state);
     }
 }
 

--- a/addons/hr_holidays/static/src/views/view_dialog/form_view_dialog.xml
+++ b/addons/hr_holidays/static/src/views/view_dialog/form_view_dialog.xml
@@ -7,7 +7,14 @@
         </xpath>
 
         <xpath expr="//button[contains(@class, 'o_form_button_cancel')]" position="after">
-            <button class="btn btn-secondary" t-if="canDelete" t-on-click="deleteRecord" data-hotkey="x">Delete</button>
+            <button class="btn btn-secondary"
+                    t-if="canCancel"
+                    t-on-click="cancelRecord"
+                    data-hotkey="x">Cancel</button>
+            <button class="btn btn-secondary"
+                    t-if="canDelete"
+                    t-on-click="deleteRecord"
+                    data-hotkey="x">delete</button>
         </xpath>
         <xpath expr="//div[contains(@class, 'o_cp_buttons')]" position="inside">
             <div class="flex-grow-1 d-flex flex-row-reverse gap-1">

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -248,7 +248,6 @@
                 <field name="state" widget="statusbar" statusbar_visible="confirm,validate,cancel"/>
             </header>
             <sheet>
-                <widget name="web_ribbon" title="Cancelled" bg_color="text-bg-danger" invisible="state != 'cancel'"/>
                 <div class="alert alert-info" role="alert" invisible="not request_unit_hours or not tz_mismatch">
                     <span>The employee has a different timezone than yours! Here dates and times are displayed in the employee's timezone</span>
                     (<field name="tz"/>).
@@ -257,6 +256,7 @@
                 <field name="leave_type_request_unit" invisible="1"/>
                 <div class="o_hr_leave_content row">
                     <div class="o_hr_leave_column col_left col-md-6 col-12">
+                        <widget name="web_ribbon" title="Cancelled" bg_color="text-bg-danger" invisible="state != 'cancel'"/>
                         <div name="title" class="o_hr_leave_title" invisible="1">
                             <field name="display_name" invisible="not holiday_status_id"/>
                         </div>
@@ -367,7 +367,7 @@
             <xpath expr="//div[hasclass('o_hr_leave_column')]" position="attributes">
                 <attribute name="class" remove="col_left col-md-6" separator=" "/>
             </xpath>
-            <xpath expr="//sheet/widget[@name='web_ribbon']" position="after">
+            <xpath expr="//div[hasclass('o_hr_leave_content')]" position="before">
                 <widget name="web_ribbon" title="Refused" bg_color="bg-danger" invisible="state != 'refuse' or not id"/>
                 <widget name="web_ribbon" title="Approved" bg_color="bg-success" invisible="state != 'validate' or not id"/>
             </xpath>

--- a/addons/hr_holidays/wizard/hr_holidays_cancel_leave_views.xml
+++ b/addons/hr_holidays/wizard/hr_holidays_cancel_leave_views.xml
@@ -6,10 +6,14 @@
             <form string="Cancel Time Off">
                 <group>
                     <field name="leave_id" invisible="1" />
-                    <field name="reason" placeholder="Provide a reason to delete an approved time off" />
+                    <field name="reason" placeholder="Provide a reason to cancel an approved time off" />
                 </group>
                 <footer>
-                    <button name="action_cancel_leave" type="object" class="btn-primary" string="Delete Time Off" accesskey="c" />
+                    <button name="action_cancel_leave"
+                            type="object"
+                            class="btn-primary"
+                            string="Cancel Time Off"
+                            accesskey="c" />
                     <button special="cancel" string="Discard" close="1" accesskey="j" />
                 </footer>
             </form>


### PR DESCRIPTION
The text of cancel time off was misleading. It
was stating 'delete' instead of 'cancel'. This
commit changes the text to 'cancel' to make it
more clear.

Also the ribbon was misplaced for cancelled time
off. This commit fix that as well.

task-3919151

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
