### PR TITLE
[FIX] l10n_es_edi_facutrae: fix TotalGrossAmount and new fields

### DIFF
--- a/addons/l10n_es_edi_facturae/data/facturae_templates.xml
+++ b/addons/l10n_es_edi_facturae/data/facturae_templates.xml
@@ -182,6 +182,9 @@
                     </ExchangeRateDetails>
                     <TaxCurrencyCode t-out="invoice['invoice_currency'].name"/>
                     <LanguageName t-out="invoice['InvoiceIssueData']['LanguageName']"/>
+                    <ReceiverTransactionReference t-out="invoice['InvoiceIssueData']['ReceiverTransactionReference']"/>
+                    <FileReference t-out="invoice['InvoiceIssueData']['FileReference']"/>
+                    <ReceiverContractReference t-out="invoice['InvoiceIssueData']['ReceiverContractReference']"/>
                 </InvoiceIssueData>
                 <TaxesOutputs>
                     <t t-foreach="invoice['TaxOutputs']" t-as="tax"><t t-call="l10n_es_edi_facturae.tax_type"/></t>

--- a/addons/l10n_es_edi_facturae/models/account_move.py
+++ b/addons/l10n_es_edi_facturae/models/account_move.py
@@ -234,9 +234,7 @@ class AccountMove(models.Model):
             price_before_discount = sum(to_update['price_subtotal'] for _dummy, to_update in tax_before_discount['base_lines_to_update'])
             discount = max(0., (price_before_discount - line.price_subtotal))
             surcharge = abs(min(0., (price_before_discount - line.price_subtotal)))
