### PR TITLE
[FIX] sale: downpayment reference on SOlines

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -329,8 +329,8 @@ class SaleOrderLine(models.Model):
                     name = _("%(line_description)s (Canceled)", line_description=name)
                 else:
                     invoice = line._get_invoice_lines().filtered(
-                        lambda aml: aml.quantity >= 0  # Original downpayment invoice
-                    ).move_id
+                        lambda aml: aml.quantity >= 0
+                    ).move_id.filtered(lambda move: move.move_type == 'out_invoice')
                     if len(invoice) == 1 and invoice.payment_reference and invoice.invoice_date:
                         name = _(
                             "%(line_description)s (ref: %(reference)s on %(date)s)",


### PR DESCRIPTION
Credit notes shoudn't make the down payment reference disappear from the matching down payment SO line.

opw-3904918

See #168418 for further details
