### PR TITLE
[IMP] website, *: add record fields as field visibility conditions

### DIFF
--- a/addons/test_website/controllers/main.py
+++ b/addons/test_website/controllers/main.py
@@ -145,6 +145,7 @@ class WebsiteTest(Home):
         values = {
             'record': record,
             'main_object': record,
+            'tag': record.tag_id,
         }
         return request.render("test_website.model_item", values)
 

--- a/addons/test_website/data/test_website_data.xml
+++ b/addons/test_website/data/test_website_data.xml
@@ -14,8 +14,15 @@
         <record id="test_tag_generic" model="test.tag">
             <field name="name">Test Tag</field>
         </record>
+        <record id="test_tag_2" model="test.tag">
+            <field name="name">Test Tag #2</field>
+        </record>
+        <record id="test_tag_3" model="test.tag">
+            <field name="name">Test Tag #3</field>
+        </record>
         <record id="test_model_generic" model="test.model">
             <field name="name">Test Model</field>
+            <field name="tag_id" ref="test_website.test_tag_generic"/>
         </record>
         <record id="test_submodel_generic" model="test.submodel">
             <field name="name">Test Submodel</field>

--- a/addons/test_website/models/model.py
+++ b/addons/test_website/models/model.py
@@ -29,6 +29,7 @@ class TestModel(models.Model):
         sanitize_attributes=False,
         sanitize_form=False,
     )
+    tag_id = fields.Many2one('test.tag')
 
     @api.model
     def _search_get_detail(self, website, order, options):

--- a/addons/test_website/static/tests/tours/form.js
+++ b/addons/test_website/static/tests/tours/form.js
@@ -1,0 +1,68 @@
+import {
+    clickOnEditAndWaitEditMode,
+    clickOnSave,
+    registerWebsitePreviewTour,
+} from "@website/js/tours/tour_utils";
+
+registerWebsitePreviewTour(
+    "test_form_conditional_visibility_record_field",
+    {
+        url: "/test_website/model_item/1",
+        edition: true,
+        test: true,
+    },
+    () => [
+        {
+            content: "Select name field",
+            trigger: ":iframe .s_website_form .s_website_form_input[name=name]",
+            run: "click",
+        },
+        {
+            content: "Open visibility dropdown",
+            trigger: 'we-select:has([data-set-visibility="conditional"])',
+            run: "click",
+        },
+        {
+            content: "Set visibility to conditional",
+            trigger: '[data-set-visibility="conditional"]',
+            run: "click",
+        },
+        {
+            content: "Open model selector",
+            trigger: 'we-select:has([data-select-data-attribute="2"])',
+            run: "click",
+        },
+        {
+            content: "Set model to tag #2",
+            trigger: '[data-select-data-attribute="2"]',
+            run: "click",
+        },
+        ...clickOnSave(),
+        {
+            content: "Name field is hidden",
+            trigger: ":iframe .s_website_form:has(.s_website_form_field_hidden_if.d-none)",
+        },
+        ...clickOnEditAndWaitEditMode(),
+
+        {
+            content: "Select name field",
+            trigger: ":iframe .s_website_form .s_website_form_input[name=name]",
+            run: "click",
+        },
+        {
+            content: "Open comparator dropdown",
+            trigger: 'we-select:has([data-select-data-attribute="!selected"])',
+            run: "click",
+        },
+        {
+            content: "Set comparator to Is not equal",
+            trigger: '[data-select-data-attribute="!selected"]',
+            run: "click",
+        },
+        ...clickOnSave(),
+        {
+            content: "Name field is shown",
+            trigger: ":iframe .s_website_form:has(.s_website_form_field_hidden_if:not(.d-none))",
+        },
+    ],
+);

--- a/addons/test_website/tests/__init__.py
+++ b/addons/test_website/tests/__init__.py
@@ -4,6 +4,7 @@
 from . import test_controller_args
 from . import test_custom_snippet
 from . import test_error
+from . import test_form
 from . import test_fuzzy
 from . import test_image_upload_progress
 from . import test_is_multilang

--- a/addons/test_website/tests/test_form.py
+++ b/addons/test_website/tests/test_form.py
@@ -1,0 +1,14 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import tagged, HttpCase
+
+
+@tagged('-at_install', 'post_install')
+class TestForm(HttpCase):
+
+    def test_form_conditional_visibility_record_field(self):
+        self.start_tour(
+            self.env['website'].get_client_action_url('/test_website/model_item/1'),
+            'test_form_conditional_visibility_record_field',
+            login='admin',
+        )

--- a/addons/test_website/views/templates.xml
+++ b/addons/test_website/views/templates.xml
@@ -33,8 +33,48 @@
                         </div>
                     </div>
                 </section>
+                <t t-call="test_website.test_form"/>
             </div>
         </t>
