### PR TITLE
[FIX] web: fix catch_attention on empty kanban view

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_renderer.js
+++ b/addons/web/static/src/views/kanban/kanban_renderer.js
@@ -129,7 +129,7 @@ export class KanbanRenderer extends Component {
         }
 
         useBounceButton(this.rootRef, (clickedEl) => {
-            if (!this.props.list.count || this.props.list.model.useSampleModel) {
+            if (this.props.list.isGrouped ? !this.props.list.recordCount : !this.props.list.count || this.props.list.model.useSampleModel) {
                 return clickedEl.matches(
                     [
                         ".o_kanban_renderer",


### PR DESCRIPTION
When the kanban view is empty, if the user click on the kanban view, the NEW button should shake to catch the user attention.
With the previous code, if the kanban was empty but with some stages, the "count" of the list was set to the number of stages and not the number of kanban elements.