### PR TITLE
[IMP] account_debit_note: introduce debit note filter for moves

### DIFF
--- a/addons/account_debit_note/models/account_move.py
+++ b/addons/account_debit_note/models/account_move.py
@@ -30,5 +30,5 @@ class AccountMove(models.Model):
         }
 
     def action_debit_note(self):
-        action = self.env.ref('account_debit_note.action_view_account_move_debit').read()[0]
+        action = self.env.ref('account_debit_note.action_view_account_move_debit')._get_action_dict()
         return action

--- a/addons/account_debit_note/views/account_move_view.xml
+++ b/addons/account_debit_note/views/account_move_view.xml
@@ -32,4 +32,40 @@ if records:
         </field>
     </record>
 
+    <record id="view_account_move_filter_debit" model="ir.ui.view">
+        <field name="name">account.move.filter.debit</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_account_move_filter" />
+        <field name="arch" type="xml">
+            <filter name="reversed" position="after">
+                <filter string="Debit Note" name="debit_note_filter"
+                    domain="[('debit_origin_id', '!=', False)]" />
+            </filter>
+        </field>
+    </record>
+
+    <record id="view_account_invoice_filter_debit" model="ir.ui.view">
+        <field name="name">account.invoice.select.debit</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_account_invoice_filter" />
+        <field name="arch" type="xml">
+            <filter name="to_check" position="before">
+                <filter string="Debit Note" name="debit_note_filter"
+                    domain="[('debit_origin_id', '!=', False)]" />
+                <separator />
+            </filter>
+        </field>
+    </record>
+
+    <record id="view_account_move_line_filter_debit" model="ir.ui.view">
+        <field name="name">account.move.line.search.debit</field>
+        <field name="model">account.move.line</field>
+        <field name="inherit_id" ref="account.view_account_move_line_filter" />
+        <field name="arch" type="xml">
+            <filter name="unreconciled" position="after">
+                <filter string="Debit Note" name="debit_note_filter"
+                    domain="[('move_id.debit_origin_id', '!=', False)]" />
+            </filter>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
- Before Commit:
Users were unable to filter moves specifically for debit notes.
An `ir.act.window` access error prevented users with invoice access rights from
creating debit notes.

- After Commit:
Users can now directly filter debit notes using the new Debit Note filter over
Customer Invoices, Vendor Bills, Journal Entries & Journal items views.
And resolved the `ir.act.window` access error by updating the method to retrieve
the action dictionary appropriately.

**task**-3992112