### PR TITLE
[IMP] website: improve UX around modifying page 404

### DIFF
--- a/addons/website/static/src/components/dialog/add_page_dialog.js
+++ b/addons/website/static/src/components/dialog/add_page_dialog.js
@@ -27,6 +27,10 @@ export class AddPageConfirmDialog extends Component {
             optional: true,
         },
         name: String,
+        url: {
+            type: String,
+            optional: true,
+        }
     };
     static defaultProps = {
         onAddPage: NO_OP,
@@ -49,8 +53,16 @@ export class AddPageConfirmDialog extends Component {
 
         this.state = useState({
             addMenu: true,
-            name: this.props.name,
+            name: this.props.name || this._tryGuessName(this.props.url),
         });
+    }
+
+    _tryGuessName(url) {
+        if (!url) {
+            return null;
+        }
+        const urlParts = url.replace(/^\/*/, "").split("-");
+        return urlParts.map(part => part.charAt(0).toUpperCase() + part.slice(1)).join(" ");
     }
 
     onChangeAddMenu(value) {
@@ -389,6 +401,10 @@ export class AddPageDialog extends Component {
         websiteId: {
             type: Number,
         },
+        url: {
+            type: String,
+            optional: true,
+        }
     };
     static defaultProps = {
         onAddPage: NO_OP,
@@ -435,6 +451,7 @@ export class AddPageDialog extends Component {
             websiteId: this.props.websiteId,
             sectionsArch: sectionsArch,
             name: name || this.lastTabName,
+            url: this.props.url,
         });
     }
 

--- a/addons/website/static/src/systray_items/edit_website.js
+++ b/addons/website/static/src/systray_items/edit_website.js
@@ -6,6 +6,7 @@ import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { useService } from '@web/core/utils/hooks';
 import { Component, useState, useEffect } from "@odoo/owl";
+import { AddPageDialog } from "../components/dialog/add_page_dialog";
 
 class EditWebsiteSystray extends Component {
     static template = "website.EditWebsiteSystray";
@@ -16,6 +17,7 @@ class EditWebsiteSystray extends Component {
     static props = {};
     setup() {
         this.websiteService = useService('website');
+        this.dialogs = useService('dialog');
         this.websiteContext = useState(this.websiteService.context);
 
         this.state = useState({
@@ -73,6 +75,18 @@ class EditWebsiteSystray extends Component {
         } else {
             this.websiteContext.edition = true;
         }
+    }
+
+    is404() {
+        const { metadata: { viewXmlid } } = this.websiteService.currentWebsite;
+        return viewXmlid === "website.page_404";
+    }
+
+    async createPage() {
+        this.dialogs.add(AddPageDialog, {
+            websiteId: this.websiteService.currentWebsite.id,
+            url: this.websiteService.contentWindow.location.pathname,
+        });
     }
 }
 

--- a/addons/website/static/src/systray_items/edit_website.xml
+++ b/addons/website/static/src/systray_items/edit_website.xml
@@ -2,23 +2,53 @@
 <templates xml:space="preserve">
 <t t-name="website.EditWebsiteSystray">
     <div class="o_menu_systray_item o_edit_website_container d-none d-md-flex">
-        <a t-if="!translatable" href="#" class="o-website-btn-custo-primary btn position-relative d-flex align-items-center rounded-0 border-0 px-3" accesskey="a" t-on-click="startEdit">
+        <a t-if="!translatable and !this.is404()" href="#"
+           class="o-website-btn-custo-primary btn position-relative d-flex align-items-center rounded-0 border-0 px-3"
+           accesskey="a" t-on-click="startEdit">
             <span t-if="this.state.isLoading" class="position-absolute top-50 start-50 translate-middle">
                 <i class="fa fa-refresh fa-spin"/>
             </span>
             <span t-out="label" t-attf-class="{{ this.state.isLoading ? 'opacity-0' : 'opacity-100' }}"/>
         </a>
         <Dropdown t-else="">
-            <button class="o-dropdown-toggle-custo o-website-btn-custo-primary btn rounded-0 border-0 px-3" data-hotkey="a">
+            <button class="o-dropdown-toggle-custo o-website-btn-custo-primary btn rounded-0 border-0 px-3"
+                    data-hotkey="a">
                 <span t-out="label"/>
             </button>
             <t t-set-slot="content">
-                <DropdownItem onSelected="() => this.startTranslate()" class="'o_translate_website_dropdown_item'">
-                    Translate - <span class="text-muted" t-out="this.websiteService.currentWebsite.metadata.langName"/>
-                </DropdownItem>
-                <DropdownItem onSelected="() => this.startEdit()" class="'o_edit_website_dropdown_item'">
-                    Edit - <span class="text-muted" t-out="this.websiteService.currentWebsite.metadata.defaultLangName"/>
-                </DropdownItem>
+                <t t-if="translatable and this.is404()">
+                    <DropdownItem onSelected="() => this.startTranslate()" class="'o_translate_website_dropdown_item'">
+                        Translate - <span class="text-muted"
+                                          t-out="this.websiteService.currentWebsite.metadata.langName"/>
+                    </DropdownItem>
+                    <DropdownItem onSelected="() => this.startEdit()" class="'o_edit_website_dropdown_item'">
+                        Edit 404 page - <span class="text-muted"
+                                     t-out="this.websiteService.currentWebsite.metadata.defaultLangName"/>
+                    </DropdownItem>
+                    <DropdownItem onSelected="() => this.createPage()"
+                                  class="'o_edit_website_dropdown_item'">
+                        Create page
+                    </DropdownItem>
+                </t>
+                <t t-elif="translatable">
+                    <DropdownItem onSelected="() => this.startTranslate()" class="'o_translate_website_dropdown_item'">
+                        Translate - <span class="text-muted"
+                                          t-out="this.websiteService.currentWebsite.metadata.langName"/>
+                    </DropdownItem>
+                    <DropdownItem onSelected="() => this.startEdit()" class="'o_edit_website_dropdown_item'">
+                        Edit - <span class="text-muted"
+                                     t-out="this.websiteService.currentWebsite.metadata.defaultLangName"/>
+                    </DropdownItem>
+                </t>
+                <t t-elif="this.is404()">
+                    <DropdownItem onSelected="() => this.startEdit()" class="'o_edit_website_dropdown_item'">
+                        Edit 404 page
+                    </DropdownItem>
+                    <DropdownItem onSelected="() => this.createPage()"
+                                  class="'o_edit_website_dropdown_item'">
+                        Create page
+                    </DropdownItem>
+                </t>
             </t>
         </Dropdown>
     </div>

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -2385,16 +2385,6 @@
 <!-- PAGE 404 -->
 <template id="page_404" name="Page Not Found">
     <t t-call="http_routing.404">
-        <div class="o_not_editable bg-100 pt40">
-            <div class="container">
-                <div class="alert alert-info text-center d-lg-flex justify-content-between align-items-center">
-                    <p class="m-lg-0 text-info">This page does not exist, but you can create it as you are editor of this site.</p>
-                    <a role="button" class="btn btn-info js_disable_on_click post_link" data-post_force-top-window="true" t-attf-href="/website/add/#{path}?redirect=1#{from_template and '&amp;template=%s' % from_template}">Create Page</a>
-                </div>
-                <div class="text-center text-muted p-3"><i class="fa fa-info-circle"></i> Edit the content below this line to adapt the default <strong>Page not found</strong> page.</div>
-            </div>
-            <hr/>
-        </div>
     </t>
 </template>
 


### PR DESCRIPTION
This commit has for main purpose to make people understand they're editing the 404 page.

This commit remove UI elements from the content window as we don't want them in it.

This commit also adapt Edit button based on current page to display a dropdown when located on a 404 page so we can choose between editing the 404 page itself or creating the corresponding page based on the URL. Based on the URL, we try to guess the name of the page to fill the page name input at the creation of the page by the user.

task-3634878

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
