### PR TITLE
[FIX] spreadsheet: do not create an array each time

### DIFF
--- a/addons/spreadsheet/static/src/pivot/pivot_model.js
+++ b/addons/spreadsheet/static/src/pivot/pivot_model.js
@@ -392,7 +392,7 @@ export class OdooPivotModel extends PivotModel {
      */
     _getSpreadsheetRows(tree) {
         /**@type {PivotTableRow[]}*/
-        let rows = [];
+        const rows = [];
         const group = tree.root;
         const indent = group.labels.length;
         const rowGroupBys = this.metaData.fullRowGroupBys;
@@ -403,10 +403,10 @@ export class OdooPivotModel extends PivotModel {
             indent,
         });
 
-        const subTreeKeys = tree.sortedKeys || [...tree.directSubTrees.keys()];
+        const subTreeKeys = tree.sortedKeys || tree.directSubTrees.keys();
         subTreeKeys.forEach((subTreeKey) => {
             const subTree = tree.directSubTrees.get(subTreeKey);
-            rows = rows.concat(this._getSpreadsheetRows(subTree));
+            rows.push(...this._getSpreadsheetRows(subTree));
         });
         return rows;
     }


### PR DESCRIPTION
When the arguments for the creation of the SpreadsheetPivotTable are computed, an array was created for each subgroups (due to `concat`).

This allows to reduce by +/- 62% the time spent in the creation of the arguments.

It was done by using `push` instead of `concat`. Note that `splice` has been evaluated but it was sightly slower than `push`.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
