### PR TITLE
[FIX] l10n_in_edi_ewaybill: multi fix e-way bill

### DIFF
--- a/addons/l10n_in_edi_ewaybill/views/account_move_views.xml
+++ b/addons/l10n_in_edi_ewaybill/views/account_move_views.xml
@@ -16,7 +16,7 @@
                     <group name="ewaybill_group">
                         <group string="Transaction Details" name="Transaction_group" 
                             invisible="not l10n_in_edi_ewaybill_direct_api">
-                            <field name="l10n_in_type_id" domain="[('allowed_supply_type', 'in', ('in', 'both'))] if move_type in ('in_invoice', 'in_refund', 'in_receipt') else [('allowed_supply_type', 'in', ('out', 'both'))]"/>
+                            <field name="l10n_in_type_id" domain="[('code', '!=', 'CHL'), ('allowed_supply_type', 'in', ('in', 'both'))] if move_type in ('in_invoice', 'in_refund', 'in_receipt') else [('code', '!=', 'CHL'), ('allowed_supply_type', 'in', ('out', 'both'))]"/>
                         </group>
                         <group string="Transportation Details" name="transportation_group">
                             <field name="l10n_in_mode" widget="radio" options="{'horizontal': True}"/>

--- a/addons/l10n_in_ewaybill_stock/models/stock_picking.py
+++ b/addons/l10n_in_ewaybill_stock/models/stock_picking.py
@@ -22,10 +22,6 @@ class StockPicking(models.Model):
             raise UserError(_("Please set HSN code in below products: \n%s", '\n'.join(
                 [product.name for product in product_with_no_hsn]
             )))
-        if lines_with_no_tax := self.move_ids.filtered(lambda line: not line.ewaybill_tax_ids):
-            raise UserError(_("Please set Tax on below products: \n%s", '\n'.join(
-                [product.name for product in lines_with_no_tax.mapped('product_id')]
-            )))
         if self.l10n_in_ewaybill_id:
             raise UserError(_("Ewaybill already created for this picking."))
         action = self._get_l10n_in_ewaybill_form_action()


### PR DESCRIPTION
- With this commit, the following issues are fixed:

1. Hide the E-Waybill Document Type if the document type is "delivery challan". Because functionality could not be accessed from the invoice. So, it's unusable here.

2. Tax Rates are optional but will get through validation if mentioned. So, allow E -Way bills to be sent with and without tax rates.

task:3961036