### PR TITLE
[FIX] l10n_be_pos_sale: force invoice for intracom

### DIFF
--- a/addons/l10n_be_pos_sale/__init__.py
+++ b/addons/l10n_be_pos_sale/__init__.py
@@ -1,1 +1,3 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models

--- a/addons/l10n_be_pos_sale/i18n/l10n_be_pos_sale.pot
+++ b/addons/l10n_be_pos_sale/i18n/l10n_be_pos_sale.pot
@@ -20,8 +20,9 @@ msgstr ""
 #: code:addons/l10n_be_pos_sale/static/src/js/PaymentScreen.js:0
 #, python-format
 msgid ""
-"If you do not invoice imported orders you will encounter issues in your "
-"accounting. Especially in the EC Sale List report"
+"If you do not invoice imported orders containing intra-community taxes you "
+"will encounter issues in your accounting. Especially in the EC Sales List "
+"report"
 msgstr ""
 
 #. module: l10n_be_pos_sale

--- a/addons/l10n_be_pos_sale/models/__init__.py
+++ b/addons/l10n_be_pos_sale/models/__init__.py
@@ -1,0 +1,1 @@
+from . import pos_session

--- a/addons/l10n_be_pos_sale/models/pos_session.py
+++ b/addons/l10n_be_pos_sale/models/pos_session.py
@@ -1,0 +1,13 @@
+from odoo import models
+
+
+class PosSession(models.Model):
+    _inherit = 'pos.session'
+
+    def _pos_data_process(self, loaded_data):
+        res = super()._pos_data_process(loaded_data)
+        if self.company_id.country_code == 'BE':
+            intracom_fpos = self.env["account.chart.template"].with_company(
+                self.company_id).ref("fiscal_position_template_3", False)
+            loaded_data['intracom_tax_ids'] = intracom_fpos.tax_ids.tax_dest_id.ids
+        return res

--- a/addons/l10n_be_pos_sale/static/src/js/PaymentScreen.js
+++ b/addons/l10n_be_pos_sale/static/src/js/PaymentScreen.js
@@ -6,12 +6,14 @@ import { patch } from "@web/core/utils/patch";
 import { _t } from "@web/core/l10n/translation";
 
 patch(PaymentScreen.prototype, {
-    toggleIsToInvoice() {
-        const has_origin_order = this.currentOrder.get_orderlines().some(line => line.sale_order_origin_id);
-        if(this.currentOrder.is_to_invoice() && this.pos.company.country && this.pos.company.country.code === "BE" && has_origin_order){
+    async toggleIsToInvoice() {
+        const orderLines = this.currentOrder.get_orderlines();
+        const has_origin_order = orderLines.some(line => line.sale_order_origin_id);
+        const has_intracom_taxes = orderLines.some(line=>line.tax_ids?.some(tax=>this.pos.intracom_tax_ids.includes(tax)));
+        if(this.currentOrder.is_to_invoice() && this.pos.company.country?.code === "BE" && has_origin_order && has_intracom_taxes){
             this.popup.add(ErrorPopup, {
                 title: _t('This order needs to be invoiced'),
-                body: _t('If you do not invoice imported orders you will encounter issues in your accounting. Especially in the EC Sale List report'),
+                body: _t('If you do not invoice imported orders containing intra-community taxes you will encounter issues in your accounting. Especially in the EC Sales List report'),
             });
         }
         else{

--- a/addons/l10n_be_pos_sale/static/src/js/models.js
+++ b/addons/l10n_be_pos_sale/static/src/js/models.js
@@ -2,6 +2,7 @@
 
 import { patch } from "@web/core/utils/patch";
 import { Order } from "@point_of_sale/app/store/models";
+import { PosStore } from "@point_of_sale/app/store/pos_store";
 
 patch(Order.prototype, {
     async pay() {
@@ -11,4 +12,13 @@ patch(Order.prototype, {
         }
         return super.pay(...arguments);
     }
+});
+
+patch(PosStore.prototype, {
+    async _processData(loadedData) {
+        await super._processData(...arguments);
+        if (this.company.country?.code == "BE") {
+            this.intracom_tax_ids = loadedData["intracom_tax_ids"];
+        }
+    },
 });

--- a/addons/l10n_be_pos_sale/tests/test_l10n_be_pos_sale.py
+++ b/addons/l10n_be_pos_sale/tests/test_l10n_be_pos_sale.py
@@ -16,6 +16,27 @@ class TestPoSSaleL10NBe(TestPointOfSaleHttpCommon):
         #Change company country to Belgium
         self.env.user.company_id.country_id = self.env.ref('base.be')
 
+        intracom_fpos = self.env["account.chart.template"].with_company(
+            self.env.user.company_id).ref("fiscal_position_template_3", False)
+
+        intracom_tax = self.env['account.tax'].create({
+            'name': 'test_intracom_taxes_computation_0_1',
+            'amount_type': 'percent',
+            'amount': 21,
+            'invoice_repartition_line_ids': [
+                (0, 0, {'repartition_type': 'base', 'factor_percent': 100.0}),
+                (0, 0, {'repartition_type': 'tax', 'factor_percent': 100.0}),
+                (0, 0, {'repartition_type': 'tax', 'factor_percent': -100.0}),
+            ],
+            'refund_repartition_line_ids': [
+                (0, 0, {'repartition_type': 'base', 'factor_percent': 100.0}),
+                (0, 0, {'repartition_type': 'tax', 'factor_percent': 100.0}),
+                (0, 0, {'repartition_type': 'tax', 'factor_percent': -100.0}),
+            ],
+        })
+
+        intracom_fpos.tax_ids.tax_dest_id = intracom_tax
+
         self.product_a = self.env['product.product'].create({
             'name': 'Product A',
             'type': 'product',
@@ -31,7 +52,7 @@ class TestPoSSaleL10NBe(TestPointOfSaleHttpCommon):
                 'product_uom_qty': 10,
                 'product_uom': self.product_a.uom_id.id,
                 'price_unit': 10,
-                'tax_id': False,
+                'tax_id': intracom_tax,
             })],
         })
 


### PR DESCRIPTION
Previously, settling a sale.order from the POS of a Belgian company
would require the creation of an invoice.

This was actually only necessary when the sale contains intra-community
(EU) taxes. Those are the taxes that are mapped to (dest_tax_id) by the
Intra-Community fiscal position.
See https://github.com/odoo-dev/odoo/commit/70f3b748f7098b60e02e8235f2007e4b94f666c3

This commit narrows down the enforcement of the invoice creation to only
target sales made with such taxes.

opw-[3986443](https://www.odoo.com/odoo/project.task/3986443?cids=1)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
