### PR TITLE
[IMP] web: Add within operator in tree editor

### DIFF
--- a/addons/web/static/src/core/domain_selector/domain_selector_operator_editor.js
+++ b/addons/web/static/src/core/domain_selector/domain_selector_operator_editor.js
@@ -26,7 +26,7 @@ export function getDomainDisplayedOperators(fieldDef) {
             return ["=", "!=", "ilike", "not ilike", "in", "not in", "set", "not_set"];
         case "date":
         case "datetime":
-            return ["=", "!=", ">", ">=", "<", "<=", "between", "set", "not_set"];
+            return ["=", "!=", ">", ">=", "<", "<=", "between", "within", "set", "not_set"];
         case "integer":
         case "float":
         case "monetary":

--- a/addons/web/static/src/core/expression_editor/expression_editor_operator_editor.js
+++ b/addons/web/static/src/core/expression_editor/expression_editor_operator_editor.js
@@ -6,6 +6,7 @@ const EXPRESSION_VALID_OPERATORS = [
     ">",
     ">=",
     "between",
+    "within",
     "in",
     "not in",
     "=",

--- a/addons/web/static/src/core/tree_editor/condition_tree.js
+++ b/addons/web/static/src/core/tree_editor/condition_tree.js
@@ -1,6 +1,8 @@
 import { Domain } from "@web/core/domain";
 import { formatAST, parseExpr } from "@web/core/py_js/py";
 import { toPyValue } from "@web/core/py_js/py_utils";
+import { Within } from "./tree_editor_components";
+import { memoize } from "../utils/functions";
 
 /** @typedef { import("@web/core/py_js/py_parser").AST } AST */
 /** @typedef {import("@web/core/domain").DomainRepr} DomainRepr */
@@ -79,6 +81,9 @@ const EXCHANGE = {
 };
 
 const COMPARATORS = ["<", "<=", ">", ">=", "in", "not in", "==", "is", "!=", "is not"];
+
+const DATETIME_TODAY_STRING_EXPRESSION = `datetime.datetime.combine(context_today(), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")`;
+const DATE_TODAY_STRING_EXPRESSION = `context_today().strftime("%Y-%m-%d")`;
 
 export class Expression {
     constructor(ast) {
@@ -746,6 +751,86 @@ function createBetweenOperators(tree) {
  * @param {Tree} tree
  * @returns {Tree}
  */
+function createWithinOperators(tree, options = {}) {
+    if (tree.children) {
+        return {
+            ...tree,
+            children: tree.children.map((child) => createWithinOperators(child, options)),
+        };
+    }
+    const fieldType = options.getFieldDef?.(tree.path)?.type;
+    if (tree.operator !== "between" || !["date", "datetime"].includes(fieldType)) {
+        return tree;
+    }
+    const isTodayDateTimeExpr = (expression) =>
+        expression._expr === DATETIME_TODAY_STRING_EXPRESSION;
+    const isTodayDateExpr = (expression) => expression._expr === DATE_TODAY_STRING_EXPRESSION;
+    const processDeltaExpr = memoize(function processDeltaExpr(
+        expression,
+        regex,
+        periodShouldBePositive = true
+    ) {
+        const matches = regex.exec(expression._expr);
+        if (!matches || matches.length !== 3) {
+            return false;
+        }
+        const [, period, amount] = matches;
+        if (!Within.options.some((o) => o[0] === period)) {
+            return false;
+        }
+        const periodAmount = parseInt(amount);
+        if (
+            (periodAmount < 0 && periodShouldBePositive) ||
+            (periodAmount > 0 && !periodShouldBePositive)
+        ) {
+            return false;
+        }
+        return [periodAmount, period];
+    });
+    const processDeltaDateExpr = (expression, periodShouldBePositive = true) => {
+        const regex =
+            /^\(context_today\(\)\s*\+\s*relativedelta\(\s*(\w+)\s*=\s*(-?\d+)\s*\)\)\.strftime\("%Y-%m-%d"\)$/;
+        return processDeltaExpr(expression, regex, periodShouldBePositive);
+    };
+    const processDeltaDateTimeExpr = (expression, periodShouldBePositive = true) => {
+        const regex =
+            /^datetime\.datetime\.combine\(context_today\(\)\s*\+\s*relativedelta\(\s*(\w+)\s*=\s*(-?\d+)\s*\),\s*datetime\.time\(0,\s*0,\s*0\)\)\.to_utc\(\)\.strftime\("%Y-%m-%d\s%H:%M:%S"\)$/;
+        return processDeltaExpr(expression, regex, periodShouldBePositive);
+    };
+
+    const newTree = { ...tree };
+
+    if (fieldType === "date") {
+        if (isTodayDateExpr(newTree.value[0]) && processDeltaDateExpr(newTree.value[1])) {
+            newTree.operator = "within";
+            newTree.value = [...processDeltaDateExpr(newTree.value[1]), "date"];
+        } else if (
+            isTodayDateExpr(newTree.value[1]) &&
+            processDeltaDateExpr(newTree.value[0], false)
+        ) {
+            newTree.operator = "within";
+            newTree.value = [...processDeltaDateExpr(newTree.value[0], false), "date"];
+        }
+    }
+    if (fieldType === "datetime") {
+        if (isTodayDateTimeExpr(newTree.value[0]) && processDeltaDateTimeExpr(newTree.value[1])) {
+            newTree.operator = "within";
+            newTree.value = [...processDeltaDateTimeExpr(newTree.value[1]), "datetime"];
+        } else if (
+            isTodayDateTimeExpr(newTree.value[1]) &&
+            processDeltaDateTimeExpr(newTree.value[0], false)
+        ) {
+            newTree.operator = "within";
+            newTree.value = [...processDeltaDateTimeExpr(newTree.value[0], false), "datetime"];
+        }
+    }
+    return newTree;
+}
+
+/**
+ * @param {Tree} tree
+ * @returns {Tree}
+ */
 export function removeBetweenOperators(tree) {
     if (tree.type === "complex_condition") {
         return tree;
@@ -771,6 +856,40 @@ export function removeBetweenOperators(tree) {
         addChild(newTree, processedChildren[i]);
     }
     return newTree;
+}
+
+export function removeWithinOperators(tree) {
+    if (tree.type === "complex_condition") {
+        return tree;
+    }
+    if (tree.type === "condition") {
+        if (tree.operator !== "within") {
+            return tree;
+        }
+        const { negate, path, value } = tree;
+        const fieldType = value[2];
+        const dateExpressions = {
+            today: expression(DATE_TODAY_STRING_EXPRESSION),
+            delta: expression(
+                `(context_today() + relativedelta(${value[1]}=${value[0]})).strftime('%Y-%m-%d')`
+            ),
+        };
+        const dateTimeExpressions = {
+            today: expression(DATETIME_TODAY_STRING_EXPRESSION),
+            delta: expression(
+                `datetime.datetime.combine(context_today() + relativedelta(${value[1]}=${value[0]}), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")`
+            ),
+        };
+        const expressions = fieldType === "date" ? dateExpressions : dateTimeExpressions;
+        return condition(
+            path,
+            "between",
+            value[0] > 0 ? Object.values(expressions) : Object.values(expressions).reverse(),
+            negate
+        );
+    }
+    const processedChildren = tree.children.map(removeWithinOperators);
+    return { ...tree, children: processedChildren };
 }
 
 /**
@@ -881,7 +1000,10 @@ function removeComplexConditions(tree) {
 export function treeFromExpression(expression, options = {}) {
     const ast = parseExpr(expression);
     const tree = _treeFromAST(ast, options);
-    return createVirtualOperators(createBetweenOperators(tree), options);
+    return createVirtualOperators(
+        createWithinOperators(createBetweenOperators(tree), options),
+        options
+    );
 }
 
 /**
@@ -891,7 +1013,7 @@ export function treeFromExpression(expression, options = {}) {
  */
 export function expressionFromTree(tree, options = {}) {
     const simplifiedTree = createComplexConditions(
-        removeBetweenOperators(removeVirtualOperators(tree))
+        removeBetweenOperators(removeWithinOperators(removeVirtualOperators(tree)))
     );
     return _expressionFromTree(simplifiedTree, options, true);
 }
@@ -902,7 +1024,7 @@ export function expressionFromTree(tree, options = {}) {
  */
 export function domainFromTree(tree) {
     const simplifiedTree = removeBetweenOperators(
-        removeVirtualOperators(removeComplexConditions(tree))
+        removeWithinOperators(removeVirtualOperators(removeComplexConditions(tree)))
     );
     const domainAST = {
         type: 4,
@@ -920,7 +1042,10 @@ export function treeFromDomain(domain, options = {}) {
     domain = new Domain(domain);
     const domainAST = domain.ast;
     const tree = construcTree(domainAST.value, options); // a simple tree
-    return createVirtualOperators(createBetweenOperators(tree), options);
+    return createVirtualOperators(
+        createWithinOperators(createBetweenOperators(tree), options),
+        options
+    );
 }
 
 /**

--- a/addons/web/static/src/core/tree_editor/tree_editor_components.js
+++ b/addons/web/static/src/core/tree_editor/tree_editor_components.js
@@ -1,5 +1,7 @@
 import { Component } from "@odoo/owl";
 import { TagsList } from "@web/core/tags_list/tags_list";
+import { capitalize } from "@web/core/utils/strings";
+import { _t } from "@web/core/l10n/translation";
 
 export class Input extends Component {
     static props = ["value", "update", "startEmpty?"];
@@ -22,6 +24,28 @@ export class Select extends Component {
 export class Range extends Component {
     static props = ["value", "update", "editorInfo"];
     static template = "web.TreeEditor.Range";
+
+    update(index, newValue) {
+        const result = [...this.props.value];
+        result[index] = newValue;
+        return this.props.update(result);
+    }
+}
+
+export class Within extends Component {
+    static props = ["value", "update"];
+    static template = "web.TreeEditor.Within";
+    static components = { Input, Select };
+    static options = [
+        ["days", _t("days")],
+        ["weeks", _t("weeks")],
+        ["months", _t("months")],
+        ["years", _t("years")],
+    ];
+
+    get options() {
+        return Within.options.map((option) => [option[0], capitalize(option[1])]);
+    }
 
     update(index, newValue) {
         const result = [...this.props.value];

--- a/addons/web/static/src/core/tree_editor/tree_editor_components.xml
+++ b/addons/web/static/src/core/tree_editor/tree_editor_components.xml
@@ -32,6 +32,13 @@
         </div>
     </t>
 
+    <t t-name="web.TreeEditor.Within">
+        <div class="d-flex align-items-center">
+            <Input value="props.value[0]" update="(val) => this.update(0, val)"/>
+            <Select value="props.value[1]" options="options" update="(val) => this.update(1, val)"/>
+        </div>
+    </t>
+
     <t t-name="web.TreeEditor.List">
         <div class="o_input d-flex flex-wrap gap-1">
             <TagsList tags="tags"/>

--- a/addons/web/static/src/core/tree_editor/tree_editor_operator_editor.js
+++ b/addons/web/static/src/core/tree_editor/tree_editor_operator_editor.js
@@ -36,6 +36,7 @@ const OPERATOR_DESCRIPTIONS = {
 
     // virtual operator (equivalent to a couple (>=,<=))
     between: _t("is between"),
+    within: _t("is within"),
 
     any: (fieldDefType) => {
         switch (fieldDefType) {

--- a/addons/web/static/src/core/tree_editor/tree_editor_value_editors.js
+++ b/addons/web/static/src/core/tree_editor/tree_editor_value_editors.js
@@ -12,7 +12,7 @@ import {
     DomainSelectorSingleAutocomplete,
 } from "@web/core/tree_editor/tree_editor_autocomplete";
 import { unique } from "@web/core/utils/arrays";
-import { Input, Select, List, Range } from "@web/core/tree_editor/tree_editor_components";
+import { Input, Select, List, Range, Within } from "@web/core/tree_editor/tree_editor_components";
 import { connector, formatValue, isTree } from "@web/core/tree_editor/condition_tree";
 import { getResModel, disambiguate, isId } from "@web/core/tree_editor/utils";
 
@@ -125,6 +125,24 @@ function getPartialValueEditorInfo(fieldDef, operator, params = {}) {
                 defaultValue: () => {
                     const { defaultValue } = editorInfo;
                     return [defaultValue(), defaultValue()];
+                },
+            };
+        }
+        case "within": {
+            return {
+                component: Within,
+                extractProps: ({ value, update }) => ({
+                    value,
+                    update,
+                }),
+                isSupported: (value) =>
+                    Array.isArray(value) &&
+                    value.length === 3 &&
+                    Number.isInteger(value[0]) &&
+                    Within.options.some((o) => o[0] === value[1]) &&
+                    value[2] === fieldDef.type,
+                defaultValue: () => {
+                    return [-1, "months", fieldDef.type];
                 },
             };
         }

--- a/addons/web/static/src/core/tree_editor/utils.js
+++ b/addons/web/static/src/core/tree_editor/utils.js
@@ -16,6 +16,7 @@ import {
     formatDateTime,
 } from "@web/core/l10n/dates";
 import { useLoadFieldInfo, useLoadPathDescription } from "@web/core/model_field_selector/utils";
+import { Within } from "./tree_editor_components";
 
 /**
  * @param {import("@web/core/tree_editor/condition_tree").Value} val
@@ -177,14 +178,21 @@ function _getConditionDescription(node, getFieldDef, getPathDescription, display
 
     const coModeldisplayNames = displayNames[getResModel(fieldDef)];
     const dis = disambiguate(value, coModeldisplayNames);
-    const values = (Array.isArray(value) ? value : [value]).map((val) =>
-        formatValue(val, dis, fieldDef, coModeldisplayNames)
-    );
+    const values =
+        operator == "within"
+            ? [value[0], Within.options.find((option) => option[0] === value[1])[1]]
+            : (Array.isArray(value) ? value : [value]).map((val) =>
+                  formatValue(val, dis, fieldDef, coModeldisplayNames)
+              );
     let join;
     let addParenthesis = Array.isArray(value);
     switch (operator) {
         case "between":
             join = _t("and");
+            addParenthesis = false;
+            break;
+        case "within":
+            join = " ";
             addParenthesis = false;
             break;
         case "in":

--- a/addons/web/static/src/search/search_model.js
+++ b/addons/web/static/src/search/search_model.js
@@ -19,7 +19,7 @@ import { FACET_ICONS, FACET_COLORS } from "./utils/misc";
 import { EventBus, toRaw } from "@odoo/owl";
 import { domainFromTree, treeFromDomain } from "@web/core/tree_editor/condition_tree";
 import { _t } from "@web/core/l10n/translation";
-import { useGetTreeDescription } from "@web/core/tree_editor/utils";
+import { useGetTreeDescription, useMakeGetFieldDef } from "@web/core/tree_editor/utils";
 import { DomainSelectorDialog } from "@web/core/domain_selector_dialog/domain_selector_dialog";
 import { getDefaultDomain } from "@web/core/domain_selector/utils";
 
@@ -178,6 +178,7 @@ export class SearchModel extends EventBus {
         this.orderByCount = false;
 
         this.getDomainTreeDescription = useGetTreeDescription(fieldService, nameService);
+        this.makeGetFieldDef = useMakeGetFieldDef(fieldService);
 
         // used to manage search items related to date/datetime fields
         this.referenceMoment = DateTime.local();
@@ -810,7 +811,8 @@ export class SearchModel extends EventBus {
             context = makeContext(contexts);
         }
 
-        const tree = treeFromDomain(domain, { distributeNot: !this.isDebugMode });
+        const getFieldDef = await this.makeGetFieldDef(this.resModel, treeFromDomain(domain));
+        const tree = treeFromDomain(domain, { distributeNot: !this.isDebugMode, getFieldDef });
         const trees = !tree.negate && tree.value === "&" ? tree.children : [tree];
         const promises = trees.map(async (tree) => {
             const description = await this.getDomainTreeDescription(this.resModel, tree);

--- a/addons/web/static/tests/core/domain_selector/domain_selector.test.js
+++ b/addons/web/static/tests/core/domain_selector/domain_selector.test.js
@@ -695,7 +695,6 @@ test("expressions in between operator", async () => {
     expect(SELECTORS.condition).toHaveCount(1);
     expect(getCurrentOperator()).toBe("is between");
     expect(SELECTORS.valueEditor).toHaveCount(1);
-    expect(SELECTORS.valueEditor).toHaveCount(1);
     expect(SELECTORS.valueEditor + " " + SELECTORS.editor).toHaveCount(2);
     expect(SELECTORS.clearNotSupported).toHaveCount(1);
     expect(`${SELECTORS.editor} .o_datetime_input`).toHaveCount(1);
@@ -1051,7 +1050,18 @@ test("support properties", async () => {
         {
             name: "xphone_prop_5",
             domain: `[("properties.xphone_prop_5", "=", "2023-10-05")]`,
-            options: ["=", "!=", ">", ">=", "<", "<=", "is between", "is set", "is not set"],
+            options: [
+                "=",
+                "!=",
+                ">",
+                ">=",
+                "<",
+                "<=",
+                "is between",
+                "is within",
+                "is set",
+                "is not set",
+            ],
         },
         {
             name: "xphone_prop_6",


### PR DESCRIPTION
Add a new operator 'within' in the tree editor.
Making it available in the domain selector and expression editor.
It takes two arguments:
- an integer (postive or negative)
- a period (day, week, month, year)

Ends up being like a between, but always starting
or ending at the current date/datetime.

Task ID: 3821281