### PR TITLE
[FIX] point_of_sale: string domains in pos.config

### DIFF
--- a/addons/l10n_es_pos/models/pos_config.py
+++ b/addons/l10n_es_pos/models/pos_config.py
@@ -19,7 +19,7 @@ class PosConfig(models.Model):
     )
     l10n_es_simplified_invoice_journal_id = fields.Many2one(
         comodel_name='account.journal',
-        domain="[('type', '=', 'sale')]",
+        domain=[('type', '=', 'sale')],
         check_company=True,
         default=_default_sinv_journal_id,
     )

--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -77,7 +77,7 @@ class PosConfig(models.Model):
         string='Operation Type',
         default=_default_picking_type_id,
         required=True,
-        domain="[('code', '=', 'outgoing'), ('warehouse_id.company_id', '=', company_id)]",
+        domain=lambda self: [('code', '=', 'outgoing'), ('warehouse_id.company_id', '=', self.env.company.id)],
         ondelete='restrict')
     journal_id = fields.Many2one(
         'account.journal', string='Point of Sale Journal',
@@ -186,8 +186,7 @@ class PosConfig(models.Model):
         "product lead time. Otherwise, it will be based on the shortest.")
     auto_validate_terminal_payment = fields.Boolean(default=True, help="Automatically validates orders paid with a payment terminal.")
     trusted_config_ids = fields.Many2many("pos.config", relation="pos_config_trust_relation", column1="is_trusting",
-                                          column2="is_trusted", string="Trusted Point of Sale Configurations",
-                                          domain="[('id', '!=', pos_config_id), ('module_pos_restaurant', '=', False)]")
+                                          column2="is_trusted", string="Trusted Point of Sale Configurations")
     access_token = fields.Char("Access Token", default=lambda self: uuid4().hex[:16])
     show_product_images = fields.Boolean(string="Show Product Images", help="Show product images in the Point of Sale interface.", default=True)
     show_category_images = fields.Boolean(string="Show Category Images", help="Show category images in the Point of Sale interface.", default=True)

--- a/addons/point_of_sale/models/res_config_settings.py
+++ b/addons/point_of_sale/models/res_config_settings.py
@@ -107,7 +107,7 @@ class ResConfigSettings(models.TransientModel):
     pos_warehouse_id = fields.Many2one(related='pos_config_id.warehouse_id', readonly=False, string="Warehouse (PoS)")
     point_of_sale_use_ticket_qr_code = fields.Boolean(related='company_id.point_of_sale_use_ticket_qr_code', readonly=False)
     pos_auto_validate_terminal_payment = fields.Boolean(related='pos_config_id.auto_validate_terminal_payment', readonly=False, string="Automatically validates orders paid with a payment terminal.")
-    pos_trusted_config_ids = fields.Many2many(related='pos_config_id.trusted_config_ids', readonly=False)
+    pos_trusted_config_ids = fields.Many2many(related='pos_config_id.trusted_config_ids', readonly=False, domain="[('id', '!=', pos_config_id), ('module_pos_restaurant', '=', False)]")
     point_of_sale_ticket_unique_code = fields.Boolean(related='company_id.point_of_sale_ticket_unique_code', readonly=False)
     pos_show_product_images = fields.Boolean(related='pos_config_id.show_product_images', readonly=False)
     pos_show_category_images = fields.Boolean(related='pos_config_id.show_category_images', readonly=False)

--- a/addons/pos_discount/models/pos_config.py
+++ b/addons/pos_discount/models/pos_config.py
@@ -12,7 +12,7 @@ class PosConfig(models.Model):
     iface_discount = fields.Boolean(string='Order Discounts', help='Allow the cashier to give discounts on the whole order.')
     discount_pc = fields.Float(string='Discount Percentage', help='The default discount percentage when clicking on the Discount button', default=10.0)
     discount_product_id = fields.Many2one('product.product', string='Discount Product',
-        domain="[('sale_ok', '=', True)]", help='The product used to apply the discount on the ticket.')
+        domain=[('sale_ok', '=', True)], help='The product used to apply the discount on the ticket.')
 
     @api.model
     def _default_discount_value_on_module_install(self):


### PR DESCRIPTION
Since [^1], string domains are not taken into account for related fields. As a result, pos fields in the `res.config.settings` don't have the correct domains. The user is then shown non-relevant records in the selections for relational fields. We fix this issue by converting the string domains to a valid list or lambda expression domains.

Related: https://github.com/odoo/enterprise/pull/64755

**Up to saas-17.2:**

<img width="1024" alt="Screenshot 2024-06-18 at 10 32 50" src="https://github.com/odoo/enterprise/assets/3245568/6b4d05d7-b7f8-4e12-8e57-65c9d70bf875">

**Starting saas-17.3:**

<img width="986" alt="Screenshot 2024-06-18 at 10 30 33" src="https://github.com/odoo/enterprise/assets/3245568/9c4964d4-8f81-4b4d-8399-7140927c5dc7">


[^1]: https://github.com/odoo/odoo/commit/f66c9159045b9b63044b6897ecc831cdad57967f

