### PR TITLE
[FIX] base: prevent errors when tz field is empty

### DIFF
--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -789,6 +789,10 @@ class Users(models.Model):
                         lang = langs[0] if langs else DEFAULT_LANG
         context['lang'] = lang
 
+        # Set fallback value for tz
+        if not context['tz']:
+            context['tz'] = 'UTC'
+
         # ensure uid is set
         context['uid'] = self.env.uid
 

--- a/odoo/addons/test_http/tests/test_echo_reply.py
+++ b/odoo/addons/test_http/tests/test_echo_reply.py
@@ -187,7 +187,7 @@ class TestHttpEchoReplyJsonWithDB(TestHttpBase):
         res = self.db_url_open("/test_http/echo-json-context", data=payload, headers=CT_JSON)
         self.assertEqual(res.status_code, 200)
         self.assertEqual(res.text, '{"jsonrpc": "2.0", "id": 0, "result": '
-            f'{{"lang": "en_US", "tz": false, "uid": {self.jackoneill.id}}}'
+            f'{{"lang": "en_US", "tz": "UTC", "uid": {self.jackoneill.id}}}'
             '}')
 
     def test_echojson3_bad_json(self):


### PR DESCRIPTION
When timezone of user is empty and the user clicks on Add a Leave button,
a traceback will appear.

Steps to reproduce the error:
- Open Profile > Preferences > Select empty in timezone > Save
- Install 'Appointments'
- Go to Appointments > Schedule > Resource Bookings > Add a Leave

Error: A traceback appears:
"AttributeError: 'bool' object has no attribute 'upper'"

https://github.com/odoo/enterprise/blob/7640860f415028d2d516a2df5e4bc26d9d6dd3b4/appointment/wizard/appointment_manage_leaves.py#L14
When the user selects an empty timezone, tz will be False.
So, It will lead to the above traceback.

Solution:
Set fallback value for "tz" field.

sentry-5443573507

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
