### PR TITLE
[FIX] website: apply ACL on pages search results

### DIFF
--- a/addons/website/models/website_page.py
+++ b/addons/website/models/website_page.py
@@ -7,6 +7,7 @@ import re
 from odoo.addons.http_routing.models.ir_http import slugify
 from odoo.addons.website.tools import text_from_html
 from odoo import api, fields, models
+from odoo.exceptions import AccessError
 from odoo.osv import expression
 from odoo.tools import escape_psql
 from odoo.tools.safe_eval import safe_eval
@@ -259,7 +260,10 @@ class Page(models.Model):
         domain = [website.website_domain()]
         if not self.env.user.has_group('website.group_website_designer'):
             # Rule must be reinforced because of sudo.
-            domain.append([('website_published', '=', True)])
+            domain.append([
+                ('website_published', '=', True),
+                ('website_indexed', '=', True),
+            ])
 
         search_fields = ['name', 'url']
         fetch_fields = ['id', 'name', 'url']
@@ -340,13 +344,21 @@ class Page(models.Model):
                 )
 
         def filter_page(search, page, all_pages):
-            # Search might have matched words in the xml tags and parameters therefore we make
-            # sure the terms actually appear inside the text.
-            text = '%s %s %s' % (page.name, page.url, text_from_html(page.arch))
-            pattern = '|'.join([re.escape(search_term) for search_term in search.split()])
-            return re.findall('(%s)' % pattern, text, flags=re.I) if pattern else False
-        if search and with_description:
-            results = results.filtered(lambda result: filter_page(search, result, results))
+            # Exclude pages that do not pass ACL.
+            try:
+                plain_page = page.sudo(False)
+                plain_page.check_access_rule('read')
+                plain_page.view_id.check_access_rule('read')
+            except AccessError:
+                return False
+            if search and with_description:
+                # Search might have matched words in the xml tags and parameters therefore we make
+                # sure the terms actually appear inside the text.
+                text = '%s %s %s' % (page.name, page.url, text_from_html(page.arch))
+                pattern = '|'.join([re.escape(search_term) for search_term in search.split()])
+                return re.findall('(%s)' % pattern, text, flags=re.I) if pattern else False
+            return True
+        results = results.filtered(lambda result: filter_page(search, result, results))
         return results[:limit], len(results)
 
 


### PR DESCRIPTION
Searching for pages on a website requires sudo. Because of this the ACL is not applied on the delivered results - making pages with restricted visibility returned in the results.

This commit fixes this by checking access rules on the returned pages and related view.

Steps to reproduce:
- Drop a "Search" block
- Save
- Create a password-restricted page
- Create a signed-in restricted page
- As a visitor, use the search facility

=> The restricted pages did show up in the results.

opw-3964793
