### PR TITLE
[FIX] hr_holidays: refuse button on time off request no rights

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -1529,7 +1529,7 @@ class HolidaysRequest(models.Model):
                     if holiday.employee_id != current_employee:
                         raise UserError(_('Only a Time Off Manager can reset other people leaves.'))
                 else:
-                    if val_type == 'no_validation' and current_employee == holiday.employee_id:
+                    if val_type == 'no_validation' and current_employee == holiday.employee_id and (is_officer or is_manager):
                         continue
                     # use ir.rule based first access check: department, members, ... (see security.xml)
                     holiday.check_access_rule('write')


### PR DESCRIPTION
When you take a time off for which there is no need of validation, you can refuse it, although you don't have any time off rights. This fixes the issue, you have to be either a time off officer or the manager of the one who took the time off.

Task: 3981373