### PR TITLE
[IMP] web: load provided signature in the draw tab

### DIFF
--- a/addons/web/static/src/core/signature/name_and_signature.js
+++ b/addons/web/static/src/core/signature/name_and_signature.js
@@ -84,6 +84,10 @@ export class NameAndSignature extends Component {
                     if (this.state.signMode === "auto") {
                         this.drawCurrentName();
                     }
+                    if (this.props.signature.signatureImage) {
+                        this.clear();
+                        this.signaturePad.fromDataURL(this.props.signature.signatureImage);
+                    }
                 }
             },
             () => [this.signatureRef.el]

--- a/addons/web/static/tests/core/name_and_signature.test.js
+++ b/addons/web/static/tests/core/name_and_signature.test.js
@@ -81,3 +81,18 @@ test("test name_and_signature widget with noInputName and without name", async f
     expect(".card-header .active").toHaveCount(1);
     expect(".card-header .active").toHaveText("Draw");
 });
+
+test("test name_and_signature widget default signature", async function () {
+    const props = {
+        signature: {
+            name: "Brandon Freeman",
+            signatureImage: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+BCQAHBQICJmhD1AAAAABJRU5ErkJggg==",
+        },
+        mode: "draw",
+        signatureType: "signature",
+        noInputName: true,
+    };
+    const res = await mountWithCleanup(NameAndSignature, { props });
+    expect(res.isSignatureEmpty).toBe(false);
+
+});


### PR DESCRIPTION
Before this commit, the saved signature of internal users was not loaded when the signature dialog was opened.

taskid: 3713718



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
