### PR TITLE
[POC] mail: slightly improve message reaction style

### DIFF
--- a/addons/mail/static/src/core/common/message_reactions.scss
+++ b/addons/mail/static/src/core/common/message_reactions.scss
@@ -1,3 +1,20 @@
-.o-mail-MessageReaction.o-selfReacted {
-    background: mix($o-brand-primary, $o-view-background-color, 10%);
+.o-mail-MessageReaction {
+    &.o-selfReacted {
+        --border-opacity: 0.5;
+        background: mix($o-brand-primary, $o-view-background-color, 7.5%);
+
+        &:hover {
+            --border-opacity: 0.75;
+        }
+    }
+
+    &:not(.o-selfReacted) {
+        --border-opacity: 0.35;
+        border-color: rgba(var(--secondary-rgb), var(--border-opacity)) !important;
+
+        &:hover {
+            --border-opacity: 1;
+        }
+    }
 }
+

--- a/addons/mail/static/src/core/common/message_reactions.xml
+++ b/addons/mail/static/src/core/common/message_reactions.xml
@@ -7,17 +7,17 @@
             'ms-3': !(env.inChatWindow and env.alignedRight) and (props.message.is_discussion),
         }"
         t-attf-class="{{ props.message.is_discussion ? 'mt-n2' : 'mt-1' }}">
-        <button t-foreach="props.message.reactions" t-as="reaction" t-key="reaction.content" class="o-mail-MessageReaction btn d-flex p-0 border rounded-1 mb-1"
+        <button t-foreach="props.message.reactions" t-as="reaction" t-key="reaction.content" class="o-mail-MessageReaction btn d-flex p-0 rounded-3 mb-1 fs-5"
             t-on-click="() => this.onClickReaction(reaction)"
             t-on-contextmenu="onContextMenu"
             t-att-class="{
-                'o-selfReacted border-primary text-primary fw-bolder': hasSelfReacted(reaction),
+                'o-selfReacted border-primary text-primary': hasSelfReacted(reaction),
                 'bg-view': !hasSelfReacted(reaction),
                 'ms-1': env.inChatWindow and env.alignedRight,
                 'me-1': !(env.inChatWindow and env.alignedRight),
          }" t-att-title="getReactionSummary(reaction)">
             <span class="mx-1" t-esc="reaction.content"/>
-            <span class="mx-1" t-esc="reaction.count"/>
+            <span class="me-1 fw-bold" t-att-class="{ 'text-primary': hasSelfReacted(reaction), 'text-muted': !hasSelfReacted(reaction) }" t-esc="reaction.count"/>
         </button>
     </div>
 </t>


### PR DESCRIPTION
1. emoji were slightly too small
2. there was too much spacing between emoji and counter
3. self reaction were too much visible (no border opacity)
4. counters were hard to read (bolder)
5. no hover effect on the reaction
6. reaction items are not rounded enough, making it harsh

This commit improves all of issues above.

<img width="1032" alt="Screenshot 2024-06-14 at 15 19 13" src="https://github.com/odoo/odoo/assets/6569390/37bde2d5-faae-411a-8028-2b7bf58eccba">


![Jun-14-2024 15-21-33](https://github.com/odoo/odoo/assets/6569390/580e2396-88e7-474c-b8a1-fc91984df6b0)
