### PR TITLE
[REF] point_of_sale: use draggable hook

### DIFF
--- a/addons/point_of_sale/static/src/app/debug/debug_widget.xml
+++ b/addons/point_of_sale/static/src/app/debug/debug_widget.xml
@@ -3,7 +3,10 @@
 
     <t t-name="point_of_sale.DebugWidget">
         <Transition visible="props.state.showWidget" name="'o-fade'" leaveDuration="200" t-slot-scope="transition">
-            <div class="debug-widget bg-100 p-2 shadow-lg" t-att-class="transition.className" t-ref="root" t-att-style="style">
+            <div class="debug-widget bg-100 p-2 position-absolute shadow-lg" t-att-class="transition.className" t-ref="root" t-att-style="`
+                top: ${this.position.top}px;
+                left: ${this.position.left}px;
+            `">
                 <header class="drag-handle">
                     <h2>Debug Window</h2>
                 </header>


### PR DESCRIPTION
In the `point_of_sale` there is a dialog window that is draggable by the user, but which uses a custom hook for achieving the dragging behavior.

In this commit we refactor the dialog window such that it now uses the default draggable hook from `web`.

This will allow us to remove the custom dragging implementation from pos in a future commit.

Task: 3997485





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
