### PR TITLE
[IMP] sale: reorganize sale order footer on mobile

### DIFF
--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -719,13 +719,12 @@
                                     groups="sale.group_discount_per_so_line"/>
                         </div>
                         <group name="note_group" col="6" class="mt-2 mt-md-0">
-                            <group colspan="4">
+                            <group colspan="4" class="order-1 order-lg-0">
                                 <field  colspan="2" name="note" nolabel="1" placeholder="Terms and conditions..."/>
                             </group>
-                            <group class="oe_subtotal_footer" colspan="2" name="sale_total">
+                            <group class="oe_subtotal_footer d-flex order-0 order-lg-1 flex-column gap-0 gap-sm-3" colspan="2" name="sale_total">
                                 <field name="tax_totals" widget="account-tax-totals-field" nolabel="1" colspan="2" readonly="1"/>
                             </group>
-                            <div class="clearfix"/>
                         </group>
                     </page>
                     <page string="Other Info" name="other_information">


### PR DESCRIPTION
### Reorder elements
Prior to this PR, the "Terms and conditions" field was between the SO lines and the total, which was confusing for users.

This PR reorganizes these elements to place the "Terms and conditions" field after the total.

### Adapt spacing
Prior to this PR, the spacing between elements in `oe_subtotal_footer` was not consistent between the media breadkpoints (the spacing was larger on mobile).

This PR adapts this spacing to maintain consistency between screen sizes.

task-3983459

Requires:
- https://github.com/odoo/enterprise/pull/64789

---

| Before | After |
|--------|--------|
| <img width="366" alt="Capture d’écran 2024-06-20 à 14 33 13" src="https://github.com/odoo/enterprise/assets/80679690/49b75bcd-7428-43cf-a667-cf8ceae3dfcb"> | <img width="359" alt="Capture d’écran 2024-06-20 à 14 32 59" src="https://github.com/odoo/enterprise/assets/80679690/b7182e35-4f99-469b-86d7-ddb1d81ad635"> |

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
