### PR TITLE
[FIX] website_event: unwrap `p` element inside `a` element

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/sanitize.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/sanitize.js
@@ -187,7 +187,7 @@ function sanitizeNode(node, root) {
         node = parent; // The node has been removed, update the reference.
     } else if (
         node.nodeName === 'P' && // Note: not sure we should limit to <p>.
-        node.parentElement.nodeName === 'LI' &&
+        ['LI', 'A'].includes(node.parentElement.nodeName) &&
         !node.parentElement.classList.contains('nav-item')
     ) {
         // Remove empty paragraphs in <li>.

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/editor.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/editor.test.js
@@ -159,6 +159,14 @@ describe('Editor', () => {
                 });
             });
         });
+        describe('sanitize should modify p within a', () => {
+            it('should unwrap p element inside editable a inside non editable div', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div contenteditable="false"><a href="" contenteditable="true"><p>abc</p></a></div>',
+                    contentAfter: '<div contenteditable="false"><a href="" contenteditable="true">abc</a></div>',
+                });
+            });
+        });
     });
     describe('deleteForward', () => {
         describe('Selection collapsed', () => {

--- a/addons/website/static/tests/tours/link_tools.js
+++ b/addons/website/static/tests/tours/link_tools.js
@@ -214,7 +214,7 @@ wTourUtils.registerWebsitePreviewTour('link_tools', {
     wTourUtils.clickOnElement("mega menu", "iframe header .o_mega_menu_toggle"),
     wTourUtils.changeOption("MegaMenuLayout", "we-toggler"),
     wTourUtils.changeOption("MegaMenuLayout", '[data-select-label="Cards"]'),
-    wTourUtils.clickOnElement("card's text", "iframe header .s_mega_menu_cards p"),
+    wTourUtils.clickOnElement("card's text", "iframe header .s_mega_menu_cards span"),
     {
         content: "Enter an URL",
         trigger: "#o_link_dialog_url_input",
@@ -222,7 +222,7 @@ wTourUtils.registerWebsitePreviewTour('link_tools', {
     },
     {
         content: "Check nothing is lost",
-        trigger: "iframe header .s_mega_menu_cards a[href='https://www.odoo.com']:has(img):has(h4):has(p)",
+        trigger: "iframe header .s_mega_menu_cards a[href='https://www.odoo.com']:has(img):has(h4):has(span)",
         isCheck: true,
     },
     // 7. Create new a link from a URL-like text.

--- a/addons/website/views/snippets/s_mega_menu_cards.xml
+++ b/addons/website/views/snippets/s_mega_menu_cards.xml
@@ -58,7 +58,7 @@
         <a href="#" class="nav-link o_default_snippet_text rounded text-wrap text-center p-3">
             <img t-att-src="_img_src" class="mb-3 rounded shadow img-fluid" alt=""/>
             <h4 t-esc="_title"/>
-            <p class="o_default_snippet_text mb-0 small"><t t-esc="_text"/></p>
+            <span class="o_default_snippet_text mb-0 small"><t t-esc="_text"/></span>
         </a>
     </div>
 </template>

--- a/addons/website_event/views/event_templates_page_registration.xml
+++ b/addons/website_event/views/event_templates_page_registration.xml
@@ -77,7 +77,7 @@
                                 (<span t-out="event.date_tz"/>)
 
                                 <a href="#" role="button" data-bs-toggle="dropdown" class="btn btn-secondary dropdown w-100 mt-3">
-                                    <p class="mb-0"><i class="fa fa-calendar me-2"/>Add to Calendar</p>
+                                    <i class="fa fa-calendar me-2"/>Add to Calendar
                                 </a>
                                 <div class="dropdown-menu">
                                     <a t-att-href="iCal_url" class="dropdown-item">iCal/Outlook</a>
@@ -101,7 +101,7 @@
                                     "fields": ["phone", "mobile", "email"]
                                 }'/>
                                 <a t-att-href="event._google_map_link()" target="_blank" class="btn btn-secondary w-100">
-                                    <p class="mb-0"><i class="fa fa-map-marker fa-fw" role="img"/>Get the direction</p>
+                                    <i class="fa fa-map-marker fa-fw" role="img"/>Get the direction
                                 </a>
                             </div>
                             <!-- Organizer -->


### PR DESCRIPTION
Issue:
======
Can't add content at the end/start of button

Steps to reproduce the issue:
=============================
- Use chrome
- Install events
- Go to website/events/conference for architects (demo data)
- Open editor and edit
- Put the cursor at the end of the "Get The direction" button
- Try to add some text, nothing happens

Note: it works in firefox

Origin of the issue:
====================
Chrome doesn't support the following case correctly when the selection
is at the start or at the end of the text.
```
<div contenteditable="false">
 <a contenteditable="true" href="http://www.example.com">
  <p>
   abcde
  </p>
 </a>
</div>
```

The `p` element inside the `a` was introduced in [1].

Solution:
=========
Unwrap the content of the `p` elements inside `a` element the same way
we do for `li` elements.

opw-3878459

[1]: https://github.com/odoo/odoo/commit/4a890e1f92a665dd53f17ee57b4e7792c33da7db