### PR TITLE
[FIX] website: missing semicolon in neutralize script

### DIFF
--- a/addons/website/data/neutralize.sql
+++ b/addons/website/data/neutralize.sql
@@ -13,4 +13,4 @@ UPDATE website
 
 -- Update robots.txt to disallow all crawling
 UPDATE website
-   SET robots_txt = E'User-agent: *\nDisallow: /'
+   SET robots_txt = E'User-agent: *\nDisallow: /';


### PR DESCRIPTION
The missing semicolon was introduced in [1] for 16.0 and above,
and breaks the neutralization on odoo.sh (at least)

[1] https://github.com/odoo/odoo/pull/167963
