### PR TITLE
[FIX] base,account: handle related bank accounts when merging partners

### DIFF
--- a/addons/account/tests/__init__.py
+++ b/addons/account/tests/__init__.py
@@ -47,3 +47,4 @@ from . import test_structured_reference
 from . import test_product
 from . import test_unexpected_invoice
 from . import test_mail_tracking_value
+from . import test_res_partner_merge

--- a/addons/account/tests/test_res_partner_merge.py
+++ b/addons/account/tests/test_res_partner_merge.py
@@ -1,0 +1,72 @@
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.tests import tagged
+
+
+@tagged('post_install', '-at_install')
+class TestMergePartner(AccountTestInvoicingCommon):
+
+    @classmethod
+    def setUpClass(cls, chart_template_ref=None):
+        super().setUpClass(chart_template_ref=chart_template_ref)
+
+        cls.Partner = cls.env['res.partner']
+        cls.Bank = cls.env['res.partner.bank']
+        cls.Payment = cls.env['account.payment']
+
+        # Create partners
+        cls.partner1 = cls.Partner.create({'name': 'Partner 1', 'email': 'partner1@example.com'})
+        cls.partner2 = cls.Partner.create({'name': 'Partner 2', 'email': 'partner2@example.com'})
+        cls.partner3 = cls.Partner.create({'name': 'Partner 3', 'email': 'partner3@example.com'})
+
+        # Create bank accounts
+        cls.bank1 = cls.Bank.create({'acc_number': '12345', 'partner_id': cls.partner1.id})
+        cls.bank2 = cls.Bank.create({'acc_number': '67890', 'partner_id': cls.partner2.id})
+        cls.bank3 = cls.Bank.create({'acc_number': '12345', 'partner_id': cls.partner3.id})
+
+        # Create payments linked to bank accounts
+        cls.payment1 = cls.Payment.create({
+            'partner_id': cls.partner1.id,
+            'partner_bank_id': cls.bank1.id,
+            'amount': 100,
+            'payment_type': 'outbound',
+            'payment_method_id': cls.env.ref('account.account_payment_method_manual_out').id,
+            'journal_id': cls.company_data['default_journal_bank'].id,
+        })
+        cls.payment2 = cls.Payment.create({
+            'partner_id': cls.partner2.id,
+            'partner_bank_id': cls.bank2.id,
+            'amount': 200,
+            'payment_type': 'outbound',
+            'payment_method_id': cls.env.ref('account.account_payment_method_manual_out').id,
+            'journal_id': cls.company_data['default_journal_bank'].id,
+        })
+        cls.payment3 = cls.Payment.create({
+            'partner_id': cls.partner3.id,
+            'partner_bank_id': cls.bank3.id,
+            'amount': 200,
+            'payment_type': 'outbound',
+            'payment_method_id': cls.env.ref('account.account_payment_method_manual_out').id,
+            'journal_id': cls.company_data['default_journal_bank'].id,
+        })
+
+    def test_merge_partners_with_bank_accounts_linked_to_payments(self):
+        wizard = self.env['base.partner.merge.automatic.wizard'].create({})
+        wizard._merge([self.partner1.id, self.partner2.id], self.partner1)
+
+        self.assertFalse(self.partner2.exists(), "Source partner should be deleted after merge")
+        self.assertTrue(self.partner1.exists(), "Destination partner should exist after merge")
+        self.assertEqual(self.payment1.partner_id, self.partner1, "Payment should be linked to the destination partner")
+        self.assertEqual(self.payment2.partner_id, self.partner1, "Payment should be linked to the destination partner")
+        self.assertEqual(self.payment1.partner_bank_id.partner_id, self.partner1, "Payment's bank account should belong to the destination partner")
+        self.assertEqual(self.payment2.partner_bank_id.partner_id, self.partner1, "Payment's bank account should belong to the destination partner")
+
+    def test_merge_partners_with_duplicate_bank_accounts_linked_to_payments(self):
+        wizard = self.env['base.partner.merge.automatic.wizard'].create({})
+        wizard._merge([self.partner1.id, self.partner3.id], self.partner1)
+
+        self.assertFalse(self.partner3.exists(), "Source partner should be deleted after merge")
+        self.assertTrue(self.partner1.exists(), "Destination partner should exist after merge")
+        self.assertEqual(self.payment1.partner_id, self.partner1, "Payment should be linked to the destination partner")
+        self.assertEqual(self.payment3.partner_id, self.partner1, "Payment should be linked to the destination partner")
+        self.assertEqual(self.payment1.partner_bank_id.partner_id, self.partner1, "Payment's bank account should belong to the destination partner")
+        self.assertEqual(self.payment3.partner_bank_id.partner_id, self.partner1, "Payment's bank account should belong to the destination partner")

