### PR TITLE
[FIX] web: restore selected week upon breadcrumb return

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_controller.js
+++ b/addons/web/static/src/views/calendar/calendar_controller.js
@@ -57,6 +57,7 @@ export class CalendarController extends Component {
                 domain: this.props.domain,
                 fields: this.props.fields,
                 allFilter: this.props.state?.allFilter ?? {},
+                date: this.props.state?.date,
             },
             {
                 onWillStart: this.onWillStartModel.bind(this),

--- a/addons/web/static/tests/views/calendar/calendar_view_tests.js
+++ b/addons/web/static/tests/views/calendar/calendar_view_tests.js
@@ -5440,6 +5440,53 @@ QUnit.module("Views", ({ beforeEach }) => {
     });
 
     QUnit.test(
+        "save selected date during view switching",
+        async function (assert) {
+            serverData.models.event.records = [];
+            serverData.actions = {
+                1: {
+                    id: 1,
+                    name: "Partners",
+                    res_model: "event",
+                    type: "ir.actions.act_window",
+                    views: [
+                        [false, "list"],
+                        [false, "calendar"],
+                    ],
+                },
+            };
+
+            serverData.views = {
+                "event,false,calendar": `<calendar date_start="start" date_stop="stop" mode="week"/>`,
+                "event,false,list": `<tree sample="1">
+                    <field name="start"/>
+                    <field name="stop"/>
+                </tree>`,
+
+                "event,false,search": `<search />`,
+            };
+
+            const webClient = await createWebClient({
+                serverData,
+                async mockRPC(route) {
+                    if (route.endsWith("/has_group")) {
+                        return true;
+                    }
+                },
+            });
+
+            await doAction(webClient, 1);
+
+            await click(target, ".o_cp_switch_buttons .o_calendar");
+            await click(target, ".o_calendar_button_next");
+            const weekNumber = target.querySelector(".fc-week-number").textContent;
+            await click(target, ".o_cp_switch_buttons .o_list");
+            await click(target, ".o_cp_switch_buttons .o_calendar");
+            assert.equal(weekNumber, target.querySelector(".fc-week-number").textContent);
+        }
+    );
+
+    QUnit.test(
         "sample data are not removed when switching back from calendar view",
         async function (assert) {
             serverData.models.event.records = [];


### PR DESCRIPTION
Steps to reproduce:
- Install Calendar
- Go to next week for example
- Click on an event -> edit
- In the breadcrumb return to the calendar view

Issues:
The calendar show the current week and not the previous one. Even though we export the state we don't restore the date from the previous ones.

opw-3946022