### PR TITLE
[I18N] add account_payment_term to tx config

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -91,6 +91,15 @@ resource_name          = account_payment
 replace_edited_strings = false
 keep_translations      = false
 
+[o:odoo:p:odoo-17:r:account_payment_term]
+file_filter            = addons/account_payment_term/i18n/<lang>.po
+source_file            = addons/account_payment_term/i18n/account_payment_term.pot
+type                   = PO
+minimum_perc           = 0
+resource_name          = account_payment_term
+replace_edited_strings = false
+keep_translations      = false
+
 [o:odoo:p:odoo-17:r:account_peppol]
 file_filter            = addons/account_peppol/i18n/<lang>.po
 source_file            = addons/account_peppol/i18n/account_peppol.pot


### PR DESCRIPTION
[This commit] introduced a new module, but the module was not added to the tx config file. Because of this, the terms to translate were not pushed to Transifex and could not be translated.

This commit adds the entry, so the terms will be available on Transifex.

[This commit]: https://github.com/odoo/odoo/commit/e5097a183ab65ff3dd04f3f4dd16182acd329018