### PR TITLE
[FIX] web: remove `Dialog` header bg

### DIFF
--- a/addons/web/static/src/core/dialog/dialog.scss
+++ b/addons/web/static/src/core/dialog/dialog.scss
@@ -48,14 +48,6 @@
                     height: 100%;
                     border: none;
 
-                    .modal-header {
-                        background: $o-navbar-background;
-
-                        .modal-title, .btn {
-                            color: $o-navbar-entry-color;
-                        }
-                    }
-
                     .modal-body {
                         height: 100%;
                         overflow-y: auto;


### PR DESCRIPTION
Before this PR: header color of `Dialog` on mobile was "community color" or white, depending on the version of Odoo the database is running. This was creating issues in in the front-end, where the user of the website would see back-end specific colors in different `Dialog`s.

This PR removes the color customization of `Dialog`'header as it was fitting a design line we had before we introduced MILK.

task-4001365

Example of the issue (mobile front-end):
<img width="376" alt="Screenshot 2024-06-20 at 10 54 04" src="https://github.com/odoo/odoo/assets/110090660/dad6a4b2-6164-45dd-9e16-0160e2989607">


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
