### PR TITLE
[FIX] base: prevents _compute_translated_display_name from dropping the context

### DIFF
--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -352,7 +352,7 @@ class Partner(models.Model):
     @api.depends_context('lang')
     @api.depends('display_name')
     def _compute_translated_display_name(self):
-        names = dict(self.with_context({'lang': self.env.lang}).name_get())
+        names = dict(self.with_context(lang=self.env.lang).name_get())
         for partner in self:
             partner.translated_display_name = names.get(partner.id)
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Passing a context as a dict rather than a key-value pair will drop the current context and only keep the explicitly passed dict.

In some modules methods like `name_get` have been overridden to have a conditional behavior based on context. This, however, will never work if `_compute_translated_display_name` drops all the context before it gets to said method.

This fix simply makes all the upstream context pass through.

Current behavior before PR:

Calls to methods that have `_compute_translated_display_name` somewhere in the call stack will not see the context that they have been originally given.

Desired behavior after PR is merged:

All methods will see the context that they have been given at the call



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
