### PR TITLE
[IMP] account_peppol: refactor phone number to mobile number

### DIFF
--- a/addons/account_peppol/i18n/account_peppol.pot
+++ b/addons/account_peppol/i18n/account_peppol.pot
@@ -198,7 +198,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/account_peppol/models/res_config_settings.py:0
 #, python-format
-msgid "Contact email and phone number are required."
+msgid "Contact email and mobile number are required."
 msgstr ""
 
 #. module: account_peppol
@@ -454,13 +454,13 @@ msgstr ""
 
 #. module: account_peppol
 #: model_terms:ir.ui.view,arch_db:account_peppol.res_config_settings_view_form
-msgid "Phone Number"
+msgid "Mobile Number"
 msgstr ""
 
 #. module: account_peppol
 #: model:ir.model.fields,field_description:account_peppol.field_res_company__account_peppol_phone_number
 #: model:ir.model.fields,field_description:account_peppol.field_res_config_settings__account_peppol_phone_number
-msgid "Phone number (for validation)"
+msgid "Mobile number (for validation)"
 msgstr ""
 
 #. module: account_peppol
@@ -474,7 +474,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/account_peppol/models/res_config_settings.py:0
 #, python-format
-msgid "Please enter a phone number to verify your application."
+msgid "Please enter a mobile number to verify your application."
 msgstr ""
 
 #. module: account_peppol
@@ -482,7 +482,7 @@ msgstr ""
 #: code:addons/account_peppol/models/res_company.py:0
 #, python-format
 msgid ""
-"Please enter the phone number in the correct international format.\n"
+"Please enter the mobile number in the correct international format.\n"
 "For example: +32123456789, where +32 is the country code.\n"
 "Currently, only European countries are supported."
 msgstr ""
@@ -727,7 +727,7 @@ msgstr ""
 
 #. module: account_peppol
 #: model_terms:ir.ui.view,arch_db:account_peppol.res_config_settings_view_form
-msgid "Verify phone number"
+msgid "Verify mobile number"
 msgstr ""
 
 #. module: account_peppol
@@ -753,7 +753,7 @@ msgstr ""
 #. module: account_peppol
 #: model:ir.model.fields,help:account_peppol.field_res_company__account_peppol_phone_number
 #: model:ir.model.fields,help:account_peppol.field_res_config_settings__account_peppol_phone_number
-msgid "You will receive a verification code to this phone number"
+msgid "You will receive a verification code to this mobile number"
 msgstr ""
 
 #. module: account_peppol

--- a/addons/account_peppol/models/res_company.py
+++ b/addons/account_peppol/models/res_company.py
@@ -48,8 +48,8 @@ class ResCompany(models.Model):
         help='Primary contact email for Peppol-related communication',
     )
     account_peppol_phone_number = fields.Char(
-        string='Phone number (for validation)',
-        help='You will receive a verification code to this phone number',
+        string='Mobile number (for validation)',
+        help='You will receive a verification code to this mobile number',
     )
     account_peppol_proxy_state = fields.Selection(
         selection=[
@@ -82,7 +82,7 @@ class ResCompany(models.Model):
         self.ensure_one()
 
         error_message = _(
-            "Please enter the phone number in the correct international format.\n"
+            "Please enter the mobile number in the correct international format.\n"
             "For example: +32123456789, where +32 is the country code.\n"
             "Currently, only European countries are supported.")
 

--- a/addons/account_peppol/models/res_config_settings.py
+++ b/addons/account_peppol/models/res_config_settings.py
@@ -156,7 +156,7 @@ class ResConfigSettings(models.TransientModel):
                 _('Cannot register a user with a %s application', self.account_peppol_proxy_state))
 
         if not self.account_peppol_phone_number:
-            raise ValidationError(_("Please enter a phone number to verify your application."))
+            raise ValidationError(_("Please enter a mobile number to verify your application."))
 
         company = self.company_id
         edi_proxy_client = self.env['account_edi_proxy_client.user']
@@ -213,7 +213,7 @@ class ResConfigSettings(models.TransientModel):
         self.ensure_one()
 
         if not self.account_peppol_contact_email or not self.account_peppol_phone_number:
-            raise ValidationError(_("Contact email and phone number are required."))
+            raise ValidationError(_("Contact email and mobile number are required."))
 
         params = {
             'update_data': {

--- a/addons/account_peppol/static/src/components/res_config_settings_buttons/res_config_settings_buttons.xml
+++ b/addons/account_peppol/static/src/components/res_config_settings_buttons/res_config_settings_buttons.xml
@@ -49,7 +49,7 @@
                             class="btn btn-primary"
                             t-on-click="sendCode"
                             t-if="proxyState === 'not_verified'">
-                            Verify phone number
+                            Verify mobile number
                     </button>
                 </div>
                 <div class="mt-3">

--- a/addons/account_peppol/views/res_config_settings_views.xml
+++ b/addons/account_peppol/views/res_config_settings_views.xml
@@ -59,7 +59,7 @@
                                             ('is_account_peppol_participant', '=', False),
                                             ('account_peppol_proxy_state', 'not in', ('not_registered', 'not_verified'))
                                         ]}">
-                                <label string="Phone Number"
+                                <label string="Mobile Number"
                                         for="account_peppol_phone_number"
                                         class="col-lg-3 o_light_label"/>
                                 <field name="account_peppol_phone_number"


### PR DESCRIPTION
According to the documentation, the user receives their registration code through SMS, so phone number label is misleading.
    
Steps to reproduce:
1.Install account_peppol > install an peppol egilible accounting l10n (i.e l10n_be)
2.In settings > technical > system parameter > set account_peppol.edi.mode to test
2.in settings search for peppol
3.notice how the phone number is requested in the registration form
4.click on validate registration
5.notice how the validation button displays "verify phone number" while the verification code is sent by sms

Solution:
refactor labels, buttons, helps and errors message to indicate mobile number. The actual field account_peppol_phone_number is not renamed as per stable version changes condition.
    
opw-3977664

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
