### PR TITLE
[FIX] sale_timesheet: make project profitability visible in project 

### DIFF
--- a/addons/sale_timesheet/views/project_update_templates.xml
+++ b/addons/sale_timesheet/views/project_update_templates.xml
@@ -31,7 +31,7 @@
 <div name="profitability" t-if="show_profitability">
 <t t-if="project.analytic_account_id and project.allow_billable and user.has_group('project.group_project_manager')" name="costs">
 <h3 style="font-weight: bolder"><u>Profitability</u></h3>
-<t t-if="project.analytic_account_id.line_ids"> The cost of the project is now at <t t-esc="profitability['costs_formatted']"/>, for a revenue of <t t-esc="profitability['revenues_formatted']"/>, leading to a
+<t t-if="project.analytic_account_id"> The cost of the project is now at <t t-esc="profitability['costs_formatted']"/>, for a revenue of <t t-esc="profitability['revenues_formatted']"/>, leading to a
 <span>
 <font t-if="profitability['margin'] &gt; 0"  style="color: rgb(0, 128, 0)">
 <b><t t-esc="profitability['margin_formatted']"/></b>


### PR DESCRIPTION
To reproduce the bug:
1- Enable margins in project app
2- Create a billable project
3- Affect to the project billable hours or a sale order 4- go in project update -> new -> profitability section

We can see that the profitability is empty. This is because of a condition that checked if a analitic_line was existant in analytic_account_id. Witch is not needed. The check on analytic_account_id is enough.

opw-3992550