### PR TITLE
[IMP] point_of_sale,*: normalized views for product_barcodelookup

### DIFF
--- a/addons/account/views/product_views.xml
+++ b/addons/account/views/product_views.xml
@@ -16,13 +16,14 @@
          <field name="model">product.product</field>
          <field name="inherit_id" ref="product.product_product_view_form_normalized"/>
          <field name="arch" type="xml">
-             <xpath expr="//div[@name='sales_price']" position="inside">
-                 <field name="tax_string"/>
-             </xpath>
-             <xpath expr="//div[@name='sales_price']" position="after">
-                 <field name="taxes_id" widget="many2many_tags"
+            <xpath expr="//field[@name='list_price']" position="after">
+                <label for="taxes_id" class="mt-1"/>
+                <div name="tax_info" class="d-flex">
+                    <field name="taxes_id" widget="many2many_tags"
                         context="{'default_type_tax_use': 'sale', 'search_default_sale': 1}"
                         options="{'create': false, 'create_edit': false}"/>
+                    <field name="tax_string"/>
+                </div>
              </xpath>
          </field>
      </record>

--- a/addons/point_of_sale/views/product_view.xml
+++ b/addons/point_of_sale/views/product_view.xml
@@ -214,15 +214,10 @@
     <record id="product_product_view_form_normalized_pos" model="ir.ui.view">
         <field name="name">product.product.view.form.normalized.inherit</field>
         <field name="model">product.product</field>
-        <field name="mode">primary</field>
         <field name="inherit_id" ref="product.product_product_view_form_normalized"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='barcode']" position="attributes">
-                <attribute name="widget">productScanner</attribute>
-            </xpath>
-            <xpath expr="//div[@name='sales_price']" position="after">
-                <field name="available_in_pos"/>
-                <field name="pos_categ_ids" widget="many2many_tags"/>
+            <xpath expr="//div[@name='tax_info']" position="after">
+                <field name="pos_categ_ids" string="POS Category" widget="many2many_tags" placeholder="Unsaleable"/>
             </xpath>
         </field>
     </record>
@@ -232,7 +227,7 @@
         <field name="res_model">product.product</field>
         <field name="view_mode">form</field>
         <field name="target">new</field>
-        <field name="context" eval="{'default_available_in_pos': True, 'create_variant_never': 'no_variant', 'dialog_size': 'medium'}"/>
+        <field name="context" eval="{'default_available_in_pos': True, 'create_variant_never': 'no_variant', 'dialog_size': 'medium', 'can_be_sold': True}"/>
         <field name="view_id" ref="product_product_view_form_normalized_pos"/>
     </record>
     <record id="product_product_action_edit_pos" model="ir.actions.act_window">
@@ -240,6 +235,7 @@
         <field name="res_model">product.product</field>
         <field name="view_mode">form</field>
         <field name="target">new</field>
+        <field name="context" eval="{'dialog_size': 'medium'}"/>
         <field name="view_id" ref="point_of_sale.product_product_view_form_normalized_pos"/>
     </record>
 </odoo>

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -470,15 +470,9 @@
                                 <field name="currency_id" invisible="1"/>
                                 <field name="cost_currency_id" invisible="1"/>
                                 <field name="name" class="oe_inline" placeholder="e.g. Cheese Burger" string="Product Name"/>
-                                <label for="barcode" class="mt-1"/>
-                                <div name="barcode_autofill" class="d-flex">
-                                    <field name="barcode" class="oe_inline" placeholder="e.g. 1234567890"/>
-                                </div>
-                                <label for="list_price" class="mt-1"/>
-                                <div name="sales_price">
-                                    <field name="list_price" class="oe_inline" widget="monetary"
-                                            options="{'currency_field': 'currency_id', 'field_digits': True}"/>
-                                </div>
+                                <field name="barcode" class="oe_inline" placeholder="e.g. 1234567890" widget="productScanner"/>
+                                <field name="list_price" class="oe_inline" widget="monetary"
+                                        options="{'currency_field': 'currency_id', 'field_digits': True}"/>
                                 <field name="description" invisible="1"/>  <!-- Hide the description field for set data in product barcodelookup -->
                                 <field name="weight" invisible="1"/>       <!-- Hide the weight field for set data in product barcodelookup -->
                                 <field name="categ_id" invisible="1"/>     <!-- Hide the categ_id field set data in product barcodelookup -->

--- a/addons/website_sale/views/product_product_add.xml
+++ b/addons/website_sale/views/product_product_add.xml
@@ -12,6 +12,9 @@
             <xpath expr="//field[@name='company_id']" position="before">
                 <field name="website_url" invisible="1"/>
             </xpath>
+            <xpath expr="//div[@name='tax_info']" position="after">
+                <field name="public_categ_ids" string="Website Category" widget="many2many_tags" placeholder="Unpublished"/>
+            </xpath>
         </field>
     </record>
 
@@ -20,6 +23,7 @@
         <field name="res_model">product.product</field>
         <field name="view_mode">form</field>
         <field name="target">new</field>
+        <field name="context" eval="{'dialog_size': 'medium', 'website_published': True}"/>
         <field name="view_id" ref="product_product_view_form_normalized_website_sale"/>
     </record>
 


### PR DESCRIPTION
*: account, product, website_sale

point_of_sale:
- fields related to pos module available_in_pos and pos category fields are set next to each other in normalized view and also set their position after the tax informations.

account:
- the taxes and the tax string are properly shown with each other in normalized view.

product:
- Now as we need the scanning widget in website_sale as well so inserted in the main form view.

website_sale:
- made available_in_pos true by default and changed form size as in pos to make it standard.

task: 3977931

Related PRs ( Enterprise ) : https://github.com/odoo/enterprise/pull/64653
Related PRs ( Upgrade ) : https://github.com/odoo/upgrade/pull/6159