### PR TITLE
[FIX] payment_razorpay: invalid email for public users while online payment

### DIFF
--- a/addons/payment_razorpay/models/payment_transaction.py
+++ b/addons/payment_razorpay/models/payment_transaction.py
@@ -54,7 +54,7 @@ class PaymentTransaction(models.Model):
         """
         payload = {
             'name': self.partner_name,
-            'email': self.partner_email,
+            'email': self.partner_email or '',
             'contact': self.partner_phone and self._validate_phone_number(self.partner_phone) or '',
             'fail_existing': '0',  # Don't throw an error if the customer already exists.
         }


### PR DESCRIPTION
Steps:
==========
- Install the point_of_sale and Razorpay payment provider modules.
- Create an online payment method for the Razorpay payment provider.
- Add the created payment method to the shop.
- Open the shop, place an order, and use the Razorpay payment method.
- Scan the QR code for payment and complete the payment with public users.

Issue:
==========
- An error occurs stating 'Email must be a valid email address,' causing the task to be blocked.

Cause:
==========
- The email for public users is not found.

FIX:
==========
- Add an empty email address option for public users.

task-3992084