### PR TITLE
[IMP] l10n_in: add option to activate TDS

### DIFF
--- a/addons/l10n_in/models/company.py
+++ b/addons/l10n_in/models/company.py
@@ -12,6 +12,8 @@ class ResCompany(models.Model):
         ],
         string="HSN Code Digit",
     )
+    l10n_in_tds_toggle = fields.Boolean(string="Toggle Indian TDS")
+    l10n_in_tan = fields.Char(string="TAN", help="Tax Deduction and Collection Account Number")
 
     def create(self, vals):
         res = super().create(vals)

--- a/addons/l10n_in/models/res_config_settings.py
+++ b/addons/l10n_in/models/res_config_settings.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models
+from odoo import api, fields, models, _
 
 
 class ResConfigSettings(models.TransientModel):
@@ -11,3 +11,12 @@ class ResConfigSettings(models.TransientModel):
     module_l10n_in_edi = fields.Boolean('Indian Electronic Invoicing')
     module_l10n_in_edi_ewaybill = fields.Boolean('Indian Electronic Waybill')
     l10n_in_hsn_code_digit = fields.Selection(related='company_id.l10n_in_hsn_code_digit', readonly=False)
+    l10n_in_tds_toggle = fields.Boolean(related='company_id.l10n_in_tds_toggle', readonly=False)
+
+    @api.onchange('l10n_in_tds_toggle')
+    def _onchange_l10n_in_tds_toggle(self):
+        if self.country_code == 'IN' and not self.env.company.l10n_in_tds_toggle and self.l10n_in_tds_toggle:
+            return {'warning': {
+                'title': _("Warning"),
+                'message': _("Once TDS is enabled, it cannot be disabled.")
+            }}

--- a/addons/l10n_in/views/res_company_views.xml
+++ b/addons/l10n_in/views/res_company_views.xml
@@ -8,6 +8,9 @@
             <xpath expr="//field[@name='currency_id']" position="after">
                 <field name="l10n_in_upi_id" invisible="country_code != 'IN'"/>
             </xpath>
+            <xpath expr="//field[@name='vat']" position="after">
+                <field name="l10n_in_tan" invisible="country_code != 'IN' or not l10n_in_tds_toggle"/>
+            </xpath>
         </field>
     </record>
 </odoo>

--- a/addons/l10n_in/views/res_config_settings_views.xml
+++ b/addons/l10n_in/views/res_config_settings_views.xml
@@ -29,6 +29,21 @@
                     </setting>
                 </block>
             </app>
+            <xpath expr="//block[@name='fiscal_localization_setting_container']" position="after">
+                <block title="Indian Localization" invisible="country_code != 'IN'">
+                    <div class="d-flex gap-3">
+                        <label string="TDS" for="l10n_in_tds_toggle"/>
+                        <field name="l10n_in_tds_toggle"
+                               force_save="1"
+                               options="{'autosave': False}"
+                               readonly="l10n_in_tds_toggle"
+                               widget="boolean_toggle"/>
+                        <span class="text-warning" invisible="l10n_in_tds_toggle">
+                            Once TDS is enabled, it cannot be disabled.
+                        </span>
+                    </div>
+                </block>
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
This PR introduces an option to enable Tax Deducted at Source (TDS). When
TDS is activated, the `l10n_in_tan` field becomes visible in the `res.company` model.

**task**-3980324

**ENT PR**: https://github.com/odoo/enterprise/pull/64857