### PR TITLE
[FIX] im_livechat: crash when thread name contains non-ASCII characters

### DIFF
--- a/addons/im_livechat/static/src/embed/common/autopopup_service.js
+++ b/addons/im_livechat/static/src/embed/common/autopopup_service.js
@@ -1,12 +1,12 @@
 /* @odoo-module */
 
+import { expirableStorage } from "@im_livechat/embed/common/expirable_storage";
 import { SESSION_STATE } from "@im_livechat/embed/common/livechat_service";
 import { browser } from "@web/core/browser/browser";
-import { cookie } from "@web/core/browser/cookie";
 import { registry } from "@web/core/registry";
 
 export class AutopopupService {
-    static COOKIE = "im_livechat_auto_popup";
+    static STORAGE_KEY = "im_livechat_auto_popup";
 
     /**
      * @param {import("@web/env").OdooEnv} env
@@ -38,7 +38,7 @@ export class AutopopupService {
             if (this.allowAutoPopup && livechatService.state === SESSION_STATE.NONE) {
                 browser.setTimeout(async () => {
                     if (!this.storeService.ChatWindow.get({ thread: livechatService.thread })) {
-                        cookie.set(AutopopupService.COOKIE, JSON.stringify(false));
+                        expirableStorage.setItem(AutopopupService.STORAGE_KEY, false);
                         livechatService.open();
                     }
                 }, livechatService.rule.auto_popup_timer * 1000);
@@ -48,7 +48,7 @@ export class AutopopupService {
 
     get allowAutoPopup() {
         return Boolean(
-            JSON.parse(cookie.get(AutopopupService.COOKIE) ?? "true") !== false &&
+            !expirableStorage.getItem(AutopopupService.STORAGE_KEY) &&
                 !this.ui.isSmall &&
                 this.livechatService.rule?.action === "auto_popup" &&
                 (this.livechatService.available || this.chatbotService.available)

--- a/addons/im_livechat/static/src/embed/common/expirable_storage.js
+++ b/addons/im_livechat/static/src/embed/common/expirable_storage.js
@@ -1,0 +1,52 @@
+/* @odoo-module */
+
+import { browser } from "@web/core/browser/browser";
+
+const BASE_STORAGE_KEY = "EXPIRABLE_STORAGE";
+const CLEAR_INTERVAL = 24 * 60 * 60 * 1000; // 24 hours in milliseconds
+
+function cleanupExpirableStorage() {
+    const now = Date.now();
+    for (const key of Object.keys(browser.localStorage)) {
+        if (key.startsWith(BASE_STORAGE_KEY)) {
+            const item = JSON.parse(browser.localStorage.getItem(key));
+            if (item.expires && item.expires < now) {
+                browser.localStorage.removeItem(key);
+            }
+        }
+    }
+}
+
+export const expirableStorage = {
+    /** @param {string} key */
+    getItem(key) {
+        cleanupExpirableStorage();
+        const item = browser.localStorage.getItem(`${BASE_STORAGE_KEY}_${key}`);
+        if (item) {
+            return JSON.parse(item).value;
+        }
+        return null;
+    },
+    /**
+     * @param {string} key
+     * @param {string} value
+     * @param {number} ttl Number of seconds after which the item should expire.
+     */
+    setItem(key, value, ttl) {
+        let expires;
+        if (ttl) {
+            expires = Date.now() + ttl * 1000;
+        }
+        browser.localStorage.setItem(
+            `${BASE_STORAGE_KEY}_${key}`,
+            JSON.stringify({ value, expires })
+        );
+    },
+    /** @param {string} key */
+    removeItem(key) {
+        browser.localStorage.removeItem(`${BASE_STORAGE_KEY}_${key}`);
+    },
+};
+
+cleanupExpirableStorage();
+setInterval(cleanupExpirableStorage, CLEAR_INTERVAL);

--- a/addons/im_livechat/static/src/embed/common/livechat_service.js
+++ b/addons/im_livechat/static/src/embed/common/livechat_service.js
@@ -1,5 +1,7 @@
 /* @odoo-module */
 
+import { expirableStorage } from "@im_livechat/embed/common/expirable_storage";
+
 import { reactive } from "@odoo/owl";
 
 import { cookie } from "@web/core/browser/cookie";
@@ -33,12 +35,13 @@ export const ODOO_VERSION_KEY = `${location.origin.replace(
     "_"
 )}_im_livechat.odoo_version`;
 
-const OPERATOR_COOKIE = "im_livechat_previous_operator";
+const OPERATOR_STORAGE_KEY = "im_livechat_previous_operator";
 const GUEST_TOKEN_STORAGE_KEY = "im_livechat_guest_token";
-const SAVED_STATE_COOKIE = "im_livechat.saved_state";
+const SAVED_STATE_STORAGE_KEY = "im_livechat.saved_state";
+const LIVECHAT_UUID_COOKIE = "im_livechat_uuid";
 
 export function getGuestToken() {
-    return localStorage.getItem(GUEST_TOKEN_STORAGE_KEY);
+    return expirableStorage.getItem(GUEST_TOKEN_STORAGE_KEY);
 }
 
 export class LivechatService {
@@ -154,7 +157,8 @@ export class LivechatService {
                 });
             }
         } finally {
-            cookie.delete(SAVED_STATE_COOKIE);
+            expirableStorage.removeItem(SAVED_STATE_STORAGE_KEY);
+            cookie.delete(LIVECHAT_UUID_COOKIE);
             this.state = SESSION_STATE.NONE;
             await Promise.all(this._onStateChangeCallbacks[SESSION_STATE.NONE].map((fn) => fn()));
         }
