### PR TITLE
python3-lxml-html-clean is not available in the Debian repositories

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -35,7 +35,7 @@ Depends:
  python3-jinja2,
  python3-libsass,
 # After lxml 5.2, lxml-html-clean is in a separate package
- python3-lxml-html-clean | python3-lxml,
+ python3-lxml,
  python3-num2words,
  python3-ofxparse,
  python3-passlib,


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
