### PR TITLE
[FIX] mail: update star counter when unknown message is deleted 

### DIFF
--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -231,15 +231,6 @@ export class Message extends Record {
                 !this.subtype_description
             );
         },
-        /** @this {import("models").Message} */
-        onUpdate() {
-            if (this.isEmpty && this.isStarred) {
-                this.starredPersonas.delete(this._store.self);
-                const starred = this._store.discuss.starred;
-                starred.counter--;
-                starred.messages.delete(this);
-            }
-        },
     });
     get isBodyEmpty() {
         return (

--- a/addons/mail/static/src/core/common/message_service.js
+++ b/addons/mail/static/src/core/common/message_service.js
@@ -55,10 +55,6 @@ export class MessageService {
             body: "",
             message_id: message.id,
         });
-        if (message.isStarred) {
-            this.store.discuss.starred.counter--;
-            this.store.discuss.starred.messages.delete(message);
-        }
         message.body = "";
         message.attachments = [];
     }

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -552,6 +552,9 @@ async function mail_message_update_content(request) {
 
     const { attachment_ids, body, message_id } = await parseRequestParams(request);
     MailMessage.write([message_id], { body, attachment_ids });
+    if (body === "" && attachment_ids.length === 0) {
+        MailMessage._cleanup_side_records([message_id]);
+    }
     BusBus._sendone(MailMessage._bus_notification_target(message_id), "mail.record/insert", {
         Message: {
             id: message_id,

--- a/addons/mail/static/tests/mock_server/mock_models/mail_message.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_message.js
@@ -510,4 +510,39 @@ export class MailMessage extends models.ServerModel {
             };
         });
     }
+
+    _cleanup_side_records([id]) {
+        /** @type {import("mock_models").BusBus} */
+        const BusBus = this.env["bus.bus"];
+        /** @type {import("mock_models").MailMessage} */
+        const MailMessage = this.env["mail.message"];
+        /** @type {import("mock_models").ResPartner} */
+        const ResPartner = this.env["res.partner"];
+        const [message] = this._filter([["id", "=", id]]);
+        const outdatedStarredPartners = message.starred_partner_ids
+            ? ResPartner._filter([["id", "in", message.starred_partner_ids]])
+            : [];
+        this.write([id], { starred_partner_ids: [Command.clear()] });
+        if (outdatedStarredPartners.length === 0) {
+            return;
+        }
+        const notifications = [];
+        for (const partner of outdatedStarredPartners) {
+            notifications.push([
+                partner,
+                "mail.record/insert",
+                {
+                    Thread: {
+                        id: "starred",
+                        messages: [["DELETE", { id: message.id }]],
+                        model: "mail.box",
+                        counter: MailMessage._filter([["starred_partner_ids", "in", partner.id]])
+                            .length,
+                        counter_bus_id: this.env["bus.bus"].lastBusNotificationId,
+                    },
+                },
+            ]);
+        }
+        BusBus._sendmany(notifications);
+    }
 }

--- a/addons/test_mail/tests/test_mail_thread_internals.py
+++ b/addons/test_mail/tests/test_mail_thread_internals.py
@@ -366,6 +366,51 @@ class TestDiscuss(MailCommon, TestRecipients):
         self.assertFalse(msg.starred)
         self.assertTrue(msg_emp.starred)
 
+    def test_delete_starred_message(self):
+        msg = self.test_record.message_post(body="Hello!", message_type="comment")
+        msg_2 = self.test_record.message_post(body="Goodbye!", message_type="comment")
+        msg.with_user(self.user_admin).toggle_message_starred()
+        msg.with_user(self.user_employee).toggle_message_starred()
+        msg_2.with_user(self.user_employee).toggle_message_starred()
+        self.assertIn(self.partner_admin, msg.starred_partner_ids)
+        self.assertIn(self.partner_employee, msg.starred_partner_ids)
+        bus_last_id = self.env["bus.bus"].sudo()._bus_last_id()
+        self.test_record._message_update_content(message=msg, body="")
+        self.assertFalse(msg.starred)
+        self.assertBusNotifications(
+            [
+                (self.cr.dbname, "res.partner", self.partner_admin.id),
+                (self.cr.dbname, "res.partner", self.partner_employee.id),
+            ],
+            [
+                {
+                    "type": "mail.record/insert",
+                    "payload": {
+                        "Thread": {
+                            "id": "starred",
+                            "messages": [["DELETE", [{"id": msg.id}]]],
+                            "model": "mail.box",
+                            "counter": 0,
+                            "counter_bus_id": bus_last_id,
+                        },
+                    },
+                },
+                {
+                    "type": "mail.record/insert",
+                    "payload": {
+                        "Thread": {
+                            "id": "starred",
+                            "messages": [["DELETE", [{"id": msg.id}]]],
+                            "model": "mail.box",
+                            "counter": 1,
+                            "counter_bus_id": bus_last_id,
+                        },
+                    },
+                }
+            ],
+            check_unique=False,
+        )
+
     def test_inbox_message_fetch_needaction(self):
         user1 = self.env['res.users'].create({'login': 'user1', 'name': 'User 1'})
         user1.notification_type = 'inbox'


### PR DESCRIPTION
Before this PR, the star message counter was not updated on message
deletion on tabs that were unaware of the message.

Steps to reproduce the issue:
- Open two tabs and log in as admin.
- Star a message; the counter should show 1 on both tabs.
- Reload one tab without accessing the channel.
- Delete the starred message from the other tab.
- Notice that the star counter on the second tab still shows 1.

The issue arose because the client-side star counter updated based on
partial information, specifically only when the message was starred.
If the message had not been fetched, this information was unavailable.

This PR resolves the issue by removing the client-side computation and
implementing a server-side notification instead.

runbot-61305,62004