### PR TITLE
[IMP] website: restore modal borders in the front-end

### DIFF
--- a/addons/website/static/src/scss/bootstrap_overridden.scss
+++ b/addons/website/static/src/scss/bootstrap_overridden.scss
@@ -336,10 +336,6 @@ $box-shadow-lg: 0px 12px 32px rgba($black, .175) !default;
 // Cards
 $card-border-color: $border-color !default;
 
-// Modals
-$modal-header-border-width: 0 !default;
-$modal-footer-border-width: 0 !default;
-
 // HR Separator
 $hr-color: $border-color !default;
 $hr-opacity: 1 !default;


### PR DESCRIPTION
The lack of borders in the modals of the front-end is problematic when there is some content overflowing the height of the modal.

This PR restores the borders for a better visual hierarchy.

Non-optimal design introduced in front-end redesign: https://github.com/odoo/odoo/pull/120302

task-4001380

| Before | After |
|--------|--------|
| <img width="979" alt="Screenshot 2024-06-20 at 11 41 54" src="https://github.com/odoo/odoo/assets/110090660/31e0d3c7-fcd9-43c9-9aae-7db3b4e49af2"> | <img width="978" alt="Screenshot 2024-06-20 at 11 42 26" src="https://github.com/odoo/odoo/assets/110090660/09f12eb0-79e4-454f-9896-af238b26a7b3"> | 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
