### PR TITLE
[FIX] web: return correct extension in test mode

### DIFF
--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -1987,6 +1987,10 @@ class ReportController(http.Controller):
             if type in ['qweb-pdf', 'qweb-text']:
                 converter = 'pdf' if type == 'qweb-pdf' else 'text'
                 extension = 'pdf' if type == 'qweb-pdf' else 'txt'
+                # In case of test environment without enough workers to perform calls to wkhtmltopdf,
+                # fallback to render_html.
+                if (odoo.tools.config['test_enable'] or odoo.tools.config['test_file']) and not request.env.context.get('force_report_rendering'):
+                    extension = 'html'
 
                 pattern = '/report/pdf/' if type == 'qweb-pdf' else '/report/text/'
                 reportname = url.split(pattern)[1].split('?')[0]


### PR DESCRIPTION
Steps:
- Start a DB with --test-tags
- Print a PDF report

Actual result:
- downloaded file is .pdf with HTML content
- invalid PDF in a browser

Expected result
- downloaded file is .html as rendered like that

Moved multiple times, initial commit with the same comment https://github.com/odoo/odoo/commit/3425752eaca236c1e4b4d616aa49b3faa6cfd957 
From the initial commit
https://github.com/odoo/odoo/commit/b50421e551ef120e0fa77cddec9247fd1ac982ed

opw-3984400

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
