### PR TITLE
[FIX] pos_restaurant: inconsistency between takeaway and manually fiscal 

### DIFF
--- a/addons/point_of_sale/static/src/app/models/utils/tax_utils.js
+++ b/addons/point_of_sale/static/src/app/models/utils/tax_utils.js
@@ -1,29 +1,5 @@
 import { accountTaxHelpers } from "@account/helpers/account_tax";
 
-export const getPriceUnitAfterFiscalPosition = (
-    taxes,
-    priceUnit,
-    product,
-    productDefaultValues,
-    fiscalPosition,
-    models
-) => {
-    if (!fiscalPosition) {
-        return priceUnit;
-    }
-
-    const newTaxes = getTaxesAfterFiscalPosition(taxes, fiscalPosition, models);
-    return accountTaxHelpers.adapt_price_unit_to_another_taxes(
-        priceUnit,
-        accountTaxHelpers.eval_taxes_computation_prepare_product_values(
-            productDefaultValues,
-            product
-        ),
-        taxes,
-        newTaxes
-    );
-};
-
 export const getTaxesValues = (
     taxes,
     priceUnit,

--- a/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.js
@@ -70,11 +70,6 @@ export class ControlButtons extends Component {
         this.currentOrder.update({
             fiscal_position_id: selectedFiscalPosition ? selectedFiscalPosition.id : false,
         });
-        // IMPROVEMENT: The following is the old implementation and I believe
-        // there could be a better way of doing it.
-        for (const line of this.currentOrder.lines) {
-            line.set_quantity(line.qty);
-        }
     }
     async clickPricelist() {
         // Create the list to be passed to the SelectionPopup.

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -22,11 +22,7 @@ import { PartnerList } from "../screens/partner_list/partner_list";
 import { ScaleScreen } from "../screens/scale_screen/scale_screen";
 import { computeComboLines } from "../models/utils/compute_combo_lines";
 import { changesToOrder, getOrderChanges } from "../models/utils/order_change";
-import {
-    getPriceUnitAfterFiscalPosition,
-    getTaxesAfterFiscalPosition,
-    getTaxesValues,
-} from "../models/utils/tax_utils";
+import { getTaxesAfterFiscalPosition, getTaxesValues } from "../models/utils/tax_utils";
 import { QRPopup } from "@point_of_sale/app/utils/qr_code_popup/qr_code_popup";
 import { ReceiptScreen } from "../screens/receipt_screen/receipt_screen";
 import { PaymentScreen } from "../screens/payment_screen/payment_screen";
@@ -1124,21 +1120,13 @@ export class PosStore extends Reactive {
 
     getProductPrice(product, p = false) {
         const pricelist = this.getDefaultPricelist();
-        let price = p === false ? product.get_price(pricelist, 1) : p;
+        const price = p === false ? product.get_price(pricelist, 1) : p;
 
         let taxes = product.taxes_id;
 
         // Fiscal position.
         const order = this.get_order();
         if (order && order.fiscal_position_id) {
-            price = getPriceUnitAfterFiscalPosition(
-                taxes,
-                price,
-                product,
-                this.config._product_default_values,
-                order.fiscal_position_id,
-                this.models
-            );
             taxes = getTaxesAfterFiscalPosition(taxes, order.fiscal_position_id, this.models);
         }
 

--- a/addons/point_of_sale/static/tests/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/product_screen_tour.js
@@ -132,13 +132,49 @@ registry.category("web_tour.tours").add("FiscalPositionNoTax", {
             ProductScreen.clickDisplayedProduct("Test Product"),
             ProductScreen.totalAmountIs("100.00"),
             ProductScreen.clickFiscalPosition("No Tax"),
-            ProductScreen.noDiscountApplied("100.00"),
-            ProductScreen.totalAmountIs("86.96"),
+            ProductScreen.totalAmountIs("100.00"),
             ProductScreen.clickPayButton(),
             PaymentScreen.clickPaymentMethod("Bank", true, { remaining: "0.00" }),
             PaymentScreen.clickValidate(),
             ReceiptScreen.isShown(),
             Order.doesNotHaveLine({ discount: "" }),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("FiscalPositionIncl", {
+    test: true,
+    steps: () =>
+        [
+            Dialog.confirm("Open session"),
+            ProductScreen.clickDisplayedProduct("Test Product 1"),
+            ProductScreen.totalAmountIs("100.00"),
+            ProductScreen.clickFiscalPosition("Incl. to Incl."),
+            ProductScreen.totalAmountIs("100.00"),
+            // changed fiscal position to Incl. to Excl.
+            ProductScreen.clickFiscalPosition("Incl. to Excl."),
+            ProductScreen.totalAmountIs("110.00"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank", true, { remaining: "0.00" }),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.isShown(),
+            ReceiptScreen.clickNextOrder(),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("FiscalPositionExcl", {
+    test: true,
+    steps: () =>
+        [
+            ProductScreen.clickDisplayedProduct("Test Product 2"),
+            ProductScreen.totalAmountIs("120.00"),
+            ProductScreen.clickFiscalPosition("Excl. to Excl."),
+            ProductScreen.totalAmountIs("110.00"),
+            // changed fiscal position to Excl. to Incl.
+            ProductScreen.clickFiscalPosition("Excl. to Incl."),
+            ProductScreen.totalAmountIs("100.00"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank", true, { remaining: "0.00" }),
+            PaymentScreen.clickValidate(),
         ].flat(),
 });
 

--- a/addons/point_of_sale/static/tests/tours/ticket_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/ticket_screen_tour.js
@@ -174,7 +174,7 @@ registry.category("web_tour.tours").add("FiscalPositionNoTaxRefund", {
             ProductScreen.clickDisplayedProduct("Product Test"),
             ProductScreen.totalAmountIs("100.00"),
             ProductScreen.clickFiscalPosition("No Tax"),
-            ProductScreen.totalAmountIs("86.96"),
+            ProductScreen.totalAmountIs("100.00"),
             ProductScreen.clickPayButton(),
             PaymentScreen.clickPaymentMethod("Bank", true, { remaining: "0.00" }),
             PaymentScreen.clickValidate(),
@@ -187,7 +187,7 @@ registry.category("web_tour.tours").add("FiscalPositionNoTaxRefund", {
             TicketScreen.confirmRefund(),
             ProductScreen.isShown(),
             { ...ProductScreen.back(), mobile: true },
-            ProductScreen.totalAmountIs("-86.96"),
+            ProductScreen.totalAmountIs("-100.00"),
         ].flat(),
 });
 

--- a/addons/point_of_sale/static/tests/tours/utils/product_screen_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/product_screen_util.js
@@ -373,12 +373,6 @@ export function totalAmountIs(amount) {
 export function modeIsActive(mode) {
     return inLeftSide(Numpad.isActive(mode));
 }
-export function noDiscountApplied(originalPrice) {
-    return inLeftSide({
-        content: "no discount is applied",
-        trigger: `.orderline .info-list:not(:contains(${originalPrice}))`,
-    });
-}
 export function cashDifferenceIs(val) {
     return [
         {

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -855,6 +855,93 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'FiscalPositionNoTax', login="pos_user")
 
+    def test_fiscal_position_inclusive_and_exclusive_tax(self):
+        """ Test the mapping of fiscal position for both Tax Inclusive ans Tax Exclusive"""
+        # create a tax with price included
+        tax_inclusive_1 = self.env['account.tax'].create({
+            'name': 'Tax incl.20%',
+            'amount': 20,
+            'price_include': True,
+            'amount_type': 'percent',
+            'type_tax_use': 'sale',
+        })
+        tax_exclusive_1 = self.env['account.tax'].create({
+            'name': 'Tax excl.20%',
+            'amount': 20,
+            'amount_type': 'percent',
+            'type_tax_use': 'sale',
+        })
+        tax_inclusive_2 = self.env['account.tax'].create({
+            'name': 'Tax incl.10%',
+            'amount': 10,
+            'price_include': True,
+            'amount_type': 'percent',
+            'type_tax_use': 'sale',
+        })
+        tax_exclusive_2 = self.env['account.tax'].create({
+            'name': 'Tax excl.10%',
+            'amount': 10,
+            'amount_type': 'percent',
+            'type_tax_use': 'sale',
+        })
+        self.test_product_1 = self.env['product.product'].create({
+            'name': 'Test Product 1',
+            'available_in_pos': True,
+            'list_price': 100,
+            'taxes_id': [(6, 0, [tax_inclusive_1.id])],
+        })
+
+        self.test_product_2 = self.env['product.product'].create({
+            'name': 'Test Product 2',
+            'available_in_pos': True,
+            'list_price': 100,
+            'taxes_id': [(6, 0, [tax_exclusive_1.id])],
+        })
+
+        # create a fiscal position that map the tax
+        fiscal_position_1 = self.env['account.fiscal.position'].create({
+            'name': 'Incl. to Incl.',
+            'tax_ids': [(0, 0, {
+                'tax_src_id': tax_inclusive_1.id,
+                'tax_dest_id': tax_inclusive_2.id,
+            })],
+        })
+        fiscal_position_2 = self.env['account.fiscal.position'].create({
+            'name': 'Incl. to Excl.',
+            'tax_ids': [(0, 0, {
+                'tax_src_id': tax_inclusive_1.id,
+                'tax_dest_id': tax_exclusive_2.id,
+            })],
+        })
+        fiscal_position_3 = self.env['account.fiscal.position'].create({
+            'name': 'Excl. to Excl.',
+            'tax_ids': [(0, 0, {
+                'tax_src_id': tax_exclusive_1.id,
+                'tax_dest_id': tax_exclusive_2.id,
+            })],
+        })
+        fiscal_position_4 = self.env['account.fiscal.position'].create({
+            'name': 'Excl. to Incl.',
+            'tax_ids': [(0, 0, {
+                'tax_src_id': tax_exclusive_1.id,
+                'tax_dest_id': tax_inclusive_2.id,
+            })],
+        })
+
+        # add the fiscal position to the PoS
+        self.main_pos_config.write({
+            'tax_regime_selection': True,
+            'fiscal_position_ids': [(6, 0, [
+                    fiscal_position_1.id,
+                    fiscal_position_2.id,
+                    fiscal_position_3.id,
+                    fiscal_position_4.id,
+                ])],
+        })
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'FiscalPositionIncl', login="pos_user")
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'FiscalPositionExcl', login="pos_user")
+
     def test_06_pos_discount_display_with_multiple_pricelist(self):
         """ Test the discount display on the POS screen when multiple pricelists are used."""
         test_product = self.env['product.product'].create({

--- a/addons/pos_restaurant/static/src/app/control_buttons/control_buttons.js
+++ b/addons/pos_restaurant/static/src/app/control_buttons/control_buttons.js
@@ -55,20 +55,6 @@ patch(ControlButtons.prototype, {
         this.currentOrder.takeaway = isTakeAway;
         this.currentOrder.update({ fiscal_position_id: isTakeAway ? takeawayFp : defaultFp });
     },
-    async clickFiscalPosition() {
-        await super.clickFiscalPosition(...arguments);
-        const takeawayFp = this.pos.config.takeaway_fp_id;
-
-        if (!takeawayFp || !this.pos.config.module_pos_restaurant) {
-            return;
-        }
-
-        if (takeawayFp.id !== this.currentOrder.fiscal_position?.id) {
-            this.currentOrder.takeaway = false;
-        } else {
-            this.currentOrder.takeaway = true;
-        }
-    },
 });
 patch(ControlButtons, {
     components: {

--- a/addons/pos_restaurant/static/src/app/control_buttons/control_buttons.xml
+++ b/addons/pos_restaurant/static/src/app/control_buttons/control_buttons.xml
@@ -24,13 +24,20 @@
                     <button class="btn btn-light rounded-0 fw-bolder" t-on-click="clickTransferOrder">
                         <i class="oi oi-arrow-right me-1" />Transfer / Merge
                     </button>
-                    <button t-if="pos.config.takeaway"
-                            t-attf-class="{{ currentOrder.takeaway ? 'btn-primary' : 'btn-light'}} btn rounded-0 fw-bolder"
-                            t-on-click="clickTakeAway">
-                        <i class="fa fa-car me-1" />Take-away
-                    </button>
                 </t>
             </t>
+        </xpath>
+        <xpath expr="//button[hasclass('o_fiscal_position_button')]" position="after">
+            <button t-if="pos.config.takeaway and props.wrapped"
+                t-attf-class="{{ currentOrder.takeaway ? 'btn-primary' : 'btn-light'}} btn rounded-0 fw-bolder"
+                t-on-click="clickTakeAway">
+                <i t-attf-class="{{ currentOrder.takeaway ? 'fa fa-car' : 'fa fa-cutlery'}} me-1"></i>
+                <span t-if="currentOrder.takeaway">Takaway</span>
+                <span t-else="">Dine in</span>
+            </button>
+        </xpath>
+        <xpath expr="//button[hasclass('o_fiscal_position_button')]" position="attributes">
+            <attribute name="t-if">!pos.config.takeaway</attribute>
         </xpath>
     </t>
 </templates>

--- a/addons/pos_restaurant/views/res_config_settings_views.xml
+++ b/addons/pos_restaurant/views/res_config_settings_views.xml
@@ -20,6 +20,7 @@
                 </setting>
                 <setting string="Eat in / Take out" help="Adjust the tax rate based on whether customers are dining in or opting for takeout."  invisible="not pos_module_pos_restaurant">
                     <field name="pos_takeaway"/>
+                    <div class="text-warning mb16" invisible="not pos_takeaway">Taxes must be included in price.</div>
                     <div class="content-group" invisible="not pos_takeaway">
                         <label string="" for="pos_takeaway_fp_id" class="me-2"/>
                         <field name="pos_takeaway_fp_id" placeholder="Alternative Fiscal Position"/>

--- a/addons/pos_self_order/controllers/orders.py
+++ b/addons/pos_self_order/controllers/orders.py
@@ -90,30 +90,17 @@ class PosSelfOrderController(http.Controller):
                     price_extra_child = sum(attr.price_extra for attr in selected_attributes)
                     price_unit += pos_order_line.combo_line_id.combo_price + price_extra_child
 
-                    price_unit_fp = child_product._get_price_unit_after_fp(price_unit, pos_config.currency_id, fiscal_pos)
                     taxes = fiscal_pos.map_tax(child_product.taxes_id) if fiscal_pos else child_product.taxes_id
-                    pdetails = taxes.compute_all(price_unit_fp, pos_config.currency_id, pos_order_line.qty, child_product)
+                    pdetails = taxes.compute_all(price_unit, pos_config.currency_id, pos_order_line.qty, child_product)
 
                     pos_order_line.write({
-                        'price_unit': price_unit_fp,
+                        'price_unit': price_unit,
                         'price_subtotal': pdetails.get('total_excluded'),
                         'price_subtotal_incl': pdetails.get('total_included'),
                         'price_extra': price_extra_child,
                         'tax_ids': child_product.taxes_id,
                     })
                 lst_price = 0
-
-            price_unit_fp = product._get_price_unit_after_fp(lst_price, pos_config.currency_id, fiscal_pos)
-            taxes_after_fp = fiscal_pos.map_tax(product.taxes_id) if fiscal_pos else product.taxes_id
-            pdetails = taxes_after_fp.compute_all(price_unit_fp, pos_config.currency_id, line.qty, product)
-
-            line.write({
-                'price_unit': price_unit_fp,
-                'price_subtotal': pdetails.get('total_excluded'),
-                'price_subtotal_incl': pdetails.get('total_included'),
-                'tax_ids': product.taxes_id,
-                'price_extra': price_extra,
-            })
 
     @http.route('/pos-self-order/get-orders', auth='public', type='json', website=True)
     def get_orders_by_access_token(self, access_token, order_access_tokens):

--- a/addons/pos_self_order/models/product_product.py
+++ b/addons/pos_self_order/models/product_product.py
@@ -72,45 +72,6 @@ class ProductProduct(models.Model):
             if attributes_by_ptal_id.get(id) is not None
         ]
 
-    def _get_price_unit_after_fp(self, lst_price, currency, fiscal_position):
-        self.ensure_one()
-
-        taxes = self.taxes_id
-
-        mapped_included_taxes = self.env['account.tax']
-        new_included_taxes = self.env['account.tax']
-
-        for tax in taxes:
-            mapped_taxes = fiscal_position.map_tax(tax)
-            if mapped_taxes and any(mapped_taxes.mapped('price_include')):
-                new_included_taxes |= mapped_taxes
-            if tax.price_include and not (tax in mapped_taxes):
-                mapped_included_taxes |= tax
-
-        if mapped_included_taxes:
-            if new_included_taxes:
-                price_untaxed = mapped_included_taxes.compute_all(
-                    lst_price,
-                    currency,
-                    1,
-                    handle_price_include=True,
-                )['total_excluded']
-                return new_included_taxes.compute_all(
-                    price_untaxed,
-                    currency,
-                    1,
-                    handle_price_include=False,
-                )['total_included']
-            else:
-                return mapped_included_taxes.compute_all(
-                    lst_price,
-                    currency,
-                    1,
-                    handle_price_include=True,
-                )['total_excluded']
-        else:
-            return lst_price
-
     def write(self, vals_list):
         res = super().write(vals_list)
         if 'self_order_available' in vals_list:

--- a/addons/pos_self_order/static/src/app/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/self_order_service.js
@@ -16,7 +16,6 @@ import { TimeoutPopup } from "@pos_self_order/app/components/timeout_popup/timeo
 import { getOnNotified, constructFullProductName, deduceUrl } from "@point_of_sale/utils";
 import { computeComboLines } from "@point_of_sale/app/models/utils/compute_combo_lines";
 import {
-    getPriceUnitAfterFiscalPosition,
     getTaxesAfterFiscalPosition,
     getTaxesValues,
 } from "@point_of_sale/app/models/utils/tax_utils";
@@ -721,21 +720,13 @@ export class SelfOrder extends Reactive {
 
     getProductDisplayPrice(product) {
         const pricelist = this.config.pricelist_id;
-        let price = product.get_price(pricelist, 1);
+        const price = product.get_price(pricelist, 1);
 
         let taxes = product.taxes_id;
 
         // Fiscal position.
         const order = this.currentOrder;
         if (order && order.fiscal_position_id) {
-            price = getPriceUnitAfterFiscalPosition(
-                taxes,
-                price,
-                product,
-                this.config._product_default_values,
-                order.fiscal_position_id,
-                this.models
-            );
             taxes = getTaxesAfterFiscalPosition(taxes, order.fiscal_position_id, this.models);
         }
 


### PR DESCRIPTION
Before this commit:
===================
- Tax mapping used for Eat In/Take Out and the tax button behaved
  inconsistently in the case of tax-inclusive prices.

- Mapping of tax using fiscal position results wrong calculation for price_unit
  in case of tax inclusive.
  EX: fiscal position :
          1. Incl. ---> Incl.
          2. Incl.----> Excl.
          3. Excl.---> Excl.
          4. Excl.---> Incl.

After this commit:
====================

- Replaced the `Tax` button with a `Takeaway` button, set `Dine In` as the
  default button, and on click, change the button to `Takeaway` and apply
  the takeaway fiscal position if the Eat In/Take Out configuration is active:.

- Mapping of tax using fiscal position will now work for all cases
  like incl. or excl.

task - 3935347