### PR TITLE
 [IMP] *: add customizable model logging

### DIFF
--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -589,6 +589,13 @@ class Message(models.Model):
 
         return self.browse()
 
+    _audit_fieldnames = {'body', 'subject', 'date', 'author_id'}
+
+    def _filter_audit_records(self):
+        # Logging all the message modification would bloat the logs but logs messages from different user than the
+        # author_id seems a good tradeoff
+        return self.filtered(lambda m: 1 != self.env.user.id != m.author_id._uid)
+
     @api.model_create_multi
     def create(self, values_list):
         tracking_values_list = []

--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -627,6 +627,8 @@ class IrActionsServer(models.Model):
                                               "The name of the action that triggered the webhook is always sent as '_name'.")
     webhook_sample_payload = fields.Text(string='Sample Payload', compute='_compute_webhook_sample_payload')
 
+    _audit_fieldnames = {'name', 'type', 'usage', 'code', 'state', 'model_id', 'groups_id', 'model_name', 'code', 'binding_model_id'}
+
     @api.constrains('webhook_field_ids')
     def _check_webhook_field_ids(self):
         """Check that the selected fields don't have group restrictions"""

--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -2006,6 +2006,8 @@ class IrModelAccess(models.Model):
     perm_create = fields.Boolean(string='Create Access')
     perm_unlink = fields.Boolean(string='Delete Access')
 
+    _audit_fieldnames = {"name", "active", "model_id", "group_id", "perm_read", "perm_write", "perm_create", "perm_unlink"}
+
     @api.model
     def group_names_with_access(self, model_name, access_mode):
         """ Return the names of visible groups which have been granted

--- a/odoo/addons/base/models/ir_rule.py
+++ b/odoo/addons/base/models/ir_rule.py
@@ -26,6 +26,9 @@ class IrRule(models.Model):
     perm_create = fields.Boolean(string='Create', default=True)
     perm_unlink = fields.Boolean(string='Delete', default=True)
 
+    _audit_fieldnames = {'name', 'active', 'model_id', 'groups', 'domain_force', 'perm_read', 'perm_write', 'perm_create',
+                    'perm_unlink'}
+
     _sql_constraints = [
         ('no_access_rights',
          'CHECK (perm_read!=False or perm_write!=False or perm_create!=False or perm_unlink!=False)',

--- a/odoo/addons/base/models/ir_ui_menu.py
+++ b/odoo/addons/base/models/ir_ui_menu.py
@@ -43,6 +43,9 @@ class IrUiMenu(models.Model):
 
     web_icon_data = fields.Binary(string='Web Icon Image', attachment=True)
 
+    _audit_fieldnames = {'name', 'active', 'sequence', 'child_id', 'parent_id', 'parent_path', 'groups_id', 'action',
+                      'complete_name'}
+
     @api.depends('name', 'parent_id.complete_name')
     def _compute_complete_name(self):
         for menu in self:

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -206,6 +206,8 @@ actual arch.
          """)
     model_id = fields.Many2one("ir.model", string="Model of the view", compute='_compute_model_id', inverse='_inverse_compute_model_id')
 
+    _audit_fieldnames = {'name', 'model', 'key', 'priority', 'inherit_id', 'xml_id', 'groups_id', 'mode'}
+
     @api.depends('arch_db', 'arch_fs', 'arch_updated')
     @api.depends_context('read_arch_from_file', 'lang', 'edit_translations', 'check_translations')
     def _compute_arch(self):

--- a/odoo/addons/base/models/res_company.py
+++ b/odoo/addons/base/models/res_company.py
@@ -83,6 +83,10 @@ class Company(models.Model):
         ('name_uniq', 'unique (name)', 'The company name must be unique!')
     ]
 
