### PR TITLE
[FIX] calendar: empty list instead of False for 2many fields

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -598,14 +598,20 @@ class Meeting(models.Model):
             for event in records:
                 if event['id'] in private_events.ids:
                     for field in private_fields:
-                        event[field] = _('Busy') if field in ['name', 'display_name'] else False
+                        if self._fields[field].type in ('one2many', 'many2many'):
+                            event[field] = []
+                        else:
+                            event[field] = _('Busy') if field in ('name', 'display_name') else False
 
             # Update the cache with the new hidden values.
             for field_name in private_fields:
                 field = self._fields[field_name]
-                replacement = field.convert_to_cache(
-                    _('Busy') if field_name in ['name', 'display_name'] else False,
-                    private_events)
+                value = False
+                if field.type in ('one2many', 'many2many'):
+                    value = []
+                elif field_name in ('name', 'display_name'):
+                    value = _('Busy')
+                replacement = field.convert_to_cache(value, private_events)
                 self.env.cache.update(private_events, field, repeat(replacement))
         return records
 


### PR DESCRIPTION
When an event is private the override of the read function hides the original value by assigning `False` instead: see here: https://github.com/odoo/odoo/commit/32931e77513b88fe080026909c941b537c857a08#diff-6c4c124bfb9e4397bed7221c7534c8f877904775e9db4cf81f72b5430b36ad06R593 For 2many fields this causes an issue during upgrades because `read` is expected to return an empty list for those.





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
