### PR TITLE
[FIX] analytic: Fix UI analytic widget

### DIFF
--- a/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.scss
+++ b/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.scss
@@ -46,6 +46,8 @@
         min-width: 400px;
         max-width: $o-form-sheet-min-width;
         max-height: 50vh;
+        // this ensures that analytic distribution widget does not cover "new model" or "search more" modals
+        z-index: $zindex-modal - 1;
         cursor: default;
 
         .o_input {


### PR DESCRIPTION
The z-index of the widget was modified to prevent it from covering opened modals.

Before this commit, the widget would cover up the modals that would open when "new model" or "search more" are clicked.

task-3996070

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
