### PR TITLE
[FIX] base: partner kanban: do not crop img in mobile

### DIFF
--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -403,7 +403,7 @@
                             <aside class="col-3 col-sm-2 col-md-4 o_kanban_aside_full">
                                 <t t-if="!record.is_company.raw_value">
                                     <div class="position-relative w-100">
-                                        <field name="avatar_128" alt="Contact image" class="position-absolute top-0 start-0 h-100 w-100" widget="image" options="{'img_class': 'object-fit-cover w-100 h-100'}"/>
+                                        <field name="avatar_128" alt="Contact image" class="position-md-absolute top-0 start-0 h-100 w-100" widget="image" options="{'img_class': 'object-fit-cover w-100 h-100'}"/>
                                         <field t-if="record.parent_id.raw_value" name="parent_id" class="position-absolute bottom-0 end-0 w-25 bg-light" widget="image" options="{'preview_image': 'image_128', 'img_class': 'object-fit-contain'}"/>
                                     </div>
                                 </t>


### PR DESCRIPTION
This commit fixes the mobile layout of the partner kanban cards, to prevent the avatar from being cropped if it bigger than the content of the card.

Following the revamp of kanban archs [1]

[1] odoo/odoo#167751

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
