### PR TITLE
[FIX] event: prevent typeerror when event is deleted

### DIFF
--- a/addons/event/controllers/main.py
+++ b/addons/event/controllers/main.py
@@ -47,7 +47,7 @@ class EventController(Controller):
         # We sudo the event in case of invitations sent before publishing it.
         event_sudo = request.env['event.event'].browse(event_id).exists().sudo()
         hash_truth = event_sudo and event_sudo._get_tickets_access_hash(registration_ids)
-        if not consteq(tickets_hash, hash_truth):
+        if not hash_truth or not consteq(tickets_hash, hash_truth):
             raise NotFound()
 
         event_registrations_sudo = event_sudo.registration_ids.filtered(lambda reg: reg.id in registration_ids)


### PR DESCRIPTION
When the event is deleted and the user tries to download tickets for that event,
a traceback will appear.

Steps to reproduce the error:
- Go to Website > Events > Open any event > register > confirm registration of the ticket
- Go to Events > Open that event > delete attendees > delete that event
- Download tickets of that event

Traceback:
```
TypeError: unsupported operand types(s) or combination of types: 'str' and 'event.event'
  File "odoo/http.py", line 2248, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1823, in _serve_db
    return self._transactioning(_serve_ir_http, readonly=ro)
  File "odoo/http.py", line 1843, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1821, in _serve_ir_http
    return self._serve_ir_http(rule, args)
  File "odoo/http.py", line 1828, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1966, in dispatch
    return self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 220, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 756, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/event/controllers/main.py", line 50, in event_my_tickets
    if not consteq(tickets_hash, hash_truth):
```

https://github.com/odoo/odoo/blob/7b9df7c95c5f6a96d4d00c5d64e394141124752b/addons/event/controllers/main.py#L50 Here, when user deletes the event, 'event_sudo' will be empty,
So, eventually 'hash_truth' will be empty.
So it will lead to the above traceback.

sentry-5499927956

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
