### PR TITLE
[REF] google_calendar: credentials refactor

### DIFF
--- a/addons/google_account/controllers/main.py
+++ b/addons/google_account/controllers/main.py
@@ -23,7 +23,7 @@ class GoogleAuth(http.Controller):
 
         if kw.get('code'):
             access_token, refresh_token, ttl = request.env['google.service'].with_context(base_url=base_url)._get_google_tokens(kw['code'], service)
-            # LUL TODO only defined in google_calendar
+            request.env.user._create_google_credentials()
             request.env.user.google_cal_account_id._set_auth_tokens(access_token, refresh_token, ttl)
             return request.redirect(url_return)
         elif kw.get('error'):

--- a/addons/google_calendar/controllers/main.py
+++ b/addons/google_calendar/controllers/main.py
@@ -22,9 +22,10 @@ class GoogleCalendarController(http.Controller):
             GoogleCal = GoogleCalendarService(request.env['google.service'].with_context(base_url=base_url))
 
             # Checking that admin have already configured Google API for google synchronization !
-            client_id = request.env['ir.config_parameter'].sudo().get_param('google_calendar_client_id')
+            has_setup_credentials = request.env['google.service'].has_setup_credentials()
+            has_external_credentials_provider = not has_setup_credentials and request.env['google.service'].has_external_credentials_provider()
 
-            if not client_id or client_id == '':
+            if not has_setup_credentials and not has_external_credentials_provider:
                 action_id = ''
                 if GoogleCal._can_authorize_google(request.env.user):
                     action_id = request.env.ref('base_setup.action_general_configuration').id

--- a/addons/google_calendar/models/google_credentials.py
+++ b/addons/google_calendar/models/google_credentials.py
@@ -45,9 +45,8 @@ class GoogleCredentials(models.Model):
     def _refresh_google_calendar_token(self):
         # LUL TODO similar code exists in google_drive. Should be factorized in google_account
         self.ensure_one()
-        get_param = self.env['ir.config_parameter'].sudo().get_param
-        client_id = get_param('google_calendar_client_id')
-        client_secret = get_param('google_calendar_client_secret')
+        client_id = self.env['google.service']._get_google_client_id('calendar')
+        client_secret = self.env['google.service']._get_google_client_secret('calendar')
 
         if not client_id or not client_secret:
             raise UserError(_("The account for the Google Calendar service is not configured."))

--- a/addons/google_calendar/models/res_users.py
+++ b/addons/google_calendar/models/res_users.py
@@ -100,8 +100,12 @@ class User(models.Model):
 
     def restart_google_synchronization(self):
         self.ensure_one()
-        if not self.google_cal_account_id:
-            self.google_cal_account_id = self.env['google.calendar.credentials'].sudo().create([{'user_ids': [Command.set(self.ids)]}])
+        self._create_google_credentials()
         self.google_synchronization_stopped = False
         self.env['calendar.recurrence']._restart_google_sync()
         self.env['calendar.event']._restart_google_sync()
+
+    def _create_google_credentials(self):
+        """ Create Google Calendar Credentials object when it is not defined. """
+        if not self.google_cal_account_id:
+            self.google_cal_account_id = self.env['google.calendar.credentials'].sudo().create([{'user_ids': [Command.set(self.ids)]}])


### PR DESCRIPTION
Refactoring synchronization's credentials methods in order to make them easy to override outside the 'google_calendar' and 'google_account' modules. The default behavior remains unchanged.

task-3864685