+    </template>
+
+    <template id="test_form" name="Test Form">
+        <span class="hidden" data-for="test_form" t-att-data-values="{'tag_id': tag and tag.id or ''}" />
+        <section class="s_website_form pt16 pb16 o_colored_level" data-vcss="001" data-snippet="s_website_form" data-name="Form">
+            <div class="container">
+                <form id="test_form" action="#fake" method="post" enctype="multipart/form-data" class="o_mark_required" data-mark="*" data-pre-fill="true" data-success-mode="redirect" data-success-page="/success" data-model_name="test.model" hide-change-model="true">
+                    <div class="s_website_form_rows row s_col_no_bgcolor">
+                        <div class="mb-0 py-2 s_website_form_field col-12 s_website_form_required" data-type="char" data-name="Field">
+                            <div class="row s_col_no_resize s_col_no_bgcolor">
+                                <label class="col-form-label col-sm-auto s_website_form_label" style="width: 200px" for="testform1">
+                                    <span class="s_website_form_label_content">Name</span>
+                                    <span class="s_website_form_mark"> *</span>
+                                </label>
+                                <div class="col-sm">
+                                    <input type="text" class="form-control s_website_form_input" name="name" required="1" data-fill-with="name" id="testform1"/>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="mb-0 py-2 s_website_form_field col-12 s_website_form_dnone" data-name="Field"
+                             data-type="record" data-model="test.tag">
+                            <div class="row s_col_no_resize s_col_no_bgcolor">
+                                <label class="col-form-label col-sm-auto s_website_form_label" style="width: 200px" for="testmodel2">
+                                    <span class="s_website_form_label_content">Tag</span>
+                                </label>
+                                <div class="col-sm">
+                                    <input type="hidden" class="form-control s_website_form_input" name="tag_id" id="testmodel2" />
+                                </div>
+                            </div>
+                        </div>
+                        <div class="mb-0 py-2 col-12 s_website_form_submit" data-name="Submit Button">
+                            <div style="width: 200px;" class="s_website_form_label"/>
+                            <a href="#" role="button" class="btn btn-primary btn-lg s_website_form_send o_default_snippet_text">Submit</a>
+                            <span id="s_website_form_result"/>
+                        </div>
+                    </div>
+                </form>
+            </div>
+        </section>
     </template>
 
     <record id="res_config_settings_view_form" model="ir.ui.view">

--- a/addons/website/views/snippets/s_website_form.xml
+++ b/addons/website/views/snippets/s_website_form.xml
@@ -297,8 +297,15 @@
                     <we-button data-select-data-attribute="fileSet">Is set</we-button>
                     <we-button data-select-data-attribute="!fileSet">Is not set</we-button>
                 </we-select>
+                <we-select data-name="hidden_condition_record_opt" data-attribute-name="visibilityComparator" data-no-preview="true">
+                    <we-button data-select-data-attribute="selected">Is equal to</we-button>
+                    <we-button data-select-data-attribute="!selected">Is not equal to</we-button>
+                </we-select>
             </we-row>
             <we-select class="o_we_large" data-name="hidden_condition_no_text_opt" data-attribute-name="visibilityCondition" data-no-preview="true">
+                <!-- checkbox, select, radio possible values -->
+            </we-select>
+            <we-select class="o_we_large" data-name="hidden_condition_record_opt" data-attribute-name="visibilityCondition" data-no-preview="true">
                 <!-- checkbox, select, radio possible values -->
             </we-select>
             <we-input class="o_we_large" data-name="hidden_condition_additional_text" data-attribute-name="visibilityCondition" data-select-data-attribute=""/>

--- a/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
+++ b/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
@@ -288,7 +288,8 @@
                                             </div>
                                         </div>
                                     </div>
-                                    <div class="col-12 mb-0 py-2 s_website_form_field s_website_form_dnone">
+                                    <div class="col-12 mb-0 py-2 s_website_form_field s_website_form_dnone"
+                                         data-type="record" data-model="hr.job">
                                         <div class="row s_col_no_resize s_col_no_bgcolor">
                                             <label class="col-4 col-sm-auto s_website_form_label" style="width: 200px" for="recruitment7">
                                                 <span class="s_website_form_label_content">Job</span>
@@ -300,7 +301,8 @@
                                             </div>
                                         </div>
                                     </div>
-                                    <div class="col-12 mb-0 py-2 s_website_form_field s_website_form_dnone">
+                                    <div class="col-12 mb-0 py-2 s_website_form_field s_website_form_dnone"
+                                         data-type="record" data-model="hr.department">
                                         <div class="row s_col_no_resize s_col_no_bgcolor">
                                             <label class="col-4 col-sm-auto s_website_form_label" style="width: 200px" for="recruitment8">
                                                 <span class="s_website_form_label_content">Department</span>


### PR DESCRIPTION
*: test_website

This commit adds support to select a single record as a form field
visibility condition.

The behavior is identical to visibility conditions on a select field,
except that the options are fetched (every record for the given model).

Usage:
Add the following attributes to the `s_website_form_field`:
 - `data-type="record"`
 - `data-model`: model name (i.e. `hr.job`)
 - `data-id-field` (optional, default=`id`): the model's primary key
   field name
 - `data-display-name-field` (optional, default=`display_name`): the
   name of the model field to use as a display string in select options

task-3864606


-----


[IMP] website_hr_recruitment: add record fields visibility conditions

Add the following fields as field visibility conditions:
- job_id
- department_id

task-3864606