-            totals['total_gross_amount'] += price_before_discount
-            totals['total_general_discounts'] += discount
-            totals['total_general_surcharges'] += surcharge
+            totals['total_gross_amount'] += line.price_subtotal
             base_line = self.env['account.tax']._convert_to_tax_base_line_dict(
                 line, partner=line.partner_id, currency=line.currency_id, product=line.product_id, taxes=line.tax_ids,
                 price_unit=line.price_unit, quantity=line.quantity, discount=line.discount, account=line.account_id,
@@ -254,7 +252,7 @@ class AccountMove(models.Model):
             totals['total_taxes_withheld'] += sum((abs(tax["tax_amount"]) for tax in taxes_withheld_computed))
 
             invoice_line_values.update({
-                'FileReference': self._l10n_es_edi_facturae_get_filename().split('.')[0][:20],
+                'FileReference': self.ref[:20] if self.ref else False,
                 'FileDate': fields.Date.context_today(self),
                 'ItemDescription': line.name,
                 'Quantity': line.quantity,
@@ -362,6 +360,9 @@ class AccountMove(models.Model):
                     'ExchangeRateDetails': need_conv,
                     'ExchangeRate': f"{round(conversion_rate, 4):.4f}",
                     'LanguageName': self._context.get('lang', 'en_US').split('_')[0],
+                    'ReceiverTransactionReference': self.ref[:20] if self.ref else False,
+                    'FileReference': self.ref[:20] if self.ref else False,
+                    'ReceiverContractReference': self.ref[:20] if self.ref else False,
                 },
                 'TaxOutputs': taxes,
                 'TaxesWithheld': taxes_withheld,

--- a/addons/l10n_es_edi_facturae/tests/data/expected_in_invoice_document.xml
+++ b/addons/l10n_es_edi_facturae/tests/data/expected_in_invoice_document.xml
@@ -123,8 +123,6 @@
       </TaxesOutputs>
       <InvoiceTotals>
         <TotalGrossAmount>2400.00</TotalGrossAmount>
-        <TotalGeneralDiscounts>100.00</TotalGeneralDiscounts>
-        <TotalGeneralSurcharges>100.00</TotalGeneralSurcharges>
         <TotalGrossAmountBeforeTaxes>2400.00</TotalGrossAmountBeforeTaxes>
         <TotalTaxOutputs>504.00</TotalTaxOutputs>
         <TotalTaxesWithheld>0.00</TotalTaxesWithheld>
@@ -134,7 +132,6 @@
       </InvoiceTotals>
       <Items>
         <InvoiceLine>
-          <FileReference>BILL_2023_01_0001_fa</FileReference>
           <FileDate>2023-01-01</FileDate>
           <ItemDescription>product_a</ItemDescription>
           <Quantity>1.0</Quantity>
@@ -156,7 +153,6 @@
           </TaxesOutputs>
         </InvoiceLine>
         <InvoiceLine>
-          <FileReference>BILL_2023_01_0001_fa</FileReference>
           <FileDate>2023-01-01</FileDate>
           <ItemDescription>product_a</ItemDescription>
           <Quantity>1.0</Quantity>
@@ -178,7 +174,6 @@
           </TaxesOutputs>
         </InvoiceLine>
         <InvoiceLine>
-          <FileReference>BILL_2023_01_0001_fa</FileReference>
           <FileDate>2023-01-01</FileDate>
           <ItemDescription>product_a</ItemDescription>
           <Quantity>1.0</Quantity>
@@ -200,7 +195,6 @@
           </TaxesOutputs>
         </InvoiceLine>
         <InvoiceLine>
-          <FileReference>BILL_2023_01_0001_fa</FileReference>
           <FileDate>2023-01-01</FileDate>
           <ItemDescription>product_a</ItemDescription>
           <Quantity>1.0</Quantity>
@@ -229,7 +223,6 @@
           </TaxesOutputs>
         </InvoiceLine>
         <InvoiceLine>
-          <FileReference>BILL_2023_01_0001_fa</FileReference>
           <FileDate>2023-01-01</FileDate>
           <ItemDescription>product_a</ItemDescription>
           <Quantity>1.0</Quantity>

--- a/addons/l10n_es_edi_facturae/tests/data/expected_refund_document.xml
+++ b/addons/l10n_es_edi_facturae/tests/data/expected_refund_document.xml
@@ -79,6 +79,9 @@
         <InvoiceCurrencyCode>EUR</InvoiceCurrencyCode>
         <TaxCurrencyCode>EUR</TaxCurrencyCode>
         <LanguageName>en</LanguageName>
+        <ReceiverTransactionReference>ABCD-2023-001</ReceiverTransactionReference>
+        <FileReference>ABCD-2023-001</FileReference>
+        <ReceiverContractReference>ABCD-2023-001</ReceiverContractReference>
       </InvoiceIssueData>
       <TaxesOutputs>
         <Tax>
@@ -113,7 +116,7 @@
       </InvoiceTotals>
       <Items>
         <InvoiceLine>
-          <FileReference>RINV_2023_00001_fact</FileReference>
+          <FileReference>ABCD-2023-001</FileReference>
           <FileDate>2023-01-01</FileDate>
           <ItemDescription>product_a</ItemDescription>
           <Quantity>1.0</Quantity>
@@ -135,7 +138,7 @@
           </TaxesOutputs>
         </InvoiceLine>
         <InvoiceLine>
-          <FileReference>RINV_2023_00001_fact</FileReference>
+          <FileReference>ABCD-2023-001</FileReference>
           <FileDate>2023-01-01</FileDate>
           <ItemDescription>product_a</ItemDescription>
           <Quantity>1.0</Quantity>

--- a/addons/l10n_es_edi_facturae/tests/data/expected_signed_document.xml
+++ b/addons/l10n_es_edi_facturae/tests/data/expected_signed_document.xml
@@ -123,8 +123,6 @@
       </TaxesOutputs>
       <InvoiceTotals>
         <TotalGrossAmount>2400.00</TotalGrossAmount>
-        <TotalGeneralDiscounts>100.00</TotalGeneralDiscounts>
-        <TotalGeneralSurcharges>100.00</TotalGeneralSurcharges>
         <TotalGrossAmountBeforeTaxes>2400.00</TotalGrossAmountBeforeTaxes>
         <TotalTaxOutputs>504.00</TotalTaxOutputs>
         <TotalTaxesWithheld>0.00</TotalTaxesWithheld>
@@ -134,7 +132,6 @@
       </InvoiceTotals>
       <Items>
         <InvoiceLine>
-          <FileReference>INV_2023_00001_factu</FileReference>
           <FileDate>2023-01-01</FileDate>
           <ItemDescription>product_a</ItemDescription>
           <Quantity>1.0</Quantity>
@@ -156,7 +153,6 @@
           </TaxesOutputs>
         </InvoiceLine>
         <InvoiceLine>
-          <FileReference>INV_2023_00001_factu</FileReference>
           <FileDate>2023-01-01</FileDate>
           <ItemDescription>product_a</ItemDescription>
           <Quantity>1.0</Quantity>
@@ -178,7 +174,6 @@
           </TaxesOutputs>
         </InvoiceLine>
         <InvoiceLine>
-          <FileReference>INV_2023_00001_factu</FileReference>
           <FileDate>2023-01-01</FileDate>
           <ItemDescription>product_a</ItemDescription>
           <Quantity>1.0</Quantity>
@@ -200,7 +195,6 @@
           </TaxesOutputs>
         </InvoiceLine>
         <InvoiceLine>
-          <FileReference>INV_2023_00001_factu</FileReference>
           <FileDate>2023-01-01</FileDate>
           <ItemDescription>product_a</ItemDescription>
           <Quantity>1.0</Quantity>
@@ -229,7 +223,6 @@
           </TaxesOutputs>
         </InvoiceLine>
         <InvoiceLine>
-          <FileReference>INV_2023_00001_factu</FileReference>
           <FileDate>2023-01-01</FileDate>
           <ItemDescription>product_a</ItemDescription>
           <Quantity>1.0</Quantity>
@@ -280,7 +273,7 @@
         <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
       </ds:Transforms>
       <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
-      <ds:DigestValue>cN6L3yc99HcqDtpzSzyc+yfZfJ0pw75UAMbuSbNtoAs=</ds:DigestValue>
+      <ds:DigestValue>+v+AUxz9tkW0fW3AllOweXyOER14IgfGTNUFE0dCilM=</ds:DigestValue>
     </ds:Reference>
     <ds:Reference Type="http://uri.etsi.org/01903#SignedProperties" URI="#SignatureProperties-Document-da39a3ee5e6b4b0d3255bfef95601890afd80709">
       <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
@@ -291,11 +284,11 @@
       <ds:DigestValue>ARCif8tQIKagVfeHX4Fit5ZfK3mXQCPclQISywh7h44=</ds:DigestValue>
     </ds:Reference>
   </ds:SignedInfo>
-  <ds:SignatureValue>PcHDk3Ey3jLr2aTxcc/uVfHllqA10t/bp54jo0EotZ6lN0dL2Q9rvsuDZLrqD6bqQ/YHbFkeGfmh
-c4QQKputlb6PZGZC1JVZ9FrI2MwstJ/d5LIMz7tS5Y5gSJnmNewD03EwRw3ne80T2PbZnaZSu5Oq
-wAyAblf+gpXawsK2sV0CBe9wtWHiY0VRYxqGz+2bmJyE6sVA3PVj8EjRbLMgo1G03D8ua/569l9I
-2iAivH/MkDpH2il3qXhqlqpp3BiN/nOie/yKJvI2DqT9VjyxQXmKXMwYmlA0z5KN6dQDZWf1mIl3
-bY1g5CfqTGONLUnGfo2Hg4spnIFfnRkgN+zKLA==
+  <ds:SignatureValue>Cj2/PhdPDOyj4wl5NAD029AUJmqDBT6AizdhBbHgRUI0Lnkd5I66qbhy0Mq2oD5XCE8dDGR7TFRI
+yWPlrSr33Boulu/isYWCfFXROjwMj20lipK3TwBuvD52SnuOiXd+dfWY+IutNyC1hSP8Sk7O1qiE
+C1abUoq2kOTYgn+US6lsS7+9bZcp/3j2KeF3zMDD/kaaVtPl4lU79wZyAyUA/GvSxcDr+7J3yxVQ
+K86e4v4S7l2FTdXGdcgauhKJ9BGbUhxVv59ceF5vGRrBoMvW61OcrLaUVyaQS9QNZH7vWOh1RyrI
+GotRRlx0kZP7HgLLv8F0DZPEUmqxzGFc8+7few==
 </ds:SignatureValue>
   <ds:KeyInfo Id="KeyInfo-Document-da39a3ee5e6b4b0d3255bfef95601890afd80709">
     <ds:X509Data>

--- a/addons/l10n_es_edi_facturae/tests/data/expected_tax_withholding.xml
+++ b/addons/l10n_es_edi_facturae/tests/data/expected_tax_withholding.xml
@@ -144,7 +144,6 @@
       </InvoiceTotals>
       <Items>
         <InvoiceLine>
-          <FileReference>INV_2023_00001_factu</FileReference>
           <FileDate>2023-01-01</FileDate>
           <ItemDescription>product_a</ItemDescription>
           <Quantity>1.0</Quantity>
@@ -178,7 +177,6 @@
           </TaxesWithheld>
         </InvoiceLine>
         <InvoiceLine>
-          <FileReference>INV_2023_00001_factu</FileReference>
           <FileDate>2023-01-01</FileDate>
           <ItemDescription>product_a</ItemDescription>
           <Quantity>1.0</Quantity>
@@ -212,7 +210,6 @@
           </TaxesWithheld>
         </InvoiceLine>
         <InvoiceLine>
-          <FileReference>INV_2023_00001_factu</FileReference>
           <FileDate>2023-01-01</FileDate>
           <ItemDescription>product_a</ItemDescription>
           <Quantity>1.0</Quantity>

--- a/addons/l10n_es_edi_facturae/tests/test_edi_xml.py
+++ b/addons/l10n_es_edi_facturae/tests/test_edi_xml.py
@@ -239,6 +239,7 @@ class TestEdiFacturaeXmls(AccountTestInvoicingCommon):
             })
             reversal_wizard.modify_moves()
             refund = invoice.reversal_move_id
