### PR TITLE
[FIX] mail: discuss header height in public page

### DIFF
--- a/addons/mail/static/src/core/common/discuss.xml
+++ b/addons/mail/static/src/core/common/discuss.xml
@@ -5,7 +5,7 @@
     <div class="o-mail-Discuss d-flex h-100 flex-grow-1" t-att-class="{ 'flex-column align-items-center bg-view': ui.isSmall }" t-ref="root">
         <div t-if="ui.isSmall and store.discuss.activeTab === 'main'" class="w-100 border-bottom" t-call="mail.Discuss.mobileTopbar" t-ref="mobileTopbar"/>
         <div t-if="store.inPublicPage or !(ui.isSmall and store.discuss.activeTab !== 'main')" class="o-mail-Discuss-content d-flex flex-column h-100 w-100 overflow-auto" t-ref="content">
-            <div class="o-mail-Discuss-header px-3 bg-view d-flex flex-shrink-0 align-items-center border-bottom z-1" t-att-class="{ 'flex-grow-1': !ui.isSmall }" t-ref="header">
+            <div class="o-mail-Discuss-header px-3 bg-view d-flex flex-shrink-0 align-items-center border-bottom z-1" t-att-class="{ 'flex-grow-1': !ui.isSmall and !store.inPublicPage }" t-ref="header">
                 <t t-if="thread">
                     <div t-if="['channel', 'group', 'chat'].includes(thread.channel_type)" class="o-mail-Discuss-threadAvatar position-relative align-self-center align-items-center mt-2 mb-2 me-2">
                         <img class="rounded" t-att-src="thread.avatarUrl" alt="Thread Image"/>


### PR DESCRIPTION
Discuss header's height increases too much in public page because of the `flex-grow-1` class.

To fix this we add this class conditionally.

Before:

![image](https://github.com/odoo/odoo/assets/99004966/3c112ebe-02d5-457e-b920-c439d7ae8407)


After:

![image](https://github.com/odoo/odoo/assets/99004966/9c12aab8-bcb5-4644-9cf2-25d5737c7c74)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
