### PR TITLE
[FIX] website: support more URL for facebook snippet

### DIFF
--- a/addons/website/static/src/snippets/s_facebook_page/options.js
+++ b/addons/website/static/src/snippets/s_facebook_page/options.js
@@ -1,7 +1,10 @@
 odoo.define('website.s_facebook_page_options', function (require) {
 'use strict';
 
+const core = require('web.core');
 const options = require('web_editor.snippets.options');
+
+const _t = core._t;
 
 options.registry.facebookPage = options.Class.extend({
     /**
@@ -161,7 +164,7 @@ options.registry.facebookPage = options.Class.extend({
         // The regex is kept as a huge one-liner for performance as it is
         // compiled once on script load. The only way to split it on several
         // lines is with the RegExp constructor, which is compiled on runtime.
-        const match = this.fbData.href.match(/^(https?:\/\/)?((www\.)?(fb|facebook)|(m\.)?facebook)\.com\/(((profile\.php\?id=|people\/[^/?#]+\/|(p\/)?[^/?#]+-)(?<id>[0-9]{15,16}))|(?<nameid>[\w.]+))($|[/?# ])/);
+        const match = this.fbData.href.trim().match(/^(https?:\/\/)?((www\.)?(fb|facebook)|(m\.)?facebook)\.com\/(((profile\.php\?id=|people\/([^/?#]+\/)?|(p\/)?[^/?#]+-)(?<id>[0-9]{12,16}))|(?<nameid>[\w.]+))($|[/?# ])/);
         if (match) {
             // Check if the page exists on Facebook or not
             const pageId = match.groups.nameid || match.groups.id;
@@ -172,11 +175,19 @@ options.registry.facebookPage = options.Class.extend({
                 } else {
                     this.fbData.id = "";
                     this.fbData.href = defaultURL;
+                    this.displayNotification({
+                        title: _t("We couldn't find the Facebook page"),
+                        type: "warning",
+                    });
                 }
             });
         }
         this.fbData.id = "";
         this.fbData.href = defaultURL;
+        this.displayNotification({
+            title: _t("You didn't provide a valid Facebook link"),
+            type: "warning",
+        });
         return Promise.resolve();
     },
 });


### PR DESCRIPTION
Some valid URLs were not working before because since [1], we were only
supporting 15-16 digits facebook page ID.

We also wanted to give feedback to a user if their link did not work for
some reason.

[1]: https://github.com/odoo/odoo/commit/82c4393fd025f9ab50197c0d68d52f57eb55ded2

task-3995431

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
