### PR TITLE
[FW][FIX] account: Traceback while creating group payment

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -1018,12 +1018,14 @@ class AccountPayment(models.Model):
 
     def action_post(self):
         ''' draft -> posted '''
-        # Do not allow to post if the account is required but not trusted
+        # Do not allow posting if the account is required but not trusted
         for payment in self:
             if payment.require_partner_bank_account and not payment.partner_bank_id.allow_out_payment:
                 raise UserError(_(
-                    "To record payments with %(method_name)s, the recipient bank account must be manually validated. You should go on the partner bank account in order to validate it.",
+                    "To record payments with %(method_name)s, the recipient bank account must be manually validated. "
+                    "You should go on the partner bank account of %(partner)s in order to validate it.",
                     method_name=self.payment_method_line_id.name,
+                    partner=payment.partner_id.display_name,
                 ))
 
         self.move_id._post(soft=False)


### PR DESCRIPTION
When a user selects many account moves and adds a group payment, there is a traceback when confirming the payment if the method requires valid bank accounts (singleton expected). They need to know which partner bank is not validated not the name of the payment method they already selected.

Here is the original complain:
Dans la V15, si il y avait un client avec un problème de compte, ça bloquait et Odoo nous indiquait un message avec le nom du client qui était problématique, cela nous permettait de régler le problème échéant puis relancer la demande.

closes: #168938

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

Forward-Port-Of: odoo/odoo#169187