### PR TITLE
[REV] account: reverts 'Fix invoice creation from mail alias'

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3126,26 +3126,20 @@ class AccountMove(models.Model):
             passed_file_data_list.append(file_data)
             attachment = file_data.get('attachment') or file_data.get('originator_pdf')
             if attachment:
-                if attachments_by_invoice.get(attachment):
+                if attachments_by_invoice[attachment]:
                     attachments_by_invoice[attachment] |= invoice
                 else:
                     attachments_by_invoice[attachment] = invoice
 
         file_data_list = attachments._unwrap_edi_attachments()
-        attachments_by_invoice = {}
+        attachments_by_invoice = {
+            attachment: None
+            for attachment in attachments
+        }
         invoices = self
         current_invoice = self
         passed_file_data_list = []
         for file_data in file_data_list:
-
-            # Rogue binaries from mail alias are skipped and unlinked.
-            if (
-                file_data['type'] == 'binary'
-                and self._context.get('from_alias')
-                and not attachments_by_invoice.get(file_data['attachment'])
-            ):
-                close_file(file_data)
-                continue
 
             # The invoice has already been decoded by an embedded file.
             if attachments_by_invoice.get(file_data['attachment']):
@@ -4737,15 +4731,10 @@ class AccountMove(models.Model):
                               author_id=odoobot.id)
             return res
         attachments_per_invoice = defaultdict(self.env['ir.attachment'].browse)
-        attachments_in_invoices = self.env['ir.attachment']
         for attachment, invoices in results.items():
-            attachments_in_invoices += attachment
             invoices = invoices or self
             for invoice in invoices:
                 attachments_per_invoice[invoice] |= attachment
-
-        # Unlink the unused attachments
-        (attachments - attachments_in_invoices).unlink()
 
         for invoice, attachments in attachments_per_invoice.items():
             if invoice == self:

--- a/addons/account/tests/test_account_incoming_supplier_invoice.py
+++ b/addons/account/tests/test_account_incoming_supplier_invoice.py
@@ -88,13 +88,11 @@ class TestAccountIncomingSupplierInvoice(AccountTestInvoicingCommon):
         with patch.object(type(self.env['ir.attachment']), '_decode_edi_pdf', decode_edi_pdf):
             yield xml_filename
 
-    def _assert_extend_with_attachments(self, input_values, expected_values=None, new=False, **context):
-        if not expected_values:
-            expected_values = input_values
-        attachments = self.env['ir.attachment'].browse([x.id for x in input_values])
+    def _assert_extend_with_attachments(self, expected_values, new=False):
+        attachments = self.env['ir.attachment'].browse([x.id for x in expected_values])
         nb_moves_before = self.env['account.move'].search_count([('company_id', '=', self.env.company.id)])
         results = self.env['account.move']\
-            .with_context(**context, default_move_type='out_invoice', default_journal_id=self.company_data['default_journal_sale'].id)\
+            .with_context(default_move_type='out_invoice', default_journal_id=self.company_data['default_journal_sale'].id)\
             ._extend_with_attachments(attachments, new=new)
         invoice_number = 0
         previous_invoice = None
@@ -208,25 +206,16 @@ class TestAccountIncomingSupplierInvoice(AccountTestInvoicingCommon):
             self._assert_extend_with_attachments({pdf1: 1, pdf2: 2}, new=True)
             self.assertEqual(decoded_files, {pdf1.name, pdf2.name})
         with self.with_success_decoder() as decoded_files:
-            self._assert_extend_with_attachments({pdf1: 1, pdf2: 2}, new=True, from_alias=True)
-            self.assertEqual(decoded_files, {pdf1.name, pdf2.name})
-        with self.with_success_decoder() as decoded_files:
             self._assert_extend_with_attachments({pdf1: 1, pdf2: 1, gif1: 1, gif2: 1}, new=False)
             self.assertEqual(decoded_files, {pdf1.name})
         with self.with_success_decoder() as decoded_files:
             self._assert_extend_with_attachments({pdf1: 1, pdf2: 2, gif1: 3, gif2: 4}, new=True)
             self.assertEqual(decoded_files, {pdf1.name, pdf2.name, gif1.name, gif2.name})
         with self.with_success_decoder() as decoded_files:
