### PR TITLE
[ADD] l10n_ro_edi_etransport: send transport data to eTransport platform

### DIFF
--- a/addons/account/static/src/components/dynamic_selection/dynamic_selection.js
+++ b/addons/account/static/src/components/dynamic_selection/dynamic_selection.js
@@ -1,0 +1,63 @@
+/** @odoo-module **/
+
+import { registry } from "@web/core/registry";
+import { SelectionField, selectionField } from "@web/views/fields/selection/selection_field";
+
+export class DynamicSelectionField extends SelectionField {
+
+    static props = {
+        ...SelectionField.props,
+        available_field: { type: String },
+    }
+
+    get availableOptions() {
+        return this.props.record.data[this.props.available_field]?.split(",") || [];
+    }
+
+    /**
+     * Filter the options with the accepted available options.
+     * @override
+     */
+    get options() {
+        const availableOptions = this.availableOptions;
+        return super.options.filter(x => availableOptions.includes(x[0]));
+    }
+
+    /**
+     * In dynamic selection field, sometimes we can have no options available.
+     * This override handles that case by adding optional chaining when accessing the found options.
+     * @override
+     */
+    get string() {
+        if (this.type === "selection") {
+            return this.props.record.data[this.props.name] !== false
+                ? this.options.find((o) => o[0] === this.props.record.data[this.props.name])?.[1]
+                : "";
+        }
+        return super.string;
+    }
+
+}
+
+/*
+EXAMPLE USAGE:
+
+In python:
+the_available_field = fields.Char()  # string of comma separated available selection field keys
+the_selection_field = fields.Selection([ ... ])
+
+In the views:
+<field name="the_available_field" column_invisible="1"/>
+<field name="the_selection_field"
+       widget="dynamic_selection"
+       options="{'available_field': 'the_available_field'}"/>
+ */
+
+registry.category("fields").add("dynamic_selection", {
+    ...selectionField,
+    component: DynamicSelectionField,
+    extractProps: (fieldInfo, dynamicInfo) => ({
+        ...selectionField.extractProps(fieldInfo, dynamicInfo),
+        available_field: fieldInfo.options.available_field,
+    }),
+})

--- a/addons/l10n_ro_edi_stock/__init__.py
+++ b/addons/l10n_ro_edi_stock/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/addons/l10n_ro_edi_stock/__manifest__.py
+++ b/addons/l10n_ro_edi_stock/__manifest__.py
@@ -1,0 +1,25 @@
+{
+    'name': 'Romania - E-Transport',
+    'version': '1.0',
+    'category': 'Accounting/Localizations/EDI',
+    'description': """
+E-Transport implementation for Romania
+    """,
+    'depends': ['stock_delivery', 'l10n_ro_efactura'],
+    'assets': {
+        'web.assets_backend': [
+            'l10n_ro_edi_stock/static/src/components/**/*',
+        ],
+    },
+    'data': [
+        'data/template_etransport.xml',
+
+        'views/res_config_settings_views.xml',
+        'views/stock_picking_views.xml',
+        'views/delivery_carrier_views.xml',
+
+        'report/report_deliveryslip.xml',
+    ],
+    'installable': True,
+    'license': "LGPL-3",
+}

--- a/addons/l10n_ro_edi_stock/data/template_etransport.xml
+++ b/addons/l10n_ro_edi_stock/data/template_etransport.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <template id="l10n_ro_template_etransport">
+        <eTransport
+                xmlns="mfp:anaf:dgti:eTransport:declaratie:v2"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="mfp:anaf:dgti:eTransport:declaratie:v2"
+                t-att-codDeclarant="data['codDeclarant']"
+                t-att-refDeclarant="data['refDeclarant']">
+
+            <t t-set="data_notificare" t-value="data['notificare']"/>
+            <notificare t-att-codTipOperatiune="data_notificare['codTipOperatiune']">
+                <t t-foreach="data_notificare['bunuriTransportate']" t-as="data_transport_content">
+                    <bunuriTransportate
+                            t-att-codScopOperatiune="data_transport_content['codScopOperatiune']"
+                            t-att-codTarifar="data_transport_content['codTarifar']"
+                            t-att-denumireMarfa="data_transport_content['denumireMarfa']"
+                            t-att-cantitate="data_transport_content['cantitate']"
+                            t-att-codUnitateMasura="data_transport_content['codUnitateMasura']"
+                            t-att-greutateNeta="data_transport_content['greutateNeta']"
+                            t-att-greutateBruta="data_transport_content['greutateBruta']"
+                            t-att-valoareLeiFaraTva="data_transport_content['valoareLeiFaraTva']"/>
+                </t>
+
+                <t t-set="data_partner" t-value="data_notificare['partenerComercial']"/>
+                <partenerComercial
+                        t-att-codTara="data_partner['codTara']"
+                        t-att-denumire="data_partner['denumire']"
+                        t-att-cod="data_partner['cod']"/>
+
+                <t t-set="data_date_transport" t-value="data_notificare['dateTransport']"/>
+                <dateTransport
+                        t-att-nrVehicul="data_date_transport['nrVehicul']"
+                        t-att-nrRemorca1="data_date_transport['nrRemorca1']"
+                        t-att-nrRemorca2="data_date_transport['nrRemorca2']"
+                        t-att-codTaraOrgTransport="data_date_transport['codTaraOrgTransport']"
+                        t-att-codOrgTransport="data_date_transport['codOrgTransport']"
+                        t-att-denumireOrgTransport="data_date_transport['denumireOrgTransport']"
+                        t-att-dataTransport="data_date_transport['dataTransport']"/>
+
+                <t t-set="data_start" t-value="data_notificare['locStartTraseuRutier']"/>
+                <t t-if="data_start['location_type'] == 'location'">
+                    <locStartTraseuRutier>
+                        <t t-set="data_start_loc" t-value="data_start['locatie']"/>
+                        <locatie
+                                t-att-codJudet="data_start_loc['codJudet']"
+                                t-att-denumireLocalitate="data_start_loc['denumireLocalitate']"
+                                t-att-denumireStrada="data_start_loc['denumireStrada']"
+                                t-att-codPostal="data_start_loc['codPostal']"
+                                t-att-alteInfo="data_start_loc['alteInfo']"/>
+                    </locStartTraseuRutier>
+                </t>
+                <t t-elif="data_start['location_type'] == 'bcp'">
+                    <locStartTraseuRutier t-att-codPtf="data_start['codPtf']"/>
+                </t>
+                <t t-elif="data_start['location_type'] == 'customs'">
+                    <locStartTraseuRutier t-att-codBirouVamal="data_start['codBirouVamal']"/>
+                </t>
+
+                <t t-set="data_end" t-value="data_notificare['locFinalTraseuRutier']"/>
+                <t t-if="data_end['location_type'] == 'location'">
+                    <locFinalTraseuRutier>
+                        <t t-set="data_end_loc" t-value="data_end['locatie']"/>
+                        <locatie
+                                t-att-codJudet="data_end_loc['codJudet']"
+                                t-att-denumireLocalitate="data_end_loc['denumireLocalitate']"
+                                t-att-denumireStrada="data_end_loc['denumireStrada']"
+                                t-att-codPostal="data_end_loc['codPostal']"
+                                t-att-alteInfo="data_end_loc['alteInfo']"/>
+                    </locFinalTraseuRutier>
+                </t>
+                <t t-elif="data_end['location_type'] == 'bcp'">
+                    <locFinalTraseuRutier t-att-codPtf="data_end['codPtf']"/>
+                </t>
+                <t t-elif="data_end['location_type'] == 'customs'">
+                    <locFinalTraseuRutier t-att-codBirouVamal="data_end['codBirouVamal']"/>
+                </t>
+
+                <t t-set="data_doc" t-value="data_notificare['documenteTransport']"/>
+                <documenteTransport
+                        t-att-tipDocument="data_doc['tipDocument']"
+                        t-att-dataDocument="data_doc['dataDocument']"
+                        t-att-numarDocument="data_doc['numarDocument']"
+                        t-att-observatii="data_doc['observatii']"/>
+            </notificare>
+        </eTransport>
+    </template>
+</odoo>

--- a/addons/l10n_ro_edi_stock/i18n/l10n_ro_edi_stock.pot
+++ b/addons/l10n_ro_edi_stock/i18n/l10n_ro_edi_stock.pot
@@ -1,0 +1,1472 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_ro_edi_stock
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 17.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-01-09 15:04+0000\n"
+"PO-Revision-Date: 2025-01-09 15:04+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid "%(location_group)s is missing following fields: %(field_names)s"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid "%(location_group)s is missing the %(field_name)s field."
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid "'End Location Type' is missing"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid "'End Location'"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid "'Start Location Type' is missing"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid "'Start Location'"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock.l10n_ro_edi_stock_report_delivery_document
+msgid "<strong>eTransport UIT:</strong>"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/etransport_api.py:0
+#, python-format
+msgid "Access token is forbidden."
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__32
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__32
+msgid "Albița(MD)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock.l10n_ro_edi_stock_view_picking_form
+msgid "Amend eTransport"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__242901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__242901
+msgid "BVF Aero Baia Mare (ROCJ0510)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__362902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__362902
+msgid "BVF Aeroport Delta Dunării Tulcea (ROGL8910)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__302902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__302902
+msgid "BVF Aeroport Satu Mare (ROCJ7830)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__372902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__372902
+msgid "BVF Albiţa (ROIS0100)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__22901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__22901
+msgid "BVF Arad Aeroport (ROTM0230)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__42901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__42901
+msgid "BVF Bacău Aeroport (ROIS0620)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__162902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__162902
+msgid "BVF Bechet (ROCR1720)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__92902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__92902
+msgid "BVF Brăila (ROGL0700)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__402901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__402901
+msgid "BVF Băneasa (ROBU1040)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__162903
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__162903
+msgid "BVF Calafat (ROCR1700)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__122901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__122901
+msgid "BVF Cluj Napoca Aero (ROCJ1810)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__132904
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__132904
+msgid "BVF Constanţa Port (ROCT1970)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__132901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__132901
+msgid "BVF Constanţa Sud Agigea (ROCT1900)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__162901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__162901
+msgid "BVF Craiova Aeroport (ROCR2110)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__332901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__332901
+msgid "BVF Dorneşti (ROIS2700)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__252904
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__252904
+msgid "BVF Drobeta Turnu Severin (ROCR9000)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__372901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__372901
+msgid "BVF Fălciu (-)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__172904
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__172904
+msgid "BVF Galaţi (ROGL3800)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__172902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__172902
+msgid "BVF Giurgiuleşti (ROGL3850)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__302901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__302901
+msgid "BVF Halmeu (ROCJ4310)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__222903
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__222903
+msgid "BVF Iaşi (ROIS4650)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__222901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__222901
+msgid "BVF Iaşi Aero (ROIS4660)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__362904
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__362904
+msgid "BVF Isaccea (ROGL8920)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__352901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__352901
+msgid "BVF Jimbolia (ROTM5010)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__132903
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__132903
+msgid "BVF Mangalia (ROCT5400)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__132902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__132902
+msgid "BVF Mihail Kogălniceanu (ROCT5100)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__352902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__352902
+msgid "BVF Moraviţa (ROTM5510)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__112901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__112901
+msgid "BVF Naidăș (ROTM6100)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__172903
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__172903
+msgid "BVF Oancea (ROGL3610)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__52901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__52901
+msgid "BVF Oradea Aeroport (ROCJ6580)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__252901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__252901
+msgid "BVF Orşova (ROCR7280)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__232901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__232901
+msgid "BVF Otopeni Călători (ROBU1030)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__252902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__252902
+msgid "BVF Porţile De Fier I (ROCR7270)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__252903
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__252903
+msgid "BVF Porţile De Fier II (ROCR7200)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__72902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__72902
+msgid "BVF Rădăuţi Prut (ROIS1620)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__222902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__222902
+msgid "BVF Sculeni (ROIS4990)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__322901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__322901
+msgid "BVF Sibiu Aeroport (ROBV7910)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__242902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__242902
+msgid "BVF Sighet (ROCJ8000)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__332902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__332902
+msgid "BVF Siret (ROIS8200)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__72901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__72901
+msgid "BVF Stanca Costeşti (ROIS1610)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__332903
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__332903
+msgid "BVF Suceava Aero (ROIS8250)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__362901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__362901
+msgid "BVF Sulina (ROCT8300)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__352903
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__352903
+msgid "BVF Timişoara Aeroport (ROTM8730)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__362903
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__362903
+msgid "BVF Tulcea (ROGL8900)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__342901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__342901
+msgid "BVF Turnu Măgurele (ROCR9100)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__262901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__262901
+msgid "BVF Târgu Mureş Aeroport (ROBV8820)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__332904
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__332904
+msgid "BVF Vicovu De Sus (ROIS9620)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__342902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__342902
+msgid "BVF Zimnicea (ROCR5800)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__92901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__92901
+msgid "BVF Zona Liberă Brăila (ROGL0710)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__22902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__22902
+msgid "BVF Zona Liberă Curtici (ROTM2300)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__172901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__172901
+msgid "BVF Zona Liberă Galaţi (ROGL3810)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__522901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__522901
+msgid "BVF Zona Liberă Giurgiu (ROBU3980)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__12801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__12801
+msgid "BVI Alba Iulia (ROBV0300)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__342801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__342801
+msgid "BVI Alexandria (ROCR0310)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__232801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__232801
+msgid "BVI Antrepozite/Ilfov (ROBU1200)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__22801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__22801
+msgid "BVI Arad (ROTM0200)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__42801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__42801
+msgid "BVI Bacău (ROIS0600)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__242801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__242801
+msgid "BVI Baia Mare (ROCJ0500)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__62801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__62801
+msgid "BVI Bistriţa-Năsăud (ROCJ0400)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__72801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__72801
+msgid "BVI Botoşani (ROIS1600)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__82801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__82801
+msgid "BVI Braşov (ROBV0900)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__402801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__402801
+msgid "BVI Bucureşti Poştă (ROBU1380)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__102801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__102801
+msgid "BVI Buzău (ROGL1500)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__122801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__122801
+msgid "BVI Cluj Napoca (ROCJ1800)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__282801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__282801
+msgid "BVI Corabia (ROCR2000)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__162801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__162801
+msgid "BVI Craiova (ROCR2100)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__512801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__512801
+msgid "BVI Călăraşi (ROCT1710)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__202801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__202801
+msgid "BVI Deva (ROTM8100)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__392801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__392801
+msgid "BVI Focșani (ROGL3600)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__522801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__522801
+msgid "BVI Giurgiu (ROBU3910)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__192801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__192801
+msgid "BVI Miercurea Ciuc (ROBV5600)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__282802
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__282802
+msgid "BVI Olt (ROCR8210)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__52801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__52801
+msgid "BVI Oradea (ROCJ6570)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__272801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__272801
+msgid "BVI Piatra Neamţ (ROIS7400)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__32801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__32801
+msgid "BVI Pitești (ROCR7000)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__292801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__292801
+msgid "BVI Ploiești (ROBU7100)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__112801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__112801
+msgid "BVI Reșița (ROTM7600)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__382801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__382801
+msgid "BVI Râmnicu Vâlcea (ROCR7700)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__302801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__302801
+msgid "BVI Satu-Mare (ROCJ7810)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__142801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__142801
+msgid "BVI Sfântu Gheorghe (ROBV7820)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__322801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__322801
+msgid "BVI Sibiu (ROBV7900)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__212801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__212801
+msgid "BVI Slobozia (ROCT8220)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__332801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__332801
+msgid "BVI Suceava (ROIS8230)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__352802
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__352802
+msgid "BVI Timişoara Bază (ROTM8720)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__152801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__152801
+msgid "BVI Târgoviște (ROBU8600)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__182801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__182801
+msgid "BVI Târgu Jiu (ROCR8810)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__262801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__262801
+msgid "BVI Târgu Mureş (ROBV8800)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__402802
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__402802
+msgid "BVI Târguri și Expoziții (ROBU1400)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__372801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__372801
+msgid "BVI Vaslui (ROIS9610)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__312801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__312801
+msgid "BVI Zalău (ROCJ9700)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__6
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__6
+msgid "Bechet(BG)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_loc_type__bcp
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_loc_type__bcp
+msgid "Border Crossing Point"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__38
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__38
+msgid "Borș 2 - A3 (HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__2
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__2
+msgid "Borș(HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid "Both 'End' and 'Start Location Type' are missing"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__5
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__5
+msgid "Calafat (BG)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__16
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__16
+msgid "Carei  (HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__17
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__17
+msgid "Cenad (HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid "City"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_operation_scope__401
+msgid "Commercial equipment"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__35
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__35
+msgid "Constanța Sud Agigea"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__14
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__14
+msgid "Corabia(BG)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_loc_type__customs
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_loc_type__customs
+msgid "Customs Office"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__13
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__13
+msgid "Călărași(BG)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_operation_scope__703
+msgid "Delivery operations with installation"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model,name:l10n_ro_edi_stock.model_l10n_ro_edi_document
+msgid "Document object for tracking CIUS-RO XML sent to E-Factura"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_operation_scope__1101
+msgid "Donations, help"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_l10n_ro_edi_document__state
+msgid "E-Factura Status"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_stock_picking__l10n_ro_edi_stock_end_bcp
+msgid "End Border Crossing Point"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_stock_picking__l10n_ro_edi_stock_end_customs_office
+msgid "End Customs Office"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock.l10n_ro_edi_stock_view_picking_form
+msgid "End Location"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_stock_picking__l10n_ro_edi_stock_end_loc_type
+msgid "End Location Type"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__18
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__18
+msgid "Episcopia Bihor (HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__l10n_ro_edi_document__state__stock_sending_failed
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_state__stock_sending_failed
+msgid "Error"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_operation_scope__901
+msgid "Exempt operations"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_operation_type__50
+msgid "Export"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock.l10n_ro_edi_stock_stock_picking_view_tree
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock.l10n_ro_edi_stock_view_picking_form
+msgid "Fetch Status"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_operation_scope__801
+msgid "Financial/operational leasing"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_operation_scope__501
+msgid "Fixed assets"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__34
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__34
+msgid "Galați Giurgiulești(MD)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock.l10n_ro_edi_stock_view_picking_form
+msgid "General"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__9
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__9
+msgid "Giurgiu(BG)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_operation_scope__705
+msgid "Goods made available to the customer"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_operation_scope__802
+msgid "Goods under warranty"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_operation_scope__301
+msgid "Gratuities"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__29
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__29
+msgid "Halmeu (UA)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,help:l10n_ro_edi_stock.field_l10n_ro_edi_document__l10n_ro_edi_stock_load_id
+msgid "Id of this document used for interacting with the anaf api."
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_operation_type__40
+msgid "Import"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock.res_config_settings_form_inherit_l10n_ro_edi
+msgid "In \"Serviciu\", select the options \"E-Factura\" and \"E-Transport\""
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_operation_type__20
+msgid "Intra-Community delivery"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_operation_type__10
+msgid "Intra-community purchase"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_operation_type__60
+msgid ""
+"Intra-community transaction - Entry for storage/formation of new transport"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_operation_type__70
+msgid ""
+"Intra-community transaction - Exit after storage/formation of new transport"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid "Invalid picking type %(type_code)s"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_operation_scope__1001
+msgid "Investment in progress"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_l10n_ro_edi_document__invoice_id
+msgid "Invoice"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__28
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__28
+msgid "Jimbolia(RS)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_stock_picking__l10n_ro_edi_stock_available_end_loc_types
+msgid "L10N Ro Edi Stock Available End Loc Types"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_stock_picking__l10n_ro_edi_stock_available_operation_scopes
+msgid "L10N Ro Edi Stock Available Operation Scopes"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_stock_picking__l10n_ro_edi_stock_available_start_loc_types
+msgid "L10N Ro Edi Stock Available Start Loc Types"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_stock_picking__l10n_ro_edi_stock_document_ids
+msgid "L10N Ro Edi Stock Document"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_stock_picking__l10n_ro_edi_stock_enable
+msgid "L10N Ro Edi Stock Enable"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_stock_picking__l10n_ro_edi_stock_enable_amend
+msgid "L10N Ro Edi Stock Enable Amend"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_stock_picking__l10n_ro_edi_stock_enable_fetch
+msgid "L10N Ro Edi Stock Enable Fetch"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_stock_picking__l10n_ro_edi_stock_enable_send
+msgid "L10N Ro Edi Stock Enable Send"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_stock_picking__l10n_ro_edi_stock_fields_readonly
+msgid "L10N Ro Edi Stock Fields Readonly"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_l10n_ro_edi_document__l10n_ro_edi_stock_load_id
+msgid "L10N Ro Edi Stock Load"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_l10n_ro_edi_document__l10n_ro_edi_stock_uit
+msgid "L10N Ro Edi Stock Uit"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock.l10n_ro_edi_stock_view_picking_form
+msgid "Load Id"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_loc_type__location
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_loc_type__location
+msgid "Location"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_operation_scope__101
+msgid "Marketing"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_l10n_ro_edi_document__message
+msgid "Message"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__26
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__26
+msgid "Naidăș(RS)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__11
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__11
+msgid "Negru Vodă(BG)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__37
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__37
+msgid "Nădlac 2 - A1 (HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__4
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__4
+msgid "Nădlac(HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__33
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__33
+msgid "Oancea(MD)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__15
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__15
+msgid "Oltenița(BG)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_stock_picking__l10n_ro_edi_stock_operation_scope
+msgid "Operation Scope"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid "Operation scope is missing."
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid "Operation type is missing."
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_operation_type__22
+msgid "Operations in lohn system (EU) - exit"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_operation_type__12
+msgid "Operations in lohn system (EU) - input"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__10
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__10
+msgid "Ostrov(BG)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_operation_scope__9901
+msgid "Other"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_operation_scope__201
+msgid "Output"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_operation_scope__601
+msgid "Own consumption"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_delivery_carrier__l10n_ro_edi_stock_partner_id
+msgid "Partner"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__1
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__1
+msgid "Petea (HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_l10n_ro_edi_document__picking_id
+msgid "Picking"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__25
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__25
+msgid "Porțile de Fier 1 (RS)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid "Postal Code"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid "Product %(name)s is missing the intrastat code value."
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid "Products %(names)s are missing the intrastat code value."
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_stock_picking__l10n_ro_edi_stock_remarks
+msgid "Remarks"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid ""
+"Romanian access token not found. Please generate or fill it in the settings."
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__19
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__19
+msgid "Salonta (HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_operation_scope__9999
+msgid "Same with operation"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__31
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__31
+msgid "Sculeni(MD)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock.l10n_ro_edi_stock_view_picking_form
+msgid "Send eTransport"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__l10n_ro_edi_document__state__stock_sent
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_state__stock_sent
+msgid "Sent"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,help:l10n_ro_edi_stock.field_l10n_ro_edi_document__state
+msgid ""
+"Sent -> Successfully sent to the SPV, waiting for validation.\n"
+"                Validated -> Sent & validated by the SPV.\n"
+"                Error -> Sending error or validation error from the SPV."
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model,name:l10n_ro_edi_stock.model_delivery_carrier
+msgid "Shipping Methods"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__36
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__36
+msgid "Siret  (UA)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__27
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__27
+msgid "Stamora Moravița(RS)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_stock_picking__l10n_ro_edi_stock_start_bcp
+msgid "Start Border Crossing Point"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_stock_picking__l10n_ro_edi_stock_start_customs_office
+msgid "Start Customs Office"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock.l10n_ro_edi_stock_view_picking_form
+msgid "Start Location"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_stock_picking__l10n_ro_edi_stock_start_loc_type
+msgid "Start Location Type"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid "State"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock.l10n_ro_edi_stock_view_picking_form
+msgid "Status"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_operation_type__14
+msgid "Stocks available to the customer (Call-off stock) - entry"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_operation_type__24
+msgid "Stocks available to the customer (Call-off stock) - exit"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid "Street"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__30
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__30
+msgid "Stânca Costești (MD)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__20
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__20
+msgid "Săcuieni (HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid "The border crossing point is missing under %(location_group)s"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid "The customs office is missing under %(location_group)s"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid ""
+"The delivery carrier of %(picking_name)s is missing the partner field value."
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid "The delivery carrier partner has to be located in Romania."
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid ""
+"The delivery carrier partner is missing following fields: %(field_names)s"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid "The delivery carrier partner is missing the %(field_name)s field."
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid "The picking %(picking_name)s is missing a delivery carrier."
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid "This document has already been successfully sent to anaf."
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid "This document has not been corrected yet because it contains errors."
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid ""
+"This document has not been successfully sent yet because it contains errors."
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_stock_picking__l10n_ro_edi_stock_trailer_1_number
+msgid "Trailer 1 Number"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_stock_picking__l10n_ro_edi_stock_trailer_2_number
+msgid "Trailer 2 Number"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model,name:l10n_ro_edi_stock.model_stock_picking
+msgid "Transfer"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_operation_scope__704
+msgid "Transfer between managements"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock.l10n_ro_edi_stock_view_picking_form
+msgid "Transport"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_operation_type__30
+msgid "Transport on the national territory"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__21
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__21
+msgid "Turnu (HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__7
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__7
+msgid "Turnu Măgurele(BG)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock.l10n_ro_edi_stock_view_picking_form
+msgid "UIT"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,help:l10n_ro_edi_stock.field_l10n_ro_edi_document__l10n_ro_edi_stock_uit
+msgid "UIT of this eTransport document."
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid "Unhandled eTransport document state: %(state)s"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__22
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__22
+msgid "Urziceni (HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid "VAT"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__23
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__23
+msgid "Valea lui Mihai (HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__l10n_ro_edi_document__state__stock_validated
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_state__stock_validated
+msgid "Validated"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__12
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__12
+msgid "Vama Veche(BG)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_stock_picking__l10n_ro_edi_stock_vehicle_number
+msgid "Vehicle Number"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid "Vehicle number and trailer number fields must be unique."
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid "Vehicle number is missing."
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__24
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__24
+msgid "Vladimirescu (HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__3
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__3
+msgid "Vărșand(HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid "XML contains errors."
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/etransport_api.py:0
+#, python-format
+msgid "You reached the limit of requests. Please try again later."
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__8
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__8
+msgid "Zimnicea(BG)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock.l10n_ro_edi_stock_view_picking_form
+msgid "eTransport"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock.l10n_ro_edi_stock_view_picking_form
+msgid "eTransport Documents"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock.l10n_ro_edi_stock_stock_picking_filter
+msgid "eTransport Error"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_stock_picking__l10n_ro_edi_stock_operation_type
+msgid "eTransport Operation Type"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock.l10n_ro_edi_stock_stock_picking_filter
+msgid "eTransport Sent"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_stock_picking__l10n_ro_edi_stock_state
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock.l10n_ro_edi_stock_stock_picking_filter
+msgid "eTransport Status"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_stock_picking__l10n_ro_edi_stock_document_uit
+msgid "eTransport UIT"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock.l10n_ro_edi_stock_stock_picking_filter
+msgid "eTransport Validated"
+msgstr ""

