### PR TITLE
[FIX] stock: rename routes on warehouses' name change

### DIFF
--- a/addons/mrp/models/stock_warehouse.py
+++ b/addons/mrp/models/stock_warehouse.py
@@ -211,11 +211,13 @@ class StockWarehouse(models.Model):
 
     def _get_sequence_values(self):
         values = super(StockWarehouse, self)._get_sequence_values()
-        values.update({
-            'pbm_type_id': {'name': self.name + ' ' + _('Sequence picking before manufacturing'), 'prefix': self.code + '/PC/', 'padding': 5, 'company_id': self.company_id.id},
-            'sam_type_id': {'name': self.name + ' ' + _('Sequence stock after manufacturing'), 'prefix': self.code + '/SFP/', 'padding': 5, 'company_id': self.company_id.id},
-            'manu_type_id': {'name': self.name + ' ' + _('Sequence production'), 'prefix': self.code + '/MO/', 'padding': 5, 'company_id': self.company_id.id},
-        })
+        ctx_name = self._context.get('name')
+        ctx_code = self._context.get('code')
+        picking_types = [('pbm_type_id', _('Sequence picking before manufacturing'), 'PC'),
+                         ('sam_type_id', _('Sequence stock after manufacturing'), 'SFP'),
+                         ('manu_type_id', _('Sequence production'), 'MO')
+                        ]
+        values.update(self._create_sequence_values(picking_types, ctx_name, ctx_code))
         return values
 
     def _get_picking_type_create_values(self, max_sequence):

--- a/addons/mrp_subcontracting/models/stock_warehouse.py
+++ b/addons/mrp_subcontracting/models/stock_warehouse.py
@@ -131,20 +131,12 @@ class StockWarehouse(models.Model):
 
     def _get_sequence_values(self):
         values = super(StockWarehouse, self)._get_sequence_values()
-        values.update({
-            'subcontracting_type_id': {
-                'name': self.name + ' ' + _('Sequence subcontracting'),
-                'prefix': self.code + '/SBC/',
-                'padding': 5,
-                'company_id': self.company_id.id
-            },
-            'subcontracting_resupply_type_id': {
-                'name': self.name + ' ' + _('Sequence Resupply Subcontractor'),
-                'prefix': self.code + '/RES/',
-                'padding': 5,
-                'company_id': self.company_id.id
-            },
-        })
+        ctx_name = self._context.get('name')
+        ctx_code = self._context.get('code')
+        picking_types = [('subcontracting_type_id', _('Sequence subcontracting'), 'SBC'),
+                         ('subcontracting_resupply_type_id', _('Sequence Resupply Subcontractor'), 'RES')
+                        ]
+        values.update(self._create_sequence_values(picking_types, ctx_name, ctx_code))
         return values
 
     def _get_picking_type_update_values(self):

--- a/addons/point_of_sale/models/stock_warehouse.py
+++ b/addons/point_of_sale/models/stock_warehouse.py
@@ -10,14 +10,10 @@ class Warehouse(models.Model):
 
     def _get_sequence_values(self):
         sequence_values = super(Warehouse, self)._get_sequence_values()
-        sequence_values.update({
-            'pos_type_id': {
-                'name': self.name + ' ' + _('Picking POS'),
-                'prefix': self.code + '/POS/',
-                'padding': 5,
-                'company_id': self.company_id.id,
-            }
-        })
+        ctx_name = self._context.get('name')
+        ctx_code = self._context.get('code')
+        picking_types = [('pos_type_id', _('Picking POS'), "POS")]
+        sequence_values.update(self._create_sequence_values(picking_types, ctx_name, ctx_code))
         return sequence_values
 
     def _get_picking_type_update_values(self):


### PR DESCRIPTION

Description of the issue/feature this PR addresses:
- Routes renaming
When a warehouse is renamed, associated route's name aren't renamed accordingly.
As previously, the call to 'route.write()' in method '_update_name_and_code' was done
after the 'super().write()', there was no way to remember the old name of the warehouse,
and the 'replace' was so uneffective.The effectivenes of the replace is reestablished by
doing the 'super().write' after the call to '_update_name_and_code'. However, it breaks
the method '_get_sequence_values' because it expects the name and code to be already written.
- Backport of commits:
https://github.com/odoo/odoo/pull/102456/commits
https://github.com/odoo/odoo/pull/103146/commits

- Operations rename
When renaming a warehouse, the sequence prefix of the operation types
gets overwritten and not all of the operation types gets renamed.
Handle the creation of the sequence values in another private method,
_create_sequence_values, to avoid redundancy.

- Return operation type created with the wrong sequence_code
When creating a new warehouse, the return operation type is
created with the wrong sequence_code which will lead to a
unique sequence error when creating stock related records

Current behavior before PR:
- When a warehouse is renamed, route's name doesn't change
- When a warehouse is renamed and the user changed the
sequence prefix of an operation type, the sequence prefix
of the operation type gets overwritten
- When a warehouse is created, the return operation type
is created with the wrong sequence_code

Desired behavior after PR is merged:
- When a warehouse is renamed, route's name change accordingly
- When a warehouse is renamed and the user changed the sequence
prefix of an operation type, the sequence prefix of the operation
type should not get overwritten unless the warehouse code or the
operation type code has been modified.
- When a warehouse is created, the return operation type's
sequence_code should be 'RET'

opw-2985735, opw- 3963840