### PR TITLE
[IMP] account: Draft restrictions split from button_draft method 

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4124,6 +4124,13 @@ class AccountMove(models.Model):
         if any(move.state not in ('cancel', 'posted') for move in self):
             raise UserError(_("Only posted/cancelled journal entries can be reset to draft."))
 
+        self._check_draftable()
+        # We remove all the analytics entries for this journal
+        self.mapped('line_ids.analytic_line_ids').unlink()
+        self.mapped('line_ids').remove_move_reconcile()
+        self.write({'state': 'draft', 'is_move_sent': False})
+
+    def _check_draftable(self):
         exchange_move_ids = set()
         if self:
             self.env['account.full.reconcile'].flush_model(['exchange_move_id'])
@@ -4159,11 +4166,6 @@ class AccountMove(models.Model):
                 raise UserError(_('You cannot reset to draft a tax cash basis journal entry.'))
             if move.restrict_mode_hash_table and move.state == 'posted':
                 raise UserError(_('You cannot modify a posted entry of this journal because it is in strict mode.'))
-            # We remove all the analytics entries for this journal
-            move.mapped('line_ids.analytic_line_ids').unlink()
-
-        self.mapped('line_ids').remove_move_reconcile()
-        self.write({'state': 'draft', 'is_move_sent': False})
 
     def button_request_cancel(self):
         """ Hook allowing the localizations to request a cancellation from the government before cancelling the invoice. """


### PR DESCRIPTION
The restrictions on `button_draft` method on account move were moved to a
new method to allow inherit and mute the restrictions in necessary cases
for some customizations.

A user case is the next:
Allow the deletion of cash basis or Exchange Differential entries to
facilitate the accounting audit process.

As the number of lines in the accounting entries generated by these
transactions can grow significantly, this occurs each time a payment
that has generated CABA or Exchange Differential entries is canceled or
unreconciled, reverse lines are generated for these entries.
Setting the posted journal entries to "draft" when canceling by using
the `button_cancel` method was introduced in [1], this does not allow deleting
the CABA or Exchange Differential entries generated in the unreconciled
and reconcile process.

[1] 1de5c98
Related: #96134





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
