### PR TITLE
[FIX] payment: update modules that depend on `account`

### DIFF
--- a/addons/payment/models/account_payment_method.py
+++ b/addons/payment/models/account_payment_method.py
@@ -14,7 +14,6 @@ class AccountPaymentMethodLine(models.Model):
         compute='_compute_payment_acquirer_id',
         store=True,
         readonly=False,
-        domain="[('provider', '=', code)]",
     )
     payment_acquirer_state = fields.Selection(
         related='payment_acquirer_id.state'

--- a/addons/payment/views/account_journal_views.xml
+++ b/addons/payment/views/account_journal_views.xml
@@ -7,7 +7,7 @@
         <field name="inherit_id" ref="account.view_account_journal_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='inbound_payment_method_line_ids']//field[@name='payment_account_id']" position="after">
-                <field name="payment_acquirer_id" options="{'no_open': True, 'no_create': True}" optional="hide"/>
+                <field name="payment_acquirer_id" options="{'no_open': True, 'no_create': True}" optional="hide" domain="[('provider', '=', code)]"/>
                 <field name="payment_acquirer_state" invisible="1"/>
                 <field name="code" invisible="1"/>
                 <button name="action_open_acquirer_form"


### PR DESCRIPTION
On some DB, it is not possible to update some modules that depend on
`account`

To reproduce the issue:
1. Checkout before [1] and install `account_accountant`
2. Checkout after [1]
3. Update `account_accountant`

Error: a server error is displayed

> Field 'code' used in domain of field 'payment_acquirer_id' ([
> ('provider', '=', code)]) must be present in view but is missing."")

Commit [1] contains unstable changes: it adds a domain on the field
`payment_acquirer_id` of `account.payment.method.line` and, to make
it work, it also adds the needed field `code` on the view
`view_account_journal_form`. But, if the view is not updated on an
existing database, the domain can not work, hence the client error.

This explains why the above use case does not work:
The module `account_accountant` has a view that also inherits the
view of account `account.view_account_journal_form`. As a result,
when updating the module (and, therefore, the view of
`account_accountant`), we `:View._validate_view` the whole view, which
will lead to:
https://github.com/odoo/odoo/blob/2cbf9d840b79520854731fd6a23431c69e451775/odoo/addons/base/models/ir_ui_view.py#L2282-L2286

[1] https://github.com/odoo-dev/odoo/commit/88782d3a76fb3941b9ed7d998ec0610aa26ff611

opw-3993709
opw-3993707
sentry-5416409171