### PR TITLE
[FIX] l10n_cl: move pdf transferable divs back to right side

### DIFF
--- a/addons/l10n_cl/views/report_invoice.xml
+++ b/addons/l10n_cl/views/report_invoice.xml
@@ -201,8 +201,13 @@
 
         <xpath expr="//div[@id='right-elements']" position="after">
             <div name="stamp" class="text-center col-6"/>
-            <div name="transferable-table" class="col-6"/>
-            <div name="transferable-legend" class="col-6"/>
+        </xpath>
+
+        <xpath expr="//div[@id='right-elements']" position="inside">
+            <div class="row">
+                <div name="transferable-table" class="col-7"/>
+                <div name="transferable-legend" class="col-5"/>
+            </div>
         </xpath>
 
     </template>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
In commit https://github.com/odoo/odoo/commit/7ee07bc8c8573ab879b1d6995b3443271fe20149 the stamp, transferable-table, and transferable-legend divs were relocated to all go on the left side. Previously, they had a width of col-4 which allowed them to fit in the same row side by side using 1/3 of the page's width each.

Current behavior before PR:
After that change they were positioned on the left side on top of each other.

Desired behavior after PR is merged:
This commit moves both transferable divs to the right half of the page below the invoice's totals to use the blank space better. It is relevant to keep in mind that these divs are inserted in the invoice to allow for easy inheritance and a future implementation of the factoring version of the pdf (cedible).



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
