### PR TITLE
[PERF] stock: fix SQL view skewed statistics

### DIFF
--- a/addons/stock/report/report_stock_quantity.py
+++ b/addons/stock/report/report_stock_quantity.py
@@ -47,18 +47,21 @@ class ReportStockQuantity(models.Model):
         query = """
 CREATE or REPLACE VIEW report_stock_quantity AS (
 WITH
+    warehouse_cte AS(
+        SELECT sl.id as sl_id, w.id as w_id
+        FROM stock_location sl
+        LEFT JOIN stock_warehouse w ON sl.parent_path::text like concat('%%/', w.view_location_id, '/%%')
+    ),
     existing_sm (id, product_id, tmpl_id, product_qty, date, state, company_id, whs_id, whd_id) AS (
-        SELECT m.id, m.product_id, pt.id, m.product_qty, m.date, m.state, m.company_id, whs.id, whd.id
+        SELECT m.id, m.product_id, pt.id, m.product_qty, m.date, m.state, m.company_id, source.w_id, dest.w_id
         FROM stock_move m
-        LEFT JOIN stock_location ls on (ls.id=m.location_id)
-        LEFT JOIN stock_location ld on (ld.id=m.location_dest_id)
-        LEFT JOIN stock_warehouse whs ON ls.parent_path like concat('%%/', whs.view_location_id, '/%%')
-        LEFT JOIN stock_warehouse whd ON ld.parent_path like concat('%%/', whd.view_location_id, '/%%')
+        LEFT JOIN warehouse_cte source ON source.sl_id = m.location_id
+        LEFT JOIN warehouse_cte dest ON dest.sl_id = m.location_dest_id
         LEFT JOIN product_product pp on pp.id=m.product_id
         LEFT JOIN product_template pt on pt.id=pp.product_tmpl_id
         WHERE pt.type = 'product' AND
-            (whs.id IS NOT NULL OR whd.id IS NOT NULL) AND
-            (whs.id IS NULL OR whd.id IS NULL OR whs.id != whd.id) AND
+            (source.w_id IS NOT NULL OR dest.w_id IS NOT NULL) AND
+            (source.w_id IS NULL OR dest.w_id IS NULL OR source.w_id <> dest.w_id) AND
             m.product_qty != 0 AND
             m.state NOT IN ('draft', 'cancel') AND
             (m.state IN ('draft', 'waiting', 'confirmed', 'partially_available', 'assigned') or m.date >= ((now() at time zone 'utc')::date - interval '%(report_period)s month'))


### PR DESCRIPTION
There is currently an issue with the `report_stock_quantity` SQL view. When there is only 1 `stock_warehouse` in a given database and `pg_stats` for `stock_warehouse` is up-to-date, the query plan for scanning the `all_sm` cte (the `existing_sm` cte is always inlined) becomes extremely bad. That's because postgres somehow expects only 1 row returned by the `all_sm` cte whereas in real databases it can be closer to 500 000. This makes postgres plan a Nested Loop Join that has very bad performances in large databases.

Another weird side-effect of this is the production vs staging (duplicate) on Odoo.sh. Because stagings and duplicates don't necessarily have up-to-date statistics, you can have the same query being very slow on the production database and very fast on a staging. That's because in the absence of statistics for the stock_warehouse table, postgres does not make any particular assumption on the number of rows returned by the `all_sm` cte and therefore produces a more efficient plan.

This commit tries to change that by introducing a new small CTE that simply does a LEFT JOIN between `stock_location` and `stock_warehouse`. Because this CTE is referenced twice in the `existing_sm` CTE, it will be materialized by postgres, i.e. evaluated first before being saved in memory for further usage. Thanks to that, postgres knows the expected number of rows of the CTE and can better plan the outer query's execution.

#### speedup

Customer database with 17 000 products, 700 000 stock.moves, 97 locations and 1 stock_warehouse. Doing a simple GROUP BY query on `report_stock_quantity`: 5min -> 1s

##### dalibo

To understand the dalibo, currently there is a workaround for this issue. If we add (and archive) a new `stock_warehouse` and then analyze the table, postgres plans an efficient plan. My guess here is that with only 1 record postgres skews the plan, probably because it tries to shortcut parts of the query execution. When there are 2 or more warehouses it cannot do that anymore and simply relies on correct statistics to plan the execution. Another possibility would be that statistics for tables with 
only 1 row are badly used by postgres. In any case, the point of the new CTE is to match the 2 or more warehouses case when
postgres plans the scanning of the `all_sm` CTE.

- [1 warehouse, base case](https://explain.dalibo.com/plan/a8fagdgd2d20ae48)
- [2 warehouses, base case](https://explain.dalibo.com/plan/2d38fb9ef6df495g)
- [1 warehouse, new CTE case](https://explain.dalibo.com/plan/92e41053c9g0ce8d)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