@@ -181,20 +185,24 @@ export class LivechatService {
     _saveLivechatState(threadData, { persisted = false } = {}) {
         const { guest_token } = threadData;
         if (guest_token) {
-            localStorage.setItem(GUEST_TOKEN_STORAGE_KEY, threadData.guest_token);
+            expirableStorage.setItem(GUEST_TOKEN_STORAGE_KEY, threadData.guest_token);
             delete threadData.guest_token;
         }
-        cookie.set(
-            SAVED_STATE_COOKIE,
+        const ONE_DAY_TTL = 60 * 60 * 24;
+        if (threadData.uuid) {
+            cookie.set(LIVECHAT_UUID_COOKIE, threadData.uuid, ONE_DAY_TTL);
+        }
+        expirableStorage.setItem(
+            SAVED_STATE_STORAGE_KEY,
             JSON.stringify({
                 threadData: persisted ? { id: threadData.id, model: threadData.model } : threadData,
                 persisted,
                 livechatUserId: this.savedState?.livechatUserId ?? session.user_id,
             }),
-            60 * 60 * 24
+            ONE_DAY_TTL
         );
         if (threadData.operator) {
-            cookie.set(OPERATOR_COOKIE, threadData.operator.id, 7 * 24 * 60 * 60);
+            expirableStorage.setItem(OPERATOR_STORAGE_KEY, threadData.operator.id, ONE_DAY_TTL * 7);
         }
     }
 
@@ -212,7 +220,7 @@ export class LivechatService {
                 chatbot_script_id: this.savedState
                     ? this.savedState.threadData.chatbot_script_id
                     : this.rule.chatbot?.scriptId,
-                previous_operator_id: cookie.get(OPERATOR_COOKIE),
+                previous_operator_id: expirableStorage.getItem(OPERATOR_STORAGE_KEY),
                 temporary_id: this.thread?.id,
                 persisted: persist,
             },
@@ -234,7 +242,7 @@ export class LivechatService {
     }
 
     get savedState() {
-        return JSON.parse(cookie.get(SAVED_STATE_COOKIE) ?? "false");
+        return JSON.parse(expirableStorage.getItem(SAVED_STATE_STORAGE_KEY) ?? false);
     }
 
     /**

--- a/addons/im_livechat/static/tests/embed/autopopup_tests.js
+++ b/addons/im_livechat/static/tests/embed/autopopup_tests.js
@@ -2,12 +2,12 @@
 
 import { startServer } from "@bus/../tests/helpers/mock_python_environment";
 
+import { expirableStorage } from "@im_livechat/embed/common/expirable_storage";
 import { start, loadDefaultConfig } from "@im_livechat/../tests/embed/helper/test_utils";
 
 import { Command } from "@mail/../tests/helpers/command";
 
 import { contains } from "@web/../tests/utils";
-import { cookie } from "@web/core/browser/cookie";
 
 QUnit.module("autopopup");
 
@@ -25,7 +25,7 @@ QUnit.test("persisted session", async () => {
         livechat_channel_id: livechatChannelId,
         livechat_operator_id: pyEnv.adminPartnerId,
     });
-    cookie.set(
+    expirableStorage.setItem(
         "im_livechat.saved_state",
         JSON.stringify({ threadData: { id: channelId, model: "discuss.channel" }, persisted: true })
     );

--- a/addons/im_livechat/static/tests/embed/livechat_service_tests.js
+++ b/addons/im_livechat/static/tests/embed/livechat_service_tests.js
@@ -2,11 +2,11 @@
 
 import { startServer } from "@bus/../tests/helpers/mock_python_environment";
 
+import { expirableStorage } from "@im_livechat/embed/common/expirable_storage";
 import { loadDefaultConfig, start } from "@im_livechat/../tests/embed/helper/test_utils";
 
 import { Command } from "@mail/../tests/helpers/command";
 
-import { cookie } from "@web/core/browser/cookie";
 import { click, contains, insertText } from "@web/../tests/utils";
 import { triggerHotkey } from "@web/../tests/helpers/utils";
 import { Deferred } from "@web/core/utils/concurrency";
@@ -27,7 +27,7 @@ QUnit.test("persisted session history", async () => {
         livechat_channel_id: livechatChannelId,
         livechat_operator_id: pyEnv.adminPartnerId,
     });
-    cookie.set(
+    expirableStorage.setItem(
         "im_livechat.saved_state",
         JSON.stringify({ threadData: { id: channelId, model: "discuss.channel" }, persisted: true })
     );
@@ -51,7 +51,7 @@ QUnit.test("previous operator prioritized", async () => {
         user_ids: [userId],
     });
     pyEnv["im_livechat.channel"].write([livechatChannelId], { user_ids: [Command.link(userId)] });
-    cookie.set("im_livechat_previous_operator", JSON.stringify(previousOperatorId));
+    expirableStorage.setItem("im_livechat_previous_operator", JSON.stringify(previousOperatorId));
     start();
     click(".o-livechat-LivechatButton");
     await contains(".o-mail-Message-author", { text: "John Doe" });

--- a/addons/im_livechat/static/tests/embed/unread_messages_tests.js
+++ b/addons/im_livechat/static/tests/embed/unread_messages_tests.js
@@ -4,12 +4,12 @@ import { rpc } from "@web/core/network/rpc";
 
 import { startServer } from "@bus/../tests/helpers/mock_python_environment";
 
+import { expirableStorage } from "@im_livechat/embed/common/expirable_storage";
 import { loadDefaultConfig, start } from "@im_livechat/../tests/embed/helper/test_utils";
 
 import { Command } from "@mail/../tests/helpers/command";
 
 import { contains, focus } from "@web/../tests/utils";
-import { cookie } from "@web/core/browser/cookie";
 
 QUnit.module("thread service");
 
@@ -27,7 +27,7 @@ QUnit.test("new message from operator displays unread counter", async () => {
         livechat_channel_id: livechatChannelId,
         livechat_operator_id: pyEnv.adminPartnerId,
     });
-    cookie.set(
+    expirableStorage.setItem(
         "im_livechat.saved_state",
         JSON.stringify({ threadData: { id: channelId, model: "discuss.channel" }, persisted: true })
     );
@@ -57,11 +57,7 @@ QUnit.test("focus on unread livechat marks it as read", async () => {
         livechat_channel_id: livechatChannelId,
         livechat_operator_id: pyEnv.adminPartnerId,
     });
-    cookie.set(
-        "im_livechat.saved_state",
-        JSON.stringify({ threadData: { id: channelId, model: "discuss.channel" }, persisted: true })
-    );
-    cookie.set(
+    expirableStorage.setItem(
         "im_livechat.saved_state",
         JSON.stringify({ threadData: { id: channelId, model: "discuss.channel" }, persisted: true })
     );

--- a/addons/website_livechat/models/website_visitor.py
+++ b/addons/website_livechat/models/website_visitor.py
@@ -124,8 +124,7 @@ class WebsiteVisitor(models.Model):
         visitor_id, upsert = super()._upsert_visitor(access_token, force_track_values=force_track_values)
         if upsert == 'inserted':
             visitor_sudo = self.sudo().browse(visitor_id)
-            discuss_channel_uuid = json.loads(request.httprequest.cookies.get('im_livechat_session', '{}')).get('uuid')
-            if discuss_channel_uuid:
+            if discuss_channel_uuid := request.httprequest.cookies.get("im_livechat_uuid"):
                 discuss_channel = request.env["discuss.channel"].sudo().search([("uuid", "=", discuss_channel_uuid)])
                 discuss_channel.write({
                     'livechat_visitor_id': visitor_sudo.id,


### PR DESCRIPTION
The live chat uses cookies to save data about the ongoing conversation, such as the thread name. When this information contains non-ASCII characters, the behavior of the cookie is not consistent across browsers.

Safari does not store it properly, and trying to parse it later on results in a crash.

Until version 17 ([1]), the fix relied on encoding the data using the `encodeURIComponent` method. However, cookie size is limited to 4096 bytes, and this limit can be reached.

Starting with version 17.3, the live chat does not use cookies anymore ([2]). This PR backports this behavior to fix the issue.

opw-3968341

[1]: https://github.com/odoo/odoo/pull/168524
[2]: https://github.com/odoo/odoo/pull/167495