### PR TITLE
[IMP] point_of_sale: hook in `onDoRefund` + fiscal_country on company

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -1758,7 +1758,7 @@ class PosSession(models.Model):
                 'fields': [
                     'currency_id', 'email', 'website', 'company_registry', 'vat', 'name', 'phone', 'partner_id',
                     'country_id', 'state_id', 'tax_calculation_rounding_method', 'nomenclature_id', 'point_of_sale_use_ticket_qr_code',
-                    'point_of_sale_ticket_unique_code',
+                    'point_of_sale_ticket_unique_code', 'account_fiscal_country_id',
                 ],
             }
         }
@@ -1772,6 +1772,11 @@ class PosSession(models.Model):
             company['country'] = self.env['res.country'].search_read(**params_country['search_params'])[0]
         else:
             company['country'] = None
+
+        company['account_fiscal_country_id'] = self.env['res.country'].search_read(
+            domain=[('id', '=', company['account_fiscal_country_id'][0])],
+            fields=['code'],
+        )[0]
 
         return company
 

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -253,6 +253,10 @@ export class TicketScreen extends Component {
             }
         }
     }
+    async addAdditionalRefundInfo(order, destinationOrder) {
+        // used by L10N, e.g: add a refund reason using a specific L10N field
+        return Promise.resolve();
+    }
     async onDoRefund() {
         const order = this.getSelectedOrder();
 
@@ -352,6 +356,7 @@ export class TicketScreen extends Component {
         if (this.pos.get_order().cid !== destinationOrder.cid) {
             this.pos.set_order(destinationOrder);
         }
+        await this.addAdditionalRefundInfo(order, destinationOrder);
 
         this.closeTicketScreen();
     }


### PR DESCRIPTION
[IMP] point_of_sale: load company fiscal_country in the client

The `account_fiscal_country_id` is required in the client to trigger
l10n_* specific behaviour.

task-3801234

[IMP] point_of_sale: add hook in onDoRefund

Allows to add extra behaviour when clicking on the "Refund" button (when
refunding a previous order).

task-3801234

https://github.com/odoo/enterprise/pull/64761