### PR TITLE
[FIX] discuss: prevent incoherent display from debounce

### DIFF
--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -965,7 +965,7 @@ export class Rtc extends Record {
                 );
             },
             3000,
-            true
+            { leading: true, trailing: true }
         );
         this.state.channel.rtcInvitingSession = undefined;
         await this.loadSfuClient();

--- a/addons/web/static/src/core/utils/timing.js
+++ b/addons/web/static/src/core/utils/timing.js
@@ -33,36 +33,49 @@ export function batched(callback, synchronize = () => Promise.resolve()) {
  * @param {number | "animationFrame"} delay how long should elapse before the function
  *      is called. If 'animationFrame' is given instead of a number, 'requestAnimationFrame'
  *      will be used instead of 'setTimeout'.
- * @param {boolean} [immediate=false] whether the function should be called on
- *      the leading edge instead of the trailing edge.
+ * @param {boolean} [options] if true, equivalent to exclusive leading. If false, equivalent to exclusive trailing.
+ * @param {object} [options]
+ * @param {boolean} [options.leading=false] whether the function should be invoked at the leading edge of the timeout
+ * @param {boolean} [options.trailing=true] whether the function should be invoked at the trailing edge of the timeout,
+ *      note that if `leading` is also true, it will only be invoked at the trailing edge if the debounced function was
+ *      called at least once more during the wait time.
  * @returns {T & { cancel: () => void }} the debounced function
  */
-export function debounce(func, delay, immediate = false) {
+export function debounce(func, delay, options) {
     let handle;
     const funcName = func.name ? func.name + " (debounce)" : "debounce";
     const useAnimationFrame = delay === "animationFrame";
     const setFnName = useAnimationFrame ? "requestAnimationFrame" : "setTimeout";
     const clearFnName = useAnimationFrame ? "cancelAnimationFrame" : "clearTimeout";
     let lastArgs;
+    let leading = false;
+    let trailing = true;
+    if (typeof options === "boolean") {
+        leading = options;
+        trailing = !options;
+    } else if (options) {
+        leading = options.leading ?? leading;
+        trailing = options.trailing ?? trailing;
+    }
+
     return Object.assign(
         {
             /** @type {any} */
             [funcName](...args) {
-                lastArgs = args;
                 return new Promise((resolve) => {
-                    const callNow = immediate && !handle;
+                    if (leading && !handle) {
+                        Promise.resolve(func.apply(this, args)).then(resolve);
+                    } else {
+                        lastArgs = args;
+                    }
                     browser[clearFnName](handle);
                     handle = browser[setFnName](() => {
                         handle = null;
-                        if (!immediate) {
-                            lastArgs = undefined;
-                            Promise.resolve(func.apply(this, args)).then(resolve);
+                        if (trailing && lastArgs) {
+                            Promise.resolve(func.apply(this, lastArgs)).then(resolve);
+                            lastArgs = null;
                         }
                     }, delay);
-                    if (callNow) {
-                        lastArgs = undefined;
-                        Promise.resolve(func.apply(this, args)).then(resolve);
-                    }
                 });
             },
         }[funcName],


### PR DESCRIPTION
Before this commit and since the refactor (odoo/odoo#110188),
updateAndBroadcastDebounce would send outdated data if used within
the debounce delay as it was immediate (the members of the call
would still have live and correct information as they obtain it from the
dataChannel).

This commit fixes this issue by adding updating the API of debounce so
that it allows more flexibility by allowing to have a combination of
leading and trailing calls.

Behavior/API inspired from lodash:
https://lodash.com/docs/4.17.15#debounce