### PR TITLE
[FIX] event: event tz not used when displaying dates on reminders

### DIFF
--- a/addons/event/models/event_registration.py
+++ b/addons/event/models/event_registration.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from dateutil.relativedelta import relativedelta
+import pytz
 
 from odoo import _, api, fields, models, SUPERUSER_ID
 from odoo.tools import format_datetime, email_normalize, email_normalize_all
@@ -339,9 +340,9 @@ class EventRegistration(models.Model):
 
     def get_date_range_str(self):
         self.ensure_one()
-        today = fields.Datetime.now()
-        event_date = self.event_begin_date
-        diff = (event_date.date() - today.date())
+        today_tz = pytz.utc.localize(fields.Datetime.now()).astimezone(pytz.timezone(self.event_id.date_tz))
+        event_date_tz = pytz.utc.localize(self.event_begin_date).astimezone(pytz.timezone(self.event_id.date_tz))
+        diff = (event_date_tz.date() - today_tz.date())
         if diff.days <= 0:
             return _('today')
         elif diff.days == 1:
@@ -350,7 +351,7 @@ class EventRegistration(models.Model):
             return _('in %d days') % (diff.days, )
         elif (diff.days < 14):
             return _('next week')
-        elif event_date.month == (today + relativedelta(months=+1)).month:
+        elif event_date_tz.month == (today_tz + relativedelta(months=+1)).month:
             return _('next month')
         else:
             return _('on %(date)s', date=format_datetime(self.env, self.event_begin_date, tz=self.event_id.date_tz, dt_format='medium'))

--- a/addons/event/tests/test_event_internals.py
+++ b/addons/event/tests/test_event_internals.py
@@ -58,6 +58,33 @@ class TestEventData(TestEventCommon):
         })
         self.assertTrue(event.is_one_day)
 
+        # Checks case when mocked today changes date before event, when event.date_tz considered
+        self.mock_datetime.now.return_value = datetime(2020, 6, 20, 20, 0, 0)
+        event.write({
+            'date_begin': datetime(2020, 6, 27, 1, 0, 0),
+            'date_end': datetime(2020, 7, 8, 2, 0, 0),
+            'date_tz': 'America/Los_Angeles'
+        })
+        # event_date_tz = 2020-06-26 18:00
+        # today_tz = 2020-06-20 13:00
+        # event_date_tz.date() - today_tz.date() = 6 days
+        self.assertEqual(registration.get_date_range_str(), u'in 6 days')
+
+        # Checks case when event changes date before mocked today, when event.date_tz considered
+        self.mock_datetime.now.return_value = datetime(2020, 6, 20, 13, 0, 0)
+        event.write({
+            'date_begin': datetime(2020, 6, 25, 20, 0, 0),
+            'date_end': datetime(2020, 7, 8, 2, 0, 0),
+            'date_tz': 'Australia/Sydney'
+        })
+        # event_date_tz = 2020-06-26 06:00
+        # today_tz = 2020-06-20 23:00
+        # event_date_tz.date() - today_tz.date() = 6 days
+        self.assertEqual(registration.get_date_range_str(), u'in 6 days')
+
+        # Resets mocked 'Today' value back to original
+        self.mock_datetime.now.return_value = datetime(2020, 1, 31, 10, 0, 0)
+
     @users('user_eventmanager')
     def test_event_date_timezone(self):
         event = self.event_0.with_user(self.env.user)


### PR DESCRIPTION
Problem: When registering for an Event, an `event.registration record` is created. Odoo will send a reminder email to these registered customers using the `Event: Reminder` email template. This template uses the `get_date_range_str`
method inside `event.registration` to calculate what the start date (`event_begin_date`) is and then decides which dynamic string to use (today, tomorrow, etc). However, this field is stored in UTC and uses a separate `date_tz` field to calculate what timezone should be used. This `date_tz` context is missing, leading to emails with the wrong subject and body content.

Purpose: Pass in the event's timezone to ensure that calculations involving the date_begin field display correctly.

Steps to Reproduce:
1) Create an Event
2) Set the timezone to America/Los Angeles
3) Set the times to 6:00 pm - 10:00pm (leading to different day in UTC compared to PST) 
4) Register customers to create `event.registration` records 
5) Trigger `get_date_range_str` function, either via Email Template or SA 
6) Check which string is returned based on time delta

opw-3993058