+    _audit_fieldnames = True
+    _audit_no_val_fieldnames = {'logo', 'logo_web', 'favicon', 'font', 'primary_color', 'secondary_color',
+                              'layout_background', 'layout_background_image'}
+
     def init(self):
         for company in self.search([('paperformat_id', '=', False)]):
             paperformat_euro = self.env.ref('base.paperformat_euro', False)

--- a/odoo/addons/base/models/res_config.py
+++ b/odoo/addons/base/models/res_config.py
@@ -8,6 +8,7 @@ from odoo import api, models, _
 from odoo.exceptions import AccessError, RedirectWarning, UserError
 
 _logger = logging.getLogger(__name__)
+_audit_logger = logging.getLogger('audit.res.config')
 
 
 class ResConfigModuleInstallationMixin(object):
@@ -326,6 +327,7 @@ class ResConfigSettings(models.TransientModel, ResConfigModuleInstallationMixin)
         self = self.with_context(active_test=False)
         classified = self._get_classified_fields()
         current_settings = self.default_get(list(self.fields_get()))
+        data_to_log = []
 
         # default values fields
         IrDefault = self.env['ir.default'].sudo()
@@ -339,6 +341,10 @@ class ResConfigSettings(models.TransientModel, ResConfigModuleInstallationMixin)
                 value = self[name]
             if name not in current_settings or value != current_settings[name]:
                 IrDefault.set(model, field, value)
+                previous_value = ""
+                if name in current_settings:
+                    previous_value = f"{current_settings[name]} ==> "
+                data_to_log.append(f"{previous_value}{model}.{field} = value")
 
         # group fields: modify group / implied groups
         for name, groups, implied_group in sorted(classified['group'], key=lambda k: self[k[0]]):
@@ -348,8 +354,10 @@ class ResConfigSettings(models.TransientModel, ResConfigModuleInstallationMixin)
                 continue
             if int(self[name]):
                 groups._apply_group(implied_group)
+                data_to_log.append(f"{implied_group} added")
             else:
                 groups._remove_group(implied_group)
+                data_to_log.append(f"{implied_group} removed")
 
         # config fields: store ir.config_parameters
         IrConfigParameter = self.env['ir.config_parameter'].sudo()
@@ -370,7 +378,12 @@ class ResConfigSettings(models.TransientModel, ResConfigModuleInstallationMixin)
 
             if current_value == str(value) or current_value == value:
                 continue
+            data_to_log.append(f" {icp} : {current_value} ==>>{value}")
             IrConfigParameter.set_param(icp, value)
