### PR TITLE
[FIX] hr_calendar : fix event's available partner's computation

### DIFF
--- a/addons/hr_calendar/models/calendar_event.py
+++ b/addons/hr_calendar/models/calendar_event.py
@@ -18,11 +18,11 @@ class CalendarEvent(models.Model):
         # Event without start and stop are skipped, except all day event: their interval is computed
         # based on company calendar's interval.
         for event, event_interval in event_intervals.items():
-            start = event_interval._items[0][0]
-            stop = event_interval._items[0][1]
-            if not event.partner_ids:
+            if not event_interval or not event.partner_ids:
                 event.unavailable_partner_ids = []
                 continue
+            start = event_interval._items[0][0]
+            stop = event_interval._items[0][1]
             schedule_by_partner = event.partner_ids._get_schedule(start, stop, merge=False)
             event.unavailable_partner_ids = event._check_employees_availability_for_event(
                 schedule_by_partner, event_interval)


### PR DESCRIPTION
STEP TO REPRODUCE:
==================
    1- Go on calendar application
    2- Click on new
    3- Change the event's start datetime to have the start
    datetime bigger than the stop datetime.
    4- Click on Apply
You will have a traceback.

To fix this issue, event's unavailable partners will be empty if the event's start datetime is bigger than the event's stop datatime.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
