### PR TITLE
[FIX] sale_coupon: fix reward lines tax-set keys

### DIFF
--- a/addons/sale_coupon/models/sale_order.py
+++ b/addons/sale_coupon/models/sale_order.py
@@ -244,7 +244,7 @@ class SaleOrder(models.Model):
                 if discount_line_amount:
                     taxes = self.fiscal_position_id.map_tax(line.tax_id).filtered(lambda t: t.amount_type != 'fixed')
 
-                    reward_dict[line.tax_id] = {
+                    reward_dict[taxes] = {
                         'name': _("Discount: %s", program.name),
                         'product_id': program.discount_line_product_id.id,
                         'price_unit': - discount_line_amount if discount_line_amount > 0 else 0,
@@ -266,12 +266,11 @@ class SaleOrder(models.Model):
 
                 if discount_line_amount:
 
-                    if line.tax_id in reward_dict:
-                        reward_dict[line.tax_id]['price_unit'] -= discount_line_amount
+                    taxes = self.fiscal_position_id.map_tax(line.tax_id).filtered(lambda t: t.amount_type != 'fixed')
+                    if taxes in reward_dict:
+                        reward_dict[taxes]['price_unit'] -= discount_line_amount
                     else:
-                        taxes = self.fiscal_position_id.map_tax(line.tax_id).filtered(lambda t: t.amount_type != 'fixed')
-
-                        reward_dict[line.tax_id] = {
+                        reward_dict[taxes] = {
                             'name': _(
                                 "Discount: %(program)s - On product with following taxes: %(taxes)s",
                                 program=program.name,

--- a/addons/sale_coupon/tests/test_program_numbers.py
+++ b/addons/sale_coupon/tests/test_program_numbers.py
@@ -1559,32 +1559,32 @@ class TestSaleCouponProgramNumbers(TestSaleCouponCommon):
         })
 
         order = self.empty_order
-        # Create taxes
-        self.tax_15pc_excl = self.env['account.tax'].create({
-            'name': "15% Tax excl",
-            'amount_type': 'percent',
-            'amount': 15,
-        })
+        # Create a fixed tax
         self.tax_10_fixed = self.env['account.tax'].create({
             'name': "10% Fixed tax",
             'amount_type': 'fixed',
             'amount': 10,
         })
 
-        # Set tax and prices on products as neeed for the test
-        self.product_A.write({'list_price': 100})
+        # Set taxes on products as neeed for the test
         self.product_A.taxes_id = (self.tax_15pc_excl + self.tax_10_fixed)
+        self.product_C.taxes_id = self.tax_15pc_excl
 
-        # Add products in order
-        self.env['sale.order.line'].create({
+        # Add products in order (list_price=100 for both products)
+        self.env['sale.order.line'].create([{
             'product_id': self.product_A.id,
             'name': 'product A',
             'product_uom_qty': 1.0,
             'order_id': order.id,
-        })
+        }, {
+            'product_id': self.product_C.id,
+            'name': 'product C',
+            'product_uom_qty': 1.0,
+            'order_id': order.id,
+        }])
 
         order.recompute_coupon_lines()
 
-        self.assertEqual(len(order.order_line), 2, 'Promotion should add 1 line')
-        self.assertEqual(order.amount_total, 67.5, '100$ + 15% tax + 10$ tax - 50%(discount) = 67.5$(total) ')
-        self.assertEqual(order.amount_tax, 17.5, '15% tax + 10$ tax$ - 50%$(discount) = 17.5$(total) ')
+        self.assertEqual(len(order.order_line), 3, 'Promotion should add 1 line')
+        self.assertEqual(order.amount_total, 125.0, '200$ + 15% tax + 10$ tax - 50%(discount) = 125$(total)')
+        self.assertEqual(order.amount_tax, 25.0, '15% tax on 200$ + 10$ tax$ - 50%$(discount) = 25$(total)')


### PR DESCRIPTION
Reward lines are created and updated from dictionaries indexed on recordsets of taxes. The assumption that each reward line has a different tax set is used for example in `_update_existing_reward_lines` to match updated values with existing reward lines.

Removing fixed taxes from percentage reward lines in odoo/odoo#145567 broke that assumption because the keys were not adapted accordingly. This commit ensures the dictionaries for reward lines have keys that match the taxes of the reward lines themselves.

Quick reproduction of the issue (full details in the task):
1. Create a promotions program with a percentage reward
2. Create a sale order with a line that has a variable tax and another line that has the same variable tax and also a fixed tax.
3. When updating the promotions program (click on "PROMOTIONS" button), two reward lines are created instead of a single one. The last reward line overrides the first's price_unit. The rewards are incorrect (in some cases such as duplicating a SO the reward lines are "correct" until clicking on the "PROMOTIONS" button again, but there's still two lines instead of one)

After this commit, there's a single line per tax set and the amounts are correct, while still ignoring fixed taxes.

Task-[3990438](https://www.odoo.com/odoo/all-tasks/3990438)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
