### PR TITLE
[FIX] iap: neuter: gracefully handle invalid tokens

### DIFF
--- a/addons/iap/data/neutralize.sql
+++ b/addons/iap/data/neutralize.sql
@@ -1,1 +1,9 @@
-UPDATE iap_account SET account_token = REGEXP_REPLACE(account_token, '(\+.*)?$', '+disabled');
+-- happy path
+UPDATE iap_account
+SET account_token = REGEXP_REPLACE(account_token, '(\+.*)?$', '+disabled')
+WHERE LENGTH(account_token) <= 33;
+-- Legacy (invalid) records (pre v17)
+UPDATE iap_account
+SET account_token = 'dummy_value+disabled'
+WHERE LENGTH(account_token) > 33
+    AND account_token NOT LIKE '%+disabled';


### PR DESCRIPTION
Since 17.0, the account_token field is limited to 43 characters
But some database created before that version might still have some
`iap.account` records with token longer than 34 characters.

If the neutralization script tries to add `+disabled` (9 characters)
to such records, it fails. This prevents the creation of duplicates on
the SaaS and PaaS until the invalid records are purged for the database,
which is not really obvious if you don't already know the details of the
implementation of the `iap.account` model.

With this commit, the neutralization script will only try to retain the
original value of the token (with `+disabled` appended) if it is going
to succeed, and falls back to a dummy value in other cases.

opw-3999439
