### PR TITLE
[IMP] stock_account: allow adjusting valuation of specific lines

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -121,7 +121,7 @@ class ProductProduct(models.Model):
         company_id = self.env.company
         self.company_currency_id = company_id.currency_id
         domain = [
-            *self.env['stock.valuation.layer']._check_company_domain(company_id),
+            *self._check_company_domain(company_id),
             ('product_id', 'in', self.ids),
         ]
         if self.env.context.get('to_date'):

--- a/addons/stock_account/tests/test_stock_valuation_layer_revaluation.py
+++ b/addons/stock_account/tests/test_stock_valuation_layer_revaluation.py
@@ -237,3 +237,87 @@ class TestStockValuationLayerRevaluation(TestStockValuationCommon):
 
         credit_lines = [l for l in new_layer.account_move_id.line_ids if l.credit > 0]
         self.assertEqual(len(credit_lines), 1)
+
+    def test_stock_valuation_layer_revaluation_partial(self):
+        """ Only adjust the valuation on some of the layers for a product """
+        self.product1.categ_id.property_cost_method = 'fifo'
+
+        product2 = self.env['product.product'].create({
+            'name': 'product2',
+            'is_storable': True,
+            'categ_id': self.env.ref('product.product_category_all').id,
+        })
+
+        self._make_in_move(self.product1, 5, unit_cost=4)
+        self._make_in_move(self.product1, 10, unit_cost=4)
+        self._make_in_move(self.product1, 5, unit_cost=8)
+        self._make_in_move(product2, 10, unit_cost=4)
+
+        self.assertEqual(self.product1.standard_price, 5)
+        self.assertEqual(self.product1.quantity_svl, 20)
+
+        old_layers = self.env['stock.valuation.layer'].search([('product_id', '=', self.product1.id)], order="create_date desc, id desc")
+
+        self.assertEqual(len(old_layers), 3)
+        self.assertEqual(old_layers.mapped("remaining_value"), [40, 40, 20])
+
+        # Adjusting layers for multiple products at once: raise
+        with self.assertRaises(UserError):
+            Form(self.env['stock.valuation.layer.revaluation'].with_context({
+                'active_ids': self.env['stock.valuation.layer'].search([]).mapped("id"),
+                'active_model': 'stock.valuation.layer'
+            })).save()
+
+        revaluation_wizard = Form(self.env['stock.valuation.layer.revaluation'].with_context({
+            'active_ids': old_layers[0:2].ids,
+            'active_model': 'stock.valuation.layer'
+        }))
+        revaluation_wizard.added_value = 30
+        revaluation_wizard.account_id = self.stock_valuation_account
+        revaluation_wizard.save().action_validate_revaluation()
+
+        # Check standard price change
+        self.assertEqual(self.product1.standard_price, 6.5)
+        self.assertEqual(self.product1.quantity_svl, 20)
+
+        # Check the creation of stock.valuation.layer
+        new_layer = self.env['stock.valuation.layer'].search([('product_id', '=', self.product1.id)], order="create_date desc, id desc", limit=1)
+        self.assertEqual(new_layer.value, 30)
+
+        # Check the remaing value of current layers: only the adjusted layers should have changed
+        # the added value should be impacted proportionally to the qty of each layer (+10 and +20)
+        self.assertEqual(old_layers.mapped("remaining_value"), [50, 60, 20])
+
+        # Check account move
+        self.assertTrue(bool(new_layer.account_move_id))
+        self.assertEqual(len(new_layer.account_move_id.line_ids), 2)
+
+        self.assertEqual(sum(new_layer.account_move_id.line_ids.mapped("debit")), 30)
+        self.assertEqual(sum(new_layer.account_move_id.line_ids.mapped("credit")), 30)
+
+        credit_lines = [l for l in new_layer.account_move_id.line_ids if l.credit > 0]
+        self.assertEqual(len(credit_lines), 1)
+        self.assertEqual(credit_lines[0].account_id.id, self.stock_valuation_account.id)
+
+        self.assertIn(
+            f"Affected valuation layers: {old_layers[1].reference} (id: {old_layers[1].id}) and {old_layers[0].reference} (id: {old_layers[0].id})",
+            new_layer.account_move_id.line_ids[0].name
+        )
+
+        # Adjusting an adjustment layer: raise
+        with self.assertRaises(UserError):
+            Form(self.env['stock.valuation.layer.revaluation'].with_context({
+                'active_ids': [new_layer.id],
+                'active_model': 'stock.valuation.layer'
+            })).save()
+
+        # remove all products from the oldest layer
+        self._make_out_move(self.product1, 5)
+        self.assertEqual(old_layers[2].remaining_qty, 0)
+
+        # Adjusting a layer with no remaining quantity: raise
+        with self.assertRaises(UserError):
+            Form(self.env['stock.valuation.layer.revaluation'].with_context({
+                'active_ids': [old_layers[2].id],
+                'active_model': 'stock.valuation.layer'
+            })).save()

