### PR TITLE
[REF] spreadsheet: normlize values

### DIFF
--- a/addons/spreadsheet/static/src/pivot/pivot_helpers.js
+++ b/addons/spreadsheet/static/src/pivot/pivot_helpers.js
@@ -86,14 +86,18 @@ export function parseGroupField(allFields, groupFieldString) {
     if (field === undefined) {
         throw new EvaluationError(sprintf(_t("Field %s does not exist"), fieldName));
     }
-    const dimensionWithGranularity = granularity ? `${fieldName}:${granularity}` : fieldName;
     if (isDateField(field)) {
         granularity = granularity || "month";
     }
+    const dimensionWithGranularity = granularity ? `${fieldName}:${granularity}` : fieldName;
     return {
         isPositional,
         field,
         granularity,
         dimensionWithGranularity,
     };
+}
+
+export function domainHasNoRecordAtThisPosition(domain) {
+    return domain.some((node) => node.value === "NO_RECORD_AT_THIS_POSITION");
 }

--- a/addons/spreadsheet/static/src/pivot/pivot_time_adapters.js
+++ b/addons/spreadsheet/static/src/pivot/pivot_time_adapters.js
@@ -54,8 +54,7 @@ const odooDayAdapter = {
         return date.toFormat("MM/dd/yyyy");
     },
     increment(normalizedValue, step) {
-        const date = DateTime.fromFormat(normalizedValue, "MM/dd/yyyy");
-        return date.plus({ days: step }).toFormat("MM/dd/yyyy");
+        return normalizedValue + step;
     },
 };
 
