### PR TITLE
[IMP] stock : permissive quant edition

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -5,6 +5,7 @@ from collections import namedtuple
 
 from ast import literal_eval
 from collections import defaultdict
+from itertools import chain
 from markupsafe import escape
 from psycopg2 import Error
 
@@ -264,11 +265,8 @@ class StockQuant(models.Model):
 
         quants = self.env['stock.quant']
         is_inventory_mode = self._is_inventory_mode()
-        allowed_fields = self._get_inventory_fields_create()
         for vals in vals_list:
             if is_inventory_mode and any(f in vals for f in ['inventory_quantity', 'inventory_quantity_auto_apply']):
-                if any(field for field in vals.keys() if field not in allowed_fields):
-                    raise UserError(_("Quant's creation is restricted, you can't do this operation."))
                 auto_apply = 'inventory_quantity_auto_apply' in vals
                 inventory_quantity = vals.pop('inventory_quantity_auto_apply', False) or vals.pop(
                     'inventory_quantity', False) or 0
@@ -346,20 +344,58 @@ class StockQuant(models.Model):
         }]
 
     @api.model
-    def _get_forbidden_fields_write(self):
-        """ Returns a list of fields user can't edit when he want to edit a quant in `inventory_mode`."""
-        return ['product_id', 'location_id', 'lot_id', 'package_id', 'owner_id']
+    def _trigger_inventory_moves(vals):
+        return any(field in vals for field in ['location_id', 'lot_id', 'package_id', 'owner_id'])
+
+    @api.model
+    def _get_specific_fields_write(self):
+        """ Model method.
+        Return a list of field for which a balanced pair of move are created on edition.
+        :return: List of String
+        """
+        return ['location_id', 'lot_id', 'package_id', 'owner_id']
+
+    def _update_quant_by_moves(self, vals):
+        """ Handle update of more specific fields"""
+        # if any key of vals in specific fields => Move+ & Move- with all values
+
+        move_vals = list(chain.from_iterable([
+            # 'Undo' actual quant
+            quant._get_inventory_move_values(
+                quant.quantity,
+                quant.location_id,
+                quant.product_id.with_company(quant.company_id).property_stock_inventory,
+                package_id=quant.package_id,
+                product_id=quant.product_id,
+                lot_id=quant.lot_id,
+                owner_id=quant.owner_id,
+            ),
+            # 'Do' new quant
+            quant._get_inventory_move_values(
+                vals.get('quantity', quant.quantity),
+                quant.product_id.with_company(quant.company_id).property_stock_inventory,
+                self.env['stock.location'].browse(vals['location_id']) if 'location_id' in vals else quant.location_id,
+                package_dest_id=self.env['stock.quant.package'].browse(vals['package_id']) if 'package_id' in vals else quant.package_id,
+                product_id=self.env['product.product'].browse(vals['product_id']) if 'product_id' in vals else quant.product_id,
+                lot_id=self.env['stock.lot'].browse(vals['lot_id']) if 'lot_id' in vals else quant.lot_id,
+                owner_id=self.env['res.partner'].browse(vals['owner_id']) if 'owner_id' in vals else quant.owner_id,
+            )
+        ] for quant in self))
+        moves = self.env['stock.move'].create(move_vals)
+        moves._action_done()
 
     def write(self, vals):
         """ Override to handle the "inventory mode" and create the inventory move. """
-        forbidden_fields = self._get_forbidden_fields_write()
-        if self._is_inventory_mode() and any(field for field in forbidden_fields if field in vals.keys()):
+        if self._is_inventory_mode():
             if any(quant.location_id.usage == 'inventory' for quant in self):
                 # Do nothing when user tries to modify manually a inventory loss
                 return
+            if self._trigger_inventory_moves(vals):
+                self._update_quant_by_moves(vals)
+                vals.pop('inventory_quantity_auto_apply', None)  # Avoid falsy 'Serial duplicated' error
             self = self.sudo()
-            raise UserError(_("Quant's editing is restricted, you can't do this operation."))
-        return super(StockQuant, self).write(vals)
+        res = super().write(vals)
+        return res
 
     @api.ondelete(at_uninstall=False)
     def _unlink_except_wrong_permission(self):
@@ -1206,22 +1242,7 @@ class StockQuant(models.Model):
         """
         return self.env.context.get('inventory_mode') and self.env.user.has_group('stock.group_stock_user')
 
-    @api.model
-    def _get_inventory_fields_create(self):
-        """ Returns a list of fields user can edit when he want to create a quant in `inventory_mode`.
-        """
-        return ['product_id', 'owner_id'] + self._get_inventory_fields_write()
-
-    @api.model
-    def _get_inventory_fields_write(self):
-        """ Returns a list of fields user can edit when he want to edit a quant in `inventory_mode`.
-        """
-        fields = ['inventory_quantity', 'inventory_quantity_auto_apply', 'inventory_diff_quantity',
-                  'inventory_date', 'user_id', 'inventory_quantity_set', 'is_outdated', 'lot_id',
-                  'location_id', 'package_id']
-        return fields
-
-    def _get_inventory_move_values(self, qty, location_id, location_dest_id, package_id=False, package_dest_id=False):
+    def _get_inventory_move_values(self, qty, location_id, location_dest_id, package_id=False, package_dest_id=False, product_id=False, lot_id=False, owner_id=False):
         """ Called when user manually set a new quantity (via `inventory_quantity`)
         just before creating the corresponding stock move.
 
