### PR TITLE
[IMP] mail: keep composer actions on same line

### DIFF
--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -70,7 +70,7 @@
                             'mx-3 border-top p-1': extended,
                         }"
                     >
-                        <div class="d-flex flex-grow-1 align-items-center" t-ref="main-actions">
+                        <div class="d-flex flex-grow-1 align-items-baseline mt-1" t-ref="main-actions">
                             <button class="btn border-0 p-1 rounded-pill" t-att-class="{'bg-300': this.picker.state.picker === this.picker.PICKERS.EMOJI}" aria-label="Emojis" t-on-click="onClickAddEmoji" t-ref="emoji-button"><i class="fa fa-fw fa-smile-o"/></button>
                             <FileUploader t-if="allowUpload" multiUpload="true" onUploaded.bind="(data) => { attachmentUploader.uploadData(data) }">
                                 <t t-set-slot="toggler">


### PR DESCRIPTION
Before this commit, when typing a long message in the composer and the textarea grows, the buttons were moving as to be centered with the textarea.

This didn't look good, because usually buttons are expected to stay in place except when they are visually inline with some other content, but that's not the case here.

Before
![before](https://github.com/odoo/odoo/assets/6569390/cceaf130-ae4b-4c44-9349-571f1fa3ca6e)

After
![after](https://github.com/odoo/odoo/assets/6569390/71017d15-07d1-45b2-a628-8235af770a41)

