### PR TITLE
[FIX] mail: fix contains helper making test hang

### DIFF
--- a/addons/mail/static/tests/mail_test_helpers_contains.js
+++ b/addons/mail/static/tests/mail_test_helpers_contains.js
@@ -504,6 +504,7 @@ function log(ok, message) {
 }
 
 let hasUsedContainsPositively = false;
+afterEach(() => (hasUsedContainsPositively = false));
 /**
  * @typedef {[string, ContainsOptions]} ContainsTuple tuple representing params of the contains
  *  function, where the first element is the selector, and the second element is the options param.
@@ -593,7 +594,6 @@ class Contains {
         if (this.options.contains && !Array.isArray(this.options.contains[0])) {
             this.options.contains = [this.options.contains];
         }
-        after(() => (hasUsedContainsPositively = false));
         if (this.options.count) {
             hasUsedContainsPositively = true;
         } else if (!hasUsedContainsPositively) {


### PR DESCRIPTION
Before this PR, a test could hang indefinitely if an error occured.

The flow is the following:
- error occurs
- the contains helper reset his internal `hasUsedContainsPositively` following the `after` callback
- an error occurs if the pending contains is a negative assertion (count=0)
- hoot never keeps going

The `hasUsedContainsPositively` variable should not be cleaned by the contains instances. It should only be cleaned once when the test is done.