### PR TITLE
[IMP] mail: show loading when fetching `@mention` suggestions

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -307,11 +307,11 @@ export class Composer extends Component {
         const props = {
             anchorRef: this.ref.el,
             position: this.env.inChatter ? "bottom-fit" : "top-fit",
-            placeholder: _t("Loading"),
             onSelect: (ev, option) => {
                 this.suggestion.insert(option);
                 markEventHandled(ev, "composer.selectSuggestion");
             },
+            isLoading: !!this.suggestion.search.term && this.suggestion.state.isFetching,
             options: [],
         };
         if (!this.hasSuggestions) {

--- a/addons/mail/static/src/core/common/navigable_list.js
+++ b/addons/mail/static/src/core/common/navigable_list.js
@@ -19,7 +19,6 @@ export class NavigableList extends Component {
         onSelect: { type: Function },
         options: { type: Array },
         optionTemplate: { type: String, optional: true },
-        placeholder: { type: String, optional: true },
         position: { type: String, optional: true },
         isLoading: { type: Boolean, optional: true },
     };
@@ -31,6 +30,7 @@ export class NavigableList extends Component {
         this.state = useState({
             activeIndex: null,
             open: false,
+            showLoading: false,
         });
         this.hotkey = useService("hotkey");
         this.hotkeysToRemove = [];
@@ -54,6 +54,17 @@ export class NavigableList extends Component {
                 this.open();
             },
             () => [this.props]
+        );
+        useEffect(
+            () => {
+                if (!this.props.isLoading) {
+                    clearTimeout(this.loadingTimeoutId);
+                    this.state.showLoading = false;
+                } else if (!this.loadingTimeoutId) {
+                    this.loadingTimeoutId = setTimeout(() => (this.state.showLoading = true), 2000);
+                }
+            },
+            () => [this.props.isLoading]
         );
     }
 

--- a/addons/mail/static/src/core/common/navigable_list.scss
+++ b/addons/mail/static/src/core/common/navigable_list.scss
@@ -1,3 +1,7 @@
 .o-mail-NavigableList {
     z-index: $o-mail-NavigableList-zIndex;
 }
+
+.o-mail-NavigableList-floatingLoading {
+    right: $border-width; // as to not overlap border
+}

--- a/addons/mail/static/src/core/common/navigable_list.xml
+++ b/addons/mail/static/src/core/common/navigable_list.xml
@@ -3,33 +3,34 @@
 
     <t t-name="mail.NavigableList">
         <div class="o-mail-NavigableList bg-view m-0 p-0" t-ref="root" t-att-class="props.class">
-            <div t-if="show" class="o-open border d-flex flex-column" t-on-mousedown.prevent="">
-                <div t-if="props.isLoading" class="o-mail-NavigableList-item">
-                    <a href="#" class="d-flex align-items-center w-100 py-2 px-4 gap-1">
-                        <i class="fa fa-spin fa-circle-o-notch"/>
-                        <t t-esc="props.placeholder"/>
-                    </a>
+            <div t-if="show" class="o-open border d-flex flex-column bg-inherit" t-on-mousedown.prevent="">
+                <div t-if="state.showLoading" t-att-class="{ 'position-absolute bg-inherit smaller o-mail-NavigableList-floatingLoading': props.options.length, 'bg-300': props.options.length and state.activeIndex === 0, 'o-mail-NavigableList-item': !props.options.length }">
+                    <t t-call="mail.NavigableList.spinner"/>
                 </div>
-                <t t-else="">
-                    <div
-                        t-foreach="sortedOptions" t-as="option" t-key="option_index"
-                        class="o-mail-NavigableList-item"
-                        t-att-class="option.classList"
-                        t-on-mouseenter="() => this.onOptionMouseEnter(option_index)"
-                        t-on-click="(ev) => this.selectOption(ev, option_index)"
-                    >
-                        <hr class="my-2" t-if="option.group != lastGroup and option_index != 0"/>
-                        <a href="#" class="d-flex align-items-center w-100 py-2 px-4" t-att-class="{ 'o-mail-NavigableList-active bg-300': state.activeIndex === option_index }">
-                            <t t-if="option.optionTemplate" t-call="{{ option.optionTemplate }}"/>
-                            <t t-elif="props.optionTemplate" t-call="{{ props.optionTemplate }}"/>
-                            <t t-else="" t-esc="option.label"/>
-                        </a>
-                        <t t-set="lastGroup" t-value="option.group"/>
-                    </div>
-                </t>
+                <div
+                    t-foreach="sortedOptions" t-as="option" t-key="option_index"
+                    class="o-mail-NavigableList-item"
+                    t-att-class="option.classList"
+                    t-on-mouseenter="() => this.onOptionMouseEnter(option_index)"
+                    t-on-click="(ev) => this.selectOption(ev, option_index)"
+                >
+                    <hr class="my-2" t-if="option.group != lastGroup and option_index != 0"/>
+                    <a role="button" class="d-flex align-items-center w-100 py-2 px-4" t-att-class="{ 'o-mail-NavigableList-active bg-300': state.activeIndex === option_index }">
+                        <t t-if="option.optionTemplate" t-call="{{ option.optionTemplate }}"/>
+                        <t t-elif="props.optionTemplate" t-call="{{ props.optionTemplate }}"/>
+                        <t t-else="" t-esc="option.label"/>
+                    </a>
+                    <t t-set="lastGroup" t-value="option.group"/>
+                </div>
                 <span t-if="props.hint" class="text-muted fst-italic form-text align-self-end m-0 me-1" t-esc="props.hint"/>
             </div>
         </div>
     </t>
 
+    <t t-name="mail.NavigableList.spinner">
+        <span class="d-flex align-items-center w-100 py-2 gap-1 text-muted opacity-75" t-att-class="{ 'px-1': props.options.length, 'px-4': !props.options.length }">
+            <i class="fa fa-spin fa-circle-o-notch"/>
+            Loading…
+        </span>
+    </t>
 </templates>

--- a/addons/mail/static/src/core/common/suggestion_hook.js
+++ b/addons/mail/static/src/core/common/suggestion_hook.js
@@ -26,9 +26,16 @@ class UseSuggestion {
                     ) {
                         return; // no need to fetch since this is more specific than last and last had no result
                     }
-                    await this.suggestionService.fetchSuggestions(this.search, {
-                        thread: this.thread,
-                    });
+                    this.state.isFetching = true;
+                    try {
+                        await this.suggestionService.fetchSuggestions(this.search, {
+                            thread: this.thread,
+                        });
+                    } catch {
+                        this.lastFetchedSearch = null;
+                    } finally {
+                        this.state.isFetching = false;
+                    }
                     if (status(comp) === "destroyed") {
                         return;
                     }
@@ -68,6 +75,7 @@ class UseSuggestion {
     state = useState({
         count: 0,
         items: undefined,
+        isFetching: false,
     });
     search = {
         delimiter: undefined,

--- a/addons/mail/static/src/core/common/suggestion_hook.js
+++ b/addons/mail/static/src/core/common/suggestion_hook.js
@@ -20,6 +20,12 @@ class UseSuggestion {
                     ) {
                         return; // ignore obsolete call
                     }
+                    if (
+                        this.lastFetchedSearch?.count === 0 &&
+                        (!this.search.delimiter || this.isSearchMoreSpecificThanLastFetch)
+                    ) {
+                        return; // no need to fetch since this is more specific than last and last had no result
+                    }
                     await this.suggestionService.fetchSuggestions(this.search, {
                         thread: this.thread,
                     });
@@ -27,6 +33,10 @@ class UseSuggestion {
                         return;
                     }
                     this.update();
+                    this.lastFetchedSearch = {
+                        ...this.search,
+                        count: this.state.items?.suggestions.length ?? 0,
+                    };
                     if (
                         this.search.delimiter === delimiter &&
                         this.search.position === position &&
@@ -64,6 +74,14 @@ class UseSuggestion {
         position: undefined,
         term: "",
     };
+    lastFetchedSearch;
+    get isSearchMoreSpecificThanLastFetch() {
+        return (
+            this.lastFetchedSearch.delimiter === this.search.delimiter &&
+            this.search.term.startsWith(this.lastFetchedSearch.term) &&
+            this.lastFetchedSearch.position >= this.search.position
+        );
+    }
     clearRawMentions() {
         this.composer.mentionedChannels.length = 0;
         this.composer.mentionedPartners.length = 0;

--- a/addons/mail/static/src/core/web/mention_list.js
+++ b/addons/mail/static/src/core/web/mention_list.js
@@ -19,6 +19,7 @@ export class MentionList extends Component {
         this.state = useState({
             searchTerm: "",
             options: [],
+            isFetching: false,
         });
         this.orm = useService("orm");
         this.store = useState(useService("mail.store"));
@@ -33,10 +34,15 @@ export class MentionList extends Component {
                     return;
                 }
                 this.sequential(async () => {
-                    await this.suggestionService.fetchSuggestions({
-                        delimiter: this.props.type === "partner" ? "@" : "#",
-                        term: this.state.searchTerm,
-                    });
+                    this.state.isFetching = true;
+                    try {
+                        await this.suggestionService.fetchSuggestions({
+                            delimiter: this.props.type === "partner" ? "@" : "#",
+                            term: this.state.searchTerm,
+                        });
+                    } finally {
+                        this.state.isFetching = false;
+                    }
                     const { suggestions } = this.suggestionService.searchSuggestions(
                         {
                             delimiter: this.props.type === "partner" ? "@" : "#",
@@ -66,7 +72,7 @@ export class MentionList extends Component {
         const props = {
             anchorRef: this.ref.el,
             position: "bottom-fit",
-            placeholder: _t("Loading"),
+            isLoading: !!this.state.searchTerm && this.state.isFetching,
             onSelect: this.props.onSelect,
             options: [],
         };

--- a/addons/mail/static/src/discuss/core/web/channel_selector.js
+++ b/addons/mail/static/src/discuss/core/web/channel_selector.js
@@ -30,7 +30,6 @@ export class ChannelSelector extends Component {
                 anchorRef: undefined,
                 position: "bottom-fit",
                 onSelect: (ev, option) => this.onSelect(option),
-                placeholder: _t("Loading"),
                 optionTemplate:
                     this.props.category.id === "channels"
                         ? "discuss.ChannelSelector.channel"

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -1948,7 +1948,7 @@ test("Chats input should wait until the previous RPC is done before starting a n
     await openDiscuss();
     await click(".o-mail-DiscussSidebarCategory-add[title='Start a conversation']");
     await insertText(".o-discuss-ChannelSelector input", "m");
-    await contains(".o-mail-NavigableList-item", { text: "Loading" });
+    await contains(".o-mail-NavigableList-item", { text: "Loading…" });
     await insertText(".o-discuss-ChannelSelector input", "a");
     await insertText(".o-discuss-ChannelSelector input", "r");
     deferred1.resolve();

--- a/addons/mail/static/tests/suggestion/suggestion.test.js
+++ b/addons/mail/static/tests/suggestion/suggestion.test.js
@@ -91,6 +91,25 @@ test('display partner mention suggestions on typing "@" in chatter', async () =>
     await contains(".o-mail-Composer-suggestion strong", { text: "Mitchell Admin" });
 });
 
+test("Do not fetch if search more specific and fetch had no result", async () => {
+    await startServer();
+    onRpc("res.partner", "get_mention_suggestions", () => {
+        step("get_mention_suggestions");
+    });
+    await start();
+    await openFormView("res.partner", serverState.partnerId);
+    await click("button", { text: "Send message" });
+    insertText(".o-mail-Composer-input", "@");
+    await contains(".o-mail-Composer-suggestion", { count: 3 }); // Mitchell Admin, Hermit, Public user
+    await contains(".o-mail-Composer-suggestion", { text: "Mitchell Admin" });
+    await assertSteps(["get_mention_suggestions"]);
+    insertText(".o-mail-Composer-input", "x");
+    await contains(".o-mail-Composer-suggestion", { count: 0 });
+    await assertSteps(["get_mention_suggestions"]);
+    insertText(".o-mail-Composer-input", "x");
+    await assertSteps([]);
+});
+
 test("show other channel member in @ mention", async () => {
     const pyEnv = await startServer();
     const partnerId = pyEnv["res.partner"].create({


### PR DESCRIPTION
Before this commit, when typing `@mention` in the composer of Discuss, some results could take a long time to be displayed.

Steps to reproduce:
- Have a DB with millions of users and partners
- Make a `@mention` in composer of Chatter
=> immediately shows some results, and about 10 seconds for more

This happens because the suggestion list relies on user data that have already been fetched, but also silently fetches for suggestions matching search term in the context of chatter. This latter process can take seconds, so the optimistic behavior of already showing some results could help immediately adding the desired mention.

We are still trying to improve speed of fetching mentions, but with current technique there's a lack of UI hint that it's fetching more suggestions.

This commit adds a "Loading..." in the showing of suggestion list when there's a silent fetching of suggestion that's ongoing. The optimistic showing of suggestions is still in place so that UX stays decent enough even though the fetching process might be long.

Part of task-3911449