### PR TITLE
[IMP] calendar: notify attendees upon event deletion

### DIFF
--- a/addons/calendar/data/mail_template_data.xml
+++ b/addons/calendar/data/mail_template_data.xml
@@ -457,5 +457,75 @@
 </div>
             </field>
         </record>
+
+        <record id="calendar_template_delete_event" model="mail.template">
+            <field name="name">Calendar: Event Deleted</field>
+            <field name="model_id" ref="calendar.model_calendar_event"/>
+            <field name="subject">Deleted event: {{ object.name }}</field>
+            <field name="email_from">{{ (object.user_id.email_formatted or user.email_formatted or '') }}</field>
+            <field name="email_to">{{ object._get_attendee_emails() }}</field>
+            <field name="lang">{{ object.partner_id.lang }}</field>
+            <field name="description">Used to manually notify attendees</field>
+            <field name="body_html" type="html">
+                <div>
+                    <t t-set="mail_tz" t-value="object._get_mail_tz() or ctx.get('mail_tz')" />
+                    <t t-set="event_name" t-value="object.name or ''"/>
+                    <t t-set="start_date" t-value="object.start or ''"/>
+                    <t t-set="end_date" t-value="object.stop or ''"/>
+                    <t t-set="event_organizer" t-value="object.user_id.name or ''"/>
+                    <div>
+                        <table border="0" cellpadding="0" cellspacing="0">
+                            <tr>
+                                <td width="130px;" style="min-width: 130px;">
+                                    <div style="border-top-start-radius: 3px; border-top-end-radius: 3px; font-size: 12px; border-collapse: separate; text-align: center; font-weight: bold; color: #ffffff; min-height: 18px; background-color: #875A7B; border: 1px solid #875A7B;">
+                                        <t t-out="format_datetime(dt=object.start, tz=mail_tz if not object.allday else None, dt_format='EEEE', lang_code=object.env.lang) ">Tuesday</t>
+                                    </div>
+                                    <div style="font-size: 48px; min-height: auto; font-weight: bold; text-align: center; color: #5F5F5F; background-color: #F8F8F8; border: 1px solid #875A7B;">
+                                        <t t-out="format_datetime(dt=object.start, tz=mail_tz if not object.allday else None, dt_format='d', lang_code=object.env.lang)">4</t>
+                                    </div>
+                                    <div style='font-size: 12px; text-align: center; font-weight: bold; color: #ffffff; background-color: #875A7B;'>
+                                        <t t-out="format_datetime(dt=object.start, tz=mail_tz if not object.allday else None, dt_format='MMMM y', lang_code=object.env.lang)">May 2021</t>
+                                    </div>
+                                    <div style="border-collapse: separate; color: #5F5F5F; text-align: center; font-size: 12px; border-bottom-end-radius: 3px; font-weight: bold; border: 1px solid #875A7B; border-bottom-start-radius: 3px;">
+                                        <t t-if="not object.allday">
+                                            <div>
+                                                <t t-out="format_time(time=object.start, tz=mail_tz, time_format='short', lang_code=object.env.lang)">11:00 AM</t>
+                                            </div>
+                                            <t t-if="mail_tz">
+                                                <div style="font-size: 10px; font-weight: normal">
+                                                    (<t t-out="mail_tz"> Europe/Brussels</t>)
+                                                </div>
+                                            </t>
+                                        </t>
+                                    </div>
+                                </td>
+                                <td width="20px;"/>
+                                <td style="padding-top: 5px;">
+                                    <p>
+                                        <strong>This event has been canceled and removed from your calendar.</strong>
+                                    </p>
+                                    <p>
+                                        This is to inform you that the event <strong><t t-out="event_name"/></strong>
+                                        scheduled from <strong><t t-out="start_date or ''"/></strong>
+                                        to <strong><t t-out="end_date or ''"/></strong>
+                                        has been deleted.
+                                    </p>
+                                    <p>
+                                        Organizer: <strong><t t-out="event_organizer"/></strong>
+                                    </p>
+                                    <p>
+                                        If you have any questions or concerns, please feel free to contact us.
+                                    </p>
+                                    <p>
+                                        Best regards,<br/>
+                                        <strong>The Calendar Team</strong>
+                                    </p>
+                                </td>
+                            </tr>
+                        </table>
+                    </div>
+                </div>
+            </field>
+        </record>
     </data>
 </odoo>

--- a/addons/calendar/models/res_users.py
+++ b/addons/calendar/models/res_users.py
@@ -185,3 +185,11 @@ class ResUsers(models.Model):
 
     def check_synchronization_status(self):
         return {}
