### PR TITLE
[IMP] l10n_it_edi_withholding: Apply Pension Fund tax by line

### DIFF
--- a/addons/l10n_it_edi_withholding/data/invoice_it_template.xml
+++ b/addons/l10n_it_edi_withholding/data/invoice_it_template.xml
@@ -35,11 +35,18 @@
             </t>
         </xpath>
         <xpath expr="//DettaglioLinee" position="inside">
-            <t t-if="enasarco_values and enasarco_values[line.id]">
+            <t t-if="enasarco_values and enasarco_values.get(line.id)">
                 <AltriDatiGestionali>
                     <TipoDato>CASSA-PREV</TipoDato>
                     <RiferimentoTesto t-esc="format_alphanumeric('TC07 - ENASARCO (' + format_numbers(abs(enasarco_values[line.id]['amount'])).rstrip('.0') + '%)')"/>
                     <RiferimentoNumero t-esc="format_monetary(enasarco_values[line.id]['tax_amount'], currency)"/>
+                </AltriDatiGestionali>
+            </t>
+            <t t-elif="pension_fund_by_line_id and pension_fund_by_line_id.get(line.id)">
+                <t t-set="pension_fund_tax" t-value="pension_fund_by_line_id[line.id]" />
+                <AltriDatiGestionali>
+                    <TipoDato>AswCassPre</TipoDato>
+                    <RiferimentoTesto t-esc="format_alphanumeric(pension_fund_tax.l10n_it_pension_fund_type + ' (' + format_numbers(abs(pension_fund_tax.amount)).rstrip('.0') + '%)')"/>
                 </AltriDatiGestionali>
             </t>
         </xpath>

--- a/addons/l10n_it_edi_withholding/models/account_move.py
+++ b/addons/l10n_it_edi_withholding/models/account_move.py
@@ -73,6 +73,18 @@ class AccountMove(models.Model):
             vat_tax, withholding_tax = pension_fund_mapping[pension_fund_tax.id]
             pension_fund_values.append(PensionFundTaxData(pension_fund_tax, line.tax_base_amount, abs(line.balance), vat_tax, withholding_tax))
 
+        # Pension fund must be expressed in the AltriDatiGestionali at the line detail level
+        pension_fund_by_line_id = {}
+        if pension_fund_values:
+            base_lines = [
+                line._convert_to_tax_base_line_dict()
+                for line in self.line_ids.filtered(lambda line: line.display_type == 'product')
+            ]
+            for base_line in base_lines:
+                for pension_fund in pension_fund_values:
+                    if pension_fund.tax.id in base_line['taxes'].ids:
+                        pension_fund_by_line_id[base_line['record'].id] = pension_fund.tax
+
         # Enasarco pension fund must be expressed in the AltriDatiGestionali at the line detail level
         enasarco_values = False
         if enasarco_taxes:
@@ -93,6 +105,7 @@ class AccountMove(models.Model):
         template_values.update({
             'withholding_values': withholding_values,
             'pension_fund_values': pension_fund_values,
+            'pension_fund_by_line_id': pension_fund_by_line_id,
             'enasarco_values': enasarco_values,
             'document_total': document_total,
         })
@@ -191,8 +204,6 @@ class AccountMove(models.Model):
             withholding_tags = element.xpath("Ritenuta")
             if withholding_tags and withholding_tags[0].text == 'SI':
                 move_line_form.tax_ids |= withholding_tax
-        for pension_fund_tax in extra_info.get('pension_fund_taxes', []):
-            move_line_form.tax_ids |= pension_fund_tax
 
         if extra_info['simplified']:
             return messages_to_log
@@ -200,29 +211,34 @@ class AccountMove(models.Model):
         price_subtotal = move_line_form.price_unit
         company = move_line_form.company_id
 
-        # ENASARCO Pension Fund tax (works as a withholding)
+        # Pension Funds applied on line level and ENASARCO Pension Fund tax (works as a withholding)
         for other_data_element in element.xpath('.//AltriDatiGestionali'):
             data_kind_element = other_data_element.xpath("./TipoDato")
             text_element = other_data_element.xpath("./RiferimentoTesto")
-            number_element = other_data_element.xpath("./RiferimentoNumero")
-            if not data_kind_element or not text_element or not number_element:
+            if not data_kind_element or not text_element:
                 continue
