### PR TITLE
[IMP] pos_mercado_pago: visibility of force pdv button

### DIFF
--- a/addons/pos_mercado_pago/views/pos_payment_method_views.xml
+++ b/addons/pos_mercado_pago/views/pos_payment_method_views.xml
@@ -10,7 +10,7 @@
                 <field name="mp_bearer_token" placeholder="APP_USR-..." invisible="use_payment_terminal != 'mercado_pago'" required="use_payment_terminal == 'mercado_pago'"/>
                 <field name="mp_webhook_secret_key" placeholder="c2f3662..." invisible="use_payment_terminal != 'mercado_pago'" required="use_payment_terminal == 'mercado_pago'"/>
                 <field name="mp_id_point_smart" placeholder="1494126963" invisible="use_payment_terminal != 'mercado_pago'" required="use_payment_terminal == 'mercado_pago'"/>
-                <button string="Force PDV" type="object" name="force_pdv" groups="base.group_no_one" class="oe_highlight"/>
+                <button string="Force PDV" type="object" name="force_pdv" groups="base.group_no_one" class="oe_highlight" invisible="use_payment_terminal != 'mercado_pago'"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Before this commit:
=========
- The Force PDV button was visible for all payment methods in the payment method form.

After this commit:
=========
- The Force PDV button will be visible only for the Mercado Pago terminal in the payment method form.

task-3989732