+            refund.ref = 'ABCD-2023-001'
             generated_file, errors = refund._l10n_es_edi_facturae_render_facturae()
             self.assertFalse(errors)
             self.assertTrue(generated_file)

--- a/addons/l10n_es_edi_facturae_adm_centers/tests/data/expected_ac_document.xml
+++ b/addons/l10n_es_edi_facturae_adm_centers/tests/data/expected_ac_document.xml
@@ -131,7 +131,6 @@
       </InvoiceTotals>
       <Items>
         <InvoiceLine>
-          <FileReference>INV_2023_00001_factu</FileReference>
           <FileDate>2023-01-01</FileDate>
           <ItemDescription>product_a</ItemDescription>
           <Quantity>1.0</Quantity>

--- a/addons/l10n_es_edi_facturae_invoice_period/tests/data/expected_invoice_period_document.xml
+++ b/addons/l10n_es_edi_facturae_invoice_period/tests/data/expected_invoice_period_document.xml
@@ -96,7 +96,6 @@
       </InvoiceTotals>
       <Items>
         <InvoiceLine>
-          <FileReference>INV_2023_00001_factu</FileReference>
           <FileDate>2023-01-01</FileDate>
           <ItemDescription>product_a</ItemDescription>
           <Quantity>1.0</Quantity>


### PR DESCRIPTION
[FIX] l10n_es_edi_facutrae: fix TotalGrossAmount and new fields

- The tag TotalGrossAmount should be the sum of the GrossAmount tag
  which is calculated as (price - discount + charge).
  Currently, the TotalGrossAmount is calculated as the sum of the price
  before subtracting the discount and adding the charge.
- Add new fields to the XML.
- Remove fields for total general discounts and charges as they were
  computed incorrectly.

task-4001821