### PR TITLE
[FIX] point_of_sale: always use usd company in pos tests

### DIFF
--- a/addons/point_of_sale/tests/common.py
+++ b/addons/point_of_sale/tests/common.py
@@ -596,6 +596,7 @@ class TestPoSCommon(ValuationReconciliationTestCommon):
             'categ_id': category.id,
             'lst_price': lst_price,
             'standard_price': standard_price if standard_price else 0.0,
+            'company_id': cls.env.company.id,
         })
         if sale_account:
             product.property_account_income_id = sale_account


### PR DESCRIPTION
The tests were failing when the company currency was not USD, because the tests were using the company currency to create the products and the pricelists. This commit changes the tests to always use USD as the company currency.

Runbot errors ids: 
64677,64676,64675,64674,64673,64672,64671,64670,64669,64668,64667,64666,64665,64664,64663,64662,64661,64660,64659,64658,64657,64656,64655,64654,64653,64652,64651,64650,64649,64648,64647,64646,64645,64644,64643,64642,64641,64640,64639,64638,64637,64636,64635,64634,64633,64632,64631,64630,64629,64628,64627,64626,64625,64624,64623,64622
