### PR TITLE
[FIX] base,web: group by many2one_reference

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -507,7 +507,7 @@ class HrExpense(models.Model):
         )
         attachment = dict(attachment_data)
         for expense in self:
-            expense.nb_attachment = attachment.get(expense._origin.id, 0)
+            expense.nb_attachment = attachment.get(expense._origin, 0)
 
     @api.constrains('payment_mode')
     def _check_payment_mode(self):

--- a/addons/hr_fleet/models/fleet_vehicle_assignation_log.py
+++ b/addons/hr_fleet/models/fleet_vehicle_assignation_log.py
@@ -24,7 +24,7 @@ class FleetVehicleAssignationLog(models.Model):
             ('res_id', 'in', self.ids)], ['res_id'], ['__count'])
         attachment = dict(attachment_data)
         for doc in self:
-            doc.attachment_number = attachment.get(doc.id, 0)
+            doc.attachment_number = attachment.get(doc, 0)
 
     def action_get_attachment_view(self):
         self.ensure_one()

--- a/addons/hr_recruitment/models/hr_applicant.py
+++ b/addons/hr_recruitment/models/hr_applicant.py
@@ -286,7 +286,7 @@ class Applicant(models.Model):
             ['res_id'], ['__count'])
         attach_data = dict(read_group_res)
         for record in self:
-            record.attachment_number = attach_data.get(record.id, 0)
+            record.attachment_number = attach_data.get(record, 0)
 
     @api.model
     def _read_group_stage_ids(self, stages, domain):

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -240,7 +240,7 @@ class MailThread(models.AbstractModel):
 
         attachment_count_dict = dict(read_group_var)
         for record in self:
-            record.message_attachment_count = attachment_count_dict.get(record.id, 0)
+            record.message_attachment_count = attachment_count_dict.get(record, 0)
 
     # ------------------------------------------------------------
     # CRUD

--- a/addons/rating/models/rating_parent_mixin.py
+++ b/addons/rating/models/rating_parent_mixin.py
@@ -64,7 +64,7 @@ class RatingParentMixin(models.AbstractModel):
             domain = expression.AND([domain, [('write_date', '>=', fields.Datetime.to_string(min_date))]])
         rating_read_group = self.env['rating.rating'].sudo()._read_group(domain, ['parent_res_id'], ['rating:avg'])
         parent_res_ids = [
-            parent_res_id
+            parent_res_id.id
             for parent_res_id, rating_avg in rating_read_group
             if rating_data.OPERATOR_MAPPING[operator](float_compare(rating_avg, value, 2), 0)
         ]

--- a/addons/web/static/src/model/relational_model/utils.js
+++ b/addons/web/static/src/model/relational_model/utils.js
@@ -555,7 +555,7 @@ function getDisplayNameFromGroupData(field, rawValue) {
     if (field.type === "selection") {
         return Object.fromEntries(field.selection)[rawValue];
     }
-    if (["many2one", "many2many", "tags"].includes(field.type)) {
+    if (["many2one", "many2many", "tags", "many2one_reference"].includes(field.type)) {
         return rawValue ? rawValue[1] : false;
     }
     return rawValue;

--- a/addons/website_mail/controllers/main.py
+++ b/addons/website_mail/controllers/main.py
@@ -71,7 +71,7 @@ class WebsiteMail(http.Controller):
                     ('partner_id', '=', partner.id)
                 ], ['res_id'])
                 # `_read_group` will filter out the ones not matching the domain
-                res[model].extend(res_id for [res_id] in mail_followers_ids)
+                res[model].extend(res_id.id for [res_id] in mail_followers_ids)
 
         return [{
             'is_user': user != public_user,

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -58,7 +58,7 @@ from .exceptions import AccessError, MissingError, ValidationError, UserError
 from .tools import (
     clean_context, config, CountingStream, date_utils, discardattr,
     DEFAULT_SERVER_DATE_FORMAT, DEFAULT_SERVER_DATETIME_FORMAT, format_list,
-    frozendict, get_lang, LastOrderedSet, lazy_classproperty, OrderedSet,
+    frozendict, get_lang, groupby, LastOrderedSet, lazy_classproperty, OrderedSet,
     ormcache, partition, populate, Query, ReversedIterable, split_every, unique,
     SQL, pycompat,
 )
@@ -1899,7 +1899,7 @@ class BaseModel(metaclass=MetaModel):
         # column_result: [(a1, a2, ...), (b1, b2, ...), (c1, c2, ...)]
         column_result = []
         for spec in groupby:
-            column = self._read_group_postprocess_groupby(spec, next(column_iterator))
+            column = self._read_group_postprocess_groupby(spec, column_iterator)
             column_result.append(column)
         for spec in aggregates:
             column = self._read_group_postprocess_aggregate(spec, next(column_iterator))
@@ -1987,6 +1987,13 @@ class BaseModel(metaclass=MetaModel):
                 )
             query.add_join("LEFT JOIN", rel_alias, field.relation, condition)
             return SQL.identifier(rel_alias, field.column2)
+
+        elif field.type == 'many2one_reference':
+            return SQL(
+                "%s, %s",
+                self._field_to_sql(self._table, fname, query),
+                self._field_to_sql(self._table, field.model_field, query),
+            )
 
         else:
             sql_expr = self._field_to_sql(self._table, fname, query)
@@ -2148,7 +2155,7 @@ class BaseModel(metaclass=MetaModel):
             return self.env[field.comodel_name] if field.relational else self.env[self._name]
         return False
 
-    def _read_group_postprocess_groupby(self, groupby_spec, raw_values):
+    def _read_group_postprocess_groupby(self, groupby_spec, column_iterator):
         """ Convert the given values of ``groupby_spec``
         from PostgreSQL to the format returned by method ``_read_group()``.
 
@@ -2160,6 +2167,14 @@ class BaseModel(metaclass=MetaModel):
 
         fname, *__ = parse_read_group_spec(groupby_spec)
         field = self._fields[fname]
+        raw_values = next(column_iterator)
+        if self._fields[fname].type == 'many2one_reference':
+            res_id_tuple = list(zip(raw_values, next(column_iterator)))
+            all_by_model = {model: tuple(ids) for model, ids in groupby(res_id_tuple, key=itemgetter(1))}
+            return (
+                self.pool[model_value](self.env, (value,), all_by_model[model_value]) if value else empty_value
+                for value, model_value in res_id_tuple
+            )
 
         if field.relational or fname == 'id':
             Model = self.pool[field.comodel_name] if field.relational else self.pool[self._name]
@@ -2476,7 +2491,7 @@ class BaseModel(metaclass=MetaModel):
                 continue
 
             for row in rows_dict:
-                value = row[group]
+                value = raw_value = row[group]
 
                 if isinstance(value, BaseModel):
                     row[group] = (value.id, value.sudo().display_name) if value else False
@@ -2489,6 +2504,9 @@ class BaseModel(metaclass=MetaModel):
                     additional_domain = [(field_name, 'not in', other_values)]
                 else:
                     additional_domain = [(field_name, '=', value)]
+
+                if field.type == 'many2one_reference':
+                    additional_domain += [(field.model_field, '=', raw_value._name)]
 
                 if field.type in ('date', 'datetime'):
                     if value and isinstance(value, (datetime.date, datetime.datetime)):


### PR DESCRIPTION
Include the `model_field` automatically when grouping by `many2one_reference` fields.

Before this commit, there were 2 issues:
* the header of the group in the webclient was displaying the id of the record instead of the `display_name`
* the related model was not taken into account:
  * it was not added in the `__domain` used to unfold the group
  * the records with the same id from different models were grouped together
