### PR TITLE
[IMP] stock: cancel origin moves when forcing done quantity

### DIFF
--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -337,6 +337,11 @@ class StockMove(models.Model):
             mo_to_cancel._action_cancel()
         return res
 
+    def _get_action_done_moves_to_cancel(self):
+        '''Do not trigger cancel of MO moves'''
+        res = super()._get_action_done_moves_to_cancel()
+        return res.filtered(lambda m: not m.production_id)
+
     def _prepare_move_split_vals(self, qty):
         defaults = super()._prepare_move_split_vals(qty)
         defaults['workorder_id'] = False


### PR DESCRIPTION
Currently, if you force the quantity on a stock move that is linked to a previous move, the previous move will be kept confirmed. This causes incoherences in the operations as you have a stock move that is not yet done but is linked to a destination move that is already done.

With the change, when a move is set to done, we make sure that the origin moves that are still not done are cancelled.

Steps to reproduce:

- In a demo environment enable for the warehouse a 2 or 3 step delivery.
- Create a sale order for an item that does not have stock. Confirm the sale order.
- In the final picking to the customer, force the quantity and validate.
- The final picking to the customer is validated and the previous transfers are not cancelled.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
