### PR TITLE
[FIX] l10n_es_pos: prevent an error when open a pos session

### DIFF
--- a/addons/l10n_es_pos/models/pos_config.py
+++ b/addons/l10n_es_pos/models/pos_config.py
@@ -35,8 +35,20 @@ class PosConfig(models.Model):
             pos.is_spanish = pos.company_id.country_code == "ES"
 
     def _compute_simplified_partner_id(self):
+        simplified_partner = self.env.ref("l10n_es.partner_simplified", raise_if_not_found=False)
+        if not simplified_partner:
+            simplified_partner = self.env['res.partner'].sudo().create({
+                'name': 'Simplified Invoice Partner (ES)',
+            })
+            self.env['ir.model.data'].sudo().create({
+                'name': 'partner_simplified',
+                'module': 'l10n_es',
+                'model': 'res.partner',
+                'res_id': simplified_partner.id
+            })
+
         for config in self:
-            config.simplified_partner_id = self.env.ref("l10n_es.partner_simplified").id
+            config.simplified_partner_id = simplified_partner.id
 
     def get_limited_partners_loading(self):
         # this function normally returns 100 partners, but we have to make sure that

--- a/addons/l10n_es_pos/tests/test_frontend.py
+++ b/addons/l10n_es_pos/tests/test_frontend.py
@@ -37,3 +37,12 @@ class TestUi(TestPointOfSaleHttpCommon):
         num_of_regular_invoices = get_number_of_regular_invoices() - initial_number_of_regular_invoices
         self.assertEqual(num_of_simp_invoices, 3)
         self.assertEqual(num_of_regular_invoices, 1)
+
+    def test_unlink_simplified_partner(self):
+        """automatically create a simplified partner when user deletes it"""
+        simplified_partner = self.env.ref("l10n_es.partner_simplified", raise_if_not_found=False)
+        if simplified_partner:
+            simplified_partner.unlink()
+        self.assertFalse(self.env.ref("l10n_es.partner_simplified", raise_if_not_found=False))
+        self.assertTrue(self.main_pos_config.simplified_partner_id)
+        self.assertTrue(self.env.ref("l10n_es.partner_simplified", raise_if_not_found=False))


### PR DESCRIPTION
Currently, an error occurs while opening a POS session, when the external ID 'l10n_es.partner_simplified' is not available

Step to produce:

- Install the 'l10n_es_pos' module.
- open a customer, And delete the 'Simplified Invoice Partner (ES)' record.
- And try to open a POS session.

```ValueError: External ID not found in the system: l10n_es.partner_simplified```

An error occurs when the system tries to retrieve an external ID of the customer 'Simplified Invoice Partner (ES)' at [1], and it is not available.

Link [1]: https://github.com/odoo/odoo/blob/4ac6722aec4a638882c41f1df563da6f051849ad/addons/l10n_es_pos/models/pos_config.py#L39

To handle this issue, create a demo customer 'Simplified Invoice Partner (ES)' if it is not available.

sentry-5503568768

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
