### PR TITLE
[FIX] web_editor: update image field on CORS protected image save

### DIFF
--- a/addons/web_editor/i18n/web_editor.pot
+++ b/addons/web_editor/i18n/web_editor.pot
@@ -3584,6 +3584,22 @@ msgstr ""
 
 #. module: web_editor
 #. odoo-javascript
+#: code:addons/web_editor/static/src/components/media_dialog/image_selector.js:0
+#, python-format
+msgid ""
+"You can not replace a field by this image. If you want to use this image, "
+"first save it on your computer and then upload it here."
+msgstr ""
+
+#. module: web_editor
+#. odoo-javascript
+#: code:addons/web_editor/static/src/components/media_dialog/image_selector.xml:0
+#, python-format
+msgid "You can not use this image in a field"
+msgstr ""
+
+#. module: web_editor
+#. odoo-javascript
 #: code:addons/web_editor/static/src/xml/snippets.xml:0
 #, python-format
 msgid "You can still access the block options but it might be ineffective."

--- a/addons/web_editor/static/src/components/media_dialog/image_selector.xml
+++ b/addons/web_editor/static/src/components/media_dialog/image_selector.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <templates id="template" xml:space="preserve">
 <t t-name="web_editor.AutoResizeImage">
-    <div t-ref="auto-resize-image-container" class="o_existing_attachment_cell o_we_image align-items-center justify-content-center me-1 mb-1 opacity-trigger-hover opacity-0 cursor-pointer" t-att-class="{ o_we_attachment_optimized: props.isOptimized, 'o_loaded position-relative opacity-100': state.loaded, o_we_attachment_selected: props.selected, 'position-fixed': !state.loaded }" t-on-click="props.onImageClick">
+    <div t-ref="auto-resize-image-container" class="o_existing_attachment_cell o_we_image align-items-center justify-content-center me-1 mb-1 opacity-trigger-hover opacity-0" t-att-class="{ o_we_attachment_optimized: props.isOptimized, 'o_loaded position-relative opacity-100': state.loaded, o_we_attachment_selected: props.selected, 'position-fixed': !state.loaded, 'cursor-pointer': !props.unselectable }" t-on-click="props.onImageClick">
         <RemoveButton t-if="props.isRemovable" model="props.model" remove="() => this.remove()"/>
-        <div class="o_we_media_dialog_img_wrapper">
-            <img t-ref="auto-resize-image" class="o_we_attachment_highlight img img-fluid w-100" t-att-src="props.src" t-att-alt="props.altDescription" t-att-title="props.title" loading="lazy"/>
+        <div class="o_we_media_dialog_img_wrapper" t-att-class="{ 'bg-light': props.unselectable }">
+            <t t-set="unselectable_attachment_title">You can not use this image in a field</t>
+            <img t-ref="auto-resize-image" class="o_we_attachment_highlight img img-fluid w-100" t-att-class="{ 'opacity-25': props.unselectable}" t-att-src="props.src" t-att-alt="props.altDescription" loading="lazy" t-att-title="props.unselectable ? unselectable_attachment_title : props.title"/>
             <a t-if="props.author" class="o_we_media_author position-absolute start-0 bottom-0 end-0 text-truncate text-center text-primary fs-6 bg-white-50" t-att-href="props.authorLink" target="_blank" t-esc="props.author"/>
         </div>
         <span t-if="props.isOptimized" class="badge position-absolute bottom-0 end-0 m-1 text-bg-success">Optimized</span>
@@ -48,6 +49,7 @@
                         src="attachment.thumbnail_src or attachment.image_src"
                         name="attachment.name"
                         title="attachment.name"
+                        unselectable = "!!attachment.unselectable"
                         altDescription="attachment.altDescription"
                         model="attachment.res_model"
                         minRowHeight="MIN_ROW_HEIGHT"

--- a/addons/web_editor/static/src/js/common/utils.js
+++ b/addons/web_editor/static/src/js/common/utils.js
@@ -505,6 +505,32 @@ function _forwardToThumbnail(imgEl) {
     }
 }
 