--- a/addons/stock_account/wizard/stock_valuation_layer_revaluation.py
+++ b/addons/stock_account/wizard/stock_valuation_layer_revaluation.py
@@ -3,7 +3,7 @@
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
-from odoo.tools import float_compare, float_is_zero
+from odoo.tools import float_compare, float_is_zero, format_list
 
 
 class StockValuationLayerRevaluation(models.TransientModel):
@@ -14,8 +14,22 @@ class StockValuationLayerRevaluation(models.TransientModel):
     @api.model
     def default_get(self, default_fields):
         res = super().default_get(default_fields)
-        if res.get('product_id'):
-            product = self.env['product.product'].browse(res['product_id'])
+        context = self.env.context
+        if context.get('active_model') == 'stock.valuation.layer':
+            # coming from action button "Adjust Valuation" in valuation layer list view
+            active_ids = context.get('active_ids')
+            layers = self.env['stock.valuation.layer'].browse(active_ids).exists()
+            product = layers.product_id
+            if len(product) > 1:
+                raise UserError(_("You cannot revalue multiple products at once"))
+            if any(float_is_zero(layer.remaining_qty, precision_rounding=product.uom_id.rounding) for layer in layers):
+                raise UserError(_("You cannot adjust the valuation of a layer with zero quantity"))
+            res['adjusted_layer_ids'] = active_ids
+            res['product_id'] = product.id
+        product = self.env['product.product'].browse(res.get('product_id'))
+        if 'product_id' in default_fields:
+            if not product:
+                raise UserError(_("You cannot adjust valuation without a product"))
             if product.categ_id.property_cost_method == 'standard':
                 raise UserError(_("You cannot revalue a product with a standard cost method."))
             if product.quantity_svl <= 0:
@@ -25,14 +39,15 @@ class StockValuationLayerRevaluation(models.TransientModel):
                 res['account_journal_id'] = accounts['stock_journal'].id
         return res
 
-    company_id = fields.Many2one('res.company', "Company", readonly=True, required=True)
+    company_id = fields.Many2one('res.company', "Company", readonly=True, required=True, default=lambda self: self.env.company)
     currency_id = fields.Many2one('res.currency', "Currency", related='company_id.currency_id', required=True)
 
+    adjusted_layer_ids = fields.Many2many('stock.valuation.layer', string="Valuation Layers", help="Valuations layers being adjusted")
     product_id = fields.Many2one('product.product', "Related product", required=True, check_company=True)
     property_valuation = fields.Selection(related='product_id.categ_id.property_valuation')
     product_uom_name = fields.Char("Unit of Measure", related='product_id.uom_id.name')
-    current_value_svl = fields.Float("Current Value", related="product_id.value_svl")
-    current_quantity_svl = fields.Float("Current Quantity", related="product_id.quantity_svl")
+    current_value_svl = fields.Float("Current Value", compute='_compute_current_value_svl')
+    current_quantity_svl = fields.Float("Current Quantity", compute='_compute_current_value_svl')
 
     added_value = fields.Monetary("Added value", required=True)
     new_value = fields.Monetary("New value", compute='_compute_new_value')
@@ -52,12 +67,25 @@ class StockValuationLayerRevaluation(models.TransientModel):
             else:
                 reval.new_value_by_qty = 0.0
 
-    def action_validate_revaluation(self):
-        """ Revaluate the stock for `self.product_id` in `self.company_id`.
+    @api.depends('product_id.quantity_svl', 'product_id.value_svl', 'adjusted_layer_ids')
+    def _compute_current_value_svl(self):
+        for reval in self:
+            if not reval.adjusted_layer_ids:
+                reval.current_quantity_svl = reval.product_id.quantity_svl
+                reval.current_value_svl = reval.product_id.value_svl
+            else:
+                reval.current_quantity_svl = sum(reval.adjusted_layer_ids.mapped('remaining_qty'))
+                reval.current_value_svl = sum(reval.adjusted_layer_ids.mapped('remaining_value'))
 
-        - Change the stardard price with the new valuation by product unit.
+    def action_validate_revaluation(self):
+        """ Adjust the valuation of layers `self.adjusted_layer_ids` for
+        `self.product_id` in `self.company_id`, or the entire stock for that
+        product if no layers are specified (all layers with positive remaining
+        quantity).
+
+        - Change the standard price with the new valuation by product unit.
         - Create a manual stock valuation layer with the `added_value` of `self`.
