### PR TITLE
[FIX] loyalty: batch consume the per_point reward

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/models/loyalty.js
+++ b/addons/pos_loyalty/static/src/overrides/models/loyalty.js
@@ -1302,10 +1302,12 @@ patch(Order.prototype, {
             return [];
         }
         let maxDiscount = reward.discount_max_amount || Infinity;
+        let is_payement_program=(["ewallet", "gift_card"].includes(reward.program_id.program_type))
         if (reward.discount_mode === "per_point") {
+            let pointUsed=is_payement_program?this._getRealCouponPoints(coupon_id):reward.required_points
             maxDiscount = Math.min(
                 maxDiscount,
-                reward.discount * this._getRealCouponPoints(coupon_id)
+                reward.discount * pointUsed
             );
         } else if (reward.discount_mode === "per_order") {
             maxDiscount = Math.min(maxDiscount, reward.discount);
@@ -1317,11 +1319,11 @@ patch(Order.prototype, {
             ? this._getRealCouponPoints(coupon_id)
             : reward.required_points;
         if (reward.discount_mode === "per_point" && !reward.clear_wallet) {
-            pointCost = Math.min(maxDiscount, discountable) / reward.discount;
+            pointCost = is_payement_program?Math.min(maxDiscount, discountable) / reward.discount:reward.required_points;
         }
         // These are considered payments and do not require to be either taxed or split by tax
         const discountProduct = reward.discount_line_product_id;
-        if (["ewallet", "gift_card"].includes(reward.program_id.program_type)) {
+        if (is_payement_program) {
             return [
                 {
                     product: discountProduct,

--- a/addons/pos_loyalty/static/tests/tours/PosLoyaltyTour.js
+++ b/addons/pos_loyalty/static/tests/tours/PosLoyaltyTour.js
@@ -236,7 +236,7 @@ registry.category("web_tour.tours").add("PosLoyaltyTour6", {
             ProductScreen.clickDisplayedProduct("Test Product A"),
             PosLoyalty.clickRewardButton(),
             SelectionPopup.clickItem("$ 1 per point on your order"),
-            ProductScreen.totalAmountIs("138.50"),
+            ProductScreen.totalAmountIs("145"),
         ].flat(),
 });
 

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -1058,7 +1058,7 @@ class TestUi(TestPointOfSaleHttpCommon):
             })],
             'reward_ids': [(0, 0, {
                 'reward_type': 'discount',
-                'required_points': 1,
+                'required_points': 120,
                 'discount': 1,
                 'discount_mode': 'per_point',
             })],

--- a/addons/sale_loyalty/models/sale_order.py
+++ b/addons/sale_loyalty/models/sale_order.py
@@ -343,10 +343,7 @@ class SaleOrder(models.Model):
         # discount should never surpass the order's current total amount
         max_discount = min(self.amount_total, max_discount)
         if reward.discount_mode == 'per_point':
-            points = self._get_real_points_for_coupon(coupon)
-            if not reward.program_id.is_payment_program:
-                # Rewards cannot be partially offered to customers
-                points = points // reward.required_points * reward.required_points
+            points = self._get_real_points_for_coupon(coupon) if reward.program_id.is_payment_program else reward.required_points
             max_discount = min(max_discount,
                 reward.currency_id._convert(reward.discount * points,
                     self.currency_id, self.company_id, fields.Date.today()))
@@ -361,7 +358,7 @@ class SaleOrder(models.Model):
         if reward.discount_mode == 'per_point' and not reward.clear_wallet:
             # Calculate the actual point cost if the cost is per point
             converted_discount = self.currency_id._convert(min(max_discount, discountable), reward.currency_id, self.company_id, fields.Date.today())
-            point_cost = converted_discount / reward.discount
+            point_cost = converted_discount / reward.discount if reward.program_id.is_payment_program else reward.required_points
         # Gift cards and eWallets are considered gift cards and should not have any taxes
         if reward.program_id.is_payment_program:
             reward_product = reward.discount_line_product_id

--- a/addons/sale_loyalty/tests/test_loyalty.py
+++ b/addons/sale_loyalty/tests/test_loyalty.py
@@ -102,7 +102,7 @@ class TestLoyalty(TestSaleCouponCommon):
             0,
             "Can only use a whole number of required points",
         )
-        self.assertEqual(vals[0]['points_cost'], 9, "Use maximum available points for the reward")
+        self.assertEqual(vals[0]['points_cost'], 3, "Use required available points for the reward")
         self.ewallet.points = 50
         order._update_programs_and_rewards()
         claimable_rewards = order._get_claimable_rewards()

--- a/addons/sale_loyalty/tests/test_program_numbers.py
+++ b/addons/sale_loyalty/tests/test_program_numbers.py
@@ -1803,4 +1803,4 @@ class TestSaleCouponProgramNumbers(TestSaleCouponNumbersCommon):
         self.assertEqual(len(order.order_line), 2, 'Promotion should add 1 line')
         self.assertEqual(order.order_line[0].tax_id, tax_15pc_excl)
         self.assertEqual(order.order_line[1].tax_id, tax_15pc_excl)
-        self.assertEqual(order.amount_total, 156.0, '140$ + 15% - 5$ = 156$')
+        self.assertEqual(order.amount_total, 160.0, '140$ + 15% - 1$ = 160')


### PR DESCRIPTION
To recreate the bug:
1- Create a loyalty program with a reward of $ per point and a fixed required ammount 
2- Test the loyalty and see the reward and point consumed 
3- We see that whenever we have an ammount of point superior to the required ammount, it get consumed totally and the reward is that total*($ per point)

We have 2 problems her. First is the total consumption and second is the fractional reward and consumtion. If a we have a 3$ per 2 points and we have a total of 5 points, we should at max use 4 with reward of 6$.

I also checked the functionality of the feature in sales module and it was the same. So I changed it so that it use always required ammount, except in the case of ewallet or gift card.

opw-3922835