### PR TITLE
[IMP] payment{_*}: improve error handling

### DIFF
--- a/addons/account_payment/wizards/payment_refund_wizard.py
+++ b/addons/account_payment/wizards/payment_refund_wizard.py
@@ -80,5 +80,5 @@ class PaymentRefundWizard(models.TransientModel):
             wizard.has_pending_refund = pending_refunds_count > 0
 
     def action_refund(self):
-        for wizard in self:
-            wizard.transaction_id.action_refund(amount_to_refund=wizard.amount_to_refund)
+        self.ensure_one()
+        return self.transaction_id.action_refund(amount_to_refund=self.amount_to_refund)

--- a/addons/payment/const.py
+++ b/addons/payment/const.py
@@ -297,3 +297,18 @@ REPORT_REASONS_MAPPING = {
     'tokenization_not_supported': _lt("tokenization not supported"),
     'validation_not_supported': _lt("tokenization without payment no supported"),
 }
+
+API_CONNECTION_ERROR = _lt("Could not establish the connection to the API.")
+API_COMMUNICATION_ERROR = _lt("The communication with the API failed. Details: ")
+MISSING_REFERENCE_ERROR = _lt("Received data with missing merchant reference.")
+MISSING_PAYMENT_STATUS = _lt("Received data with missing payment state.")
+TX_NOT_LINKED_TO_TOKEN_ERROR = _lt("The transaction is not linked to a token.")
+
+# Logging
+NO_TX_FOUND_EXCEPTION = "No transaction found matching reference %s."
+UNABLE_TO_REACH_ENDPOINT = "Unable to reach the endpoint at %s."
+INVALID_API_REQUEST = "Invalid API request at %s with data %s: %s"
+INVALID_PAYMENT_STATUS = ("Received data with invalid payment status (%s) for transaction with"
+                          " reference %s")
+
+TIMEOUT = 10

--- a/addons/payment/const.py
+++ b/addons/payment/const.py
@@ -308,7 +308,8 @@ TX_NOT_LINKED_TO_TOKEN_ERROR = _lt("The transaction is not linked to a token.")
 NO_TX_FOUND_EXCEPTION = "No transaction found matching reference %s."
 UNABLE_TO_REACH_ENDPOINT = "Unable to reach the endpoint at %s."
 INVALID_API_REQUEST = "Invalid API request at %s with data %s: %s"
-INVALID_PAYMENT_STATUS = ("Received data with invalid payment status (%s) for transaction with"
-                          " reference %s")
+INVALID_PAYMENT_STATUS = (
+    "Received data with invalid payment status (%s) for transaction with reference %s"
+)
 
 TIMEOUT = 10

--- a/addons/payment/controllers/portal.py
+++ b/addons/payment/controllers/portal.py
@@ -268,7 +268,7 @@ class PaymentPortal(portal.CustomerPortal):
         :param dict kwargs: Locally unused data passed to `_create_transaction`
         :return: The mandatory values for the processing of the transaction
         :rtype: dict
-        :raise: ValidationError if the access token is invalid
+        :raise ValidationError: If the access token is invalid.
         """
         # Check the access token against the transaction values
         amount = amount and float(amount)  # Cast as float in case the JS stripped the '.0'

--- a/addons/payment/models/payment_transaction.py
+++ b/addons/payment/models/payment_transaction.py
@@ -315,6 +315,11 @@ class PaymentTransaction(models.Model):
             return refund_tx._get_failed_tx_notification_action()
 
     def _get_failed_tx_notification_action(self):
+        """ Return the action to notify the user that the transaction failed.
+
+        :return: The action with an error message.
+        :rtype: dict
+        """
         msg = _(
             "Transaction with reference: %(ref)s failed.\nError: %(msg)s",
             ref=self.reference, msg=self.state_message

--- a/addons/payment/tests/common.py
+++ b/addons/payment/tests/common.py
@@ -96,6 +96,8 @@ class PaymentCommon(BaseCommon):
         cls.account_payment_installed = account_payment_module.state in ('installed', 'to upgrade')
         cls.enable_post_process_patcher = True
 
+        cls.response_error = {'error': 'Connection error.'}
+
     def setUp(self):
         super().setUp()
         if self.account_payment_installed and self.enable_post_process_patcher:

--- a/addons/payment/utils.py
+++ b/addons/payment/utils.py
@@ -268,11 +268,17 @@ def set_tx_error_from_response(tx, response_content):
     """
     if error_msg := get_request_error(response_content):
         tx._set_error(error_msg)  # Log the error message on linked documents' chatter.
