### PR TITLE
[IMP] website: show toaster for missing seo details on page publish

### DIFF
--- a/addons/website/static/src/js/utils.js
+++ b/addons/website/static/src/js/utils.js
@@ -461,6 +461,40 @@ export function cloneContentEls(content, keepScripts = false) {
     return copyFragment;
 }
 
+/**
+ * Checks SEO data and notifies if either the page title or description is not
+ * set.
+ *
+ * @param {Object} seo_data - The SEO data to check.
+ * @param {Component} OptimizeSEODialog - Dialog to be displayed
+ * @param {Object} services - Services object which will be used to display
+ * notifications and dialog.
+ */
+export function checkAndNotifySEO(seo_data, OptimizeSEODialog, services) {
+    if (seo_data) {
+        let message;
+        if (!seo_data.website_meta_title) {
+            message = _t("Page title not set.");
+        } else if (!seo_data.website_meta_description) {
+            message = _t("Page description not set.");
+        }
+        if (message) {
+            services.notification.add(message, {
+                type: "warning",
+                sticky: false,
+                buttons: [
+                    {
+                        name: _t("Optimize SEO"),
+                        onClick: () => {
+                            services.dialog.add(OptimizeSEODialog);
+                        },
+                    },
+                ],
+            });
+        }
+    }
+}
+
 export default {
     loadAnchors: loadAnchors,
     autocompleteWithPages: autocompleteWithPages,
@@ -476,4 +510,5 @@ export default {
     isMobile: isMobile,
     getParsedDataFor: getParsedDataFor,
     cloneContentEls: cloneContentEls,
+    checkAndNotifySEO: checkAndNotifySEO,
 };


### PR DESCRIPTION
This PR enhances the SEO workflow by displaying a toaster notification when a page is published or saved without essential SEO details. The toaster will alert users if the SEO title is not set or if the SEO title is set but the SEO description is not. This notification helps ensure that all published pages have complete SEO metadata.

The toaster appears in the following scenarios:
- when publishing a page
- when saving a page
- when saving a translation of a page

The toaster notification includes a message informing the user of the missing SEO details and a button to open the "Optimize SEO" dialog, facilitating immediate correction.

task-3861508