### PR TITLE
[FIX] mail: fix failing user profile tour

### DIFF
--- a/addons/mail/static/tests/tours/user_modify_own_profile_tour.js
+++ b/addons/mail/static/tests/tours/user_modify_own_profile_tour.js
@@ -9,10 +9,12 @@ registry.category("web_tour.tours").add("mail/static/tests/tours/user_modify_own
         {
             content: "Open user account menu",
             trigger: ".o_user_menu button",
+            run: "click",
         },
         {
             content: "Open preferences / profile screen",
             trigger: "[data-menu=settings]",
+            run: "click",
         },
         {
             content: "Update the email address",


### PR DESCRIPTION
Default "click" actions for tour steps were removed in [1]. Most tours were adapted to this change, but the `user_modify_own_profile` tour wasn't. As a result, this tour fails. This PR adds the missing click actions.

[1]: https://github.com/odoo/odoo/pull/167743

runbot-67458