### PR TITLE
[IMP] website_forum: add comment deletion modal

### DIFF
--- a/addons/website_forum/views/forum_forum_templates_post.xml
+++ b/addons/website_forum/views/forum_forum_templates_post.xml
@@ -550,7 +550,7 @@
                 <t t-set="allow_post_comment" t-value="(object.parent_id and object.parent_id.state != 'close' and object.parent_id.active != False)
                                                         or (not object.parent_id and object.state != 'close' and object.active != False)"/>
                 <t t-set="unlink_comment_required_karma" t-value="message.author_id.id == user.partner_id.id and object.forum_id.karma_comment_unlink_own or object.forum_id.karma_comment_unlink_all"/>
-                <t t-set="can_unlink_comment" t-value="user._is_admin() or user.karma >= unlink_comment_required_karma"/>
+                <t t-set="can_unlink_comment" t-value="user.karma >= unlink_comment_required_karma"/>
                 <div class="flex-grow-1 py-2 opacity-75">
                     <header>
                         <span t-call="website_forum.author_box">


### PR DESCRIPTION
Purpose
=======
Add a confirmation modal when deleting post comments.

Specification
=============
Removing the "o_wforum_comments_count" and "o_wforum_comments_count_header"
elements ".find()" calls as they don't exist anymore in the template.
ref commit: https://github.com/odoo/odoo/commit/4b1cf2e06643171e5ae10ea44648c4db66d09319

Because of the "user._is_admin()" from the "can_unlink_comment" condition,
admin users were able to call the route to delete a comment even though they
didn't have enough karma. It wasn't an issue as an exception was thrown in
the python to prevent the action. However here as a dialog is added, it would
be weird to allow the opening of the modal and the call of the rpc if the admin
doesn't have enough karma anyway.
=> Removing this part of the condition so that admin users won't be able to open
the popup if they don't have enough karma to delete a comment.

Task-3992279

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
