### PR TITLE
[FIX] mrp_subcontrating_account: use in/output account with subcontract

### DIFF
--- a/addons/mrp_subcontracting_account/models/stock_move.py
+++ b/addons/mrp_subcontracting_account/models/stock_move.py
@@ -56,13 +56,3 @@ class StockMove(models.Model):
         elif svl_id and self.stock_valuation_layer_ids.ids and svl_id not in self.stock_valuation_layer_ids.ids:
             rslt['credit_line_vals']['account_id'] = self.product_id.product_tmpl_id.get_product_accounts()['stock_input'].id
         return rslt
-
-    def _get_dest_account(self, account_data):
-        if self.raw_material_production_id.subcontractor_id:
-            return account_data['production'].id
-        return super()._get_dest_account(account_data)
-
-    def _get_src_account(self, account_data):
-        if self.production_id.subcontractor_id:
-            return account_data['production'].id
-        return super()._get_src_account(account_data)

--- a/addons/mrp_subcontracting_account/tests/test_subcontracting_account.py
+++ b/addons/mrp_subcontracting_account/tests/test_subcontracting_account.py
@@ -160,7 +160,7 @@ class TestAccountSubcontractingFlows(TestMrpSubcontractingCommon):
 
     def test_subcontracting_account_flow_2(self):
         """Test when set Cost of Production account on production location, subcontracting
-        won't use it.
+        should use it.
         """
         # pylint: disable=bad-whitespace
         self.stock_location = self.env.ref('stock.stock_location_stock')
@@ -257,17 +257,21 @@ class TestAccountSubcontractingFlows(TestMrpSubcontractingCommon):
 
         amls = self.env['account.move.line'].search([('id', 'not in', all_amls_ids)])
         all_amls_ids += amls.ids
+        # get the account/input account of production location
+        production_location = self.env['stock.location'].search([('usage', '=', 'production'), ('company_id', '=', self.env.company.id)])
+        production_in_acc_id = production_location.valuation_in_account_id.id
+        production_out_acc_id = production_location.valuation_out_account_id.id
         self.assertRecordValues(amls, [
-            # Receipt from subcontractor
-            {'account_id': stock_valu_acc_id,   'product_id': self.finished.id,    'debit': 60.0,  'credit': 0.0},
-            {'account_id': stock_in_acc_id,     'product_id': self.finished.id,    'debit': 0.0,   'credit': 30.0},
-            {'account_id': stock_cop_acc_id,    'product_id': self.finished.id,    'debit': 0.0,   'credit': 30.0},
-            # Delivery com2 to subcontractor
-            {'account_id': stock_valu_acc_id,   'product_id': self.comp2.id,       'debit': 0.0,   'credit': 20.0},
-            {'account_id': stock_cop_acc_id,    'product_id': self.comp2.id,       'debit': 20.0,  'credit': 0.0},
-            # Delivery com2 to subcontractor
-            {'account_id': stock_valu_acc_id,   'product_id': self.comp1.id,       'debit': 0.0,   'credit': 10.0},
-            {'account_id': stock_cop_acc_id,    'product_id': self.comp1.id,       'debit': 10.0,  'credit': 0.0},
+            # Receipt from subcontractor     | should use output account of production location
+            {'account_id': stock_valu_acc_id,      'product_id': self.finished.id,    'debit': 60.0,  'credit': 0.0},
+            {'account_id': stock_in_acc_id,        'product_id': self.finished.id,    'debit': 0.0,   'credit': 30.0},
+            {'account_id': production_out_acc_id,  'product_id': self.finished.id,    'debit': 0.0,   'credit': 30.0},
+            # Delivery com2 to subcontractor | should use input account of production location
+            {'account_id': stock_valu_acc_id,      'product_id': self.comp2.id,       'debit': 0.0,   'credit': 20.0},
+            {'account_id': production_in_acc_id,   'product_id': self.comp2.id,       'debit': 20.0,  'credit': 0.0},
+            # Delivery com2 to subcontractor | should use input account of production location
+            {'account_id': stock_valu_acc_id,      'product_id': self.comp1.id,       'debit': 0.0,   'credit': 10.0},
+            {'account_id': production_in_acc_id,   'product_id': self.comp1.id,       'debit': 10.0,  'credit': 0.0},
         ])
 
     def test_subcontracting_account_backorder(self):
