### PR TITLE
[FIX] payment: fix traceback when user tries to install payment in multi company

### DIFF
--- a/addons/payment/models/res_company.py
+++ b/addons/payment/models/res_company.py
@@ -47,10 +47,9 @@ class ResCompany(models.Model):
         if not stripe_provider:
             base_provider = self.env.ref('payment.payment_provider_stripe')
             # Use sudo to access payment provider record that can be in different company.
-            stripe_provider = base_provider.sudo().copy(default={
-                'company_id': self.env.company.id,
-                'website_id': False,
-            })
+            stripe_provider = base_provider.sudo().with_context(
+                stripe_connect_onboarding=True,
+            ).copy(default={'company_id': self.env.company.id})
         stripe_provider.journal_id = stripe_provider.journal_id or default_journal
 
         return stripe_provider.action_stripe_connect_account(menu_id=menu_id)

--- a/addons/website_payment/models/payment_provider.py
+++ b/addons/website_payment/models/payment_provider.py
@@ -24,3 +24,10 @@ class PaymentProvider(models.Model):
             # system and need to be converted to send to external APIs.
             return iri_to_uri(request.httprequest.url_root)
         return super().get_base_url()
+
+    def copy(self, default=None):
+        res = super().copy(default)
+        default = dict(default or {})
+        if self._context.get('stripe_connect_onboarding'):
+            res.website_id = False
+        return res


### PR DESCRIPTION
This traceback occurs when the user tries to activate stripe through onboarding without installing `website_payment`.

To reproduce this issue:-

1) Install `sale`
2) Now switch to a new company by creating a `new company` 
4) With the new company try to `activate the stripe` from the `sales Onboarding` 
5) A traceback occurs

Error:- 
```
ValueError: Invalid field 'website_id' on model 'payment.provider'
```

As you can see `website_id` field is defined in `website_payment` at [1], 
but it is used in the `payment` module [2]. Which leads to the above traceback
when `website_payment` is not installed.

[1]
https://github.com/odoo/odoo/blob/16e8de01b14ddac69cd706f8f64e762406769542/addons/website_payment/models/payment_provider.py#L12-L16

[2]
https://github.com/odoo/odoo/blob/16e8de01b14ddac69cd706f8f64e762406769542/addons/payment/models/res_company.py#L48-L53

sentry-5504774122
