### PR TITLE
[FIX] web: display correct group pager after reload

### DIFF
--- a/addons/web/static/src/model/relational_model/relational_model.js
+++ b/addons/web/static/src/model/relational_model/relational_model.js
@@ -469,6 +469,7 @@ export class RelationalModel extends Model {
                 const prom = this._loadData(groupConfig.list).then((response) => {
                     if (groupBy.length) {
                         group.groups = response ? response.groups : [];
+                        group.length = response ? response.length : 0;
                     } else {
                         group.records = response ? response.records : [];
                     }
@@ -496,11 +497,14 @@ export class RelationalModel extends Model {
 
         // if a group becomes empty at some point (e.g. we dragged its last record out of it), and the view is reloaded
         // with the same domain and groupbys, we want to keep the empty group in the UI
-        if (
-            config.currentGroups &&
-            config.currentGroups.params ===
-                JSON.stringify([config.domain, config.groupBy, config.offset, config.limit])
-        ) {
+        const params = JSON.stringify([
+            config.domain,
+            config.groupBy,
+            config.offset,
+            config.limit,
+            config.orderBy,
+        ]);
+        if (config.currentGroups && config.currentGroups.params === params) {
             const currentGroups = config.currentGroups.groups;
             currentGroups.forEach((group, index) => {
                 if (
@@ -519,10 +523,7 @@ export class RelationalModel extends Model {
                 }
             });
         }
-        config.currentGroups = {
-            params: JSON.stringify([config.domain, config.groupBy, config.offset, config.limit]),
-            groups,
-        };
+        config.currentGroups = { params, groups };
 
         return { groups, length };
     }

--- a/addons/web/static/tests/views/list_view_tests.js
+++ b/addons/web/static/tests/views/list_view_tests.js
@@ -779,7 +779,7 @@ QUnit.module("Views", (hooks) => {
         assert.containsNone(target, ".o_list_export_xlsx");
     });
 
-   QUnit.test("hide duplicate action for user without create access rights", async (assert) => {
+    QUnit.test("hide duplicate action for user without create access rights", async (assert) => {
         await makeView({
             type: "list",
             resModel: "foo",
@@ -1634,76 +1634,82 @@ QUnit.module("Views", (hooks) => {
         assert.verifySteps(["onchange", "web_save"]);
     });
 
-    QUnit.test("multi_edit: edit a required field with invalid value and click 'Ok' of alert dialog", async function (assert) {
-        serverData.models.foo.fields.foo.required = true;
+    QUnit.test(
+        "multi_edit: edit a required field with invalid value and click 'Ok' of alert dialog",
+        async function (assert) {
+            serverData.models.foo.fields.foo.required = true;
 
-        await makeView({
-            type: "list",
-            resModel: "foo",
-            serverData,
-            arch: `
+            await makeView({
+                type: "list",
+                resModel: "foo",
+                serverData,
+                arch: `
                 <tree multi_edit="1">
                     <field name="foo"/>
                     <field name="int_field"/>
                 </tree>`,
-            mockRPC(route, args) {
-                assert.step(args.method);
-            },
-        });
-        assert.containsN(target, ".o_data_row", 4);
-        assert.verifySteps(["get_views", "web_search_read"]);
+                mockRPC(route, args) {
+                    assert.step(args.method);
+                },
+            });
+            assert.containsN(target, ".o_data_row", 4);
+            assert.verifySteps(["get_views", "web_search_read"]);
 
-        const rows = target.querySelectorAll(".o_data_row");
-        await click(rows[0], ".o_list_record_selector input");
-        await click(rows[0].querySelector(".o_data_cell"));
-        await editInput(target, "[name='foo'] input", "");
-        await click(target, ".o_list_view");
-        assert.containsOnce(target, ".modal");
-        assert.strictEqual(target.querySelector(".modal .btn").textContent, "Ok");
+            const rows = target.querySelectorAll(".o_data_row");
+            await click(rows[0], ".o_list_record_selector input");
+            await click(rows[0].querySelector(".o_data_cell"));
+            await editInput(target, "[name='foo'] input", "");
+            await click(target, ".o_list_view");
+            assert.containsOnce(target, ".modal");
+            assert.strictEqual(target.querySelector(".modal .btn").textContent, "Ok");
 
-        await click(target.querySelector(".modal .btn"));
-        assert.strictEqual(
-            target.querySelector(".o_data_row .o_data_cell[name='foo']").textContent,
-            "yop"
-        );
-        assert.hasClass(target.querySelector(".o_data_row"), "o_data_row_selected");
+            await click(target.querySelector(".modal .btn"));
+            assert.strictEqual(
+                target.querySelector(".o_data_row .o_data_cell[name='foo']").textContent,
+                "yop"
+            );
+            assert.hasClass(target.querySelector(".o_data_row"), "o_data_row_selected");
 
-        assert.verifySteps([]);
-    });
+            assert.verifySteps([]);
+        }
+    );
 
-    QUnit.test("multi_edit: edit a required field with invalid value and dismiss alert dialog", async function (assert) {
-        serverData.models.foo.fields.foo.required = true;
-        await makeView({
-            type: "list",
-            resModel: "foo",
-            serverData,
-            arch: `
+    QUnit.test(
+        "multi_edit: edit a required field with invalid value and dismiss alert dialog",
+        async function (assert) {
+            serverData.models.foo.fields.foo.required = true;
+            await makeView({
+                type: "list",
+                resModel: "foo",
+                serverData,
+                arch: `
                 <tree multi_edit="1">
                     <field name="foo"/>
                     <field name="int_field"/>
                 </tree>`,
-            mockRPC(route, args) {
-                assert.step(args.method);
-            },
-        });
-        assert.containsN(target, ".o_data_row", 4);
-        assert.verifySteps(["get_views", "web_search_read"]);
+                mockRPC(route, args) {
+                    assert.step(args.method);
+                },
+            });
+            assert.containsN(target, ".o_data_row", 4);
+            assert.verifySteps(["get_views", "web_search_read"]);
 
-        const rows = target.querySelectorAll(".o_data_row");
-        await click(rows[0], ".o_list_record_selector input");
-        await click(rows[0].querySelector(".o_data_cell"));
-        await editInput(target, "[name='foo'] input", "");
-        await click(target, ".o_list_view");
+            const rows = target.querySelectorAll(".o_data_row");
+            await click(rows[0], ".o_list_record_selector input");
+            await click(rows[0].querySelector(".o_data_cell"));
+            await editInput(target, "[name='foo'] input", "");
+            await click(target, ".o_list_view");
 
-        assert.containsOnce(target, ".modal");
-        await click(target.querySelector(".modal-header .btn-close"));
-        assert.strictEqual(
-            target.querySelector(".o_data_row .o_data_cell[name='foo']").textContent,
-            "yop"
-        );
-        assert.hasClass(target.querySelector(".o_data_row"), "o_data_row_selected");
-        assert.verifySteps([]);
-    });
+            assert.containsOnce(target, ".modal");
+            await click(target.querySelector(".modal-header .btn-close"));
+            assert.strictEqual(
+                target.querySelector(".o_data_row .o_data_cell[name='foo']").textContent,
+                "yop"
+            );
+            assert.hasClass(target.querySelector(".o_data_row"), "o_data_row_selected");
+            assert.verifySteps([]);
+        }
+    );
 
     QUnit.test(
         "multi_edit: clicking on a readonly field switches the focus to the next editable field",
@@ -6879,6 +6885,44 @@ QUnit.module("Views", (hooks) => {
         await click(target.querySelector(".o_group_header"));
         assert.containsN(target, ".o_group_header", 4);
         assert.containsNone(target, ".o_group_header:first-of-type .o_group_name .o_pager");
+    });
+
+    QUnit.test("multi-level grouped list, pager inside a group, reload", async function (assert) {
+        serverData.models.foo.records.forEach((r) => (r.bar = true));
+        await makeView({
+            type: "list",
+            resModel: "foo",
+            serverData,
+            arch: `
+                <tree groups_limit="2">
+                    <field name="foo"/>
+                    <field name="int_field"/>
+                    <field name="bar"/>
+                </tree>`,
+            groupBy: ["bar", "foo"],
+        });
+
+        assert.containsOnce(target, ".o_group_header");
+
+        await click(target.querySelector(".o_group_header"));
+        assert.containsN(target, ".o_group_header", 3);
+        assert.containsOnce(target, ".o_group_header .o_group_name .o_pager");
+        assert.deepEqual(getPagerValue(target.querySelector(".o_group_header")), [1, 2]);
+        assert.strictEqual(getPagerLimit(target.querySelector(".o_group_header")), 3);
+        assert.deepEqual(getNodesTextContent(target.querySelectorAll("td.o_list_number")), [
+            "32",
+            "5",
+            "17",
+        ]);
+
+        await click(target.querySelector(".o_list_table thead th[data-name=int_field]"));
+        assert.deepEqual(getPagerValue(target.querySelector(".o_group_header")), [1, 2]);
+        assert.strictEqual(getPagerLimit(target.querySelector(".o_group_header")), 3);
+        assert.deepEqual(getNodesTextContent(target.querySelectorAll("td.o_list_number")), [
+            "32",
+            "5",
+            "10",
+        ]);
     });
 
     QUnit.test("count_limit attrs set in arch", async function (assert) {


### PR DESCRIPTION
Have a list view grouped by 2 fields (e.g. Contacts: Salesperson >
name). Open a group which contains more groups than the limit (set the groups_limit attribute on the arch if necessary). Next to the name of the group, the total number of records belonging to that group is displayed (e.g. Mitchel Admin (32)). In the group header row, the pager allows to browser the inner **groups**, so the total displayed there is the total number of inner groups in that group (e.g. 1-10 / 31).

From that point, clicking on a column header to sort by a given field produces a reload, and the group pager is updated with the wrong total: it now displays the number of records, not the number of groups (1-10 / 32 in the example).

This commit fixes that issue.

The test also hihglighted another issue: when reloaded, we sometimes have to keep former groups that became empty and that weren't returned by the last call to web_read_group (e.g. we drag and dropped the last record from a group to another group). We only do that if search query parameters didn't change. However, we forgot to take the orderBy into account, so when sorting groups, groups that were no longer on the current page were still displayed, with count 0. This commit also fixes that issue.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
