### PR TITLE
[IMP] website_profile: prepare profile edition for redesign

### DIFF
--- a/addons/website_forum/controllers/website_forum.py
+++ b/addons/website_forum/controllers/website_forum.py
@@ -404,8 +404,8 @@ class WebsiteForum(WebsiteProfile):
     def forum_post(self, forum, **post):
         user = request.env.user
         if not user.email or not tools.single_email_re.match(user.email):
-            slug = request.env['ir.http']._slug
-            return request.redirect("/forum/%s/user/%s/edit?email_required=1" % (slug(forum), request.session.uid))
+            return request.redirect(
+                f'/forum/user/{request.session.uid}?forum_id={forum.id}&forum_origin={request.httprequest.path}')
         values = self._prepare_user_values(forum=forum, searches={}, new_question=True)
         return request.render("website_forum.new_question", values)
 
@@ -674,7 +674,6 @@ class WebsiteForum(WebsiteProfile):
             elif post.get('forum_id'):
                 forums = request.env['forum.forum'].browse(int(post['forum_id']))
                 values.update({
-                    'edit_button_url_param': 'forum_id=%s' % str(post['forum_id']),
                     'forum_filtered': forums.name,
                 })
             else:

--- a/addons/website_profile/__manifest__.py
+++ b/addons/website_profile/__manifest__.py
@@ -8,6 +8,7 @@
     'summary': 'Access the website profile of the users',
     'description': "Allows to access the website profile of the users and see their statistics (karma, badges, etc..)",
     'depends': [
+        'html_editor',
         'website_partner',
         'gamification'
     ],
