### PR TITLE
[FIX] im_livechat: delete temporary livechat thread on close

### DIFF
--- a/addons/im_livechat/static/src/embed/common/chat_window_patch.js
+++ b/addons/im_livechat/static/src/embed/common/chat_window_patch.js
@@ -27,6 +27,9 @@ patch(ChatWindow.prototype, {
             this.props.chatWindow.show({ notifyState: this.thread?.state !== "open" });
         } else {
             await super.close();
+            if (this.thread.isTransient) {
+                this.thread.delete();
+            }
         }
         this.livechatService.leave();
         this.chatbotService.stop();

--- a/addons/im_livechat/static/tests/embed/livechat_button.test.js
+++ b/addons/im_livechat/static/tests/embed/livechat_button.test.js
@@ -4,7 +4,7 @@ import {
     defineLivechatModels,
     loadDefaultEmbedConfig,
 } from "@im_livechat/../tests/livechat_test_helpers";
-import { describe, test } from "@odoo/hoot";
+import { describe, expect, test } from "@odoo/hoot";
 import {
     assertSteps,
     click,
@@ -23,13 +23,15 @@ defineLivechatModels();
 test("open/close temporary channel", async () => {
     await startServer();
     await loadDefaultEmbedConfig();
-    await start({ authenticateAs: false });
+    const env = await start({ authenticateAs: false });
     await mountWithCleanup(LivechatButton);
     await click(".o-livechat-LivechatButton");
     await contains(".o-mail-ChatWindow");
     await contains(".o-livechat-LivechatButton", { count: 0 });
+    expect(Boolean(env.services["im_livechat.livechat"].thread)).toBe(true);
     await click("[title='Close Chat Window']");
     await contains(".o-mail-ChatWindow", { count: 0 });
+    expect(Boolean(env.services["im_livechat.livechat"].thread)).toBe(false);
     await contains(".o-livechat-LivechatButton", { count: 1 });
 });
 


### PR DESCRIPTION
[1] commit removed the code which would delete the temporary thread when closing a non-persisted livechat.

So, because of this when you open a new livechat channel after closing the previous one you will still see the welcome messages which were there in the previous thread which causes duplication of welcome messages.

This commit reintroduces the code which would delete this temporary thread.

[1]: 21a51f63709eb0e637911f38988527818ddf3b54

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