+        if data_to_log:
+            data = ", ".join(data_to_log)
+            _audit_logger.getChild("write").info("Settings modified for %r by user %r (#%d)", data,
+                self.env.user.login, self.env.user.id)
 
     def execute(self):
         """

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -199,6 +199,8 @@ class Groups(models.Model):
         ('check_api_key_duration', 'CHECK(api_key_duration >= 0)', 'The api key duration cannot be a negative value.'),
     ]
 
+    _audit_fieldnames = {'name', 'users', 'model_access', 'rule_groups', 'menu_access', 'view_access', 'category_id', 'share'}
+
     @api.constrains('users')
     def _check_one_user_type(self):
         self.users._check_one_user_type()
@@ -413,6 +415,9 @@ class Users(models.Model):
     _sql_constraints = [
         ('login_key', 'UNIQUE (login)', 'You can not have two users with the same login!')
     ]
+
+    _audit_fieldnames = {'partner_id', 'login', 'active', 'name', 'email', 'groups_id', 'share', 'company_id', 'company_ids'}
+    _audit_no_val_fieldnames = {'password', 'new_password', 'signature'}
 
     def init(self):
         cr = self.env.cr

--- a/odoo/addons/test_testing_utilities/ir.model.access.csv
+++ b/odoo/addons/test_testing_utilities/ir.model.access.csv
@@ -31,3 +31,5 @@ access_ttu_child,access_ttu_child,model_ttu_child,base.group_user,1,0,0,0
 access_ttu_grandchild,access_ttu_grandchild,model_ttu_grandchild,base.group_user,1,0,0,0
 access_res_config_test,access_res_config_test,test_testing_utilities.model_res_config_test,base.group_user,1,0,0,0
 access_wide,access_wide,model_test_testing_utilities_wide,,0,0,0,0
+access_test_audit,access_test_audit,test_testing_utilities.model_test_audit,base.group_user,1,0,0,0
+access_test_auditb,access_test_auditb,test_testing_utilities.model_test_auditb,base.group_user,1,0,0,0

--- a/odoo/addons/test_testing_utilities/models.py
+++ b/odoo/addons/test_testing_utilities/models.py
@@ -379,3 +379,35 @@ class Wide(models.Model):
     tax_ids = fields.Float()
     tax_line_id = fields.Float()
     tax_tag_invert = fields.Float()
+
+
+class AuditTest(models.Model):
+    _name = _description = 'test.audit'
+
+    _audit_fieldnames = True
+    _audit_no_val_fieldnames = {'field1'}
+    _no_audit_fieldnames = {'field2'}
+
+    def _filter_audit_records(self):
+        return self.filtered(lambda a: not a.bool1)
+
+    name = fields.Char()
+    field1 = fields.Char(string='Field1')
+    field2 = fields.Char(string='Field2')
+    bool1 = fields.Boolean(string="Filter Bool", default=False)
+    bool2 = fields.Boolean(string="Bool2", default=False)
+    auditb_id = fields.Many2one('test.auditb')
+    auditb_ids = fields.Many2many(comodel_name='test.auditb', string='m2mauditb')
+
+
+class AuditTestB(models.Model):
+    _name = _description = 'test.auditb'
+
+    _audit_fieldnames = {'name', 'field2', 'field1'}
+    _audit_no_val_fieldnames = {'field1'}
+    _no_audit_fieldnames = {'field2'}
+
+    name = fields.Char()
+    field1 = fields.Char(string='Field1')
+    field2 = fields.Char(string='Field2')
+    bool1 = fields.Boolean(string="Filter Bool")

--- a/odoo/addons/test_testing_utilities/tests/__init__.py
+++ b/odoo/addons/test_testing_utilities/tests/__init__.py
@@ -6,3 +6,4 @@ from . import test_xml_tools
 from . import test_res_config
 from . import test_env
 from . import test_freeze_time
+from . import test_audit

--- a/odoo/addons/test_testing_utilities/tests/test_audit.py
+++ b/odoo/addons/test_testing_utilities/tests/test_audit.py
@@ -1,0 +1,136 @@
+from odoo.tests.common import TransactionCase
+
+
+class TestAudit(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        res = super().setUpClass()
+        cls.audittestb1 = cls.env['test.auditb'].create({'name': 'auditb1'})
+        cls.audittestb2 = cls.env['test.auditb'].create({'name': 'auditb2'})
+        cls.audittestb3 = cls.env['test.auditb'].create({'name': 'audit3'})
+        cls.audittestb4 = cls.env['test.auditb'].create({'name': 'audit4'})
+        cls.audittestb5 = cls.env['test.auditb'].create({'name': 'audit5'})
+
+        cls.audittest = cls.env['test.audit'].create({'name': 'audit1'})
+        cls.audittest_filtered = cls.env['test.audit'].create({'name': 'audit_filter', 'bool1': True})
+        cls.audittest2 = cls.env['test.audit'].create({'name': "audit2", 'field2': "Hello", 'auditb_id': cls.audittestb2.id})
+        return res
+
+    def test_is_auditable_field_with_val(self):
+        # Name is neither in no_audit or no_val
+        self.assertTrue(self.audittest._is_auditable_field_with_val('name'))
+        # field1 in _audit_no_val_fieldnames
+        self.assertFalse(self.audittest._is_auditable_field_with_val('field1'))
+        # field2 in _no_audit_fieldnames
+        self.assertFalse(self.audittest._is_auditable_field_with_val('field2'))
+        # no_audit and no_val should also override hardcoded set
+        self.assertTrue(self.audittestb2._is_auditable_field_with_val('name'))
+        self.assertFalse(self.audittestb2._is_auditable_field_with_val('field1'))
+        self.assertFalse(self.audittestb2._is_auditable_field_with_val('field2'))
+        self.assertFalse(self.audittestb2._is_auditable_field_with_val('bool1'))
+        # Ensure ORM fields aren't taken into account
+        self.assertFalse(self.audittestb2._is_auditable_field_with_val('write_uid'))
+
+    def test_filter_audit_records(self):
+        # Filter remove bool1 == False
+        filtered = self.env['test.audit'].search([])._filter_audit_records()
+        self.assertIn(self.audittest, filtered)
+        self.assertNotIn(self.audittest_filtered, filtered)
+
+    def test_save_values_for_log(self):
+        saved_value = self.audittest._save_values_for_log({'name': 'audit1', 'field1': 'foo'})
+        self.assertEqual({self.audittest.id: {'name': 'audit1'}}, saved_value)
+        # Record filtered
+        self.assertEqual({}, self.audittest_filtered._save_values_for_log({'name': 'useless'}))
+        # no_audit_fieldnames
+        self.assertEqual({}, self.audittest2._save_values_for_log({'field2': 'useless'}))
+        # Save recordset
+        save_multi = self.env['test.audit'].search([])._save_values_for_log({'name': 'audit1'})
+        self.assertEqual({self.audittest.id: {'name': 'audit1'},
+            self.audittest2.id: {'name': 'audit2'}}, save_multi)
+        # No MissingError in order to be consistent with write
+        company = self.env['res.company'].browse(9999)
+        company._save_values_for_log({'name': "FakeCompany"})
+        # Unknown field
+        with self.assertRaises(ValueError):
+            self.audittest._save_values_for_log({'name': 'audit1', 'field_doesnt_exist': 'foo'})
+
+    def test_format_log(self):
+        audittest = self.audittest
+        audittest2 = self.env['test.audit'].create({'name': 'audit2', 'auditb_id': self.audittestb2.id,
+            'auditb_ids': [self.audittestb3.id, self.audittestb4.id]})
+        # No saved_values
+        self.assertEqual("name: 'audit1'", audittest._format_log('name'))
+        # Default value or empty recordset not logged
+        self.assertEqual("", audittest._format_log('auditb_id'))
+        self.assertEqual("", audittest._format_log('field1'))
+        # Boolean default value is audited
+        self.assertEqual("bool1: False", audittest._format_log('bool1'))
+        self.assertEqual(f"auditb_id: {self.audittestb2}", self.audittest2._format_log('auditb_id'))
+        # With saved_values
+        saved_values = audittest._save_values_for_log({'name'})
+        # Before and Current is the same so log nothing
+        self.assertEqual("", audittest._format_log('name', saved_values[audittest.id]))
+        audittest.name = "audit1_new"
+        self.assertEqual("name: 'audit1' ==> 'audit1_new'", audittest._format_log('name',
+            saved_values[audittest.id]))
+        # Remove 1 from recordset
+        saved_values = audittest2._save_values_for_log({'auditb_ids'})
+        audittest2.auditb_ids = [self.audittestb3.id]
+        self.assertEqual(f"auditb_ids: Removed: {self.audittestb4} ", audittest2._format_log('auditb_ids',
+            saved_values[audittest2.id]))
+        # Add 1 to recordset
+        saved_values = audittest2._save_values_for_log({'auditb_ids'})
+        audittest2.auditb_ids = [self.audittestb3.id, self.audittestb4.id]
+        self.assertEqual(f"auditb_ids: Added: {self.audittestb4}", audittest2._format_log('auditb_ids',
+            saved_values[audittest2.id]))
+        # Remove multiple from recordset
+        saved_values = audittest2._save_values_for_log({'auditb_ids'})
+        audittest2.auditb_ids = None
+        self.assertEqual(f"auditb_ids: Removed: {self.audittestb3 | self.audittestb4} ", audittest2._format_log('auditb_ids',
+            saved_values[audittest2.id]))
+        # Add multiple to recordset
+        saved_values = audittest2._save_values_for_log({'auditb_ids'})
+        audittest2.auditb_ids = [self.audittestb3.id, self.audittestb4.id]
+        self.assertEqual(f"auditb_ids: Added: {self.audittestb3 | self.audittestb4}", audittest2._format_log('auditb_ids',
+            saved_values[audittest2.id]))
+        # Add & Remove to recordset
+        saved_values = audittest2._save_values_for_log({'auditb_ids'})
+        audittest2.auditb_ids = [self.audittestb3.id, self.audittestb5.id]
+        self.assertEqual(f"auditb_ids: Removed: {self.audittestb4} Added: {self.audittestb5}",
+            audittest2._format_log('auditb_ids', saved_values[audittest2.id]))
+        # Add single record
+        saved_values = audittest._save_values_for_log({'auditb_ids'})
+        audittest.auditb_ids = [self.audittestb3.id]
+        self.assertEqual(f"auditb_ids: {self.env['test.auditb']} ==> {self.audittestb3}",
+            audittest._format_log('auditb_ids', saved_values[audittest.id]))
+        # Remove from single record
+        saved_values = audittest._save_values_for_log({'auditb_ids'})
+        audittest.auditb_ids = None
+        self.assertEqual(f"auditb_ids: {self.audittestb3} ==> {self.env['test.auditb']}",
+            audittest._format_log('auditb_ids', saved_values[audittest.id]))
+
+    def test_log_audit_changes(self):
+        create_vals = {'name': 'audit1', 'bool2': True, 'auditb_id': self.audittestb2.id}
+        audittest = self.env['test.audit'].create(create_vals)
+        saved_values = {audittest.id: {'name': 'foo', 'bool2': False, 'auditb_id': self.audittestb1}}
+        audittest._log_audit_changes(create_vals, "suffix", saved_values)
+        with self.assertLogs() as audit_log:
+            audittest._log_audit_changes(create_vals, "suffix", saved_values)
+        expected_log_value = f"{audittest} with \"name: 'foo' ==> 'audit1', bool2: True, auditb_id: {self.audittestb1} ==> {self.audittestb2}\" by {self.env.user}"
+        self.assertEqual(expected_log_value, audit_log.records[0].getMessage())
+
+    def test_create_write(self):
+        create_vals = {'name': 'audit1', 'bool2': True, 'auditb_id': self.audittestb2.id}
+        with self.assertLogs() as audit_log:
+            audittest = self.env['test.audit'].create(create_vals)
+            audittest.name = "foo"
+        self.assertEqual('audit.test.audit.create', audit_log.records[0].name)
+        expected_log_value = f"{audittest} with \"name: 'audit1', bool2: True, auditb_id: {self.audittestb2}\" by {self.env.user}"
+        self.assertEqual(expected_log_value, audit_log.records[0].getMessage())
+        self.assertEqual('audit.test.audit.write', audit_log.records[1].name)
+        expected_log_value = f"{audittest} with \"name: 'audit1' ==> 'foo'\" by {self.env.user}"
+        self.assertEqual(expected_log_value, audit_log.records[1].getMessage())
+        with self.assertNoLogs():
+            self.audittest_filtered.name = "Test"

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -76,6 +76,7 @@ if typing.TYPE_CHECKING:
 _lt = LazyTranslate('base')
 _logger = logging.getLogger(__name__)
 _unlink = logging.getLogger(__name__ + '.unlink')
+_audit_logger = logging.getLogger("audit")
 
 regex_alphanumeric = re.compile(r'^[a-z0-9_]+$')
 regex_order = re.compile(r'''
@@ -653,6 +654,13 @@ class BaseModel(metaclass=MetaModel):
     _transient_max_hours = lazy_classproperty(lambda _: config.get('transient_age_limit'))
     "maximum idle lifetime (in hours), unlimited if ``0``"
 
+    _audit_fieldnames = set()
+    "Define which fields to log with value on write and create for the audit logging"
+    _no_audit_fieldnames = set(LOG_ACCESS_COLUMNS)  # Only useful when _audit_fieldnames is True
+    "Define which fields that should not be log with value on write and create for the audit logging"
+    _audit_no_val_fieldnames = set()
+    "Define which fields to log without value on write and create for the audit logging"
+
     def _valid_field_parameter(self, field, name):
         """ Return whether the given parameter name is valid for the field. """
         return name == 'related_sudo'
@@ -834,6 +842,12 @@ class BaseModel(metaclass=MetaModel):
             for cons in base._sql_constraints:
                 cls._sql_constraints[cons[0]] = cons
 
+            cls._no_audit_fieldnames = cls._no_audit_fieldnames | base._no_audit_fieldnames
+            cls._audit_no_val_fieldnames = cls._audit_no_val_fieldnames | base._audit_no_val_fieldnames
+            if not (isinstance(cls._audit_fieldnames, bool) or isinstance(base._audit_fieldnames, bool)):
+                cls._audit_fieldnames = cls._audit_fieldnames | base._audit_fieldnames
+            else:
+                cls._audit_fieldnames = cls._audit_fieldnames or base._audit_fieldnames
         cls._sql_constraints = list(cls._sql_constraints.values())
 
         # avoid assigning an empty dict to save memory
@@ -4584,6 +4598,8 @@ class BaseModel(metaclass=MetaModel):
             if not(self.env.uid == SUPERUSER_ID and not self.pool.ready):
                 bad_names.update(LOG_ACCESS_COLUMNS)
 
+        _log_saved_data = self._save_values_for_log(vals)
+
         # set magic fields
         vals = {key: val for key, val in vals.items() if key not in bad_names}
         if self._log_access:
@@ -4713,6 +4729,7 @@ class BaseModel(metaclass=MetaModel):
 
         if check_company and self._check_company_auto:
             self._check_company()
+        self._log_audit_changes(vals, "write", _log_saved_data)
         return True
 
     def _write(self, vals):
@@ -4929,6 +4946,8 @@ class BaseModel(metaclass=MetaModel):
 
         if self._check_company_auto:
             records._check_company()
+
+        records._log_audit_changes(vals_list, "create")
 
         import_module = self.env.context.get('_import_current_module')
         if not import_module: # not an import -> bail
@@ -7201,6 +7220,106 @@ class BaseModel(metaclass=MetaModel):
             complete path to access it (eg: module/path/to/image.png).
         """
         return False
