### PR TITLE
[FIX] pos_self_order: allow access to combo choices and product attributes in consultation

### DIFF
--- a/addons/pos_self_order/static/src/app/components/product_card/product_card.js
+++ b/addons/pos_self_order/static/src/app/components/product_card/product_card.js
@@ -88,7 +88,7 @@ export class ProductCard extends Component {
     async selectProduct(qty = 1) {
         const product = this.props.product;
 
-        if (!this.selfOrder.ordering || !product.self_order_available) {
+        if (!product.self_order_available) {
             return;
         }
 
@@ -97,6 +97,9 @@ export class ProductCard extends Component {
         } else if (product.attributes.length > 0) {
             this.router.navigate("product", { id: product.id });
         } else {
+            if (!this.selfOrder.ordering) {
+                return;
+            }
             this.flyToCart();
             this.scaleUpPrice();
             const isProductInCart = this.selfOrder.currentOrder.lines.find(

--- a/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.xml
@@ -104,7 +104,7 @@
             </div>
             <t t-if="state.showResume">
                 <div class="bg-view p-3 text-end">
-                    <div class="o_self_order_incr_button btn-group" role="group" aria-label="Quantity select">
+                    <div t-if="selfOrder.ordering" class="o_self_order_incr_button btn-group" role="group" aria-label="Quantity select">
                         <button type="button"
                             t-on-click = "() => this.changeQuantity(false)"
                             t-attf-class="btn btn-secondary btn-lg"><span class="fs-2 lh-1 fa-fw d-inline-block">－</span></button>
@@ -120,7 +120,7 @@
             t-if="state.showResume || (!state.showResume and showQtyButtons)"
             class="page-buttons d-flex justify-content-end gap-3 p-3 border-top bg-view">
             <button t-if="!state.showResume and showQtyButtons" class="btn btn-primary btn-lg" t-on-click="next">Next</button>
-            <button t-if="state.showResume" class="btn btn-primary btn-lg" t-on-click="addToCart">Add to cart</button>
+            <button t-if="state.showResume and selfOrder.ordering" class="btn btn-primary btn-lg" t-on-click="addToCart">Add to cart</button>
         </div>
     </t>
 </templates>

--- a/addons/pos_self_order/static/src/app/pages/product_page/product_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/product_page/product_page.xml
@@ -37,7 +37,7 @@
                     product="product"/>
             </div>
 
-            <div t-if="showQtyButtons" class="p-3 text-end">
+            <div t-if="showQtyButtons and selfOrder.ordering" class="p-3 text-end">
                 <div class="o_self_order_incr_button btn-group " role="group" aria-label="Quantity select">
                     <button type="button"
                         t-on-click = "() => this.changeQuantity(false)"
@@ -50,7 +50,7 @@
             </div>
 
             <div t-if="showQtyButtons and !props.onValidate" class="page-buttons d-flex justify-content-end p-3 gap-3 bg-view border-top">
-                <button t-if="showQtyButtons and !props.onValidate" class="btn btn-primary btn-lg" t-att-class="{ 'disabled': this.isEveryValueSelected() }" t-on-click="addToCart">Add to cart</button>
+                <button t-if="showQtyButtons and !props.onValidate and selfOrder.ordering" class="btn btn-primary btn-lg" t-att-class="{ 'disabled': this.isEveryValueSelected() }" t-on-click="addToCart">Add to cart</button>
             </div>
         </div>
     </t>

--- a/addons/pos_self_order/static/tests/helpers/product_page.js
+++ b/addons/pos_self_order/static/tests/helpers/product_page.js
@@ -20,13 +20,14 @@ export function clickCancel() {
     ];
 }
 
-export function setupAttribute(attributes) {
-    const steps = [
-        {
+export function setupAttribute(attributes, addToCart=true) {
+    const steps = [];
+    if (addToCart) {
+        steps.push({
             content: `Click on 'Add to cart' button`,
             trigger: `.btn.btn-primary`,
-        },
-    ];
+        })
+    }
 
     for (const attr of attributes) {
         steps.unshift({
@@ -38,7 +39,7 @@ export function setupAttribute(attributes) {
     return steps;
 }
 
-export function setupCombo(products) {
+export function setupCombo(products, addToCart=true) {
     const steps = [];
 
     for (const product of products) {
@@ -49,10 +50,12 @@ export function setupCombo(products) {
         }
     }
 
-    steps.push({
-        content: `Click on 'Add to cart' button`,
-        trigger: `.btn.btn-primary`,
-    });
+    if (addToCart) {
+        steps.push({
+            content: `Click on 'Add to cart' button`,
+            trigger: `.btn.btn-primary`,
+        });
+    }
 
     return steps;
 }

--- a/addons/pos_self_order/static/tests/tours/test_self_order_common.js
+++ b/addons/pos_self_order/static/tests/tours/test_self_order_common.js
@@ -24,3 +24,42 @@ registry.category("web_tour.tours").add("self_order_is_open_consultation", {
         Utils.checkIsNoBtn("Order"),
     ],
 });
+
+registry.category("web_tour.tours").add("self_order_pos_is_closed", {
+    test: true,
+    steps: () => [
+        LandingPage.isClosed(),
+        // Normal product
+        Utils.clickBtn("Order Now"),
+        ProductPage.clickProduct("Coca-Cola"),
+        Utils.checkIsNoBtn("Order"),
+        // Product with attributes
+        ProductPage.clickProduct("Desk Organizer"),
+        ...ProductPage.setupAttribute([
+            { name: "Size", value: "M" },
+            { name: "Fabric", value: "Leather" },
+        ], false),
+        Utils.checkIsNoBtn("Add to cart"),
+        Utils.clickBtn("Discard"),
+        // Combo product
+        ProductPage.clickProduct("Office Combo"),
+        ...ProductPage.setupCombo([
+            {
+                product: "Desk Organizer",
+                attributes: [
+                    { name: "Size", value: "M" },
+                    { name: "Fabric", value: "Leather" },
+                ],
+            },
+            {
+                product: "Combo Product 5",
+                attributes: [],
+            },
+            {
+                product: "Combo Product 8",
+                attributes: [],
+            },
+        ], false),
+        Utils.checkIsNoBtn("Add to cart"),
+    ],
+});

--- a/addons/pos_self_order/tests/test_self_order_common.py
+++ b/addons/pos_self_order/tests/test_self_order_common.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import odoo.tests
+from odoo.addons.point_of_sale.tests.common_setup_methods import setup_pos_combo_items
 from odoo.addons.pos_self_order.tests.self_order_common_test import SelfOrderCommonTest
 
 
@@ -29,3 +30,21 @@ class TestSelfOrderCommon(SelfOrderCommonTest):
         # Verify behavior when self Order is opened
         self.pos_config.with_user(self.pos_user).open_ui()
         self.start_tour(self_route, "self_order_is_open_consultation")
+
+    def test_self_order_pos_closed(self):
+        """
+        Verify than when the pos is closed and self ordering is set to mobile, consultation or kiosk,
+        we can see the attributes of a product or the choices of a combo
+        """
+        setup_pos_combo_items(self)
+        desk_organizer_with_attributes_combo_line = self.env["pos.combo.line"].create({
+            "product_id": self.desk_organizer.id,
+            "combo_price": 0,
+        })
+        self.desk_accessories_combo.combo_line_ids += desk_organizer_with_attributes_combo_line
+
+        self_route = self.pos_config._get_self_order_route()
+
+        for mode in ("mobile", "consultation", "kiosk"):
+            self.pos_config.write({"self_ordering_mode": mode})
+            self.start_tour(self_route, "self_order_pos_is_closed")


### PR DESCRIPTION
Current behavior:
When the restaurant is closed and "Self Ordering" is set to "QR menu + ordering", we can't access the combo choices and product attributes. Same issue when "Self Ordering" is set to "QR menu" (restaurant can be opened or closed)

Steps to reproduce:
- Install "Point of Sale" app and "pos_restaurant" module
- In the settings, set "Self Ordering" to "QR menu + Ordering" and save
- Click on "Preview Web interface"
- Click on the button to access the products
- You can't see the attributes of a product or the possibilities of a combo when click on these products

Solution:
Allow to access the next steps for combo or product with attributes and remove button "Add to cart" if we shouldn't process a command

opw-3854839


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
