### PR TITLE
[FIX] fleet: filter null expiration_date

### DIFF
--- a/addons/fleet/models/fleet_vehicle.py
+++ b/addons/fleet/models/fleet_vehicle.py
@@ -196,7 +196,7 @@ class FleetVehicle(models.Model):
         delay_alert_contract = int(params.get_param('hr_fleet.delay_alert_contract', default=30))
         current_date = fields.Date.context_today(self)
         data = self.env['fleet.vehicle.log.contract']._read_group(
-            domain=[('vehicle_id', 'in', self.ids), ('state', '!=', 'closed')],
+            domain=[('expiration_date', '!=', False), ('vehicle_id', 'in', self.ids), ('state', '!=', 'closed')],
             groupby=['vehicle_id', 'state'],
             aggregates=['expiration_date:max'])
 


### PR DESCRIPTION
_compute_contract_reminder is reading 'fleet.vehicle.log.contract' records with null expiration_date, later expiration_date is compared with a date without checking its validity. expiration_date can be null according to this:
https://github.com/odoo/odoo/blob/saas-17.2/addons/fleet/models/fleet_vehicle.py#L261

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
