### PR TITLE
[FIX] account: always get tax tags using the base term when they are translatable

### DIFF
--- a/addons/account/models/account_account_tag.py
+++ b/addons/account/models/account_account_tag.py
@@ -34,7 +34,9 @@ class AccountAccountTag(models.Model):
         in the specified country.
         """
         domain = self._get_tax_tags_domain(tag_name, country_id)
-        return self.env['account.account.tag'].with_context(active_test=False).search(domain)
+        original_lang = self._context.get('lang', 'en_US')
+        rslt_tags = self.env['account.account.tag'].with_context(active_test=False, lang='en_US').search(domain)
+        return rslt_tags.with_context(lang=original_lang)  # Restore original language, in case the name of the tags needs to be shown/modified
 
     @api.model
     def _get_tax_tags_domain(self, tag_name, country_id, sign=None):

--- a/addons/account/models/account_report.py
+++ b/addons/account/models/account_report.py
@@ -557,7 +557,8 @@ class AccountReportExpression(models.Model):
                     if former_tax_tags and all(tag_expr in self for tag_expr in former_tax_tags._get_related_tax_report_expressions()):
                         # If we're changing the formula of all the expressions using that tag, rename the tag
                         positive_tags, negative_tags = former_tax_tags.sorted(lambda x: x.tax_negate)
-                        positive_tags.name, negative_tags.name = f"+{vals['formula']}", f"-{vals['formula']}"
+                        positive_tags._update_field_translations('name', {'en_US': f"+{vals['formula']}"})
+                        negative_tags._update_field_translations('name', {'en_US': f"-{vals['formula']}"})
                     else:
                         # Else, create a new tag. Its the compute functions will make sure it is properly linked to the expressions
                         tag_vals = self.env['account.report.expression']._get_tags_create_vals(vals['formula'], country.id)
@@ -577,7 +578,7 @@ class AccountReportExpression(models.Model):
         for tag in expressions_tags:
             other_expression_using_tag = self.env['account.report.expression'].sudo().search([
                 ('engine', '=', 'tax_tags'),
-                ('formula', '=', tag.name[1:]),  # we escape the +/- sign
+                ('formula', '=', tag.with_context(lang='en_US').name[1:]),  # we escape the +/- sign
                 ('report_line_id.report_id.country_id.id', '=', tag.country_id.id),
                 ('id', 'not in', self.ids),
             ], limit=1)
@@ -665,7 +666,7 @@ class AccountReportExpression(models.Model):
             country = tag_expression.report_line_id.report_id.country_id
             or_domains.append(self.env['account.account.tag']._get_tax_tags_domain(tag_expression.formula, country.id, sign))
 
-        return self.env['account.account.tag'].with_context(active_test=False).search(osv.expression.OR(or_domains))
+        return self.env['account.account.tag'].with_context(active_test=False, lang='en_US').search(osv.expression.OR(or_domains))
 
     @api.model
     def _get_tags_create_vals(self, tag_name, country_id, existing_tag=None):

--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -1578,7 +1578,7 @@ class AccountTaxRepartitionLineTemplate(models.Model):
                 domains.append(self.env['account.account.tag']._get_tax_tags_domain(report_expression.formula, country.id, sign=sign))
 
         if domains:
-            tags_to_add |= self.env['account.account.tag'].with_context(active_test=False).search(osv.expression.OR(domains))
+            tags_to_add |= self.env['account.account.tag'].with_context(active_test=False, lang='en_US').search(osv.expression.OR(domains))
 
         return tags_to_add
 


### PR DESCRIPTION
To reproduce the issue:

1) Make an invoice using a tax impacting some tag
2) Add a tanslation to that tag
3) Switch the user language to the one you added a translation for 4) Open the tax report: the line the tag is linked to has a value of 0 ===> It should contain the value you added in 1)

l10n_multilang makes the 'name' field of account.account.tag translatable. Because of that, it is important to always check the tags matching a report expression's formula using en_US as the language, to make sure the formula of the report expression matches the tag name (since that expression's formula is not translatable).

enterprise: https://github.com/odoo/enterprise/pull/65030