### PR TITLE
[REV] point_of_sale,pos_sale: revert fix due to a bad implementation

### DIFF
--- a/addons/point_of_sale/wizard/pos_payment.py
+++ b/addons/point_of_sale/wizard/pos_payment.py
@@ -70,10 +70,6 @@ class PosMakePayment(models.TransientModel):
             order._process_saved_order(False)
             if order.state in {'paid', 'done', 'invoiced'}:
                 order._send_order()
-
-                active_pos_order = self.env["pos.order"].browse(self.env.context.get("active_id"))
-                active_pos_order.lines.sale_order_line_id._compute_name()
-
             return {'type': 'ir.actions.act_window_close'}
 
         return self.launch_payment()

--- a/addons/pos_sale/models/sale_order.py
+++ b/addons/pos_sale/models/sale_order.py
@@ -76,15 +76,6 @@ class SaleOrderLine(models.Model):
         for sale_line in self:
             sale_line.qty_invoiced += sum([self._convert_qty(sale_line, pos_line.qty, 'p2s') for pos_line in sale_line.pos_order_line_ids], 0)
 
-    @api.depends('product_id', 'pos_order_line_ids.order_id.refund_orders_count')
-    def _compute_name(self):
-        super()._compute_name()
-        for line in self.filtered(lambda l: l.is_downpayment and not l.display_type):
-            if line.pos_order_line_ids.order_id.filtered(lambda o: o.refund_orders_count or o.account_move.state == 'cancel'):
-                name = line._get_sale_order_line_multiline_description_sale()
-                # Update the name with the Cancelled statement
-                line.name = _("%(line_description)s (Cancelled)", line_description=name)
-
     def _get_sale_order_fields(self):
         return ["product_id", "display_name", "price_unit", "product_uom_qty", "tax_id", "qty_delivered", "qty_invoiced", "discount", "qty_to_invoice", "price_total"]
 


### PR DESCRIPTION
This fix isn't working, trying to access to `sale_order_line_id` from point_of_sale, but this field is declared in pos_sale.

Revert commit: 2dfe718ce3a8f9056553cc716e820f1d79a242ff

Runbot error ids:
68148, 68147, 68146, 68145, 68144, 68143, 68142, 68179, 68178, 68177, 68141, 68140, 68139, 68176, 68175, 68138, 68174, 68137, 68136, 68135, 68134, 68133, 68132, 68131, 68130, 68129, 68128, 68127, 68126, 68125, 68124, 68123, 68122, 68121, 68120, 68119, 68118, 68173, 68172, 68171, 68170, 68169, 68168, 68167, 68166, 68165, 68164, 68163, 68162, 68161, 68160, 68159, 68158, 68157, 68156, 68155, 68154, 68153, 68152, 68150, 68149, 68110, 68109, 68108, 68107, 68106, 68116, 68115, 68114, 68113, 68112