### PR TITLE
[FIX] website: fix semicolon missing in neutralize sql script

### DIFF
--- a/addons/website/data/neutralize.sql
+++ b/addons/website/data/neutralize.sql
@@ -13,4 +13,4 @@ UPDATE website
 
 -- Update robots.txt to disallow all crawling
 UPDATE website
-   SET robots_txt = E'User-agent: *\nDisallow: /'
+   SET robots_txt = E'User-agent: *\nDisallow: /';


### PR DESCRIPTION
In commit [1], a missing semicolon breaks the neutralization of a database.

This commit fixes the issue.

task-3895772

[1]: https://github.com/odoo/odoo/commit/44ecef1c6a22afba3e5151fa857fe550ed5d4f8c
