### PR TITLE
[FIX] website_event*: remove wrong microdata

### DIFF
--- a/addons/event/report/event_event_templates.xml
+++ b/addons/event/report/event_event_templates.xml
@@ -133,10 +133,10 @@
             <div class="o_event_full_page_ticket_wrapper">
                 <div class="o_event_full_page_ticket_details d-flex">
                     <div class="o_event_full_page_left_details ps-3 pt-4 pb-3 pe-2">
-                        <span itemprop="startDate" t-field="event.date_begin"
+                        <span t-field="event.date_begin"
                             t-options='{"widget": "datetime", "date_only": True, "tz_name": event.date_tz}'
                             class="fw-bold"/>
-                        <span itemprop="startDateTime" t-field="event.date_begin"
+                        <span t-field="event.date_begin"
                             class="fw-bold"
                             t-options='{"widget": "datetime", "time_only": True, "hide_seconds": True, "tz_name": event.date_tz}'/>
                         <h2 class="o_event_full_page_ticket_event_name fw-bold pt-3 pb-2" t-field="event.name"/>

--- a/addons/website_event/views/event_templates_list.xml
+++ b/addons/website_event/views/event_templates_list.xml
@@ -301,6 +301,7 @@
                             <t t-call="website.record_cover">
                                 <t t-set="_record" t-value="event"/>
                                 <!-- Short Date -->
+                                <meta itemprop="startDate" t-att-content="event.date_begin.isoformat()"/>
                                 <div t-attf-class="o_wevent_event_date position-absolute shadow-sm o_not_editable #{(not opt_events_list_columns) and 'left'} ">
                                     <span t-out="event.date_begin" t-options="{'widget': 'datetime', 'tz_name': event.date_tz, 'format': 'LLL'}" class="o_wevent_event_month"/>
                                     <span t-out="event.date_begin" t-options="{'widget': 'datetime', 'tz_name': event.date_tz, 'format': 'dd'}" class="o_wevent_event_day oe_hide_on_date_edit"/>

--- a/addons/website_event/views/event_templates_page_registration.xml
+++ b/addons/website_event/views/event_templates_page_registration.xml
@@ -89,22 +89,24 @@
                         </div>
                         <!-- Date & Time (desktop only) -->
                         <div class="d-none d-lg-block border-bottom pb-2 mb-3">
+                            <meta itemprop="startDate" t-att-content="event.date_begin.isoformat()" />
+                            <meta itemprop="endDate" t-att-content="event.date_end.isoformat()" />
                             <t t-call="website_event.event_description_dates"/>
                         </div>
                         <header class="d-lg-none mt-4 mb-2 py-3 border-top">
                             <h5 class="my-0">Event Info</h5>
+                            <meta itemprop="eventStatus" content="https://schema.org/EventScheduled" />
                         </header>
                         <!-- Location -->
-                        <div t-if="event.address_id" class="o_wevent_sidebar_block border-bottom pb-3 mb-4">
+                        <meta itemprop="eventAttendanceMode" t-attf-content="https://schema.org/{{'Offline' if event.address_id else 'Online'}}EventAttendanceMode"/>
+                        <div t-if="event.address_id" class="o_wevent_sidebar_block border-bottom pb-3 mb-4" itemprop="location" itemscope="itemscope" itemtype="https://schema.org/Place">
                             <h6 class="o_wevent_sidebar_title">Location</h6>
-                            <div class="mb-1" t-field="event.address_id" t-options='{
-                                "widget": "contact",
-                                "fields": ["name"]
-                            }'/>
-                            <small itemprop="location" class="d-block mb-2" t-field="event.address_id" t-options='{
+                            <div itemprop="name" class="mb-1" t-field="event.address_id"/>
+                            <small class="d-block mb-2" t-field="event.address_id" t-options='{
                                 "widget": "contact",
                                 "fields": ["address"],
-                                "no_marker": True
+                                "no_marker": True,
+                                "with_microdata": True,
                             }'/>
                             <small t-field="event.address_id" class="d-block mb-2" t-options='{
                                 "widget": "contact",
@@ -123,10 +125,10 @@
                             <i class="fa fa-map-marker" title="Location"/> Online event
                         </div>
                         <!-- Organizer -->
