### PR TITLE
[FIX] hr_expense: typo in extra_trigger

### DIFF
--- a/addons/hr_expense/static/src/js/tours/hr_expense.js
+++ b/addons/hr_expense/static/src/js/tours/hr_expense.js
@@ -27,7 +27,7 @@ tour.register('hr_expense_tour' , {
     position: 'bottom',
 }, {
     trigger: '.o_expense_submit',
-    extra_triggger: ".o_expense_form",
+    extra_trigger: ".o_expense_form",
     content: Markup(_t('<p>Click on <b> Create Report </b> to create the report.</p>')),
     position: 'right',
 }, {


### PR DESCRIPTION
The tour is not actually ran in this version, and is blocked before in other versions.
We should fix it in an other PR.
This typo causes a check on available steps to fail in master.

runbot-68355




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
