### PR TITLE
[IMP] account_peppol: refactor partner verification

### DIFF
--- a/addons/account_peppol/__init__.py
+++ b/addons/account_peppol/__init__.py
@@ -3,3 +3,8 @@
 from . import models
 from . import wizard
 from . import tools
+
+
+def _account_peppol_post_init(env):
+    for company in env['res.company'].sudo().search([]):
+        env['ir.property']._set_default('peppol_verification_state', 'res.partner', 'not_verified', company)

--- a/addons/account_peppol/__manifest__.py
+++ b/addons/account_peppol/__manifest__.py
@@ -27,6 +27,7 @@
     'demo': [
         'demo/account_peppol_demo.xml',
     ],
+    'post_init_hook': '_account_peppol_post_init',
     'license': 'LGPL-3',
     'assets': {
         'web.assets_backend': [

--- a/addons/account_peppol/models/account_edi_proxy_user.py
+++ b/addons/account_peppol/models/account_edi_proxy_user.py
@@ -85,7 +85,8 @@ class AccountEdiProxyClientUser(models.Model):
     def _check_company_on_peppol(self, company, edi_identification):
         if (
             not company.account_peppol_migration_key
-            and (participant_info := company.partner_id._check_peppol_participant_exists(edi_identification, check_company=True))
+            and (participant_info := company.partner_id._get_participant_info(edi_identification)) is not None
+            and company.partner_id._check_peppol_participant_exists(participant_info, edi_identification, check_company=True)
         ):
             error_msg = _(
                 "A participant with these details has already been registered on the network. "

--- a/addons/account_peppol/models/account_move.py
+++ b/addons/account_peppol/models/account_move.py
@@ -36,7 +36,7 @@ class AccountMove(models.Model):
         for move in self:
             if all([
                 move.company_id.account_peppol_proxy_state in can_send,
-                move.commercial_partner_id.account_peppol_is_endpoint_valid,
+                move.commercial_partner_id.peppol_verification_state == 'valid',
                 move.state == 'posted',
                 move.is_sale_document(include_receipts=True),
                 not move.peppol_move_state,

--- a/addons/account_peppol/models/res_company.py
+++ b/addons/account_peppol/models/res_company.py
@@ -206,7 +206,17 @@ class ResCompany(models.Model):
     def create(self, vals_list):
         for vals in vals_list:
             vals = self._sanitize_peppol_endpoint(vals)
-        return super().create(vals_list)
+
+        res = super().create(vals_list)
+        if res:
+            for company in res:
+                self.env['ir.property']._set_default(
+                    'peppol_verification_state',
+                    'res.partner',
+                    'not_verified',
+                    company,
+                )
+        return res
 
     def write(self, vals):
         for company in self:

--- a/addons/account_peppol/models/res_partner.py
+++ b/addons/account_peppol/models/res_partner.py
@@ -3,56 +3,67 @@
 import contextlib
 import requests
 from lxml import etree
+from markupsafe import Markup
 from hashlib import md5
 from urllib import parse
 
 from odoo import api, fields, models
 from odoo.addons.account_peppol.tools.demo_utils import handle_demo
-from odoo.tools.sql import column_exists, create_column
+from odoo.addons.account.models.company import PEPPOL_LIST
 
 TIMEOUT = 10
+NON_PEPPOL_FORMAT = (False, 'facturx', 'oioubl_201', 'ciusro')
+
 
 class ResPartner(models.Model):
     _inherit = 'res.partner'
 
-    account_peppol_is_endpoint_valid = fields.Boolean(
-        string="PEPPOL endpoint validity",
-        help="The partner's EAS code and PEPPOL endpoint are valid",
-        compute="_compute_account_peppol_is_endpoint_valid", store=True,
-        copy=False,
-    )
-    account_peppol_validity_last_check = fields.Date(
-        string="Checked on",
-        help="Last Peppol endpoint verification",
-        compute="_compute_account_peppol_is_endpoint_valid", store=True,
-        copy=False,
-    )
-    account_peppol_verification_label = fields.Selection(
+    peppol_verification_state = fields.Selection(
         selection=[
             ('not_verified', 'Not verified yet'),
             ('not_valid', 'Not valid'),  # does not exist on Peppol at all
             ('not_valid_format', 'Cannot receive this format'),  # registered on Peppol but cannot receive the selected document type
             ('valid', 'Valid'),
         ],
-        string='Peppol endpoint validity',
-        compute='_compute_account_peppol_verification_label',
-        copy=False,
-    )  # field to compute the label to show for partner endpoint
+        string='Peppol endpoint verification',
+        default='not_verified',
+        company_dependent=True,
+    )
     is_peppol_edi_format = fields.Boolean(compute='_compute_is_peppol_edi_format')
 
-    def _auto_init(self):
-        """Create columns `account_peppol_is_endpoint_valid` and `account_peppol_validity_last_check`
-        to avoid having them computed by the ORM on installation.
-        """
-        if not column_exists(self.env.cr, 'res_partner', 'account_peppol_is_endpoint_valid'):
-            create_column(self.env.cr, 'res_partner', 'account_peppol_is_endpoint_valid', 'boolean')
-        if not column_exists(self.env.cr, 'res_partner', 'account_peppol_validity_last_check'):
-            create_column(self.env.cr, 'res_partner', 'account_peppol_validity_last_check', 'timestamp')
-        return super()._auto_init()
+    # -------------------------------------------------------------------------
+    # HELPERS
+    # -------------------------------------------------------------------------
 
-    # -------------------------------------------------------------------------
-    # BUSINESS ACTIONS
-    # -------------------------------------------------------------------------
+    def _log_verification_state_update(self, company, old_value, new_value):
+        # log the update of the peppol verification state
+        # we do this instead of regular tracking because of the customized message
+        # and because we want to log the change for every company in the db
+        if old_value == new_value:
+            return
+
+        peppol_verification_state_field = self._fields['peppol_verification_state']
+        selection_values = dict(peppol_verification_state_field.selection)
+        old_label = selection_values[old_value] if old_value else False  # get translated labels
+        new_label = selection_values[new_value] if new_value else False
+
+        body = Markup("""
+            <ul>
+                <li>
+                    <span class='o-mail-Message-trackingOld me-1 px-1 text-muted fw-bold'>{old}</span>
+                    <i class='o-mail-Message-trackingSeparator fa fa-long-arrow-right mx-1 text-600'/>
+                    <span class='o-mail-Message-trackingNew me-1 fw-bold text-info'>{new}</span>
+                    <span class='o-mail-Message-trackingField ms-1 fst-italic text-muted'>({field})</span>
+                    <span class='o-mail-Message-trackingCompany ms-1 fst-italic text-muted'>({company})</span>
+                </li>
+            </ul>
+        """).format(
+            old=old_label,
+            new=new_label,
+            field=peppol_verification_state_field.string,
+            company=company.display_name,
+        )
+        self._message_log(body=body)
 
     @api.model
     def _get_participant_info(self, edi_identification):
@@ -72,11 +83,7 @@ class ResPartner(models.Model):
         return etree.fromstring(response.content)
 
     @api.model
-    def _check_peppol_participant_exists(self, edi_identification, check_company=False, ubl_cii_format=False):
-        participant_info = self._get_participant_info(edi_identification)
-        if participant_info is None:
-            return False
-
+    def _check_peppol_participant_exists(self, participant_info, edi_identification, check_company=False):
         participant_identifier = participant_info.findtext('{*}ParticipantIdentifier')
         service_metadata = participant_info.find('.//{*}ServiceMetadataReference')
         service_href = ''
@@ -101,18 +108,36 @@ class ResPartner(models.Model):
                     access_point_contact = access_point_info.findtext('.//{*}TechnicalContactUrl') or access_point_info.findtext('.//{*}TechnicalInformationUrl')
             return access_point_contact
 
-        return self._check_document_type_support(participant_info, ubl_cii_format)
+        return True
 
     def _check_document_type_support(self, participant_info, ubl_cii_format):
-        service_metadata = participant_info.find('.//{*}ServiceMetadataReferenceCollection')
-        if service_metadata is None:
-            return False
-
+        service_references = participant_info.findall(
+            '{*}ServiceMetadataReferenceCollection/{*}ServiceMetadataReference'
+        )
         document_type = self.env['account.edi.xml.ubl_21']._get_customization_ids()[ubl_cii_format]
-        for service in service_metadata.iterfind('{*}ServiceMetadataReference'):
+        for service in service_references:
             if document_type in parse.unquote_plus(service.attrib.get('href', '')):
                 return True
         return False
+
+    def _update_peppol_state_per_company(self, vals=None):
+        partners = self.env['res.partner']
+        if vals is None:
+            partners = self.filtered(lambda p: all([p.peppol_eas, p.peppol_endpoint, p.ubl_cii_format, p.country_code in PEPPOL_LIST]))
+        elif {'peppol_eas', 'peppol_endpoint', 'ubl_cii_format'}.intersection(vals.keys()):
+            partners = self.filtered(lambda p: p.country_code in PEPPOL_LIST)
+
+        all_companies = None
+        for partner in partners.sudo():
+            if partner.company_id:
+                partner.with_company(partner.company_id).button_account_peppol_check_partner_endpoint()
+                continue
+
+            if all_companies is None:
+                all_companies = self.env['res.company'].sudo().search([])
+
+            for company in all_companies:
+                partner.with_company(company).button_account_peppol_check_partner_endpoint()
 
     # -------------------------------------------------------------------------
     # COMPUTE METHODS
@@ -121,29 +146,22 @@ class ResPartner(models.Model):
     @api.depends('ubl_cii_format')
     def _compute_is_peppol_edi_format(self):
         for partner in self:
-            partner.is_peppol_edi_format = partner.ubl_cii_format not in (False, 'facturx', 'oioubl_201', 'ciusro')
+            partner.is_peppol_edi_format = partner.ubl_cii_format not in NON_PEPPOL_FORMAT
 
-    @api.depends('peppol_eas', 'peppol_endpoint', 'ubl_cii_format')
-    def _compute_account_peppol_is_endpoint_valid(self):
-        for partner in self:
-            partner.button_account_peppol_check_partner_endpoint()
+    # -------------------------------------------------------------------------
+    # LOW-LEVEL METHODS
+    # -------------------------------------------------------------------------
 
-    @api.depends('account_peppol_is_endpoint_valid', 'account_peppol_validity_last_check')
-    def _compute_account_peppol_verification_label(self):
-        for partner in self:
-            if not partner.account_peppol_validity_last_check:
-                partner.account_peppol_verification_label = 'not_verified'
-            elif (
-                partner.is_peppol_edi_format
-                and (participant_info := self._get_participant_info(f'{partner.peppol_eas}:{partner.peppol_endpoint}'.lower())) is not None
-                and not partner._check_document_type_support(participant_info, partner.ubl_cii_format)
-            ):
-                # the partner might exist on the network, but not be able to receive that specific format
-                partner.account_peppol_verification_label = 'not_valid_format'
-            elif partner.account_peppol_is_endpoint_valid:
-                partner.account_peppol_verification_label = 'valid'
-            else:
-                partner.account_peppol_verification_label = 'not_valid'
+    def write(self, vals):
+        res = super().write(vals)
+        self._update_peppol_state_per_company(vals=vals)
+        return res
+
+    def create(self, vals_list):
+        res = super().create(vals_list)
+        if res:
+            res._update_peppol_state_per_company()
+        return res
 
     # -------------------------------------------------------------------------
     # BUSINESS ACTIONS
@@ -161,10 +179,24 @@ class ResPartner(models.Model):
         """
         self.ensure_one()
 
-        if not (self.peppol_eas and self.peppol_endpoint) or not self.is_peppol_edi_format:
-            self.account_peppol_is_endpoint_valid = False
+        old_value = self.peppol_verification_state
+        if (
+            not (self.peppol_eas and self.peppol_endpoint)
+            or self.ubl_cii_format in NON_PEPPOL_FORMAT
+        ):
+            self.peppol_verification_state = False
         else:
-            edi_identification = f'{self.peppol_eas}:{self.peppol_endpoint}'.lower()
-            self.account_peppol_validity_last_check = fields.Date.context_today(self)
-            self.account_peppol_is_endpoint_valid = bool(self._check_peppol_participant_exists(edi_identification, ubl_cii_format=self.ubl_cii_format))
+            edi_identification = f"{self.peppol_eas}:{self.peppol_endpoint}".lower()
+            participant_info = self._get_participant_info(edi_identification)
+            if participant_info is None:
+                self.peppol_verification_state = 'not_valid'
+            else:
+                is_participant_on_network = self._check_peppol_participant_exists(participant_info, edi_identification)
+                if is_participant_on_network:
+                    is_valid_format = self._check_document_type_support(participant_info, self.ubl_cii_format)
+                    self.peppol_verification_state = 'valid' if is_valid_format else 'not_valid_format'
+                else:
+                    self.peppol_verification_state = 'not_valid'
+
+        self._log_verification_state_update(self.env.company, old_value, self.peppol_verification_state)
         return False

--- a/addons/account_peppol/tests/test_peppol_messages.py
+++ b/addons/account_peppol/tests/test_peppol_messages.py
@@ -56,9 +56,6 @@ class TestPeppolMessage(TestAccountMoveSendCommon):
             'peppol_endpoint': '2718281828',
         }])
 
-        cls.valid_partner.account_peppol_is_endpoint_valid = True
-        cls.valid_partner.account_peppol_validity_last_check = '2022-12-01'
-
         cls.env['res.partner.bank'].create({
             'acc_number': '0144748555',
             'partner_id': cls.env.company.partner_id.id,
@@ -148,7 +145,9 @@ class TestPeppolMessage(TestAccountMoveSendCommon):
             response.status_code = 404
             return response
         if r.url.endswith('iso6523-actorid-upis%3A%3A0208%3A2718281828'):
-            response._content = b'<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n<smp:ServiceGroup xmlns:wsa="http://www.w3.org/2005/08/addressing" xmlns:id="http://busdox.org/transport/identifiers/1.0/" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:smp="http://busdox.org/serviceMetadata/publishing/1.0/"><id:ParticipantIdentifier scheme="iso6523-actorid-upis">0208:2718281828</id:ParticipantIdentifier></smp:ServiceGroup>'
+            response._content = b"""<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n<smp:ServiceGroup xmlns:wsa="http://www.w3.org/2005/08/addressing" xmlns:id="http://busdox.org/transport/identifiers/1.0/" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:smp="http://busdox.org/serviceMetadata/publishing/1.0/"><id:ParticipantIdentifier scheme="iso6523-actorid-upis">0208:2718281828</id:ParticipantIdentifier>
+            '<smp:ServiceMetadataReferenceCollection><smp:ServiceMetadataReference href="https://iap-services.odoo.com/iso6523-actorid-upis%3A%3A0208%3A0477472701/services/busdox-docid-qns%3A%3Aurn%3Aoasis%3Anames%3Aspecification%3Aubl%3Aschema%3Axsd%3AInvoice-2%3A%3AInvoice%23%23urn%3Acen.eu%3Aen16931%3A2017%23compliant%23urn%3Afdc%3Apeppol.eu%3A2017%3Apoacc%3Abilling%3A3.0%3A%3A2.1"/>'
+            '</smp:ServiceMetadataReferenceCollection></smp:ServiceGroup>"""
             return response
         if r.url.endswith('iso6523-actorid-upis%3A%3A0198%3Adk16356706'):
             response._content = b'<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n<smp:ServiceGroup xmlns:wsa="http://www.w3.org/2005/08/addressing" xmlns:id="http://busdox.org/transport/identifiers/1.0/" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:smp="http://busdox.org/serviceMetadata/publishing/1.0/"><id:ParticipantIdentifier scheme="iso6523-actorid-upis">0198:dk16356706</id:ParticipantIdentifier></smp:ServiceGroup>'
@@ -342,8 +341,7 @@ class TestPeppolMessage(TestAccountMoveSendCommon):
         })
         self.assertRecordValues(
             new_partner, [{
-                'account_peppol_verification_label': 'not_verified',
-                'account_peppol_is_endpoint_valid': False,
+                'peppol_verification_state': 'not_verified',
                 'peppol_eas': '0208',
                 'peppol_endpoint': False,
             }])
@@ -351,8 +349,7 @@ class TestPeppolMessage(TestAccountMoveSendCommon):
         new_partner.peppol_endpoint = '0477472701'
         self.assertRecordValues(
             new_partner, [{
-                'account_peppol_verification_label': 'valid',
-                'account_peppol_is_endpoint_valid': True,  # should validate automatically
+                'peppol_verification_state': 'valid',  # should validate automatically
                 'peppol_eas': '0208',
                 'peppol_endpoint': '0477472701',
             }])
@@ -360,14 +357,13 @@ class TestPeppolMessage(TestAccountMoveSendCommon):
         new_partner.peppol_endpoint = '3141592654'
         self.assertRecordValues(
             new_partner, [{
-                'account_peppol_verification_label': 'not_valid',
-                'account_peppol_is_endpoint_valid': False,
+                'peppol_verification_state': 'not_valid',
                 'peppol_eas': '0208',
                 'peppol_endpoint': '3141592654',
             }])
 
         new_partner.ubl_cii_format = False
-        self.assertFalse(new_partner.account_peppol_is_endpoint_valid)
+        self.assertFalse(new_partner.peppol_verification_state)
 
         # the participant exists on the network but cannot receive XRechnung
         new_partner.write({
@@ -376,8 +372,7 @@ class TestPeppolMessage(TestAccountMoveSendCommon):
         })
         self.assertRecordValues(
             new_partner, [{
-                'account_peppol_verification_label': 'not_valid_format',
-                'account_peppol_is_endpoint_valid': False,
+                'peppol_verification_state': 'not_valid_format',
                 'peppol_eas': '0208',
                 'peppol_endpoint': '0477472701',
             }])

--- a/addons/account_peppol/tools/demo_utils.py
+++ b/addons/account_peppol/tools/demo_utils.py
@@ -82,8 +82,9 @@ def _mock_make_request(func, self, *args, **kwargs):
 
 def _mock_button_verify_partner_endpoint(func, self, *args, **kwargs):
     self.ensure_one()
-    self.account_peppol_validity_last_check = fields.Date.today()
-    self.account_peppol_is_endpoint_valid = True
+    old_value = self.peppol_verification_state
+    self.peppol_verification_state = 'valid'
+    self._log_verification_state_update(self.env.company, old_value, 'valid')
 
 def _mock_user_creation(func, self, *args, **kwargs):
     func(self, *args, **kwargs)

--- a/addons/account_peppol/views/res_partner_views.xml
+++ b/addons/account_peppol/views/res_partner_views.xml
@@ -18,20 +18,19 @@
                     <div class="alert alert-warning"
                          colspan="2"
                          role="alert"
-                         invisible="not account_peppol_is_endpoint_valid or country_code">
+                         invisible="peppol_verification_state != 'valid' or country_code">
                          To generate complete electronic invoices, also set a country for this partner.
                     </div>
                 </xpath>
                 <xpath expr="//field[@name='peppol_endpoint']" position="after">
-                    <field name="account_peppol_is_endpoint_valid" invisible="1"/>
-                    <field name="account_peppol_validity_last_check" invisible="1"/>
                     <field name="is_peppol_edi_format" invisible="1"/>
-                    <label for="account_peppol_verification_label"
+                    <field name="peppol_verification_state" invisible="1" force_save="1"/>
+                    <label for="peppol_verification_state"
                            invisible="not is_peppol_edi_format or not peppol_endpoint"/>
                     <div class="row"
                         invisible="not is_peppol_edi_format or not peppol_endpoint">
                         <div class="col-4">
-                            <field name="account_peppol_verification_label"/>
+                            <field name="peppol_verification_state" readonly="1"/>
                         </div>
                         <div class="col-8 pt-0">
                             <button name="button_account_peppol_check_partner_endpoint"
@@ -54,7 +53,7 @@
             <xpath expr="//field[@name='ubl_cii_format']" position="after">
                 <field name="peppol_eas" string="Peppol EAS" optional="hide"/>
                 <field name="peppol_endpoint" string="Peppol Endpoint" optional="hide"/>
-                <field name="account_peppol_is_endpoint_valid" string="Peppol Validity" optional="hide"/>
+                <field name="peppol_verification_state" string="Peppol Validity" optional="hide"/>
             </xpath>
         </field>
     </record>

--- a/addons/account_peppol/wizard/account_move_send.py
+++ b/addons/account_peppol/wizard/account_move_send.py
@@ -71,7 +71,7 @@ class AccountMoveSend(models.TransientModel):
             warnings = {}
 
             invalid_partners = wizard.move_ids.partner_id.commercial_partner_id.filtered(
-                lambda partner: not partner.account_peppol_is_endpoint_valid)
+                lambda partner: partner.peppol_verification_state != 'valid')
             ubl_warning_already_displayed = wizard.warnings and 'account_edi_ubl_cii_configure_partner' in wizard.warnings
             if invalid_partners and not ubl_warning_already_displayed:
                 warnings['account_peppol_warning_partner'] = {
@@ -188,7 +188,7 @@ class AccountMoveSend(models.TransientModel):
                     invoice_data['error'] = _('The partner is missing Peppol EAS and/or Endpoint identifier.')
                     continue
 
-                if not partner.account_peppol_is_endpoint_valid:
+                if partner.peppol_verification_state != 'valid':
                     invoice.peppol_move_state = 'error'
                     invoice_data['error'] = _('Please verify partner configuration in partner settings.')
                     continue


### PR DESCRIPTION
Current partner verification is complex. We do not need three fields to handle one verification.
Another problem is that the field is stored and that value remains on the partner regardless of the EDI mode of the active company in the database.

This commit cleans up the verification process.

task-4038127



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
