### PR TITLE
[FIX] mail: fix failing activity test

### DIFF
--- a/addons/mail/static/src/web/activity/activity.js
+++ b/addons/mail/static/src/web/activity/activity.js
@@ -73,7 +73,7 @@ export class Activity extends Component {
     }
 
     get onUpdate() {
-        return this.props.onUpdate?.();
+        return this.props.onUpdate;
     }
 
     toggleDetails() {


### PR DESCRIPTION
In [1], the `onUpdate` props of the activity component was replaced by a getter in order to ease overrides.

However, the getter does not return anything but calls the method instead.

As a result, calling `this.onUpdate` results in a crash. This PR fixes the issue.

[1]: https://github.com/odoo/odoo/pull/160069

runbot-69356