### PR TITLE
[IMP] various: make page unaccesible when hidden through editor

### DIFF
--- a/addons/account/controllers/portal.py
+++ b/addons/account/controllers/portal.py
@@ -80,6 +80,8 @@ class PortalAccount(CustomerPortal):
 
     @http.route(['/my/invoices', '/my/invoices/page/<int:page>'], type='http', auth="user", website=True)
     def portal_my_invoices(self, page=1, date_begin=None, date_end=None, sortby=None, filterby=None, **kw):
+        if not self._check_page_visibility("account.portal_my_home_invoice"):
+            return request.not_found()
         values = self._prepare_my_invoices_values(page, date_begin, date_end, sortby, filterby)
 
         # pager

--- a/addons/hr_timesheet/controllers/portal.py
+++ b/addons/hr_timesheet/controllers/portal.py
@@ -69,6 +69,8 @@ class TimesheetCustomerPortal(CustomerPortal):
 
     @http.route(['/my/timesheets', '/my/timesheets/page/<int:page>'], type='http', auth="user", website=True)
     def portal_my_timesheets(self, page=1, sortby=None, filterby=None, search=None, search_in='all', groupby='none', **kw):
+        if not self._check_page_visibility("hr_timesheet.portal_my_home_timesheet"):
+            return request.not_found()
         Timesheet = request.env['account.analytic.line']
         domain = Timesheet._timesheet_get_portal_domain()
         Timesheet_sudo = Timesheet.sudo()

--- a/addons/mrp_subcontracting/controllers/portal.py
+++ b/addons/mrp_subcontracting/controllers/portal.py
@@ -22,6 +22,8 @@ class CustomerPortal(portal.CustomerPortal):
 
     @http.route(['/my/productions', '/my/productions/page/<int:page>'], type='http', auth="user", website=True)
     def portal_my_productions(self, page=1, date_begin=None, date_end=None, sortby='date', filterby='all'):
+        if not self._check_page_visibility("mrp_subcontracting.portal_my_home_productions"):
+            return request.not_found()
         commercial_partner = request.env.user.partner_id.commercial_partner_id
         StockPicking = request.env['stock.picking']
         domain = [('partner_id.commercial_partner_id', '=', commercial_partner.id), ('move_ids.is_subcontract', '=', True)]

--- a/addons/payment/controllers/portal.py
+++ b/addons/payment/controllers/portal.py
@@ -198,6 +198,8 @@ class PaymentPortal(portal.CustomerPortal):
         :return: The rendered manage form
         :rtype: str
         """
+        if not self._check_page_visibility("payment.portal_my_home_payment"):
+            return request.not_found()
         partner_sudo = request.env.user.partner_id  # env.user is always sudoed
 
         availability_report = {}

--- a/addons/portal/controllers/portal.py
+++ b/addons/portal/controllers/portal.py
@@ -8,6 +8,7 @@ from werkzeug import urls
 from odoo import http, tools, _, SUPERUSER_ID
 from odoo.exceptions import AccessDenied, AccessError, MissingError, UserError, ValidationError
 from odoo.http import content_disposition, Controller, request, route
+from odoo.osv.expression import AND
 from odoo.tools import consteq
 
 # --------------------------------------------------
@@ -131,6 +132,15 @@ def _build_url_w_params(url_string, query_params, remove_duplicates=True):
 class CustomerPortal(Controller):
 
     _items_per_page = 80
+
+    def _check_page_visibility(self, key):
+        if hasattr(request, 'website'):
+            domain = AND([[("key", "=", key)], request.website.website_domain(request.website.id)])
+            record = request.env['ir.ui.view'].with_context(active_test=False).sudo().search(domain)
+            record_with_website = record.filtered(lambda x: x.website_id)
+            record_without_website = record - record_with_website
+            return record_with_website.active if record_with_website else record_without_website.active
+        return True
 
     def _prepare_portal_layout_values(self):
         """Values for /my/* templates rendering.

--- a/addons/project/controllers/portal.py
+++ b/addons/project/controllers/portal.py
@@ -68,6 +68,8 @@ class ProjectCustomerPortal(CustomerPortal):
 
     @http.route(['/my/projects', '/my/projects/page/<int:page>'], type='http', auth="user", website=True)
     def portal_my_projects(self, page=1, date_begin=None, date_end=None, sortby=None, **kw):
+        if not self._check_page_visibility("project.portal_my_home"):
+            return request.not_found()
         values = self._prepare_portal_layout_values()
         Project = request.env['project.project']
         domain = self._prepare_project_domain()
@@ -511,6 +513,8 @@ class ProjectCustomerPortal(CustomerPortal):
 
     @http.route(['/my/tasks', '/my/tasks/page/<int:page>'], type='http', auth="user", website=True)
     def portal_my_tasks(self, page=1, date_begin=None, date_end=None, sortby=None, filterby=None, search=None, search_in='content', groupby=None, **kw):
+        if not self._check_page_visibility("project.portal_my_home"):
+            return request.not_found()
         searchbar_filters = self._get_my_tasks_searchbar_filters()
 
         if not filterby:

--- a/addons/purchase/controllers/portal.py
+++ b/addons/purchase/controllers/portal.py
@@ -111,6 +111,8 @@ class CustomerPortal(portal.CustomerPortal):
 
     @http.route(['/my/rfq', '/my/rfq/page/<int:page>'], type='http', auth="user", website=True)
     def portal_my_requests_for_quotation(self, page=1, date_begin=None, date_end=None, sortby=None, filterby=None, **kw):
+        if not self._check_page_visibility("purchase.portal_my_home_purchase"):
+            return request.not_found()
         return self._render_portal(
             "purchase.portal_my_purchase_rfqs",
             page, date_begin, date_end, sortby, filterby,
@@ -125,6 +127,8 @@ class CustomerPortal(portal.CustomerPortal):
 
     @http.route(['/my/purchase', '/my/purchase/page/<int:page>'], type='http', auth="user", website=True)
     def portal_my_purchase_orders(self, page=1, date_begin=None, date_end=None, sortby=None, filterby=None, **kw):
+        if not self._check_page_visibility("purchase.portal_my_home_purchase"):
+            return request.not_found()
         return self._render_portal(
             "purchase.portal_my_purchase_orders",
             page, date_begin, date_end, sortby, filterby,

--- a/addons/sale/controllers/portal.py
+++ b/addons/sale/controllers/portal.py
@@ -103,12 +103,16 @@ class CustomerPortal(payment_portal.PaymentPortal):
 
     @http.route(['/my/quotes', '/my/quotes/page/<int:page>'], type='http', auth="user", website=True)
     def portal_my_quotes(self, **kwargs):
+        if not self._check_page_visibility("sale.portal_my_home_sale"):
+            return request.not_found()
         values = self._prepare_sale_portal_rendering_values(quotation_page=True, **kwargs)
         request.session['my_quotations_history'] = values['quotations'].ids[:100]
         return request.render("sale.portal_my_quotations", values)
 
     @http.route(['/my/orders', '/my/orders/page/<int:page>'], type='http', auth="user", website=True)
     def portal_my_orders(self, **kwargs):
+        if not self._check_page_visibility("sale.portal_my_home_sale"):
+            return request.not_found()
         values = self._prepare_sale_portal_rendering_values(quotation_page=False, **kwargs)
         request.session['my_orders_history'] = values['orders'].ids[:100]
         return request.render("sale.portal_my_orders", values)


### PR DESCRIPTION
Earlier when we made a certain page hidden through the web_editor options we could still access them by providing the URL manually.

This PR addresses the issue and now when a certain page is hidden it will not be accessible.

Task-3974268
