### PR TITLE
[FIX] web: askChanges before discard

### DIFF
--- a/addons/web/static/src/model/relational_model/dynamic_list.js
+++ b/addons/web/static/src/model/relational_model/dynamic_list.js
@@ -118,7 +118,9 @@ export class DynamicList extends DataPoint {
         if (this.editedRecord) {
             let canProceed = true;
             if (discard) {
+                this._recordToDiscard = this.editedRecord;
                 await this.editedRecord.discard();
+                this._recordToDiscard = null;
                 if (this.editedRecord && this.editedRecord.isNew) {
                     this._removeRecords([this.editedRecord.id]);
                 }
@@ -261,7 +263,7 @@ export class DynamicList extends DataPoint {
 
     async _multiSave(record) {
         const changes = record._getChanges();
-        if (!Object.keys(changes).length) {
+        if (!Object.keys(changes).length || record === this._recordToDiscard) {
             return;
         }
         const validSelection = this.selection.filter((record) => {

--- a/addons/web/static/src/model/relational_model/record.js
+++ b/addons/web/static/src/model/relational_model/record.js
@@ -179,10 +179,11 @@ export class Record extends DataPoint {
         });
     }
 
-    discard() {
+    async discard() {
         if (this.model._closeUrgentSaveNotification) {
             this.model._closeUrgentSaveNotification();
         }
+        await this.model._askChanges();
         return this.model.mutex.exec(() => this._discard());
     }
 
@@ -1115,7 +1116,12 @@ export class Record extends DataPoint {
         if (canProceed === false) {
             return;
         }
-        if (this.selected && this.model.multiEdit && !this._invalidFields.has(fieldName)) {
+        if (
+            this.selected &&
+            this.model.multiEdit &&
+            this.model.root._recordToDiscard !== this &&
+            !this._invalidFields.has(fieldName)
+        ) {
             await this.model.dialog.add(AlertDialog, {
                 body: _t("No valid record to save"),
                 confirm: async () => {

--- a/addons/web/static/tests/legacy/views/list_view_tests.js
+++ b/addons/web/static/tests/legacy/views/list_view_tests.js
@@ -1,28 +1,31 @@
 /** @odoo-module alias=@web/../tests/views/list_view_tests default=false */
 
-import { Component, markup, onRendered, onWillStart, xml } from "@odoo/owl";
+import { Component, markup, onRendered, onWillStart, useRef, xml } from "@odoo/owl";
+import { AutoComplete } from "@web/core/autocomplete/autocomplete";
 import { browser } from "@web/core/browser/browser";
-import { Domain } from "@web/core/domain";
 import { currencies } from "@web/core/currency";
+import { Domain } from "@web/core/domain";
 import { errorService } from "@web/core/errors/error_service";
 import { localization } from "@web/core/l10n/localization";
 import { registry } from "@web/core/registry";
 import { tooltipService } from "@web/core/tooltip/tooltip_service";
 import { uiService } from "@web/core/ui/ui_service";
+import { useBus } from "@web/core/utils/hooks";
 import { getNextTabableElement } from "@web/core/utils/ui";
+import { RelationalModel } from "@web/model/relational_model/relational_model";
 import { session } from "@web/session";
 import { floatField } from "@web/views/fields/float/float_field";
-import { AutoComplete } from "@web/core/autocomplete/autocomplete";
 import { Many2XAutocomplete } from "@web/views/fields/relational_utils";
+import { standardFieldProps } from "@web/views/fields/standard_field_props";
 import { textField } from "@web/views/fields/text/text_field";
 import { ListController } from "@web/views/list/list_controller";
-import { RelationalModel } from "@web/model/relational_model/relational_model";
 import { actionService } from "@web/webclient/actions/action_service";
 import { getPickerApplyButton, getPickerCell } from "../core/datetime/datetime_test_helpers";
+import { makeServerError } from "../helpers/mock_server";
 import {
     makeFakeLocalizationService,
-    patchUserWithCleanup,
     patchUserContextWithCleanup,
+    patchUserWithCleanup,
 } from "../helpers/mock_services";
 import {
     addRow,
@@ -51,24 +54,23 @@ import {
 import {
     editFavoriteName,
     editPager,
-    getVisibleButtons,
     getFacetTexts,
     getPagerLimit,
     getPagerValue,
+    getVisibleButtons,
     groupByMenu,
     pagerNext,
     pagerPrevious,
     removeFacet,
     saveFavorite,
     toggleActionMenu,
-    toggleSearchBarMenu,
     toggleMenuItem,
     toggleSaveFavorite,
+    toggleSearchBarMenu,
     validateSearch,
 } from "../search/helpers";
 import { createWebClient, doAction } from "../webclient/helpers";
 import { makeView, makeViewInDialog, setupViewRegistries } from "./helpers";
-import { makeServerError } from "../helpers/mock_server";
 
 const fieldRegistry = registry.category("fields");
 const serviceRegistry = registry.category("services");
@@ -778,7 +780,7 @@ QUnit.module("Views", (hooks) => {
         assert.containsNone(target, ".o_list_export_xlsx");
     });
 
-   QUnit.test("hide duplicate action for user without create access rights", async (assert) => {
+    QUnit.test("hide duplicate action for user without create access rights", async (assert) => {
         await makeView({
             type: "list",
             resModel: "foo",
@@ -2183,11 +2185,12 @@ QUnit.module("Views", (hooks) => {
             });
 
             assert.strictEqual(
-                target.querySelector(".o_group_header th").getAttribute("colspan"), "2"
+                target.querySelector(".o_group_header th").getAttribute("colspan"),
+                "2"
             );
             assert.strictEqual(
                 target.querySelector(".o_group_header th:last-child").getAttribute("colspan"),
-                "2",
+                "2"
             );
         }
     );
@@ -2210,11 +2213,12 @@ QUnit.module("Views", (hooks) => {
             });
 
             assert.strictEqual(
-                target.querySelector(".o_group_header th").getAttribute("colspan"), "2"
+                target.querySelector(".o_group_header th").getAttribute("colspan"),
+                "2"
             );
             assert.strictEqual(
                 target.querySelector(".o_group_header th:last-child").getAttribute("colspan"),
-                "1",
+                "1"
             );
         }
     );
@@ -2381,7 +2385,7 @@ QUnit.module("Views", (hooks) => {
             groupBy: ["m2m"],
         });
 
-        const groups = target.querySelectorAll(".o_group_name")
+        const groups = target.querySelectorAll(".o_group_name");
         await click(groups[1]); // open second group
         await click(groups[2]); // open third group
         // Check for the initial number of records
@@ -2427,7 +2431,7 @@ QUnit.module("Views", (hooks) => {
             groupBy: ["m2m"],
         });
 
-        const groups = target.querySelectorAll(".o_group_name")
+        const groups = target.querySelectorAll(".o_group_name");
         await click(groups[1]); // open second group
         await click(groups[2]); // open third group
         // Check for the initial number of records
@@ -2472,7 +2476,7 @@ QUnit.module("Views", (hooks) => {
             groupBy: ["m2m"],
         });
 
-        const groups = target.querySelectorAll(".o_group_name")
+        const groups = target.querySelectorAll(".o_group_name");
         await click(groups[1]); // open second group
         await click(groups[2]); // open third group
         // Check for the initial number of records
@@ -2506,8 +2510,8 @@ QUnit.module("Views", (hooks) => {
         serverData.models.foo.fields.m2m.groupable = true;
         // creating archived records
         serverData.models.foo.records = [
-            { id: 1, foo: 'First record', m2m: [1, 2], active: false },
-            { id: 2, foo: 'Second record', m2m: [1, 2], active: false },
+            { id: 1, foo: "First record", m2m: [1, 2], active: false },
+            { id: 2, foo: "Second record", m2m: [1, 2], active: false },
         ];
 
         await makeView({
@@ -2522,10 +2526,10 @@ QUnit.module("Views", (hooks) => {
             actionMenus: {},
             groupBy: ["m2m"],
             // apply the filter to show only records with active = false
-            domain: [['active', '=', false]]
+            domain: [["active", "=", false]],
         });
 
-        const groups = target.querySelectorAll(".o_group_name")
+        const groups = target.querySelectorAll(".o_group_name");
         await click(groups[0]); // open first group
         await click(groups[1]); // open second group
         // Check for the initial number of records
@@ -7908,13 +7912,9 @@ QUnit.module("Views", (hooks) => {
             noContentHelp: "click new to add a foo",
         });
 
-        assert.containsOnce(
-            target,
-            ".o_view_nocontent",
-            "should display the no content helper"
-        );
+        assert.containsOnce(target, ".o_view_nocontent", "should display the no content helper");
         assert.containsN(
-            target.querySelector('.o_list_view table tbody'),
+            target.querySelector(".o_list_view table tbody"),
             "tr",
             0,
             "should not have any empty rows"
@@ -12366,16 +12366,10 @@ QUnit.module("Views", (hooks) => {
         assert.containsOnce(document.body, ".modal", "should have open the modal");
 
         await click(target.querySelector(".modal .o_data_row .o_field_cell"));
-        assert.containsOnce(
-            target,
-            "[role='alert']",
-            "should have open the confirmation modal"
-        );
+        assert.containsOnce(target, "[role='alert']", "should have open the confirmation modal");
         assert.containsN(target, ".o_field_many2many_tags .badge", 6);
         assert.strictEqual(
-            target
-                .querySelector(".o_field_many2many_tags .badge:nth-child(2)")
-                .textContent.trim(),
+            target.querySelector(".o_field_many2many_tags .badge:nth-child(2)").textContent.trim(),
             "Value 2",
             "should have display_name in badge"
         );
@@ -12498,6 +12492,84 @@ QUnit.module("Views", (hooks) => {
                 $(target).find(".o_data_row:first() .o_data_cell:first()").text(),
                 "yop"
             );
+        }
+    );
+
+    QUnit.test(
+        "discard has to wait for changes in each field in multi edit",
+        async function (assert) {
+            const def = new makeDeferred();
+            class CustomField extends Component {
+                static template = xml`<input t-ref="input" t-att-value="value" t-on-blur="onBlur" t-on-input="onInput" />`;
+                static props = {
+                    ...standardFieldProps,
+                };
+                setup() {
+                    this.input = useRef("input");
+                    useBus(this.props.record.model.bus, "NEED_LOCAL_CHANGES", ({ detail }) =>
+                        detail.proms.push(this.updateValue())
+                    );
+                }
+
+                get value() {
+                    return this.props.record.data[this.props.name];
+                }
+
+                async updateValue() {
+                    if (!this.isDirty) {
+                        return;
+                    }
+                    const value = this.input.el.value;
+                    await def;
+                    await this.props.record.update({ [this.props.name]: `update value: ${value}` });
+                }
+
+                onBlur() {
+                    return this.updateValue();
+                }
+
+                onInput() {
+                    this.isDirty = true;
+                    this.props.record.model.bus.trigger("FIELD_IS_DIRTY", true);
+                }
+            }
+            registry.category("fields").add("custom", { component: CustomField });
+            await makeView({
+                type: "list",
+                arch: `
+                    <tree editable="top" multi_edit="1">
+                        <field name="foo" widget="custom"/>
+                    </tree>`,
+                serverData,
+                resModel: "foo",
+            });
+
+            // select two records
+            const rows = target.querySelectorAll(".o_data_row");
+            await click(rows[0], ".o_list_record_selector input");
+            await click(rows[1], ".o_list_record_selector input");
+            await click(rows[0].querySelector(".o_data_cell"));
+            target.querySelector(".o_data_row .o_data_cell input").value = "oof";
+
+            const discardButton = $(".o_list_button_discard:visible").get(0);
+            // Simulates an actual click (event chain is: mousedown > change > blur > focus > mouseup > click)
+            await triggerEvents(discardButton, null, ["mousedown"]);
+            await triggerEvents(target.querySelector(".o_data_row .o_data_cell input"), null, [
+                "input",
+                "change",
+                "blur",
+                "focusout",
+            ]);
+            await triggerEvents(discardButton, null, ["focus"]);
+            await triggerEvents(discardButton, null, ["mouseup"]);
+            await click(discardButton);
+            assert.containsNone(document.body, ".modal", "should not open modal");
+            assert.strictEqual(target.querySelector(".o_data_row .o_data_cell input").value, "oof");
+
+            def.resolve();
+            await nextTick();
+            assert.containsNone(document.body, ".modal", "should not open modal");
+            assert.strictEqual(target.querySelector(".o_data_row .o_data_cell input").value, "yop");
         }
     );
 
@@ -16897,7 +16969,7 @@ QUnit.module("Views", (hooks) => {
             // optional columns.
             assert.verifySteps([
                 "setItem " + localStorageKey + ' to "m2o,reference"',
-                "getItem optional_fields,foo,list,42,foo,m2o,reference"
+                "getItem optional_fields,foo,list,42,foo,m2o,reference",
             ]);
 
             // 5 th (1 for checkbox, 3 for columns, 1 for optional columns)
@@ -16984,14 +17056,10 @@ QUnit.module("Views", (hooks) => {
                 "dropdown has 2 optional column headers"
             );
             // disable optional field "reference" (no optional column enabled)
-            await click(
-                target.querySelectorAll(
-                    ".o-dropdown--menu span.dropdown-item input"
-                )[1]
-            );
+            await click(target.querySelectorAll(".o-dropdown--menu span.dropdown-item input")[1]);
             assert.verifySteps([
                 "setItem " + localStorageKey + ' to ""',
-                "getItem optional_fields,foo,list,42,foo,m2o,reference"
+                "getItem optional_fields,foo,list,42,foo,m2o,reference",
             ]);
             verifyHeaders(["foo"]);
             // mount again to ensure that active optional columns will not be reset while empty
@@ -19742,54 +19810,60 @@ QUnit.module("Views", (hooks) => {
         assert.containsOnce(target, ".o_list_table thead th.o_list_actions_header");
     });
 
-    QUnit.test("properties: optional show/hide (at reload, config from local storage)", async (assert) => {
-        const definition = {
-            type: "char",
-            name: "property_char",
-            string: "Property char",
-        };
-        serverData.models.bar.records[0].definitions = [definition];
-        for (const record of serverData.models.foo.records) {
-            if (record.m2o === 1) {
-                record.properties = [{ ...definition, value: "0" }];
+    QUnit.test(
+        "properties: optional show/hide (at reload, config from local storage)",
+        async (assert) => {
+            const definition = {
+                type: "char",
+                name: "property_char",
+                string: "Property char",
+            };
+            serverData.models.bar.records[0].definitions = [definition];
+            for (const record of serverData.models.foo.records) {
+                if (record.m2o === 1) {
+                    record.properties = [{ ...definition, value: "0" }];
+                }
             }
-        }
 
-        patchWithCleanup(browser.localStorage, {
-            getItem(key) {
-                return "properties.property_char";
-            },
-        });
+            patchWithCleanup(browser.localStorage, {
+                getItem(key) {
+                    return "properties.property_char";
+                },
+            });
 
-        await makeView({
-            type: "list",
-            resModel: "foo",
-            serverData,
-            arch: `
+            await makeView({
+                type: "list",
+                resModel: "foo",
+                serverData,
+                arch: `
                 <tree editable="bottom">
                     <field name="m2o"/>
                     <field name="properties"/>
                 </tree>`,
-            groupBy: ["m2o"],
-        });
+                groupBy: ["m2o"],
+            });
 
-        // list is grouped, no record displayed
-        assert.containsN(target, ".o_group_header", 2);
-        assert.containsNone(target, ".o_data_row");
+            // list is grouped, no record displayed
+            assert.containsN(target, ".o_group_header", 2);
+            assert.containsNone(target, ".o_data_row");
 
-        assert.containsN(target, ".o_list_table thead th", 2);
-        assert.containsOnce(target, ".o_list_table thead th.o_list_record_selector");
-        assert.containsOnce(target, ".o_list_table thead th[data-name=m2o]");
+            assert.containsN(target, ".o_list_table thead th", 2);
+            assert.containsOnce(target, ".o_list_table thead th.o_list_record_selector");
+            assert.containsOnce(target, ".o_list_table thead th[data-name=m2o]");
 
-        await click(target.querySelector(".o_group_header")); // open group Value 1
+            await click(target.querySelector(".o_group_header")); // open group Value 1
 
-        assert.containsN(target, ".o_data_row", 3);
-        assert.containsN(target, ".o_list_table thead th", 4);
-        assert.containsOnce(target, ".o_list_table thead th.o_list_record_selector");
-        assert.containsOnce(target, ".o_list_table thead th[data-name=m2o]");
-        assert.containsOnce(target, ".o_list_table thead th[data-name='properties.property_char']");
-        assert.containsOnce(target, ".o_list_table thead th.o_list_actions_header");
-    });
+            assert.containsN(target, ".o_data_row", 3);
+            assert.containsN(target, ".o_list_table thead th", 4);
+            assert.containsOnce(target, ".o_list_table thead th.o_list_record_selector");
+            assert.containsOnce(target, ".o_list_table thead th[data-name=m2o]");
+            assert.containsOnce(
+                target,
+                ".o_list_table thead th[data-name='properties.property_char']"
+            );
+            assert.containsOnce(target, ".o_list_table thead th.o_list_actions_header");
+        }
+    );
 
     QUnit.test("reload properties definitions when domain change", async (assert) => {
         const definition0 = {


### PR DESCRIPTION
The purpose of this commit is to ensure that discard waits for all current changes. This will ensure that all changes are properly discarded. Previously, it was possible that some fields needed time in order to process their value before being able to call "update" which resulted in not all changes being deleted.

How to reproduce:
================
Edit a field which is processing its value async and updating it in the onBlur Click on the "Discard" button
the event blur is triggered

Before this commit:
===================
The update will be applied after the discard. The field will therefore display the updated value.

After this commit:
=================
The update takes place before the discard. The field will therefore display the initial value.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