-                        <div t-if="event.organizer_id" class="o_wevent_sidebar_block border-bottom pb-3 mb-4">
+                        <div t-if="event.organizer_id" class="o_wevent_sidebar_block border-bottom pb-3 mb-4" itemprop="organizer" itemscope="itemscope" itemtype="http://schema.org/Organization">
                             <h6 class="o_wevent_sidebar_title">Organizer</h6>
-                            <div class="mb-1" t-field="event.organizer_id"/>
-                            <small itemprop="location" t-field="event.organizer_id" t-options="{'widget': 'contact', 'fields': ['phone', 'mobile', 'email']}"/>
+                            <div itemprop="name" class="mb-1" t-field="event.organizer_id"/>
+                            <small t-field="event.organizer_id" t-options="{'widget': 'contact', 'fields': ['phone', 'mobile', 'email'], 'with_microdata': True,}"/>
                         </div>
                         <!-- Social -->
                         <div class="o_wevent_sidebar_block">
@@ -353,7 +355,7 @@
                             <b>Start</b>
                         </div>
                         <div class="col ps-0">
-                            <span itemprop="startDate" t-out="event.date_begin_located"/>
+                            <span t-out="event.date_begin_located"/>
                             (<span t-out="event.date_tz"/>)
                         </div>
                     </div>
@@ -362,7 +364,7 @@
                             <b>End</b>
                         </div>
                         <div class="col ps-0">
-                            <span itemprop="endDate" t-out="event.date_end_located"/>
+                            <span t-out="event.date_end_located"/>
                             (<span t-out="event.date_tz"/>)
                         </div>
                     </div>
@@ -371,11 +373,11 @@
                             "widget": "contact",
                             "fields": ["name"]
                             }'/>
-                        <a itemprop="location" t-att-href="event.google_map_link()" target="_BLANK" temprop="location" t-field="event.address_id" t-options='{
+                        <a t-att-href="event.google_map_link()" target="_BLANK" t-field="event.address_id" t-options='{
                             "widget": "contact",
                             "fields": ["address"]
                             }'/>
-                        <div itemprop="contactInfo" t-field="event.organizer_id" t-options='{
+                        <div t-field="event.organizer_id" t-options='{
                             "widget": "contact",
                             "fields": ["phone", "mobile", "email"]
                             }'/>

--- a/addons/website_event/views/snippets/s_events.xml
+++ b/addons/website_event/views/snippets/s_events.xml
@@ -26,7 +26,7 @@
             <figcaption class="text-center w-100 h-100 px-3 d-flex flex-column flex-grow-1">
                 <div t-if="is_sample" class="h5 o_ribbon_right bg-primary text-uppercase">Sample</div>
                 <div class="s_events_event_title text-white" t-field="record.name"/>
-                <time itemprop="startDate" t-att-datetime="record.date_begin" class="text-white">
+                <time t-att-datetime="record.date_begin" class="text-white">
                     <span t-out="record.date_begin"
                           t-options="{'widget': 'datetime', 'date_only': 'true', 'format': 'long', 'tz_name': record.date_tz}"/>
                     -
@@ -60,7 +60,7 @@
             <div class="card-body p-3">
                 <div t-if="is_sample" class="h5 o_ribbon_right bg-primary text-uppercase">Sample</div>
                 <h5 class="mb-0 text-truncate" t-field="record.name"/>
-                <time itemprop="startDate" t-att-datetime="record.date_begin">
+                <time t-att-datetime="record.date_begin">
                     <span t-field="record.date_begin"
                           t-options="{'date_only': 'true', 'format': 'long', 'tz_name': record.date_tz}"/>
                     -
@@ -68,7 +68,7 @@
                           t-options="{'time_only': 'true', 'format': 'short', 'tz_name': record.date_tz}"/>
                     (<span t-out="record.date_tz"/>)
                 </time>
-                <div itemprop="location" t-field="record.address_id"
+                <div t-field="record.address_id"
                      t-options="{'widget': 'contact', 'fields': ['city'], 'no_marker': 'true'}"/>
             </div>
         </div>

--- a/addons/website_event_booth/views/event_booth_templates.xml
+++ b/addons/website_event_booth/views/event_booth_templates.xml
@@ -4,8 +4,7 @@
     <template id="event_booth_layout" name="Event Booth Layout">
         <t t-call="website_event.layout">
             <div class="oe_structure oe_empty" id="oe_structure_website_event_booth_1"/>
