### PR TITLE
[FIX] website_event: ensure uniqueness for submenu URL

### DIFF
--- a/addons/website_event/controllers/main.py
+++ b/addons/website_event/controllers/main.py
@@ -149,8 +149,14 @@ class WebsiteEventController(http.Controller):
         if '.' not in page:
             page = 'website_event.%s' % page
 
+        view = request.env["website.event.menu"].sudo().search([
+            ("event_id", "=", event.id), ("view_id.key", "ilike", page)]).view_id
+        if not view:
+            return request.not_found()
+
         try:
             # Every event page view should have its own SEO.
+            page = view.key
             values['seo_object'] = request.website.get_template(page)
             values['main_object'] = event
         except ValueError:

--- a/addons/website_event/models/event_event.py
+++ b/addons/website_event/models/event_event.py
@@ -376,8 +376,9 @@ class Event(models.Model):
             page_result = self.env['website'].sudo().new_page(
                 name=name + ' ' + self.name, template=xml_id,
                 add_menu=False, ispage=False)
-            url = "/event/" + slug(self) + "/page" + page_result['url']  # url contains starting "/"
             view_id = page_result['view_id']
+            view = self.env["ir.ui.view"].browse(view_id)
+            url = "/event/" + slug(self) + "/page/" + view.key.split(".")[-1]
 
         website_menu = self.env['website.menu'].sudo().create({
             'name': name,


### PR DESCRIPTION
Steps to reproduce:
-------------------

- Install `website_event` module
- Create an event with name `Test Event` and enable `Website Submenu` option
- Click on `Go to Website` stat button
- Edit the `Introduction` page by adding a new block under the event name for example
- Save it and go back to backend
- Create a new event with same name `Test Event` and enable `Website Submenu` option
- Click on `Go to Website` stat button

Issue:
------

The second event will have the edited
`Introduction` page from the first event.

Cause:
------

When creating the menu, since we do not create a
page, the URL retrieved in the process will be
always the same and therefore redirect to the
edited page of the first event (since the last
part of the URL is used to retrieve the right
view).

Solution:
---------

Ensure the URL is unique by using the view key
(who is unique) as last part of the URL.

opw-3945840