### PR TITLE
[IMP] l10n_in_pos: kiosk mode payment terminal configuration message

### DIFF
--- a/addons/l10n_in_pos/__manifest__.py
+++ b/addons/l10n_in_pos/__manifest__.py
@@ -12,6 +12,7 @@
     ],
     'data': [
         'views/pos_order_line_views.xml',
+        'views/res_config_settings_views.xml',
         'data/pos_bill_data.xml',
     ],
     'demo': [

--- a/addons/l10n_in_pos/views/res_config_settings_views.xml
+++ b/addons/l10n_in_pos/views/res_config_settings_views.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<odoo>
+    <record id="res_config_settings_view_form_l10n_in_pos_inherit" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit.l10n_in_pos.view</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="point_of_sale.res_config_settings_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[@id='available_payment_terminal']" position="attributes">
+                <attribute name="invisible">not is_kiosk_mode or country_code == 'IN'</attribute>
+            </xpath>
+            <xpath expr="//div[@id='available_payment_terminal']" position="after">
+                <div class="o_notification_alert alert alert-warning" role="alert" invisible="not is_kiosk_mode or country_code != 'IN'">
+                    <span>Please note that the kiosk for INR currency only works with Razorpay terminal</span>
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/addons/point_of_sale/views/res_config_settings_views.xml
+++ b/addons/point_of_sale/views/res_config_settings_views.xml
@@ -50,6 +50,9 @@
                             </setting>
                         </block>
                         <block title="Payment" id="pos_payment_section">
+                            <div id="available_payment_terminal" class="o_notification_alert alert alert-warning" role="alert" invisible="not is_kiosk_mode">
+                                <span>Please note that the kiosk only works with Adyen &amp; Stripe terminals</span>
+                            </div>
                             <setting id="payment_methods_new" string="Payment Methods" help="Payment methods available" documentation="/applications/sales/point_of_sale/payment_methods.html">
                                 <field name="pos_payment_method_ids" colspan="4" widget="many2many_tags" readonly="pos_has_active_session" required="pos_company_has_template" options="{'no_create': True}" />
                                 <div>

--- a/addons/pos_self_order/views/res_config_settings_views.xml
+++ b/addons/pos_self_order/views/res_config_settings_views.xml
@@ -5,11 +5,6 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="point_of_sale.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//setting[@id='payment_methods_new']" position="before">
-                <div class="o_notification_alert alert alert-warning" role="alert" invisible="not is_kiosk_mode">
-                    <span>Please note that the kiosk only works with Adyen &amp; Stripe terminals</span>
-                </div>
-            </xpath>
             <block id="restaurant_section" position="after">
                 <block title="Mobile self-order &amp; Kiosk" id="self_ordering_section">
                     <setting string="QR menu &amp; Kiosk activation" help="Let your customers order using their mobile or a kiosk.">a


### PR DESCRIPTION
Before this commit:
====================
In KIOSK mode, the message for the payment terminal was specific to Stripe and Adyen.

After this commit:
===================
In KIOSK mode, we now support the `Razorpay` terminal for `l10n_in`. The message for the payment terminal in the res config settings has been updated to. "Please note that the kiosk for INR currency only works with Razorpay terminal" for INR currency.

task- 3981002

