### PR TITLE
[FIX] web: removing \r characters from error msg added in fw-port

### DIFF
--- a/addons/web/i18n/web.pot
+++ b/addons/web/i18n/web.pot
@@ -5856,9 +5856,9 @@ msgstr ""
 #: code:addons/web/static/src/core/confirmation_dialog/confirmation_dialog.js:0
 #, python-format
 msgid ""
-"Ready to make your record disappear into thin air? Are you sure?\r\n"
-"It will be gone forever!\r\n"
-"\r\n"
+"Ready to make your record disappear into thin air? Are you sure?\n"
+"It will be gone forever!\n"
+"\n"
 "Think twice before you click that 'Delete' button!"
 msgstr ""
 


### PR DESCRIPTION
Problem: A recent commit (below) added carriage return characters to the .pot file for new `deleteConfirmationMessage` popup. Since the value of the string itself doesn't contain these characters, we'll never see a translation for this popup.

Purpose: Revert .pot msgid back to its previous state.

FW commit
/pull/162106/commits/50f9df296c44d3c86bc251a67944bb0ce36a154e

opw-3954024