### PR TITLE
[FIX] *:  fix rule to avoid unexpected errors that affect other modules

### DIFF
--- a/addons/account/security/account_security.xml
+++ b/addons/account/security/account_security.xml
@@ -295,6 +295,7 @@
         <field name="model_id" ref="model_account_invoice_send"/>
         <field name="domain_force">[(1, '=', 1)]</field>
         <field name="groups" eval="[(4, ref('account.group_account_invoice'))]"/>
+        <field name="perm_unlink" eval="False"/>
     </record>
 
     <record id="report_external_value_comp_rule" model="ir.rule">

--- a/addons/crm/security/crm_security.xml
+++ b/addons/crm/security/crm_security.xml
@@ -24,6 +24,7 @@
         <field ref="model_crm_lead" name="model_id"/>
         <field name="domain_force">['|',('user_id','=',user.id),('user_id','=',False)]</field>
         <field name="groups" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
+        <field name="perm_unlink" eval="False" />
     </record>
 
     <record id="crm_lead_company_rule" model="ir.rule">
@@ -37,6 +38,7 @@
         <field ref="model_crm_lead" name="model_id"/>
         <field name="domain_force">[(1,'=',1)]</field>
         <field name="groups" eval="[(4, ref('sales_team.group_sale_salesman_all_leads'))]"/>
+        <field name="perm_unlink" eval="False" />
     </record>
 
     <record id="crm_activity_report_rule_all_activities" model="ir.rule">

--- a/addons/google_calendar/security/google_calendar_security.xml
+++ b/addons/google_calendar/security/google_calendar_security.xml
@@ -25,6 +25,8 @@
             <field name="model_id" ref="model_google_calendar_credentials"/>
             <field name="domain_force">[(1,'=',1)]</field>
             <field name="groups" eval="[(4, ref('base.group_system'))]"/>
+            <field name="perm_create" eval="0"/>
+            <field name="perm_unlink" eval="0"/>
         </record>
     </data>
 </odoo>

--- a/addons/hr_contract/security/security.xml
+++ b/addons/hr_contract/security/security.xml
@@ -34,6 +34,9 @@
             <field name="model_id" ref="model_hr_contract"/>
             <field name="groups" eval="[(4, ref('hr_contract.group_hr_contract_employee_manager'))]"/>
             <field name="domain_force">['|', ('employee_id.parent_id.user_id', '=', user.id), ('employee_id.user_id', '=', user.id)]</field>
+            <field name="perm_create" eval="False"/>
+            <field name="perm_write" eval="False"/>
+            <field name="perm_unlink" eval="False"/>
         </record>
 
         <record id="ir_rule_hr_contract_manager" model="ir.rule">

--- a/addons/hr_expense/security/ir_rule.xml
+++ b/addons/hr_expense/security/ir_rule.xml
@@ -80,12 +80,18 @@
             <field name="model_id" ref="account.model_account_move"/>
             <field name="domain_force">[('line_ids.expense_id', '!=', False)]</field>
             <field name="groups" eval="[(4, ref('hr_expense.group_hr_expense_team_approver'))]"/>
+            <field name="perm_create" eval="False"/>
+            <field name="perm_write" eval="False"/>
+            <field name="perm_unlink" eval="False"/>
         </record>
         <record id="hr_expense_team_approver_account_move_line_rule" model="ir.rule">
             <field name="name">Expense Team Approver Account Move Line</field>
             <field name="model_id" ref="account.model_account_move_line"/>
             <field name="domain_force">[('expense_id', '!=', False)]</field>
             <field name="groups" eval="[(4, ref('hr_expense.group_hr_expense_team_approver'))]"/>
+            <field name="perm_create" eval="False"/>
+            <field name="perm_write" eval="False"/>
+            <field name="perm_unlink" eval="False"/>
         </record>
 
 </odoo>

--- a/addons/hr_recruitment_skills/security/hr_recruitment_skills_security.xml
+++ b/addons/hr_recruitment_skills/security/hr_recruitment_skills_security.xml
@@ -10,5 +10,8 @@
                 ('applicant_id.interviewer_ids', 'in', user.id),
         ]</field>
         <field name="groups" eval="[(4, ref('hr_recruitment.group_hr_recruitment_interviewer'))]"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_write" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
     </record>
 </odoo>

