### PR TITLE
[FIX] pos_loyalty: prevent partial reward with loyalty points

### DIFF
--- a/addons/pos_loyalty/static/src/js/Loyalty.js
+++ b/addons/pos_loyalty/static/src/js/Loyalty.js
@@ -1379,7 +1379,10 @@ const PosLoyaltyOrder = (Order) => class PosLoyaltyOrder extends Order {
         }
         let maxDiscount = reward.discount_max_amount || Infinity;
         if (reward.discount_mode === 'per_point') {
-            maxDiscount = Math.min(maxDiscount, reward.discount * this._getRealCouponPoints(coupon_id));
+            let points = (["ewallet", "gift_card"].includes(reward.program_id.program_type)) ?
+                this._getRealCouponPoints(coupon_id) :
+                Math.floor(this._getRealCouponPoints(coupon_id) / reward.required_points) * reward.required_points;
+            maxDiscount = Math.min(maxDiscount, reward.discount * points);
         } else if (reward.discount_mode === 'per_order') {
             maxDiscount = Math.min(maxDiscount, reward.discount);
         } else if (reward.discount_mode === 'percent') {

--- a/addons/pos_loyalty/static/src/tours/PosLoyaltyTour.js
+++ b/addons/pos_loyalty/static/src/tours/PosLoyaltyTour.js
@@ -216,7 +216,7 @@ ProductScreen.do.clickPartnerButton();
 ProductScreen.do.clickCustomer('AAA Partner');
 ProductScreen.do.clickDisplayedProduct('Test Product A');
 PosLoyalty.do.clickRewardButton();
-ProductScreen.check.totalAmountIs('138.50');
+ProductScreen.check.totalAmountIs('139');
 
 Tour.register('PosLoyaltyTour6', { test: true, url: '/pos/web' }, getSteps());
 


### PR DESCRIPTION
To recreate the bug:
1- Create a loyalty program with a reward of $ per point and a fixed required amount.
2- Test the loyalty program and observe the rewards and points consumed.
3- We see that whenever we have an amount of points exceeding the required amount, they get consumed entirely, and the reward is calculated as total points * ($ per point).

The problem here is that when using a loyalty reward with points, it is possible to give partial rewards. This commit
prevents partial rewards.  Example: - Rule: Grant 1 point per product bought; - Reward: 1.5$ per point in exchange of
2 points (3$)  Before this commit, if you buy 3 products, you get 4.5$ by using 3 points. After, you only use 2 points
and get 3$ (no partial reward).

opw-3922835