### PR TITLE
[FIX] purchase_stock, dropshipping: no correction on bill

### DIFF
--- a/addons/purchase_stock/models/account_move_line.py
+++ b/addons/purchase_stock/models/account_move_line.py
@@ -131,7 +131,7 @@ class AccountMoveLine(models.Model):
                     sign = 1
                     layers_to_consume = []
                     for layer in qty_to_invoice_per_layer:
-                        if layer.stock_move_id._is_in():
+                        if layer.stock_move_id._is_in() or layer.stock_move_id._is_dropshipped():
                             layers_to_consume.append((layer, qty_to_invoice_per_layer[layer][1]))
                 while float_compare(aml_qty, 0, precision_rounding=product_uom.rounding) > 0 and layers_to_consume:
                     layer, total_layer_qty_to_invoice = layers_to_consume[0]


### PR DESCRIPTION
Usecase to reproduce:
- Automatic valuation, avco or fifo
- Dropship configured
- Do a purchase order for 12$
- Receipt
- Bill at 20$

Current behavior (in interim receipt acc):

debit 20$ for bill and credit 12$ on receipt. Not balanced nor reconcile

Expected behavior:

debit 20$ for bill and credit 12$ on receipt. But with an extra entry of 8$ (balanced with expense). Account balanced and reconciled

It happens because the price diff code only match in move but ignore dropship move. They should behave the same in those case.

opw-3764826

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
