### PR TITLE
[FIX] Forecast button on form view - access error for user with only …

### DIFF
--- a/addons/stock/report/stock_forecasted.py
+++ b/addons/stock/report/stock_forecasted.py
@@ -158,7 +158,7 @@ class StockForecasted(models.AbstractModel):
         if move_in:
             document_in = move_in._get_source_document()
             line.update({
-                'move_in' : move_in.read()[0] if read else move_in,
+                'move_in': move_in.sudo().read()[0] if read else move_in,
                 'document_in' : {
                     '_name' : document_in._name,
                     'id' : document_in.id,
@@ -170,7 +170,7 @@ class StockForecasted(models.AbstractModel):
         if move_out:
             document_out = move_out._get_source_document()
             line.update({
-                'move_out' : move_out.read()[0] if read else move_out,
+                'move_out': move_out.sudo().read()[0] if read else move_out,
                 'document_out' : {
                     '_name' : document_out._name,
                     'id' : document_out.id,

--- a/doc/cla/corporate/oerp.md
+++ b/doc/cla/corporate/oerp.md
@@ -18,3 +18,4 @@ Lucas Jagel lj@oerp.ca https://github.com/lj-oerp
 Daryl Chen dc@oerp.ca https://github.com/dc-oerp
 Hetal Solanki hs@oerp.ca https://github.com/hs-oerp
 Foram Darji fd@oerp.ca https://github.com/fd-oerp
+Mitesh Savani ms@oerp.ca https://github.com/ms-oerp


### PR DESCRIPTION
…access of Inventory/user and Sales/All Documents

Description of the issue/feature this PR addresses:

To solve the Access Right Warning when User with the following aceess try to access forecast report from forecast button in product form view.

Internal User: With Access of Inventory/User, Sales/User: All Documents

This is because user is allowed to do sales operations only. and with inventory user access right so they should able to click on Forecast button to see future availability of the stock in order to close the sales


Current behavior before PR:
User Will Face error of access right of "Stock.Valuation.Layer" read access Missing.
and Ones we give Read access of "stock.valuation.layer" user will another error for "purchase.requisition.line" read access.
(If Purchase Requisition module is installed)

Desired behavior after PR is merged:
User should not face access error and able to see the forecast report. as they want to perform sales operation.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