-            <div class="o_wbooth_registration" t-att-data-event-id="event.id"
-                 itemscope="itemscope" itemtype="http://schema.org/Event">
+            <div class="o_wbooth_registration" t-att-data-event-id="event.id">
                 <section>
                     <div class="container overflow-hidden">
                         <div class="row g-0">

--- a/addons/website_event_exhibitor/views/event_exhibitor_templates_list.xml
+++ b/addons/website_event_exhibitor/views/event_exhibitor_templates_list.xml
@@ -236,8 +236,7 @@
 <!-- ============================================================ -->
 
 <template id="exhibitor_card" name="Exhibitor Card">
-    <article class="o_wesponsor_card card h-100"
-        itemscope="itemscope" itemtype="http://schema.org/Event">
+    <article class="o_wesponsor_card card h-100">
         <div class="row g-0 h-100" t-att-data-publish="sponsor.website_published and 'on' or 'off'">
             <t t-set="sponsor_image_url" t-value="sponsor.website_image_url"/>
             <header t-att-class="'overflow-hidden col-12 %s' % ('bg-secondary' if not sponsor_image_url else '')">
@@ -265,7 +264,7 @@
                 <main class="card-body">
                     <!-- Title -->
                     <h5 class="card-title d-flex align-items-start justify-content-between mt-0 mb-0">
-                        <span t-field="sponsor.name" itemprop="name" class="text-break fs-6 mb-2"/>
+                        <span t-field="sponsor.name" class="text-break fs-6 mb-2"/>
                         <span t-if="sponsor.is_in_opening_hours and sponsor.chat_room_id"
                             class="alert alert-danger mb-2 px-2 py-1 smaller lh-1">Live
                         </span>

--- a/addons/website_event_track/views/event_track_templates_list.xml
+++ b/addons/website_event_track/views/event_track_templates_list.xml
@@ -357,8 +357,7 @@
 </template>
 
 <template id="track_card" name="Track Card">
-    <article t-att-class="'card o_wesession_track_card h-100 %s' % ('o_wesession_track_card_unpublished' if (not track.website_published and is_event_user) else '')"
-        itemscope="itemscope" itemtype="http://schema.org/Event">
+    <article t-att-class="'card o_wesession_track_card h-100 %s' % ('o_wesession_track_card_unpublished' if (not track.website_published and is_event_user) else '')">
         <div class="h-100 row g-0">
             <header class="overflow-hidden bg-secondary col-12">
                 <small t-if="not track.website_published and is_event_user" class="o_wesession_track_card_header_badge bg-danger">
@@ -393,7 +392,7 @@
                     </div>
                     <!-- Title -->
                     <h5 class="card-title mb-0 text-truncate">
-                        <span t-field="track.name" itemprop="name"/>
+                        <span t-field="track.name"/>
                     </h5>
                 </main>
             </div>
@@ -401,15 +400,15 @@
             <footer class="small align-self-end w-100 p-3">
                 <div class="d-flex justify-content-between align-items-center">
                     <!-- Speaker -->
-                    <span class="opacity-75 text-truncate" t-field="track.partner_name" itemprop="performer"/>
+                    <span class="opacity-75 text-truncate" t-field="track.partner_name"/>
                     <!-- Starts -->
                     <span class="opacity-75 ms-auto">
                         <t t-if="track.track_start_remaining &gt;= 60">In
-                            <span class="ms-auto" t-field="track.track_start_remaining" itemprop="duration"
+                            <span class="ms-auto" t-field="track.track_start_remaining"
                                 t-options="{'widget': 'duration', 'digital': False, 'format': 'short', 'unit': 'second', 'round': 'minute'}"/>
                         </t>
                         <t t-elif="track.track_start_relative &gt;= 60">
-                            <span class="ms-auto" t-field="track.track_start_relative" itemprop="duration"
+                            <span class="ms-auto" t-field="track.track_start_relative"
                                 t-options="{'widget': 'duration', 'digital': False, 'format': 'short', 'unit': 'second', 'round': 'minute'}"/>
                             ago
                         </t>

--- a/addons/website_forum/views/base_contact_templates.xml
+++ b/addons/website_forum/views/base_contact_templates.xml
@@ -2,7 +2,7 @@
 <odoo><data>
 
 <template id="contact" inherit_id="base.contact" name="Forum Contact Widget">
