### PR TITLE
[FIX] web, website: fix the values set on the buttons CSS variables

### DIFF
--- a/addons/web/static/src/scss/utils.scss
+++ b/addons/web/static/src/scss/utils.scss
@@ -221,10 +221,20 @@
     @return $-with-support-font;
 }
 
-// Function to remove all null values of a map
+// Function to remove all null values of a map. Also transforms `'True'` and
+// `'False'` values into boolean `true` and `false`. This is needed in website
+// because of some options that wrongly set some CSS variables to these values.
+// TODO in master, this should be moved in website, as the only use case is in
+// website user values files.
 @function o-map-omit($map) {
     $-map: ();
     @each $key, $value in $map {
+        @if $value == 'True' {
+            $value: true;
+        }
+        @if $value == 'False' {
+            $value: false;
+        }
         @if $value != null {
             $-map: map-merge($-map, (
                 $key: $value,

--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -1484,8 +1484,8 @@ options.registry.OptionsTab = options.Class.extend({
      */
     async customizeButtonStyle(previewMode, widgetValue, params) {
         await this._customizeWebsiteVariables({
-            [`btn-${params.button}-outline`]: widgetValue === 'outline',
-            [`btn-${params.button}-flat`]: widgetValue === 'flat',
+            [`btn-${params.button}-outline`]: widgetValue === "outline" ? "true" : "false",
+            [`btn-${params.button}-flat`]: widgetValue === "flat" ? "true" : "false",
         }, params.nullValue);
     },
 
@@ -1569,7 +1569,7 @@ options.registry.OptionsTab = options.Class.extend({
         if (methodName === 'customizeButtonStyle') {
             const isOutline = weUtils.getCSSVariableValue(`btn-${params.button}-outline`);
             const isFlat = weUtils.getCSSVariableValue(`btn-${params.button}-flat`);
-            return isFlat === "'True'" ? 'flat' : isOutline === "'True'" ? 'outline' : 'fill';
+            return isFlat === "true" ? "flat" : isOutline === "true" ? "outline" : "fill";
         }
         return this._super(...arguments);
     },


### PR DESCRIPTION
In commit [1], the "Themes Options" have been reorganized to make them
easier to find. With this relayout, the buttons style options have also
been modified in order to have a third choice "Flat", in addition to
"Fill" and "Outline". However, the way it was done causes some issues.

Indeed, it wrongly sets the `btn-(primary|secondary)-(outline|flat)` CSS
variables to `'True'` instead of the `true` boolean, and to `null`
instead of `false`, which is not correct. This happens because
`customizeButtonStyle` now sends boolean values to the `_makeSCSSCusto`
function, instead of strings representing these booleans. This results
in the backend RPC call setting the variables to the Python boolean
`True`, or to `null` in the falsy case because of the `"null"` default
value.

While it does not seem to break anything in general, there are issues
when using themes that redefine these variables (e.g. "Avantgarde",
"Enark", "Cobalt",...). Indeed, it is impossible to set the buttons
corresponding style to "Fill". This happens because choosing "Fill" is
supposed to set both variables to `false`, but because of the boolean
values being sent to `_makeSCSSCusto`, the value that is in fact set is
`"null"`. This therefore makes them fallback to the value defined in the
theme, forcing them to `true` and preventing the "Fill" style from being
applied.

This commit fixes these issues by properly giving string values to
`_makeSCSSCusto`. For already existing databases, all the variables that
have been set to `'True'` will have their value replaced by `true`,
thanks to the `o-map-omit` SCSS function. Note that the `'False'` case
is also added, in order to be consistent.

[1]: https://github.com/odoo/odoo/commit/388e4bb2bfcaebdd4ff30277fb49a034592d7086

opw-3957157