### PR TITLE
[IMP] stock, sale_stock: allow to select replenishment from SOL

### DIFF
--- a/addons/sale_stock/__manifest__.py
+++ b/addons/sale_stock/__manifest__.py
@@ -26,6 +26,7 @@ Preferences
 
         'views/sale_order_views.xml',
         'views/stock_route_views.xml',
+        'views/replenishment_warehouse_select_views.xml',
         'views/res_config_settings_views.xml',
         'views/sale_stock_portal_template.xml',
         'views/stock_lot_views.xml',

--- a/addons/sale_stock/models/__init__.py
+++ b/addons/sale_stock/models/__init__.py
@@ -3,6 +3,7 @@
 
 from . import account_move
 from . import product_template
+from . import replenishment_warhouse_select
 from . import res_company
 from . import res_config_settings
 from . import res_users

--- a/addons/sale_stock/models/replenishment_warhouse_select.py
+++ b/addons/sale_stock/models/replenishment_warhouse_select.py
@@ -1,0 +1,69 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models
+from odoo.osv import expression
+
+
+class SaleStockReplenishmentWarehouseSelect(models.TransientModel):
+    _name = 'sale_stock.replenishment.warehouse.select'
+    _description = 'Replenishment Warehouse Select'
+    _rec_name = 'sale_order_line_id'
+
+    sale_order_line_id = fields.Many2one('sale.order.line')
+    product_id = fields.Many2one('product.product', related='sale_order_line_id.product_id')
+    qty_to_order = fields.Float(related='sale_order_line_id.product_uom_qty')
+
+    route_ids = fields.One2many('stock.route', compute='_compute_route_ids')
+    wh_replenishment_option_ids = fields.One2many('stock.replenishment.option', string='Warehouse Replenishment Options', compute='_compute_wh_replenishment_options')
+
+    def _compute_route_ids(self):
+        customer_location = self.sale_order_line_id.order_id.partner_shipping_id.property_stock_customer
+        routes = self.env['stock.rule'].search(expression.AND([
+            self.env['stock.rule']._check_company_domain(self.env.company),
+            [
+                ('location_dest_id', '=', customer_location.id),
+                ('warehouse_id', '!=', False),
+            ],
+        ])).route_id
+        for warehouse_select in self:
+            warehouse_select.route_ids = routes
+
+    @api.depends('sale_order_line_id')
+    def _compute_wh_replenishment_options(self):
+        for warehouse_select in self:
+            warehouse_select.wh_replenishment_option_ids = self.env['stock.replenishment.option'].create([{
+                'product_id': warehouse_select.product_id.id,
+                'route_id': route_id.id,
+                'warehouse_id': route_id.warehouse_ids[0].id,
+                'location_id': route_id.warehouse_ids[0].lot_stock_id.id,
+                'replenishment_info_id': '%s,%s' % (warehouse_select._name, warehouse_select.id),
+            } for route_id in warehouse_select.route_ids]).sorted(lambda o: o.free_qty, reverse=True)
+
+    def order_avbl(self, route_id, free_qty):
+        so_line = self.sale_order_line_id
+        if so_line.product_uom_qty > free_qty:
+            so_line.copy({'product_uom_qty': so_line.product_uom_qty - free_qty, 'order_id': so_line.order_id.id})
+        so_line.write({'route_id': route_id, 'product_uom_qty': free_qty})
+        return {
+            'type': 'ir.actions.act_window',
+            'res_model': 'sale.order',
+            'view_mode': 'form',
+            'res_id': so_line.order_id.id,
+        }
+
+    def order_all(self, route_id):
+        self.sale_order_line_id.write({'route_id': route_id})
+        return {
+            'type': 'ir.actions.act_window',
+            'res_model': 'sale.order',
+            'view_mode': 'form',
+            'res_id': self.sale_order_line_id.order_id.id,
+        }
+
+
+class StockReplenishmentOption(models.TransientModel):
+    _inherit = 'stock.replenishment.option'
+
+    replenishment_info_id = fields.Reference(selection_add=[
+        ('sale_stock.replenishment.warehouse.select', 'sale_stock.replenishment.warehouse.select'),
+    ])

