### PR TITLE
[IMP] mail: several discuss style improvements (2)

### DIFF
--- a/addons/im_livechat/static/src/core/web/discuss_sidebar_categories_patch.xml
+++ b/addons/im_livechat/static/src/core/web/discuss_sidebar_categories_patch.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="im_livechat.DiscussSidebarCategory" t-inherit="mail.DiscussSidebarCategory" t-inherit-mode="extension">
-        <xpath expr="//*[@t-ref='actions']/div[hasclass('btn-group')]" position="inside">
-            <button t-if="store.has_access_livechat and category.livechatChannel and category.open" class="btn btn-light" t-on-click="() => category.livechatChannel.hasSelfAsMember ? category.livechatChannel.leave({ notify: false }) : category.livechatChannel.join({ notify: false })">
+        <xpath expr="//*[@name='commands']" position="inside">
+            <button t-if="store.has_access_livechat and category.livechatChannel and category.open" class="btn p-0 bg-inherit" t-att-class="{ 'o-green': !category.livechatChannel.hasSelfAsMember, 'o-red': category.livechatChannel.hasSelfAsMember }" t-on-click="() => category.livechatChannel.hasSelfAsMember ? category.livechatChannel.leave({ notify: false }) : category.livechatChannel.join({ notify: false })">
                 <i t-att-class="{
-                       'fa fa-sign-out text-danger': category.livechatChannel.hasSelfAsMember,
-                       'fa fa-sign-in text-success': !category.livechatChannel.hasSelfAsMember
+                       'fa fa-fw fa-sign-out text-danger': category.livechatChannel.hasSelfAsMember,
+                       'fa fa-fw fa-sign-in text-success': !category.livechatChannel.hasSelfAsMember
                    }"
                    t-att-title="category.livechatChannel.hasSelfAsMember ? category.livechatChannel.leaveTitle : category.livechatChannel.joinTitle"
                    role="img"

--- a/addons/im_livechat/static/tests/embed/chat_window.test.js
+++ b/addons/im_livechat/static/tests/embed/chat_window.test.js
@@ -67,7 +67,7 @@ test("internal users can upload file to temporary thread", async () => {
         name: "text.txt",
     });
     await contains(".o-mail-Composer");
-    await contains("button[title='Attach files']");
+    await contains("button[title='Attach Files']");
     await inputFiles(".o-mail-Composer-coreMain .o_input_file", [file]);
     await contains(".o-mail-AttachmentCard", { text: "text.txt", contains: [".fa-check"] });
     await triggerHotkey("Enter");

--- a/addons/im_livechat/static/tests/embed/message_actions.test.js
+++ b/addons/im_livechat/static/tests/embed/message_actions.test.js
@@ -41,7 +41,7 @@ test("Only two quick actions are shown", async () => {
     await contains("[title='Expand']");
     await click("[title='Expand']");
     await contains(".o-mail-Message-actions i, .o-mail-Message-moreMenu i", { count: 6 });
-    await contains("[title='Edit']");
-    await contains("[title='Delete']");
-    await contains("[title='View Reactions']");
+    await contains("[aria-label='Edit']");
+    await contains("[aria-label='Delete']");
+    await contains("[aria-label='View Reactions']");
 });

--- a/addons/mail/static/src/chatter/web/chatter.xml
+++ b/addons/mail/static/src/chatter/web/chatter.xml
@@ -115,14 +115,16 @@
                             unlinkAttachment.bind="unlinkAttachment"
                             imagesHeight="100"
                         />
-                        <FileUploader multiUpload="true" fileUploadClass="'o-mail-Chatter-fileUploader'" onUploaded.bind="onUploaded" onClick="(ev) => this.onClickAttachFile(ev)">
-                            <t t-set-slot="toggler">
-                                <button class="btn btn-link" type="button" t-att-disabled="!state.thread.hasWriteAccess">
-                                    <i class="fa fa-plus-square"/>
-                                    Attach files
-                                </button>
-                            </t>
-                        </FileUploader>
+                        <div class="d-flex justify-content-center">
+                            <FileUploader multiUpload="true" fileUploadClass="'o-mail-Chatter-fileUploader'" onUploaded.bind="onUploaded" onClick="(ev) => this.onClickAttachFile(ev)">
+                                <t t-set-slot="toggler">
+                                    <button class="btn btn-link" type="button" t-att-disabled="!state.thread.hasWriteAccess">
+                                        <i class="fa fa-plus-square"/>
+                                        Attach Files
+                                    </button>
+                                </t>
+                            </FileUploader>
+                        </div>
                     </div>
                 </div>
                 <Thread t-if="!state.isSearchOpen" thread="state.thread" t-key="state.thread.localId" order="'desc'" scrollRef="rootRef" jumpPresent="state.jumpThreadPresent"/>
@@ -151,7 +153,7 @@
 </t>
 
 <t t-name="mail.Chatter.attachFiles">
-    <button class="o-mail-Chatter-attachFiles btn btn-link text-action px-1 d-flex align-items-center" aria-label="Attach files" t-att-class="{ 'my-2': !props.compactHeight }" t-on-click="onClickAddAttachments" t-att-disabled="state.isSearchOpen">
+    <button class="o-mail-Chatter-attachFiles btn btn-link text-action px-1 d-flex align-items-center" aria-label="Attach Files" t-att-class="{ 'my-2': !props.compactHeight }" t-on-click="onClickAddAttachments" t-att-disabled="state.isSearchOpen">
         <i class="fa fa-paperclip fa-lg me-1"/>
         <sup t-if="attachments.length > 0" t-esc="attachments.length"/>
         <i t-if="!state.thread.areAttachmentsLoaded and state.thread.isLoadingAttachments and state.showAttachmentLoading" class="fa fa-circle-o-notch fa-spin" aria-label="Attachment counter loading..."/>

--- a/addons/mail/static/src/core/common/attachment_list.js
+++ b/addons/mail/static/src/core/common/attachment_list.js
@@ -20,6 +20,7 @@ export class AttachmentList extends Component {
 
     setup() {
         super.setup();
+        this.store = useState(useService("mail.store"));
         this.ui = useState(useService("ui"));
         // Arbitrary high value, this is effectively a max-width.
         this.imagesWidth = 1920;
@@ -37,7 +38,7 @@ export class AttachmentList extends Component {
         return url(attachment.urlRoute, {
             ...attachment.urlQueryParams,
             width: this.imagesWidth,
-            height: this.props.imagesHeight,
+            height: this.props.imagesHeight * 2, // not blurry on upscaled monitors
         });
     }
 

--- a/addons/mail/static/src/core/common/attachment_list.scss
+++ b/addons/mail/static/src/core/common/attachment_list.scss
@@ -29,6 +29,10 @@
     min-width: 20px;
     min-height: 20px;
 
+    &:hover {
+        box-shadow: var(--box-shadow-sm) !important;
+    }
+
     img {
         object-fit: contain;
     }

--- a/addons/mail/static/src/core/common/attachment_list.xml
+++ b/addons/mail/static/src/core/common/attachment_list.xml
@@ -2,21 +2,18 @@
 <templates xml:space="preserve">
 
     <t t-name="mail.AttachmentList">
-        <div class="o-mail-AttachmentList overflow-y-auto d-flex flex-column mt-1"
+        <div class="o-mail-AttachmentList overflow-y-auto d-flex flex-column mt-1 p-2"
             t-att-class="{
                 'o-inComposer': env.inComposer,
                 'o-inChatWindow': env.inChatWindow,
-                'me-2 pe-4': isInChatWindowAndIsAlignedLeft and !env.inComposer,
-                'ms-2 ps-4': isInChatWindowAndIsAlignedRight and !env.inComposer,
             }"
         >
-            <div class="d-flex flex-grow-1 flex-wrap mx-1 align-items-center" t-att-class="{
+            <div class="d-flex flex-grow-1 flex-wrap mx-1 align-items-center gap-1" t-att-class="{
                 'justify-content-end': isInChatWindowAndIsAlignedRight and !env.inComposer,
                         }" role="menu" >
                 <div t-foreach="images" t-as="attachment" t-key="attachment.id"
                      t-att-aria-label="attachment.filename"
-                     class="o-mail-AttachmentImage d-flex position-relative flex-shrink-0 mw-100 mb-1 me-1"
-                     t-att-title="attachment.name"
+                     class="o-mail-AttachmentImage o-viewable d-flex position-relative flex-shrink-0 mw-100 mb-1"
                      t-att-class="{ 'o-isUploading': attachment.uploading }"
                      tabindex="0"
                      t-att-data-mimetype="attachment.mimetype"
@@ -24,7 +21,7 @@
                      role="menuitem"
                 >
                     <img
-                        class="img img-fluid my-0 mx-auto o-viewable rounded"
+                        class="img img-fluid my-0 mx-auto rounded"
                         t-att-class="{ 'opacity-25': attachment.uploading }"
                         t-att-src="getImageUrl(attachment)"
                         t-att-alt="attachment.name"
@@ -34,14 +31,15 @@
                     <div t-if="attachment.uploading" class="position-absolute top-0 bottom-0 start-0 end-0 d-flex align-items-center justify-content-center" title="Uploading">
                         <i class="fa fa-spin fa-spinner"/>
                     </div>
-                    <div class="position-absolute top-0 bottom-0 start-0 end-0 p-2 text-white o-opacity-hoverable opacity-0 opacity-100-hover d-flex align-items-end flax-wrap flex-column">
+                    <div class="position-absolute top-0 bottom-0 start-0 end-0 p-2 text-white o-opacity-hoverable opacity-0 opacity-100-hover d-flex align-items-end flax-wrap flex-column gap-1">
                         <button t-if="showDelete"
-                             class="btn btn-sm btn-dark rounded opacity-75 opacity-100-hover"
+                             class="btn btn-sm rounded opacity-75 opacity-100-hover px-1"
+                             t-att-class="store.theme === 'dark' ? 'btn-light' : 'btn-dark'"
                              tabindex="0" aria-label="Remove" role="menuitem" t-on-click.stop="() => this.onClickUnlink(attachment)" title="Remove">
-                            <i class="fa fa-trash"/>
+                            <i class="fa fa-fw fa-trash"/>
                         </button>
-                        <button t-if="canDownload(attachment)" class="btn btn-sm btn-dark rounded opacity-75 opacity-100-hover mt-auto" t-on-click.stop="() => this.onClickDownload(attachment)" title="Download">
-                            <i class="fa fa-download"/>
+                        <button t-if="canDownload(attachment) and !ui.isSmall" class="btn btn-sm rounded opacity-75 opacity-100-hover px-1" t-att-class="store.theme === 'dark' ? 'btn-light' : 'btn-dark'" t-on-click.stop="() => this.onClickDownload(attachment)" title="Download">
+                            <i class="fa fa-fw fa-download"/>
                         </button>
                     </div>
                 </div>

--- a/addons/mail/static/src/core/common/autoresize_input.scss
+++ b/addons/mail/static/src/core/common/autoresize_input.scss
@@ -6,7 +6,7 @@
             --o-input-border-color: #{$border-color};
         }
         &:focus {
-            --o-input-border-color: #{$black};
+            --o-input-border-color: #{rgba($o-action, 0.5)};
         }
     }
 }

--- a/addons/mail/static/src/core/common/chat_bubble.scss
+++ b/addons/mail/static/src/core/common/chat_bubble.scss
@@ -40,10 +40,13 @@
     z-index: 6;
     font-size: 11px;
     display: none;
+    border-color: transparent !important;
 
     &:hover {
-        background-color: $o-gray-300 !important;
+        color: darken($danger, 10%) !important;
+        border-color: darken($danger, 10%) !important;
     }
+
 }
 
 .o-mail-ChatBubble-counter {
@@ -76,6 +79,13 @@
     right: -3px;
 }
 
+.o-mail-ChatBubble-unread {
+    right: -8px;
+    top: 25px;
+    font-size: 0.4rem;
+    opacity: 50%;
+}
+
 @keyframes o-mail-ChatBubble-bouncing { 
     from { 
         transform: translate3d(0, 0, 0); 
@@ -83,4 +93,4 @@
     to {
         transform: translate3d(0, -10px, 0); 
     } 
-} 
+}

--- a/addons/mail/static/src/core/common/chat_bubble.xml
+++ b/addons/mail/static/src/core/common/chat_bubble.xml
@@ -11,18 +11,21 @@
     </t>
 
     <t t-name="mail.ChatBubble.core">
-        <button class="o-mail-ChatBubble" t-att-name="props.chatWindow.displayName" t-att-class="{ 'o-bouncing': state.bouncing, 'position-fixed': env.embedLivechat, 'position-relative': !env.embedLivechat }" t-att-style="env.embedLivechat ? `top: ${ position.top }; left: ${ position.left };` : ''" t-on-click="() => props.chatWindow.open()" t-on-animationend="() => state.bouncing = false" t-ref="root">
-            <div t-if="thread?.importantCounter > 0" class="o-mail-ChatBubble-counter position-absolute badge rounded-pill fw-bold o-discuss-badge" t-out="thread?.importantCounter"/>
-            <button t-if="state.showClose and !env.embedLivechat" class="o-mail-ChatBubble-close position-absolute border-0 shadow rounded-pill fw-bold oi oi-close bg-view p-0" title="Close Chat Window" t-on-click.stop="() => this.props.chatWindow.close()"/>
-            <ImStatus t-if="thread?.correspondent?.persona?.im_status and thread?.correspondent?.persona?.im_status != 'offline'" className="'o-mail-ChatBubble-status position-absolute o-mail-brighter'" persona="thread.correspondent.persona" thread="thread"/>
-            <button class="o-mail-ChatHub-bubbleBtn btn ms-1 border-0">
-                <img class="o-mail-ChatBubble-avatar rounded-circle shadow" t-att-class="{ 'o-big': env.embedLivechat }" t-att-src="thread?.avatarUrl" alt="Thread image" draggable="false"/>
+        <div class="position-relative">
+            <button class="o-mail-ChatBubble" t-att-name="props.chatWindow.displayName" t-att-class="{ 'o-bouncing': state.bouncing, 'position-fixed': env.embedLivechat, 'position-relative': !env.embedLivechat }" t-att-style="env.embedLivechat ? `top: ${ position.top }; left: ${ position.left };` : ''" t-on-click="() => props.chatWindow.open()" t-on-animationend="() => state.bouncing = false" t-ref="root">
+                <div t-if="thread?.importantCounter > 0" class="o-mail-ChatBubble-counter position-absolute badge rounded-pill o-discuss-badge" t-out="thread?.importantCounter"/>
+                <button t-if="(state.showClose and !env.embedLivechat) or true" class="o-mail-ChatBubble-close position-absolute border shadow-sm rounded-pill bg-view p-0" title="Close Chat Window" t-on-click.stop="() => this.props.chatWindow.close()"><i class="oi oi-close"/></button>
+                <ImStatus t-if="thread?.correspondent?.persona?.im_status and thread?.correspondent?.persona?.im_status != 'offline'" className="'o-mail-ChatBubble-status position-absolute o-mail-brighter'" persona="thread.correspondent.persona" thread="thread"/>
+                <button class="o-mail-ChatHub-bubbleBtn btn ms-1 border-0">
+                    <img class="o-mail-ChatBubble-avatar rounded-circle shadow-sm" t-att-class="{ 'o-big': env.embedLivechat }" t-att-src="thread?.avatarUrl" alt="Thread image" draggable="false"/>
+                </button>
             </button>
-        </button>
+            <i t-if="thread.isUnread" class="o-mail-ChatBubble-unread position-absolute border-0 shadow-sm rounded-pill fa fa-circle p-0" title="thread has new messages"/>
+        </div>
     </t>
 
     <t t-name="mail.ChatBubble.preview">
-        <div class="o-mail-ChatBubble-preview px-0 py-1 shadow border rounded-3" t-ref="preview">
+        <div class="o-mail-ChatBubble-preview px-0 py-1 shadow-sm border rounded-3" t-ref="preview">
             <div class="text-truncate fw-bolder mb-0 mx-2" t-esc="props.chatWindow.displayName"/>
             <div t-if="previewContent" class="text-truncate small mx-2">
                 <t t-call="mail.message_preview_prefix">

--- a/addons/mail/static/src/core/common/chat_hub.scss
+++ b/addons/mail/static/src/core/common/chat_hub.scss
@@ -18,7 +18,7 @@
 
 .o-mail-ChatHub-hiddenBtn {
     color: #FFFFFF!important;
-    background-color: #875A7B !important;
+    background-color: $primary !important;
     width: $o-mail-ChatBubble-sizeBig !important;
     height: $o-mail-ChatBubble-sizeBig !important;
 
@@ -49,7 +49,7 @@
     align-items: center;
     max-width: 225px;
 
-    &:hover:not(:has(.o-mail-ChatHub-hiddenClose:hover)), &.o-active {
+    &:hover, &.o-active {
         background-color: $o-gray-300;
     }
 
@@ -57,16 +57,26 @@
         cursor: pointer;
 
         .o-mail-ChatHub-hiddenClose {
-            opacity: 100%;
+            opacity: 50%;
+
+            &:hover {
+                opacity: 100%;
+            }
         }
     }
 }
 
 .o-mail-ChatHub-option {
     &:hover, &.o-active {
-        background-color: $o-gray-300;
+        background-color: $o-gray-200;
         cursor: pointer;
+
+        &[name='close'] {
+            color: darken($danger, 10%);
+            background-color: rgba($danger, 0.1) !important;
+        }
     }
+
 }
 
 .o-mail-ChatHub-optionsBtn {

--- a/addons/mail/static/src/core/common/chat_hub.xml
+++ b/addons/mail/static/src/core/common/chat_hub.xml
@@ -17,8 +17,8 @@
                     <Dropdown t-if="chatHub.actuallyFolded.length gt 1" state="options" position="'top-end'" menuClass="'o-mail-ChatHub-optionsMenu d-flex flex-column bg-view shadow m-0 p-0 mb-1'">
                         <button class="o-mail-ChatHub-bubbleBtn btn o-mail-ChatHub-optionsBtn ms-1 rounded-circle shadow fa fa-ellipsis-h bg-view mt-1 border" t-att-class="{ 'opacity-0': !chatHub.actuallyFolded.length or !bubblesHover.isHover and !options.isOpen }" aria-label="Chat Hub Options"/>
                         <t t-set-slot="content">
-                            <button class="o-mail-ChatHub-option btn border-0 d-flex align-items-center gap-2 rounded-0" t-on-click="() => chatHub.closeAll()"><i class="oi fa-fw oi-close"></i>Close all conversations</button>
-                            <button class="o-mail-ChatHub-option btn border-0 d-flex align-items-center gap-2 rounded-0" t-on-click="() => chatHub.compact = true"><i class="fa fa-fw fa-eye-slash"></i>Hide all conversations</button>
+                            <button class="o-mail-ChatHub-option btn border-0 d-flex align-items-center gap-2 rounded-0 px-1" name="close" t-on-click="() => chatHub.closeAll()"><i class="oi fa-fw oi-close"></i>Close all conversations</button>
+                            <button class="o-mail-ChatHub-option btn border-0 d-flex align-items-center gap-2 rounded-0 px-1" t-on-click="() => chatHub.compact = true"><i class="fa fa-fw fa-eye-slash"></i>Hide all conversations</button>
                         </t>
                     </Dropdown>
                     <t t-foreach="chatHub.actuallyFolded" t-as="cw" t-key="cw.localId">
@@ -35,7 +35,7 @@
     <!-- In dropdown to keep same layout as other items-->
     <Dropdown>
         <div class="o-mail-ChatHub-bubbleBtn o-mail-ChatHub-compact o-mail-ChatBubble justify-content-center ms-1 border-0" t-ref="compact">
-            <div t-if="compactCounter > 0" class="o-mail-ChatHub-hiddenBtnCounter position-absolute badge rounded-pill fw-bold o-discuss-badge">
+            <div t-if="compactCounter > 0" class="o-mail-ChatHub-hiddenBtnCounter position-absolute badge rounded-pill o-discuss-badge">
                 <t t-out="compactCounter"/>
             </div>
             <button class="o-mail-ChatHub-bubbleBtn btn border-0 fs-2" t-on-click="expand">
@@ -48,7 +48,7 @@
 <t t-name="mail.ChatHub.hiddenButton">
     <Dropdown t-if="chatHub.actuallyHidden.length > 0" state="more" position="'left-middle'" menuClass="'bg-view shadow p-0 m-0 rounded-3'" manual="true">
         <div class="o-mail-ChatHub-bubbleBtn o-mail-ChatBubble justify-content-center border-0" t-on-click="() => store.chatHub.compact = true" t-ref="more-button">
-            <div t-if="hiddenCounter > 0" class="o-mail-ChatHub-hiddenBtnCounter position-absolute badge rounded-pill fw-bold o-discuss-badge">
+            <div t-if="hiddenCounter > 0" class="o-mail-ChatHub-hiddenBtnCounter position-absolute badge rounded-pill o-discuss-badge">
                 <t t-out="hiddenCounter"/>
             </div>
             <button class="o-mail-ChatHub-bubbleBtn ms-1 btn outline-0 border-0">
@@ -61,11 +61,11 @@
                     <li class="o-mail-ChatHub-hiddenItem gap-2 px-2 py-1" role="menuitem" t-att-name="cw.displayName" t-on-click="() => cw.open()">
                         <img class="o-mail-ChatHub-hiddenAvatar rounded-circle" t-att-src="cw.thread?.avatarUrl" alt="Thread image" draggable="false"/>
                         <p class="text-truncate fw-bold mb-0" t-esc="cw.displayName"/>
-                        <div t-if="cw.thread?.importantCounter > 0" class="o-mail-ChatHub-hiddenCounter badge rounded-pill fw-bold o-discuss-badge" style="padding: 3px 6px">
+                        <div t-if="cw.thread?.importantCounter > 0" class="o-mail-ChatHub-hiddenCounter badge rounded-pill o-discuss-badge" style="padding: 3px 6px">
                             <t t-out="cw.thread?.importantCounter"/>
                         </div>
-                        <button class="o-mail-ChatHub-hiddenClose o-mail-ChatBubble-close d-flex align-items-center rounded-circle p-0" t-on-click.stop="() => cw.close()">
-                            <i class="oi fa-fw oi-close"/>
+                        <button class="o-mail-ChatHub-hiddenClose o-mail-ChatBubble-close d-flex align-items-center rounded-circle p-0 border" t-on-click.stop="() => cw.close()">
+                            <i class="oi oi-close fs-6"/>
                         </button>
                     </li>
                 </t>

--- a/addons/mail/static/src/core/common/chat_window.js
+++ b/addons/mail/static/src/core/common/chat_window.js
@@ -62,6 +62,13 @@ export class ChatWindow extends Component {
         });
     }
 
