### PR TITLE
[FIX] point_of_sale: translate vat label on receipt

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -221,6 +221,7 @@ class PosSession(models.Model):
             'res.country': {
                 'domain': [],
                 'fields': ['id', 'name', 'code', 'vat_label'],
+                'context': {**self.env.context},
             },
             'res.lang': {
                 'domain': [],


### PR DESCRIPTION
Currently, when the VAT number of a company is displayed on the POS receipt, its label `vat_label` on `res.country` is always displayed in English, despite the rest of the receipt being in the user's language.

We want to display the VAT label also in the user's language.

The reason is that the retrieval of the `res.country` records is done with an empty context (removing the current lang). Passing in the current context solves that.