### PR TITLE
[FIX] pos_restaurant: keep user's choice about floor plan

### DIFF
--- a/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.js
+++ b/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.js
@@ -43,9 +43,6 @@ export class FloorScreen extends Component {
             floorMapScrollTop: 0,
             isColorPicker: false,
         });
-        const ui = useState(useService("ui"));
-        const mode = localStorage.getItem("floorPlanStyle");
-        this.pos.floorPlanStyle = ui.isSmall || mode == "kanban" ? "kanban" : "default";
         this.floorMapRef = useRef("floor-map-ref");
         this.addFloorRef = useRef("add-floor-ref");
         this.map = useRef("map");

--- a/addons/pos_restaurant/static/src/app/pos_store.js
+++ b/addons/pos_restaurant/static/src/app/pos_store.js
@@ -32,7 +32,8 @@ patch(PosStore.prototype, "pos_restaurant.PosStore", {
         }
         this.orderToTransfer = null; // table transfer feature
         this.transferredOrdersSet = new Set(); // used to know which orders has been transferred but not sent to the back end yet
-        this.floorPlanStyle = "default";
+        this.floorPlanStyle =
+            localStorage.getItem("floorPlanStyle") || (this.ui.isSmall ? "kanban" : "default");
         this.isEditMode = false;
     },
     setActivityListeners() {


### PR DESCRIPTION
The user can select between `kanban` and `default` views in `pos_restaurant`. When a selection is made, it should be kept, which is not the case now. Each time the `FloorScreen` is rerendered, the choice is lost.

This commit fixes the issue.

Task: 3999451




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