+    get attClass() {
+        return {
+            "w-100 h-100 o-mobile": this.ui.isSmall,
+            "rounded-top-3": !this.ui.isSmall,
+        };
+    }
+
     get composerType() {
         if (this.thread && this.thread.model !== "discuss.channel") {
             return "note";

--- a/addons/mail/static/src/core/common/chat_window.scss
+++ b/addons/mail/static/src/core/common/chat_window.scss
@@ -2,22 +2,43 @@
     height: 480px;
     width: $o-mail-ChatWindow-width;
     z-index: 999; // messaging menu is dropdown (1000)
+
     &.o-mobile {
         z-index: 1001; // above messaging menu (chat window takes whole screen)
     }
-    box-shadow: -5px -5px 10px rgba(#000000, 0.09);
+
     outline: none;
+}
 
-    &.o-folded {
-        height: $o-mail-Discuss-headerHeight;
-    }
-
+.o-mail-ChatWindow-area {
+    height: 480px;
+    width: calc(#{$o-mail-ChatWindow-width} - 2px);
 }
 
 .o-mail-ChatWindow-command {
     color: inherit !important;
-    &:hover, &.o-active {
-        background-color: rgba(0, 0, 0, 0.05);
+    border: 1px solid transparent;
+
+    &:not(:hover):not(.o-active) {
+        opacity: 85%;
+    }
+
+    &:hover {
+        border-color: $gray-500;
+    }
+
+    &[name='call'] {
+        color: darken($success, 5%) !important;
+        @media (hover: hover) {
+            &:hover {
+                background-color: rgba($success, 0.1) !important;
+                border-color: rgba(darken($success, 10%), 0.65);
+                color: darken($success, 10%) !important;
+            }
+        }
+        @media (hover: none) {
+            color: darken($success, 5%) !important;
+        }
     }
 }
 
@@ -30,16 +51,12 @@
 }
 
 .o-mail-ChatWindow-header {
-    height: $o-mail-Discuss-headerHeight;
+    height: 42px;
+}
 
-    &:not(.o-folded) {
-        box-shadow: 0px 3px 12px -3px rgba(50, 50, 50, 0.15);
-    }
-
-    .o-mail-ChatWindow-threadAvatar img {
-        height: 28px;
-        width: 28px;
-    }
+.o-mail-ChatWindow-threadAvatar img {
+    height: 28px;
+    width: 28px;
 }
 
 .o-mail-ChatWindow-typing {

--- a/addons/mail/static/src/core/common/chat_window.xml
+++ b/addons/mail/static/src/core/common/chat_window.xml
@@ -2,39 +2,36 @@
 <templates xml:space="preserve">
 
 <t t-name="mail.ChatWindow">
-    <div class="o-mail-ChatWindow fixed-bottom overflow-hidden d-flex flex-column"
+    <div class="o-mail-ChatWindow fixed-bottom overflow-hidden d-flex flex-column shadow"
         t-att-style="style"
-        t-att-class="{
-            'w-100 h-100 o-mobile': ui.isSmall,
-            'o-folded': props.chatWindow.folded,
-            'rounded-top-3': !ui.isSmall,
-        }"
+        t-att-class="attClass"
         t-on-keydown="onKeydown"
         tabindex="1"
     >
-        <div class="o-mail-ChatWindow-header d-flex align-items-center flex-shrink-0 bg-100 border-bottom z-1" t-on-click="onClickHeader" t-att-class="{ 'cursor-pointer': !ui.isSmall, 'o-folded': props.chatWindow.folded }">
+        <div class="o-mail-ChatWindow-area position-fixed bg-300 rounded-3"/>
+        <div class="o-mail-ChatWindow-header d-flex align-items-center flex-shrink-0 bg-100 z-1 rounded-top-3" t-on-click="onClickHeader" t-att-class="{ 'cursor-pointer': !ui.isSmall }">
             <t t-if="threadActions.actions.length > 3">
-                <div class="d-flex text-truncate">
-                    <Dropdown position="'left-start'" onStateChanged="isOpen => this.onActionsMenuStateChanged(isOpen)" menuClass="'d-flex flex-column py-0'">
+                <div class="d-flex text-truncate rounded-3 rounded-end-0 rounded-bottom-0">
+                    <Dropdown position="'left-start'" onStateChanged="isOpen => this.onActionsMenuStateChanged(isOpen)" menuClass="'d-flex flex-column py-1 rounded-3' + (ui.isSmall ? ' my-0' : '')">
                         <button
-                            class="o-mail-ChatWindow-command btn rounded-0 d-flex align-items-center px-1 py-2 m-0 opacity-75 opacity-100-hover w-100"
-                            t-att-class="{ 'ps-2 pe-1 rounded-top-3': !ui.isSmall, 'o-active': state.actionsMenuOpened }"
+                            class="o-mail-ChatWindow-moreActions o-mail-ChatWindow-command btn d-flex align-items-center p-1 pt-2 m-0 w-100"
+                            t-att-class="{ 'pe-1 rounded-3 rounded-end-0 rounded-bottom-0': !ui.isSmall, 'o-active': state.actionsMenuOpened }"
                             t-att-disabled="state.editingName"
                             t-att-title="actionsMenuTitleText"
                         >
                             <t t-call="mail.ChatWindow.headerContent"/>
-                            <i class="fa fa-fw fa-caret-down opacity-50 ms-1"/>
+                            <i class="fa fa-fw fa-caret-down" t-att-class="{ 'opacity-100': state.actionsMenuOpened, 'opacity-50': !state.actionsMenuOpened, 'fs-3': ui.isSmall }"/>
                         </button>
                         <t t-set-slot="content">
                             <t t-if="ui.isSmall" t-set="actions" t-value="threadActions.actions.slice(1, -1)"/>
                             <t t-else="" t-set="actions" t-value="threadActions.actions.slice(1, -2)"/>
                             <DropdownItem t-foreach="actions" t-as="action" t-key="action.id"
-                                class="'o-mail-ChatWindow-command btn rounded-0 d-flex align-items-center px-2 py-2 m-0 opacity-75 opacity-100-hover'"
-                                attrs="{ title: action.name }"
+                                class="'o-mail-ChatWindow-command btn rounded-0 d-flex align-items-center m-0' + (ui.isSmall ? ' fs-4 px-3 py-2' : ' px-2 py-1')"
+                                attrs="{ 'aria-label': action.name }"
                                 onSelected="() => action.onSelect()"
                             >
-                                <i t-att-class="action.icon"/>
-                                <span class="mx-2" t-out="action.name"/>
+                                <i t-att-class="action.icon" t-attf-class="{ ui.isSmall ? 'fa-lg' : '' }"/>
+                                <span class="mx-2" t-att-class="{ 'small': !ui.isSmall }" t-out="action.name"/>
                             </DropdownItem>
                         </t>
                     </Dropdown>
@@ -52,23 +49,25 @@
                 <t t-call="mail.ChatWindow.headerContent"/>
             </t>
             <div class="flex-grow-1"/>
-            <div t-if="thread and thread.needactionCounter > 0" class="o-mail-ChatWindow-counter mx-1 my-0 badge rounded-pill fw-bold o-discuss-badge" t-ref="needactionCounter">
+            <div t-if="thread and thread.needactionCounter > 0" class="o-mail-ChatWindow-counter mx-1 my-0 badge rounded-pill o-discuss-badge" t-ref="needactionCounter">
                 <t t-out="thread.needactionCounter"/>
             </div>
-            <t t-if="threadActions.actions.length > 1" t-call="mail.ChatWindow.dropdownAction">
-                <t t-set="action" t-value="threadActions.actions[0]"/>
-            </t>
-            <t t-if="!ui.isSmall and threadActions.actions.length > 2">
-                <t t-call="mail.ChatWindow.dropdownAction">
-                    <t t-set="action" t-value="threadActions.actions.at(-2)"/>
+            <div t-if="threadActions.actions.length > 0" class="o-mail-ChatWindow-quickActions d-flex">
+                <t t-if="threadActions.actions.length > 1" t-call="mail.ChatWindow.quickAction">
+                    <t t-set="action" t-value="threadActions.actions[0]"/>
                 </t>
-            </t>
-            <t t-call="mail.ChatWindow.dropdownAction">
-                <t t-set="action" t-value="threadActions.actions.at(-1)"/>
-                <t t-set="itemClass" t-value="'me-1'"/>
-            </t>
+                <t t-if="!ui.isSmall and threadActions.actions.length > 2">
+                    <t t-call="mail.ChatWindow.quickAction">
+                        <t t-set="action" t-value="threadActions.actions.at(-2)"/>
+                    </t>
+                </t>
+                <t t-call="mail.ChatWindow.quickAction">
+                    <t t-set="action" t-value="threadActions.actions.at(-1)"/>
+                    <t t-set="itemClass" t-value="'me-2'"/>
+                </t>
+            </div>
         </div>
-        <div t-if="!props.chatWindow.folded or ui.isSmall" class="bg-100 d-flex flex-column h-100 overflow-auto position-relative" t-ref="content">
+        <div class="o-mail-ChatWindow-content bg-100 d-flex flex-column h-100 overflow-auto position-relative" t-ref="content">
             <t t-if="thread" name="thread content">
                 <div t-if="threadActions.activeAction?.componentCondition" class="h-100" t-attf-class="{{ threadActions.activeAction.panelOuterClass }}">
                     <t t-component="threadActions.activeAction.component" t-props="{ ...threadActions.activeAction.componentProps, thread }"/>
@@ -87,8 +86,8 @@
     </div>
 </t>
 
-<t t-name="mail.ChatWindow.dropdownAction">
-    <button class="o-mail-ChatWindow-command btn d-flex p-2 opacity-75 opacity-100-hover" t-att-class="itemClass" t-att-title="action.name" t-on-click.stop="() => action.onSelect()"><i t-att-class="action.icon"/></button>
+<t t-name="mail.ChatWindow.quickAction">
+    <button class="o-mail-ChatWindow-command btn d-flex p-1" t-att-class="itemClass" t-attf-class="{{ ui.isSmall ? 'mx-1 fs-4' : '' }}" t-att-title="action.name" t-att-name="action.id" t-on-click.stop="() => action.onSelect()"><i t-att-class="action.icon" t-attf-class="{{ ui.isSmall ? 'fa-lg' : '' }}"/></button>
 </t>
 
 <t t-name="mail.ChatWindow.headerContent">
@@ -96,6 +95,7 @@
         <img class="rounded" t-att-src="thread.avatarUrl" alt="Thread Image"/>
     </div>
     <ThreadIcon t-if="thread and thread.channel_type === 'chat' and thread.correspondent" thread="thread"/>
-    <div t-if="!state.editingName" class="text-truncate fw-bold border border-transparent me-1 my-0" t-att-title="props.chatWindow.displayName" t-esc="props.chatWindow.displayName" t-att-class="thread ? 'ms-1' : 'ms-3'"/>
+    <i t-if="!thread" class="ms-2 fa fa-fw fa-pencil fs-5"/>
+    <div t-if="!state.editingName" class="text-truncate fw-bolder border border-transparent ms-1 me-1 my-0" t-att-title="props.chatWindow.displayName" t-esc="props.chatWindow.displayName" t-att-class="{ 'fs-3': ui.isSmall }"/>
 </t>
 </templates>

--- a/addons/mail/static/src/core/common/chat_window_model.js
+++ b/addons/mail/static/src/core/common/chat_window_model.js
@@ -35,7 +35,7 @@ export class ChatWindow extends Record {
     hubAsFolded = Record.one("ChatHub");
 
     get displayName() {
-        return this.thread?.displayName ?? _t("New message");
+        return this.thread?.displayName ?? _t("New Message");
     }
 
     get isOpen() {

--- a/addons/mail/static/src/core/common/composer.dark.scss
+++ b/addons/mail/static/src/core/common/composer.dark.scss
@@ -1,3 +1,7 @@
 .o-mail-Composer-actions button:hover {
     background-color: $gray-300;
 }
+
+.o-mail-Composer-send:not(.o-extended):not(.o-disabled) {
+    background-color: darken($o-action, 10%);
+}

--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -29,6 +29,7 @@ import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
 import { FileUploader } from "@web/views/fields/file_handler";
 import { escape, sprintf } from "@web/core/utils/strings";
+import { Dropdown } from "@web/core/dropdown/dropdown";
 
 const EDIT_CLICK_TYPE = {
     CANCEL: "cancel",
@@ -54,6 +55,7 @@ const EDIT_CLICK_TYPE = {
 export class Composer extends Component {
     static components = {
         AttachmentList,
+        Dropdown,
         Picker,
         FileUploader,
         NavigableList,
@@ -159,6 +161,9 @@ export class Composer extends Component {
         );
         useEffect(
             () => {
+                if (!this.ref.el) {
+                    return;
+                }
                 this.ref.el.style.height = this.fakeTextarea.el.scrollHeight + "px";
                 this.saveContentDebounced();
             },
@@ -180,6 +185,12 @@ export class Composer extends Component {
                 this.restoreContent();
             }
         });
+    }
+
+    get emojiButtonAttClass() {
+        return {
+            "bg-300": this.picker.state.picker === this.picker.PICKERS.EMOJI,
+        };
     }
 
     get pickerSettings() {

--- a/addons/mail/static/src/core/common/composer.scss
+++ b/addons/mail/static/src/core/common/composer.scss
@@ -11,8 +11,8 @@
     }
 
     .o-mail-Composer-sidebarMain {
-        padding-top: 0.1875rem; // avatar centered with composer text input: 36px (avatar) + 2*3px (this value) = 20px + 2 * { 10px (padding) + 1px (border) }
-        width: 48px;
+        // padding-top: 0.09375rem; // avatar centered with composer text input: 32px (avatar) + 2*1.5px (this value) = 25px ($input-height) + 7px (padding-top) + 2px (border)
+        width: 40px;
     }
 
     .o-mail-Composer-coreHeader {
@@ -32,17 +32,80 @@
     }
 }
 
-.o-mail-Composer-actions button {
-    opacity: 75%;
-    &:hover {
-        background-color: $gray-200;
-        opacity: 100%;
+.o-mail-Composer-actions {
+
+    &.o-left {
+        margin-top: 1px;
+        margin-left: 1px;
+    }
+
+    &.o-right {
+        margin-top: 1px;
+        margin-right: 1px;
+    }
+
+    &.o-mobile {
+        margin-top: 2px;
+        margin-right: 0px;
+    }
+
+    &:not(.o-focused) button {
+        color: $text-muted;
+    }
+
+    button {
+        &:hover {
+            background-color: $gray-200;
+            border-color: $gray-500 !important;
+            i {
+                filter: contrast(2);
+            }
+            &.o-mail-Composer-send:not(.o-extended) {
+                background-color: $o-action !important;
+                border-color: darken($o-action, 5%) !important;
+            }
+        }
+    }
+}
+
+.o-mail-Composer-mainActions {
+    gap: 1px;
+}
+
+.o-mail-Composer-moreActions button {
+    background-color: $gray-200;
+}
+
+.o-mail-Composer-coreMainInner {
+    --border-opacity: 0.75;
+
+    &.o-fuse {
+        background-color: $o-gray-100 !important;
+    }
+
+    &.o-fuse.o-focused {
+        background-color: $o-view-background-color !important;
+    }
+
+    &.o-focused {
+        border-color: rgba($o-action, 0.25) !important;
     }
 }
 
 .o-mail-Composer-input {
-    padding-top: 10px; // carefully crafted to have the text in the middle in chat window
-    padding-bottom: 10px;
+    padding-top: 7px; // carefully crafted to have the text in the middle
+    padding-bottom: 6px;
+
+    &.o-normal {
+        padding-left: (map-get($spacers, 3) + map-get($spacers, 2)) / 2 !important;
+        padding-right: (map-get($spacers, 3) + map-get($spacers, 2)) / 2 !important;
+    }
+
+    &.o-focused {
+        border-color: rgba($o-action, 0.5) !important;
+        background-color: $o-view-background-color;
+    }
+
     max-height: 100px;
     resize: none;
     line-height: 1.42857143 !important; // so that input is rounded to 20px = 14px (base font) * 1.42857143 (line-height)
@@ -52,26 +115,36 @@
     }
 
     &::placeholder {
+        opacity: 75%;
         @include text-truncate();
+        user-select: none;
     }
 }
 
 .o-mail-Composer-avatar {
-    --Avatar-size: #{$o-mail-Avatar-size};
+    --Avatar-size: 34px;
 }
 
 .o-mail-Composer-fake {
     height: 0;
     top: -10000px;
-    padding-top: 10px;
-    padding-bottom: 10px;
-    line-height: 1.42857143 !important; // so that input is rounded to 20px = 14px (base font) * 1.42857143 (line-height)
-}
 
-.o-mail-Composer-compactContainer {
-    box-shadow: 0px -3px 25px 3px rgba(50, 50, 50, 0.1);
+    padding-top: 7px;
+    padding-bottom: 6px;
+
+    &.o-normal {
+        padding-left: (map-get($spacers, 3) + map-get($spacers, 2)) / 2 !important;
+        padding-right: (map-get($spacers, 3) + map-get($spacers, 2)) / 2 !important;
+    }
+
+    line-height: 1.42857143 !important; // so that input is rounded to 20px = 14px (base font) * 1.42857143 (line-height)
 }
 
 .o-mail-Composer-input {
     font-family: "text-emoji", $font-family-base;
+}
+
+.o-mail-Composer-send:not(.o-extended):not(.o-disabled) {
+    background-color: lighten($o-action, 5%);
+    color: white;    
 }

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -2,16 +2,19 @@
 <templates xml:space="preserve">
 
 <t t-name="mail.Composer">
+    <t t-if="props.composer.exists()">
     <t t-set="compact" t-value="props.mode === 'compact'"/>
     <t t-set="normal" t-value="props.mode === 'normal'"/>
     <t t-set="extended" t-value="props.mode === 'extended'"/>
     <div t-ref="composer">
-        <div class="o-mail-Composer d-grid flex-shrink-0 pt-0"
+        <div class="o-mail-Composer d-grid flex-shrink-0"
                 t-att-class="{
+                    'pt-0': extended or props.composer.message or env.inChatWindow,
+                    'pt-1': !(extended or props.composer.message or env.inChatWindow),
                     'pb-2': extended and !props.composer.message,
                     'o-extended': extended,
                     'o-isUiSmall': ui.isSmall,
-                    'p-3': normal,
+                    'p-3 pb-2': normal,
                     'o-hasSelfAvatar': !env.inChatWindow and thread,
                 }" t-attf-class="{{ props.className }}">
             <div class="o-mail-Composer-sidebarMain flex-shrink-0" t-if="!compact and props.sidebar">
@@ -29,18 +32,32 @@
             <div class="o-mail-Composer-coreMain d-flex flex-nowrap align-items-start flex-grow-1"
                 t-att-class="{ 'flex-column' : extended }"
             >
-                <div class="d-flex bg-view flex-grow-1"
+                <div class="o-mail-Composer-coreMainInner d-flex flex-grow-1 border border-secondary o-fuse rounded-3"
                     t-att-class="{
-                        'o-mail-Composer-compactContainer border-top': compact and !props.composer.message,
-                        'border': props.composer.message,
-                        'border rounded-3' : normal,
-                        'border rounded-3 align-self-stretch flex-column' : extended,
+                        'my-1': compact,
+                        'mx-1': compact and !props.composer.message,
+                        'align-self-stretch flex-column' : extended,
+                        'o-focused': props.composer.isFocused,
                     }"
                 >
+                    <div t-if="env.inChatWindow" class="o-mail-Composer-actions o-left d-flex align-items-baseline" t-att-class="{ 'o-focused': props.composer.isFocused, 'o-mobile': ui.isSmall }">
+                        <Dropdown position="'top-start'" menuClass="'o-mail-Composer-moreActions rounded-3 px-0 py-1'">
+                            <button class="btn p-1"><i class="fa fa-fw fa-plus-circle" t-att-class="{ 'fa-lg': ui.isSmall }"/></button>
+                            <t t-set-slot="content" name="dropdown-actions">
+                                <t t-call="mail.Composer.attachFiles"/>
+                            </t>
+                        </Dropdown>
+                    </div>
                     <div class="position-relative flex-grow-1">
-                        <textarea class="o-mail-Composer-input form-control bg-view px-3 border-0 rounded-3 shadow-none overflow-auto"
+                        <textarea class="o-mail-Composer-input form-control shadow-none overflow-auto rounded-3 border-0"
+                            t-att-class="{
+                                'px-3': extended,
+                                'o-normal': normal,
+                                'px-1': env.inChatWindow and !ui.isSmall,
+                                'o-focused': env.inChatWindow and props.composer.isFocused,
+                            }"
                             t-ref="textarea"
-                            style="height:40px;"
+                            t-att-style="ui.isSmall ? 'height:60px;' : (env.inChatWindow ? 'height:26px;' : 'height:40px;')"
                             t-on-keydown="onKeydown"
                             t-on-focusin="onFocusin"
                             t-on-focusout="() => this.props.composer.isFocused = false"
@@ -56,27 +73,24 @@
                              the textarea properly without flicker.
                         -->
                         <textarea
-                            class="o-mail-Composer-fake position-absolute"
+                            class="o-mail-Composer-fake position-absolute border-0"
+                            t-att-class="{ 'px-3': extended, 'o-normal': normal, 'px-1': env.inChatWindow and !ui.isSmall }"
                             t-model="props.composer.text"
                             t-ref="fakeTextarea"
                             disabled="1"
                         />
                     </div>
-                    <div class="o-mail-Composer-actions d-flex bg-view rounded"
+                    <div class="o-mail-Composer-actions o-right d-flex rounded"
                         t-att-class="{
                             'ms-1': compact and ui.isSmall,
-                            'mx-1': compact and !ui.isSmall,
                             'ms-3': normal,
                             'mx-3 border-top p-1': extended,
+                            'o-focused': props.composer.isFocused,
                         }"
                     >
-                        <div class="d-flex flex-grow-1 align-items-baseline mt-1" t-ref="main-actions">
-                            <button class="btn border-0 p-1 rounded-pill" t-att-class="{'bg-300': this.picker.state.picker === this.picker.PICKERS.EMOJI}" aria-label="Emojis" t-on-click="onClickAddEmoji" t-ref="emoji-button"><i class="fa fa-fw fa-smile-o"/></button>
-                            <FileUploader t-if="allowUpload" multiUpload="true" onUploaded.bind="(data) => { attachmentUploader.uploadData(data) }">
-                                <t t-set-slot="toggler">
-                                    <button t-att-disabled="!state.active" class="o-mail-Composer-attachFiles btn border-0 rounded-pill p-1" title="Attach files" aria-label="Attach files" type="button" t-on-click="onClickAddAttachment"><i class="fa fa-fw fa-paperclip"/></button>
-                                </t>
-                            </FileUploader>
+                        <div class="o-mail-Composer-mainActions d-flex flex-grow-1 align-items-baseline" t-att-class="{ 'o-mobile': ui.isSmall }" t-ref="main-actions">
+                            <button class="btn p-1" t-att-class="emojiButtonAttClass" aria-label="Emojis" title="Emojis" t-on-click="onClickAddEmoji" t-ref="emoji-button"><i class="fa fa-fw fa-smile-o" t-att-class="{ 'fa-lg': ui.isSmall }"/></button>
+                            <t t-if="!env.inChatWindow" t-call="mail.Composer.attachFiles"/>
                             <t t-if="extended and ui.isSmall and props.composer.message" t-call="mail.Composer.sendButton"/>
                             <t t-if="!extended" t-call="mail.Composer.fullComposer"/>
                             <t t-if="!extended" t-call="mail.Composer.sendButton"/>
@@ -89,35 +103,47 @@
                     <span t-if="!isSendButtonDisabled and !props.composer.message" t-out="SEND_KEYBIND_TO_SEND"/>
                 </div>
             </div>
-            <div class="o-mail-Composer-footer overflow-auto">
+            <div class="o-mail-Composer-footer overflow-auto smaller" t-att-class="{ 'border-top': compact and props.composer.attachments.length > 0 }">
                 <AttachmentList
                     t-if="allowUpload and props.composer.attachments.length > 0"
                     attachments="props.composer.attachments"
                     unlinkAttachment.bind="(...args) => attachmentUploader.unlink(...args)"
-                    imagesHeight="50"/>
+                    imagesHeight="75"/>
                 <Picker t-props="picker"/>
             </div>
         </div>
         <span t-if="props.composer.message" class="text-muted" t-out="CANCEL_OR_SAVE_EDIT_TEXT" t-on-click="onClickCancelOrSaveEditText"/>
     </div>
     <NavigableList t-if="suggestion" class="'o-mail-Composer-suggestionList'" t-props="navigableListProps"/>
+    </t>
+</t>
+
+<t t-name="mail.Composer.attachFiles">
+    <FileUploader t-if="allowUpload" multiUpload="true" onUploaded.bind="(data) => { attachmentUploader.uploadData(data) }">
+        <t t-set-slot="toggler">
+            <button t-if="env.inChatWindow" t-att-disabled="!state.active" class="o-mail-Composer-attachFiles btn p-1 mx-1" aria-label="Attach Files" type="button" t-on-click="onClickAddAttachment"><i class="fa fa-fw fa-paperclip" t-att-class="{ 'fa-lg': ui.isSmall }"/><span class="small ms-1">Attach Files</span></button>
+            <button t-else="" t-att-disabled="!state.active" class="o-mail-Composer-attachFiles btn p-1" title="Attach Files" aria-label="Attach Files" type="button" t-on-click="onClickAddAttachment"><i class="fa fa-fw fa-paperclip" t-att-class="{ 'fa-lg': ui.isSmall }"/></button>
+        </t>
+    </FileUploader>
 </t>
 
 <t t-name="mail.Composer.sendButton">
+    <t t-set="sendTitle">Send</t>
     <button class="o-mail-Composer-send btn"
-        t-att-class="{'btn-primary': extended, 'p-1 rounded-pill': !extended, 'btn-link': !extended, 'border-start-0 me-2': env.inDiscussApp}"
+        t-att-class="{'btn-primary o-extended': extended, 'p-1': !extended, 'btn-link': !extended, 'border-start-0': env.inDiscussApp, 'me-1': ui.isSmall, 'o-disabled': isSendButtonDisabled}"
         t-on-click="sendMessage"
         t-att-disabled="isSendButtonDisabled"
+        t-att-title="thread and thread.model !== 'discuss.channel' ? '' : sendTitle"
         t-att-aria-label="SEND_TEXT"
     >
         <t t-if="thread and thread.model !== 'discuss.channel'" t-out="SEND_TEXT"/>
-        <t t-else=""><i class="fa fa-fw fa-paper-plane-o"/></t>
+        <t t-else=""><i class="fa fa-fw fa-paper-plane-o" t-att-class="{ 'fa-lg': ui.isSmall }"/></t>
     </button>
 </t>
 
 <t t-name="mail.Composer.fullComposer">
-    <button t-if="props.showFullComposer and thread and thread.model !== 'discuss.channel'" class="o-mail-Composer-fullComposer btn p-1 border-0 rounded-pill" title="Full composer" aria-label="Full composer" type="button" t-on-click="onClickFullComposer" data-hotkey="shift+c">
-        <i class="fa fa-fw fa-expand"/>
+    <button t-if="props.showFullComposer and thread and thread.model !== 'discuss.channel'" class="o-mail-Composer-fullComposer btn p-1" title="Full composer" aria-label="Full composer" type="button" t-on-click="onClickFullComposer" data-hotkey="shift+c">
+        <i class="fa fa-fw fa-expand" t-att-class="{ 'fa-lg': ui.isSmall }"/>
     </button>
 </t>
 

--- a/addons/mail/static/src/core/common/core.dark.scss
+++ b/addons/mail/static/src/core/common/core.dark.scss
@@ -1,13 +1,23 @@
-.o-mail-discussSidebarBgColor {
+$o-mail-inspectorBg: mix($o-gray-100, $o-gray-200) !default;
+
+.o-mail-inspectorBg {
     background-color: mix($o-gray-100, $o-gray-200);
 }
 
 a.o_mail_redirect, a.o_channel_redirect {
-    @include o-mention-variant(rgba($primary, .2), rgba($primary, .2), lighten($link-color, 5%), rgba($primary, .3), rgba($primary, .3), lighten($link-color, 10%));
+    &:not(.o-selfMention) {
+        // @include o-mention-variant(rgba($o-gray-300, .5), rgba($o-gray-300, 1), lighten($link-color, 7%), rgba($o-gray-300, .75), rgba($o-gray-300, 1), lighten($link-color, 12%));
+        @include o-mention-variant(rgba($link-color, .075), rgba($link-color, .05), $link-color, rgba($link-color, .1), rgba($link-color, .075), lighten($link-color, 5%));
+    }
+
+    &.o-selfMention {
+        // @include o-mention-variant(rgba(lighten($warning, 5%), .075), rgba(darken($warning, 2.5%), .05), darken($warning, 2.5%), rgba(lighten($warning, 5%), .1), rgba($warning, .05), $warning);
+        @include o-mention-variant(rgba($link-color, .075), rgba(darken($warning, 2.5%), .1), darken($warning, 2.5%), rgba($link-color, .1), rgba(darken($warning, 2.5%), .15), lighten($warning, 2.5%));
+    }
 }
 
 a.o-discuss-mention {
-    @include o-mention-variant(rgba($primary, .2), rgba($primary, .2), lighten($link-color, 5%), rgba($primary, .2), rgba($primary, .2), lighten($link-color, 5%));
+    @include o-mention-variant(rgba($o-gray-300, .5), rgba($o-gray-300, 1), lighten($link-color, 7%), rgba($o-gray-300, .5), rgba($o-gray-300, 1), lighten($link-color, 7%));
 }
 
 .o-mail-DiscussSystray-class {

--- a/addons/mail/static/src/core/common/core.scss
+++ b/addons/mail/static/src/core/common/core.scss
@@ -1,5 +1,11 @@
-.o-mail-discussSidebarBgColor {
-    background-color: mix($white, $o-gray-100);
+$o-mail-inspectorBg: mix($white, $o-gray-100) !default;
+
+.o-discuss-itemName-discrete {
+    opacity: 75%;
+}
+
+.o-mail-inspectorBg {
+    background-color: $o-mail-inspectorBg;
 }
 
 .o-mail-brighter {
@@ -16,7 +22,7 @@
     background-color: var(--o-discuss-badge-bg) !important;
 
     &.o-muted {
-        --o-discuss-badge-bg: #{$gray-400};
+        --o-discuss-badge-bg: #{$gray-500};
     }
 }
 
@@ -28,18 +34,12 @@
     display: flex;
     transform: translate(0, 0) !important; // cancel systray style on badge
     font-size: .78572 * $font-size-base !important; // roughly 11px, small but readable
+    align-items: center;
+    justify-content: center;
 }
 
 .o-min-height-0 {
     min-height: 0;
-}
-
-.o-min-width-0 {
-    min-width: 0;
-}
-
-.o-smaller {
-    font-size: smaller;
 }
 
 .o-hover-text-underline:hover {
@@ -47,7 +47,7 @@
 }
 
 .o-text-white {
-    color: #FFF;
+    color: #FFF !important;
 }
 
 .o-yellow {
@@ -96,14 +96,29 @@ a.o_mail_redirect, a.o_channel_redirect, a.o-discuss-mention {
     @include rfs($btn-font-size-sm, $btn-font-size-sm);
     border-radius: $btn-border-radius-sm;
     padding: 0rem 0.1875rem;
+    font-weight: $font-weight-bold;
+    border: 1px solid;
 }
 
 a.o_mail_redirect, a.o_channel_redirect {
-    @include o-mention-variant(rgba($primary, .2), rgba($primary, .2), darken($link-color, 5%), rgba($primary, .3), rgba($primary, .3), darken($link-color, 10%));
+    border-radius: $border-radius-sm;
+    &:hover {
+        text-decoration: underline;
+    }
+
+    &:not(.o-selfMention) {
+        @include o-mention-variant(rgba($link-color, .075), rgba(darken($link-color, 10%), .05), darken($link-color, 10%), rgba($link-color, .1), rgba(darken($link-color, 10%), .05), darken($link-color, 17.5%));
+    }
+
+    &.o-selfMention {
+        // font-weight: bold;
+        font-style: italic;
+        @include o-mention-variant(rgba(darken($warning, 5%), .075), rgba(darken($warning, 17.5%), .05), darken($warning, 10%), rgba(darken($warning, 5%), .1), rgba(darken($warning, 17.5%), .05), darken($warning, 17.5%));
+    }
 }
 
-a.o-discuss-mention {
-    @include o-mention-variant(rgba($primary, .2), rgba($primary, .2), darken($link-color, 5%), rgba($primary, .2), rgba($primary, .2), darken($link-color, 5%));
+a.o-discuss-mention {    
+    @include o-mention-variant(rgba($link-color, .075), rgba(darken($link-color, 5%), 0.1), darken($link-color, 10%), rgba($link-color, .075), rgba(darken($link-color, 5%), 0.1), darken($link-color, 10%));
     cursor: default !important;
 }
 

--- a/addons/mail/static/src/core/common/date_section.xml
+++ b/addons/mail/static/src/core/common/date_section.xml
@@ -4,7 +4,7 @@
 <t t-name="mail.DateSection">
     <div class="o-mail-DateSection d-flex align-items-center w-100 fw-bold z-1" t-attf-class="{{ props.className }}">
         <hr class="o-discuss-separator flex-grow-1"/>
-        <span class="px-3 opacity-75 small text-muted"><t t-esc="props.date"/></span>
+        <span class="px-2 opacity-50 smaller text-muted"><t t-esc="props.date"/></span>
         <hr class="o-discuss-separator flex-grow-1"/>
     </div>
 </t>

--- a/addons/mail/static/src/core/common/message.dark.scss
+++ b/addons/mail/static/src/core/common/message.dark.scss
@@ -1,0 +1,24 @@
+.o-mail-Message.o-important {
+    background-color: rgba(lighten($warning, 10%), .1);
+}
+
+.o-mail-Message-bubble {
+
+    &.o-blue {
+        background-color: mix($o-view-background-color, $o-info, 87.5%);
+        border-color: mix($o-view-background-color, $o-info, 80%) !important;
+    }
+
+    &.o-green {
+        background-color: mix($o-view-background-color, $o-success, 87.5%);
+        border-color: mix($o-view-background-color, $o-success, 80%) !important;
+
+        .o-mail-Message.o-important & {
+            border-color: mix($o-view-background-color, $o-success, 75%) !important;
+        }
+    }
+    &.o-orange {
+        background-color: mix($o-view-background-color, darken($o-warning, 25%), 77.5%);
+        border-color: mix($o-view-background-color, $o-warning, 65%) !important;
+    }
+}

--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -195,13 +195,13 @@ export class Message extends Component {
                 this.props.thread,
                 this.props.message
             ),
-            "o-squashed": this.props.squashed,
-            "mt-1": !this.props.squashed && this.props.thread && !this.env.messageCard,
-            "px-2": this.props.isInChatWindow,
+            "o-squashed pb-1": this.props.squashed,
+            "py-1": !this.props.squashed && this.props.thread && !this.env.messageCard,
             "opacity-50": this.props.messageToReplyTo?.isNotSelected(
                 this.props.thread,
                 this.props.message
             ),
+            "o-important": this.message.isHighlightedFromMention,
         };
     }
 
@@ -244,7 +244,7 @@ export class Message extends Component {
     }
 
     get quickActionCount() {
-        return this.env.inChatter ? 2 : 3;
+        return this.env.inChatter ? 2 : this.env.inChatWindow ? 1 : 3;
     }
 
     get showSeenIndicator() {
@@ -462,7 +462,17 @@ export class Message extends Component {
     }
 
     /** @param {HTMLElement} bodyEl */
-    prepareMessageBody(bodyEl) {}
+    prepareMessageBody(bodyEl) {
+        if (this.store.self.type !== "partner") {
+            return;
+        }
+        const selfMentionEls = bodyEl.querySelectorAll(
+            `.o_mail_redirect[data-oe-model='res.partner'][data-oe-id='${this.store.self.id}']`
+        );
+        for (const selfMentionEl of selfMentionEls) {
+            selfMentionEl.classList.add("o-selfMention");
+        }
+    }
 
     enterEditMode() {
         const message = toRaw(this.props.message);
@@ -484,7 +494,10 @@ export class Message extends Component {
     }
 
     getAvatarContainerAttClass() {
-        return { "opacity-50": this.message.isPending };
+        return {
+            "opacity-50": this.message.isPending,
+            "o-small": this.env.inChatWindow || this.ui.isSmall,
+        };
     }
 
     exitEditMode() {

--- a/addons/mail/static/src/core/common/message.scss
+++ b/addons/mail/static/src/core/common/message.scss
@@ -1,8 +1,36 @@
 .o-mail-Message {
-    transition: background-color .2s ease-out, opacity .5s ease-out, box-shadow .5s ease-out, transform .2s ease-out;
+    border: solid transparent;
+    border-width: 0px 2px 0px 2px;
+    padding-left: 2px;
+    transition: background-color .2s ease-out, opacity .5s ease-out, box-shadow .5s ease-out, transform .2s ease-out, border-left-color .5s ease-out;
 
     &.o-highlighted {
-        transform: translateY(-#{map-get($spacers, 3)});
+        border-left-color: $o-info;
+    }
+
+    &.o-important {
+        border-left-color: lighten($warning, 10%);
+        background-color: rgba(lighten($warning, 10%), .15);
+    }
+}
+
+.o-mail-Message-bubble {
+
+    &.o-blue {
+        background-color: mix($o-view-background-color, $o-info, 87.5%);
+        border-color: mix($o-view-background-color, $o-info, 75%) !important;
+    }
+    &.o-green {
+        background-color: mix($o-view-background-color, $o-success, 87.5%);
+        border-color: mix($o-view-background-color, $o-success, 75%) !important;
+
+        .o-mail-Message.o-important & {
+            border-color: mix($o-view-background-color, $o-success, 70%) !important;
+        }
+    }
+    &.o-orange {
+        background-color: mix($o-view-background-color, $o-warning, 80%);
+        border-color: mix($o-view-background-color, $o-warning, 65%) !important;
     }
 }
 
@@ -15,14 +43,24 @@
     flex-basis: $o-mail-Message-sidebarWidth;
     max-width: $o-mail-Message-sidebarWidth;
 
+    &.o-small {
+        flex-basis: $o-mail-Message-sidebarWidthSmall;
+        max-width: $o-mail-Message-sidebarWidthSmall;
+    }
+
     .o-mail-Message-date {
         font-size: 0.75rem;
     }
 }
 
 .o-mail-Message-avatarContainer {
-    width: $o-mail-Avatar-size;
-    height: $o-mail-Avatar-size;
+    width: 34px;
+    height: 34px;
+
+    &.o-small {
+        width: 28px;
+        height: 28px;
+    }
 }
 
 @font-face {
@@ -57,6 +95,10 @@
 .o-mail-ChatWindow .o-mail-Message.o-selfAuthored {
     flex-direction: row-reverse;
 
+    .o-mail-Message-contentContainer {
+        flex-direction: row-reverse;
+    }
+
     .o-mail-Message-core, .o-mail-Message-textContent {
         flex-direction: row-reverse;
     }
@@ -69,14 +111,28 @@
 }
 
 .o-mail-Message-actions {
+    button {
+        opacity: 50%;
+    }
     z-index: $o-mail-NavigableList-zIndex - 3;
 
     &.o-expanded {
         z-index: $o-mail-NavigableList-zIndex - 2;
     }
 
-    button:hover, .focus {
-        background-color: mix($o-gray-100, $o-gray-200) !important;
+    button:hover, button.show, .focus {
+        border: $border-width solid;
+        border-color: $o-gray-300;
+        opacity: 100%;
+        i {
+            filter: contrast(2);
+        }
+    }
+}
+
+.o-mail-Message-action[name='delete'] {
+    &:hover, &.focus, &.show {
+        background-color: rgba($danger, 0.2) !important;
     }
 }
 

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -3,7 +3,7 @@
 
     <t t-name="mail.Message">
         <ActionSwiper onRightSwipe="hasTouch() and isInInbox ? { action: () => this.message.setDone(), bgColor: 'bg-success', icon: 'fa-check-circle' } : undefined">
-            <div class="o-mail-Message position-relative pt-1"
+            <div class="o-mail-Message position-relative"
                 t-att-class="attClass"
                 role="group"
                 t-att-aria-label="messageTypeText"
@@ -14,30 +14,25 @@
                 t-if="message.exists()"
             >
                 <MessageInReply t-if="message.parentMessage" alignedRight="isAlignedRight" message="message" onClick="props.onParentMessageClick"/>
-                <div class="o-mail-Message-core position-relative d-flex flex-shrink-0">
-                    <div class="o-mail-Message-sidebar d-flex flex-shrink-0" t-att-class="{ 'justify-content-end': isAlignedRight, 'align-items-start justify-content-start': !isAlignedRight  }">
-                        <div t-if="!props.squashed" class="o-mail-Message-avatarContainer position-relative bg-view" t-att-class="getAvatarContainerAttClass()">
+                <div class="o-mail-Message-core position-relative d-flex flex-shrink-0 pe-1" t-att-class="{ 'ms-1 ps-2': !env.inChatWindow }">
+                    <div class="o-mail-Message-sidebar d-flex flex-shrink-0" t-att-class="{ 'justify-content-end': isAlignedRight, 'align-items-start justify-content-start': !isAlignedRight, 'o-small': env.inChatWindow or ui.isSmall }">
+                        <div t-if="!props.squashed" class="o-mail-Message-avatarContainer position-relative" t-att-class="getAvatarContainerAttClass()">
                             <img class="o-mail-Message-avatar w-100 h-100 rounded" t-att-src="authorAvatarUrl" t-att-class="authorAvatarAttClass"/>
                         </div>
                         <t t-elif="message.isPending" t-call="mail.Message.pendingStatus"/>
                         <t t-elif="!message.is_transient">
-                            <small t-if="isActive and props.showDates" class="o-mail-Message-date text-muted opacity-75 o-smaller mt-2">
+                            <small t-if="isActive and props.showDates" class="o-mail-Message-date text-muted opacity-75 smaller mt-2">
                                 <t t-esc="message.dateSimple"/>
                             </small>
                         </t>
                     </div>
-                    <div class="w-100 o-min-width-0" t-att-class="{ 'flex-grow-1': message.composer }" t-ref="messageContent">
+                    <div class="min-w-0" t-att-class="{ 'flex-grow-1': message.composer }" t-ref="messageContent">
                         <div t-if="!props.squashed" class="o-mail-Message-header d-flex flex-wrap align-items-baseline lh-1" t-att-class="{ 'mb-1': !message.is_note }">
                             <span t-if="authorName and shouldDisplayAuthorName" class="o-mail-Message-author" t-att-class="getAuthorAttClass()">
-                                <strong class="me-1 text-truncate" t-esc="authorName"/>
+                                <strong class="me-1 text-truncate" t-att-class="{ 'smaller': env.inChatWindow or ui.isSmall, 'small': !env.inChatWindow and !ui.isSmall }" t-esc="authorName"/>
                             </span>
                             <t t-if="!isAlignedRight" t-call="mail.Message.notification"/>
-                            <small t-if="!message.is_transient" class="o-mail-Message-date text-muted opacity-75 o-smaller" t-att-title="message.datetimeShort">
-                                <t t-if="shouldDisplayAuthorName">- </t>
-                                <t t-if="message.isPending" t-call="mail.Message.pendingStatus"/>
-                                <RelativeTime t-else="" datetime="message.datetime"/>
-                            </small>
-                            <small t-if="!isOriginThread and !message.is_transient and message.thread" t-on-click.prevent="openRecord" class="ms-1 text-500">
+                            <small t-if="!isOriginThread and !message.is_transient and message.thread" t-on-click.prevent="openRecord" class="me-1 text-500">
                                 <t t-if="message.thread.model !== 'discuss.channel'">
                                     on <a t-att-href="message.resUrl"><t t-esc="message.thread.displayName"/></a>
                                 </t>
@@ -50,39 +45,44 @@
                                     <i class="fa fa-calendar-o"/>
                                 </span>
                             </div>
+                            <small t-if="!message.is_transient" class="o-mail-Message-date text-muted opacity-75 smaller ms-1" t-att-title="message.datetimeShort">
+                                <t t-if="message.isPending" t-call="mail.Message.pendingStatus"/>
+                                <t t-esc="message.dateSimple"/>
+                            </small>
                             <t t-if="isAlignedRight" t-call="mail.Message.notification"/>
                             <t t-if="message.is_note and !message.isPending" t-call="mail.Message.actions"/>
                         </div>
                         <div
-                            class="position-relative d-flex"
+                            class="o-mail-Message-contentContainer position-relative d-flex"
                             t-att-class="{
                                    'justify-content-end': isAlignedRight,
-                                   'ps-4': env.inChatWindow and isAlignedRight and !state.isEditing,
                                    'ps-2': env.inChatWindow and isAlignedRight and state.isEditing,
-                                   'pe-4': env.inChatWindow and !isAlignedRight and !state.isEditing and !env.messageCard,
                                    'pe-2': env.inChatWindow and !isAlignedRight and composerViewInEditing,
                                    }"
                         >
-                            <div class="o-mail-Message-content o-min-width-0" t-att-class="{ 'w-100': state.isEditing, 'opacity-50': message.isPending, 'pt-1': message.is_note }">
+                            <div class="o-mail-Message-content min-w-0" t-att-class="{ 'w-100': state.isEditing, 'opacity-50': message.isPending, 'pt-1': message.is_note }">
                                 <div class="o-mail-Message-textContent position-relative d-flex" t-att-class="{ 'w-100': state.isEditing }">
                                     <t t-if="message.message_type === 'notification' and message.body" t-call="mail.Message.bodyAsNotification" name="bodyAsNotification"/>
-                                    <t t-if="message.message_type !== 'notification' and !message.is_transient and (message.hasTextContent or message.subtype_description or state.isEditing)">
+                                    <t t-if="message.message_type !== 'notification' and !message.is_transient and (message.hasTextContent or message.subtype_description or state.isEditing or message.attachments.length > 0)">
                                         <LinkPreviewList t-if="!state.isEditing and message.linkPreviewSquash" linkPreviews="message.linkPreviews" deletable="false"/>
                                         <t t-else="">
-                                            <div class="position-relative overflow-x-auto d-inline-block" t-att-class="{ 'w-100': state.isEditing }">
-                                                <div class="o-mail-Message-bubble rounded-bottom-3 position-absolute top-0 start-0 w-100 h-100" t-att-class="{
+                                            <div class="position-relative overflow-x-auto d-inline-block" t-att-class="{ 'w-100': state.isEditing, 'align-self-start rounded-bottom-3': !state.isEditing and !message.is_note, 'rounded-3': props.squashed, 'rounded-bottom-3': !props.squashed }">
+                                                <div class="o-mail-Message-bubble position-absolute top-0 start-0 w-100 h-100" t-att-class="{
                                                     'border': state.isEditing and !message.is_note,
-                                                    'bg-info-light border border-info opacity-25': !message.isSelfAuthored and !message.is_note and !message.isHighlightedFromMention,
-                                                    'bg-success-light border border-success opacity-25': message.isSelfAuthored and !message.is_note and !message.isHighlightedFromMention,
-                                                    'bg-warning-light border border-warning opacity-50': message.isHighlightedFromMention,
-                                                    }" t-attf-class="{{ isAlignedRight ? 'rounded-start-3' : 'rounded-end-3' }}"/>
-                                                <div class="position-relative text-break o-mail-Message-body" t-att-class="{
-                                                            'p-1': message.is_note,
-                                                            'fs-1': !state.isEditing and !env.inChatter and message.onlyEmojis,
-                                                            'mb-0 py-2 px-3': !message.is_note,
-                                                            'align-self-start rounded-end-3 rounded-bottom-3': !state.isEditing and !message.is_note,
-                                                            'o-mail-Message-editable flex-grow-1': state.isEditing,
-                                                            }" t-ref="body">
+                                                    'o-blue border': !message.isSelfAuthored and !message.is_note,
+                                                    'o-green border': message.isSelfAuthored and !message.is_note,
+                                                    'rounded-3': props.squashed,
+                                                    'rounded-start-3 rounded-bottom-3': !props.squashed and isAlignedRight,
+                                                    'rounded-end-3 rounded-bottom-3': !props.squashed and !isAlignedRight,
+                                                }"/>
+                                                <div t-if="message.hasTextContent" class="position-relative text-break o-mail-Message-body" t-ref="body" t-att-class="{
+                                                    'p-1': message.is_note,
+                                                    'fs-1': !state.isEditing and !env.inChatter and message.onlyEmojis,
+                                                    'mb-0 py-2 px-3': !message.is_note and !state.isEditing,
+                                                    'align-self-start rounded-end-3 rounded-bottom-3': !props.squashed and !state.isEditing and !message.is_note,
+                                                    'rounded-3': props.squashed,
+                                                    'o-mail-Message-editable flex-grow-1 px-2': state.isEditing,
+                                                }">
                                                     <Composer t-if="state.isEditing" autofocus="true" composer="message.composer" messageComponent="constructor" onDiscardCallback.bind="exitEditMode" onPostCallback.bind="exitEditMode" mode="env.inChatter ? 'extended' : 'compact'" sidebar="false"/>
                                                     <t t-else="">
                                                         <em t-if="message.subject and !message.isSubjectSimilarToThreadName and !message.isSubjectDefault" class="mb-1 me-2">Subject: <t t-out="props.messageSearch?.highlight(message.subject) ?? message.subject"/></em>
@@ -100,6 +100,12 @@
                                                         <t t-if="showSubtypeDescription" t-out="props.messageSearch?.highlight(message.subtype_description) ?? message.subtype_description"/>
                                                     </t>
                                                 </div>
+                                                <AttachmentList
+                                                    t-if="message.attachments.length > 0"
+                                                    attachments="message.attachments.map((a) => a)"
+                                                    unlinkAttachment.bind="onClickAttachmentUnlink"
+                                                    imagesHeight="message.attachments.length === 1 ? 300 : 150"
+                                                    messageSearch="props.messageSearch"/>
                                                 <div class="o-mail-Message-seenContainer position-absolute bottom-0">
                                                     <MessageSeenIndicator
                                                         t-if="showSeenIndicator"
@@ -110,17 +116,12 @@
                                             </div>
                                         </t>
                                     </t>
-                                    <t t-if="!message.is_note and !message.isPending and message.hasTextContent and !env.inChatWindow" t-call="mail.Message.actions"/>
+                                    <t t-if="!message.is_note and !message.isPending and message.hasTextContent" t-call="mail.Message.actions"/>
                                 </div>
-                                <AttachmentList
-                                    t-if="message.attachments.length > 0"
-                                    attachments="message.attachments.map((a) => a)"
-                                    unlinkAttachment.bind="onClickAttachmentUnlink"
-                                    imagesHeight="message.attachments.length === 1 ? 300 : 75"
-                                    messageSearch="props.messageSearch"/>
+                                
                                 <LinkPreviewList t-if="message.linkPreviews.length > 0 and store.hasLinkPreviewFeature and !message.linkPreviewSquash" linkPreviews="message.linkPreviews" deletable="deletable"/>
                             </div>
-                            <t t-if="!message.is_note and !message.isPending and (!message.hasTextContent or env.inChatWindow)" t-call="mail.Message.actions"/>
+                            <t t-if="!message.is_note and !message.isPending and !message.hasTextContent" t-call="mail.Message.actions"/>
                         </div>
                         <MessageReactions message="message" openReactionMenu="openReactionMenu" t-if="message.reactions.length"/>
                     </div>
@@ -132,50 +133,44 @@
 <t t-name="mail.Message.actions">
     <div t-if="props.hasActions and message.hasActions and !state.isEditing" class="o-mail-Message-actions d-print-none"
         t-att-class="{
-            'start-0 ms-3': isAlignedRight,
-            'end-0 me-3': (env.inChatWindow or ui.isSmall) and !isAlignedRight,
-            'position-absolute top-0 mt-n3': env.inChatWindow or ui.isSmall,
-            'ms-2': !env.inChatWindow and !ui.isSmall,
-            'mt-1': !env.inChatWindow and !ui.isSmall and !message.is_note,
+            'start-0': isAlignedRight,
+            'mx-1': !ui.isSmall,
+            'mt-1': !ui.isSmall and !message.is_note,
             'my-n2': message.is_note,
             'invisible': !isActive,
-            'o-expanded': optionsDropdown.isOpen
+            'o-expanded': optionsDropdown.isOpen,
         }"
     >
         <t t-set="isReverse" t-value="env.inChatWindow and isAlignedRight"/>
         <div class="d-flex rounded-1 overflow-hidden" t-att-class="{
                 'flex-row-reverse': isReverse,
-                'bg-view shadow-sm': env.inChatWindow,
+                'list-group list-group-flush': ui.isSmall,
+                'flex-row': ui.isSmall and !isReverse,
             }"
         >
             <t t-foreach="messageActions.actions.slice(0, quickActionCount)" t-as="action" t-key="action.id">
-                <t t-set="isStart" t-value="(!isReverse and action.isFirst) or (isReverse and action.isLast)"/>
-                <t t-set="isEnd" t-value="(!isReverse and action.isLast) or (isReverse and action.isFirst)"/>
-                <t t-if="action.callComponent" t-component="action.callComponent" t-props="action.props" classNames="{
-                    'rounded-start-1': isStart,
-                    'rounded-end-1': isEnd,
-                }"/>
-                <button t-else="" class="btn px-1 py-0 rounded-0" t-att-title="action.title" t-att-name="action.id" t-on-click.stop="action.onClick" t-att-class="{
-                    'rounded-start-1': isStart,
-                    'rounded-end-1': isEnd,
-                }">
-                    <i class="fa fa-lg" t-att-class="action.icon"/>
-                </button>
+                <t t-call="mail.Message.quickAction">
+                    <t t-set="action" t-value="action"/>
+                </t>
             </t>
-            <div t-if="messageActions.actions.length gt quickActionCount" class="d-flex rounded-0">
-                <Dropdown state="optionsDropdown" position="props.message.threadAsNewest  ? 'top-start' : 'bottom-start'" menuClass="'d-flex flex-column py-0 o-mail-Message-moreMenu'" >
+            <t t-if="messageActions.actions.length === quickActionCount + 1" t-call="mail.Message.quickAction">
+                <t t-set="action" t-value="messageActions.actions.at(quickActionCount)"/>
+            </t>
+            <div t-if="messageActions.actions.length gt quickActionCount + 1" class="d-flex rounded-0">
+                <Dropdown state="optionsDropdown" position="props.message.threadAsNewest  ? 'top-start' : 'bottom-start'" menuClass="'d-flex flex-column py-0 o-mail-Message-moreMenu rounded-3'" >
                     <button class="btn px-1 py-0 rounded-0" t-att-title="expandText" t-att-class="{
                         'bg-200': optionsDropdown.isOpen,
                         'rounded-start-1': isReverse,
                         'rounded-end-1': !isReverse,
+                        'fs-4': ui.isSmall,
                     }">
                         <i class="fa fa-lg fa-ellipsis-h" t-att-class="{ 'order-1': props.isInChatWindow }" tabindex="1"/>
                     </button>
                     <t t-set-slot="content">
                         <t t-foreach="messageActions.actions.slice(quickActionCount)" t-as="action" t-key="action.id">
