### PR TITLE
[FIX] payment_razorpay: fix duplicate token creation issue

### DIFF
--- a/addons/payment_razorpay/models/payment_transaction.py
+++ b/addons/payment_razorpay/models/payment_transaction.py
@@ -405,8 +405,12 @@ class PaymentTransaction(models.Model):
             if self.provider_id.capture_manually:
                 self._set_authorized()
         elif entity_status in const.PAYMENT_STATUS_MAPPING['done']:
-            if entity_data.get('token_id') and self.provider_id.allow_tokenization:
-                self._razorpay_tokenize_from_notification_data(notification_data)
+            if (
+                not self.token_id
+                and entity_data.get('token_id')
+                and self.provider_id.allow_tokenization
+            ):
+                self._razorpay_tokenize_from_notification_data(entity_data)
             self._set_done()
 
             # Immediately post-process the transaction if it is a refund, as the post-processing


### PR DESCRIPTION
Steps:
- Install sale and razopay app.
- Set-up razorpay provider.
- Create quotation.
- Pay that quotation via razorpay and save payment details.
- Duplicate that quote and pay it via already saved method.

Issue:
- Creating duplicate token when paying via token.

Cause:
- Since [PR] we are creating token in odoo when razorpay give token_id in notification_data and tokenization is enabled on razorpay and in some case when we pay quote via token it return token in notification_data and since we forgot to check if transaction is already connected to token or not it always create new token :(

Fix:
- Add condition to check if transaction is connected to token or not and only create token if transaction is not connected to token. Additionally pass entity_data in token creation method so it pass proper data when we don't find `id` in `notification_data`.

[PR]: https://github.com/odoo/odoo/pull/159250