### PR TITLE
[FIX] sale: set tax on fixed amount discount

### DIFF
--- a/addons/sale/wizard/sale_order_discount.py
+++ b/addons/sale/wizard/sale_order_discount.py
@@ -84,7 +84,7 @@ class SaleOrderDiscount(models.TransientModel):
                 self._prepare_discount_line_values(
                     product=discount_product,
                     amount=self.discount_amount,
-                    taxes=self.env['account.tax'],
+                    taxes=discount_product.taxes_id,
                 )
             ]
         else: # so_discount


### PR DESCRIPTION
Steps to reproduce:
- Apply fixed amount discount on sales order.
- Go to the discount product which got created and set tax for it. 
- Again apply fixed amount discount on sales order.

Issue:
If tax is set for fixed amount discount product, tax is not applied when discount is applied on sales order.

Cause:
User have to manually set the tax even if he has set tax for fixed amount discount.

Fix:
Consider the tax from discount product if there is any.

opw-3935350

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
