### PR TITLE
[FIX] point_of_sale: send display background image with IOT

### DIFF
--- a/addons/point_of_sale/models/__init__.py
+++ b/addons/point_of_sale/models/__init__.py
@@ -7,6 +7,7 @@ from . import account_journal
 from . import account_tax
 from . import account_move
 from . import barcode_rule
+from . import binary
 from . import chart_template
 from . import digest
 from . import pos_category

--- a/addons/point_of_sale/models/binary.py
+++ b/addons/point_of_sale/models/binary.py
@@ -1,0 +1,13 @@
+from odoo import http
+from odoo.http import request
+from odoo.addons.web.controllers.binary import Binary
+
+
+class PointOfSaleBinary(Binary):
+    @http.route([
+        '/web/image/pos.config/<id>/<string:field>',
+        '/web/image/pos.config/<id>/<string:field>/<int:width>x<int:height>'], type='http', auth="public")
+    def point_of_sale_content_image(self, field='raw', **kwargs):
+        if request.env.user._is_public() and field == 'iface_customer_facing_display_background_image_1920':
+            request.env = request.env(su=True)
+        return super().content_image(field=field, model='pos.config', **kwargs)

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1151,6 +1151,13 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'MultiProductOptionsTour', login="pos_user")
 
+    def test_customer_display_as_public(self):
+        self.main_pos_config.iface_customer_facing_display = True
+        self.main_pos_config.iface_customer_facing_display_background_image_1920 = b'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGNgYGAAAAAEAAH2FzhVAAAAAElFTkSuQmCC'
+        response = self.url_open(f"/web/image/pos.config/{self.main_pos_config.id}/iface_customer_facing_display_background_image_1920")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue('Shop.png' in response.headers['Content-Disposition'])
+
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):
     browser_size = '375x667'


### PR DESCRIPTION
Currently, when using the customer display feature with a display connected to an IoT box, the background image is not used. Instead the placeholder image is used.

Steps to reproduce:
-------------------
* Install and configure an IoT box
* Go to **Point of Sale**
* Select the Shop, edit it
* Check `IoT Box`
* Configure `Customer Display`
* Now go to the settings of the Shop
* Enable `Customer Display` if not already done previously
* Upload a background image, save
* Open the Shop session
* Select the customer display

> Observation: The background image is not shown.

Why the fix:
------------
When using the customer display feature with the IoT box, the request is done with a Public User:
https://github.com/odoo/odoo/blob/f7e3ada5ed290a6f418e4e1a2abddfb9f242270c/addons/web/controllers/binary.py#L171-L176

Since Public Users don't have reading access on the `pos.config` model, access rights & rules are triggered:
https://github.com/odoo/odoo/blob/f7e3ada5ed290a6f418e4e1a2abddfb9f242270c/odoo/addons/base/models/ir_binary.py#L52-L58

Since we failed the try block, we end up loading the placehorder image by default:
https://github.com/odoo/odoo/blob/f7e3ada5ed290a6f418e4e1a2abddfb9f242270c/addons/web/controllers/binary.py#L185

We want the field `iface_customer_facing_display_background_image_1920` to be available to public user. In the case we are trying to access it with a public user, we make the request in sudo. Sudo environment stops existing once the request is made.

opw-3873765
