### PR TITLE
[FIX] website: simplify local anchor links

### DIFF
--- a/addons/website/static/src/js/content/snippets.animation.js
+++ b/addons/website/static/src/js/content/snippets.animation.js
@@ -1065,8 +1065,13 @@ registry.anchorSlide = publicWidget.Widget.extend({
      * @private
      */
     _onAnimateClick: function (ev) {
-        if (this.$target[0].pathname !== window.location.pathname) {
+        const ensureSlash = path => path.endsWith("/") ? path : path + "/";
+        if (ensureSlash(this.$target[0].pathname) !== ensureSlash(window.location.pathname)) {
             return;
+        }
+        // Avoid flicker at destination in case of ending "/" difference.
+        if (this.$target[0].pathname !== window.location.pathname) {
+            this.$target[0].pathname = window.location.pathname;
         }
         var hash = this.$target[0].hash;
         if (hash === '#top' || hash === '#bottom') {


### PR DESCRIPTION
When a menu link is defined towards an anchor, the scroll effect of the browser does not trigger from within the translated pages where the URL contains the additional path element about the used locale.

This scrolling is achieved by the browser itself, it is not related to `scroller_service.js`.
The URL is not transformed by `website.menu`'s `clean_url` method. The language is added in `ir.http`'s `url_lang` method, but we cannot always know the current URL at that point, nor during the template rendering - making it impossible to determine if the rendered anchor is local.

This commit solves this client-side by replacing link's `href` values with their anchor only whenever they are targeting the current page.

Steps to reproduce:
- Install a second language on the website.
- Put some content in the Home page so that the bottom section requires scrolling to be seen.
- Add a menu element that targets `#bottom`.
- Either be a visitor or a connected user.
- Go to the default language Home page.
- Click on the new link. => Page scrolls to the bottom.
- Switch to the second language Home page.
- Click on the new link.

=> Page reloads targeting the bottom instead of scrolling.

opw-3956066
