### PR TITLE
[FIX] l10n_sa_edi: prevent error while generate invoice for pos order

### DIFF
--- a/addons/l10n_sa_edi/models/account_move.py
+++ b/addons/l10n_sa_edi/models/account_move.py
@@ -87,7 +87,7 @@ class AccountMove(models.Model):
         def xpath_ns(expr):
             return root.xpath(expr, namespaces=edi_format._l10n_sa_get_namespaces())[0].text.strip()
 
-        qr_code_str = ''
+        qr_code_str = b''
         root = etree.fromstring(unsigned_xml)
         edi_format = self.env['account.edi.xml.ubl_21.zatca']
 
@@ -98,7 +98,7 @@ class AccountMove(models.Model):
         invoice_time = xpath_ns('//cbc:IssueTime')
         invoice_datetime = datetime.strptime(invoice_date + ' ' + invoice_time, '%Y-%m-%d %H:%M:%S')
 
-        if invoice_datetime and journal_id.company_id.vat and x509_cert:
+        if invoice_datetime and journal_id.company_id.vat and x509_cert and signature:
             prehash_content = etree.tostring(root)
             invoice_hash = edi_format._l10n_sa_generate_invoice_xml_hash(prehash_content, 'digest')
 


### PR DESCRIPTION
When a user tries to validate an invoice of the POS order a traceback will occur.

Steps to produce:

- Install 'l10n_sa_edi', 'point_of_sale', and 'contacts' modules.
- Switch to a 'SA Company' company.
- Open 'Point of Sale' and create and open New Session.
- Select any products (with customer taxes )> payment > Select payment method > Invoice > Select individual customer > Validate error will generated in the backend.

```AttributeError: 'bool' object has no attribute 'encode'```

This is because 'signature' is 'False' at [1] while generating an invoice for an order and a system tries to encode it.

link [1]: https://github.com/odoo/odoo/blob/149a2acea96cff14990b667ee611c3afbdc146f2/addons/l10n_sa_edi/models/account_move.py#L115

This commit solves the above issue by adding a condition if 'signature' is 'False'  then encodes a blank string.

sentry-5482247880

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