-            data_kind, data_text, number_text = data_kind_element[0].text.lower(), text_element[0].text.lower(), number_element[0].text
-            if data_kind != 'cassa-prev' or ('enasarco' not in data_text and 'tc07' not in data_text):
-                continue
-            enasarco_amount = float(number_text)
-            enasarco_percentage = -self.env.company.currency_id.round(enasarco_amount / price_subtotal * 100)
-            enasarco_tax = self._l10n_it_edi_search_tax_for_import(
-                company,
-                enasarco_percentage,
-                [('l10n_it_pension_fund_type', '=', 'TC07')] + type_tax_use_domain,
-                vat_only=False)
-            if enasarco_tax:
-                move_line_form.tax_ids |= enasarco_tax
-            else:
-                messages_to_log.append(Markup("%s<br/>%s") % (
-                    _("Enasarco tax not found for line with description '%s'", move_line_form.name),
-                    self.env['account.move']._compose_info_message(other_data_element, '.'),
-                ))
+            data_kind, data_text = data_kind_element[0].text.lower(), text_element[0].text.lower()
+            if data_kind == 'cassa-prev' and ('enasarco' in data_text or 'tc07' in data_text):
+                number_element = other_data_element.xpath("./RiferimentoNumero")
+                if not number_element:
+                    continue
+                enasarco_amount = float(number_element[0].text)
+                enasarco_percentage = -self.env.company.currency_id.round(enasarco_amount / price_subtotal * 100)
+                enasarco_tax = self._l10n_it_edi_search_tax_for_import(
+                    company,
+                    enasarco_percentage,
+                    [('l10n_it_pension_fund_type', '=', 'TC07')] + type_tax_use_domain,
+                    vat_only=False)
+                if enasarco_tax:
+                    move_line_form.tax_ids |= enasarco_tax
+                else:
+                    messages_to_log.append(Markup("%s<br/>%s") % (
+                        _("Enasarco tax not found for line with description '%s'", move_line_form.name),
+                        self.env['account.move']._compose_info_message(other_data_element, '.'),
+                    ))
+            elif data_kind == 'aswcasspre' and 'tc' in data_text:
+                for pension_fund_tax in extra_info.get('pension_fund_taxes', []):
+                    if pension_fund_tax.l10n_it_pension_fund_type.lower() in data_text:
+                        move_line_form.tax_ids |= pension_fund_tax
 
         return messages_to_log

--- a/addons/l10n_it_edi_withholding/tests/export_xmls/inps_tax_invoice.xml
+++ b/addons/l10n_it_edi_withholding/tests/export_xmls/inps_tax_invoice.xml
@@ -81,6 +81,10 @@
                 <PrezzoTotale>350.00</PrezzoTotale>
                 <AliquotaIVA>0.00</AliquotaIVA>
                 <Natura>N2.2</Natura>
+                <AltriDatiGestionali>
+                    <TipoDato>AswCassPre</TipoDato>
+                    <RiferimentoTesto>TC22 (4%)</RiferimentoTesto>
+                </AltriDatiGestionali>
             </DettaglioLinee>
             <DettaglioLinee>
                 <NumeroLinea>2</NumeroLinea>
@@ -92,6 +96,10 @@
                 <PrezzoTotale>300.00</PrezzoTotale>
                 <AliquotaIVA>0.00</AliquotaIVA>
                 <Natura>N2.2</Natura>
+                <AltriDatiGestionali>
+                    <TipoDato>AswCassPre</TipoDato>
+                    <RiferimentoTesto>TC22 (4%)</RiferimentoTesto>
+                </AltriDatiGestionali>
             </DettaglioLinee>
             <DettaglioLinee>
                 <NumeroLinea>3</NumeroLinea>
@@ -103,6 +111,10 @@
                 <PrezzoTotale>50.00</PrezzoTotale>
                 <AliquotaIVA>0.00</AliquotaIVA>
                 <Natura>N2.2</Natura>
+                <AltriDatiGestionali>
+                    <TipoDato>AswCassPre</TipoDato>
+                    <RiferimentoTesto>TC22 (4%)</RiferimentoTesto>
+                </AltriDatiGestionali>
             </DettaglioLinee>
             <DettaglioLinee>
                 <NumeroLinea>4</NumeroLinea>
@@ -114,6 +126,10 @@
                 <PrezzoTotale>50.00</PrezzoTotale>
                 <AliquotaIVA>0.00</AliquotaIVA>
                 <Natura>N2.2</Natura>
+                <AltriDatiGestionali>
+                    <TipoDato>AswCassPre</TipoDato>
+                    <RiferimentoTesto>TC22 (4%)</RiferimentoTesto>
+                </AltriDatiGestionali>
             </DettaglioLinee>
             <DatiRiepilogo>
                 <AliquotaIVA>0.00</AliquotaIVA>

--- a/addons/l10n_it_edi_withholding/tests/export_xmls/pension_fund_tax_invoice.xml
+++ b/addons/l10n_it_edi_withholding/tests/export_xmls/pension_fund_tax_invoice.xml
@@ -86,6 +86,10 @@
         <PrezzoTotale>350.00</PrezzoTotale>
         <AliquotaIVA>22.00</AliquotaIVA>
         <Ritenuta>SI</Ritenuta>
