### PR TITLE
[FIX] website_livechat: do not show welcome message on chat requests

### DIFF
--- a/addons/website_livechat/models/discuss_channel.py
+++ b/addons/website_livechat/models/discuss_channel.py
@@ -31,6 +31,7 @@ class DiscussChannel(models.Model):
         channel_infos = super()._channel_info()
         channel_infos_dict = dict((c['id'], c) for c in channel_infos)
         for channel in self.filtered('livechat_visitor_id'):
+            channel_infos_dict[channel.id]["requested_by_operator"] = channel.create_uid in channel.livechat_operator_id.user_ids
             visitor = channel.livechat_visitor_id
             try:
                 country_id = visitor.partner_id.country_id or visitor.country_id


### PR DESCRIPTION
Live chat displays a welcome message when the visitor opens the chat. However, when an operator sends a chat request, the welcome message is not necessary as the first operator message will act as a welcome message.

Before [1], chat requests data were inserted directly into the JS and the information about who opend the chat was given.

However, the data is now fetched from the server and this information is missing.

This PR adds this information so that the client can decide whether to display this message.

Steps to reproduce this issue:
- Go on the website as a visitor
- Send a chat request from admin, send a first message
- Navigate to another page with the visitor
- The welcome message appears in addition to the operator message.

[1]: https://github.com/odoo/odoo/pull/142155

Before:
![image](https://github.com/odoo/odoo/assets/48757558/aaf1861d-f836-465f-b464-4cdecb43c929)

After:
![image](https://github.com/odoo/odoo/assets/48757558/1105b104-6ad7-4c72-9364-16fd6ee571c2)
