### PR TITLE
[FIX] stock: 'picked' to False on Done stock.move(.line)

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -611,6 +611,8 @@ Please change the quantity done or the rounding precision of your unit of measur
             picking_id = self.env['stock.picking'].browse(vals.get('picking_id'))
             if picking_id.group_id and 'group_id' not in vals:
                 vals['group_id'] = picking_id.group_id.id
+            if vals.get('state') == 'done':
+                vals['picked'] = True
         return super().create(vals_list)
 
     def write(self, vals):

--- a/addons/stock_account/tests/test_stockvaluation.py
+++ b/addons/stock_account/tests/test_stockvaluation.py
@@ -1959,6 +1959,31 @@ class TestStockValuation(TestStockValuationBase):
         self._make_in_move(product, 1, unit_cost=77)
         self.assertEqual(product.standard_price, 77)
 
+    def test_create_done_move(self):
+        """Stock Move created directly in Done state must impact de valuation."""
+        self.product1.categ_id.property_cost_method = 'average'
+        self.env['stock.move'].create({
+            'name': '',
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
+            'product_id': self.product1.id,
+            'product_uom': self.uom_unit.id,
+            'product_uom_qty': 8.0,
+            'price_unit': 1,
+            'state': 'done',
+            'move_line_ids': [(0, 0, {
+                'product_id': self.product1.id,
+                'location_id': self.supplier_location.id,
+                'location_dest_id': self.stock_location.id,
+                'product_uom_id': self.uom_unit.id,
+                'quantity': 8.0,
+                'state': 'done',
+            })]
+        })
+        self.assertEqual(self.product1.qty_available, 8.0)
+        self.assertEqual(self.product1.quantity_svl, 8.0)
+        self.assertEqual(self.product1.value_svl, 8.0)
+
     def test_average_perpetual_1(self):
         # http://accountingexplained.com/financial/inventories/avco-method
         self.product1.categ_id.property_cost_method = 'average'


### PR DESCRIPTION
When unlocking a picking and adding a new line, the 'picked' field would be False for both the new stock.move and stock.move.line. The main issue it creates is that no stock.valuation.layer would be created on stock_account.

https://github.com/odoo/odoo/assets/29302288/f11b7122-dd64-40f3-a0c3-1de6f442c9b7

OPW-3980565

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
