### PR TITLE
[IMP] base: json config parameter

### DIFF
--- a/odoo/addons/base/data/neutralize.sql
+++ b/odoo/addons/base/data/neutralize.sql
@@ -19,9 +19,9 @@ UPDATE ir_cron
 
 -- neutralization flag for the database
 INSERT INTO ir_config_parameter (key, value)
-VALUES ('database.is_neutralized', true)
+VALUES ('database.is_neutralized', 'true'::jsonb)
     ON CONFLICT (key) DO
-       UPDATE SET value = true;
+       UPDATE SET value = 'true'::jsonb;
 
 -- deactivate webhooks
 UPDATE ir_act_server

--- a/odoo/addons/base/models/ir_config_parameter.py
+++ b/odoo/addons/base/models/ir_config_parameter.py
@@ -142,6 +142,18 @@ class IrConfigParameter(models.Model):
         self.env.registry.clear_cache()
         return super(IrConfigParameter, self).create(vals_list)
 
+    def _load_records_create(self, vals_list):
+        key_to_vals = {vals['key']: vals for vals in vals_list}
+        key_to_id = dict.fromkeys(key_to_vals, False)
+        existing_params = self.search([('key', 'in', list(key_to_vals))])
+        for param in existing_params:
+            param.write(key_to_vals.pop(param.key))
+            key_to_id[param.key] = param.id
+        new_params = self.create(key_to_vals.values())
+        for param in new_params:
+            key_to_id[param.key] = param.id
+        return self.browse(key_to_id.values())
+
     def write(self, vals):
         if 'key' in vals:
             illegal = _default_parameters.keys() & self.mapped('key')

--- a/odoo/addons/base/models/ir_config_parameter.py
+++ b/odoo/addons/base/models/ir_config_parameter.py
@@ -107,9 +107,11 @@ class IrConfigParameter(models.Model):
         self.flush_model(['key', 'value'])
         self.env.cr.execute("SELECT value FROM ir_config_parameter WHERE key = %s", [key])
         result = self.env.cr.fetchone()
+        if result is not None:
+            result = result[0]
         if result is None:
             return False
-        return result[0]
+        return result
 
     @api.model
     def set_param(self, key, value):

--- a/odoo/addons/base/models/res_config.py
+++ b/odoo/addons/base/models/res_config.py
@@ -177,8 +177,9 @@ class ResConfigSettings(models.TransientModel, ResConfigModuleInstallationMixin)
         config_parameters = []
         ICP = self.env['ir.config_parameter']
         config_value_field = ICP._fields['value']
-        for field in self._fields.values():
-            if hasattr(field, 'config_parameter') and field.config_parameter and field.default:
+        new_attributes = set(self.__class__.__bases__[0].__dict__)  # hacky and optional
+        for field_name, field in self._fields.items():
+            if field_name in new_attributes and hasattr(field, 'config_parameter') and field.config_parameter and field.default:
                 default = field.default(self)
                 default = field.convert_to_cache(default, self)
                 default = config_value_field.convert_to_column(default, ICP)

--- a/odoo/addons/base/views/ir_config_parameter_views.xml
+++ b/odoo/addons/base/views/ir_config_parameter_views.xml
@@ -25,7 +25,7 @@
                   <sheet>
                     <group>
                         <field name="key"/>
-                        <field name="value"/>
+                        <field name="value_edit"/>
                     </group>
                   </sheet>
                 </form>

--- a/odoo/cli/obfuscate.py
+++ b/odoo/cli/obfuscate.py
@@ -41,12 +41,12 @@ class Obfuscate(Command):
     @_ensure_cr
     def set_pwd(self, pwd):
         """Set password to cypher/uncypher datas"""