--- a/addons/l10n_ro_edi_stock/i18n/ro.po
+++ b/addons/l10n_ro_edi_stock/i18n/ro.po
@@ -1,0 +1,1488 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_ro_edi_stock
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 17.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-01-09 15:05+0000\n"
+"PO-Revision-Date: 2025-01-09 15:05+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid "%(location_group)s is missing following fields: %(field_names)s"
+msgstr "%(location_group)s lipsesc următoarele câmpuri: %(field_names)s"
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid "%(location_group)s is missing the %(field_name)s field."
+msgstr "%(location_group)s lipsește câmpul %(field_name)s."
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid "'End Location Type' is missing"
+msgstr "„Tipul locație finală” lipsește"
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid "'End Location'"
+msgstr "„Locația finală”"
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid "'Start Location Type' is missing"
+msgstr "„Tipul de locație de pornire” lipsește"
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid "'Start Location'"
+msgstr "„Locația de pornire”"
+
+#. module: l10n_ro_edi_stock
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock.l10n_ro_edi_stock_report_delivery_document
+msgid "<strong>eTransport UIT:</strong>"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/etransport_api.py:0
+#, python-format
+msgid "Access token is forbidden."
+msgstr "Jetonul de acces este interzis"
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__32
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__32
+msgid "Albița(MD)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock.l10n_ro_edi_stock_view_picking_form
+msgid "Amend eTransport"
+msgstr "Modificați eTransport"
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__242901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__242901
+msgid "BVF Aero Baia Mare (ROCJ0510)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__362902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__362902
+msgid "BVF Aeroport Delta Dunării Tulcea (ROGL8910)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__302902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__302902
+msgid "BVF Aeroport Satu Mare (ROCJ7830)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__372902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__372902
+msgid "BVF Albiţa (ROIS0100)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__22901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__22901
+msgid "BVF Arad Aeroport (ROTM0230)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__42901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__42901
+msgid "BVF Bacău Aeroport (ROIS0620)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__162902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__162902
+msgid "BVF Bechet (ROCR1720)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__92902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__92902
+msgid "BVF Brăila (ROGL0700)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__402901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__402901
+msgid "BVF Băneasa (ROBU1040)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__162903
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__162903
+msgid "BVF Calafat (ROCR1700)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__122901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__122901
+msgid "BVF Cluj Napoca Aero (ROCJ1810)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__132904
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__132904
+msgid "BVF Constanţa Port (ROCT1970)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__132901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__132901
+msgid "BVF Constanţa Sud Agigea (ROCT1900)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__162901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__162901
+msgid "BVF Craiova Aeroport (ROCR2110)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__332901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__332901
+msgid "BVF Dorneşti (ROIS2700)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__252904
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__252904
+msgid "BVF Drobeta Turnu Severin (ROCR9000)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__372901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__372901
+msgid "BVF Fălciu (-)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__172904
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__172904
+msgid "BVF Galaţi (ROGL3800)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__172902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__172902
+msgid "BVF Giurgiuleşti (ROGL3850)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__302901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__302901
+msgid "BVF Halmeu (ROCJ4310)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__222903
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__222903
+msgid "BVF Iaşi (ROIS4650)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__222901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__222901
+msgid "BVF Iaşi Aero (ROIS4660)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__362904
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__362904
+msgid "BVF Isaccea (ROGL8920)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__352901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__352901
+msgid "BVF Jimbolia (ROTM5010)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__132903
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__132903
+msgid "BVF Mangalia (ROCT5400)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__132902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__132902
+msgid "BVF Mihail Kogălniceanu (ROCT5100)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__352902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__352902
+msgid "BVF Moraviţa (ROTM5510)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__112901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__112901
+msgid "BVF Naidăș (ROTM6100)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__172903
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__172903
+msgid "BVF Oancea (ROGL3610)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__52901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__52901
+msgid "BVF Oradea Aeroport (ROCJ6580)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__252901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__252901
+msgid "BVF Orşova (ROCR7280)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__232901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__232901
+msgid "BVF Otopeni Călători (ROBU1030)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__252902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__252902
+msgid "BVF Porţile De Fier I (ROCR7270)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__252903
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__252903
+msgid "BVF Porţile De Fier II (ROCR7200)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__72902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__72902
+msgid "BVF Rădăuţi Prut (ROIS1620)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__222902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__222902
+msgid "BVF Sculeni (ROIS4990)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__322901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__322901
+msgid "BVF Sibiu Aeroport (ROBV7910)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__242902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__242902
+msgid "BVF Sighet (ROCJ8000)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__332902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__332902
+msgid "BVF Siret (ROIS8200)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__72901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__72901
+msgid "BVF Stanca Costeşti (ROIS1610)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__332903
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__332903
+msgid "BVF Suceava Aero (ROIS8250)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__362901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__362901
+msgid "BVF Sulina (ROCT8300)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__352903
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__352903
+msgid "BVF Timişoara Aeroport (ROTM8730)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__362903
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__362903
+msgid "BVF Tulcea (ROGL8900)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__342901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__342901
+msgid "BVF Turnu Măgurele (ROCR9100)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__262901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__262901
+msgid "BVF Târgu Mureş Aeroport (ROBV8820)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__332904
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__332904
+msgid "BVF Vicovu De Sus (ROIS9620)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__342902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__342902
+msgid "BVF Zimnicea (ROCR5800)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__92901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__92901
+msgid "BVF Zona Liberă Brăila (ROGL0710)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__22902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__22902
+msgid "BVF Zona Liberă Curtici (ROTM2300)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__172901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__172901
+msgid "BVF Zona Liberă Galaţi (ROGL3810)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__522901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__522901
+msgid "BVF Zona Liberă Giurgiu (ROBU3980)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__12801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__12801
+msgid "BVI Alba Iulia (ROBV0300)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__342801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__342801
+msgid "BVI Alexandria (ROCR0310)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__232801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__232801
+msgid "BVI Antrepozite/Ilfov (ROBU1200)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__22801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__22801
+msgid "BVI Arad (ROTM0200)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__42801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__42801
+msgid "BVI Bacău (ROIS0600)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__242801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__242801
+msgid "BVI Baia Mare (ROCJ0500)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__62801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__62801
+msgid "BVI Bistriţa-Năsăud (ROCJ0400)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__72801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__72801
+msgid "BVI Botoşani (ROIS1600)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__82801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__82801
+msgid "BVI Braşov (ROBV0900)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__402801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__402801
+msgid "BVI Bucureşti Poştă (ROBU1380)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__102801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__102801
+msgid "BVI Buzău (ROGL1500)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__122801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__122801
+msgid "BVI Cluj Napoca (ROCJ1800)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__282801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__282801
+msgid "BVI Corabia (ROCR2000)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__162801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__162801
+msgid "BVI Craiova (ROCR2100)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__512801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__512801
+msgid "BVI Călăraşi (ROCT1710)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__202801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__202801
+msgid "BVI Deva (ROTM8100)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__392801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__392801
+msgid "BVI Focșani (ROGL3600)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__522801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__522801
+msgid "BVI Giurgiu (ROBU3910)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__192801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__192801
+msgid "BVI Miercurea Ciuc (ROBV5600)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__282802
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__282802
+msgid "BVI Olt (ROCR8210)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__52801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__52801
+msgid "BVI Oradea (ROCJ6570)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__272801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__272801
+msgid "BVI Piatra Neamţ (ROIS7400)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__32801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__32801
+msgid "BVI Pitești (ROCR7000)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__292801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__292801
+msgid "BVI Ploiești (ROBU7100)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__112801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__112801
+msgid "BVI Reșița (ROTM7600)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__382801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__382801
+msgid "BVI Râmnicu Vâlcea (ROCR7700)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__302801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__302801
+msgid "BVI Satu-Mare (ROCJ7810)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__142801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__142801
+msgid "BVI Sfântu Gheorghe (ROBV7820)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__322801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__322801
+msgid "BVI Sibiu (ROBV7900)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__212801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__212801
+msgid "BVI Slobozia (ROCT8220)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__332801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__332801
+msgid "BVI Suceava (ROIS8230)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__352802
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__352802
+msgid "BVI Timişoara Bază (ROTM8720)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__152801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__152801
+msgid "BVI Târgoviște (ROBU8600)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__182801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__182801
+msgid "BVI Târgu Jiu (ROCR8810)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__262801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__262801
+msgid "BVI Târgu Mureş (ROBV8800)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__402802
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__402802
+msgid "BVI Târguri și Expoziții (ROBU1400)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__372801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__372801
+msgid "BVI Vaslui (ROIS9610)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_customs_office__312801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_customs_office__312801
+msgid "BVI Zalău (ROCJ9700)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__6
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__6
+msgid "Bechet(BG)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_loc_type__bcp
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_loc_type__bcp
+msgid "Border Crossing Point"
+msgstr "Punct de trecere a frontierei"
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__38
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__38
+msgid "Borș 2 - A3 (HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__2
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__2
+msgid "Borș(HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid "Both 'End' and 'Start Location Type' are missing"
+msgstr "Lipsesc atât „Sfârșit”, cât și „Tipul de locație de început”."
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__5
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__5
+msgid "Calafat (BG)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__16
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__16
+msgid "Carei  (HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__17
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__17
+msgid "Cenad (HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid "City"
+msgstr "Oraș"
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_operation_scope__401
+msgid "Commercial equipment"
+msgstr "Echipament comercial"
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__35
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__35
+msgid "Constanța Sud Agigea"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__14
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__14
+msgid "Corabia(BG)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_loc_type__customs
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_loc_type__customs
+msgid "Customs Office"
+msgstr "Birou vamal"
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__13
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__13
+msgid "Călărași(BG)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_operation_scope__703
+msgid "Delivery operations with installation"
+msgstr "Operațiuni de livrare cu instalare"
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model,name:l10n_ro_edi_stock.model_l10n_ro_edi_document
+msgid "Document object for tracking CIUS-RO XML sent to E-Factura"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_operation_scope__1101
+msgid "Donations, help"
+msgstr "Donații, ajutoare"
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_l10n_ro_edi_document__state
+msgid "E-Factura Status"
+msgstr "Stare E-Factura"
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_stock_picking__l10n_ro_edi_stock_end_bcp
+msgid "End Border Crossing Point"
+msgstr "Punct de trecere a frontierei"
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_stock_picking__l10n_ro_edi_stock_end_customs_office
+msgid "End Customs Office"
+msgstr "Birou vamal"
+
+#. module: l10n_ro_edi_stock
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock.l10n_ro_edi_stock_view_picking_form
+msgid "End Location"
+msgstr "Locația finală"
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_stock_picking__l10n_ro_edi_stock_end_loc_type
+msgid "End Location Type"
+msgstr "Tip locație"
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__18
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__18
+msgid "Episcopia Bihor (HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__l10n_ro_edi_document__state__stock_sending_failed
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_state__stock_sending_failed
+msgid "Error"
+msgstr "Eroare"
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_operation_scope__901
+msgid "Exempt operations"
+msgstr "Operațiuni scutite"
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_operation_type__50
+msgid "Export"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock.l10n_ro_edi_stock_stock_picking_view_tree
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock.l10n_ro_edi_stock_view_picking_form
+msgid "Fetch Status"
+msgstr "Preluare stare"
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_operation_scope__801
+msgid "Financial/operational leasing"
+msgstr "Leasing financiar/operațional"
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_operation_scope__501
+msgid "Fixed assets"
+msgstr "Mijloace fixe"
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__34
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__34
+msgid "Galați Giurgiulești(MD)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock.l10n_ro_edi_stock_view_picking_form
+msgid "General"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__9
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__9
+msgid "Giurgiu(BG)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_operation_scope__705
+msgid "Goods made available to the customer"
+msgstr "Bunuri puse la dispoziția clientului"
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_operation_scope__802
+msgid "Goods under warranty"
+msgstr "Bunuri în garanție"
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_operation_scope__301
+msgid "Gratuities"
+msgstr "Gratuități"
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__29
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__29
+msgid "Halmeu (UA)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,help:l10n_ro_edi_stock.field_l10n_ro_edi_document__l10n_ro_edi_stock_load_id
+msgid "Id of this document used for interacting with the anaf api."
+msgstr "Id-ul acestui document folosit pentru interacțiunea cu API-ul anaf."
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_operation_type__40
+msgid "Import"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock.res_config_settings_form_inherit_l10n_ro_edi
+msgid "In \"Serviciu\", select the options \"E-Factura\" and \"E-Transport\""
+msgstr "În \"Serviciu\", selectați opțiunile \"E-Factura\" și \"E-Transport\""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_operation_type__20
+msgid "Intra-Community delivery"
+msgstr "Livrare intracomunitară"
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_operation_type__10
+msgid "Intra-community purchase"
+msgstr "Achiziţie intracomunitară"
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_operation_type__60
+msgid ""
+"Intra-community transaction - Entry for storage/formation of new transport"
+msgstr ""
+"Tranzacţie intracomunitară - Intrare pentru depozitare/formare nou transport"
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_operation_type__70
+msgid ""
+"Intra-community transaction - Exit after storage/formation of new transport"
+msgstr ""
+"Tranzacţie intracomunitară - Ieşire după depozitare/formare nou transport"
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid "Invalid picking type %(type_code)s"
+msgstr "Tip de alegere nevalid %(type_code)s"
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_operation_scope__1001
+msgid "Investment in progress"
+msgstr "Investiție în curs"
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_l10n_ro_edi_document__invoice_id
+msgid "Invoice"
+msgstr "Factura"
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__28
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__28
+msgid "Jimbolia(RS)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_stock_picking__l10n_ro_edi_stock_available_end_loc_types
+msgid "L10N Ro Edi Stock Available End Loc Types"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_stock_picking__l10n_ro_edi_stock_available_operation_scopes
+msgid "L10N Ro Edi Stock Available Operation Scopes"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_stock_picking__l10n_ro_edi_stock_available_start_loc_types
+msgid "L10N Ro Edi Stock Available Start Loc Types"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_stock_picking__l10n_ro_edi_stock_document_ids
+msgid "L10N Ro Edi Stock Document"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_stock_picking__l10n_ro_edi_stock_enable
+msgid "L10N Ro Edi Stock Enable"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_stock_picking__l10n_ro_edi_stock_enable_amend
+msgid "L10N Ro Edi Stock Enable Amend"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_stock_picking__l10n_ro_edi_stock_enable_fetch
+msgid "L10N Ro Edi Stock Enable Fetch"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_stock_picking__l10n_ro_edi_stock_enable_send
+msgid "L10N Ro Edi Stock Enable Send"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_stock_picking__l10n_ro_edi_stock_fields_readonly
+msgid "L10N Ro Edi Stock Fields Readonly"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_l10n_ro_edi_document__l10n_ro_edi_stock_load_id
+msgid "L10N Ro Edi Stock Load"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_l10n_ro_edi_document__l10n_ro_edi_stock_uit
+msgid "L10N Ro Edi Stock Uit"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock.l10n_ro_edi_stock_view_picking_form
+msgid "Load Id"
+msgstr "Index Incarcare"
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_loc_type__location
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_loc_type__location
+msgid "Location"
+msgstr "Locație"
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_operation_scope__101
+msgid "Marketing"
+msgstr "Comercializare"
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_l10n_ro_edi_document__message
+msgid "Message"
+msgstr "Mesaj"
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__26
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__26
+msgid "Naidăș(RS)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__11
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__11
+msgid "Negru Vodă(BG)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__37
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__37
+msgid "Nădlac 2 - A1 (HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__4
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__4
+msgid "Nădlac(HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__33
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__33
+msgid "Oancea(MD)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__15
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__15
+msgid "Oltenița(BG)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_stock_picking__l10n_ro_edi_stock_operation_scope
+msgid "Operation Scope"
+msgstr "Domeniul de aplicare"
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid "Operation scope is missing."
+msgstr "Domeniul de operare lipsește."
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid "Operation type is missing."
+msgstr "Tipul de operație lipsește."
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_operation_type__22
+msgid "Operations in lohn system (EU) - exit"
+msgstr "Operaţiuni în sistem lohn (UE) - ieşire"
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_operation_type__12
+msgid "Operations in lohn system (EU) - input"
+msgstr "Operaţiuni în sistem lohn (UE) - intrare"
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__10
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__10
+msgid "Ostrov(BG)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_operation_scope__9901
+msgid "Other"
+msgstr "Altele"
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_operation_scope__201
+msgid "Output"
+msgstr "Producție"
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_operation_scope__601
+msgid "Own consumption"
+msgstr "Consum propriu"
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_delivery_carrier__l10n_ro_edi_stock_partner_id
+msgid "Partner"
+msgstr "Partener"
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__1
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__1
+msgid "Petea (HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_l10n_ro_edi_document__picking_id
+msgid "Picking"
+msgstr "Culegerea"
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__25
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__25
+msgid "Porțile de Fier 1 (RS)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid "Postal Code"
+msgstr "Cod poștal"
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid "Product %(name)s is missing the intrastat code value."
+msgstr "Produsul %(name)s lipsește valoarea codului intrastat"
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid "Products %(names)s are missing the intrastat code value."
+msgstr "Produselor %(names)s lipsește valoarea codului intrastat"
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_stock_picking__l10n_ro_edi_stock_remarks
+msgid "Remarks"
+msgstr "Remarci"
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid ""
+"Romanian access token not found. Please generate or fill it in the settings."
+msgstr ""
+"Tokenul de acces românesc nu a fost găsit. Vă rugăm să o generați sau să o "
+"completați în setări."
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__19
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__19
+msgid "Salonta (HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_operation_scope__9999
+msgid "Same with operation"
+msgstr "Același cu operațiunea"
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__31
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__31
+msgid "Sculeni(MD)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock.l10n_ro_edi_stock_view_picking_form
+msgid "Send eTransport"
+msgstr "Trimiteți eTransport"
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__l10n_ro_edi_document__state__stock_sent
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_state__stock_sent
+msgid "Sent"
+msgstr "Trimis"
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,help:l10n_ro_edi_stock.field_l10n_ro_edi_document__state
+msgid ""
+"Sent -> Successfully sent to the SPV, waiting for validation.\n"
+"                Validated -> Sent & validated by the SPV.\n"
+"                Error -> Sending error or validation error from the SPV."
+msgstr ""
+"Trimis -> Trimis cu succes către SPV, în așteptarea validării.\n"
+"                Validat -> Trimis și validat de SPV.\n"
+"                Eroare -> Eroare de trimitere sau eroare de validare de la SPV."
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model,name:l10n_ro_edi_stock.model_delivery_carrier
+msgid "Shipping Methods"
+msgstr "Metode de expediere"
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__36
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__36
+msgid "Siret  (UA)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__27
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__27
+msgid "Stamora Moravița(RS)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_stock_picking__l10n_ro_edi_stock_start_bcp
+msgid "Start Border Crossing Point"
+msgstr "Punct de trecere a frontierei"
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_stock_picking__l10n_ro_edi_stock_start_customs_office
+msgid "Start Customs Office"
+msgstr "Începeți Biroul Vamal"
+
+#. module: l10n_ro_edi_stock
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock.l10n_ro_edi_stock_view_picking_form
+msgid "Start Location"
+msgstr "Locația de pornire"
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_stock_picking__l10n_ro_edi_stock_start_loc_type
+msgid "Start Location Type"
+msgstr "Tip locație"
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid "State"
+msgstr "Stat"
+
+#. module: l10n_ro_edi_stock
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock.l10n_ro_edi_stock_view_picking_form
+msgid "Status"
+msgstr "Stare"
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_operation_type__14
+msgid "Stocks available to the customer (Call-off stock) - entry"
+msgstr "Stocuri la dispoziţia clientului (Call-off stock) - intrare"
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_operation_type__24
+msgid "Stocks available to the customer (Call-off stock) - exit"
+msgstr "Stocuri la dispoziţia clientului (Call-off stock) - ieşire"
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid "Street"
+msgstr "Stradă"
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__30
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__30
+msgid "Stânca Costești (MD)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__20
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__20
+msgid "Săcuieni (HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid "The border crossing point is missing under %(location_group)s"
+msgstr "Punctul de trecere a frontierei lipsește sub %(location_group)s"
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid "The customs office is missing under %(location_group)s"
+msgstr "Biroul vamal lipsește sub %(location_group)s"
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid ""
+"The delivery carrier of %(picking_name)s is missing the partner field value."
+msgstr ""
+"Transportatorului de livrare %(picking_name)s lipsește valoarea câmpului "
+"partener."
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid "The delivery carrier partner has to be located in Romania."
+msgstr ""
+"Partenerul transportatorului de livrare trebuie să fie situat în România."
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid ""
+"The delivery carrier partner is missing following fields: %(field_names)s"
+msgstr ""
+"Partenerului transportatorului de livrare lipsesc următoarele câmpuri: "
+"%(field_names)s"
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid "The delivery carrier partner is missing the %(field_name)s field."
+msgstr ""
+"Partenerului transportatorului de livrare lipsește câmpul %(field_name)s."
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid "The picking %(picking_name)s is missing a delivery carrier."
+msgstr "Pentru picking %(picking_name)s lipsește un transportator."
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid "This document has already been successfully sent to anaf."
+msgstr "Acest document a fost deja trimis cu succes către anaf."
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid "This document has not been corrected yet because it contains errors."
+msgstr "Acest document nu a fost încă corectat deoarece conține erori."
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid ""
+"This document has not been successfully sent yet because it contains errors."
+msgstr ""
+"Acest document nu a fost încă trimis cu succes deoarece conține erori."
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_stock_picking__l10n_ro_edi_stock_trailer_1_number
+msgid "Trailer 1 Number"
+msgstr "Numărul remorcii 1"
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_stock_picking__l10n_ro_edi_stock_trailer_2_number
+msgid "Trailer 2 Number"
+msgstr "Numărul remorcii 2"
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model,name:l10n_ro_edi_stock.model_stock_picking
+msgid "Transfer"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_operation_scope__704
+msgid "Transfer between managements"
+msgstr "Transfer între gestiuni"
+
+#. module: l10n_ro_edi_stock
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock.l10n_ro_edi_stock_view_picking_form
+msgid "Transport"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_operation_type__30
+msgid "Transport on the national territory"
+msgstr "Transport pe teritoriul naţional"
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__21
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__21
+msgid "Turnu (HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__7
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__7
+msgid "Turnu Măgurele(BG)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock.l10n_ro_edi_stock_view_picking_form
+msgid "UIT"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,help:l10n_ro_edi_stock.field_l10n_ro_edi_document__l10n_ro_edi_stock_uit
+msgid "UIT of this eTransport document."
+msgstr "UIT al acestui document de transport electronic."
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid "Unhandled eTransport document state: %(state)s"
+msgstr "Starea documentului eTransport netratată: %(state)s"
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__22
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__22
+msgid "Urziceni (HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid "VAT"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__23
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__23
+msgid "Valea lui Mihai (HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__l10n_ro_edi_document__state__stock_validated
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_state__stock_validated
+msgid "Validated"
+msgstr "Validat"
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__12
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__12
+msgid "Vama Veche(BG)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_stock_picking__l10n_ro_edi_stock_vehicle_number
+msgid "Vehicle Number"
+msgstr "Numărul vehiculului"
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid "Vehicle number and trailer number fields must be unique."
+msgstr ""
+"Câmpurile pentru numărul vehiculului și numărul remorcii trebuie să fie "
+"unice."
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid "Vehicle number is missing."
+msgstr "Numărul vehiculului lipsește"
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__24
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__24
+msgid "Vladimirescu (HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__3
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__3
+msgid "Vărșand(HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/stock_picking.py:0
+#, python-format
+msgid "XML contains errors."
+msgstr "XML conține erori."
+
+#. module: l10n_ro_edi_stock
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock/models/etransport_api.py:0
+#, python-format
+msgid "You reached the limit of requests. Please try again later."
+msgstr "Ai atins limita de cereri. Vă rugăm să încercați din nou mai târziu."
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_end_bcp__8
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock.selection__stock_picking__l10n_ro_edi_stock_start_bcp__8
+msgid "Zimnicea(BG)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock.l10n_ro_edi_stock_view_picking_form
+msgid "eTransport"
+msgstr ""
+
+#. module: l10n_ro_edi_stock
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock.l10n_ro_edi_stock_view_picking_form
+msgid "eTransport Documents"
+msgstr "Documente eTransport"
+
+#. module: l10n_ro_edi_stock
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock.l10n_ro_edi_stock_stock_picking_filter
+msgid "eTransport Error"
+msgstr "Eroare de eTransport"
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_stock_picking__l10n_ro_edi_stock_operation_type
+msgid "eTransport Operation Type"
+msgstr "Tip operațiune"
+
+#. module: l10n_ro_edi_stock
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock.l10n_ro_edi_stock_stock_picking_filter
+msgid "eTransport Sent"
+msgstr "eTransport Trimis"
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_stock_picking__l10n_ro_edi_stock_state
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock.l10n_ro_edi_stock_stock_picking_filter
+msgid "eTransport Status"
+msgstr "Starea eTransport"
+
+#. module: l10n_ro_edi_stock
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock.field_stock_picking__l10n_ro_edi_stock_document_uit
+msgid "eTransport UIT"
+msgstr "UIT eTransport"
+
+#. module: l10n_ro_edi_stock
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock.l10n_ro_edi_stock_stock_picking_filter
+msgid "eTransport Validated"
+msgstr "eTransport Validat"