--- a/addons/iap/security/ir_rule.xml
+++ b/addons/iap/security/ir_rule.xml
@@ -6,6 +6,8 @@
       <field name="groups" eval="[(4, ref('base.group_user'))]"/>
       <!-- partners can CUD services linked to themselves -->
       <field name="domain_force">['|', ('company_ids', '=', False), ('company_ids', 'in', company_ids)]</field>
+      <field name="perm_write" eval="False"/>
+      <field name="perm_unlink" eval="False"/>
     </record>
 
 </odoo>

--- a/addons/lunch/security/lunch_security.xml
+++ b/addons/lunch/security/lunch_security.xml
@@ -23,6 +23,9 @@
             <field name="model_id" ref="model_lunch_cashmove"/>
             <field name="groups" eval="[(4, ref('group_lunch_user'))]"/>
             <field name="domain_force">[('user_id', '=', user.id)]</field>
+            <field name="perm_create" eval="False"/>
+            <field name="perm_write" eval="False"/>
+            <field name="perm_unlink" eval="False"/>
         </record>
         <record id="lunch_mind_other_food_money" model="ir.rule">
             <field name="name">lunch.cashmove: do see other people's cashmove</field>

--- a/addons/maintenance/security/maintenance.xml
+++ b/addons/maintenance/security/maintenance.xml
@@ -17,6 +17,7 @@
         <field name="model_id" ref="model_maintenance_request"/>
         <field name="domain_force">['|', '|', ('owner_user_id', '=', user.id), ('message_partner_ids', 'in', [user.partner_id.id]), ('user_id', '=', user.id)]</field>
         <field name="groups" eval="[(4, ref('base.group_user'))]"/>
+        <field name="perm_unlink" eval="False"/>
     </record>
 
     <record id="equipment_rule_user" model="ir.rule">
@@ -24,6 +25,9 @@
         <field name="model_id" ref="model_maintenance_equipment"/>
         <field name="domain_force">[('message_partner_ids', 'in', [user.partner_id.id])]</field>
         <field name="groups" eval="[(4, ref('base.group_user'))]"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_write" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
     </record>
 
     <record id="equipment_request_rule_admin_user" model="ir.rule">

--- a/addons/point_of_sale/security/point_of_sale_security.xml
+++ b/addons/point_of_sale/security/point_of_sale_security.xml
@@ -22,30 +22,44 @@
         <field name="model_id" ref="account.model_account_move_line" />
         <field name="groups" eval="[(4, ref('group_pos_user'))]"/>
         <field name="domain_force">[('move_id.pos_order_ids','!=',False)]</field>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_write" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
     </record>
     <record id="rule_pos_account_move" model="ir.rule">
         <field name="name">Point Of Sale Account move</field>
         <field name="model_id" ref="account.model_account_move" />
         <field name="groups" eval="[(4, ref('group_pos_user'))]"/>
         <field name="domain_force">[('pos_order_ids', '!=', False)]</field>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_write" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
     </record>
     <record id="rule_pos_bank_statement_account_user" model="ir.rule">
         <field name="name">Point Of Sale Bank Statement Accountant</field>
         <field name="model_id" ref="account.model_account_bank_statement" />
         <field name="groups" eval="[(4, ref('account.group_account_invoice'))]"/>
         <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_write" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
     </record>
     <record id="rule_pos_bank_statement_line_user" model="ir.rule">
         <field name="name">Point Of Sale Bank Statement Line POS User</field>
         <field name="model_id" ref="account.model_account_bank_statement_line" />
         <field name="groups" eval="[(4, ref('group_pos_user'))]"/>
         <field name="domain_force">[('pos_session_id', '!=', False)]</field>
+        <field name="perm_unlink" eval="False"/>
+        
     </record>
     <record id="rule_pos_bank_statement_line_account_user" model="ir.rule">
         <field name="name">Point Of Sale Bank Statement Line Accountant</field>
         <field name="model_id" ref="account.model_account_bank_statement_line" />
         <field name="groups" eval="[(4, ref('account.group_account_invoice'))]"/>
         <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_write" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
     </record>
     <record id="rule_pos_multi_company" model="ir.rule">
         <field name="name">Point Of Sale Order</field>

