### PR TITLE
[16.0] [IMP] Double confirmation to use --force in case of database drop

### DIFF
--- a/odoo/cli/db.py
+++ b/odoo/cli/db.py
@@ -168,7 +168,14 @@ class Db(Command):
     def _check_target(self, target, *, delete_if_exists):
         if exp_db_exist(target):
             if delete_if_exists:
+                self._confirm_drop(target)
                 exp_drop(target)
             else:
                 exit(f"Target database {target} exists, aborting.\n\n"
                      f"\tuse `--force` to delete the existing database anyway.")
+
+    def _confirm_drop(self, target):
+        conf_target_db = input(f"Target database {target} exists, and will be dropped. Please type the target database name to confirm deletion: ")
+        if conf_target_db != target:
+            exit("Target database name to drop not confirmed, aborting.\n\n")
+        return True


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

When using the db cli with --force parameter the db is dropped if it exists, without asking if this is intended; if this is accidentally run in a production environment, the database is dropped.

Current behavior before PR:

Desired behavior after PR is merged:

If a database exists and is to be dropped if a --force parameter is set, a double confirmation is requested to allow the database to be dropped.

This can prevent potential data loss if inadvertently in production environments



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
