### PR TITLE
[IMP] mail, im_livechat: use thread in getting the upload url

### DIFF
--- a/addons/im_livechat/static/src/embed/cors/attachment_upload_service_patch.js
+++ b/addons/im_livechat/static/src/embed/cors/attachment_upload_service_patch.js
@@ -4,8 +4,11 @@ import { patch } from "@web/core/utils/patch";
 import { url } from "@web/core/utils/urls";
 
 patch(AttachmentUploadService.prototype, {
-    get uploadURL() {
-        return url("/im_livechat/cors/attachment/upload");
+    getUploadURL(thread) {
+        if (thread.channel_type === "livechat") {
+            return url("/im_livechat/cors/attachment/upload");
+        }
+        return super.getUploadURL(...arguments);
     },
 
     _buildFormData() {

--- a/addons/mail/static/src/core/common/attachment_upload_service.js
+++ b/addons/mail/static/src/core/common/attachment_upload_service.js
@@ -110,7 +110,7 @@ export class AttachmentUploadService {
         this.store.Attachment.get(tmpId).remove();
     }
 
-    get uploadURL() {
+    getUploadURL(thread) {
         return "/mail/attachment/upload";
     }
 
@@ -136,7 +136,7 @@ export class AttachmentUploadService {
         this.targetsByTmpId.set(tmpId, { composer, thread });
         this.uploadingAttachmentIds.add(tmpId);
         await this.fileUploadService
-            .upload(this.uploadURL, [file], {
+            .upload(this.getUploadURL(thread), [file], {
                 buildFormData: (formData) => {
                     this._buildFormData(formData, tmpURL, thread, composer, tmpId, options);
                 },


### PR DESCRIPTION
The uploading URL is different in the portal from the backend one. So if the livechat is not the only available thread on the page, to get the proper uploading URL, we need to know which thread is uploading.

Part of task-2828744

