### PR TITLE
[IMP] hr_contract:  configure contract working calendar for flexible

### DIFF
--- a/addons/hr_contract/views/hr_contract_views.xml
+++ b/addons/hr_contract/views/hr_contract_views.xml
@@ -203,11 +203,9 @@
                                 <div id="resource_calendar_warning" class="d-flex align-items-center">
                                         <field name="resource_calendar_id"
                                             groups="!hr_contract.group_hr_contract_manager"
-                                            required="1"
                                             options="{'no_open': True, 'no_create': True}"/>
                                         <field name="resource_calendar_id"
-                                            groups="hr_contract.group_hr_contract_manager"
-                                            required="1"/>
+                                            groups="hr_contract.group_hr_contract_manager"/>
                                         <widget
                                             name="contract_warning_tooltip"
                                             invisible="not calendar_mismatch or state != 'open'"/>

--- a/addons/hr_work_entry_contract/views/hr_contract_views.xml
+++ b/addons/hr_work_entry_contract/views/hr_contract_views.xml
@@ -5,7 +5,20 @@
         <field name="model">hr.contract</field>
         <field name="inherit_id" ref="hr_contract.hr_contract_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[@id='resource_calendar_warning']" position="after">
+            <xpath expr="//div[@id='resource_calendar_warning']" position="replace">
+                <div id="resource_calendar_warning" class="d-flex align-items-center">
+                    <!-- resource calendar is only required when work_entry_source is set to 'calendar' -->
+                    <field name="resource_calendar_id"
+                    groups="!hr_contract.group_hr_contract_manager"
+                        required="work_entry_source == 'calendar'"
+                        options="{'no_open': True, 'no_create': True}"/>
+                    <field name="resource_calendar_id"
+                        groups="hr_contract.group_hr_contract_manager"
+                        required="work_entry_source == 'calendar'"/>
+                    <widget
+                        name="contract_warning_tooltip"
+                        invisible="not calendar_mismatch or state != 'open'"/>
+                </div>
                 <!-- Makes no sense to display only one possibility -->
                 <field name="work_entry_source" widget="radio" invisible="1"/>
             </xpath>


### PR DESCRIPTION
Prior to this commit, the field `resource_calendar_id` was a required field. However, with the introduction of fully flexible employee which is defined as an employee without a resource calendar, we needed to drop this requirement.

With this commit, the field `resource_calendar_id` will only be required when the field `work_entry_source` is set to 'Working Schedule'. By default, the field will be not required.

related [community PR](https://github.com/odoo/enterprise/pull/65068)
Task: 3976534

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
