### PR TITLE
[IMP] mail: remove notification on channel uuid

### DIFF
--- a/addons/mail/models/discuss/discuss_channel_member.py
+++ b/addons/mail/models/discuss/discuss_channel_member.py
@@ -193,7 +193,6 @@ class ChannelMember(models.Model):
             formatted_member = member._discuss_channel_member_format().get(member)
             formatted_member['isTyping'] = is_typing
             notifications.append([member.channel_id, 'discuss.channel.member/typing_status', formatted_member])
-            notifications.append([member.channel_id.uuid, 'discuss.channel.member/typing_status', formatted_member])  # notify livechat users
         self.env['bus.bus']._sendmany(notifications)
 
     @api.model


### PR DESCRIPTION
Since [1], the usage of channel uuid has been removed. Indeed, live chat users are now real channel members so there is no need for another notification mechanism.

This PR removes a notification that was missed during the conversion.

[1]: https://github.com/odoo/odoo/pull/152659