### PR TITLE
[FIX] event: remove seat availability mention on ticket pdf sent by email 

### DIFF
--- a/addons/event/models/event_registration.py
+++ b/addons/event/models/event_registration.py
@@ -282,6 +282,7 @@ class EventRegistration(models.Model):
             default_template_id=template and template.id,
             default_composition_mode='comment',
             default_email_layout_xmlid="mail.mail_notification_light",
+            name_with_seats_availability=False,
         )
         return {
             'name': _('Compose Email'),


### PR DESCRIPTION
When sending to an attendee event tickets by email, the mention "seats left" is added to the tickets name then printed on the pdf.

Steps to reproduce:
1.go to events > click on any event with attendees
2.click on Attendees > select one where the Event Ticket value mention the seats remaining
3.in the attendee form click on SEND BY EMAIL
4.download the attached pdf "foldable badge"
5.notice how the mention "seats remaining" is displayed on the pdf
6.you can compare it the pdf generate when going to print > foldable ticket in the attendee form

Cause:
the context value name_with_seats_availability was left on True

Solution:
set name_with_seats_availability to false when generating the pdf for emails.

opw-3987499
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
