### PR TITLE
[FIX] spreadsheet: parse list arabic dates

### DIFF
--- a/addons/spreadsheet/static/src/list/list_data_source.js
+++ b/addons/spreadsheet/static/src/list/list_data_source.js
@@ -178,17 +178,15 @@ export default class ListDataSource extends OdooViewsDataSource {
 
     _formatDateTime(dateValue) {
         const date = deserializeDateTime(dateValue);
-        return formatDateTime(date, {
+        return formatDateTime(date.reconfigure({ numberingSystem: "latn" }), {
             format: "yyyy-MM-dd HH:mm:ss",
-            numberingSystem: "latn",
         });
     }
 
     _formatDate(dateValue) {
         const date = deserializeDate(dateValue);
-        return formatDate(date, {
+        return formatDate(date.reconfigure({ numberingSystem: "latn" }), {
             format: "yyyy-MM-dd",
-            numberingSystem: "latn",
         });
     }
 


### PR DESCRIPTION
Steps to reproduce:
- install point of sale and HR
- create some data in the point of sale app
- switch the user language to arabic
- open the point of sale dashboard => some cells are in error, the date cannot be recognised.

The reason is that `formatDateTime` returns the date with arabic numbers, which can't be parsed by the spreadsheet engine.
The option `numberingSystem` is ignored by `formatDateTime`.

With this commit, we change the date numbering system before.

opw-3992621


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
