### PR TITLE
[IMP] website_sale: import payment_token file

### DIFF
--- a/addons/website_sale/models/__init__.py
+++ b/addons/website_sale/models/__init__.py
@@ -6,6 +6,7 @@ from . import crm_team
 from . import delivery_carrier
 from . import digest
 from . import ir_http
+from . import payment_token
 from . import product_attribute
 from . import product_image
 from . import product_pricelist


### PR DESCRIPTION
This commit import payment_token file in __init__
which was missed by [1] PR to properly execute
it's code and do not return any token for express
checkout.

[1]: https://github.com/odoo/odoo/pull/107788

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
