### PR TITLE
[IMP] mail: wrap sidebar button into <button>

### DIFF
--- a/addons/im_livechat/static/src/core/web/discuss_sidebar_categories_patch.xml
+++ b/addons/im_livechat/static/src/core/web/discuss_sidebar_categories_patch.xml
@@ -1,19 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="im_livechat.DiscussSidebarCategory" t-inherit="mail.DiscussSidebarCategory" t-inherit-mode="extension">
-        <xpath expr="//*[@t-ref='actions']" position="inside">
-            <i
-                t-if="store.has_access_livechat and category.livechatChannel and category.open"
-                class="ms-1"
-                t-att-class="{
-                    'fa fa-sign-out text-danger': category.livechatChannel.hasSelfAsMember,
-                    'fa fa-sign-in text-success': !category.livechatChannel.hasSelfAsMember
-                }"
-                t-attf-class="{{ hover_class }}"
-                t-on-click="() => category.livechatChannel.hasSelfAsMember ? category.livechatChannel.leave({ notify: false }) : category.livechatChannel.join({ notify: false })"
-                t-att-title="category.livechatChannel.hasSelfAsMember ? category.livechatChannel.leaveTitle : category.livechatChannel.joinTitle"
-                role="img"
-            />
+        <xpath expr="//*[@t-ref='actions']/div[hasclass('btn-group')]" position="inside">
+            <button t-if="store.has_access_livechat and category.livechatChannel and category.open" class="btn btn-light" t-on-click="() => category.livechatChannel.hasSelfAsMember ? category.livechatChannel.leave({ notify: false }) : category.livechatChannel.join({ notify: false })">
+                <i t-att-class="{
+                       'fa fa-sign-out text-danger': category.livechatChannel.hasSelfAsMember,
+                       'fa fa-sign-in text-success': !category.livechatChannel.hasSelfAsMember
+                   }"
+                   t-att-title="category.livechatChannel.hasSelfAsMember ? category.livechatChannel.leaveTitle : category.livechatChannel.joinTitle"
+                   role="img"
+                />
+            </button>
         </xpath>
     </t>
 </templates>