+
+    def _has_any_active_synchronization(self):
+        """
+        Overridable method for checking if user has any synchronization active in inherited modules.
+
+        :return: boolean indicating if any synchronization is active.
+        """
+        return False

--- a/addons/calendar/static/src/views/calendar_form/calendar_form_controller.js
+++ b/addons/calendar/static/src/views/calendar_form/calendar_form_controller.js
@@ -6,6 +6,7 @@ export class CalendarFormController extends FormController {
     setup() {
         super.setup();
         const ormService = useService("orm");
+        this.actionService = useService("action");
 
         onWillStart(async () => {
             this.discussVideocallLocation = await ormService.call(
@@ -37,5 +38,38 @@ export class CalendarFormController extends FormController {
             return false; // no continue
         }
         return super.beforeExecuteActionButton(...arguments);
+    }
+
+    /**
+     * Custom delete function for calendar events, which can call the unlink action or not.
+     * When there is only one attendee, who is also the organizer, and the organizer is not listed in the current attendees, it performs the default delete.
+     * Otherwise, it calls the unlink action on the server.
+     */
+    async deleteRecord() {
+        const rootValues = this.model.root._values;
+        if (rootValues.attendees_count == 1 && rootValues.user_id[0] !== rootValues.partner_ids._currentIds[0]) {
+            // Call the default delete if the event has only one attendee and the user is not listed in partner_ids.
+            super.deleteRecord(...arguments);
+        } else {
+            await this.orm.call("calendar.event", "action_unlink_event", [
+                this.model.root.resId,
+                this.model.root.data.partner_ids.resIds,
+                this.model.root.data.recurrence_update,
+            ])
+            .then((action) => {
+                if (action && action.context) {
+                    this.actionService.doAction(action);
+                } else {
+                    this.actionService.doAction({
+                        type: "ir.actions.act_window",
+                        name: "Meetings",
+                        res_model: "calendar.event",
+                        view_mode: "calendar",
+                        views: [[false, "calendar"]],
+                        target: "current",
+                    });
+                }
+            });
+        }
     }
 }

--- a/addons/calendar/wizard/calendar_popover_delete_wizard.py
+++ b/addons/calendar/wizard/calendar_popover_delete_wizard.py
@@ -1,17 +1,27 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class CalendarPopoverDeleteWizard(models.TransientModel):
     _name = 'calendar.popover.delete.wizard'
+    _inherit = ['mail.composer.mixin']
     _description = 'Calendar Popover Delete Wizard'
 
 
     record = fields.Many2one('calendar.event', 'Calendar Event')
     delete = fields.Selection([('one', 'Delete this event'), ('next', 'Delete this and following events'), ('all', 'Delete all the events')], default='one')
+    recipient_ids = fields.Many2many(
+        'res.partner',
+        string="Recipients",
+        compute='_compute_recipient_ids',
+        readonly=False,
+    )
 
     def close(self):
+        # Return if there are multiple attendees or if the organizer's partner_id differs
+        if self.record.attendees_count != 1 or self.record.user_id.partner_id != self.record.partner_ids:
+            return self.record.action_unlink_event(self.record.partner_id.id, self.delete)
         if not self.record or not self.delete:
             pass
         elif self.delete == 'one':
@@ -22,3 +32,63 @@ class CalendarPopoverDeleteWizard(models.TransientModel):
                 'all': 'all_events'
             }
             self.record.action_mass_deletion(switch.get(self.delete, ''))
+
+    @api.depends('record')
+    def _compute_recipient_ids(self):
+        """ Compute the recipients by combining the record's partner and message partners. """
+        for wizard in self:
+            wizard.recipient_ids = wizard.record.partner_id | wizard.record.message_partner_ids
+
+    @api.depends('record')
+    def _compute_subject(self):
+        """ Compute the subject by rendering the template's subject field based on the record. """
+        for wizard in self.filtered('template_id'):
+            wizard.subject = wizard.template_id._render_field(
+                'subject',
+                [wizard.record.id],
+                compute_lang=True,
+                options={'post_process': True},
+            )[wizard.record.id]
+
+    @api.depends('record')
+    def _compute_body(self):
+        """ Compute the body by rendering the template's body HTML field based on the record. """
+        for wizard in self.filtered('template_id'):
+            wizard.body = wizard.template_id._render_field(
+                'body_html',
+                [wizard.record.id],
+                compute_lang=True,
+                options={'post_process': True},
+            )[wizard.record.id]
+
+    def action_delete(self):
+        """
+        Delete the event based on the specified deletion type.
+
+        :return: Action URL to redirect to the calendar view
+        """
+        self.ensure_one()
+        event = self.record
+        deletion_type = self._context.get('default_recurrence')
+
+        # Unlink recurrent events.
+        if event.recurrency:
+            if deletion_type in ['one', 'self_only']:
+                event.unlink()
+            elif deletion_type in ['next', 'all']:
+                event.action_mass_deletion('future_events' if deletion_type == 'next' else 'all_events')
+        else:
+            event.unlink()
+
+        return {
+            'type': 'ir.actions.act_url',
+            'target': 'self',
+            'url': '/odoo/calendar'
+        }
+
+    def action_send_mail_and_delete(self):
+        """ Send email notification and delete the event based on the specified deletion type. """
+        self.env.ref('calendar.calendar_template_delete_event').send_mail(
+            self.record.id, email_layout_xmlid='mail.mail_notification_light', force_send=True
+        )
+        return self.action_delete()

--- a/addons/calendar/wizard/calendar_popover_delete_wizard.xml
+++ b/addons/calendar/wizard/calendar_popover_delete_wizard.xml
@@ -13,4 +13,51 @@
             </form>
         </field>
     </record>
+
+    <record id="view_event_delete_wizard_form" model="ir.ui.view">
+        <field name="name">calendar.popover.delete.wizard.form</field>
+        <field name="model">calendar.popover.delete.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Delete Event">
+                <field name="record" invisible="1"/>
+                <div col="2" class="alert alert-warning" role="alert">
+                    <span>Are you sure you want to delete this event? <br/></span>
+                </div>
+                <group col="2">
+                    <field name="recipient_ids"
+                           widget="many2many_tags_email"
+                           context="{'force_email': True,' show_email': True, 'no_create_edit': True}"
+                    />
+                </group>
+                <group col="2">
+                    <field name="subject" placeholder="Subject"/>
+                </group>
+                <field name="body"
+                       class="oe-bordered-editor"
+                       options="{'style-inline': true}"/>
+                <footer>
+                    <button string="Send and delete"
+                            name="action_send_mail_and_delete"
+                            type="object"
+                            class="btn-primary o_cw_send_notify_delete"/>
+                    <button string="Delete"
+                            name="action_delete"
+                            type="object"
+                            class="btn-primary mx-1"/>
+                    <button string="Discard"
+                            class="btn-secondary"
+                            special="cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_event_delete_wizard" model="ir.actions.act_window">
+        <field name="name">Event Cancel Wizard</field>
+        <field name="res_model">calendar.popover.delete.wizard</field>
+        <field name="view_mode">form</field>
+        <field name="view_id" ref="view_event_delete_wizard_form"/>
+        <field name="target">new</field>
+        <field name="context">{}</field>
+    </record>
 </odoo>

--- a/addons/google_calendar/models/res_users.py
+++ b/addons/google_calendar/models/res_users.py
@@ -185,3 +185,17 @@ class ResUsers(models.Model):
                 sync_status = 'sync_stopped'
         res['google_calendar'] = sync_status
         return res
+
+    def _has_any_active_synchronization(self):
+        """
+        Check if synchronization is active for Google Calendar.
+        This function retrieves the synchronization status from the user's environment
+        and checks if the Google Calendar synchronization is active.
+
+        :return: Action to delete the event
+        """
+        sync_status = self.check_synchronization_status()
+        res = super()._has_any_active_synchronization()
+        if sync_status.get('google_calendar') == 'sync_active':
+            return True
+        return res

--- a/addons/microsoft_calendar/models/res_users.py
+++ b/addons/microsoft_calendar/models/res_users.py
@@ -179,3 +179,17 @@ class ResUsers(models.Model):
                 sync_status = 'sync_stopped'
         res['microsoft_calendar'] = sync_status
         return res
+
+    def _has_any_active_synchronization(self):
+        """
+        Check if synchronization is active for Microsoft Calendar.
+        This function retrieves the synchronization status from the user's environment
+        and checks if the Microsoft Calendar synchronization is active.
+
+        :return: Action to delete the event
+        """
+        sync_status = self.check_synchronization_status()
+        res = super()._has_any_active_synchronization()
+        if sync_status.get('microsoft_calendar') == 'sync_active':
+            return True
+        return res


### PR DESCRIPTION
Before this commit, when an event was deleted in Odoo, attendees were not notified, which could lead to confusion.

This commit introduces the following improvements:

1. Event Deletion Notification: When an event with attendees is deleted, a mail wizard prompts the user to send a notification to inform attendees about the cancellation.

2. Attendee Status Update: Upon sending the notification, the status of all attendees is automatically set to "Declined" (assuming there are one or more attendees).

Introduce a configuration option allowing users to choose whether attendees should be automatically declined upon event cancellation.The mail wizard can provide pre-populated email content, including details about the canceled event and a brief cancellation message.

task-3928050