--- a/addons/sale_stock/models/sale_order_line.py
+++ b/addons/sale_stock/models/sale_order_line.py
@@ -395,6 +395,18 @@ class SaleOrderLine(models.Model):
                 pickings_to_confirm.action_confirm()
         return True
 
+    def order_line_warehouse_select_action(self):
+        action = self.env['ir.actions.actions']._for_xml_id('sale_stock.action_order_line_warehouse_select')
+        res = self.env['sale_stock.replenishment.warehouse.select'].create({
+            'sale_order_line_id': self.env.context['sale_order_line_id'],
+        })
+        action['name'] = _(
+            'Replenishment Information for %(product)s',
+            product=res.product_id.display_name,
+        )
+        action['res_id'] = res.id
+        return action
+
     def _update_line_quantity(self, values):
         precision = self.env['decimal.precision'].precision_get('Product Unit of Measure')
         line_products = self.filtered(lambda l: l.product_id.type == 'consu')

--- a/addons/sale_stock/security/ir.model.access.csv
+++ b/addons/sale_stock/security/ir.model.access.csv
@@ -17,3 +17,4 @@ access_stock_location_sale_manager,stock.location sale manager,stock.model_stock
 access_stock_rule_salemanager,stock_rule salemanager,stock.model_stock_rule,sales_team.group_sale_manager,1,1,1,1
 access_stock_rule,stock.rule.flow,stock.model_stock_rule,sales_team.group_sale_salesman,1,0,0,0
 access_stock_package_type_salesman,stock_package_type salesman,stock.model_stock_package_type,sales_team.group_sale_salesman,1,0,0,0
+access_sale_stock_replenishment_warehouse_select,sale_stock.replenishment.warehouse.select,model_sale_stock_replenishment_warehouse_select,stock.group_stock_manager,1,1,1,0

--- a/addons/sale_stock/static/src/widgets/qty_at_date_widget.js
+++ b/addons/sale_stock/static/src/widgets/qty_at_date_widget.js
@@ -5,7 +5,8 @@ import { localization } from "@web/core/l10n/localization";
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
 import { usePopover } from "@web/core/popover/popover_hook";
-import { Component, onWillRender } from "@odoo/owl";
+import { user } from "@web/core/user";
+import { Component, onWillRender, onWillStart } from "@odoo/owl";
 import { standardWidgetProps } from "@web/views/widgets/standard_widget_props";
 
 export class QtyAtDatePopover extends Component {
@@ -17,6 +18,11 @@ export class QtyAtDatePopover extends Component {
     };
     setup() {
         this.actionService = useService("action");
+
+        onWillStart(async () => {
+            this.hasMultiWarehousesGroup = await user.hasGroup('stock.group_stock_multi_warehouses');
+            console.log('hasMultiWarehousesGroup', this.hasMultiWarehousesGroup);
+        });
     }
 
     openForecast() {
@@ -27,6 +33,16 @@ export class QtyAtDatePopover extends Component {
                 warehouse_id: this.props.record.data.warehouse_id && this.props.record.data.warehouse_id[0],
                 move_to_match_ids: this.props.record.data.move_ids.records.map(record => record.resId),
                 sale_line_to_match_id: this.props.record.resId,
+            },
+        });
+    }
+
+    openWarehouses() {
+        this.actionService.doAction("sale_stock.action_server_order_line_warehouse_select", {
+            additionalContext: {
+                active_model: 'sale.order.line',
+                active_id: this.props.record.resId,
+                sale_order_line_id: this.props.record.resId,
             },
         });
     }

--- a/addons/sale_stock/static/src/widgets/qty_at_date_widget.xml
+++ b/addons/sale_stock/static/src/widgets/qty_at_date_widget.xml
@@ -2,7 +2,8 @@
 <template id="template" xml:space="preserve">
 
     <t t-name="sale_stock.QtyAtDate">