@@ -122,7 +121,10 @@ function falseHandlerDecorator(adapter) {
             return adapter.normalizeServerValue(groupBy, field, readGroupResult);
         },
         increment(normalizedValue, step) {
-            if (normalizedValue === false) {
+            if (
+                normalizedValue === false ||
+                (typeof normalizedValue === "string" && normalizedValue.toLowerCase() === "false")
+            ) {
                 return false;
             }
             return adapter.increment(normalizedValue, step);
@@ -133,18 +135,20 @@ function falseHandlerDecorator(adapter) {
             }
             return adapter.normalizeFunctionValue(value);
         },
-        getFormat: adapter.getFormat.bind(adapter),
-        formatValue(normalizedValue, locale) {
-            if (normalizedValue === false) {
-                return _t("None");
+        toValueAndFormat(normalizedValue, locale) {
+            if (
+                normalizedValue === false ||
+                (typeof normalizedValue === "string" && normalizedValue.toLowerCase() === "false")
+            ) {
+                return { value: _t("None") };
             }
-            return adapter.formatValue(normalizedValue, locale);
+            return adapter.toValueAndFormat(normalizedValue, locale);
         },
-        toCellValue(normalizedValue) {
-            if (normalizedValue === false) {
-                return _t("None");
+        toFunctionValue(value) {
+            if (value === false) {
+                return "FALSE";
             }
-            return adapter.toCellValue(normalizedValue);
+            return adapter.toFunctionValue(value);
         },
     };
 }

--- a/addons/spreadsheet/static/src/pivot/pivot_to_function_values.js
+++ b/addons/spreadsheet/static/src/pivot/pivot_to_function_values.js
@@ -1,0 +1,51 @@
+import { registries, helpers, constants } from "@odoo/o-spreadsheet";
+
+const { DEFAULT_LOCALE } = constants;
+const { pivotToFunctionValueRegistry } = registries;
+const { toString, toNumber } = helpers;
+
+/**
+ * Add pivot formatting functions to support odoo specific fields
+ * in spreadsheet
+ */
+
+const toFunctionValueDateTime = pivotToFunctionValueRegistry.get("date");
+
+function isFalseValue(value) {
+    return value === false || (typeof value === "string" && value.toLowerCase() === "false");
+}
+
+function _toDate(value, granularity) {
+    if (isFalseValue(value)) {
+        return "FALSE";
+    }
+    if (!granularity) {
+        granularity = "month";
+    }
+    return toFunctionValueDateTime(value, granularity);
+}
+
+function _toString(value) {
+    if (isFalseValue(value)) {
+        return "FALSE";
+    }
+    return `"${toString(value).replace(/"/g, '\\"')}"`;
+}
+function _toNumber(value) {
+    if (isFalseValue(value)) {
+        return "FALSE";
+    }
+    return `${toNumber(value, DEFAULT_LOCALE)}`;
+}
+
+pivotToFunctionValueRegistry
+    .add("text", _toString)
+    .add("selection", _toString)
+    .add("char", _toString)
+    .add("integer", _toNumber)
+    .add("monetary", _toNumber)
+    .add("many2one", _toNumber)
+    .add("many2many", _toNumber)
+    .add("float", _toNumber)
+    .add("date", _toDate)
+    .add("datetime", _toDate);

--- a/addons/spreadsheet/static/src/pivot/plugins/pivot_odoo_ui_plugin.js
+++ b/addons/spreadsheet/static/src/pivot/plugins/pivot_odoo_ui_plugin.js
@@ -20,8 +20,8 @@ export class PivotOdooUIPlugin extends OdooUIPlugin {
                 this.refreshAllPivots();
                 break;
             case "INSERT_ODOO_FIX_PIVOT": {
-                const { cols, rows, measures, rowTitle } = cmd.table;
-                const table = new SpreadsheetPivotTable(cols, rows, measures, rowTitle);
+                const { cols, rows, measures, fieldsType } = cmd.table;
+                const table = new SpreadsheetPivotTable(cols, rows, measures, fieldsType);
                 this.insertOdooFixPivot(cmd.pivotId, cmd.position, table);
                 break;
             }

--- a/addons/spreadsheet/static/tests/pivots/model/pivot_plugin.test.js
+++ b/addons/spreadsheet/static/tests/pivots/model/pivot_plugin.test.js
@@ -208,9 +208,7 @@ test("Format header displays an error for non-existing field", async function ()
     expect(getCellValue(model, "G10")).toBe("#ERROR");
     expect(getCellValue(model, "G11")).toBe("#ERROR");
     expect(getEvaluatedCell(model, "G10").message).toBe("Field non-existing does not exist");
-    expect(getEvaluatedCell(model, "G11").message).toBe(
-        "Dimensions don't match the pivot definition"
-    );
+    expect(getEvaluatedCell(model, "G11").message).toBe("Field non-existing does not exist");
 });
 
 test("invalid group dimensions", async function () {
@@ -543,13 +541,13 @@ test("pivot grouped by char field which represents numbers", async function () {
                 </pivot>`,
     });
     expect(getCell(model, "A3").content).toBe('=PIVOT.HEADER(1,"name","000111")');
-    expect(getCell(model, "A4").content).toBe('=PIVOT.HEADER(1,"name",111)');
+    expect(getCell(model, "A4").content).toBe('=PIVOT.HEADER(1,"name","111")');
     expect(getCell(model, "A5").content).toBe('=PIVOT.HEADER(1,"name","14.0")');
     expect(getEvaluatedCell(model, "A3").value).toBe("000111");
     expect(getEvaluatedCell(model, "A4").value).toBe("111");
     expect(getEvaluatedCell(model, "A5").value).toBe("14.0");
     expect(getCell(model, "B3").content).toBe('=PIVOT.VALUE(1,"probability","name","000111")');
-    expect(getCell(model, "B4").content).toBe('=PIVOT.VALUE(1,"probability","name",111)');
+    expect(getCell(model, "B4").content).toBe('=PIVOT.VALUE(1,"probability","name","111")');
     expect(getCell(model, "B5").content).toBe('=PIVOT.VALUE(1,"probability","name","14.0")');
     expect(getEvaluatedCell(model, "B3").value).toBe(15);
     expect(getEvaluatedCell(model, "B4").value).toBe(11);
@@ -773,18 +771,18 @@ test("Can group by many2many field ", async () => {
     });
     expect(getCellFormula(model, "A3")).toBe('=PIVOT.HEADER(1,"tag_ids",42)');
     expect(getCellFormula(model, "A4")).toBe('=PIVOT.HEADER(1,"tag_ids",67)');
-    expect(getCellFormula(model, "A5")).toBe('=PIVOT.HEADER(1,"tag_ids","false")');
+    expect(getCellFormula(model, "A5")).toBe('=PIVOT.HEADER(1,"tag_ids",FALSE)');
 
     expect(getCellFormula(model, "B3")).toBe('=PIVOT.VALUE(1,"probability","tag_ids",42,"foo",1)');
     expect(getCellFormula(model, "B4")).toBe('=PIVOT.VALUE(1,"probability","tag_ids",67,"foo",1)');
     expect(getCellFormula(model, "B5")).toBe(
-        '=PIVOT.VALUE(1,"probability","tag_ids","false","foo",1)'
+        '=PIVOT.VALUE(1,"probability","tag_ids",FALSE,"foo",1)'
     );
 
     expect(getCellFormula(model, "C3")).toBe('=PIVOT.VALUE(1,"probability","tag_ids",42,"foo",2)');
     expect(getCellFormula(model, "C4")).toBe('=PIVOT.VALUE(1,"probability","tag_ids",67,"foo",2)');
     expect(getCellFormula(model, "C5")).toBe(
-        '=PIVOT.VALUE(1,"probability","tag_ids","false","foo",2)'
+        '=PIVOT.VALUE(1,"probability","tag_ids",FALSE,"foo",2)'
     );
 
     expect(getCellValue(model, "A3")).toBe("isCool");

--- a/addons/spreadsheet/static/tests/pivots/pivot_helpers.test.js
+++ b/addons/spreadsheet/static/tests/pivots/pivot_helpers.test.js
@@ -98,11 +98,11 @@ describe("toNormalizedPivotValue", () => {
             };
 
             dimension.granularity = "day";
-            expect(toNormalizedPivotValue(dimension, "1/11/2020")).toBe("01/11/2020");
-            expect(toNormalizedPivotValue(dimension, "01/11/2020")).toBe("01/11/2020");
-            expect(toNormalizedPivotValue(dimension, "11/2020")).toBe("11/01/2020");
-            expect(toNormalizedPivotValue(dimension, "1")).toBe("12/31/1899");
-            expect(toNormalizedPivotValue(dimension, 1)).toBe("12/31/1899");
+            expect(toNormalizedPivotValue(dimension, "1/11/2020")).toBe(43841);
+            expect(toNormalizedPivotValue(dimension, "01/11/2020")).toBe(43841);
+            expect(toNormalizedPivotValue(dimension, "11/2020")).toBe(44136);
+            expect(toNormalizedPivotValue(dimension, "1")).toBe(1);
+            expect(toNormalizedPivotValue(dimension, 1)).toBe(1);
             expect(toNormalizedPivotValue(dimension, "false")).toBe(false);
             expect(toNormalizedPivotValue(dimension, false)).toBe(false);
 
@@ -196,35 +196,58 @@ describe("toNormalizedPivotValue", () => {
 describe("pivot time adapters formatted value", () => {
     test("Day adapter", () => {
         const adapter = pivotTimeAdapter("day");
-        expect(adapter.formatValue("11/12/2020", DEFAULT_LOCALE)).toBe("11/12/2020");
-        expect(adapter.formatValue("01/11/2020", DEFAULT_LOCALE)).toBe("1/11/2020");
-        expect(adapter.formatValue("12/05/2020", DEFAULT_LOCALE)).toBe("12/5/2020");
+        expect(adapter.toValueAndFormat("11/12/2020", DEFAULT_LOCALE)).toEqual({
+            value: 44147,
+            format: "m/d/yyyy",
+        });
+        expect(adapter.toValueAndFormat("01/11/2020", DEFAULT_LOCALE)).toEqual({
+            value: 43841,
+            format: "m/d/yyyy",
+        });
+        expect(adapter.toValueAndFormat("12/05/2020", DEFAULT_LOCALE)).toEqual({
+            value: 44170,
+            format: "m/d/yyyy",
+        });
     });
 
     test("Week adapter", () => {
         patchTranslations();
         const adapter = pivotTimeAdapter("week");
-        expect(adapter.formatValue("5/2024", DEFAULT_LOCALE)).toBe("W5 2024");
-        expect(adapter.formatValue("51/2020", DEFAULT_LOCALE)).toBe("W51 2020");
+        expect(adapter.toValueAndFormat("5/2024", DEFAULT_LOCALE)).toEqual({ value: "W5 2024" });
+        expect(adapter.toValueAndFormat("51/2020", DEFAULT_LOCALE)).toEqual({
+            value: "W51 2020",
+        });
     });
 
     test("Month adapter", () => {
         patchTranslations();
         const adapter = pivotTimeAdapter("month");
-        expect(adapter.formatValue("12/2020", DEFAULT_LOCALE)).toBe("December 2020");
-        expect(adapter.formatValue("02/2020", DEFAULT_LOCALE)).toBe("February 2020");
+        expect(adapter.toValueAndFormat("12/2020", DEFAULT_LOCALE)).toEqual({
+            value: 44166,
+            format: "mmmm yyyy",
+        });
+        expect(adapter.toValueAndFormat("02/2020", DEFAULT_LOCALE)).toEqual({
+            value: 43862,
+            format: "mmmm yyyy",
+        });
     });
 
     test("Quarter adapter", () => {
         patchTranslations();
         const adapter = pivotTimeAdapter("quarter");
-        expect(adapter.formatValue("1/2022", DEFAULT_LOCALE)).toBe("Q1 2022");
-        expect(adapter.formatValue("3/1998", DEFAULT_LOCALE)).toBe("Q3 1998");
+        expect(adapter.toValueAndFormat("1/2022", DEFAULT_LOCALE)).toEqual({ value: "Q1 2022" });
+        expect(adapter.toValueAndFormat("3/1998", DEFAULT_LOCALE)).toEqual({ value: "Q3 1998" });
     });
 
     test("Year adapter", () => {
         const adapter = pivotTimeAdapter("year");
-        expect(adapter.formatValue("2020", DEFAULT_LOCALE)).toBe("2020");
-        expect(adapter.formatValue("1997", DEFAULT_LOCALE)).toBe("1997");
+        expect(adapter.toValueAndFormat("2020", DEFAULT_LOCALE)).toEqual({
+            value: 2020,
+            format: "0",
+        });
+        expect(adapter.toValueAndFormat("1997", DEFAULT_LOCALE)).toEqual({
+            value: 1997,
+            format: "0",
+        });
     });
 });

--- a/addons/spreadsheet/static/tests/pivots/pivot_see_records.test.js
+++ b/addons/spreadsheet/static/tests/pivots/pivot_see_records.test.js
@@ -162,19 +162,19 @@ test("Can see records on PIVOT cells", async function () {
         // B2 is a measure header
         B2: '=PIVOT.HEADER(1,"foo",1,"measure","probability")',
         // A3 is a row header
-        A3: '=PIVOT.HEADER(1,"bar","false")',
+        A3: '=PIVOT.HEADER(1,"bar",FALSE)',
         // A5 is a total header
         A5: "=PIVOT.HEADER(1)",
     };
     const data_cells = {
         // B3 is an empty value
-        B3: '=PIVOT.VALUE(1,"probability","bar","false","foo",1)',
+        B3: '=PIVOT.VALUE(1,"probability","bar",FALSE,"foo",1)',
         // B4 is an non-empty value
-        B4: '=PIVOT.VALUE(1,"probability","bar","true","foo",1)',
+        B4: '=PIVOT.VALUE(1,"probability","bar",TRUE,"foo",1)',
         // B5 is a column group total value
         B5: '=PIVOT.VALUE(1,"probability","foo",1)',
         // F3 is a row group total value
-        F3: '=PIVOT.VALUE(1,"probability","bar","false")',
+        F3: '=PIVOT.VALUE(1,"probability","bar",FALSE)',
         // F5 is the total
         F5: '=PIVOT.VALUE(1,"probability")',
     };
@@ -188,7 +188,7 @@ test("Can see records on PIVOT cells", async function () {
 
 test("Cannot see records of pivot formula without value", async function () {
     const { env, model } = await createSpreadsheetWithPivot();
-    expect(getCellFormula(model, "B3")).toBe(`=PIVOT.VALUE(1,"probability","bar","false","foo",1)`);
+    expect(getCellFormula(model, "B3")).toBe(`=PIVOT.VALUE(1,"probability","bar",FALSE,"foo",1)`);
     expect(getCellValue(model, "B3")).toBe("", { message: "B3 is empty" });
     selectCell(model, "B3");
     const action = await getActionMenu(cellMenuRegistry, ["pivot_see_records"], env);

--- a/addons/spreadsheet/static/tests/public_spreadsheet/freeze.test.js
+++ b/addons/spreadsheet/static/tests/public_spreadsheet/freeze.test.js
@@ -24,10 +24,8 @@ defineSpreadsheetModels();
 
 test("odoo pivot functions are replaced with their value", async function () {
     const { model } = await createSpreadsheetWithPivot();
-    expect(getCell(model, "A3").content).toBe('=PIVOT.HEADER(1,"bar","false")');
-    expect(getCell(model, "C3").content).toBe(
-        '=PIVOT.VALUE(1,"probability","bar","false","foo",2)'
-    );
+    expect(getCell(model, "A3").content).toBe('=PIVOT.HEADER(1,"bar",FALSE)');
+    expect(getCell(model, "C3").content).toBe('=PIVOT.VALUE(1,"probability","bar",FALSE,"foo",2)');
     expect(getEvaluatedCell(model, "A3").value).toBe("No");
     expect(getEvaluatedCell(model, "C3").value).toBe(15);
     const data = await freezeOdooData(model);
@@ -77,10 +75,8 @@ test("Pivot with a type different of ODOO is not converted", async function () {
 
 test("values are not exported formatted", async function () {
     const { model } = await createSpreadsheetWithPivot();
-    expect(getCell(model, "A3").content).toBe('=PIVOT.HEADER(1,"bar","false")');
-    expect(getCell(model, "C3").content).toBe(
-        '=PIVOT.VALUE(1,"probability","bar","false","foo",2)'
-    );
+    expect(getCell(model, "A3").content).toBe('=PIVOT.HEADER(1,"bar",FALSE)');
+    expect(getCell(model, "C3").content).toBe('=PIVOT.VALUE(1,"probability","bar",FALSE,"foo",2)');
     setCellFormat(model, "C3", "mmmm yyyy");
     setCellContent(model, "C4", "=C3+31");
     expect(getEvaluatedCell(model, "C3").value).toBe(15);


### PR DESCRIPTION
This commit is the counterpart of https://github.com/odoo/o-spreadsheet/pull/4466.
It adapts the code to the changes made in the pivot formulas.

In addition, the handling of positional arguments is simplified.
Before this commit, the positinal arguments were replaced by their
actual values in the `getPivotCellValueAndFormat` and
`getPivotHeaderValueAndFormat`.
Now, this replacement is done before calling these functions. So, these
functions can get rid of the positional arguments.

Task: 3991743