### PR TITLE
[FIX] web_editor: respect opacity's type in ColorpickerUserValueWidget

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -1794,7 +1794,7 @@ const ColorpickerUserValueWidget = SelectUserValueWidget.extend({
             options.excluded = this.options.dataAttributes.excluded.replace(/ /g, '').split(',');
         }
         if (this.options.dataAttributes.opacity) {
-            options.opacity = this.options.dataAttributes.opacity;
+            options.opacity = parseFloat(this.options.dataAttributes.opacity);
         }
         if (this.options.dataAttributes.withCombinations) {
             options.withCombinations = !!this.options.dataAttributes.withCombinations;


### PR DESCRIPTION
Since [1], `opacity` needs to be a number as defined in ColorPlaette's props definition. However, in the ColorpickerUserValueWidget, when the props is passed to the ColorPalette component, it is given from the dataAttributes, which are strings. This leads to a crash in debug mode as the types are miss-matching.

This commit fixes that by parsing the dataAttribute to float.

[1]: https://github.com/odoo/odoo/commit/d7245d2abf528d093226c80e40975e63d61e8997#diff-c4e4c8cbbe59c3e61eba1cdcfd8f23809818a0b78c118d84606a1ab5d7bf1203

task-4001189