+/**
+ * @param {HTMLImageElement} img
+ * @returns {Promise<Boolean>}
+ */
+async function _isImageCorsProtected(img) {
+    const src = img.getAttribute("src");
+    if (!src) {
+        return false;
+    }
+    let isCorsProtected = false;
+    if (!src.startsWith("/") || /\/web\/image\/\d+-redirect\//.test(src)) {
+        // The `fetch()` used later in the code might fail if the image is
+        // CORS protected. We check upfront if it's the case.
+        // Two possible cases:
+        // 1. the `src` is an absolute URL from another domain.
+        //    For instance, abc.odoo.com vs abc.com which are actually the
+        //    same database behind.
+        // 2. A "attachment-url" which is just a redirect to the real image
+        //    which could be hosted on another website.
+        isCorsProtected = await fetch(src, { method: "HEAD" })
+            .then(() => false)
+            .catch(() => true);
+    }
+    return isCorsProtected;
+}
+
 export default {
     COLOR_PALETTE_COMPATIBILITY_COLOR_NAMES: COLOR_PALETTE_COMPATIBILITY_COLOR_NAMES,
     CSS_SHORTHANDS: CSS_SHORTHANDS,
@@ -534,4 +560,5 @@ export default {
     isMobileView: _isMobileView,
     getLinkLabel: _getLinkLabel,
     forwardToThumbnail: _forwardToThumbnail,
+    isImageCorsProtected: _isImageCorsProtected,
 };

--- a/addons/web_editor/static/src/js/common/utils.js
+++ b/addons/web_editor/static/src/js/common/utils.js
@@ -531,6 +531,16 @@ async function _isImageCorsProtected(img) {
     return isCorsProtected;
 }
 
+/**
+ * @param {string} src
+ * @returns {Promise<Boolean>}
+ */
+async function _isSrcCorsProtected(src) {
+    const dummyImg = document.createElement("img");
+    dummyImg.src = src;
+    return _isImageCorsProtected(dummyImg);
+}
+
 export default {
     COLOR_PALETTE_COMPATIBILITY_COLOR_NAMES: COLOR_PALETTE_COMPATIBILITY_COLOR_NAMES,
     CSS_SHORTHANDS: CSS_SHORTHANDS,
@@ -561,4 +571,5 @@ export default {
     getLinkLabel: _getLinkLabel,
     forwardToThumbnail: _forwardToThumbnail,
     isImageCorsProtected: _isImageCorsProtected,
+    isSrcCorsProtected: _isSrcCorsProtected,
 };

--- a/addons/web_editor/static/src/js/editor/image_processing.js
+++ b/addons/web_editor/static/src/js/editor/image_processing.js
@@ -551,31 +551,6 @@ export function isImageSupportedForStyle(img) {
 
     return !isTFieldImg && !isEditableRootElement;
 }
-/**
- * @param {HTMLImageElement} img
- * @returns {Promise<Boolean>}
- */
-export async function isImageCorsProtected(img) {
-    const src = img.getAttribute('src');
-    if (!src) {
-        return false;
-    }
-    let isCorsProtected = false;
-    if (!src.startsWith("/") || /\/web\/image\/\d+-redirect\//.test(src)) {
-        // The `fetch()` used later in the code might fail if the image is
-        // CORS protected. We check upfront if it's the case.
-        // Two possible cases:
-        // 1. the `src` is an absolute URL from another domain.
-        //    For instance, abc.odoo.com vs abc.com which are actually the
-        //    same database behind.
-        // 2. A "attachment-url" which is just a redirect to the real image
-        //    which could be hosted on another website.
-        isCorsProtected = await fetch(src, {method: 'HEAD'})
-            .then(() => false)
-            .catch(() => true);
-    }
-    return isCorsProtected;
-}
 
 /**
  * @param {Blob} blob

--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -10,7 +10,6 @@ import { NavbarLinkPopoverWidget } from "@website/js/widgets/link_popover_widget
 import wUtils from "@website/js/utils";
 import {
     applyModifications,
-    isImageCorsProtected,
     isImageSupportedForStyle,
     loadImageInfo,
 } from "@web_editor/js/editor/image_processing";
@@ -3779,7 +3778,7 @@ options.registry.WebsiteAnimate = options.Class.extend({
                     const imageToolsOpt = hoverEffectWidget.getParent();
                     return (
                         imageToolsOpt._canHaveHoverEffect() && imageToolsOpt._isImageSupportedForShapes()
-                        && !await isImageCorsProtected(this.$target[0])
+                        && !await weUtils.isImageCorsProtected(this.$target[0])
                     );
                 }
                 return false;

--- a/addons/website_sale/static/src/js/website_sale.editor.js
+++ b/addons/website_sale/static/src/js/website_sale.editor.js
@@ -6,6 +6,7 @@ import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_d
 import { _t } from "@web/core/l10n/translation";
 import "@website/js/editor/snippets.options";
 import { renderToElement } from "@web/core/utils/render";
+import { useChildSubEnv } from "@odoo/owl";
 
 options.registry.WebsiteSaleGridLayout = options.Class.extend({
     init() {
@@ -448,6 +449,10 @@ options.registry.WebsiteSaleProductsItem = options.Class.extend({
 
 // Small override of the MediaDialog to retrieve the attachment ids instead of img elements
 class AttachmentMediaDialog extends MediaDialog {
+    setup() {
+        super.setup();
+        useChildSubEnv({ addFieldImage: true });
+    }
     /**
      * @override
      */

--- a/addons/website_sale/static/src/js/website_sale.editor.js
+++ b/addons/website_sale/static/src/js/website_sale.editor.js
@@ -7,6 +7,7 @@ import { _t } from "@web/core/l10n/translation";
 import "@website/js/editor/snippets.options";
 import { renderToElement } from "@web/core/utils/render";
 import { useChildSubEnv } from "@odoo/owl";
+import weUtils from '@web_editor/js/common/utils';
 
 options.registry.WebsiteSaleGridLayout = options.Class.extend({
     init() {
@@ -614,6 +615,10 @@ options.registry.WebsiteSaleProductPage = options.Class.extend({
         // This method is widely adapted from onFileUploaded in ImageField.
         // Upon change, make sure to verify whether the same change needs
         // to be applied on both sides.
+        if (await weUtils.isImageCorsProtected(imageEl)) {
+            // The image is CORS protected; do not transform it into webp
+            return;
+        }
         // Generate alternate sizes and format for reports.
         const imgEl = document.createElement("img");
         imgEl.src = imageEl.src;


### PR DESCRIPTION
[MOV] web_editor, website: move isImageCorsProtected function in utils
The goal of this commit is to move the `isImageCorsProtected()` function
in the `web_editor` utils as it is will be needed in the next commit.

opw-3959983

----------------------------------------------------------------------------------------------------------------------------------------------



[FIX] web_editor,*: forbid the change of image field by webp CORS image
*: website_sale

The goal of this commit is to avoid that a user replaces an image field
by a webp CORS protected image (e.g.
https://www.gstatic.com/webp/gallery/1.webp). There are two main reasons
for that:
- As explained in [1], the resized images have to be generated when a
webp image has been uploaded. This is something that we are currently
not able to do for CORS protected images.
- As explained in [2], a jpeg image has to be generated when a webp
image has been uploaded. This is also something that we are currently
not able to do for CORS protected images.

We also apply the same logic for the addition of extra product images.
Indeed, in this case, when choosing an image among the existing
attachments or when uploading new images, we can not rely on DOM
information to determine if the changed image is an image field as the
image is not already part of the DOM.

[1]: https://github.com/odoo/odoo/commit/0ba3617f9dacf2a63288b30245a610782d943c5a
[2]: https://github.com/odoo/odoo/commit/c035d0003d09289fde0aabcb21849c2914524c01

opw-3959983


-----------------------------------------------------------------------------------------------------------------------------------------------------------

[FIX] website_sale: avoid converting some extra images to webp

Steps to reproduce the bug:
- Go on a product page.
- Enter in edit mode and click on "Add Extra Images".
- Click on "Add URL" and upload an external CORS protected image (e.g.
https://tinyjpg.com/images/social/website.jpg).
- Click on "Add" to use this image as an external image.

-> Error.

Since [3], images uploaded through the website builder that are neither
gif nor svg are converted to the webp format by default except if those
images are CORS protected. The goal of this commit is to adapt [4] to
follow the same logic and not convert uploaded product extra image to
webp if the image is CORS protected.

[3]: https://github.com/odoo/odoo/commit/0449fe85cb0e1d639a4e1aeba26e90906f79254d
[4]: https://github.com/odoo/odoo/commit/b284293c18b6bcdafe2bda989c5e0a084d1acbd1

opw-3959983