### PR TITLE
[FIX] l10n_be_pos_sale, point_of_sale: remove making invoice mandatory if the partner is Belgian

### DIFF
--- a/addons/l10n_be_pos_sale/static/src/js/PaymentScreen.js
+++ b/addons/l10n_be_pos_sale/static/src/js/PaymentScreen.js
@@ -7,7 +7,9 @@ export const PoSSaleBePaymentScreen = (PaymentScreen) =>
     class extends PaymentScreen {
         toggleIsToInvoice() {
             const has_origin_order = this.currentOrder.get_orderlines().some(line => line.sale_order_origin_id);
-            if(this.currentOrder.is_to_invoice() && this.env.pos.company.country && this.env.pos.company.country.code === "BE" && has_origin_order){
+            if(this.currentOrder.is_to_invoice() && this.env.pos.company.country && this.env.pos.company.country.code === "BE" && has_origin_order
+                && (!this.currentOrder.partner?.country_id || this.currentOrder.partner.country_id[0] !== this.env.pos.company.country.id))
+            {
                 this.showPopup('ErrorPopup', {
                     title: this.env._t('This order needs to be invoiced'),
                     body: this.env._t('If you do not invoice imported orders you will encounter issues in your accounting. Especially in the EC Sale List report'),

--- a/addons/l10n_be_pos_sale/static/tests/tours/l10n_be_pos_sale_tour.js
+++ b/addons/l10n_be_pos_sale/static/tests/tours/l10n_be_pos_sale_tour.js
@@ -21,4 +21,17 @@ odoo.define('l10n_be_pos_sale.tour', function (require) {
     ErrorPopup.do.clickConfirm();
 
     Tour.register('PosSettleOrderIsInvoice', { test: true, url: '/pos/ui' }, getSteps());
+
+    startSteps();
+
+    ProductScreen.do.confirmOpeningPopup();
+    ProductScreen.do.clickQuotationButton();
+    ProductScreen.do.selectFirstOrder();
+    ProductScreen.do.clickPayButton();
+    PaymentScreen.check.isInvoiceButtonChecked();
+    PaymentScreen.do.clickInvoiceButton();
+    PaymentScreen.check.isInvoiceButtonChecked(false);
+    ErrorPopup.check.isShown(false);
+
+    Tour.register('PosSettleOrderBelgianPartner', { test: true, url: '/pos/ui' }, getSteps());
 });

--- a/addons/l10n_be_pos_sale/tests/test_l10n_be_pos_sale.py
+++ b/addons/l10n_be_pos_sale/tests/test_l10n_be_pos_sale.py
@@ -38,3 +38,34 @@ class TestPoSSaleL10NBe(TestPointOfSaleHttpCommon):
         sale_order.action_confirm()
         self.main_pos_config.open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PosSettleOrderIsInvoice', login="accountman")
+
+    def test_settle_order_belgian_partner(self):
+        """Verify that when the company is Belgian and the partner of the sale is Belgian too, the invoice is not mandatory"""
+        # Change company country to Belgium
+        self.env.user.company_id.country_id = self.env.ref('base.be')
+
+        self.product_a = self.env['product.product'].create({
+            'name': 'Product A',
+            'type': 'product',
+            'list_price': 10,
+            'taxes_id': False,
+            'available_in_pos': True,
+        })
+
+        # Set partner country to Belgium
+        self.partner_a.country_id = self.env.ref('base.be')
+
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.partner_a.id,
+            'order_line': [Command.create({
+                'product_id': self.product_a.id,
+                'product_uom_qty': 10,
+                'product_uom': self.product_a.uom_id.id,
+                'price_unit': 10,
+                'tax_id': False,
+            })],
+        })
+
+        sale_order.action_confirm()
+        self.main_pos_config.open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PosSettleOrderBelgianPartner', login="accountman")

--- a/addons/point_of_sale/static/tests/tours/helpers/ErrorPopupTourMethods.js
+++ b/addons/point_of_sale/static/tests/tours/helpers/ErrorPopupTourMethods.js
@@ -15,11 +15,11 @@ odoo.define('point_of_sale.tour.ErrorPopupTourMethods', function (require) {
     }
 
     class Check {
-        isShown() {
+        isShown(isShown=true) {
             return [
                 {
-                    content: 'error popup is shown',
-                    trigger: '.modal-dialog .popup-error',
+                    content: 'error popup is ' + (isShown ? '' : 'not ') + 'shown',
+                    trigger: isShown ? '.modal-dialog .popup-error' : 'body:not(:has(.modal-dialog .popup-error))',
                     run: () => {},
                 },
             ];

--- a/addons/point_of_sale/static/tests/tours/helpers/PaymentScreenTourMethods.js
+++ b/addons/point_of_sale/static/tests/tours/helpers/PaymentScreenTourMethods.js
@@ -206,11 +206,11 @@ odoo.define('point_of_sale.tour.PaymentScreenTourMethods', function (require) {
                 },
             ];
         }
-        isInvoiceButtonChecked() {
+        isInvoiceButtonChecked(isChecked=true) {
             return [
                 {
-                    content: 'check invoice button is checked',
-                    trigger: '.js_invoice.highlight',
+                    content: 'check invoice button is ' + (isChecked ? '' : 'not ') + 'checked',
+                    trigger: isChecked ? '.js_invoice.highlight' : '.payment-buttons:not(:has(.js_invoice.highlight))',
                     run: () => {},
                 }
             ]


### PR DESCRIPTION
Current behavior:
The invoice is mandatory when selling a quotation from the shop from a Belgian company. It shouldn't be mandatory if the partner is Belgian too

Steps to reproduce:
- Install "Point of Sale", "Sales" apps and "l10n_be_pos_sale" module
- From Sales, create a quotation for a Belgian partner
- Go to PoS and start a shop session
- Settle the order for the previously created quotation
- Go to the payment screen
- Try to unselect the Invoice. An error popup is shown saying that we should have an invoice. While we don't care as the partner is from the same country.

Solution:
Verify that the partner's country is not the same than the company's before showing the error

opw-3986443

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
