### PR TITLE
[REF] mail: flatten store data sent on network (part 2 - RTC)

### DIFF
--- a/addons/mail/controllers/discuss/rtc.py
+++ b/addons/mail/controllers/discuss/rtc.py
@@ -130,7 +130,7 @@ class RtcController(http.Controller):
             ]
             channel_member_sudo.channel_id.rtc_session_ids.filtered_domain(domain).write({})  # update write_date
         current_rtc_sessions, outdated_rtc_sessions = channel_member_sudo._rtc_sync_sessions(check_rtc_session_ids)
-        store = Store("RtcSession", current_rtc_sessions._mail_rtc_session_format())
+        store = Store(current_rtc_sessions)
         channel_info = {
             "id": member.channel_id.id,
             "model": "discuss.channel",

--- a/addons/mail/controllers/discuss/rtc.py
+++ b/addons/mail/controllers/discuss/rtc.py
@@ -86,7 +86,7 @@ class RtcController(http.Controller):
         if not member:
             raise NotFound()
         # sudo: discuss.channel.rtc.session - member of current user can leave call
-        return member.sudo()._rtc_leave_call()
+        member.sudo()._rtc_leave_call()
 
     @http.route("/mail/rtc/channel/cancel_call_invitation", methods=["POST"], type="json", auth="public")
     @add_guest_to_context
@@ -99,7 +99,7 @@ class RtcController(http.Controller):
         if not channel:
             raise NotFound()
         # sudo: discuss.channel.rtc.session - can cancel invitations in accessible channel
-        return channel.sudo()._rtc_cancel_invitations(member_ids=member_ids)
+        channel.sudo()._rtc_cancel_invitations(member_ids=member_ids)
 
     @http.route("/mail/rtc/audio_worklet_processor", methods=["GET"], type="http", auth="public")
     def audio_worklet_processor(self):

--- a/addons/mail/controllers/discuss/rtc.py
+++ b/addons/mail/controllers/discuss/rtc.py
@@ -71,8 +71,10 @@ class RtcController(http.Controller):
         member = channel._find_or_create_member_for_self()
         if not member:
             raise NotFound()
+        store = Store()
         # sudo: discuss.channel.rtc.session - member of current user can join call
-        return member.sudo()._rtc_join_call(check_rtc_session_ids=check_rtc_session_ids)
+        member.sudo()._rtc_join_call(store, check_rtc_session_ids=check_rtc_session_ids)
+        return store.get_result()
 
     @http.route("/mail/rtc/channel/leave_call", methods=["POST"], type="json", auth="public")
     @add_guest_to_context

--- a/addons/mail/controllers/discuss/rtc.py
+++ b/addons/mail/controllers/discuss/rtc.py
@@ -130,9 +130,7 @@ class RtcController(http.Controller):
             ]
             channel_member_sudo.channel_id.rtc_session_ids.filtered_domain(domain).write({})  # update write_date
         current_rtc_sessions, outdated_rtc_sessions = channel_member_sudo._rtc_sync_sessions(check_rtc_session_ids)
-        store = Store(
-            "RtcSession", [session._mail_rtc_session_format() for session in current_rtc_sessions]
-        )
+        store = Store("RtcSession", current_rtc_sessions._mail_rtc_session_format())
         channel_info = {
             "id": member.channel_id.id,
             "model": "discuss.channel",

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -869,7 +869,7 @@ class Channel(models.Model):
         # sudo: bus.bus: reading non-sensitive last id
         bus_last_id = self.env["bus.bus"].sudo()._bus_last_id()
         # sudo: discuss.channel.rtc.session - reading sessions of accessible channel is acceptable
-        store.add("RtcSession", self.sudo().rtc_session_ids._mail_rtc_session_format(extra=True))
+        store.add(self.sudo().rtc_session_ids, extra=True)
         current_partner, current_guest = self.env["res.partner"]._get_current_persona()
         self.env['discuss.channel'].flush_model()
         self.env['discuss.channel.member'].flush_model()

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -486,7 +486,6 @@ class Channel(models.Model):
         if members:
             channel_data['invitedMembers'] = [('DELETE', list(members._discuss_channel_member_format(fields={'id': True, 'channel': {}, 'persona': {'partner': {'id': True, 'name': True, 'im_status': True}, 'guest': {'id': True, 'name': True, 'im_status': True}}}).values()))]
             self.env['bus.bus']._sendone(self, 'mail.record/insert', {'Thread': channel_data})
-        return channel_data
 
     # ------------------------------------------------------------
     # MAILING

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -466,26 +466,46 @@ class Channel(models.Model):
         ]
         if member_ids:
             channel_member_domain = expression.AND([channel_member_domain, [('id', 'in', member_ids)]])
-        invitation_notifications = []
+        notifications = []
         members = self.env['discuss.channel.member'].search(channel_member_domain)
         for member in members:
             member.rtc_inviting_session_id = False
-            if member.partner_id:
-                target = member.partner_id
-            else:
-                target = member.guest_id
-            invitation_notifications.append((target, 'mail.record/insert', {
-                'Thread': {
-                    'id': self.id,
-                    'model': 'discuss.channel',
-                    'rtcInvitingSession': False,
+            target = member.partner_id or member.guest_id
+            store = Store(
+                "Thread",
+                {
+                    "id": self.id,
+                    "model": "discuss.channel",
+                    "rtcInvitingSession": False,
                 }
-            }))
-        self.env['bus.bus']._sendmany(invitation_notifications)
-        channel_data = {'id': self.id, 'model': 'discuss.channel'}
+            )
+            notifications.append((target, "mail.record/insert", store.get_result()))
         if members:
-            channel_data['invitedMembers'] = [('DELETE', list(members._discuss_channel_member_format(fields={'id': True, 'channel': {}, 'persona': {'partner': {'id': True, 'name': True, 'im_status': True}, 'guest': {'id': True, 'name': True, 'im_status': True}}}).values()))]
-            self.env['bus.bus']._sendone(self, 'mail.record/insert', {'Thread': channel_data})
+            store = Store(
+                "Thread",
+                {
+                    "id": self.id,
+                    "model": "discuss.channel",
+                    "invitedMembers": [("DELETE", [{"id": member.id} for member in members])],
+                },
+            )
+            store.add(
+                "ChannelMember",
+                list(
+                    members._discuss_channel_member_format(
+                        fields={
+                            "id": True,
+                            "channel": {},
+                            "persona": {
+                                "partner": {"id": True, "name": True, "im_status": True},
+                                "guest": {"id": True, "name": True, "im_status": True},
+                            },
+                        }
+                    ).values()
+                ),
+            )
+            notifications.append((self, "mail.record/insert", store.get_result()))
+        self.env["bus.bus"]._sendmany(notifications)
 
     # ------------------------------------------------------------
     # MAILING

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -926,7 +926,7 @@ class Channel(models.Model):
                     info['custom_channel_name'] = member.custom_channel_name
                     info['is_pinned'] = member.is_pinned
                     if member.rtc_inviting_session_id:
-                        info['rtcInvitingSession'] = member.rtc_inviting_session_id._mail_rtc_session_format()
+                        info['rtcInvitingSession'] = member.rtc_inviting_session_id._mail_rtc_session_format()[0]
             # add members info
             if channel.channel_type != 'channel':
                 # avoid sending potentially a lot of members for big channels

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -926,7 +926,10 @@ class Channel(models.Model):
                     info['custom_channel_name'] = member.custom_channel_name
                     info['is_pinned'] = member.is_pinned
                     if member.rtc_inviting_session_id:
-                        info['rtcInvitingSession'] = member.rtc_inviting_session_id._mail_rtc_session_format()[0]
+                        info["rtcInvitingSession"] = {"id": member.rtc_inviting_session_id.id}
+                        store.add(
+                            "RtcSession", member.rtc_inviting_session_id._mail_rtc_session_format()
+                        )
             # add members info
             if channel.channel_type != 'channel':
                 # avoid sending potentially a lot of members for big channels

--- a/addons/mail/models/discuss/discuss_channel_member.py
+++ b/addons/mail/models/discuss/discuss_channel_member.py
@@ -431,9 +431,27 @@ class ChannelMember(models.Model):
             invitation_notifications.append((target, "mail.record/insert", store.get_result()))
         self.env['bus.bus']._sendmany(invitation_notifications)
         if members:
-            channel_data = {'id': self.channel_id.id, 'model': 'discuss.channel'}
-            channel_data['invitedMembers'] = [('ADD', list(members._discuss_channel_member_format(fields={'id': True, 'channel': {}, 'persona': {'partner': {'id': True, 'name': True, 'im_status': True}, 'guest': {'id': True, 'name': True, 'im_status': True}}}).values()))]
+            channel_data = {
+                "id": self.channel_id.id,
+                "model": "discuss.channel",
+                "invitedMembers": [("ADD", [{"id": member.id} for member in members])],
+            }
             store = Store("Thread", channel_data)
+            store.add(
+                "ChannelMember",
+                list(
+                    members._discuss_channel_member_format(
+                        fields={
+                            "id": True,
+                            "channel": {},
+                            "persona": {
+                                "partner": {"id": True, "name": True, "im_status": True},
+                                "guest": {"id": True, "name": True, "im_status": True},
+                            },
+                        }
+                    ).values()
+                ),
+            )
             self.env["bus.bus"]._sendone(self.channel_id, "mail.record/insert", store.get_result())
         return members
 

--- a/addons/mail/models/discuss/discuss_channel_member.py
+++ b/addons/mail/models/discuss/discuss_channel_member.py
@@ -307,7 +307,7 @@ class ChannelMember(models.Model):
                     ],
                 },
             )
-            store.add("RtcSession", current_rtc_sessions._mail_rtc_session_format())
+            store.add(current_rtc_sessions)
             store.add(
                 "Rtc",
                 {
@@ -427,7 +427,7 @@ class ChannelMember(models.Model):
                 "rtcInvitingSession": {"id": member.rtc_inviting_session_id.id},
             }
             store = Store("Thread", channel_data)
-            store.add("RtcSession", member.rtc_inviting_session_id._mail_rtc_session_format())
+            store.add(member.rtc_inviting_session_id)
             invitation_notifications.append((target, "mail.record/insert", store.get_result()))
         self.env['bus.bus']._sendmany(invitation_notifications)
         if members:

--- a/addons/mail/models/discuss/discuss_channel_member.py
+++ b/addons/mail/models/discuss/discuss_channel_member.py
@@ -424,9 +424,10 @@ class ChannelMember(models.Model):
             channel_data = {
                 "id": self.channel_id.id,
                 "model": "discuss.channel",
-                "rtcInvitingSession": self.rtc_session_ids._mail_rtc_session_format()[0],
+                "rtcInvitingSession": {"id": member.rtc_inviting_session_id.id},
             }
             store = Store("Thread", channel_data)
+            store.add("RtcSession", member.rtc_inviting_session_id._mail_rtc_session_format())
             invitation_notifications.append((target, "mail.record/insert", store.get_result()))
         self.env['bus.bus']._sendmany(invitation_notifications)
         if members:

--- a/addons/mail/models/discuss/discuss_channel_member.py
+++ b/addons/mail/models/discuss/discuss_channel_member.py
@@ -306,9 +306,7 @@ class ChannelMember(models.Model):
         }
         if len(self.channel_id.rtc_session_ids) == 1 and self.channel_id.channel_type in {'chat', 'group'}:
             self.channel_id.message_post(body=_("%s started a live conference", self.partner_id.name or self.guest_id.name), message_type='notification')
-            invited_members = self._rtc_invite_members()
-            if invited_members:
-                res['invitedMembers'] = [('ADD', list(invited_members._discuss_channel_member_format(fields={'id': True, 'channel': {}, 'persona': {'partner': {'id': True, 'name': True, 'im_status': True}, 'guest': {'id': True, 'name': True, 'im_status': True}}}).values()))]
+            self._rtc_invite_members()
         return res
 
     def _join_sfu(self, ice_servers=None):

--- a/addons/mail/models/discuss/discuss_channel_member.py
+++ b/addons/mail/models/discuss/discuss_channel_member.py
@@ -383,7 +383,7 @@ class ChannelMember(models.Model):
         if self.rtc_session_ids:
             self.rtc_session_ids.unlink()
         else:
