### PR TITLE
[FIX] payment_stripe: set API version in js api

### DIFF
--- a/addons/payment_stripe/static/src/js/payment_form.js
+++ b/addons/payment_stripe/static/src/js/payment_form.js
@@ -38,7 +38,9 @@ odoo.define('payment_stripe.payment_form', require => {
          * @return {object}
          */
         _prepareStripeOptions: function (processingValues) {
-            return {};
+            return {
+                'apiVersion': '2019-05-16',  // The API version of Stripe implemented in this module
+            };
         },
     };
 


### PR DESCRIPTION
Before this commit, no API version was given to StripeJS. This could lead to discrepancies between the APIs.

Now, the API version used will be the same client-side and server-side.

