### PR TITLE
[FIX] sale: in portal, only show quotes button if at least 1

### DIFF
--- a/addons/sale/static/src/js/sale_portal.js
+++ b/addons/sale/static/src/js/sale_portal.js
@@ -7,6 +7,6 @@ PortalHomeCounters.include({
      * @override
      */
     _getCountersAlwaysDisplayed() {
-        return this._super(...arguments).concat(['quotation_count', 'order_count']);
+        return this._super(...arguments).concat(['order_count']);
     },
 });


### PR DESCRIPTION
Problem
---
Since the [portal redesign](https://github.com/odoo/odoo/commit/df8535fbd40e1e5c09dbe616a3332c76c23525c8), made the "Quotations to review" button in the portal an alert, it no longer makes sense to display it when there are 0 quotes to review

opw-3991880