### PR TITLE
[FIX] web: use back button don't break filters in search view

### DIFF
--- a/addons/web/static/src/core/browser/router.js
+++ b/addons/web/static/src/core/browser/router.js
@@ -344,7 +344,7 @@ function makeDebouncedPush(mode) {
         pushArgs.title = document.title;
         Object.assign(pushArgs.state, state);
         browser.clearTimeout(pushTimeout);
-        pushTimeout = browser.setTimeout(() => {
+        const push = () => {
             doPush();
             pushTimeout = null;
             pushArgs = {
@@ -352,7 +352,14 @@ function makeDebouncedPush(mode) {
                 reload: false,
                 state: {},
             };
-        });
+        };
+        if (options.sync) {
+            push();
+        } else {
+            pushTimeout = browser.setTimeout(() => {
+                push();
+            });
+        }
     };
 }
 

--- a/addons/web/static/src/core/browser/router.js
+++ b/addons/web/static/src/core/browser/router.js
@@ -116,7 +116,7 @@ function pathFromActionState(state) {
  */
 export function stateToUrl(state) {
     let path = "";
-    const pathKeysToOmit = [..._hideKeysFromUrl];
+    const pathKeysToOmit = [..._hiddenKeysFromUrl];
     const actionStack = (state.actionStack || [state]).map((a) => ({ ...a }));
     if (actionStack.at(-1)?.action !== "menu") {
         for (const [prevAct, currentAct] of slidingWindow(actionStack, 2).reverse()) {
@@ -228,7 +228,7 @@ let state;
 let pushTimeout;
 let pushArgs;
 let _lockedKeys;
-let _hideKeysFromUrl = new Set();
+let _hiddenKeysFromUrl = new Set();
 
 export function startRouter() {
     const url = new URL(browser.location);
@@ -247,7 +247,7 @@ export function startRouter() {
         state: {},
     };
     _lockedKeys = new Set(["debug", "lang"]);
-    _hideKeysFromUrl = new Set([...PATH_KEYS, "actionStack"]);
+    _hiddenKeysFromUrl = new Set([...PATH_KEYS, "actionStack"]);
 }
 
 /**
@@ -375,7 +375,7 @@ export const router = {
     replaceState: makeDebouncedPush("replace"),
     cancelPushes: () => browser.clearTimeout(pushTimeout),
     addLockedKey: (key) => _lockedKeys.add(key),
-    hideKeyFromUrl: (key) => _hideKeysFromUrl.add(key),
+    hideKeyFromUrl: (key) => _hiddenKeysFromUrl.add(key),
     skipLoad: false,
 };
 

--- a/addons/web/static/src/core/browser/router.js
+++ b/addons/web/static/src/core/browser/router.js
@@ -116,7 +116,7 @@ function pathFromActionState(state) {
  */
 export function stateToUrl(state) {
     let path = "";
-    const pathKeysToOmit = [...PATH_KEYS, "actionStack"];
+    const pathKeysToOmit = [..._hideKeysFromUrl];
     const actionStack = (state.actionStack || [state]).map((a) => ({ ...a }));
     if (actionStack.at(-1)?.action !== "menu") {
         for (const [prevAct, currentAct] of slidingWindow(actionStack, 2).reverse()) {
@@ -228,6 +228,7 @@ let state;
 let pushTimeout;
 let pushArgs;
 let _lockedKeys;
+let _hideKeysFromUrl = new Set();
 
 export function startRouter() {
     const url = new URL(browser.location);
@@ -246,6 +247,7 @@ export function startRouter() {
         state: {},
     };
     _lockedKeys = new Set(["debug", "lang"]);
+    _hideKeysFromUrl = new Set([...PATH_KEYS, "actionStack"]);
 }
 
 /**
@@ -366,6 +368,7 @@ export const router = {
     replaceState: makeDebouncedPush("replace"),
     cancelPushes: () => browser.clearTimeout(pushTimeout),
     addLockedKey: (key) => _lockedKeys.add(key),
+    hideKeyFromUrl: (key) => _hideKeysFromUrl.add(key),
     skipLoad: false,
 };
 

--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -133,6 +133,8 @@ export function makeActionManager(env, router = _router) {
     let dialog = null;
     let nextDialog = null;
 
+    router.hideKeyFromUrl("globalState");
+
     env.bus.addEventListener("CLEAR-CACHES", () => {
         actionCache = {};
     });
@@ -488,8 +490,14 @@ export function makeActionManager(env, router = _router) {
                     viewType: state.resId ? "form" : state.view_type,
                 });
             }
-            if (state.resId && state.resId !== "new") {
-                options.props = { resId: state.resId };
+            if ((state.resId && state.resId !== "new") || state.globalState) {
+                options.props = {};
+                if (state.resId && state.resId !== "new") {
+                    options.props.resId = state.resId;
+                }
+                if (state.globalState) {
+                    options.props.globalState = state.globalState;
+                }
             }
         } else if (state.model) {
             if (state.resId || state.view_type === "form") {
@@ -961,11 +969,14 @@ export function makeActionManager(env, router = _router) {
         // if globalState is not useful for client actions --> maybe use that thing in useSetupView instead of useSetupAction?
         // a good thing: the Object.assign seems to reflect the use of "externalState" in legacy Model class --> things should be fine.
         if (currentController && currentController.getGlobalState) {
-            currentController.action.globalState = Object.assign(
+            const globalState = Object.assign(
                 {},
                 currentController.action.globalState,
                 currentController.getGlobalState() // what if this = {}?
             );
+
+            currentController.action.globalState = globalState;
+            router.pushState({ globalState }, { sync: true });
         }
         if (controller.action.globalState) {
             controller.props.globalState = controller.action.globalState;

--- a/addons/web/static/tests/core/router.test.js
+++ b/addons/web/static/tests/core/router.test.js
@@ -1358,6 +1358,22 @@ describe("pushState", () => {
         expect(router.current).toEqual({ k1: 3 });
     });
 
+    test("can push state directly", async () => {
+        createRouter();
+
+        expect(router.current).toEqual({});
+
+        router.pushState({ k1: 2 }, { sync: true });
+        expect(router.current).toEqual({ k1: 2 });
+
+        router.pushState({ k1: 3 }, { sync: true });
+        expect(router.current).toEqual({ k1: 3 });
+
+        router.pushState({ k1: 4 });
+        router.pushState({ k2: 1 }, { sync: true });
+        expect(router.current).toEqual({ k1: 4, k2: 1 });
+    });
+
     test("can lock keys", async () => {
         createRouter();
 

--- a/addons/web/static/tests/core/router.test.js
+++ b/addons/web/static/tests/core/router.test.js
@@ -1517,6 +1517,16 @@ describe("pushState", () => {
             ],
         });
     });
+    test("can hide keys", async () => {
+        createRouter();
+
+        router.hideKeyFromUrl("k1");
+
+        router.pushState({ k1: 2, k2: 3 });
+        await tick();
+        expect(router.current).toEqual({ k1: 2, k2: 3 });
+        expect(browser.location.href).toBe("https://www.hoot.test/odoo?k2=3");
+    });
 });
 
 describe("History", () => {
@@ -1588,6 +1598,30 @@ describe("History", () => {
         expect(router.current).toEqual({
             actionStack: [{ action: "other-path", displayName: "A different display name" }],
         });
+    });
+    test("properly handles history.back with hidden keys", async () => {
+        redirect("/");
+        on(routerBus, "ROUTE_CHANGE", () => expect.step("ROUTE_CHANGE"));
+        createRouter();
+
+        router.hideKeyFromUrl("k1");
+
+        router.pushState({ k1: 1, k2: 2 });
+        await tick();
+        expect(router.current).toEqual({ k1: 1, k2: 2 });
+        expect(browser.location.href).toBe("https://www.hoot.test/odoo?k2=2");
+
+        router.pushState({ k3: 3 }, { replace: true }); // Click on a link
+        await tick();
+        expect(router.current).toEqual({ k3: 3 });
+        expect(browser.location.href).toBe("https://www.hoot.test/odoo?k3=3");
+
+        browser.history.back(); // Click on back button
+        await tick();
+        expect(router.current).toEqual({ k1: 1, k2: 2 });
+        expect(browser.location.href).toBe("https://www.hoot.test/odoo?k2=2");
+
+        expect(["ROUTE_CHANGE"]).toVerifySteps();
     });
 });
 


### PR DESCRIPTION
[FIX] web: use back button don't break filters in search view

Open a kanban view or a list view;
Enter a filter in the search view;
Open a record;
Go back to the multi-record view using the browser (back button).

Before this commit, the previously entered filter is not there anymore.
Now, the filter stays. To achieve this, before leaving the multi-record view, the global state is saved on the history state.

To be able to push a key (the global state) on the state to be saved on the history and not shown in the browser, a new way to add a key/value to the state,
but omit it on the URL was developed. Also, a way to push the state synchronous was added.