### PR TITLE
[FIX] stock: merge moves

### DIFF
--- a/addons/purchase_stock/models/stock_move.py
+++ b/addons/purchase_stock/models/stock_move.py
@@ -25,10 +25,7 @@ class StockMove(models.Model):
 
     @api.model
     def _prepare_merge_negative_moves_excluded_distinct_fields(self):
-        excluded_fields = super()._prepare_merge_negative_moves_excluded_distinct_fields() + ['created_purchase_line_id']
-        if self.env['ir.config_parameter'].sudo().get_param('purchase_stock.merge_different_procurement'):
-            excluded_fields += ['procure_method']
-        return excluded_fields
+        return super()._prepare_merge_negative_moves_excluded_distinct_fields() + ['created_purchase_line_id']
 
     def _compute_partner_id(self):
         # dropshipped moves should have their partner_ids directly set

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1033,7 +1033,10 @@ Please change the quantity done or the rounding precision of your unit of measur
 
     @api.model
     def _prepare_merge_negative_moves_excluded_distinct_fields(self):
-        return ['description_picking', 'price_unit']
+        excluded_fields = ['description_picking', 'price_unit']
+        if self.env['ir.config_parameter'].sudo().get_param('stock.merge_different_procurement'):
+            excluded_fields += ['procure_method']
+        return excluded_fields
 
     def _clean_merged(self):
         """Cleanup hook used when merging moves"""


### PR DESCRIPTION
the issue fixed here https://github.com/odoo/odoo/pull/153439 in purchase can also be reproduced with a manufacturing rule (or any other pull rule)

Steps to Replicate:
1) Enable multistep routes and unarchive the MTO route 
2) Create a storable product and enable the MTO and manufacture routes 
3) Create and confirm a sale order for 1 of the just created product 
4) Notice that when changing the quantity on the sale order to 0, the delivery picking is cancelled. When changed back to 1, a new picking is created and this behavior repeats itself 
5) Create and confirm another sale order for 1 of the product but cancel the initial delivery picking 
6) Repeat the same process as before and notice that a return picking is generated when the so line is set to 0 instead of cancelling the existing delivery picking

Fix:
The system parameter should be implemented in more generic place I.e. stock since the issue can be triggered without the purchase app installed

opw-3907566