### PR TITLE
[IMP] pos_coupon: PoS coupons and programs improve loanding latency

### DIFF
--- a/addons/pos_coupon/models/coupon_program.py
+++ b/addons/pos_coupon/models/coupon_program.py
@@ -82,11 +82,13 @@ class CouponProgram(models.Model):
     def _compute_valid_partner_ids(self):
         domain_partners = {}
         for program in self:
-            partner_ids = domain_partners.get(program.rule_partners_domain)
-            if partner_ids is None:
-                domain = ast.literal_eval(program.rule_partners_domain) if program.rule_partners_domain else []
-                partner_ids = self.env["res.partner"].search(domain, order="id").ids
-                domain_partners[program.rule_partners_domain] = partner_ids
+            partner_ids = []
+            if program.rule_partners_domain and program.rule_partners_domain != "[]":
+                partner_ids = domain_partners.get(program.rule_partners_domain)
+                if partner_ids is None:
+                    domain = ast.literal_eval(program.rule_partners_domain)
+                    partner_ids = self.env["res.partner"].search(domain, order="id").ids
+                    domain_partners[program.rule_partners_domain] = partner_ids
             program.valid_partner_ids = partner_ids
 
     @api.depends('pos_order_ids')


### PR DESCRIPTION
In a databse with a large data on res.partner there is several latency when loanding coupons programs.
In order to skip searchs domains like '[]' to improve PoS atency loading we avoid populating programs.valid_partner_ids with all the res.partner data when is not neccesary.

see following:
https://github.com/odoo/odoo/blob/255963141785440fded859bdb2da971c8e0e703b/addons/pos_coupon/static/src/js/coupon.js#L843

where we only check valid_partner_ids when program.rule_partners_domain is different that '[]' so for those cases is not necessary to populate the valid_partner_ids with all the ids on res.partner

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:


### OPW 4003522


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
