### PR TITLE
[FIX] pos_restaurant: consistent table size during setup

### DIFF
--- a/addons/pos_restaurant/models/pos_config.py
+++ b/addons/pos_restaurant/models/pos_config.py
@@ -104,8 +104,8 @@ class PosConfig(models.Model):
                 'seats': 1,
                 'position_h': 100,
                 'position_v': 100,
-                'width': 100,
-                'height': 100,
+                'width': 130,
+                'height': 130,
             })
 
     @api.model


### PR DESCRIPTION
Steps:
---
- Create a new POS Restaurant
- One default table is created on the floor
- Add a new table from Edit Plan
- Two tables with different sizes can be seen

Issue:
---
The size of the table should be the same for both the pre-created table and manually added table.

Cause:
---
The size was set to 100x100 pixels during the default setup of the floor.

Fix:
--
Change the size to 130px, which is the norm when adding new tables.

task-3764068
