### PR TITLE
[FIX] point_of_sale: remove price on combo first order line

### DIFF
--- a/addons/point_of_sale/i18n/point_of_sale.pot
+++ b/addons/point_of_sale/i18n/point_of_sale.pot
@@ -2729,7 +2729,7 @@ msgstr ""
 
 #. module: point_of_sale
 #. odoo-javascript
-#: code:addons/point_of_sale/static/src/app/generic_components/orderline/orderline.xml:0
+#: code:addons/point_of_sale/static/src/app/store/models.js:0
 #, python-format
 msgid "Free"
 msgstr ""

--- a/addons/point_of_sale/static/src/app/generic_components/orderline/orderline.xml
+++ b/addons/point_of_sale/static/src/app/generic_components/orderline/orderline.xml
@@ -9,10 +9,7 @@
                     <t t-slot="product-name"/>
                 </div>
                 <div class="product-price d-inline-block text-end price fw-bolder">
-                    <t t-if="line.price === 'free'">
-                        Free
-                    </t>
-                    <t t-else="" t-esc="line.price"/>
+                    <t t-esc="line.price"/>
                 </div>
             </div>
             <ul class="info-list ms-2">

--- a/addons/point_of_sale/static/src/app/store/models.js
+++ b/addons/point_of_sale/static/src/app/store/models.js
@@ -1159,13 +1159,19 @@ export class Orderline extends PosModel {
         }
         return listOfAttributes;
     }
+    getPriceString() {
+        return this.get_discount_str() === "100"
+            ? // free if the discount is 100
+            _t("Free")
+            : (this.comboLines && this.comboLines.length > 0)
+            ? // empty string if it is a combo parent line
+            ""
+            : this.env.utils.formatCurrency(this.get_display_price(), this.currency);
+    }
     getDisplayData() {
         return {
             productName: this.get_full_product_name(),
-            price:
-                this.get_discount_str() === "100"
-                    ? "free"
-                    : this.env.utils.formatCurrency(this.get_display_price()),
+            price: this.getPriceString(),
             qty: this.get_quantity_str(),
             unit: this.get_unit().name,
             unitPrice: this.env.utils.formatCurrency(this.get_unit_display_price()),

--- a/addons/point_of_sale/static/tests/tours/PosComboTour.js
+++ b/addons/point_of_sale/static/tests/tours/PosComboTour.js
@@ -42,6 +42,9 @@ registry.category("web_tour.tours").add("PosComboPriceTaxIncludedTour", {
         ...ProductScreen.clickOrderline("Combo Product 8"),
         ...ProductScreen.selectedOrderlineHas("Combo Product 8", "1.0", "30.00"),
 
+        // check that there is no price shown on the parent line
+        ...inLeftSide(Order.doesNotHaveLine({productName: "Office Combo", price: "0.0"})),
+
         // check that you can change the quantity of a combo product
         ...ProductScreen.pressNumpad("2"),
         ...ProductScreen.clickOrderline("Combo Product 3", "2.0"),


### PR DESCRIPTION
Currently the top line of a combo product is always showing a 0$ price.

Steps to reproduce:
-------------------
* Open a POS Shop session
* Add a combo product, confirm selection choices
> Observation: The first order line representing the combo product will
show a price of 0$

Why the fix:
------------
In saas-17.3 the price is not shown on the combo parent line anymore to avoid any confusion. Discussed with the PO and he asked to put this in 17.0 as well if possible.

Here is the commit that did the change in saas-17.3: https://github.com/odoo/odoo/commit/72267340663e47581d42f46deded6830c72fbda3

Slight change as in saas-17.3 `combo_line_ids` is always a list, empty or not and in 17.0 if you have a simple product, `combo_line_ids` will be `undefined`.

opw-3942339
