### PR TITLE
[IMP] website_slides: add duplicate button for quiz question

### DIFF
--- a/addons/website_slides/__manifest__.py
+++ b/addons/website_slides/__manifest__.py
@@ -74,6 +74,8 @@ Featuring
             'website_slides/static/src/activity/**/*',
             'website_slides/static/src/slide_category_one2many_field.js',
             'website_slides/static/src/slide_category_list_renderer.js',
+            'website_slides/static/src/slide_question_one2many_field.js',
+            'website_slides/static/src/slide_question_list_renderer.js',
             'website_slides/static/src/scss/slide_views.scss',
             'website_slides/static/src/js/tours/slides_tour.js',
             'website_slides/static/src/js/components/**/*.js',

--- a/addons/website_slides/models/slide_question.py
+++ b/addons/website_slides/models/slide_question.py
@@ -58,6 +58,12 @@ class SlideQuestion(models.Model):
                 'This question must have at least one correct answer and one incorrect answer.'
             ) if not correct or correct == question.answer_ids else ''
 
+    def copy(self, default=None):
+        new_question = super().copy(default)
+        new_answers = [answer.copy({'question_id': new_question.id}).id for answer in self.answer_ids]
+        new_question.write({'answer_ids': [(6, 0, new_answers)]})
+        return new_question
+
 class SlideAnswer(models.Model):
     _name = "slide.answer"
     _rec_name = "text_value"

--- a/addons/website_slides/static/src/js/slides_course_quiz.js
+++ b/addons/website_slides/static/src/js/slides_course_quiz.js
@@ -38,6 +38,7 @@
             'click .o_wslides_js_quiz_add': '_onCreateQuizClick',
             'click .o_wslides_js_quiz_edit_question': '_onEditQuestionClick',
             'click .o_wslides_js_quiz_delete_question': '_onDeleteQuestionClick',
+            'click .o_wslides_js_quiz_copy': '_onCopyQuestionClick',
         },
 
         custom_events: {
@@ -571,6 +572,22 @@
                 },
                 confirmLabel: _t('Yes'),
             });
+        },
+
+        /**
+         * When clicking on the dulpicate button of a question it sends
+         * an RPC request to copy the Question. When a question is copied,
+         * it increase the questions count and reload the window.
+         *
+         * @param ev
+         * @private
+         */
+        _onCopyQuestionClick: async function(ev) {
+            const question = ev.currentTarget.closest('.o_wslides_js_lesson_quiz_question');
+            const questionId = parseInt(question.dataset.questionId);
+            await this.orm.call('slide.question', 'copy', [questionId]);
+            this.quiz.questionsCount++;
+            window.location.reload();
         },
 
         /**

--- a/addons/website_slides/static/src/slide_question_list_renderer.js
+++ b/addons/website_slides/static/src/slide_question_list_renderer.js
@@ -1,0 +1,18 @@
+/** @odoo-module **/
+
+import { ListRenderer } from "@web/views/list/list_renderer";
+import { useService } from "@web/core/utils/hooks";
+
+export class SlideQuestionListRenderer extends ListRenderer {
+    setup() {
+        super.setup();
+        this.orm = useService("orm");
+    }
+
+    async onDeleteRecord(record) {
+        await this.orm.unlink("slide.question", [record.resId]);
+        const res = await super.onDeleteRecord(record);
+        await this.props.list.model.root.save();
+        return res;
+    }
+}

--- a/addons/website_slides/static/src/slide_question_one2many_field.js
+++ b/addons/website_slides/static/src/slide_question_one2many_field.js
@@ -1,26 +1,23 @@
-/** @odoo-module */
+/** @odoo-module **/
 
 import { registry } from "@web/core/registry";
-import { SlideCategoryListRenderer } from "./slide_category_list_renderer";
-import { X2ManyField, x2ManyField } from "@web/views/fields/x2many/x2many_field";
+import { SlideQuestionListRenderer } from "./slide_question_list_renderer";
 import { useOpenX2ManyRecord, useX2ManyCrud } from "@web/views/fields/relational_utils";
+import { X2ManyField, x2ManyField } from "@web/views/fields/x2many/x2many_field";
 
 import { useSubEnv } from "@odoo/owl";
 
