### PR TITLE
[FIX] calendar: save access token upon calendar meeting creation

### DIFF
--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -300,7 +300,7 @@
                 <sheet>
                     <field name="recurrence_update" invisible="1"/>
                     <field name="videocall_source" invisible="1"/>
-                    <field name="access_token" invisible="1"/>
+                    <field name="access_token" invisible="1" force_save="1"/>
                     <div class="o_row">
                         <h1 class="w-100"><field name="name" nolabel="1" placeholder="Add title" colspan="2"/></h1>
                     </div>


### PR DESCRIPTION
Steps to reproduce:
- Install Calendar and Appointment
- Go to Calendar
- Create a meeting with a name and click on "+ Odoo Meeting"
- Copy this link and keep it on the side
- Create the event and edit it
- Copy the link

Issues:
The link doesn't match, this is because we are not sending the access token upon the creation of the meeting to the backend. This causes a new access token to be created which ends up in a new link.

opw-3910706