### PR TITLE
[FIX] im_livechat: fix chat bot flow as portal user

### DIFF
--- a/addons/im_livechat/models/chatbot_script.py
+++ b/addons/im_livechat/models/chatbot_script.py
@@ -208,8 +208,7 @@ class ChatbotScript(models.Model):
                 "'%(input_email)s' does not look like a valid email. Can you please try again?",
                 input_email=email_address
             )
-            # sudo - mail.message - chat bot can post a message as part of the email validation
-            posted_message = discuss_channel.sudo()._chatbot_post_message(self, plaintext2html(error_message))
+            posted_message = discuss_channel._chatbot_post_message(self, plaintext2html(error_message))
 
         return {
             'success': bool(email_normalized),

--- a/addons/im_livechat/models/chatbot_script_step.py
+++ b/addons/im_livechat/models/chatbot_script_step.py
@@ -317,8 +317,7 @@ class ChatbotScriptStep(models.Model):
 
         if self.step_type == 'forward_operator':
             return self._process_step_forward_operator(discuss_channel)
-        # sudo: mail.message - chat bot is allowed to send messages related to its steps
-        return discuss_channel.sudo()._chatbot_post_message(self.chatbot_script_id, plaintext2html(self.message))
+        return discuss_channel._chatbot_post_message(self.chatbot_script_id, plaintext2html(self.message))
 
     def _process_step_forward_operator(self, discuss_channel):
         """ Special type of step that will add a human operator to the conversation when reached,

--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -204,8 +204,9 @@ class DiscussChannel(models.Model):
 
         :param record chatbot_script
         :param string body: message HTML body """
-
-        return self.with_context(mail_create_nosubscribe=True).message_post(
+        # sudo: mail.message - chat bot is allowed to post a message which
+        # requires reading its partner among other things.
+        return self.with_context(mail_create_nosubscribe=True).sudo().message_post(
             author_id=chatbot_script.sudo().operator_partner_id.id,
             body=body,
             message_type='comment',
@@ -250,8 +251,7 @@ class DiscussChannel(models.Model):
         self.sudo().chatbot_current_step_id = False
         # sudo: chatbot.message - visitor can clear chatbot messages to restart the script
         self.sudo().chatbot_message_ids.unlink()
-        # sudo: mail.message - chat bot can send the restart message
-        return self.sudo()._chatbot_post_message(
+        return self._chatbot_post_message(
             chatbot_script,
             Markup('<div class="o_mail_notification">%s</div>') % _('Restarting conversation...'),
         )

--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_flow.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_flow.js
@@ -213,9 +213,19 @@ registry.category("web_tour.tours").add("website_livechat_chatbot_flow_tour", {
             trigger: messagesContain("Ok bye!"),
         },
         {
-            // wait for chatbot script to finish.
             trigger: ".o-mail-ChatWindow-command[title='Restart Conversation']",
-            run() {},
+            run: "click",
+        },
+        {
+            trigger: "li:contains(I want to speak with an operator)",
+            run: "click",
+        },
+        {
+            trigger: messagesContain("I will transfer you to a human."),
+        },
+        {
+            trigger: ".o-mail-Composer-input:enabled",
+            isCheck: true,
         },
     ],
 });

--- a/addons/website_livechat/tests/test_chatbot_ui.py
+++ b/addons/website_livechat/tests/test_chatbot_ui.py
@@ -60,7 +60,7 @@ class TestLivechatChatbotUI(TestLivechatCommon, ChatbotCase):
             ("Restarting conversation...", operator, False),
             ("Hello! I'm a bot!", operator, False),
             ("I help lost visitors find their way.", operator, False),
-            ("How can I help you?", operator, self.step_dispatch_pricing),
+            ("How can I help you?", operator, False),
             ("Pricing Question", False, False),
             ("For any pricing question, feel free ton contact us at pricing@mycompany.com", operator, False),
             ("We will reach back to you as soon as we can!", operator, False),
@@ -69,6 +69,13 @@ class TestLivechatChatbotUI(TestLivechatCommon, ChatbotCase):
             ("Great, do you want to leave any feedback for us to improve?", operator, False),
             ("no, nothing so say", False, False),
             ("Ok bye!", operator, False),
+            ("Restarting conversation...", operator, False),
+            ("Hello! I'm a bot!", operator, False),
+            ("I help lost visitors find their way.", operator, False),
+            ("How can I help you?", operator, self.step_dispatch_operator),
+            ("I want to speak with an operator", False, False),
+            ("I will transfer you to a human", operator, False),
+            (f"{self.operator.livechat_username} has joined", operator, False),
         ]
 
         self.assertEqual(len(conversation_messages), len(expected_messages))


### PR DESCRIPTION
Before this PR, the "forward_operator" chat bot step would fail when logged in as a portal user.

Indeed, this step post a message which requires reading the partner of the operator but portal users are not allowed to do so.

This PR fixes the issue.

opw-3987375
