### PR TITLE
[FIX] hr_attendance: add scroll if overflow in department section

### DIFF
--- a/addons/hr_attendance/static/src/components/manual_selection/manual_selection.xml
+++ b/addons/hr_attendance/static/src/components/manual_selection/manual_selection.xml
@@ -35,7 +35,7 @@
                     </div>
                 </div>
                 <div class="o_content o_component_with_search_panel">
-                <div class="o_search_panel flex-grow-0 flex-shrink-0 h-100 pb-5 bg-view overflow-auto pe-1 ps-3">
+                <div class="o_search_panel flex-grow-0 flex-shrink-0 h-100 pb-5 bg-view overflow-auto pe-1 ps-3" style="max-height:500px;">
                     <section class="o_search_panel_section o_search_panel_category">
                         <header class="o_search_panel_section_header pt-4 pb-2 text-uppercase cursor-default">
                             <i class="fa fa-users o_search_panel_section_icon text-odoo me-2"/>


### PR DESCRIPTION
Issue:
------
With many departments (for example 40), in the kiosk mode, when we identify ourselves manually,
we are obliged to reduce the screen size
in order to access the employees.

Solution:
---------
Force a max height for the section with the departments. This enables the `overflow-auto` class to take effect.

It is now possible to scroll along the Y axis.

opw-3956359
