### PR TITLE
[FIX] im_livechat: change the xpath target on thread patch

### DIFF
--- a/addons/im_livechat/static/src/embed/common/thread_patch.xml
+++ b/addons/im_livechat/static/src/embed/common/thread_patch.xml
@@ -6,7 +6,7 @@
                 <Message message="props.thread.livechatWelcomeMessage" hasActions="false" thread="props.thread" className="'px-3'"/>
             </div>
         </xpath>
-        <xpath expr="//*[@name='content']" position="after">
+        <xpath expr="(//div[hasclass('o-mail-Thread')])" position="inside">
             <Message t-if="props.thread.chatbot?.typingMessage" message="props.thread.chatbot.typingMessage" hasActions="false" isInChatWindow="env.inChatWindow" isTypingMessage="true"  thread="props.thread"/>
         </xpath>
         <xpath expr="//*[hasclass('o-mail-Thread-empty')]" position="replace">


### PR DESCRIPTION
This commit makes sure the right element is targeted in case of having livechat and another thread (non livechat) with some content at a same time. Relevant discussion is [here](https://github.com/odoo/odoo/pull/138233/files#r1604727480
).

part of task-2828744

