### PR TITLE
[IMP] base, web, product: `KanbanView`, adjust `<aside>` sizing 

### DIFF
--- a/addons/product/views/product_template_views.xml
+++ b/addons/product/views/product_template_views.xml
@@ -95,8 +95,8 @@
                 <field name="categ_id"/>
                 <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}'/>
                 <templates>
-                    <t t-name="kanban-card" class="row g-0">
-                        <main class="col-10 pe-2">
+                    <t t-name="kanban-card" class="flex-row">
+                        <main class="pe-2">
                             <div class="mb-1">
                                 <div class="d-flex mb-0 h5">
                                     <field class="me-1" name="is_favorite" widget="boolean_favorite" nolabel="1"/>
@@ -114,8 +114,8 @@
                             </span>
                             <field name="product_properties" widget="properties"/>
                         </main>
-                        <aside class="col-2 p-0">
-                            <field name="image_128" widget="image" alt="Product"/>
+                        <aside>
+                            <field name="image_128" widget="image" alt="Product" options="{'img_class': 'w-100 object-fit-contain'}"/>
                         </aside>
                     </t>
                 </templates>

--- a/addons/web/static/src/views/kanban/kanban_controller.scss
+++ b/addons/web/static/src/views/kanban/kanban_controller.scss
@@ -85,13 +85,23 @@
             border: $border-width solid $border-color;
             background-color: $o-view-background-color;
         }
-        &:not(.row) {
+
+        &:where(:not(.row)) {
             flex-flow: column;
+
+            main {
+                flex-grow: 1;
+            }
+
+            aside {
+                flex: 0 0 var(--KanbanRecord__image-width);
+            }
         }
 
         > main {
             display: flex;
             flex-flow: column;
+            min-width: 0;
         }
 
         > footer, > main > footer {
@@ -103,13 +113,28 @@
             font-size: var(--Card-Footer-font-size, 1rem);
         }
 
-        aside.o_kanban_aside_full > * {
-            height: 100%;
-            @include media-breakpoint-up(md) {
-                height: calc(100% + var(--KanbanRecord-padding-v)* 2);
-                margin-top: calc(var(--KanbanRecord-padding-v)* -1);
-                margin-bottom: calc(var(--KanbanRecord-padding-v)* -1);
-                margin-left: calc(var(--KanbanRecord-padding-h)* -1);
+        aside {
+            img {
+                height: var(--KanbanRecord__image-height, var(--KanbanRecord__image-width));
+            }
+
+            &.o_kanban_aside_full {
+                --KanbanRecord__image-height: 100%;
+                --KanbanRecord__image-width: var(--KanbanRecord__image--fill-width);
+
+                .o_kanban_image_fill {
+                    min-height: var(--KanbanRecord__image-fill-width);
+                    max-height: var(--KanbanRecord__image-max-height, $o-kanban-image-fill-width * 1.5);
+                }
+
+                > * {
+                    @include media-breakpoint-up(md) {
+                        height: calc(100% + var(--KanbanRecord-padding-v)* 2);
+                        margin-top: calc(var(--KanbanRecord-padding-v)* -1);
+                        margin-bottom: calc(var(--KanbanRecord-padding-v)* -1);
+                        margin-left: calc(var(--KanbanRecord-padding-h)* -1);
+                    }
+                }
             }
         }
 

--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -218,11 +218,11 @@
                                     <field name="color"/>
                                     <field name="type"/>
                                     <templates>
-                                        <t t-name="kanban-card" class="row g-0">
-                                            <aside class="col-3 col-sm-2 col-md-3 o_kanban_aside_full">
-                                                <field name="avatar_128" widget="image" options="{'img_class': 'object-fit-cover'}" alt="Contact image"/>
+                                        <t t-name="kanban-card" class="flex-row">
+                                            <aside class="o_kanban_aside_full">
+                                                <field name="avatar_128" class="o_kanban_image_fill w-100" widget="image" options="{'img_class': 'object-fit-cover'}" alt="Contact image"/>
                                             </aside>
-                                            <main class="col-9 col-sm-10 col-md-9 ps-2">
+                                            <main class="ps-2 ps-md-0">
                                                 <field name="name" class="fw-bold"/>
                                                 <field name="function"/>
                                                 <field name="email" widget="email"/>
@@ -398,12 +398,12 @@
                     <field name="is_company"/>
                     <field name="active"/>
                     <templates>
-                        <t t-name="kanban-card" class="row g-0">
+                        <t t-name="kanban-card" class="flex-row">
                             <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
-                            <aside class="col-3 col-sm-2 col-md-4 o_kanban_aside_full">
+                            <aside class="o_kanban_aside_full">
                                 <t t-if="!record.is_company.raw_value">
-                                    <div class="position-relative w-100">
-                                        <field name="avatar_128" alt="Contact image" class="position-md-absolute top-0 start-0 h-100 w-100" widget="image" options="{'img_class': 'object-fit-cover w-100 h-100'}"/>
+                                    <div class="o_kanban_image_fill position-relative w-100">
+                                        <field name="avatar_128" alt="Contact image" class="h-100" widget="image" options="{'img_class': 'object-fit-cover'}"/>
                                         <field t-if="record.parent_id.raw_value" name="parent_id" class="position-absolute bottom-0 end-0 w-25 bg-light" widget="image" options="{'preview_image': 'image_128', 'img_class': 'object-fit-contain'}"/>
                                     </div>
                                 </t>
@@ -411,7 +411,7 @@
                                     <field name="avatar_128" class="w-100" widget="image" options="{'img_class': 'object-fit-contain w-100 h-100'}"/>
                                 </t>
                             </aside>
-                            <main class="col-9 col-sm-10 col-md-8  ps-2">
+                            <main class="ps-2 ps-md-0">
                                 <div class="mb-1">
                                     <field name="display_name" class="mb-0 h5"/>
                                     <field t-if="record.parent_id.raw_value and !record.function.raw_value" class="text-muted" name="parent_id"/>


### PR DESCRIPTION
### Adjust `<aside>` sizing 
PR odoo/https://github.com/odoo/odoo/pull/167751, introduced Bootstrap columns to manage kanban cards using an `aside` element.
But the rendering is not optimal for some cards (eg. Contacts, Products) and the these are less easy to read.

This commit adjusts the default size of `<aside>` and its inner image elements. Bootstrap columns can still be defined if we want to customize the size of the `<main>` and `<aside>`.

### Reintroduce `min-width` on `<main>`
PR odoo/https://github.com/odoo/odoo/pull/167751, also removed a `min-width` defined on the `<main>` that was useful to force its content to be truncated. The property has been reintroduced since it's still necessary.

task-3997115



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
