### PR TITLE
[REF] web, im_livechat: remove CopyClipboardText widget

### DIFF
--- a/addons/im_livechat/views/im_livechat_channel_views.xml
+++ b/addons/im_livechat/views/im_livechat_channel_views.xml
@@ -168,7 +168,7 @@
                                     <p>
                                         Copy and paste this code into your website, within the &lt;head&gt; tag:
                                     </p>
-                                    <field name="script_external" readonly="1" widget="CopyClipboardText"/>
+                                    <field name="script_external" readonly="1" widget="CopyClipboardChar"/>
                                     <p>
                                         or copy this url and send it by email to your customers or suppliers:
                                     </p>

--- a/addons/web/static/src/views/fields/copy_clipboard/copy_clipboard_field.js
+++ b/addons/web/static/src/views/fields/copy_clipboard/copy_clipboard_field.js
@@ -4,10 +4,9 @@ import { registry } from "@web/core/registry";
 import { omit } from "@web/core/utils/objects";
 
 import { CopyButton } from "@web/core/copy_button/copy_button";
-import { UrlField } from "../url/url_field";
 import { CharField } from "../char/char_field";
-import { TextField } from "../text/text_field";
 import { standardFieldProps } from "../standard_field_props";
+import { UrlField } from "../url/url_field";
 
 import { Component } from "@odoo/owl";
 
@@ -56,10 +55,6 @@ export class CopyClipboardCharField extends CopyClipboardField {
     static components = { Field: CharField, CopyButton };
 }
 
-export class CopyClipboardTextField extends CopyClipboardField {
-    static components = { Field: TextField, CopyButton };
-}
-
 export class CopyClipboardURLField extends CopyClipboardField {
     static components = { Field: UrlField, CopyButton };
 }
@@ -89,15 +84,6 @@ export const copyClipboardCharField = {
 };
 
 registry.category("fields").add("CopyClipboardChar", copyClipboardCharField);
-
-export const copyClipboardTextField = {
-    component: CopyClipboardTextField,
-    displayName: _t("Copy Multiline Text to Clipboard"),
-    supportedTypes: ["text"],
-    extractProps,
-};
-
-registry.category("fields").add("CopyClipboardText", copyClipboardTextField);
 
 export const copyClipboardURLField = {
     component: CopyClipboardURLField,

--- a/addons/web/static/src/views/fields/copy_clipboard/copy_clipboard_field.scss
+++ b/addons/web/static/src/views/fields/copy_clipboard/copy_clipboard_field.scss
@@ -1,4 +1,4 @@
-.o_field_CopyClipboardText, .o_field_CopyClipboardURL, .o_field_CopyClipboardChar {
+.o_field_CopyClipboardURL, .o_field_CopyClipboardChar {
     > div {
         grid-template-columns: auto min-content;
         border: 1px solid $primary;
@@ -20,12 +20,9 @@
             margin-right: 4px;
             align-self: center;
             text-align: center;
-
-            &:not(.o_field_CopyClipboardText) {
-                overflow: hidden;
-                text-overflow: ellipsis;
-                white-space: nowrap;
-            }
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
         }
     }
 }

--- a/addons/web/static/tests/views/fields/copy_clipboard_field.test.js
+++ b/addons/web/static/tests/views/fields/copy_clipboard_field.test.js
@@ -19,7 +19,6 @@ class Partner extends models.Model {
         searchable: true,
         trim: true,
     });
-    text_field = fields.Text({ default: "This is a text field" });
 
     _records = [
         {
@@ -33,7 +32,6 @@ class Partner extends models.Model {
             <form>
                 <sheet>
                     <group>
-                        <field name="text_field" widget="CopyClipboardText"/>
                         <field name="char_field" widget="CopyClipboardChar"/>
                     </group>
                 </sheet>
@@ -43,27 +41,24 @@ class Partner extends models.Model {
 
 defineModels([Partner]);
 
-test("Char & Text Fields: Copy to clipboard button", async () => {
+test("Char Field: Copy to clipboard button", async () => {
     await mountView({
         type: "form",
         resModel: "res.partner",
         resId: 1,
     });
 
-    expect(".o_clipboard_button.o_btn_text_copy").toHaveCount(1);
     expect(".o_clipboard_button.o_btn_char_copy").toHaveCount(1);
 });
 
 test("Show copy button even on empty field", async () => {
     Partner._records.push({
         char_field: false,
-        text_field: false,
     });
 
     await mountView({ type: "form", resModel: "res.partner", resId: 2 });
 
     expect(".o_field_CopyClipboardChar[name='char_field'] .o_clipboard_button").toHaveCount(1);
-    expect(".o_field_CopyClipboardText[name='text_field'] .o_clipboard_button").toHaveCount(1);
 });
 
 test("Show copy button even on readonly empty field", async () => {
@@ -106,9 +101,9 @@ test("Display a tooltip on click", async () => {
         resId: 1,
     });
 
-    await expect(".o_clipboard_button.o_btn_text_copy").toHaveCount(1);
+    await expect(".o_clipboard_button.o_btn_char_copy").toHaveCount(1);
     await contains(".o_clipboard_button").click();
-    expect(["This is a text field", "copied tooltip"]).toVerifySteps();
+    expect(["char value", "copied tooltip"]).toVerifySteps();
 });
 
 test("CopyClipboardButtonField in form view", async () => {
@@ -125,21 +120,17 @@ test("CopyClipboardButtonField in form view", async () => {
         arch: `
             <form>
                 <group>
-                    <field name="text_field" widget="CopyClipboardButton"/>
                     <field name="char_field" widget="CopyClipboardButton"/>
                 </group>
             </form>`,
     });
 
     expect(".o_field_widget[name=char_field] input").toHaveCount(0);
-    expect(".o_field_widget[name=text_field] input").toHaveCount(0);
-    expect(".o_clipboard_button.o_btn_text_copy").toHaveCount(1);
     expect(".o_clipboard_button.o_btn_char_copy").toHaveCount(1);
 
-    await contains(".o_clipboard_button.o_btn_text_copy").click();
     await contains(".o_clipboard_button.o_btn_char_copy").click();
 
-    expect(["This is a text field", "char value"]).toVerifySteps();
+    expect(["char value"]).toVerifySteps();
 });
 
 test("CopyClipboardButtonField can be disabled", async () => {
@@ -157,14 +148,12 @@ test("CopyClipboardButtonField can be disabled", async () => {
             <form>
                 <sheet>
                     <group>
-                        <field name="text_field" disabled="1" widget="CopyClipboardButton"/>
                         <field name="char_field" disabled="char_field == 'char value'" widget="CopyClipboardButton"/>
                         <field name="char_field" widget="char"/>
                     </group>
                 </sheet>
             </form>`,
     });
-    expect(".o_clipboard_button.o_btn_text_copy[disabled]").toHaveCount(1);
     expect(".o_clipboard_button.o_btn_char_copy[disabled]").toHaveCount(1);
     await fieldInput("char_field").edit("another char value");
     expect(".o_clipboard_button.o_btn_char_copy[disabled]").toHaveCount(0);


### PR DESCRIPTION
This commit removes the CopyClipboardText widget since it is pretty much unused throughout the codebase and its design doesn't fit with the milk update.

task-3964629