--- a/addons/project/security/project_security.xml
+++ b/addons/project/security/project_security.xml
@@ -236,6 +236,9 @@
                     ('project_id.user_id', '=', user.id)
         ]</field>
         <field name="groups" eval="[(4,ref('base.group_user'))]"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_write" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
     </record>
 
     <record model="ir.rule" id="report_project_task_user_rule">
@@ -304,6 +307,9 @@
                 ('project_id.user_id', '=', user.id),
         ]</field>
         <field name="groups" eval="[(4, ref('base.group_user'))]"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_write" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
     </record>
 
     <record id="milestone_visibility_project_admin" model="ir.rule">

--- a/addons/purchase/security/purchase_security.xml
+++ b/addons/purchase/security/purchase_security.xml
@@ -68,6 +68,7 @@
         <field name="model_id" ref="account.model_account_move_line"/>
         <field name="domain_force">[('move_id.move_type', 'in', ('in_invoice', 'in_refund', 'in_receipt'))]</field>
         <field name="groups" eval="[(4, ref('purchase.group_purchase_user'))]"/>
+        <field name="perm_unlink" eval="0"/>
     </record>
     <record id="purchase_user_account_move_rule" model="ir.rule">
         <field name="name">Purchase User Account Move</field>

--- a/addons/sale/security/ir_rules.xml
+++ b/addons/sale/security/ir_rules.xml
@@ -46,6 +46,7 @@
         <field ref="model_sale_order" name="model_id"/>
         <field name="domain_force">['|',('user_id','=',user.id),('user_id','=',False)]</field>
         <field name="groups" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
+        <field name="perm_unlink" eval="False"/>
     </record>
     <record id="sale_order_see_all" model="ir.rule">
         <field name="name">All Orders</field>
@@ -120,6 +121,9 @@
         <field name="model_id" ref="model_account_move"/>
         <field name="domain_force">[('move_type', 'in', ('out_invoice', 'out_refund')), '|', ('invoice_user_id', '=', user.id), ('invoice_user_id', '=', False)]</field>
         <field name="groups" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_write" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
     </record>
 
     <record id="account_invoice_rule_see_all" model="ir.rule">
@@ -134,6 +138,9 @@
         <field name="model_id" ref="model_account_move_line"/>
         <field name="domain_force">[('move_id.move_type', 'in', ('out_invoice', 'out_refund')), '|', ('move_id.invoice_user_id', '=', user.id), ('move_id.invoice_user_id', '=', False)]</field>
         <field name="groups" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_write" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
     </record>
 
     <record id="account_invoice_line_rule_see_all" model="ir.rule">
@@ -141,6 +148,9 @@
         <field name="model_id" ref="model_account_move_line"/>
         <field name="domain_force">[('move_id.move_type', 'in', ('out_invoice', 'out_refund'))]</field>
         <field name="groups" eval="[(4, ref('sales_team.group_sale_salesman_all_leads'))]"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_write" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
     </record>
 
     <!-- Wizard access rules -->
@@ -149,6 +159,7 @@
         <field name="model_id" ref="account.model_account_invoice_send"/>
         <field name="domain_force">[('invoice_ids.move_type', 'in', ('out_invoice', 'out_refund')), '|', ('invoice_ids.invoice_user_id', '=', user.id), ('invoice_ids.invoice_user_id', '=', False)]</field>
         <field name="groups" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
+        <field name="perm_unlink" eval="False"/>
     </record>
 
     <record id="account_invoice_send_rule_see_all" model="ir.rule">
@@ -156,6 +167,7 @@
         <field name="model_id" ref="account.model_account_invoice_send"/>
         <field name="domain_force">[('invoice_ids.move_type', 'in', ('out_invoice', 'out_refund'))]</field>
         <field name="groups" eval="[(4, ref('sales_team.group_sale_salesman_all_leads'))]"/>
+        <field name="perm_unlink" eval="False"/>
     </record>
 
     <record id="sale_payment_provider_onboarding_wizard_rule" model="ir.rule">

--- a/addons/sales_team/security/sales_team_security.xml
+++ b/addons/sales_team/security/sales_team_security.xml
@@ -38,6 +38,7 @@
             <field ref="sales_team.model_crm_team" name="model_id"/>
             <field name="domain_force">[(1,'=',1)]</field>
             <field name="groups" eval="[(4, ref('sales_team.group_sale_salesman_all_leads'))]"/>
