### PR TITLE
[16.0][ADD] purchase.order.line: add _get_select_seller_params()

### DIFF
--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -1246,7 +1246,7 @@ class PurchaseOrderLine(models.Model):
             if not line.product_id or line.invoice_lines or not line.company_id:
                 continue
             line = line.with_company(line.company_id)
-            params = {'order_id': line.order_id}
+            params = line._get_select_sellers_params()
             seller = line.product_id._select_seller(
                 partner_id=line.partner_id,
                 quantity=line.product_qty,
@@ -1506,3 +1506,9 @@ class PurchaseOrderLine(models.Model):
                 'business_domain': 'purchase_order',
                 'company_id': line.company_id.id,
             })
+
+    def _get_select_sellers_params(self):
+        self.ensure_one()
+        return {
+            "order_id": self.order_id,
+        }


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This PR simply adds a hook to allow changing the parameters used by _select_seller during order line price computation.

Current behavior before PR:
Unable to inherit properly to change the selection of the seller, and have the correct price

Desired behavior after PR is merged:
Can change the parameter of _select_seller before price computation


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