-            return self.channel_id._rtc_cancel_invitations(member_ids=self.ids)
+            self.channel_id._rtc_cancel_invitations(member_ids=self.ids)
 
     def _rtc_sync_sessions(self, check_rtc_session_ids=None):
         """Synchronize the RTC sessions for self channel member.

--- a/addons/mail/models/discuss/discuss_channel_member.py
+++ b/addons/mail/models/discuss/discuss_channel_member.py
@@ -307,10 +307,7 @@ class ChannelMember(models.Model):
                     ],
                 },
             )
-            store.add(
-                "RtcSession",
-                [session._mail_rtc_session_format() for session in current_rtc_sessions],
-            )
+            store.add("RtcSession", current_rtc_sessions._mail_rtc_session_format())
             store.add(
                 "Rtc",
                 {
@@ -427,7 +424,7 @@ class ChannelMember(models.Model):
             channel_data = {
                 "id": self.channel_id.id,
                 "model": "discuss.channel",
-                "rtcInvitingSession": self.rtc_session_ids._mail_rtc_session_format(),
+                "rtcInvitingSession": self.rtc_session_ids._mail_rtc_session_format()[0],
             }
             store = Store("Thread", channel_data)
             invitation_notifications.append((target, "mail.record/insert", store.get_result()))

--- a/addons/mail/models/discuss/discuss_channel_rtc_session.py
+++ b/addons/mail/models/discuss/discuss_channel_rtc_session.py
@@ -152,10 +152,10 @@ class MailRtcSession(models.Model):
         return self.env['bus.bus']._sendmany([(target, 'discuss.channel.rtc.session/peer_notification', payload) for target, payload in payload_by_target.items()])
 
     def _to_store(self, store: Store, extra=False):
-        for rtc_session in self:
-            vals = {
-                "id": rtc_session.id,
-                "channelMember": rtc_session.channel_member_id._discuss_channel_member_format(
+        store.add(
+            "ChannelMember",
+            list(
+                self.channel_member_id._discuss_channel_member_format(
                     fields={
                         "id": True,
                         "channel": {},
@@ -164,7 +164,13 @@ class MailRtcSession(models.Model):
                             "guest": {"id": True, "name": True, "im_status": True},
                         },
                     }
-                ).get(rtc_session.channel_member_id),
+                ).values()
+            ),
+        )
+        for rtc_session in self:
+            vals = {
+                "id": rtc_session.id,
+                "channelMember": {"id": rtc_session.channel_member_id.id},
             }
             if extra:
                 vals.update(

--- a/addons/mail/models/discuss/discuss_channel_rtc_session.py
+++ b/addons/mail/models/discuss/discuss_channel_rtc_session.py
@@ -87,11 +87,11 @@ class MailRtcSession(models.Model):
         """
         valid_values = {'is_screen_sharing_on', 'is_camera_on', 'is_muted', 'is_deaf'}
         self.write({key: values[key] for key in valid_values if key in values})
-        session_data = self._mail_rtc_session_format(extra=True)
+        store = Store("RtcSession", self._mail_rtc_session_format(extra=True))
         self.env["bus.bus"]._sendone(
             self.channel_id,
             "discuss.channel.rtc.session/update_and_broadcast",
-            {"data": session_data, "channelId": self.channel_id.id},
+            {"data": store.get_result(), "channelId": self.channel_id.id},
         )
 
     @api.autovacuum

--- a/addons/mail/models/discuss/discuss_channel_rtc_session.py
+++ b/addons/mail/models/discuss/discuss_channel_rtc_session.py
@@ -144,30 +144,32 @@ class MailRtcSession(models.Model):
         return self.env['bus.bus']._sendmany([(target, 'discuss.channel.rtc.session/peer_notification', payload) for target, payload in payload_by_target.items()])
 
     def _mail_rtc_session_format(self, extra=False):
-        self.ensure_one()
-        vals = {
-            "id": self.id,
-            "channelMember": self.channel_member_id._discuss_channel_member_format(
-                fields={
-                    "id": True,
-                    "channel": {},
-                    "persona": {"partner": {"id": True, "name": True, "im_status": True}, "guest": {"id": True, "name": True, "im_status": True}},
-                }
-            ).get(self.channel_member_id),
-        }
-        if extra:
-            vals.update({
-                "isCameraOn": self.is_camera_on,
-                "isDeaf": self.is_deaf,
-                "isSelfMuted": self.is_muted,
-                "isScreenSharingOn": self.is_screen_sharing_on,
-            })
-        return vals
+        res = []
+        for rtc_session in self:
+            vals = {
+                "id": rtc_session.id,
+                "channelMember": rtc_session.channel_member_id._discuss_channel_member_format(
+                    fields={
+                        "id": True,
+                        "channel": {},
+                        "persona": {"partner": {"id": True, "name": True, "im_status": True}, "guest": {"id": True, "name": True, "im_status": True}},
+                    }
+                ).get(rtc_session.channel_member_id),
+            }
+            if extra:
+                vals.update({
+                    "isCameraOn": rtc_session.is_camera_on,
+                    "isDeaf": rtc_session.is_deaf,
+                    "isSelfMuted": rtc_session.is_muted,
+                    "isScreenSharingOn": rtc_session.is_screen_sharing_on,
+                })
+            res.append(vals)
+        return res
 
     def _mail_rtc_session_format_by_channel(self, extra=False):
         data = {}
         for rtc_session in self:
-            data.setdefault(rtc_session.channel_id, []).append(rtc_session._mail_rtc_session_format(extra=extra))
+            data.setdefault(rtc_session.channel_id, []).append(rtc_session._mail_rtc_session_format(extra=extra)[0])
         return data
 
     @api.model

