### PR TITLE
[IMP] l10n_pl: fill accounting date with delivery date

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -302,6 +302,7 @@ class AccountMove(models.Model):
         copy=False,
         store=True,
         compute='_compute_delivery_date',
+        precompute=True,
     )
     show_delivery_date = fields.Boolean(compute='_compute_show_delivery_date')
     invoice_payment_term_id = fields.Many2one(

--- a/addons/l10n_pl/models/__init__.py
+++ b/addons/l10n_pl/models/__init__.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from . import product
 from . import account_move
+from . import account_move_line
 from . import res_partner
 from . import res_company
 from . import res_config_settings

--- a/addons/l10n_pl/models/account_move.py
+++ b/addons/l10n_pl/models/account_move.py
@@ -1,4 +1,5 @@
-from odoo import fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
 
 
 class AccountMove(models.Model):
@@ -16,3 +17,33 @@ class AccountMove(models.Model):
         string='B_MPV_Prowizja',
         help="Supply of agency and other services pertaining to the transfer of a single-purpose voucher",
     )
+
+    def action_post(self):
+        "Validation to avoid having credit notes with more than the invoice"
+        if self.filtered(lambda record: record.country_code == 'PL' and record.reversed_entry_id and
+                record.reversed_entry_id.amount_total < record.amount_total and record.move_type != 'entry'):
+            raise ValidationError(_("Credit notes can't have a total amount greater than the invoice's"))
+        return super().action_post()
+
+    @api.depends('delivery_date')
+    def _compute_show_delivery_date(self):
+        # EXTENDS 'account'
+        for move in self.filtered(lambda move: move.country_code == 'PL'):
+            move.show_delivery_date = bool(move.delivery_date)
+
+    @api.depends('delivery_date')
+    def _compute_date(self):
+        # EXTENDS 'account'
+        for move in self.filtered(lambda move: move.country_code == 'PL' and move.delivery_date and move.state == 'draft'):
+            accounting_date = move.date
+            if move.is_sale_document(True):
+                accounting_date = move.delivery_date
+            elif move.is_purchase_document(True):
+                accounting_date = min(move.delivery_date, move.date or move.invoice_date or fields.Date.context_today(self))
+            if accounting_date and accounting_date != move.date:
+                move.date = move._get_accounting_date(accounting_date, move._affect_tax_report())
+                # non purchase/sale shouldn't have a delivery_date
+                # _affect_tax_report may trigger premature recompute of line_ids.date
+                self.env.add_to_compute(move.line_ids._fields['date'], move.line_ids)
+                # might be protected because `_get_accounting_date` requires the `name`
+                self.env.add_to_compute(self._fields['name'], move)

--- a/addons/l10n_pl/models/account_move_line.py
+++ b/addons/l10n_pl/models/account_move_line.py
@@ -1,0 +1,12 @@
+from odoo import fields, models
+
+
+class AccountMoveLine(models.Model):
+    _inherit = "account.move.line"
+
+    def _get_rate_date(self):
+        # EXTENDS 'account'
+        self.ensure_one()
+        if self.company_id.account_fiscal_country_id.code == 'PL':
+            return self.move_id.delivery_date or self.move_id.date or fields.Date.context_today(self)
+        return super()._get_rate_date()

--- a/addons/l10n_pl/tests/__init__.py
+++ b/addons/l10n_pl/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_move

--- a/addons/l10n_pl/tests/test_move.py
+++ b/addons/l10n_pl/tests/test_move.py
@@ -1,0 +1,40 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import tagged
+from odoo import Command, fields
+
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class TestAccountPL(AccountTestInvoicingCommon):
+
+    @classmethod
+    def setUpClass(cls, chart_template_ref='pl'):
+        super().setUpClass(chart_template_ref=chart_template_ref)
+
+        cls.currency_usd = cls.env.ref('base.USD')
+        cls.invoice_a = cls.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'invoice_date': '2024-07-10',
+            'currency_id': cls.currency_usd.id,
+            'invoice_line_ids': [Command.create({
+                'quantity': 1.0,
+                'price_unit': 1000.0,
+            })],
+        })
+
+    def test_pl_out_invoice_onchange_accounting_date(self):
+        self.invoice_a.delivery_date = '2024-03-31'
+        self.assertEqual(self.invoice_a.date, fields.Date.to_date('2024-03-31'))
+        self.assertEqual(self.invoice_a.invoice_line_ids[0].currency_rate, 1.0)
+
+        self.env['res.currency.rate'].create({
+                'name': '2024-04-28',
+                'rate': 4.2799058421,
+                'currency_id': self.currency_usd.id,
+        })
+
+        self.invoice_a.delivery_date = '2024-05-31'
+        self.assertEqual(self.invoice_a.date, fields.Date.to_date('2024-05-31'))
+        self.assertEqual(self.invoice_a.invoice_line_ids[0].currency_rate, 4.2799058421)

--- a/addons/l10n_pl/views/account_move_views.xml
+++ b/addons/l10n_pl/views/account_move_views.xml
@@ -18,6 +18,9 @@
                     </group>
                 </page>
             </notebook>
+            <xpath expr="//group[@name='accounting_info_group']" position='inside'>
+                <field name="delivery_date" readonly="state != 'draft'" invisible="move_type not in ('in_invoice', 'in_refund') or country_code != 'PL'"/>
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
It seems that in Eastern European country, they need to use the delivery date as accounting date in majority of cases

solution: So the idea is to use the same feature that we have now but  use the delivery date as reference
in place of invoice date in the sales (always) and in the purchase if delivery date is earlier than invoice date

Also, the currency conversion rate is dependent on accounting date
but It seems that in Eastern European country needs to use the delivery date as currency rate date in the first place

Solution: the currency rate now is dependent on delivery date in first place

Task [link](https://www.odoo.com/odoo/project/967/tasks/3953743)
task-3953743