### PR TITLE
[IMP] website, *: improve page 404 edition / page creation UX 

### DIFF
--- a/addons/website/static/src/services/website_service.js
+++ b/addons/website/static/src/services/website_service.js
@@ -186,6 +186,19 @@ export const websiteService = {
             get isDesigner() {
                 return isDesigner === true;
             },
+            get is404() {
+                return currentMetadata.viewXmlid === "website.page_404";
+            },
+            get currentLocation() {
+                const path = decodeURIComponent(this.contentWindow.location.pathname);
+                if (!this.currentWebsite.metadata.translatable) {
+                    return path;
+                }
+                // If the website is translatable, remove the /lang in the
+                // location pathname, e.g. /fr/hello-page -> /hello-page
+                const lang = path.split("/")[1];
+                return path.slice(lang.length + 1);
+            },
             get hasMultiWebsites() {
                 return hasMultiWebsites === true;
             },

--- a/addons/website/static/src/systray_items/edit_website.js
+++ b/addons/website/static/src/systray_items/edit_website.js
@@ -1,4 +1,5 @@
 import { _t } from "@web/core/l10n/translation";
+import { AddPageDialog } from "../components/dialog/add_page_dialog";
 import { rpc } from "@web/core/network/rpc";
 import { registry } from "@web/core/registry";
 import { Dropdown } from "@web/core/dropdown/dropdown";
@@ -15,6 +16,7 @@ class EditWebsiteSystray extends Component {
     static props = {};
     setup() {
         this.websiteService = useService('website');
+        this.dialogService = useService("dialog");
         this.websiteContext = useState(this.websiteService.context);
 
         this.state = useState({
@@ -65,7 +67,7 @@ class EditWebsiteSystray extends Component {
                     res_model,
                     res_id,
                 })),
-            })
+            });
         }
         this.startTranslate();
     }
@@ -100,6 +102,13 @@ class EditWebsiteSystray extends Component {
         } else {
             this.websiteContext.edition = true;
         }
+    }
+
+    async createPage() {
+        this.dialogService.add(AddPageDialog, {
+            websiteId: this.websiteService.currentWebsite.id,
+            forcedURL: this.websiteService.currentLocation,
+        });
     }
 }
 

--- a/addons/website/static/src/systray_items/edit_website.xml
+++ b/addons/website/static/src/systray_items/edit_website.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 <t t-name="website.EditWebsiteSystray">
     <div class="o_menu_systray_item o_edit_website_container d-none d-md-flex">
-        <a t-if="!translatable" href="#" class="o-website-btn-custo-primary btn position-relative d-flex align-items-center rounded-0 border-0 px-3" accesskey="a" t-on-click="startEdit">
+        <a t-if="!translatable and !this.websiteService.is404" href="#" class="o-website-btn-custo-primary btn position-relative d-flex align-items-center rounded-0 border-0 px-3" accesskey="a" t-on-click="startEdit">
             <span t-if="this.state.isLoading" class="position-absolute top-50 start-50 translate-middle">
                 <i class="fa fa-refresh fa-spin"/>
             </span>
@@ -13,12 +13,28 @@
                 <span t-out="label"/>
             </button>
             <t t-set-slot="content">
-                <DropdownItem onSelected="() => this.attemptStartTranslate()" class="'o_translate_website_dropdown_item'">
-                    Translate - <span class="text-muted" t-out="this.websiteService.currentWebsite.metadata.langName"/>
-                </DropdownItem>
-                <DropdownItem onSelected="() => this.startEdit()" class="'o_edit_website_dropdown_item'">
-                    Edit - <span class="text-muted" t-out="this.websiteService.currentWebsite.metadata.defaultLangName"/>
-                </DropdownItem>
+                <t t-if="this.websiteService.is404">
+                    <t t-if="translatable">
+                        <DropdownItem onSelected="() => this.attemptStartTranslate()" class="'o_translate_website_dropdown_item'">
+                            Translate 404 page<t t-translation="off"> - <span class="text-muted" t-out="this.websiteService.currentWebsite.metadata.langName"/></t>
+                        </DropdownItem>
+                    </t>
+                    <DropdownItem onSelected="() => this.startEdit()" class="'o_edit_website_dropdown_item'">
+                        Edit 404 page<t t-if="translatable" t-translation="off"> - <span class="text-muted" t-out="this.websiteService.currentWebsite.metadata.defaultLangName"/></t>
+                    </DropdownItem>
+                    <DropdownItem onSelected="() => this.createPage()" class="'o_edit_website_dropdown_item'">
+                        <t t-set="url" t-value="this.websiteService.currentLocation"/>
+                        Create <span class="text-muted" t-out="url"/> page
+                    </DropdownItem>
+                </t>
+                <t t-else=""><!-- In this case, this is translatable -->
+                    <DropdownItem onSelected="() => this.attemptStartTranslate()" class="'o_translate_website_dropdown_item'">
+                        Translate<t t-translation="off"> - <span class="text-muted" t-out="this.websiteService.currentWebsite.metadata.langName"/></t>
+                    </DropdownItem>
+                    <DropdownItem onSelected="() => this.startEdit()" class="'o_edit_website_dropdown_item'">
+                        Edit<t t-translation="off"> - <span class="text-muted" t-out="this.websiteService.currentWebsite.metadata.defaultLangName"/></t>
+                    </DropdownItem>
+                </t>
             </t>
         </Dropdown>
     </div>

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -2494,18 +2494,7 @@
 
 <!-- PAGE 404 -->
 <template id="page_404" name="Page Not Found">
-    <t t-call="http_routing.404">
-        <div class="o_not_editable bg-100 pt40">
-            <div class="container">
-                <div class="alert alert-info text-center d-lg-flex justify-content-between align-items-center">
-                    <p class="m-lg-0 text-info">This page does not exist, but you can create it as you are editor of this site.</p>
-                    <a role="button" class="btn btn-info js_disable_on_click post_link" data-post_force-top-window="true" t-attf-href="/website/add/#{path}?redirect=1#{from_template and '&amp;template=%s' % from_template}">Create Page</a>
-                </div>
-                <div class="text-center text-muted p-3"><i class="fa fa-info-circle"></i> Edit the content below this line to adapt the default <strong>Page not found</strong> page.</div>
-            </div>
-            <hr/>
-        </div>
-    </t>
+    <t t-call="http_routing.404"/>
 </template>
 
 <template id="404_plausible" inherit_id="http_routing.404" name="Plausible 404">

--- a/addons/website_event/controllers/main.py
+++ b/addons/website_event/controllers/main.py
@@ -173,7 +173,7 @@ class WebsiteEventController(http.Controller):
             # page not found
             values['path'] = re.sub(r"^website_event\.", '', page)
             values['from_template'] = 'website_event.default_page'  # .strip('website_event.')
-            page = request.env.user.has_group('website.group_website_designer') and 'website.page_404' or 'http_routing.404'
+            page = 'website.page_404'
 
         return request.render(page, values)
 


### PR DESCRIPTION
\*: website_event

When an user lands on a 404 page and enters edit mode, sometimes they
don't understand that they are actually editing the 404 page itself and
they miss the fact that there is a button inside the 404 page to
actually create the page that was reached. Those UI elements inside the
pages are something we want to avoid in general anyway.

This commit adapts the Edit button based on current page to display a
dropdown when located on a 404 page so we can choose between editing the
404 page itself or creating the corresponding page based on the URL.

This also allow to use the whole new page dialog when creating a page
through that flow (which was not the case and was always created blank).

task-3634878