--- a/addons/im_livechat/static/tests/sidebar_patch.test.js
+++ b/addons/im_livechat/static/tests/sidebar_patch.test.js
@@ -392,7 +392,7 @@ test("unknown livechat can be displayed and interacted with", async () => {
     await waitNotifications([env, "discuss.channel/new_message"]);
     await click("button", { text: "Inbox" });
     await contains(".o-mail-DiscussSidebarChannel:not(.o-active)", { text: "Jane" });
-    await click("div[title='Unpin Conversation']", {
+    await click("[title='Unpin Conversation']", {
         parent: [".o-mail-DiscussSidebarChannel", { text: "Jane" }],
     });
     await contains(".o-mail-DiscussSidebarCategory-livechat", { count: 0 });

--- a/addons/mail/static/src/discuss/core/web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/web/discuss_sidebar_categories.xml
@@ -11,16 +11,21 @@
     </t>
 
     <t t-name="mail.DiscussSidebarCategory">
-        <t t-set="hover_class" t-value="'btn p-0 text-start opacity-100-hover opacity-75'"/>
         <div class="o-mail-DiscussSidebarCategory d-flex align-items-center my-1" t-att-class="category.extraClass">
-            <div t-attf-class="flex-grow-1 d-flex align-items-baseline mx-1 {{ hover_class }}" t-on-click="() => this.toggleCategory(category)">
+            <div t-attf-class="flex-grow-1 d-flex align-items-baseline mx-1 btn p-0 text-start opacity-100-hover opacity-75" t-on-click="() => this.toggleCategory(category)">
                 <span t-if="store.channels.status === 'fetching'" class="o-visible-short-delay"><i class="o-mail-DiscussSidebarCategory-icon o-smaller me-1 fa fa-fw fa-circle-o-notch fa-spin opacity-50"/></span>
                 <i t-else="" class="o-mail-DiscussSidebarCategory-icon o-smaller me-1" t-att-class="category.open ? 'oi oi-chevron-down' : 'oi oi-chevron-right'"/>
                 <span class="btn-sm p-0 text-uppercase text-break fw-bolder o-smaller"><t t-esc="category.name"/></span>
             </div>
             <div class="d-flex me-3" t-ref="actions">
-                <i t-if="category.canView" t-attf-class="fa fa-cog {{ hover_class }}" title="View or join channels" t-on-click="() => this.openCategory(category)" role="img"/>
-                <i t-if="category.canAdd and category.open" class="o-mail-DiscussSidebarCategory-add" t-attf-class="fa fa-plus {{ hover_class }} ms-1" t-on-click="() => this.addToCategory(category)" t-att-title="category.addTitle" role="img"  t-att-data-hotkey="category.addHotkey"/>
+                <div class="btn-group btn-group-sm">
+                    <button t-if="category.canView" class="btn btn-light" t-on-click="() => this.openCategory(category)" title="View or join channels">
+                        <i class="fa fa-cog" role="img"/>
+                    </button>
+                    <button t-if="category.canAdd and category.open" class="o-mail-DiscussSidebarCategory-add btn btn-light" t-on-click="() => this.addToCategory(category)" t-att-title="category.addTitle" t-att-data-hotkey="category.addHotkey">
+                        <i class="fa fa-plus" role="img"/>
+                    </button>
+                </div>
             </div>
             <div t-if="!category.open and store.getDiscussSidebarCategoryCounter(category.id) > 0" class="o-mail-DiscussSidebar-badge badge rounded-pill me-3 o-discuss-badge fw-bold">
                 <t t-esc="store.getDiscussSidebarCategoryCounter(category.id)"/>
@@ -40,33 +45,42 @@
     </t>
 
     <t t-name="mail.DiscussSidebarChannel">
-        <button class="o-mail-DiscussSidebarChannel o-mail-DiscussSidebar-item btn btn-secondary d-flex align-items-center px-0 py-2 mx-2 border-0 rounded-0 text-reset"
-            t-att-class="{
-                'bg-inherit': thread.notEq(store.discuss.thread),
-                'o-active': thread.eq(store.discuss.thread),
-                'o-unread': thread.message_unread_counter > 0 and !thread.mute_until_dt,
-                'opacity-50': thread.mute_until_dt,
-            }"
-            t-on-click="(ev) => this.openThread(ev, thread)"
+        <div class="o-mail-DiscussSidebarChannel o-mail-DiscussSidebar-item d-flex align-items-center mx-2 cursor-pointer"
+             t-att-class="{
+                    'bg-inherit': thread.notEq(store.discuss.thread),
+                    'o-active': thread.eq(store.discuss.thread),
+                    'o-unread': thread.message_unread_counter > 0 and !thread.mute_until_dt,
+                    'opacity-50': thread.mute_until_dt,
+                    }"
+             t-on-click="(ev) => this.openThread(ev, thread)"
         >
-            <div class="bg-inherit position-relative d-flex ms-3 flex-shrink-0" style="width:26px;height:26px">
-                <img class="w-100 h-100 rounded" t-att-src="thread.avatarUrl" alt="Thread Image"/>
-                <ThreadIcon t-if="thread.channel_type === 'chat' or (thread.channel_type === 'channel' and !thread.authorizedGroupFullName)" thread="thread" size="'small'" className="'o-mail-DiscussSidebarChannel-threadIcon position-absolute bottom-0 end-0 p-1 me-n1 mb-n1 d-flex align-items-center justify-content-center rounded-circle bg-inherit'"/>
-            </div>
-            <span class="mx-2 text-truncate" t-att-class="thread.message_unread_counter > 0 and !thread.mute_until_dt ? 'o-item-unread fw-bolder' : 'text-muted'">
-                <t t-esc="thread.displayName"/>
-            </span>
+            <button class="btn border-0 rounded-0 text-reset d-flex align-items-center px-0 py-2">
+                <div class="bg-inherit position-relative d-flex ms-3 flex-shrink-0" style="width:26px;height:26px">
+                    <img class="w-100 h-100 rounded" t-att-src="thread.avatarUrl" alt="Thread Image"/>
+                    <ThreadIcon t-if="thread.channel_type === 'chat' or (thread.channel_type === 'channel' and !thread.authorizedGroupFullName)" thread="thread" size="'small'" className="'o-mail-DiscussSidebarChannel-threadIcon position-absolute bottom-0 end-0 p-1 me-n1 mb-n1 d-flex align-items-center justify-content-center rounded-circle bg-inherit'"/>
+                </div>
+                <span class="mx-2 text-truncate" t-att-class="thread.message_unread_counter > 0 and !thread.mute_until_dt ? 'o-item-unread fw-bolder' : 'text-muted'">
+                    <t t-esc="thread.displayName"/>
+                </span>
+            </button>
             <div class="flex-grow-1"/>
             <div class="o-mail-DiscussSidebarChannel-commands d-none ms-1 me-2">
-                <i t-if="thread.channel_type === 'channel'" t-attf-class="fa fa-cog {{ hover_class }} text-700" title="Channel settings" t-on-click.stop="() => this.openSettings(thread)" role="img"/>
-                <div t-if="thread.canLeave" class="fa fa-times ms-1" t-attf-class="{{ hover_class }} text-700"
-                    t-on-click.stop="() => this.leaveChannel(thread)" title="Leave this channel" role="img"/>
-                <div t-if="thread.canUnpin" t-attf-class="fa fa-times ms-1 {{ hover_class }} text-700" t-on-click.stop="() => thread.unpin()" title="Unpin Conversation" role="img"/>
+                <div class="btn-group btn-group-sm">
+                    <button t-if="thread.channel_type === 'channel'" class="btn btn-secondary" t-on-click="() => this.openSettings(thread)" title="Channel settings">
+                        <i t-attf-class="fa fa-cog" role="img"/>
+                    </button>
+                    <button t-if="thread.canLeave" class="btn btn-secondary" t-on-click="() => this.leaveChannel(thread)" title="Leave this channel">
+                        <i t-attf-class="fa fa-times" role="img"/>
+                    </button>
+                    <button t-if="thread.canUnpin" class="btn btn-secondary" t-on-click="() => thread.unpin()" title="Unpin Conversation">
+                        <i t-attf-class="fa fa-times" role="img"/>
+                    </button>
+                </div>
             </div>
             <t t-foreach="channelIndicators" t-as="indicator" t-key="indicator_index" t-component="indicator" t-props="{ thread }"/>
             <div t-if="thread.importantCounter > 0">
                 <span t-attf-class="o-mail-DiscussSidebar-badge badge rounded-pill o-discuss-badge ms-1 me-2 fw-bold {{thread.mute_until_dt ? 'o-muted' : ''}}" t-esc="thread.importantCounter"/>
             </div>
-        </button>
+        </div>
     </t>
 </templates>

--- a/addons/mail/static/tests/discuss/call/web/call.test.js
+++ b/addons/mail/static/tests/discuss/call/web/call.test.js
@@ -19,7 +19,7 @@ test("no default rtc after joining a chat conversation", async () => {
     pyEnv["res.users"].create({ partner_id: partnerId });
     await start();
     await openDiscuss();
-    await click(".o-mail-DiscussSidebar i[title='Start a conversation']");
+    await click(".o-mail-DiscussSidebar [title='Start a conversation']");
     await contains(".o-mail-DiscussSidebarChannel", { count: 0 });
     await insertText(".o-discuss-ChannelSelector input", "mario");
     await click(".o-discuss-ChannelSelector-suggestion");
@@ -39,7 +39,7 @@ test("no default rtc after joining a group conversation", async () => {
     pyEnv["res.users"].create([{ partner_id: partnerId_1 }, { partner_id: partnerId_2 }]);
     await start();
     await openDiscuss();
-    await click(".o-mail-DiscussSidebar i[title='Start a conversation']");
+    await click(".o-mail-DiscussSidebar [title='Start a conversation']");
     await contains(".o-mail-DiscussSidebarChannel", { count: 0 });
     await insertText(".o-discuss-ChannelSelector input", "mario");
     await click(".o-discuss-ChannelSelector-suggestion", { text: "Mario" });

--- a/addons/mail/static/tests/discuss/core/discuss.test.js
+++ b/addons/mail/static/tests/discuss/core/discuss.test.js
@@ -46,7 +46,7 @@ test("bus subscription is refreshed when channel is joined", async () => {
     await assertSteps(["subscribe - []"]);
     await openDiscuss();
     await assertSteps([]);
-    await click(".o-mail-DiscussSidebar i[title='Add or join a channel']");
+    await click(".o-mail-DiscussSidebar [title='Add or join a channel']");
     await insertText(".o-discuss-ChannelSelector input", "new channel");
     await click(".o-discuss-ChannelSelector-suggestion");
     await assertSteps(["subscribe - []"]);

--- a/addons/mail/static/tests/discuss/core/web/discuss.test.js
+++ b/addons/mail/static/tests/discuss/core/web/discuss.test.js
@@ -59,7 +59,7 @@ test("can create a new channel [REQUIRE FOCUS]", async () => {
         })}`,
         '/mail/inbox/messages - {"limit":30}',
     ]);
-    await click(".o-mail-DiscussSidebar i[title='Add or join a channel']");
+    await click(".o-mail-DiscussSidebar [title='Add or join a channel']");
     await contains(".o-mail-DiscussSidebarChannel", { count: 0 });
     await insertText(".o-discuss-ChannelSelector input", "abc");
     await assertSteps([
@@ -115,7 +115,7 @@ test("do not close channel selector when creating chat conversation after select
     pyEnv["res.users"].create({ partner_id: partnerId });
     await start();
     await openDiscuss();
-    await click("i[title='Start a conversation']");
+    await click("[title='Start a conversation']");
     await insertText(".o-discuss-ChannelSelector input", "mario");
     await click(".o-discuss-ChannelSelector-suggestion");
     await contains(".o-discuss-ChannelSelector span[title='Mario']");
@@ -167,7 +167,7 @@ test("can join a chat conversation", async () => {
         })}`,
         '/mail/inbox/messages - {"limit":30}',
     ]);
-    await click(".o-mail-DiscussSidebar i[title='Start a conversation']");
+    await click(".o-mail-DiscussSidebar [title='Start a conversation']");
     await contains(".o-mail-DiscussSidebarChannel", { count: 0 });
     await insertText(".o-discuss-ChannelSelector input", "mario");
     await click(".o-discuss-ChannelSelector-suggestion");
@@ -207,7 +207,7 @@ test("can create a group chat conversation", async () => {
     pyEnv["res.users"].create([{ partner_id: partnerId_1 }, { partner_id: partnerId_2 }]);
     await start();
     await openDiscuss();
-    await click(".o-mail-DiscussSidebar i[title='Start a conversation']");
+    await click(".o-mail-DiscussSidebar [title='Start a conversation']");
     await contains(".o-mail-DiscussSidebarChannel", { count: 0 });
     await insertText(".o-discuss-ChannelSelector input", "Mario");
     await click(".o-discuss-ChannelSelector-suggestion");
@@ -226,7 +226,7 @@ test("should create DM chat when adding self and another user", async () => {
     pyEnv["res.users"].create({ partner_id });
     await start();
     await openDiscuss();
-    await click(".o-mail-DiscussSidebar i[title='Start a conversation']");
+    await click(".o-mail-DiscussSidebar [title='Start a conversation']");
     await contains(".o-mail-DiscussSidebarChannel", { count: 0 });
     await insertText(".o-discuss-ChannelSelector input", "Mi"); // Mitchell Admin
     await click(".o-discuss-ChannelSelector-suggestion");
@@ -241,7 +241,7 @@ test("should create DM chat when adding self and another user", async () => {
 test("chat search should display no result when no matches found", async () => {
     await start();
     await openDiscuss();
-    await click(".o-mail-DiscussSidebar i[title='Start a conversation']");
+    await click(".o-mail-DiscussSidebar [title='Start a conversation']");
     await insertText(".o-discuss-ChannelSelector input", "Rainbow Panda");
     await contains(".o-discuss-ChannelSelector-suggestion", { text: "No results found" });
 });
@@ -252,7 +252,7 @@ test("chat search should not be visible when clicking outside of the field", asy
     pyEnv["res.users"].create({ partner_id: partnerId });
     await start();
     await openDiscuss();
-    await click(".o-mail-DiscussSidebar i[title='Start a conversation']");
+    await click(".o-mail-DiscussSidebar [title='Start a conversation']");
     await insertText(".o-discuss-ChannelSelector input", "Panda");
     await contains(".o-discuss-ChannelSelector-suggestion");
     await click(".o-mail-DiscussSidebar");

--- a/addons/mail/static/tests/discuss/core/web/sidebar.test.js
+++ b/addons/mail/static/tests/discuss/core/web/sidebar.test.js
@@ -81,7 +81,7 @@ test("unknown channel can be displayed and interacted with", async () => {
     await waitNotifications([env, "discuss.channel/new_message"]);
     await click("button", { text: "Inbox" });
     await contains(".o-mail-DiscussSidebarChannel:not(.o-active)", { text: "Not So Secret" });
-    await click("div[title='Leave this channel']", {
+    await click("[title='Leave this channel']", {
         parent: [".o-mail-DiscussSidebarChannel", { text: "Not So Secret" }],
     });
     await click("button", { text: "Leave Conversation" });

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -533,10 +533,10 @@ test("sidebar: basic channel rendering", async () => {
     await contains(".o-mail-DiscussSidebarChannel img[data-alt='Thread Image']");
     await contains(".o-mail-DiscussSidebarChannel .o-mail-DiscussSidebarChannel-commands.d-none");
     await contains(
-        ".o-mail-DiscussSidebarChannel .o-mail-DiscussSidebarChannel-commands i[title='Channel settings']"
+        ".o-mail-DiscussSidebarChannel .o-mail-DiscussSidebarChannel-commands [title='Channel settings']"
     );
     await contains(
-        ".o-mail-DiscussSidebarChannel .o-mail-DiscussSidebarChannel-commands div[title='Leave this channel']"
+        ".o-mail-DiscussSidebarChannel .o-mail-DiscussSidebarChannel-commands [title='Leave this channel']"
     );
 });
 
@@ -1761,7 +1761,7 @@ test("sidebar: cannot unpin channel group_based_subscription: mandatorily pinned
     await start();
     await openDiscuss();
     await contains("button", { text: "General" });
-    await contains("div[title='Leave this channel']", { count: 0 });
+    await contains("[title='Leave this channel']", { count: 0 });
 });
 
 test("restore thread scroll position", async () => {
@@ -1928,7 +1928,7 @@ test("Escape key should close the channel selector and focus the composer [REQUI
     await start();
     await openDiscuss(channelId);
     await contains(".o-mail-Composer-input:focus");
-    await click("i[title='Add or join a channel']");
+    await click("[title='Add or join a channel']");
     await contains(".o-discuss-ChannelSelector");
     await triggerHotkey("escape");
     await contains(".o-discuss-ChannelSelector", { count: 0 });
@@ -2094,7 +2094,10 @@ test("Read of unread chat where new message is deleted should mark as read [REQU
     });
     await start();
     await openDiscuss();
-    await contains("button", { text: "Marc Demo", contains: [".badge", { text: "1" }] });
+    await contains(".o-mail-DiscussSidebar-item", {
+        text: "Marc Demo",
+        contains: [".badge", { text: "1" }],
+    });
     // simulate deleted message
     rpc("/mail/message/update_content", {
         message_id: messageId,
@@ -2102,5 +2105,8 @@ test("Read of unread chat where new message is deleted should mark as read [REQU
         attachment_ids: [],
     });
     await click("button", { text: "Marc Demo" });
-    await contains("button", { text: "Marc Demo", contains: [".badge", { count: 0 }] });
+    await contains(".o-mail-DiscussSidebar-item", {
+        text: "Marc Demo",
+        contains: [".badge", { count: 0 }],
+    });
 });

--- a/addons/mail/static/tests/discuss_app/inbox.test.js
+++ b/addons/mail/static/tests/discuss_app/inbox.test.js
@@ -679,7 +679,13 @@ test("Clear need action counter when opening a channel", async () => {
     ]);
     await start();
     await openDiscuss();
-    await contains("button", { text: "General", contains: [".badge", { text: "2" }] });
+    await contains(".o-mail-DiscussSidebar-item", {
+        text: "General",
+        contains: [".badge", { text: "2" }],
+    });
     await click(".o-mail-DiscussSidebarChannel", { text: "General" });
-    await contains("button", { text: "General", contains: [".badge", { count: 0 }] });
+    await contains(".o-mail-DiscussSidebar-item", {
+        text: "General",
+        contains: [".badge", { count: 0 }],
+    });
 });

--- a/addons/mail/static/tests/discuss_app/sidebar.test.js
+++ b/addons/mail/static/tests/discuss_app/sidebar.test.js
@@ -99,7 +99,7 @@ test("Opening a category sends the updated user setting to the server.", async (
 test("channel - command: should have view command when category is unfolded", async () => {
     await start();
     await openDiscuss();
-    await contains("i[title='View or join channels']");
+    await contains("[title='View or join channels']");
 });
 
 test("channel - command: should have view command when category is folded", async () => {
@@ -111,13 +111,13 @@ test("channel - command: should have view command when category is folded", asyn
     await start();
     await openDiscuss();
     await click(".o-mail-DiscussSidebarCategory-channel .btn", { text: "Channels" });
-    await contains("i[title='View or join channels']");
+    await contains("[title='View or join channels']");
 });
 
 test("channel - command: should have add command when category is unfolded", async () => {
     await start();
     await openDiscuss();
-    await contains("i[title='Add or join a channel']");
+    await contains("[title='Add or join a channel']");
 });
 
 test("channel - command: should not have add command when category is folded", async () => {
@@ -129,7 +129,7 @@ test("channel - command: should not have add command when category is folded", a
     await start();
     await openDiscuss();
     await contains(".o-mail-DiscussSidebarCategory", { text: "Channels" });
-    await contains("i[title='Add or join a channel']", { count: 0 });
+    await contains("[title='Add or join a channel']", { count: 0 });
 });
 
 test("channel - states: close manually by clicking the title", async () => {
@@ -273,7 +273,7 @@ test("sidebar: basic chat rendering", async () => {
     await contains(".o-mail-DiscussSidebarChannel", { text: "Demo" });
     await contains(".o-mail-DiscussSidebarChannel img[data-alt='Thread Image']");
     await contains(
-        ".o-mail-DiscussSidebarChannel .o-mail-DiscussSidebarChannel-commands div[title='Unpin Conversation']"
+        ".o-mail-DiscussSidebarChannel .o-mail-DiscussSidebarChannel-commands [title='Unpin Conversation']"
     );
     await contains(".o-mail-DiscussSidebarChannel .badge", { count: 0 });
 });
@@ -316,7 +316,7 @@ test("sidebar: open channel and leave it", async () => {
     await click(".o-mail-DiscussSidebarChannel", { text: "General" });
     await contains(".o-mail-Discuss-threadName", { value: "General" });
     await assertSteps([]);
-    await click(".btn[title='Leave this channel']", {
+    await click("[title='Leave this channel']", {
         parent: [".o-mail-DiscussSidebarChannel.o-active", { text: "General" }],
     });
     await click("button", { text: "Leave Conversation" });
@@ -650,7 +650,7 @@ test("chat - command: should have add command when category is unfolded", async 
         contains: [
             ["i.oi.oi-chevron-down"],
             ["span", { text: "Direct messages" }],
-            ["i[title='Start a conversation']"],
+            ["[title='Start a conversation']"],
         ],
     });
 });
@@ -668,7 +668,7 @@ test("chat - command: should not have add command when category is folded", asyn
         contains: [
             ["i.oi.oi-chevron-right"],
             ["span", { text: "Direct messages" }],
-            ["i[title='Start a conversation']", { count: 0 }],
+            ["[title='Start a conversation']", { count: 0 }],
         ],
     });
 });
@@ -891,7 +891,7 @@ test("channel - states: the active category item should be visible even if the c
     await start();
     await openDiscuss();
     await click(".o-mail-DiscussSidebarChannel", { text: "channel1" });
-    await contains("button.o-active", { text: "channel1" });
+    await contains("div.o-active", { text: "channel1" });
     await click(".o-mail-DiscussSidebarCategory .btn", { text: "Channels" });
     await contains(".o-mail-DiscussSidebarCategory-channel .oi-chevron-right");
     await contains("button", { text: "channel1" });
@@ -1046,7 +1046,7 @@ test("chat - states: the active category item should be visible even if the cate
     await contains(".o-mail-DiscussSidebarCategory-chat .oi-chevron-down");
     await contains(".o-mail-DiscussSidebar button", { text: "Mitchell Admin" });
     await click(".o-mail-DiscussSidebar button", { text: "Mitchell Admin" });
-    await contains("button.o-active", { text: "Mitchell Admin" });
+    await contains("div.o-active", { text: "Mitchell Admin" });
     await click(".o-mail-DiscussSidebarCategory-chat .btn", { text: "Direct messages" });
     await contains(".o-mail-DiscussSidebarCategory-chat .oi-chevron-right");
     await contains(".o-mail-DiscussSidebar button", { text: "Mitchell Admin" });


### PR DESCRIPTION
Before this PR, actions in the sidebar would be triggered by a click on the icon `<i>`. This is not correct and could be a challenge for people using accessibility tools.

This PR wraps them into a `<button>`.

Preview:
![image](https://github.com/odoo/odoo/assets/1810149/94fd8db5-81e6-478f-819d-a13f75cb965d)
![image](https://github.com/odoo/odoo/assets/1810149/8381d21a-a827-4507-8cc0-d1e3c240fe04)

Enterprise PR: https://github.com/odoo/enterprise/pull/64886