### PR TITLE
[FIX] project: conditionally launch sub-task steps in tour

### DIFF
--- a/addons/project/static/src/js/tours/project.js
+++ b/addons/project/static/src/js/tours/project.js
@@ -126,19 +126,23 @@ registry.category("web_tour.tours").add('project_tour', {
     trigger: 'a[name="sub_tasks_page"]',
     content: _t('Open sub-tasks notebook section'),
     run: 'click',
+    auto: true,
 }, {
     trigger: '.o_field_subtasks_one2many .o_list_renderer a[role="button"]',
     content: _t('Add a sub-task'),
     run: 'click',
+    auto: true,
 }, {
     trigger: '.o_field_subtasks_one2many div[name="name"] input',
     content: markup(_t('Give the sub-task a <b>name</b>')),
-    run: 'text New Sub-task'
+    run: 'text New Sub-task',
+    auto: true,
 }, {
     trigger: ".o_form_button_save",
     extra_trigger: '.o_form_project_tasks .o_form_dirty',
     content: markup(_t("You have unsaved changes - no worries! Odoo will automatically save it as you navigate.<br/> You can discard these changes from here or manually save your task.<br/>Let's save it manually.")),
     position: "bottom",
+    auto: true,
 }, {
     trigger: ".o_breadcrumb .o_back_button",
     extra_trigger: '.o_form_project_tasks',
@@ -148,25 +152,31 @@ registry.category("web_tour.tours").add('project_tour', {
 }, {
     trigger: ".o_kanban_record .oe_kanban_content .o_widget_subtask_counter .subtask_list_button",
     content: _t("You can open sub-tasks from the kanban card!"),
+    auto: true,
 }, {
     trigger: ".o_kanban_record .o_widget_subtask_kanban_list .subtask_create",
     extra_trigger: ".o_widget_subtask_kanban_list .subtask_list",
     content: _t("Create a new sub-task"),
+    auto: true,
 }, {
     trigger: ".o_kanban_record .o_widget_subtask_kanban_list .subtask_create_input input",
     extra_trigger: ".subtask_create_input",
     content: markup(_t("Give the sub-task a <b>name</b>")),
-    run: 'text Newer Sub-task'
+    run: 'text Newer Sub-task',
+    auto: true,
 }, {
     trigger: ".o_kanban_record .o_widget_subtask_kanban_list .subtask_list_row:first-child .o_field_project_task_state_selection button",
     content: _t("You can change the sub-task state here!"),
+    auto: true,
 }, {
     trigger: ".o_widget_subtask_kanban_list .o_field_project_task_state_selection .dropdown-menu span.text-danger",
     extra_trigger: ".o_field_project_task_state_selection .dropdown-menu",
     content: markup(_t("Mark the task as <b>Canceled</b>")),
+    auto: true,
 }, {
     trigger: ".o_kanban_record .oe_kanban_content .o_widget_subtask_counter .subtask_list_button:contains('1/2')",
     content: _t("Close the sub-tasks list"),
+    auto: true,
 }, {
     trigger: '.o_kanban_renderer',
     // last step to confirm we've come back before considering the tour successful


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:
- In the onboarding tour, a step guides users in creating sub-tasks.

Desired behavior after PR is merged:
- Launch the sub-task steps only when the tour is automatically started.

task-3990244

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