+        <AltriDatiGestionali>
+          <TipoDato>AswCassPre</TipoDato>
+          <RiferimentoTesto>TC01 (4%)</RiferimentoTesto>
+        </AltriDatiGestionali>
       </DettaglioLinee>
       <DettaglioLinee>
         <NumeroLinea>2</NumeroLinea>
@@ -95,6 +99,10 @@
         <PrezzoTotale>300.00</PrezzoTotale>
         <AliquotaIVA>22.00</AliquotaIVA>
         <Ritenuta>SI</Ritenuta>
+        <AltriDatiGestionali>
+          <TipoDato>AswCassPre</TipoDato>
+          <RiferimentoTesto>TC01 (4%)</RiferimentoTesto>
+        </AltriDatiGestionali>
       </DettaglioLinee>
       <DettaglioLinee>
         <NumeroLinea>3</NumeroLinea>
@@ -104,6 +112,10 @@
         <PrezzoTotale>50.00</PrezzoTotale>
         <AliquotaIVA>22.00</AliquotaIVA>
         <Ritenuta>SI</Ritenuta>
+        <AltriDatiGestionali>
+          <TipoDato>AswCassPre</TipoDato>
+          <RiferimentoTesto>TC01 (4%)</RiferimentoTesto>
+        </AltriDatiGestionali>
       </DettaglioLinee>
       <DettaglioLinee>
         <NumeroLinea>4</NumeroLinea>
@@ -113,6 +125,10 @@
         <PrezzoTotale>50.00</PrezzoTotale>
         <AliquotaIVA>22.00</AliquotaIVA>
         <Ritenuta>SI</Ritenuta>
+        <AltriDatiGestionali>
+          <TipoDato>AswCassPre</TipoDato>
+          <RiferimentoTesto>TC01 (4%)</RiferimentoTesto>
+        </AltriDatiGestionali>
       </DettaglioLinee>
       <DatiRiepilogo>
         <AliquotaIVA>22.00</AliquotaIVA>

--- a/addons/l10n_it_edi_withholding/tests/import_xmls/IT00470550013_pfund.xml
+++ b/addons/l10n_it_edi_withholding/tests/import_xmls/IT00470550013_pfund.xml
@@ -84,6 +84,10 @@
         <PrezzoTotale>350.00</PrezzoTotale>
         <Ritenuta>SI</Ritenuta>
         <AliquotaIVA>22.00</AliquotaIVA>
+        <AltriDatiGestionali>
+          <TipoDato>AswCassPre</TipoDato>
+          <RiferimentoTesto>TC22 (4%)</RiferimentoTesto>
+        </AltriDatiGestionali>
       </DettaglioLinee>
       <DettaglioLinee>
         <NumeroLinea>2</NumeroLinea>
@@ -95,6 +99,10 @@
         <PrezzoTotale>300.00</PrezzoTotale>
         <Ritenuta>SI</Ritenuta>
         <AliquotaIVA>22.00</AliquotaIVA>
+        <AltriDatiGestionali>
+          <TipoDato>AswCassPre</TipoDato>
+          <RiferimentoTesto>TC22 (4%)</RiferimentoTesto>
+        </AltriDatiGestionali>
       </DettaglioLinee>
       <DettaglioLinee>
         <NumeroLinea>3</NumeroLinea>
@@ -106,6 +114,10 @@
         <PrezzoTotale>50.00</PrezzoTotale>
         <Ritenuta>SI</Ritenuta>
         <AliquotaIVA>22.00</AliquotaIVA>
+        <AltriDatiGestionali>
+          <TipoDato>AswCassPre</TipoDato>
+          <RiferimentoTesto>TC22 (4%)</RiferimentoTesto>
+        </AltriDatiGestionali>
       </DettaglioLinee>
       <DettaglioLinee>
         <NumeroLinea>4</NumeroLinea>
@@ -117,6 +129,10 @@
         <PrezzoTotale>50.00</PrezzoTotale>
         <Ritenuta>SI</Ritenuta>
         <AliquotaIVA>22.00</AliquotaIVA>
+        <AltriDatiGestionali>
+          <TipoDato>AswCassPre</TipoDato>
+          <RiferimentoTesto>TC22 (4%)</RiferimentoTesto>
+        </AltriDatiGestionali>
       </DettaglioLinee>
       <DatiRiepilogo>
         <AliquotaIVA>22.00</AliquotaIVA>


### PR DESCRIPTION
Pension Fund tax was incorrectly applied at the invoice level instead of the line level. When importing it as a vendor bill, this caused incorrect amounts due to the tax being applied to all lines.

This commit exports TipoDato = "AswCassPre" for lines with the pension fund applied. During XML import, it checks which lines should have the "pension fund" tax and applies it accordingly.

Ticket [link](https://www.odoo.com/odoo/project/967/tasks/3969730)
opw-3969730