### PR TITLE
[FIX] l10n_es_edi_facturae: custom format for certificate issuer

### DIFF
--- a/addons/l10n_es_edi_facturae/models/l10n_es_edi_facturae_certificate.py
+++ b/addons/l10n_es_edi_facturae/models/l10n_es_edi_facturae_certificate.py
@@ -1,4 +1,3 @@
-import re
 from base64 import b64decode, b64encode, encodebytes
 from copy import deepcopy
 from hashlib import sha1
@@ -73,7 +72,9 @@ class Certificate(models.Model):
         root = deepcopy(edi_data)
         cert_private, cert_public = self._decode_certificate()
         public_key_numbers = cert_public.public_key().public_numbers()
-        issuer = ', '.join(sorted(element.rfc4514_string() for element in cert_public.issuer.rdns if re.match(r'[A-Z]{1,2}', element.rfc4514_string())))
+
+        rfc4514_attr = dict(element.rfc4514_string().split("=", 1) for element in cert_public.issuer.rdns)
+        issuer = f"CN={rfc4514_attr['CN']}, OU={rfc4514_attr['OU']}, O={rfc4514_attr['O']}, C={rfc4514_attr['C']}"
 
         # Identifiers
         document_id = f"Document-{sha1(etree.tostring(edi_data)).hexdigest()}"

--- a/addons/l10n_es_edi_facturae/tests/data/expected_signed_document.xml
+++ b/addons/l10n_es_edi_facturae/tests/data/expected_signed_document.xml
@@ -284,18 +284,18 @@
     </ds:Reference>
     <ds:Reference Type="http://uri.etsi.org/01903#SignedProperties" URI="#SignatureProperties-Document-da39a3ee5e6b4b0d3255bfef95601890afd80709">
       <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
-      <ds:DigestValue>Tf2Mjxm9l6+Y4M8azDTj4gbHNWyRfKr8QtVGZCoBTho=</ds:DigestValue>
+      <ds:DigestValue>YXyvKAVjnGxvHZabPY9gmDt0YQgcpBcEq5Hv7ioXR1E=</ds:DigestValue>
     </ds:Reference>
     <ds:Reference URI="#KeyInfo-Document-da39a3ee5e6b4b0d3255bfef95601890afd80709">
       <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
       <ds:DigestValue>ARCif8tQIKagVfeHX4Fit5ZfK3mXQCPclQISywh7h44=</ds:DigestValue>
     </ds:Reference>
   </ds:SignedInfo>
-  <ds:SignatureValue>holVFa4WcSzgnWSemrVttd/yfN3rlEZc0Nq+j0Jrrv7x69ExysoFywIeUUMe0QFaL4xgDS6Hwz84
-vKFYcbMHYPE6N1pGXiW+HSvpNdZC9qobIu4PEACxs1OduqFgVy7eK5OhfzbWFo+maClCsRv/Alx0
-CNh5Ih+EzaBpaAXW5XlM4+bcuNXC08X9EHJegEMtKvCOvU8hJ0SYCMfeFSmnhpnzmx5fstxiiO2z
-EvpQAWDxzlf34pbnUxuhkr2XNiweLwpJfChwt7qthzqmeRgta82455OfciCzfsYofOWYzEIrbTG2
-/4+nCxLDsTM2jrvCCIPfKpFJKQ+iXIr4eODVKw==
+  <ds:SignatureValue>PcHDk3Ey3jLr2aTxcc/uVfHllqA10t/bp54jo0EotZ6lN0dL2Q9rvsuDZLrqD6bqQ/YHbFkeGfmh
+c4QQKputlb6PZGZC1JVZ9FrI2MwstJ/d5LIMz7tS5Y5gSJnmNewD03EwRw3ne80T2PbZnaZSu5Oq
+wAyAblf+gpXawsK2sV0CBe9wtWHiY0VRYxqGz+2bmJyE6sVA3PVj8EjRbLMgo1G03D8ua/569l9I
+2iAivH/MkDpH2il3qXhqlqpp3BiN/nOie/yKJvI2DqT9VjyxQXmKXMwYmlA0z5KN6dQDZWf1mIl3
+bY1g5CfqTGONLUnGfo2Hg4spnIFfnRkgN+zKLA==
 </ds:SignatureValue>
   <ds:KeyInfo Id="KeyInfo-Document-da39a3ee5e6b4b0d3255bfef95601890afd80709">
     <ds:X509Data>
@@ -344,7 +344,7 @@ aWAYAMCL4KhvISclysD+5juDLpGCLHPtKxBXTQ==
                 <ds:DigestValue>FHf2lN+5FALNa7JXV2+pByL92/dr8LeCVhpItYic5oA=</ds:DigestValue>
               </xades:CertDigest>
               <xades:IssuerSerial>
-                <ds:X509IssuerName>C=BE, CN=runbot.odoo.com, L=Ramillies, O=Odoo, OU=R&amp;D, ST=Wallonnia</ds:X509IssuerName>
+                <ds:X509IssuerName>CN=runbot.odoo.com, OU=R&amp;D, O=Odoo, C=BE</ds:X509IssuerName>
                 <ds:X509SerialNumber>548631688851000697209704649636588277530075594025</ds:X509SerialNumber>
               </xades:IssuerSerial>
             </xades:Cert>


### PR DESCRIPTION
The certificate issuer name in the Factura-e XML needs to be formatted in a very specific way. Else it fails the validators of the Basque Region in Spain.

This commit changes the format to be the same as in module l10n_es_edi_tbai .

task-3990176

