### PR TITLE
[IMP] point_of_sale: dropdown icon when there is orders

### DIFF
--- a/addons/point_of_sale/static/src/app/generic_components/list_container/list_container.js
+++ b/addons/point_of_sale/static/src/app/generic_components/list_container/list_container.js
@@ -36,7 +36,7 @@ export class ListContainer extends Component {
                     <t t-slot="default" item="item"/>
                 </t>
             </div>
-            <button t-if="isLarger() or ui.isSmall" t-on-click="toggle"
+            <button t-if="(isLarger() or ui.isSmall) and props.items.length" t-on-click="toggle"
                 class="btn btn-secondary ms-2"
                 t-attf-class="fa {{popover.isOpen ? 'fa-caret-up' : 'fa-caret-down'}}"/>
     `;

--- a/addons/point_of_sale/static/src/app/navbar/navbar.js
+++ b/addons/point_of_sale/static/src/app/navbar/navbar.js
@@ -78,7 +78,7 @@ export class Navbar extends Component {
     }
 
     get orderCount() {
-        return this.pos.get_order_list().length;
+        return this.pos.get_open_orders().length;
     }
 
     async closeSession() {

--- a/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.js
+++ b/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.js
@@ -52,7 +52,7 @@ export class PartnerList extends Component {
     goToOrders(partner) {
         this.props.close();
         const partnerHasActiveOrders = this.pos
-            .get_order_list()
+            .get_open_orders()
             .some((order) => order.partner?.id === partner.id);
         const stateOverride = {
             search: {

--- a/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.js
@@ -132,7 +132,7 @@ export class ControlButtons extends Component {
         this.notification.add(_t("Order saved for later"));
     }
     _selectEmptyOrder() {
-        const orders = this.pos.get_order_list();
+        const orders = this.pos.get_open_orders();
         const emptyOrders = orders.filter((order) => order.is_empty());
         if (emptyOrders.length > 0) {
             this.pos.syncAllOrders();

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
@@ -90,7 +90,7 @@ export class ReceiptScreen extends Component {
         this.pos.showScreen(name, props);
     }
     isResumeVisible() {
-        return this.pos.get_order_list().length > 1;
+        return this.pos.get_open_orders().length > 1;
     }
     async _sendReceiptToCustomer({ action }) {
         const order = this.currentOrder;

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -165,8 +165,8 @@ export class TicketScreen extends Component {
                 order.uiState.displayed = true;
             }
 
-            if (this.pos.get_order_list().length > 0) {
-                this.state.selectedOrder = this.pos.get_order_list()[0];
+            if (this.pos.get_open_orders().length > 0) {
+                this.state.selectedOrder = this.pos.get_open_orders()[0];
             }
         }
         return true;
@@ -453,7 +453,7 @@ export class TicketScreen extends Component {
         const productScreenStatus = this._getScreenToStatusMap().ProductScreen;
         return (
             order.get_orderlines().length === 0 &&
-            this.pos.get_order_list().length === 1 &&
+            this.pos.get_open_orders().length === 1 &&
             status === productScreenStatus &&
             order.payment_ids.length === 0
         );

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1087,7 +1087,7 @@ export class PosStore extends Reactive {
     }
 
     // return the list of unpaid orders
-    get_order_list() {
+    get_open_orders() {
         return this.models["pos.order"].filter((o) => !o.finalized);
     }
 

--- a/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.js
+++ b/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.js
@@ -111,7 +111,7 @@ export class FloorScreen extends Component {
         const table = this.pos.selectedTable;
         const tableByIds = this.pos.models["restaurant.table"].getAllBy("id");
         if (table) {
-            const orders = this.pos.get_order_list();
+            const orders = this.pos.get_open_orders();
             const tableOrders = orders.filter(
                 (order) => order.table_id?.id === table.id && !order.finalized
             );
@@ -621,7 +621,7 @@ export class FloorScreen extends Component {
                 return;
             }
 
-            const orderList = [...this.pos.get_order_list()];
+            const orderList = [...this.pos.get_open_orders()];
             for (const order of orderList) {
                 if (activeFloor.table_ids.includes(order.tableId)) {
                     this.pos.removeOrder(order, false);
@@ -662,7 +662,7 @@ export class FloorScreen extends Component {
             if (response) {
                 for (const id of originalSelectedTableIds) {
                     //remove order not send to server
-                    for (const order of this.pos.get_order_list()) {
+                    for (const order of this.pos.get_open_orders()) {
                         if (order.table_id == id) {
                             this.pos.removeOrder(order, false);
                         }

--- a/addons/pos_restaurant/static/src/overrides/components/navbar/navbar.js
+++ b/addons/pos_restaurant/static/src/overrides/components/navbar/navbar.js
@@ -48,7 +48,7 @@ patch(Navbar.prototype, {
         this.pos.showScreen("ProductScreen");
     },
     getFloatingOrders() {
-        return this.pos.get_order_list().filter((order) => !order.table_id);
+        return this.pos.get_open_orders().filter((order) => !order.table_id);
     },
     selectFloatingOrder(order) {
         this.pos.set_order(order);

--- a/addons/pos_restaurant/static/src/overrides/models/pos_store.js
+++ b/addons/pos_restaurant/static/src/overrides/models/pos_store.js
@@ -278,7 +278,7 @@ patch(PosStore.prototype, {
         }
     },
     getTableOrders(tableId) {
-        return this.get_order_list().filter((order) => order.table_id?.id === tableId);
+        return this.get_open_orders().filter((order) => order.table_id?.id === tableId);
     },
     async unsetTable() {
         try {


### PR DESCRIPTION
### Commit 1:
Rename method `get_order_list` to `get_open_orders` to be more explicit

---
### Commit 2:
Only display the dropdown icon for floating orders when there is at
least one order in the list.

Task ID: 3999224