### PR TITLE
[FIX] point_of_sale: restore big scrollbar options

### DIFF
--- a/addons/point_of_sale/static/src/app/pos_app.js
+++ b/addons/point_of_sale/static/src/app/pos_app.js
@@ -26,6 +26,11 @@ export class Chrome extends Component {
             }
         });
 
+        if (this.pos.config.iface_big_scrollbars) {
+            const body = document.getElementsByTagName("body")[0];
+            body.classList.add("big-scrollbars");
+        }
+
         onWillStart(this.pos._loadFonts);
         onMounted(this.props.disableLoader);
     }

--- a/addons/point_of_sale/static/src/app/pos_app.xml
+++ b/addons/point_of_sale/static/src/app/pos_app.xml
@@ -2,7 +2,7 @@
 <templates id="template" xml:space="preserve">
 
     <t t-name="point_of_sale.Chrome">
-        <div class="pos dvh-100 d-flex flex-column" t-att-class="{ 'big-scrollbars': pos.hasBigScrollBars }">
+        <div class="pos dvh-100 d-flex flex-column">
             <Navbar />
             <div class="pos-content flex-grow-1 overflow-auto bg-200">
                 <!-- FIXME POSREF: better error handling in main screens (currently, a crash in owl lifecycle of a main screen blows up the application and the error can't be displayed) -->

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -82,7 +82,6 @@ const getProductImage = memoize(function getProductImage(productId, writeDate) {
 });
 
 export class PosStore extends Reactive {
-    hasBigScrollBars = false;
     loadingSkipButtonIsShown = false;
     mainScreen = { name: null, component: null };
 

--- a/addons/point_of_sale/static/src/scss/pos.scss
+++ b/addons/point_of_sale/static/src/scss/pos.scss
@@ -83,6 +83,14 @@ button {
 
 /*  ********* The Webkit Scrollbar  ********* */
 
+// Remove this scrollbar double button
+::-webkit-scrollbar-button:vertical:start:increment,
+::-webkit-scrollbar-button:vertical:end:decrement,
+::-webkit-scrollbar-button:horizontal:start:increment,
+::-webkit-scrollbar-button:horizontal:end:decrement
+{
+    display: none;
+}
 .pos *::-webkit-scrollbar{
     width:  4px;
     height: 4px;
@@ -96,7 +104,6 @@ button {
     background: #393939;
     min-height: 30px;
 }
-
 .pos.big-scrollbars *::-webkit-scrollbar{
     width:  40px;
     height: 40px;


### PR DESCRIPTION
After the refatoring of the POS, the big scrollbar options does not work anymore. This commit restore the big scrollbar options.

taskId: 3419014
opw-3998526

Close this one:
https://github.com/odoo/odoo/pull/170746
