### PR TITLE
[FIX] account: Fix tax_totals with round_globally / price included taxes

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -1078,6 +1078,7 @@ class AccountTax(models.Model):
         rounding_method='round_per_line',
         precision_rounding=None,
         reverse=False,
+        round_price_include=True,
     ):
         """ Prepare a dictionary that can be used to evaluate the prepared taxes computation (see '_prepare_taxes_computation').
 
@@ -1093,14 +1094,27 @@ class AccountTax(models.Model):
                                     Flag indicating if we want a reverse computation.
                                     You can only expect accurate symmetrical taxes computation with not rounded price_unit
                                     as input and 'round_globally' computation. Otherwise, it's not guaranteed.
+        :param round_price_include: Indicate if we want to force the rounding in price_include whatever the tax computation method.
+                                    In case you have 2 invoice lines of 21.53 with 21% price included taxes, the code will compute
+                                    21.53 / 1.21 * 2 ~= 35.59 as untaxed amount, 7.47 as tax amount and 40.06 as total amount.
+                                    However, for now, we decided we want to put the rounding into the tax amount instead of making
+                                    an adjustment on the untaxed amount because we want the untaxed amount being the sum of the price
+                                    excluded amount of each line. Here, 2 * round(21.53 / 1.21) = 35.58. So we are forced to put the
+                                    rounding on the tax instead to have 35.58 + 7.48 = 43.06 and then, round like the round_per_line
+                                    when the tax is price included.
         :return:                    A python dictionary.
         """
+        if rounding_method == 'round_globally' and not round_price_include:
+            precision_rounding = None
+        elif not precision_rounding:
+            precision_rounding = 0.01
         return {
             'product': product_values,
             'price_unit': price_unit,
             'quantity': quantity,
             'rounding_method': rounding_method,
-            'precision_rounding': None if rounding_method == 'round_globally' else precision_rounding or 0.01,
+            'precision_rounding': precision_rounding,
+            'round_price_include': round_price_include,
         }
 
     @api.model
@@ -1188,10 +1202,12 @@ class AccountTax(models.Model):
         eval_order_indexes = taxes_computation['eval_order_indexes']
         rounding_method = evaluation_context['rounding_method']
         prec_rounding = evaluation_context['precision_rounding']
+        round_price_include = evaluation_context['round_price_include']
         eval_taxes_data = [dict(tax_data) for tax_data in taxes_data]
         skipped = set()
         for quid, index in eval_order_indexes:
             tax_data = eval_taxes_data[index]
+            special_mode = tax_data['evaluation_context']['special_mode']
             if quid == 'tax':
                 extra_base = 0.0
                 for extra_base_sign, extra_base_index in tax_data['extra_base_for_tax']:
@@ -1206,7 +1222,7 @@ class AccountTax(models.Model):
                     tax_amount = 0.0
                 tax_data['tax_amount'] = tax_amount
                 tax_data['tax_amount_factorized'] = tax_data['tax_amount'] * tax_data['_factor']
-                if rounding_method == 'round_per_line':
+                if rounding_method == 'round_per_line' or (not special_mode and tax_data['price_include'] and round_price_include):
                     tax_data['tax_amount_factorized'] = float_round(tax_data['tax_amount_factorized'], precision_rounding=prec_rounding)
             elif quid == 'base':
                 extra_base = 0.0
@@ -1221,7 +1237,7 @@ class AccountTax(models.Model):
                     'extra_base': extra_base,
                     'total_tax_amount': total_tax_amount,
                 }))
-                if rounding_method == 'round_per_line':
+                if rounding_method == 'round_per_line' or (not special_mode and tax_data['price_include'] and round_price_include):
                     tax_data['base'] = float_round(tax_data['base'], precision_rounding=prec_rounding)
                     tax_data['display_base'] = float_round(tax_data['display_base'], precision_rounding=prec_rounding)
 
@@ -1289,6 +1305,7 @@ class AccountTax(models.Model):
             1.0,
             product_values,
             rounding_method='round_globally',
+            round_price_include=False,
         )
         taxes_computation = self._eval_taxes_computation(taxes_computation, evaluation_context)
         price_unit = taxes_computation['total_excluded']
