### PR TITLE
[FIX] mrp,sale_stock,purchase_stock: fix typo in template t-name synta…

### DIFF
--- a/addons/mrp/static/src/mrp_forecasted/forecasted_buttons.xml
+++ b/addons/mrp/static/src/mrp_forecasted/forecasted_buttons.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <templates xml:space="preserve">
-    <t name="mrp.ForecastedButtons" owl="1" t-inherit="stock.ForecastedButtons" t-inherit-mode="extension">
+    <t t-name="mrp.ForecastedButtons" owl="1" t-inherit="stock.ForecastedButtons" t-inherit-mode="extension">
         <xpath expr="//button[@title='Replenish']" position="after">
             <button t-if="bomId" t-name="mrp_replenish_report_buttons"
                 class="btn btn-primary o_bom_overview_report"

--- a/addons/mrp/static/src/mrp_forecasted/forecasted_details.xml
+++ b/addons/mrp/static/src/mrp_forecasted/forecasted_details.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <templates id="template">
-    <t name="mrp.ForecastedDetails" owl="1" t-inherit="stock.ForecastedDetails" t-inherit-mode="extension">
+    <t t-name="mrp.ForecastedDetails" owl="1" t-inherit="stock.ForecastedDetails" t-inherit-mode="extension">
         <xpath expr="//tr[@name='draft_picking_in']" position="after">
             <tr t-if="props.docs.draft_production_qty.in" name="draft_mo_in">
                 <td colspan="2">Production of Draft MO</td>

--- a/addons/purchase_stock/static/src/purchase_stock_forecasted/forecasted_details.xml
+++ b/addons/purchase_stock/static/src/purchase_stock_forecasted/forecasted_details.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <templates id="template" xml:space="preserve">
-    <t name="purchase_stock.ForecastedDetails" owl="1" t-inherit="stock.ForecastedDetails" t-inherit-mode="extension">
+    <t t-name="purchase_stock.ForecastedDetails" owl="1" t-inherit="stock.ForecastedDetails" t-inherit-mode="extension">
          <xpath expr="//tr[@name='draft_picking_in']" position="after">
             <tr t-if="props.docs.draft_purchase_qty" name="draft_po_in" t-attf-class="#{props.docs.draft_purchase_orders_matched and 'o_grid_match'}">
                 <td colspan="2">Requests for quotation</td>

--- a/addons/sale_stock/static/src/sale_stock_forecasted/forecasted_details.xml
+++ b/addons/sale_stock/static/src/sale_stock_forecasted/forecasted_details.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <templates id="template" xml:space="preserve">
-    <t name="sale_stock.ForecastedDetails" owl="1" t-inherit="stock.ForecastedDetails" t-inherit-mode="extension">
+    <t t-name="sale_stock.ForecastedDetails" owl="1" t-inherit="stock.ForecastedDetails" t-inherit-mode="extension">
         <xpath expr="//tr[@name='draft_picking_out']" position="after">
             <tr t-if="props.docs.draft_sale_qty" name="draft_so_out" t-attf-class="#{props.docs.draft_sale_orders_matched and 'o_grid_match'}">
                 <td colspan="2">Quotations</td>

--- a/addons/stock_account/static/src/stock_account_forecasted/forecasted_header.xml
+++ b/addons/stock_account/static/src/stock_account_forecasted/forecasted_header.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <templates id="template">
-    <t name="stock_account.ForecastedHeader" owl="1" t-inherit="stock.ForecastedHeader" t-inherit-mode="extension">
+    <t t-name="stock_account.ForecastedHeader" owl="1" t-inherit="stock.ForecastedHeader" t-inherit-mode="extension">
         <xpath expr="//h6[@name='product_variants']" position="after">
             <h6 t-if="() => env.user.has_group('stock.group_stock_manager')">
                 Value On Hand:


### PR DESCRIPTION
…xerror

ForecastedDetails template inheritance wrong declaration of name (sale_stock, mrp, purchase_stock)

Steps to Reproduce

customer want to add an additional column to the ForecastedDetails template. customer able to do it to basic template

But not for prepared inheritances in sale_stock, mrp, purchase_stock.

The problem is that system can’t resolve symbol e.g t-inherit="sale_stock.ForecastedDetails”

because somebody declatest in code
```py
<t name="sale_stock.ForecastedDetails" t-inherit="stock.ForecastedDetails" t-inherit-mode="extension"> instead
<t t-name="sale_stock.ForecastedDetails" t-inherit="stock.ForecastedDetails" t-inherit-mode="extension">
```
here is a issue link :- ﻿﻿https://github.com/odoo/odoo/issues/167741

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