-        - Distribute the `added_value` on the remaining_value of layers still in stock (with a remaining quantity)
+        - Distribute the `added_value` on the remaining_value of the layers
         - If the Inventory Valuation of the product category is automated, create
         related account move.
         """
@@ -66,53 +94,49 @@ class StockValuationLayerRevaluation(models.TransientModel):
             raise UserError(_("The added value doesn't have any impact on the stock valuation"))
 
         product_id = self.product_id.with_company(self.company_id)
-
-        remaining_svls = self.env['stock.valuation.layer'].search([
+        layers_with_qty = self.env['stock.valuation.layer'].search([
             ('product_id', '=', product_id.id),
             ('remaining_qty', '>', 0),
             ('company_id', '=', self.company_id.id),
         ])
+        adjusted_layers = self.adjusted_layer_ids or layers_with_qty
+        qty_to_adjust = sum(adjusted_layers.mapped('remaining_qty'))
+        value_change_to_apply = self.added_value
+        unit_value_change = self.currency_id.round(self.added_value / qty_to_adjust)
+        # adjust all layers by the unit value change per unit, except the last layer which gets
+        # whatever is left. This avoids rounding issues e.g. $10 on 3 products => 3.33, 3.33, 3.34
+        for layer in adjusted_layers:
+            if layer != adjusted_layers[-1]:
+                value_change = unit_value_change * layer.remaining_qty
+                layer.remaining_value += value_change
+                value_change_to_apply -= value_change
+            else:
+                layer.remaining_value += value_change_to_apply
 
-        # Create a manual stock valuation layer
-        if self.reason:
-            description = _("Manual Stock Valuation: %s.", self.reason)
-        else:
-            description = _("Manual Stock Valuation: No Reason Given.")
-        if product_id.categ_id.property_cost_method == 'average':
+            if float_compare(layer.remaining_value, 0, precision_rounding=self.product_id.uom_id.rounding) < 0:
+                raise UserError(_('The value of a stock valuation layer cannot be negative. Landed cost could be used to correct a specific transfer.'))
+
+        description = _("Manual Stock Valuation: %s.", self.reason or _("No Reason Given"))
+        # Update the stardard price in case of AVCO/FIFO
+        cost_method = product_id.categ_id.property_cost_method
+        if cost_method in ['average', 'fifo']:
+            previous_cost = product_id.standard_price
+            total_product_qty = sum(layers_with_qty.mapped('remaining_qty'))
+            product_id.with_context(disable_auto_svl=True).standard_price += self.added_value / total_product_qty
             description += _(
                 " Product cost updated from %(previous)s to %(new_cost)s.",
-                previous=product_id.standard_price,
-                new_cost=product_id.standard_price + self.added_value / self.current_quantity_svl
+                previous=previous_cost,
+                new_cost=product_id.standard_price
             )
-        revaluation_svl_vals = {
+
+        previous_value_svl = self.current_value_svl
+        revaluation_layer = self.env['stock.valuation.layer'].create({
             'company_id': self.company_id.id,
             'product_id': product_id.id,
             'description': description,
             'value': self.added_value,
             'quantity': 0,
-        }
-
-        remaining_qty = sum(remaining_svls.mapped('remaining_qty'))
-        remaining_value = self.added_value
-        remaining_value_unit_cost = self.currency_id.round(remaining_value / remaining_qty)
-        for svl in remaining_svls:
-            if float_is_zero(svl.remaining_qty - remaining_qty, precision_rounding=self.product_id.uom_id.rounding):
-                taken_remaining_value = remaining_value
-            else:
-                taken_remaining_value = remaining_value_unit_cost * svl.remaining_qty
-            if float_compare(svl.remaining_value + taken_remaining_value, 0, precision_rounding=self.product_id.uom_id.rounding) < 0:
-                raise UserError(_('The value of a stock valuation layer cannot be negative. Landed cost could be use to correct a specific transfer.'))
-
-            svl.remaining_value += taken_remaining_value
-            remaining_value -= taken_remaining_value
-            remaining_qty -= svl.remaining_qty
-
-        previous_value_svl = self.current_value_svl
-        revaluation_svl = self.env['stock.valuation.layer'].create(revaluation_svl_vals)
-
-        # Update the stardard price in case of AVCO/FIFO
-        if product_id.categ_id.property_cost_method in ['average', 'fifo']:
-            product_id.with_context(disable_auto_svl=True).standard_price += self.added_value / self.current_quantity_svl
+        })
 
         # If the Inventory Valuation of the product category is automated, create related account move.
         if self.property_valuation != 'real_time':
@@ -127,31 +151,33 @@ class StockValuationLayerRevaluation(models.TransientModel):
             debit_account_id = accounts.get('stock_valuation') and accounts['stock_valuation'].id
             credit_account_id = self.account_id.id
 
+        move_description = _('%(user)s changed stock valuation from  %(previous)s to %(new_value)s - %(product)s\n%(reason)s',
+            user=self.env.user.name,
+            previous=previous_value_svl,
+            new_value=previous_value_svl + self.added_value,
+            product=product_id.display_name,
+            reason=description,
+        )
+
+        if self.adjusted_layer_ids:
+            adjusted_layer_descriptions = [f"{layer.reference} (id: {layer.id})" for layer in self.adjusted_layer_ids]
+            move_description += _("\nAffected valuation layers: %s", format_list(self.env, adjusted_layer_descriptions))
+
         move_vals = {
             'journal_id': self.account_journal_id.id or accounts['stock_journal'].id,
             'company_id': self.company_id.id,
             'ref': _("Revaluation of %s", product_id.display_name),
-            'stock_valuation_layer_ids': [(6, None, [revaluation_svl.id])],
+            'stock_valuation_layer_ids': [(6, None, [revaluation_layer.id])],
             'date': self.date or fields.Date.today(),
             'move_type': 'entry',
             'line_ids': [(0, 0, {
-                'name': _('%(user)s changed stock valuation from  %(previous)s to %(new_value)s - %(product)s',
-                    user=self.env.user.name,
-                    previous=previous_value_svl,
-                    new_value=previous_value_svl + self.added_value,
-                    product=product_id.display_name,
-                ),
+                'name': move_description,
                 'account_id': debit_account_id,
                 'debit': abs(self.added_value),
                 'credit': 0,
                 'product_id': product_id.id,
             }), (0, 0, {
-                'name': _('%(user)s changed stock valuation from  %(previous)s to %(new_value)s - %(product)s',
-                    user=self.env.user.name,
-                    previous=previous_value_svl,
-                    new_value=previous_value_svl + self.added_value,
-                    product=product_id.display_name,
-                ),
+                'name': move_description,
                 'account_id': credit_account_id,
                 'debit': 0,
                 'credit': abs(self.added_value),

--- a/addons/stock_account/wizard/stock_valuation_layer_revaluation_views.xml
+++ b/addons/stock_account/wizard/stock_valuation_layer_revaluation_views.xml
@@ -1,6 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
+    <record id="action_revalue_layers" model="ir.actions.act_window">
+        <field name="name">Adjust Valuation</field>
+        <field name="res_model">stock.valuation.layer.revaluation</field>
+        <field name="view_mode">form</field>
+        <field name="binding_model_id" ref="stock_account.model_stock_valuation_layer"/>
+        <!-- Not available in form view because clicking a layer only opens its form view if it's already an adjustment layer, the action would always fail with a UserError because the quantity is 0 -->
+        <field name="binding_view_types">list</field>
+        <field name="target">new</field>
+    </record>
+
     <record id="stock_valuation_layer_revaluation_form_view" model="ir.ui.view">
         <field name="name">stock.valuation.layer.revaluation.form</field>
         <field name="model">stock.valuation.layer.revaluation</field>


### PR DESCRIPTION
Previously, it was only possible to adjust the valuation for the entire stock of a product from the inventory valuation screen, and it was only possible to do so when grouping by product. While this is generally fine, because the valuation adjustment applies to all product in stock, it's not very granular and can be inaccurate if the user is trying to represent changes in value that only affect a subset of a product's inventory. When a product's costing method is FIFO, it can also cause the reported valuation and actual valuation to be out of sync while products which were not supposed to have their value adjusted are still in stock.

This commit adds a button to the action menu of the stock valuation screen which allows you to apply a value adjustment to only the selected lines, and adapts the underlying code to work on those specific lines, if any.

task-3987604
