### PR TITLE
[FIX] (sale|pos)_loyalty: reward deletion

### DIFF
--- a/addons/pos_loyalty/models/loyalty_reward.py
+++ b/addons/pos_loyalty/models/loyalty_reward.py
@@ -13,6 +13,6 @@ class LoyaltyReward(models.Model):
         return res
 
     def unlink(self):
-        if len(self) == 1 and self.env['pos.order.line'].search_count([('reward_id', 'in', self.ids)], limit=1):
+        if len(self) == 1 and self.env['pos.order.line'].sudo().search_count([('reward_id', 'in', self.ids)], limit=1):
             return self.action_archive()
         return super().unlink()

--- a/addons/sale_loyalty/models/loyalty_reward.py
+++ b/addons/sale_loyalty/models/loyalty_reward.py
@@ -17,6 +17,6 @@ class LoyaltyReward(models.Model):
         return res
 
     def unlink(self):
-        if len(self) == 1 and self.env['sale.order.line'].search_count([('reward_id', 'in', self.ids)], limit=1):
+        if len(self) == 1 and self.env['sale.order.line'].sudo().search_count([('reward_id', 'in', self.ids)], limit=1):
             return self.action_archive()
         return super().unlink()


### PR DESCRIPTION
Commit 95726f3d99ba7cf5796a9acd1c13a631db63fbd7 made it so that rewards are archived instead of unlinked when linked to a specific SO/PO, but forgot to bypass access rights to search the linked PO/SO.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
