### PR TITLE
[FIX] website: avoid failing when selecting empty image gallery

### DIFF
--- a/addons/website/static/src/snippets/s_image_gallery/options.js
+++ b/addons/website/static/src/snippets/s_image_gallery/options.js
@@ -545,9 +545,12 @@ options.registry.gallery = options.Class.extend({
         const $carousel = this.$target.find(".carousel:first");
         let _previousEditor;
         let _miniatureClicked;
-        this.$target[0].querySelector(".carousel-indicators").addEventListener("click", () => {
-            _miniatureClicked = true;
-        });
+        const carouselIndicatorsEl = this.$target[0].querySelector(".carousel-indicators");
+        if (carouselIndicatorsEl) {
+            carouselIndicatorsEl.addEventListener("click", () => {
+                _miniatureClicked = true;
+            });
+        }
         let lastSlideTimeStamp;
         $carousel.on("slide.bs.carousel.image_gallery", (ev) => {
             lastSlideTimeStamp = ev.timeStamp;


### PR DESCRIPTION
Since [1] when an empty image gallery was saved, an error is raised upon selection.

This commit avoids that error.

Steps to reproduce:
- Drop an "Image Gallery" block
- Remove all images
- Save
- Edit
- Select the image gallery

=> An error was raised.

opw-3969901
