### PR TITLE
[FIX] point_of_sale: load product_id for line with undefined product

### DIFF
--- a/addons/point_of_sale/static/src/app/models/data_service.js
+++ b/addons/point_of_sale/static/src/app/models/data_service.js
@@ -142,7 +142,8 @@ export class PosData extends Reactive {
             }
         }
 
-        const results = this.models.loadData(data, [], true);
+        const dataAndMissing = await this.missingRecursive(data);
+        const results = this.models.loadData(dataAndMissing);
         for (const [model, data] of Object.entries(results)) {
             for (const record of data) {
                 if (record.raw.JSONuiState) {


### PR DESCRIPTION
When a line has a product_id but no product, the product_id is not loaded in the line. This is a problem when the product came from a sale order and the product do not match requirement to be loaded at the initialization of the pos.

This commit fix this issue by loading the product_id in the line when the product is not loaded.

taskId: 3981111