--- a/addons/l10n_ro_edi_stock/models/__init__.py
+++ b/addons/l10n_ro_edi_stock/models/__init__.py
@@ -1,0 +1,4 @@
+from . import delivery_carrier
+from . import l10n_ro_edi_stock_document
+from . import stock_picking
+from . import etransport_api

--- a/addons/l10n_ro_edi_stock/models/delivery_carrier.py
+++ b/addons/l10n_ro_edi_stock/models/delivery_carrier.py
@@ -1,0 +1,7 @@
+from odoo import fields, models
+
+
+class DeliveryCarrier(models.Model):
+    _inherit = 'delivery.carrier'
+
+    l10n_ro_edi_stock_partner_id = fields.Many2one(comodel_name='res.partner', string="Partner")

--- a/addons/l10n_ro_edi_stock/models/etransport_api.py
+++ b/addons/l10n_ro_edi_stock/models/etransport_api.py
@@ -1,0 +1,77 @@
+import requests
+import re
+
+from odoo import _
+
+
+SCHEMATRON_ERROR_ID_PATTERN = r'BR-(?:CL-)?\d{3}'
+
+ETRANSPORT_URLS = {
+    'test': 'https://api.anaf.ro/test/ETRANSPORT/ws/v1',
+    'prod': 'https://api.anaf.ro/prod/ETRANSPORT/ws/v1'
+}
+
+
+def _cleanup_errors(errors: list[str]) -> list[str]:
+    def _cleanup_schematron_error(error: str) -> str:
+        for part in error.split('; '):
+            key, value = part.split('=', maxsplit=1)
+            if key == 'textEroare':
+                return value.strip()
+
+    return [_cleanup_schematron_error(err) if re.search(SCHEMATRON_ERROR_ID_PATTERN, err) else err.strip() for err in errors]
+
+
+class ETransportAPI:
+    def get_status(self, company_id, document_load_id, session=None):
+        return self._make_etransport_request(
+            company=company_id,
+            endpoint=f'stareMesaj/{document_load_id}',
+            method='get',
+            session=session,
+        )
+
+    def upload_data(self, company_id, data):
+        cif = company_id.vat.replace('RO', '')
+        return self._make_etransport_request(
+            company=company_id,
+            endpoint=f'upload/ETRANSP/{cif}/2',
+            method='post',
+            data=data,
+        )
+
+    def _make_etransport_request(self, company, endpoint: str, method: str, session=None, data=None) -> dict:
+        api_env = 'test' if company.l10n_ro_edi_test_env else 'prod'
+        url = f"{ETRANSPORT_URLS[api_env]}/{endpoint}"
+        headers = {
+            'Content-Type': 'application/xml',
+            'Authorization': f'Bearer {company.l10n_ro_edi_access_token}',
+        }
+
+        # encode data to utf-8 because it could contain some Romanian characters that are not part of latin-1
+        if data:
+            data = data.encode()
+
+        if not session:
+            session = requests.Session()
+
+        response = session.request(method=method, url=url, data=data, headers=headers, timeout=10)
+
+        match response.status_code:
+            case 404:
+                return {'error': response.json()['message']}
+            case 403:
+                return {'error': _("Access token is forbidden.")}
+            case 204:
+                return {'error': _("You reached the limit of requests. Please try again later.")}
+
+        try:
+            response_data = response.json()
+        except requests.exceptions.JSONDecodeError as e:
+            return {'error': str(e)}
+
+        if response_data['ExecutionStatus'] == 1:
+            errors = _cleanup_errors([error['errorMessage'] for error in response_data['Errors']])
+            return {'error': '\n'.join(errors)}
+
+        return {'content': response_data}

--- a/addons/l10n_ro_edi_stock/models/l10n_ro_edi_stock_document.py
+++ b/addons/l10n_ro_edi_stock/models/l10n_ro_edi_stock_document.py
@@ -1,0 +1,19 @@
+from odoo import fields, models
+
+DOCUMENT_STATES = [
+    ('stock_sent', "Sent"),
+    ('stock_sending_failed', "Error"),
+    ('stock_validated', 'Validated'),
+]
+
+
+class L10nRoEdiStockDocument(models.Model):
+    _inherit = 'l10n_ro_edi.document'
+
+    invoice_id = fields.Many2one(required=False)
+    picking_id = fields.Many2one(comodel_name='stock.picking')
+
+    state = fields.Selection(selection_add=DOCUMENT_STATES, ondelete={k: 'cascade' for k, v in DOCUMENT_STATES})
+    message = fields.Char(string="Message", copy=False)
+    l10n_ro_edi_stock_uit = fields.Char(help="UIT of this eTransport document.", copy=False)
+    l10n_ro_edi_stock_load_id = fields.Char(help="Id of this document used for interacting with the anaf api.", copy=False)

