### PR TITLE
[FIX] account: Fix bills from mail alias creation without OCR

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3102,6 +3102,8 @@ class AccountMove(models.Model):
                    - new: whether the invoice is newly created
                    returns True if was able to process the invoice
         """
+        if file_data['type'] in ('pdf', 'binary'):
+            return lambda *args: False
         return
 
     def _extend_with_attachments(self, attachments, new=False):

--- a/addons/account/tests/test_account_incoming_supplier_invoice.py
+++ b/addons/account/tests/test_account_incoming_supplier_invoice.py
@@ -54,6 +54,11 @@ class TestAccountIncomingSupplierInvoice(AccountTestInvoicingCommon):
             'mimetype': 'image/gif',
         })
 
+    def _disable_ocr(self, company):
+        if 'extract_in_invoice_digitalization_mode' in company._fields:
+            company.extract_in_invoice_digitalization_mode = 'no_send'
+            company.extract_out_invoice_digitalization_mode = 'no_send'
+
     @contextmanager
     def with_success_decoder(self, omit=None):
         decoded_files = set()
@@ -195,6 +200,7 @@ class TestAccountIncomingSupplierInvoice(AccountTestInvoicingCommon):
         self.assertEqual(following_partners, self.env.user.partner_id | self.internal_user.partner_id)
 
     def test_extend_with_attachments_multi_pdf(self):
+        self._disable_ocr(self.company_data['company'])
         pdf1 = self._create_dummy_pdf_attachment()
         pdf2 = self._create_dummy_pdf_attachment()
         gif1 = self._create_dummy_gif_attachment()


### PR DESCRIPTION
Problem
---------
When the OCR was deactivated, the attachments from the mail would get deleted.

Solution
---------
By default, when requesting a decoder, return a function that returns False. That way, we always have a 'decoder' and attachments create an invoice.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
