### PR TITLE
[FIX] base,purchase,sale: set default values on automated PO and SO

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -554,6 +554,13 @@ class SaleOrder(models.Model):
             vals['partner_shipping_id'] = vals.setdefault('partner_shipping_id', addr['delivery'])
             vals['pricelist_id'] = vals.setdefault('pricelist_id', partner.property_product_pricelist.id)
         result = super(SaleOrder, self).create(vals)
+        if self.env.uid == self.env.ref('base.user_root').id:
+            for field_name in vals.keys():
+                field = self._fields[field_name]
+                value = field.convert_to_write(result[field_name], result)
+                condition = "%s=%s" % (field_name, value)
+                defaults = self.env['ir.default'].get_model_defaults(self._name, condition)
+                result.update(defaults)
         return result
 
     def _compute_field_value(self, field):


### PR DESCRIPTION
## Issue:
- When creating a sale or purchase order and setting default values for any field under a specific condition, these default values are applied in manually created orders but not in automatically generated ones.

## Steps To Reproduce:
Here are the steps for the case of a PO. The same behavior
    applies to an automated SO as the bug exists in both.
- Create a purchase order
- Select the vendor (e.g., Azure).- Add a comment in the "Terms & Conditions" field.
- with debug mode on, use the "Set Default" option to set the "Terms & Conditions" as default values for this vendor(e.g., Azure).
- Create a new purchase order manually with the same vendor.
- Ensure the default "Terms & Conditions" appear automatically.
- Create a sale order that includes an item configured with (MTO) route or a Reordering Rule for the same vendor.
- Notice that the default "Terms & Conditions" aren't included in the automatically generated purchase order.

## Solution:
- When defining a default value with a condition, the method `set` is called with the current user `user_id = self.env.uid`, this default value is then applied only for the current user.

- When a purchase order is generated automatically, it is created with `base.user_root`, to which the previously set default values do not apply.

- As a solution, each time a default value is set/updated for a specific user, the same value should also be set for `base.user_root`.

- When we manually create a PO/SO, `onchange` is called, which triggers `onchange_default`. However, `onchange` isn't triggered  when the PO is generated automatically. Therefore, I modified the `create` method to update the record values with the default values.

opw-3972581

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
