### PR TITLE
[FIX] im_livechat: traceback on closing chatbot thread

### DIFF
--- a/addons/im_livechat/static/src/embed/common/chatbot/chatbot_model.js
+++ b/addons/im_livechat/static/src/embed/common/chatbot/chatbot_model.js
@@ -57,7 +57,7 @@ export class Chatbot extends Record {
             await this._simulateTyping();
         }
         await this._goToNextStep();
-        if (!this.currentStep || this.currentStep.completed) {
+        if (!this.currentStep || this.currentStep.completed || !this.thread) {
             return;
         }
         this.currentStep.message = this._store.Message.insert(


### PR DESCRIPTION
When bot is processing steps and you close the `chatwindow` it throws error as the thread has been deleted so it won't be able to process next steps.

This PR fixes the issue by adding necessary checks.

Runbot Issue:-[64922](https://runbot.odoo.com/web/#id=64922&view_type=form&model=runbot.build.error&menu_id=405&cids=1)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
