### PR TITLE
[FIX] pos_restaurant: show only highest dominant category

### DIFF
--- a/addons/pos_restaurant/static/src/overrides/components/product_screen/actionpad_widget/actionpad_widget.js
+++ b/addons/pos_restaurant/static/src/overrides/components/product_screen/actionpad_widget/actionpad_widget.js
@@ -52,16 +52,14 @@ patch(ActionpadWidget.prototype, {
             const categories =
                 this.pos.models["product.product"].get(curr.product_id)?.pos_categ_ids || [];
 
-            for (const category of categories) {
-                if (category) {
-                    if (!acc[category.id]) {
-                        acc[category.id] = {
-                            count: curr.quantity,
-                            name: category.name,
-                        };
-                    } else {
-                        acc[category.id].count += curr.quantity;
-                    }
+            for (const category of categories.slice(0, 1)) {
+                if (!acc[category.id]) {
+                    acc[category.id] = {
+                        count: curr.quantity,
+                        name: category.name,
+                    };
+                } else {
+                    acc[category.id].count += curr.quantity;
                 }
             }
 

--- a/addons/pos_restaurant/static/tests/tours/helpers/ProductScreenTourMethods.js
+++ b/addons/pos_restaurant/static/tests/tours/helpers/ProductScreenTourMethods.js
@@ -52,3 +52,14 @@ export function tableNameShown(table_name) {
         },
     ];
 }
+export function OrderButtonNotContain(data) {
+    const steps = [
+        {
+            content: "check order button not contain data",
+            trigger: `.product-screen .submit-order:not(:contains("${data}"))`,
+            run: function () {}, // it's a check
+            mobile: false,
+        },
+    ];
+    return steps;
+}

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant.js
@@ -388,3 +388,14 @@ registry.category("web_tour.tours").add("MergeTableTour", {
             },
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("CategLabelCheck", {
+    test: true,
+    steps: () =>
+        [
+            Dialog.confirm("Open session"),
+            FloorScreen.clickTable("5"),
+            ProductScreen.clickDisplayedProduct("Test Multi Category Product"),
+            ProductScreen.OrderButtonNotContain("Drinks"),
+        ].flat(),
+});

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -37,7 +37,8 @@ class TestFrontend(AccountTestInvoicingCommon, HttpCaseWithUserDemo):
                                                  'account_type': 'asset_receivable',
                                                  'reconcile': True})
 
-        drinks_category = cls.env['pos.category'].create({'name': 'Drinks'})
+        food_category = cls.env['pos.category'].create({'name': 'Food', 'sequence': 1})
+        drinks_category = cls.env['pos.category'].create({'name': 'Drinks', 'sequence': 2})
 
         printer = cls.env['pos.printer'].create({
             'name': 'Preparation Printer',
@@ -191,6 +192,16 @@ class TestFrontend(AccountTestInvoicingCommon, HttpCaseWithUserDemo):
             'taxes_id': [(6, 0, [])],
         })
 
+        # multiple categories product
+        cls.env['product.product'].create({
+            'available_in_pos': True,
+            'list_price': 2.20,
+            'name': 'Test Multi Category Product',
+            'weight': 0.01,
+            'pos_categ_ids': [(4, drinks_category.id), (4, food_category.id)],
+            'categ_id': cls.env.ref('point_of_sale.product_category_pos').id,
+            'taxes_id': [(6, 0, [])],
+        })
         #desk organizer (variant product)
         cls.desk_organizer = cls.env['product.product'].create({
             'name': 'Desk Organizer',
@@ -330,3 +341,7 @@ class TestFrontend(AccountTestInvoicingCommon, HttpCaseWithUserDemo):
     def test_12_merge_table(self):
         self.pos_config.with_user(self.pos_admin).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.pos_config.id, 'MergeTableTour', login="pos_admin")
+
+    def test_13_category_check(self):
+        self.pos_config.with_user(self.pos_admin).open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.pos_config.id, 'CategLabelCheck', login="pos_admin")


### PR DESCRIPTION
Steps to reproduce :
- Install pos_restaurant
- Go to products
- Set 2 pos_categories in a product
- Open restaurant and add that product to order

Issue :
Both categories will be shown in order button and also not in correct sequence.

Cause :
Trying to show all categories and not the dominant once.

Fix :
Showing only the dominant once to make it more relatable.

task: 3976224
