### PR TITLE
[FIX] web: make `open_form_view` attr show the view btn in readonly too

### DIFF
--- a/addons/web/static/src/views/fields/x2many/x2many_field.js
+++ b/addons/web/static/src/views/fields/x2many/x2many_field.js
@@ -222,7 +222,7 @@ export class X2ManyField extends Component {
                 !this.props.readonly && ("editable" in params ? params.editable : editable);
             this.onAdd(params);
         };
-        const openFormView = props.editable ? archInfo.openFormView : false;
+        const openFormView = archInfo.editable ? archInfo.openFormView : false;
         props.onOpenFormView = openFormView ? this.switchToForm.bind(this) : undefined;
         return props;
     }

--- a/addons/web/static/tests/views/list_view_tests.js
+++ b/addons/web/static/tests/views/list_view_tests.js
@@ -697,6 +697,41 @@ QUnit.module("Views", (hooks) => {
         assert.verifySteps(["switch to form - resId: 1 activeIds: 1,2,3,4"]);
     });
 
+    QUnit.test("editable readonly list with open_form_view", async function (assert) {
+        serverData.models.foo.fields.foo_o2m = {
+            string: "Foo O2M",
+            type: "one2many",
+            relation: "foo",
+        };
+        serverData.models.foo.records.push({ id: 5, bar: true, foo: "xxx" });
+        serverData.models.foo.records.push({ id: 6, bar: true, foo: "yyy" });
+        serverData.models.foo.records[0].foo_o2m = [5, 6];
+        await makeView({
+            type: "form",
+            resModel: "foo",
+            serverData,
+            resId: 1,
+            arch: `
+                <form>
+                    <sheet>
+                        <field name="foo_o2m" readonly="1">
+                            <tree editable="top" open_form_view="1">
+                                <field name="foo"/>
+                                <field name="bar"/>
+                            </tree>
+                        </field>
+                    </sheet>
+                </form>
+            `,
+        });
+        assert.containsN(
+            target,
+            "td.o_list_record_open_form_view",
+            2,
+            "button to open form view should be present on each rows"
+        );
+    });
+
     QUnit.test(
         "export feature in list for users not in base.group_allow_export",
         async function (assert) {


### PR DESCRIPTION
Commit [1] introduced a way for an editable list view to open the record inside a form view in the current window (adding itself to the breadcrumb) when clicked.

It's done by adding a `open_form_view` attribute on the tree node, which then adds automatically a "View" button/action on each tree lines.

But there was an unseen issue where when that x2m (tree) field was set as readonly, the button would not be shown, preventing the navigation.

[1]: https://github.com/odoo/odoo/commit/258e6a019a21042bf4f6cf70fcce386d37afd50c

task-3973116