@@ -1300,6 +1317,7 @@ class AccountTax(models.Model):
             1.0,
             product_values,
             rounding_method='round_globally',
+            round_price_include=False,
         )
         taxes_computation = self._eval_taxes_computation(taxes_computation, evaluation_context)
         delta = sum(x['tax_amount_factorized'] for x in taxes_computation['taxes_data'] if x['_original_price_include'])

--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -754,7 +754,10 @@ class TestTaxCommon(AccountTestInvoicingHttpCommon):
                 'price_unit': price_unit,
                 'quantity': quantity,
                 'product_values': product_values,
-                'evaluation_context_kwargs': evaluation_context_kwargs,
+                'evaluation_context_kwargs': {
+                    'round_price_include': False,
+                    **evaluation_context_kwargs,
+                },
                 'compute_kwargs': compute_kwargs,
                 'is_round_globally': is_round_globally,
                 'excluded_special_modes': excluded_special_modes,

--- a/addons/account/tests/test_invoice_tax_totals.py
+++ b/addons/account/tests/test_invoice_tax_totals.py
@@ -751,7 +751,7 @@ class TestTaxTotals(AccountTestInvoicingCommon):
             'subtotals_order': ["Untaxed Amount"],
         })
 
-    def test_round_globally_price_included_tax(self):
+    def test_round_globally_price_included_tax_1(self):
         self.env.company.tax_calculation_rounding_method = 'round_globally'
         tax_1 = self.env['account.tax'].create({
             'name': "tax_1",
@@ -783,7 +783,7 @@ class TestTaxTotals(AccountTestInvoicingCommon):
             ],
         })
         self.assert_document_tax_totals(invoice, {
-            'amount_total': 43.050000000000004,
+            'amount_total': 43.06,
             'amount_untaxed': 33.58,
             'display_tax_base': True,
             'groups_by_subtotal': {
@@ -791,13 +791,13 @@ class TestTaxTotals(AccountTestInvoicingCommon):
                     {
                         'tax_group_name': self.tax_group1.name,
                         'tax_group_amount': 2,
-                        'tax_group_base_amount': 33.59,
+                        'tax_group_base_amount': 33.58,
                         'tax_group_id': self.tax_group1.id,
                     },
                     {
                         'tax_group_name': self.tax_group2.name,
-                        'tax_group_amount': 7.47,
-                        'tax_group_base_amount': 35.59,
+                        'tax_group_amount': 7.48,
+                        'tax_group_base_amount': 35.58,
                         'tax_group_id': self.tax_group2.id,
                     }
                 ]
@@ -806,6 +806,63 @@ class TestTaxTotals(AccountTestInvoicingCommon):
                 {
                     'name': "Untaxed Amount",
                     'amount': 33.58,
+                }
+            ],
+            'subtotals_order': ["Untaxed Amount"],
+        })
+
+    def test_round_globally_price_included_tax_2(self):
+        self.env.company.tax_calculation_rounding_method = 'round_globally'
+        taxes = self.env['account.tax'].create([
+            {
+                'name': f"tax_6_{i}",
+                'amount_type': 'percent',
+                'tax_group_id': tax_group.id,
+                'amount': 6.0,
+                'price_include': True,
+                'include_base_amount': True,
+                'is_base_affected': False,
+            }
+            for i, tax_group in enumerate(self.tax_group1 + self.tax_group2)
+        ])
+        invoice = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'partner_id': self.partner_a.id,
+            'invoice_date': '2019-01-01',
+            'invoice_line_ids': [
+                Command.create({
+                    'name': f'line{i}',
+                    'display_type': 'product',
+                    'price_unit': 21.53,
+                    'tax_ids': [Command.set(taxes.ids)],
+                })
+                for i in range(2)
+            ],
+        })
+        self.assert_document_tax_totals(invoice, {
+            'amount_total': 43.06,
+            'amount_untaxed': 38.46,
+            'display_tax_base': False,
+            'groups_by_subtotal': {
+                'Untaxed Amount': [
+                    {
+                        'tax_group_name': self.tax_group1.name,
+                        'tax_group_amount': 2.3000000000000003,
+                        'tax_group_base_amount': 38.46,
+                        'tax_group_id': self.tax_group1.id,
+                    },
+                    {
+                        'tax_group_name': self.tax_group2.name,
+                        'tax_group_amount': 2.3000000000000003,
+                        'tax_group_base_amount': 38.46,
+                        'tax_group_id': self.tax_group2.id,
+                    }
+                ]
+            },
+            'subtotals': [
+                {
+                    'name': "Untaxed Amount",
+                    'amount': 38.46,
                 }
             ],
             'subtotals_order': ["Untaxed Amount"],

--- a/addons/l10n_hu_edi/tests/invoice_xmls/invoice_complex_eur.xml
+++ b/addons/l10n_hu_edi/tests/invoice_xmls/invoice_complex_eur.xml
@@ -218,13 +218,13 @@
                         </vatRateVatData>
                     </summaryByVatRate>
                     <invoiceNetAmount>343.99</invoiceNetAmount>
-                    <invoiceNetAmountHUF>130980.48</invoiceNetAmountHUF>
+                    <invoiceNetAmountHUF>130981.06</invoiceNetAmountHUF>
                     <invoiceVatAmount>29.88</invoiceVatAmount>
                     <invoiceVatAmountHUF>11376.38</invoiceVatAmountHUF>
                 </summaryNormal>
                 <summaryGrossData>
                     <invoiceGrossAmount>373.87</invoiceGrossAmount>
-                    <invoiceGrossAmountHUF>142356.86</invoiceGrossAmountHUF>
+                    <invoiceGrossAmountHUF>142357.44</invoiceGrossAmountHUF>
                 </summaryGrossData>
             </invoiceSummary>
         </invoice>

--- a/addons/l10n_it_edi/tests/export_xmls/invoice_price_included_taxes.xml
+++ b/addons/l10n_it_edi/tests/export_xmls/invoice_price_included_taxes.xml
@@ -62,7 +62,7 @@
                 <Divisa>EUR</Divisa>
                 <Data>2022-03-24</Data>
                 <Numero>INV/2022/00001</Numero>
-                <ImportoTotaleDocumento>2577.30</ImportoTotaleDocumento>
+                <ImportoTotaleDocumento>2577.29</ImportoTotaleDocumento>
             </DatiGeneraliDocumento>
         </DatiGenerali>
         <DatiBeniServizi>
@@ -92,9 +92,9 @@
             </DettaglioLinee>
             <DatiRiepilogo>
                 <AliquotaIVA>22.00</AliquotaIVA>
-                <Arrotondamento>0.00521610</Arrotondamento>
-                <ImponibileImporto>1312.14</ImponibileImporto>
-                <Imposta>288.67</Imposta>
+                <Arrotondamento>-0.04909091</Arrotondamento>
+                <ImponibileImporto>1312.09</ImponibileImporto>
+                <Imposta>288.66</Imposta>
                 <EsigibilitaIVA>I</EsigibilitaIVA>
             </DatiRiepilogo>
             <DatiRiepilogo>
@@ -109,7 +109,7 @@
             <DettaglioPagamento>
                 <ModalitaPagamento>MP05</ModalitaPagamento>
                 <DataScadenzaPagamento>2022-03-24</DataScadenzaPagamento>
-                <ImportoPagamento>2577.30</ImportoPagamento>
+                <ImportoPagamento>2577.29</ImportoPagamento>
                 <CodicePagamento>INV/2022/00001</CodicePagamento>
             </DettaglioPagamento>
         </DatiPagamento>


### PR DESCRIPTION
In case you have 2 invoice lines of 21.53 with 21% price included taxes, the code will compute 21.53 / 1.21 * 2 ~= 35.59 as untaxed amount, 7.47 as tax amount and 40.06 as total amount. However, for now, we decided we want to put the rounding into the tax amount instead of making an adjustment on the untaxed amount because we want the untaxed amount being the sum of the price excluded amount of each line. Here, 2 * round(21.53 / 1.21) = 35.58. So we are forced to put the rounding on the tax instead to have 35.58 + 7.48 = 43.06 and then, round like the round_per_line when the tax is price included.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
