### PR TITLE
[FIX] account: display preview when uploading PDF on a new invoice

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1369,7 +1369,7 @@
                     <div class="oe_chatter">
                         <field name="message_follower_ids" groups="base.group_user"/>
                         <field name="activity_ids"/>
-                        <field name="message_ids"/>
+                        <field name="message_ids" options="{'post_refresh': 'always'}"/>
                     </div>
                 </form>
             </field>


### PR DESCRIPTION
**Steps to reproduce:**
- Install Invoicing
- Go to "Invoicing / Configuration / Settings"
- Deactivate "Document Digitalization"
- Create an invoice
- Upload a PDF via paperclip button or drag and drop in the chatter

**Issue:**
The preview box appears but it is empty.

**Cause:**
In "onUploaded" function of Chatter component, the parent view is not reloaded once the attachment is uploaded because "hasParentReloadOnAttachmentsChanged" property is False. This property depends on "post_refresh" option.

**Solution:**
Add "post_refresh" option for "message_ids" field in the view as it is done when "account_invoice_extract" module is installed.

opw-3887671



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
