### PR TITLE
[FIX] web_editor: won't place font element between if else nodes

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
@@ -605,7 +605,7 @@ export const editorCommands = {
         if (!range) return;
         const restoreCursor = preserveCursor(editor.document);
         // Get the <font> nodes to color
-        const selectionNodes = getSelectedNodes(editor.editable).filter(node => closestElement(node).isContentEditable);
+        const selectionNodes = getSelectedNodes(editor.editable).filter(node => closestElement(node).isContentEditable && node.nodeName !== "T");
         if (isEmptyBlock(range.endContainer)) {
             selectionNodes.push(range.endContainer, ...descendants(range.endContainer));
         }

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/color.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/color.test.js
@@ -144,6 +144,36 @@ describe('applyColor', () => {
             contentAfter: '<p>[abcabc]</p>',
         });
     });
+    it('Shall not apply font tag to t nodes (protects if else nodes separation)', async () => {
+        await testEditor(BasicEditor, {
+            contentBefore: unformat(`[
+                <p>
+                    <t t-if="object.partner_id.parent_id">
+                       <t t-out="object.partner_id.parent_id.name or ''">Azure Interior</t>
+                    </t>
+                    <t t-else="">
+                        <t t-out="object.partner_id.name or ''">Brandon Freeman</t>,
+                    </t>
+                </p>
+            ]`),
+            stepFunction: setColor('red', 'backgroundColor'),
+            contentAfter: unformat(`
+                <p>
+                    <t t-if="object.partner_id.parent_id">
+                        <t t-out="object.partner_id.parent_id.name or ''">
+                            <font style="background-color: red;">[AzureInterior</font>
+                        </t>
+                    </t>
+                    <t t-else="">
+                        <t t-out="object.partner_id.name or ''">
+                            <font style="background-color: red;">BrandonFreeman</font>
+                        </t>
+                        <font style="background-color: red;">,]</font>
+                    </t>
+                </p>
+            `),
+        });
+    });
 });
 describe('rgbToHex', () => {
     it('should convert an rgb color to hexadecimal', async () => {


### PR DESCRIPTION
[FIX] web_editor: won't place font element between if else nodes

Previously when we updated color on multiple selected nodes, </font> tag
would get inserted between qweb if and else tags. This caused qweb processor to crash.

After this change we don't insert font on the "t" elements.

[Reproduce]
- Install account
- Open Email Template called "Invoice: Sending"
- Change color of all of its content
- Open preview

opw-3912434