-    <xpath expr="//div[@itemprop='address']" position="after">
+    <xpath expr="//div[@itemscope='itemscope']" position="after">
         <div>
              <div t-if="'karma' in fields" class='css_editable_mode_hidden'>
                 <div t-if="options.get('UserBio')" class="mb-2">

--- a/addons/website_partner/views/website_partner_templates.xml
+++ b/addons/website_partner/views/website_partner_templates.xml
@@ -16,13 +16,14 @@
 </template>
 
 <template id="partner_detail" name="Partner Details">
-    <div class="row">
+    <div class="row" itemscope="itemscope" itemtype="http://schema.org/Organization">
         <div class="col-lg-3 col-md-4">
-            <div t-field="partner.avatar_1920" t-options='{"widget": "image", "preview_image": "avatar_1920", "style": "object-fit: cover", "class": "w-100 mb-2 rounded-3 border"}'/>
+            <div t-field="partner.avatar_1920" t-options='{"widget": "image", "preview_image": "avatar_1920", "style": "object-fit: cover", "class": "w-100 mb-2 rounded-3 border", "itemprop": "image"}'/>
             <div class="o_wcrm_contact_details">
                 <div t-field="partner.self" t-options='{
                     "widget": "contact",
-                    "fields": ["address", "website", "phone", "email"]
+                    "fields": ["address", "website", "phone", "email"],
+                    "with_microdata": True,
                 }'/>
                 <t t-out="left_column or ''"/>
             </div>
@@ -30,7 +31,7 @@
         <div class="col-lg-9 col-md-8">
             <div class="d-flex align-items-center flex-wrap mb-4">
                 <div class="flex-grow-1">
-                    <h1 id="partner_name" t-field="partner.display_name"/>
+                    <h1 id="partner_name" t-field="partner.display_name" itemprop="name"/>
                 </div>
             </div>
             <t t-if="partner">

--- a/odoo/addons/base/views/ir_qweb_widget_templates.xml
+++ b/odoo/addons/base/views/ir_qweb_widget_templates.xml
@@ -15,14 +15,15 @@
 </template>
 
 <template id="contact">
-    <address t-ignore="true" class="o_portal_address mb-0" itemscope="itemscope" itemtype="http://schema.org/Organization">
+    <address t-ignore="true" class="o_portal_address mb-0">
         <div t-if="not (('name' in fields) or (address and 'address' in fields) or (city and 'city' in fields) or (mobile and 'mobile' in fields) or (website and 'website' in fields) or (email and 'email' in fields))" class="css_non_editable_mode_hidden">
             --<span class="text-muted" t-esc="name"/>--
         </div>
         <t t-if="object.country_id.name_position != 'after'">
             <t t-call="base.contact_name"/>
         </t>
-        <div class="gap-2" itemprop="address" itemscope="itemscope" itemtype="http://schema.org/PostalAddress">
+        <div class="gap-2" t-att-itemprop="options.get('with_microdata') and 'address'" itemscope="itemscope" itemtype="http://schema.org/PostalAddress">
+
             <div t-if="address and 'address' in fields" t-attf-class="d-flex align-items-baseline gap-1">
                 <i t-if="not options.get('no_marker')" class="fa fa-map-marker fa-fw" role="img" aria-label="Address" title="Address"/>
                 <span class="d-block w-100 lh-sm" itemprop="streetAddress" t-esc="address"/>
@@ -56,8 +57,8 @@
 </template>
 
 <template id="no_contact">
-    <address t-ignore="true" class="mb-0" itemscope="itemscope" itemtype="http://schema.org/Organization">
-        <div itemprop="address" itemscope="itemscope" itemtype="http://schema.org/PostalAddress">
+    <address t-ignore="true" class="mb-0">
+        <div>
             <div class="d-flex align-items-baseline">
                 <i t-if="not options.get('no_marker')" class="fa fa-map-marker fa-fw" role="img" aria-label="Address" title="Address"/>
                 <span class="w-100 o_force_ltr d-block" t-out="options.get('null_text')"/>


### PR DESCRIPTION
Remove schema event from some template:
- a sponsor, a track, .. is not an event.

We add startDate, endDate, eventStatus, eventAttendanceMode, image ... missing
values and fix the organization/location/address structure.

After this commit we hope to have less warning into the GSC.

Tested with https://search.google.com/test/rich-results