-                            <DropdownItem class="'px-2 d-flex align-items-center rounded-0'" onSelected="action.onClick" attrs="{ title: action.title}">
-                                <i class="fa fa-lg fa-fw pe-2" t-att-class="action.icon"/>
-                                <t t-esc="action.title"/>
+                            <DropdownItem class="'o-mail-Message-action d-flex align-items-center rounded-0' + (ui.isSmall ? ' fs-4 p-2' : ' px-2') + ' ' + action.class" onSelected="action.onClick" attrs="{ 'aria-label': action.title, 'name': action.id }">
+                                <i class="fa fa-fw pe-2 me-1" t-att-class="action.icon" t-attf-class="{{ ui.isSmall ? 'fa-lg' : '' }}"/>
+                                <span t-att-class="{ 'small': !ui.isSmall }" t-esc="action.title"/>
                             </DropdownItem>
                         </t>
                     </t>
@@ -183,6 +178,23 @@
             </div>
         </div>
     </div>
+</t>
+
+<t t-name="mail.Message.quickAction">
+    <t t-set="isStart" t-value="(!isReverse and action.isFirst) or (isReverse and action.isLast)"/>
+    <t t-set="isEnd" t-value="(!isReverse and action.isLast) or (isReverse and action.isFirst)"/>
+    <t t-if="action.callComponent" t-component="action.callComponent" t-props="action.props" classNames="{
+        'rounded-start-1': isStart,
+        'rounded-end-1': isEnd,
+        'fs-4': ui.isSmall,
+    }"/>
+    <button t-else="" class="o-mail-Message-action btn px-1 py-0 rounded-0" t-att-title="action.title" t-att-name="action.id" t-on-click.stop="action.onClick" t-att-class="{
+        'rounded-start-1': isStart,
+        'rounded-end-1': isEnd,
+        'fs-4': ui.isSmall,
+    }">
+        <i class="fa fa-lg" t-att-class="action.icon"/>
+    </button>
 </t>
 
 <t t-name="mail.Message.notification">

