### PR TITLE
[IMP] account: simplify kanban archs

### DIFF
--- a/addons/account/static/tests/legacy/bills_upload.js
+++ b/addons/account/static/tests/legacy/bills_upload.js
@@ -90,10 +90,8 @@ QUnit.module("Widgets", (hooks) => {
         serverData.views["partner,false,kanban"] = `
             <kanban js_class="account_documents_kanban">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="display_name"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="display_name"/>
                     </t>
                 </templates>
             </kanban>`;

--- a/addons/account/views/account_account_views.xml
+++ b/addons/account/views/account_account_views.xml
@@ -109,23 +109,19 @@
             <field name="model">account.account</field>
             <field name="arch" type="xml">
                 <kanban class="o_kanban_mobile">
-                    <field name="name"/>
-                    <field name="code"/>
-                    <field name="account_type"/>
                     <templates>
-                        <t t-name="kanban-box">
-                            <div t-attf-class="oe_kanban_global_click">
-                                <div class="row">
-                                    <div class="col-8">
-                                        <strong><field name="name"/></strong>
-                                    </div>
-                                    <div class="col-4 text-end">
-                                        <span class="badge rounded-pill"><t t-out="record.code.value"/></span>
-                                    </div>
+                        <t t-name="kanban-card">
+                            <div class="row">
+                                <div class="col-8">
+                                    <field class="fw-bolder" name="name"/>
                                 </div>
-                                <div>
-                                    <strong>Type: </strong><t t-out="record.account_type.value"/>
+                                <div class="col-4 text-end">
+                                    <field class="badge rounded-pill" name="code"/>
                                 </div>
+                            </div>
+                            <div>
+                                <strong>Type: </strong>
+                                <field name="account_type"/>
                             </div>
                         </t>
                     </templates>

--- a/addons/account/views/account_journal_views.xml
+++ b/addons/account/views/account_journal_views.xml
@@ -192,16 +192,12 @@
             <field name="arch" type="xml">
                 <kanban class="o_kanban_mobile">
                     <templates>
-                        <t t-name="kanban-box">
-                            <div t-attf-class="oe_kanban_content oe_kanban_global_click">
-                                <div class="row">
-                                    <div class="col-6">
-                                        <strong><field name="name"/></strong>
-                                    </div>
-                                    <div class="col-6">
-                                        <span class="float-end"><field name="type"/></span>
-                                    </div>
-                                </div>
+                        <t t-name="kanban-card" class="row g-0">
+                            <div class="col-6">
+                                <field class="fw-bolder" name="name"/>
+                            </div>
+                            <div class="col-6 ">
+                                <field class="float-end" name="type"/>
                             </div>
                         </t>
                     </templates>

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -94,38 +94,35 @@
             <field name="arch" type="xml">
                 <kanban class="o_kanban_mobile" create="false" group_create="false">
                     <field name="company_currency_id"/>
-                    <field name="partner_id"/>
                     <templates>
-                        <t t-name="kanban-box">
-                            <div class="oe_kanban_global_click">
-                                <div class="row mb4">
-                                    <div class="col-8">
-                                        <field name="account_id"/>
-                                    </div>
-                                    <strong t-if="record.date_maturity.raw_value" class="col-4 ps-0 text-end">
-                                        <i class="fa fa-clock-o" aria-label="Date" role="img" title="Date"/> <field name="date_maturity"/>
-                                    </strong>
+                        <t t-name="kanban-card">
+                            <div class="row mb4">
+                                <div class="col-8">
+                                    <field name="account_id"/>
                                 </div>
-                                <div class="row mb4" style="min-height: 60px;">
-                                    <em class="col-10">
-                                        <field name="name"/>
-                                    </em>
-                                    <div class="col-2 text-end">
-                                        <img t-att-src="kanban_image('res.partner', 'avatar_128', record.partner_id.raw_value)" t-att-title="record.partner_id.value" t-att-alt="record.partner_id.value" class="oe_kanban_avatar o_avatar rounded"/>
-                                    </div>
+                                <strong t-if="record.date_maturity.raw_value" class="col-4 ps-0 text-end">
+                                    <i class="fa fa-clock-o" aria-label="Date" role="img" title="Date"/> <field name="date_maturity"/>
+                                </strong>
+                            </div>
+                            <div class="row mb4" style="min-height: 60px;">
+                                <em class="col-10">
+                                    <field name="name"/>
+                                </em>
+                                <div class="col-2 text-end">
+                                    <field name="partner_id" widget="image" options="{'preview_image': 'avatar_128'}"/>
                                 </div>
-                                <div class="row">
-                                    <div class="col-6">
-                                        <field name="tax_ids" widget="many2many_tags"/>
-                                    </div>
-                                    <div class="col-6 text-end">
-                                        <t t-if="record.debit.raw_value > 0">
-                                            <field name="debit"/><span> (DR)</span>
-                                        </t>
-                                        <t t-if="record.credit.raw_value > 0">
-                                            <field name="credit"/><span> (CR)</span>
-                                        </t>
-                                    </div>
+                            </div>
+                            <div class="row">
+                                <div class="col-6">
+                                    <field name="tax_ids" widget="many2many_tags"/>
+                                </div>
+                                <div class="col-6 text-end">
+                                    <t t-if="record.debit.raw_value > 0">
+                                        <field name="debit"/><span> (DR)</span>
+                                    </t>
+                                    <t t-if="record.credit.raw_value > 0">
+                                        <field name="credit"/><span> (CR)</span>
+                                    </t>
                                 </div>
                             </div>
                         </t>
@@ -644,43 +641,25 @@
             <field name="model">account.move</field>
             <field name="arch" type="xml">
                 <kanban class="o_kanban_mobile" sample="1" js_class="account_documents_kanban">
-                    <field name="move_type" invisible="1"/>
-                    <field name="journal_id"/>
-                    <field name="partner_id"/>
-                    <field name="ref"/>
-                    <field name="date"/>
-                    <field name="state"/>
+                    <field name="currency_id"/>
                     <templates>
-                        <t t-name="kanban-box">
-                            <div t-attf-class="oe_kanban_global_click">
-                                <div class="row mb4">
-                                    <div class="col-6 o_kanban_record_headings">
-                                        <strong>
-                                            <span>
-                                                <field name="partner_id" invisible="not partner_id" readonly="state != 'draft'" />
-                                                <field name="journal_id" invisible="partner_id" />
-                                            </span>
-                                        </strong>
-                                    </div>
-                                    <div class="col-6 text-end">
-                                        <strong><i class="fa fa-clock-o" aria-label="Date" role="img" title="Date"/> <t t-out="record.date.value"/></strong>
-                                    </div>
+                        <t t-name="kanban-card">
+                            <div class="row mb4">
+                                <div class="col-6">
+                                    <field class="fw-bold" name="partner_id" invisible="not partner_id" readonly="state != 'draft'" />
+                                    <field class="fw-bold" name="journal_id" invisible="partner_id" />
                                 </div>
-                                <div class="row">
-                                    <div class="col-12">
-                                        <span><field name="ref"/></span>
-                                    </div>
+                                <div class="col-6 text-end">
+                                    <i class="fa fa-clock-o fw-bold" aria-label="Date" role="img" title="Date"/> <field class="fw-bold" name="date"/>
                                 </div>
-                                <div class="row">
-                                    <div class="col-6">
-                                        <span><field name="amount_total" widget='monetary'/></span>
-                                        <span><field name="currency_id" invisible="1" readonly="state in ['cancel', 'posted']"/></span>
-                                    </div>
-                                    <div class="col-6">
-                                        <span class="float-end">
-                                            <field name="state" widget="label_selection" options="{'classes': {'draft': 'default', 'posted': 'success'}}"/>
-                                        </span>
-                                    </div>
+                            </div>
+                            <field name="ref"/>
+                            <div class="row">
+                                <div class="col-6">
+                                    <field name="amount_total" widget='monetary'/>
+                                </div>
+                                <div class="col-6">
+                                    <field class="float-end" name="state" widget="label_selection" options="{'classes': {'draft': 'default', 'posted': 'success'}}"/>
                                 </div>
                             </div>
                         </t>
@@ -1119,55 +1098,38 @@
                                     </tree>
                                     <kanban class="o_kanban_mobile">
                                         <!-- Displayed fields -->
-                                        <field name="name"/>
-                                        <field name="product_id"/>
-                                        <field name="price_subtotal"
-                                               string="Tax excl."/>
-                                        <field name="price_total"
-                                               string="Tax incl."
-                                               optional="hide"/>
-                                        <field name="quantity"/>
-                                        <field name="product_uom_category_id"/>
-                                        <field name="product_uom_id" groups="uom.group_uom"/>
-                                        <field name="price_unit"/>
                                         <templates>
-                                            <t t-name="kanban-box">
-                                                <div t-attf-class="oe_kanban_card oe_kanban_global_click ps-0 pe-0 {{ record.display_type.raw_value ? 'o_is_' + record.display_type.raw_value : '' }}">
+                                            <t t-name="kanban-card">
+                                                <div t-attf-class="ps-0 pe-0 {{ record.display_type.raw_value ? 'o_is_' + record.display_type.raw_value : '' }}">
                                                     <t t-if="!['line_note', 'line_section'].includes(record.display_type.raw_value)">
                                                         <div class="row g-0">
                                                             <div class="col-2 pe-3">
-                                                                <img t-att-src="kanban_image('product.product', 'image_128', record.product_id.raw_value)" t-att-title="record.product_id.value" t-att-alt="record.product_id.value" style="max-width: 100%;"/>
+                                                                <field name="product_id" widget="image" options="{'preview_image': 'image_128'}" class="w-100"/>
                                                             </div>
                                                             <div class="col-10">
                                                                 <div class="row">
                                                                     <div class="col">
-                                                                        <strong t-out="record.product_id.value"/>
+                                                                        <field class="fw-bold" name="product_id"/>
                                                                     </div>
-                                                                    <div class="col-auto">
-                                                                        <strong class="float-end text-end">
-                                                                            <t t-out="record.price_subtotal.value"/>
-                                                                            <t t-out="record.price_total.value" t-if="tax_calculation_rounding_method == 'round_per_line'"/>
-                                                                        </strong>
+                                                                    <div class="col-auto fw-bold float-end text-end">
+                                                                        <field name="price_subtotal"/>
+                                                                        <field name="price_total" t-if="tax_calculation_rounding_method == 'round_per_line'"/>
                                                                     </div>
                                                                 </div>
                                                                 <div class="text-muted">
                                                                     Quantity:
-                                                                    <t t-out="record.quantity.value"/>
-                                                                    <t t-out="record.product_uom_id.value" groups="uom.group_uom"/>
+                                                                    <field name="quantity"/>
+                                                                    <field name="product_uom_id" groups="uom.group_uom"/>
                                                                 </div>
                                                                 <div class="text-muted">
                                                                     Unit Price:
-                                                                    <t t-out="record.price_unit.value"/>
+                                                                    <field name="price_unit"/>
                                                                 </div>
                                                             </div>
                                                         </div>
                                                     </t>
                                                     <t t-if="record.display_type.raw_value === 'line_section' || record.display_type.raw_value === 'line_note'">
-                                                        <div class="row">
-                                                            <div class="col-12">
-                                                                <t t-out="record.name.value"/>
-                                                            </div>
-                                                        </div>
+                                                        <field name="name"/>
                                                     </t>
                                                 </div>
                                             </t>

--- a/addons/account/views/account_payment_term_views.xml
+++ b/addons/account/views/account_payment_term_views.xml
@@ -105,14 +105,10 @@
             <field name="model">account.payment.term</field>
             <field name="arch" type="xml">
                 <kanban class="o_kanban_mobile">
-                    <field name="name"/>
-                    <field name="note"/>
                     <templates>
-                        <t t-name="kanban-box">
-                            <div t-attf-class="oe_kanban_global_click">
-                                <div><strong class="o_kanban_record_title"><t t-out="record.name.value"/></strong></div>
-                                <div t-if="!widget.isHtmlEmpty(record.note.raw_value)"><t t-out="record.note.value"/></div>
-                            </div>
+                        <t t-name="kanban-card">
+                            <field class="fw-bolder fs-5" name="name"/>
+                            <field t-if="!widget.isHtmlEmpty(record.note.raw_value)" name="note"/>
                         </t>
                     </templates>
                 </kanban>

--- a/addons/account/views/account_payment_view.xml
+++ b/addons/account/views/account_payment_view.xml
@@ -60,36 +60,24 @@
             <field name="model">account.payment</field>
             <field name="arch" type="xml">
                 <kanban class="o_kanban_mobile" create="0" group_create="0" sample="1">
-                    <field name="name"/>
-                    <field name="partner_id"/>
-                    <field name="date"/>
-                    <field name="state"/>
                     <templates>
-                        <t t-name="kanban-box">
-                            <div t-attf-class="oe_kanban_global_click">
-                                <div class="row mb4">
-                                    <div class="col-6">
-                                        <strong><span><field name="name"/></span></strong>
-                                    </div>
-                                    <div class="col-6 text-end">
-                                        <strong><i class="fa fa-clock-o" role="img" aria-label="Date" title="Date"/> <t t-out="record.date.value"/></strong>
-                                    </div>
+                        <t t-name="kanban-card">
+                            <div class="row mb4">
+                                <div class="col-6">
+                                   <field class="fw-bolder" name="name"/>
                                 </div>
-                                <div class="row">
-                                    <div class="col-12">
-                                        <span><field name="partner_id"/></span>
-                                    </div>
+                                <div class="col-6 text-end">
+                                    <i class="fa fa-clock-o fw-bold" role="img" aria-label="Date" title="Date"/> <field class="fw-bold" name="date"/>
                                 </div>
-                                <div class="row">
-                                    <div class="col-6">
-                                        <field name="amount" widget='monetary'/>
-                                        <field name="currency_id" invisible="1"/>
-                                    </div>
-                                    <div class="col-6">
-                                        <span class="float-end">
-                                            <field name="state" widget="label_selection" options="{'classes': {'draft': 'secondary', 'sent': 'success'}}"/>
-                                        </span>
-                                    </div>
+                            </div>
+                            <field name="partner_id"/>
+                            <div class="row">
+                                <div class="col-6">
+                                    <field name="amount" widget='monetary'/>
+                                    <field name="currency_id" invisible="1"/>
+                                </div>
+                                <div class="col-6">
+                                    <field class="float-end" name="state" widget="label_selection" options="{'classes': {'draft': 'secondary', 'sent': 'success'}}"/>
                                 </div>
                             </div>
                         </t>

--- a/addons/account/views/account_tax_views.xml
+++ b/addons/account/views/account_tax_views.xml
@@ -71,28 +71,18 @@
             <field name="model">account.tax</field>
             <field name="arch" type="xml">
                 <kanban class="o_kanban_mobile">
-                    <field name="name"/>
-                    <field name="type_tax_use"/>
-                    <field name="tax_scope"/>
-                    <field name="description"/>
                     <templates>
-                        <t t-name="kanban-box">
-                            <div t-attf-class="oe_kanban_card oe_kanban_global_click">
-                                <div class="row mb4">
-                                    <div class="col-6">
-                                        <strong><span><t t-out="record.name.value"/></span></strong>
-                                    </div>
-                                    <div class="col-6 text-end">
-                                        <span class="badge rounded-pill"><t t-out="record.type_tax_use.value"/></span>
-                                        <span class="badge rounded-pill"><t t-out="record.tax_scope.value"/></span>
-                                    </div>
+                        <t t-name="kanban-card">
+                            <div class="row mb4">
+                                <div class="col-6">
+                                    <field class="fw-bolder" name="name"/>
                                 </div>
-                                <div class="row mb4">
-                                    <div class="col-12">
-                                        <span class="text-muted" t-out="record.description.value"/>
-                                    </div>
+                                <div class="col-6 text-end">
+                                    <field class="badge rounded-pill" name="type_tax_use"/>
+                                    <field class="badge rounded-pill" name="tax_scope"/>
                                 </div>
                             </div>
+                            <field class="text-muted" name="description"/>
                         </t>
                     </templates>
                 </kanban>


### PR DESCRIPTION
In this commit we have simplified the kanban arch for the account module.the goal is to simplify them, make them easier to read, and use bootstrap utility classnames.
- Previously, we used `kanban-box`, but now we are using `kanban-card` instead.
- Deprecated `oe_kanban_global_click` and `oe_kanban_global_click_edit`.
- More use of `<field/>` tags
- Removed the `oe_kanban_colorpicker` class and replaced it with the `kanban_color_picker` widget.
- Changed type='edit' to type='open' to open records. since version 16, records always open in edit mode by default.

Task:3992107

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
