### PR TITLE
[REV] web: prevent empty column from being hidden in Safari

### DIFF
--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -240,9 +240,6 @@ export class ListRenderer extends Component {
 
         if (!this.columnWidths || !this.columnWidths.length) {
             // no column widths to restore
-
-            table.style.tableLayout = "fixed";
-            const allowedWidth = table.parentNode.getBoundingClientRect().width;
             // Set table layout auto and remove inline style to make sure that css
             // rules apply (e.g. fixed width of record selector)
             table.style.tableLayout = "auto";
@@ -255,7 +252,7 @@ export class ListRenderer extends Component {
 
             // Squeeze the table by applying a max-width on largest columns to
             // ensure that it doesn't overflow
-            this.columnWidths = this.computeColumnWidthsFromContent(allowedWidth);
+            this.columnWidths = this.computeColumnWidthsFromContent();
             table.style.tableLayout = "fixed";
         }
         headers.forEach((th, index) => {
@@ -288,7 +285,7 @@ export class ListRenderer extends Component {
         });
     }
 
-    computeColumnWidthsFromContent(allowedWidth) {
+    computeColumnWidthsFromContent() {
         const table = this.tableRef.el;
 
         // Toggle a className used to remove style that could interfere with the ideal width
@@ -319,6 +316,7 @@ export class ListRenderer extends Component {
         const sortedThs = [...table.querySelectorAll("thead th:not(.o_list_button)")].sort(
             (a, b) => getWidth(b) - getWidth(a)
         );
+        const allowedWidth = table.parentNode.getBoundingClientRect().width;
 
         let totalWidth = getTotalWidth();
         for (let index = 1; totalWidth > allowedWidth; index++) {

--- a/addons/web/static/tests/views/form/form_view_tests.js
+++ b/addons/web/static/tests/views/form/form_view_tests.js
@@ -13650,52 +13650,6 @@ QUnit.module("Views", (hooks) => {
         }
     );
 
-    QUnit.test("containing a nested x2many list view should not overflow", async function (assert) {
-        serverData.models.partner_type.records.push({
-            id: 3,
-            display_name: "very".repeat(30) + "_long_name",
-            color: 10,
-        });
-
-        const record = serverData.models.partner.records[0];
-        record.timmy = [3];
-
-        await makeView({
-            type: "form",
-            resModel: "partner",
-            resId: record.id,
-            serverData,
-            arch: `
-            <form>
-                <sheet>
-                    <group>
-                        <group/>
-                        <group>
-                            <field name="timmy" widget="many2many">
-                                <tree>
-                                    <field name="display_name"/>
-                                    <field name="color"/>
-                                </tree>
-                            </field>
-                        </group>
-                    </group>
-                </sheet>
-            </form>`,
-        });
-
-        const table = target.querySelector("table");
-        const group = target.querySelector(".o_inner_group:last-child");
-
-        // Testing not overflowing on render
-        assert.equal(group.clientWidth, group.scrollWidth);
-
-        // Testing that the table will overflow if no value is calculated
-        table.style.tableLayout = "auto";
-        // Allow overflowing over the inner group for testing purpose
-        group.querySelectorAll(".o_cell").forEach((el) => (el.style.minWidth = "min-content"));
-        assert.ok(group.clientWidth < group.scrollWidth);
-    });
-
     QUnit.test(
         "reload records in the context of the form to avoid having partial field values",
         async function (assert) {


### PR DESCRIPTION
Steps to reproduce
==================

- Use a webkit based browser (safari or epiphany)
- Go to accounting > configuration > journals
- Open the cash record
- Switch to the incoming payments tab
- In the optional column dropdown, enable the outstanding receipts accounts

=> The column is hidden but should be displayed

Cause of the issue
==================

The table width was computed with a fixed table layout. At that point in safari, the width was not yet correctly computed.

Solution
========

We can revert commit 4163f1f4ff3f28c04cfde5427e6b25323d62a857: [FIX] web: prevent inline x2many list view overflows

The original issue fixed by that commit isn't present anymore. It has probably been fixed due to some unrelated code changes or browser update.

opw-3869696