--- a/addons/mail/static/src/core/common/message_actions.js
+++ b/addons/mail/static/src/core/common/message_actions.js
@@ -70,6 +70,7 @@ messageActionsRegistry
         sequence: 80,
     })
     .add("delete", {
+        class: "text-danger fw-bold",
         condition: (component) => component.deletable,
         icon: "fa-trash",
         title: _t("Delete"),
@@ -103,6 +104,10 @@ function transformAction(component, id, action) {
     return {
         component: action.component,
         id,
+        /** Class on the button of this action. */
+        get class() {
+            return typeof action.class === "function" ? action.class(component) : action.class;
+        },
         /** Condition to display this action. */
         get condition() {
             return action.condition(component);

--- a/addons/mail/static/src/core/common/message_card_list.scss
+++ b/addons/mail/static/src/core/common/message_card_list.scss
@@ -1,9 +1,28 @@
-.o-mail-MessageCardList .card-body:hover .o-mail-MessageCard-jump {
-    opacity: 100 !important;
+.o-mail-MessageCardList .card-body:hover {
+    .o-mail-MessageCardList-close {
+        opacity: 75%;
+    }
+
+    .o-mail-MessageCard-jump {
+        opacity: 100% !important;
+    }
+}
+
+.o-mail-MessageCardList-close {
+    opacity: 25%;
+
+    &:hover {
+        background-color: $o-gray-300;
+        opacity: 100% !important;
+    }
 }
 
 .o-mail-MessageCard-jump {
     color: white;
+    
+    &:hover {
+        filter: brightness(95%);
+    }
 }
 
 .o_touch_device .o-mail-MessageCard-jump.btn {

--- a/addons/mail/static/src/core/common/message_card_list.xml
+++ b/addons/mail/static/src/core/common/message_card_list.xml
@@ -2,15 +2,15 @@
 <templates xml:space="preserve">
     <t t-name="mail.MessageCardList">
         <div class="o-mail-MessageCardList d-flex flex-column" t-att-class="{ 'justify-content-center flex-grow-1': props.messages.length === 0 }" t-ref="message-list">
-            <div class="card mb-2" t-foreach="props.messages" t-as="message" t-key="message.id">
-                <div class="card-body py-2">
-                    <div class="position-absolute top-0 end-0 z-1 m-2">
-                        <a role="button" class="o-mail-MessageCard-jump rounded bg-400 badge opacity-0" t-att-class="{ 'opacity-100 py-1 px-2': ui.isSmall }" t-on-click="() => this.onClickJump(message)">Jump</a>
-                        <button t-if="props.mode === 'pin'" class="btn btn-link text-reset ms-2 p-0" t-att-class="{ 'fs-5': ui.isSmall }" title="Unpin" t-on-click="message.unpin">
-                            <i class="fa fa-times"/>
+            <div class="card mb-2 mx-3" t-foreach="props.messages" t-as="message" t-key="message.id">
+                <div class="card-body p-0">
+                    <div class="position-absolute top-0 end-0 z-1 me-1">
+                        <a role="button" class="o-mail-MessageCard-jump rounded bg-400 badge opacity-0 fw-bold" t-att-class="{ 'opacity-100 py-1 px-2': ui.isSmall }" t-on-click="() => this.onClickJump(message)">Jump</a>
+                        <button t-if="props.mode === 'pin'" class="o-mail-MessageCardList-close btn btn-link text-reset ms-2 p-0 rounded-circle smaller" t-att-class="{ 'fs-5': ui.isSmall }" title="Unpin" t-on-click="message.unpin">
+                            <i class="oi oi-close fa-fw"/>
                         </button>
                     </div>
-                    <Message hasActions="false" message="message" thread="props.thread" messageSearch="props.messageSearch"/>
+                    <Message hasActions="false" message="message" thread="props.thread" messageSearch="props.messageSearch" className="'px-0 py-2'"/>
                 </div>
             </div>
             <span t-if="props.loadMore" t-ref="load-more"/>

--- a/addons/mail/static/src/core/common/message_reaction_button.js
+++ b/addons/mail/static/src/core/common/message_reaction_button.js
@@ -14,6 +14,7 @@ export class MessageReactionButton extends Component {
     setup() {
         super.setup();
         this.store = useState(useService("mail.store"));
+        this.ui = useState(useService("ui"));
         this.emojiPickerRef = useRef("emoji-picker");
         this.emojiPicker = useEmojiPicker(this.emojiPickerRef, {
             onSelect: (emoji) => {

--- a/addons/mail/static/src/core/common/message_reactions.dark.scss
+++ b/addons/mail/static/src/core/common/message_reactions.dark.scss
@@ -1,0 +1,17 @@
+.o-mail-MessageReaction {
+    &.o-selfReacted {
+        border-color: rgba(lighten($primary, 10%), 0.65) !important;
+
+        &:hover {
+            border-color: rgba(lighten($primary, 20%), 0.7) !important;
+        }
+    }
+
+    &:not(.o-selfReacted) {
+        border-color: $gray-300 !important;
+
+        &:hover {
+            border-color: mix($gray-500, $gray-600) !important;
+        }
+    }
+}

--- a/addons/mail/static/src/core/common/message_reactions.scss
+++ b/addons/mail/static/src/core/common/message_reactions.scss
@@ -1,3 +1,34 @@
-.o-mail-MessageReaction.o-selfReacted {
-    background: mix($o-brand-primary, $o-view-background-color, 10%);
+.o-mail-MessageReaction {
+
+    &:hover {
+        backdrop-filter: brightness(1.3);
+        -webkit-backdrop-filter: brightness(1.3);
+
+        .o-mail-MessageReaction-counter {
+            filter: brightness(1.3);
+        }
+    }
+
+    &.o-selfReacted {
+        border-color: rgba(lighten($primary, 10%), 0.5) !important;
+        background: mix($o-brand-primary, $o-view-background-color, 7.5%);
+
+        &:hover {
+            border-color: rgba(lighten($primary, 25%), 1) !important;
+        }
+    }
+
+    &:not(.o-selfReacted) {
+        border-color: lighten($gray-200, 2.5%) !important;
+        background: $o-view-background-color;
+
+        &:hover {
+            border-color: mix($gray-300, $gray-400) !important;
+        }
+    }
 }
+
+.o-mail-MessageReaction-counter {
+    color: $text-muted;
+}
+

--- a/addons/mail/static/src/core/common/message_reactions.xml
+++ b/addons/mail/static/src/core/common/message_reactions.xml
@@ -7,17 +7,16 @@
             'ms-3': !(env.inChatWindow and env.alignedRight) and (props.message.is_discussion),
         }"
         t-attf-class="{{ props.message.is_discussion ? 'mt-n1' : 'mt-1' }}">
-        <button t-foreach="props.message.reactions" t-as="reaction" t-key="reaction.content" class="o-mail-MessageReaction btn d-flex p-0 border rounded-1 mb-1"
+        <button t-foreach="props.message.reactions" t-as="reaction" t-key="reaction.content" class="o-mail-MessageReaction btn d-flex p-0 rounded-3 mb-1"
             t-on-click="() => this.onClickReaction(reaction)"
             t-on-contextmenu="onContextMenu"
             t-att-class="{
-                'o-selfReacted border-primary text-primary fw-bolder': hasSelfReacted(reaction),
-                'bg-view': !hasSelfReacted(reaction),
+                'o-selfReacted text-primary border-primary': hasSelfReacted(reaction),
                 'ms-1': env.inChatWindow and env.alignedRight,
                 'me-1': !(env.inChatWindow and env.alignedRight),
          }" t-att-title="getReactionSummary(reaction)">
             <span class="mx-1" t-esc="reaction.content"/>
-            <span class="mx-1" t-esc="reaction.count"/>
+            <span class="o-mail-MessageReaction-counter me-1 fw-bold" t-att-class="{ 'text-primary': hasSelfReacted(reaction) }" t-esc="reaction.count"/>
         </button>
     </div>
 </t>

--- a/addons/mail/static/src/core/common/message_seen_indicator.dark.scss
+++ b/addons/mail/static/src/core/common/message_seen_indicator.dark.scss
@@ -1,0 +1,3 @@
+.o-mail-MessageSeenIndicator:not(.o-all-seen) i {
+    color: $o-gray-600;
+}

--- a/addons/mail/static/src/core/common/message_seen_indicator.scss
+++ b/addons/mail/static/src/core/common/message_seen_indicator.scss
@@ -1,8 +1,22 @@
-.o-mail-MessageSeenIndicator i {
-    // fa icons have a line height of 1 by default which breaks alignment
-    line-height: 1.5;
+.o-mail-MessageSeenIndicator {
+    border-color: transparent !important;
 
-    &.o-second {
-        top: -3px;
+    &:not(.o-all-seen) i {
+        color: $o-gray-400;
+    }
+
+    &.cursor-pointer:hover {
+        background-color: $o-gray-200;
+        border-color: rgba($primary, 0.25) !important;
+    }
+
+    i {
+        // fa icons have a line height of 1 by default which breaks alignment
+        line-height: 1.5;
+    
+        &.o-second {
+            top: -3px;
+        }
     }
 }
+

--- a/addons/mail/static/src/core/common/message_seen_indicator.xml
+++ b/addons/mail/static/src/core/common/message_seen_indicator.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.MessageSeenIndicator">
-        <span class="o-mail-MessageSeenIndicator position-relative" t-att-class="{ 'opacity-50': !props.message.hasEveryoneSeen, 'o-all-seen text-primary': props.message.hasEveryoneSeen, 'cursor-pointer': props.message.channelMemberHaveSeen.length }" t-att-title="summary" t-attf-class="{{ props.className }}" t-on-click="openDialog">
+        <span class="o-mail-MessageSeenIndicator position-relative border rounded" t-att-class="{ 'o-all-seen text-primary': props.message.hasEveryoneSeen, 'cursor-pointer': props.message.channelMemberHaveSeen.length }" t-att-title="summary" t-attf-class="{{ props.className }}" t-on-click="openDialog">
             <t t-if="!props.message.isMessagePreviousToLastSelfMessageSeenByEveryone">
                 <i t-if="props.message.hasSomeoneFetched or props.message.hasSomeoneSeen" class="fa fa-check ps-1"/>
                 <i t-if="props.message.hasSomeoneSeen" class="o-second start-0 fa fa-check position-absolute"/>

--- a/addons/mail/static/src/core/common/navigable_list.dark.scss
+++ b/addons/mail/static/src/core/common/navigable_list.dark.scss
@@ -1,0 +1,3 @@
+.o-mail-NavigableList-active {
+    background-color: $gray-300;
+}

--- a/addons/mail/static/src/core/common/navigable_list.scss
+++ b/addons/mail/static/src/core/common/navigable_list.scss
@@ -1,3 +1,7 @@
 .o-mail-NavigableList {
     z-index: $o-mail-NavigableList-zIndex;
 }
+
+.o-mail-NavigableList-active {
+    background-color: $gray-200;
+}

--- a/addons/mail/static/src/core/common/navigable_list.xml
+++ b/addons/mail/static/src/core/common/navigable_list.xml
@@ -2,10 +2,10 @@
 <templates xml:space="preserve">
 
     <t t-name="mail.NavigableList">
-        <div class="o-mail-NavigableList bg-view m-0 p-0" t-ref="root" t-att-class="props.class">
-            <div t-if="show" class="o-open border d-flex flex-column" t-on-mousedown.prevent="">
+        <div class="o-mail-NavigableList bg-view m-0 p-0 rounded-3" t-ref="root" t-att-class="props.class">
+            <div t-if="show" class="o-open border d-flex flex-column rounded-3" t-on-mousedown.prevent="">
                 <div t-if="props.isLoading" class="o-mail-NavigableList-item">
-                    <a href="#" class="d-flex align-items-center w-100 py-2 px-4 gap-1">
+                    <a href="#" class="d-flex align-items-center w-100 py-1 px-3 gap-1">
                         <i class="fa fa-spin fa-circle-o-notch"/>
                         <t t-esc="props.placeholder"/>
                     </a>
@@ -19,7 +19,7 @@
                         t-on-click="(ev) => this.selectOption(ev, option_index)"
                     >
                         <hr class="my-2" t-if="option.group != lastGroup and option_index != 0"/>
-                        <a href="#" class="d-flex align-items-center w-100 py-2 px-4" t-att-class="{ 'o-mail-NavigableList-active bg-300': state.activeIndex === option_index }">
+                        <a href="#" class="d-flex align-items-center w-100 py-1 px-3" t-att-class="{ 'o-mail-NavigableList-active': state.activeIndex === option_index }">
                             <t t-if="option.optionTemplate" t-call="{{ option.optionTemplate }}"/>
                             <t t-elif="props.optionTemplate" t-call="{{ props.optionTemplate }}"/>
                             <t t-else="" t-esc="option.label"/>

--- a/addons/mail/static/src/core/common/picker.js
+++ b/addons/mail/static/src/core/common/picker.js
@@ -90,6 +90,7 @@ export class Picker extends Component {
             closeOnClickAway: false,
             animation: false,
             arrow: false,
+            popoverClass: "rounded-3",
         };
     }
 

--- a/addons/mail/static/src/core/common/primary_variables.scss
+++ b/addons/mail/static/src/core/common/primary_variables.scss
@@ -15,11 +15,11 @@ $o-mail-LinkPreview-width: 320px !default;
 $o-mail-LinkPreview-height: 240px !default;
 $o-mail-LinkPreviewCard-height: 80px !default;
 
-$o-mail-Message-sidebarWidth: 42px !default;
+$o-mail-Message-sidebarWidth: 40px !default;
+$o-mail-Message-sidebarWidthSmall: 34px !default;
 $o-mail-NavigableList-zIndex: 11;
 $o-mail-Chatter-minWidth: 530px !default;
 $o-mail-Discuss-inspector: 300px !default;
-$o-mail-Discuss-headerHeight: 48px !default;
 
 @mixin o-FileViewer-arrow {
     background-color: rgba(black, 0.4);

--- a/addons/mail/static/src/core/common/search_messages_panel.xml
+++ b/addons/mail/static/src/core/common/search_messages_panel.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-name="mail.SearchMessagesPanel">
         <ActionPanel title="env.inChatter ? undefined : title">
-            <div class="d-flex pb-2">
+            <div class="d-flex pb-2 px-2">
                 <div class="input-group">
                     <div class="o_searchview form-control d-flex align-items-center py-1" role="search" aria-autocomplete="list">
                         <div class="o_searchview_input_container d-flex flex-grow-1 flex-wrap gap-1">

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -10,6 +10,7 @@ import { debounce } from "@web/core/utils/timing";
 import { session } from "@web/session";
 import { _t } from "@web/core/l10n/translation";
 import { cleanTerm, prettifyMessageContent } from "@mail/utils/common/format";
+import { cookie } from "@web/core/browser/cookie";
 
 /**
  * @typedef {{isSpecial: boolean, channel_types: string[], label: string, displayName: string, description: string}} SpecialMention
@@ -84,6 +85,8 @@ export class Store extends BaseStore {
     /** @type {typeof import("@mail/core/common/volume_model").Volume} */
     Volume;
 
+    /** @type {"dark"|"light"} */
+    theme = cookie.get("color_scheme") ?? "light";
     /**
      * Defines channel types that have the message seen indicator/info feature.
      * @see `discuss.channel`._types_allowing_seen_infos()

--- a/addons/mail/static/src/core/common/thread.js
+++ b/addons/mail/static/src/core/common/thread.js
@@ -454,7 +454,7 @@ export class Thread extends Component {
 
     getMessageClassName(message) {
         return this.messageHighlight?.highlightedMessageId === message.id
-            ? "o-highlighted bg-view shadow-lg pb-1"
+            ? "o-highlighted bg-view shadow-lg"
             : "";
     }
 

--- a/addons/mail/static/src/core/common/thread.scss
+++ b/addons/mail/static/src/core/common/thread.scss
@@ -3,9 +3,24 @@
 }
 .o-mail-Thread-newMessage {
     transition: opacity 0.5s;
+    user-select: none;
+
+    hr {
+        border-top-width: 2px;
+        opacity: 80%;
+    }
 
     span {
-        font-size: 0.8rem;
+        padding-top: map-get($spacers, 1) / 2;
+        padding-bottom: map-get($spacers, 1) / 2;
+        font-size: 0.65rem;
+        clip-path: polygon(-2% 52%, 25% 0%, 100% 0%, 100% 100%, 25% 100%);
+        opacity: 90%;
+
+        &.o-small {
+            font-size: 0.5rem;
+            clip-path: polygon(-4% 50%, 25% 0%, 100% 0%, 100% 100%, 25% 100%);
+        }
     }
 }
 
@@ -31,5 +46,19 @@
 }
 
 .o-mail-Thread-bannerHover:hover {
-    filter: brightness(98%);
+    filter: brightness(95%);
+}
+
+.o-mail-Thread-jumpToPresent {
+    --border-opacity: 0.75;
+
+    bottom: 10px;
+    right: 10px;
+    z-index: $o-mail-NavigableList-zIndex - 1;
+    color: darken($o-action, 5%) !important;
+    border-color: rgba(darken($o-action, 5%), 0.75) !important;
+
+    &:hover {
+        filter: brightness(90%);
+    }
 }

--- a/addons/mail/static/src/core/common/thread.xml
+++ b/addons/mail/static/src/core/common/thread.xml
@@ -4,7 +4,7 @@
 <t t-name="mail.Thread">
     <t t-if="env.inChatter" t-call="mail.Thread.jumpPresent"/> <!-- chatter has its own scrollable, this ensures proper sticky showing -->
     <t t-else="" t-call="mail.Thread.jumpUnread"/>
-    <div class="o-mail-Thread position-relative flex-grow-1 d-flex flex-column overflow-auto" t-att-class="{ 'pb-4':  props.showJumpPresent and !state.showJumpPresent, 'px-3': !env.inChatter and !props.isInChatWindow }" t-ref="messages" tabindex="-1">
+    <div class="o-mail-Thread position-relative flex-grow-1 d-flex flex-column overflow-auto" t-att-class="{ 'pb-3':  props.showJumpPresent and !state.showJumpPresent }" t-ref="messages" tabindex="-1">
         <t t-if="!props.thread.isEmpty or props.thread.loadOlder or props.thread.hasLoadingFailed" name="content">
             <div class="d-flex flex-column position-relative flex-grow-1" t-att-class="{'justify-content-end': !env.inChatter and props.thread.model !== 'mail.box'}">
                 <span class="position-absolute w-100 invisible" t-att-class="props.order === 'asc' ? 'bottom-0' : 'top-0'" t-ref="present-treshold" t-att-style="`height: Min(${PRESENT_THRESHOLD}px, 100%)`"/>
@@ -21,8 +21,8 @@
                         <DateSection date="msg.dateDay" className="'pt-2'"/>
                         <t t-set="currentDay" t-value="msg.dateDay"/>
                     </t>
-                    <div t-if="msg.threadAsFirstUnread?.eq(props.thread)" class="o-mail-Thread-newMessage d-flex align-items-center fw-bolder z-1">
-                        <hr class="ms-2 flex-grow-1 border border-danger opacity-50"/><span class="px-2 text-danger">New messages</span><hr class="me-2 flex-grow-1 border border-danger opacity-50"/>
+                    <div t-if="msg.threadAsFirstUnread?.eq(props.thread)" class="o-mail-Thread-newMessage d-flex align-items-center fw-bolder z-1 mx-1">
+                        <hr class="flex-grow-1 border-danger"/><span class="ps-2 pe-1 text-danger text-uppercase bg-danger o-text-white rounded-start-0 rounded-end" t-att-class="{ 'o-small': env.inChatWindow }">New</span>
                     </div>
                     <t t-if="msg.isNotification">
                         <t t-call="mail.NotificationMessage"/>
@@ -56,24 +56,21 @@
                 </t>
             </div>
         </t>
+        <t t-if="!env.inChatter" t-call="mail.Thread.jumpPresent"/>
     </div>
-    <t t-if="!env.inChatter" t-call="mail.Thread.jumpPresent"/>
 </t>
 
 <t t-name="mail.Thread.jumpPresent">
-    <span t-if="props.showJumpPresent and state.showJumpPresent" t-att-class="{
-        'm-0 px-4 position-sticky top-0': env.inChatter,
-    }" class="o-mail-Thread-banner o-mail-Thread-bannerHover d-flex d-print-none justify-content-between alert alert-primary border-0 rounded-0 mb-0 py-1 cursor-pointer shadow-sm small fw-bold" t-on-click="() => this.jumpToPresent()">
-        <span>You're viewing older messages</span>
-        <span>Jump to Present<i class="ms-2 fa" t-att-class="{ 'fa-caret-up': props.order !== 'asc', 'fa-caret-down': props.order === 'asc' }"/></span>
-    </span>
+    <button t-if="props.showJumpPresent and state.showJumpPresent" class="o-mail-Thread-jumpToPresent btn rounded-circle bg-view position-sticky align-self-end px-1 py-0 shadow-sm border" title="Jump to Present" t-on-click="() => this.jumpToPresent()">
+        <i class="oi oi-chevron-down smaller"/>
+    </button>
 </t>
 
 <t t-name="mail.Thread.jumpUnread">
-    <span t-if="props.thread.showUnreadBanner" class="o-mail-Thread-banner d-flex cursor-pointer shadow-sm small fw-bold">
-        <t t-set="alertClass" t-value="'alert alert-info m-0 border-start-0 o-mail-Thread-bannerHover rounded-0 py-1'"/>
+    <span t-if="props.thread.showUnreadBanner" class="o-mail-Thread-banner d-flex cursor-pointer fw-bold" t-att-class="{ 'smaller': env.inChatWindow, 'small': !env.inChatWindow }">
+        <t t-set="alertClass" t-value="'alert alert-warning m-0 border-start-0 o-mail-Thread-bannerHover rounded-0 py-1'"/>
         <span t-attf-class="{{ alertClass }} flex-grow-1" t-on-click="onClickUnreadMessagesBanner" t-esc="newMessageBannerText"/>
-        <span t-attf-class="{{ alertClass }}" t-on-click="() => props.thread.markAsRead({ sync: true })">Mark as Read<i class="ms-2 fa fa-check-square"/></span>
+        <span t-attf-class="{{ alertClass }}" t-on-click="() => props.thread.markAsRead({ sync: true })">Mark as Read<i class="ms-2 fa fa-check-circle"/></span>
     </span>
 </t>
 <t t-name="mail.Thread.loadOlder">
@@ -92,8 +89,10 @@
 </t>
 
 <t t-name="mail.NotificationMessage">
-    <div class="o-mail-NotificationMessage text-break mx-auto text-500 small px-3 text-center" t-on-click="onClickNotification" t-att-class="{
+    <div class="o-mail-NotificationMessage text-break mx-auto text-500 px-3 text-center" t-on-click="onClickNotification" t-att-class="{
         'mt-1': prevMsg and !prevMsg.isNotification,
+        'smaller': env.inChatWindow,
+        'small': !env.inChatWindow,
     }" t-ref="root">
         <i t-if="msg.notificationIcon" t-attf-class="{{ msg.notificationIcon }} me-1"/>
         <span class="o-mail-NotificationMessage-author d-inline" t-if="msg.author and !msg.body.includes(escape(msg.author.name))" t-esc="msg.author.name"/> <t t-out="msg.body"/>

--- a/addons/mail/static/src/core/common/thread_actions.js
+++ b/addons/mail/static/src/core/common/thread_actions.js
@@ -9,7 +9,11 @@ export const threadActionsRegistry = registry.category("mail.thread/actions");
 threadActionsRegistry
     .add("fold-chat-window", {
         condition(component) {
-            return !component.ui.isSmall && component.props.chatWindow;
+            return (
+                !component.ui.isSmall &&
+                component.props.chatWindow &&
+                component.props.chatWindow.thread
+            );
         },
         icon: "fa fa-fw fa-minus",
         name(component) {

--- a/addons/mail/static/src/core/common/thread_icon.xml
+++ b/addons/mail/static/src/core/common/thread_icon.xml
@@ -5,8 +5,8 @@
         <div class="o-mail-ThreadIcon d-flex justify-content-center flex-shrink-0" t-att-class="props.className">
             <t t-set="largeClass" t-value="props.size === 'large' ? 'fa-lg' : ''"/>
             <t t-if="props.thread.channel_type === 'channel'">
-                <div t-if="props.thread.authorizedGroupFullName" class="fa fa-fw fa-hashtag" t-att-class="largeClass" t-att-title="props.thread.accessRestrictedToGroupText"/>
-                <div t-if="!props.thread.authorizedGroupFullName" class="fa fa-fw fa-globe" t-att-class="largeClass" title="Public Channel"/>
+                <div t-if="props.thread.authorizedGroupFullName" class="fa fa-fw fa-hashtag text-dark" t-att-class="largeClass" t-att-title="props.thread.accessRestrictedToGroupText"/>
+                <div t-if="!props.thread.authorizedGroupFullName" class="fa fa-fw fa-globe text-dark" t-att-class="largeClass" title="Public Channel"/>
             </t>
             <t t-elif="props.thread.channel_type === 'chat' and correspondent">
                 <t name="chat">

--- a/addons/mail/static/src/core/public_web/discuss.scss
+++ b/addons/mail/static/src/core/public_web/discuss.scss
@@ -22,19 +22,24 @@
     max-width: 75%;
 }
 .o-mail-Discuss-header {
-    height: $o-mail-Discuss-headerHeight;
-    box-shadow: 0px 1px 6px -3px rgba(50, 50, 50, 0.15);
+    height: 40px;
 }
 
-.o-mail-Discuss-headerActions button {
-    &:not(.o-isActive):hover {
-        background-color: $gray-200;
-    }
-    &.o-isActive {
-        background-color: $gray-300;
-    }
-    &.o-isActive:hover {
-        background-color: $gray-300;
+.o-mail-Discuss-headerActions {
+    gap: 1px;
+
+    button {
+        &:hover, &.o-isActive {
+            background-color: $gray-200;
+            border-color: $gray-500;
+    
+            i {
+                filter: contrast(2);
+            }
+        }
+        &.o-isActive {
+            background-color: $gray-300;
+        }
     }
 }
 

--- a/addons/mail/static/src/core/public_web/discuss.xml
+++ b/addons/mail/static/src/core/public_web/discuss.xml
@@ -4,7 +4,7 @@
 <t t-name="mail.Discuss">
     <div class="o-mail-Discuss d-flex h-100 flex-grow-1" t-att-class="{ 'flex-column align-items-center bg-view': ui.isSmall }" t-ref="root">
         <div t-if="store.inPublicPage or !(ui.isSmall and store.discuss.activeTab !== 'main')" class="o-mail-Discuss-content d-flex flex-column h-100 w-100 overflow-auto" t-ref="content">
-            <div class="o-mail-Discuss-header px-3 bg-view d-flex flex-shrink-0 align-items-center border-bottom z-1" t-att-class="{ 'flex-grow-1': !ui.isSmall and !store.inPublicPage }" t-ref="header">
+            <div class="o-mail-Discuss-header px-3 bg-view d-flex flex-shrink-0 align-items-center border-bottom shadow-sm z-1" t-att-class="{ 'flex-grow-1': !ui.isSmall and !store.inPublicPage }" t-ref="header">
                 <t t-if="thread">
                     <div t-if="['channel', 'group', 'chat'].includes(thread.channel_type)" class="o-mail-Discuss-threadAvatar position-relative align-self-center align-items-center mt-2 mb-2 me-2">
                         <img class="rounded" t-att-src="thread.avatarUrl" alt="Thread Image"/>
@@ -22,7 +22,7 @@
                     <ImStatus t-if="thread.channel_type === 'chat' and thread.correspondent" className="'me-1'" persona="thread.correspondent.persona" thread="thread" />
                     <div class="d-flex flex-grow-1 align-self-center align-items-center h-100 py-2">
                         <AutoresizeInput
-                            className="'o-mail-Discuss-threadName lead fw-bold flex-shrink-1 text-dark py-0'"
+                            className="'o-mail-Discuss-threadName lead fw-bold flex-shrink-1 py-0 rounded'"
                             enabled="thread.is_editable or thread.channel_type === 'chat'"
                             onValidate.bind="renameThread"
                             value="thread.displayName"
@@ -31,7 +31,7 @@
                             <div class="flex-shrink-0 mx-2 py-2 border-start"/>
                             <t t-set="autogrowDescriptionPlaceholder">Add a description</t>
                             <AutoresizeInput
-                                className="'o-mail-Discuss-threadDescription flex-shrink-1 py-1'"
+                                className="'o-mail-Discuss-threadDescription flex-shrink-1 py-0 text-muted rounded'"
                                 enabled="thread.is_editable"
                                 onValidate.bind="updateThreadDescription"
                                 placeholder="thread.is_editable ? autogrowDescriptionPlaceholder : ''"
@@ -47,11 +47,11 @@
                         </t>
                         <div t-if="store.inPublicPage and !ui.isSmall" class="d-flex align-items-center">
                             <img class="o-mail-Discuss-selfAvatar mx-1 rounded-circle o_object_fit_cover flex-shrink-0" alt="Avatar" t-att-src="store.self.avatarUrl"/>
-                            <div class="lead fw-bold flex-shrink-1 text-dark">
+                            <div class="lead fw-bold flex-shrink-1">
                                 <t t-if="store.self.type === 'partner'" t-esc="store.self.name"/>
                                 <t t-else="">
                                     <AutoresizeInput
-                                        className="'py-1'"
+                                        className="'py-1 rounded'"
                                         onValidate.bind="renameGuest"
                                         value="store.self.name"
                                     />
@@ -61,7 +61,7 @@
                     </div>
                 </t>
             </div>
-            <div class="o-mail-Discuss-main d-flex overflow-hidden flex-grow-1" t-ref="main">
+            <div class="o-mail-Discuss-main d-flex overflow-hidden flex-grow-1 position-relative" t-ref="main">
                 <t t-if="ui.isSmall" t-call="mail.Discuss.loading"/>
                 <DiscussSidebar t-elif="props.hasSidebar"/>
                 <div class="o-mail-Discuss-core overflow-auto d-flex flex-grow-1" t-ref="core">
@@ -84,11 +84,9 @@
 </t>
 
 <t t-name="mail.MobileMailbox">
-    <button class="btn btn-secondary flex-grow-1 p-2"
-        t-att-class="{
-            'active o-active shadow-none': mailbox.eq(store.discuss.thread),
-        }" t-on-click="mailbox.setAsDiscussThread" t-esc="mailbox.name"
-    />
+    <button class="btn btn-secondary flex-grow-1 p-2 d-flex align-items-center justify-content-center gap-1" t-att-class="{ 'active o-active shadow-none': mailbox.eq(store.discuss.thread) }" t-on-click="mailbox.setAsDiscussThread">
+        <ThreadIcon thread="mailbox"/><span t-esc="mailbox.name"/>
+    </button>
 </t>
 
 <t t-name="mail.Discuss.loading">

--- a/addons/mail/static/src/core/public_web/discuss_sidebar.js
+++ b/addons/mail/static/src/core/public_web/discuss_sidebar.js
@@ -1,9 +1,16 @@
-import { Component, useState } from "@odoo/owl";
+import { useVisible } from "@mail/utils/common/hooks";
+import { Component, useRef, useState, useSubEnv } from "@odoo/owl";
 
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
 
 export const discussSidebarItemsRegistry = registry.category("mail.discuss_sidebar_items");
+
+const ACTIVE_VISIBILITY = {
+    VISIBLE: "VISIBLE",
+    HIDDEN_TOP: "HIDDEN_TOP",
+    HIDDEN_BOTTOM: "HIDDEN_BOTTOM",
+};
 
 /**
  * @typedef {Object} Props
@@ -14,9 +21,49 @@ export class DiscussSidebar extends Component {
     static props = {};
     static components = {};
 
+    /** @type {ReturnType<import("@odoo/owl").useRef>} */
+    activeRef;
+
     setup() {
         super.setup();
+        this.ACTIVE_VISIBILITY = ACTIVE_VISIBILITY;
+        this.root = useRef("root");
+        this.state = useState({ activeVisibility: null });
+        this.activeVisible = useVisible(this.activeRef, () => this.updateActiveVisible(), {
+            log: true,
+        });
         this.store = useState(useService("mail.store"));
+        window.aku = this;
+        useSubEnv({
+            discussSidebar: {
+                setActiveRef: (ref) => {
+                    this.activeRef = ref;
+                    this.activeVisible.setNewRef(ref);
+                    this.updateActiveVisible();
+                },
+            },
+        });
+    }
+
+    scrollToActive() {
+        this.activeRef.el?.scrollIntoView(true);
+    }
+
+    updateActiveVisible() {
+        if (!this.activeRef?.el) {
+            this.state.activeVisibility = null;
+        }
+        if (this.activeVisible.isVisible) {
+            this.state.activeVisibility = ACTIVE_VISIBILITY.VISIBLE;
+            return;
+        }
+        const activeTop = this.activeRef.el.getBoundingClientRect().top;
+        const rootTop = this.root.el.getBoundingClientRect().top;
+        if (activeTop < rootTop) {
+            this.state.activeVisibility = ACTIVE_VISIBILITY.HIDDEN_TOP;
+        } else {
+            this.state.activeVisibility = ACTIVE_VISIBILITY.HIDDEN_BOTTOM;
+        }
     }
 
     get discussSidebarItems() {

--- a/addons/mail/static/src/core/public_web/discuss_sidebar.scss
+++ b/addons/mail/static/src/core/public_web/discuss_sidebar.scss
@@ -1,18 +1,150 @@
 .o-mail-DiscussSidebar {
     width: $o-mail-Discuss-inspector;
-    box-shadow: 1px 0px 6px -3px rgba(50, 50, 50, 0.15);
+}
+
+.o-mail-DiscussSidebar-active {
+    background-color:$o-action;
+    width: 2px;
+}
+
+.o-mail-DiscussSidebar-activeDirection {
+    left: $o-mail-Discuss-inspector / 2;
+    border-color: rgba($o-action, 0.35) !important;
+
+    &:hover {
+        border-color: rgba(darken($o-action, 10%), 0.65) !important;
+        background-color: mix($o-view-background-color, $o-action, 95%) !important;
+
+        i {
+            color: darken($o-action, 15%);
+        }
+    }
+
+    i {
+        color: rgba($o-action, 0.75);
+    }
 }
 
 .o-mail-DiscussSidebar-badge {
-    padding: 3px 6px;
+    padding: 3px 4px;
+}
+
+.o-mail-DiscussSidebarChannel-commands, .o-mail-DiscussSidebarCategory {
+    button {
+        opacity: 75%;
+
+        &:hover {
+            opacity: 100%;
+        }
+    }
+}
+
+.o-mail-DiscussSidebarChannel-commands button {
+    --btn-border-color: transparent;
+    --btn-hover-bg: #{$o-mail-inspectorBg};
+    --btn-hover-border-color: transparent;
+    --btn-hover-color: $black;
+
+    &:active, &:hover {
+        border-color: mix($o-mail-inspectorBg, black, 50%) !important;
+    }
+
+    &.o-red {
+
+        &:active, &:hover {
+            border-color: mix($o-mail-inspectorBg, darken($danger, 10%), 25%) !important;
+
+            i {
+                color: $danger;
+            }
+        }
+    }
+
+}
+
+.o-mail-DiscussSidebarCategory [name='commands'] button {
+    --btn-border-color: transparent;
+    --btn-hover-bg: #{$o-mail-inspectorBg};
+    --btn-hover-border-color: transparent;
+    --btn-hover-color: $black;
+
+    &:active, &:hover {
+        border-color: mix($o-mail-inspectorBg, black, 50%) !important;
+    }
+
+    &.o-green {
+        &:active, &:hover {
+            border-color: mix($o-mail-inspectorBg, darken($success, 10%), 50%) !important;
+            background-color: mix($o-mail-inspectorBg, darken($success, 10%), 92.5%) !important;
+
+            i {
+                color: darken($success, 5%);
+            }
+        }
+    }
+
+    &.o-red {
+        &:active, &:hover {
+            border-color: mix($o-mail-inspectorBg, darken($danger, 10%), 50%) !important;
+            background-color: mix($o-mail-inspectorBg, darken($danger, 10%), 92.5%) !important;
+
+            i {
+                color: $danger;
+            }
+        }
+    }
 }
 
 .o-mail-DiscussSidebar-item {
-    margin: 1px 0;
+    border: solid transparent;
+    border-width: 1px;
+
+    &::before {
+        content: "\200b"; /* unicode zero width space character */
+        height: 100%;
+        min-width: 4px + map-get($spacers, 1);
+        max-width: 4px + map-get($spacers, 1);
+        width: 4px + map-get($spacers, 1);
+        border: 4px solid transparent;
+    }
+
+    &:active {
+        border-color: transparent !important;
+    }
+
     &:hover {
-        background-color: mix($o-gray-100, $o-gray-200);
+        background-color: mix($o-mail-inspectorBg, $o-action, 95%);
+        border-color: mix($o-mail-inspectorBg, $o-action, 82.5%);
+
+        .o-mail-DiscussSidebar-itemMain {
+            background-color: inherit !important;
+        }
+
+        .o-mail-DiscussSidebar-itemName {
+            opacity: 100% !important;
+        }
+        .o-mail-DiscussSidebar-itemAvatar {
+            box-shadow: $box-shadow-sm;
+        }
     }
     &.o-active {
-        background-color: mix($o-gray-100, $o-gray-200);
+        background-color: mix($o-mail-inspectorBg, $o-action, 87.5%);
+        border-top-color: mix($o-mail-inspectorBg, $o-action, 80%);
+        border-bottom-color: mix($o-mail-inspectorBg, $o-action, 80%);
+        border-left-color: $o-action;
+        &::before {
+            border-left-color: $o-action;
+        }
+
+        .o-mail-DiscussSidebarChannel-commands button {
+            --btn-hover-border-color: #{mix($o-mail-inspectorBg, $o-action, 92.5%)};
+        }
+    }
+    &:not(.o-active) {
+        &:hover, &.o-unread {
+            .o-mail-DiscussSidebar-itemName {
+                font-weight: $font-weight-bold;
+            }
+        }
     }
 }

--- a/addons/mail/static/src/core/public_web/discuss_sidebar.xml
+++ b/addons/mail/static/src/core/public_web/discuss_sidebar.xml
@@ -1,7 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.DiscussSidebar">
-        <div class="o-mail-DiscussSidebar d-flex d-print-none flex-column overflow-auto flex-shrink-0 h-100 pt-3 border-end z-1 o-mail-discussSidebarBgColor">
+        <div class="o-mail-DiscussSidebar d-flex d-print-none flex-column overflow-auto flex-shrink-0 h-100 pt-3 border-end shadow-sm z-1 o-mail-inspectorBg" t-ref="root">
+            <t t-if="state.activeVisibility and state.activeVisibility !== ACTIVE_VISIBILITY.VISIBLE">
+                <button class="o-mail-DiscussSidebar-activeDirection position-absolute rounded-circle bg-view p-1 m-1 z-1 border d-flex justify-content-center align-items-center shadow" title="Go to active conversation" t-on-click.stop="scrollToActive" t-att-class="{
+                    'top-0 o-top': state.activeVisibility === ACTIVE_VISIBILITY.HIDDEN_TOP,
+                    'bottom-0 o-bottom mb-2': state.activeVisibility === ACTIVE_VISIBILITY.HIDDEN_BOTTOM,
+                }">
+                    <i class="oi" t-att-class="{
+                        'oi-arrow-up': state.activeVisibility === ACTIVE_VISIBILITY.HIDDEN_TOP,
+                        'oi-arrow-down': state.activeVisibility === ACTIVE_VISIBILITY.HIDDEN_BOTTOM,
+                    }"/>
+                </button>
+            </t>
             <t t-foreach="discussSidebarItems" t-as="item" t-key="item_index" t-component="item"/>
         </div>
     </t>

--- a/addons/mail/static/src/core/web/chat_window_patch.dark.scss
+++ b/addons/mail/static/src/core/web/chat_window_patch.dark.scss
@@ -1,5 +1,5 @@
 .o-mail-ChatWindow-command {
     &:hover, &.o-active {
-        background-color: $gray-200;
+        background-color: $gray-300;
     }
 }

--- a/addons/mail/static/src/core/web/chat_window_patch.js
+++ b/addons/mail/static/src/core/web/chat_window_patch.js
@@ -1,0 +1,12 @@
+import { ChatWindow } from "@mail/core/common/chat_window";
+
+import { patch } from "@web/core/utils/patch";
+
+patch(ChatWindow.prototype, {
+    get attClass() {
+        return {
+            ...super.attClass,
+            border: true,
+        };
+    },
+});

--- a/addons/mail/static/src/core/web/chat_window_patch.scss
+++ b/addons/mail/static/src/core/web/chat_window_patch.scss
@@ -1,0 +1,29 @@
+.o-mail-ChatWindow.o-focused {
+    box-shadow: $box-shadow, 0 0 1px 1px rgba(lighten($o-action, 5%), 0.5) !important;
+}
+
+.o-mail-ChatWindow-command {
+    &:hover {
+        i {
+            filter: contrast(2);
+        }
+
+        &.o-mail-ChatWindow-moreActions {
+            filter: contrast(2);
+
+            img {
+                filter: contrast(0.5);
+            }
+        }
+    }
+    
+    &:hover {
+        background-color: mix($gray-100, $gray-200);
+    }
+    &.o-active {
+        i {
+            filter: contrast(2);
+        }
+        background-color: mix($gray-100, $gray-200);
+    }
+}

--- a/addons/mail/static/src/core/web/command_palette.xml
+++ b/addons/mail/static/src/core/web/command_palette.xml
@@ -11,7 +11,7 @@
             <span t-if="props.persona and props.persona.email" t-out="'- ' + props.persona.email"/>
             <span class="flex-grow-1"/>
             <div t-if="props.counter > 0">
-                <span t-attf-class="badge rounded-pill o-discuss-badge ms-3 me-1 fw-bold" t-esc="props.counter"/>
+                <span t-attf-class="badge rounded-pill o-discuss-badge ms-3 me-1" t-esc="props.counter"/>
             </div>
         </div>
     </t>

--- a/addons/mail/static/src/core/web/discuss_patch.xml
+++ b/addons/mail/static/src/core/web/discuss_patch.xml
@@ -24,8 +24,8 @@
         </xpath>
         <xpath expr="//*[@t-ref='header']" position="replace">
             <div t-if="!ui.isSmall" class="d-flex w-100">
-                <span class="o-mail-Discuss-headerStartMeeting d-flex justify-content-center flex-shrink-0 p-2 border-end o-mail-discussSidebarBgColor">
-                    <button class="btn btn-primary rounded" t-on-click="store.startMeeting" data-hotkey="m">Start a meeting</button>
+                <span class="o-mail-Discuss-headerStartMeeting d-flex justify-content-center flex-shrink-0 px-2 py-1 border-end o-mail-inspectorBg">
+                    <button class="btn btn-primary rounded border-0 d-flex align-items-center justify-content-center gap-1" t-on-click="store.startMeeting" data-hotkey="m"><i class="fa fa-fw fa-users"/><span>Start a meeting</span></button>
                 </span>
                 <t>$0</t>
             </div>

--- a/addons/mail/static/src/core/web/discuss_sidebar_mailbox.js
+++ b/addons/mail/static/src/core/web/discuss_sidebar_mailbox.js
@@ -1,0 +1,36 @@
+import { Component, useEffect, useRef, useState } from "@odoo/owl";
+
+import { ThreadIcon } from "@mail/core/common/thread_icon";
+
+import { useService } from "@web/core/utils/hooks";
+import { markEventHandled } from "@web/core/utils/misc";
+
+/**
+ * @typedef {Object} Props
+ * @extends {Component<Props, Env>}
+ */
+export class DiscussSidebarMailbox extends Component {
+    static template = "mail.DiscussSidebarMailbox";
+    static props = ["mailbox"];
+    static components = { ThreadIcon };
+
+    setup() {
+        super.setup();
+        this.store = useState(useService("mail.store"));
+        this.root = useRef("root");
+        useEffect(
+            () => {
+                if (this.props.mailbox.eq(this.store.discuss.thread)) {
+                    this.env.discussSidebar.setActiveRef(this.root);
+                }
+            },
+            () => [this.store.discuss.thread]
+        );
+    }
+
+    /** @param {MouseEvent} ev */
+    openThread(ev) {
+        markEventHandled(ev, "sidebar.openThread");
+        this.props.mailbox.setAsDiscussThread();
+    }
+}

--- a/addons/mail/static/src/core/web/discuss_sidebar_mailbox.xml
+++ b/addons/mail/static/src/core/web/discuss_sidebar_mailbox.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+
+    <t t-name="mail.DiscussSidebarMailbox">
+        <button
+            class="o-mail-DiscussSidebarMailbox o-mail-DiscussSidebar-item btn d-flex align-items-center p-0 pe-2 rounded-0 text-reset"
+            t-att-class="{
+                'bg-inherit': props.mailbox.notEq(store.discuss.thread),
+                'o-active': props.mailbox.eq(store.discuss.thread),
+            }"
+            t-on-click="(ev) => this.openThread(ev)"
+            t-ref="root"
+        >
+            <ThreadIcon className="'ms-3 me-2 bg-inherit'" thread="props.mailbox"/>
+            <div class="o-mail-DiscussSidebar-itemName me-2 text-truncate py-1" t-att-class="{ 'o-discuss-itemName-discrete': props.mailbox.notEq(store.discuss.thread) }" t-esc="props.mailbox.name"/>
+            <div t-attf-class="flex-grow-1 {{ props.mailbox.counter === 0 ? 'me-3': '' }}"/>
+            <span
+                t-if="props.mailbox.counter > 0"
+                class="o-mail-DiscussSidebar-badge o-discuss-badge badge rounded-pill ms-1 me-2"
+                t-att-class="{ 'o-muted': props.mailbox.id === 'starred' }"
+                t-esc="props.mailbox.counter"
+            />
+        </button>
+    </t>
+
+</templates>

--- a/addons/mail/static/src/core/web/discuss_sidebar_mailboxes.js
+++ b/addons/mail/static/src/core/web/discuss_sidebar_mailboxes.js
@@ -1,10 +1,9 @@
-import { ThreadIcon } from "@mail/core/common/thread_icon";
 import { discussSidebarItemsRegistry } from "@mail/core/public_web/discuss_sidebar";
 
 import { Component, useState } from "@odoo/owl";
 
 import { useService } from "@web/core/utils/hooks";
-import { markEventHandled } from "@web/core/utils/misc";
+import { DiscussSidebarMailbox } from "./discuss_sidebar_mailbox";
 
 /**
  * @typedef {Object} Props
@@ -13,20 +12,11 @@ import { markEventHandled } from "@web/core/utils/misc";
 export class DiscussSidebarMailboxes extends Component {
     static template = "mail.DiscussSidebarMailboxes";
     static props = {};
-    static components = { ThreadIcon };
+    static components = { DiscussSidebarMailbox };
 
     setup() {
         super.setup();
         this.store = useState(useService("mail.store"));
-    }
-
-    /**
-     * @param {MouseEvent} ev
-     * @param {import("models").Thread} thread
-     */
-    openThread(ev, thread) {
-        markEventHandled(ev, "sidebar.openThread");
-        thread.setAsDiscussThread();
     }
 }
 

--- a/addons/mail/static/src/core/web/discuss_sidebar_mailboxes.xml
+++ b/addons/mail/static/src/core/web/discuss_sidebar_mailboxes.xml
@@ -3,37 +3,10 @@
 
     <t t-name="mail.DiscussSidebarMailboxes">
         <div class="d-flex flex-column flex-grow-0">
-            <t t-call="mail.Mailbox">
-                <t t-set="mailbox" t-value="store.inbox"/>
-            </t>
-            <t t-call="mail.Mailbox">
-                <t t-set="mailbox" t-value="store.starred"/>
-            </t>
-            <t t-call="mail.Mailbox">
-                <t t-set="mailbox" t-value="store.history"/>
-            </t>
+            <DiscussSidebarMailbox mailbox="store.inbox"/>
+            <DiscussSidebarMailbox mailbox="store.starred"/>
+            <DiscussSidebarMailbox mailbox="store.history"/>
         </div>
-    </t>
-
-    <t t-name="mail.Mailbox">
-        <button
-            class="o-mail-DiscussSidebar-item btn d-flex align-items-center py-1 px-0 mx-2 border-0 rounded-2 fw-normal text-reset"
-            t-att-class="{
-                'bg-inherit': mailbox.notEq(store.discuss.thread),
-                'o-active': mailbox.eq(store.discuss.thread),
-            }"
-            t-on-click="(ev) => this.openThread(ev, mailbox)"
-        >
-            <ThreadIcon className="'ms-3 me-2 bg-inherit'" thread="mailbox"/>
-            <div class="me-2 text-truncate" t-esc="mailbox.name"/>
-            <div t-attf-class="flex-grow-1 {{ mailbox.counter === 0 ? 'me-3': '' }}"/>
-            <span
-                t-if="mailbox.counter > 0"
-                class="o-mail-DiscussSidebar-badge o-discuss-badge badge rounded-pill ms-1 me-2 fw-bold"
-                t-att-class="{ 'o-muted': mailbox.id === 'starred' }"
-                t-esc="mailbox.counter"
-            />
-        </button>
     </t>
 
 </templates>

--- a/addons/mail/static/src/core/web/follower_list.xml
+++ b/addons/mail/static/src/core/web/follower_list.xml
@@ -29,7 +29,7 @@
 
 <t t-name="mail.Follower">
     <div class="dropdown-item o-mail-Follower d-flex justify-content-between p-0">
-        <a class="o-mail-Follower-details d-flex align-items-center flex-grow-1 px-3 o-min-width-0" t-att-class="{ 'o-inactive fst-italic opacity-25': !follower.is_active }" href="#" role="menuitem" t-on-click.prevent="(ev) => this.onClickDetails(ev, follower)">
+        <a class="o-mail-Follower-details d-flex align-items-center flex-grow-1 px-3 min-w-0" t-att-class="{ 'o-inactive fst-italic opacity-25': !follower.is_active }" href="#" role="menuitem" t-on-click.prevent="(ev) => this.onClickDetails(ev, follower)">
             <img class="o-mail-Follower-avatar me-2 rounded" t-att-src="follower.partner.avatarUrl" alt=""/>
             <span class="flex-shrink text-truncate" t-esc="follower.partner.name"/>
         </a>

--- a/addons/mail/static/src/core/web/messaging_menu.dark.scss
+++ b/addons/mail/static/src/core/web/messaging_menu.dark.scss
@@ -3,3 +3,8 @@
         background-color: mix($o-gray-200, $o-gray-300);
     }
 }
+.o-mail-MessagingMenu-header button {
+    &.o-active, &:hover {
+        background-color: inherit;
+    }
+}

--- a/addons/mail/static/src/core/web/messaging_menu.scss
+++ b/addons/mail/static/src/core/web/messaging_menu.scss
@@ -4,18 +4,34 @@
     max-height: Min(calc(#{ $o-dropdown-max-height } - 5px), 630px); // -5px for borders
 }
 
-.o-mail-MessagingMenu-header {
-    box-shadow: 0px 7px 7px -7px rgba(50, 50, 50, 0.15);
-}
-
 .o-mail-MessagingMenu-navbar, .o-mail-MessagingMenu-header {
     button {
         &.o-active {
-            background-color: mix($o-gray-100, $o-gray-200);
+            background-color: mix($o-gray-100, $o-gray-200, 75%);
         }
     }
 }
 
 .o-mail-MessagingMenu-navbar button:hover {
     background-color: mix($o-gray-100, $o-gray-200);
+}
+
+.o-mail-MessagingMenu-search:not(:hover) {
+    color: $text-muted;
+}
+
+.o-mail-MessagingMenu-tab {
+    border: 0px solid;
+    border-width: 0px;
+    border-bottom-width: 2px;
+    border-color: transparent;
+
+    &.o-active {
+        background-color: mix($o-mail-inspectorBg, $o-action, 95%) !important;
+        border-color: mix($o-mail-inspectorBg, $o-action, 20%);
+    }
+
+    &:hover {
+        background-color: mix($o-mail-inspectorBg, $o-action, 97.5%) !important;
+    }
 }

--- a/addons/mail/static/src/core/web/messaging_menu.xml
+++ b/addons/mail/static/src/core/web/messaging_menu.xml
@@ -18,19 +18,21 @@
 
 <t t-name="mail.MessagingMenu.content">
     <div t-if="!(ui.isSmall and env.inDiscussApp and store.discuss.activeTab === 'main')" t-att-class="`${discussSystray.contentClass} o-mail-MessagingMenu`">
-        <div class="o-mail-MessagingMenu-header d-flex" t-att-class="{'text-uppercase border-start-0 border-end-0': ui.isSmall, 'bg-view border-bottom': !ui.isSmall, 'flex-shrink-0': !env.inDiscussApp }">
+        <div class="o-mail-MessagingMenu-header d-flex" t-att-class="{'border-start-0 border-end-0 gap-1 pb-1': ui.isSmall, 'o-mail-inspectorBg': !ui.isSmall, 'flex-shrink-0': !env.inDiscussApp }">
             <t t-if="!ui.isSmall">
                 <MessagingMenuQuickSearch t-if="state.searchOpen" onClose.bind="toggleSearch"/>
                 <t t-else="">
-                    <button class="btn btn-link py-1 rounded-0" t-att-class="store.discuss.activeTab === 'main' ? 'fw-bold o-active' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'main'">All</button>
-                    <button class="btn btn-link py-1 rounded-0" t-att-class="store.discuss.activeTab === 'chat' ? 'fw-bold o-active' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'chat'">Chats</button>
-                    <button class="btn btn-link py-1 rounded-0" t-att-class="store.discuss.activeTab === 'channel' ? 'fw-bold o-active' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'channel'">Channels</button>
-                    <button t-if="threads.length >= 20 and store.channels.status !== 'fetching'" class="btn btn-link py-1 rounded-0 text-muted" type="button" title="Quick search" t-on-click="toggleSearch"><i class="fa fa-fw fa-search"/></button>
+                    <div class="d-flex gap-1">
+                        <button class="o-mail-MessagingMenu-tab btn btn-link px-2 py-1 rounded-0" t-att-class="store.discuss.activeTab === 'main' ? 'fw-bold o-active' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'main'">All</button>
+                        <button class="o-mail-MessagingMenu-tab btn btn-link px-2 py-1 rounded-0" t-att-class="store.discuss.activeTab === 'chat' ? 'fw-bold o-active' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'chat'">Chats</button>
+                        <button class="o-mail-MessagingMenu-tab btn btn-link px-2 py-1 rounded-0" t-att-class="store.discuss.activeTab === 'channel' ? 'fw-bold o-active' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'channel'">Channels</button>
+                    </div>
+                    <button t-if="threads.length >= 20 and store.channels.status !== 'fetching'" class="o-mail-MessagingMenu-search btn btn-light py-1 rounded-0 opacity-75 opacity-100-hover" type="button" t-on-click="toggleSearch"><i class="fa fa-fw fa-search"/></button>
                     <button t-if="store.channels.status === 'fetching'" class="btn btn-light py-1 rounded-0" disabled="true" type="button"><i class="fa fa-fw fa-circle-o-notch fa-spin"/></button>
                 </t>
             </t>
         </div>
-        <div t-if="!env.inDiscussApp or store.discuss.activeTab !== 'main'" class="d-flex flex-column overflow-auto flex-grow-1 list-group list-group-flush" t-ref="notification-list">
+        <div t-if="!env.inDiscussApp or store.discuss.activeTab !== 'main'" class="o-mail-MessagingMenu-list d-flex flex-column overflow-auto flex-grow-1 list-group list-group-flush" t-ref="notification-list">
             <div t-if="store.channels.status !== 'fetching' and !hasPreviews" class="d-flex justify-content-center py-4 px-2 text-muted">
                 No conversation yet...
             </div>
@@ -54,7 +56,7 @@
                         <a t-if="ui.isSmall" class="btn fa fa-cloud-download" />
                         <t t-else="">
                             <a class="btn btn-primary">Install</a>
-                            <span t-if="!hasTouch()" t-on-click.stop="() => this.installPrompt.decline()" class="text-dark bg-transparent fa fa-close opacity-50 opacity-100-hover" title="Dismiss"></span>
+                            <span t-if="!hasTouch()" t-on-click.stop="() => this.installPrompt.decline()" class="text-dark bg-transparent oi oi-close opacity-50 opacity-100-hover" title="Dismiss"></span>
                         </t>
                     </t>
                 </NotificationItem>
@@ -122,7 +124,7 @@
         </div>
     </div>
     <div t-if="ui.isSmall" class="o-mail-MessagingMenu-navbar d-flex border-top bg-view shadow-lg w-100 btn-group">
-        <button t-foreach="tabs" t-key="tab.id" t-as="tab" class="o-mail-MessagingMenu-tab btn d-flex flex-column align-items-center flex-grow-1 flex-basis-0 p-2 mx-0" t-att-class="{
+        <button t-foreach="tabs" t-key="tab.id" t-as="tab" class="o-mail-MessagingMenu-tab btn d-flex flex-column align-items-center flex-grow-1 flex-basis-0 p-2 mx-0 border-0" t-att-class="{
             'text-primary fw-bolder o-active': store.discuss.activeTab === tab.id,
             'border-end': !tab_last,
         }" t-on-click="() => this.onClickNavTab(tab.id)">

--- a/addons/mail/static/src/core/web/messaging_menu_quick_search.xml
+++ b/addons/mail/static/src/core/web/messaging_menu_quick_search.xml
@@ -1,6 +1,6 @@
 <t t-name="mail.MessagingMenuQuickSearch">
-    <div class="position-relative w-50 m-1" t-ref="search" t-on-keydown="onKeydownInput">
-        <input t-model="store.discuss.searchTerm" t-ref="autofocus" class="form-control px-1 py-0" placeholder="Quick search…" type="text" />
-        <button class="btn btn-link text-muted p-1 position-absolute top-50 end-0 translate-middle-y" title="Close search" t-on-click="props.onClose"><i class="oi oi-close"/></button>
+    <div class="position-relative w-50" t-ref="search" t-on-keydown="onKeydownInput">
+        <input t-model="store.discuss.searchTerm" t-ref="autofocus" class="form-control p-1 rounded-0" placeholder="Quick search…" type="text" />
+        <button class="btn btn-link text-muted p-1 position-absolute top-50 end-0 translate-middle-y" t-on-click="props.onClose"><i class="oi oi-close"/></button>
     </div>
 </t>

--- a/addons/mail/static/src/core/web/notification_item.dark.scss
+++ b/addons/mail/static/src/core/web/notification_item.dark.scss
@@ -1,8 +1,18 @@
 .o-mail-NotificationItem {
-    &.o-important {
-        background-color: mix($o-gray-200, $o-gray-300) !important;
+    &:hover {
+        &:not(&.o-important) .o-mail-NotificationItem-name {
+            opacity: 75% !important;
+        }
     }
-    &:hover, &.o-active {
+    &:not(:hover):not(.o-important) .o-mail-NotificationItem-name {
+        color: $text-muted;
+    }
+
+    &.o-active {
         background-color: $o-gray-300 !important;
     }
+}
+
+.o-mail-NotificationItem-text.o-muted {
+    opacity: 50%;
 }

--- a/addons/mail/static/src/core/web/notification_item.scss
+++ b/addons/mail/static/src/core/web/notification_item.scss
@@ -1,13 +1,47 @@
 .o-mail-NotificationItem {
+
+    &.o-mobile {
+        --list-group-item-padding-x: #{map-get($spacers, 2)};
+    }
     &.o-important {
-        background-color: mix($o-gray-100, $o-gray-200) !important;
+        --list-group-border-color: #{mix($o-view-background-color, $o-action, 75%)};
+        background-color: mix($o-view-background-color, $o-action, 95%) !important;
     }
     &.o-active {
         box-shadow: inset 0px 0px 0px 1px rgba($o-action, 0.5);
     }
-    &:hover, &.o-active {
-        background-color: $o-gray-200 !important;
+    &:hover {
+        background-color: mix($o-gray-100, $o-gray-200, 100%) !important;
+
+        &.o-important {
+            background-color: mix($o-view-background-color, $o-action, 87.5%) !important;
+
+            .o-mail-NotificationItem-text {
+                opacity: 100% !important;
+            }
+        }
+
+        .o-mail-NotificationItem-name, .o-mail-NotificationItem-content {
+            opacity: 100% !important;
+        }
+        .o-mail-NotificationItem-avatar {
+            box-shadow: $box-shadow-sm;
+        }
     }
+
+    &:not(:hover) .o-mail-NotificationItem-text {
+        color: $text-muted;
+    }
+}
+
+.o-mail-NotificationItem-content {
+    &.o-muted {
+        opacity: 75%;
+    }
+}
+
+.o-mail-NotificationItem-name {
+    font-weight: 600 !important;
 }
 
 
@@ -17,16 +51,23 @@
 
 .o-mail-NotificationItem-markAsRead {
     background-color: transparent !important;
-    font-size: 0.85rem !important;
-    color: $success !important;
+    font-size: 0.75rem !important;
+    color: darken($success, 10%) !important;
+    border: 1px solid;
+    border-color: transparent;
 
     &:hover {
-        background-color: rgba(0, 0, 0, 0.075) !important;
+        background-color: mix($o-view-background-color, $o-action, 95%) !important;
+        border-color: mix($o-view-background-color, $o-action, 50%);
+        color: darken($success, 5%) !important;
     }
 }
 
-.o-mail-NotificationItem-text:before {
-    // invisible character so that typing status bar has constant height, regardless of text content.
-    content: "\200b"; /* unicode zero width space character */
-}
+.o-mail-NotificationItem-text {
+    opacity: 75%;
 
+    &::before {
+        // invisible character so that typing status bar has constant height, regardless of text content.
+        content: "\200b"; /* unicode zero width space character */
+    }
+}

--- a/addons/mail/static/src/core/web/notification_item.xml
+++ b/addons/mail/static/src/core/web/notification_item.xml
@@ -3,28 +3,28 @@
 
 <t t-name="mail.NotificationItem">
     <ActionSwiper onLeftSwipe="props.onSwipeLeft ? props.onSwipeLeft : undefined" onRightSwipe="props.onSwipeRight ? props.onSwipeRight : undefined">
-        <button class="o-mail-NotificationItem list-group-item d-flex cursor-pointer align-items-center bg-view w-100 gap-2" t-att-class="{ 'o-important': props.muted === 0, 'text-muted': props.muted === 1, 'opacity-50': props.muted === 2, 'border-start-0 border-end-0': ui.isSmall, 'border-top-0': props.first, 'p-2 pe-3': !ui.isSmall, 'o-active': props.isActive }" t-on-click="onClick" t-ref="root">
-            <div class="position-relative bg-inherit m-1 flex-shrink-0" style="width:40px;height:40px;">
+        <button class="o-mail-NotificationItem list-group-item d-flex cursor-pointer align-items-center bg-view w-100 gap-2" t-att-class="{ 'o-important': props.muted === 0, 'opacity-50': props.muted === 2, 'border-start-0 border-end-0 o-mobile': ui.isSmall, 'border-top-0': props.first, 'p-2 pe-3': !ui.isSmall, 'o-active': props.isActive }" t-on-click="onClick" t-ref="root">
+            <div class="o-mail-NotificationItem-avatar position-relative bg-inherit m-1 flex-shrink-0" t-att-style="ui.isSmall ? 'width:45px;height:45px;' : 'width:38px;height:38px;'">
                 <img class="o_avatar w-100 h-100 rounded" alt="Notification Item Image" t-att-src="props.iconSrc"/>
                 <t t-slot="icon"/>
             </div>
-            <div class="d-flex flex-column flex-grow-1 align-self-start overflow-auto">
+            <div class="o-mail-NotificationItem-content d-flex flex-column flex-grow-1 align-self-start overflow-auto" t-att-class="{ 'fs-5': ui.isSmall, 'o-muted': props.muted === 1 }">
                 <div class="d-flex text-nowrap">
-                    <span class="o-mail-NotificationItem-name text-truncate fw-bold" t-esc="props.displayName"/>
+                    <span class="o-mail-NotificationItem-name text-truncate" t-att-class="{ 'o-discuss-itemName-discrete': props.muted }" t-esc="props.displayName"/>
                     <span class="flex-grow-1"/>
-                    <small t-if="props.datetime" class="o-mail-NotificationItem-date ms-2 opacity-75" t-att-class="{ 'opacity-50 fw-bold': !props.muted, 'opacity-25 text-muted': props.muted }" t-att-title="props.datetime?.toLocaleString(DateTime.DATETIME_SHORT) ?? ''">
+                    <small t-if="props.datetime" class="o-mail-NotificationItem-date ms-2 text-muted smaller" t-att-class="{ 'fw-bold': !props.muted }" t-att-title="props.datetime?.toLocaleString(DateTime.DATETIME_SHORT) ?? ''">
                         <t t-esc="dateText"/>
                     </small>
                 </div>
                 <div class="d-flex">
-                    <div class="o-mail-NotificationItem-text text-truncate opacity-75">
+                    <div class="o-mail-NotificationItem-text text-truncate small" t-att-class="{ 'o-muted': props.muted }">
                         <t t-slot="body-icon"/>
                         <t t-if="props.body" t-esc="props.body" name="notificationBody"/>
                     </div>
                     <div class="flex-grow-1"/>
                     <div class="d-flex align-items-center">
-                        <span t-if="props.counter > 0 and !rootHover.isHover" t-attf-class="o-mail-NotificationItem-badge o-discuss-badge {{props.muted === 2 ? 'o-muted' : ''}} d-flex align-items-center justify-content-center m-0 badge rounded-pill fw-bold o-mail-NotificationItem-counter"><t t-esc="props.counter"/></span>
-                        <span t-if="props.hasMarkAsReadButton and rootHover.isHover" class="o-mail-NotificationItem-badge o-discuss-badgeShape text-success d-flex align-items-center justify-content-center m-0 badge rounded-pill fw-bold o-mail-NotificationItem-markAsRead fa fa-check text-600 opacity-75 opacity-100-hover cursor-pointer" title="Mark As Read" t-ref="markAsRead"/>
+                        <span t-if="props.counter > 0 and !rootHover.isHover" t-attf-class="o-mail-NotificationItem-badge o-discuss-badge {{props.muted === 2 ? 'o-muted' : ''}} d-flex align-items-center justify-content-center m-0 badge rounded-pill o-mail-NotificationItem-counter"><t t-esc="props.counter"/></span>
+                        <span t-if="props.hasMarkAsReadButton and rootHover.isHover" class="text-success d-flex align-items-center justify-content-center p-1 m-0 badge rounded o-mail-NotificationItem-markAsRead text-600 cursor-pointer" title="Mark As Read" t-ref="markAsRead"><i class="fa fa-check"/></span>
                     </div>
                 </div>
             </div>

--- a/addons/mail/static/src/core/web_portal/message_patch.js
+++ b/addons/mail/static/src/core/web_portal/message_patch.js
@@ -18,6 +18,7 @@ patch(Message.prototype, {
      * @param {HTMLElement} bodyEl
      */
     prepareMessageBody(bodyEl) {
+        super.prepareMessageBody(bodyEl);
         Array.from(bodyEl.querySelectorAll(".o-mail-read-more-less")).forEach((el) => el.remove());
         this.insertReadMoreLess(bodyEl);
     },

--- a/addons/mail/static/src/discuss/call/common/discuss_patch.scss
+++ b/addons/mail/static/src/discuss/call/common/discuss_patch.scss
@@ -1,0 +1,7 @@
+.o-mail-Discuss-headerActions [name='call'] {
+    color: $success !important;
+
+    &:hover {
+        background-color: rgba($success, 0.1) !important;
+    }
+}

--- a/addons/mail/static/src/discuss/call/web/discuss_sidebar_call_indicator.js
+++ b/addons/mail/static/src/discuss/call/web/discuss_sidebar_call_indicator.js
@@ -1,5 +1,5 @@
 import { Thread } from "@mail/core/common/thread_model";
-import { discussSidebarChannelIndicatorsRegistry } from "@mail/discuss/core/public_web/discuss_sidebar_categories";
+import { discussSidebarChannelIndicatorsRegistry } from "@mail/discuss/core/public_web/discuss_sidebar_channel_indicators_registry";
 
 import { Component, useState } from "@odoo/owl";
 import { useService } from "@web/core/utils/hooks";

--- a/addons/mail/static/src/discuss/core/common/action_panel.js
+++ b/addons/mail/static/src/discuss/core/common/action_panel.js
@@ -11,6 +11,7 @@ export class ActionPanel extends Component {
     static template = "mail.ActionPanel";
     static components = { ResizablePanel };
     static props = {
+        className: { type: String, optional: true },
         title: { type: String, optional: true },
         resizable: { type: Boolean, optional: true },
         slots: { type: Object, optional: true },
@@ -19,9 +20,19 @@ export class ActionPanel extends Component {
         resizable: true,
     };
 
+    get attClass() {
+        return {
+            "o-mail-ActionPanel overflow-auto d-flex flex-column flex-shrink-0 position-relative h-100": true,
+            [this.props.className]: true,
+            "o-mail-inspectorBg": !this.env.inChatter,
+            "o-mail-ActionPanel-chatter": this.env.inChatter,
+        };
+    }
+
     get classNames() {
-        return `o-mail-ActionPanel overflow-auto d-flex flex-column flex-shrink-0 position-relative py-3 pt-0 h-100 ${
-            !this.env.inChatter ? " px-3 bg-view" : " o-mail-ActionPanel-chatter"
-        }`;
+        return Object.entries(this.attClass)
+            .filter(([key, val]) => val)
+            .map(([key]) => key)
+            .join(" ");
     }
 }

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.dark.scss
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.dark.scss
@@ -1,0 +1,11 @@
+.o-discuss-ChannelInvitation-selectedList button {
+    background-color: darken($o-action, 15%);
+
+    &:hover  {
+        background-color: $o-gray-600;
+        i {
+            background-color: $danger;
+            color: #fff;
+        }
+    }
+}

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.js
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.js
@@ -41,6 +41,13 @@ export class ChannelInvitation extends Component {
         });
     }
 
+    get narrowResultText() {
+        return _t("%(partial)s results out of %(total)s. Narrow search for more.", {
+            partial: this.state.selectablePartners.length,
+            total: this.state.searchResultCount,
+        });
+    }
+
     async fetchPartnersToInvite() {
         const results = await this.sequential(() =>
             this.orm.call("res.partner", "search_for_channel_invite", [

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.scss
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.scss
@@ -1,5 +1,10 @@
 .o-discuss-ChannelInvitation {
     min-height: 0;
+
+    .o-mail-ImStatus {
+        width: 1rem;
+        height: 1rem;
+    }
 }
 
 .o-discuss-ChannelInvitation-has-size-constraints {
@@ -7,17 +12,32 @@
     max-height: Min(calc(100vh - 140px), 530px);
 }
 
+.o-discuss-ChannelInvitation-search:focus {
+    border-color: rgba($o-action, 0.5) !important;
+}
+
 .o-discuss-ChannelInvitation-selectedList {
     max-height: 100px;
+
+    button {
+        background-color: $o-action;
+
+        &:hover  {
+            background-color: $o-gray-600;
+            i {
+                background-color: $o-gray-300;
+                color: $danger;
+            }
+        }
+    }
+}
+
+.o-discuss-ChannelInvitation-selectable.o-selected {
+    background-color: mix($o-mail-inspectorBg, $o-action, 95%);
+    --list-group-border-color: #{mix($o-view-background-color, $o-action, 75%)};
 }
 
 .o-discuss-ChannelInvitation-avatar {
-    width: $o-mail-Avatar-size;
-    height: $o-mail-Avatar-size;
-}
-
-.o-discuss-ChannelInvitation-invitationBox {
-    position: sticky;
-    background-color: $o-view-background-color;
-    bottom: - map-get($spacers, 3); // Ignore p-3 class of ActionPanel
+    width: 32px;
+    height: 32px;
 }

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.xml
@@ -2,55 +2,50 @@
 <templates xml:space="preserve">
 
     <t t-name="discuss.ChannelInvitation">
-        <ActionPanel title="title" resizable="false">
+        <ActionPanel title="title" resizable="false" className="'rounded-3'">
             <div t-att-class="{ 'o-discuss-ChannelInvitation-has-size-constraints': props.hasSizeConstraints }">
                 <t t-if="store.self.type === 'partner'">
-                    <input class="o-discuss-ChannelInvitation-search border form-control" t-ref="input" placeholder="Type the name of a person" t-on-input="onInput"/>
-                    <div class="d-flex flex-column mx-0 pt-1 pb-0 overflow-auto">
+                    <div class="w-100 px-2">
+                        <input class="o-discuss-ChannelInvitation-search border form-control rounded-3" t-ref="input" placeholder="Type the name of a person" t-on-input="onInput"/>
+                    </div>
+                    <div class="d-flex flex-column mx-0 pt-2 pb-0 list-group list-group-flush">
                         <t t-foreach="state.selectablePartners" t-as="selectablePartner" t-key="selectablePartner.id">
-                            <div class="o-discuss-ChannelInvitation-selectable o_object_fit_cover d-flex align-items-center px-3 py-1 btn" t-on-click="() => this.onClickSelectablePartner(selectablePartner)">
-                                <div class="d-flex align-items-center p-2">
-                                    <div class="o-discuss-ChannelInvitation-avatar position-relative d-flex flex-shrink-0">
-                                        <img class="w-100 h-100 rounded o_object_fit_cover"
-                                            t-att-src="selectablePartner.avatarUrl"/>
-                                        <ImStatus persona="selectablePartner" className="'position-absolute top-100 start-100 translate-middle bg-view mt-n1 ms-n1'"/>
+                            <div class="o-discuss-ChannelInvitation-selectable o_object_fit_cover d-flex align-items-center px-3 py-1 list-group-item rounded-0 cursor-pointer" t-att-class="{ 'o-selected': selectablePartner.in(state.selectedPartners) }" t-on-click="() => this.onClickSelectablePartner(selectablePartner)">
+                                <div class="d-flex align-items-center bg-inherit">
+                                    <div class="o-discuss-ChannelInvitation-avatar position-relative d-flex flex-shrink-0 bg-inherit">
+                                        <img class="w-100 h-100 rounded o_object_fit_cover" t-att-src="selectablePartner.avatarUrl"/>
+                                        <ImStatus persona="selectablePartner" className="'position-absolute top-100 start-100 translate-middle bg-inherit mt-n1 ms-n1 smaller'"/>
                                     </div>
                                 </div>
                                 <t name="selectablePartnerDetail">
                                     <span class="flex-grow-1 mx-2 text-truncate text-start fs-6" t-esc="selectablePartner.name"/>
                                 </t>
-                                <input class="form-check-input flex-shrink-0" type="checkbox" t-att-checked="selectablePartner.in(state.selectedPartners) ? 'checked' : undefined"/>
+                                <input class="form-check-input flex-shrink-0 lh-1" type="checkbox" t-att-checked="selectablePartner.in(state.selectedPartners) ? 'checked' : undefined"/>
                             </div>
                         </t>
-                        <div t-if="state.selectablePartners.length === 0">No user found that is not already a member of this channel.</div>
-                        <div t-if="state.searchResultCount > state.selectablePartners.length">
-                            Showing
-                            <t t-esc="state.selectablePartners.length"/>
-                            results out of
-                            <t t-esc="state.searchResultCount"/>
-                            . Narrow your search to see more choices.
-                        </div>
                     </div>
                 </t>
-                <div class="o-discuss-ChannelInvitation-invitationBox pt-0 pb-2">
+                <div class="py-0 position-sticky bottom-0 bg-view">
+                    <div t-if="state.selectablePartners.length === 0" class="px-3 py-1 smaller text-muted">No user found that is not already a member of this channel.</div>
+                    <div t-if="state.searchResultCount > state.selectablePartners.length" class="px-3 py-1 smaller text-muted" t-esc="narrowResultText"/>
                     <t t-if="store.self.type === 'partner'" >
-                        <div t-if="state.selectedPartners.length > 0" class="mt-3">
-                            <h4>Selected users:</h4>
+                        <div t-if="state.selectedPartners.length > 0" class="mt-1 mb-3 px-2">
+                            <h6 class="smaller text-uppercase text-muted mb-1">Selected users:</h6>
                             <div class="o-discuss-ChannelInvitation-selectedList d-flex flex-wrap gap-1 overflow-auto">
                                 <t t-foreach="state.selectedPartners" t-as="selectedPartner" t-key="selectedPartner.id">
-                                    <button class="btn btn-secondary" t-on-click="() => this.onClickSelectedPartner(selectedPartner)">
-                                        <t t-esc="selectedPartner.name"/> <i class="fa fa-times"/>
+                                    <button class="btn px-1 py-0 o-text-white border-0 rounded-0 smaller" t-on-click="() => this.onClickSelectedPartner(selectedPartner)">
+                                        <t t-esc="selectedPartner.name"/> <i class="oi oi-close rounded-circle"/>
                                     </button>
                                 </t>
                             </div>
                         </div>
-                        <button class="btn btn-primary w-100 my-2" t-att-disabled="this.state.selectedPartners.length === 0" t-att-title="invitationButtonText" t-on-click="onClickInvite">
+                        <button class="btn btn-primary w-100 rounded-0" t-att-disabled="this.state.selectedPartners.length === 0" t-att-title="invitationButtonText" t-on-click="onClickInvite">
                             <t t-esc="invitationButtonText"/>
                         </button>
                     </t>
-                    <div t-if="props.thread.invitationLink" class="input-group">
-                        <input class="border form-control" type="text" t-att-value="props.thread.invitationLink" readonly="" t-on-focus="onFocusInvitationLinkInput"/>
-                        <button class="btn btn-primary" t-on-click="onClickCopy">
+                    <div t-if="props.thread.invitationLink" class="input-group border-top">
+                        <input class="border form-control smaller rounded-0 border-0" type="text" t-att-value="props.thread.invitationLink" readonly="" t-on-focus="onFocusInvitationLinkInput"/>
+                        <button class="btn btn-primary px-2 py-1 rounded-0" t-on-click="onClickCopy">
                             <i class="fa fa-copy"/>
                         </button>
                     </div>

--- a/addons/mail/static/src/discuss/core/common/channel_member_list.dark.scss
+++ b/addons/mail/static/src/discuss/core/common/channel_member_list.dark.scss
@@ -1,0 +1,3 @@
+.o-discuss-ChannelMember.cursor-pointer:hover {
+    background-color: mix($o-gray-200, $o-gray-300);
+}

--- a/addons/mail/static/src/discuss/core/common/channel_member_list.scss
+++ b/addons/mail/static/src/discuss/core/common/channel_member_list.scss
@@ -1,8 +1,18 @@
 .o-discuss-ChannelMember.cursor-pointer:hover {
-    background-color: $gray-200;
+    background-color: mix($gray-100, $gray-200);
+
+    img {
+        box-shadow: $box-shadow-sm;
+    }
 }
 
 .o-discuss-ChannelMember-avatar {
-    width: $o-mail-Avatar-size;
-    height: $o-mail-Avatar-size;
+    width: 32px;
+    height: 32px;
+
+    .o-mail-ImStatus {
+        font-size: 0.75rem;
+        height: 1rem;
+        width: 1rem;
+    }
 }

--- a/addons/mail/static/src/discuss/core/common/channel_member_list.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_member_list.xml
@@ -3,16 +3,16 @@
 
     <t t-name="discuss.ChannelMemberList">
         <ActionPanel title="title">
-            <button t-on-click="() => props.openChannelInvitePanel({ keepPrevious: env.inChatWindow })" class="btn btn-secondary m-3 mt-0">Invite a User</button>
+            <button t-on-click="() => props.openChannelInvitePanel({ keepPrevious: env.inChatWindow })" class="btn btn-secondary mx-3">Invite a User</button>
             <t t-if="props.thread.onlineMembers.length > 0">
-                <h6 class="mx-3 text-700">
+                <h6 class="mx-3 my-2 text-muted text-uppercase smaller">
                     Online -
                     <t t-esc="props.thread.onlineMembers.length"/>
                 </h6>
                 <t t-foreach="props.thread.onlineMembers" t-as="member" t-key="member.id" t-call="discuss.channel_member"/>
             </t>
             <t t-if="props.thread.offlineMembers.length > 0">
-                <h6 class="mx-3 text-700">
+                <h6 class="mx-3 my-2 text-muted text-uppercase smaller">
                     Offline -
                     <t t-esc="props.thread.offlineMembers.length"/>
                 </h6>
@@ -27,13 +27,13 @@
     </t>
 
     <t t-name="discuss.channel_member">
-        <div class="o-discuss-ChannelMember d-flex align-items-center p-2 bg-view" t-att-class="{ 'cursor-pointer': canOpenChatWith(member) }" t-on-click.stop="(ev) => this.onClickAvatar(ev, member)">
+        <div class="o-discuss-ChannelMember d-flex align-items-center px-1 py-2 bg-inherit" t-att-class="{ 'cursor-pointer': canOpenChatWith(member) }" t-on-click.stop="(ev) => this.onClickAvatar(ev, member)">
             <div class="bg-inherit o-discuss-ChannelMember-avatar position-relative d-flex ms-4 flex-shrink-0">
                 <img class="w-100 h-100 rounded o_object_fit_cover"
                      t-att-src="member.persona.avatarUrl"/>
                 <ImStatus persona="member.persona" className="'position-absolute top-100 start-100 translate-middle mt-n1 ms-n1'"/>
             </div>
-            <span t-ref="displayName" class="ms-2 text-truncate" t-esc="member.name"/>
+            <span t-ref="displayName" class="ms-2 text-truncate fw-bold" t-esc="member.name"/>
             <span class="ms-auto">
                 <span t-if="member.in(props.thread.invitedMembers)" class="p-1 fa fa-user-plus"/>
                 <span t-if="member.rtcSession?.isSelfMuted and !member.rtcSession?.isDeaf" class="p-1 fa fa-microphone-slash"/>

--- a/addons/mail/static/src/discuss/core/common/notification_settings.xml
+++ b/addons/mail/static/src/discuss/core/common/notification_settings.xml
@@ -9,7 +9,7 @@
                     <button class="btn w-100 d-flex p-1 opacity-75 opacity-100-hover" t-on-click="()=>this.setMute(false)">
                         <div class="d-flex flex-column flex-grow-1 px-2 py-1 w-100 rounded">
                             <span class="fs-6 fw-bold text-wrap text-start text-break">Unmute Channel</span>
-                            <span class="fw-normal o-smaller" t-out="store.settings.getMuteUntilText(props.thread.mute_until_dt)"/>
+                            <span class="fw-normal smaller" t-out="store.settings.getMuteUntilText(props.thread.mute_until_dt)"/>
                         </div>
                     </button>
                 </t>
@@ -44,7 +44,7 @@
                         <div class="d-flex flex-grow-1 align-items-center p-2 rounded">
                             <div class="d-flex flex-column align-items-start">
                                 <span class="fs-6 fw-normal text-wrap text-start text-break">Use Default</span>
-                                <span class="fw-bolder o-smaller"><t t-out="store.settings.NOTIFICATIONS.find((n) => n.label === store.settings.channel_notifications).name"/></span>
+                                <span class="fw-bolder smaller"><t t-out="store.settings.NOTIFICATIONS.find((n) => n.label === store.settings.channel_notifications).name"/></span>
                             </div>
                             <div class="o-discuss-NotificationSettings-separator flex-grow-1"/>
                             <input class="form-check-input" type="radio" t-att-checked="!props.thread.custom_notifications"/>

--- a/addons/mail/static/src/discuss/core/common/thread_actions.js
+++ b/addons/mail/static/src/discuss/core/common/thread_actions.js
@@ -79,7 +79,7 @@ threadActionsRegistry
                 (!component.props.chatWindow || component.props.chatWindow.isOpen)
             );
         },
-        panelOuterClass: "o-discuss-ChannelInvitation",
+        panelOuterClass: "o-discuss-ChannelInvitation rounded-3",
         icon: "fa fa-fw fa-user-plus",
         iconLarge: "fa fa-fw fa-lg fa-user-plus",
         name: _t("Add Users"),

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar.dark.scss
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar.dark.scss
@@ -1,8 +1,19 @@
 .o-mail-DiscussSidebar-item {
     &:hover {
-        background-color: mix($o-gray-200, $o-gray-300);
+        background-color: mix($o-mail-inspectorBg, $o-action, 77.5%);
+        border-color: mix($o-mail-inspectorBg, $o-action, 70%);
     }
     &.o-active {
-        background-color: $o-gray-300;
+        background-color: mix($o-mail-inspectorBg, $o-action, 70%);
+        border-top-color: mix($o-mail-inspectorBg, $o-action, 65%);
+        border-bottom-color: mix($o-mail-inspectorBg, $o-action, 65%);
+        border-left-color: darken($o-action, 10%);
+        &::before {
+            border-left-color: darken($o-action, 10%);
+        }
+    }
+
+    &:not(:hover):not(.o-active):not(.o-unread) .o-mail-DiscussSidebar-itemName {
+        color: $text-muted;
     }
 }

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.js
@@ -1,19 +1,10 @@
-import { ImStatus } from "@mail/core/common/im_status";
-import { ThreadIcon } from "@mail/core/common/thread_icon";
 import { discussSidebarItemsRegistry } from "@mail/core/public_web/discuss_sidebar";
+import { DiscussSidebarChannel } from "@mail/discuss/core/public_web/discuss_sidebar_channel";
 import { cleanTerm } from "@mail/utils/common/format";
 
 import { Component, useState } from "@odoo/owl";
 
-import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
-import { _t } from "@web/core/l10n/translation";
-import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
-import { markEventHandled } from "@web/core/utils/misc";
-
-export const discussSidebarChannelIndicatorsRegistry = registry.category(
-    "mail.discuss_sidebar_channel_indicators"
-);
 
 /**
  * @typedef {Object} Props
@@ -22,7 +13,7 @@ export const discussSidebarChannelIndicatorsRegistry = registry.category(
 export class DiscussSidebarCategories extends Component {
     static template = "mail.DiscussSidebarCategories";
     static props = {};
-    static components = { ImStatus, ThreadIcon };
+    static components = { DiscussSidebarChannel };
 
     setup() {
         super.setup();
@@ -33,21 +24,6 @@ export class DiscussSidebarCategories extends Component {
         });
         this.dialogService = useService("dialog");
         this.orm = useService("orm");
-    }
-
-    askConfirmation(body) {
-        return new Promise((resolve) => {
-            this.dialogService.add(ConfirmationDialog, {
-                body: body,
-                confirmLabel: _t("Leave Conversation"),
-                confirm: resolve,
-                cancel: () => {},
-            });
-        });
-    }
-
-    get channelIndicators() {
-        return discussSidebarChannelIndicatorsRegistry.getAll();
     }
 
     filteredThreads(category) {
@@ -68,38 +44,7 @@ export class DiscussSidebarCategories extends Component {
         );
     }
 
-    /**
-     * @param {import("models").Thread} thread
-     */
-    async leaveChannel(thread) {
-        if (thread.channel_type !== "group" && thread.create_uid === thread.store.self.userId) {
-            await this.askConfirmation(
-                _t("You are the administrator of this channel. Are you sure you want to leave?")
-            );
-        }
-        if (thread.channel_type === "group") {
-            await this.askConfirmation(
-                _t(
-                    "You are about to leave this group conversation and will no longer have access to it unless you are invited again. Are you sure you want to continue?"
-                )
-            );
-        }
-        thread.leave();
-    }
-
-    /**
-     * @param {MouseEvent} ev
-     * @param {import("models").Thread} thread
-     */
-    openThread(ev, thread) {
-        markEventHandled(ev, "sidebar.openThread");
-        thread.setAsDiscussThread();
-    }
-
-    /**
-     *
-     * @param {import("models").DiscussAppCategory} category
-     */
+    /** @param {import("models").DiscussAppCategory} category */
     toggleCategory(category) {
         if (this.store.channels.status === "fetching") {
             return;

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-name="mail.DiscussSidebarCategories">
         <hr class="my-2 w-100 opacity-0 flex-shrink-0"/>
-        <input t-if="hasQuickSearch" class="form-control mx-4 mb-2 rounded-3 w-auto" placeholder="Quick search..." t-model="state.quickSearchVal"/>
+        <input t-if="hasQuickSearch" class="form-control mx-4 mb-2 rounded-3 w-auto lh-1" placeholder="Quick search…" t-model="state.quickSearchVal"/>
         <t t-foreach="store.discuss.allCategories" t-as="cat" t-key="cat_index">
             <t t-if="cat.isVisible" t-call="mail.DiscussSidebarCategory">
                 <t t-set="category" t-value="cat"/>
@@ -12,59 +12,19 @@
 
     <t t-name="mail.DiscussSidebarCategory">
         <div class="o-mail-DiscussSidebarCategory d-flex align-items-center my-1" t-att-class="category.extraClass" name="header">
-            <button class="btn btn-link text-reset flex-grow-1 d-flex align-items-baseline mx-1 p-0 text-start opacity-100-hover opacity-75" t-on-click="() => this.toggleCategory(category)" name="toggler">
+            <button class="btn btn-link text-reset flex-grow-1 d-flex align-items-baseline me-1 px-2 py-1 text-start" t-att-class="{ 'opacity-75-hover opacity-50': store.theme === 'dark', 'opacity-100-hover opacity-75': store.theme !== 'dark' }" t-on-click="() => this.toggleCategory(category)" name="toggler">
                 <span t-if="store.channels.status === 'fetching'" class="o-visible-short-delay"><i class="o-mail-DiscussSidebarCategory-icon o-smaller me-1 fa fa-fw fa-circle-o-notch fa-spin opacity-50"/></span>
-                <i t-else="" class="o-mail-DiscussSidebarCategory-icon o-smaller me-1" t-att-class="category.open ? 'oi oi-chevron-down' : 'oi oi-chevron-right'"/>
-                <span class="btn-sm p-0 text-uppercase text-break fw-bolder o-smaller"><t t-esc="category.name"/></span>
+                <i t-else="" class="o-mail-DiscussSidebarCategory-icon smaller" t-att-class="category.open ? 'oi oi-chevron-down' : 'oi oi-chevron-right'"/>
+                <span class="btn-sm p-0 text-uppercase text-break fw-bolder smaller"><t t-esc="category.name"/></span>
             </button>
             <div t-if="!category.open and store.getDiscussSidebarCategoryCounter(category.id) > 0" class="o-mail-DiscussSidebar-badge badge rounded-pill me-3 o-discuss-badge fw-bold">
                 <t t-esc="store.getDiscussSidebarCategoryCounter(category.id)"/>
             </div>
         </div>
         <t t-if="category.open">
-            <t t-foreach="filteredThreads(category)" t-as="thread" t-key="thread.localId" t-call="mail.DiscussSidebarChannel">
-                <t t-set="thread" t-value="thread"/>
-            </t>
+            <DiscussSidebarChannel t-foreach="filteredThreads(category)" t-as="thread" t-key="thread.localId" thread="thread"/>
         </t>
-        <t t-elif="store.discuss.thread?.in(category.threads)" t-call="mail.DiscussSidebarChannel">
-            <t t-set="thread" t-value="store.discuss.thread"/>
-        </t>
+        <DiscussSidebarChannel t-elif="store.discuss.thread?.in(category.threads)" thread="store.discuss.thread"/>
     </t>
 
-    <t t-name="mail.DiscussSidebarChannel">
-        <div class="o-mail-DiscussSidebarChannel o-mail-DiscussSidebar-item d-flex rounded-2 align-items-center mx-2 cursor-pointer"
-             t-att-class="{
-                    'bg-inherit': thread.notEq(store.discuss.thread),
-                    'o-active': thread.eq(store.discuss.thread),
-                    'o-unread': thread.selfMember?.message_unread_counter > 0 and !thread.mute_until_dt,
-                    'opacity-50': thread.mute_until_dt,
-                    }"
-             t-on-click="(ev) => this.openThread(ev, thread)"
-        >
-            <button class="o-mail-DiscussSidebarChannel-itemMain btn border-0 rounded-0 text-reset overflow-hidden d-flex align-items-center px-0 py-2">
-                <div class="bg-inherit position-relative d-flex ms-3 flex-shrink-0" style="width:26px;height:26px">
-                    <img class="w-100 h-100 rounded" t-att-src="thread.avatarUrl" alt="Thread Image"/>
-                    <ThreadIcon t-if="thread.channel_type === 'chat' or (thread.channel_type === 'channel' and !thread.authorizedGroupFullName)" thread="thread" size="'small'" className="'o-mail-DiscussSidebarChannel-threadIcon position-absolute bottom-0 end-0 p-1 me-n1 mb-n1 d-flex align-items-center justify-content-center rounded-circle bg-inherit'"/>
-                </div>
-                <span class="mx-2 text-truncate" t-att-class="thread.selfMember?.message_unread_counter > 0 and !thread.mute_until_dt ? 'o-item-unread fw-bolder' : 'text-muted'">
-                    <t t-esc="thread.displayName"/>
-                </span>
-            </button>
-            <div class="flex-grow-1"/>
-            <div class="o-mail-DiscussSidebarChannel-commands d-none ms-1 me-2">
-                <div class="btn-group btn-group-sm">
-                    <button t-if="thread.canLeave" class="btn btn-secondary" t-on-click.stop="() => this.leaveChannel(thread)" title="Leave this channel">
-                        <i t-attf-class="fa fa-times" role="img"/>
-                    </button>
-                    <button t-if="thread.canUnpin" class="btn btn-secondary" t-on-click.stop="() => thread.unpin()" title="Unpin Conversation">
-                        <i t-attf-class="fa fa-times" role="img"/>
-                    </button>
-                </div>
-            </div>
-            <t t-foreach="channelIndicators" t-as="indicator" t-key="indicator_index" t-component="indicator" t-props="{ thread }"/>
-            <div t-if="thread.importantCounter > 0">
-                <span t-attf-class="o-mail-DiscussSidebar-badge badge rounded-pill o-discuss-badge ms-1 me-2 fw-bold {{thread.mute_until_dt ? 'o-muted' : ''}}" t-esc="thread.importantCounter"/>
-            </div>
-        </div>
-    </t>
 </templates>

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_channel.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_channel.js
@@ -1,0 +1,79 @@
+import { ImStatus } from "@mail/core/common/im_status";
+import { ThreadIcon } from "@mail/core/common/thread_icon";
+import { Component, useEffect, useRef, useState } from "@odoo/owl";
+import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
+import { _t } from "@web/core/l10n/translation";
+import { useService } from "@web/core/utils/hooks";
+import { markEventHandled } from "@web/core/utils/misc";
+import { discussSidebarChannelIndicatorsRegistry } from "./discuss_sidebar_channel_indicators_registry";
+
+/**
+ * @typedef {Object} Props
+ * @extends {Component<Props, Env>}
+ */
+export class DiscussSidebarChannel extends Component {
+    static template = "mail.DiscussSidebarChannel";
+    static props = ["thread"];
+    static components = { ImStatus, ThreadIcon };
+
+    setup() {
+        super.setup();
+        this.store = useState(useService("mail.store"));
+        this.root = useRef("root");
+        useEffect(
+            () => {
+                if (this.props.thread.eq(this.store.discuss.thread)) {
+                    this.env.discussSidebar.setActiveRef(this.root);
+                }
+            },
+            () => [this.store.discuss.thread]
+        );
+    }
+
+    get channelIndicators() {
+        return discussSidebarChannelIndicatorsRegistry.getAll();
+    }
+
+    get isUnread() {
+        return (
+            this.props.thread.selfMember?.message_unread_counter > 0 &&
+            !this.props.thread.mute_until_dt
+        );
+    }
+
+    askConfirmation(body) {
+        return new Promise((resolve) => {
+            this.dialogService.add(ConfirmationDialog, {
+                body: body,
+                confirmLabel: _t("Leave Conversation"),
+                confirm: resolve,
+                cancel: () => {},
+            });
+        });
+    }
+
+    async leaveChannel() {
+        if (
+            this.props.thread.channel_type !== "group" &&
+            this.props.thread.create_uid === this.props.thread.store.self.userId
+        ) {
+            await this.askConfirmation(
+                _t("You are the administrator of this channel. Are you sure you want to leave?")
+            );
+        }
+        if (this.props.thread.channel_type === "group") {
+            await this.askConfirmation(
+                _t(
+                    "You are about to leave this group conversation and will no longer have access to it unless you are invited again. Are you sure you want to continue?"
+                )
+            );
+        }
+        this.props.thread.leave();
+    }
+
+    /** @param {MouseEvent} ev */
+    openThread(ev) {
+        markEventHandled(ev, "sidebar.openThread");
+        this.props.thread.setAsDiscussThread();
+    }
+}

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_channel.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_channel.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="mail.DiscussSidebarChannel">
+        <div class="o-mail-DiscussSidebarChannel o-mail-DiscussSidebar-item d-flex rounded-0 align-items-center pe-2 cursor-pointer position-relative"
+             t-att-class="{
+                'bg-inherit': props.thread.notEq(store.discuss.thread),
+                'o-active': props.thread.eq(store.discuss.thread),
+                'o-unread': isUnread,
+                'opacity-50': props.thread.mute_until_dt,
+                }"
+             t-on-click="(ev) => this.openThread(ev)"
+             t-ref="root"
+        >
+            <t t-if="isUnread and store.theme === 'light'" t-set="unreadIndicatorTitle">Unread messages</t>
+            <t t-else="" t-set="unreadIndicatorTitle"></t>
+            <i class="flex-grow-0 flex-shrink-0 fa fa-circle fa-fw me-2 text-dark-subtle" t-att-title="unreadIndicatorTitle ?? ''" t-att-class="(isUnread and store.theme === 'light') ? 'opacity-100' : (isUnread ? ' opacity-50' : 'opacity-0')" style="font-size: 0.3rem;"/>
+            <button class="o-mail-DiscussSidebar-itemMain btn border-0 rounded-0 text-reset overflow-hidden d-flex align-items-center px-0 py-2 bg-inherit">
+                <div class="o-mail-DiscussSidebar-itemAvatar bg-inherit position-relative d-flex flex-shrink-0" style="width:26px;height:26px">
+                    <img class="w-100 h-100 rounded" t-att-src="props.thread.avatarUrl" alt="Thread Image"/>
+                    <ThreadIcon t-if="props.thread.channel_type === 'chat' or (props.thread.channel_type === 'channel' and !thread.authorizedGroupFullName)" thread="props.thread" size="'small'" className="'o-mail-DiscussSidebarChannel-threadIcon position-absolute bottom-0 end-0 p-1 me-n1 mb-n1 d-flex align-items-center justify-content-center rounded-circle bg-inherit'"/>
+                </div>
+                <span class="o-mail-DiscussSidebar-itemName mx-2 text-truncate" t-att-class="{ 'fw-bolder': isUnread, 'o-discuss-itemName-discrete': !isUnread and props.thread.notEq(store.discuss.thread) }">
+                    <t t-esc="props.thread.displayName"/>
+                </span>
+            </button>
+            <div class="flex-grow-1"/>
+            <div class="o-mail-DiscussSidebarChannel-commands d-none ms-1" t-att-class="{ 'me-1': props.thread.importantCounter === 0 }">
+                <div class="d-flex align-items-center" name="commands">
+                    <button t-if="props.thread.canLeave" class="btn btn-secondary p-0 bg-inherit o-red" name="leave" t-on-click.stop="() => this.leaveChannel()" title="Leave this channel">
+                        <i t-attf-class="oi oi-close fa-fw" role="img"/>
+                    </button>
+                    <button t-if="props.thread.canUnpin" class="btn btn-secondary p-0 bg-inherit o-red" t-on-click.stop="() => props.thread.unpin()" title="Unpin Conversation">
+                        <i t-attf-class="oi oi-close fa-fw" role="img"/>
+                    </button>
+                </div>
+            </div>
+            <t t-foreach="channelIndicators" t-as="indicator" t-key="indicator_index" t-component="indicator" t-props="{ thread: props.thread }"/>
+            <div t-if="props.thread.importantCounter > 0">
+                <span t-attf-class="o-mail-DiscussSidebar-badge badge rounded-pill o-discuss-badge mx-1 {{props.thread.mute_until_dt ? 'o-muted' : ''}}" t-esc="props.thread.importantCounter"/>
+            </div>
+        </div>
+    </t>
+</templates>

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_channel_indicators_registry.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_channel_indicators_registry.js
@@ -1,0 +1,5 @@
+import { registry } from "@web/core/registry";
+
+export const discussSidebarChannelIndicatorsRegistry = registry.category(
+    "mail.discuss_sidebar_channel_indicators"
+);

--- a/addons/mail/static/src/discuss/core/web/channel_selector.scss
+++ b/addons/mail/static/src/discuss/core/web/channel_selector.scss
@@ -1,4 +1,9 @@
 .o-discuss-ChannelSelector {
+    
+    &:has(input:focus) {
+        border-color: rgba($o-action, 0.5);
+    }
+
     input {
         width: unset !important;
     }

--- a/addons/mail/static/src/discuss/core/web/channel_selector.xml
+++ b/addons/mail/static/src/discuss/core/web/channel_selector.xml
@@ -2,10 +2,10 @@
 <templates xml:space="preserve">
 
 <t t-name="discuss.ChannelSelector">
-    <div class="o-discuss-ChannelSelector d-flex flex-wrap form-control rounded p-1" t-att-class="props.class" t-ref="root">
+    <div class="o-discuss-ChannelSelector d-flex flex-wrap form-control rounded-3 p-1" t-att-class="props.class" t-ref="root">
         <TagsList t-if="props.multiple" tags="tagsList"/>
         <input
-            class="text-truncate form-control flex-grow-1 border-0 px-2 py-0"
+            class="text-truncate form-control flex-grow-1 border-0 px-2 py-0 lh-1"
             t-att-placeholder="inputPlaceholder"
             t-model="state.value"
             t-ref="input"

--- a/addons/mail/static/src/discuss/core/web/discuss_sidebar_categories_patch.js
+++ b/addons/mail/static/src/discuss/core/web/discuss_sidebar_categories_patch.js
@@ -37,18 +37,6 @@ const DiscussCategoriesPatch = {
             });
         }
     },
-    /** @param {import("models").Thread} thread */
-    openSettings(thread) {
-        if (thread.channel_type === "channel") {
-            this.actionService.doAction({
-                type: "ir.actions.act_window",
-                res_model: "discuss.channel",
-                res_id: thread.id,
-                views: [[false, "form"]],
-                target: "current",
-            });
-        }
-    },
     stopEditing() {
         this.state.editing = false;
     },

--- a/addons/mail/static/src/discuss/core/web/discuss_sidebar_categories_patch.xml
+++ b/addons/mail/static/src/discuss/core/web/discuss_sidebar_categories_patch.xml
@@ -2,28 +2,21 @@
 <templates xml:space="preserve">
     <t t-inherit="mail.DiscussSidebarCategory" t-inherit-mode="extension">
         <xpath expr="//*[@name='header']" position="after">
-            <div t-if="state.editing === category.id" class="p-2" t-ref="selector">
+            <div t-if="state.editing === category.id" class="px-4 py-2" t-ref="selector">
                 <ChannelSelector category="category" onValidate.bind="stopEditing" autofocus="true" close.bind="stopEditing" />
             </div>
         </xpath>
         <xpath expr="//*[@name='toggler']" position="after">
-            <div class="d-flex me-3" t-ref="actions">
-                <div class="btn-group btn-group-sm">
-                    <button t-if="category.canView" class="btn btn-light" t-on-click="() => this.openCategory(category)" title="View or join channels">
-                        <i class="fa fa-cog" role="img"/>
+            <div class="d-flex me-2" t-ref="actions">
+                <div class="d-flex align-items-center me-1" name="commands">
+                    <button t-if="category.canView" class="btn p-0 bg-inherit" t-on-click="() => this.openCategory(category)" title="View or join channels">
+                        <i class="fa fa-fw fa-cog" role="img"/>
                     </button>
-                    <button t-if="category.canAdd and category.open" class="o-mail-DiscussSidebarCategory-add btn btn-light" t-on-click="() => this.addToCategory(category)" t-att-title="category.addTitle" t-att-data-hotkey="category.addHotkey">
-                        <i class="fa fa-plus" role="img"/>
+                    <button t-if="category.canAdd and category.open" class="o-mail-DiscussSidebarCategory-add o-green btn p-0 bg-inherit" t-on-click="() => this.addToCategory(category)" t-att-title="category.addTitle" t-att-data-hotkey="category.addHotkey">
+                        <i class="fa fa-fw fa-plus" role="img"/>
                     </button>
                 </div>
             </div>
-        </xpath>
-    </t>
-    <t t-inherit="mail.DiscussSidebarChannel" t-inherit-mode="extension">
-        <xpath expr="//button[@title='Leave this channel']" position="before">
-            <button t-if="thread.channel_type === 'channel'" class="btn btn-secondary" t-on-click.stop="() => this.openSettings(thread)" title="Channel settings">
-                <i t-attf-class="fa fa-cog" role="img"/>
-            </button>
         </xpath>
     </t>
 </templates>

--- a/addons/mail/static/src/discuss/core/web/discuss_sidebar_channel_patch.js
+++ b/addons/mail/static/src/discuss/core/web/discuss_sidebar_channel_patch.js
@@ -1,0 +1,25 @@
+import { patch } from "@web/core/utils/patch";
+import { useService } from "@web/core/utils/hooks";
+import { DiscussSidebarChannel } from "@mail/discuss/core/public_web/discuss_sidebar_channel";
+
+/**
+ * @type {import("@mail/discuss/core/public_web/discuss_sidebar_channel").DiscussSidebarChannel}
+ */
+const DiscussSidebarChannelPatch = {
+    setup() {
+        super.setup(...arguments);
+        this.actionService = useService("action");
+    },
+    openSettings() {
+        if (this.props.thread.channel_type === "channel") {
+            this.actionService.doAction({
+                type: "ir.actions.act_window",
+                res_model: "discuss.channel",
+                res_id: this.props.thread.id,
+                views: [[false, "form"]],
+                target: "current",
+            });
+        }
+    },
+};
+patch(DiscussSidebarChannel.prototype, DiscussSidebarChannelPatch);

--- a/addons/mail/static/src/discuss/core/web/discuss_sidebar_channel_patch.xml
+++ b/addons/mail/static/src/discuss/core/web/discuss_sidebar_channel_patch.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-inherit="mail.DiscussSidebarChannel" t-inherit-mode="extension">
+        <xpath expr="//*[@name='leave']" position="before">
+            <button t-if="props.thread.channel_type === 'channel'" class="btn btn-secondary p-0 bg-inherit" t-on-click.stop="() => this.openSettings()" title="Channel settings">
+                <i t-attf-class="fa fa-fw fa-cog" role="img"/>
+            </button>
+        </xpath>
+    </t>
+</templates>

--- a/addons/mail/static/src/discuss/core/web/messaging_menu_patch.scss
+++ b/addons/mail/static/src/discuss/core/web/messaging_menu_patch.scss
@@ -1,0 +1,3 @@
+.o-mail-MessagingMenu-newMessage:not(:hover) {
+    color: $text-muted;
+}

--- a/addons/mail/static/src/discuss/core/web/messaging_menu_patch.xml
+++ b/addons/mail/static/src/discuss/core/web/messaging_menu_patch.xml
@@ -10,20 +10,20 @@
                     <ChannelSelector category="category" autofocus="true"/>
                 </div>
             </t>
-            <button t-if="!ui.isSmall and !store.discuss.isActive" t-att-class="ui.isSmall ? 'w-50 p-2 btn btn-secondary m-1' : 'btn btn-link px-2 py-1'" t-on-click.stop="onClickNewMessage">
-                New Message
+            <button t-if="!ui.isSmall and !store.discuss.isActive" t-att-class="ui.isSmall ? 'w-50 p-2 btn btn-secondary m-1' : 'o-mail-MessagingMenu-newMessage btn btn-light px-2 py-0 rounded-0 opacity-75 opacity-100-hover'" t-on-click.stop="onClickNewMessage">
+                <i class="fa fa-fw fa-pencil pe-1"/><span class="small">New Message</span>
             </button>
             <t t-if="ui.isSmall">
                 <t t-if="store.discuss.activeTab !== 'main' or !env.inDiscussApp">
-                    <button name="startMeetingButton" t-if="!state.adding" class="w-50 m-1 me-0 btn btn-primary" t-on-click.stop="onClickStartMeeting">
-                        Start a meeting
+                    <button name="startMeetingButton" t-if="!state.adding" class="w-50 m-1 me-0 btn btn-primary d-flex align-items-center justify-content-center gap-1" t-on-click.stop="onClickStartMeeting">
+                        <i class="fa fa-fw fa-users pe-1"/><span>Start a meeting</span>
                     </button>
-                    <button t-if="displayStartConversation" t-att-class="ui.isSmall ? 'w-50 p-2 btn btn-secondary m-1' : 'btn btn-link p-2'" t-on-click.stop="onClickNewMessage">
-                        Start a conversation
+                    <button t-if="displayStartConversation" t-att-class="ui.isSmall ? 'w-50 btn btn-secondary m-1 d-flex align-items-center justify-content-center gap-1' : 'btn btn-link p-2'" t-on-click.stop="onClickNewMessage">
+                        <i class="fa fa-fw fa-pencil pe-1"/><span>Start a conversation</span>
                     </button>
                 </t>
-                <button t-if="store.discuss.activeTab === 'channel' and !state.adding" class="w-50 p-2 btn btn-secondary m-1" t-on-click.stop="() => this.state.adding = 'channel'">
-                    New Channel
+                <button t-if="store.discuss.activeTab === 'channel' and !state.adding" class="w-50 btn btn-secondary m-1 d-flex align-items-center justify-content-center gap-1" t-on-click.stop="() => this.state.adding = 'channel'">
+                    <i class="fa fa-fw fa-hashtag pe-1"/><span>New channel</span>
                 </button>
             </t>
         </xpath>

--- a/addons/mail/static/src/discuss/gif_picker/common/composer_patch.js
+++ b/addons/mail/static/src/discuss/gif_picker/common/composer_patch.js
@@ -33,6 +33,14 @@ const composerPatch = {
     get hasGifPickerButton() {
         return this.hasGifPicker && !this.ui.isSmall && !this.env.inChatWindow;
     },
+    get emojiButtonAttClass() {
+        return {
+            ...super.emojiButtonAttClass,
+            "bg-300":
+                this.picker.state.picker === this.picker.PICKERS.EMOJI ||
+                (this.picker.state.picker === this.picker.PICKERS.GIF && this.ui.isSmall),
+        };
+    },
     onClickAddGif(ev) {
         markEventHandled(ev, "Composer.onClickAddGif");
     },

--- a/addons/mail/static/src/discuss/gif_picker/common/composer_patch.xml
+++ b/addons/mail/static/src/discuss/gif_picker/common/composer_patch.xml
@@ -1,13 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-inherit="mail.Composer" t-inherit-mode="extension">
-        <xpath expr="//*[@t-ref='emoji-button']" position="attributes">
-            <attribute name="t-att-class">
-                {'bg-300': this.picker.state.picker === this.picker.PICKERS.EMOJI or (this.picker.state.picker === this.picker.PICKERS.GIF and this.ui.isSmall)}
-            </attribute>
-        </xpath>
         <xpath expr="//*[@t-ref='emoji-button']" position="after">
-            <button t-if="hasGifPickerButton" class="btn border-0 rounded-pill p-1" t-att-class="{'bg-300': this.picker.state.picker === this.picker.PICKERS.GIF}" aria-label="GIFs" t-on-click="onClickAddGif" t-ref="gif-button"><i class="oi oi-fw oi-gif-picker"/></button>
+            <button t-if="hasGifPickerButton" class="btn border-0 p-1" t-att-class="{ 'bg-300': this.picker.state.picker === this.picker.PICKERS.GIF }" aria-label="GIFs" t-on-click="onClickAddGif" t-ref="gif-button"><i class="oi oi-fw oi-gif-picker" t-att-class="{ 'fa-lg': ui.isSmall }"/></button>
         </xpath>
     </t>
 </templates>

--- a/addons/mail/static/src/discuss/gif_picker/common/picker_content_patch.xml
+++ b/addons/mail/static/src/discuss/gif_picker/common/picker_content_patch.xml
@@ -3,11 +3,11 @@
     <t t-inherit="mail.PickerContent" t-inherit-mode="extension">
         <xpath expr="//div[hasclass('o-mail-PickerContent-picker')]" position="before">
             <div t-if="Object.keys(props.pickers).length > 1" class="o-mail-PickerContent-tab d-flex m-1">
-                <nav class="btn-group w-100">
-                    <button t-if="props.pickers.emoji" class="btn btn-secondary" t-on-click="() => this.props.state.picker = this.props.PICKERS.EMOJI" t-att-class="{ 'active': props.state.picker === this.props.PICKERS.EMOJI }">
+                <nav class="btn-group w-100 px-2 pt-1">
+                    <button t-if="props.pickers.emoji" class="btn btn-secondary btn-sm rounded-start-3" t-on-click="() => this.props.state.picker = this.props.PICKERS.EMOJI" t-att-class="{ 'active': props.state.picker === this.props.PICKERS.EMOJI, 'rounded-end-3': !props.pickers.gif }">
                         Emoji
                     </button>
-                    <button t-if="props.pickers.gif" class="btn btn-secondary" t-on-click="() => this.props.state.picker = this.props.PICKERS.GIF" t-att-class="{ 'active': props.state.picker === this.props.PICKERS.GIF }">
+                    <button t-if="props.pickers.gif" class="btn btn-secondary btn-sm rounded-end-3" t-on-click="() => this.props.state.picker = this.props.PICKERS.GIF" t-att-class="{ 'active': props.state.picker === this.props.PICKERS.GIF, 'rounded-start-3': !props.pickers.emoji }">
                         GIFs
                     </button>
                 </nav>

--- a/addons/mail/static/src/discuss/voice_message/common/composer_patch.xml
+++ b/addons/mail/static/src/discuss/voice_message/common/composer_patch.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
-    <t t-inherit="mail.Composer.sendButton" t-inherit-mode="extension">
-        <xpath expr="//button[hasclass('o-mail-Composer-send')]" position="replace">
+    <t t-inherit="mail.Composer" t-inherit-mode="extension">
+        <xpath expr="//*[@name='dropdown-actions']" position="inside">
             <VoiceRecorder t-if="thread?.model === 'discuss.channel' and allowUpload"
                 composer="props.composer"
                 attachmentUploader="attachmentUploader"
                 onchangeRecording.bind="() => this.state.recording = !this.state.recording"/>
-            <t>$0</t>
         </xpath>
     </t>
 </templates>

--- a/addons/mail/static/src/discuss/voice_message/common/voice_recorder.js
+++ b/addons/mail/static/src/discuss/voice_message/common/voice_recorder.js
@@ -47,6 +47,7 @@ export class VoiceRecorder extends Component {
         });
         this.notification = useService("notification");
         this.store = useState(useService("mail.store"));
+        this.ui = useState(useService("ui"));
         this.voiceMessageService = useState(useService("discuss.voice_message"));
         this.config = {
             // 128 or 160 kbit/s – mid-range bitrate quality

--- a/addons/mail/static/src/discuss/voice_message/common/voice_recorder.xml
+++ b/addons/mail/static/src/discuss/voice_message/common/voice_recorder.xml
@@ -9,7 +9,7 @@
                 'mw-0': !state.recording,
                 'text-danger': state.limitWarning,
             }" style="font-variant-numeric: tabular-nums;"><span class="d-flex text-truncate" t-esc="state.elapsed"/></div>
-            <button t-att-disabled="state.isActionPending or props.composer.voiceAttachment" class="border-0 btn rounded-pill p-1" t-att-title="title" t-on-click="onClick"><i t-att-class="!state.recording ? 'fa fa-fw fa-microphone' : 'fa fa-fw fa-circle text-danger o-mail-VoiceRecorder-dot'"/></button>
+            <button t-att-disabled="state.isActionPending or props.composer.voiceAttachment" class="border-0 btn rounded-pill p-1 mx-1" t-on-click="onClick"><i t-att-class="{ 'fa fa-fw fa-circle text-danger o-mail-VoiceRecorder-dot': state.recording, 'fa fa-fw fa-microphone': !state.recording, 'fa-lg': ui.isSmall }"/><span class="ms-1 small" t-esc="title"/></button>
         </div>
     </t>
 

--- a/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.scss
+++ b/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.scss
@@ -8,7 +8,6 @@
         bottom: -4px;
         right: -4px;
         border-radius: 2rem;
-        background-color: white;
         height: 18px;
         width: 18px;
     }

--- a/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.xml
+++ b/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.AvatarCardPopover">
-        <div class="o_avatar_card">
-            <div class="card-body">
-                <div class="d-flex align-items-start gap-2">
-                    <span class="o_avatar pt-1 position-relative o_card_avatar">
+        <div class="o_avatar_card bg-inherit">
+            <div class="card-body bg-inherit">
+                <div class="d-flex align-items-start gap-2 bg-inherit">
+                    <span class="o_avatar pt-1 position-relative o_card_avatar bg-inherit">
                         <img t-if="props.id"
                             t-attf-src="/web/image/res.users/{{props.id}}/avatar_128"
                             class="rounded"
                         />
-                        <span t-if="user.im_status" name="icon" class="o_card_avatar_im_status position-absolute d-flex align-items-center justify-content-center">
+                        <span t-if="user.im_status" name="icon" class="o_card_avatar_im_status position-absolute d-flex align-items-center justify-content-center bg-inherit">
                             <i t-if="user.im_status === 'online'" class="fa fa-fw fa-circle text-success" title="Online" role="img" aria-label="User is online"/>
                             <i t-elif="user.im_status === 'away'" class="fa fa-fw fa-circle text-warning" title="Idle" role="img" aria-label="User is idle"/>
                             <i t-elif="user.im_status === 'offline'" class="fa fa-fw fa-circle-o text-700" title="Offline" role="img" aria-label="User is offline"/>

--- a/addons/mail/static/src/scss/variables/primary_variables.scss
+++ b/addons/mail/static/src/scss/variables/primary_variables.scss
@@ -1,4 +1,4 @@
-$o-mail-Avatar-size: 42px !default;
+$o-mail-Avatar-size: 36px !default;
 $o-mail-ChatWindow-width: 360px !default; // same value as WINDOW
 $o-mail-Discuss-inspector: 300px !default;
 $o-mail-Avatar-sizeSmall: 24px !default;
@@ -6,7 +6,7 @@ $o-mail-Avatar-sizeSmall: 24px !default;
 $o-RoundedRectangle-small: .2rem !default;
 $o-RoundedRectangle-large: 3 * $o-RoundedRectangle-small !default;
 
-$o-mail-Message-sidebarWidth: 42px !default;
+$o-mail-Message-sidebarWidth: 40px !default;
 
 $o-mail-LinkPreview-width: 320px !default;
 $o-mail-LinkPreview-height: 240px !default;

--- a/addons/mail/static/tests/activity/activity.test.js
+++ b/addons/mail/static/tests/activity/activity.test.js
@@ -71,7 +71,7 @@ test("activity can upload a document", async () => {
         }),
     ]);
     await contains(".o-mail-Activity .btn", { count: 0, text: "Upload Document" });
-    await contains("button[aria-label='Attach files']", { text: "1" });
+    await contains("button[aria-label='Attach Files']", { text: "1" });
 });
 
 test("activity simplest layout", async () => {

--- a/addons/mail/static/tests/chat_window/chat_window.test.js
+++ b/addons/mail/static/tests/chat_window/chat_window.test.js
@@ -180,15 +180,15 @@ test("chat window: basic rendering", async () => {
     });
     await click("[title='Open Actions Menu']");
     await contains(".o-mail-ChatWindow-command", { count: 13 });
-    await contains("[title='Search Messages']");
-    await contains("[title='Notification Settings']");
-    await contains("[title='Rename']");
-    await contains("[title='Pinned Messages']");
-    await contains("[title='Show Attachments']");
-    await contains("[title='Add Users']");
-    await contains("[title='Show Member List']");
-    await contains("[title='Show Call Settings']");
-    await contains("[title='Open in Discuss']");
+    await contains("[aria-label='Search Messages']");
+    await contains("[aria-label='Notification Settings']");
+    await contains("[aria-label='Rename']");
+    await contains("[aria-label='Pinned Messages']");
+    await contains("[aria-label='Show Attachments']");
+    await contains("[aria-label='Add Users']");
+    await contains("[aria-label='Show Member List']");
+    await contains("[aria-label='Show Call Settings']");
+    await contains("[aria-label='Open in Discuss']");
 });
 
 test.skip("Fold state of chat window is sync among browser tabs", async () => {
@@ -786,20 +786,20 @@ test("folded chat window should hide member-list and settings buttons", async ()
     await click("button i[aria-label='Messages']");
     await click(".o-mail-NotificationItem");
     await click("[title='Open Actions Menu']");
-    await contains("[title='Show Member List']");
-    await contains("[title='Show Call Settings']");
+    await contains("[aria-label='Show Member List']");
+    await contains("[aria-label='Show Call Settings']");
     await click(".o-mail-ChatWindow-header"); // click away to close the more menu
-    await contains("[title='Show Member List']", { count: 0 });
+    await contains("[aria-label='Show Member List']", { count: 0 });
     // Fold chat window
     await click(".o-mail-ChatWindow-command[title='Fold']");
     await contains("[title='Open Actions Menu']", { count: 0 });
-    await contains("[title='Show Member List']", { count: 0 });
-    await contains("[title='Show Call Settings']", { count: 0 });
+    await contains("[aria-label='Show Member List']", { count: 0 });
+    await contains("[aria-label='Show Call Settings']", { count: 0 });
     // Unfold chat window
     await click(".o-mail-ChatBubble");
     await click("[title='Open Actions Menu']");
-    await contains("[title='Show Member List']");
-    await contains("[title='Show Call Settings']");
+    await contains("[aria-label='Show Member List']");
+    await contains("[aria-label='Show Call Settings']");
 });
 
 test("Chat window in mobile are not foldable", async () => {
@@ -844,7 +844,7 @@ test("chat window of channels should not have 'Open in Discuss' (mobile)", async
     await contains(".o-mail-ChatWindow");
     await contains("[title='Open Actions Menu']");
     await click("[title='Open Actions Menu']");
-    await contains("[title='Open in Discuss']", { count: 0 });
+    await contains("[aria-label='Open in Discuss']", { count: 0 });
 });
 
 test("Open chat window of new inviter", async () => {

--- a/addons/mail/static/tests/chatter/web/attachment_box.test.js
+++ b/addons/mail/static/tests/chatter/web/attachment_box.test.js
@@ -40,7 +40,7 @@ test("base non-empty rendering", async () => {
             </form>`,
     });
     await contains(".o-mail-AttachmentBox");
-    await contains("button", { text: "Attach files" });
+    await contains("button", { text: "Attach Files" });
     await contains(".o-mail-Chatter input[type='file']");
     await contains(".o-mail-AttachmentList");
 });
@@ -63,8 +63,8 @@ test("remove attachment should ask for confirmation", async () => {
             </form>`,
     });
     await contains(".o-mail-AttachmentCard");
-    await contains("button[title='Remove']");
-    await click("button[title='Remove']");
+    await contains("[title='Remove']");
+    await click("[title='Remove']");
     await contains(".modal-body", { text: 'Do you really want to delete "Blah.txt"?' });
     // Confirm the deletion
     await click(".modal-footer .btn-primary");
@@ -128,7 +128,7 @@ test("scroll to attachment box when toggling on", async () => {
     await openFormView("res.partner", partnerId);
     await contains(".o-mail-Message", { count: 30 });
     await scroll(".o-mail-Chatter", "bottom");
-    await click("button[aria-label='Attach files']");
+    await click("button[aria-label='Attach Files']");
     await contains(".o-mail-AttachmentBox");
     await contains(".o-mail-Chatter", { scroll: 0 });
     await contains(".o-mail-AttachmentBox", { visible: true });
@@ -173,8 +173,8 @@ test("attachment box should order attachments from newest to oldest", async () =
     ]);
     await start();
     await openFormView("res.partner", partnerId);
-    await contains(".o-mail-Chatter [aria-label='Attach files']", { text: "3" });
-    await click(".o-mail-Chatter [aria-label='Attach files']"); // open attachment box
+    await contains(".o-mail-Chatter [aria-label='Attach Files']", { text: "3" });
+    await click(".o-mail-Chatter [aria-label='Attach Files']"); // open attachment box
     await contains(":nth-child(1 of .o-mail-AttachmentCard)", { text: "C.txt" });
     await contains(":nth-child(2 of .o-mail-AttachmentCard)", { text: "B.txt" });
     await contains(":nth-child(3 of .o-mail-AttachmentCard)", { text: "A.txt" });

--- a/addons/mail/static/tests/chatter/web/chatter.test.js
+++ b/addons/mail/static/tests/chatter/web/chatter.test.js
@@ -133,8 +133,8 @@ test("can post a note on a record thread", async () => {
 test("No attachment loading spinner when creating records", async () => {
     await start();
     await openFormView("res.partner");
-    await contains("button[aria-label='Attach files']");
-    await contains("button[aria-label='Attach files'] .fa-spin", { count: 0 });
+    await contains("button[aria-label='Attach Files']");
+    await contains("button[aria-label='Attach Files'] .fa-spin", { count: 0 });
 });
 
 test("No attachment loading spinner when switching from loading record to creation of record", async () => {
@@ -143,11 +143,11 @@ test("No attachment loading spinner when switching from loading record to creati
     await start();
     const partnerId = pyEnv["res.partner"].create({ name: "John" });
     await openFormView("res.partner", partnerId);
-    await contains("button[aria-label='Attach files']");
+    await contains("button[aria-label='Attach Files']");
     await advanceTime(DELAY_FOR_SPINNER);
-    await contains("button[aria-label='Attach files'] .fa-spin");
+    await contains("button[aria-label='Attach Files'] .fa-spin");
     await click(".o_control_panel_main_buttons .o_form_button_create");
-    await contains("button[aria-label='Attach files'] .fa-spin", { count: 0 });
+    await contains("button[aria-label='Attach Files'] .fa-spin", { count: 0 });
 });
 
 test("Composer toggle state is kept when switching from aside to bottom", async () => {
@@ -371,10 +371,10 @@ test("show attachment box", async () => {
     await openFormView("res.partner", partnerId);
     await contains(".o-mail-Chatter");
     await contains(".o-mail-Chatter-topbar");
-    await contains("button[aria-label='Attach files']");
-    await contains("button[aria-label='Attach files']", { text: "2" });
+    await contains("button[aria-label='Attach Files']");
+    await contains("button[aria-label='Attach Files']", { text: "2" });
     await contains(".o-mail-AttachmentBox", { count: 0 });
-    await click("button[aria-label='Attach files']");
+    await click("button[aria-label='Attach Files']");
     await contains(".o-mail-AttachmentBox");
 });
 
@@ -643,8 +643,8 @@ test("upload attachment on draft record", async () => {
                 <chatter/>
             </form>`,
     });
-    await contains("button[aria-label='Attach files']");
-    await contains("button[aria-label='Attach files']", { count: 0, text: "1" });
+    await contains("button[aria-label='Attach Files']");
+    await contains("button[aria-label='Attach Files']", { count: 0, text: "1" });
     const files = [
         await createFile({
             content: "hello, world",
@@ -654,7 +654,7 @@ test("upload attachment on draft record", async () => {
     ];
     await dragenterFiles(".o-mail-Chatter", files);
     await dropFiles(".o-mail-Dropzone", files);
-    await contains("button[aria-label='Attach files']", { text: "1" });
+    await contains("button[aria-label='Attach Files']", { text: "1" });
 });
 
 test("Follower count of draft record is set to 0", async () => {

--- a/addons/mail/static/tests/chatter/web/chatter_topbar.test.js
+++ b/addons/mail/static/tests/chatter/web/chatter_topbar.test.js
@@ -25,7 +25,7 @@ test("base rendering", async () => {
     await contains("button", { text: "Send message" });
     await contains("button", { text: "Log note" });
     await contains("button", { text: "Activities" });
-    await contains("button[aria-label='Attach files']");
+    await contains("button[aria-label='Attach Files']");
     await contains(".o-mail-Followers");
 });
 
@@ -112,8 +112,8 @@ test("attachment counter without attachments", async () => {
     const partnerId = pyEnv["res.partner"].create({});
     await start();
     await openFormView("res.partner", partnerId);
-    await contains("button[aria-label='Attach files']");
-    await contains("button[aria-label='Attach files']", { count: 0, text: "0" });
+    await contains("button[aria-label='Attach Files']");
+    await contains("button[aria-label='Attach Files']", { count: 0, text: "0" });
 });
 
 test("attachment counter with attachments", async () => {
@@ -135,7 +135,7 @@ test("attachment counter with attachments", async () => {
     ]);
     await start();
     await openFormView("res.partner", partnerId);
-    await contains("button[aria-label='Attach files']", { text: "2" });
+    await contains("button[aria-label='Attach Files']", { text: "2" });
 });
 
 test("attachment counter while loading attachments", async () => {
@@ -144,10 +144,10 @@ test("attachment counter while loading attachments", async () => {
     onRpc("/mail/thread/data", async () => await new Deferred()); // simulate long loading
     await start();
     await openFormView("res.partner", partnerId);
-    await contains("button[aria-label='Attach files']");
+    await contains("button[aria-label='Attach Files']");
     await advanceTime(DELAY_FOR_SPINNER);
-    await contains("button[aria-label='Attach files'] .fa-spin");
-    await contains("button[aria-label='Attach files']", { count: 0, text: "0" });
+    await contains("button[aria-label='Attach Files'] .fa-spin");
+    await contains("button[aria-label='Attach Files']", { count: 0, text: "0" });
 });
 
 test("attachment counter transition when attachments become loaded", async () => {
@@ -157,11 +157,11 @@ test("attachment counter transition when attachments become loaded", async () =>
     onRpcBefore("/mail/thread/data", async () => await deferred);
     await start();
     await openFormView("res.partner", partnerId);
-    await contains("button[aria-label='Attach files']");
+    await contains("button[aria-label='Attach Files']");
     await advanceTime(DELAY_FOR_SPINNER);
-    await contains("button[aria-label='Attach files'] .fa-spin");
+    await contains("button[aria-label='Attach Files'] .fa-spin");
     deferred.resolve();
-    await contains("button[aria-label='Attach files'] .fa-spin", { count: 0 });
+    await contains("button[aria-label='Attach Files'] .fa-spin", { count: 0 });
 });
 
 test("attachment icon open directly the file uploader if there is no attachment yet", async () => {
@@ -186,10 +186,10 @@ test("attachment icon open the attachment box when there is at least 1 attachmen
     ]);
     await start();
     await openFormView("res.partner", partnerId);
-    await contains("button[aria-label='Attach files']");
+    await contains("button[aria-label='Attach Files']");
     await contains(".o-mail-AttachmentBox", { count: 0 });
     await contains(".o-mail-Chatter-fileUploader", { count: 0 });
-    await click("button[aria-label='Attach files']");
+    await click("button[aria-label='Attach Files']");
     await contains(".o-mail-AttachmentBox");
     await contains(".o-mail-Chatter-fileUploader");
 });
@@ -202,11 +202,11 @@ test("composer state conserved when clicking on another topbar button", async ()
     await contains(".o-mail-Chatter-topbar");
     await contains("button", { text: "Send message" });
     await contains("button", { text: "Log note" });
-    await contains("button[aria-label='Attach files']");
+    await contains("button[aria-label='Attach Files']");
     await click("button", { text: "Log note" });
     await contains("button.active", { text: "Log note" });
     await contains("button:not(.active)", { text: "Send message" });
-    await click(".o-mail-Chatter-topbar button[aria-label='Attach files']");
+    await click(".o-mail-Chatter-topbar button[aria-label='Attach Files']");
     await contains("button.active", { text: "Log note" });
     await contains("button:not(.active)", { text: "Send message" });
 });

--- a/addons/mail/static/tests/chatter/web/form_renderer.test.js
+++ b/addons/mail/static/tests/chatter/web/form_renderer.test.js
@@ -94,15 +94,15 @@ test("Attachments that have been unlinked from server should be visually unlinke
         resId: partnerId_1,
         resIds: [partnerId_1, partnerId_2],
     });
-    await contains("button[aria-label='Attach files']", { text: "2" });
+    await contains("button[aria-label='Attach Files']", { text: "2" });
     // The attachment links are updated on (re)load,
     // so using pager is a way to reload the record "Partner1".
     await click(".o_pager_next");
-    await contains("button[aria-label='Attach files']:not(:has(sup))");
+    await contains("button[aria-label='Attach Files']:not(:has(sup))");
     // Simulate unlinking attachment 1 from Partner 1.
     pyEnv["ir.attachment"].write([attachmentId_1], { res_id: 0 });
     await click(".o_pager_previous");
-    await contains("button[aria-label='Attach files']", { text: "1" });
+    await contains("button[aria-label='Attach Files']", { text: "1" });
 });
 
 test("read more/less links are not duplicated when switching from read to edit mode", async () => {

--- a/addons/mail/static/tests/core/new_message_separator.test.js
+++ b/addons/mail/static/tests/core/new_message_separator.test.js
@@ -49,12 +49,12 @@ test("keep new message separator when message is deleted", async () => {
     await click("[title='Expand']", {
         parent: [".o-mail-Message", { text: "message 0" }],
     });
-    await click(".o-mail-Message-moreMenu [title='Mark as Unread']");
+    await click(".o-mail-Message-moreMenu [aria-label='Mark as Unread']");
     await contains(".o-mail-Thread-newMessage ~ .o-mail-Message", { text: "message 0" });
     await click("[title='Expand']", {
         parent: [".o-mail-Message", { text: "message 0" }],
     });
-    await click(".o-mail-Message-moreMenu [title='Delete']");
+    await click(".o-mail-Message-moreMenu [aria-label='Delete']");
     await click("button", { text: "Confirm" });
     await contains(".o-mail-Message", { text: "message 0", count: 0 });
     await contains(".o-mail-Thread-newMessage ~ .o-mail-Message", { text: "message 1" });
@@ -156,7 +156,7 @@ test("keep new message separator until current user sends a message", async () =
     await triggerHotkey("Enter");
     await contains(".o-mail-Message", { text: "hello" });
     await click(".o-mail-Message [title='Expand']");
-    await click(".o-mail-Message-moreMenu [title='Mark as Unread']");
+    await click(".o-mail-Message-moreMenu [aria-label='Mark as Unread']");
     await contains(".o-mail-Thread-newMessage hr + span", { count: 1, text: "New messages" });
     await insertText(".o-mail-Composer-input", "hey!");
     await click(".o-mail-Composer-send:enabled");
@@ -173,10 +173,10 @@ test("keep new message separator when switching between chat window and discuss 
     await insertText(".o-mail-Composer-input", "Very important message!");
     await triggerHotkey("Enter");
     await click(".o-mail-Message [title='Expand']");
-    await click(".o-mail-Message-moreMenu [title='Mark as Unread']");
+    await click(".o-mail-Message-moreMenu [aria-label='Mark as Unread']");
     await contains(".o-mail-Thread-newMessage");
     await click("[title='Open Actions Menu']");
-    await click("[title='Open in Discuss']");
+    await click("[aria-label='Open in Discuss']");
     await contains(".o-mail-Discuss-threadName", { value: "General" });
     await contains(".o-mail-Thread-newMessage");
     await openFormView("res.partner", serverState.partnerId);

--- a/addons/mail/static/tests/crosstab/crosstab.test.js
+++ b/addons/mail/static/tests/crosstab/crosstab.test.js
@@ -50,7 +50,7 @@ test("Delete starred message updates counter", async () => {
     await contains(".o-mail-Message", { target: env2, text: "Hello World!" });
     await contains("button", { target: env2, text: "Starred1" });
     await click(":nth-child(1 of .o-mail-Message) [title='Expand']", { target: env2 });
-    await click(".o-mail-Message-moreMenu [title='Delete']", { target: env2 });
+    await click(".o-mail-Message-moreMenu [aria-label='Delete']", { target: env2 });
     await click("button", { text: "Confirm" }, { target: env2 });
     await contains("button", { count: 0, target: env2, text: "Starred1" });
 });
@@ -188,7 +188,6 @@ test("Message delete notification", async () => {
     });
     await start();
     await openDiscuss();
-    await click("[title='Expand']");
     await click("[title='Mark as Todo']");
     await contains("button", { text: "Inbox", contains: [".badge", { text: "1" }] });
     await contains("button", { text: "Starred", contains: [".badge", { text: "1" }] });

--- a/addons/mail/static/tests/discuss/call/call.test.js
+++ b/addons/mail/static/tests/discuss/call/call.test.js
@@ -315,7 +315,7 @@ test("'Start a meeting' in mobile", async () => {
     await click("button:not([disabled])", { text: "Invite to Group Chat" });
     await contains(".o-discuss-Call");
     await click("[title='Open Actions Menu']");
-    await click("[title='Show Member List']");
+    await click("[aria-label='Show Member List']");
     await contains(".o-discuss-ChannelMember", { text: "Partner 2" });
 });
 

--- a/addons/mail/static/tests/discuss/core/channel_invitation.test.js
+++ b/addons/mail/static/tests/discuss/core/channel_invitation.test.js
@@ -50,7 +50,7 @@ test("can invite users in channel from chat window", async () => {
     });
     await start();
     await click("[title='Open Actions Menu']");
-    await click("[title='Add Users']");
+    await click("[aria-label='Add Users']");
     await contains(".o-discuss-ChannelInvitation");
     await click(".o-discuss-ChannelInvitation-selectable", { text: "TestPartner" });
     await click("[title='Invite to Channel']:enabled");

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -374,7 +374,7 @@ test("reply to message from inbox (message linked to document) [REQUIRE FOCUS]",
     await contains(".o-mail-Message");
     await contains(".o-mail-Message-header small", { text: "on Refactoring" });
     await click("[title='Expand']");
-    await click("[title='Reply']");
+    await click("[aria-label='Reply']");
     await contains(".o-mail-Message.o-selected");
     await contains(".o-mail-Composer");
     await contains(".o-mail-Composer-coreHeader", { text: "on: Refactoring" });
@@ -694,7 +694,7 @@ test("rendering of inbox message", async () => {
     await click("[title='Expand']");
     await contains(".o-mail-Message-actions i", { count: 4 });
     await contains(".o-mail-Message-moreMenu i", { count: 1 });
-    await contains("[title='Reply']");
+    await contains("[aria-label='Reply']");
     await contains("[title='Mark as Todo']");
     await contains("[title='Mark as Read']");
     await contains("[title='Expand']");
@@ -733,34 +733,34 @@ test("Unfollow message", async function () {
         contains: [[".o-mail-Message-header small", { text: "on Thread followed" }]],
     });
     await contains(".o-mail-Message-moreMenu", { count: 1 });
-    await contains("span[title='Unfollow']", { count: 1 });
+    await contains("span[aria-label='Unfollow']", { count: 1 });
     await click(":nth-child(2 of .o-mail-Message) button[title='Expand']");
     await contains(":nth-child(2 of .o-mail-Message)", {
         contains: [[".o-mail-Message-header small", { text: "on Thread followed" }]],
     });
     await contains(".o-mail-Message-moreMenu", { count: 1 });
-    await contains("span[title='Unfollow']", { count: 1 });
+    await contains("span[aria-label='Unfollow']", { count: 1 });
     await click(":nth-child(3 of .o-mail-Message) button[title='Expand']");
     await contains(":nth-child(3 of .o-mail-Message)", {
         contains: [[".o-mail-Message-header small", { text: "on Thread not followed" }]],
     });
     await contains(".o-mail-Message-moreMenu", { count: 1 });
-    await contains("span[title='Unfollow']", { count: 0 });
+    await contains("span[aria-label='Unfollow']", { count: 0 });
     await click(":nth-child(1 of .o-mail-Message) button[title='Expand']");
-    await click("span[title='Unfollow']");
+    await click("span[aria-label='Unfollow']");
     await contains(".o-mail-Message", { count: 2 }); // Unfollowing message 0 marks it as read -> Message removed
     await click(":nth-child(1 of .o-mail-Message) button[title='Expand']");
     await contains(":nth-child(1 of .o-mail-Message)", {
         contains: [[".o-mail-Message-header small", { text: "on Thread followed" }]],
     });
     await contains(".o-mail-Message-moreMenu", { count: 1 });
-    await contains("span[title='Unfollow']", { count: 0 });
+    await contains("span[aria-label='Unfollow']", { count: 0 });
     await click(":nth-child(2 of .o-mail-Message) button[title='Expand']");
     await contains(":nth-child(2 of .o-mail-Message)", {
         contains: [[".o-mail-Message-header small", { text: "on Thread not followed" }]],
     });
     await contains(".o-mail-Message-moreMenu", { count: 1 });
-    await contains("span[title='Unfollow']", { count: 0 });
+    await contains("span[aria-label='Unfollow']", { count: 0 });
 });
 
 test('messages marked as read move to "History" mailbox', async () => {
@@ -1864,7 +1864,7 @@ test("Correct breadcrumb when open discuss from chat window then see settings", 
     await click(".o_main_navbar i[aria-label='Messages']");
     await click(".o-mail-NotificationItem", { text: "General" });
     await click("[title='Open Actions Menu']");
-    await click("[title='Open in Discuss']");
+    await click("[aria-label='Open in Discuss']");
     await click("[title='Channel settings']", {
         parent: [".o-mail-DiscussSidebarChannel", { text: "General" }],
     });

--- a/addons/mail/static/tests/discuss_app/inbox.test.js
+++ b/addons/mail/static/tests/discuss_app/inbox.test.js
@@ -39,10 +39,10 @@ test("reply: discard on reply button toggle", async () => {
     await openDiscuss();
     await contains(".o-mail-Message");
     await click("[title='Expand']");
-    await click("[title='Reply']");
+    await click("[aria-label='Reply']");
     await contains(".o-mail-Composer");
     await click("[title='Expand']");
-    await click("[title='Reply']");
+    await click("[aria-label='Reply']");
     await contains(".o-mail-Composer", { count: 0 });
 });
 
@@ -68,7 +68,7 @@ test("reply: discard on pressing escape [REQUIRE FOCUS]", async () => {
     await openDiscuss();
     await contains(".o-mail-Message");
     await click(".o-mail-Message [title='Expand']");
-    await click(".o-mail-Message-moreMenu [title='Reply']");
+    await click(".o-mail-Message-moreMenu [aria-label='Reply']");
     await contains(".o-mail-Composer");
     // Escape on emoji picker does not stop replying
     await click(".o-mail-Composer button[aria-label='Emojis']");
@@ -112,7 +112,7 @@ test('"reply to" composer should log note if message replied to is a note', asyn
     await openDiscuss();
     await contains(".o-mail-Message");
     await click("[title='Expand']");
-    await click("[title='Reply']");
+    await click("[aria-label='Reply']");
     await contains(".o-mail-Composer [placeholder='Log an internal note…']");
     await insertText(".o-mail-Composer-input", "Test");
     await click(".o-mail-Composer-send:enabled", { text: "Log" });
@@ -145,7 +145,7 @@ test('"reply to" composer should send message if message replied to is not a not
     await openDiscuss();
     await contains(".o-mail-Message");
     await click("[title='Expand']");
-    await click("[title='Reply']");
+    await click("[aria-label='Reply']");
     await contains(".o-mail-Composer [placeholder='Send a message to followers…']");
     await insertText(".o-mail-Composer-input", "Test");
     await click(".o-mail-Composer-send[aria-label='Send']:enabled");
@@ -523,7 +523,7 @@ test("reply: stop replying button click", async () => {
     await openDiscuss();
     await contains(".o-mail-Message");
     await click("[title='Expand']");
-    await click("[title='Reply']");
+    await click("[aria-label='Reply']");
     await contains(".o-mail-Composer");
     await contains("i[title='Stop replying']");
     await click("i[title='Stop replying']");

--- a/addons/mail/static/tests/discuss_app/jump_to_present.test.js
+++ b/addons/mail/static/tests/discuss_app/jump_to_present.test.js
@@ -40,13 +40,8 @@ test("Basic jump to present when scrolling to outdated messages", async () => {
         PRESENT_VIEWPORT_THRESHOLD * document.querySelector(".o-mail-Thread").clientHeight,
         { message: "should have enough scroll height to trigger jump to present" }
     );
-    await click(".o-mail-Thread-banner", {
-        text: "You're viewing older messagesJump to Present",
-    });
-    await contains(".o-mail-Thread-banner", {
-        count: 0,
-        text: "You're viewing older messagesJump to Present",
-    });
+    await click("button[title='Jump to Present']");
+    await contains("button[title='Jump to Present']", { count: 0 });
     await contains(".o-mail-Thread", { scroll: "bottom" });
 });
 
@@ -72,13 +67,8 @@ test("Basic jump to present when scrolling to outdated messages (chatter, DESC)"
     );
     await contains(".o-mail-Chatter", { scroll: 0 });
     await scroll(".o-mail-Chatter", "bottom");
-    await click(".o-mail-Thread-banner", {
-        text: "You're viewing older messagesJump to Present",
-    });
-    await contains(".o-mail-Thread-banner", {
-        count: 0,
-        text: "You're viewing older messagesJump to Present",
-    });
+    await click("button[title='Jump to Present']");
+    await contains("button[title='Jump to Present']", { count: 0 });
     await contains(".o-mail-Chatter", { scroll: 0 });
 });
 
@@ -124,13 +114,8 @@ test("Jump to old reply should prompt jump to present", async () => {
     await click(".o-mail-MessageInReply .cursor-pointer");
     await contains(".o-mail-Message", { count: 30 });
     await contains(":nth-child(1 of .o-mail-Message)", { text: "Hello world!" });
-    await click(".o-mail-Thread-banner", {
-        text: "You're viewing older messagesJump to Present",
-    });
-    await contains(".o-mail-Thread-banner", {
-        count: 0,
-        text: "You're viewing older messagesJump to Present",
-    });
+    await click("button[title='Jump to Present']");
+    await contains("button[title='Jump to Present']", { count: 0 });
     await contains(".o-mail-Message", { count: 30 });
     await contains(".o-mail-Thread", { scroll: "bottom" });
 });
@@ -177,13 +162,8 @@ test("Jump to old reply should prompt jump to present (RPC small delay)", async 
     await openDiscuss(channelId);
     await contains(".o-mail-Message", { count: 30 });
     await click(".o-mail-MessageInReply .cursor-pointer");
-    await click(".o-mail-Thread-banner", {
-        text: "You're viewing older messagesJump to Present",
-    });
-    await contains(".o-mail-Thread-banner", {
-        count: 0,
-        text: "You're viewing older messagesJump to Present",
-    });
+    await click("button[title='Jump to Present']");
+    await contains("button[title='Jump to Present']", { count: 0 });
     await contains(".o-mail-Thread", { scroll: "bottom" });
 });
 
@@ -220,15 +200,10 @@ test("Post message when seeing old message should jump to present", async () => 
     await openDiscuss(channelId);
     await contains(".o-mail-Message", { count: 30 });
     await click(".o-mail-MessageInReply .cursor-pointer");
-    await contains(".o-mail-Thread-banner", {
-        text: "You're viewing older messagesJump to Present",
-    });
+    await contains("button[title='Jump to Present']");
     await insertText(".o-mail-Composer-input", "Newly posted");
     await click(".o-mail-Composer button[aria-label='Send']:enabled");
-    await contains(".o-mail-Thread-banner", {
-        count: 0,
-        text: "You're viewing older messagesJump to Present",
-    });
+    await contains("button[title='Jump to Present']", { count: 0 });
     await contains(".o-mail-Thread", { scroll: "bottom" });
     await contains(".o-mail-Message-content", {
         text: "Newly posted",
@@ -277,19 +252,11 @@ test("show jump to present banner after scrolling up 10 messages", async () => {
     const messageHeight = top2 - top1;
     // scroll slightly (1 long message)
     await scroll(".o-mail-Thread", queryFirst(".o-mail-Thread").scrollTop - messageHeight);
-    await contains(".o-mail-Thread-banner", {
-        count: 0,
-        text: "You're viewing older messagesJump to Present",
-    });
+    await contains("button[title='Jump to Present']", { count: 0 });
     // scroll to 5th message before newest
     await scroll(".o-mail-Thread", queryFirst(".o-mail-Thread").scrollTop - 4 * messageHeight);
-    await contains(".o-mail-Thread-banner", {
-        count: 0,
-        text: "You're viewing older messagesJump to Present",
-    });
+    await contains("button[title='Jump to Present']", { count: 0 });
     // scroll to around 10th message before newest
     await scroll(".o-mail-Thread", queryFirst(".o-mail-Thread").scrollTop - 5 * messageHeight);
-    await contains(".o-mail-Thread-banner", {
-        text: "You're viewing older messagesJump to Present",
-    });
+    await contains("button[title='Jump to Present']");
 });

--- a/addons/mail/static/tests/discuss_app/sidebar.test.js
+++ b/addons/mail/static/tests/discuss_app/sidebar.test.js
@@ -209,20 +209,20 @@ test("sidebar quick search at 20 or more pinned channels", async () => {
     await start();
     await openDiscuss();
     await contains(".o-mail-DiscussSidebarChannel", { count: 20 });
-    await contains(".o-mail-DiscussSidebar input[placeholder='Quick search...']");
-    await insertText(".o-mail-DiscussSidebar input[placeholder='Quick search...']", "1");
+    await contains(".o-mail-DiscussSidebar input[placeholder='Quick search…']");
+    await insertText(".o-mail-DiscussSidebar input[placeholder='Quick search…']", "1");
     await contains(".o-mail-DiscussSidebarChannel", { count: 11 });
-    await insertText(".o-mail-DiscussSidebar input[placeholder='Quick search...']", "12", {
+    await insertText(".o-mail-DiscussSidebar input[placeholder='Quick search…']", "12", {
         replace: true,
     });
     await contains(".o-mail-DiscussSidebarChannel");
     await contains(".o-mail-DiscussSidebarChannel", { text: "channel12" });
-    await insertText(".o-mail-DiscussSidebar input[placeholder='Quick search...']", "123", {
+    await insertText(".o-mail-DiscussSidebar input[placeholder='Quick search…']", "123", {
         replace: true,
     });
     await contains(".o-mail-DiscussSidebarChannel", { count: 0 });
     // search should work in case-insensitive
-    await insertText(".o-mail-DiscussSidebar input[placeholder='Quick search...']", "C", {
+    await insertText(".o-mail-DiscussSidebar input[placeholder='Quick search…']", "C", {
         replace: true,
     });
     await contains(".o-mail-DiscussSidebarChannel", { count: 20 });
@@ -252,7 +252,7 @@ test("sidebar quick search takes DM custom name into account", async () => {
     triggerHotkey("Enter");
     await contains(".o-mail-DiscussSidebarChannel", { text: "Marc" });
     // search
-    await insertText(".o-mail-DiscussSidebar input[placeholder='Quick search...']", "Marc");
+    await insertText(".o-mail-DiscussSidebar input[placeholder='Quick search…']", "Marc");
     await contains(".o-mail-DiscussSidebarChannel");
     await contains(".o-mail-DiscussSidebarChannel", { text: "Marc" });
 });

--- a/addons/mail/static/tests/emoji/emoji.test.js
+++ b/addons/mail/static/tests/emoji/emoji.test.js
@@ -96,13 +96,13 @@ test("recent category (basic)", async () => {
     await start();
     await openDiscuss(channelId);
     await click("button[aria-label='Emojis']");
-    await contains(".o-EmojiPicker-navbar [title='Frequently used']", { count: 0 });
+    await contains(".o-EmojiPicker-navbar [title='Frequently Used']", { count: 0 });
     await click(".o-EmojiPicker-content .o-Emoji", { text: "😀" });
     await click("button[aria-label='Emojis']");
-    await contains(".o-EmojiPicker-navbar [title='Frequently used']");
+    await contains(".o-EmojiPicker-navbar [title='Frequently Used']");
     await contains(".o-Emoji", {
         text: "😀",
-        after: ["span", { textContent: "Frequently used" }],
+        after: ["span", { textContent: "Frequently Used" }],
         before: ["span", { textContent: "Smileys & Emotion" }],
     });
 });
@@ -121,12 +121,12 @@ test("emoji usage amount orders frequent emojis", async () => {
     await click("button[aria-label='Emojis']");
     await contains(".o-Emoji", {
         text: "👽",
-        after: ["span", { textContent: "Frequently used" }],
+        after: ["span", { textContent: "Frequently Used" }],
         before: [
             ".o-Emoji",
             {
                 text: "😀",
-                after: ["span", { textContent: "Frequently used" }],
+                after: ["span", { textContent: "Frequently Used" }],
                 before: ["span", { textContent: "Smileys & Emotion" }],
             },
         ],
@@ -149,7 +149,7 @@ test("selecting an emoji while holding down the Shift key prevents the emoji pic
     await openDiscuss(channelId);
     await click("button[aria-label='Emojis']");
     await click(".o-EmojiPicker-content .o-Emoji", { shiftKey: true, text: "👺" });
-    await contains(".o-EmojiPicker-navbar [title='Frequently used']");
+    await contains(".o-EmojiPicker-navbar [title='Frequently Used']");
     await contains(".o-EmojiPicker");
     await contains(".o-mail-Composer-input", { value: "👺" });
 });

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -41,7 +41,7 @@ test("Start edition on click edit", async () => {
     await start();
     await openDiscuss(channelId);
     await click(".o-mail-Message [title='Expand']");
-    await click(".o-mail-Message-moreMenu [title='Edit']");
+    await click(".o-mail-Message-moreMenu [aria-label='Edit']");
     await contains(".o-mail-Message-editable .o-mail-Composer-input", { value: "Hello world" });
 });
 
@@ -66,13 +66,13 @@ test("Edit message (mobile)", async () => {
     await click("button", { text: "general" });
     await contains(".o-mail-Message");
     await click(".o-mail-Message [title='Expand']");
-    await click(".o-mail-Message-moreMenu [title='Edit']");
+    await click(".o-mail-Message-moreMenu [aria-label='Edit']");
     await contains(".o-mail-Message-editable .o-mail-Composer-input", { value: "Hello world" });
     await click("button", { text: "Discard editing" });
     await contains(".o-mail-Message-editable .o-mail-Composer", { count: 0 });
     await contains(".o-mail-Message-content", { text: "Hello world" });
     await click(".o-mail-Message [title='Expand']");
-    await click(".o-mail-Message-moreMenu [title='Edit']");
+    await click(".o-mail-Message-moreMenu [aria-label='Edit']");
     await insertText(".o-mail-Message .o-mail-Composer-input", "edited message", { replace: true });
     await click(".o-mail-Message .fa-paper-plane-o");
     await contains(".o-mail-Message-content", { text: "edited message" });
@@ -91,7 +91,7 @@ test("Can edit message comment in chatter", async () => {
     await start();
     await openFormView("res.partner", partnerId);
     await click(".o-mail-Message [title='Expand']");
-    await click(".o-mail-Message-moreMenu [title='Edit']");
+    await click(".o-mail-Message-moreMenu [aria-label='Edit']");
     await insertText(".o-mail-Message .o-mail-Composer-input", "edited message", { replace: true });
     await click(".o-mail-Message a", { text: "save" });
     await contains(".o-mail-Message-content", { text: "edited message" });
@@ -111,7 +111,7 @@ test("Can edit message comment in chatter (mobile)", async () => {
     await start();
     openFormView("res.partner", partnerId);
     await click(".o-mail-Message [title='Expand']");
-    await click(".o-mail-Message-moreMenu [title='Edit']");
+    await click(".o-mail-Message-moreMenu [aria-label='Edit']");
     await contains("button", { text: "Discard editing" });
     await insertText(".o-mail-Message .o-mail-Composer-input", "edited message", { replace: true });
     await click("button[aria-label='Save editing']");
@@ -133,7 +133,7 @@ test("Cursor is at end of composer input on edit", async () => {
     await start();
     await openDiscuss(channelId);
     await click(".o-mail-Message [title='Expand']");
-    await click(".o-mail-Message-moreMenu [title='Edit']");
+    await click(".o-mail-Message-moreMenu [aria-label='Edit']");
     const textarea = $(".o-mail-Composer-input")[0];
     const contentLength = textarea.value.length;
     expect(textarea.selectionStart).toBe(contentLength);
@@ -156,7 +156,7 @@ test("Stop edition on click cancel", async () => {
     await start();
     await openDiscuss(channelId);
     await click(".o-mail-Message [title='Expand']");
-    await click(".o-mail-Message-moreMenu [title='Edit']");
+    await click(".o-mail-Message-moreMenu [aria-label='Edit']");
     await click(".o-mail-Message a", { text: "cancel" });
     await contains(".o-mail-Message-editable .o-mail-Composer", { count: 0 });
 });
@@ -177,7 +177,7 @@ test("Stop edition on press escape", async () => {
     await start();
     await openDiscuss(channelId);
     await click(".o-mail-Message [title='Expand']");
-    await click(".o-mail-Message-moreMenu [title='Edit']");
+    await click(".o-mail-Message-moreMenu [aria-label='Edit']");
     triggerHotkey("Escape", false);
     await contains(".o-mail-Message-editable .o-mail-Composer", { count: 0 });
 });
@@ -198,7 +198,7 @@ test("Stop edition on click save", async () => {
     await start();
     await openDiscuss(channelId);
     await click(".o-mail-Message [title='Expand']");
-    await click(".o-mail-Message-moreMenu [title='Edit']");
+    await click(".o-mail-Message-moreMenu [aria-label='Edit']");
     await click(".o-mail-Message a", { text: "save" });
     await contains(".o-mail-Message-editable .o-mail-Composer", { count: 0 });
 });
@@ -219,7 +219,7 @@ test("Stop edition on press enter", async () => {
     await start();
     await openDiscuss(channelId);
     await click(".o-mail-Message [title='Expand']");
-    await click(".o-mail-Message-moreMenu [title='Edit']");
+    await click(".o-mail-Message-moreMenu [aria-label='Edit']");
     triggerHotkey("Enter", false);
     await contains(".o-mail-Message-editable .o-mail-Composer", { count: 0 });
 });
@@ -240,7 +240,7 @@ test("Do not stop edition on click away when clicking on emoji", async () => {
     await start();
     await openDiscuss(channelId);
     await click(".o-mail-Message [title='Expand']");
-    await click(".o-mail-Message-moreMenu [title='Edit']");
+    await click(".o-mail-Message-moreMenu [aria-label='Edit']");
     await click(".o-mail-Composer button[aria-label='Emojis']");
     await click(".o-EmojiPicker-content :nth-child(1 of .o-Emoji)");
     await contains(".o-mail-Message-editable .o-mail-Composer");
@@ -262,7 +262,7 @@ test("Edit and click save", async () => {
     await start();
     await openDiscuss(channelId);
     await click(".o-mail-Message [title='Expand']");
-    await click(".o-mail-Message-moreMenu [title='Edit']");
+    await click(".o-mail-Message-moreMenu [aria-label='Edit']");
     await insertText(".o-mail-Message .o-mail-Composer-input", "Goodbye World", { replace: true });
     await click(".o-mail-Message a", { text: "save" });
     await contains(".o-mail-Message-body", { text: "Goodbye World" });
@@ -285,7 +285,7 @@ test("Do not call server on save if no changes", async () => {
     await start();
     await openDiscuss(channelId);
     await click(".o-mail-Message [title='Expand']");
-    await click(".o-mail-Message-moreMenu [title='Edit']");
+    await click(".o-mail-Message-moreMenu [aria-label='Edit']");
     await click(".o-mail-Message a", { text: "save" });
     await assertSteps([]);
 });
@@ -307,7 +307,7 @@ test("Update the link previews when a message is edited", async () => {
     await start();
     await openDiscuss(channelId);
     await click(".o-mail-Message [title='Expand']");
-    await click(".o-mail-Message-moreMenu [title='Edit']");
+    await click(".o-mail-Message-moreMenu [aria-label='Edit']");
     await insertText(".o-mail-Message .o-mail-Composer-input", "http://odoo.com", {
         replace: true,
     });
@@ -332,7 +332,7 @@ test("Scroll bar to the top when edit starts", async () => {
     await start();
     await openDiscuss(channelId);
     await click(".o-mail-Message [title='Expand']");
-    await click(".o-mail-Message-moreMenu [title='Edit']");
+    await click(".o-mail-Message-moreMenu [aria-label='Edit']");
     await contains(".o-mail-Message .o-mail-Composer-input");
     const textarea = document.querySelector(".o-mail-Message .o-mail-Composer-input");
     expect(textarea.scrollHeight).toBeGreaterThan(textarea.clientHeight);
@@ -356,7 +356,7 @@ test("mentions are kept when editing message", async () => {
     await start();
     await openDiscuss(channelId);
     await click(".o-mail-Message [title='Expand']");
-    await click(".o-mail-Message-moreMenu [title='Edit']");
+    await click(".o-mail-Message-moreMenu [aria-label='Edit']");
     await insertText(".o-mail-Message .o-mail-Composer-input", "Hi @Mitchell Admin", {
         replace: true,
     });
@@ -392,7 +392,7 @@ test("can add new mentions when editing message", async () => {
     await start();
     await openDiscuss(channelId);
     await click(".o-mail-Message [title='Expand']");
-    await click(".o-mail-Message-moreMenu [title='Edit']");
+    await click(".o-mail-Message-moreMenu [aria-label='Edit']");
     await insertText(".o-mail-Message .o-mail-Composer-input", " @");
     await click(".o-mail-Composer-suggestion strong", { text: "TestPartner" });
     await contains(".o-mail-Composer-input", { value: "Hello @TestPartner " });
@@ -464,7 +464,7 @@ test("Updating the parent message of a reply also updates the visual of the repl
     await start();
     await openDiscuss(channelId);
     await click(":nth-child(1 of .o-mail-Message) [title='Expand']");
-    await click(".o-mail-Message-moreMenu [title='Edit']");
+    await click(".o-mail-Message-moreMenu [aria-label='Edit']");
     await insertText(".o-mail-Message .o-mail-Composer-input", "Goodbye World", {
         replace: true,
     });
@@ -490,7 +490,7 @@ test("Deleting parent message of a reply should adapt reply visual", async () =>
     await insertText(".o-mail-Composer-input", "FooBarFoo");
     triggerHotkey("Enter", false);
     await click(".o-mail-Message [title='Expand']");
-    await click(".o-mail-Message-moreMenu [title='Delete']");
+    await click(".o-mail-Message-moreMenu [aria-label='Delete']");
     await click("button", { text: "Confirm" });
     await contains(".o-mail-MessageInReply", { text: "Original message was deleted" });
 });
@@ -510,7 +510,7 @@ test("Can open emoji picker after edit mode", async () => {
     await start();
     await openDiscuss(channelId);
     await click(".o-mail-Message [title='Expand']");
-    await click(".o-mail-Message-moreMenu [title='Edit']");
+    await click(".o-mail-Message-moreMenu [aria-label='Edit']");
     await click(".o-mail-Message a", { text: "save" });
     await click("[title='Add a Reaction']");
     await contains(".o-EmojiPicker");
@@ -907,7 +907,7 @@ test("click on message edit button should open edit composer", async () => {
     await start();
     await openDiscuss(channelId);
     await click(".o-mail-Message [title='Expand']");
-    await click(".o-mail-Message-moreMenu [title='Edit']");
+    await click(".o-mail-Message-moreMenu [aria-label='Edit']");
     await contains(".o-mail-Message .o-mail-Composer");
 });
 
@@ -1027,7 +1027,7 @@ test("Editing a message to clear its composer opens message delete dialog.", asy
     await start();
     await openDiscuss(channelId);
     await click(".o-mail-Message [title='Expand']");
-    await click(".o-mail-Message-moreMenu [title='Edit']");
+    await click(".o-mail-Message-moreMenu [aria-label='Edit']");
     await insertText(".o-mail-Message-editable .o-mail-Composer-input", "", { replace: true });
     triggerHotkey("Enter");
     await contains(".modal-body p", { text: "Are you sure you want to delete this message?" });
@@ -1052,7 +1052,7 @@ test("Clear message body should not open message delete dialog if it has attachm
     await start();
     await openDiscuss(channelId);
     await click(".o-mail-Message [title='Expand']");
-    await click(".o-mail-Message-moreMenu [title='Edit']");
+    await click(".o-mail-Message-moreMenu [aria-label='Edit']");
     await insertText(".o-mail-Message-editable .o-mail-Composer-input", "", { replace: true });
     triggerHotkey("Enter");
     await contains(".o-mail-Message-textContent", { text: "" });
@@ -1080,7 +1080,7 @@ test("highlight the message mentioning the current user inside the channel", asy
     });
     await start();
     await openDiscuss(channelId);
-    await contains(".o-mail-Message-bubble.bg-warning-light");
+    await contains(".o-mail-Message-bubble.bg-warning");
 });
 
 test("not highlighting the message if not mentioning the current user inside the channel", async () => {
@@ -1103,7 +1103,7 @@ test("not highlighting the message if not mentioning the current user inside the
     });
     await start();
     await openDiscuss(channelId);
-    await contains(".o-mail-Message-bubble:not(.bg-warning-light)");
+    await contains(".o-mail-Message-bubble:not(.bg-warning)");
 });
 
 test("allow attachment delete on authored message", async () => {
@@ -1153,7 +1153,7 @@ test("prevent attachment delete on non-authored message in channels", async () =
     await start();
     await openDiscuss(channelId);
     await contains(".o-mail-AttachmentImage");
-    await contains(".o-mail-AttachmentImage div[title='Remove']", { count: 0 });
+    await contains(".o-mail-AttachmentImage [title='Remove']", { count: 0 });
 });
 
 test("Toggle star should update starred counter on all tabs", async () => {
@@ -1225,9 +1225,9 @@ test("Can download all files of a message", async () => {
     await start();
     await openDiscuss(channelId);
     await click(":nth-child(1 of .o-mail-Message) [title='Expand']");
-    await contains("[title='Download Files']");
+    await contains("[aria-label='Download Files']");
     await click(":nth-child(2 of .o-mail-Message) [title='Expand']");
-    await contains("[title='Download Files']", { count: 0 });
+    await contains("[aria-label='Download Files']", { count: 0 });
 });
 
 test("Can remove files of message individually", async () => {
@@ -1435,7 +1435,7 @@ test("delete all attachments of message without content should no longer display
     await openDiscuss(channelId);
     await contains(".o-mail-Message");
     await click(".o-mail-Message [title='Expand']");
-    await click(".o-mail-Message-moreMenu [title='Delete']");
+    await click(".o-mail-Message-moreMenu [aria-label='Delete']");
     await click("button", { text: "Confirm" });
     await contains(".o-mail-Message", { count: 0 });
 });
@@ -1457,7 +1457,7 @@ test("delete all attachments of a message with some text content should still ke
     await start();
     await openDiscuss(channelId);
     await contains(".o-mail-Message");
-    await click(".o-mail-AttachmentCard button[title='Remove']");
+    await click(".o-mail-AttachmentCard [title='Remove']");
     await click(".modal button", { text: "Ok" });
     await contains(".o-mail-Message");
 });
@@ -1594,7 +1594,7 @@ test("Mark as unread", async () => {
     await start();
     await openDiscuss(channelId);
     await click(".o-mail-Message [title='Expand']");
-    await click(".o-mail-Message-moreMenu [title='Mark as Unread']");
+    await click(".o-mail-Message-moreMenu [aria-label='Mark as Unread']");
     await contains(".o-mail-Thread-newMessage");
     await contains(".o-mail-DiscussSidebarChannel .badge", { text: "1" });
 });
@@ -1709,7 +1709,7 @@ test("Can edit a message only containing an attachment", async () => {
     await start();
     await openDiscuss(channelId);
     await click(".o-mail-Message [title='Expand']");
-    await click(".o-mail-Message-moreMenu [title='Edit']");
+    await click(".o-mail-Message-moreMenu [aria-label='Edit']");
     await contains(".o-mail-Message-editable .o-mail-Composer-input");
 });
 
@@ -1731,7 +1731,7 @@ test("Click on view reactions shows the reactions on the message", async () => {
     await click(".o-Emoji", { text: "😅" });
     await contains(".o-mail-MessageReaction", { text: "😅1" });
     await click(".o-mail-Message [title='Expand']");
-    await click(".o-mail-Message-moreMenu [title='View Reactions']");
+    await click(".o-mail-Message-moreMenu [aria-label='View Reactions']");
     await contains(".o-mail-MessageReactionMenu", { text: "😅1" });
 });
 
@@ -1806,7 +1806,7 @@ test("Delete starred message decrements starred counter once", async () => {
     await openDiscuss(channelId);
     await contains("button", { count: 1, text: "Starred3" });
     await click(":nth-child(1 of .o-mail-Message) [title='Expand']");
-    await click(".o-mail-Message-moreMenu [title='Delete']");
+    await click(".o-mail-Message-moreMenu [aria-label='Delete']");
     await click("button", { text: "Confirm" });
     await contains("button", { count: 1, text: "Starred2" });
 });

--- a/addons/mail/static/tests/messaging_menu/messaging_menu.test.js
+++ b/addons/mail/static/tests/messaging_menu/messaging_menu.test.js
@@ -476,7 +476,7 @@ test("mark unread channel as read", async () => {
     await click(".o_menu_systray i[aria-label='Messages']");
     await triggerEvents(".o-mail-NotificationItem", ["mouseenter"]);
     await click(".o-mail-NotificationItem [title='Mark As Read']");
-    await contains(".o-mail-NotificationItem.text-muted");
+    await contains(".o-mail-NotificationItem [title='Mark As Read']", { count: 0 });
     await assertSteps(["mark_as_read"]);
     await triggerEvents(".o-mail-NotificationItem", ["mouseenter"]);
     await contains(".o-mail-NotificationItem [title='Mark As Read']", { count: 0 });

--- a/addons/mail/static/tests/thread/attachment_list.test.js
+++ b/addons/mail/static/tests/thread/attachment_list.test.js
@@ -298,12 +298,12 @@ test("should not view attachment from click on non-viewable attachment in list c
     });
     await start();
     await openDiscuss(channelId);
-    await contains(".o-mail-AttachmentImage[title='test.png'] img.o-viewable");
+    await contains(".o-mail-AttachmentImage.o-viewable[aria-label='test.png']");
     await contains(".o-mail-AttachmentCard:not(.o-viewable)", { text: "test.odt" });
     await click(".o-mail-AttachmentCard", { text: "test.odt" });
     // weak test, no guarantee that we waited long enough for the potential file viewer to show
     await contains(".o-FileViewer", { count: 0 });
-    await click(".o-mail-AttachmentImage[title='test.png']");
+    await click(".o-mail-AttachmentImage[aria-label='test.png']");
     await contains(".o-FileViewer");
 });
 
@@ -329,6 +329,6 @@ test("img file has proper src in discuss.channel", async () => {
     await start();
     await openDiscuss(channelId);
     await contains(
-        `.o-mail-AttachmentImage[title='test.png'] img[data-src='${getOrigin()}/discuss/channel/${channelId}/image/${attachmentId}?filename=test.png&width=1920&height=300']`
+        `.o-mail-AttachmentImage[aria-label='test.png'] img[data-src='${getOrigin()}/discuss/channel/${channelId}/image/${attachmentId}?filename=test.png&width=1920&height=600']`
     );
 });

--- a/addons/mail/static/tests/tours/discuss_channel_public_tour.js
+++ b/addons/mail/static/tests/tours/discuss_channel_public_tour.js
@@ -35,7 +35,7 @@ registry.category("web_tour.tours").add("discuss_channel_public_tour.js", {
         },
         {
             content: "Add one file in composer",
-            trigger: ".o-mail-Composer button[aria-label='Attach files']",
+            trigger: ".o-mail-Composer button[aria-label='Attach Files']",
             async run() {
                 await inputFiles(".o-mail-Composer-coreMain .o_input_file", [
                     await createFile({
@@ -73,7 +73,7 @@ registry.category("web_tour.tours").add("discuss_channel_public_tour.js", {
         },
         {
             content: "Click on edit",
-            trigger: ".o-mail-Message-moreMenu [title='Edit'], .o-mail-Message [title='Edit']",
+            trigger: ".o-mail-Message-moreMenu [aria-label='Edit'], .o-mail-Message [title='Edit']",
             run: "click",
         },
         {
@@ -83,7 +83,7 @@ registry.category("web_tour.tours").add("discuss_channel_public_tour.js", {
         },
         {
             content: "Add one more file in composer",
-            trigger: ".o-mail-Message .o-mail-Composer button[aria-label='Attach files']",
+            trigger: ".o-mail-Message .o-mail-Composer button[aria-label='Attach Files']",
             async run() {
                 inputFiles(".o-mail-Message .o-mail-Composer-coreMain .o_input_file", [
                     await createFile({

--- a/addons/mail/static/tests/tours/mail_composer_test_tour.js
+++ b/addons/mail/static/tests/tours/mail_composer_test_tour.js
@@ -34,7 +34,7 @@ registry.category("web_tour.tours").add("mail/static/tests/tours/mail_composer_t
         },
         {
             content: "Add one file in composer",
-            trigger: ".o-mail-Composer button[aria-label='Attach files']",
+            trigger: ".o-mail-Composer button[aria-label='Attach Files']",
             async run() {
                 await inputFiles(".o-mail-Composer-coreMain .o_input_file", [
                     await createFile({

--- a/addons/mail/static/tests/translation/translation.test.js
+++ b/addons/mail/static/tests/translation/translation.test.js
@@ -31,22 +31,20 @@ test("Toggle display of original/translated version of chatter message", async (
     await start();
     await openFormView("res.partner", partnerId);
     await click("button[title='Expand']");
-    await contains("span[title='Translate']");
-    await contains("span[title='Revert']", { count: 0 });
+    await contains("[aria-label='Translate']");
+    await contains("[title='Revert']", { count: 0 });
     // Click acts as a toogle affecting its appearence and the actual message content displayed.
-    await click("span[title='Translate']");
-    await click("button[title='Expand']");
+    await click("[aria-label='Translate']");
     await contains(".o-mail-Message-body", {
         text: "To bad weather, good face.(Translated from: Spanish)",
     });
-    await contains("span[title='Translate']", { count: 0 });
-    await contains("span[title='Revert']");
-    await click("span[title='Revert']");
     await click("button[title='Expand']");
-    await contains(".o-mail-Message", {
-        text: "Al mal tiempo, buena cara.",
-    });
-    await click("span[title='Translate']");
+    await contains("[aria-label='Revert']");
+    await contains("[title='Translate']", { count: 0 });
+    await click("[aria-label='Revert']");
+    await contains(".o-mail-Message", { text: "Al mal tiempo, buena cara." });
+    await click("button[title='Expand']");
+    await click("[aria-label='Translate']");
     // The translation button should not trigger more than one external request for a single message.
     await assertSteps(["Request"]);
 });
@@ -71,7 +69,7 @@ test("translation of email message", async () => {
         parent: [".o-mail-Message-body > div", { shadowRoot: true }],
     });
     await click("button[title='Expand']");
-    await click("span[title='Translate']");
+    await click("[aria-label='Translate']");
     await contains("span", {
         text: "To bad weather, good face.",
         parent: [".o-mail-Message-body > div", { shadowRoot: true }],
@@ -80,7 +78,7 @@ test("translation of email message", async () => {
         text: "(Translated from: Spanish)",
     });
     await click("button[title='Expand']");
-    await click("span[title='Revert']");
+    await click("[aria-label='Revert']");
     await contains("span", {
         text: "Al mal tiempo, buena cara.",
         parent: [".o-mail-Message-body > div", { shadowRoot: true }],

--- a/addons/test_mail/static/tests/chatter.test.js
+++ b/addons/test_mail/static/tests/chatter.test.js
@@ -115,7 +115,7 @@ test("basic chatter rendering with a model without activities", async () => {
     await openFormView("mail.test.simple", recordId);
     await contains(".o-mail-Chatter");
     await contains(".o-mail-Chatter-topbar");
-    await contains("button[aria-label='Attach files']");
+    await contains("button[aria-label='Attach Files']");
     await contains("button", { count: 0, text: "Activities" });
     await contains(".o-mail-Followers");
     await contains(".o-mail-Thread");

--- a/addons/web/static/src/core/emoji_picker/emoji_picker.js
+++ b/addons/web/static/src/core/emoji_picker/emoji_picker.js
@@ -167,8 +167,8 @@ export class EmojiPicker extends Component {
             );
             this.state.categoryId = this.categories[0]?.sortId;
             this.recentCategory = {
-                name: "Frequently used",
-                displayName: _t("Frequently used"),
+                name: "Frequently Used",
+                displayName: _t("Frequently Used"),
                 title: "🕓",
                 sortId: 0,
             };

--- a/addons/web/static/src/core/emoji_picker/emoji_picker.scss
+++ b/addons/web/static/src/core/emoji_picker/emoji_picker.scss
@@ -3,8 +3,27 @@
     height: 350px;
 }
 
+.o-EmojiPicker-searchInner {
+    input::placeholder {
+        opacity: 75%;
+    }
+
+    &:has(input:focus, input:active) {
+        input::placeholder {
+            opacity: 100%;
+        }
+
+        border-color: rgba($o-action, 0.65) !important;
+    
+        i {
+            color: $o-action;
+        }
+    }
+}
+
 .o-EmojiPicker {
-    --o-emoji-picker-active: #{$gray-200};
+    --o-emoji-picker-active: #{mix(#fff, $o-action, 90%)};
+
     .o-active {
         background-color: var(--o-emoji-picker-active) !important;
     }
@@ -20,7 +39,18 @@
 
     .o-EmojiPicker-navbar {
         .o-Emoji {
-            filter: grayscale(1);
+            border: 0px solid;
+            border-bottom-width: 2px;
+            border-color: transparent;
+
+            span {
+                filter: grayscale(1) contrast(1.2);
+            }
+
+            &.o-active {
+                background-color: mix($white, $o-action, 85%) !important;
+                border-bottom-color: mix($white, $o-action, 35%);
+            }
         }
     }
 

--- a/addons/web/static/src/core/emoji_picker/emoji_picker.xml
+++ b/addons/web/static/src/core/emoji_picker/emoji_picker.xml
@@ -2,19 +2,19 @@
 <templates xml:space="preserve">
 
 <t t-name="web.EmojiPicker">
-    <div class="o-EmojiPicker bg-view d-flex flex-column justify-content-center" t-att-class="{ 'align-items-center': emojis.length === 0 }" t-on-click="onClick" t-on-keydown="onKeydown">
+    <div class="o-EmojiPicker bg-view d-flex flex-column justify-content-center rounded-3" t-att-class="{ 'align-items-center': emojis.length === 0 }" t-on-click="onClick" t-on-keydown="onKeydown">
         <t t-if="emojis.length === 0">
             <span class="o-EmojiPicker-empty">😵‍💫</span>
             <span class="fs-5 text-muted">Failed to load emojis...</span>
         </t>
         <t t-else="">
             <div class="o-EmojiPicker-search d-flex align-items-center mx-2 mt-2 rounded">
-                <span class="d-flex mx-1 w-100 rounded o-active">
+                <span class="o-EmojiPicker-searchInner d-flex mx-1 w-100 border rounded-4">
                     <t t-call="web.EmojiPicker.searchInput">
                         <t t-if="props.state" t-set="localState" t-value="props.state"/>
                         <t t-else="" t-set="localState" t-value="state"/>
                     </t>
-                    <i class="oi oi-search p-2 fs-5 rounded-start-0 rounded-3 o-active" title="Search..." role="img" aria-label="Search..."/>
+                    <i class="oi oi-search p-1 me-1 rounded-start-0 rounded-4" title="Search..." role="img" aria-label="Search..."/>
                 </span>
             </div>
             <t t-set="itemIndex" t-value="0"/>
@@ -50,7 +50,7 @@
                     <t t-set="itemIndex" t-value="itemIndex + 1"/>
                 </t>
             </div>
-            <div class="o-EmojiPicker-navbar d-flex flex-shrink-0 w-100 align-items-center bg-100 overflow-auto border-top">
+            <div class="o-EmojiPicker-navbar d-flex flex-shrink-0 w-100 align-items-center overflow-auto rounded-bottom-1">
                 <t t-if="recentEmojis.length > 0" t-call="web.EmojiPicker.tab">
                     <t t-set="category" t-value="recentCategory"/>
                 </t>
@@ -65,13 +65,13 @@
 </t>
 
 <t t-name="web.EmojiPicker.tab">
-    <span class="o-Emoji text-center p-1 cursor-pointer" t-att-class="{'o-active': category.sortId === state.categoryId}" t-att-title="category.name" t-att-data-id="category.sortId" t-on-click="selectCategory">
-        <t t-esc="category.title"/>
+    <span class="o-Emoji text-center p-0 cursor-pointer" t-att-class="{'o-active': category.sortId === state.categoryId}" t-att-title="category.name" t-att-data-id="category.sortId" t-on-click="selectCategory">
+        <span t-esc="category.title"/>
     </span>
 </t>
 
 <t t-name="web.EmojiPicker.section">
-    <span class="w-100 fs-7 p-2 position-sticky top-0 bg-view" t-att-data-category="category.sortId"><span class="o-EmojiPicker-sectionIcon" t-esc="category.title"/><span class="ms-2" t-esc="category.displayName"/></span>
+    <span class="w-100 fs-7 px-2 py-0 position-sticky top-0 bg-view d-flex align-items-center" t-att-data-category="category.sortId"><span class="o-EmojiPicker-sectionIcon fs-5" t-esc="category.title"/><span class="ms-2 text-muted" t-esc="category.displayName"/></span>
     <span class="o-EmojiPicker-category opacity-100 fs-7 py-2" t-att-data-category="category.sortId"/>
 </t>
 
@@ -82,7 +82,7 @@
 </t>
 
 <t t-name="web.EmojiPicker.searchInput">
-    <input class="form-control border-0 flex-grow-1 rounded-3 rounded-end-0 o-active" placeholder="Search for an emoji" t-model="localState.searchTerm" t-ref="autofocus" t-att-model="localState.searchTerm" t-on-input="() => this.state.activeEmojiIndex = 0"/>
+    <input class="form-control border-0 flex-grow-1 rounded-4 rounded-end-0 py-1 m-0 lh-1 smaller" placeholder="Search for an emoji" t-model="localState.searchTerm" t-ref="autofocus" t-att-model="localState.searchTerm" t-on-input="() => this.state.activeEmojiIndex = 0"/>
 </t>
 
 </templates>

--- a/addons/web/static/src/core/file_viewer/file_viewer.dark.scss
+++ b/addons/web/static/src/core/file_viewer/file_viewer.dark.scss
@@ -2,10 +2,6 @@
 // ============================================================================
 // No CSS hacks, variables overrides only
 
-.o-FileViewer-header {
-    --FileViewer-toolbarBgColor: #{$o-gray-200};
-}
-
-.o-FileViewer-toolbarButton {
-    --FileViewer-toolbarBgColor: #{$o-gray-200};
+.o-FileViewer {
+    --FileViewer-bgColor: #{$o-gray-200};
 }

--- a/addons/web/static/src/core/file_viewer/file_viewer.scss
+++ b/addons/web/static/src/core/file_viewer/file_viewer.scss
@@ -3,14 +3,20 @@
     outline: none;
 }
 
+@mixin o-FileViewer-bgColor {
+    background-color: var(--FileViewer-bgColor, #{$o-gray-800});
+}
+
 .o-FileViewer-navigation {
+    @include o-FileViewer-bgColor();
+    color: #fff;
     width: 40px;
     height: 40px;
 }
 
 .o-FileViewer-header {
+    @include o-FileViewer-bgColor();
     color: #fff;
-    background-color: var(--FileViewer-toolbarBgColor, #{$o-gray-800});
     height: $o-navbar-height;
 }
 
@@ -29,7 +35,7 @@
 }
 
 .o-FileViewer-toolbarButton {
-    background-color: var(--FileViewer-toolbarBgColor, #{$o-gray-800});
+    @include o-FileViewer-bgColor();
     color: #fff;
 
     &:hover {

--- a/addons/web/static/src/scss/utilities_custom.scss
+++ b/addons/web/static/src/scss/utilities_custom.scss
@@ -9,6 +9,7 @@ $rounded-sizes: map-merge(
         1: $border-radius-sm,
         2: $border-radius,
         3: $border-radius-lg,
+        4: $border-radius-xl,
         circle: 50%,
         pill: $border-radius-pill,
     )

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/chatgpt_prompt_dialog.xml
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/chatgpt_prompt_dialog.xml
@@ -13,12 +13,12 @@
                             t-att-src="message.author === 'user' ? userAvatarUrl : assistantAvatarUrl"/>
                     </div>
                 </div>
-                <div class="w-100 o-min-width-0">
+                <div class="w-100 min-w-0">
                     <div class="d-flex flex-wrap align-items-baseline mb-1 lh-1">
                         <strong class="me-1 text-truncate"><t t-esc="message.author === 'user' ? 'You' : 'OdooBot'"/></strong>
                     </div>
                     <div class="position-relative d-flex">
-                        <div class="o-min-width-0">
+                        <div class="min-w-0">
                             <div class="position-relative d-flex">
                                 <div class="position-relative overflow-x-auto d-inline-block">
                                     <div class="rounded-bottom-3 position-absolute top-0 start-0 w-100 h-100 border opacity-25"


### PR DESCRIPTION
- Action Panel:
  - fully matches bg color of discuss sidebar
- Attachments:
  - sharper images
  - bigger images on messages with several files
  - cursor + shadow effect on viewable images
  - download button aligned top below delete
  - smaller delete/download buttons
  - delete/download buttons stay dark (even in dark theme)
- Chatter:
  - "Attach files" in "Files" section clickable area takes
    button size rather than whole chatter width
- Chat Window:
  - Better visual separation in-between composer input and
    attachment footer
  - More action (name dropdown) trigger button has nicer border
  - Chat window have border
  - replace `title` by `aria-label` for dropdown items
- Discuss sidebar
  - slightly better hover effects on category and item actions
  - align category title and actions
  - more distinct between important items (active / hover / unread)
    and unimportant items.
  - unread items have a small indicator on the right, just to help
    further seeing them in addition to bolder name.
- Composer:
  - reduce visibility of placeholder
- File viewer:
  - More visible navigation button (Previous/next)
- Message:
  - delete action has red text color
  - replace `title` by `aria-label` for dropdown items
  - improved style of mentions
- Messaging Menu:
  - mobile items are bigger
  - navbar active item has no border (was unintentional and glitched)
- Mobile:
  - bigger composer buttons and message quick actions
  - bigger dropdown menu and items (message + thread actions)
  - more spacing around chat window quick buttons
  - bigger composer height
- Thread:
  - highlighted message does not overlap previous message content
    (moves up slightly less)
  - more visible bubbles

- Misc:
  - harmonize shadows

https://github.com/odoo/enterprise/pull/65071