--- a/addons/l10n_ro_edi_stock/models/stock_picking.py
+++ b/addons/l10n_ro_edi_stock/models/stock_picking.py
@@ -1,0 +1,934 @@
+from typing import Literal
+
+import markupsafe
+import requests
+
+from odoo import api, fields, models, _
+from odoo.addons.l10n_ro_edi_stock.models.l10n_ro_edi_stock_document import DOCUMENT_STATES
+from odoo.addons.l10n_ro_edi_stock.models.etransport_api import ETransportAPI
+from odoo.exceptions import UserError
+
+OPERATION_TYPES = [
+    ('10', "Intra-community purchase"),
+    ('12', "Operations in lohn system (EU) - input"),
+    ('14', "Stocks available to the customer (Call-off stock) - entry"),
+    ('20', "Intra-Community delivery"),
+    ('22', "Operations in lohn system (EU) - exit"),
+    ('24', "Stocks available to the customer (Call-off stock) - exit"),
+    ('30', "Transport on the national territory"),
+    ('40', "Import"),
+    ('50', "Export"),
+    ('60', "Intra-community transaction - Entry for storage/formation of new transport"),
+    ('70', "Intra-community transaction - Exit after storage/formation of new transport"),
+]
+
+OPERATION_SCOPES = [
+    ('101', "Marketing"),
+    ('201', "Output"),
+    ('301', "Gratuities"),
+    ('401', "Commercial equipment"),
+    ('501', "Fixed assets"),
+    ('601', "Own consumption"),
+    ('703', "Delivery operations with installation"),
+    ('704', "Transfer between managements"),
+    ('705', "Goods made available to the customer"),
+    ('801', "Financial/operational leasing"),
+    ('802', "Goods under warranty"),
+    ('901', "Exempt operations"),
+    ('1001', "Investment in progress"),
+    ('1101', "Donations, help"),
+    ('9901', "Other"),
+    ('9999', "Same with operation"),
+]
+
+OPERATION_TYPE_TO_ALLOWED_SCOPE_CODES = {
+    "10": ("101", "201", "301", "401", "501", "601", "703", "801", "802", "901", "1001", "1101", "9901"),
+    "20": ("101", "301", "703", "801", "802", "9901"),
+    "30": ("101", "704", "705", "9901"),
+}
+
+LOCATION_TYPES = [('location', "Location"), ('bcp', "Border Crossing Point"), ('customs', "Customs Office")]
+
+LOCATION_TYPE_MAP = {
+    'start': {
+        'customs_code': '40',
+        'bcp_codes': ('10', '12', '14', '60'),
+    },
+    'end': {
+        'customs_code': '50',
+        'bcp_codes': ('10', '20', '22', '24', '70'),
+    }
+}
+
+BORDER_CROSSING_POINTS = [
+    ('1', "Petea (HU)"),
+    ('2', "Borș(HU)"),
+    ('3', "Vărșand(HU)"),
+    ('4', "Nădlac(HU)"),
+    ('5', "Calafat (BG)"),
+    ('6', "Bechet(BG)"),
+    ('7', "Turnu Măgurele(BG)"),
+    ('8', "Zimnicea(BG)"),
+    ('9', "Giurgiu(BG)"),
+    ('10', "Ostrov(BG)"),
+    ('11', "Negru Vodă(BG)"),
+    ('12', "Vama Veche(BG)"),
+    ('13', "Călărași(BG)"),
+    ('14', "Corabia(BG)"),
+    ('15', "Oltenița(BG)"),
+    ('16', "Carei  (HU)"),
+    ('17', "Cenad (HU)"),
+    ('18', "Episcopia Bihor (HU)"),
+    ('19', "Salonta (HU)"),
+    ('20', "Săcuieni (HU)"),
+    ('21', "Turnu (HU)"),
+    ('22', "Urziceni (HU)"),
+    ('23', "Valea lui Mihai (HU)"),
+    ('24', "Vladimirescu (HU)"),
+    ('25', "Porțile de Fier 1 (RS)"),
+    ('26', "Naidăș(RS)"),
+    ('27', "Stamora Moravița(RS)"),
+    ('28', "Jimbolia(RS)"),
+    ('29', "Halmeu (UA)"),
+    ('30', "Stânca Costești (MD)"),
+    ('31', "Sculeni(MD)"),
+    ('32', "Albița(MD)"),
+    ('33', "Oancea(MD)"),
+    ('34', "Galați Giurgiulești(MD)"),
+    ('35', "Constanța Sud Agigea"),
+    ('36', "Siret  (UA)"),
+    ('37', "Nădlac 2 - A1 (HU)"),
+    ('38', "Borș 2 - A3 (HU)"),
+]
+
+CUSTOMS_OFFICES = [
+    ('12801', "BVI Alba Iulia (ROBV0300)"),
+    ('22801', "BVI Arad (ROTM0200)"),
+    ('22901', "BVF Arad Aeroport (ROTM0230)"),
+    ('22902', "BVF Zona Liberă Curtici (ROTM2300)"),
+    ('32801', "BVI Pitești (ROCR7000)"),
+    ('42801', "BVI Bacău (ROIS0600)"),
+    ('42901', "BVF Bacău Aeroport (ROIS0620)"),
+    ('52801', "BVI Oradea (ROCJ6570)"),
+    ('52901', "BVF Oradea Aeroport (ROCJ6580)"),
+    ('62801', "BVI Bistriţa-Năsăud (ROCJ0400)"),
+    ('72801', "BVI Botoşani (ROIS1600)"),
+    ('72901', "BVF Stanca Costeşti (ROIS1610)"),
+    ('72902', "BVF Rădăuţi Prut (ROIS1620)"),
+    ('82801', "BVI Braşov (ROBV0900)"),
+    ('92901', "BVF Zona Liberă Brăila (ROGL0710)"),
+    ('92902', "BVF Brăila (ROGL0700)"),
+    ('102801', "BVI Buzău (ROGL1500)"),
+    ('112801', "BVI Reșița (ROTM7600)"),
+    ('112901', "BVF Naidăș (ROTM6100)"),
+    ('122801', "BVI Cluj Napoca (ROCJ1800)"),
+    ('122901', "BVF Cluj Napoca Aero (ROCJ1810)"),
+    ('132901', "BVF Constanţa Sud Agigea (ROCT1900)"),
+    ('132902', "BVF Mihail Kogălniceanu (ROCT5100)"),
+    ('132903', "BVF Mangalia (ROCT5400)"),
+    ('132904', "BVF Constanţa Port (ROCT1970)"),
+    ('142801', "BVI Sfântu Gheorghe (ROBV7820)"),
+    ('152801', "BVI Târgoviște (ROBU8600)"),
+    ('162801', "BVI Craiova (ROCR2100)"),
+    ('162901', "BVF Craiova Aeroport (ROCR2110)"),
+    ('162902', "BVF Bechet (ROCR1720)"),
+    ('162903', "BVF Calafat (ROCR1700)"),
+    ('172901', "BVF Zona Liberă Galaţi (ROGL3810)"),
+    ('172902', "BVF Giurgiuleşti (ROGL3850)"),
+    ('172903', "BVF Oancea (ROGL3610)"),
+    ('172904', "BVF Galaţi (ROGL3800)"),
+    ('182801', "BVI Târgu Jiu (ROCR8810)"),
+    ('192801', "BVI Miercurea Ciuc (ROBV5600)"),
+    ('202801', "BVI Deva (ROTM8100)"),
+    ('212801', "BVI Slobozia (ROCT8220)"),
+    ('222901', "BVF Iaşi Aero (ROIS4660)"),
+    ('222902', "BVF Sculeni (ROIS4990)"),
+    ('222903', "BVF Iaşi (ROIS4650)"),
+    ('232801', "BVI Antrepozite/Ilfov (ROBU1200)"),
+    ('232901', "BVF Otopeni Călători (ROBU1030)"),
+    ('242801', "BVI Baia Mare (ROCJ0500)"),
+    ('242901', "BVF Aero Baia Mare (ROCJ0510)"),
+    ('242902', "BVF Sighet (ROCJ8000)"),
+    ('252901', "BVF Orşova (ROCR7280)"),
+    ('252902', "BVF Porţile De Fier I (ROCR7270)"),
+    ('252903', "BVF Porţile De Fier II (ROCR7200)"),
+    ('252904', "BVF Drobeta Turnu Severin (ROCR9000)"),
+    ('262801', "BVI Târgu Mureş (ROBV8800)"),
+    ('262901', "BVF Târgu Mureş Aeroport (ROBV8820)"),
+    ('272801', "BVI Piatra Neamţ (ROIS7400)"),
+    ('282801', "BVI Corabia (ROCR2000)"),
+    ('282802', "BVI Olt (ROCR8210)"),
+    ('292801', "BVI Ploiești (ROBU7100)"),
+    ('302801', "BVI Satu-Mare (ROCJ7810)"),
+    ('302901', "BVF Halmeu (ROCJ4310)"),
+    ('302902', "BVF Aeroport Satu Mare (ROCJ7830)"),
+    ('312801', "BVI Zalău (ROCJ9700)"),
+    ('322801', "BVI Sibiu (ROBV7900)"),
+    ('322901', "BVF Sibiu Aeroport (ROBV7910)"),
+    ('332801', "BVI Suceava (ROIS8230)"),
+    ('332901', "BVF Dorneşti (ROIS2700)"),
+    ('332902', "BVF Siret (ROIS8200)"),
+    ('332903', "BVF Suceava Aero (ROIS8250)"),
+    ('332904', "BVF Vicovu De Sus (ROIS9620)"),
+    ('342801', "BVI Alexandria (ROCR0310)"),
+    ('342901', "BVF Turnu Măgurele (ROCR9100)"),
+    ('342902', "BVF Zimnicea (ROCR5800)"),
+    ('352802', "BVI Timişoara Bază (ROTM8720)"),
+    ('352901', "BVF Jimbolia (ROTM5010)"),
+    ('352902', "BVF Moraviţa (ROTM5510)"),
+    ('352903', "BVF Timişoara Aeroport (ROTM8730)"),
+    ('362901', "BVF Sulina (ROCT8300)"),
+    ('362902', "BVF Aeroport Delta Dunării Tulcea (ROGL8910)"),
+    ('362903', "BVF Tulcea (ROGL8900)"),
+    ('362904', "BVF Isaccea (ROGL8920)"),
+    ('372801', "BVI Vaslui (ROIS9610)"),
+    ('372901', "BVF Fălciu (-)"),
+    ('372902', "BVF Albiţa (ROIS0100)"),
+    ('382801', "BVI Râmnicu Vâlcea (ROCR7700)"),
+    ('392801', "BVI Focșani (ROGL3600)"),
+    ('402801', "BVI Bucureşti Poştă (ROBU1380)"),
+    ('402802', "BVI Târguri și Expoziții (ROBU1400)"),
+    ('402901', "BVF Băneasa (ROBU1040)"),
+    ('512801', "BVI Călăraşi (ROCT1710)"),
+    ('522801', "BVI Giurgiu (ROBU3910)"),
+    ('522901', "BVF Zona Liberă Giurgiu (ROBU3980)"),
+]
+
+STATE_CODES = {
+    'AB': '1',
+    'AR': '2',
+    'AG': '3',
+    'BC': '4',
+    'BH': '5',
+    'BN': '6',
+    'BT': '7',
+    'BV': '8',
+    'BR': '9',
+    'BZ': '10',
+    'CS': '11',
+    'CJ': '12',
+    'CT': '13',
+    'CV': '14',
+    'DB': '15',
+    'DJ': '16',
+    'GL': '17',
+    'GJ': '18',
+    'HR': '19',
+    'HD': '20',
+    'IL': '21',
+    'IS': '22',
+    'IF': '23',
+    'MM': '24',
+    'MH': '25',
+    'MS': '26',
+    'NT': '27',
+    'OT': '28',
+    'PH': '29',
+    'SM': '30',
+    'SJ': '31',
+    'SB': '32',
+    'SV': '33',
+    'TR': '34',
+    'TM': '35',
+    'TL': '36',
+    'VS': '37',
+    'VL': '38',
+    'VN': '39',
+    'B': '40',
+    'CL': '51',
+    'GR': '52',
+}
+
+
+class Picking(models.Model):
+    _inherit = 'stock.picking'
+
+    # Document fields
+    l10n_ro_edi_stock_document_ids = fields.One2many(comodel_name='l10n_ro_edi.document', inverse_name='picking_id')
+    l10n_ro_edi_stock_document_uit = fields.Char(compute='_compute_l10n_ro_edi_stock_current_document_uit', string="eTransport UIT")
+    l10n_ro_edi_stock_state = fields.Selection(
+        selection=DOCUMENT_STATES,
+        compute='_compute_l10n_ro_edi_stock_current_document_state',
+        string="eTransport Status",
+        store=True,
+    )
+
+    # Data fields
+    l10n_ro_edi_stock_operation_type = fields.Selection(selection=OPERATION_TYPES, string="eTransport Operation Type")
+    l10n_ro_edi_stock_available_operation_scopes = fields.Char(compute='_compute_l10n_ro_edi_stock_available_operation_scopes')
+    l10n_ro_edi_stock_operation_scope = fields.Selection(selection=OPERATION_SCOPES, string="Operation Scope")
+
+    l10n_ro_edi_stock_vehicle_number = fields.Char(string="Vehicle Number", size=20)
+    l10n_ro_edi_stock_trailer_1_number = fields.Char(string="Trailer 1 Number", size=20)
+    l10n_ro_edi_stock_trailer_2_number = fields.Char(string="Trailer 2 Number", size=20)
+
+    l10n_ro_edi_stock_available_start_loc_types = fields.Char(compute='_compute_l10n_ro_edi_stock_available_location_types')
+    l10n_ro_edi_stock_start_loc_type = fields.Selection(
+        selection=LOCATION_TYPES,
+        string="Start Location Type",
+        compute='_compute_l10n_ro_edi_stock_default_location_type',
+        store=True,
+        readonly=False,
+    )
+
+    l10n_ro_edi_stock_available_end_loc_types = fields.Char(compute='_compute_l10n_ro_edi_stock_available_location_types')
+    l10n_ro_edi_stock_end_loc_type = fields.Selection(
+        selection=LOCATION_TYPES,
+        string="End Location Type",
+        compute='_compute_l10n_ro_edi_stock_default_location_type',
+        store=True,
+        readonly=False,
+    )
+
+    l10n_ro_edi_stock_start_bcp = fields.Selection(selection=BORDER_CROSSING_POINTS, string="Start Border Crossing Point")
+    l10n_ro_edi_stock_start_customs_office = fields.Selection(selection=CUSTOMS_OFFICES, string="Start Customs Office")
+    l10n_ro_edi_stock_end_bcp = fields.Selection(selection=BORDER_CROSSING_POINTS, string="End Border Crossing Point")
+    l10n_ro_edi_stock_end_customs_office = fields.Selection(selection=CUSTOMS_OFFICES, string="End Customs Office")
+
+    l10n_ro_edi_stock_remarks = fields.Text(string="Remarks")
+
+    # View control fields
+    l10n_ro_edi_stock_enable = fields.Boolean(compute='_compute_l10n_ro_edi_stock_enable')
+    l10n_ro_edi_stock_enable_send = fields.Boolean(compute='_compute_l10n_ro_edi_stock_enable_send')
+    l10n_ro_edi_stock_enable_fetch = fields.Boolean(compute='_compute_l10n_ro_edi_stock_enable_fetch')
+    l10n_ro_edi_stock_enable_amend = fields.Boolean(compute='_compute_l10n_ro_edi_stock_enable_amend')
+
+    l10n_ro_edi_stock_fields_readonly = fields.Boolean(compute='_compute_l10n_ro_edi_stock_fields_readonly')
+
+    ################################################################################
+    # Onchange Methods
+    ################################################################################
+
+    @api.onchange('l10n_ro_edi_stock_operation_type')
+    def _l10n_ro_edi_stock_reset_variable_selection_fields(self):
+        self.l10n_ro_edi_stock_operation_scope = False
+
+        # the 'location' value is always valid, regardless of which operation type is chosen
+        self.l10n_ro_edi_stock_start_loc_type = 'location'
+        self.l10n_ro_edi_stock_end_loc_type = 'location'
+
+    ################################################################################
+    # Compute Methods
+    ################################################################################
+
+    @api.depends('company_id.account_fiscal_country_id.code')
+    def _compute_l10n_ro_edi_stock_default_location_type(self):
+        for picking in self:
+            if picking.company_id.account_fiscal_country_id.code == 'RO':
+                if not picking.l10n_ro_edi_stock_start_loc_type:
+                    picking.l10n_ro_edi_stock_start_loc_type = 'location'
+                else:
+                    picking.l10n_ro_edi_stock_start_loc_type = picking.l10n_ro_edi_stock_start_loc_type
+
+                if not picking.l10n_ro_edi_stock_end_loc_type:
+                    picking.l10n_ro_edi_stock_end_loc_type = 'location'
+                else:
+                    picking.l10n_ro_edi_stock_end_loc_type = picking.l10n_ro_edi_stock_end_loc_type
+            else:
+                picking.l10n_ro_edi_stock_start_loc_type = False
+                picking.l10n_ro_edi_stock_end_loc_type = False
+
+    @api.depends('l10n_ro_edi_stock_operation_type')
+    def _compute_l10n_ro_edi_stock_available_operation_scopes(self):
+        for picking in self:
+            if picking.l10n_ro_edi_stock_operation_type:
+                allowed_scopes = OPERATION_TYPE_TO_ALLOWED_SCOPE_CODES.get(picking.l10n_ro_edi_stock_operation_type, ("9999",))
+            else:
+                allowed_scopes = [c for c, _dummy in OPERATION_SCOPES]
+
+            picking.l10n_ro_edi_stock_available_operation_scopes = ','.join(allowed_scopes)
+
+    @api.depends('l10n_ro_edi_stock_operation_type')
+    def _compute_l10n_ro_edi_stock_available_location_types(self):
+        for picking in self:
+            picking.l10n_ro_edi_stock_available_start_loc_types = picking._l10n_ro_edi_stock_get_available_location_types(picking.l10n_ro_edi_stock_operation_type, 'start')
+            picking.l10n_ro_edi_stock_available_end_loc_types = picking._l10n_ro_edi_stock_get_available_location_types(picking.l10n_ro_edi_stock_operation_type, 'end')
+
+    @api.depends('l10n_ro_edi_stock_document_ids', 'company_id.account_fiscal_country_id.code')
+    def _compute_l10n_ro_edi_stock_current_document_state(self):
+        for picking in self:
+            if picking.company_id.account_fiscal_country_id.code == 'RO' and (document := picking._l10n_ro_edi_stock_get_current_document()):
+                picking.l10n_ro_edi_stock_state = document.state
+            else:
+                picking.l10n_ro_edi_stock_state = False
+
+    @api.depends('l10n_ro_edi_stock_document_ids', 'company_id.account_fiscal_country_id.code')
+    def _compute_l10n_ro_edi_stock_current_document_uit(self):
+        for picking in self:
+            if picking.company_id.account_fiscal_country_id.code == 'RO' and (document := picking._l10n_ro_edi_stock_get_current_document()):
+                picking.l10n_ro_edi_stock_document_uit = document.l10n_ro_edi_stock_uit
+            else:
+                picking.l10n_ro_edi_stock_document_uit = False
+
+    @api.depends('company_id.account_fiscal_country_id.code')
+    def _compute_l10n_ro_edi_stock_enable(self):
+        for picking in self:
+            picking.l10n_ro_edi_stock_enable = picking.company_id.account_fiscal_country_id.code == 'RO'
+
+    @api.depends('l10n_ro_edi_stock_enable', 'state', 'l10n_ro_edi_stock_state')
+    def _compute_l10n_ro_edi_stock_enable_send(self):
+        for picking in self:
+            picking.l10n_ro_edi_stock_enable_send = (
+                    picking.l10n_ro_edi_stock_enable
+                    and picking.state == 'done'
+                    and picking.l10n_ro_edi_stock_state in (False, 'stock_sending_failed')
+                    and not picking._l10n_ro_edi_stock_get_last_document('stock_validated')
+            )
+
+    @api.depends('company_id', 'state', 'l10n_ro_edi_stock_state')
+    def _compute_l10n_ro_edi_stock_enable_fetch(self):
+        for picking in self:
+            picking.l10n_ro_edi_stock_enable_fetch = picking.l10n_ro_edi_stock_enable and picking.l10n_ro_edi_stock_state == 'stock_sent'
+
+    @api.depends('l10n_ro_edi_stock_state')
+    def _compute_l10n_ro_edi_stock_enable_amend(self):
+        for picking in self:
+            picking.l10n_ro_edi_stock_enable_amend = picking.l10n_ro_edi_stock_enable and (
+                    picking.l10n_ro_edi_stock_state == 'stock_validated'
+                    or (
+                        picking.l10n_ro_edi_stock_state == 'stock_sending_failed'
+                        and picking._l10n_ro_edi_stock_get_last_document('stock_validated')
+                    )
+            )
+
+    @api.depends('l10n_ro_edi_stock_state')
+    def _compute_l10n_ro_edi_stock_fields_readonly(self):
+        for picking in self:
+            picking.l10n_ro_edi_stock_fields_readonly = picking.l10n_ro_edi_stock_state == 'stock_sent'
+
+    ################################################################################
+    # Validation methods
+    ################################################################################
+
+    def button_validate(self):
+        # EXTENDS 'stock'
+
+        # Validate the carrier first because it cannot be changed after the super call
+        self._l10n_ro_edi_stock_validate_carrier()
+
+        return super().button_validate()
+
+    def _l10n_ro_edi_stock_validate_carrier(self):
+        for picking in self.filtered(self._l10n_ro_edi_stock_validate_carrier_filter):
+            # validate carrier
+            if not picking.carrier_id:
+                raise UserError(_("The picking %(picking_name)s is missing a delivery carrier.", picking_name=picking.name))
+
+            # validate carrier partner
+            if not picking.carrier_id.l10n_ro_edi_stock_partner_id:
+                raise UserError(_("The delivery carrier of %(picking_name)s is missing the partner field value.", picking_name=picking.name))
+
+    @api.model
+    def _l10n_ro_edi_stock_validate_carrier_filter(self, picking):
+        # To be overridden by stock.picking.batch
+        return picking.l10n_ro_edi_stock_enable
+
+    @api.model
+    def _l10n_ro_edi_stock_validate_data(self, data: dict):
+        errors = []
+
+        # API access token
+        if not data['company_id'].l10n_ro_edi_access_token:
+            errors.append(_('Romanian access token not found. Please generate or fill it in the settings.'))
+
+        # carrier partner fields
+        partner = data['transport_partner_id']
+        missing_carrier_partner_fields = []
+
+        if partner.country_id.code != 'RO':
+            errors.append(_("The delivery carrier partner has to be located in Romania."))
+
+        if not partner.vat:
+            missing_carrier_partner_fields.append(_("VAT"))
+
+        if not partner.city:
+            missing_carrier_partner_fields.append(_("City"))
+
+        if not partner.street:
+            missing_carrier_partner_fields.append(_("Street"))
+
+        if len(missing_carrier_partner_fields) == 1:
+            errors.append(_("The delivery carrier partner is missing the %(field_name)s field.", field_name=missing_carrier_partner_fields[0]))
+        elif len(missing_carrier_partner_fields) > 1:
+            errors.append(_("The delivery carrier partner is missing following fields: %(field_names)s", field_names=', '.join(missing_carrier_partner_fields)))
+
+        # operation type
+        if not data['l10n_ro_edi_stock_operation_type']:
+            errors.append(_("Operation type is missing."))
+            return errors  # return prematurely because a lot of fields depend on the operation type
+
+        # operation scope
+        if not data['l10n_ro_edi_stock_operation_scope']:
+            errors.append(_("Operation scope is missing."))
+
+        # vehicle & trailer numbers
+        if not data['l10n_ro_edi_stock_vehicle_number']:
+            errors.append(_("Vehicle number is missing."))
+
+        # All filled-in vehicle and trailer numbers must be unique
+        license_plates = [num for num in (data['l10n_ro_edi_stock_vehicle_number'], data['l10n_ro_edi_stock_trailer_1_number'], data['l10n_ro_edi_stock_trailer_2_number']) if num]
+        if len(license_plates) != len(set(license_plates)):
+            errors.append(_("Vehicle number and trailer number fields must be unique."))
+
+        # rate codes
+        if 'intrastat_code_id' in self.env['product.product']._fields and data['l10n_ro_edi_stock_operation_type'] not in ('60', '70'):
+            product_without_code_names = {move_line.product_id.name
+                                          for move in data['stock_move_ids']
+                                          for move_line in move.move_line_ids
+                                          if not move_line.product_id.intrastat_code_id.code}
+
+            if product_without_code_names:
+                if len(product_without_code_names) == 1:
+                    (product_name,) = product_without_code_names
+                    errors.append(_("Product %(name)s is missing the intrastat code value.", name=product_name))
+                else:
+                    errors.append(_("Products %(names)s are missing the intrastat code value.", names=", ".join(product_without_code_names)))
+
+        # Location types
+        if not data['l10n_ro_edi_stock_start_loc_type']:
+            if not data['l10n_ro_edi_stock_end_loc_type']:
+                errors.append(_("Both 'End' and 'Start Location Type' are missing"))
+            else:
+                errors.append(_("'Start Location Type' is missing"))
+
+            return errors  # return prematurely because all the start location fields depend on this field
+
+        if not data['l10n_ro_edi_stock_end_loc_type']:
+            errors.append(_("'End Location Type' is missing"))
+            return errors  # return prematurely because all the end location fields depend on this field
+
+        # Location fields
+        for location in ('start', 'end'):
+            loc_value = data[f'l10n_ro_edi_stock_{location}_loc_type']
+            loc_group = _("'Start Location'") if location == 'start' else _("'End Location'")
+
+            if loc_value == 'bcp' and not data[f'l10n_ro_edi_stock_{location}_bcp']:
+                errors.append(_("The border crossing point is missing under %(location_group)s", location_group=loc_group))
+            elif loc_value == 'customs' and not data[f'l10n_ro_edi_stock_{location}_customs_office']:
+                errors.append(_("The customs office is missing under %(location_group)s", location_group=loc_group))
+            elif loc_value == 'location':
+                match data['picking_type_id'].code:
+                    case 'outgoing':
+                        partner = data['picking_type_id'].warehouse_id.partner_id if location == 'start' else data['partner_id']
+                    case 'incoming':
+                        partner = data['picking_type_id'].warehouse_id.partner_id if location == 'end' else data['partner_id']
+                    case _other:
+                        errors.append(_("Invalid picking type %(type_code)s", type_code=_other))
+                        continue
+
+                missing_field_names = []
+                if not partner.state_id:
+                    missing_field_names.append(_("State"))
+                if not partner.city:
+                    missing_field_names.append(_("City"))
+                if not partner.street:
+                    missing_field_names.append(_("Street"))
+                if not partner.zip:
+                    missing_field_names.append(_("Postal Code"))
+
+                if len(missing_field_names) == 1:
+                    errors.append(_("%(location_group)s is missing the %(field_name)s field.", location_group=loc_group, field_name=missing_field_names[0]))
+                elif len(missing_field_names) > 1:
+                    errors.append(_("%(location_group)s is missing following fields: %(field_names)s", location_group=loc_group, field_names=missing_field_names))
+
+        return errors
+
+    def _l10n_ro_edi_stock_validate_fetch_data(self, errors=None):
+        if errors is None:
+            errors = []
+        self.ensure_one()
+
+        if not self.company_id.l10n_ro_edi_access_token:
+            errors.append(_('Romanian access token not found. Please generate or fill it in the settings.'))
+            return errors
+
+        match self.l10n_ro_edi_stock_state:
+            case 'stock_sending_failed':
+                if not self._l10n_ro_edi_stock_get_last_document('stock_validated'):
+                    errors.append(_("This document has not been successfully sent yet because it contains errors."))
+                else:
+                    errors.append(_("This document has not been corrected yet because it contains errors."))
+            case 'stock_validated':
+                errors.append(_("This document has already been successfully sent to anaf."))
+
+        return errors
+
+    ################################################################################
+    # Actions
+    ################################################################################
+
+    def action_l10n_ro_edi_stock_send_etransport(self):
+        self.ensure_one()
+
+        send_type = self.env.context.get('l10n_ro_edi_stock_send_type', 'send')
+        self._l10n_ro_edi_stock_send_etransport_document(send_type=send_type)
+
+    def action_l10n_ro_edi_stock_fetch_status(self):
+        self._l10n_ro_edi_stock_fetch_document_status()
+
+    ################################################################################
+    # Document Helpers
+    ################################################################################
+
+    def _l10n_ro_edi_stock_get_current_document(self):
+        """
+        Returns the most recently created document in l10n_ro_edi_stock_document_ids
+        """
+        self.ensure_one()
+        return self.l10n_ro_edi_stock_document_ids.sorted()[0] if self.l10n_ro_edi_stock_document_ids else None
+
+    def _l10n_ro_edi_stock_get_all_documents(self, states):
+        """
+        Returns filtered documents by state
+        """
+        self.ensure_one()
+
+        if isinstance(states, str):
+            states = [states]
+
+        return self.l10n_ro_edi_stock_document_ids.filtered(lambda doc: doc.state in states)
+
+    def _l10n_ro_edi_stock_get_last_document(self, state):
+        """
+        Returns the most recently created document with the given state
+        """
+        self.ensure_one()
+        documents_in_state = self.l10n_ro_edi_stock_document_ids.filtered(lambda doc: doc.state == state).sorted()
+
+        return documents_in_state and documents_in_state[0]
+
+    @api.model
+    def _l10n_ro_edi_stock_create_attachment(self, values: dict):
+        data = {
+            'name': f"etransport_{values['name'].replace('/', '_')}.xml",
+            'res_model': 'l10n_ro_edi.document',
+            'res_id': values['res_id'],
+            'raw': values['raw'],
+            'type': 'binary',
+            'mimetype': 'application/xml',
+        }
+
+        return self.env['ir.attachment'].sudo().create(data)
+
+    def _l10n_ro_edi_stock_create_document_stock_sent(self, values: dict[str, object]):
+        self.ensure_one()
+        document = self.env['l10n_ro_edi.document'].create({
+            'picking_id': self.id,
+            'state': 'stock_sent',
+            'l10n_ro_edi_stock_load_id': values['l10n_ro_edi_stock_load_id'],
+            'l10n_ro_edi_stock_uit': values['l10n_ro_edi_stock_uit'],
+        })
+
+        document.attachment_id = self._l10n_ro_edi_stock_create_attachment({
+            'name': self.name,
+            'res_id': document.id,
+            'raw': values['raw_xml'],
+        })
+
+        return document
+
+    def _l10n_ro_edi_stock_create_document_stock_sending_failed(self, values: dict[str, object]):
+        self.ensure_one()
+        document = self.env['l10n_ro_edi.document'].create({
+            'picking_id': self.id,
+            'state': 'stock_sending_failed',
+            'message': values['message'],
+            'l10n_ro_edi_stock_load_id': values.get('l10n_ro_edi_stock_load_id'),
+            'l10n_ro_edi_stock_uit': values.get('l10n_ro_edi_stock_uit'),
+        })
+
+        if 'raw_xml' in values:
+            # when an error is thrown during data validation there will be no 'raw_xml'
+            document.attachment_id = self._l10n_ro_edi_stock_create_attachment({
+                'name': self.name,
+                'res_id': document.id,
+                'raw': values['raw_xml'],
+            })
+
+        return document
+
+    def _l10n_ro_edi_stock_create_document_stock_validated(self, values: dict[str, object]):
+        self.ensure_one()
+        document = self.env['l10n_ro_edi.document'].create({
+            'picking_id': self.id,
+            'state': 'stock_validated',
+            'l10n_ro_edi_stock_load_id': values['l10n_ro_edi_stock_load_id'],
+            'l10n_ro_edi_stock_uit': values['l10n_ro_edi_stock_uit'],
+        })
+
+        document.attachment_id = self._l10n_ro_edi_stock_create_attachment({
+            'name': self.name,
+            'res_id': document.id,
+            'raw': values['raw_xml'],
+        })
+
+        return document
+
+    ################################################################################
+    # Send Logic
+    ################################################################################
+
+    def _l10n_ro_edi_stock_send_etransport_document(self, send_type: str):
+        """
+        Send the eTransport document to anaf
+        :param send_type: 'send' (initial sending of document) | 'amend' (correct the already sent document)
+        """
+        self.ensure_one()
+
+        data = {
+            'partner_id': self.partner_id,
+            'transport_partner_id': self.carrier_id.l10n_ro_edi_stock_partner_id,
+            'company_id': self.company_id,
+            'scheduled_date': self.scheduled_date,
+            'name': self.name,
+            'send_type': send_type,
+            'l10n_ro_edi_stock_operation_type': self.l10n_ro_edi_stock_operation_type,
+            'l10n_ro_edi_stock_operation_scope': self.l10n_ro_edi_stock_operation_scope,
+            'stock_move_ids': self.move_ids,
+            'l10n_ro_edi_stock_vehicle_number': self.l10n_ro_edi_stock_vehicle_number,
+            'l10n_ro_edi_stock_trailer_1_number': self.l10n_ro_edi_stock_trailer_1_number,
+            'l10n_ro_edi_stock_trailer_2_number': self.l10n_ro_edi_stock_trailer_2_number,
+            'l10n_ro_edi_stock_start_loc_type': self.l10n_ro_edi_stock_start_loc_type,
+            'l10n_ro_edi_stock_end_loc_type': self.l10n_ro_edi_stock_end_loc_type,
+            'l10n_ro_edi_stock_remarks': self.l10n_ro_edi_stock_remarks,
+            'picking_type_id': self.picking_type_id,
+            'l10n_ro_edi_stock_start_bcp': self.l10n_ro_edi_stock_start_bcp,
+            'l10n_ro_edi_stock_end_bcp': self.l10n_ro_edi_stock_end_bcp,
+            'l10n_ro_edi_stock_start_customs_office': self.l10n_ro_edi_stock_start_customs_office,
+            'l10n_ro_edi_stock_end_customs_office': self.l10n_ro_edi_stock_end_customs_office,
+            'l10n_ro_edi_stock_document_uit': self.l10n_ro_edi_stock_document_uit,
+        }
+
+        if errors := self._l10n_ro_edi_stock_validate_data(data=data):
+            document_values = {'message': '\n'.join(errors)}
+
+            if send_type == 'amend':
+                last_sent_document = self._l10n_ro_edi_stock_get_last_document('stock_validated')
+                document_values |= {
+                    'l10n_ro_edi_stock_load_id': last_sent_document.l10n_ro_edi_stock_load_id,
+                    'l10n_ro_edi_stock_uit': last_sent_document.l10n_ro_edi_stock_uit,
+                    'raw_xml': last_sent_document.attachment_id.raw,
+                }
+
+            self._l10n_ro_edi_stock_create_document_stock_sending_failed(document_values)
+            return
+
+        raw_xml = markupsafe.Markup("<?xml version='1.0' encoding='UTF-8'?>\n") + self.env['ir.qweb']._render(
+            'l10n_ro_edi_stock.l10n_ro_template_etransport',
+            values=self._l10n_ro_edi_stock_get_template_data(data=data),
+        )
+
+        result = ETransportAPI().upload_data(company_id=self.company_id, data=raw_xml)
+
+        if 'error' in result:
+            document_values = {'message': result['error'], 'raw_xml': raw_xml}
+
+            if send_type == 'amend':
+                last_sent_document = self._l10n_ro_edi_stock_get_last_document('stock_validated')
+                document_values |= {
+                    'l10n_ro_edi_stock_load_id': last_sent_document.l10n_ro_edi_stock_load_id,
+                    'l10n_ro_edi_stock_uit': last_sent_document.l10n_ro_edi_stock_uit,
+                }
+
+            self._l10n_ro_edi_stock_create_document_stock_sending_failed(document_values)
+        else:
+            self._l10n_ro_edi_stock_get_all_documents({'stock_sending_failed', 'stock_sent'}).unlink()
+
+            content = result['content']
+
+            if send_type == 'send':
+                uit = content['UIT']
+            else:
+                last_validated = self._l10n_ro_edi_stock_get_last_document('stock_validated')
+                uit = last_validated.l10n_ro_edi_stock_uit
+
+            self._l10n_ro_edi_stock_create_document_stock_sent({
+                'l10n_ro_edi_stock_load_id': content['index_incarcare'],
+                'l10n_ro_edi_stock_uit': uit,
+                'raw_xml': raw_xml,
+            })
+
+    def _l10n_ro_edi_stock_fetch_document_status(self):
+        session = requests.Session()
+        documents_to_delete = self.env['l10n_ro_edi.document']
+        to_fetch = self.filtered(lambda p: p.l10n_ro_edi_stock_state == 'stock_sent')
+
+        for picking in to_fetch:
+            current_sending_document = picking.l10n_ro_edi_stock_document_ids.filtered(lambda doc: doc.state == 'stock_sent')[0]
+
+            if errors := picking._l10n_ro_edi_stock_validate_fetch_data():
+                picking._l10n_ro_edi_stock_create_document_stock_sending_failed({
+                    'message': '\n'.join(errors),
+                    'l10n_ro_edi_stock_load_id': current_sending_document.l10n_ro_edi_stock_load_id,
+                    'l10n_ro_edi_stock_uit': current_sending_document.l10n_ro_edi_stock_uit,
+                    'raw_xml': current_sending_document.attachment_id.raw,
+                })
+                continue
+
+            result = ETransportAPI().get_status(
+                company_id=picking.company_id,
+                document_load_id=current_sending_document.l10n_ro_edi_stock_load_id,
+                session=session,
+            )
+
+            if 'error' in result:
+                picking._l10n_ro_edi_stock_create_document_stock_sending_failed({
+                    'message': result['error'],
+                    'l10n_ro_edi_stock_load_id': current_sending_document.l10n_ro_edi_stock_load_id,
+                    'l10n_ro_edi_stock_uit': current_sending_document.l10n_ro_edi_stock_uit,
+                    'raw_xml': current_sending_document.attachment_id.raw,
+                })
+            else:
+                documents_to_delete |= picking._l10n_ro_edi_stock_get_all_documents(('stock_sent', 'stock_sending_failed'))
+                new_document_data = {
+                    'l10n_ro_edi_stock_load_id': current_sending_document.l10n_ro_edi_stock_load_id,
+                    'l10n_ro_edi_stock_uit': current_sending_document.l10n_ro_edi_stock_uit,
+                    'raw_xml': current_sending_document.attachment_id.raw,
+                }
+                match state := result['content']['stare']:
+                    case 'ok':
+                        picking._l10n_ro_edi_stock_create_document_stock_validated(new_document_data)
+                    case 'in prelucrare':
+                        # Document is still being validated
+                        picking._l10n_ro_edi_stock_create_document_stock_sent(new_document_data)
+                    case 'XML cu erori nepreluat de sistem':
+                        new_document_data['message'] = _("XML contains errors.")
+                        picking._l10n_ro_edi_stock_create_document_stock_sending_failed(new_document_data)
+                    case _:
+                        picking._l10n_ro_edi_stock_report_unhandled_document_state(state)
+
+        documents_to_delete.unlink()
+
+    ################################################################################
+    # Template helpers
+    ################################################################################
+
+    @api.model
+    def _l10n_ro_edi_stock_get_template_data(self, data: dict):
+        """
+        Returns the data necessary to render the eTransport template
+        """
+        commercial_partner = data['partner_id'].commercial_partner_id
+        transport_partner = data['transport_partner_id']
+        company_id = data['company_id']
+        scheduled_date = data['scheduled_date'].date()
+        name = data['name']
+        commercial_partner_code = None
+
+        if commercial_partner.vat:
+            commercial_partner_code = self._l10n_ro_edi_stock_get_cod(commercial_partner)
+        elif self.l10n_ro_edi_stock_operation_type == '30':
+            commercial_partner_code = 'PF'
+
+        template_data = {
+            'send_type': data['send_type'],
+            'codDeclarant': self._l10n_ro_edi_stock_get_cod(company_id),
+            'refDeclarant': name,
+            'notificare': {
+                'codTipOperatiune': data['l10n_ro_edi_stock_operation_type'],
+                'bunuriTransportate': [
+                    {
+                        'codScopOperatiune': data['l10n_ro_edi_stock_operation_scope'],
+                        'codTarifar': (product.intrastat_code_id.code if 'intrastat_code_id' in product._fields else None) or '00000000',
+                        'denumireMarfa': product.name,
+                        'cantitate': move.product_qty,
+                        'codUnitateMasura': move.product_uom._get_unece_code(),
+                        'greutateNeta': move.weight,
+                        'greutateBruta': self._l10n_ro_edi_stock_get_gross_weight(move),
+                        'valoareLeiFaraTva': product.list_price,
+                    }
+                    for move in data['stock_move_ids'] for product in move.product_id
+                ],
+                'partenerComercial': {
+                    'codTara': commercial_partner.country_code,
+                    'denumire': commercial_partner.name,
+                    'cod': commercial_partner_code,
+                },
+                'dateTransport': {
+                    'nrVehicul': data['l10n_ro_edi_stock_vehicle_number'].upper(),
+                    'nrRemorca1': data['l10n_ro_edi_stock_trailer_1_number'].upper() if data['l10n_ro_edi_stock_trailer_1_number'] else None,
+                    'nrRemorca2': data['l10n_ro_edi_stock_trailer_2_number'].upper() if data['l10n_ro_edi_stock_trailer_2_number'] else None,
+                    'codTaraOrgTransport': transport_partner.country_code,
+                    'codOrgTransport': self._l10n_ro_edi_stock_get_cod(transport_partner),
+                    'denumireOrgTransport': transport_partner.name,
+                    'dataTransport': scheduled_date,
+                },
+                'locStartTraseuRutier': {
+                    'location_type': data['l10n_ro_edi_stock_start_loc_type'],
+                },
+                'locFinalTraseuRutier': {
+                    'location_type': data['l10n_ro_edi_stock_end_loc_type'],
+                },
+                'documenteTransport': {
+                    'tipDocument': "30",
+                    'dataDocument': scheduled_date,
+                    'numarDocument': name,
+                    'observatii': data['l10n_ro_edi_stock_remarks'],
+                }
+            },
+        }
+
+        if data['send_type'] == 'amend':
+            template_data['notificare']['uit'] = data['l10n_ro_edi_stock_document_uit']
+
+        for loc in ('start', 'end'):
+            key = 'locStartTraseuRutier' if loc == 'start' else 'locFinalTraseuRutier'
+
+            match template_data['notificare'][key]['location_type']:
+                case 'location':
+                    match data['picking_type_id'].code:
+                        case 'outgoing':
+                            partner = data['picking_type_id'].warehouse_id.partner_id if loc == 'start' else data['partner_id']
+                        case 'incoming':
+                            partner = data['picking_type_id'].warehouse_id.partner_id if loc == 'end' else data['partner_id']
+
+                    template_data['notificare'][key]['locatie'] = {
+                        'codJudet': STATE_CODES[partner.state_id.code],
+                        'denumireLocalitate': partner.city,
+                        'denumireStrada': partner.street,
+                        'codPostal': partner.zip,
+                        'alteInfo': partner.street2,
+                    }
+                case 'bcp':
+                    template_data['notificare'][key]['codPtf'] = data[f'l10n_ro_edi_stock_{loc}_bcp']
+                case 'customs':
+                    template_data['notificare'][key]['codBirouVamal'] = data[f'l10n_ro_edi_stock_{loc}_customs_office']
+
+        return {'data': template_data}
+
+    ################################################################################
+    # Misc helpers
+    ################################################################################
+
+    @api.model
+    def _l10n_ro_edi_stock_get_available_location_types(self, operation_type, location: Literal['start', 'end']) -> str:
+        """
+        :return comma separated list of available location types for the start or end location based on the operation type
+        """
+        if operation_type == LOCATION_TYPE_MAP[location]['customs_code']:
+            return 'location,bcp,customs'
+        elif operation_type in LOCATION_TYPE_MAP[location]['bcp_codes']:
+            return 'location,bcp'
+        else:
+            return 'location'
+
+    @api.model
+    def _l10n_ro_edi_stock_get_cod(self, record):
+        """
+        :return the records vat in the format required by anaf
+        """
+        return record.vat.upper().replace('RO', '')
+
+    @api.model
+    def _l10n_ro_edi_stock_get_gross_weight(self, move):
+        """
+        :return the gross weight of a stock.move
+        """
+        return move.weight + sum(line.result_package_id.shipping_weight for line in move.move_line_ids if line.result_package_id)
+
+    def _l10n_ro_edi_stock_report_unhandled_document_state(self, state: str):
+        """
+        Reports an unknown document state from anaf to the user in the chatter
+        """
+        self.ensure_one()
+        self.message_post(body=_("Unhandled eTransport document state: %(state)s", state=state))

--- a/addons/l10n_ro_edi_stock/report/report_deliveryslip.xml
+++ b/addons/l10n_ro_edi_stock/report/report_deliveryslip.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <template id="l10n_ro_edi_stock_report_delivery_document" inherit_id="stock.report_delivery_document" priority="100">
+        <xpath expr="//div/strong[text()='Tracking Number:']/.. | //div/strong[text()='Total Weight:']/.." position="after">
+            <div t-if="o.l10n_ro_edi_stock_enable and o.l10n_ro_edi_stock_document_uit" class="col-auto" name="div_etransport_uit">
+                <strong>eTransport UIT:</strong>
+                <p t-field="o.l10n_ro_edi_stock_document_uit"/>
+            </div>
+        </xpath>
+    </template>
+</odoo>

--- a/addons/l10n_ro_edi_stock/static/src/components/document_state/document_state_field.js
+++ b/addons/l10n_ro_edi_stock/static/src/components/document_state/document_state_field.js
@@ -1,0 +1,24 @@
+/** @odoo-module **/
+import { registry } from "@web/core/registry";
+import { selectionField } from "@web/views/fields/selection/selection_field";
+import { DocumentState } from "@account/components/document_state/document_state_field";
+
+export class RoDocumentState extends DocumentState {
+    // Override
+    get message() {
+        let errors = this.props.record.data.message
+            ?.split("\n")
+            ?.filter((error) => error?.trim()?.length > 0);
+
+        if (errors && errors.length === 1) {
+            return errors[0];
+        }
+
+        return errors?.map((error) => "• " + error)?.join("\n");
+    }
+}
+
+registry.category("fields").add("l10n_ro_edi_stock_document_state", {
+    ...selectionField,
+    component: RoDocumentState,
+});

--- a/addons/l10n_ro_edi_stock/tests/__init__.py
+++ b/addons/l10n_ro_edi_stock/tests/__init__.py
@@ -1,0 +1,2 @@
+from . import common
+from . import test_etransport_flows

