### PR TITLE
[FIX] sale: fix traceback when creating a SO without quotation date

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -382,7 +382,7 @@ class SaleOrder(models.Model):
     def _compute_currency_rate(self):
         cache = {}
         for order in self:
-            order_date = order.date_order.date()
+            order_date = (order.date_order or fields.Datetime.now()).date()
             if not order.company_id:
                 order.currency_rate = order.currency_id.with_context(date=order_date).rate or 1.0
                 continue


### PR DESCRIPTION
A traceback is occurig when the user creating a SO without Qutation date.

To reproduce this issue:-

1) Install `Sales`
2) Enable `Sales Credit Limit` in the settings
3) Try to create a `Quotation` by removing the default `Quotation Date`
   and then add a `Customer`
4) A traceback occurs

Error:- 
```
AttributeError: 'bool' object has no attribute 'date'
```

When the user removes the `date_order` its value will be false. 
This leads to the traceback when the `date` is extracted from `date_order`.

https://github.com/odoo/odoo/blob/16e8de01b14ddac69cd706f8f64e762406769542/addons/sale/models/sale_order.py#L385

After applying this commit will resolve this issue by taking the current date if the 'date_order' is false. This makes code more robust.

senrty-5500467446