### PR TITLE
[FIX] spreadsheet: add new getter to get odoo pivot ids

### DIFF
--- a/addons/spreadsheet/static/src/pivot/plugins/pivot_odoo_core_plugin.js
+++ b/addons/spreadsheet/static/src/pivot/plugins/pivot_odoo_core_plugin.js
@@ -5,6 +5,8 @@ import { Domain } from "@web/core/domain";
 import { OdooCorePlugin } from "@spreadsheet/plugins";
 
 export class PivotOdooCorePlugin extends OdooCorePlugin {
+    static getters = ["getOdooPivotIds"];
+
     handle(cmd) {
         switch (cmd.type) {
             // this command is deprecated. use UPDATE_PIVOT instead
@@ -18,6 +20,13 @@ export class PivotOdooCorePlugin extends OdooCorePlugin {
                 });
                 break;
         }
+    }
+
+    getOdooPivotIds() {
+        return this.getters.getPivotIds().filter((id) => {
+            const pivot = this.getters.getPivotCoreDefinition(id);
+            return pivot.type === "ODOO";
+        });
     }
 
     /**


### PR DESCRIPTION
In order to fix an issue with the odoo pivot actions, we need to add a new getter to get the odoo pivot ids.

Task: 3992325

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
