### PR TITLE
[FIX] website_forum: fix warning delete comment

### DIFF
--- a/addons/website_forum/static/src/js/website_forum.js
+++ b/addons/website_forum/static/src/js/website_forum.js
@@ -33,7 +33,7 @@ publicWidget.registry.websiteForum = publicWidget.Widget.extend({
         'click .o_js_validation_queue a[href*="/validate"]': '_onValidationQueueClick',
         'click .o_wforum_validate_toggler:not(.karma_required)': '_onAcceptAnswerClick',
         'click .o_wforum_favourite_toggle': '_onFavoriteQuestionClick',
-        'click .comment_delete': '_onDeleteCommentClick',
+        'click .comment_delete:not(.karma_required)': '_onDeleteCommentClick',
         'click .js_close_intro': '_onCloseIntroClick',
         'submit .js_wforum_submit_form:has(:not(.karma_required).o_wforum_submit_post)': '_onSubmitForm',
     },

--- a/addons/website_forum/views/website_forum.xml
+++ b/addons/website_forum/views/website_forum.xml
@@ -1462,7 +1462,9 @@
             <t t-foreach="reversed(object.website_message_ids)" t-as="message">
                 <div t-attf-class="o_wforum_post_comment #{not message_first and 'mt-3'}">
                     <div>
-                        <t t-set="required_karma" t-value="message.author_id.id == user.partner_id.id and object.forum_id.karma_comment_unlink_own or object.forum_id.karma_comment_unlink_all"/>
+                        <t t-set="unlink_comment_required_karma" t-value="message.author_id.id == user.partner_id.id and object.forum_id.karma_comment_unlink_own or object.forum_id.karma_comment_unlink_all"/>
+                        <t t-set="can_unlink_comment" t-value="user._is_admin() or user.karma >= unlink_comment_required_karma"/>
+
                         <t t-set="required_karma" t-value="message.author_id.id == user.partner_id.id and object.forum_id.karma_comment_convert_own or object.forum_id.karma_comment_convert_all"/>
                         <t t-if="(object.parent_id and object.parent_id.state != 'close' and object.parent_id.active != False) or (not object.parent_id and object.state != 'close' and object.active != False)">
                             <t t-set="allow_post_comment" t-value="True" />
@@ -1486,7 +1488,7 @@
                                         <t t-set="inDropdown" t-value="True"/>
                                         <t t-set="icon" t-value="'fa-trash-o text-muted'"/>
                                         <t t-set="classes" t-value="'comment_delete'"/>
-                                        <t t-set="karma" t-value="not object.can_unlink and object.karma_unlink or 0"/>
+                                        <t t-set="karma" t-value="unlink_comment_required_karma if not can_unlink_comment and unlink_comment_required_karma else 0"/>
                                     </t>
                                     <t t-call="website_forum.link_button">
                                         <t t-set="url" t-value="'/forum/' + slug(forum) + '/post/' + slug(object) + '/comment/' + slug(message) +  '/convert_to_answer'"/>


### PR DESCRIPTION
Purpose
=======
Considering that the user isn't admin, has enough karma to delete a post comment but not enough karma to delete a post. When the user deletes a comment, fix the warning alert saying that he doesn't have enough karma even though he has.

Specification
=============
Changing the condition to display the warning in the xml to use the comment unlink required karma instead of the post one.
There is no comment can_unlink field so rebuilding the can_unlink condition.

Task-4001283

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
