### PR TITLE
[IMP] web: search: orderByCount

### DIFF
--- a/addons/web/static/src/search/search_bar/search_bar.js
+++ b/addons/web/static/src/search/search_bar/search_bar.js
@@ -140,7 +140,7 @@ export class SearchBar extends Component {
         this.items.push({
             title: _t("Add a custom filter"),
             isAddCustomFilterButton: true,
-        });    
+        });
     }
 
     /**
@@ -410,7 +410,10 @@ export class SearchBar extends Component {
 
     onFacetLabelClick(target, facet) {
         const { domain, groupId } = facet;
-        if (!domain) {
+        if (this.env.searchModel.canOrderByCount && facet.type === "groupBy") {
+            this.env.searchModel.switchGroupBySort();
+            return;
+        } else if (!domain) {
             return;
         }
         const { resModel } = this.env.searchModel;

--- a/addons/web/static/src/search/search_bar/search_bar.xml
+++ b/addons/web/static/src/search/search_bar/search_bar.xml
@@ -14,13 +14,14 @@
                 <!-- :hover overlay -->
                 <div class="position-absolute start-0 top-0 bottom-0 end-0 bg-view border rounded-2 shadow opacity-0 opacity-100-hover"/>
 
-                <div class="o_searchview_facet_label position-relative rounded-start-2 px-1"
+                <div class="o_searchview_facet_label position-relative rounded-start-2 px-1 rounded-end-0 p-0"
                     t-on-click="(ev) => this.onFacetLabelClick(ev.target, facet)"
                     t-att-role="facet.domain ? 'button' : 'img'"
                     t-att-class="{
-                        'text-bg-action d-flex align-items-center': facet.type == 'groupBy' || facet.type == 'comparison',
-                        'btn btn-primary rounded-end-0 p-0': facet.type == 'field' || facet.type == 'filter',
-                        'btn btn-favourite rounded-end-0 p-0': facet.type == 'favorite'
+                        'text-bg-action': facet.type == 'groupBy' || facet.type == 'comparison',
+                        'btn': facet.type == 'groupBy' and env.searchModel.canOrderByCount,
+                        'btn btn-primary': facet.type == 'field' || facet.type == 'filter',
+                        'btn btn-favourite': facet.type == 'favorite'
                     }"
                     >
                     <i t-if="facet.icon" class="small fa-fw" t-att-class="facet.icon" role="image"/>
@@ -32,6 +33,12 @@
                         t-att-class="{'px-2 transition-base': !facet.icon}"
                         >
                         <i class="fa fa-fw fa-cog"/>
+                    </span>
+                    <span t-if="env.searchModel.canOrderByCount and facet.type === 'groupBy' and !env.searchModel.orderByCount"
+                        class="position-absolute start-0 top-0 bottom-0 end-0 bg-inherit opacity-0 opacity-100-hover"
+                        t-att-class="{'px-2 transition-base': !facet.icon}"
+                        >
+                        <i class="fa fa-fw fa-sort"/>
                     </span>
                 </div>
 

--- a/addons/web/static/src/search/utils/misc.js
+++ b/addons/web/static/src/search/utils/misc.js
@@ -1,6 +1,8 @@
 export const FACET_ICONS = {
     filter: "fa fa-filter",
     groupBy: "oi oi-group",
+    groupByAsc: "fa fa-sort-numeric-asc",
+    groupByDesc: "fa fa-sort-numeric-desc",
     favorite: "fa fa-star",
     comparison: "fa fa-adjust",
 };

--- a/addons/web/static/src/search/with_search/with_search.js
+++ b/addons/web/static/src/search/with_search/with_search.js
@@ -38,6 +38,7 @@ export class WithSearch extends Component {
         dynamicFilters: { type: Array, element: Object, optional: true },
         hideCustomGroupBy: { type: Boolean, optional: true },
         searchMenuTypes: { type: Array, element: String, optional: true },
+        canOrderByCount: { type: Boolean, optional: true },
     };
 
     setup() {

--- a/addons/web/static/src/views/list/list_view.js
+++ b/addons/web/static/src/views/list/list_view.js
@@ -11,6 +11,7 @@ export const listView = {
     ArchParser: ListArchParser,
     Model: RelationalModel,
     buttonTemplate: "web.ListView.Buttons",
+    canOrderByCount: true,
 
     limit: 80,
 

--- a/addons/web/static/src/views/view.js
+++ b/addons/web/static/src/views/view.js
@@ -179,6 +179,7 @@ export class View extends Component {
     static template = "web.View";
     static components = { WithSearch };
     static searchMenuTypes = ["filter", "groupBy", "favorite"];
+    static canOrderByCount = false;
     static defaultProps = {
         display: {},
         context: {},
@@ -387,6 +388,7 @@ export class View extends Component {
         const searchMenuTypes =
             props.searchMenuTypes || descr.searchMenuTypes || this.constructor.searchMenuTypes;
         viewProps.searchMenuTypes = searchMenuTypes;
+        const canOrderByCount = descr.canOrderByCount || this.constructor.canOrderByCount;
 
         const finalProps = descr.props ? descr.props(viewProps, descr, this.env.config) : viewProps;
         // prepare the WithSearch component props
@@ -396,6 +398,7 @@ export class View extends Component {
             ...toRaw(props),
             hideCustomGroupBy: props.hideCustomGroupBy || descr.hideCustomGroupBy,
             searchMenuTypes,
+            canOrderByCount,
             SearchModel: descr.SearchModel,
         };
 


### PR DESCRIPTION
This commit adds the possibility to sort groups of records by count by clicking on the facet icon of the groupby inside of the search bar. This is only accessible in list view though the order will remain after switching to another view.

Task ID: 3943823
