### PR TITLE
[DRAFT][FIX] hr_expense: compute total_amount to 0.0 when no cost

### DIFF
--- a/addons/hr_expense/tests/test_expenses.py
+++ b/addons/hr_expense/tests/test_expenses.py
@@ -1391,3 +1391,28 @@ class TestExpenses(TestExpenseCommon):
             {'name': 'test sheet no update', 'unit_amount': 100.0, 'quantity': 1, 'total_amount': 100.0},
             {'name':    'test sheet update', 'unit_amount': 250.0, 'quantity': 1, 'total_amount': 250.0},  # no update
         ])
+
+    def test_expense_total_amount_change(self):
+        '''
+        Test the behavior of total_amount field when changing the product to one without a cost
+        and manually setting the total_amount.
+        '''
+
+        expense = self.env['hr.expense'].create({
+            'name': 'Expense with cost',
+            'employee_id': self.expense_employee.id,
+            'product_id': self.product_a.id,  # Assuming product_a has a cost
+            'unit_amount': 100.0,
+            'quantity': 1,
+        })
+        self.assertEqual(expense.total_amount, 100.0)
+
+        expense_form = Form(expense)
+        expense_form.product_id = self.product_zero_cost
+        self.assertEqual(expense_form.total_amount, 0.0)
+
+        expense_form.total_amount = 200.0
+        self.assertEqual(expense_form.total_amount, 200.0)
+
+        expense = expense_form.save()
+        self.assertEqual(expense.total_amount, 200.0)


### PR DESCRIPTION
When an expense category is being set to a product with cost, _compute_amount will update total_amount. But when the category is being change to a product with no cost (product_has_cost = False), _compute_amount will not update total_amount to 0.0

Steps to reproduce:
1.In Expense > New > in category, use a product with a cost > 1 2.See the total (total_amount) being computed according the chosen product cost 3.In the same form, change the category by choosing a product with no cost 4.Notice how the total has not changed to 0, but kept unchanged

cause:
total_amount is not being computed when product has no cost

Solution:
remove produt_has_cost from if statement when computing the total_amount and unit_amount. Computing unit_amount when a product is added triggers a dependency to _compute_total_amount, for which the calulation is based on the unit_amount * quanitty. Or the default behavior when the product has no cost is :
    (hr_expense.py, line 309)
    else:  # Even if we don't add a product, the unit_amount is still used for the move.line balance computation
        expense.unit_amount = expense.company_currency_id.round(expense.total_amount_company / (expense.quantity or 1))
Causing the lsot of the product price information if it is 0, yet 0 cost on a product is still information. In addition to that, when computing total_amount, ignoring the computation when has_product_cost is False will also lead to the lost of information regarding 0 as a cost.

An other solution would be to set produt_has_cost field True even if product cost is 0, but that would mess up the views logic.

opw-3983863
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