-            self._assert_extend_with_attachments({pdf1: 1, pdf2: 2, gif1: 3, gif2: 4}, expected_values={pdf1: 1, pdf2: 2}, new=True, from_alias=True)
-            self.assertEqual(decoded_files, {pdf1.name, pdf2.name})
-        with self.with_success_decoder() as decoded_files:
             self._assert_extend_with_attachments({pdf1: 1, xml1: 1}, new=False)
             self.assertEqual(decoded_files, {xml1.name})
         with self.with_success_decoder() as decoded_files:
             self._assert_extend_with_attachments({pdf1: 1, xml1: 1}, new=True)
-            self.assertEqual(decoded_files, {xml1.name})
-        with self.with_success_decoder() as decoded_files:
-            self._assert_extend_with_attachments({pdf1: 1, xml1: 1}, new=True, from_alias=True)
             self.assertEqual(decoded_files, {xml1.name})
         with self.with_success_decoder() as decoded_files:
             self._assert_extend_with_attachments({xml1: 1, xml2: 1}, new=False)
@@ -234,14 +223,8 @@ class TestAccountIncomingSupplierInvoice(AccountTestInvoicingCommon):
         with self.with_success_decoder() as decoded_files:
             self._assert_extend_with_attachments({xml1: 1, xml2: 2}, new=True)
             self.assertEqual(decoded_files, {xml1.name, xml2.name})
-        with self.with_success_decoder() as decoded_files:
-            self._assert_extend_with_attachments({xml1: 1, xml2: 2}, new=True, from_alias=True)
-            self.assertEqual(decoded_files, {xml1.name, xml2.name})
         with self.with_success_decoder(omit={pdf1.name}) as decoded_files:
             self._assert_extend_with_attachments({pdf1: 1, pdf2: 2}, new=True)
-            self.assertEqual(decoded_files, {pdf2.name})
-        with self.with_success_decoder(omit={pdf1.name}) as decoded_files:
-            self._assert_extend_with_attachments({pdf1: 1, pdf2: 2}, new=True, from_alias=True)
             self.assertEqual(decoded_files, {pdf2.name})
         with self.with_success_decoder() as decoded_files, self.with_simulated_embedded_xml(pdf1) as xml_filename:
             self._assert_extend_with_attachments({pdf1: 1, pdf2: 1}, new=False)
@@ -249,15 +232,9 @@ class TestAccountIncomingSupplierInvoice(AccountTestInvoicingCommon):
         with self.with_success_decoder() as decoded_files, self.with_simulated_embedded_xml(pdf1) as xml_filename:
             self._assert_extend_with_attachments({pdf1: 1, pdf2: 2}, new=True)
             self.assertEqual(decoded_files, {xml_filename, pdf2.name})
-        with self.with_success_decoder() as decoded_files, self.with_simulated_embedded_xml(pdf1) as xml_filename:
-            self._assert_extend_with_attachments({pdf1: 1, pdf2: 2}, new=True, from_alias=True)
-            self.assertEqual(decoded_files, {xml_filename, pdf2.name})
         with self.with_success_decoder() as decoded_files, self.with_simulated_embedded_xml(pdf1):
             self._assert_extend_with_attachments({pdf1: 1, xml1: 1}, new=False)
             self.assertEqual(decoded_files, {xml1.name})
         with self.with_success_decoder() as decoded_files, self.with_simulated_embedded_xml(pdf1):
             self._assert_extend_with_attachments({pdf1: 1, xml1: 1}, new=True)
-            self.assertEqual(decoded_files, {xml1.name})
-        with self.with_success_decoder() as decoded_files, self.with_simulated_embedded_xml(pdf1):
-            self._assert_extend_with_attachments({pdf1: 1, xml1: 1}, new=True, from_alias=True)
             self.assertEqual(decoded_files, {xml1.name})


### PR DESCRIPTION
This reverts commit bbf812198f36d57499f293ecfad4216f5bd8f860.

Steps to reproduce:
[account_accountant]
- configure incoming mail sever
- configure bills alias
- "Digitize on demand"
- Send an email with the pdf

Issue:
The PDF will not be attached

We revert asap as we have dozens of tickets about it in less than 24 hours

opw-3989141