### PR TITLE
[FIX] pos_self_order: remove banner shown for QR menu when restaurant open

### DIFF
--- a/addons/pos_self_order/static/src/app/self_order_index.xml
+++ b/addons/pos_self_order/static/src/app/self_order_index.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="pos_self_order.selfOrderIndex">
-        <div t-if="!selfOrder.ordering" class="o-self-closed w-100 m-0 text-center bg-black text-white">
+        <div t-if="!selfOrder.pos_session" class="o-self-closed w-100 m-0 text-center bg-black text-white">
             <p>We're currently closed.</p>
         </div>
         <div t-if="selfOrder.rpcLoading">

--- a/addons/pos_self_order/static/tests/helpers/landing_page.js
+++ b/addons/pos_self_order/static/tests/helpers/landing_page.js
@@ -14,3 +14,11 @@ export function isClosed() {
         run: () => {},
     };
 }
+
+export function isOpened(){
+    return {
+        content: `Check if the POS is opened`,
+        trigger: `body:not(:has(.o-self-closed))`,
+        run: () => {},
+    };
+}

--- a/addons/pos_self_order/static/tests/tours/test_self_order_common.js
+++ b/addons/pos_self_order/static/tests/tours/test_self_order_common.js
@@ -14,3 +14,13 @@ registry.category("web_tour.tours").add("self_order_is_close", {
         Utils.checkIsNoBtn("Order"),
     ],
 });
+
+registry.category("web_tour.tours").add("self_order_is_open_consultation", {
+    test: true,
+    steps: () => [
+        LandingPage.isOpened(),
+        Utils.clickBtn("Order Now"),
+        ProductPage.clickProduct("Coca-Cola"),
+        Utils.checkIsNoBtn("Order"),
+    ],
+});

--- a/addons/pos_self_order/tests/test_self_order_common.py
+++ b/addons/pos_self_order/tests/test_self_order_common.py
@@ -19,3 +19,13 @@ class TestSelfOrderCommon(SelfOrderCommonTest):
 
         # Verify behavior when self Order is closed
         self.start_tour(self_route, "self_order_is_close")
+
+    def test_self_order_consultation_open(self):
+        """Verify than when the pos is open and self ordering is set to consultation the banner isn't shown"""
+        self.pos_config.write({'self_ordering_mode': 'consultation'})
+
+        self_route = self.pos_config._get_self_order_route()
+
+        # Verify behavior when self Order is opened
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour(self_route, "self_order_is_open_consultation")


### PR DESCRIPTION
Current behavior:
When the restaurant is opened and "Self Ordering" is set to "QR menu", the banner "We're currently closed." is shown.

Steps to reproduce:
- Install "Point of Sale" app and "pos_restaurant" module
- Start a restaurant session and go to the backend
- In the settings, set "Self Ordering" to "QR menu" and save
- Click on "Preview Web interface"
- Problem: The banner is shown

Solutions:
Display the banner if the session is not opened rather than when we have a token (in mode "QR menu", there is no token)

opw-3854839


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
