### PR TITLE
[FIX] hr_holidays: avoid overriding `responsible_id` domain

### DIFF
--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -77,7 +77,8 @@ class HolidaysType(models.Model):
     company_id = fields.Many2one('res.company', string='Company', default=lambda self: self.env.company)
     responsible_id = fields.Many2one(
         'res.users', 'Responsible Time Off Officer',
-        domain=lambda self: [('groups_id', 'in', self.env.ref('hr_holidays.group_hr_holidays_user').id)],
+        domain=lambda self: [('groups_id', 'in', self.env.ref('hr_holidays.group_hr_holidays_user').id),
+                             ('share', '=', False)],
         help="Choose the Time Off Officer who will be notified to approve allocation or Time Off request")
     leave_validation_type = fields.Selection([
         ('no_validation', 'No Validation'),

--- a/addons/hr_holidays/views/hr_leave_type_views.xml
+++ b/addons/hr_holidays/views/hr_leave_type_views.xml
@@ -49,7 +49,7 @@
                             <h2>Time Off Requests</h2>
                             <field name="active" invisible="1"/>
                             <field name="leave_validation_type" string="Approval" widget="radio"/>
-                            <field name="responsible_id" domain="[('share', '=', False)]"
+                            <field name="responsible_id"
                                 attrs="{
                                 'invisible': [('leave_validation_type', 'in', ['no_validation', 'manager']), '|', ('requires_allocation', '=', 'no'), ('allocation_validation_type', '!=', 'officer')],
                                 'required': ['|',('leave_validation_type', 'in', ['both', 'hr']), ('requires_allocation', '=', 'yes'), ('allocation_validation_type', '=', 'officer')]}"/>


### PR DESCRIPTION
Steps to reproduce:
If we have a user that does not have access rights in time off, and we try to create a new time off type, we can select that user as the responsible time off officer in the view.

The issue is that the domain in the form view overrides the one in the field.

This commit moves the domain for the field `responsible_id` from the form view to the field definition.

A similar fix was done in https://github.com/odoo/odoo/pull/100381, but it is only available for 16.1 and above.

task: 3973617

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
