### PR TITLE
[FIX] sale: impossible to search tags

### DIFF
--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -701,6 +701,7 @@
                     will not be searched as often, and if they need to be searched it's usually in the context of products
                     and then they can be searched from the page listing the sale order lines related to a product (from the product itself).
                 -->
+                <field name="tag_ids"/>
                 <filter string="My Orders" domain="[('user_id', '=', uid)]" name="my_sale_orders_filter"/>
                 <filter invisible="1" string="Late Activities" name="activities_overdue"
                     domain="[('my_activity_date_deadline', '&lt;', context_today().strftime('%Y-%m-%d'))]"


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Before this commit, it is not possible to search sale order by tags. But the field is show in view list and view form.

@tde-banana-odoo 

![image](https://github.com/odoo/odoo/assets/16716992/c7ce8fd4-7e36-4329-ad46-ca4a4f4f3482)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
