### PR TITLE
[CLA] Update Vauxoo's CLA adding maneandrea

### DIFF
--- a/doc/cla/corporate/vauxoo.md
+++ b/doc/cla/corporate/vauxoo.md
@@ -73,3 +73,4 @@ Andrea Gidalti andreag@vauxoo.com  https://github.com/andreagidaltig
 German Loredo german@vauxoo.com https://github.com/xmglord 
 Antonio Aguilar antonio@vauxoo.com https://github.com/antonag32
 Christihan Laurel laurel@vauxoo.com https://github.com/CLaurelB
+Andrea Manenti manenti@vauxoo.com https://github.com/maneandrea


### PR DESCRIPTION
Incorporate Andrea Manenti (maneandrea) as Vauxoo's contributor.

I confirm I have signed the CLA and read the PR guidelines at http://www.odoo.com/submit-pr