### PR TITLE
[FIX] survey: all caps name change certificate fonts

### DIFF
--- a/addons/survey/report/survey_templates.xml
+++ b/addons/survey/report/survey_templates.xml
@@ -21,19 +21,22 @@
                                 <br/>
                                 <t t-set="certif_style" t-value="''"/>
                                 <t t-set="certified_name" t-value="user_input.partner_id.name or user_input.email or ''"/>
-                                <t t-if="certified_name.isupper()">
-                                    <t t-set="certif_style" t-value="certif_style + 'font-family: certification-serif;'"/>
-                                </t>
                                 <t t-if="len(certified_name) > 35 and layout_template == 'classic'">
-                                    <t t-set="certif_style" t-value="certif_style + 'font-size: 20px; line-height: 4; font-family: certification-serif; '"/>
+                                    <t t-set="certif_style" t-value="certif_style + 'font-size: 20px; line-height: 4; font-family: certification-serif;'"/>
                                 </t>
-                                <t t-elif="len(certified_name) > 20">
-                                    <t t-if="layout_template == 'modern'">
-                                        <t t-set="certif_style" t-value="certif_style + 'font-size: 40px; line-height: 4;'"/>
+                                <t t-elif="layout_template == 'modern'">
+                                    <t t-if="len(certified_name) > 45">
+                                        <t t-set="certif_style" t-value="certif_style + 'font-size: 20px; line-height: 4;'"/>
                                     </t>
-                                    <t t-else="">
+                                    <t t-elif="len(certified_name) > 35">
                                         <t t-set="certif_style" t-value="certif_style + 'font-size: 30px; line-height: 4;'"/>
                                     </t>
+                                    <t t-elif="len(certified_name) > 20">
+                                        <t t-set="certif_style" t-value="certif_style + 'font-size: 40px; line-height: 4;'"/>
+                                    </t>
+                                </t>
+                                <t t-else="">
+                                    <t t-set="certif_style" t-value="certif_style + 'font-size: 30px; line-height: 4;'"/>
                                 </t>
                                 <span t-att-style="certif_style" class="user-name" t-out="certified_name">DEMO_CERTIFIED_NAME</span>
 


### PR DESCRIPTION
### Before this PR:

- Entering the user's name in all capital letters altered the font on the certificate.
- Names exceeding 35 characters disrupted the certificate layout.

### After this PR:

- Entering the user's name in all capital letters no longer alters the font on the certificate.
- The certificate layout is now robust to long names.
        - If the name exceeds 45 characters, the font size is adjusted to 20px.
        - If the name exceeds 35 characters, the font size is adjusted to 30px.

Task-3991500
