### PR TITLE
[FIX] hr_expense: show Create Report, Scan buttons in mobile

### DIFF
--- a/addons/hr_expense/static/src/mixins/document_upload.js
+++ b/addons/hr_expense/static/src/mixins/document_upload.js
@@ -62,11 +62,23 @@ export const ExpenseDocumentUpload = {
         this.http = useService('http');
         this.fileInput = useRef('fileInput');
         this.root = useRef("root");
+        this.isExpense = this.model.rootParams.resModel === "hr.expense";
 
         useBus(this.env.bus, "change_file_input", async (ev) => {
             this.fileInput.el.files = ev.detail.files;
             await this.onChangeFileInput();
         });
+    },
+
+    displayCreateReport() {
+        return this.isExpense;
+    },
+
+    async onCreateReportClick() {
+        const records = this.model.root.selection;
+        const recordIds = records.map((a) => a.resId);
+        const action = await this.orm.call('hr.expense', 'get_expenses_to_submit', [recordIds]);
+        this.actionService.doAction(action);
     },
 
     uploadDocument() {

--- a/addons/hr_expense/static/src/scss/hr_expense.scss
+++ b/addons/hr_expense/static/src/scss/hr_expense.scss
@@ -19,6 +19,10 @@
     }
 }
 
+.o_kanban_view .o_cp_bottom_left:has(.o_button_create_report) {
+    align-items: baseline;
+}
+
 .o_expense_container {
     @include media-breakpoint-down(sm) {
         overflow: auto visible;

--- a/addons/hr_expense/static/src/views/kanban.xml
+++ b/addons/hr_expense/static/src/views/kanban.xml
@@ -15,15 +15,20 @@
     </t>
 
     <t t-name="hr_expense.KanbanButtons" t-inherit="web.KanbanView.Buttons" t-inherit-mode="primary" owl="1">
+        <!-- Remove class 'align-items-baseline' to ensure consistency with list buttons when adding a third button
+         (Create Report) on mobile. Instead, align-items: baseline is added to parent div in css -->
+        <xpath expr="//div[@t-if='props.showButtons']" position="attributes">
+            <attribute name="class" remove="align-items-baseline" separator=" "/>
+        </xpath>
         <xpath expr="//t[@t-if='canCreate']" position="after">
+            <button type="button" class="d-inline d-md-none o_button_upload_expense btn btn-primary mx-1" t-on-click.prevent="uploadDocument">
+                Scan
+            </button>
             <button type="button" class="d-none d-md-inline o_button_upload_expense btn btn-primary mx-1" t-on-click.prevent="uploadDocument">
                 Upload
             </button>
-        </xpath>
-
-        <xpath expr="//t[@t-if='canCreate']" position="before">
-            <button type="button" class="d-inline d-md-none o_button_upload_expense btn btn-primary mx-1" t-on-click.prevent="uploadDocument">
-                Scan
+            <button t-if="displayCreateReport()" class="btn btn-secondary o_button_create_report" t-on-click="onCreateReportClick">
+                Create Report
             </button>
         </xpath>
 

--- a/addons/hr_expense/static/src/views/list.js
+++ b/addons/hr_expense/static/src/views/list.js
@@ -22,16 +22,11 @@ export class ExpenseListController extends ListController {
         this.rpc = useService("rpc");
         this.user = useService("user");
         this.isExpenseSheet = this.model.rootParams.resModel === "hr.expense.sheet";
-        this.isExpense = this.model.rootParams.resModel === "hr.expense";
 
         onWillStart(async () => {
             this.is_expense_team_approver = await this.user.hasGroup("hr_expense.group_hr_expense_team_approver");
             this.is_account_invoicing = await this.user.hasGroup("account.group_account_invoice");
         });
-    }
-
-    displayCreateReport() {
-        return this.isExpense;
     }
 
     displaySubmit() {
@@ -61,13 +56,6 @@ export class ExpenseListController extends ListController {
         // sgv note: we tried this.model.notify(); and does not work
         await this.model.root.load();
         this.render(true);
-    }
-
-    async onCreateReportClick() {
-        const records = this.model.root.selection;
-        const recordIds = records.map((a) => a.resId);
-        const action = await this.orm.call('hr.expense', 'get_expenses_to_submit', [recordIds]);
-        this.actionService.doAction(action);
     }
 
 }

--- a/addons/hr_expense/static/src/views/list.xml
+++ b/addons/hr_expense/static/src/views/list.xml
@@ -4,20 +4,19 @@
 
        <!-- hr.expense and hr.expense.sheet -->
         <xpath expr="//button[hasclass('o_list_button_add')]" position="after">
-            <button type="button" class="d-none d-md-inline o_button_upload_expense btn btn-primary mx-1" t-on-click.prevent="uploadDocument">
+            <button type="button" class="d-inline d-md-none o_button_upload_expense btn btn-primary mx-1" t-on-click.prevent="uploadDocument">
                 Scan
+            </button>
+            <button type="button" class="d-none d-md-inline o_button_upload_expense btn btn-primary mx-1" t-on-click.prevent="uploadDocument">
+                Upload
+            </button>
+            <button t-if="displayCreateReport()" class="btn btn-secondary o_button_create_report" t-on-click="onCreateReportClick">
+                Create Report
             </button>
         </xpath>
 
         <xpath expr="//div" position="inside">
             <input type="file" name="ufile" class="d-none" t-ref="fileInput" multiple="1" accept="*" t-on-change="onChangeFileInput"/>
-        </xpath>
-
-        <!-- hr.expense -->
-        <xpath expr="//button[hasclass('o_button_upload_expense')]" position="after">
-            <button t-if="displayCreateReport()" class="d-none d-md-block btn btn-secondary" t-on-click="onCreateReportClick">
-                Create Report
-            </button>
         </xpath>
 
         <!-- hr.expense.sheet -->

--- a/addons/hr_expense/static/tests/tours/expense_upload_tours.js
+++ b/addons/hr_expense/static/tests/tours/expense_upload_tours.js
@@ -12,20 +12,23 @@ odoo.define('hr_expense.tests.tours', function (require) {
             trigger: '.o_app[data-menu-xmlid="hr_expense.menu_hr_expense_root"]',
         },
         {
-            content: "Go to My Expenses",
-            trigger: 'a[data-menu-xmlid="hr_expense.menu_hr_expense_my_expenses"]',
-        },
-        {
-            content: "Go to My Expenses to Report",
-            trigger: 'a[data-menu-xmlid="hr_expense.menu_hr_expense_my_expenses_to_submit"]',
-        },
-        {
             content: "Check Upload Button",
             trigger: '.o_button_upload_expense',
             run() {
                 const button = document.querySelector('.o_button_upload_expense');
                 if(!button) {
                     console.error('Missing Upload button in My Expenses to Report > List View');
+                }
+            }
+        },
+        {
+            content: "Check Create Report Button, but not click on it",
+            trigger: "button.o_switch_view.o_list.active",
+            run() {
+                const button = Array.from(document.querySelectorAll('.btn-secondary'))
+                    .filter(element => element.textContent.includes('Create Report'));
+                if(!button) {
+                    console.error('Missing Create Report button in My Expenses to Report > List View');
                 }
             }
         },
@@ -44,34 +47,33 @@ odoo.define('hr_expense.tests.tours', function (require) {
             }
         },
         {
+            content: "Check Create Report Button and click on it",
+            trigger: ".btn-secondary:contains(\"Create Report\")",
+        },
+        {
+            trigger: '.fa-cloud-upload',
+            content: 'Save the new report',
+            run: 'click',
+        },
+        {
             content: "Go to Reporting",
-            trigger: 'a[data-menu-xmlid="hr_expense.menu_hr_expense_reports"]',
+            trigger: 'button[data-menu-xmlid="hr_expense.menu_hr_expense_reports"]',
         },
         {
             content: "Go to Expenses Analysis",
             trigger: 'a[data-menu-xmlid="hr_expense.menu_hr_expense_all_expenses"]',
         },
         {
+            content: "Go to list view",
+            trigger: "button.o_switch_view.o_list",
+        },
+        {
             content: "Check Upload Button",
-            trigger: 'li.breadcrumb-item:contains("Expenses Analysis")',
+            trigger: "button.o_switch_view.o_list.active",
             run() {
                 const button = document.querySelector('.o_button_upload_expense');
                 if(!button) {
                     console.error('Missing Upload button in Expenses Analysis > List View');
-                }
-            }
-        },
-        {
-            content: "Go to kanban view",
-            trigger: "button.o_switch_view.o_kanban",
-        },
-        {
-            content: "Check Upload Button",
-            trigger: "button.o_switch_view.o_kanban.active",
-            run() {
-                const button = document.querySelector('.o_button_upload_expense');
-                if(!button) {
-                    console.error('Missing Upload button in Expenses Analysis > Kanban View');
                 }
             }
         },

--- a/addons/hr_expense/tests/__init__.py
+++ b/addons/hr_expense/tests/__init__.py
@@ -7,3 +7,4 @@ from . import test_expenses_mail_import
 from . import test_expenses_multi_company
 from . import test_expenses_standard_price_update_warning
 from . import test_expenses_states
+from . import test_expenses_tour

--- a/addons/hr_expense/tests/test_expenses_tour.py
+++ b/addons/hr_expense/tests/test_expenses_tour.py
@@ -1,0 +1,7 @@
+from odoo.tests import tagged, HttpCase
+
+
+@tagged('post_install', '-at_install')
+class TestExpensesTour(HttpCase):
+    def test_tour_expenses(self):
+        self.start_tour("/web", "hr_expense_test_tour", login="admin")


### PR DESCRIPTION
Current behavior:
In hr_expenses, list and kanban views have different buttons being shown: list view displays 'New', 'Scan' and 'Create Report', while kanban view displays only 'New' and 'Upload'. In mobile, list view shows only 'New', and kanban shows 'Scan' and 'New'.

Expected behavior:
'Create Report' button should be displayed in both list and kanban view, in mobile or desktop. In mobile list view, 'Scan' should also be displayed.

Cause of the issue:
The static view for list includes only button 'Scan' with display utility classes that hide the button in mobile. Similarly for 'Create Report' button in list. In Kanban, the button 'Create Report' has not been added.

Fix:
In the list view, 'Upload' button was added for desktop view, and the classes of the 'Scan' button were changed to display it in mobile view. The display utility classes for 'Create Report' were removed, so the button is displayed in mobile.

In kanban view, button 'Create Report' was added. The main div of web.KanbanView.Buttons is replaced to ensure that the mobile view buttons are also displayed correctly. Without replacing it, the buttons 'New' and 'Scan' do not match the height of 'Create Report'.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