--- a/addons/l10n_ro_edi_stock/tests/common.py
+++ b/addons/l10n_ro_edi_stock/tests/common.py
@@ -1,0 +1,45 @@
+from odoo.addons.stock_account.tests.test_anglo_saxon_valuation_reconciliation_common import ValuationReconciliationTestCommon
+
+
+class TestL10nRoEdiStockCommon(ValuationReconciliationTestCommon):
+    @classmethod
+    def setUpClass(cls, chart_template_ref='ro'):
+        super().setUpClass(chart_template_ref=chart_template_ref)
+
+        cls.warehouse = cls.company_data['default_warehouse']
+        cls.customer_location = cls.env.ref('stock.stock_location_customers').id
+        cls.stock_location = cls.warehouse.lot_stock_id.id
+
+    @classmethod
+    def create_stock_picking(cls, partner, name=False, location_id=None, location_dest_id=None, picking_type=None, product_data=None):
+        picking = cls.env['stock.picking'].create({
+            'name': name or f'{cls.env.company.name} picking',
+            'partner_id': partner.id,
+            'location_id': location_id if location_id else cls.stock_location,
+            'location_dest_id': location_dest_id if location_dest_id else cls.customer_location,
+            'picking_type_id': picking_type.id if picking_type else cls.warehouse.out_type_id.id,
+        })
+
+        for data in product_data or []:
+            product = data['product_id']
+            cls.env['stock.move'].create({
+                'name': product.name,
+                'product_id': product.id,
+                'product_uom': product.uom_id.id,
+                'product_uom_qty': data['product_uom_qty'],
+                'quantity': data['quantity'],
+                'procure_method': data.get('procure_method', 'make_to_stock'),
+                'picking_id': picking.id,
+                'location_id': picking.location_id.id,
+                'location_dest_id': picking.location_dest_id.id,
+                'company_id': cls.env.company.id
+            })
+
+        return picking
+
+    def change_product_qty(self, product, new_quantity, product_tmpl=None):
+        self.env['stock.change.product.qty'].create({
+            'product_id': product.id,
+            'product_tmpl_id': product_tmpl.id if product_tmpl else product.product_tmpl_id.id,
+            'new_quantity': new_quantity,
+        }).change_product_qty()

--- a/addons/l10n_ro_edi_stock/tests/test_etransport_flows.py
+++ b/addons/l10n_ro_edi_stock/tests/test_etransport_flows.py
@@ -1,0 +1,245 @@
+from odoo.exceptions import UserError
+from odoo.tests import tagged
+from odoo.tools import misc
+
+from odoo.addons.l10n_ro_edi_stock.tests.common import TestL10nRoEdiStockCommon
+
+from unittest.mock import patch
+from freezegun import freeze_time
+
+
+@freeze_time('2025-01-14')
+@patch('odoo.addons.l10n_ro_edi_stock.models.etransport_api.ETransportAPI._make_etransport_request')
+@tagged("post_install_l10n", "post_install", "-at_install")
+class TestETransportFlows(TestL10nRoEdiStockCommon):
+    @classmethod
+    def setUpClass(cls, chart_template_ref='ro'):
+        super().setUpClass(chart_template_ref=chart_template_ref)
+        company = cls.company_data['company']
+
+        company.write({
+            'vat': '9000123456789',
+            'street': 'Calea Nationala 85',
+            'city': 'Botosani',
+            'zip': '710052',
+            'state_id': cls.env.ref('base.RO_BT').id,
+            'l10n_ro_edi_access_token': 'some access token',
+        })
+
+        cls.shipping_partner = cls.env['res.partner'].create({
+            'name': 'RO Shipping Partner',
+            'vat': '8001011234567',
+            'street': 'Strada Mihai Viteazul 22',
+            'city': 'Caransebes',
+            'zip': '325400',
+            'state_id': cls.env.ref('base.RO_CS').id,
+            'country_id': cls.env.ref('base.ro').id,
+        })
+
+        cls.customer = cls.env['res.partner'].create({
+            'name': 'RO Customer',
+            'vat': 'RO1234567897',
+            'street': 'Strada General Traian Moșoiu 24',
+            'city': 'Bran',
+            'zip': '507025',
+            'state_id': cls.env.ref('base.RO_BV').id,
+            'country_id': cls.env.ref('base.ro').id,
+        })
+
+        cls.carrier = cls.env.ref('delivery.free_delivery_carrier')
+        cls.product_a.write({
+            'type': 'product',
+            'weight': '1',
+        })
+
+        if 'intrastat_code_id' in cls.env['product.product']._fields:
+            cls.default_intrastat_code = cls.env.ref('account_intrastat.commodity_code_2018_1012100')
+            cls.product_a.intrastat_code_id = cls.default_intrastat_code
+
+        cls.delivery_picking = cls.create_stock_picking(
+            partner=cls.customer,
+            product_data=[{
+                'product_id': cls.product_a,
+                'product_uom_qty': 10.0,
+                'quantity': 10.0,
+            }],
+        )
+
+        cls.receipt_picking = cls.create_stock_picking(
+            name='receipt_picking',
+            partner=cls.customer,
+            picking_type=cls.warehouse.in_type_id,
+            product_data=[{
+                'product_id': cls.product_a,
+                'product_uom_qty': 10.0,
+                'quantity': 10.0,
+            }],
+        )
+
+        cls.successful_upload_response = {
+            'content': {
+                "dateResponse": "202212231132",
+                "ExecutionStatus": 0,
+                "index_incarcare": 1,
+                "UIT": "A0002",
+                "trace_id": "96cd587e-298b-4245-ad7d-2607d973f9d4",
+                "ref_declarant": "",
+                "atentie": "Verificati starea XML-ului transmis. Codul UIT este valabil din momentul in care apare ca valid dupa apelul de stare",
+            }
+        }
+
+    def _assert_picking_state(self, picking, state=False, amt_documents=0, enabled_fields=('enable', 'fields_readonly')):
+        self.assertEqual(picking.l10n_ro_edi_stock_state, state)
+        if amt_documents > 0:
+            self.assertTrue(picking.l10n_ro_edi_stock_document_ids)
+            self.assertEqual(len(picking.l10n_ro_edi_stock_document_ids), amt_documents)
+        else:
+            self.assertFalse(picking.l10n_ro_edi_stock_document_ids)
+
+        for suffix in ('enable', 'enable_send', 'enable_fetch', 'enable_amend', 'fields_readonly'):
+            field_value = getattr(picking, f'l10n_ro_edi_stock_{suffix}')
+            self.assertEqual(field_value, suffix in enabled_fields)
+
+    def _assert_etransport_document(self, document, filename):
+        with misc.file_open(f'{self.test_module}/tests/test_files/{filename}.xml', 'rb') as file:
+            expected_document = file.read()
+
+        expected_tree = self.get_xml_tree_from_string(expected_document)
+
+        if 'intrastat_code_id' in self.env['product.product']._fields:
+            nsmap = expected_tree.nsmap
+            nsmap['etr'] = nsmap[None]
+            nsmap.pop(None)
+            for tag in expected_tree.xpath('//*/etr:bunuriTransportate', namespaces=nsmap):
+                tag.attrib['codTarifar'] = self.default_intrastat_code.code
+
+        self.assertXmlTreeEqual(
+            self.get_xml_tree_from_string(document.attachment_id.raw),
+            expected_tree,
+        )
+
+    def test_send_and_amend_etransport(self, make_request):
+        self._assert_picking_state(self.delivery_picking, enabled_fields=['enable'])
+
+        with self.assertRaises(UserError, msg=f'The picking {self.delivery_picking.name} is missing a delivery carrier.'):
+            self.delivery_picking.button_validate()
+
+        self.delivery_picking.carrier_id = self.carrier
+        with self.assertRaises(UserError, msg=f'The delivery carrier of {self.delivery_picking.name} is missing the partner field value.'):
+            self.delivery_picking.button_validate()
+
+        self.delivery_picking.carrier_id.l10n_ro_edi_stock_partner_id = self.shipping_partner
+        self.delivery_picking.button_validate()
+        self._assert_picking_state(self.delivery_picking, enabled_fields=['enable', 'enable_send'])
+
+        # Add eTransport data
+        self.delivery_picking.write({
+            'l10n_ro_edi_stock_operation_type': '30',
+            'l10n_ro_edi_stock_operation_scope': '705',
+            'l10n_ro_edi_stock_vehicle_number': 'BN18CTL',
+        })
+
+        # Sending to ANAF failed
+        make_request.return_value = {'error': 'some error happened'}
+        self.delivery_picking.action_l10n_ro_edi_stock_send_etransport()
+        self._assert_picking_state(self.delivery_picking, 'stock_sending_failed', 1, ('enable', 'enable_send'))
+        self.assertTrue(self.delivery_picking.l10n_ro_edi_stock_document_ids.message == 'some error happened')
+
+        # Successfully sent to ANAF
+        make_request.return_value = self.successful_upload_response
+        self.delivery_picking.action_l10n_ro_edi_stock_send_etransport()
+        self._assert_picking_state(self.delivery_picking, 'stock_sent', 1, ('enable', 'enable_fetch', 'fields_readonly'))
+        self._assert_etransport_document(self.delivery_picking.l10n_ro_edi_stock_document_ids, 'test_send_and_amend_etransport_1')
+
+        # ANAF is still validating the document
+        make_request.return_value = {
+            'content': {
+                "stare": "in prelucrare",
+                "dateResponse": "202208021100",
+                "ExecutionStatus": 0,
+                "trace_id": "096c6b71-b7b8-42b1-b3f1-b4f5dafdce74",
+            }
+        }
+        self.delivery_picking.action_l10n_ro_edi_stock_fetch_status()
+        self._assert_picking_state(self.delivery_picking, 'stock_sent', 1, ('enable', 'enable_fetch', 'fields_readonly'))
+
+        # Document has been successfully validated
+        make_request.return_value = {
+            'content': {
+                "stare": "ok",
+                "dateResponse": "202208021047",
+                "ExecutionStatus": 0,
+                "trace_id": "366efb31-57a0-42c2-9404-72bfcbba4693",
+            }
+        }
+        self.delivery_picking.action_l10n_ro_edi_stock_fetch_status()
+        self._assert_picking_state(self.delivery_picking, 'stock_validated', 1, ('enable', 'enable_amend'))
+
+        # Add some changes to the etransport data
+        self.delivery_picking.write({
+            'l10n_ro_edi_stock_remarks': 'some remarks',
+            'l10n_ro_edi_stock_vehicle_number': 'BM19CTK',
+        })
+
+        # Send amended changes to ANAF
+        make_request.return_value = self.successful_upload_response
+        with patch.object(self.env, 'context', dict(self.env.context) | {'l10n_ro_edi_stock_send_type': 'amend'}):
+            self.delivery_picking.action_l10n_ro_edi_stock_send_etransport()
+
+        self._assert_picking_state(self.delivery_picking, 'stock_sent', 2, ('enable', 'enable_fetch', 'fields_readonly'))
+        self._assert_etransport_document(self.delivery_picking._l10n_ro_edi_stock_get_last_document('stock_sent'), 'test_send_and_amend_etransport_2')
+
+        # Amended document has been successfully validated
+        make_request.return_value = {
+            'content': {
+                "stare": "ok",
+                "dateResponse": "202208021047",
+                "ExecutionStatus": 0,
+                "trace_id": "366efb31-57a0-42c2-9404-72bfcbba4693",
+            }
+        }
+        self.delivery_picking.action_l10n_ro_edi_stock_fetch_status()
+        self._assert_picking_state(self.delivery_picking, 'stock_validated', 2, ('enable', 'enable_amend'))
+        self._assert_etransport_document(self.delivery_picking._l10n_ro_edi_stock_get_last_document('stock_validated'), 'test_send_and_amend_etransport_2')
+
+    def test_intra_community_purchase(self, make_request):
+        self.receipt_picking.carrier_id = self.carrier
+        self.receipt_picking.carrier_id.l10n_ro_edi_stock_partner_id = self.shipping_partner
+        self.receipt_picking.button_validate()
+
+        # Add eTransport data
+        self.receipt_picking.write({
+            'l10n_ro_edi_stock_operation_type': '10',
+            'l10n_ro_edi_stock_operation_scope': '201',
+            'l10n_ro_edi_stock_vehicle_number': 'BN18CTL',
+            'l10n_ro_edi_stock_trailer_1_number': 'B865MHO',
+            'l10n_ro_edi_stock_start_loc_type': 'bcp',  # Select border crossing point as start location type
+            'l10n_ro_edi_stock_start_bcp': '3',
+        })
+
+        # Successfully sent to ANAF
+        make_request.return_value = self.successful_upload_response
+        self.receipt_picking.action_l10n_ro_edi_stock_send_etransport()
+        self._assert_picking_state(self.receipt_picking, 'stock_sent', 1, ('enable', 'enable_fetch', 'fields_readonly'))
+        self._assert_etransport_document(self.receipt_picking.l10n_ro_edi_stock_document_ids, 'test_intra_community_purchase_1')
+
+    def test_export(self, make_request):
+        self.delivery_picking.carrier_id = self.carrier
+        self.delivery_picking.carrier_id.l10n_ro_edi_stock_partner_id = self.shipping_partner
+        self.delivery_picking.button_validate()
+
+        self.delivery_picking.write({
+            'l10n_ro_edi_stock_operation_type': '50',
+            'l10n_ro_edi_stock_operation_scope': '9999',
+            'l10n_ro_edi_stock_vehicle_number': 'BN18CTL',
+            'l10n_ro_edi_stock_trailer_1_number': 'B865MHO',
+            'l10n_ro_edi_stock_trailer_2_number': 'AB12AAA',
+            'l10n_ro_edi_stock_end_loc_type': 'customs',  # Select customs office as end location type
+            'l10n_ro_edi_stock_end_customs_office': '112901',
+        })
+
+        # Successfully sent to ANAF
+        make_request.return_value = self.successful_upload_response
+        self.delivery_picking.action_l10n_ro_edi_stock_send_etransport()
+        self._assert_picking_state(self.delivery_picking, 'stock_sent', 1, ('enable', 'enable_fetch', 'fields_readonly'))
+        self._assert_etransport_document(self.delivery_picking.l10n_ro_edi_stock_document_ids, 'test_export_1')

--- a/addons/l10n_ro_edi_stock/tests/test_files/test_export_1.xml
+++ b/addons/l10n_ro_edi_stock/tests/test_files/test_export_1.xml
@@ -1,0 +1,12 @@
+<eTransport xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="mfp:anaf:dgti:eTransport:declaratie:v2" xsi:schemaLocation="mfp:anaf:dgti:eTransport:declaratie:v2" codDeclarant="9000123456789" refDeclarant="company_1_data picking">
+	<notificare codTipOperatiune="50">
+		<bunuriTransportate codScopOperatiune="9999" codTarifar="00000000" denumireMarfa="product_a" cantitate="10.0" codUnitateMasura="C62" greutateNeta="10.0" greutateBruta="10.0" valoareLeiFaraTva="1000.0"/>
+		<partenerComercial codTara="RO" denumire="RO Customer" cod="1234567897"/>
+		<dateTransport nrVehicul="BN18CTL" nrRemorca1="B865MHO" nrRemorca2="AB12AAA" codTaraOrgTransport="RO" codOrgTransport="8001011234567" denumireOrgTransport="RO Shipping Partner" dataTransport="2025-01-14"/>
+		<locStartTraseuRutier>
+			<locatie codJudet="7" denumireLocalitate="Botosani" denumireStrada="Calea Nationala 85" codPostal="710052"/>
+		</locStartTraseuRutier>
+		<locFinalTraseuRutier codBirouVamal="112901"/>
+		<documenteTransport tipDocument="30" dataDocument="2025-01-14" numarDocument="company_1_data picking"/>
+	</notificare>
+</eTransport>

--- a/addons/l10n_ro_edi_stock/tests/test_files/test_intra_community_purchase_1.xml
+++ b/addons/l10n_ro_edi_stock/tests/test_files/test_intra_community_purchase_1.xml
@@ -1,0 +1,12 @@
+<eTransport xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="mfp:anaf:dgti:eTransport:declaratie:v2" xsi:schemaLocation="mfp:anaf:dgti:eTransport:declaratie:v2" codDeclarant="9000123456789" refDeclarant="receipt_picking">
+	<notificare codTipOperatiune="10">
+		<bunuriTransportate codScopOperatiune="201" codTarifar="00000000" denumireMarfa="product_a" cantitate="10.0" codUnitateMasura="C62" greutateNeta="10.0" greutateBruta="10.0" valoareLeiFaraTva="1000.0"/>
+		<partenerComercial codTara="RO" denumire="RO Customer" cod="1234567897"/>
+		<dateTransport nrVehicul="BN18CTL" nrRemorca1="B865MHO" codTaraOrgTransport="RO" codOrgTransport="8001011234567" denumireOrgTransport="RO Shipping Partner" dataTransport="2025-01-14"/>
+		<locStartTraseuRutier codPtf="3"/>
+		<locFinalTraseuRutier>
+			<locatie codJudet="7" denumireLocalitate="Botosani" denumireStrada="Calea Nationala 85" codPostal="710052"/>
+		</locFinalTraseuRutier>
+		<documenteTransport tipDocument="30" dataDocument="2025-01-14" numarDocument="receipt_picking"/>
+	</notificare>
+</eTransport>

--- a/addons/l10n_ro_edi_stock/tests/test_files/test_send_and_amend_etransport_1.xml
+++ b/addons/l10n_ro_edi_stock/tests/test_files/test_send_and_amend_etransport_1.xml
@@ -1,0 +1,14 @@
+<eTransport xmlns="mfp:anaf:dgti:eTransport:declaratie:v2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="mfp:anaf:dgti:eTransport:declaratie:v2" codDeclarant="9000123456789" refDeclarant="company_1_data picking">
+	<notificare codTipOperatiune="30">
+		<bunuriTransportate codScopOperatiune="705" codTarifar="00000000" denumireMarfa="product_a" cantitate="10.0" codUnitateMasura="C62" greutateNeta="10.0" greutateBruta="10.0" valoareLeiFaraTva="1000.0"/>
+		<partenerComercial codTara="RO" denumire="RO Customer" cod="1234567897"/>
+		<dateTransport nrVehicul="BN18CTL" codTaraOrgTransport="RO" codOrgTransport="8001011234567" denumireOrgTransport="RO Shipping Partner" dataTransport="2025-01-14"/>
+		<locStartTraseuRutier>
+			<locatie codJudet="7" denumireLocalitate="Botosani" denumireStrada="Calea Nationala 85" codPostal="710052"/>
+		</locStartTraseuRutier>
+		<locFinalTraseuRutier>
+			<locatie codJudet="8" denumireLocalitate="Bran" denumireStrada="Strada General Traian Moșoiu 24" codPostal="507025"/>
+		</locFinalTraseuRutier>
+		<documenteTransport tipDocument="30" dataDocument="2025-01-14" numarDocument="company_1_data picking"/>
+	</notificare>
+</eTransport>

--- a/addons/l10n_ro_edi_stock/tests/test_files/test_send_and_amend_etransport_2.xml
+++ b/addons/l10n_ro_edi_stock/tests/test_files/test_send_and_amend_etransport_2.xml
@@ -1,0 +1,14 @@
+<eTransport xmlns="mfp:anaf:dgti:eTransport:declaratie:v2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="mfp:anaf:dgti:eTransport:declaratie:v2" codDeclarant="9000123456789" refDeclarant="company_1_data picking">
+	<notificare codTipOperatiune="30">
+		<bunuriTransportate codScopOperatiune="705" codTarifar="00000000" denumireMarfa="product_a" cantitate="10.0" codUnitateMasura="C62" greutateNeta="10.0" greutateBruta="10.0" valoareLeiFaraTva="1000.0"/>
+		<partenerComercial codTara="RO" denumire="RO Customer" cod="1234567897"/>
+		<dateTransport nrVehicul="BM19CTK" codTaraOrgTransport="RO" codOrgTransport="8001011234567" denumireOrgTransport="RO Shipping Partner" dataTransport="2025-01-14"/>
+		<locStartTraseuRutier>
+			<locatie codJudet="7" denumireLocalitate="Botosani" denumireStrada="Calea Nationala 85" codPostal="710052"/>
+		</locStartTraseuRutier>
+		<locFinalTraseuRutier>
+			<locatie codJudet="8" denumireLocalitate="Bran" denumireStrada="Strada General Traian Moșoiu 24" codPostal="507025"/>
+		</locFinalTraseuRutier>
+		<documenteTransport tipDocument="30" dataDocument="2025-01-14" numarDocument="company_1_data picking" observatii="some remarks"/>
+	</notificare>
+</eTransport>

--- a/addons/l10n_ro_edi_stock/views/delivery_carrier_views.xml
+++ b/addons/l10n_ro_edi_stock/views/delivery_carrier_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="l10n_ro_edi_stock_view_delivery_carrier_form" model="ir.ui.view">
+        <field name="name">delivery.carrier.form.inherit.l10n_ro.edi.stock</field>
+        <field name="model">delivery.carrier</field>
+        <field name="inherit_id" ref="delivery.view_delivery_carrier_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='integration_level']" position="after">
+                <field name="l10n_ro_edi_stock_partner_id"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/addons/l10n_ro_edi_stock/views/res_config_settings_views.xml
+++ b/addons/l10n_ro_edi_stock/views/res_config_settings_views.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="res_config_settings_form_inherit_l10n_ro_edi" model="ir.ui.view">
+        <field name="name">res.config.settings.form.inherit.l10n.ro.edi</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="account.res_config_settings_view_form"/>
+        <field name="arch" type="xml">
+            <!-- Match the appropriate <li> by using contains() instead of matching the whole text() because we can't properly escape the double quotes in the text -->
+            <xpath expr="//block[@id='l10n_ro_edi_settings']//li[contains(text(), 'Serviciu') and contains(text(), 'select the option')]" position="replace">
+                <li>In "Serviciu", select the options "E-Factura" and "E-Transport"</li>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/addons/l10n_ro_edi_stock/views/stock_picking_views.xml
+++ b/addons/l10n_ro_edi_stock/views/stock_picking_views.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="l10n_ro_edi_stock_view_picking_form" model="ir.ui.view">
+        <field name="name">stock.picking.form.inherit.l10n_ro_edi_stock</field>
+        <field name="model">stock.picking</field>
+        <field name="inherit_id" ref="stock.view_picking_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//button[@name='%(stock.act_stock_return_picking)d']" position="after">
+                <field name="l10n_ro_edi_stock_enable_send" invisible="1"/>
+                <field name="l10n_ro_edi_stock_enable_fetch" invisible="1"/>
+                <field name="l10n_ro_edi_stock_enable_amend" invisible="1"/>
+
+                <button name="action_l10n_ro_edi_stock_send_etransport"
+                        string="Send eTransport"
+                        type="object"
+                        context="{'l10n_ro_edi_stock_send_type': 'send'}"
+                        invisible="not l10n_ro_edi_stock_enable_send"/>
+                <button name="action_l10n_ro_edi_stock_send_etransport"
+                        string="Amend eTransport"
+                        type="object"
+                        context="{'l10n_ro_edi_stock_send_type': 'amend'}"
+                        invisible="not l10n_ro_edi_stock_enable_amend"/>
+                <button name="action_l10n_ro_edi_stock_fetch_status" string="Fetch Status" type="object" invisible="not l10n_ro_edi_stock_enable_fetch"/>
+            </xpath>
+
+            <xpath expr="//field[@name='owner_id']" position="after">
+                <field name="l10n_ro_edi_stock_state" invisible="1"/>
+
+                <field name="l10n_ro_edi_stock_state"
+                       invisible="not l10n_ro_edi_stock_enable or state != 'done' or not l10n_ro_edi_stock_state"
+                       readonly="1"/>
+            </xpath>
+
+            <xpath expr="//page[@name='note']" position="after">
+                <field name="l10n_ro_edi_stock_enable" invisible="1"/>
+
+                <page name="etransport" string="eTransport" invisible="not l10n_ro_edi_stock_enable">
+                    <field name="l10n_ro_edi_stock_available_operation_scopes" invisible="1"/>
+                    <field name="l10n_ro_edi_stock_state" invisible="1"/>
+                    <field name="l10n_ro_edi_stock_fields_readonly" invisible="1"/>
+
+                    <group>
+                        <group string="General">
+                            <field name="l10n_ro_edi_stock_operation_type" readonly="l10n_ro_edi_stock_fields_readonly"/>
+                            <field name="l10n_ro_edi_stock_operation_scope"
+                                   widget="dynamic_selection"
+                                   options="{'available_field': 'l10n_ro_edi_stock_available_operation_scopes'}"
+                                   readonly="l10n_ro_edi_stock_fields_readonly"/>
+                            <field name="l10n_ro_edi_stock_remarks" readonly="l10n_ro_edi_stock_fields_readonly"/>
+                        </group>
+
+                        <group string="Transport">
+                            <field name="l10n_ro_edi_stock_vehicle_number" readonly="l10n_ro_edi_stock_fields_readonly"/>
+                            <field name="l10n_ro_edi_stock_trailer_1_number" readonly="l10n_ro_edi_stock_fields_readonly"/>
+                            <field name="l10n_ro_edi_stock_trailer_2_number" readonly="l10n_ro_edi_stock_fields_readonly"/>
+                        </group>
+
+                        <group string="Start Location">
+                            <field name="l10n_ro_edi_stock_available_start_loc_types" invisible="1"/>
+                            <field name="l10n_ro_edi_stock_start_loc_type"
+                                   widget="dynamic_selection"
+                                   options="{'available_field': 'l10n_ro_edi_stock_available_start_loc_types'}"
+                                   readonly="l10n_ro_edi_stock_fields_readonly"/>
+
+                            <field name="l10n_ro_edi_stock_start_bcp" readonly="l10n_ro_edi_stock_fields_readonly" invisible="l10n_ro_edi_stock_start_loc_type != 'bcp'" />
+                            <field name="l10n_ro_edi_stock_start_customs_office" readonly="l10n_ro_edi_stock_fields_readonly" invisible="l10n_ro_edi_stock_start_loc_type != 'customs'"/>
+                        </group>
+
+                        <group string="End Location">
+                            <field name="l10n_ro_edi_stock_available_end_loc_types" invisible="1"/>
+                            <field name="l10n_ro_edi_stock_end_loc_type"
+                                   widget="dynamic_selection"
+                                   options="{'available_field': 'l10n_ro_edi_stock_available_end_loc_types'}"
+                                   readonly="l10n_ro_edi_stock_fields_readonly"/>
+
+                            <field name="l10n_ro_edi_stock_end_bcp" readonly="l10n_ro_edi_stock_fields_readonly" invisible="l10n_ro_edi_stock_end_loc_type != 'bcp'"/>
+                            <field name="l10n_ro_edi_stock_end_customs_office" readonly="l10n_ro_edi_stock_fields_readonly" invisible="l10n_ro_edi_stock_end_loc_type != 'customs'"/>
+                        </group>
+                    </group>
+                </page>
+
+                <page id="l10n_ro_edi_stock_documents"
+                      name="etransport_documents"
+                      string="eTransport Documents"
+                      invisible="not (l10n_ro_edi_stock_enable and l10n_ro_edi_stock_document_ids)">
+                    <field name="l10n_ro_edi_stock_document_ids">
+                        <tree create="false" delete="false" edit="false" no_open="1"
+                              decoration-danger="state == 'stock_sending_failed'"
+                              decoration-warning="state == 'stock_sent'"
+                              decoration-success="state == 'stock_validated'">
+                            <field name="message" column_invisible="1"/>
+                            <field name="attachment_id" column_invisible="1"/>
+                            <field name="datetime"/>
+                            <field name="state" string="Status" widget="l10n_ro_edi_stock_document_state"/>
+                            <field name="l10n_ro_edi_stock_uit" string="UIT"/>
+                            <field name="l10n_ro_edi_stock_load_id" string="Load Id"/>
+                        </tree>
+                    </field>
+                </page>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="l10n_ro_edi_stock_stock_picking_view_tree" model="ir.ui.view">
+        <field name="model">stock.picking</field>
+        <field name="inherit_id" ref="stock.vpicktree"/>
+        <field name="arch" type="xml">
+            <xpath expr="//header/button[@name='action_assign']" position="after">
+                <button name="action_l10n_ro_edi_stock_fetch_status" string="Fetch Status" type="object"/>
+            </xpath>
+            <field name="state" position="before">
+                <field name="l10n_ro_edi_stock_state" optional="hide"/>
+            </field>
+        </field>
+    </record>
+
+    <record id="l10n_ro_edi_stock_stock_picking_filter" model="ir.ui.view">
+        <field name="model">stock.picking</field>
+        <field name="inherit_id" ref="stock.view_picking_internal_search"/>
+        <field name="arch" type="xml">
+            <field name="lot_id" position="after">
+                <field name="l10n_ro_edi_stock_state"/>
+            </field>
+
+            <filter name="available" position="after">
+                <filter string="eTransport Error" name="l10n_ro_edi_stock_state_stock_sending_failed"
+                        domain="[('l10n_ro_edi_stock_state', '=', 'stock_sending_failed')]"/>
+                <filter string="eTransport Sent" name="l10n_ro_edi_stock_state_stock_sent"
+                        domain="[('l10n_ro_edi_stock_state', '=', 'stock_sent')]"/>
+                <filter string="eTransport Validated" name="l10n_ro_edi_stock_state_stock_validated"
+                        domain="[('l10n_ro_edi_stock_state', '=', 'stock_validated')]"/>
+            </filter>
+
+            <xpath expr="//group/filter[@name='status']" position="after">
+                <filter string="eTransport Status"
+                        name="l10n_ro_edi_stock_state_group"
+                        domain=""
+                        context="{'group_by': 'l10n_ro_edi_stock_state'}"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/addons/l10n_ro_edi_stock_batch/__init__.py
+++ b/addons/l10n_ro_edi_stock_batch/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/addons/l10n_ro_edi_stock_batch/__manifest__.py
+++ b/addons/l10n_ro_edi_stock_batch/__manifest__.py
@@ -1,0 +1,17 @@
+{
+    'name': 'Romania - E-Transport Batch Pickings',
+    'version': '1.0',
+    'category': 'Accounting/Localizations/EDI',
+    'description': """
+E-Transport implementation for Batch Pickings in Romania
+    """,
+    'depends': ['l10n_ro_edi_stock', 'stock_picking_batch'],
+    'auto_install': True,
+    'data': [
+        'views/stock_picking_batch_views.xml',
+
+        'report/report_picking_batch.xml',
+    ],
+    'installable': True,
+    'license': "LGPL-3",
+}

