### PR TITLE
[IMP] payment: enhance payment method configuration

### DIFF
--- a/addons/account_payment/models/account_payment.py
+++ b/addons/account_payment/models/account_payment.py
@@ -54,8 +54,8 @@ class AccountPayment(models.Model):
                 or tx_sudo.payment_method_id
             )
             if (
-                tx_sudo.provider_id.support_refund
-                and payment_method.support_refund
+                tx_sudo.provider_id.support_refund != 'none'
+                and payment_method.support_refund != 'none'
                 and tx_sudo.operation != 'refund'
             ):
                 # Only consider refund transactions that are confirmed by summing the amounts of

--- a/addons/account_payment/tests/test_account_payment.py
+++ b/addons/account_payment/tests/test_account_payment.py
@@ -12,7 +12,7 @@ from odoo.tests import tagged
 class TestAccountPayment(AccountPaymentCommon):
 
     def test_no_amount_available_for_refund_when_not_supported(self):
-        self.provider.support_refund = False
+        self.provider.support_refund = 'none'
         tx = self._create_transaction('redirect', state='done')
         tx._post_process()  # Create the payment
         self.assertEqual(

--- a/addons/account_payment/views/payment_provider_views.xml
+++ b/addons/account_payment/views/payment_provider_views.xml
@@ -15,6 +15,7 @@
                 <field name="journal_id"
                     context="{'default_type': 'bank'}"
                     required="state != 'disabled' and code not in ['none', 'custom']"/>
+                <field name="support_refund" groups="base.group_no_one"/>
             </group>
         </field>
     </record>

--- a/addons/account_payment/wizards/payment_refund_wizard.py
+++ b/addons/account_payment/wizards/payment_refund_wizard.py
@@ -27,8 +27,8 @@ class PaymentRefundWizard(models.TransientModel):
     )
     currency_id = fields.Many2one(string="Currency", related='transaction_id.currency_id')
     support_refund = fields.Selection(
-        string="Type of Refund Supported",
-        selection=[('full_only', "Full Only"), ('partial', "Partial")],
+        string="Refund",
+        selection=[('none', "Unsupported"), ('full_only', "Full Only"), ('partial', "Partial")],
         compute='_compute_support_refund',
     )
     has_pending_refund = fields.Boolean(
@@ -61,8 +61,8 @@ class PaymentRefundWizard(models.TransientModel):
             p_support_refund = wizard.transaction_id.provider_id.support_refund
             pm = wizard.transaction_id.payment_method_id
             pm_support_refund = (pm.primary_payment_method_id or pm).support_refund
-            if not p_support_refund or not pm_support_refund:
-                wizard.support_refund = False
+            if p_support_refund == 'none' or pm_support_refund == 'none':
+                wizard.support_refund = 'none'
             elif p_support_refund == 'full_only' or pm_support_refund == 'full_only':
                 wizard.support_refund = 'full_only'
             else:  # Both support partial refunds.

--- a/addons/payment/data/payment_method_data.xml
+++ b/addons/payment/data/payment_method_data.xml
@@ -104,7 +104,7 @@
         <field name="image" type="base64" file="payment/static/img/afterpay_riverty.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.nl'),
@@ -129,7 +129,7 @@
         <field name="image" type="base64" file="payment/static/img/akulaku.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.id'),
@@ -267,7 +267,7 @@
         <field name="image" type="base64" file="payment/static/img/axis.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.fr'),
@@ -309,7 +309,7 @@
         <field name="image" type="base64" file="payment/static/img/bancnet.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.ph'),
@@ -330,7 +330,7 @@
         <field name="image" type="base64" file="payment/static/img/bancomat_pay.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.it'),
@@ -372,7 +372,7 @@
         <field name="image" type="base64" file="payment/static/img/bank.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.th'),
@@ -393,7 +393,7 @@
         <field name="image" type="base64" file="payment/static/img/bank.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
     </record>
 
     <record id="payment_method_bank_bca" model="payment.method">
@@ -404,7 +404,7 @@
         <field name="image" type="base64" file="payment/static/img/bank_bca.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.id'),
@@ -425,7 +425,7 @@
         <field name="image" type="base64" file="payment/static/img/bank.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.th'),
@@ -446,7 +446,7 @@
         <field name="image" type="base64" file="payment/static/img/bank_permata.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.id'),
@@ -467,7 +467,7 @@
         <field name="image" type="base64" file="payment/static/img/bank.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
     </record>
 
     <record id="payment_method_bank_transfer" model="payment.method">
@@ -478,7 +478,7 @@
         <field name="image" type="base64" file="payment/static/img/bank.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_currency_ids"
                eval="[Command.set([
                          ref('base.INR'),
@@ -516,7 +516,7 @@
         <field name="image" type="base64" file="payment/static/img/belfius.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.be'),
@@ -558,7 +558,7 @@
         <field name="image" type="base64" file="payment/static/img/bharatqr.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.in'),
@@ -579,7 +579,7 @@
         <field name="image" type="base64" file="payment/static/img/billease.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
               eval="[Command.set([
                         ref('base.ph'),
@@ -600,7 +600,7 @@
         <field name="image" type="base64" file="payment/static/img/billink.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.nl'),
@@ -664,7 +664,7 @@
         <field name="image" type="base64" file="payment/static/img/bni.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.id'),
@@ -685,7 +685,7 @@
         <field name="image" type="base64" file="payment/static/img/boleto.png"/>
         <field name="support_tokenization">True</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.br'),
@@ -706,7 +706,7 @@
         <field name="image" type="base64" file="payment/static/img/boost.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.my'),
@@ -727,7 +727,7 @@
        <field name="image" type="base64" file="payment/static/img/bank.png"/>
        <field name="support_tokenization">False</field>
        <field name="support_express_checkout">False</field>
-       <field name="support_refund"></field>
+       <field name="support_refund">none</field>
        <field name="supported_country_ids"
               eval="[Command.set([
                         ref('base.ph'),
@@ -748,7 +748,7 @@
         <field name="image" type="base64" file="payment/static/img/brankas.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.id'),
@@ -769,7 +769,7 @@
         <field name="image" type="base64" file="payment/static/img/bri.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.id'),
@@ -790,7 +790,7 @@
         <field name="image" type="base64" file="payment/static/img/bsi.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.id'),
@@ -906,7 +906,7 @@
         <field name="image" type="base64" file="payment/static/img/cimb_niaga.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.id'),
@@ -927,7 +927,7 @@
         <field name="image" type="base64" file="payment/static/img/cofidis.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.be'),
@@ -969,7 +969,7 @@
         <field name="image" type="base64" file="payment/static/img/dolfin.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.th'),
@@ -1032,7 +1032,7 @@
         <field name="image" type="base64" file="payment/static/img/enets.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.sg'),
@@ -1074,7 +1074,7 @@
         <field name="image" type="base64" file="payment/static/img/floa_bank.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.fr'),
@@ -1095,7 +1095,7 @@
         <field name="image" type="base64" file="payment/static/img/card.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.hk'),
@@ -1137,7 +1137,7 @@
         <field name="image" type="base64" file="payment/static/img/frafinance.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.be'),
@@ -1246,7 +1246,7 @@
         <field name="image" type="base64" file="payment/static/img/bank.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.th'),
@@ -1267,7 +1267,7 @@
         <field name="image" type="base64" file="payment/static/img/bank.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.vn'),
@@ -1288,7 +1288,7 @@
         <field name="image" type="base64" file="payment/static/img/hoolah.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.sg'),
@@ -1315,7 +1315,7 @@
         <field name="image" type="base64" file="payment/static/img/humm.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.au'),
@@ -1363,7 +1363,7 @@
         <field name="image" type="base64" file="payment/static/img/in3.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.nl'),
@@ -1405,7 +1405,7 @@
         <field name="image" type="base64" file="payment/static/img/jkopay.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.cn'),
@@ -1447,7 +1447,7 @@
         <field name="image" type="base64" file="payment/static/img/bank.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.th'),
@@ -1635,7 +1635,7 @@
         <field name="image" type="base64" file="payment/static/img/kredivo.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.id'),
@@ -1656,7 +1656,7 @@
         <field name="image" type="base64" file="payment/static/img/bank.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.th'),
@@ -1677,7 +1677,7 @@
         <field name="image" type="base64" file="payment/static/img/linepay.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.jp'),
@@ -1702,7 +1702,7 @@
         <field name="image" type="base64" file="payment/static/img/linkaja.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.id'),
@@ -1723,7 +1723,7 @@
         <field name="image" type="base64" file="payment/static/img/lydia.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.fr'),
@@ -1745,7 +1745,7 @@
         <field name="image" type="base64" file="payment/static/img/lyfpay.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.fr'),
@@ -1766,7 +1766,7 @@
         <field name="image" type="base64" file="payment/static/img/mada.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.sa'),
@@ -1788,7 +1788,7 @@
         <field name="image" type="base64" file="payment/static/img/mandiri.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.id'),
@@ -1809,7 +1809,7 @@
         <field name="image" type="base64" file="payment/static/img/maya.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.ph'),
@@ -1830,7 +1830,7 @@
         <field name="image" type="base64" file="payment/static/img/maybank.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.id'),
@@ -1872,7 +1872,7 @@
         <field name="image" type="base64" file="payment/static/img/mtn-mobile-money.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.gh'),
@@ -1951,7 +1951,7 @@
         <field name="image" type="base64" file="payment/static/img/mpesa.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.ke'),
@@ -1972,7 +1972,7 @@
         <field name="image" type="base64" file="payment/static/img/multibanco.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.pt'),
@@ -1993,7 +1993,7 @@
         <field name="image" type="base64" file="payment/static/img/mybank.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.it'),
@@ -2014,7 +2014,7 @@
         <field name="image" type="base64" file="payment/static/img/napas_card.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="support_refund">full_only</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -2036,7 +2036,7 @@
         <field name="image" type="base64" file="payment/static/img/naver_pay.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.kr'),
@@ -2078,7 +2078,7 @@
         <field name="image" type="base64" file="payment/static/img/octopus.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.hk'),
@@ -2120,7 +2120,7 @@
         <field name="image" type="base64" file="payment/static/img/bank.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="support_refund">full_only</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -2163,7 +2163,7 @@
         <field name="image" type="base64" file="payment/static/img/bank.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.th'),
@@ -2205,7 +2205,7 @@
         <field name="image" type="base64" file="payment/static/img/ovo.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.id'),
@@ -2247,7 +2247,7 @@
         <field name="image" type="base64" file="payment/static/img/pace.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.sg'),
@@ -2278,7 +2278,7 @@
         <field name="image" type="base64" file="payment/static/img/pay_later.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="support_refund">full_only</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -2300,7 +2300,7 @@
         <field name="image" type="base64" file="payment/static/img/pay_easy.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.jp'),
@@ -2321,7 +2321,7 @@
         <field name="image" type="base64" file="payment/static/img/pay_id.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.au'),
@@ -2344,7 +2344,7 @@
         <field name="image" type="base64" file="payment/static/img/paylib.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.fr'),
@@ -2365,7 +2365,7 @@
         <field name="image" type="base64" file="payment/static/img/payme.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.hk'),
@@ -2418,7 +2418,7 @@
         <field name="image" type="base64" file="payment/static/img/paypay.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.jp'),
@@ -2439,7 +2439,7 @@
         <field name="image" type="base64" file="payment/static/img/paysafecard.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="support_refund">full_only</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -2578,7 +2578,7 @@
         <field name="image" type="base64" file="payment/static/img/payu.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.pl'),
@@ -2620,7 +2620,7 @@
         <field name="image" type="base64" file="payment/static/img/poli.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.au'),
@@ -2643,7 +2643,7 @@
         <field name="image" type="base64" file="payment/static/img/poste_pay.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.it'),
@@ -2664,7 +2664,7 @@
         <field name="image" type="base64" file="payment/static/img/card.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.hk'),
@@ -2706,7 +2706,7 @@
         <field name="image" type="base64" file="payment/static/img/card.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.co'),
@@ -2749,7 +2749,7 @@
         <field name="image" type="base64" file="payment/static/img/qris.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.id'),
@@ -2770,7 +2770,7 @@
         <field name="image" type="base64" file="payment/static/img/rabbit_line_pay.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.th'),
@@ -2849,7 +2849,7 @@
         <field name="image" type="base64" file="payment/static/img/bank.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.th'),
@@ -2919,7 +2919,7 @@
         <field name="image" type="base64" file="payment/static/img/shopback.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.sg'),
@@ -3014,7 +3014,7 @@
         <field name="image" type="base64" file="payment/static/img/techcom.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.vn'),
@@ -3035,7 +3035,7 @@
         <field name="image" type="base64" file="payment/static/img/tendopay.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.ph'),
@@ -3056,7 +3056,7 @@
         <field name="image" type="base64" file="payment/static/img/tenpay.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.cn'),
@@ -3077,7 +3077,7 @@
         <field name="image" type="base64" file="payment/static/img/bank.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.vn'),
@@ -3098,7 +3098,7 @@
         <field name="image" type="base64" file="payment/static/img/tinka.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.nl'),
@@ -3119,7 +3119,7 @@
         <field name="image" type="base64" file="payment/static/img/tmb.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.th'),
@@ -3140,7 +3140,7 @@
         <field name="image" type="base64" file="payment/static/img/toss_pay.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.kr'),
@@ -3182,7 +3182,7 @@
         <field name="image" type="base64" file="payment/static/img/truemoney.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.th'),
@@ -3240,7 +3240,7 @@
         <field name="image" type="base64" file="payment/static/img/card.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.th'),
@@ -3282,7 +3282,7 @@
         <field name="image" type="base64" file="payment/static/img/uatp.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
     </record>
 
     <record id="payment_method_unknown" model="payment.method">
@@ -3304,7 +3304,7 @@
         <field name="image" type="base64" file="payment/static/img/bank.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.sg'),
@@ -3346,7 +3346,7 @@
         <field name="image" type="base64" file="payment/static/img/flutterwave.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
     </record>
 
     <record id="payment_method_venmo" model="payment.method">
@@ -3378,7 +3378,7 @@
         <field name="image" type="base64" file="payment/static/img/vietcom.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.vn'),
@@ -3420,7 +3420,7 @@
         <field name="image" type="base64" file="payment/static/img/vpay.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_currency_ids"
                eval="[Command.set([
                          ref('base.EUR'),
@@ -3443,7 +3443,7 @@
         <field name="image" type="base64" file="payment/static/img/wallet.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="support_refund">full_only</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -3517,7 +3517,7 @@
         <field name="image" type="base64" file="payment/static/img/welend.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.hk'),
@@ -3538,7 +3538,7 @@
         <field name="image" type="base64" file="payment/static/img/zalopay.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
                          ref('base.vn'),

--- a/addons/payment/models/payment_method.py
+++ b/addons/payment/models/payment_method.py
@@ -58,29 +58,35 @@ class PaymentMethod(models.Model):
 
     # Feature support fields.
     support_tokenization = fields.Boolean(
-        string="Tokenization Supported",
+        string="Tokenization",
         help="Tokenization is the process of saving the payment details as a token that can later"
              " be reused without having to enter the payment details again.",
     )
     support_express_checkout = fields.Boolean(
-        string="Express Checkout Supported",
+        string="Express Checkout",
         help="Express checkout allows customers to pay faster by using a payment method that"
              " provides all required billing and shipping information, thus allowing to skip the"
              " checkout process.",
     )
     support_refund = fields.Selection(
-        string="Type of Refund Supported",
-        selection=[('full_only', "Full Only"), ('partial', "Partial")],
+        string="Refund",
         help="Refund is a feature allowing to refund customers directly from the payment in Odoo.",
+        selection=[
+            ('none', "Unsupported"),
+            ('full_only', "Full Only"),
+            ('partial', "Full & Partial"),
+        ],
+        required=True,
+        default='none',
     )
     supported_country_ids = fields.Many2many(
-        string="Supported Countries",
+        string="Countries",
         comodel_name='res.country',
         help="The list of countries in which this payment method can be used (if the provider"
              " allows it). In other countries, this payment method is not available to customers."
     )
     supported_currency_ids = fields.Many2many(
-        string="Supported Currencies",
+        string="Currencies",
         comodel_name='res.currency',
         help="The list of currencies for that are supported by this payment method (if the provider"
              " allows it). When paying with another currency, this payment method is not available "

--- a/addons/payment/models/payment_provider.py
+++ b/addons/payment/models/payment_provider.py
@@ -149,7 +149,7 @@ class PaymentProvider(models.Model):
 
     # Feature support fields
     support_tokenization = fields.Boolean(
-        string="Tokenization Supported", compute='_compute_feature_support_fields'
+        string="Tokenization", compute='_compute_feature_support_fields'
     )
     support_manual_capture = fields.Selection(
         string="Manual Capture Supported",
@@ -157,11 +157,16 @@ class PaymentProvider(models.Model):
         compute='_compute_feature_support_fields',
     )
     support_express_checkout = fields.Boolean(
-        string="Express Checkout Supported", compute='_compute_feature_support_fields'
+        string="Express Checkout", compute='_compute_feature_support_fields'
     )
     support_refund = fields.Selection(
-        string="Type of Refund Supported",
-        selection=[('full_only', "Full Only"), ('partial', "Partial")],
+        string="Refund",
+        help="Refund is a feature allowing to refund customers directly from the payment in Odoo.",
+        selection=[
+            ('none', "Unsupported"),
+            ('full_only', "Full Only"),
+            ('partial', "Full & Partial"),
+        ],
         compute='_compute_feature_support_fields',
     )
 
@@ -232,12 +237,12 @@ class PaymentProvider(models.Model):
 
         :return: None
         """
-        self.update(dict.fromkeys((
-            'support_express_checkout',
-            'support_manual_capture',
-            'support_refund',
-            'support_tokenization',
-        ), None))
+        self.update({
+            'support_express_checkout': None,
+            'support_manual_capture': None,
+            'support_tokenization': None,
+            'support_refund': 'none',
+        })
 
     #=== ONCHANGE METHODS ===#
 

--- a/addons/payment_custom/data/payment_method_data.xml
+++ b/addons/payment_custom/data/payment_method_data.xml
@@ -9,7 +9,7 @@
         <field name="image" type="base64" file="payment_custom/static/img/wire_transfer.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
     </record>
 
 </odoo>

--- a/addons/website_sale_picking/data/payment_method_data.xml
+++ b/addons/website_sale_picking/data/payment_method_data.xml
@@ -8,7 +8,7 @@
         <field name="image" type="base64" file="website_sale_picking/static/img/pay_on_site.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">none</field>
     </record>
 
 </odoo>


### PR DESCRIPTION
-> This commit improves the clarity and usability of the payment method
configurations, specifically focusing on the labels and refund options.

Before this commit:
-> The labels in the payment method configuration were unclear to users.
-> The options for the type of refund supported were not clearly defined,
leading to confusion.

After this commit:
-> Labels in the payment method configuration have been enhanced for better
 clarity and user understanding.
-> The type of refund option has been updated from an  "empty"
value to a "Unsupported," making it more intuitive for users.

task-3974054

See also:
- https://github.com/odoo/enterprise/pull/64687
- https://github.com/odoo/upgrade/pull/6162