-        self.cr.execute("INSERT INTO ir_config_parameter (key, value) VALUES ('odoo_cyph_pwd', 'odoo_cyph_'||encode(pgp_sym_encrypt(%s, %s), 'base64')) ON CONFLICT(key) DO NOTHING", [pwd, pwd])
+        self.cr.execute("""INSERT INTO ir_config_parameter (key, value) VALUES ('odoo_cyph_pwd', ('"odoo_cyph_'||encode(pgp_sym_encrypt(%s, %s), 'base64')||'"')::jsonb)) ON CONFLICT(key) DO NOTHING""", [pwd, pwd])
 
     @_ensure_cr
     def check_pwd(self, pwd):
         """If password is set, check if it's valid"""
-        uncypher_pwd = self.uncypher_string(sql.Identifier('value'))
+        uncypher_pwd = self.uncypher_string(sql.Identifier('value') + '->>0')
 
         try:
             qry = sql.SQL("SELECT {uncypher_pwd} FROM ir_config_parameter WHERE key='odoo_cyph_pwd'").format(uncypher_pwd=uncypher_pwd)

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -3315,6 +3315,9 @@ class Json(Field):
     type = 'json'
     column_type = ('jsonb', 'jsonb')
 
+    def _convert_db_column(self, model, column):
+        sql.convert_column_jsonb(model._cr, model._table, self.name, column['udt_name'])
+
     def convert_to_record(self, value, record):
         """ Return a copy of the value """
         return False if value is None else copy.deepcopy(value)

--- a/odoo/tools/sql.py
+++ b/odoo/tools/sql.py
@@ -342,6 +342,17 @@ def convert_column_translatable(cr, tablename, columnname, columntype):
     _convert_column(cr, tablename, columnname, columntype, using)
 
 
+def convert_column_jsonb(cr, tablename, columnname, fromcolumntype):
+    if fromcolumntype in ('text', 'varchar'):
+        using = SQL(
+            """to_jsonb(%s::text)""",
+            SQL.identifier(columnname),
+        )
+    else:
+        raise Exception('not supported for now')
+    _convert_column(cr, tablename, columnname, 'jsonb', using)
+
+
 def _convert_column(cr, tablename, columnname, columntype, using: SQL):
     query = SQL(
         "ALTER TABLE %s ALTER COLUMN %s DROP DEFAULT, ALTER COLUMN %s TYPE %s USING %s",


### PR DESCRIPTION
There are 3 ways to modify the ir.config_parameter
1. set_param(key, value)
2. import from xml
```xml
    <record id="xml_id" model="ir.config_parameter">
        <field name="key">key_name</field>
        <field name="value">value</field>
    </record>
```
4. ['res.config.settings'].create({"key": value}).execute()
5. 'res.config.settings' from UI

Tricky use case 1
If the ir.config_parameter is set by 2:
when the user set it to a falsy value (`False`, `""`), the database will remove
it as well as its ir.model.data. So if we hope the config won't be changed after
upgrade, the record tag in must have both `noupdate="1"` and `forcecreate="0"`

Tricky use case 2
In the ir.config.settings, if a field has both config_parameter and truthy
default attributes, the developers have to promise all use cases for get_param
for the key must have the same default value. The get_param(key, default) will
return `str` if config has a truthy value, and default otherwise. So the return
type is unknown and the developer must call str2bool/int/float to manually
convert the type. `bool(get_parm(key, True))` is a very intuitive but wrong code

Tricky use case 3
In the ir.config.settings if a boolean field has both config_parameter and
default=True attributes, the developer must be very careful about
`set_param(key, value)`
`set_param(key, False)` means fallback the config to the default,
`str2bool(get_param(key, 'True'))` will return `True`
`set_param(key, 'False')` means set the value to 'False',
`str2bool(get_param(key, 'True'))` will return `False`
From the UI of settings, there is no way to set it the ir.config_parameter to
`'False'`

For compatibility
the old set_param, and get_param is still usable

New apis
get:
usually get has ``default`` when undefined. But for configuration, it should be
better to define the default value at one place. Using different default values
at different places is tricky and bug prone for configurations.

the ir.config_parameter can be set by res.config.settings' fields with attribute
config_parameter. These fields can be Boolean/Char/Text/Integer/Float. So it
would be more intuitive, easier-to-use and less error-prone to directly `get`
their values as their record format (bool/str/int/float) instead of always str

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
