### PR TITLE
[FIX] hw_drivers: Handle non-json response in the all devices request

### DIFF
--- a/addons/hw_drivers/main.py
+++ b/addons/hw_drivers/main.py
@@ -77,9 +77,10 @@ class Manager(Thread):
                 )
                 if iot_client:
                     iot_client.iot_channel = json.loads(resp.data).get('result', '')
-            except Exception as e:
-                _logger.error('Could not reach configured server')
-                _logger.error('A error encountered : %s ' % e)
+            except json.decoder.JSONDecodeError:
+                _logger.exception('Could not load JSON data: Received data is not in valid JSON format\ncontent:\n%s', resp.data)
+            except Exception:
+                _logger.exception('Could not reach configured server')
         else:
             _logger.warning('Odoo server not set')
 

--- a/doc/cla/individual/jlong1307.md
+++ b/doc/cla/individual/jlong1307.md
@@ -1,0 +1,11 @@
+Belgium, 2024-06-19
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Jeremy long  <jeremylong1307@hotmai.com> https://github.com/jlong1307


### PR DESCRIPTION
Before commit:

To reproduce the error: A device may send non-JSON data to the IoT controller, or the CDN might return an error in a non-JSON format.

We just get a very non-explicit error: "Expecting value: line 1 column 1 (char 0)".

After commit:

We add a catch for non-JSON data and log the error along with the incorrect data to have more information.

opw-3876631