@@ -467,6 +471,47 @@ class TestAccountSubcontractingFlows(TestMrpSubcontractingCommon):
             # Delivery com2 to subcontractor
             {'account_id': stock_valu_acc_id,   'product_id': self.comp1.id,       'debit': 0.0,   'credit': 10.0},
             {'account_id': stock_cop_acc_id,    'product_id': self.comp1.id,       'debit': 10.0,  'credit': 0.0},
+        ])
+
+    def test_input_output_accout_with_subcontract(self):
+        """
+        Test that the production stock account is optional, and we will fallback on input/output accounts.
+        """
+        product_category_all = self.env.ref('product.product_category_all')
+        product_category_all.property_cost_method = 'fifo'
+        product_category_all.property_valuation = 'real_time'
+        # set the production account to False
+        product_category_all.property_stock_account_production_cost_id = False
+        product_category_all.invalidate_recordset()
+        self.assertFalse(product_category_all.property_stock_account_production_cost_id)
+        self.assertEqual(self.bom.type, 'subcontract')
+        self.comp1.standard_price = 1.0
+        picking_form = Form(self.env['stock.picking'])
+        picking_form.picking_type_id = self.env.ref('stock.picking_type_in')
+        picking_form.partner_id = self.subcontractor_partner1
+        with picking_form.move_ids_without_package.new() as move:
+            move.product_id = self.finished
+            move.product_uom_qty = 1
+        picking_receipt = picking_form.save()
+        picking_receipt.action_confirm()
+        picking_receipt.move_ids.quantity = 1.0
+        picking_receipt.move_ids.picked = True
+        picking_receipt._action_done()
+        self.assertEqual(picking_receipt.state, 'done')
+
+        mo = picking_receipt._get_subcontract_production()
+        stock_valu_acc_id = product_category_all.property_stock_valuation_account_id.id
+        out_account = product_category_all.property_stock_account_output_categ_id.id
+        in_account = product_category_all.property_stock_account_input_categ_id.id
+        # Check that the input account is used for the finished move, as the production account is set to False.
+        self.assertRecordValues(mo.move_finished_ids.stock_valuation_layer_ids.account_move_id.line_ids, [
+            {'account_id': in_account, 'product_id': self.finished.id, 'debit': 0.0, 'credit': 1.0},
+            {'account_id': stock_valu_acc_id, 'product_id': self.finished.id, 'debit': 1.0, 'credit': 0.0},
+        ])
+        # Check that the output account is used for the move raw, as the production account is set to False.
+        self.assertRecordValues(mo.move_raw_ids.stock_valuation_layer_ids.account_move_id.line_ids, [
+            {'account_id': stock_valu_acc_id, 'product_id': self.comp1.id, 'debit': 0.0, 'credit': 1.0},
+            {'account_id': out_account, 'product_id': self.comp1.id, 'debit': 1.0, 'credit': 0.0},
         ])
 
 


### PR DESCRIPTION
Revert of: https://github.com/odoo/odoo/commit/be911c2c587f7e191d141ae37602ddc590a8737a

**Steps to reproduce the bug:**
- Go to accounting settings:
    - Enable “Automatic Accounting” option
    - Set the “Production Account” to False
- Go to the product category “All”:
    - Costing Method: AVCO
- Create a storable product P1:
    - product category: All
    - BoM:
        - Component: C1
        - Type: subcontracting
        - subcontractor: Azure interior

- C1: cost = $1

- Create a purchase order:
    - vendor: Azure interior
    - product: P1

- Confirm the PO
- try to receive the picking

**Problem**:
An userError is raised:
“Cannot find a stock input account for the product “P1”. You must define one on the product category, or on the location, before processing this operation.”


This commit make the production account optional and fallback with input/output accounts

Opw-3990006
