### PR TITLE
[IMP] point_of_sale: Cancel open orders when closing the session

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -889,7 +889,8 @@ class PosOrder(models.Model):
         }
 
     def action_pos_order_cancel(self):
-        return self.write({'state': 'cancel'})
+        cancellable_orders = self.filtered(lambda order: order.state == 'draft')
+        return cancellable_orders.write({'state': 'cancel'})
 
     def _apply_invoice_payments(self, is_reverse=False):
         receivable_account = self.env["res.partner"]._find_accounting_partner(self.partner_id).with_company(self.company_id).property_account_receivable_id

--- a/addons/point_of_sale/static/src/app/models/related_models.js
+++ b/addons/point_of_sale/static/src/app/models/related_models.js
@@ -160,7 +160,7 @@ export class Base {
         this.model.update(this, vals);
     }
     delete() {
-        this.model.delete(this);
+        return this.model.delete(this);
     }
     /**
      * @param {object} options
@@ -561,6 +561,7 @@ export function createRelatedModels(modelDefs, modelClasses = {}, indexes = {}) 
             }
         }
         models[model].triggerEvents("delete", id);
+        return id;
     }
 
     function createCRUD(model, fields) {

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -144,31 +144,21 @@ export class TicketScreen extends Component {
                 this.state.selectedOrder = null;
             }
         }
+
         order.uiState.displayed = false;
-        if (order && (await this._onBeforeDeleteOrder(order))) {
-            if (Object.keys(order.last_order_preparation_change).length > 0) {
-                await this.pos.sendOrderInPreparationUpdateLastChange(order, true);
-            }
-            if (order === this.pos.get_order()) {
-                this._selectNextOrder(order);
-            }
-            const cancelled = this.pos.removeOrder(order, true);
+        if (order.id === this.pos.get_order()?.id) {
+            this._selectNextOrder(order);
+        }
 
-            const idToCancel = [...this.pos.pendingOrder.delete];
-
-            if (idToCancel.length > 0) {
-                this.pos.pendingOrder.delete.clear();
-                await this.pos.data.call("pos.order", "action_pos_order_cancel", idToCancel);
-            }
-
-            if (!cancelled) {
-                order.uiState.displayed = true;
-            }
-
+        const result = await this.pos.deleteOrders([order]);
+        if (!result) {
+            order.uiState.displayed = true;
+        } else {
             if (this.pos.get_order_list().length > 0) {
                 this.state.selectedOrder = this.pos.get_order_list()[0];
             }
         }
+
         return true;
     }
     async onNextPage() {
@@ -675,15 +665,6 @@ export class TicketScreen extends Component {
             PaymentScreen: "PAYMENT",
             ReceiptScreen: "RECEIPT",
         };
-    }
-    /**
-     * Override to do something before deleting the order.
-     * Make sure to return true to proceed on deleting the order.
-     * @param {*} order
-     * @returns {boolean}
-     */
-    async _onBeforeDeleteOrder(order) {
-        return true;
     }
     _getOrderStates() {
         // We need the items to be ordered, therefore, Map is used instead of normal object.


### PR DESCRIPTION
When closing a session, allow the user to cancel all open order by clicking on a button. This will cancel all the orders that are in the draft state in the current session.

Task ID: 3987032

Related: https://github.com/odoo/enterprise/pull/64846