### PR TITLE
[FIX] mrp: by-products readonly

### DIFF
--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -432,7 +432,7 @@
                                 context="{'default_date': date_finished, 'default_date_deadline': date_deadline, 'default_location_id': production_location_id, 'default_location_dest_id': location_dest_id, 'default_state': 'draft', 'default_production_id': id, 'default_picking_type_id': picking_type_id, 'default_company_id': company_id, 'form_view_ref': 'stock.view_stock_move_operations'}"
                                 readonly="state == 'cancel' or (state == 'done' and is_locked)" options="{'delete': [('state', '=', 'draft')]}">
                                 <tree default_order="is_done,sequence" decoration-muted="is_done" editable="bottom">
-                                    <field name="product_id" context="{'default_detailed_type': 'product'}" domain="[('id', '!=', parent.product_id)]" required="1" readonly="state == 'done'"/>
+                                    <field name="product_id" context="{'default_detailed_type': 'product'}" domain="[('id', '!=', parent.product_id)]" required="1"/>
                                     <field name="location_dest_id" string="To" readonly="1" force_save="1" groups="stock.group_stock_multi_locations"/>
                                     <field name="company_id" column_invisible="True"/>
                                     <field name="product_uom_category_id" column_invisible="True"/>


### PR DESCRIPTION
Steps to reproduce:

1. Complete a manufacturing order and validate it
2. Unlock the manufacturing order
3. Go to the by-products tab and attempt to add by-products or change the quantity of existing by-products
4. Unable to select a product from the database

Bug:
the condition for readonly on the by-product product_id should be the same as its parent move `readonly="state == 'cancel' or (state == 'done' and is_locked)` therefore I'am simply removing the atribute

opw-3992201