@@ -20,9 +21,12 @@
     ],
     'assets': {
         'web.assets_frontend': [
+            'web/static/src/views/fields/file_handler.*',
             'website_profile/static/src/scss/website_profile.scss',
+            'website_profile/static/src/components/**/*',
             'website_profile/static/src/interactions/**/*',
             ('remove', 'website_profile/static/src/interactions/**/*.edit.js'),
+            ('include', 'html_editor.assets_editor'),
         ],
         'website.assets_edit_frontend': [
             'website_profile/static/src/**/*.edit.js',

--- a/addons/website_profile/static/src/components/profile_dialog/profile_dialog.js
+++ b/addons/website_profile/static/src/components/profile_dialog/profile_dialog.js
@@ -1,0 +1,144 @@
+import { Wysiwyg } from "@html_editor/wysiwyg";
+import { Component, onMounted, onWillStart, reactive, useRef, useState } from "@odoo/owl";
+import { Dialog } from "@web/core/dialog/dialog";
+import { localization } from "@web/core/l10n/localization";
+import { _t } from "@web/core/l10n/translation";
+import { rpc } from "@web/core/network/rpc";
+import { user } from "@web/core/user";
+import { useAutofocus, useService } from "@web/core/utils/hooks";
+import { isHtmlEmpty } from "@web/core/utils/html";
+import { isEmail } from "@web/core/utils/strings";
+import { FileUploader } from "@web/views/fields/file_handler";
+import { setCursorEnd } from "@web_editor/js/editor/odoo-editor/src/utils/utils";
+
+export class ProfileDialog extends Component {
+    static template = "website_profile.ProfileDialog";
+    static components = {
+        Dialog,
+        FileUploader,
+        Wysiwyg,
+    };
+    static props = {
+        close: Function,
+        confirm: { type: Function, optional: true },
+        focusWebsiteDescription: {
+            type: Boolean,
+            optional: true,
+        },
+        userId: { type: Number },
+    };
+    static defaultProps = {
+        confirm: () => {},
+        focusWebsiteDescription: false,
+    };
+
+    setup() {
+        super.setup();
+        this.orm = useService("orm");
+        this.upload = useRef("upload");
+        this.profileImg = useRef("profileImg");
+        this.profileImgData = null;
+        this.state = useState({
+            isProcessing: false,
+            hasError: false,
+            emailHasError: false,
+            nameHasError: false,
+        });
+        const websiteDescriptionClass = "website_profile_profile_dialog_website_description";
+        useAutofocus({ refName: "name" });
+
+        onWillStart(async () => {
+            const [users, countries] = await Promise.all([
+                this.orm.read(
+                    "res.users",
+                    [this.props.userId],
+                    [
+                        "city",
+                        "country_id",
+                        "email",
+                        "name",
+                        "website",
+                        "website_description",
+                        "website_published",
+                    ]
+                ),
+                this.orm.searchRead("res.country", [], ["id", "name"]),
+            ]);
+            const userData = users[0];
+            userData.country_id = userData.country_id && userData.country_id[0]; // keep only id
+            this.user = reactive(userData, () => this.validate());
+            this.countries = countries;
+            const isInternalUser = await user.hasGroup("base.group_user");
+            this.descriptionWysiwygConfig = {
+                allowFile: isInternalUser,
+                allowImage: isInternalUser,
+                classList: ["form-control", websiteDescriptionClass],
+                content: this.user.website_description,
+                debug: !!this.env.debug,
+                direction: localization.direction || "ltr",
+                placeholder: _t("Write a few words about yourself..."),
+            };
+        });
+
+        onMounted(() => {
+            if (this.props.focusWebsiteDescription) {
+                const websiteDescription = document.querySelector(
+                    `.${websiteDescriptionClass}[contenteditable="true"]`
+                );
+                if (websiteDescription) {
+                    setCursorEnd(websiteDescription);
+                }
+            }
+            this.validate();
+        });
+    }
+
+    validate() {
+        this.state.emailHasError = !isEmail(this.user.email);
+        this.state.nameHasError = !this.user.name || !this.user.name.trim().length;
+        this.state.hasError = this.state.emailHasError || this.state.nameHasError;
+    }
+
+    get isEditingMyProfile() {
+        return user.userId === this.props.userId;
+    }
+
+    get title() {
+        return _t("Edit Profile");
+    }
+
+    onClearProfileImg() {
+        this.profileImgData = false;
+        this.profileImg.el.src = "/web/static/img/placeholder.png";
+    }
+
+    async onConfirm() {
+        this.state.isProcessing = true;
+        const descriptionElContent = this.websiteDescriptionEditor.getElContent();
+        const data = {
+            ...this.user,
+            country_id: this.user.country_id && parseInt(this.user.country_id),
+            website_description: isHtmlEmpty(descriptionElContent.innerText)
+                ? ""
+                : descriptionElContent.innerHTML,
+            user_id: this.props.userId,
+        };
+        if (this.profileImgData != null) {
+            data.image_1920 = this.profileImgData;
+        }
+        await rpc("/profile/user/save", data);
+        if (this.props.confirm) {
+            await this.props.confirm();
+        }
+        this.props.close();
+    }
+
+    onUploadProfileImg(file) {
+        this.profileImg.el.src = `data:${file.type};base64,${file.data}`;
+        this.profileImgData = file.data;
+    }
+
+    onWebsiteDescriptionEditorLoad(editor) {
+        this.websiteDescriptionEditor = editor;
+    }
+}

--- a/addons/website_profile/static/src/components/profile_dialog/profile_dialog.xml
+++ b/addons/website_profile/static/src/components/profile_dialog/profile_dialog.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="website_profile.ProfileDialog">
+        <Dialog size="'xl'" title="title" modalRef="modalRef">
+            <div class="row">
+                <div class="col-12 col-sm-3 mb-3">
+                    <div class="card o_card_people">
+                        <div class="card-body">
+                            <img class="o_wforum_avatar_img w-100 mb-3" t-ref="profileImg" t-attf-src="/web/image/res.users/#{user.id}/avatar_128"/>
+                            <div class="d-flex justify-content-center gap-1">
+                                <FileUploader onUploaded.bind="onUploadProfileImg" acceptedFileExtensions="'image/*'">
+                                    <t t-set-slot="toggler">
+                                        <button href="#" title="Edit" aria-label="Edit" class="btn btn-primary">
+                                            <i class="fa fa-pencil fa-1g float-sm-none float-md-start"/>
+                                        </button>
+                                    </t>
+                                    <t t-slot="default"/>
+                                </FileUploader>
+                                <button href="#" title="Clear" aria-label="Clear" class="btn border-primary" t-on-click="onClearProfileImg">
+                                    <i class="fa fa-trash-o float-sm-none float-md-end"></i>
+                                </button>
+                            </div>
+                            <div class="my-3 mb-0 pt-2 border-top" t-if="isEditingMyProfile">
+                                <label class="text-primary fw-bold" for="website_profile_profile_dialog_user_website_published">Public Profile</label>
+                                <input type="checkbox" class="float-end mt8" name="website_published" id="website_profile_profile_dialog_user_website_published" t-model="user.website_published"/>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-12 col-sm-9">
+                    <div class="row">
+                        <div class="mb-3 col-12">
+                            <label class="text-primary mb-1 d-block fw-bold" for="website_profile_profile_dialog_user_name">Name</label>
+                            <input type="text" t-attf-class="form-control #{state.nameHasError ? 'is-invalid': ''}" name="name" id="website_profile_profile_dialog_user_name" required="True"
+                                t-model="user.name" t-ref="name"/>
+                        </div>
+
+                        <div class="mb-3 col-6">
+                            <label class="mb-1 text-primary fw-bold" for="website_profile_profile_dialog_user_website">Website</label>
+                            <input type="text" class="form-control" name="website" id="website_profile_profile_dialog_user_website" t-model="user.website"/>
+                        </div>
+                        <div class="mb-3 col-6">
+                            <label class="mb-1 text-primary fw-bold" for="website_profile_profile_dialog_user_email">Email</label>
+                            <input type="email" t-attf-class="form-control #{state.emailHasError ? 'is-invalid': ''}" name="email" id="website_profile_profile_dialog_user_email" required="True" t-model="user.email"/>
+                        </div>
+                        <div class="mb-3 col-6">
+                            <label class="mb-1 text-primary fw-bold" for="website_profile_profile_dialog_user_city">City</label>
+                            <input type="text" class="form-control" name="city" id="website_profile_profile_dialog_user_city" t-model="user.city"/>
+                        </div>
+                        <div class="mb-3 col-6">
+                            <label class="mb-1 text-primary fw-bold" for="website_profile_profile_dialog_user_country">Country</label>
+                            <div>
+                                <select name="country" class="form-control" id="website_profile_profile_dialog_user_country" t-model="user.country_id">
+                                    <option>Country...</option>
+                                    <option t-foreach="countries" t-as="country"
+                                        t-key="country.id" t-att-value="country.id" t-out="country.name"/>
+                                </select>
+                            </div>
+                        </div>
+                        <div class="mb-3 col-12">
+                            <label class="mb-1 text-primary fw-bold">Biography</label>
+                            <Wysiwyg config="descriptionWysiwygConfig" t-key="description"
+                                onLoad.bind="onWebsiteDescriptionEditorLoad"/>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <t t-set-slot="footer">
+                <button class="btn btn-primary" t-on-click="onConfirm" data-hotkey="q"
+                    t-att-disabled="state.isProcessing or state.hasError">Update</button>
+                <button class="btn btn-secondary" t-on-click="props.close" data-hotkey="x"
+                    t-att-disabled="state.isProcessing">Discard</button>
+              </t>
+        </Dialog>
+    </t>
+
+</templates>

--- a/addons/website_profile/static/src/interactions/profile_editor.js
+++ b/addons/website_profile/static/src/interactions/profile_editor.js
@@ -1,77 +1,26 @@
-
-import { Interaction } from "@web/public/interaction";
+import { browser } from "@web/core/browser/browser";
 import { registry } from "@web/core/registry";
-
-import { loadWysiwygFromTextarea } from "@web_editor/js/frontend/loadWysiwygFromTextarea";
+import { Interaction } from "@web/public/interaction";
+import { ProfileDialog } from "../components/profile_dialog/profile_dialog";
 
 export class ProfileEditor extends Interaction {
-    static selector = ".o_wprofile_editor_form";
+    static selector = ".o_wprofile_editor";
     dynamicContent = {
-        ".o_forum_file_upload": { "t-on-change": this.onFileChange },
-        ".o_forum_profile_pic_edit": { "t-on-click.prevent": this.onEditProfilePicClick },
-        ".o_forum_profile_pic_clear": { "t-on-click": this.onClearProfilePicClick },
-        ".o_forum_profile_bio_edit": {
-            "t-on-click.prevent": () => this.isEditingBio = true,
-            "t-att-class": () => ({ "d-none": this.isEditingBio }),
+        _root: {
+            "t-on-click.prevent": this.openDialog,
         },
-        ".o_forum_profile_bio_cancel_edit": {
-            "t-on-click.prevent": () => this.isEditingBio = false,
-            "t-att-class": () => ({ "d-none": !this.isEditingBio }),
-        },
-        ".o_forum_profile_bio_form": { "t-att-class": () => ({ "d-none": !this.isEditingBio }) },
-        ".o_forum_profile_bio": { "t-att-class": () => ({ "d-none": this.isEditingBio, }) },
     };
 
-    setup() {
-        this.isEditingBio = false;
-
-        this.textareaEl = this.el.querySelector("textarea.o_wysiwyg_loader");
-
-        this.options = {
-            recordInfo: {
-                context: this.services.website_page.context,
-                res_model: "res.users",
-                res_id: parseInt(this.el.querySelector("input[name=user_id]").value),
+    openDialog() {
+        this.services.dialog.add(ProfileDialog, {
+            confirm: () => {
+                browser.location.reload();
             },
-            value: this.textareaEl.getAttribute("content"),
-            resizable: true,
-            userGeneratedContent: true,
-        };
-
-        if (this.textareaEl.attributes.placeholder) {
-            this.options.placeholder = this.textareaEl.attributes.placeholder.value;
-        }
-
-        this.fileUploadEl = this.el.querySelector(".o_forum_file_upload");
-        this.avatarImgEl = this.el.querySelector(".o_wforum_avatar_img");
-    }
-
-    async willStart() {
-        await loadWysiwygFromTextarea(this, this.textareaEl, this.options);
-    }
-
-    onEditProfilePicClick() {
-        this.fileUploadEl.click();
-    }
-
-    onClearProfilePicClick() {
-        this.fileUploadEl.value = null;
-        this.avatarImgEl.src = "/web/static/img/placeholder.png";
-        const inputElement = document.createElement("input");
-        inputElement.setAttribute("name", "clear_image");
-        inputElement.setAttribute("id", "forum_clear_image");
-        inputElement.setAttribute("type", "hidden");
-        this.insert(inputElement);
-    }
-
-    onFileChange() {
-        if (!this.fileUploadEl.files.length) {
-            return;
-        }
-        const reader = new window.FileReader();
-        reader.readAsDataURL(this.fileUploadEl.files[0]);
-        this.addListener(reader, "load", (ev) => this.avatarImgEl.src = ev.target.result);
-        this.el.querySelector("#forum_clear_image")?.remove();
+            focusWebsiteDescription:
+                this.el.dataset.focusWebsiteDescription &&
+                this.el.dataset.focusWebsiteDescription === "true",
+            userId: parseInt(this.el.dataset.userId),
+        });
     }
 }
 

--- a/addons/website_profile/static/tests/tours/tour_website_profile_description.js
+++ b/addons/website_profile/static/tests/tours/tour_website_profile_description.js
@@ -12,7 +12,7 @@ registry.category("web_tour.tours").add('website_profile_description', {
         run: "click",
     }, {
         content: "Add some content",
-        trigger: ".odoo-editor-editable p",
+        trigger: ".odoo-editor-editable",
         run: "editor content <p>code here</p>",
     }, {
         content: "Save changes",

--- a/addons/website_profile/views/website_profile.xml
+++ b/addons/website_profile/views/website_profile.xml
@@ -67,108 +67,6 @@
     Single User Profile Page
     -->
 
-    <!-- Edit Profile Page -->
-    <template id="user_profile_edit_main" name="Edit Profile">
-        <t t-set="body_classname" t-value="'o_wprofile_body'"/>
-        <t t-call="website.layout">
-            <div id="wrap" class="o_wprofile_wrap">
-                <div class="container pt-4 pb-5">
-                    <t t-call="website_profile.user_profile_edit_content"/>
-                </div>
-            </div>
-        </t>
-    </template>
-
-    <template id="user_profile_edit_content" name="Edit Profile">
-        <h1 class="o_page_header">Edit Profile</h1>
-        <div>
-            <form t-attf-action="/profile/user/save" method="post" role="form" class="o_wprofile_editor_form js_website_submit_form row" enctype="multipart/form-data">
-                <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
-                <input type="file" class="d-none o_forum_file_upload" name="ufile" accept="image/*"/>
-                <input type="hidden" name="url_param" t-att-value="request.params.get('url_param')"/>
-                <div class="col-12 col-sm-3">
-                    <div class="card o_card_people">
-                        <div class="card-body">
-                            <img class="o_wforum_avatar_img w-100 mb-3" t-att-src="website.image_url(user, 'avatar_128')"/>
-                            <div class="text-center">
-                                <a href="#" class="o_forum_profile_pic_edit btn btn-primary" aria-label="Edit">
-                                    <i class="fa fa-pencil fa-1g float-sm-none float-md-start" title="Edit"></i>
-                                </a>
-                                <a href="#" title="Clear" aria-label="Clear" class="btn border-primary o_forum_profile_pic_clear">
-                                    <i class="fa fa-trash-o float-sm-none float-md-end"></i>
-                                </a>
-                            </div>
-                            <div class="my-3 mb-0 pt-2 border-top">
-                                <label class="text-primary" for="user_website_published" t-if="user.id == uid"><span class="fw-bold">Public Profile</span></label>
-                                <div class=" mb-0 float-end" t-if="user.id == uid">
-                                    <input type="checkbox" class="mt8" name="website_published" id="user_website_published" value="True" t-if="not user.website_published"/>
-                                    <input type="checkbox" class="mt8" name="website_published" id="user_website_published" value="True" checked="checked" t-if="user.website_published"/>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div class="col-12 col-sm-9 mb-3">
-                    <div class="card">
-                        <div class="card-body">
-                            <div class="row">
-                                <input name="user_id" t-att-value="user.id" type="hidden"/>
-                                <div class="mb-3 col-12">
-                                    <label class="text-primary mb-1 d-block" for="user_name"><span class="fw-bold">Name</span></label>
-                                    <div>
-                                        <input type="text" class="form-control" name="name" id="user_name" required="True" t-attf-value="#{user.name}"/>
-                                    </div>
-                                </div>
-
-                                <div class="mb-3 col-6">
-                                    <label class="mb-1 text-primary" for="user_website"><span class="fw-bold">Website</span></label>
-                                    <div>
-                                        <input type="text" class="form-control" name="website" id="user_website" t-attf-value="#{user.partner_id.website or ''}"/>
-                                    </div>
-                                </div>
-                                <div class="mb-3 col-6">
-                                    <div t-if="email_required" class="alert alert-danger alert-dismissable oe_email_required" role="alert">
-                                        <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
-                                        <p>Please enter a valid email address in order to receive notifications from answers or comments.</p>
-                                    </div>
-                                    <label class="mb-1 text-primary" for="user_email"><span class="fw-bold">Email</span></label>
-                                    <div>
-                                        <input type="text" class="form-control" name="email" id="user_email" required="True" t-attf-value="#{user.partner_id.email}"/>
-                                    </div>
-                                </div>
-                                <div class="mb-3 col-6">
-                                    <label class="mb-1 text-primary" for="user_city"><span class="fw-bold">City</span></label>
-                                    <div>
-                                        <input type="text" class="form-control" name="city" id="user_city" t-attf-value="#{user.partner_id.city or ''}"/>
-                                    </div>
-                                </div>
-                                <div class="mb-3 col-6">
-                                    <label class="mb-1 text-primary"><span class="fw-bold">Country</span></label>
-                                    <div>
-                                        <select class="form-select" name="country">
-                                            <option value="">Country...</option>
-                                            <t t-foreach="countries or []" t-as="country">
-                                                <option t-att-value="country.id" t-att-selected="country.id == user.partner_id.country_id.id"><t t-esc="country.name"/></option>
-                                            </t>
-                                         </select>
-                                    </div>
-                                </div>
-                                <div class="mb-3 col-12">
-                                    <label class="mb-1 text-primary" for="description"><span class="fw-bold">Biography</span></label>
-                                    <textarea name="description" id="description" style="min-height: 120px"
-                                        class="form-control o_wysiwyg_loader" placeholder="Write a few words about yourself..." t-att-content="user.partner_id.website_description"><t t-out="user.partner_id.website_description"/></textarea>
-                                </div>
-                                <div class="col">
-                                    <button type="submit" class="btn btn-primary o_wprofile_submit_btn">Update</button>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </form>
-        </div>
-    </template>
-
     <!-- Profile Page -->
     <template id="user_profile_main" name="Profile Page">
         <t t-set="body_classname" t-value="'o_wprofile_body'"/>
@@ -194,7 +92,7 @@
                             <div class="o_wprofile_pict d-inline-block mb-3 mb-md-0" t-attf-style="background-image: url(#{website.image_url(user, 'avatar_1024')});"/>
                             <a class="btn btn-primary d-inline-block d-md-none"
                                 t-if="request.env.user == user and user.karma != 0"
-                                t-attf-href="/profile/edit?url_param=#{edit_button_url_param}&amp;user_id=#{user.id}">
+                                data-bs-toggle="modal" data-bs-target="#o_wprofile_edit_profile_modal">
                                 <i class="fa fa-pencil me-1"/>EDIT
                             </a>
                         </div>
@@ -206,7 +104,8 @@
                             <h1 class="o_card_people_name">
                                 <span t-field="user.name"/><small t-if="user.karma == 0"> (not verified)</small>
                             </h1>
-                            <a class="btn btn-primary d-none d-md-inline-block" t-if="request.env.user == user and user.karma != 0 or request.env.user._is_admin()" t-attf-href="/profile/edit?url_param=#{edit_button_url_param}&amp;user_id=#{user.id}">
+                            <a class="btn o_wprofile_editor btn-primary d-none d-md-inline-block" t-if="(request.env.user == user and user.karma != 0) or request.env.user._is_admin()"
+                                t-att-data-user-id="user.id">
                                 <i class="fa fa-pencil me-2"/>EDIT PROFILE
                             </a>
                         </div>
@@ -286,48 +185,21 @@
                                 <h5 class="border-bottom pb-1">Badges</h5>
                                 <t t-call="website_profile.user_badges"></t>
                             </div>
-                            <div t-if="user.partner_id.website_description" class="o_wprofile_editor_form mb32">
+                            <div t-if="user.partner_id.website_description" class="mb32">
                                 <t t-if="request.env.user == user and user.karma != 0 or request.env.user._is_admin()">
-                                    <a href="#" class="o_forum_profile_bio_edit btn btn-link float-end">
-                                        <i class="fa fa-pencil me-1"/>Edit    
-                                    </a>
-                                    <a href="#" class="o_forum_profile_bio_cancel_edit btn btn-link float-end d-none">
-                                        <i class="fa fa-close me-1"/>Cancel    
+                                    <a href="#" class="o_wprofile_editor btn btn-link float-end"
+                                        t-att-data-user-id="user.id" data-focus-website-description="true">
+                                        <i class="fa fa-pencil me-1"/>Edit
                                     </a>
                                 </t>
                                 <h5 class="border-bottom pb-1">Biography</h5>
                                 <span class="o_forum_profile_bio text-break" t-field="user.partner_id.website_description"/>
-                                <t t-call="website_profile.user_biography_editor"/>
                             </div>
                         </div>
                     </div>
                 </div>
             </div>
         </div>
-    </template>
-
-    <template id="user_biography_editor" name="Edit User Biography">
-        <form t-attf-action="/profile/user/save" method="post" role="form" class="o_forum_profile_bio_form js_website_submit_form row d-none">
-            <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
-            <input name="user_id" t-att-value="user.id" type="hidden"/>
-            <input name="name" t-att-value="user.name" type="hidden"/>
-            <input name="website" t-att-value="user.partner_id.website" type="hidden"/>
-            <input name="email" t-att-value="user.partner_id.email" type="hidden"/>
-            <input name="city" t-att-value="user.partner_id.city" type="hidden"/>
-            <input name="country" t-att-value="user.partner_id.country_id.id" type="hidden"/>
-            <div class="row">
-                <div class="mb-1 col-12">
-                    <textarea name="description" id="description" style="min-height: 120px"
-                        class="form-control o_wysiwyg_loader" placeholder="Write a few words about yourself..."
-                        t-att-content="user.partner_id.website_description">
-                        <t t-out="user.partner_id.website_description"/>
-                    </textarea>
-                </div>
-                <div class="col">
-                    <button type="submit" class="btn btn-primary o_wprofile_submit_btn">Update</button>
-                </div>
-            </div>
-        </form>
     </template>
 
     <template id="profile_next_rank_card" name="Profile Next Rank Card">

--- a/addons/website_slides/controllers/main.py
+++ b/addons/website_slides/controllers/main.py
@@ -1578,8 +1578,6 @@ class WebsiteSlides(WebsiteProfile):
 
     def _prepare_user_profile_values(self, user, **post):
         values = super(WebsiteSlides, self)._prepare_user_profile_values(user, **post)
-        if post.get('channel_id'):
-            values.update({'edit_button_url_param': 'channel_id=' + str(post['channel_id'])})
         channels = self._get_channels(**post)
         if not channels:
             channels = request.env['slide.channel'].search([])


### PR DESCRIPTION
Instead of loading a new page for editing the profile, the profile is now edited in a popup.

To simplify the code, the "edit" link next to the "biography" that allowed the user to edit it directly in the profile page, is now also replaced by the edit profile popup (biography field being automatically focused).

Technical notes:
- we have converted the profile edition in OWL instead of using a simple bootstrap modal because the wysiwyg component was not compatible with bootstrap modal (ex.: when opening the chatGPT plugin from the wysiwyg field of the profile bootstrap modal, the prompt field was readonly/not focusable)
- We remove the "edit_button_url_param" and "url_param" that were used to transmit the forum_id/channel_id to the page /profile/edit so that when saving on /profile/user/save, the server could redirect to the page /profile/user with the right parameters. As we have converted the profile edition to OWL and used it in the same page, the page is refreshed with the same parameters after saving the profile through ajax call.
- We keep the save controller end point as operation for the current user are done in sudo so it cannot be replaced by simple orm call from the client.

Task-3975540