### PR TITLE
[FIX] website_sale_picking: Set data as noupdate

### DIFF
--- a/addons/website_sale_picking/data/website_sale_picking_data.xml
+++ b/addons/website_sale_picking/data/website_sale_picking_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<odoo noupdate="1">
 
     <record id="payment_provider_onsite" model="payment.provider">
         <field name="name">Pay in store when picking the product</field>


### PR DESCRIPTION
This data is possible to be modified by users.
Marking it as noupdate also avoids possible errors during upgrades, as if some values get updated (eg: product.product.type) it can [trigger validation errors](https://github.com/odoo/odoo/blob/16.0/addons/stock/models/product.py#L890).




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
