### PR TITLE
[FIX] l10n_es_edi_facturae: do not always stop when Facturae EDI fails

### DIFF
--- a/addons/l10n_es_edi_facturae/wizard/account_move_send.py
+++ b/addons/l10n_es_edi_facturae/wizard/account_move_send.py
@@ -1,4 +1,9 @@
+import logging
+
 from odoo import _, api, fields, models, SUPERUSER_ID
+from odoo.exceptions import UserError
+
+_logger = logging.getLogger(__name__)
 
 
 class AccountMoveSend(models.TransientModel):
@@ -79,21 +84,31 @@ class AccountMoveSend(models.TransientModel):
         super()._hook_invoice_document_before_pdf_report_render(invoice, invoice_data)
 
         if invoice_data.get('l10n_es_edi_facturae_xml') and invoice._l10n_es_edi_facturae_get_default_enable():
-            xml_content, errors = invoice._l10n_es_edi_facturae_render_facturae()
-            if errors:
-                invoice_data['error'] = {
-                    'error_title': _("Errors occurred while creating the EDI document (format: %s):", "Facturae"),
-                    'errors': errors,
-                }
-            else:
-                invoice_data['l10n_es_edi_facturae_attachment_values'] = {
-                    'name': invoice._l10n_es_edi_facturae_get_filename(),
-                    'raw': xml_content,
-                    'mimetype': 'application/xml',
-                    'res_model': invoice._name,
-                    'res_id': invoice.id,
-                    'res_field': 'l10n_es_edi_facturae_xml_file',  # Binary field
-                }
+            try:
+                xml_content, errors = invoice._l10n_es_edi_facturae_render_facturae()
+                if errors:
+                    invoice_data['error'] = {
+                        'error_title': _("Errors occurred while creating the EDI document (format: %s):", "Facturae"),
+                        'errors': errors,
+                    }
+                else:
+                    invoice_data['l10n_es_edi_facturae_attachment_values'] = {
+                        'name': invoice._l10n_es_edi_facturae_get_filename(),
+                        'raw': xml_content,
+                        'mimetype': 'application/xml',
+                        'res_model': invoice._name,
+                        'res_id': invoice.id,
+                        'res_field': 'l10n_es_edi_facturae_xml_file',  # Binary field
+                    }
+            except UserError as e:
+                if self.env.context.get('forced_invoice'):
+                    _logger.warning(
+                        'An error occured during generation of Facturae EDI of %s: %s',
+                        invoice.name,
+                        e.args[0]
+                    )
+                else:
+                    raise
 
     @api.model
     def _link_invoice_documents(self, invoice, invoice_data):


### PR DESCRIPTION
**Steps to reproduce:**
- Install Accounting, website_sale_subscription and l10n_es_edi_facturae
- Switch to a Spanish company (e.g. ES Company)
- Install a payment provider (e.g. Demo)
- Create a 1-year recurring service product
- Go to the Shop page as a public user
- Add the recurring service to the cart
- Process checkout without entering a VAT number
- Process payment

**Issue:**
An Internal server error is raised while trying to generate Facturae EDI because no VAT has been entered.

**Cause:**
After a transaction is done for a subscription, an invoice is created and sent automatically.
As "l10n_es_edi_facturae" module is installed, it tries to generate the EDI document when sending the invoice, but it fails because the partner has no VAT.

**Solution:**
The Facturae EDI xml is not a mandatory document.
It should not block any flow when not generated manually.
Just ignore any UserError from the generation of Facturae EDI when the invoice has been forced-created.

opw-936227


Linked enterprise PR: https://github.com/odoo/enterprise/pull/65086

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
