### PR TITLE
[FIX] stock: should_bypass_reservation for internal scrap locations

### DIFF
--- a/addons/stock/models/stock_location.py
+++ b/addons/stock/models/stock_location.py
@@ -348,7 +348,11 @@ class Location(models.Model):
 
     def should_bypass_reservation(self):
         self.ensure_one()
-        return self.usage in ('supplier', 'customer', 'inventory', 'production') or self.scrap_location or (self.usage == 'transit' and not self.company_id)
+        return (
+            self.usage in ('supplier', 'customer', 'inventory', 'production')
+            or (self.scrap_location and self.usage != 'internal')
+            or (self.usage == 'transit' and not self.company_id)
+        )
 
     def _check_can_be_used(self, product, quantity=0, package=None, location_qty=0):
         """Check if product/package can be stored in the location. Quantity

--- a/doc/cla/individual/Kosaaaaa.md
+++ b/doc/cla/individual/Kosaaaaa.md
@@ -1,0 +1,11 @@
+Poland, 2024-08-03
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Oskar Kosobucki 43652764+kosaaaaa@users.noreply.github.com https://github.com/Kosaaaaa


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR: It is possible to skip reservation on internal scrap locations and have negative quantity on this location.

Desired behavior after PR is merged: Make reservation on scrap internal location to prevent this situation.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