--- a/odoo/addons/base/tests/__init__.py
+++ b/odoo/addons/base/tests/__init__.py
@@ -58,6 +58,7 @@ from . import test_res_currency
 from . import test_res_country
 from . import test_res_partner
 from . import test_res_partner_bank
+from . import test_res_partner_merge
 from . import test_res_users
 from . import test_reports
 from . import test_test_retry

--- a/odoo/addons/base/tests/test_res_partner_merge.py
+++ b/odoo/addons/base/tests/test_res_partner_merge.py
@@ -1,0 +1,101 @@
+from odoo.tests.common import TransactionCase
+
+
+class TestMergePartner(TransactionCase):
+
+    def setUp(self):
+        super().setUp()
+        self.Partner = self.env['res.partner']
+        self.Bank = self.env['res.partner.bank']
+
+        # Create partners
+        self.partner1 = self.Partner.create({'name': 'Partner 1', 'email': 'partner1@example.com'})
+        self.partner2 = self.Partner.create({'name': 'Partner 2', 'email': 'partner2@example.com'})
+        self.partner3 = self.Partner.create({'name': 'Partner 3', 'email': 'partner3@example.com'})
+
+        # Create bank accounts
+        self.bank1 = self.Bank.create({'acc_number': '12345', 'partner_id': self.partner1.id})
+        self.bank2 = self.Bank.create({'acc_number': '54321', 'partner_id': self.partner2.id})
+        self.bank3 = self.Bank.create({'acc_number': '12345', 'partner_id': self.partner3.id})  # Duplicate account number
+
+        # Create references
+        self.attachment1 = self.env['ir.attachment'].create({
+            'name': 'Attachment 1',
+            'res_model': 'res.partner',
+            'res_id': self.partner1.id,
+        })
+        self.attachment2 = self.env['ir.attachment'].create({
+            'name': 'Attachment 2',
+            'res_model': 'res.partner',
+            'res_id': self.partner2.id,
+        })
+        self.attachment_bank1 = self.env['ir.attachment'].create({
+            'name': 'Attachment Bank 1',
+            'res_model': 'res.partner.bank',
+            'res_id': self.bank1.id,
+        })
+        self.attachment_bank2 = self.env['ir.attachment'].create({
+            'name': 'Attachment Bank 2',
+            'res_model': 'res.partner.bank',
+            'res_id': self.bank2.id,
+        })
+        self.attachment_bank3 = self.env['ir.attachment'].create({
+            'name': 'Attachment Bank 2',
+            'res_model': 'res.partner.bank',
+            'res_id': self.bank3.id,
+        })
+
+    def test_merge_partners_without_bank_accounts(self):
+        """ Test merging partners without any bank accounts """
+        partner4 = self.Partner.create({'name': 'Partner 4', 'email': 'partner4@example.com'})
+        partner5 = self.Partner.create({'name': 'Partner 5', 'email': 'partner5@example.com'})
+        wizard = self.env['base.partner.merge.automatic.wizard'].create({})
+        wizard._merge([partner4.id, partner5.id], partner4)
+        self.assertFalse(partner5.exists(), "Source partner should be deleted after merge")
+        self.assertTrue(partner4.exists(), "Destination partner should exist after merge")
+
+    def test_merge_partners_with_unique_bank_accounts(self):
+        """ Test merging partners with unique bank accounts """
+        wizard = self.env['base.partner.merge.automatic.wizard'].create({})
+        wizard._merge([self.partner1.id, self.partner2.id], self.partner1)
+
+        self.assertFalse(self.partner2.exists(), "Source partner should be deleted after merge")
+        self.assertTrue(self.partner1.exists(), "Destination partner should exist after merge")
+        self.assertEqual(self.bank1.partner_id, self.partner1, "Bank account should belong to destination partner")
+        self.assertEqual(self.bank2.partner_id, self.partner1, "Bank account should be reassigned to destination partner")
+
+    def test_merge_partners_with_duplicate_bank_accounts(self):
+        """ Test merging partners with duplicate bank accounts among themselves """
+        wizard = self.env['base.partner.merge.automatic.wizard'].create({})
+        src_partners = self.partner1 + self.partner3
+        wizard._merge((src_partners + self.partner2).ids, self.partner2)
+
+        self.assertFalse(src_partners.exists(), "Source partners should be deleted after merge")
+        self.assertTrue(self.partner2.exists(), "Destination partner should exist after merge")
+        self.assertRecordValues(self.partner2.bank_ids, [
+            {'acc_number': '12345'},
+            {'acc_number': '54321'},
+        ])
+        self.assertEqual(self.attachment_bank1.res_id, self.bank1.id, "Bank attachment should remain linked to the correct bank account")
+        self.assertEqual(self.attachment_bank3.res_id, self.bank1.id, "Bank attachment should be reassigned to the correct bank account")
+
+    def test_merge_partners_with_duplicate_bank_accounts_with_destination(self):
+        """ Test merging partners with duplicate bank accounts with the destination partner """
+        wizard = self.env['base.partner.merge.automatic.wizard'].create({})
+        wizard._merge([self.partner1.id, self.partner3.id], self.partner1)
+
+        self.assertFalse(self.partner3.exists(), "Source partner should be deleted after merge")
+        self.assertTrue(self.partner1.exists(), "Destination partner should exist after merge")
+        self.assertEqual(len(self.partner1.bank_ids), 1, "There should be a single bank account after merge")
+        self.assertIn(self.bank1, self.partner1.bank_ids, "The original bank account of the destination partner should remain")
+        self.assertFalse(self.bank3.exists(), "The duplicate bank account should have been deleted.")
+
+    def test_merge_partners_with_references(self):
+        """ Test merging partners with references """
+        wizard = self.env['base.partner.merge.automatic.wizard'].create({})
+        wizard._merge([self.partner1.id, self.partner2.id], self.partner1)
+
+        self.assertFalse(self.partner2.exists(), "Source partner should be deleted after merge")
+        self.assertTrue(self.partner1.exists(), "Destination partner should exist after merge")
+        self.assertEqual(self.attachment1.res_id, self.partner1.id, "Attachment should be linked to the destination partner")
+        self.assertEqual(self.attachment2.res_id, self.partner1.id, "Attachment should be reassigned to the destination partner")


### PR DESCRIPTION
Currently, you cannot merge partners if they have bank accounts linked to payments.

### Steps to reproduce

* Install the `account` module.
* Create two partners having the same bank account number.
* Create and post payments for each of those partners.
* Attempt to merge those partners.

You should be met with the following message:
```
The operation cannot be completed: another model requires the record being deleted. If possible, archive it instead.

Model: Journal Entry (account.move)
Constraint: account_move_partner_bank_id_fkey
```

### Cause
When merging partners, the system attempts to update all foreign keys referencing the partners being merged. In certain circumstances, this update violates unicity constraints. In such cases, the system simply deletes the records that can't be updated.

In our case, the `res_partner_bank` table has the following unicity constraint: `unique(sanitized_acc_number, partner_id)`. When we merge the two partners and the system attempts to update the `partner_id` field on `res_partner_bank`, the constraint is violated because both partners originally had the same account number. The system then tries to delete those bank accounts, but it fails because they are linked to payments (with an `ondelete restrict` clause).

### Fix

Identify the bank accounts that are duplicated between the source and destination partners, and merge them before merging the partners.

opw-3925952