### PR TITLE
[IMP] mail: push-to talk in mobile

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_action_list.dark.scss
+++ b/addons/mail/static/src/discuss/call/common/call_action_list.dark.scss
@@ -5,3 +5,12 @@
 .o-discuss-CallActionList button:not(.btn-danger) {
     --o-discuss-CallActionList-bgColor: #{$o-gray-200};
 }
+
+.o-discuss-CallActionList-pushToTalk {
+    @include button-variant(
+        $primary,
+        $primary,
+        $active-background: $o-gray-200,
+        $active-border: $o-gray-200,
+    )
+}

--- a/addons/mail/static/src/discuss/call/common/call_action_list.js
+++ b/addons/mail/static/src/discuss/call/common/call_action_list.js
@@ -13,6 +13,7 @@ export class CallActionList extends Component {
 
     setup() {
         super.setup();
+        this.store = useState(useService("mail.store"));
         this.rtc = useState(useService("discuss.rtc"));
     }
 

--- a/addons/mail/static/src/discuss/call/common/call_action_list.scss
+++ b/addons/mail/static/src/discuss/call/common/call_action_list.scss
@@ -1,4 +1,4 @@
-.o-discuss-CallActionList button:not(.btn-danger):not(.btn-success) {
+.o-discuss-CallActionList button:not(.btn-danger):not(.btn-success):not(.o-discuss-CallActionList-pushToTalk) {
     background-color: var(--o-discuss-CallActionList-bgColor, #{$o-gray-800});
     color: #FFFFFF;
 }

--- a/addons/mail/static/src/discuss/call/common/call_action_list.xml
+++ b/addons/mail/static/src/discuss/call/common/call_action_list.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="discuss.CallActionList">
-        <div class="o-discuss-CallActionList d-flex justify-content-center" t-attf-class="{{ className }}" t-ref="root">
+        <div class="o-discuss-CallActionList d-flex flex-column justify-content-center" t-attf-class="{{ className }}" t-ref="root">
             <div class="d-flex align-items-center flex-wrap justify-content-between" t-att-class="{ 'w-100 ps-2 pe-2': isSmall }">
                 <t t-if="isOfActiveCall and rtc.selfSession">
                     <t t-if="rtc.selfSession.isMute" t-set="micText">Unmute</t>
@@ -86,6 +86,14 @@
                     <div class="fa-stack">
                         <i class="fa fa-phone fa-stack-1x" t-att-class="{ 'fa-lg': !isSmall }"/>
                     </div>
+                </button>
+            </div>
+            <div t-if="isMobileOS and store.settings.use_push_to_talk and isOfActiveCall" class="d-flex align-items-center flex-wrap justify-content-between p-2">
+                <button class="o-discuss-CallActionList-pushToTalk btn btn-primary d-flex w-100 border-0 shadow-none"
+                    aria-label="Push to talk"
+                    t-on-touchstart.stop="rtc.onPushToTalk"
+                    t-on-touchend.stop="rtc.setPttReleaseTimeout">
+                    <span class="w-100 fs-4 text-center">Push to talk</span>
                 </button>
             </div>
         </div>

--- a/addons/mail/static/src/discuss/call/common/call_settings.js
+++ b/addons/mail/static/src/discuss/call/common/call_settings.js
@@ -2,6 +2,7 @@ import { Component, onWillStart, useExternalListener, useState } from "@odoo/owl
 
 import { _t } from "@web/core/l10n/translation";
 import { browser } from "@web/core/browser/browser";
+import { isMobileOS } from "@web/core/browser/feature_detection";
 import { useService } from "@web/core/utils/hooks";
 
 export class CallSettings extends Component {
@@ -40,6 +41,10 @@ export class CallSettings extends Component {
             Boolean
         );
         return keys.join(" + ");
+    }
+
+    get isMobileOS() {
+        return isMobileOS();
     }
 
     _onKeyDown(ev) {

--- a/addons/mail/static/src/discuss/call/common/call_settings.xml
+++ b/addons/mail/static/src/discuss/call/common/call_settings.xml
@@ -31,7 +31,7 @@
                     <input class="form-check-input" type="radio" t-att-checked="store.settings.use_push_to_talk ? 'checked' : ''"/>
                     <span class="text-start flex-grow-1 mx-3">Push to Talk</span>
                 </button>
-                <span t-if="store.settings.use_push_to_talk and !pttExtService.isEnabled" class="small text-muted fst-italic mb-3" t-out="pttExtService.downloadText"/>
+                <span t-if="store.settings.use_push_to_talk and !isMobileOS and !pttExtService.isEnabled" class="small text-muted fst-italic mb-3" t-out="pttExtService.downloadText"/>
             </div>
             <div class="d-flex flex-column">
                 <label t-if="!store.settings.use_push_to_talk" class="d-flex flex-column flex-wrap flex-grow-1 align-items-start" title="Voice detection threshold" aria-label="Voice detection threshold">
@@ -42,7 +42,7 @@
                     </div>
                 </label>
                 <div t-if="store.settings.use_push_to_talk" class="d-flex" t-att-class="{'flex-column': props.isCompact}">
-                    <div class="d-flex flex-column align-items-center" t-att-class="{'me-1 w-50': !props.isCompact}">
+                    <div t-if="!isMobileOS" class="d-flex flex-column align-items-center" t-att-class="{'me-1 w-50': !props.isCompact}">
                         <label class="d-flex flex-column align-items-start flex-wrap w-100" title="Push-to-talk key" aria-label="Push-to-talk key">
                             <span class="me-2 my-1 text-truncate text-wrap">Push-to-talk key</span>
                             <span class="d-flex border border-2 rounded w-100" t-attf-class="{{ store.settings.isRegisteringKey ? 'border-danger' : 'border-primary' }}">

--- a/addons/mail/static/src/discuss/call/common/ptt_ad_banner.js
+++ b/addons/mail/static/src/discuss/call/common/ptt_ad_banner.js
@@ -1,5 +1,6 @@
 import { Component, useState } from "@odoo/owl";
 import { browser } from "@web/core/browser/browser";
+import { isMobileOS } from "@web/core/browser/feature_detection";
 import { useService } from "@web/core/utils/hooks";
 
 export class PttAdBanner extends Component {
@@ -25,6 +26,7 @@ export class PttAdBanner extends Component {
         return (
             !this.pttExtService.isEnabled &&
             this.store.settings.use_push_to_talk &&
+            !isMobileOS() &&
             !this.state.wasDiscarded
         );
     }

--- a/addons/mail/static/tests/discuss/call/web/call.test.js
+++ b/addons/mail/static/tests/discuss/call/web/call.test.js
@@ -3,12 +3,17 @@ import {
     contains,
     defineMailModels,
     insertText,
+    mockGetMedia,
     openDiscuss,
+    patchUiSize,
+    SIZES,
     start,
     startServer,
     triggerHotkey,
 } from "@mail/../tests/mail_test_helpers";
 import { describe, test } from "@odoo/hoot";
+import { mockUserAgent } from "@odoo/hoot-mock";
+import { mockService } from "@web/../tests/web_test_helpers";
 
 describe.current.tags("desktop");
 defineMailModels();
@@ -49,4 +54,26 @@ test("no default rtc after joining a group conversation", async () => {
     await contains(".o-mail-DiscussSidebarChannel");
     await contains(".o-mail-Discuss-content .o-mail-Message", { count: 0 });
     await contains(".o-discuss-Call", { count: 0 });
+});
+
+test.tags("mobile")("show Push-to-Talk button on mobile", async () => {
+    mockGetMedia();
+    mockUserAgent("android");
+    const pyEnv = await startServer();
+    pyEnv["discuss.channel"].create({ name: "General" });
+    mockService("discuss.ptt_extension", {
+        get isEnabled() {
+            return false;
+        },
+    });
+    patchUiSize({ size: SIZES.SM });
+    await start();
+    await click(".o_menu_systray i[aria-label='Messages']");
+    await click(".o-mail-NotificationItem", { text: "General" });
+    await click("[title='Start a Call']");
+    await click("[title='Open Actions Menu']");
+    await click("[title='Show Call Settings']");
+    await click("button", { text: "Push to Talk" });
+    await click("[title='Hide Call Settings']");
+    await contains("button", { text: "Push to talk" });
 });


### PR DESCRIPTION
The current push-to-talk option doesn't make much sense in mobile, since you usually don't use your keyboard while being on a call. Should create a specific button for that purpose.

1. Add a new button in the call action list to start/stop the talk;
2. Remove the ptt_ad_banner for small devices since it's not used;
![1718811145848](https://github.com/odoo/odoo/assets/26395662/9aad36fc-4270-4b7b-b8e9-56958eeab025)

task-3605765

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
