### PR TITLE
[FIX] mail: jump to present works with notification

### DIFF
--- a/addons/mail/static/src/core/common/thread.js
+++ b/addons/mail/static/src/core/common/thread.js
@@ -411,12 +411,13 @@ export class Thread extends Component {
     }
 
     get PRESENT_THRESHOLD() {
-        const viewportHeight = this.scrollableRef.el?.clientHeight * PRESENT_VIEWPORT_THRESHOLD;
+        const viewportHeight =
+            (this.scrollableRef.el?.clientHeight ?? 0) * PRESENT_VIEWPORT_THRESHOLD;
         const messagesHeight = [...this.props.thread.nonEmptyMessages]
             .reverse()
             .slice(0, PRESENT_MESSAGE_THRESHOLD)
             .map((message) => this.refByMessageId.get(message.id))
-            .reduce((totalHeight, message) => totalHeight + message?.el?.clientHeight, 0);
+            .reduce((totalHeight, message) => totalHeight + (message?.el?.clientHeight ?? 0), 0);
         const threshold = Math.max(viewportHeight, messagesHeight);
         return this.state.showJumpPresent ? threshold - 200 : threshold;
     }

--- a/addons/mail/static/tests/discuss_app/jump_to_present.test.js
+++ b/addons/mail/static/tests/discuss_app/jump_to_present.test.js
@@ -16,6 +16,7 @@ import { describe, expect, test } from "@odoo/hoot";
 
 import { PRESENT_VIEWPORT_THRESHOLD } from "@mail/core/common/thread";
 import { serverState } from "@web/../tests/web_test_helpers";
+import { queryFirst } from "@odoo/hoot-dom";
 
 describe.current.tags("desktop");
 defineMailModels();
@@ -232,5 +233,63 @@ test("Post message when seeing old message should jump to present", async () => 
     await contains(".o-mail-Message-content", {
         text: "Newly posted",
         after: [".o-mail-Message-content", { text: "Most Recent!" }], // should load around present
+    });
+});
+
+test("show jump to present banner after scrolling up 10 messages", async () => {
+    // when messages are short, 3 x PRESENT_VIEWPORT_THRESHOLD is used, otherwise
+    // this is 10 x PRESENT_MESSAGE_THRESHOLD
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({
+        channel_type: "channel",
+        name: "General",
+    });
+    for (let i = 0; i < 100; i++) {
+        pyEnv["mail.message"].create({
+            body: "<p>Non Empty Body</p>".repeat(100),
+            message_type: "comment",
+            model: "discuss.channel",
+            res_id: channelId,
+        });
+    }
+    const newestMessageId = pyEnv["mail.message"].create({
+        body: "<p>Newest</p>",
+        message_type: "comment",
+        model: "discuss.channel",
+        res_id: channelId,
+    });
+    const [selfMember] = pyEnv["discuss.channel.member"].search_read([
+        ["partner_id", "=", serverState.partnerId],
+        ["channel_id", "=", channelId],
+    ]);
+    pyEnv["discuss.channel.member"].write([selfMember.id], {
+        new_message_separator: newestMessageId + 1,
+    });
+    await start();
+    await openDiscuss(channelId);
+    // make a notification in thread, just to make things complicated
+    // pinning a message adds such notification
+    await click(".o-mail-Message:contains(Newest) [title='Expand']");
+    await click(".dropdown-item", { text: "Pin" });
+    await click(".modal-footer button", { text: "Yeah, pin it!" });
+    const top1 = queryFirst(".o-mail-Message").getBoundingClientRect().top;
+    const top2 = queryFirst(".o-mail-Message:eq(1)").getBoundingClientRect().top;
+    const messageHeight = top2 - top1;
+    // scroll slightly (1 long message)
+    await scroll(".o-mail-Thread", queryFirst(".o-mail-Thread").scrollTop - messageHeight);
+    await contains(".o-mail-Thread-banner", {
+        count: 0,
+        text: "You're viewing older messagesJump to Present",
+    });
+    // scroll to 5th message before newest
+    await scroll(".o-mail-Thread", queryFirst(".o-mail-Thread").scrollTop - 4 * messageHeight);
+    await contains(".o-mail-Thread-banner", {
+        count: 0,
+        text: "You're viewing older messagesJump to Present",
+    });
+    // scroll to around 10th message before newest
+    await scroll(".o-mail-Thread", queryFirst(".o-mail-Thread").scrollTop - 5 * messageHeight);
+    await contains(".o-mail-Thread-banner", {
+        text: "You're viewing older messagesJump to Present",
     });
 });


### PR DESCRIPTION
Before this commit, when message list contained a recent notification such as "X has joined the conversation", the jump to present alert was showing much sooner than expected.

Steps to reproduce:
- Make a channel
- Post a few messages
- Invite someone in the channel
- Slightly scroll top (around 20px)

=> Jump to present is visible.

This happens because the computation of jump to present threshold was NaN, resulting to displaying a 0px height. This meant that the jump to present was immediately present when just barely scrolling.

In the original PR[1], there was a review[2] that stated that `NaN` could theoretically happen with lack of `scrollableRef`, but this would only be punctual and would barely be a flicker at worst.

However, this could actually persistently happen with the computation of message threshold, as not necessarily all messages are shown as `Message` component. In particular, the notification "X has joined the conversation" is displayed as a notification and not as a message. Because this is not a message, this was contributing on `messageHeight` with `undefined`, and adding `undefined` resulted to `messageHeight` being `NaN`. `NaN` is always the biggest value, therefore, height was `NaN`, which in CSS is treated as 0px. This results in jump to present being shown immediately after slight scrolling from newest message.

This commit fixes the issue by preventing non-number contribution in computing heights for `PRESENT_THRESHOLD`. If some intermediate data are lacking, e.g. lacking `ref.el`, then their contribution is `0`.

[1]: https://github.com/odoo/odoo/pull/166996
[2]: https://github.com/odoo/odoo/pull/166996#discussion_r1626124264

Before / After
![before](https://github.com/odoo/odoo/assets/6569390/a29432bd-9aac-46cf-9826-e17e99f57c7f) ![after](https://github.com/odoo/odoo/assets/6569390/5c679d29-0096-42b0-8bc5-3cd1c2533b43)
_(Gifs show weird artefact on top/bottom of thread, these are subtle blurred shadows that the gif recording has a hard time to capture)_