@@ -1229,6 +1250,8 @@ class StockQuant(models.Model):
         :param location_dest_id: `stock.location`
         :param package_id: `stock.quant.package`
         :param package_dest_id: `stock.quant.package`
+        :param lot_id: `stock.lot`
+        :param owner_id: `res.partner`
         :return: dict with all values needed to create a new `stock.move` with its move line.
         """
         self.ensure_one()
@@ -1243,27 +1266,27 @@ class StockQuant(models.Model):
 
         return {
             'name': name,
-            'product_id': self.product_id.id,
-            'product_uom': self.product_uom_id.id,
+            'product_id': product_id.id if product_id else self.product_id.id,
+            'product_uom': product_id.uom_id.id if product_id else self.product_uom_id.id,
             'product_uom_qty': qty,
             'company_id': self.company_id.id or self.env.company.id,
             'state': 'confirmed',
             'location_id': location_id.id,
             'location_dest_id': location_dest_id.id,
-            'restrict_partner_id':  self.owner_id.id,
+            'restrict_partner_id': owner_id.id if owner_id else self.owner_id.id,
             'is_inventory': True,
             'picked': True,
             'move_line_ids': [(0, 0, {
-                'product_id': self.product_id.id,
-                'product_uom_id': self.product_uom_id.id,
+                'product_id': product_id.id if product_id else self.product_id.id,
+                'product_uom_id': product_id.uom_id.id if product_id else self.product_uom_id.id,
                 'quantity': qty,
                 'location_id': location_id.id,
                 'location_dest_id': location_dest_id.id,
                 'company_id': self.company_id.id or self.env.company.id,
-                'lot_id': self.lot_id.id,
+                'lot_id': lot_id.id if lot_id else self.lot_id.id,
                 'package_id': package_id.id if package_id else False,
                 'result_package_id': package_dest_id.id if package_dest_id else False,
-                'owner_id': self.owner_id.id,
+                'owner_id': owner_id.id if owner_id else self.owner_id.id,
             })]
         }
 

--- a/addons/stock/tests/test_quant.py
+++ b/addons/stock/tests/test_quant.py
@@ -910,24 +910,7 @@ class StockQuant(TransactionCase):
         quant_2 = product.stock_quant_ids[1]
         self.assertEqual(quant_2.with_context(inventory_mode=True).sn_duplicated, True)
         with self.assertRaises(UserError):
-            quant_2.with_context(inventory_mode=True).write({'location_id': self.stock_subloc2})
-
-    def test_update_quant_with_forbidden_field_02(self):
-        """
-        Test that updating the package from the quant raise an error
-        but if the package is unpacked, the quant can be updated.
-        """
-        package = self.env['stock.quant.package'].create({
-            'name': 'Package',
-        })
-        self.env['stock.quant']._update_available_quantity(self.product, self.stock_location, 1.0, package_id=package)
-        quant = self.product.stock_quant_ids
-        self.assertEqual(len(self.product.stock_quant_ids), 1)
-        with self.assertRaises(UserError):
-            quant.with_context(inventory_mode=True).write({'package_id': False})
-        package.with_context(inventory_mode=True).unpack()
-        self.assertFalse(quant.exists())
-        self.assertFalse(self.product.stock_quant_ids.package_id)
+            quant_2.with_context(inventory_mode=True).write({'location_id': self.stock_subloc2.id})  # Still forbiden as SN is duplicated
 
     def test_relocate(self):
         """ Test the relocation wizard. """

--- a/addons/stock/tests/test_quant_inventory_mode.py
+++ b/addons/stock/tests/test_quant_inventory_mode.py
@@ -151,15 +151,15 @@ class TestEditableQuant(TransactionCase):
             'inventory_quantity': 20,
         })
         inventoried_quant.action_apply_inventory()
-        with self.assertRaises(UserError):
-            invalid_quant = self.env['stock.quant'].with_context(inventory_mode=True).create({
-                'product_id': self.product.id,
-                'location_id': self.room2.id,
-                'quantity': 10,
-                'inventory_quantity': 20,
-            })
+        specific_fields_quant = self.env['stock.quant'].with_context(inventory_mode=True).create({
+            'product_id': self.product.id,
+            'location_id': self.room2.id,
+            'quantity': 10,
+            'inventory_quantity': 20,
+        })
         self.assertEqual(valid_quant.quantity, 10)
         self.assertEqual(inventoried_quant.quantity, 20)
+        self.assertEqual(specific_fields_quant.quantity, 10)
 
     def test_edit_quant_1(self):
         """ Increases manually quantity of a quant.

