### PR TITLE
[IMP] auth_totp_mail_enforce: install it by defauld

### DIFF
--- a/addons/auth_totp_mail_enforce/__manifest__.py
+++ b/addons/auth_totp_mail_enforce/__manifest__.py
@@ -9,6 +9,7 @@ To enforce users to use a two-factor authentication by default,
 and encourage users to configure their 2FA using an authenticator app.
     """,
     'depends': ['auth_totp', 'mail'],
+    'auto_install': True,
     'category': 'Extra Tools',
     'data': [
         'data/mail_template_data.xml',


### PR DESCRIPTION
The module is installed but the config parameter is not activated (yet)

Master plan:
- saas-17.2 : auth_totp_mail_enforced install by default (#169621)
- master: auth_totp_mail_enforced merged into auth_totp_mail + activated by default for everybody (#169608)