### PR TITLE
[FIX] account_peppol: edit the warning on the partner

### DIFF
--- a/addons/account_peppol/i18n/account_peppol.pot
+++ b/addons/account_peppol/i18n/account_peppol.pot
@@ -773,6 +773,13 @@ msgstr ""
 #. module: account_peppol
 #: model_terms:ir.ui.view,arch_db:account_peppol.res_partner_form_account_peppol
 msgid ""
+"To generate complete electronic invoices, also set a country for this "
+"partner."
+msgstr ""
+
+#. module: account_peppol
+#: model_terms:ir.ui.view,arch_db:account_peppol.res_partner_form_account_peppol
+msgid ""
 "To generate electronic invoices, also set a country and a bank account for "
 "this partner."
 msgstr ""

--- a/addons/account_peppol/views/res_partner_views.xml
+++ b/addons/account_peppol/views/res_partner_views.xml
@@ -18,8 +18,8 @@
                     <div class="alert alert-warning"
                          colspan="2"
                          role="alert"
-                         invisible="not account_peppol_is_endpoint_valid or (bank_account_count != 0 and country_code)">
-                         To generate electronic invoices, also set a country and a bank account for this partner.
+                         invisible="not account_peppol_is_endpoint_valid or country_code">
+                         To generate complete electronic invoices, also set a country for this partner.
                     </div>
                 </xpath>
                 <xpath expr="//field[@name='peppol_endpoint']" position="after">


### PR DESCRIPTION
There was some miscommunication about the warning message in https://github.com/odoo/odoo/commit/2384a059e25f66117326d9bfde1e40b2dd493962 The warning on the partner should not check the bank account. What needs to be checked is the Recipient bank on the invoice, the warning should be visible in send & print. It is ok to add it in later versions where it is easier to add more warnings.

Part of:
task-3989435




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
