### PR TITLE
[FIX] product: prevent auto grouping by template

### DIFF
--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -233,7 +233,7 @@
                     <field name="product_tmpl_id" string="Product Template"/>
                 </field>
                 <filter name="categ_id" position="after">
-                    <filter string="Product Template" name="product_tmpl_id" context="{'group_by':'product_tmpl_id'}"/>
+                    <filter string="Product Template" name="group_by_product_tmpl_id" context="{'group_by':'product_tmpl_id'}"/>
                 </filter>
             </field>
         </record>


### PR DESCRIPTION
Inventory B2B 16 7 task introduced grouping by product template ID. When the product variants list is accessed from the product page, this grouping is enabled by default, although it shouldn't be:

https://github.com/odoo/odoo/pull/135104#issuecomment-2162505672

The reason is that using `search_default_product_tmpl_id` in the action's context not only filters by the product template, but also activates the "Group By" filter. A quick fix for this problem is to rename the grouping.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