--- a/addons/l10n_ro_edi_stock_batch/i18n/l10n_ro_edi_stock_batch.pot
+++ b/addons/l10n_ro_edi_stock_batch/i18n/l10n_ro_edi_stock_batch.pot
@@ -1,0 +1,1235 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_ro_edi_stock_batch
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 17.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-01-09 15:12+0000\n"
+"PO-Revision-Date: 2025-01-09 15:12+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_ro_edi_stock_batch
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock_batch.l10n_ro_edi_stock_report_picking_batch
+msgid "3U3H3P4C2U5Y8N20"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock_batch.l10n_ro_edi_stock_report_picking_batch
+msgid "<strong>eTransport UIT:</strong>"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__32
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__32
+msgid "Albița(MD)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock_batch/models/stock_picking_batch.py:0
+#, python-format
+msgid "All Pickings in a Batch Transfer should have the same Carrier"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock_batch/models/stock_picking_batch.py:0
+#, python-format
+msgid ""
+"All Pickings in a Batch Transfer should have the same Commercial Partner"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock_batch.l10n_ro_edi_stock_view_batch_form
+msgid "Amend eTransport"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__242901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__242901
+msgid "BVF Aero Baia Mare (ROCJ0510)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__362902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__362902
+msgid "BVF Aeroport Delta Dunării Tulcea (ROGL8910)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__302902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__302902
+msgid "BVF Aeroport Satu Mare (ROCJ7830)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__372902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__372902
+msgid "BVF Albiţa (ROIS0100)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__22901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__22901
+msgid "BVF Arad Aeroport (ROTM0230)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__42901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__42901
+msgid "BVF Bacău Aeroport (ROIS0620)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__162902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__162902
+msgid "BVF Bechet (ROCR1720)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__92902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__92902
+msgid "BVF Brăila (ROGL0700)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__402901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__402901
+msgid "BVF Băneasa (ROBU1040)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__162903
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__162903
+msgid "BVF Calafat (ROCR1700)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__122901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__122901
+msgid "BVF Cluj Napoca Aero (ROCJ1810)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__132904
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__132904
+msgid "BVF Constanţa Port (ROCT1970)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__132901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__132901
+msgid "BVF Constanţa Sud Agigea (ROCT1900)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__162901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__162901
+msgid "BVF Craiova Aeroport (ROCR2110)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__332901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__332901
+msgid "BVF Dorneşti (ROIS2700)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__252904
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__252904
+msgid "BVF Drobeta Turnu Severin (ROCR9000)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__372901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__372901
+msgid "BVF Fălciu (-)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__172904
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__172904
+msgid "BVF Galaţi (ROGL3800)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__172902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__172902
+msgid "BVF Giurgiuleşti (ROGL3850)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__302901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__302901
+msgid "BVF Halmeu (ROCJ4310)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__222903
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__222903
+msgid "BVF Iaşi (ROIS4650)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__222901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__222901
+msgid "BVF Iaşi Aero (ROIS4660)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__362904
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__362904
+msgid "BVF Isaccea (ROGL8920)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__352901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__352901
+msgid "BVF Jimbolia (ROTM5010)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__132903
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__132903
+msgid "BVF Mangalia (ROCT5400)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__132902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__132902
+msgid "BVF Mihail Kogălniceanu (ROCT5100)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__352902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__352902
+msgid "BVF Moraviţa (ROTM5510)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__112901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__112901
+msgid "BVF Naidăș (ROTM6100)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__172903
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__172903
+msgid "BVF Oancea (ROGL3610)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__52901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__52901
+msgid "BVF Oradea Aeroport (ROCJ6580)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__252901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__252901
+msgid "BVF Orşova (ROCR7280)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__232901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__232901
+msgid "BVF Otopeni Călători (ROBU1030)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__252902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__252902
+msgid "BVF Porţile De Fier I (ROCR7270)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__252903
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__252903
+msgid "BVF Porţile De Fier II (ROCR7200)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__72902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__72902
+msgid "BVF Rădăuţi Prut (ROIS1620)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__222902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__222902
+msgid "BVF Sculeni (ROIS4990)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__322901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__322901
+msgid "BVF Sibiu Aeroport (ROBV7910)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__242902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__242902
+msgid "BVF Sighet (ROCJ8000)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__332902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__332902
+msgid "BVF Siret (ROIS8200)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__72901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__72901
+msgid "BVF Stanca Costeşti (ROIS1610)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__332903
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__332903
+msgid "BVF Suceava Aero (ROIS8250)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__362901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__362901
+msgid "BVF Sulina (ROCT8300)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__352903
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__352903
+msgid "BVF Timişoara Aeroport (ROTM8730)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__362903
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__362903
+msgid "BVF Tulcea (ROGL8900)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__342901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__342901
+msgid "BVF Turnu Măgurele (ROCR9100)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__262901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__262901
+msgid "BVF Târgu Mureş Aeroport (ROBV8820)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__332904
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__332904
+msgid "BVF Vicovu De Sus (ROIS9620)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__342902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__342902
+msgid "BVF Zimnicea (ROCR5800)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__92901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__92901
+msgid "BVF Zona Liberă Brăila (ROGL0710)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__22902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__22902
+msgid "BVF Zona Liberă Curtici (ROTM2300)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__172901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__172901
+msgid "BVF Zona Liberă Galaţi (ROGL3810)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__522901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__522901
+msgid "BVF Zona Liberă Giurgiu (ROBU3980)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__12801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__12801
+msgid "BVI Alba Iulia (ROBV0300)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__342801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__342801
+msgid "BVI Alexandria (ROCR0310)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__232801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__232801
+msgid "BVI Antrepozite/Ilfov (ROBU1200)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__22801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__22801
+msgid "BVI Arad (ROTM0200)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__42801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__42801
+msgid "BVI Bacău (ROIS0600)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__242801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__242801
+msgid "BVI Baia Mare (ROCJ0500)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__62801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__62801
+msgid "BVI Bistriţa-Năsăud (ROCJ0400)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__72801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__72801
+msgid "BVI Botoşani (ROIS1600)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__82801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__82801
+msgid "BVI Braşov (ROBV0900)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__402801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__402801
+msgid "BVI Bucureşti Poştă (ROBU1380)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__102801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__102801
+msgid "BVI Buzău (ROGL1500)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__122801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__122801
+msgid "BVI Cluj Napoca (ROCJ1800)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__282801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__282801
+msgid "BVI Corabia (ROCR2000)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__162801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__162801
+msgid "BVI Craiova (ROCR2100)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__512801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__512801
+msgid "BVI Călăraşi (ROCT1710)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__202801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__202801
+msgid "BVI Deva (ROTM8100)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__392801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__392801
+msgid "BVI Focșani (ROGL3600)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__522801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__522801
+msgid "BVI Giurgiu (ROBU3910)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__192801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__192801
+msgid "BVI Miercurea Ciuc (ROBV5600)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__282802
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__282802
+msgid "BVI Olt (ROCR8210)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__52801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__52801
+msgid "BVI Oradea (ROCJ6570)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__272801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__272801
+msgid "BVI Piatra Neamţ (ROIS7400)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__32801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__32801
+msgid "BVI Pitești (ROCR7000)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__292801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__292801
+msgid "BVI Ploiești (ROBU7100)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__112801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__112801
+msgid "BVI Reșița (ROTM7600)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__382801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__382801
+msgid "BVI Râmnicu Vâlcea (ROCR7700)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__302801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__302801
+msgid "BVI Satu-Mare (ROCJ7810)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__142801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__142801
+msgid "BVI Sfântu Gheorghe (ROBV7820)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__322801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__322801
+msgid "BVI Sibiu (ROBV7900)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__212801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__212801
+msgid "BVI Slobozia (ROCT8220)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__332801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__332801
+msgid "BVI Suceava (ROIS8230)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__352802
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__352802
+msgid "BVI Timişoara Bază (ROTM8720)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__152801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__152801
+msgid "BVI Târgoviște (ROBU8600)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__182801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__182801
+msgid "BVI Târgu Jiu (ROCR8810)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__262801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__262801
+msgid "BVI Târgu Mureş (ROBV8800)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__402802
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__402802
+msgid "BVI Târguri și Expoziții (ROBU1400)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__372801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__372801
+msgid "BVI Vaslui (ROIS9610)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__312801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__312801
+msgid "BVI Zalău (ROCJ9700)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock_batch.field_l10n_ro_edi_document__batch_id
+msgid "Batch"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model,name:l10n_ro_edi_stock_batch.model_stock_picking_batch
+msgid "Batch Transfer"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__6
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__6
+msgid "Bechet(BG)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_loc_type__bcp
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_loc_type__bcp
+msgid "Border Crossing Point"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__38
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__38
+msgid "Borș 2 - A3 (HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__2
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__2
+msgid "Borș(HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__5
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__5
+msgid "Calafat (BG)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__16
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__16
+msgid "Carei  (HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__17
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__17
+msgid "Cenad (HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_operation_scope__401
+msgid "Commercial equipment"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__35
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__35
+msgid "Constanța Sud Agigea"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__14
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__14
+msgid "Corabia(BG)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_loc_type__customs
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_loc_type__customs
+msgid "Customs Office"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__13
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__13
+msgid "Călărași(BG)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_operation_scope__703
+msgid "Delivery operations with installation"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model,name:l10n_ro_edi_stock_batch.model_l10n_ro_edi_document
+msgid "Document object for tracking CIUS-RO XML sent to E-Factura"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_operation_scope__1101
+msgid "Donations, help"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock_batch.field_stock_picking_batch__l10n_ro_edi_stock_end_bcp
+msgid "End Border Crossing Point"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock_batch.field_stock_picking_batch__l10n_ro_edi_stock_end_customs_office
+msgid "End Customs Office"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock_batch.l10n_ro_edi_stock_view_batch_form
+msgid "End Location"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock_batch.field_stock_picking_batch__l10n_ro_edi_stock_end_loc_type
+msgid "End Location Type"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__18
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__18
+msgid "Episcopia Bihor (HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_state__stock_sending_failed
+msgid "Error"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_operation_scope__901
+msgid "Exempt operations"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_operation_type__50
+msgid "Export"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock_batch.l10n_ro_edi_stock_stock_picking_batch_view_tree
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock_batch.l10n_ro_edi_stock_view_batch_form
+msgid "Fetch Status"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_operation_scope__801
+msgid "Financial/operational leasing"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_operation_scope__501
+msgid "Fixed assets"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__34
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__34
+msgid "Galați Giurgiulești(MD)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock_batch.l10n_ro_edi_stock_view_batch_form
+msgid "General"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__9
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__9
+msgid "Giurgiu(BG)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_operation_scope__705
+msgid "Goods made available to the customer"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_operation_scope__802
+msgid "Goods under warranty"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_operation_scope__301
+msgid "Gratuities"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__29
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__29
+msgid "Halmeu (UA)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_operation_type__40
+msgid "Import"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_operation_type__20
+msgid "Intra-Community delivery"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_operation_type__10
+msgid "Intra-community purchase"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_operation_type__60
+msgid ""
+"Intra-community transaction - Entry for storage/formation of new transport"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_operation_type__70
+msgid ""
+"Intra-community transaction - Exit after storage/formation of new transport"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_operation_scope__1001
+msgid "Investment in progress"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__28
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__28
+msgid "Jimbolia(RS)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock_batch.field_stock_picking_batch__l10n_ro_edi_stock_available_end_loc_types
+msgid "L10N Ro Edi Stock Available End Loc Types"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock_batch.field_stock_picking_batch__l10n_ro_edi_stock_available_operation_scopes
+msgid "L10N Ro Edi Stock Available Operation Scopes"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock_batch.field_stock_picking_batch__l10n_ro_edi_stock_available_start_loc_types
+msgid "L10N Ro Edi Stock Available Start Loc Types"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock_batch.field_stock_picking_batch__l10n_ro_edi_stock_document_ids
+msgid "L10N Ro Edi Stock Document"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock_batch.field_stock_picking_batch__l10n_ro_edi_stock_enable
+msgid "L10N Ro Edi Stock Enable"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock_batch.field_stock_picking_batch__l10n_ro_edi_stock_enable_amend
+msgid "L10N Ro Edi Stock Enable Amend"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock_batch.field_stock_picking_batch__l10n_ro_edi_stock_enable_fetch
+msgid "L10N Ro Edi Stock Enable Fetch"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock_batch.field_stock_picking_batch__l10n_ro_edi_stock_enable_send
+msgid "L10N Ro Edi Stock Enable Send"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock_batch.field_stock_picking_batch__l10n_ro_edi_stock_fields_readonly
+msgid "L10N Ro Edi Stock Fields Readonly"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock_batch.l10n_ro_edi_stock_view_batch_form
+msgid "Load Id"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_loc_type__location
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_loc_type__location
+msgid "Location"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_operation_scope__101
+msgid "Marketing"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__26
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__26
+msgid "Naidăș(RS)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__11
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__11
+msgid "Negru Vodă(BG)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__37
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__37
+msgid "Nădlac 2 - A1 (HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__4
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__4
+msgid "Nădlac(HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__33
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__33
+msgid "Oancea(MD)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__15
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__15
+msgid "Oltenița(BG)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock_batch.field_stock_picking_batch__l10n_ro_edi_stock_operation_scope
+msgid "Operation Scope"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_operation_type__22
+msgid "Operations in lohn system (EU) - exit"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_operation_type__12
+msgid "Operations in lohn system (EU) - input"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__10
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__10
+msgid "Ostrov(BG)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_operation_scope__9901
+msgid "Other"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_operation_scope__201
+msgid "Output"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_operation_scope__601
+msgid "Own consumption"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__1
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__1
+msgid "Petea (HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__25
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__25
+msgid "Porțile de Fier 1 (RS)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock_batch.field_stock_picking_batch__l10n_ro_edi_stock_remarks
+msgid "Remarks"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock_batch/models/stock_picking_batch.py:0
+#, python-format
+msgid ""
+"Romanian access token not found. Please generate or fill it in the settings."
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__19
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__19
+msgid "Salonta (HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_operation_scope__9999
+msgid "Same with operation"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__31
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__31
+msgid "Sculeni(MD)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock_batch.l10n_ro_edi_stock_view_batch_form
+msgid "Send eTransport"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_state__stock_sent
+msgid "Sent"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__36
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__36
+msgid "Siret  (UA)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__27
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__27
+msgid "Stamora Moravița(RS)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock_batch.field_stock_picking_batch__l10n_ro_edi_stock_start_bcp
+msgid "Start Border Crossing Point"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock_batch.field_stock_picking_batch__l10n_ro_edi_stock_start_customs_office
+msgid "Start Customs Office"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock_batch.l10n_ro_edi_stock_view_batch_form
+msgid "Start Location"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock_batch.field_stock_picking_batch__l10n_ro_edi_stock_start_loc_type
+msgid "Start Location Type"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock_batch.l10n_ro_edi_stock_view_batch_form
+msgid "Status"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_operation_type__14
+msgid "Stocks available to the customer (Call-off stock) - entry"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_operation_type__24
+msgid "Stocks available to the customer (Call-off stock) - exit"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__30
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__30
+msgid "Stânca Costești (MD)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__20
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__20
+msgid "Săcuieni (HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock_batch/models/stock_picking_batch.py:0
+#, python-format
+msgid "This document has already been successfully sent to anaf."
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock_batch/models/stock_picking_batch.py:0
+#, python-format
+msgid "This document has not been corrected yet because it contains errors."
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock_batch/models/stock_picking_batch.py:0
+#, python-format
+msgid ""
+"This document has not been successfully sent yet because it contains errors."
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock_batch.field_stock_picking_batch__l10n_ro_edi_stock_trailer_1_number
+msgid "Trailer 1 Number"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock_batch.field_stock_picking_batch__l10n_ro_edi_stock_trailer_2_number
+msgid "Trailer 2 Number"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model,name:l10n_ro_edi_stock_batch.model_stock_picking
+msgid "Transfer"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_operation_scope__704
+msgid "Transfer between managements"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock_batch.l10n_ro_edi_stock_view_batch_form
+msgid "Transport"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_operation_type__30
+msgid "Transport on the national territory"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__21
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__21
+msgid "Turnu (HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__7
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__7
+msgid "Turnu Măgurele(BG)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock_batch.l10n_ro_edi_stock_view_batch_form
+msgid "UIT"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock_batch/models/stock_picking_batch.py:0
+#, python-format
+msgid "Unhandled eTransport document state: %(state)s"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__22
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__22
+msgid "Urziceni (HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__23
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__23
+msgid "Valea lui Mihai (HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_state__stock_validated
+msgid "Validated"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__12
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__12
+msgid "Vama Veche(BG)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock_batch.field_stock_picking_batch__l10n_ro_edi_stock_vehicle_number
+msgid "Vehicle Number"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__24
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__24
+msgid "Vladimirescu (HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__3
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__3
+msgid "Vărșand(HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock_batch/models/stock_picking_batch.py:0
+#, python-format
+msgid "XML contains errors."
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__8
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__8
+msgid "Zimnicea(BG)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock_batch.l10n_ro_edi_stock_view_batch_form
+msgid "eTransport"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock_batch.l10n_ro_edi_stock_view_batch_form
+msgid "eTransport Documents"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock_batch.l10n_ro_edi_stock_stock_picking_batch_filter
+msgid "eTransport Error"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock_batch.field_stock_picking_batch__l10n_ro_edi_stock_operation_type
+msgid "eTransport Operation Type"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock_batch.l10n_ro_edi_stock_stock_picking_batch_filter
+msgid "eTransport Sent"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock_batch.field_stock_picking_batch__l10n_ro_edi_stock_state
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock_batch.l10n_ro_edi_stock_stock_picking_batch_filter
+msgid "eTransport Status"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock_batch.field_stock_picking_batch__l10n_ro_edi_stock_document_uit
+msgid "eTransport UIT"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock_batch.l10n_ro_edi_stock_stock_picking_batch_filter
+msgid "eTransport Validated"
+msgstr ""

