### PR TITLE
[FIX] website_sale: allow variant specific `default_code` on website

### DIFF
--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -573,3 +573,19 @@ class WebsiteSaleExtraField(models.Model):
     )
     label = fields.Char(related='field_id.field_description')
     name = fields.Char(related='field_id.name')
+
+    def _value_for_product(self, template=None, variant=None):
+        variant_field_name = self._corresponding_variant_field_name()
+        if variant and variant_field_name:
+            return variant[variant_field_name]
+        elif template:
+            return template[self.name]
+        else:
+            return False
+
+    def _corresponding_variant_field_name(self):
+        # assumption: variant fields must have ttype=char
+        variant_fields = {
+            'default_code': 'default_code',
+        }
+        return variant_fields.get(self.name, False)

--- a/addons/website_sale/static/src/js/variant_mixin.js
+++ b/addons/website_sale/static/src/js/variant_mixin.js
@@ -57,6 +57,28 @@ VariantMixin._onChangeCombination = function (ev, $parent, combination) {
         contactUsButton.removeClass('d-flex').addClass('d-none');
         product_unavailable.removeClass('d-flex').addClass('d-none')
     }
+
+    // Dynamically render extra fields
+    $('[data-variant-field]').remove();
+    if (combination.variant_extra_fields) {
+        const variantExtras = combination.variant_extra_fields.map((item) => {
+            const [label, val] = item;
+            return `<b data-variant-field>${label}: </b><span data-variant-field>${val}</span>`;
+        }).join('</br data-variant-field>');
+
+        // either append to existing extra fields or create a <p> when none
+        if (combination.any_template_extra_field) {
+            $('div#product_details > p').last().append(variantExtras);
+        } else {
+            $('div#product_details').append([
+                '<hr data-variant-field/>',
+                '<p data-variant-field class="text-muted">',
+                variantExtras,
+                '</p>',
+            ].join(''));
+        }
+    }
+
     originalOnChangeCombination.apply(this, [ev, $parent, combination]);
 };
 

--- a/addons/website_sale/static/tests/tours/website_sale_category_page_and_products_snippet.js
+++ b/addons/website_sale/static/tests/tours/website_sale_category_page_and_products_snippet.js
@@ -57,3 +57,23 @@ tour.register('category_page_and_products_snippet_use', {
         },
     },
 ]);
+
+tour.register('variant_extra_fields_tour', {
+    test: true,
+}, [
+    {
+        content: "Check that the reference of the default variant is shown on the page",
+        isCheck: true,
+        trigger: '[data-variant-field]:contains(LED01)',
+    },
+    {
+        content: "Change variant (red -> green)",
+        trigger: '[title=green]',
+        run: 'click',
+    },
+    {
+        content: "Check that the internal reference has changed accordingly",
+        isCheck: true,
+        trigger: '[data-variant-field]:contains(LED02)',
+    },
+]);

--- a/addons/website_sale/tests/__init__.py
+++ b/addons/website_sale/tests/__init__.py
@@ -24,3 +24,4 @@ from . import test_website_sale_reorder_from_portal
 from . import test_website_sale_snippets
 from . import test_website_sale_fiscal_position
 from . import test_website_sale_invoice
+from . import test_product_page_tours

--- a/addons/website_sale/tests/test_product_page_tours.py
+++ b/addons/website_sale/tests/test_product_page_tours.py
@@ -1,0 +1,44 @@
+from odoo import Command
+from odoo.tests import tagged, HttpCase
+from odoo.addons.website_sale.controllers.main import WebsiteSale
+
+
+@tagged('post_install', '-at_install')
+class WebsiteSaleProductTestTours(HttpCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.WebsiteSaleController = WebsiteSale()
+        cls.website = cls.env.ref('website.default_website')
+        cls.website.company_id = cls.env.company
+
+    def test_variant_extra_field_rendering(self):
+        color_attribute = self.env['product.attribute'].create({
+            'name': 'Color',
+            'value_ids': [
+                Command.create({'name': 'red', 'sequence': 1}),
+                Command.create({'name': 'green', 'sequence': 2}),
+                Command.create({'name': 'blue', 'sequence': 3}),
+            ],
+        })
+        (red, green, blue) = color_attribute.value_ids
+
+        led_tmpl = self.env['product.template'].create({
+            'name': 'LED',
+            'is_published': True,
+            'attribute_line_ids': [Command.create({
+                'attribute_id': color_attribute.id,
+                'value_ids': [Command.link(color.id) for color in (red, green, blue)],
+            })],
+        })
+        code_field = self.env['ir.model.fields'].search(['&', ('name', '=', 'default_code'), ('model_id.model', '=', 'product.template')])
+
+        self.website.write({
+            'shop_extra_field_ids': [Command.create({'field_id': code_field.id})],
+        })
+
+        led_variants = led_tmpl.product_variant_ids
+        for i, variant in enumerate(led_variants):
+            variant.default_code = f"LED0{i + 1}"
+
+        self.start_tour(f'/shop/led-{led_tmpl.id}', 'variant_extra_fields_tour')


### PR DESCRIPTION
Problem
---
Extra fields displayed on the website product page do not take variants into account.

Steps
---
* configure the Website to show *Internal Reference* (`default_code`) as an extra field:
```
    use debug mode:
    Website > Configuration > Websites > [choose website]
            > Product Page Extra Fields
```
* configure a product to have several variants, each with their own `default_code`. (or use the *Customizable Desk* from demo data)
* go to the product's shop page.  

==> No *Internal Reference* is displayed

Fix
---
* create a mechanism for the `website.sale.extra.field` to register variant specific fields, which correspond to a template field. When possible we want to prioritize these.
* Using it, specify `default_code` -> `default_code`
* Make the extra-fields be dynamically rendered depending on the current variant on the website

opw-3981889
