### PR TITLE
[FIX] product: fix product variant kanban card layout

### DIFF
--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -499,8 +499,8 @@
                     <field name="color"/>
                     <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}'/>
                     <templates>
-                        <t t-name="kanban-card">
-                            <main class="pe-2">
+                        <t t-name="kanban-card" class="row g-0">
+                            <main class="col-10 pe-2">
                                 <div class="d-flex mb-1 h5">
                                     <field class="me-1" name="is_favorite" widget="boolean_favorite" nolabel="1"/>
                                     <field name="name"/>
@@ -513,7 +513,7 @@
                                     Price: <field name="lst_price"></field>
                                 </span>
                             </main>
-                            <aside>
+                            <aside class="col-2">
                                 <field name="image_128" widget="image" options="{'img_class': 'o_image_64_contain mw-100'}" alt="Product"/>
                             </aside>
                         </t>


### PR DESCRIPTION
Commit [1] reworked the layout of product and variants kanban cards, following the framework changes aiming to simplify kanban archs [2]. However, we kind of forgot to adapt the variant view to the last changes of specs. As a consequence, the image of the product was displayed below the content of the card, instead of being on the side.

[1] odoo/odoo@0279c53930735b65e9342ca66fbb62ff61ac65f6
[2] odoo/odoo#167751

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