--- a/addons/mail/static/src/core/common/channel_member_model.js
+++ b/addons/mail/static/src/core/common/channel_member_model.js
@@ -24,7 +24,6 @@ export class ChannelMember extends Record {
     /** @type {luxon.DateTime} */
     last_interest_dt = Record.attr(undefined, { type: "datetime" });
     persona = Record.one("Persona", { inverse: "channelMembers" });
-    rtcSession = Record.one("RtcSession");
     thread = Record.one("Thread", { inverse: "channelMembers" });
     threadAsSelf = Record.one("Thread", {
         compute() {

--- a/addons/mail/static/src/core/common/settings_model.js
+++ b/addons/mail/static/src/core/common/settings_model.js
@@ -125,20 +125,6 @@ export class Settings extends Record {
         return undefined;
     }
 
-    getVolume(rtcSession) {
-        return (
-            rtcSession.volume ||
-            this.volumes.find(
-                (volume) =>
-                    (volume.type === "partner" && volume.persona.id === rtcSession.partnerId) ||
-                    (volume.type === "guest" && volume.persona.id === rtcSession.guestId)
-            )?.volume ||
-            0.5
-        );
-    }
-
-    // "setters"
-
     /**
      * @param {string} notif
      */

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -66,8 +66,6 @@ export class Store extends BaseStore {
     Notification;
     /** @type {typeof import("@mail/core/common/persona_model").Persona} */
     Persona;
-    /** @type {typeof import("@mail/discuss/call/common/rtc_session_model").RtcSession} */
-    RtcSession;
     /** @type {typeof import("@mail/core/common/settings_model").Settings} */
     Settings;
     /** @type {typeof import("@mail/core/common/thread_model").Thread} */

--- a/addons/mail/static/src/discuss/call/common/@types/models.d.ts
+++ b/addons/mail/static/src/discuss/call/common/@types/models.d.ts
@@ -1,9 +1,11 @@
 declare module "models" {
+    import { Rtc as RtcClass } from "@mail/discuss/call/common/rtc_service";
     import { RtcSession as RtcSessionClass } from "@mail/discuss/call/common/rtc_session_model";
 
     export interface DiscussApp {
         ringingThreads: Thread[],
     }
+    export interface Rtc extends RtcClass {}
     export interface RtcSession extends RtcSessionClass {}
 
     export interface Models {

--- a/addons/mail/static/src/discuss/call/common/call_action_list.js
+++ b/addons/mail/static/src/discuss/call/common/call_action_list.js
@@ -24,7 +24,7 @@ export class CallActionList extends Component {
         const acts = [];
         acts.push({
             id: "raiseHand",
-            name: !this.rtc.state?.selfSession.raisingHand ? _t("Raise Hand") : _t("Lower Hand"),
+            name: !this.rtc.selfSession.raisingHand ? _t("Raise Hand") : _t("Lower Hand"),
             icon: "fa fa-fw fa-hand-paper-o",
             onSelect: (ev) => this.onClickRaiseHand(ev),
         });
@@ -70,7 +70,7 @@ export class CallActionList extends Component {
      * @param {MouseEvent} ev
      */
     async onClickDeafen(ev) {
-        if (this.rtc.state.selfSession.isDeaf) {
+        if (this.rtc.selfSession.isDeaf) {
             this.rtc.undeafen();
         } else {
             this.rtc.deafen();
@@ -78,18 +78,18 @@ export class CallActionList extends Component {
     }
 
     async onClickRaiseHand(ev) {
-        this.rtc.raiseHand(!this.rtc.state.selfSession.raisingHand);
+        this.rtc.raiseHand(!this.rtc.selfSession.raisingHand);
     }
 
     /**
      * @param {MouseEvent} ev
      */
     onClickMicrophone(ev) {
-        if (this.rtc.state.selfSession.isMute) {
-            if (this.rtc.state.selfSession.isSelfMuted) {
+        if (this.rtc.selfSession.isMute) {
+            if (this.rtc.selfSession.isSelfMuted) {
                 this.rtc.unmute();
             }
-            if (this.rtc.state.selfSession.isDeaf) {
+            if (this.rtc.selfSession.isDeaf) {
                 this.rtc.undeafen();
             }
         } else {

--- a/addons/mail/static/src/discuss/call/common/call_action_list.xml
+++ b/addons/mail/static/src/discuss/call/common/call_action_list.xml
@@ -4,8 +4,8 @@
     <t t-name="discuss.CallActionList">
         <div class="o-discuss-CallActionList d-flex justify-content-center" t-attf-class="{{ className }}" t-ref="root">
             <div class="d-flex align-items-center flex-wrap justify-content-between" t-att-class="{ 'w-100 ps-2 pe-2': isSmall }">
-                <t t-if="isOfActiveCall and rtc.state.selfSession">
-                    <t t-if="rtc.state?.selfSession.isMute" t-set="micText">Unmute</t>
+                <t t-if="isOfActiveCall and rtc.selfSession">
+                    <t t-if="rtc.selfSession.isMute" t-set="micText">Unmute</t>
                     <t t-else="" t-set="micText">Mute</t>
                     <button class="btn d-flex m-1 border-0 rounded-circle shadow-none opacity-100 opacity-75-hover"
                         t-att-class="{ 'p-2': isSmall, 'p-3': !isSmall }"
@@ -15,13 +15,13 @@
                         <div class="fa-stack">
                             <i class="fa fa-stack-1x" t-att-class="{
                                 'fa-lg': !isSmall,
-                                'fa-microphone': !rtc.state.selfSession.isMute,
-                                'fa-microphone-slash': rtc.state.selfSession.isMute,
-                                'text-danger': rtc.state.selfSession.isMute,
+                                'fa-microphone': !rtc.selfSession.isMute,
+                                'fa-microphone-slash': rtc.selfSession.isMute,
+                                'text-danger': rtc.selfSession.isMute,
                             }"/>
                         </div>
                     </button>
-                    <t t-if="rtc.state?.selfSession.isDeaf" t-set="headphoneText">Undeafen</t>
+                    <t t-if="rtc.selfSession.isDeaf" t-set="headphoneText">Undeafen</t>
                     <t t-else="" t-set="headphoneText">Deafen</t>
                     <button class="btn d-flex m-1 border-0 rounded-circle shadow-none opacity-100 opacity-75-hover"
                         t-att-class="{ 'p-2': isSmall, 'p-3': !isSmall }"
@@ -31,9 +31,9 @@
                         <div class="fa-stack">
                             <i class="fa fa-stack-1x" t-att-class="{
                                 'fa-lg': !isSmall,
-                                'fa-headphones': !rtc.state.selfSession.isDeaf,
-                                'fa-deaf': rtc.state.selfSession.isDeaf,
-                                'text-danger': rtc.state.selfSession.isDeaf,
+                                'fa-headphones': !rtc.selfSession.isDeaf,
+                                'fa-deaf': rtc.selfSession.isDeaf,
+                                'text-danger': rtc.selfSession.isDeaf,
                             }"/>
                         </div>
                     </button>

--- a/addons/mail/static/src/discuss/call/common/call_context_menu.js
+++ b/addons/mail/static/src/discuss/call/common/call_context_menu.js
@@ -35,7 +35,7 @@ export class CallContextMenu extends Component {
     }
 
     get isSelf() {
-        return this.rtc.state.selfSession?.eq(this.props.rtcSession);
+        return this.rtc.selfSession?.eq(this.props.rtcSession);
     }
 
     get inboundConnectionTypeText() {
@@ -73,7 +73,7 @@ export class CallContextMenu extends Component {
     }
 
     async updateStats() {
-        if (this.rtc.state.selfSession?.eq(this.props.rtcSession)) {
+        if (this.rtc.selfSession?.eq(this.props.rtcSession)) {
             if (this.rtc.sfuClient) {
                 const { uploadStats, downloadStats, ...producerStats } =
                     await this.rtc.sfuClient.getStats();

--- a/addons/mail/static/src/discuss/call/common/call_participant_card.js
+++ b/addons/mail/static/src/discuss/call/common/call_participant_card.js
@@ -141,11 +141,10 @@ export class CallParticipantCard extends Component {
             }
             return;
         }
-        const channelData = await rpc("/mail/rtc/channel/cancel_call_invitation", {
+        await rpc("/mail/rtc/channel/cancel_call_invitation", {
             channel_id: this.props.thread.id,
             member_ids: [this.channelMember.id],
         });
-        this.props.thread.invitedMembers = channelData.invitedMembers;
     }
 
     async onClickReplay() {

--- a/addons/mail/static/src/discuss/call/common/call_participant_card.js
+++ b/addons/mail/static/src/discuss/call/common/call_participant_card.js
@@ -59,7 +59,7 @@ export class CallParticipantCard extends Component {
         if (this.env.debug) {
             return true;
         }
-        return !this.rtcSession?.eq(this.rtc.state.selfSession);
+        return !this.rtcSession?.eq(this.rtc.selfSession);
     }
 
     get rtcSession() {

--- a/addons/mail/static/src/discuss/call/common/call_participant_card.xml
+++ b/addons/mail/static/src/discuss/call/common/call_participant_card.xml
@@ -27,7 +27,7 @@
                         'o-isInvitation': !rtcSession,
                         }"
                         class="h-100 rounded-circle border-5 o_object_fit_cover"
-                        t-att-src="channelMember.persona.avatarUrl"
+                        t-att-src="channelMember?.persona.avatarUrl"
                         draggable="false"
                 />
             </div>

--- a/addons/mail/static/src/discuss/call/common/channel_member_patch.js
+++ b/addons/mail/static/src/discuss/call/common/channel_member_patch.js
@@ -1,0 +1,13 @@
+import { ChannelMember } from "@mail/core/common/channel_member_model";
+import { Record } from "@mail/core/common/record";
+
+import { patch } from "@web/core/utils/patch";
+
+/** @type {import("models").ChannelMember} */
+const ChannelMemberPatch = {
+    setup() {
+        super.setup(...arguments);
+        this.rtcSession = Record.one("RtcSession");
+    },
+};
+patch(ChannelMember.prototype, ChannelMemberPatch);

--- a/addons/mail/static/src/discuss/call/common/ptt_extension_service.js
+++ b/addons/mail/static/src/discuss/call/common/ptt_extension_service.js
@@ -32,9 +32,9 @@ export const pttExtensionHookService = {
                 case "push-to-talk-pressed":
                     {
                         voiceActivated = false;
-                        const isFirstPress = !rtc.state.selfSession?.isTalking;
+                        const isFirstPress = !rtc.selfSession?.isTalking;
                         rtc.onPushToTalk();
-                        if (rtc.state.selfSession?.isTalking) {
+                        if (rtc.selfSession?.isTalking) {
                             // Second key press is slow to come thus, the first timeout
                             // must be greater than the following ones.
                             rtc.setPttReleaseTimeout(

--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -1843,16 +1843,6 @@ export const rtcService = {
                 });
             }
         });
-        services["bus_service"].subscribe(
-            "discuss.channel/rtc_sessions_update",
-            ({ id, rtcSessions }) => {
-                env.services["mail.store"].Thread.insert({
-                    model: "discuss.channel",
-                    id,
-                    rtcSessions,
-                });
-            }
-        );
         services["bus_service"].subscribe("res.users.settings.volumes", (payload) => {
             if (payload) {
                 rtc.store.Volume.insert(payload);

--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -117,6 +117,11 @@ export class Rtc extends Record {
     timeouts = new Map();
     /** @type {Map<number, number>} timeoutId by sessionId for download pausing delay */
     downloadTimeouts = new Map();
+    iceServers = Record.attr(DEFAULT_ICE_SERVERS, {
+        compute() {
+            return this.iceServers ? this.iceServers : DEFAULT_ICE_SERVERS;
+        },
+    });
     selfSession = Record.one("RtcSession");
     /** @type {import("@mail/static/libs/odoo_sfu/odoo_sfu").SfuClient} */
     sfuClient = undefined;
@@ -127,7 +132,6 @@ export class Rtc extends Record {
             connectionType: undefined,
             hasPendingRequest: false,
             channel: undefined,
-            iceServers: DEFAULT_ICE_SERVERS,
             logs: new Map(),
             sendCamera: false,
             sendScreen: false,
@@ -728,7 +732,7 @@ export class Rtc extends Record {
                     this.state.serverInfo.jsonWebToken,
                     {
                         channelUUID: this.state.serverInfo.channelUUID,
-                        iceServers: this.state.iceServers,
+                        iceServers: this.iceServers,
                     }
                 );
             }
@@ -747,7 +751,7 @@ export class Rtc extends Record {
     }
 
     createConnection(session) {
-        const peerConnection = new window.RTCPeerConnection({ iceServers: this.state.iceServers });
+        const peerConnection = new window.RTCPeerConnection({ iceServers: this.iceServers });
         this.log(session, "RTCPeerConnection created", {
             step: "peer connection created",
         });
@@ -925,10 +929,10 @@ export class Rtc extends Record {
         this.state.serverInfo = serverInfo;
         this.state.channel.rtcSessions = rtcSessions;
         this.selfSession = this.store.RtcSession.get(sessionId);
-        this.state.iceServers = iceServers || DEFAULT_ICE_SERVERS;
+        this.iceServers = iceServers || DEFAULT_ICE_SERVERS;
         this.state.logs.set("channelId", this.state.channel.id);
         this.state.logs.set("selfSessionId", this.selfSession.id);
-        this.state.logs.set("hasTURN", hasTurn(this.state.iceServers));
+        this.state.logs.set("hasTURN", hasTurn(this.iceServers));
         const channelProxy = reactive(this.state.channel, () => {
             if (channel.notEq(this.state.channel)) {
                 throw new Error("channel has changed");

--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -1857,7 +1857,7 @@ export const rtcService = {
                  * through the peer to peer connection. So we do not use this less accurate broadcast.
                  */
                 if (channelId !== rtc.state.channel?.id) {
-                    rtc.store.RtcSession.insert(data);
+                    rtc.store.insert(data);
                 }
             }
         );

--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -910,7 +910,7 @@ export class Rtc extends Record {
         }
         this.pttExtService.subscribe();
         this.state.hasPendingRequest = true;
-        const { rtcSessions, iceServers, sessionId, serverInfo } = await rpc(
+        const data = await rpc(
             "/mail/rtc/channel/join_call",
             {
                 channel_id: channel.id,
@@ -922,10 +922,7 @@ export class Rtc extends Record {
         this.clear();
         this.state.logs.clear();
         this.state.channel = channel;
-        this.serverInfo = serverInfo;
-        this.state.channel.rtcSessions = rtcSessions;
-        this.selfSession = this.store.RtcSession.get(sessionId);
-        this.iceServers = iceServers || DEFAULT_ICE_SERVERS;
+        this.store.insert(data);
         this.state.logs.set("channelId", this.state.channel.id);
         this.state.logs.set("selfSessionId", this.selfSession.id);
         this.state.logs.set("hasTURN", hasTurn(this.iceServers));

--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -1031,7 +1031,7 @@ export class Rtc {
     }
 
     async ping() {
-        const { rtcSessions } = await rpc(
+        const data = await rpc(
             "/discuss/channel/ping",
             {
                 channel_id: this.state.channel.id,
@@ -1040,16 +1040,7 @@ export class Rtc {
             },
             { silent: true }
         );
-        if (this.state.channel && rtcSessions) {
-            const activeSessionsData = rtcSessions[0][1];
-            for (const sessionData of activeSessionsData) {
-                this.state.channel.rtcSessions.add(sessionData);
-            }
-            const outdatedSessionsData = rtcSessions[1][1];
-            for (const sessionData of outdatedSessionsData) {
-                this.deleteSession(sessionData);
-            }
-        }
+        this.store.insert(data);
     }
 
     /**

--- a/addons/mail/static/src/discuss/call/common/settings_model_patch.js
+++ b/addons/mail/static/src/discuss/call/common/settings_model_patch.js
@@ -1,0 +1,22 @@
+import { Settings } from "@mail/core/common/settings_model";
+
+import { patch } from "@web/core/utils/patch";
+
+/** @type {import("models").Settings} */
+const SettingsPatch = {
+    setup() {
+        super.setup(...arguments);
+    },
+    getVolume(rtcSession) {
+        return (
+            rtcSession.volume ||
+            this.volumes.find(
+                (volume) =>
+                    (volume.type === "partner" && volume.persona.id === rtcSession.partnerId) ||
+                    (volume.type === "guest" && volume.persona.id === rtcSession.guestId)
+            )?.volume ||
+            0.5
+        );
+    },
+};
+patch(Settings.prototype, SettingsPatch);

--- a/addons/mail/static/src/discuss/call/common/store_service_patch.js
+++ b/addons/mail/static/src/discuss/call/common/store_service_patch.js
@@ -1,0 +1,21 @@
+import { Record } from "@mail/core/common/record";
+import { Store } from "@mail/core/common/store_service";
+
+import { patch } from "@web/core/utils/patch";
+
+/** @type {import("models").Store} */
+const StorePatch = {
+    setup() {
+        super.setup(...arguments);
+        this.rtc = Record.one("Rtc", {
+            compute() {
+                return {};
+            },
+        });
+    },
+    onStarted() {
+        super.onStarted(...arguments);
+        this.rtc.start();
+    },
+};
+patch(Store.prototype, StorePatch);

--- a/addons/mail/static/src/discuss/call/common/store_service_patch.js
+++ b/addons/mail/static/src/discuss/call/common/store_service_patch.js
@@ -1,5 +1,6 @@
 import { Record } from "@mail/core/common/record";
 import { Store } from "@mail/core/common/store_service";
+import { RtcSession } from "@mail/discuss/call/common/rtc_session_model";
 
 import { patch } from "@web/core/utils/patch";
 
@@ -7,6 +8,8 @@ import { patch } from "@web/core/utils/patch";
 const StorePatch = {
     setup() {
         super.setup(...arguments);
+        /** @type {typeof import("@mail/discuss/call/common/rtc_session_model").RtcSession} */
+        this.RtcSession = RtcSession;
         this.rtc = Record.one("Rtc", {
             compute() {
                 return {};

--- a/addons/mail/static/src/discuss/call/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/call/common/thread_model_patch.js
@@ -1,0 +1,56 @@
+import { Record } from "@mail/core/common/record";
+import { Thread } from "@mail/core/common/thread_model";
+
+import { patch } from "@web/core/utils/patch";
+
+patch(Thread, {
+    sortOnlineMembers(m1, m2) {
+        const m1HasRtc = Boolean(m1.rtcSession);
+        const m2HasRtc = Boolean(m2.rtcSession);
+        if (m1HasRtc === m2HasRtc) {
+            /**
+             * If raisingHand is falsy, it gets an Infinity value so that when
+             * we sort by [oldest/lowest-value]-first, falsy values end up last.
+             */
+            const m1RaisingValue = m1.rtcSession?.raisingHand || Infinity;
+            const m2RaisingValue = m2.rtcSession?.raisingHand || Infinity;
+            if (m1HasRtc && m1RaisingValue !== m2RaisingValue) {
+                return m1RaisingValue - m2RaisingValue;
+            } else {
+                return super.sortOnlineMembers(m1, m2);
+            }
+        } else {
+            return m2HasRtc - m1HasRtc;
+        }
+    },
+});
+
+/** @type {import("models").Thread} */
+const ThreadPatch = {
+    setup() {
+        super.setup(...arguments);
+        this.activeRtcSession = Record.one("RtcSession");
+        this.rtcInvitingSession = Record.one("RtcSession", {
+            /** @this {import("models").Thread} */
+            onAdd(r) {
+                this.rtcSessions.add(r);
+                this.store.discuss.ringingThreads.add(this);
+            },
+            /** @this {import("models").Thread} */
+            onDelete(r) {
+                this.store.discuss.ringingThreads.delete(this);
+            },
+        });
+        this.rtcSessions = Record.many("RtcSession", {
+            /** @this {import("models").Thread} */
+            onDelete(r) {
+                this.store.env.services["discuss.rtc"].deleteSession(r.id);
+            },
+        });
+    },
+    get videoCount() {
+        return Object.values(this.store.RtcSession.records).filter((session) => session.hasVideo)
+            .length;
+    },
+};
+patch(Thread.prototype, ThreadPatch);

--- a/addons/mail/static/tests/discuss/call/call.test.js
+++ b/addons/mail/static/tests/discuss/call/call.test.js
@@ -172,10 +172,8 @@ test("should display invitations", async () => {
     const [partner] = pyEnv["res.partner"].read(serverState.partnerId);
     // send after init_messaging because bus subscription is done after init_messaging
     pyEnv["bus.bus"]._sendone(partner, "mail.record/insert", {
-        Thread: {
-            id: channelId,
-            model: "discuss.channel",
-            rtcInvitingSession: {
+        RtcSession: [
+            {
                 id: sessionId,
                 channelMember: {
                     id: memberId,
@@ -186,6 +184,11 @@ test("should display invitations", async () => {
                     },
                 },
             },
+        ],
+        Thread: {
+            id: channelId,
+            model: "discuss.channel",
+            rtcInvitingSession: { id: sessionId },
         },
     });
     await contains(".o-discuss-CallInvitation");

--- a/addons/mail/static/tests/legacy/helpers/mock_server/controllers/discuss.js
+++ b/addons/mail/static/tests/legacy/helpers/mock_server/controllers/discuss.js
@@ -545,10 +545,15 @@ patch(MockServer.prototype, {
             });
             notifications.push([
                 channel,
-                "discuss.channel/rtc_sessions_update",
+                "mail.record/insert",
                 {
-                    id: Number(channelId), // JS object keys are strings, but the type from the server is number
-                    rtcSessions: [["DELETE", notificationRtcSessions]],
+                    Thread: [
+                        {
+                            id: Number(channelId), // JS object keys are strings, but the type from the server is number
+                            model: "discuss.channel",
+                            rtcSessions: [["DELETE", notificationRtcSessions]],
+                        },
+                    ],
                 },
             ]);
         }

--- a/addons/mail/static/tests/legacy/helpers/mock_server/models/discuss_channel_rtc_session.js
+++ b/addons/mail/static/tests/legacy/helpers/mock_server/models/discuss_channel_rtc_session.js
@@ -100,7 +100,7 @@ patch(MockServer.prototype, {
         this.pyEnv["bus.bus"]._sendone(
             channel,
             "discuss.channel.rtc.session/update_and_broadcast",
-            { data: sessionData, channelId: channel.id }
+            { data: { RtcSession: [sessionData] }, channelId: channel.id }
         );
     },
 });

--- a/addons/mail/static/tests/legacy/helpers/mock_server/models/discuss_channel_rtc_session.js
+++ b/addons/mail/static/tests/legacy/helpers/mock_server/models/discuss_channel_rtc_session.js
@@ -18,10 +18,18 @@ patch(MockServer.prototype, {
             ]);
             notifications.push([
                 channel,
-                "discuss.channel/rtc_sessions_update",
+                "mail.record/insert",
                 {
-                    id: channel.id,
-                    rtcSessions: [["ADD", sessionData]],
+                    RtcSession: [sessionData],
+                    Thread: [
+                        {
+                            id: channel.id,
+                            model: "discuss.channel",
+                            rtcSessions: [
+                                ["ADD", sessionData.map((session) => ({ id: session.id }))],
+                            ],
+                        },
+                    ],
                 },
             ]);
         }

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -189,16 +189,20 @@ async function channel_call_join(request) {
         ["channel_member_id", "in", channelMembers.map((channelMember) => channelMember.id)],
     ]);
     return {
-        iceServers: false,
-        rtcSessions: [
-            [
-                "ADD",
-                rtcSessions.map((rtcSession) =>
-                    DiscussChannelRtcSession._mail_rtc_session_format(rtcSession.id)
-                ),
-            ],
+        Rtc: {
+            iceServers: false,
+            selfSession: { id: sessionId },
+        },
+        RtcSession: rtcSessions.map((rtcSession) =>
+            DiscussChannelRtcSession._mail_rtc_session_format(rtcSession.id)
+        ),
+        Thread: [
+            {
+                id: channel_id,
+                model: "discuss.channel",
+                rtcSessions: [["ADD", rtcSessions.map((rtcSession) => ({ id: rtcSession.id }))]],
+            },
         ],
-        sessionId: sessionId,
     };
 }
 

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -238,10 +238,15 @@ async function channel_call_leave(request) {
         });
         notifications.push([
             channel,
-            "discuss.channel/rtc_sessions_update",
+            "mail.record/insert",
             {
-                id: Number(channelId), // JS object keys are strings, but the type from the server is number
-                rtcSessions: [["DELETE", notificationRtcSessions]],
+                Thread: [
+                    {
+                        id: Number(channelId), // JS object keys are strings, but the type from the server is number
+                        model: "discuss.channel",
+                        rtcSessions: [["DELETE", notificationRtcSessions]],
+                    },
+                ],
             },
         ]);
     }

--- a/addons/mail/static/tests/mock_server/mock_models/discuss_channel_rtc_session.js
+++ b/addons/mail/static/tests/mock_server/mock_models/discuss_channel_rtc_session.js
@@ -16,8 +16,19 @@ export class DiscussChannelRtcSession extends models.ServerModel {
             const [channel] = DiscussChannel.search_read([["id", "=", Number(channelId)]]);
             notifications.push([
                 channel,
-                "discuss.channel/rtc_sessions_update",
-                { id: channel.id, rtcSessions: [["ADD", sessionData]] },
+                "mail.record/insert",
+                {
+                    RtcSession: [sessionData],
+                    Thread: [
+                        {
+                            id: channel.id,
+                            model: "discuss.channel",
+                            rtcSessions: [
+                                ["ADD", sessionData.map((session) => ({ id: session.id }))],
+                            ],
+                        },
+                    ],
+                },
             ]);
         }
         BusBus._sendmany(notifications);

--- a/addons/mail/static/tests/mock_server/mock_models/discuss_channel_rtc_session.js
+++ b/addons/mail/static/tests/mock_server/mock_models/discuss_channel_rtc_session.js
@@ -113,7 +113,7 @@ export class DiscussChannelRtcSession extends models.ServerModel {
             ["id", "=", sessionData.channelMember.thread.id],
         ]);
         BusBus._sendone(channel, "discuss.channel.rtc.session/update_and_broadcast", {
-            data: sessionData,
+            data: { RtcSession: [sessionData] },
             channelId: channel.id,
         });
     }

--- a/addons/mail/tests/discuss/test_rtc.py
+++ b/addons/mail/tests/discuss/test_rtc.py
@@ -149,18 +149,7 @@ class TestChannelRTC(MailCommon):
         ):
             now = fields.Datetime.now()
             with patch.object(fields.Datetime, 'now', lambda: now + relativedelta(seconds=5)):
-                res = channel_member._rtc_join_call()
-        self.assertIn('invitedMembers', res)
-        self.assertEqual(res['invitedMembers'], [('ADD', [{
-            'id': channel_member_test_user.id,
-            'thread': {'id': channel_member_test_user.channel_id.id, 'model': "discuss.channel"},
-            'persona': {
-                'id': channel_member_test_user.partner_id.id,
-                'name': channel_member_test_user.partner_id.name,
-                'im_status': channel_member_test_user.partner_id.im_status,
-                'type': "partner",
-            },
-        }])])
+                channel_member._rtc_join_call()
 
     @users('employee')
     @mute_logger('odoo.models.unlink')
@@ -262,30 +251,7 @@ class TestChannelRTC(MailCommon):
         ):
             now = fields.Datetime.now()
             with patch.object(fields.Datetime, 'now', lambda: now + relativedelta(seconds=5)):
-                res = channel_member._rtc_join_call()
-        self.assertIn('invitedMembers', res)
-        self.assertEqual(res['invitedMembers'], [('ADD', [
-            {
-                'id': channel_member_test_user.id,
-                'thread': {'id': channel_member_test_user.channel_id.id, 'model': "discuss.channel"},
-                'persona': {
-                    'id': channel_member_test_user.partner_id.id,
-                    'name': channel_member_test_user.partner_id.name,
-                    'im_status': channel_member_test_user.partner_id.im_status,
-                    'type': "partner",
-                },
-            },
-            {
-                'id': channel_member_test_guest.id,
-                'thread': {'id': channel_member_test_guest.channel_id.id, 'model': "discuss.channel"},
-                'persona': {
-                    'id': channel_member_test_guest.guest_id.id,
-                    'name': channel_member_test_guest.guest_id.name,
-                    'im_status': channel_member_test_guest.guest_id.im_status,
-                    'type': "guest",
-                },
-            },
-        ])])
+                channel_member._rtc_join_call()
 
     @users('employee')
     @mute_logger('odoo.models.unlink')

--- a/addons/mail/tests/discuss/test_rtc.py
+++ b/addons/mail/tests/discuss/test_rtc.py
@@ -347,13 +347,13 @@ class TestChannelRTC(MailCommon):
             ],
             [
                 {
-                    'type': 'mail.record/insert',
-                    'payload': {
-                        'Thread': {
-                            'id': channel.id,
-                            'model': 'discuss.channel',
-                            'rtcInvitingSession': False,
-                        }
+                    "type": "mail.record/insert",
+                    "payload": {
+                        "Thread": {
+                            "id": channel.id,
+                            "model": "discuss.channel",
+                            "rtcInvitingSession": False,
+                        },
                     },
                 },
                 {
@@ -421,13 +421,13 @@ class TestChannelRTC(MailCommon):
             ],
             [
                 {
-                    'type': 'mail.record/insert',
-                    'payload': {
-                        'Thread': {
-                            'id': channel.id,
-                            'model': 'discuss.channel',
-                            'rtcInvitingSession': False,
-                        }
+                    "type": "mail.record/insert",
+                    "payload": {
+                        "Thread": {
+                            "id": channel.id,
+                            "model": "discuss.channel",
+                            "rtcInvitingSession": False,
+                        },
                     },
                 },
                 {
@@ -504,13 +504,13 @@ class TestChannelRTC(MailCommon):
             ],
             [
                 {
-                    'type': 'mail.record/insert',
-                    'payload': {
-                        'Thread': {
-                            'id': channel.id,
-                            'model': 'discuss.channel',
-                            'rtcInvitingSession': False,
-                        }
+                    "type": "mail.record/insert",
+                    "payload": {
+                        "Thread": {
+                            "id": channel.id,
+                            "model": "discuss.channel",
+                            "rtcInvitingSession": False,
+                        },
                     },
                 },
                 {
@@ -545,13 +545,13 @@ class TestChannelRTC(MailCommon):
             ],
             [
                 {
-                    'type': 'mail.record/insert',
-                    'payload': {
-                        'Thread': {
-                            'id': channel.id,
-                            'model': 'discuss.channel',
-                            'rtcInvitingSession': False,
-                        }
+                    "type": "mail.record/insert",
+                    "payload": {
+                        "Thread": {
+                            "id": channel.id,
+                            "model": "discuss.channel",
+                            "rtcInvitingSession": False,
+                        },
                     },
                 },
                 {
@@ -606,23 +606,23 @@ class TestChannelRTC(MailCommon):
                     },
                 },
                 {
-                    'type': 'mail.record/insert',
-                    'payload': {
-                        'Thread': {
-                            'id': channel.id,
-                            'model': 'discuss.channel',
-                            'rtcInvitingSession': False,
-                        }
+                    "type": "mail.record/insert",
+                    "payload": {
+                        "Thread": {
+                            "id": channel.id,
+                            "model": "discuss.channel",
+                            "rtcInvitingSession": False,
+                        },
                     },
                 },
                 {
-                    'type': 'mail.record/insert',
-                    'payload': {
-                        'Thread': {
-                            'id': channel.id,
-                            'model': 'discuss.channel',
-                            'rtcInvitingSession': False,
-                        }
+                    "type": "mail.record/insert",
+                    "payload": {
+                        "Thread": {
+                            "id": channel.id,
+                            "model": "discuss.channel",
+                            "rtcInvitingSession": False,
+                        },
                     },
                 },
                 {
@@ -710,16 +710,24 @@ class TestChannelRTC(MailCommon):
             ],
             message_items=[
                 {
-                    'type': 'mail.record/insert',
-                    'payload': {
-                        'Thread': [{
-                            'id': channel.id,
-                            'model': 'discuss.channel',
-                            'rtcInvitingSession': {
-                                'id': channel_member.rtc_session_ids.id,
-                                'channelMember': {
+                    "type": "mail.record/insert",
+                    "payload": {
+                        "Thread": [
+                            {
+                                "id": channel.id,
+                                "model": "discuss.channel",
+                                "rtcInvitingSession": {"id": channel_member.rtc_session_ids.id},
+                            },
+                        ],
+                        "RtcSession": [
+                            {
+                                "id": channel_member.rtc_session_ids.id,
+                                "channelMember": {
                                     "id": channel_member.id,
-                                    "thread": {"id": channel_member.channel_id.id, "model": "discuss.channel"},
+                                    "thread": {
+                                        "id": channel_member.channel_id.id,
+                                        "model": "discuss.channel",
+                                    },
                                     "persona": {
                                         "id": channel_member.partner_id.id,
                                         "name": channel_member.partner_id.name,
@@ -728,20 +736,28 @@ class TestChannelRTC(MailCommon):
                                     },
                                 },
                             },
-                        }],
+                        ],
                     },
                 },
                 {
-                    'type': 'mail.record/insert',
-                    'payload': {
-                        'Thread': [{
-                            'id': channel.id,
-                            'model': 'discuss.channel',
-                            'rtcInvitingSession': {
-                                'id': channel_member.rtc_session_ids.id,
-                                'channelMember': {
+                    "type": "mail.record/insert",
+                    "payload": {
+                        "Thread": [
+                            {
+                                "id": channel.id,
+                                "model": "discuss.channel",
+                                "rtcInvitingSession": {"id": channel_member.rtc_session_ids.id},
+                            },
+                        ],
+                        "RtcSession": [
+                            {
+                                "id": channel_member.rtc_session_ids.id,
+                                "channelMember": {
                                     "id": channel_member.id,
-                                    "thread": {"id": channel_member.channel_id.id, "model": "discuss.channel"},
+                                    "thread": {
+                                        "id": channel_member.channel_id.id,
+                                        "model": "discuss.channel",
+                                    },
                                     "persona": {
                                         "id": channel_member.partner_id.id,
                                         "name": channel_member.partner_id.name,
@@ -750,7 +766,7 @@ class TestChannelRTC(MailCommon):
                                     },
                                 },
                             },
-                        }],
+                        ],
                     },
                 },
                 {

--- a/addons/mail/tests/discuss/test_rtc.py
+++ b/addons/mail/tests/discuss/test_rtc.py
@@ -389,30 +389,42 @@ class TestChannelRTC(MailCommon):
                 {
                     "type": "mail.record/insert",
                     "payload": {
-                        "Thread": {
-                            "id": channel.id,
-                            "model": "discuss.channel",
-                            "rtcInvitingSession": False,
-                        },
+                        "Thread": [
+                            {
+                                "id": channel.id,
+                                "model": "discuss.channel",
+                                "rtcInvitingSession": False,
+                            },
+                        ],
                     },
                 },
                 {
-                    'type': 'mail.record/insert',
-                    'payload': {
-                        'Thread': {
-                            'id': channel.id,
-                            'model': 'discuss.channel',
-                            'invitedMembers': [('DELETE', [{
-                                'id': channel_member_test_user.id,
-                                'thread': {'id': channel_member_test_user.channel_id.id, 'model': "discuss.channel"},
-                                'persona': {
-                                    'id': channel_member_test_user.partner_id.id,
-                                    'name': channel_member_test_user.partner_id.name,
-                                    'im_status': channel_member_test_user.partner_id.im_status,
-                                    'type': "partner",
+                    "type": "mail.record/insert",
+                    "payload": {
+                        "Thread": [
+                            {
+                                "id": channel.id,
+                                "model": "discuss.channel",
+                                "invitedMembers": [
+                                    ("DELETE", [{"id": channel_member_test_user.id}]),
+                                ],
+                            },
+                        ],
+                        "ChannelMember": [
+                            {
+                                "id": channel_member_test_user.id,
+                                "thread": {
+                                    "id": channel_member_test_user.channel_id.id,
+                                    "model": "discuss.channel",
                                 },
-                            }])],
-                        }
+                                "persona": {
+                                    "id": channel_member_test_user.partner_id.id,
+                                    "name": channel_member_test_user.partner_id.name,
+                                    "im_status": channel_member_test_user.partner_id.im_status,
+                                    "type": "partner",
+                                },
+                            },
+                        ],
                     },
                 },
                 {
@@ -466,30 +478,42 @@ class TestChannelRTC(MailCommon):
                 {
                     "type": "mail.record/insert",
                     "payload": {
-                        "Thread": {
-                            "id": channel.id,
-                            "model": "discuss.channel",
-                            "rtcInvitingSession": False,
-                        },
+                        "Thread": [
+                            {
+                                "id": channel.id,
+                                "model": "discuss.channel",
+                                "rtcInvitingSession": False,
+                            },
+                        ],
                     },
                 },
                 {
-                    'type': 'mail.record/insert',
-                    'payload': {
-                        'Thread': {
-                            'id': channel.id,
-                            'model': 'discuss.channel',
-                            'invitedMembers': [('DELETE', [{
-                                'id': channel_member_test_guest.id,
-                                'thread': {'id': channel_member_test_guest.channel_id.id, 'model': "discuss.channel"},
-                                'persona': {
-                                    'id': channel_member_test_guest.guest_id.id,
-                                    'name': channel_member_test_guest.guest_id.name,
-                                    'im_status': channel_member_test_guest.guest_id.im_status,
-                                    'type': "guest",
+                    "type": "mail.record/insert",
+                    "payload": {
+                        "Thread": [
+                            {
+                                "id": channel.id,
+                                "model": "discuss.channel",
+                                "invitedMembers": [
+                                    ("DELETE", [{"id": channel_member_test_guest.id}]),
+                                ],
+                            },
+                        ],
+                        "ChannelMember": [
+                            {
+                                "id": channel_member_test_guest.id,
+                                "thread": {
+                                    "id": channel_member_test_guest.channel_id.id,
+                                    "model": "discuss.channel",
                                 },
-                            }])],
-                        }
+                                "persona": {
+                                    "id": channel_member_test_guest.guest_id.id,
+                                    "name": channel_member_test_guest.guest_id.name,
+                                    "im_status": channel_member_test_guest.guest_id.im_status,
+                                    "type": "guest",
+                                },
+                            },
+                        ],
                     },
                 },
                 {
@@ -552,33 +576,45 @@ class TestChannelRTC(MailCommon):
                 {
                     "type": "mail.record/insert",
                     "payload": {
-                        "Thread": {
-                            "id": channel.id,
-                            "model": "discuss.channel",
-                            "rtcInvitingSession": False,
-                        },
+                        "Thread": [
+                            {
+                                "id": channel.id,
+                                "model": "discuss.channel",
+                                "rtcInvitingSession": False,
+                            },
+                        ],
                     },
                 },
                 {
-                    'type': 'mail.record/insert',
-                    'payload': {
-                        'Thread': {
-                            'id': channel.id,
-                            'model': 'discuss.channel',
-                            'invitedMembers': [('DELETE', [{
-                                'id': channel_member_test_user.id,
-                                'thread': {'id': channel_member_test_user.channel_id.id, 'model': "discuss.channel"},
-                                'persona': {
-                                    'id': channel_member_test_user.partner_id.id,
-                                    'name': channel_member_test_user.partner_id.name,
-                                    'im_status': channel_member_test_user.partner_id.im_status,
-                                    'type': "partner",
+                    "type": "mail.record/insert",
+                    "payload": {
+                        "Thread": [
+                            {
+                                "id": channel.id,
+                                "model": "discuss.channel",
+                                "invitedMembers": [
+                                    ("DELETE", [{"id": channel_member_test_user.id}]),
+                                ],
+                            },
+                        ],
+                        "ChannelMember": [
+                            {
+                                "id": channel_member_test_user.id,
+                                "thread": {
+                                    "id": channel_member_test_user.channel_id.id,
+                                    "model": "discuss.channel",
                                 },
-                            }])],
-                        }
+                                "persona": {
+                                    "id": channel_member_test_user.partner_id.id,
+                                    "name": channel_member_test_user.partner_id.name,
+                                    "im_status": channel_member_test_user.partner_id.im_status,
+                                    "type": "partner",
+                                },
+                            },
+                        ],
                     },
                 },
-            ]
+            ],
         ):
             channel_member_test_user._rtc_leave_call()
 
@@ -593,33 +629,45 @@ class TestChannelRTC(MailCommon):
                 {
                     "type": "mail.record/insert",
                     "payload": {
-                        "Thread": {
-                            "id": channel.id,
-                            "model": "discuss.channel",
-                            "rtcInvitingSession": False,
-                        },
+                        "Thread": [
+                            {
+                                "id": channel.id,
+                                "model": "discuss.channel",
+                                "rtcInvitingSession": False,
+                            },
+                        ],
                     },
                 },
                 {
-                    'type': 'mail.record/insert',
-                    'payload': {
-                        'Thread': {
-                            'id': channel.id,
-                            'model': 'discuss.channel',
-                            'invitedMembers': [('DELETE', [{
-                                'id': channel_member_test_guest.id,
-                                'thread': {'id': channel_member_test_guest.channel_id.id, 'model': "discuss.channel"},
-                                'persona': {
-                                    'id': channel_member_test_guest.guest_id.id,
-                                    'name': channel_member_test_guest.guest_id.name,
-                                    'im_status': channel_member_test_guest.guest_id.im_status,
-                                    'type': "guest",
+                    "type": "mail.record/insert",
+                    "payload": {
+                        "Thread": [
+                            {
+                                "id": channel.id,
+                                "model": "discuss.channel",
+                                "invitedMembers": [
+                                    ("DELETE", [{"id": channel_member_test_guest.id}]),
+                                ],
+                            },
+                        ],
+                        "ChannelMember": [
+                            {
+                                "id": channel_member_test_guest.id,
+                                "thread": {
+                                    "id": channel_member_test_guest.channel_id.id,
+                                    "model": "discuss.channel",
                                 },
-                            }])],
-                        }
+                                "persona": {
+                                    "id": channel_member_test_guest.guest_id.id,
+                                    "name": channel_member_test_guest.guest_id.name,
+                                    "im_status": channel_member_test_guest.guest_id.im_status,
+                                    "type": "guest",
+                                },
+                            },
+                        ],
                     },
                 },
-            ]
+            ],
         ):
             channel_member_test_guest._rtc_leave_call()
 
@@ -654,52 +702,73 @@ class TestChannelRTC(MailCommon):
                 {
                     "type": "mail.record/insert",
                     "payload": {
-                        "Thread": {
-                            "id": channel.id,
-                            "model": "discuss.channel",
-                            "rtcInvitingSession": False,
-                        },
+                        "Thread": [
+                            {
+                                "id": channel.id,
+                                "model": "discuss.channel",
+                                "rtcInvitingSession": False,
+                            },
+                        ],
                     },
                 },
                 {
                     "type": "mail.record/insert",
                     "payload": {
-                        "Thread": {
-                            "id": channel.id,
-                            "model": "discuss.channel",
-                            "rtcInvitingSession": False,
-                        },
+                        "Thread": [
+                            {
+                                "id": channel.id,
+                                "model": "discuss.channel",
+                                "rtcInvitingSession": False,
+                            },
+                        ],
                     },
                 },
                 {
-                    'type': 'mail.record/insert',
-                    'payload': {
-                        'Thread': {
-                            'id': channel.id,
-                            'model': 'discuss.channel',
-                            'invitedMembers': [('DELETE', [
-                                {
-                                    'id': channel_member_test_user.id,
-                                    'thread': {'id': channel_member_test_user.channel_id.id, 'model': "discuss.channel"},
-                                    'persona': {
-                                        'id': channel_member_test_user.partner_id.id,
-                                        'name': channel_member_test_user.partner_id.name,
-                                        'im_status': channel_member_test_user.partner_id.im_status,
-                                        'type': "partner",
-                                    },
+                    "type": "mail.record/insert",
+                    "payload": {
+                        "Thread": [
+                            {
+                                "id": channel.id,
+                                "model": "discuss.channel",
+                                "invitedMembers": [
+                                    (
+                                        "DELETE",
+                                        [
+                                            {"id": channel_member_test_user.id},
+                                            {"id": channel_member_test_guest.id},
+                                        ],
+                                    )
+                                ],
+                            },
+                        ],
+                        "ChannelMember": [
+                            {
+                                "id": channel_member_test_user.id,
+                                "thread": {
+                                    "id": channel_member_test_user.channel_id.id,
+                                    "model": "discuss.channel",
                                 },
-                                {
-                                    'id': channel_member_test_guest.id,
-                                    'thread': {'id': channel_member_test_guest.channel_id.id, 'model': "discuss.channel"},
-                                    'persona': {
-                                        'id': channel_member_test_guest.guest_id.id,
-                                        'name': channel_member_test_guest.guest_id.name,
-                                        'im_status': channel_member_test_guest.guest_id.im_status,
-                                        'type': "guest",
-                                    },
+                                "persona": {
+                                    "id": channel_member_test_user.partner_id.id,
+                                    "name": channel_member_test_user.partner_id.name,
+                                    "im_status": channel_member_test_user.partner_id.im_status,
+                                    "type": "partner",
                                 },
-                            ])],
-                        }
+                            },
+                            {
+                                "id": channel_member_test_guest.id,
+                                "thread": {
+                                    "id": channel_member_test_guest.channel_id.id,
+                                    "model": "discuss.channel",
+                                },
+                                "persona": {
+                                    "id": channel_member_test_guest.guest_id.id,
+                                    "name": channel_member_test_guest.guest_id.name,
+                                    "im_status": channel_member_test_guest.guest_id.im_status,
+                                    "type": "guest",
+                                },
+                            },
+                        ],
                     },
                 },
                 {

--- a/addons/mail/tests/discuss/test_rtc.py
+++ b/addons/mail/tests/discuss/test_rtc.py
@@ -36,32 +36,52 @@ class TestChannelRTC(MailCommon):
                     },
                 },
                 {
-                    'type': 'discuss.channel/rtc_sessions_update',
-                    'payload': {
-                        'id': channel.id,
-                        'rtcSessions': [('DELETE', [{'id': channel_member.rtc_session_ids.id}])],
+                    "type": "mail.record/insert",
+                    "payload": {
+                        "Thread": [
+                            {
+                                "id": channel.id,
+                                "model": "discuss.channel",
+                                "rtcSessions": [
+                                    ("DELETE", [{"id": channel_member.rtc_session_ids.id}]),
+                                ],
+                            },
+                        ],
                     },
                 },
                 {
-                    'type': 'discuss.channel/rtc_sessions_update',
-                    'payload': {
-                        'id': channel.id,
-                        'rtcSessions': [('ADD', [{
-                            'id': channel_member.rtc_session_ids.id + 1,
-                            'channelMember': {
-                                "id": channel_member.id,
-                                "thread": {"id": channel_member.channel_id.id, "model": "discuss.channel"},
-                                "persona": {
-                                    "id": channel_member.partner_id.id,
-                                    "name": channel_member.partner_id.name,
-                                    "im_status": channel_member.partner_id.im_status,
-                                    "type": "partner",
+                    "type": "mail.record/insert",
+                    "payload": {
+                        "RtcSession": [
+                            {
+                                "id": channel_member.rtc_session_ids.id + 1,
+                                "channelMember": {
+                                    "id": channel_member.id,
+                                    "thread": {
+                                        "id": channel_member.channel_id.id,
+                                        "model": "discuss.channel",
+                                    },
+                                    "persona": {
+                                        "id": channel_member.partner_id.id,
+                                        "name": channel_member.partner_id.name,
+                                        "im_status": channel_member.partner_id.im_status,
+                                        "type": "partner",
+                                    },
                                 },
                             },
-                        }])],
+                        ],
+                        "Thread": [
+                            {
+                                "id": channel.id,
+                                "model": "discuss.channel",
+                                "rtcSessions": [
+                                    ("ADD", [{"id": channel_member.rtc_session_ids.id + 1}]),
+                                ],
+                            },
+                        ],
                     },
                 },
-            ]
+            ],
         ):
             store = Store()
             channel_member._rtc_join_call(store)
@@ -90,7 +110,7 @@ class TestChannelRTC(MailCommon):
                                 "type": "partner",
                             },
                         },
-                    }
+                    },
                 ],
                 "Thread": [
                     {
@@ -100,7 +120,7 @@ class TestChannelRTC(MailCommon):
                             ("ADD", [{"id": channel_member.rtc_session_ids.id}]),
                             ("DELETE", [{"id": channel_member.rtc_session_ids.id - 1}]),
                         ],
-                    }
+                    },
                 ],
             },
         )
@@ -129,22 +149,33 @@ class TestChannelRTC(MailCommon):
             ],
             [
                 {
-                    'type': 'discuss.channel/rtc_sessions_update',
-                    'payload': {
-                        'id': channel.id,
-                        'rtcSessions': [('ADD', [{
-                            'id': last_rtc_session_id + 1,
-                            'channelMember': {
-                                "id": channel_member.id,
-                                "thread": {"id": channel_member.channel_id.id, "model": "discuss.channel"},
-                                "persona": {
-                                    "id": channel_member.partner_id.id,
-                                    "name": channel_member.partner_id.name,
-                                    "im_status": channel_member.partner_id.im_status,
-                                    "type": "partner",
+                    "type": "mail.record/insert",
+                    "payload": {
+                        "RtcSession": [
+                            {
+                                "id": last_rtc_session_id + 1,
+                                "channelMember": {
+                                    "id": channel_member.id,
+                                    "thread": {
+                                        "id": channel_member.channel_id.id,
+                                        "model": "discuss.channel",
+                                    },
+                                    "persona": {
+                                        "id": channel_member.partner_id.id,
+                                        "name": channel_member.partner_id.name,
+                                        "im_status": channel_member.partner_id.im_status,
+                                        "type": "partner",
+                                    },
                                 },
                             },
-                        }])],
+                        ],
+                        "Thread": [
+                            {
+                                "id": channel.id,
+                                "model": "discuss.channel",
+                                "rtcSessions": [("ADD", [{"id": last_rtc_session_id + 1}])],
+                            },
+                        ],
                     },
                 },
                 {
@@ -166,7 +197,7 @@ class TestChannelRTC(MailCommon):
                         }],
                     },
                 },
-            ]
+            ],
         ):
             now = fields.Datetime.now()
             with patch.object(fields.Datetime, 'now', lambda: now + relativedelta(seconds=5)):
@@ -200,41 +231,63 @@ class TestChannelRTC(MailCommon):
             ],
             [
                 {
-                    'type': 'discuss.channel/rtc_sessions_update',
-                    'payload': {
-                        'id': channel.id,
-                        'rtcSessions': [('ADD', [{
-                            'id': last_rtc_session_id + 1,
-                            'channelMember': {
-                                "id": channel_member.id,
-                                "thread": {"id": channel_member.channel_id.id, "model": "discuss.channel"},
-                                "persona": {
-                                    "id": channel_member.partner_id.id,
-                                    "name": channel_member.partner_id.name,
-                                    "im_status": channel_member.partner_id.im_status,
-                                    "type": "partner",
+                    "type": "mail.record/insert",
+                    "payload": {
+                        "RtcSession": [
+                            {
+                                "id": last_rtc_session_id + 1,
+                                "channelMember": {
+                                    "id": channel_member.id,
+                                    "thread": {
+                                        "id": channel_member.channel_id.id,
+                                        "model": "discuss.channel",
+                                    },
+                                    "persona": {
+                                        "id": channel_member.partner_id.id,
+                                        "name": channel_member.partner_id.name,
+                                        "im_status": channel_member.partner_id.im_status,
+                                        "type": "partner",
+                                    },
                                 },
                             },
-                        }])],
+                        ],
+                        "Thread": [
+                            {
+                                "id": channel.id,
+                                "model": "discuss.channel",
+                                "rtcSessions": [("ADD", [{"id": last_rtc_session_id + 1}])],
+                            },
+                        ],
                     },
                 },
                 {
-                    'type': 'discuss.channel/rtc_sessions_update',
-                    'payload': {
-                        'id': channel.id,
-                        'rtcSessions': [('ADD', [{
-                            'id': last_rtc_session_id + 1,
-                            'channelMember': {
-                                "id": channel_member.id,
-                                "thread": {"id": channel_member.channel_id.id, "model": "discuss.channel"},
-                                "persona": {
-                                    "id": channel_member.partner_id.id,
-                                    "name": channel_member.partner_id.name,
-                                    "im_status": channel_member.partner_id.im_status,
-                                    "type": "partner",
+                    "type": "mail.record/insert",
+                    "payload": {
+                        "RtcSession": [
+                            {
+                                "id": last_rtc_session_id + 1,
+                                "channelMember": {
+                                    "id": channel_member.id,
+                                    "thread": {
+                                        "id": channel_member.channel_id.id,
+                                        "model": "discuss.channel",
+                                    },
+                                    "persona": {
+                                        "id": channel_member.partner_id.id,
+                                        "name": channel_member.partner_id.name,
+                                        "im_status": channel_member.partner_id.im_status,
+                                        "type": "partner",
+                                    },
                                 },
                             },
-                        }])],
+                        ],
+                        "Thread": [
+                            {
+                                "id": channel.id,
+                                "model": "discuss.channel",
+                                "rtcSessions": [("ADD", [{"id": last_rtc_session_id + 1}])],
+                            },
+                        ],
                     },
                 },
                 {
@@ -268,7 +321,7 @@ class TestChannelRTC(MailCommon):
                         }],
                     },
                 },
-            ]
+            ],
         ):
             now = fields.Datetime.now()
             with patch.object(fields.Datetime, 'now', lambda: now + relativedelta(seconds=5)):
@@ -323,15 +376,17 @@ class TestChannelRTC(MailCommon):
                     },
                 },
                 {
-                    'type': 'discuss.channel/rtc_sessions_update',
-                    'payload': {
-                        'id': channel.id,
-                        'rtcSessions': [('ADD', [
+                    "type": "mail.record/insert",
+                    "payload": {
+                        "RtcSession": [
                             {
-                                'id': channel_member.rtc_session_ids.id + 1,
-                                'channelMember': {
+                                "id": channel_member.rtc_session_ids.id + 1,
+                                "channelMember": {
                                     "id": channel_member_test_user.id,
-                                    "thread": {"id": channel_member_test_user.channel_id.id, "model": "discuss.channel"},
+                                    "thread": {
+                                        "id": channel_member_test_user.channel_id.id,
+                                        "model": "discuss.channel",
+                                    },
                                     "persona": {
                                         "id": channel_member_test_user.partner_id.id,
                                         "name": channel_member_test_user.partner_id.name,
@@ -340,10 +395,19 @@ class TestChannelRTC(MailCommon):
                                     },
                                 },
                             },
-                        ])],
+                        ],
+                        "Thread": [
+                            {
+                                "id": channel.id,
+                                "model": "discuss.channel",
+                                "rtcSessions": [
+                                    ("ADD", [{"id": channel_member.rtc_session_ids.id + 1}]),
+                                ],
+                            },
+                        ],
                     },
                 },
-            ]
+            ],
         ):
             channel_member_test_user._rtc_join_call()
 
@@ -386,27 +450,38 @@ class TestChannelRTC(MailCommon):
                     },
                 },
                 {
-                    'type': 'discuss.channel/rtc_sessions_update',
-                    'payload': {
-                        'id': channel.id,
-                        'rtcSessions': [('ADD', [
+                    "type": "mail.record/insert",
+                    "payload": {
+                        "RtcSession": [
                             {
-                                'id': channel_member.rtc_session_ids.id + 2,
-                                'channelMember': {
+                                "id": channel_member.rtc_session_ids.id + 2,
+                                "channelMember": {
                                     "id": channel_member_test_guest.id,
-                                    "thread": {"id": channel_member_test_guest.channel_id.id, "model": "discuss.channel"},
+                                    "thread": {
+                                        "id": channel_member_test_guest.channel_id.id,
+                                        "model": "discuss.channel",
+                                    },
                                     "persona": {
                                         "id": channel_member_test_guest.guest_id.id,
                                         "name": channel_member_test_guest.guest_id.name,
-                                        'im_status': channel_member_test_guest.guest_id.im_status,
+                                        "im_status": channel_member_test_guest.guest_id.im_status,
                                         "type": "guest",
                                     },
                                 },
                             },
-                        ])],
+                        ],
+                        "Thread": [
+                            {
+                                "id": channel.id,
+                                "model": "discuss.channel",
+                                "rtcSessions": [
+                                    ("ADD", [{"id": channel_member.rtc_session_ids.id + 2}]),
+                                ],
+                            },
+                        ],
                     },
                 },
-            ]
+            ],
         ):
             channel_member_test_guest._rtc_join_call()
 
@@ -582,13 +657,20 @@ class TestChannelRTC(MailCommon):
                     },
                 },
                 {
-                    'type': 'discuss.channel/rtc_sessions_update',
-                    'payload': {
-                        'id': channel.id,
-                        'rtcSessions': [('DELETE', [{'id': channel_member.rtc_session_ids.id}])],
+                    "type": "mail.record/insert",
+                    "payload": {
+                        "Thread": [
+                            {
+                                "id": channel.id,
+                                "model": "discuss.channel",
+                                "rtcSessions": [
+                                    ("DELETE", [{"id": channel_member.rtc_session_ids.id}]),
+                                ],
+                            },
+                        ],
                     },
                 },
-            ]
+            ],
         ):
             channel_member._rtc_leave_call()
 
@@ -726,10 +808,17 @@ class TestChannelRTC(MailCommon):
                     },
                 },
                 {
-                    'type': 'discuss.channel/rtc_sessions_update',
-                    'payload': {
-                        'id': channel.id,
-                        'rtcSessions': [('DELETE', [{'id': channel_member.rtc_session_ids.id}])],
+                    "type": "mail.record/insert",
+                    "payload": {
+                        "Thread": [
+                            {
+                                "id": channel.id,
+                                "model": "discuss.channel",
+                                "rtcSessions": [
+                                    ("DELETE", [{"id": channel_member.rtc_session_ids.id}]),
+                                ],
+                            },
+                        ],
                     },
                 },
             ],
@@ -761,10 +850,17 @@ class TestChannelRTC(MailCommon):
                     },
                 },
                 {
-                    'type': 'discuss.channel/rtc_sessions_update',
-                    'payload': {
-                        'id': channel.id,
-                        'rtcSessions': [('DELETE', [{'id': channel_member.rtc_session_ids.id}])],
+                    "type": "mail.record/insert",
+                    "payload": {
+                        "Thread": [
+                            {
+                                "id": channel.id,
+                                "model": "discuss.channel",
+                                "rtcSessions": [
+                                    ("DELETE", [{"id": channel_member.rtc_session_ids.id}]),
+                                ],
+                            },
+                        ],
                     },
                 },
             ],
@@ -792,10 +888,17 @@ class TestChannelRTC(MailCommon):
                     },
                 },
                 {
-                    'type': 'discuss.channel/rtc_sessions_update',
-                    'payload': {
-                        'id': channel.id,
-                        'rtcSessions': [('DELETE', [{'id': channel_member.rtc_session_ids.id}])],
+                    "type": "mail.record/insert",
+                    "payload": {
+                        "Thread": [
+                            {
+                                "id": channel.id,
+                                "model": "discuss.channel",
+                                "rtcSessions": [
+                                    ("DELETE", [{"id": channel_member.rtc_session_ids.id}]),
+                                ],
+                            },
+                        ],
                     },
                 },
             ],
@@ -834,10 +937,15 @@ class TestChannelRTC(MailCommon):
                     },
                 },
                 {
-                    'type': 'discuss.channel/rtc_sessions_update',
-                    'payload': {
-                        'id': channel.id,
-                        'rtcSessions': [('DELETE', [{'id': test_session.id}])],
+                    "type": "mail.record/insert",
+                    "payload": {
+                        "Thread": [
+                            {
+                                "id": channel.id,
+                                "model": "discuss.channel",
+                                "rtcSessions": [("DELETE", [{"id": test_session.id}])],
+                            },
+                        ],
                     },
                 },
             ],

--- a/addons/mail/tests/discuss/test_rtc.py
+++ b/addons/mail/tests/discuss/test_rtc.py
@@ -52,22 +52,25 @@ class TestChannelRTC(MailCommon):
                 {
                     "type": "mail.record/insert",
                     "payload": {
+                        "ChannelMember": [
+                            {
+                                "id": channel_member.id,
+                                "thread": {
+                                    "id": channel_member.channel_id.id,
+                                    "model": "discuss.channel",
+                                },
+                                "persona": {
+                                    "id": channel_member.partner_id.id,
+                                    "name": channel_member.partner_id.name,
+                                    "im_status": channel_member.partner_id.im_status,
+                                    "type": "partner",
+                                },
+                            },
+                        ],
                         "RtcSession": [
                             {
                                 "id": channel_member.rtc_session_ids.id + 1,
-                                "channelMember": {
-                                    "id": channel_member.id,
-                                    "thread": {
-                                        "id": channel_member.channel_id.id,
-                                        "model": "discuss.channel",
-                                    },
-                                    "persona": {
-                                        "id": channel_member.partner_id.id,
-                                        "name": channel_member.partner_id.name,
-                                        "im_status": channel_member.partner_id.im_status,
-                                        "type": "partner",
-                                    },
-                                },
+                                "channelMember": {"id": channel_member.id},
                             },
                         ],
                         "Thread": [
@@ -89,6 +92,21 @@ class TestChannelRTC(MailCommon):
         self.assertEqual(
             res,
             {
+                "ChannelMember": [
+                    {
+                        "id": channel_member.id,
+                        "thread": {
+                            "id": channel_member.channel_id.id,
+                            "model": "discuss.channel",
+                        },
+                        "persona": {
+                            "id": channel_member.partner_id.id,
+                            "name": channel_member.partner_id.name,
+                            "im_status": channel_member.partner_id.im_status,
+                            "type": "partner",
+                        },
+                    },
+                ],
                 "Rtc": {
                     "iceServers": False,
                     "selfSession": {"id": channel_member.rtc_session_ids.id},
@@ -97,19 +115,7 @@ class TestChannelRTC(MailCommon):
                 "RtcSession": [
                     {
                         "id": channel_member.rtc_session_ids.id,
-                        "channelMember": {
-                            "id": channel_member.id,
-                            "thread": {
-                                "id": channel_member.channel_id.id,
-                                "model": "discuss.channel",
-                            },
-                            "persona": {
-                                "id": channel_member.partner_id.id,
-                                "name": channel_member.partner_id.name,
-                                "im_status": channel_member.partner_id.im_status,
-                                "type": "partner",
-                            },
-                        },
+                        "channelMember": {"id": channel_member.id},
                     },
                 ],
                 "Thread": [
@@ -151,22 +157,25 @@ class TestChannelRTC(MailCommon):
                 {
                     "type": "mail.record/insert",
                     "payload": {
+                        "ChannelMember": [
+                            {
+                                "id": channel_member.id,
+                                "thread": {
+                                    "id": channel_member.channel_id.id,
+                                    "model": "discuss.channel",
+                                },
+                                "persona": {
+                                    "id": channel_member.partner_id.id,
+                                    "name": channel_member.partner_id.name,
+                                    "im_status": channel_member.partner_id.im_status,
+                                    "type": "partner",
+                                },
+                            },
+                        ],
                         "RtcSession": [
                             {
                                 "id": last_rtc_session_id + 1,
-                                "channelMember": {
-                                    "id": channel_member.id,
-                                    "thread": {
-                                        "id": channel_member.channel_id.id,
-                                        "model": "discuss.channel",
-                                    },
-                                    "persona": {
-                                        "id": channel_member.partner_id.id,
-                                        "name": channel_member.partner_id.name,
-                                        "im_status": channel_member.partner_id.im_status,
-                                        "type": "partner",
-                                    },
-                                },
+                                "channelMember": {"id": channel_member.id},
                             },
                         ],
                         "Thread": [
@@ -233,22 +242,25 @@ class TestChannelRTC(MailCommon):
                 {
                     "type": "mail.record/insert",
                     "payload": {
+                        "ChannelMember": [
+                            {
+                                "id": channel_member.id,
+                                "thread": {
+                                    "id": channel_member.channel_id.id,
+                                    "model": "discuss.channel",
+                                },
+                                "persona": {
+                                    "id": channel_member.partner_id.id,
+                                    "name": channel_member.partner_id.name,
+                                    "im_status": channel_member.partner_id.im_status,
+                                    "type": "partner",
+                                },
+                            },
+                        ],
                         "RtcSession": [
                             {
                                 "id": last_rtc_session_id + 1,
-                                "channelMember": {
-                                    "id": channel_member.id,
-                                    "thread": {
-                                        "id": channel_member.channel_id.id,
-                                        "model": "discuss.channel",
-                                    },
-                                    "persona": {
-                                        "id": channel_member.partner_id.id,
-                                        "name": channel_member.partner_id.name,
-                                        "im_status": channel_member.partner_id.im_status,
-                                        "type": "partner",
-                                    },
-                                },
+                                "channelMember": {"id": channel_member.id},
                             },
                         ],
                         "Thread": [
@@ -263,22 +275,25 @@ class TestChannelRTC(MailCommon):
                 {
                     "type": "mail.record/insert",
                     "payload": {
+                        "ChannelMember": [
+                            {
+                                "id": channel_member.id,
+                                "thread": {
+                                    "id": channel_member.channel_id.id,
+                                    "model": "discuss.channel",
+                                },
+                                "persona": {
+                                    "id": channel_member.partner_id.id,
+                                    "name": channel_member.partner_id.name,
+                                    "im_status": channel_member.partner_id.im_status,
+                                    "type": "partner",
+                                },
+                            },
+                        ],
                         "RtcSession": [
                             {
                                 "id": last_rtc_session_id + 1,
-                                "channelMember": {
-                                    "id": channel_member.id,
-                                    "thread": {
-                                        "id": channel_member.channel_id.id,
-                                        "model": "discuss.channel",
-                                    },
-                                    "persona": {
-                                        "id": channel_member.partner_id.id,
-                                        "name": channel_member.partner_id.name,
-                                        "im_status": channel_member.partner_id.im_status,
-                                        "type": "partner",
-                                    },
-                                },
+                                "channelMember": {"id": channel_member.id},
                             },
                         ],
                         "Thread": [
@@ -378,22 +393,25 @@ class TestChannelRTC(MailCommon):
                 {
                     "type": "mail.record/insert",
                     "payload": {
+                        "ChannelMember": [
+                            {
+                                "id": channel_member_test_user.id,
+                                "thread": {
+                                    "id": channel_member_test_user.channel_id.id,
+                                    "model": "discuss.channel",
+                                },
+                                "persona": {
+                                    "id": channel_member_test_user.partner_id.id,
+                                    "name": channel_member_test_user.partner_id.name,
+                                    "im_status": channel_member_test_user.partner_id.im_status,
+                                    "type": "partner",
+                                },
+                            },
+                        ],
                         "RtcSession": [
                             {
                                 "id": channel_member.rtc_session_ids.id + 1,
-                                "channelMember": {
-                                    "id": channel_member_test_user.id,
-                                    "thread": {
-                                        "id": channel_member_test_user.channel_id.id,
-                                        "model": "discuss.channel",
-                                    },
-                                    "persona": {
-                                        "id": channel_member_test_user.partner_id.id,
-                                        "name": channel_member_test_user.partner_id.name,
-                                        "im_status": channel_member_test_user.partner_id.im_status,
-                                        "type": "partner",
-                                    },
-                                },
+                                "channelMember": {"id": channel_member_test_user.id},
                             },
                         ],
                         "Thread": [
@@ -452,22 +470,25 @@ class TestChannelRTC(MailCommon):
                 {
                     "type": "mail.record/insert",
                     "payload": {
+                        "ChannelMember": [
+                            {
+                                "id": channel_member_test_guest.id,
+                                "thread": {
+                                    "id": channel_member_test_guest.channel_id.id,
+                                    "model": "discuss.channel",
+                                },
+                                "persona": {
+                                    "id": channel_member_test_guest.guest_id.id,
+                                    "name": channel_member_test_guest.guest_id.name,
+                                    "im_status": channel_member_test_guest.guest_id.im_status,
+                                    "type": "guest",
+                                },
+                            },
+                        ],
                         "RtcSession": [
                             {
                                 "id": channel_member.rtc_session_ids.id + 2,
-                                "channelMember": {
-                                    "id": channel_member_test_guest.id,
-                                    "thread": {
-                                        "id": channel_member_test_guest.channel_id.id,
-                                        "model": "discuss.channel",
-                                    },
-                                    "persona": {
-                                        "id": channel_member_test_guest.guest_id.id,
-                                        "name": channel_member_test_guest.guest_id.name,
-                                        "im_status": channel_member_test_guest.guest_id.im_status,
-                                        "type": "guest",
-                                    },
-                                },
+                                "channelMember": {"id": channel_member_test_guest.id},
                             },
                         ],
                         "Thread": [
@@ -719,22 +740,25 @@ class TestChannelRTC(MailCommon):
                                 "rtcInvitingSession": {"id": channel_member.rtc_session_ids.id},
                             },
                         ],
+                        "ChannelMember": [
+                            {
+                                "id": channel_member.id,
+                                "thread": {
+                                    "id": channel_member.channel_id.id,
+                                    "model": "discuss.channel",
+                                },
+                                "persona": {
+                                    "id": channel_member.partner_id.id,
+                                    "name": channel_member.partner_id.name,
+                                    "im_status": channel_member.partner_id.im_status,
+                                    "type": "partner",
+                                },
+                            },
+                        ],
                         "RtcSession": [
                             {
                                 "id": channel_member.rtc_session_ids.id,
-                                "channelMember": {
-                                    "id": channel_member.id,
-                                    "thread": {
-                                        "id": channel_member.channel_id.id,
-                                        "model": "discuss.channel",
-                                    },
-                                    "persona": {
-                                        "id": channel_member.partner_id.id,
-                                        "name": channel_member.partner_id.name,
-                                        "im_status": channel_member.partner_id.im_status,
-                                        "type": "partner",
-                                    },
-                                },
+                                "channelMember": {"id": channel_member.id},
                             },
                         ],
                     },
@@ -749,22 +773,25 @@ class TestChannelRTC(MailCommon):
                                 "rtcInvitingSession": {"id": channel_member.rtc_session_ids.id},
                             },
                         ],
+                        "ChannelMember": [
+                            {
+                                "id": channel_member.id,
+                                "thread": {
+                                    "id": channel_member.channel_id.id,
+                                    "model": "discuss.channel",
+                                },
+                                "persona": {
+                                    "id": channel_member.partner_id.id,
+                                    "name": channel_member.partner_id.name,
+                                    "im_status": channel_member.partner_id.im_status,
+                                    "type": "partner",
+                                },
+                            },
+                        ],
                         "RtcSession": [
                             {
                                 "id": channel_member.rtc_session_ids.id,
-                                "channelMember": {
-                                    "id": channel_member.id,
-                                    "thread": {
-                                        "id": channel_member.channel_id.id,
-                                        "model": "discuss.channel",
-                                    },
-                                    "persona": {
-                                        "id": channel_member.partner_id.id,
-                                        "name": channel_member.partner_id.name,
-                                        "im_status": channel_member.partner_id.im_status,
-                                        "type": "partner",
-                                    },
-                                },
+                                "channelMember": {"id": channel_member.id},
                             },
                         ],
                     },

--- a/addons/mail/tests/discuss/test_rtc.py
+++ b/addons/mail/tests/discuss/test_rtc.py
@@ -188,22 +188,30 @@ class TestChannelRTC(MailCommon):
                     },
                 },
                 {
-                    'type': 'mail.record/insert',
-                    'payload': {
-                        'Thread': [{
-                            'id': channel.id,
-                            'model': 'discuss.channel',
-                            'invitedMembers': [('ADD', [{
-                                'id': channel_member_test_user.id,
-                                'thread': {'id': channel_member_test_user.channel_id.id, 'model': "discuss.channel"},
-                                'persona': {
-                                    'id': channel_member_test_user.partner_id.id,
-                                    'name': channel_member_test_user.partner_id.name,
-                                    'im_status': channel_member_test_user.partner_id.im_status,
-                                    'type': "partner",
+                    "type": "mail.record/insert",
+                    "payload": {
+                        "Thread": [
+                            {
+                                "id": channel.id,
+                                "model": "discuss.channel",
+                                "invitedMembers": [("ADD", [{"id": channel_member_test_user.id}])],
+                            }
+                        ],
+                        "ChannelMember": [
+                            {
+                                "id": channel_member_test_user.id,
+                                "thread": {
+                                    "id": channel_member_test_user.channel_id.id,
+                                    "model": "discuss.channel",
                                 },
-                            }])],
-                        }],
+                                "persona": {
+                                    "id": channel_member_test_user.partner_id.id,
+                                    "name": channel_member_test_user.partner_id.name,
+                                    "im_status": channel_member_test_user.partner_id.im_status,
+                                    "type": "partner",
+                                },
+                            },
+                        ],
                     },
                 },
             ],
@@ -306,34 +314,51 @@ class TestChannelRTC(MailCommon):
                     },
                 },
                 {
-                    'type': 'mail.record/insert',
-                    'payload': {
-                        'Thread': [{
-                            'id': channel.id,
-                            'model': 'discuss.channel',
-                            'invitedMembers': [('ADD', [
-                                {
-                                    'id': channel_member_test_user.id,
-                                    'thread': {'id': channel_member_test_user.channel_id.id, 'model': "discuss.channel"},
-                                    'persona': {
-                                        'id': channel_member_test_user.partner_id.id,
-                                        'name': channel_member_test_user.partner_id.name,
-                                        'im_status': channel_member_test_user.partner_id.im_status,
-                                        'type': "partner",
-                                    },
+                    "type": "mail.record/insert",
+                    "payload": {
+                        "Thread": [
+                            {
+                                "id": channel.id,
+                                "model": "discuss.channel",
+                                "invitedMembers": [
+                                    (
+                                        "ADD",
+                                        [
+                                            {"id": channel_member_test_user.id},
+                                            {"id": channel_member_test_guest.id},
+                                        ],
+                                    )
+                                ],
+                            }
+                        ],
+                        "ChannelMember": [
+                            {
+                                "id": channel_member_test_user.id,
+                                "thread": {
+                                    "id": channel_member_test_user.channel_id.id,
+                                    "model": "discuss.channel",
                                 },
-                                {
-                                    'id': channel_member_test_guest.id,
-                                    'thread': {'id': channel_member_test_guest.channel_id.id, 'model': "discuss.channel"},
-                                    'persona': {
-                                        'id': channel_member_test_guest.guest_id.id,
-                                        'name': channel_member_test_guest.guest_id.name,
-                                        'im_status': channel_member_test_guest.guest_id.im_status,
-                                        'type': "guest",
-                                    },
+                                "persona": {
+                                    "id": channel_member_test_user.partner_id.id,
+                                    "name": channel_member_test_user.partner_id.name,
+                                    "im_status": channel_member_test_user.partner_id.im_status,
+                                    "type": "partner",
                                 },
-                            ])],
-                        }],
+                            },
+                            {
+                                "id": channel_member_test_guest.id,
+                                "thread": {
+                                    "id": channel_member_test_guest.channel_id.id,
+                                    "model": "discuss.channel",
+                                },
+                                "persona": {
+                                    "id": channel_member_test_guest.guest_id.id,
+                                    "name": channel_member_test_guest.guest_id.name,
+                                    "im_status": channel_member_test_guest.guest_id.im_status,
+                                    "type": "guest",
+                                },
+                            },
+                        ],
                     },
                 },
             ],
@@ -797,34 +822,51 @@ class TestChannelRTC(MailCommon):
                     },
                 },
                 {
-                    'type': 'mail.record/insert',
-                    'payload': {
-                        'Thread': [{
-                            'id': channel.id,
-                            'model': 'discuss.channel',
-                            'invitedMembers': [('ADD', [
-                                {
-                                    'id': channel_member_test_user.id,
-                                    'thread': {'id': channel_member_test_user.channel_id.id, 'model': "discuss.channel"},
-                                    'persona': {
-                                        'id': channel_member_test_user.partner_id.id,
-                                        'name': channel_member_test_user.partner_id.name,
-                                        'im_status': channel_member_test_user.partner_id.im_status,
-                                        'type': "partner",
-                                    },
+                    "type": "mail.record/insert",
+                    "payload": {
+                        "Thread": [
+                            {
+                                "id": channel.id,
+                                "model": "discuss.channel",
+                                "invitedMembers": [
+                                    (
+                                        "ADD",
+                                        [
+                                            {"id": channel_member_test_user.id},
+                                            {"id": channel_member_test_guest.id},
+                                        ],
+                                    )
+                                ],
+                            }
+                        ],
+                        "ChannelMember": [
+                            {
+                                "id": channel_member_test_user.id,
+                                "thread": {
+                                    "id": channel_member_test_user.channel_id.id,
+                                    "model": "discuss.channel",
                                 },
-                                {
-                                    'id': channel_member_test_guest.id,
-                                    'thread': {'id': channel_member_test_guest.channel_id.id, 'model': "discuss.channel"},
-                                    'persona': {
-                                        'id': channel_member_test_guest.guest_id.id,
-                                        'name': channel_member_test_guest.guest_id.name,
-                                        'im_status': channel_member_test_guest.guest_id.im_status,
-                                        'type': "guest",
-                                    },
+                                "persona": {
+                                    "id": channel_member_test_user.partner_id.id,
+                                    "name": channel_member_test_user.partner_id.name,
+                                    "im_status": channel_member_test_user.partner_id.im_status,
+                                    "type": "partner",
                                 },
-                            ])],
-                        }],
+                            },
+                            {
+                                "id": channel_member_test_guest.id,
+                                "thread": {
+                                    "id": channel_member_test_guest.channel_id.id,
+                                    "model": "discuss.channel",
+                                },
+                                "persona": {
+                                    "id": channel_member_test_guest.guest_id.id,
+                                    "name": channel_member_test_guest.guest_id.name,
+                                    "im_status": channel_member_test_guest.guest_id.im_status,
+                                    "type": "guest",
+                                },
+                            },
+                        ],
                     },
                 },
             ],

--- a/addons/mail/tools/discuss.py
+++ b/addons/mail/tools/discuss.py
@@ -36,6 +36,7 @@ ids_by_model = defaultdict(lambda: ("id",))
 ids_by_model.update(
     {
         "Persona": ("type", "id"),
+        "Rtc": (),
         "Store": (),
         "Thread": ("model", "id"),
     }

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -232,6 +232,7 @@ class TestDiscussFullPerformance(HttpCase):
         bus_last_id = self.env["bus.bus"].sudo()._bus_last_id()
         return {
             "ChannelMember": [
+                self._expected_result_for_channel_member(self.channel_channel_group_1, self.users[2].partner_id),
                 self._expected_result_for_channel_member(self.channel_channel_group_1, self.users[0].partner_id),
                 self._expected_result_for_channel_member(self.channel_chat_1, self.users[0].partner_id),
                 self._expected_result_for_channel_member(self.channel_chat_1, self.users[14].partner_id),
@@ -284,6 +285,7 @@ class TestDiscussFullPerformance(HttpCase):
         """
         return {
             "ChannelMember": [
+                self._expected_result_for_channel_member(self.channel_channel_group_1, self.users[2].partner_id),
                 self._expected_result_for_channel_member(self.channel_general, self.users[0].partner_id),
                 self._expected_result_for_channel_member(self.channel_channel_public_1, self.users[0].partner_id),
                 self._expected_result_for_channel_member(self.channel_channel_public_2, self.users[0].partner_id),
@@ -869,6 +871,20 @@ class TestDiscussFullPerformance(HttpCase):
                 "fetched_message_id": {"id": last_message.id},
                 "seen_message_id": {"id": last_message.id},
                 "new_message_separator": last_message.id + 1,
+            }
+        if channel == self.channel_channel_group_1 and partner == self.users[2].partner_id:
+            return {
+                "id": member_2.id,
+                "thread": {
+                    "id": channel.id,
+                    "model": "discuss.channel",
+                },
+                "persona": {
+                    "id": self.users[2].partner_id.id,
+                    "im_status": "offline",
+                    "name": "test2",
+                    "type": "partner",
+                },
             }
         if channel == self.channel_channel_group_2 and partner == self.users[0].partner_id:
             return {
@@ -1529,16 +1545,7 @@ class TestDiscussFullPerformance(HttpCase):
             return {
                 # sudo: discuss.channel.rtc.session - reading a session in a test file
                 "id": member_2.sudo().rtc_session_ids.id,
-                "channelMember": {
-                    "id": member_2.id,
-                    "persona": {
-                        "id": member_2.partner_id.id,
-                        "im_status": "offline",
-                        "name": "test2",
-                        "type": "partner",
-                    },
-                    "thread": {"id": channel.id, "model": "discuss.channel"},
-                },
+                "channelMember": {"id": member_2.id},
                 "isCameraOn": False,
                 "isDeaf": False,
                 "isScreenSharingOn": False,

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -463,34 +463,8 @@ class TestDiscussFullPerformance(HttpCase):
                 "name": "group restricted channel 1",
                 # sudo: discuss.channel.rtc.session - reading a session in a test file
                 "rtcInvitingSession": {"id": member_2.sudo().rtc_session_ids.id},
-                "rtcSessions": [
-                    [
-                        "ADD",
-                        [
-                            {
-                                "channelMember": {
-                                    "id": member_2.id,
-                                    "persona": {
-                                        "id": member_2.partner_id.id,
-                                        "im_status": "offline",
-                                        "name": "test2",
-                                        "type": "partner",
-                                    },
-                                    "thread": {
-                                        "id": channel.id,
-                                        "model": "discuss.channel",
-                                    },
-                                },
-                                # sudo: discuss.channel.rtc.session - reading a session in a test file
-                                "id": member_2.sudo().rtc_session_ids.id,
-                                "isCameraOn": False,
-                                "isDeaf": False,
-                                "isScreenSharingOn": False,
-                                "isSelfMuted": False,
-                            }
-                        ],
-                    ]
-                ],
+                # sudo: discuss.channel.rtc.session - reading a session in a test file
+                "rtcSessions": [["ADD", [{"id": member_2.sudo().rtc_session_ids.id}]]],
                 "custom_notifications": False,
                 "mute_until_dt": False,
                 "state": "closed",
@@ -1565,5 +1539,9 @@ class TestDiscussFullPerformance(HttpCase):
                     },
                     "thread": {"id": channel.id, "model": "discuss.channel"},
                 },
+                "isCameraOn": False,
+                "isDeaf": False,
+                "isScreenSharingOn": False,
+                "isSelfMuted": False,
             }
         return {}


### PR DESCRIPTION
This will reduce data transferred to the client and processed in JS when the same rtc session or channel member was appearing multiple times.

This also makes more clear what is transferred by avoiding nested values.

This is part 2, focusing on RTC related code.

Formatting code eventually becomes simpler too, by always adding data to the store rather than updating pre-existing dict manually.

Part of task-3605717