### PR TITLE
[IMP] web: hide count on folded kanban stages

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_header.xml
+++ b/addons/web/static/src/views/kanban/kanban_header.xml
@@ -7,7 +7,7 @@
                 <div t-if="group.isFolded" class="o_column_title d-flex align-items-center pt-1 fs-4 lh-1 text-nowrap opacity-50 opacity-100-hover flex-grow-1"
                      t-on-mouseenter="onTitleMouseEnter" t-on-mouseleave="onTitleMouseLeave">
                     <t t-esc="groupName"></t>
-                    <span class="badge text-bg-500 rounded-pill lh-1 ms-2" t-esc="group.count"></span>
+                    <span t-if="group.count > 0 and !props.list.model.useSampleModel" class="badge text-bg-500 rounded-pill lh-1 ms-2" t-esc="group.count"></span>
                 </div>
                 <span t-if="!group.isFolded"
                     t-esc="groupName"

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -6304,6 +6304,51 @@ test("quick create column with x_name as _rec_name", async () => {
     expect(".o_kanban_group").toHaveCount(3, { message: "should now have three columns" });
 });
 
+test.tags("desktop")("count of folded groups in empty kanban with sample data", async () => {
+    onRpc("web_read_group", () => {
+        return {
+            groups: [
+                {
+                    product_id: [1, "New"],
+                    product_id_count: 0,
+                    __domain: [],
+                },
+                {
+                    product_id: [2, "In Progress"],
+                    product_id_count: 0,
+                    __domain: [],
+                    __fold: true,
+                },
+            ],
+            length: 2,
+        };
+    });
+
+    await mountView({
+        resModel: "partner",
+        type: "kanban",
+        arch: `
+            <kanban sample="1">
+                <field name="product_id"/>
+                <templates>
+                    <div t-name="kanban-box">
+                        <field name="foo"/>
+                    </div>
+                </templates>
+            </kanban>`,
+        groupBy: ["product_id"],
+        domain: [["id", "<", 0]],
+    });
+
+    expect(queryFirst(".o_content")).toHaveClass("o_view_sample_data");
+    expect(".o_kanban_group").toHaveCount(2);
+    expect(queryAll(".o_kanban_record").length > 0).toBe(true, {
+        message: "should contain sample records",
+    });
+    expect(getKanbanColumn(1)).toHaveClass("o_column_folded");
+    expect(queryAllTexts(".o_kanban_group")).toEqual(["New", "In Progress"]);
+});
+
 test.tags("desktop")("quick create column and examples: with folded columns", async () => {
     registry.category("kanban_examples").add("test", {
         allowedGroupBys: ["product_id"],
@@ -6362,7 +6407,7 @@ test.tags("desktop")("quick create column and examples: with folded columns", as
     expect(".o_kanban_group").toHaveCount(2);
     expect(".o_kanban_group:not(.o_column_folded)").toHaveCount(1);
     expect(".o_kanban_group.o_column_folded").toHaveCount(1);
-    expect(queryAllTexts(".o_kanban_group")).toEqual(["not folded", "folded\n0"]);
+    expect(queryAllTexts(".o_kanban_group")).toEqual(["not folded", "folded"]);
 });
 
 test.tags("desktop")("quick create column's apply button's display text", async () => {


### PR DESCRIPTION
**Current behavior before PR:**

The count is always displayed in folded `kanban` sample stages, even if its value is zero.

**Desired behavior after PR is merged:**

When the search is invalid and no records are found, the count is hidden in folded `kanban` stages.

task-3940527