### PR TITLE
[FIX] mail : force all companies at first alias domain init

### DIFF
--- a/addons/mail/models/mail_alias_domain.py
+++ b/addons/mail/models/mail_alias_domain.py
@@ -149,7 +149,12 @@ class AliasDomain(models.Model):
 
         # alias domain init: populate companies and aliases at first creation
         if alias_domains and self.search_count([]) == len(alias_domains):
-            self.env['res.company'].search(
+            # during first init we assume that we want to attribute this
+            # alias domain to all companies, irrespective of the fact
+            # that they are archived or not. So we run active_test=False
+            # on the just created alias domain
+
+            self.env['res.company'].with_context(active_test=False).search(
                 [('alias_domain_id', '=', False)]
             ).alias_domain_id = alias_domains[0].id
             self.env['mail.alias'].sudo().search(

--- a/addons/test_mail/tests/test_mail_alias.py
+++ b/addons/test_mail/tests/test_mail_alias.py
@@ -386,6 +386,66 @@ class TestMailAlias(TestMailAliasCommon):
 class TestAliasCompany(TestMailAliasCommon):
     """ Test company / alias domain and configuration synchronization """
 
+    def test_alias_domain_setup_archived_company(self):
+        """Test initialization of alias domain with at least one archived company
+        and at least one mail.alias record points to one mail.thread of the
+        archived company"""
+
+        # add archived company to multi company setup
+        self.company_archived = self.env['res.company'].create({
+                'country_id': self.env.ref('base.be').id,
+                'currency_id': self.env.ref('base.EUR').id,
+                'email': 'company_archived@test.example.com',
+                'name': 'Company Archived Test',
+            })
+        self.company_archived.action_archive()
+
+        # create record inheriting from mail.thread to be used as owner/target thread
+        test_record_archived_company = self.env['mail.test.simple.unfollow'].create({
+                'name': 'Test record (mail.thread) specific to archived company',
+                'company_id': self.company_archived.id,
+            })
+
+        unfollow_model_id = self.env['ir.model']._get_id('mail.test.simple.unfollow')
+        mc_archived_parent = self.env['mail.alias'].create({
+                'alias_name': 'alias_parent_specific_to_archived_company',
+                'alias_parent_model_id': unfollow_model_id,
+                'alias_model_id': unfollow_model_id,
+                'alias_parent_thread_id': test_record_archived_company.id,
+            })  # case where the parent thread is specific to archived company
+
+        mc_archived_target = self.env['mail.alias'].create({
+                'alias_name': 'alias_target_specific_to_archived_company',
+                'alias_parent_model_id': unfollow_model_id,
+                'alias_model_id': unfollow_model_id,
+                'alias_force_thread_id': test_record_archived_company.id,
+            })  # case where the target thread is specific to archived company
+
+        # eject linked aliases then remove all alias domains; should
+        # trigger the init condition at next create() call
+        all_mail_aliases = self.env['mail.alias'].search([])
+        all_mail_aliases.write({'alias_domain_id': False})
+        self.env['mail.alias.domain'].search([]).unlink()
+
+        self.assertFalse(any(all_mail_aliases.mapped("alias_domain_id")),
+                         'Mail aliases should have no linked alias domain at this stage')
+
+        # since we nuked all alias domain records, creating a new alias domain
+        # will initialize it as the default for all mail.alias records.
+        # Should not raise any errors (see _check_alias_domain_id_mc)
+        mc_alias_domain = self.env['mail.alias.domain'].create({
+                'bounce_alias': 'bounce.mc.archived',
+                'catchall_alias': 'catchall.bounce.mc.archived',
+                'name': 'test.init.mc.archived.com',
+            })
+
+        self.assertEqual(mc_archived_parent.alias_domain_id.id, mc_alias_domain.id,
+                         'Parent thread has the wrong alias domain')
+        self.assertEqual(mc_archived_target.alias_domain_id.id, mc_alias_domain.id,
+                         'Target thread has the wrong alias domain')
+        self.assertEqual(self.company_archived.alias_domain_id.id, mc_alias_domain.id,
+                         'Archived company was attributed wrong alias domain')
+
     @mute_logger('odoo.models.unlink')
     @users('erp_manager')
     def test_alias_domain_setup(self):


### PR DESCRIPTION
# Context:

The `create` method in the `mail.alias.domain` model currently tries to make the created alias domain record the default for all companies and `mail.alias` records if it's the first of it's kind to be created.

But in it's current form it fails to accound for grandfathered databases (pre 17.0) or miss confgurations by a user, where we have archived companies attached to `mail.alias` where the `alias_domain_id` field is False.

In such a edge case, it is impossible to create a alias domain record, because during the save (create), the user is faced with a Validation Error produce by the checks in the `_check_alias_domain_id_mc` in the `mail.alias` model.

Example error message:
```
"We could not create alias archived-company-alias@example.com because
domain example.com belongs to company ActiveCompany while the owner
document belongs to company ArchivedCompany."
```

It follow that the user is blocked from setting up an alias domain unless they temporarily unarchive a company.

# Proposed solution:

Assuming that the objective is to initialize all current mail aliases in the DB with the "first" alias domain record to be created, we should force the `company_ids` field in the just created `mail_alias_domain` record to contain ALL companies (active or not).

# Reproduction steps:

One way to reproduce the issue on a fresh DB is:
- install mail
- define a domain alias in the general settings
- create a second company
- install Accounting
- make sure a localization pack is loaded for each company (the idea is to create default sale and purchase accounting journals with their email alias)
- archive second company
- in Technical > Aliases menu, clear alias domain from aliases (set `alias_domain_id` = False)
- delete alias domain
- create a new alias domain

--> Validation Error

OPW-3955936

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
