### PR TITLE
[IMP] hr_expense: `product_id` required in views

### DIFF
--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -52,7 +52,7 @@
                     <field name="is_multiple_currency" column_invisible="True"/>
                     <field name="product_has_cost" column_invisible="True"/>
                     <field name="date" optional="show" readonly="not is_editable"/>
-                    <field name="product_id" optional="hide" readonly="not is_editable"/>
+                    <field name="product_id" optional="hide" readonly="not is_editable" required="1"/>
                     <field name="name" readonly="not is_editable"/>
                     <field name="employee_id" widget="many2one_avatar_user" readonly="not is_editable"/>
                     <field name="sheet_id" optional="show" readonly="True" column_invisible="not context.get('show_report', False)"/>
@@ -900,7 +900,7 @@
                                     <field name="is_multiple_currency" column_invisible="True"/>
                                     <field name="product_has_cost" column_invisible="True"/>
                                     <field name="date" optional="show"/>
-                                    <field name="product_id"/>
+                                    <field name="product_id" required="1"/>
                                     <field name="name"/>
                                     <field name="description" optional="hide"/>
                                     <field name="vendor_id" optional="hide" column_invisible="parent.payment_mode != 'company_account'"/>


### PR DESCRIPTION
The aim of this commit is to restrict even more the cases where the field `product_id` is voided on `hr.expenses`

Context:
The field `product_id` on the model `hr.expense`
has always been quite problematic. Due to the
possibility of creating expense from a mail and/or the OCR, it was never set as required, but is always considered as such.

After this commit:
Because setting it to required would require some partial re-design of the module, we won't do it in this commit. What we can do is forbid the user to empty that field by making sure every view considers it as required.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