--- a/addons/l10n_ro_edi_stock_batch/i18n/ro.po
+++ b/addons/l10n_ro_edi_stock_batch/i18n/ro.po
@@ -1,0 +1,1243 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_ro_edi_stock_batch
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 17.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-01-09 15:13+0000\n"
+"PO-Revision-Date: 2025-01-09 15:13+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_ro_edi_stock_batch
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock_batch.l10n_ro_edi_stock_report_picking_batch
+msgid "3U3H3P4C2U5Y8N20"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock_batch.l10n_ro_edi_stock_report_picking_batch
+msgid "<strong>eTransport UIT:</strong>"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__32
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__32
+msgid "Albița(MD)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock_batch/models/stock_picking_batch.py:0
+#, python-format
+msgid "All Pickings in a Batch Transfer should have the same Carrier"
+msgstr ""
+"Toate alegerile dintr-un transfer de lot ar trebui să aibă același operator"
+
+#. module: l10n_ro_edi_stock_batch
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock_batch/models/stock_picking_batch.py:0
+#, python-format
+msgid ""
+"All Pickings in a Batch Transfer should have the same Commercial Partner"
+msgstr ""
+"Toate alegerile dintr-un transfer de lot ar trebui să aibă același partener "
+"comercial"
+
+#. module: l10n_ro_edi_stock_batch
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock_batch.l10n_ro_edi_stock_view_batch_form
+msgid "Amend eTransport"
+msgstr "Modificați eTransport"
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__242901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__242901
+msgid "BVF Aero Baia Mare (ROCJ0510)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__362902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__362902
+msgid "BVF Aeroport Delta Dunării Tulcea (ROGL8910)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__302902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__302902
+msgid "BVF Aeroport Satu Mare (ROCJ7830)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__372902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__372902
+msgid "BVF Albiţa (ROIS0100)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__22901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__22901
+msgid "BVF Arad Aeroport (ROTM0230)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__42901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__42901
+msgid "BVF Bacău Aeroport (ROIS0620)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__162902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__162902
+msgid "BVF Bechet (ROCR1720)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__92902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__92902
+msgid "BVF Brăila (ROGL0700)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__402901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__402901
+msgid "BVF Băneasa (ROBU1040)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__162903
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__162903
+msgid "BVF Calafat (ROCR1700)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__122901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__122901
+msgid "BVF Cluj Napoca Aero (ROCJ1810)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__132904
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__132904
+msgid "BVF Constanţa Port (ROCT1970)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__132901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__132901
+msgid "BVF Constanţa Sud Agigea (ROCT1900)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__162901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__162901
+msgid "BVF Craiova Aeroport (ROCR2110)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__332901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__332901
+msgid "BVF Dorneşti (ROIS2700)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__252904
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__252904
+msgid "BVF Drobeta Turnu Severin (ROCR9000)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__372901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__372901
+msgid "BVF Fălciu (-)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__172904
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__172904
+msgid "BVF Galaţi (ROGL3800)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__172902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__172902
+msgid "BVF Giurgiuleşti (ROGL3850)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__302901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__302901
+msgid "BVF Halmeu (ROCJ4310)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__222903
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__222903
+msgid "BVF Iaşi (ROIS4650)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__222901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__222901
+msgid "BVF Iaşi Aero (ROIS4660)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__362904
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__362904
+msgid "BVF Isaccea (ROGL8920)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__352901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__352901
+msgid "BVF Jimbolia (ROTM5010)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__132903
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__132903
+msgid "BVF Mangalia (ROCT5400)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__132902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__132902
+msgid "BVF Mihail Kogălniceanu (ROCT5100)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__352902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__352902
+msgid "BVF Moraviţa (ROTM5510)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__112901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__112901
+msgid "BVF Naidăș (ROTM6100)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__172903
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__172903
+msgid "BVF Oancea (ROGL3610)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__52901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__52901
+msgid "BVF Oradea Aeroport (ROCJ6580)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__252901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__252901
+msgid "BVF Orşova (ROCR7280)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__232901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__232901
+msgid "BVF Otopeni Călători (ROBU1030)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__252902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__252902
+msgid "BVF Porţile De Fier I (ROCR7270)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__252903
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__252903
+msgid "BVF Porţile De Fier II (ROCR7200)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__72902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__72902
+msgid "BVF Rădăuţi Prut (ROIS1620)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__222902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__222902
+msgid "BVF Sculeni (ROIS4990)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__322901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__322901
+msgid "BVF Sibiu Aeroport (ROBV7910)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__242902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__242902
+msgid "BVF Sighet (ROCJ8000)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__332902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__332902
+msgid "BVF Siret (ROIS8200)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__72901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__72901
+msgid "BVF Stanca Costeşti (ROIS1610)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__332903
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__332903
+msgid "BVF Suceava Aero (ROIS8250)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__362901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__362901
+msgid "BVF Sulina (ROCT8300)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__352903
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__352903
+msgid "BVF Timişoara Aeroport (ROTM8730)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__362903
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__362903
+msgid "BVF Tulcea (ROGL8900)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__342901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__342901
+msgid "BVF Turnu Măgurele (ROCR9100)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__262901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__262901
+msgid "BVF Târgu Mureş Aeroport (ROBV8820)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__332904
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__332904
+msgid "BVF Vicovu De Sus (ROIS9620)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__342902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__342902
+msgid "BVF Zimnicea (ROCR5800)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__92901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__92901
+msgid "BVF Zona Liberă Brăila (ROGL0710)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__22902
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__22902
+msgid "BVF Zona Liberă Curtici (ROTM2300)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__172901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__172901
+msgid "BVF Zona Liberă Galaţi (ROGL3810)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__522901
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__522901
+msgid "BVF Zona Liberă Giurgiu (ROBU3980)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__12801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__12801
+msgid "BVI Alba Iulia (ROBV0300)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__342801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__342801
+msgid "BVI Alexandria (ROCR0310)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__232801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__232801
+msgid "BVI Antrepozite/Ilfov (ROBU1200)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__22801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__22801
+msgid "BVI Arad (ROTM0200)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__42801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__42801
+msgid "BVI Bacău (ROIS0600)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__242801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__242801
+msgid "BVI Baia Mare (ROCJ0500)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__62801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__62801
+msgid "BVI Bistriţa-Năsăud (ROCJ0400)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__72801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__72801
+msgid "BVI Botoşani (ROIS1600)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__82801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__82801
+msgid "BVI Braşov (ROBV0900)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__402801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__402801
+msgid "BVI Bucureşti Poştă (ROBU1380)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__102801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__102801
+msgid "BVI Buzău (ROGL1500)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__122801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__122801
+msgid "BVI Cluj Napoca (ROCJ1800)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__282801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__282801
+msgid "BVI Corabia (ROCR2000)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__162801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__162801
+msgid "BVI Craiova (ROCR2100)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__512801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__512801
+msgid "BVI Călăraşi (ROCT1710)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__202801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__202801
+msgid "BVI Deva (ROTM8100)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__392801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__392801
+msgid "BVI Focșani (ROGL3600)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__522801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__522801
+msgid "BVI Giurgiu (ROBU3910)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__192801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__192801
+msgid "BVI Miercurea Ciuc (ROBV5600)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__282802
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__282802
+msgid "BVI Olt (ROCR8210)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__52801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__52801
+msgid "BVI Oradea (ROCJ6570)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__272801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__272801
+msgid "BVI Piatra Neamţ (ROIS7400)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__32801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__32801
+msgid "BVI Pitești (ROCR7000)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__292801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__292801
+msgid "BVI Ploiești (ROBU7100)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__112801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__112801
+msgid "BVI Reșița (ROTM7600)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__382801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__382801
+msgid "BVI Râmnicu Vâlcea (ROCR7700)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__302801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__302801
+msgid "BVI Satu-Mare (ROCJ7810)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__142801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__142801
+msgid "BVI Sfântu Gheorghe (ROBV7820)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__322801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__322801
+msgid "BVI Sibiu (ROBV7900)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__212801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__212801
+msgid "BVI Slobozia (ROCT8220)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__332801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__332801
+msgid "BVI Suceava (ROIS8230)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__352802
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__352802
+msgid "BVI Timişoara Bază (ROTM8720)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__152801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__152801
+msgid "BVI Târgoviște (ROBU8600)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__182801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__182801
+msgid "BVI Târgu Jiu (ROCR8810)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__262801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__262801
+msgid "BVI Târgu Mureş (ROBV8800)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__402802
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__402802
+msgid "BVI Târguri și Expoziții (ROBU1400)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__372801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__372801
+msgid "BVI Vaslui (ROIS9610)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_customs_office__312801
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_customs_office__312801
+msgid "BVI Zalău (ROCJ9700)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock_batch.field_l10n_ro_edi_document__batch_id
+msgid "Batch"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model,name:l10n_ro_edi_stock_batch.model_stock_picking_batch
+msgid "Batch Transfer"
+msgstr "Transfer în lot"
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__6
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__6
+msgid "Bechet(BG)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_loc_type__bcp
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_loc_type__bcp
+msgid "Border Crossing Point"
+msgstr "Punct de trecere a frontierei"
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__38
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__38
+msgid "Borș 2 - A3 (HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__2
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__2
+msgid "Borș(HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__5
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__5
+msgid "Calafat (BG)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__16
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__16
+msgid "Carei  (HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__17
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__17
+msgid "Cenad (HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_operation_scope__401
+msgid "Commercial equipment"
+msgstr "Echipamente comerciale"
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__35
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__35
+msgid "Constanța Sud Agigea"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__14
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__14
+msgid "Corabia(BG)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_loc_type__customs
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_loc_type__customs
+msgid "Customs Office"
+msgstr "Biroul Vamal"
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__13
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__13
+msgid "Călărași(BG)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_operation_scope__703
+msgid "Delivery operations with installation"
+msgstr "Operatii de livrare cu montaj"
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model,name:l10n_ro_edi_stock_batch.model_l10n_ro_edi_document
+msgid "Document object for tracking CIUS-RO XML sent to E-Factura"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_operation_scope__1101
+msgid "Donations, help"
+msgstr "Donații, ajutor"
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock_batch.field_stock_picking_batch__l10n_ro_edi_stock_end_bcp
+msgid "End Border Crossing Point"
+msgstr "Sfârșitul punctului de trecere a frontierei"
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock_batch.field_stock_picking_batch__l10n_ro_edi_stock_end_customs_office
+msgid "End Customs Office"
+msgstr "Biroul Vamal"
+
+#. module: l10n_ro_edi_stock_batch
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock_batch.l10n_ro_edi_stock_view_batch_form
+msgid "End Location"
+msgstr "Locația finală"
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock_batch.field_stock_picking_batch__l10n_ro_edi_stock_end_loc_type
+msgid "End Location Type"
+msgstr "Tip Locație"
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__18
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__18
+msgid "Episcopia Bihor (HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_state__stock_sending_failed
+msgid "Error"
+msgstr "Eroare"
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_operation_scope__901
+msgid "Exempt operations"
+msgstr "Operațiuni scutite"
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_operation_type__50
+msgid "Export"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock_batch.l10n_ro_edi_stock_stock_picking_batch_view_tree
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock_batch.l10n_ro_edi_stock_view_batch_form
+msgid "Fetch Status"
+msgstr "Preluare Stare"
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_operation_scope__801
+msgid "Financial/operational leasing"
+msgstr "Leasing financiar/operational"
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_operation_scope__501
+msgid "Fixed assets"
+msgstr "Mijloace fixe"
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__34
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__34
+msgid "Galați Giurgiulești(MD)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock_batch.l10n_ro_edi_stock_view_batch_form
+msgid "General"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__9
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__9
+msgid "Giurgiu(BG)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_operation_scope__705
+msgid "Goods made available to the customer"
+msgstr "Bunuri puse la dispozitia clientului"
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_operation_scope__802
+msgid "Goods under warranty"
+msgstr "Bunuri aflate in garantie"
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_operation_scope__301
+msgid "Gratuities"
+msgstr "Gratuitatii"
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__29
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__29
+msgid "Halmeu (UA)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_operation_type__40
+msgid "Import"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_operation_type__20
+msgid "Intra-Community delivery"
+msgstr "Livrare intracomunitara"
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_operation_type__10
+msgid "Intra-community purchase"
+msgstr "Achizitie intracomunitara"
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_operation_type__60
+msgid ""
+"Intra-community transaction - Entry for storage/formation of new transport"
+msgstr ""
+"Tranzacție intracomunitară - Intrare pentru depozitare/formare transport nou"
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_operation_type__70
+msgid ""
+"Intra-community transaction - Exit after storage/formation of new transport"
+msgstr ""
+"Tranzacție intracomunitară - Ieșire după depozitare/formare de transport nou"
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_operation_scope__1001
+msgid "Investment in progress"
+msgstr "Investiție în curs"
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__28
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__28
+msgid "Jimbolia(RS)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock_batch.field_stock_picking_batch__l10n_ro_edi_stock_available_end_loc_types
+msgid "L10N Ro Edi Stock Available End Loc Types"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock_batch.field_stock_picking_batch__l10n_ro_edi_stock_available_operation_scopes
+msgid "L10N Ro Edi Stock Available Operation Scopes"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock_batch.field_stock_picking_batch__l10n_ro_edi_stock_available_start_loc_types
+msgid "L10N Ro Edi Stock Available Start Loc Types"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock_batch.field_stock_picking_batch__l10n_ro_edi_stock_document_ids
+msgid "L10N Ro Edi Stock Document"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock_batch.field_stock_picking_batch__l10n_ro_edi_stock_enable
+msgid "L10N Ro Edi Stock Enable"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock_batch.field_stock_picking_batch__l10n_ro_edi_stock_enable_amend
+msgid "L10N Ro Edi Stock Enable Amend"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock_batch.field_stock_picking_batch__l10n_ro_edi_stock_enable_fetch
+msgid "L10N Ro Edi Stock Enable Fetch"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock_batch.field_stock_picking_batch__l10n_ro_edi_stock_enable_send
+msgid "L10N Ro Edi Stock Enable Send"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock_batch.field_stock_picking_batch__l10n_ro_edi_stock_fields_readonly
+msgid "L10N Ro Edi Stock Fields Readonly"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock_batch.l10n_ro_edi_stock_view_batch_form
+msgid "Load Id"
+msgstr "Index Incarcare"
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_loc_type__location
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_loc_type__location
+msgid "Location"
+msgstr "Locaţie"
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_operation_scope__101
+msgid "Marketing"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__26
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__26
+msgid "Naidăș(RS)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__11
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__11
+msgid "Negru Vodă(BG)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__37
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__37
+msgid "Nădlac 2 - A1 (HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__4
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__4
+msgid "Nădlac(HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__33
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__33
+msgid "Oancea(MD)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__15
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__15
+msgid "Oltenița(BG)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock_batch.field_stock_picking_batch__l10n_ro_edi_stock_operation_scope
+msgid "Operation Scope"
+msgstr "Domeniul de Aplicare"
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_operation_type__22
+msgid "Operations in lohn system (EU) - exit"
+msgstr "Operațiuni în sistem lohn (UE) - ieșire"
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_operation_type__12
+msgid "Operations in lohn system (EU) - input"
+msgstr "Operațiuni în sistemul lohn (UE) - intrare"
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__10
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__10
+msgid "Ostrov(BG)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_operation_scope__9901
+msgid "Other"
+msgstr "Alte"
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_operation_scope__201
+msgid "Output"
+msgstr "Ieșire"
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_operation_scope__601
+msgid "Own consumption"
+msgstr "Consum propriu"
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__1
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__1
+msgid "Petea (HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__25
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__25
+msgid "Porțile de Fier 1 (RS)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock_batch.field_stock_picking_batch__l10n_ro_edi_stock_remarks
+msgid "Remarks"
+msgstr "Remarci"
+
+#. module: l10n_ro_edi_stock_batch
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock_batch/models/stock_picking_batch.py:0
+#, python-format
+msgid ""
+"Romanian access token not found. Please generate or fill it in the settings."
+msgstr ""
+"Tokenul de acces românesc nu a fost găsit. Vă rugăm să o generați sau să o "
+"completați în setări."
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__19
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__19
+msgid "Salonta (HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_operation_scope__9999
+msgid "Same with operation"
+msgstr "La fel și cu funcționarea"
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__31
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__31
+msgid "Sculeni(MD)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock_batch.l10n_ro_edi_stock_view_batch_form
+msgid "Send eTransport"
+msgstr "Trimite eTransport"
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_state__stock_sent
+msgid "Sent"
+msgstr "Trimis"
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__36
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__36
+msgid "Siret  (UA)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__27
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__27
+msgid "Stamora Moravița(RS)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock_batch.field_stock_picking_batch__l10n_ro_edi_stock_start_bcp
+msgid "Start Border Crossing Point"
+msgstr "Începeți punctul de trecere a frontierei"
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock_batch.field_stock_picking_batch__l10n_ro_edi_stock_start_customs_office
+msgid "Start Customs Office"
+msgstr "Începeți Biroul Vamal"
+
+#. module: l10n_ro_edi_stock_batch
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock_batch.l10n_ro_edi_stock_view_batch_form
+msgid "Start Location"
+msgstr "Locația de pornire"
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock_batch.field_stock_picking_batch__l10n_ro_edi_stock_start_loc_type
+msgid "Start Location Type"
+msgstr "Tip Locație"
+
+#. module: l10n_ro_edi_stock_batch
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock_batch.l10n_ro_edi_stock_view_batch_form
+msgid "Status"
+msgstr "Stare"
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_operation_type__14
+msgid "Stocks available to the customer (Call-off stock) - entry"
+msgstr "Stocuri disponibile clientului (Call-off stock) - intrare"
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_operation_type__24
+msgid "Stocks available to the customer (Call-off stock) - exit"
+msgstr "Stocuri disponibile clientului (Call-off stock) - ieșire"
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__30
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__30
+msgid "Stânca Costești (MD)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__20
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__20
+msgid "Săcuieni (HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock_batch/models/stock_picking_batch.py:0
+#, python-format
+msgid "This document has already been successfully sent to anaf."
+msgstr "Acest document a fost deja trimis cu succes către anaf."
+
+#. module: l10n_ro_edi_stock_batch
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock_batch/models/stock_picking_batch.py:0
+#, python-format
+msgid "This document has not been corrected yet because it contains errors."
+msgstr "Acest document nu a fost încă corectat deoarece conține erori."
+
+#. module: l10n_ro_edi_stock_batch
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock_batch/models/stock_picking_batch.py:0
+#, python-format
+msgid ""
+"This document has not been successfully sent yet because it contains errors."
+msgstr ""
+"Acest document nu a fost trimis încă cu succes deoarece conține erori."
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock_batch.field_stock_picking_batch__l10n_ro_edi_stock_trailer_1_number
+msgid "Trailer 1 Number"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock_batch.field_stock_picking_batch__l10n_ro_edi_stock_trailer_2_number
+msgid "Trailer 2 Number"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model,name:l10n_ro_edi_stock_batch.model_stock_picking
+msgid "Transfer"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_operation_scope__704
+msgid "Transfer between managements"
+msgstr "Transfer între conduceri"
+
+#. module: l10n_ro_edi_stock_batch
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock_batch.l10n_ro_edi_stock_view_batch_form
+msgid "Transport"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_operation_type__30
+msgid "Transport on the national territory"
+msgstr "Transport pe teritoriul national"
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__21
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__21
+msgid "Turnu (HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__7
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__7
+msgid "Turnu Măgurele(BG)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock_batch.l10n_ro_edi_stock_view_batch_form
+msgid "UIT"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock_batch/models/stock_picking_batch.py:0
+#, python-format
+msgid "Unhandled eTransport document state: %(state)s"
+msgstr "Starea documentului eTransport netratată: %(state)s"
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__22
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__22
+msgid "Urziceni (HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__23
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__23
+msgid "Valea lui Mihai (HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_state__stock_validated
+msgid "Validated"
+msgstr "Validat"
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__12
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__12
+msgid "Vama Veche(BG)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock_batch.field_stock_picking_batch__l10n_ro_edi_stock_vehicle_number
+msgid "Vehicle Number"
+msgstr "Numărul vehiculului"
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__24
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__24
+msgid "Vladimirescu (HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__3
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__3
+msgid "Vărșand(HU)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#. odoo-python
+#: code:addons/l10n_ro_edi_stock_batch/models/stock_picking_batch.py:0
+#, python-format
+msgid "XML contains errors."
+msgstr "XML conține erori."
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_end_bcp__8
+#: model:ir.model.fields.selection,name:l10n_ro_edi_stock_batch.selection__stock_picking_batch__l10n_ro_edi_stock_start_bcp__8
+msgid "Zimnicea(BG)"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock_batch.l10n_ro_edi_stock_view_batch_form
+msgid "eTransport"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock_batch.l10n_ro_edi_stock_view_batch_form
+msgid "eTransport Documents"
+msgstr "Documente eTransport"
+
+#. module: l10n_ro_edi_stock_batch
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock_batch.l10n_ro_edi_stock_stock_picking_batch_filter
+msgid "eTransport Error"
+msgstr "Eroare de eTransport"
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock_batch.field_stock_picking_batch__l10n_ro_edi_stock_operation_type
+msgid "eTransport Operation Type"
+msgstr "Tip Operațiune"
+
+#. module: l10n_ro_edi_stock_batch
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock_batch.l10n_ro_edi_stock_stock_picking_batch_filter
+msgid "eTransport Sent"
+msgstr "eTransport Trimis"
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock_batch.field_stock_picking_batch__l10n_ro_edi_stock_state
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock_batch.l10n_ro_edi_stock_stock_picking_batch_filter
+msgid "eTransport Status"
+msgstr "Starea eTransport"
+
+#. module: l10n_ro_edi_stock_batch
+#: model:ir.model.fields,field_description:l10n_ro_edi_stock_batch.field_stock_picking_batch__l10n_ro_edi_stock_document_uit
+msgid "eTransport UIT"
+msgstr ""
+
+#. module: l10n_ro_edi_stock_batch
+#: model_terms:ir.ui.view,arch_db:l10n_ro_edi_stock_batch.l10n_ro_edi_stock_stock_picking_batch_filter
+msgid "eTransport Validated"
+msgstr "eTransport Validat"

--- a/addons/l10n_ro_edi_stock_batch/models/__init__.py
+++ b/addons/l10n_ro_edi_stock_batch/models/__init__.py
@@ -1,0 +1,3 @@
+from . import l10n_ro_edi_stock_document
+from . import stock_picking_batch
+from . import stock_picking

--- a/addons/l10n_ro_edi_stock_batch/models/l10n_ro_edi_stock_document.py
+++ b/addons/l10n_ro_edi_stock_batch/models/l10n_ro_edi_stock_document.py
@@ -1,0 +1,7 @@
+from odoo import models, fields
+
+
+class L10nRoEdiStockDocument(models.Model):
+    _inherit = 'l10n_ro_edi.document'
+
+    batch_id = fields.Many2one(comodel_name='stock.picking.batch')

--- a/addons/l10n_ro_edi_stock_batch/models/stock_picking.py
+++ b/addons/l10n_ro_edi_stock_batch/models/stock_picking.py
@@ -1,0 +1,20 @@
+from odoo import api, models
+
+
+class Picking(models.Model):
+    _inherit = 'stock.picking'
+
+    @api.depends('batch_id', 'company_id')
+    def _compute_l10n_ro_edi_stock_enable(self):
+        # OVERRIDES 'l10n_ro_edi_stock'
+        for picking in self:
+            picking.l10n_ro_edi_stock_enable = not picking.batch_id and picking.company_id.country_id.code == 'RO'
+
+    @api.model
+    def _l10n_ro_edi_stock_validate_carrier_filter(self, picking):
+        # OVERRIDE l10n_ro_edi_stock
+
+        # Override for when the batch picking calls this function to validate the carriers
+        validate_carrier = self.env.context.get('l10n_ro_edi_stock_validate_carrier', False)
+
+        return picking.company_id.account_fiscal_country_id.code == 'RO' and (picking.l10n_ro_edi_stock_enable or validate_carrier)