--- a/addons/stock/views/stock_quant_views.xml
+++ b/addons/stock/views/stock_quant_views.xml
@@ -125,7 +125,6 @@
                 <field name="company_id" column_invisible="True"/>
                 <field name="location_id"
                        column_invisible="context.get('hide_location', False)"
-                       readonly="id"
                        options="{'no_create': True}"/>
                 <field name="storage_category_id" optional="hide"/>
                 <field name="product_id"
@@ -133,14 +132,12 @@
                        options="{'no_create': True}" widget="many2one"/>
                 <field name="product_categ_id" optional="hide"/>
                 <field name='company_id' groups="base.group_multi_company" optional="hidden"/>
-                <field name="package_id" groups="stock.group_tracking_lot"
-                       readonly="id"/>
+                <field name="package_id" groups="stock.group_tracking_lot"/>
                 <field name="lot_id" groups="stock.group_production_lot"
                        column_invisible="context.get('hide_lot', False)"
-                       readonly="id or tracking not in ['serial', 'lot']"
+                       readonly="tracking not in ['serial', 'lot']"
                        context="{'default_product_id': product_id}"/>
                 <field name="owner_id" groups="stock.group_tracking_owner"
-                       readonly="id"
                        options="{'no_create': True}"/>
                 <field name="inventory_quantity_auto_apply" string="On Hand Quantity" readonly="0" sum="Total On Hand"/>
                 <field name="reserved_quantity" optional="show" sum="Total Reserved"/>
@@ -438,17 +435,17 @@ in this location. That leads to a negative stock.
                 <field name="storage_category_id" groups="stock.group_stock_multi_locations" column_invisible="context.get('hide_location', False)" options="{'no_create': True}" optional="hidden"/>
                 <field name="cyclic_inventory_frequency" column_invisible="context.get('hide_location', False)" options="{'no_create': True}" optional="hidden"/>
                 <field name="is_favorite" widget="boolean_favorite" nolabel="1" optional="hidden"/>
-                <field name="product_id" readonly="context.get('single_product', False) or id" force_save="1" options="{'no_create': True}"/>
+                <field name="product_id" readonly="context.get('single_product', False)" force_save="1" options="{'no_create': True}"/>
                 <field name="product_categ_id" optional="hide"/>
                 <button name="action_warning_duplicated_sn" type="object" invisible="not sn_duplicated" title="This lot/serial number is already in another location" class="btn btn-secondary text-warning float-end" icon="fa-warning"/>
                 <field name="lot_id" groups="stock.group_production_lot"
                     column_invisible="context.get('hide_lot', False)"
-                    readonly="tracking not in ['serial', 'lot'] or (id and (lot_id or quantity != 0))"
+                    readonly="tracking not in ['serial', 'lot']"
                     context="{'default_product_id': product_id}"
                     decoration-warning="sn_duplicated"
                     force_save="1"/>
-                <field name="package_id" groups="stock.group_tracking_lot" readonly="id"/>
-                <field name="owner_id" groups="stock.group_tracking_owner" readonly="id" options="{'no_create': True}"/>
+                <field name="package_id" groups="stock.group_tracking_lot"/>
+                <field name="owner_id" groups="stock.group_tracking_owner" options="{'no_create': True}"/>
                 <field name="last_count_date" optional='hidden' readonly='1'/>
                 <field name="available_quantity" string="Available Quantity" decoration-danger="available_quantity &lt; 0" optional="hidden"/>
                 <field name="quantity" optional="show" decoration-warning="quantity &lt; 0" string="On Hand Quantity"/>

--- a/addons/stock_account/models/stock_quant.py
+++ b/addons/stock_account/models/stock_quant.py
@@ -89,8 +89,8 @@ class StockQuant(models.Model):
             else:
                 super(StockQuant, inventories)._apply_inventory()
 
-    def _get_inventory_move_values(self, qty, location_id, location_dest_id, package_id=False, package_dest_id=False):
-        res_move = super()._get_inventory_move_values(qty, location_id, location_dest_id, package_id, package_dest_id)
+    def _get_inventory_move_values(self, qty, location_id, location_dest_id, package_id=False, package_dest_id=False, product_id=False, lot_id=False, owner_id=False):
+        res_move = super()._get_inventory_move_values(qty, location_id, location_dest_id, package_id, package_dest_id, product_id, lot_id, owner_id)
         if not self.env.context.get('inventory_name'):
             force_period_date = self.env.context.get('force_period_date', False)
             if force_period_date:


### PR DESCRIPTION
Main: 
Allow the user to edit previously forbidden fields.

Before:
The edition of the fields location_id, lot_id, package_id and owner_id are not allowed.

After:
On edition of the aforementioned fields, stock move are generated to apply the change .


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
