### PR TITLE
[FIX] spreadsheet: falsy date filter traceback

### DIFF
--- a/addons/spreadsheet/static/src/pivot/plugins/pivot_ui_plugin.js
+++ b/addons/spreadsheet/static/src/pivot/plugins/pivot_ui_plugin.js
@@ -201,7 +201,10 @@ export class PivotUIPlugin extends spreadsheet.UIPlugin {
     getPivotIdFromPosition(position) {
         const cell = this.getters.getCorrespondingFormulaCell(position);
         if (cell && cell.isFormula) {
-            const pivotFunction = this.getters.getFirstPivotFunction(position.sheetId, cell.compiledFormula.tokens);
+            const pivotFunction = this.getters.getFirstPivotFunction(
+                position.sheetId,
+                cell.compiledFormula.tokens
+            );
             if (pivotFunction && pivotFunction.args[0]) {
                 return pivotFunction.args[0].toString();
             }
@@ -415,9 +418,16 @@ export class PivotUIPlugin extends spreadsheet.UIPlugin {
                 switch (filter.type) {
                     case "date":
                         if (filter.rangeType === "fixedPeriod" && time) {
-                            transformedValue = pivotPeriodToFilterValue(time, value);
-                            if (JSON.stringify(transformedValue) === JSON.stringify(currentValue)) {
+                            if (value === "false") {
                                 transformedValue = undefined;
+                            } else {
+                                transformedValue = pivotPeriodToFilterValue(time, value);
+                                if (
+                                    JSON.stringify(transformedValue) ===
+                                    JSON.stringify(currentValue)
+                                ) {
+                                    transformedValue = undefined;
+                                }
                             }
                         } else {
                             continue;

--- a/addons/spreadsheet/static/tests/global_filters/global_filters_model_test.js
+++ b/addons/spreadsheet/static/tests/global_filters/global_filters_model_test.js
@@ -2060,6 +2060,36 @@ QUnit.module("spreadsheet > Global filters model", {}, () => {
         }
     );
 
+    QUnit.test("getFiltersMatchingPivot works with date=false", async function (assert) {
+        const { model } = await createSpreadsheetWithPivot({
+            arch: /*xml*/ `
+                <pivot>
+                    <field name="product_id" type="row"/>
+                    <field name="probability" type="measure"/>
+                    <field name="date" interval="month" type="col"/>
+                </pivot>`,
+        });
+
+        await addGlobalFilter(
+            model,
+            {
+                id: "43",
+                type: "date",
+                label: "date filter 1",
+                rangeType: "fixedPeriod",
+                defaultValue: "this_month",
+            },
+            {
+                pivot: { 1: { chain: "date", type: "date" } },
+            }
+        );
+        const dateFilters1 = getFiltersMatchingPivot(
+            model,
+            '=ODOO.PIVOT.HEADER(1,"expected_revenue","date:month","false")'
+        );
+        assert.deepEqual(dateFilters1, [{ filterId: "43", value: undefined }]);
+    });
+
     QUnit.test(
         "getFiltersMatchingPivot return an empty array if there is no pivot formula",
         async function (assert) {


### PR DESCRIPTION
Before this fix, when grouping by a date filter that only had "false" value, the global filter matching was causing a traceback trying to split a non existant month/year value.

This commit fixes this behavior by checking for "false" in date filter and setting the matching filter to "undefied"

OPW: 3776544
OPW: 3952358





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