--- a/addons/l10n_ro_edi_stock_batch/models/stock_picking_batch.py
+++ b/addons/l10n_ro_edi_stock_batch/models/stock_picking_batch.py
@@ -1,0 +1,442 @@
+import markupsafe
+import requests
+
+from odoo import fields, models, api, _
+from odoo.exceptions import UserError
+from odoo.addons.l10n_ro_edi_stock.models.stock_picking import OPERATION_TYPES, OPERATION_SCOPES, OPERATION_TYPE_TO_ALLOWED_SCOPE_CODES, LOCATION_TYPES, LOCATION_TYPE_MAP, BORDER_CROSSING_POINTS, CUSTOMS_OFFICES, STATE_CODES
+from odoo.addons.l10n_ro_edi_stock.models.l10n_ro_edi_stock_document import DOCUMENT_STATES
+from odoo.addons.l10n_ro_edi_stock.models.etransport_api import ETransportAPI
+
+
+class StockPickingBatch(models.Model):
+    _inherit = 'stock.picking.batch'
+
+    # Document fields
+    l10n_ro_edi_stock_document_ids = fields.One2many(comodel_name='l10n_ro_edi.document', inverse_name='batch_id')
+    l10n_ro_edi_stock_document_uit = fields.Char(compute='_compute_l10n_ro_edi_stock_current_document_uit', string="eTransport UIT")
+    l10n_ro_edi_stock_state = fields.Selection(
+        selection=DOCUMENT_STATES,
+        compute='_compute_l10n_ro_edi_stock_current_document_state',
+        string="eTransport Status",
+        store=True,
+    )
+
+    # Data fields
+    l10n_ro_edi_stock_operation_type = fields.Selection(selection=OPERATION_TYPES, string="eTransport Operation Type")
+    l10n_ro_edi_stock_available_operation_scopes = fields.Char(compute='_compute_l10n_ro_edi_stock_available_operation_scopes')
+    l10n_ro_edi_stock_operation_scope = fields.Selection(selection=OPERATION_SCOPES, string="Operation Scope")
+
+    l10n_ro_edi_stock_vehicle_number = fields.Char(string="Vehicle Number", size=20)
+    l10n_ro_edi_stock_trailer_1_number = fields.Char(string="Trailer 1 Number", size=20)
+    l10n_ro_edi_stock_trailer_2_number = fields.Char(string="Trailer 2 Number", size=20)
+
+    l10n_ro_edi_stock_available_start_loc_types = fields.Char(compute='_compute_l10n_ro_edi_stock_available_location_types')
+    l10n_ro_edi_stock_start_loc_type = fields.Selection(
+        selection=LOCATION_TYPES,
+        string="Start Location Type",
+        compute='_compute_l10n_ro_edi_stock_default_location_type',
+        store=True,
+        readonly=False,
+    )
+
+    l10n_ro_edi_stock_available_end_loc_types = fields.Char(compute='_compute_l10n_ro_edi_stock_available_location_types')
+    l10n_ro_edi_stock_end_loc_type = fields.Selection(
+        selection=LOCATION_TYPES,
+        string="End Location Type",
+        compute='_compute_l10n_ro_edi_stock_default_location_type',
+        store=True,
+        readonly=False,
+    )
+
+    # Data fields for every location type
+    l10n_ro_edi_stock_start_bcp = fields.Selection(selection=BORDER_CROSSING_POINTS, string="Start Border Crossing Point")
+    l10n_ro_edi_stock_start_customs_office = fields.Selection(selection=CUSTOMS_OFFICES, string="Start Customs Office")
+
+    l10n_ro_edi_stock_end_bcp = fields.Selection(selection=BORDER_CROSSING_POINTS, string="End Border Crossing Point")
+    l10n_ro_edi_stock_end_customs_office = fields.Selection(selection=CUSTOMS_OFFICES, string="End Customs Office")
+
+    l10n_ro_edi_stock_remarks = fields.Text(string="Remarks")
+
+    # View control fields
+    l10n_ro_edi_stock_enable = fields.Boolean(compute='_compute_l10n_ro_edi_stock_enable')
+    l10n_ro_edi_stock_enable_send = fields.Boolean(compute='_compute_l10n_ro_edi_stock_enable_send')
+    l10n_ro_edi_stock_enable_fetch = fields.Boolean(compute='_compute_l10n_ro_edi_stock_enable_fetch')
+    l10n_ro_edi_stock_enable_amend = fields.Boolean(compute='_compute_l10n_ro_edi_stock_enable_amend')
+
+    l10n_ro_edi_stock_fields_readonly = fields.Boolean(compute='_compute_l10n_ro_edi_stock_fields_readonly')
+
+    ################################################################################
+    # Onchange Methods
+    ################################################################################
+
+    @api.onchange('l10n_ro_edi_stock_operation_type')
+    def _l10n_ro_edi_stock_reset_variable_selection_fields(self):
+        self.l10n_ro_edi_stock_operation_scope = False
+
+        # the 'location' value is always valid, regardless of which operation type is chosen
+        self.l10n_ro_edi_stock_start_loc_type = 'location'
+        self.l10n_ro_edi_stock_end_loc_type = 'location'
+
+    ################################################################################
+    # Compute Methods
+    ################################################################################
+
+    @api.depends('company_id.account_fiscal_country_id.code')
+    def _compute_l10n_ro_edi_stock_default_location_type(self):
+        for batch in self:
+            if batch.company_id.account_fiscal_country_id.code == 'RO':
+                if not batch.l10n_ro_edi_stock_start_loc_type:
+                    batch.l10n_ro_edi_stock_start_loc_type = 'location'
+                else:
+                    batch.l10n_ro_edi_stock_start_loc_type = batch.l10n_ro_edi_stock_start_loc_type
+
+                if not batch.l10n_ro_edi_stock_end_loc_type:
+                    batch.l10n_ro_edi_stock_end_loc_type = 'location'
+                else:
+                    batch.l10n_ro_edi_stock_start_loc_type = batch.l10n_ro_edi_stock_start_loc_type
+            else:
+                batch.l10n_ro_edi_stock_start_loc_type = False
+                batch.l10n_ro_edi_stock_end_loc_type = False
+
+    @api.depends('l10n_ro_edi_stock_operation_type')
+    def _compute_l10n_ro_edi_stock_available_operation_scopes(self):
+        for batch in self:
+            if batch.l10n_ro_edi_stock_operation_type:
+                allowed_scopes = OPERATION_TYPE_TO_ALLOWED_SCOPE_CODES.get(batch.l10n_ro_edi_stock_operation_type, ("9999",))
+            else:
+                allowed_scopes = [c for c, _dummy in OPERATION_SCOPES]
+
+            batch.l10n_ro_edi_stock_available_operation_scopes = ','.join(allowed_scopes)
+
+    @api.depends('l10n_ro_edi_stock_operation_type')
+    def _compute_l10n_ro_edi_stock_available_location_types(self):
+        for batch in self:
+            batch.l10n_ro_edi_stock_available_start_loc_types = self.env['stock.picking']._l10n_ro_edi_stock_get_available_location_types(batch.l10n_ro_edi_stock_operation_type, 'start')
+            batch.l10n_ro_edi_stock_available_end_loc_types = self.env['stock.picking']._l10n_ro_edi_stock_get_available_location_types(batch.l10n_ro_edi_stock_operation_type, 'end')
+
+    @api.depends('l10n_ro_edi_stock_document_ids', 'company_id.account_fiscal_country_id.code')
+    def _compute_l10n_ro_edi_stock_current_document_state(self):
+        for batch in self:
+            if batch.company_id.account_fiscal_country_id.code == 'RO' and (document := batch._l10n_ro_edi_stock_get_current_document()):
+                batch.l10n_ro_edi_stock_state = document.state
+            else:
+                batch.l10n_ro_edi_stock_state = False
+
+    @api.depends('l10n_ro_edi_stock_document_ids', 'company_id.account_fiscal_country_id.code')
+    def _compute_l10n_ro_edi_stock_current_document_uit(self):
+        for batch in self:
+            if batch.company_id.account_fiscal_country_id.code == 'RO' and (document := batch._l10n_ro_edi_stock_get_current_document()):
+                batch.l10n_ro_edi_stock_document_uit = document.l10n_ro_edi_stock_uit
+            else:
+                batch.l10n_ro_edi_stock_document_uit = False
+
+    @api.depends('company_id.account_fiscal_country_id.code')
+    def _compute_l10n_ro_edi_stock_enable(self):
+        for batch in self:
+            batch.l10n_ro_edi_stock_enable = batch.company_id.account_fiscal_country_id.code == 'RO'
+
+    @api.depends('l10n_ro_edi_stock_enable', 'state', 'l10n_ro_edi_stock_state')
+    def _compute_l10n_ro_edi_stock_enable_send(self):
+        for batch in self:
+            batch.l10n_ro_edi_stock_enable_send = (batch.l10n_ro_edi_stock_enable
+                                                   and batch.state != 'draft'
+                                                   and batch.l10n_ro_edi_stock_state in (False, 'stock_sending_failed')
+                                                   and not batch._l10n_ro_edi_stock_get_last_document('stock_validated'))
+
+    @api.depends('l10n_ro_edi_stock_enable', 'state', 'l10n_ro_edi_stock_state')
+    def _compute_l10n_ro_edi_stock_enable_fetch(self):
+        for batch in self:
+            batch.l10n_ro_edi_stock_enable_fetch = batch.l10n_ro_edi_stock_enable and batch.l10n_ro_edi_stock_state == 'stock_sent'
+
+    @api.depends('l10n_ro_edi_stock_state')
+    def _compute_l10n_ro_edi_stock_enable_amend(self):
+        for batch in self:
+            batch.l10n_ro_edi_stock_enable_amend = (batch.l10n_ro_edi_stock_enable
+                                                    and batch.l10n_ro_edi_stock_state == 'stock_validated'
+                                                    or (batch.l10n_ro_edi_stock_state == 'stock_sending_failed'
+                                                        and batch._l10n_ro_edi_stock_get_last_document('stock_validated')))
+
+    @api.depends('l10n_ro_edi_stock_state')
+    def _compute_l10n_ro_edi_stock_fields_readonly(self):
+        for batch in self:
+            batch.l10n_ro_edi_stock_fields_readonly = batch.l10n_ro_edi_stock_state == 'stock_sent'
+
+    ################################################################################
+    # Validation methods
+    ################################################################################
+
+    def action_done(self):
+        # EXTENDS 'stock_picking_batch'
+        self.ensure_one()
+        self._check_company()
+
+        self.picking_ids.with_context(l10n_ro_edi_stock_validate_carrier=True)._l10n_ro_edi_stock_validate_carrier()
+
+        # Carrier should be the same on all pickings
+        first_carrier = self.picking_ids[0].carrier_id
+        if any(picking.carrier_id != first_carrier for picking in self.picking_ids):
+            raise UserError(_("All Pickings in a Batch Transfer should have the same Carrier"))
+
+        # Commercial partner should be the same on all pickings
+        first_commercial_partner = self.picking_ids[0].partner_id.commercial_partner_id
+        if any(picking.partner_id.commercial_partner_id != first_commercial_partner for picking in self.picking_ids):
+            raise UserError(_("All Pickings in a Batch Transfer should have the same Commercial Partner"))
+
+        return super().action_done()
+
+    def _l10n_ro_edi_stock_validate_fetch_data(self, errors=None):
+        if errors is None:
+            errors = []
+        self.ensure_one()
+
+        if not self.company_id.l10n_ro_edi_access_token:
+            errors.append(_('Romanian access token not found. Please generate or fill it in the settings.'))
+            return errors
+
+        match self.l10n_ro_edi_stock_state:
+            case 'stock_sending_failed':
+                if not self._l10n_ro_edi_stock_get_last_document('stock_validated'):
+                    errors.append(_("This document has not been successfully sent yet because it contains errors."))
+                else:
+                    errors.append(_("This document has not been corrected yet because it contains errors."))
+            case 'stock_validated':
+                errors.append(_("This document has already been successfully sent to anaf."))
+
+        return errors
+
+    ################################################################################
+    # Actions
+    ################################################################################
+
+    def action_l10n_ro_edi_stock_send_etransport(self):
+        self.ensure_one()
+
+        send_type = self.env.context.get('l10n_ro_edi_stock_send_type', 'send')
+        self._l10n_ro_edi_stock_send_etransport_document(send_type=send_type)
+
+    def action_l10n_ro_edi_stock_fetch_status(self):
+        self._l10n_ro_edi_stock_fetch_document_status()
+
+    ################################################################################
+    # Document Helpers
+    ################################################################################
+
+    def _l10n_ro_edi_stock_get_current_document(self):
+        self.ensure_one()
+        return self.l10n_ro_edi_stock_document_ids.sorted()[0] if self.l10n_ro_edi_stock_document_ids else None
+
+    def _l10n_ro_edi_stock_get_all_documents(self, states):
+        self.ensure_one()
+
+        if isinstance(states, str):
+            states = [states]
+
+        return self.l10n_ro_edi_stock_document_ids.filtered(lambda doc: doc.state in states)
+
+    def _l10n_ro_edi_stock_get_last_document(self, state):
+        self.ensure_one()
+        documents_in_state = self.l10n_ro_edi_stock_document_ids.filtered(lambda doc: doc.state == state).sorted()
+
+        return documents_in_state and documents_in_state[0]
+
+    def _l10n_ro_edi_stock_create_document_stock_sent(self, values: dict[str, object]):
+        self.ensure_one()
+        document = self.env['l10n_ro_edi.document'].create({
+            'batch_id': self.id,
+            'state': 'stock_sent',
+            'l10n_ro_edi_stock_load_id': values['l10n_ro_edi_stock_load_id'],
+            'l10n_ro_edi_stock_uit': values['l10n_ro_edi_stock_uit'],
+        })
+
+        document.attachment_id = self.env['stock.picking']._l10n_ro_edi_stock_create_attachment({
+            'name': self.name,
+            'res_id': document.id,
+            'raw': values['raw_xml'],
+        })
+
+        return document
+
+    def _l10n_ro_edi_stock_create_document_stock_sending_failed(self, values: dict[str, object]):
+        self.ensure_one()
+        document = self.env['l10n_ro_edi.document'].create({
+            'batch_id': self.id,
+            'state': 'stock_sending_failed',
+            'message': values['message'],
+            'l10n_ro_edi_stock_load_id': values.get('l10n_ro_edi_stock_load_id'),
+            'l10n_ro_edi_stock_uit': values.get('l10n_ro_edi_stock_uit'),
+        })
+
+        if 'raw_xml' in values:
+            # when an error is thrown during data validation there will be no 'raw_xml'
+            document.attachment_id = self.env['stock.picking']._l10n_ro_edi_stock_create_attachment({
+                'name': self.name,
+                'res_id': document.id,
+                'raw': values['raw_xml'],
+            })
+
+        return document
+
+    def _l10n_ro_edi_stock_create_document_stock_validated(self, values: dict[str, object]):
+        self.ensure_one()
+        document = self.env['l10n_ro_edi.document'].create({
+            'batch_id': self.id,
+            'state': 'stock_validated',
+            'l10n_ro_edi_stock_load_id': values['l10n_ro_edi_stock_load_id'],
+            'l10n_ro_edi_stock_uit': values['l10n_ro_edi_stock_uit'],
+        })
+
+        document.attachment_id = self.env['stock.picking']._l10n_ro_edi_stock_create_attachment({
+            'name': self.name,
+            'res_id': document.id,
+            'raw': values['raw_xml'],
+        })
+
+        return document
+
+    ################################################################################
+    # Send Logic
+    ################################################################################
+
+    def _l10n_ro_edi_stock_send_etransport_document(self, send_type: str):
+        """
+        Send the eTransport document to anaf
+        :param send_type: 'send' (initial sending of document) | 'amend' (correct the already sent document)
+        """
+        self.ensure_one()
+
+        data = {
+            'partner_id': self.picking_ids[0].partner_id,
+            'transport_partner_id': self.picking_ids[0].carrier_id.l10n_ro_edi_stock_partner_id,
+            'company_id': self.company_id,
+            'scheduled_date': self.scheduled_date,
+            'name': self.name,
+            'send_type': send_type,
+            'l10n_ro_edi_stock_operation_type': self.l10n_ro_edi_stock_operation_type,
+            'l10n_ro_edi_stock_operation_scope': self.l10n_ro_edi_stock_operation_scope,
+            'stock_move_ids': self.move_ids,
+            'l10n_ro_edi_stock_vehicle_number': self.l10n_ro_edi_stock_vehicle_number,
+            'l10n_ro_edi_stock_trailer_1_number': self.l10n_ro_edi_stock_trailer_1_number,
+            'l10n_ro_edi_stock_trailer_2_number': self.l10n_ro_edi_stock_trailer_2_number,
+            'l10n_ro_edi_stock_start_loc_type': self.l10n_ro_edi_stock_start_loc_type,
+            'l10n_ro_edi_stock_end_loc_type': self.l10n_ro_edi_stock_end_loc_type,
+            'l10n_ro_edi_stock_remarks': self.l10n_ro_edi_stock_remarks,
+            'picking_type_id': self.picking_type_id,
+            'l10n_ro_edi_stock_start_bcp': self.l10n_ro_edi_stock_start_bcp,
+            'l10n_ro_edi_stock_end_bcp': self.l10n_ro_edi_stock_end_bcp,
+            'l10n_ro_edi_stock_start_customs_office': self.l10n_ro_edi_stock_start_customs_office,
+            'l10n_ro_edi_stock_end_customs_office': self.l10n_ro_edi_stock_end_customs_office,
+            'l10n_ro_edi_stock_document_uit': self.l10n_ro_edi_stock_document_uit,
+        }
+
+        if errors := self.env['stock.picking']._l10n_ro_edi_stock_validate_data(data=data):
+            self._l10n_ro_edi_stock_get_all_documents('stock_sending_failed').unlink()
+            document_values = {'message': '\n'.join(errors)}
+
+            if send_type == 'amend':
+                last_sent_document = self._l10n_ro_edi_stock_get_last_document('stock_validated')
+                document_values |= {
+                    'l10n_ro_edi_stock_load_id': last_sent_document.l10n_ro_edi_stock_load_id,
+                    'l10n_ro_edi_stock_uit': last_sent_document.l10n_ro_edi_stock_uit,
+                    'raw_xml': last_sent_document.attachment_id.raw,
+                }
+
+            self._l10n_ro_edi_stock_create_document_stock_sending_failed(document_values)
+            return
+
+        raw_xml = markupsafe.Markup("<?xml version='1.0' encoding='UTF-8'?>\n") + self.env['ir.qweb']._render(
+            'l10n_ro_edi_stock.l10n_ro_template_etransport',
+            values=self.env['stock.picking']._l10n_ro_edi_stock_get_template_data(data=data),
+        )
+
+        result = ETransportAPI().upload_data(company_id=self.company_id, data=raw_xml)
+
+        if 'error' in result:
+            self._l10n_ro_edi_stock_get_all_documents('stock_sending_failed').unlink()
+            document_values = {'message': result['error'], 'raw_xml': raw_xml}
+
+            if send_type == 'amend':
+                last_sent_document = self._l10n_ro_edi_stock_get_last_document('stock_validated')
+                document_values |= {
+                    'l10n_ro_edi_stock_load_id': last_sent_document.l10n_ro_edi_stock_load_id,
+                    'l10n_ro_edi_stock_uit': last_sent_document.l10n_ro_edi_stock_uit,
+                }
+
+            self._l10n_ro_edi_stock_create_document_stock_sending_failed(document_values)
+        else:
+            self._l10n_ro_edi_stock_get_all_documents({'stock_sending_failed', 'stock_sent'}).unlink()
+
+            content = result['content']
+
+            if send_type == 'send':
+                uit = content['UIT']
+            else:
+                last_validated = self._l10n_ro_edi_stock_get_last_document('stock_validated')
+                uit = last_validated.l10n_ro_edi_stock_uit
+                raw_xml = last_validated.attachment_id.raw
+
+            self._l10n_ro_edi_stock_create_document_stock_sent({
+                'l10n_ro_edi_stock_load_id': content['index_incarcare'],
+                'l10n_ro_edi_stock_uit': uit,
+                'raw_xml': raw_xml,
+            })
+
+    def _l10n_ro_edi_stock_fetch_document_status(self):
+        session = requests.Session()
+        documents_to_delete = self.env['l10n_ro_edi.document']
+        to_fetch = self.filtered(lambda b: b.l10n_ro_edi_stock_state == 'stock_sent')
+
+        for batch in to_fetch:
+            current_sending_document = batch.l10n_ro_edi_stock_document_ids.filtered(lambda doc: doc.state == 'stock_sent')[0]
+
+            if errors := batch._l10n_ro_edi_stock_validate_fetch_data():
+                documents_to_delete |= batch._l10n_ro_edi_stock_get_all_documents('stock_sending_failed')
+                batch._l10n_ro_edi_stock_create_document_stock_sending_failed({
+                    'message': '\n'.join(errors),
+                    'l10n_ro_edi_stock_load_id': current_sending_document.l10n_ro_edi_stock_load_id,
+                    'l10n_ro_edi_stock_uit': current_sending_document.l10n_ro_edi_stock_uit,
+                    'raw_xml': current_sending_document.attachment_id.raw,
+                })
+                continue
+
+            result = ETransportAPI().get_status(
+                company_id=batch.company_id,
+                document_load_id=current_sending_document.l10n_ro_edi_stock_load_id,
+                session=session,
+            )
+
+            if 'error' in result:
+                documents_to_delete |= batch._l10n_ro_edi_stock_get_all_documents('stock_sending_failed')
+                batch._l10n_ro_edi_stock_create_document_stock_sending_failed({
+                    'message': result['error'],
+                    'l10n_ro_edi_stock_load_id': current_sending_document.l10n_ro_edi_stock_load_id,
+                    'l10n_ro_edi_stock_uit': current_sending_document.l10n_ro_edi_stock_uit,
+                    'raw_xml': current_sending_document.attachment_id.raw,
+                })
+            else:
+                documents_to_delete |= batch._l10n_ro_edi_stock_get_all_documents(('stock_sent', 'stock_sending_failed'))
+                new_document_data = {
+                    'l10n_ro_edi_stock_load_id': current_sending_document.l10n_ro_edi_stock_load_id,
+                    'l10n_ro_edi_stock_uit': current_sending_document.l10n_ro_edi_stock_uit,
+                    'raw_xml': current_sending_document.attachment_id.raw,
+                }
+                match state := result['content']['stare']:
+                    case 'ok':
+                        batch._l10n_ro_edi_stock_create_document_stock_validated(new_document_data)
+                    case 'in prelucrare':
+                        # Document is still being validated
+                        batch._l10n_ro_edi_stock_create_document_stock_sent(new_document_data)
+                    case 'XML cu erori nepreluat de sistem':
+                        new_document_data['message'] = _("XML contains errors.")
+                        batch._l10n_ro_edi_stock_create_document_stock_sending_failed(new_document_data)
+                    case _:
+                        batch._l10n_ro_edi_stock_report_unhandled_document_state(state)
+
+        documents_to_delete.unlink()
+
+    ################################################################################
+    # Misc helpers
+    ################################################################################
+
+    def _l10n_ro_edi_stock_report_unhandled_document_state(self, state: str):
+        self.ensure_one()
+        self.message_post(body=_("Unhandled eTransport document state: %(state)s", state=state))

--- a/addons/l10n_ro_edi_stock_batch/report/report_picking_batch.xml
+++ b/addons/l10n_ro_edi_stock_batch/report/report_picking_batch.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <template id="l10n_ro_edi_stock_report_picking_batch" inherit_id="stock_picking_batch.report_picking_batch">
+        <xpath expr="//div/h3[contains(text(), 'Summary:')]/../.." position="after">
+            <div t-if="o.l10n_ro_edi_stock_enable and o.l10n_ro_edi_stock_document_uit" name="div_etransport_uit">
+                <strong>eTransport UIT:</strong>
+                <span t-field="o.l10n_ro_edi_stock_document_uit">3U3H3P4C2U5Y8N20</span>
+            </div>
+        </xpath>
+    </template>
+</odoo>

--- a/addons/l10n_ro_edi_stock_batch/views/stock_picking_batch_views.xml
+++ b/addons/l10n_ro_edi_stock_batch/views/stock_picking_batch_views.xml
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+   <record id="l10n_ro_edi_stock_view_batch_form" model="ir.ui.view">
+      <field name="name">stock.picking.batch.form.inherit.l10n_ro_edi_stock</field>
+      <field name="model">stock.picking.batch</field>
+      <field name="inherit_id" ref="stock_picking_batch.stock_picking_batch_form"/>
+      <field name="arch" type="xml">
+         <xpath expr="//button[@name='action_open_label_layout']" position="after">
+             <field name="l10n_ro_edi_stock_enable_send" invisible="1"/>
+             <field name="l10n_ro_edi_stock_enable_fetch" invisible="1"/>
+             <field name="l10n_ro_edi_stock_enable_amend" invisible="1"/>
+
+             <button name="action_l10n_ro_edi_stock_send_etransport"
+                     string="Send eTransport"
+                     type="object"
+                     context="{'l10n_ro_edi_stock_send_type': 'send'}"
+                     invisible="not l10n_ro_edi_stock_enable_send"/>
+             <button name="action_l10n_ro_edi_stock_send_etransport"
+                     string="Amend eTransport"
+                     type="object"
+                     context="{'l10n_ro_edi_stock_send_type': 'amend'}"
+                     invisible="not l10n_ro_edi_stock_enable_amend"/>
+             <button name="action_l10n_ro_edi_stock_fetch_status" string="Fetch Status" type="object" invisible="not l10n_ro_edi_stock_enable_fetch"/>
+         </xpath>
+
+         <xpath expr="//field[@name='scheduled_date']" position="after">
+             <field name="l10n_ro_edi_stock_state" invisible="1"/>
+             <field name="l10n_ro_edi_stock_state" invisible="state == 'draft' or not l10n_ro_edi_stock_state" readonly="1"/>
+         </xpath>
+
+         <xpath expr="//page[@name='page_transfers']" position="after">
+             <field name="l10n_ro_edi_stock_enable" invisible="1"/>
+
+             <page name="etransport" string="eTransport" invisible="not l10n_ro_edi_stock_enable">
+                 <field name="l10n_ro_edi_stock_available_operation_scopes" invisible="1"/>
+                 <field name="l10n_ro_edi_stock_state" invisible="1"/>
+                 <field name="l10n_ro_edi_stock_fields_readonly" invisible="1"/>
+
+                 <group>
+                     <group string="General">
+                         <field name="l10n_ro_edi_stock_operation_type" readonly="l10n_ro_edi_stock_fields_readonly"/>
+                         <field name="l10n_ro_edi_stock_operation_scope"
+                                widget="dynamic_selection"
+                                options="{'available_field': 'l10n_ro_edi_stock_available_operation_scopes'}"
+                                readonly="l10n_ro_edi_stock_fields_readonly"/>
+                         <field name="l10n_ro_edi_stock_remarks" readonly="l10n_ro_edi_stock_fields_readonly"/>
+                     </group>
+
+                     <group string="Transport">
+                         <field name="l10n_ro_edi_stock_vehicle_number" readonly="l10n_ro_edi_stock_fields_readonly"/>
+                         <field name="l10n_ro_edi_stock_trailer_1_number" readonly="l10n_ro_edi_stock_fields_readonly"/>
+                         <field name="l10n_ro_edi_stock_trailer_2_number" readonly="l10n_ro_edi_stock_fields_readonly"/>
+                     </group>
+
+                     <group string="Start Location">
+                         <field name="l10n_ro_edi_stock_available_start_loc_types" invisible="1"/>
+                         <field name="l10n_ro_edi_stock_start_loc_type"
+                                widget="dynamic_selection"
+                                options="{'available_field': 'l10n_ro_edi_stock_available_start_loc_types'}"
+                                readonly="l10n_ro_edi_stock_fields_readonly"/>
+
+                         <field name="l10n_ro_edi_stock_start_bcp" readonly="l10n_ro_edi_stock_fields_readonly" invisible="l10n_ro_edi_stock_start_loc_type != 'bcp'" />
+                         <field name="l10n_ro_edi_stock_start_customs_office" readonly="l10n_ro_edi_stock_fields_readonly" invisible="l10n_ro_edi_stock_start_loc_type != 'customs'"/>
+                     </group>
+
+                     <group string="End Location">
+                         <field name="l10n_ro_edi_stock_available_end_loc_types" invisible="1"/>
+                         <field name="l10n_ro_edi_stock_end_loc_type"
+                                widget="dynamic_selection"
+                                options="{'available_field': 'l10n_ro_edi_stock_available_end_loc_types'}"
+                                readonly="l10n_ro_edi_stock_fields_readonly"/>
+
+                         <field name="l10n_ro_edi_stock_end_bcp" readonly="l10n_ro_edi_stock_fields_readonly" invisible="l10n_ro_edi_stock_end_loc_type != 'bcp'"/>
+                         <field name="l10n_ro_edi_stock_end_customs_office" readonly="l10n_ro_edi_stock_fields_readonly" invisible="l10n_ro_edi_stock_end_loc_type != 'customs'"/>
+                     </group>
+                 </group>
+             </page>
+
+             <page id="l10n_ro_edi_stock_documents"
+                   name="etransport_documents"
+                   string="eTransport Documents"
+                   invisible="not (l10n_ro_edi_stock_enable and l10n_ro_edi_stock_document_ids)">
+                 <field name="l10n_ro_edi_stock_document_ids">
+                     <tree create="false" delete="false" edit="false" no_open="1"
+                           decoration-danger="state == 'stock_sending_failed'"
+                           decoration-warning="state == 'stock_sent'"
+                           decoration-success="state == 'stock_validated'">
+                         <field name="message" column_invisible="1"/>
+                         <field name="attachment_id" column_invisible="1"/>
+                         <field name="datetime"/>
+                         <field name="state" string="Status" widget="l10n_ro_edi_stock_document_state"/>
+                         <field name="l10n_ro_edi_stock_uit" string="UIT"/>
+                         <field name="l10n_ro_edi_stock_load_id" string="Load Id"/>
+                     </tree>
+                 </field>
+             </page>
+         </xpath>
+      </field>
+   </record>
+
+    <record id="l10n_ro_edi_stock_stock_picking_batch_view_tree" model="ir.ui.view">
+        <field name="model">stock.picking.batch</field>
+        <field name="inherit_id" ref="stock_picking_batch.stock_picking_batch_tree"/>
+        <field name="arch" type="xml">
+            <field name="company_id" position="before">
+                <header>
+                    <button name="action_l10n_ro_edi_stock_fetch_status" string="Fetch Status" type="object"/>
+                </header>
+            </field>
+            <field name="state" position="before">
+                <field name="l10n_ro_edi_stock_state" optional="hide"/>
+            </field>
+        </field>
+    </record>
+
+    <record id="l10n_ro_edi_stock_stock_picking_batch_filter" model="ir.ui.view">
+        <field name="model">stock.picking.batch</field>
+        <field name="inherit_id" ref="stock_picking_batch.stock_picking_batch_filter"/>
+        <field name="arch" type="xml">
+            <field name="user_id" position="after">
+                <field name="l10n_ro_edi_stock_state"/>
+            </field>
+
+            <filter name="done" position="after">
+                <filter string="eTransport Error" name="l10n_ro_edi_stock_state_stock_sending_failed"
+                        domain="[('l10n_ro_edi_stock_state', '=', 'stock_sending_failed')]"/>
+                <filter string="eTransport Sent" name="l10n_ro_edi_stock_state_stock_sent"
+                        domain="[('l10n_ro_edi_stock_state', '=', 'stock_sent')]"/>
+                <filter string="eTransport Validated" name="l10n_ro_edi_stock_state_stock_validated"
+                        domain="[('l10n_ro_edi_stock_state', '=', 'stock_validated')]"/>
+            </filter>
+
+            <xpath expr="//group/filter[@name='state']" position="after">
+                <filter string="eTransport Status"
+                        name="l10n_ro_edi_stock_state_group"
+                        domain=""
+                        context="{'group_by': 'l10n_ro_edi_stock_state'}"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Romania requires its companies to send information of all transports of goods on Romanian territory to a specific web service on their eTransport platform.

This commit implements a way to gather all the necessary data needed to send the eTransport document and the actual sending of this document to the eTransport platform.

Authentication:
the authentication needed to interact with the eTransport platform is the same as (and was already implemented in) the l10n_ro_efactura module. see [eFactura PR](https://github.com/odoo/odoo/pull/144061)

eTransport flow:
- Add the necessary eTransport data to a delivery
- send the eTransport document to ANAF
- the document gets processed by ANAF
- Fetch the status of the document:
    - which can result in an error, in which case the flow starts again from the beginning with the corrected data
    - or in a success

 task-id: 3810735

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
