### PR TITLE
[FIX] pos_restaurant: unique table number and duplicate table

### DIFF
--- a/addons/pos_restaurant/static/src/app/floor_screen/edit_bar.js
+++ b/addons/pos_restaurant/static/src/app/floor_screen/edit_bar.js
@@ -2,6 +2,7 @@
 
 import { Component, useExternalListener, useState } from "@odoo/owl";
 import { useService } from "@web/core/utils/hooks";
+import { useTrackedAsync } from "@point_of_sale/app/utils/hooks";
 
 export class EditBar extends Component {
     static template = "pos_restaurant.EditBar";
@@ -26,6 +27,7 @@ export class EditBar extends Component {
     setup() {
         this.ui = useState(useService("ui"));
         useExternalListener(window, "click", this.onOutsideClick);
+        this.doCreateTable = useTrackedAsync(this.props.createTable);
     }
 
     onOutsideClick() {

--- a/addons/pos_restaurant/static/src/app/floor_screen/edit_bar.xml
+++ b/addons/pos_restaurant/static/src/app/floor_screen/edit_bar.xml
@@ -4,8 +4,13 @@
     <t t-name="pos_restaurant.EditBar">
         <div class="edit-bar-top d-flex align-items-center justify-content-between px-3 border-bottom bg-view overflow-x-auto h-54 w-100">
             <div class="flex-fill d-flex justify-content-center">
-                <span role="button" class="edit-button text-center d-flex flex-column btn btn-light text-uppercase" t-on-click.stop="props.createTable">
-                    <i class="fa fa-plus icon-button" role="img" aria-label="Add" title="Add"></i>
+                <span role="button" class="edit-button text-center d-flex flex-column btn btn-light text-uppercase" t-on-click.stop="doCreateTable.call" t-att-disabled="doCreateTable.status === 'loading'">
+                    <t t-if="doCreateTable.status === 'loading'">
+                        <i class="fa fa-spinner fa-spin icon-button" role="img" aria-label="Loading" title="Loading"></i>
+                    </t>
+                    <t t-else="">
+                        <i class="fa fa-plus icon-button" role="img" aria-label="Add" title="Add"></i>
+                    </t>
                     <span class="text-button d-block">Table</span>
                 </span>
                 <span role="button" class="edit-button text-center d-flex flex-column btn btn-light text-uppercase" t-att-class="{ 'disabled': props.selectedTables.length == 0 }" t-on-click.stop="props.changeSeatsNum">


### PR DESCRIPTION
Steps:
---
- Open POS Restaurant
- Edit floor & click on a table
- Rapidly click add table multiple times
- Multiple tables with the same number are created
- Duplicate tables also overlap the original table completely

Issue:
---
Duplicate tables should not be created.

Cause:
---
The "Add" button that creates the table calls an async function. Rapid clicks make new calls even before the promises are successful.

FIX:
---
Disable the button and creation until the previous table is created so that rapid clicks are handled.

task-3956310