-        return True
-    return False
+    return bool(error_msg)
 
 
 def get_user_notification_action(message, notification_type='danger'):
+    """ Return a notification action to notify the user with the provided message.
+
+    :param str message: The message to display in the notification.
+    :param str notification_type: The type of notification to display.
+    :return: The notification with the provided message.
+    :rtype: dict
+    """
     return {
         'type': 'ir.actions.client',
         'tag': 'display_notification',

--- a/addons/payment_adyen/models/payment_transaction.py
+++ b/addons/payment_adyen/models/payment_transaction.py
@@ -276,9 +276,9 @@ class PaymentTransaction(models.Model):
                 converted_notification_amount = payment_utils.to_major_currency_units(
                     notification_data_amount, source_tx.currency_id
                 )
-                if source_tx.state != 'authorized':  # if tx is cancelled by the user
+                if source_tx.state != 'authorized':  # The source tx is cancelled by the user.
                     tx = source_tx
-                else:  # if capture/void
+                else:  # Capture/void.
                     tx = self.search([
                         ('provider_reference', '=', provider_reference),
                         ('provider_code', '=', 'adyen'),

--- a/addons/payment_adyen/utils.py
+++ b/addons/payment_adyen/utils.py
@@ -1,4 +1,3 @@
-
 from odoo.addons.payment import utils as payment_utils
 
 

--- a/addons/payment_aps/controllers/main.py
+++ b/addons/payment_aps/controllers/main.py
@@ -7,7 +7,6 @@ import pprint
 from werkzeug.exceptions import Forbidden
 
 from odoo import http
-from odoo.exceptions import ValidationError
 from odoo.http import request
 
 
@@ -40,10 +39,11 @@ class APSController(http.Controller):
         tx_sudo = request.env['payment.transaction'].sudo()._get_tx_from_notification_data(
             'aps', data
         )
-        self._verify_notification_signature(data, tx_sudo)
+        if tx_sudo:
+            self._verify_notification_signature(data, tx_sudo)
 
-        # Handle the notification data.
-        tx_sudo._handle_notification_data('aps', data)
+            # Handle the notification data.
+            tx_sudo._handle_notification_data('aps', data)
         return request.redirect('/payment/status')
 
     @http.route(_webhook_url, type='http', auth='public', methods=['POST'], csrf=False)
@@ -57,17 +57,15 @@ class APSController(http.Controller):
         :rtype: str
         """
         _logger.info("Notification received from APS with data:\n%s", pprint.pformat(data))
-        try:
-            # Check the integrity of the notification.
-            tx_sudo = request.env['payment.transaction'].sudo()._get_tx_from_notification_data(
-                'aps', data
-            )
+        # Check the integrity of the notification.
+        tx_sudo = request.env['payment.transaction'].sudo()._get_tx_from_notification_data(
+            'aps', data
+        )
+        if tx_sudo:
             self._verify_notification_signature(data, tx_sudo)
 
             # Handle the notification data.
             tx_sudo._handle_notification_data('aps', data)
-        except ValidationError:  # Acknowledge the notification to avoid getting spammed.
-            _logger.exception("Unable to handle the notification data; skipping to acknowledge.")
 
         return ''  # Acknowledge the notification.
 

--- a/addons/payment_asiapay/controllers/main.py
+++ b/addons/payment_asiapay/controllers/main.py
@@ -7,7 +7,6 @@ import pprint
 from werkzeug.exceptions import Forbidden
 
 from odoo import http
-from odoo.exceptions import ValidationError
 from odoo.http import request
 
 
@@ -37,17 +36,15 @@ class AsiaPayController(http.Controller):
         :rtype: str
         """
         _logger.info("Notification received from AsiaPay with data:\n%s", pprint.pformat(data))
-        try:
-            # Check the integrity of the notification data.
-            tx_sudo = request.env['payment.transaction'].sudo()._get_tx_from_notification_data(
-                'asiapay', data
-            )
+        # Check the integrity of the notification data.
+        tx_sudo = request.env['payment.transaction'].sudo()._get_tx_from_notification_data(
+            'asiapay', data
+        )
+        if tx_sudo:
             self._verify_notification_signature(data, tx_sudo)
 
             # Handle the notification data.
             tx_sudo._handle_notification_data('asiapay', data)
-        except ValidationError:  # Acknowledge the notification to avoid getting spammed.
-            _logger.exception("Unable to handle the notification data; skipping to acknowledge.")
 
         return 'OK'  # Acknowledge the notification.
 

--- a/addons/payment_authorize/controllers/main.py
+++ b/addons/payment_authorize/controllers/main.py
@@ -27,7 +27,7 @@ class AuthorizeController(http.Controller):
         """
         # Check that the transaction details have not been altered
         if not payment_utils.check_access_token(access_token, reference, partner_id):
-            raise ValidationError("Authorize.Net: " + _("Received tampered payment request data."))
+            raise ValidationError(_("Received tampered payment request data."))
 
         # Make the payment request to Authorize.Net
         tx_sudo = request.env['payment.transaction'].sudo().search([('reference', '=', reference)])

--- a/addons/payment_authorize/models/authorize_request.py
+++ b/addons/payment_authorize/models/authorize_request.py
@@ -8,7 +8,9 @@ from uuid import uuid4
 
 import requests
 
+from odoo.addons.payment import const as payment_const
 from odoo.addons.payment import utils as payment_utils
+
 
 _logger = logging.getLogger(__name__)
 
@@ -52,7 +54,7 @@ class AuthorizeAPI:
         logged_request = {operation: data or {}}
 
         _logger.info("sending request to %s:\n%s", self.url, pprint.pformat(logged_request))
-        response = requests.post(self.url, json.dumps(request), timeout=60)
+        response = requests.post(self.url, json.dumps(request), timeout=payment_const.TIMEOUT)
         response.raise_for_status()
         response = json.loads(response.content)
         _logger.info("response received:\n%s", pprint.pformat(response))

--- a/addons/payment_authorize/models/payment_transaction.py
+++ b/addons/payment_authorize/models/payment_transaction.py
@@ -261,12 +261,10 @@ class PaymentTransaction(models.Model):
                     'ref': self.reference,
                 },
             )
-            self._set_error(
-                "Authorize.Net: " + _(
-                    "Received data with status code \"%(status)s\" and error code \"%(error)s\"",
-                    status=status_code, error=error_code
-                )
-            )
+            self._set_error(_(
+                "Received data with status code \"%(status)s\" and error code \"%(error)s\"",
+                status=status_code, error=error_code
+            ))
 
     def _authorize_tokenize(self):
         """ Create a token for the current transaction.

--- a/addons/payment_authorize/static/src/js/payment_form.js
+++ b/addons/payment_authorize/static/src/js/payment_form.js
@@ -1,7 +1,6 @@
 /* global Accept */
 
 import { loadJS } from '@web/core/assets';
-import { _t } from '@web/core/l10n/translation';
 
 import paymentForm from '@payment/js/payment_form';
 import { rpc, RPCError } from '@web/core/network/rpc';
@@ -134,7 +133,7 @@ paymentForm.include({
         if (response.messages.resultCode === 'Error') {
             let error = '';
             response.messages.message.forEach(msg => error += `${msg.code}: ${msg.text}\n`);
-            this._displayErrorDialog(_t("Payment processing failed"), error);
+            this._displayErrorDialog(this.errorMapping['paymentProcessingError'], error);
             this._enableButton();
             return;
         }
@@ -149,7 +148,9 @@ paymentForm.include({
             window.location = '/payment/status';
         }).catch((error) => {
             if (error instanceof RPCError) {
-                this._displayErrorDialog(_t("Payment processing failed"), error.data.message);
+                this._displayErrorDialog(
+                    this.errorMapping['paymentProcessingError'], error.data.message
+                );
                 this._enableButton();
             } else {
                 return Promise.reject(error);

--- a/addons/payment_custom/models/payment_transaction.py
+++ b/addons/payment_custom/models/payment_transaction.py
@@ -3,8 +3,8 @@
 import logging
 
 from odoo import _, models
-from odoo.exceptions import ValidationError
 
+from odoo.addons.payment import const as payment_const
 from odoo.addons.payment_custom.controllers.main import CustomController
 
 
@@ -66,9 +66,7 @@ class PaymentTransaction(models.Model):
         reference = notification_data.get('reference')
         tx = self.search([('reference', '=', reference), ('provider_code', '=', 'custom')])
         if not tx:
-            raise ValidationError(
-                "Wire Transfer: " + _("No transaction found matching reference %s.", reference)
-            )
+            _logger.warning(payment_const.NO_TX_FOUND_EXCEPTION, reference)
         return tx
 
     def _process_notification_data(self, notification_data):

--- a/addons/payment_demo/models/payment_transaction.py
+++ b/addons/payment_demo/models/payment_transaction.py
@@ -3,7 +3,8 @@
 import logging
 
 from odoo import _, fields, models
-from odoo.exceptions import UserError, ValidationError
+
+from odoo.addons.payment import const as payment_const
 
 
 _logger = logging.getLogger(__name__)
@@ -72,7 +73,8 @@ class PaymentTransaction(models.Model):
             return
 
         if not self.token_id:
-            raise UserError("Demo: " + _("The transaction is not linked to a token."))
+            self._set_error(payment_const.TX_NOT_LINKED_TO_TOKEN_ERROR)
+            return
 
         simulated_state = self.token_id.demo_simulated_state
         notification_data = {'reference': self.reference, 'simulated_state': simulated_state}
@@ -140,9 +142,7 @@ class PaymentTransaction(models.Model):
         reference = notification_data.get('reference')
         tx = self.search([('reference', '=', reference), ('provider_code', '=', 'demo')])
         if not tx:
-            raise ValidationError(
-                "Demo: " + _("No transaction found matching reference %s.", reference)
-            )
+            _logger.warning(payment_const.NO_TX_FOUND_EXCEPTION, reference)
         return tx
 
     def _process_notification_data(self, notification_data):

--- a/addons/payment_demo/static/src/js/payment_demo_mixin.js
+++ b/addons/payment_demo/static/src/js/payment_demo_mixin.js
@@ -1,4 +1,3 @@
-import { _t } from "@web/core/l10n/translation";
 import { rpc, RPCError } from "@web/core/network/rpc";
 
 export default {
@@ -22,8 +21,8 @@ export default {
             window.location = '/payment/status';
         }).catch(error => {
             if (error instanceof RPCError) {
-                this._displayErrorDialog(_t("Payment processing failed"), error.data.message);
-                this._enableButton?.(); // This method doesn't exists in Express Checkout form.
+                this._displayErrorDialog(this.errorMapping['paymentProcessingError'], error.data.message);
+                this._enableButton?.(); // This method doesn't exist in Express Checkout form.
             } else {
                 return Promise.reject(error);
             }

--- a/addons/payment_demo/tests/test_payment_transaction.py
+++ b/addons/payment_demo/tests/test_payment_transaction.py
@@ -81,12 +81,13 @@ class TestPaymentTransaction(PaymentDemoCommon, PaymentHttpCommon):
             tx._send_payment_request()
             self.assertEqual(tx.state, tx.token_id.demo_simulated_state)
 
-    def test_send_full_capture_request_does_not_create_capture_tx(self):
+    def test_send_full_capture_request_creates_capture_tx(self):
         self.provider.capture_manually = True
         source_tx = self._create_transaction(flow='direct', state='authorized')
-        child_tx = source_tx._send_capture_request()
-        self.assertFalse(
-            child_tx, msg="Full capture should not create a child transaction."
+        source_tx._send_capture_request()
+        self.assertTrue(
+            source_tx.child_transaction_ids,
+            msg="Full capture should create a child transaction and linked it to the source tx.",
         )
 
     def test_send_partial_capture_request_creates_capture_tx(self):

--- a/addons/payment_flutterwave/tests/test_payment_transaction.py
+++ b/addons/payment_flutterwave/tests/test_payment_transaction.py
@@ -59,3 +59,14 @@ class TestPaymentTransaction(FlutterwaveCommon):
         ) as tokenize_mock:
             tx._process_notification_data(self.redirect_notification_data)
         self.assertEqual(tokenize_mock.call_count, 1)
+
+    def test_x_state_after_processing_notification_data_when_request_error(self):
+        tx = self._create_transaction(flow='redirect', tokenize=True)
+        with patch(
+            'odoo.addons.payment_flutterwave.models.payment_provider.PaymentProvider'
+            '._flutterwave_make_request', return_value=self.response_error,
+        ):
+            tx._process_notification_data(self.redirect_notification_data)
+        self.assertEqual(
+            tx.state, 'error', msg="When request failed tx state should be changed to error."
+        )

--- a/addons/payment_flutterwave/tests/test_payment_transaction.py
+++ b/addons/payment_flutterwave/tests/test_payment_transaction.py
@@ -60,7 +60,7 @@ class TestPaymentTransaction(FlutterwaveCommon):
             tx._process_notification_data(self.redirect_notification_data)
         self.assertEqual(tokenize_mock.call_count, 1)
 
-    def test_x_state_after_processing_notification_data_when_request_error(self):
+    def test_tx_state_after_processing_notification_data_when_request_error(self):
         tx = self._create_transaction(flow='redirect', tokenize=True)
         with patch(
             'odoo.addons.payment_flutterwave.models.payment_provider.PaymentProvider'

--- a/addons/payment_mercado_pago/controllers/main.py
+++ b/addons/payment_mercado_pago/controllers/main.py
@@ -4,7 +4,6 @@ import logging
 import pprint
 
 from odoo import http
-from odoo.exceptions import ValidationError
 from odoo.http import request
 
 
@@ -54,11 +53,8 @@ class MercadoPagoController(http.Controller):
         # other types of events.
         if data.get('action') in ('payment.created', 'payment.updated'):
             # Handle the notification data.
-            try:
-                payment_id = data.get('data', {}).get('id')
-                request.env['payment.transaction'].sudo()._handle_notification_data(
-                    'mercado_pago', {'external_reference': reference, 'payment_id': payment_id}
-                )  # Use 'external_reference' as the reference key like in the redirect data.
-            except ValidationError:  # Acknowledge the notification to avoid getting spammed.
-                _logger.exception("Unable to handle the notification data; skipping to acknowledge")
+            payment_id = data.get('data', {}).get('id')
+            request.env['payment.transaction'].sudo()._handle_notification_data(
+                'mercado_pago', {'external_reference': reference, 'payment_id': payment_id}
+            )  # Use 'external_reference' as the reference key like in the redirect data.
         return ''  # Acknowledge the notification.

--- a/addons/payment_mercado_pago/models/payment_provider.py
+++ b/addons/payment_mercado_pago/models/payment_provider.py
@@ -72,11 +72,10 @@ class PaymentProvider(models.Model):
         except requests.exceptions.HTTPError as err:
             _logger.exception(payment_const.INVALID_API_REQUEST, url, payload, err.response.text)
             response_content = err.response.json()
-            response_error = payment_utils.format_error_response(
-                payment_const.API_COMMUNICATION_ERROR
-                + response_content.get("code") + ' ' + response_content.get("message")
+            return payment_utils.format_error_response(
+                f'{payment_const.API_COMMUNICATION_ERROR}{response_content.get("code")}'
+                f' {response_content.get("message")}'
             )
-            return response_error
         return response.json()
 
     def _get_default_payment_method_codes(self):

--- a/addons/payment_mollie/controllers/main.py
+++ b/addons/payment_mollie/controllers/main.py
@@ -47,8 +47,5 @@ class MollieController(http.Controller):
         :rtype: str
         """
         _logger.info("notification received from Mollie with data:\n%s", pprint.pformat(data))
-        try:
-            request.env['payment.transaction'].sudo()._handle_notification_data('mollie', data)
-        except ValidationError:  # Acknowledge the notification to avoid getting spammed
-            _logger.exception("unable to handle the notification data; skipping to acknowledge")
+        request.env['payment.transaction'].sudo()._handle_notification_data('mollie', data)
         return ''  # Acknowledge the notification

--- a/addons/payment_mollie/models/payment_provider.py
+++ b/addons/payment_mollie/models/payment_provider.py
@@ -7,8 +7,9 @@ import requests
 from werkzeug import urls
 
 from odoo import _, fields, models, service
-from odoo.exceptions import ValidationError
 
+from odoo.addons.payment import const as payment_const
+from odoo.addons.payment import utils as payment_utils
 from odoo.addons.payment_mollie import const
 
 
@@ -65,23 +66,17 @@ class PaymentProvider(models.Model):
         }
 
         try:
-            response = requests.request(method, url, json=data, headers=headers, timeout=60)
-            try:
-                response.raise_for_status()
-            except requests.exceptions.HTTPError:
-                _logger.exception(
-                    "Invalid API request at %s with data:\n%s", url, pprint.pformat(data)
-                )
-                raise ValidationError(
-                    "Mollie: " + _(
-                        "The communication with the API failed. Mollie gave us the following "
-                        "information: %s", response.json().get('detail', '')
-                    ))
-        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
-            _logger.exception("Unable to reach endpoint at %s", url)
-            raise ValidationError(
-                "Mollie: " + _("Could not establish the connection to the API.")
+            response = requests.request(
+                method, url, json=data, headers=headers, timeout=payment_const.TIMEOUT
             )
+            response.raise_for_status()
+        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
+            _logger.exception(payment_const.UNABLE_TO_REACH_ENDPOINT, url)
+            return payment_utils.format_error_response(payment_const.API_CONNECTION_ERROR)
+        except requests.exceptions.HTTPError as err:
+            _logger.exception(payment_const.INVALID_API_REQUEST, url, data, err.response.text)
+            msg = err.response.json().get('detail', '')
+            return payment_utils.format_error_response(payment_const.API_COMMUNICATION_ERROR + msg)
         return response.json()
 
     def _get_default_payment_method_codes(self):

--- a/addons/payment_nuvei/controllers/main.py
+++ b/addons/payment_nuvei/controllers/main.py
@@ -6,7 +6,6 @@ import pprint
 from werkzeug.exceptions import Forbidden
 
 from odoo import http
-from odoo.exceptions import ValidationError
 from odoo.http import request
 from odoo.tools import consteq
 
@@ -54,17 +53,16 @@ class NuveiController(http.Controller):
         :rtype: str
         """
         _logger.info("Notification received from Nuvei with data:\n%s", pprint.pformat(data))
-        try:
-            # Check the integrity of the notification.
-            tx_sudo = request.env['payment.transaction'].sudo()._get_tx_from_notification_data(
-                'nuvei', data
-            )
+
+        # Check the integrity of the notification.
+        tx_sudo = request.env['payment.transaction'].sudo()._get_tx_from_notification_data(
+            'nuvei', data
+        )
+        if tx_sudo:
             self._verify_notification_signature(tx_sudo, data)
 
             # Handle the notification data.
             tx_sudo._handle_notification_data('nuvei', data)
-        except ValidationError:  # Acknowledge the notification to avoid getting spammed.
-            _logger.exception("Unable to handle the notification data; skipping to acknowledge.")
 
         return 'OK'  # Acknowledge the notification.
 

--- a/addons/payment_paypal/static/src/js/payment_form.js
+++ b/addons/payment_paypal/static/src/js/payment_form.js
@@ -155,6 +155,7 @@ paymentForm.include({
      */
     async _paypalOnApprove(data) {
         const orderID = data.orderID;
+        const { provider_id } = this.inlineFormValues;
 
         const response = await rpc('/payment/paypal/complete_order', {
             'provider_id': provider_id,

--- a/addons/payment_razorpay/static/src/js/payment_form.js
+++ b/addons/payment_razorpay/static/src/js/payment_form.js
@@ -2,7 +2,6 @@
 
 import paymentForm from '@payment/js/payment_form';
 import { loadJS } from '@web/core/assets';
-import { _t } from '@web/core/l10n/translation';
 
 paymentForm.include({
 
@@ -46,7 +45,9 @@ paymentForm.include({
         const RazorpayJS = Razorpay(razorpayOptions);
         RazorpayJS.open();
         RazorpayJS.on('payment.failed', response => {
-            this._displayErrorDialog(_t("Payment processing failed"), response.error.description);
+            this._displayErrorDialog(
+                this.errorMapping['paymentProcessingError'], response.error.description
+            );
         });
     },
 

--- a/addons/payment_stripe/models/payment_transaction.py
+++ b/addons/payment_stripe/models/payment_transaction.py
@@ -277,6 +277,7 @@ class PaymentTransaction(models.Model):
         )
         if payment_utils.set_tx_error_from_response(child_capture_tx, payment_intent):
             return child_capture_tx
+
         _logger.info(
             "capture request response for transaction with reference %s:\n%s",
             self.reference, pprint.pformat(payment_intent)

--- a/addons/payment_stripe/static/src/js/payment_form.js
+++ b/addons/payment_stripe/static/src/js/payment_form.js
@@ -2,7 +2,6 @@
 
 import paymentForm from '@payment/js/payment_form';
 import { StripeOptions } from '@payment_stripe/js/stripe_options';
-import { _t } from '@web/core/l10n/translation';
 
 paymentForm.include({
 
@@ -87,7 +86,7 @@ paymentForm.include({
             'payment', paymentElementOptions
         );
         paymentElement.on('loaderror', response => {
-            this._displayErrorDialog(_t("Cannot display the payment form"), response.error.message);
+            this._displayErrorDialog(this.errorMapping['displayFormError'], response.error.message);
         });
         paymentElement.mount(stripeInlineForm);
 
@@ -131,7 +130,7 @@ paymentForm.include({
         try {
             await this.stripeElements[paymentOptionId].submit();
         } catch (error) {
-            this._displayErrorDialog(_t("Incorrect payment details"), error.message);
+            this._displayErrorDialog(this.errorMapping['incorrectPaymentDetails'], error.message);
             this._enableButton();
             return
         }
@@ -157,7 +156,7 @@ paymentForm.include({
 
         const { error } = await this._stripeConfirmIntent(processingValues, paymentOptionId);
         if (error) {
-            this._displayErrorDialog(_t("Payment processing failed"), error.message);
+            this._displayErrorDialog(this.errorMapping['paymentProcessingError'], error.message);
             this._enableButton();
         }
     },

--- a/addons/payment_worldline/models/payment_transaction.py
+++ b/addons/payment_worldline/models/payment_transaction.py
@@ -297,7 +297,8 @@ class PaymentTransaction(models.Model):
         status = payment_data.get('status')
         has_token_data = 'token' in payment_method_data
         if not status:
-            _logger.warning(payment_const.MISSING_PAYMENT_STATUS)
+            self._set_error(payment_const.MISSING_PAYMENT_STATUS)
+            return
 
         if status in const.PAYMENT_STATUS_MAPPING['pending']:
             if status == 'AUTHORIZATION_REQUESTED':

--- a/addons/payment_xendit/models/payment_transaction.py
+++ b/addons/payment_xendit/models/payment_transaction.py
@@ -6,9 +6,9 @@ import pprint
 from werkzeug import urls
 
 from odoo import _, models
-from odoo.exceptions import ValidationError
 from odoo.tools import float_round
 
+from odoo.addons.payment import const as payment_const
 from odoo.addons.payment import utils as payment_utils
 from odoo.addons.payment_xendit import const
 
@@ -115,14 +115,14 @@ class PaymentTransaction(models.Model):
         Note: self.ensure_one()
 
         :return: None
-        :raise UserError: If the transaction is not linked to a token.
         """
         super()._send_payment_request()
         if self.provider_code != 'xendit':
             return
 
         if not self.token_id:
-            raise ValidationError("Xendit: " + _("The transaction is not linked to a token."))
+            self._set_error(payment_const.TX_NOT_LINKED_TO_TOKEN_ERROR)
+            return
 
         self._xendit_create_charge(self.token_id.provider_ref)
 
@@ -146,7 +146,8 @@ class PaymentTransaction(models.Model):
         charge_notification_data = self.provider_id._xendit_make_request(
             'credit_card_charges', payload=payload
         )
-        self._handle_notification_data('xendit', charge_notification_data)
+        if not payment_utils.set_tx_error_from_response(self, charge_notification_data):
+            self._handle_notification_data('xendit', charge_notification_data)
 
     def _get_tx_from_notification_data(self, provider_code, notification_data):
         """ Override of `payment` to find the transaction based on the notification data.
@@ -155,8 +156,6 @@ class PaymentTransaction(models.Model):
         :param dict notification_data: The notification data sent by the provider.
         :return: The transaction if found.
         :rtype: payment.transaction
-        :raise ValidationError: If inconsistent data were received.
-        :raise ValidationError: If the data match no transaction.
         """
         tx = super()._get_tx_from_notification_data(provider_code, notification_data)
         if provider_code != 'xendit' or len(tx) == 1:
@@ -164,13 +163,12 @@ class PaymentTransaction(models.Model):
 
         reference = notification_data.get('external_id')
         if not reference:
-            raise ValidationError("Xendit: " + _("Received data with missing reference."))
+            _logger.warning(payment_const.MISSING_REFERENCE_ERROR)
+            return tx
 
         tx = self.search([('reference', '=', reference), ('provider_code', '=', 'xendit')])
         if not tx:
-            raise ValidationError(
-                "Xendit: " + _("No transaction found matching reference %s.", reference)
-            )
+            _logger.warning(payment_const.NO_TX_FOUND_EXCEPTION, reference)
         return tx
 
     def _process_notification_data(self, notification_data):
@@ -180,7 +178,6 @@ class PaymentTransaction(models.Model):
 
         :param dict notification_data: The notification data sent by the provider.
         :return: None
-        :raise ValidationError: If inconsistent data were received.
         """
         self.ensure_one()
 

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1735,10 +1735,11 @@ class SaleOrder(models.Model):
 
     def payment_action_void(self):
         """ Void all transactions linked to this sale order. """
+        self.ensure_one()
         payment_utils.check_rights_on_recordset(self)
 
         # In sudo mode to bypass the checks on the rights on the transactions.
-        self.authorized_transaction_ids.sudo().action_void()
+        return self.authorized_transaction_ids.sudo().action_void()
 
     def get_portal_last_transaction(self):
         self.ensure_one()

--- a/addons/website_payment/static/src/js/payment_form.js
+++ b/addons/website_payment/static/src/js/payment_form.js
@@ -81,7 +81,7 @@ PaymentForm.include({
                     });
                 }
                 this._displayErrorDialog(
-                    _t("Payment processing failed"),
+                    this.errorMapping['paymentProcessingError'],
                     _t("Some information is missing to process your payment.")
                 );
                 this._enableButton();


### PR DESCRIPTION
Before this commit the payment engine relied on raising
exceptions. That was inconvenient for other modules (ex. Subscription)to
use payment as it was needed to handle exceptions and cursor rollback.

After this commit the payment engine will rely on only the transaction
state.

task-3648413

See also:

- https://github.com/odoo/enterprise/pull/65343