### PR TITLE
[IMP] web: standardize dialog buttons justify

### DIFF
--- a/addons/web/static/src/core/dialog/dialog.scss
+++ b/addons/web/static/src/core/dialog/dialog.scss
@@ -18,10 +18,6 @@
             flex: 1 1 auto;
             justify-content: flex-start;
             gap: map-get($spacers, 1);
-
-            @include media-breakpoint-down(md) {
-                justify-content: space-around;
-            }
         }
 
         button {


### PR DESCRIPTION
During some test, I figured out that back end dialog don't display actions buttons the same way depending on if the dialog is from the dialog.xml or the form_controller.xml
([See excalidraw for illustration](https://excalidraw.com/#json=BQ63z3GKayVZgmeI8TC-h,n9olGoA1nxuB-MtzHXQqxw))
