### PR TITLE
[FIX] web, website: use the right CodeEditor mode for js files

### DIFF
--- a/addons/web/static/src/core/code_editor/code_editor.js
+++ b/addons/web/static/src/core/code_editor/code_editor.js
@@ -1,5 +1,5 @@
 /** @odoo-module */
-import { Component, onWillDestroy, onWillStart, useEffect, useRef } from "@odoo/owl";
+import { Component, onWillDestroy, onWillStart, useEffect, useRef, useState } from "@odoo/owl";
 import { loadBundle } from "@web/core/assets";
 import { useDebounced } from "@web/core/utils/timing";
 
@@ -58,6 +58,9 @@ export class CodeEditor extends Component {
 
     setup() {
         this.editorRef = useRef("editorRef");
+        this.state = useState({
+            activeMode: undefined,
+        });
 
         onWillStart(async () => await loadBundle("web.ace_lib"));
 
@@ -84,6 +87,10 @@ export class CodeEditor extends Component {
                     useWorker: false,
                 });
                 this.aceEditor.$blockScrolling = true;
+
+                this.aceEditor.on("changeMode", () => {
+                    this.state.activeMode = this.aceEditor.getSession().$modeId.split("/").at(-1);
+                });
 
                 const session = aceEditor.getSession();
                 if (!sessions[this.props.sessionId]) {

--- a/addons/web/static/src/core/code_editor/code_editor.xml
+++ b/addons/web/static/src/core/code_editor/code_editor.xml
@@ -2,7 +2,7 @@
 <templates>
 
     <t t-name="web.CodeEditor">
-        <div t-ref="editorRef" class="w-100" t-att-class="props.class" />
+        <div t-ref="editorRef" class="w-100" t-att-class="props.class" t-att-data-mode="state.activeMode"/>
     </t>
 
 </templates>

--- a/addons/website/static/src/components/resource_editor/resource_editor.js
+++ b/addons/website/static/src/components/resource_editor/resource_editor.js
@@ -60,6 +60,12 @@ export class ResourceEditor extends Component {
             scss: "SCSS (CSS)",
             js: "JS",
         };
+        this.typeToCodeEditorModeMap = {
+            xml: "qweb",
+            scss: "scss",
+            js: "javascript",
+        };
+
         this.xmlFilters = {
             views: _t("Only Views"),
             all: _t("Views and Assets bundles"),

--- a/addons/website/static/src/components/resource_editor/resource_editor.xml
+++ b/addons/website/static/src/components/resource_editor/resource_editor.xml
@@ -64,7 +64,7 @@
                     class="'h-100'"
                     value="state.currentResource.arch"
                     sessionId="state.currentResource.id"
-                    mode="state.type === 'xml' ? 'qweb' : state.type"
+                    mode="typeToCodeEditorModeMap[state.type]"
                     theme="'monokai'"
                     onChange.bind="onEditorChange"/>
             </div>

--- a/addons/website/static/tests/tours/html_editor.js
+++ b/addons/website/static/tests/tours/html_editor.js
@@ -215,3 +215,58 @@ wTourUtils.registerWebsitePreviewTour('test_html_editor_scss_2', {
         },
     ]
 );
+
+wTourUtils.registerWebsitePreviewTour(
+    "website_code_editor_usable",
+    {
+        // TODO: enable debug mode when failing tests have been fixed (props validation)
+        url: "/",
+        test: true,
+    },
+    () => [
+        {
+            content: "Open Site menu",
+            trigger: 'button[data-menu-xmlid="website.menu_site"]',
+        },
+        {
+            content: "Open HTML / CSS Editor",
+            trigger: 'a[data-menu-xmlid="website.menu_ace_editor"]',
+        },
+        {
+            content: "Bypass warning",
+            trigger: ".o_resource_editor_wrapper div:nth-child(2) button:nth-child(3)",
+        },
+        // Test all 3 file type options
+        ...[{
+            menuItemIndex: 1,
+            editorMode: 'qweb',
+        }, {
+            menuItemIndex: 2,
+            editorMode: 'scss',
+        }, {
+            menuItemIndex: 3,
+            editorMode: 'javascript',
+        }]
+            .map(({ menuItemIndex, editorMode }) => [
+                {
+                    content: "Open file type dropdown",
+                    trigger: ".o_resource_editor_type_switcher .dropdown-toggle",
+                },
+                {
+                    content: `Select type ${menuItemIndex}`,
+                    trigger: `.o_resource_editor_type_switcher .dropdown-item:nth-child(${menuItemIndex})`,
+                },
+                {
+                    content: "Wait for editor mode to change",
+                    trigger: `.ace_editor[data-mode="${editorMode}"]`,
+                    isCheck: true,
+                },
+                {
+                    content: "Make sure text is being highlighted",
+                    trigger: ".ace_content .ace_text-layer .ace_line:first-child span",
+                    isCheck: true,
+                },
+            ])
+            .flat(),
+    ]
+);

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -138,6 +138,11 @@ class TestUiHtmlEditor(HttpCaseWithUserDemo):
 
         self.start_tour("/", 'website_media_dialog_undraw', login='admin')
 
+    def test_code_editor_usable(self):
+        # TODO: enable debug mode when failing tests have been fixed (props validation)
+        url = '/web#action=website.website_preview'
+        self.start_tour(url, 'website_code_editor_usable', login='admin')
+
 
 @odoo.tests.tagged('external', '-standard', '-at_install', 'post_install')
 class TestUiHtmlEditorWithExternal(HttpCaseWithUserDemo):


### PR DESCRIPTION
Trying to edit custom javascript:
- Outside of developer mode, doesn't highlight the code
- In developer mode, fails with a props validation error

Steps to reproduce:
- Stay in normal mode / Switch to developer mode
- Go to Website > Homepage
- Click on the "Site" menu
- Click on "HTML / CSS Editor"
- Click on "Edit HTML anyway"
- In the file type dropdown (top left of the code editor right panel),
  select "JS"

Old behavior: Code is not highlighted / CodeEditor props validation
error (invalid mode)
New behavior: Code is properly highlighted, no error

This issue is happening since commit [1] because the ace CodeEditor
mode "js" was renamed to "javascript".

This commit fixes this by mapping the `ResourceEditor` type `js` to the
`CodeEditor` mode `javascript`.

This commit adds a class to the CodeEditor component usable by tests to
detect when the ace editor has changed mode.

[1]: 3e6a6d34702b2145ff998abcdf0a60ff9fbcd873

opw-3963421