-class SlideCategoryOneToManyField extends X2ManyField {
+
+class SlideContentOneToManyField extends X2ManyField {
     static components = {
         ...X2ManyField.components,
-        ListRenderer: SlideCategoryListRenderer,
-    };
-    static defaultProps = {
-        ...X2ManyField.defaultProps,
-        editable: "bottom",
+        ListRenderer: SlideQuestionListRenderer,
     };
     setup() {
         super.setup();
         useSubEnv({ openRecord: this.openRecord.bind(this) });
 
-        // Systematically and automatically save SlideChannelForm at each content edit/creation
+        // Systematically and automatically save Slide Content at each Question edit/creation/deletion
         const { saveRecord, updateRecord } = useX2ManyCrud(() => this.list, this.isMany2Many);
 
         const openRecord = useOpenX2ManyRecord({
@@ -37,7 +34,7 @@ class SlideCategoryOneToManyField extends X2ManyField {
         this._openRecord = async ({ record: paramRecord, ...params }) => {
             const { record } = this.props;
             if (!await record.save())
-                // don't open slide form as it can't be saved
+                // don't open question form as it can't be saved
                 return;
             await openRecord({ record: paramRecord, ...params });
         };
@@ -45,8 +42,8 @@ class SlideCategoryOneToManyField extends X2ManyField {
     }
 }
 
-registry.category("fields").add("slide_category_one2many", {
+registry.category("fields").add("slide_question_one2many", {
     ...x2ManyField,
-    component: SlideCategoryOneToManyField,
+    component: SlideContentOneToManyField,
     additionalClasses: [...x2ManyField.additionalClasses || [], "o_field_one2many"],
 });

--- a/addons/website_slides/tests/test_slide_question.py
+++ b/addons/website_slides/tests/test_slide_question.py
@@ -36,3 +36,18 @@ class TestSlideQuestionManagement(slides_common.SlidesCase):
             question.answer_ids[0].is_correct = val
             question.answer_ids[1].is_correct = val
             self.assertTrue(question.answers_validation_error)
+
+    def test_copy_quiz_question(self):
+        """Verify that the copy question method correctly copies a question record and its associated answers."""
+        question = self.question_1
+        # Copy the question record
+        copied_question = question.copy()
+
+        # Check that the new question has the same attributes as the original
+        self.assertEqual(copied_question.question, question.question)
+        self.assertEqual(copied_question.slide_id.id, question.slide_id.id)
+
+        # Check that the answers have been copied correctly
+        self.assertEqual(len(copied_question.answer_ids), 2)
+        self.assertTrue(any(answer.text_value == "25' at 180°C" and answer.is_correct for answer in copied_question.answer_ids))
+        self.assertTrue(any(answer.text_value == "Raw" and not answer.is_correct for answer in copied_question.answer_ids))

--- a/addons/website_slides/views/slide_slide_views.xml
+++ b/addons/website_slides/views/slide_slide_views.xml
@@ -164,11 +164,12 @@
                                         </group>
                                     </group>
                                     <group name="questions" string="Questions">
-                                        <field name="question_ids" nolabel="1" colspan="2">
+                                        <field name="question_ids" nolabel="1" colspan="2" widget="slide_question_one2many">
                                             <tree>
                                                 <field name="sequence" widget="handle"/>
                                                 <field name="question" string="Question"/>
                                                 <field name="answer_ids" string="Answers" widget="many2many_tags"/>
+                                                <button name="copy" type="object" icon="fa-clone" title="Duplicate Question"/>
                                             </tree>
                                         </field>
                                     </group>

--- a/addons/website_slides/views/website_slides_templates_lesson.xml
+++ b/addons/website_slides/views/website_slides_templates_lesson.xml
@@ -508,6 +508,7 @@
             <div class="ms-auto o_wslides_js_quiz_edit_del" t-if="slide.channel_id.can_upload and not slide_completed" >
                 <i class="o_wslides_js_quiz_icon o_wslides_js_quiz_edit_question fa fa-pencil-square-o p-1 text-muted"></i>
                 <i class="o_wslides_js_quiz_icon o_wslides_js_quiz_delete_question fa fa-trash p-1 text-muted"></i>
+                <i class="o_wslides_js_quiz_icon o_wslides_js_quiz_copy fa fa-sm fa-clone p-1 text-muted"></i>
             </div>
         </div>
         <div class="list-group">


### PR DESCRIPTION
## Purpose:
Currently, we don't have a duplicate button for quiz questions like we do in surveys. Implementing this feature in E-learning would greatly enhance usability and improve the user interface.

## After this PR:
Added a Duplicate Button to copy the quiz question.

#### Button Location:

- Backend - Before Delete Button In quiz question list view.
- Frontend - After the Delete Button, above the quiz question.

## Technical
Due to the behavior of X2Many fields, user can't copied a newly created
quiz question without saving the SlideChannel and SlideSlide first.
The whole Slide had to be saved first, including questions needed to copy,
which wasn't a smooth experience for the user.

This PR will save the slide and question at several times:
See this commit for more info - odoo@b1d1856

Task-3989711