+            <field name="perm_unlink" eval="False"/>
         </record>
 
         <record model="ir.rule" id="sale_team_comp_rule">

--- a/addons/spreadsheet_dashboard/security/security.xml
+++ b/addons/spreadsheet_dashboard/security/security.xml
@@ -4,6 +4,9 @@
         <field name="model_id" ref="model_spreadsheet_dashboard"/>
         <field name="groups" eval="[(4, ref('base.group_user'))]"/>
         <field name="domain_force">[('group_ids', 'in', user.groups_id.ids)]</field>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_write" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
     </record>
 </odoo>
 

--- a/addons/website_crm_iap_reveal/security/ir_rules.xml
+++ b/addons/website_crm_iap_reveal/security/ir_rules.xml
@@ -5,12 +5,18 @@
         <field name="model_id" ref="model_crm_reveal_rule"/>
         <field name="domain_force">[(1, '=', 1)]</field>
         <field name="groups" eval="[(4, ref('sales_team.group_sale_salesman_all_leads'))]"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_write" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
     </record>
     <record id="ir_rule_crm_reveal_rule_salesman" model="ir.rule">
         <field name="name">CRM Reveal Rules: Personal / Global Rules</field>
         <field name="model_id" ref="model_crm_reveal_rule"/>
         <field name="domain_force">['|', ('user_id', '=', user.id), ('user_id', '=', False)]</field>
         <field name="groups" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_write" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
     </record>
 
     <record id="ir_rule_crm_reveal_view_all" model="ir.rule">
@@ -18,11 +24,17 @@
         <field name="model_id" ref="model_crm_reveal_view"/>
         <field name="domain_force">[(1, '=', 1)]</field>
         <field name="groups" eval="[(4, ref('sales_team.group_sale_salesman_all_leads'))]"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_write" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
     </record>
     <record id="ir_rule_crm_reveal_view_salesman" model="ir.rule">
         <field name="name">CRM Reveal Views: Personal / Global Views</field>
         <field name="model_id" ref="model_crm_reveal_view"/>
         <field name="domain_force">['|', ('reveal_rule_id.user_id', '=', user.id), ('reveal_rule_id.user_id', '=', False)]</field>
         <field name="groups" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_write" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
     </record>
 </odoo>

--- a/addons/website_slides_forum/security/website_slides_forum_security.xml
+++ b/addons/website_slides_forum/security/website_slides_forum_security.xml
@@ -11,6 +11,7 @@
         <field name="model_id" ref="website_forum.model_forum_forum"/>
         <field name="domain_force">[(1, '=', 1)]</field>
         <field name="groups" eval="[(4, ref('website_slides.group_website_slides_officer'))]"/>
+        <field name="perm_unlink" eval="False"/>
     </record>
 
     <record id="website_slides_forum_public_post" model="ir.rule">

--- a/odoo/addons/base/security/base_security.xml
+++ b/odoo/addons/base/security/base_security.xml
@@ -85,9 +85,9 @@
                 Command.link(ref('base.group_user')),
             ]"/>
             <field name="perm_read" eval="True"/>
-            <field name="perm_write" eval="True"/>
-            <field name="perm_create" eval="True"/>
-            <field name="perm_unlink" eval="True"/>
+            <field name="perm_write" eval="False"/>
+            <field name="perm_create" eval="False"/>
+            <field name="perm_unlink" eval="False"/>
         </record>
         <!-- Relex previous rule for group_private_addresses -->
         <record id="res_partner_rule_private_group" model="ir.rule">


### PR DESCRIPTION
Case:
-----------
Group A not have the right write model X
Rule R1 applies to Group A, including write permissions (perm_write = True or undeclared, default is True)

Group B has the right write model xyz
Rule R2 applies to Group B

If the user belongs to both groups A and B, True with Rule R1, but False with Rule R2 => Still has the right to write because check the group first, then check the Rule condition

Expected:
---------
No edit permissions

Solution:
----------
Declare the perm_write or other perm_* of rule explicitly for each group on the model

Description of the issue/feature this PR addresses:


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
