### PR TITLE
[FIX] web: BasicModel: clear x2many changes after creation

### DIFF
--- a/addons/web/static/src/legacy/js/views/basic/basic_model.js
+++ b/addons/web/static/src/legacy/js/views/basic/basic_model.js
@@ -1193,7 +1193,7 @@ var BasicModel = AbstractModel.extend({
 
                             // Erase changes as they have been applied
                             record._changes = {};
-                            var data = Object.assign({}, record.data, record._changes);
+                            var data = Object.assign({}, record.data, _changes);
                             for (var fieldName in record.fields) {
                                 var type = record.fields[fieldName].type;
                                 if (type === 'many2many' || type === 'one2many') {

--- a/addons/web/static/tests/legacy/fields/relational_fields/field_one2many_tests.js
+++ b/addons/web/static/tests/legacy/fields/relational_fields/field_one2many_tests.js
@@ -10189,6 +10189,55 @@ QUnit.module('fields', {}, function () {
 
             form.destroy();
         });
+
+        QUnit.test('add a row to an x2many and ask canBeRemoved twice (new record)', async function (assert) {
+            // This test simulates that the view is asked twice to save its changes because the user
+            // is leaving. Before the corresponding fix, the changes in the x2many field weren't
+            // removed after the save, and as a consequence they were saved twice (i.e. the row was
+            // created twice).
+
+            const form = await createView({
+                View: FormView,
+                model: 'partner',
+                data: this.data,
+                arch: `
+                    <form>
+                        <field name="p">
+                            <tree editable="bottom">
+                                <field name="display_name"/>
+                            </tree>
+                        </field>
+                    </form>`,
+                async mockRPC(route, args) {
+                    if (args.method === "create") {
+                        assert.step("create");
+                        assert.deepEqual(args.args[0], {
+                            p: [[0, args.args[0].p[0][1], { display_name: "a name" }]],
+                        });
+                    }
+                    if (args.method === "write") {
+                        assert.step("write"); // should not be called
+                    }
+                    return this._super(route, args);
+                },
+                viewOptions: {
+                    mode: 'edit',
+                },
+            });
+
+            // click add food
+            await testUtils.dom.click(form.$('.o_field_x2many_list_row_add a'));
+            await testUtils.fields.editInput(form.$('.o_input[name="display_name"]'), 'a name');
+            assert.containsOnce(form, ".o_data_row");
+
+            form.canBeRemoved();
+            form.canBeRemoved();
+            await testUtils.nextTick();
+            assert.containsOnce(form, ".o_data_row");
+            assert.verifySteps(["create"]);
+
+            form.destroy();
+        });
     });
 });
 });


### PR DESCRIPTION
This commit is a followup [1], where we (tried to) clear changes on x2many fields once the record was saved. However, due to a typo, it only worked on existing records (when saving), not when creating new records. This commit fixes the issue.

[1] https://github.com/odoo/odoo/pull/123274

Closes https://github.com/odoo/odoo/pull/157673

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
