### PR TITLE
[FIX] point_of_sale: constrain the customer display type

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -380,6 +380,12 @@ class PosConfig(models.Model):
         if not self.env.is_admin() and {'is_header_or_footer', 'receipt_header', 'receipt_footer'} & values.keys():
             raise AccessError(_('Only administrators can edit receipt headers and footers'))
 
+    @api.constrains('customer_display_type', 'proxy_ip', 'is_posbox')
+    def _check_customer_display_type(self):
+        for config in self:
+            if config.customer_display_type == 'proxy' and (not config.is_posbox or not config.proxy_ip):
+                raise UserError(_("You must set the iot box's IP address to use an IoT-connected screen. You'll find the field under the 'IoT Box' option."))
+
     @api.model_create_multi
     def create(self, vals_list):
         for vals in vals_list:

--- a/addons/point_of_sale/views/res_config_settings_views.xml
+++ b/addons/point_of_sale/views/res_config_settings_views.xml
@@ -338,7 +338,7 @@
                             <setting id="pos_other_devices" string="ePos Printer" help="Connect device to your PoS without an IoT Box">
                                 <field name="pos_other_devices"/>
                             </setting>
-                            <setting id="customer_display" string="Customer Display" help="Show checkout to customers through a second display" invisible="pos_customer_display_type == 'none'" documentation="/applications/sales/point_of_sale/shop/customer_display.html" >
+                            <setting id="customer_display" string="Customer Display" help="Show checkout to customers through a second display" documentation="/applications/sales/point_of_sale/shop/customer_display.html" >
                                 <div>
                                     <field name="pos_customer_display_type"/>
                                     <div class="mt-1" invisible="pos_customer_display_type == 'none'">


### PR DESCRIPTION
Prevent crashes when using the pos app by blocking the user during
configuration. We raise an error if the user selected `an IoT-connected screen`
('proxy') for the `customer_display_type` but he didn't specify the iot box's IP
address.

Also, in this commit, we fix the issue where the `customer_display_type` field
get hidden the moment the user switches it to 'none'.

Related: https://github.com/odoo/enterprise/pull/64803