+
+    def _save_values_for_log(self, values):
+        """ Saves specific data before record modification. When logging modification of
+        data (write), it is better to know the changed value.
+
+        Didn't use read() as it doesn't return recordset but list of ids/display_name.
+        :param dict values: fields to update and the value to set on them (as on create/write)
+        :return: A dict {record_id:{fields:values}}
+        """
+        saved_data = {}
+        if self._audit_fieldnames:
+            for record in self._filter_audit_records():
+                _saved_data_by_id = {}
+                for key in values:
+                    if self._is_auditable_field_with_val(key):
+                        try:
+                            _saved_data_by_id[key] = record[key]
+                        except MissingError:
+                            continue
+                        except KeyError:  # raise ValueError to be consistent with write
+                            raise ValueError("Invalid field %r on model %r" % (key, self._name))
+                if _saved_data_by_id:
+                    saved_data[record.id] = _saved_data_by_id
+        return saved_data
+
+    def _format_log(self, key, saved_values=None):
+        """ Formats log based on their type.
+        In case of a recordset modification, only the added and removed records are logged.
+        :param string key: The key of the modified field
+        :param record saved_values: In case of a modification of data, the state of the record self before modification
+        :return: A formated string in order to display the new record state on a specific key
+        """
+        if saved_values and saved_values[key] == self[key]:
+            return ""
+        elif not saved_values or (saved_values and isinstance(saved_values[key], bool)):
+            # Don't log fields without value set
+            if not saved_values and (
+                (isinstance(self[key], bool) and self._fields[key].type != 'boolean') or
+                (isinstance(self[key], BaseModel) and not self[key])):
+                return ""
+            return f"{key}: {self[key]!r}"
+        elif isinstance(saved_values[key], BaseModel):
+            if len(self[key]) <= 1 >= len(saved_values[key]):
+                return f"{key}: {saved_values[key]} ==> {self[key]}"
+            else:  # Log only the changes for recordset
+                added_diff = self[key] - saved_values[key]
+                removed_diff = saved_values[key] - self[key]
+                crafted_string = ""
+                if removed_diff:
+                    crafted_string += f"Removed: {removed_diff} "
+                if added_diff:
+                    crafted_string += f"Added: {added_diff}"
+                return f"{key}: {crafted_string}" if crafted_string else ""
+        else:
+            return f"{key}: {saved_values[key]!r} ==> {self[key]!r}"
+
+    def _is_auditable_field_with_val(self, key):
+        """ Check if the fields should be audited with vals"""
+        if not self._audit_fieldnames or key in (self._no_audit_fieldnames | self._audit_no_val_fieldnames):
+            return False
+        if isinstance(self._audit_fieldnames, bool):
+            return True
+        else:
+            return key in self._audit_fieldnames
+
+    def _get_logging_strings(self, vals, before_modification=None):
+        """ For each record generate a string containing the change on required auditing fields.
+        :param dict vals: values for the model's fields, as a list of dictionaries (as used in create/write)
+        :param dict before_modification: In order to log previous to new data, a dict {record_id:{fields:values}}
+            usually returned by _save_values_for_log()
+        :returns: A generator of record, data_to_log where data_to_log is a string with all the data that should be
+            logged
+        """
+        for index, record in enumerate(self._filter_audit_records()):
+            data_to_log = []
+            vals = vals[index] if isinstance(vals, list) else vals
+            for key in vals:
+                if self._is_auditable_field_with_val(key):
+                    past_value = None
+                    if before_modification:
+                        past_value = before_modification[record.id]
+                    log_formated = record._format_log(key, past_value)
+                    if log_formated:
+                        data_to_log.append(log_formated)
+                elif self._audit_no_val_fieldnames and key in self._audit_no_val_fieldnames:
+                    data_to_log.append(f"{key!r} set")
+            if data_to_log:
+                yield record, ", ".join(data_to_log)
+
+    def _log_audit_changes(self, vals, logger_suffix, _log_saved_data=None):
+        if self._audit_fieldnames or self._audit_no_val_fieldnames:
+            _audit_logger_temp = _audit_logger.getChild(f"{self.__class__.__name__}.{logger_suffix}")
+            string_to_log = ', '.join(f"{record} with {data!r}" for record, data in
+                self._get_logging_strings(vals, _log_saved_data))
+            if string_to_log:
+                _audit_logger_temp.info("%s by %s", string_to_log, self.env.user)
+
+    def _filter_audit_records(self):
+        """This can be used to filter the audited records"""
+        return self
 
 
 collections.abc.Set.register(BaseModel)


### PR DESCRIPTION
Add a logging mechanism for write and create.

The goal of this new feature is to improve the logging system in odoo,
werkzeug doesn't provide enough information about changes in model.

This feature aim to be highly overridable for user to add or remove any
fields in a specific models. Once a fields is removed in a parent model,
it is not possible to add it in a child model as there should be a good
reason to remove a specific fields from logging.