### PR TITLE
[IMP] web: close button should be in dialog footer when user has no rights

### DIFF
--- a/addons/web/static/src/views/view_dialogs/form_view_dialog.js
+++ b/addons/web/static/src/views/view_dialogs/form_view_dialog.js
@@ -84,7 +84,7 @@ export class FormViewDialog extends Component {
         }
 
         onMounted(() => {
-            if (this.modalRef.el.querySelector(".modal-footer").childElementCount > 1) {
+            if (this.modalRef.el.querySelectorAll(".modal-footer button").length > 1) {
                 const defaultButton = this.modalRef.el.querySelector(
                     ".modal-footer button.o-default-button"
                 );

--- a/addons/web/static/src/views/view_dialogs/form_view_dialog.xml
+++ b/addons/web/static/src/views/view_dialogs/form_view_dialog.xml
@@ -5,12 +5,7 @@
     <Dialog size="props.size" title="props.title" withBodyPadding="false" modalRef="modalRef">
       <View t-props="viewProps"/>
       <t t-set-slot="footer">
-        <t t-if="props.preventEdit and props.preventCreate">
-          <button class="btn btn-primary" t-on-click="() => props.close()">Close</button>
-        </t>
-        <t t-else="">
-          <button class="btn btn-primary o-default-button" t-on-click="() => props.close()">Ok</button>
-        </t>
+        <button class="btn btn-primary o-default-button" t-on-click="() => props.close()">Close</button>
       </t>
     </Dialog>
   </t>


### PR DESCRIPTION
**Current behaviour before PR:**

In Gantt view, when user has no rights to edit or delete a record then clicking on `View` button in Gantt popover opens a `FormViewDialog` with an empty footer which looks weird. This happens because `Ok` button is rendered instead of `Close` button due to wrong props. Later `Ok` button gets invisible through `d-none` class by `onMounted` method.

Steps to reproduce:
- Set no editing rights for demo user for planning app.
- Log in as demo user, open planning app.
- Click on view button in Gantt Popover.
- Notice that the Dialog box gets opened with an empty footer.

**Desired behaviour after PR:**

This commit aims to remove `Ok` button as it will not be visible at any case and show `Close` button if user has not rights.

task-3823315




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
