### PR TITLE
[FIX] portal: Fix message and attachment position on Sign pop-up 

### DIFF
--- a/addons/portal/static/src/scss/portal.scss
+++ b/addons/portal/static/src/scss/portal.scss
@@ -360,6 +360,7 @@ img, .media_iframe_video, .o_image {
     .o_portal_sidebar_content {
         @include media-breakpoint-up(lg) {
             @include o-position-sticky($top: $spacer * 5);
+            z-index: 1;
         }
     }
 }


### PR DESCRIPTION
Steps to reproduce:
-------------------

- Install `Project` and `Field Service Reports` modules (for testing purpose)
- Go to `Project` and select `Field Service` project
- Open `Boiler Maintenance` task
- Add some Timesheets (ensure `Hours spent` is set) and save
- Click on `Sign Report`
- Scroll to ensure that the `Communication History` is in the middle of the page but still can click on `Sign` button
- Click on Sign

Issue:
------

The message section is on top of the Sign pop-up.
Same issue with attachment if we post a comment with attachment.

Cause:
------

There is a conflict with the `Stacking Context` of the modal, added
inside the portal sidebar who have `position:sticky`, and the message
section, that is inside a seperate div (the portal content) who have
`position:relative`.

Solution:
---------

Add a `z-index` to the sticky sidebar.

Fore more info:
https://web.dev/learn/css/z-index#stacking_context
https://talk.tiddlywiki.org/t/minimal-css-a-fix-for-dropdown-popup-hidden-by-position-sticky-title/9338

opw-3917549