### PR TITLE
[FIX] web, website: searchbar menu columns width and tooltips

### DIFF
--- a/addons/web/static/src/search/search_bar_menu/search_bar_menu.scss
+++ b/addons/web/static/src/search/search_bar_menu/search_bar_menu.scss
@@ -6,15 +6,12 @@
     max-width: $-menu-max-width;
     .o_dropdown_container {
         border-color: $dropdown-divider-bg !important;
+        min-width: 200px;
     }
 
     @include media-breakpoint-up(lg) {
-        .o_favorite_menu {
-            max-width: calc(#{$-menu-max-width} / 3);
-        }
-
-        .o_comparison_menu + .o_favorite_menu {
-            max-width: calc(#{$-menu-max-width} / 4);
+        .o_dropdown_container {
+            max-width: calc(#{$-menu-max-width} / 6);
         }
     }
 }

--- a/addons/web/static/src/search/search_bar_menu/search_bar_menu.xml
+++ b/addons/web/static/src/search/search_bar_menu/search_bar_menu.xml
@@ -12,7 +12,7 @@
             </t>
             <!-- Filter -->
             <t t-if="this.env.searchModel.searchMenuTypes.has('filter')">
-                <div class="o_dropdown_container o_filter_menu w-100 w-lg-auto px-3 mb-4 mb-lg-0 border-end">
+                <div class="o_dropdown_container o_filter_menu w-100 h-100 w-lg-auto px-3 mb-4 mb-lg-0 border-end">
                     <div class="px-3 fs-5 mb-2">
                         <i class="me-2 text-primary" t-att-class="facet_icons.filter"/>
                         <h5 class="o_dropdown_title d-inline">Filters</h5>
@@ -47,6 +47,7 @@
                                                 checked="item.isActive"
                                                 parentClosingMode="'none'"
                                                 t-esc="item.description"
+                                                 title="item.description.length > 15 ? item.description : ''"
                                                 onSelected="() => this.onFilterSelected({ itemId: item.id })"
                             />
                         </t>
@@ -60,7 +61,7 @@
             </t>
             <!-- GroupBy -->
             <t t-if="this.env.searchModel.searchMenuTypes.has('groupBy')">
-                <div class="o_dropdown_container o_group_by_menu w-100 w-lg-auto px-3 mb-4 mb-lg-0 border-end">
+                <div class="o_dropdown_container o_group_by_menu w-100 h-100 w-lg-auto px-3 mb-4 mb-lg-0 border-end">
                     <div class="px-3 fs-5 mb-2">
                         <i class="me-2 text-action" t-att-class="facet_icons.groupBy"/>
                         <h5 class="o_dropdown_title d-inline">Group By</h5>
@@ -84,6 +85,7 @@
                                                         checked="option.isActive ? true : false"
                                                         parentClosingMode="'none'"
                                                         t-esc="option.description"
+                                                        title="option.description.length > 15 ? option.description : ''"
                                                         onSelected="() => this.onGroupBySelected({ itemId: item.id, optionId: option.id})"
                                     />
                                     <t t-set="subGroup" t-value="option.groupNumber"/>
@@ -95,6 +97,7 @@
                                                 checked="item.isActive"
                                                 parentClosingMode="'none'"
                                                 t-esc="item.description"
+                                                title="item.description.length > 15 ? item.description : ''"
                                                 onSelected="() => this.onGroupBySelected({ itemId: item.id })"
                             />
                         </t>
@@ -108,7 +111,7 @@
             </t>
             <!-- Comparison -->
             <t t-if="showComparisonMenu">
-                <div class="o_dropdown_container o_comparison_menu w-100 w-lg-auto px-3 border-end">
+                <div class="o_dropdown_container o_comparison_menu w-100 h-100 w-lg-auto px-3 border-end">
                     <div class="px-3 fs-5 mb-2">
                         <i class="me-2 text-danger" t-att-class="facet_icons.comparison"/>
                         <h5 class="o_dropdown_title d-inline">Comparison</h5>
@@ -118,6 +121,7 @@
                                             checked="item.isActive"
                                             parentClosingMode="'none'"
                                             t-esc="item.description"
+                                            title="item.description.length > 15 ? item.description : ''"
                                             onSelected="() => this.onComparisonSelected(item.id)"
                         />
                     </t>
@@ -125,7 +129,7 @@
             </t>
             <!-- Favorite -->
             <t t-if="this.env.searchModel.searchMenuTypes.has('favorite')">
-                <div class="o_dropdown_container o_favorite_menu w-100 w-lg-auto px-3">
+                <div class="o_dropdown_container o_favorite_menu w-100 h-100 w-lg-auto px-3">
                     <div class="px-3 fs-5 mb-2">
                         <i class="me-2 text-favourite" t-att-class="facet_icons.favorite"/>
                         <h5 class="o_dropdown_title d-inline">Favorites</h5>
@@ -142,7 +146,7 @@
                                                 onSelected="() => this.onFavoriteSelected(item.id)"
                             >
                                 <span class="d-flex p-0 align-items-center justify-content-between">
-                                    <span t-out="item.description" class="text-truncate"/>
+                                    <span t-out="item.description" t-att-title="item.description.length > 15 ? item.description : ''" class="text-truncate"/>
                                     <i class="ms-1 o_icon_right fa fa-trash-o"
                                        title="Delete item"
                                        t-on-click.stop="() => this.openConfirmationDialog(item.id)"

--- a/addons/website/static/src/components/views/page_list.xml
+++ b/addons/website/static/src/components/views/page_list.xml
@@ -27,16 +27,17 @@
 </t>
 
 <t t-name="website.RecordFilter" owl="1">
-    <div t-if="websiteSelection.length > 1" class="o_dropdown_container o_website_menu w-100 w-lg-auto px-3 border-start">
+    <div t-if="websiteSelection.length > 1" class="o_dropdown_container o_website_menu w-100 w-lg-auto h-100 px-3 border-start">
         <div class="px-3 fs-5 mb-2">
             <i class="me-2 fa fa-globe"/>
             <h5 class="o_dropdown_title d-inline">Website</h5>
         </div>
         <t t-foreach="websiteSelection" t-as="website" t-key="website.id">
-            <SearchDropdownItem class="{ o_menu_item: true, selected: state.activeWebsite.id === website.id }"
+            <SearchDropdownItem class="{ 'o_menu_item text-truncate': true, selected: state.activeWebsite.id === website.id }"
                 checked="state.activeWebsite.id === website.id"
                 parentClosingMode="'none'"
                 t-esc="website.name"
+                title="website.name.length > 15 ? website.name : ''"
                 onSelected="() => this.onSelectWebsite(website)"
             />
             <div t-if="!website.id" class="dropdown-divider"/>


### PR DESCRIPTION
This commit addresses the same issue as in https://github.com/odoo/odoo/pull/137214 which is overflowing of search bar menu items when their name is too long while also adapting some width values and make it apply to the website
name column. It also adds a height value to the containers so that the bottom is no longer squished when the content overflows and finally adds tooltips for long item names which will most likely be truncated.

opw-3963754
