### PR TITLE
[FIX] mrp: delete blocked_by_operation when changing bom in OP

### DIFF
--- a/addons/mrp/models/mrp_routing.py
+++ b/addons/mrp/models/mrp_routing.py
@@ -160,4 +160,5 @@ class MrpRoutingWorkcenter(models.Model):
             for op in self:
                 op.bom_id.bom_line_ids.filtered(lambda line: line.operation_id == op).operation_id = False
                 op.bom_id.byproduct_ids.filtered(lambda byproduct: byproduct.operation_id == op).operation_id = False
+                op.bom_id.operation_ids.filtered(lambda operation: operation.blocked_by_operation_ids == op).blocked_by_operation_ids = False
         return super().write(values)

--- a/addons/mrp/tests/test_bom.py
+++ b/addons/mrp/tests/test_bom.py
@@ -1637,15 +1637,24 @@ class TestBoM(TestMrpCommon):
                     'product_id': byproduct.id, 'product_uom_id': byproduct.uom_id.id, 'product_qty': 1.0,
                 })]
         })
-        operation = self.env['mrp.routing.workcenter'].create({
-            'name': 'Operation',
-            'workcenter_id': self.env.ref('mrp.mrp_workcenter_1').id,
-            'bom_id': bom.id,
-        })
-        bom.bom_line_ids.operation_id = operation
-        bom.byproduct_ids.operation_id = operation
-        self.assertEqual(operation.bom_id, bom)
-        operation.bom_id = self.bom_1
-        self.assertEqual(operation.bom_id, self.bom_1)
+        operation_1, operation_2 = self.env['mrp.routing.workcenter'].create([
+            {
+                'name': 'Operation 1',
+                'workcenter_id': self.env.ref('mrp.mrp_workcenter_1').id,
+                'bom_id': bom.id,
+            },
+            {
+                'name': 'Operation 2',
+                'workcenter_id': self.env.ref('mrp.mrp_workcenter_1').id,
+                'bom_id': bom.id,
+            }
+        ])
+        bom.bom_line_ids.operation_id = operation_1
+        bom.byproduct_ids.operation_id = operation_1
+        operation_2.blocked_by_operation_ids = operation_1
+        self.assertEqual(operation_1.bom_id, bom)
+        operation_1.bom_id = self.bom_1
+        self.assertEqual(operation_1.bom_id, self.bom_1)
         self.assertFalse(bom.bom_line_ids.operation_id)
         self.assertFalse(bom.byproduct_ids.operation_id)
+        self.assertFalse(operation_2.blocked_by_operation_ids)


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a storable product “P1” with BoM - Operation: OP1, OP2 - OP2 blocked by OP1

- Navigate to Mrp > Configuration > Operations
- Select OP1 and select another BoM
- Return to the BoM of “P1”

Problem:
The OP2 is still linked to OP1, And a traceback when attempting to duplicate the BoM.

Solution:
Remove the link between OP2 and OP1

opw-3948817