-        <a t-att-tabindex="props.record.data.display_qty_widget ? '0' : '-1'"
+        <a t-if="props.record.resId"
+            t-att-tabindex="props.record.data.display_qty_widget ? '0' : '-1'"
             t-on-click="showPopup"
             t-att-class="!props.record.data.display_qty_widget ? 'invisible' : ''"
             t-attf-class="fa fa-area-chart cursor-pointer {{ calcData.forecasted_issue ? 'text-danger' : '' }}"
@@ -65,6 +66,11 @@
             type="button" t-on-click="openForecast">
             <i class="oi oi-fw o_button_icon oi-arrow-right"></i>
             View Forecast
+        </button>
+        <button t-if="!props.record.data.is_mto &amp;&amp; hasMultiWarehousesGroup" class="text-start btn btn-link"
+            type="button" t-on-click="openWarehouses">
+            <i class="oi oi-fw o_button_icon oi-arrow-right"></i>
+            Select Warehouse
         </button>
         </div>
     </t>

--- a/addons/sale_stock/views/replenishment_warehouse_select_views.xml
+++ b/addons/sale_stock/views/replenishment_warehouse_select_views.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0"?>
+<odoo>
+
+<record id="view_replenishment_warehouse_select" model="ir.ui.view">
+    <field name="name">Replenishment Warehouse Select</field>
+    <field name="model">sale_stock.replenishment.warehouse.select</field>
+    <field name="arch" type="xml">
+        <form>
+            <field name="sale_order_line_id" invisible="1"/>
+            <field name="qty_to_order" invisible="1"/>
+            <!-- <div class="oe_edit_only alert alert-info" role="alert" invisible="route_ids">
+                There is no warehouse available for replenishment.
+            </div> -->
+            <notebook>
+                <field name="route_ids" invisible="1"/>
+                <page string="Warehouses" name="page_warehouses">
+                    <field name="wh_replenishment_option_ids"/>
+                </page>
+            </notebook>
+            <footer>
+                <button string="Close" class="btn-secondary" special="cancel" data-hotkey="x"/>
+            </footer>
+        </form>
+    </field>
+</record>
+
+<!--
+TODO: Only have one XML defined action? But when doing so, since no python is
+involved to call .create() on the transient model / wizard, the wizard record is
+an empty record set, which doesn't work has then I don't have any field set on
+it.
+-->
+<record id="action_order_line_warehouse_select" model="ir.actions.act_window">
+    <field name="name">Replenishment Warehouse Select</field>
+    <field name="res_model">sale_stock.replenishment.warehouse.select</field>
+    <field name="view_mode">form</field>
+    <field name="view_id" ref="view_replenishment_warehouse_select"/>
+    <field name="target">new</field>
+    <field name="context">{'default_sale_order_line_id': active_id}</field>
+</record>
+
+<record id="action_server_order_line_warehouse_select" model="ir.actions.server">
+    <field name="name">Replenishment Warehouse Select</field>
+    <field name="model_id" ref="sale.model_sale_order_line"/>
+    <field name="binding_model_id" ref="sale.model_sale_order_line"/>
+    <field name="state">code</field>
+    <field name="code">
+        action = model.order_line_warehouse_select_action()
+    </field>
+</record>
+
+</odoo>


### PR DESCRIPTION
Currently, the sale order triggers the `stock.rule` and create a need in the warehouse selected.
However, it could happen that you want to do replenishment from a different warehouse, depending on the available stock.

This commit introduce a way to do it by adding a "Select Warehouse" action on the sale order line, inside the "quantity at date" / "Availability" widget (which is currently used to show forecasted qty of the product).

Technically, it's done by reusing the code from the warehouse selection existing in the warehouse orderpoints ("Replenishment" info popup when clicking on the fa-info icon on an orderpoint.

task-3980593
