### PR TITLE
[FIX] auth_signup: set user to public when signup auth is partial

### DIFF
--- a/addons/auth_signup/controllers/main.py
+++ b/addons/auth_signup/controllers/main.py
@@ -42,6 +42,13 @@ class AuthSignupHome(Home):
         if 'error' not in qcontext and request.httprequest.method == 'POST':
             try:
                 self.do_signup(qcontext)
+
+                # Set user to public if they were not signed in by do_signup
+                # (mfa enabled)
+                if request.session.uid is None:
+                    public_user = request.env.ref('base.public_user')
+                    request.update_env(user=public_user)
+
                 # Send an account creation confirmation email
                 User = request.env['res.users']
                 user_sudo = User.sudo().search(

--- a/addons/auth_totp_mail_enforce/__init__.py
+++ b/addons/auth_totp_mail_enforce/__init__.py
@@ -3,3 +3,4 @@
 
 from . import controllers
 from . import models
+from . import tests

--- a/addons/auth_totp_mail_enforce/tests/__init__.py
+++ b/addons/auth_totp_mail_enforce/tests/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import test_auth_signup

--- a/addons/auth_totp_mail_enforce/tests/test_auth_signup.py
+++ b/addons/auth_totp_mail_enforce/tests/test_auth_signup.py
@@ -1,0 +1,45 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.base.tests.common import HttpCaseWithUserDemo, HttpCaseWithUserPortal
+
+from odoo import http
+from odoo.tests.common import tagged
+
+
+@tagged('post_install', '-at_install')
+class TestAuthSignupFlowWith2faEnforced(HttpCaseWithUserPortal, HttpCaseWithUserDemo):
+
+    def setUp(self):
+        super().setUp()
+        self.env['res.config.settings'].create(
+            {
+                # Activate free signup
+                'auth_signup_uninvited': 'b2c',
+                # Enforce 2FA for all users
+                'auth_totp_enforce': True,
+                'auth_totp_policy': 'all_required',
+            }
+        ).execute()
+
+    def test_signup_with_2fa_enforced(self):
+        """
+        Check that registration cleanly succeeds with 2FA enabled and enforced
+        """
+
+        # Get csrf_token
+        self.authenticate(None, None)
+        csrf_token = http.Request.csrf_token(self)
+
+        # Values from login form
+        name = 'toto'
+        payload = {
+            'login': 'toto@example.com',
+            'name': name,
+            'password': 'mypassword',
+            'confirm_password': 'mypassword',
+            'csrf_token': csrf_token,
+        }
+        response = self.url_open('/web/signup', data=payload)
+        new_user = self.env['res.users'].search([('name', '=', name)])
+        self.assertTrue(new_user)
+        self.assertEqual(response.status_code, 200, "Signup request should succeed with a 200")


### PR DESCRIPTION
When mail totp is enforced, users are required to perform the MFA step
after signup, before signin. The authentication is partial and the user
is set to None. This causes the signup request to fail at the mail
template rendering step with an access right error even though the
registration is actually successful.

Steps to reproduce:
- Install apps `auth_totp_mail_enforce` and `website`
- Login with admin user
- In Settings:
  - Enable "Enforce two-factor authentication", set it to "All users"
  - Set "Customer Account" to "Free sign up"
- In a clean session (private browsing), try to sign up an account

Old behavior: 403 error
New behavior: 2FA page

opw-3968129