### PR TITLE
[FIX] mail: error on leaving channel

### DIFF
--- a/addons/mail/static/src/core/common/thread_service.js
+++ b/addons/mail/static/src/core/common/thread_service.js
@@ -495,8 +495,8 @@ export class ThreadService {
     }
 
     async leaveChannel(channel) {
-        await this.orm.call("discuss.channel", "action_unfollow", [channel.id]);
         channel.delete();
+        await this.orm.call("discuss.channel", "action_unfollow", [channel.id]);
         this.setDiscussThread(
             this.store.discuss.channels.threads[0]
                 ? this.store.discuss.channels.threads[0]


### PR DESCRIPTION
**Current behavior before PR:**

when leaving discuss channel from discuss it results in error because leave notification is send to the leaving person itself.

**Desired behavior after PR is merged:**

The issue was resolved by replacing the logic. Now, before sending a notification to the channel, we remove the channel member and the channel itself from the thread of the person leaving.

task-3893498

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
