### PR TITLE
[FIX] mass_mailing: compressed mode for template

### DIFF
--- a/addons/mass_mailing/static/src/scss/mass_mailing.scss
+++ b/addons/mass_mailing/static/src/scss/mass_mailing.scss
@@ -23,6 +23,11 @@
 
 .o_form_view.o_mass_mailing_mailing_form .wysiwyg_iframe {
     border: none;
+    flex: auto 1 0;
+}
+
+.o_form_fullscreen_ancestor .wysiwyg_iframe {
+    width: calc(100% - #{$o-we-sidebar-width}) !important;
 }
 
 .o_form_view.o_mass_mailing_mailing_form .o_form_renderer {

--- a/addons/mass_mailing/static/src/scss/mass_mailing.wysiwyg.scss
+++ b/addons/mass_mailing/static/src/scss/mass_mailing.wysiwyg.scss
@@ -103,3 +103,8 @@
     // view. We reduce the width of the chatter to avoid this.
     width: $o-mail-Chatter-minWidth - $o-we-sidebar-width;
 }
+
+.o_mail_body div.d-flex:has(> iframe) {
+    // Center the content within the parent container of the iframe and snippet
+    justify-content: center;
+}


### PR DESCRIPTION
**Current behavior before PR:**
Templates were displayed in a compressed mode, similar to how they appear on
small devices.

**Desired behavior after PR is merged:**
Templates are now displayed in a more expanded, desktop-like mode, providing
a clearer and more accurate visual representation.

**Task**-[3916601](https://www.odoo.com/odoo/my-tasks/3916601?cids=2)