### PR TITLE
[IMP] im_livechat: only show livechat sidebar categories for members

### DIFF
--- a/addons/im_livechat/static/src/core/web/livechat_channel_model.js
+++ b/addons/im_livechat/static/src/core/web/livechat_channel_model.js
@@ -13,8 +13,8 @@ export class LivechatChannel extends Record {
         compute() {
             return {
                 extraClass: "o-mail-DiscussSidebarCategory-livechat",
+                hideWhenEmpty: !this.hasSelfAsMember,
                 id: `im_livechat.category_${this.id}`,
-                livechatChannel: this,
                 name: this.name,
                 sequence: 22,
             };

--- a/addons/im_livechat/static/tests/channel_join_leave.test.js
+++ b/addons/im_livechat/static/tests/channel_join_leave.test.js
@@ -1,4 +1,4 @@
-import { serverState } from "@web/../tests/web_test_helpers";
+import { Command, serverState } from "@web/../tests/web_test_helpers";
 import { defineLivechatModels } from "@im_livechat/../tests/livechat_test_helpers";
 import {
     click,
@@ -20,7 +20,20 @@ test("from the discuss app", async () => {
             .search_read([["id", "=", serverState.groupLivechatId]])
             .map(({ id }) => id),
     });
-    pyEnv["im_livechat.channel"].create({ name: "HR", user_ids: [serverState.userId] });
+    const guestId = pyEnv["mail.guest"].create({ name: "Visitor" });
+    const livechatChannelId = pyEnv["im_livechat.channel"].create({
+        name: "HR",
+        user_ids: [serverState.userId],
+    });
+    pyEnv["discuss.channel"].create({
+        channel_type: "livechat",
+        channel_member_ids: [
+            Command.create({ partner_id: serverState.partnerId }),
+            Command.create({ guest_id: guestId }),
+        ],
+        livechat_channel_id: livechatChannelId,
+        livechat_operator_id: serverState.partnerId,
+    });
     await start();
     await openDiscuss();
     await click("[title='Leave HR']", {
@@ -29,9 +42,13 @@ test("from the discuss app", async () => {
     await click("[title='Join HR']", {
         parent: [".o-mail-DiscussSidebarCategory-livechat", { text: "HR" }],
     });
-    await contains("[title='Leave HR']", {
+    await click("[title='Unpin Conversation']", {
+        parent: [".o-mail-DiscussSidebarChannel", { text: "Visitor" }],
+    });
+    await click("[title='Leave HR']", {
         parent: [".o-mail-DiscussSidebarCategory-livechat", { text: "HR" }],
     });
+    await contains(".o-mail-DiscussSidebarCategory-livechat", { text: "HR", count: 0 });
 });
 
 test("from the command palette", async () => {


### PR DESCRIPTION
Before this PR, every live chat channel was displayed in the discuss sidebar for live chat users.

This PR improves the discuss UI by displaying only categories linked to channels the user is a member of or has ongoing conversations with.

task-3997562