### PR TITLE
[IMP] base,base_import,base_import_module: simplify kanban archs

### DIFF
--- a/addons/base_import/static/tests/import_records_tests.js
+++ b/addons/base_import/static/tests/import_records_tests.js
@@ -134,8 +134,8 @@ QUnit.module("Base Import Tests", (hooks) => {
             arch: `
                 <kanban>
                     <templates>
-                        <t t-name="kanban-box">
-                            <div><field name="foo"/></div>
+                        <t t-name="kanban-card">
+                            <field name="foo"/>
                         </t>
                     </templates>
                 </kanban>`,
@@ -160,8 +160,8 @@ QUnit.module("Base Import Tests", (hooks) => {
                 arch: `
                     <kanban create="0">
                         <templates>
-                            <t t-name="kanban-box">
-                                <div><field name="foo"/></div>
+                            <t t-name="kanban-card">
+                                <field name="foo"/>
                             </t>
                         </templates>
                     </kanban>`,
@@ -184,8 +184,8 @@ QUnit.module("Base Import Tests", (hooks) => {
                 arch: `
                     <kanban import="0">
                         <templates>
-                            <t t-name="kanban-box">
-                                <div><field name="foo"/></div>
+                            <t t-name="kanban-card">
+                                <field name="foo"/>
                             </t>
                         </templates>
                     </kanban>`,

--- a/addons/base_import_module/views/ir_module_views.xml
+++ b/addons/base_import_module/views/ir_module_views.xml
@@ -16,12 +16,12 @@
                 <xpath expr="//button[@name='button_immediate_install']" position="attributes">
                     <attribute name="invisible">state != 'uninstalled' or (module_type and module_type != 'official')</attribute>
                 </xpath>
-                <xpath expr="//t[@t-name='kanban-menu']/a[@type='edit']" position="attributes">
+                <xpath expr="//t[@t-name='kanban-menu']/a[@type='open']" position="attributes">
                     <attribute name="context">{'module_type': module_type, 'module_name':name}</attribute>
                     <attribute name="type">object</attribute>
                     <attribute name="name">more_info</attribute>
                 </xpath>
-                <xpath expr="//div[hasclass('oe_module_action')]/a[@type='edit']" position="attributes">
+                <xpath expr="//footer/a[@type='edit']" position="attributes">
                     <attribute name="context">{'module_type': module_type, 'module_name':name}</attribute>
                     <attribute name="type">object</attribute>
                     <attribute name="name">more_info</attribute>

--- a/odoo/addons/base/views/ir_module_views.xml
+++ b/odoo/addons/base/views/ir_module_views.xml
@@ -151,8 +151,6 @@
             <field name="model">ir.module.module</field>
             <field name="arch" type="xml">
                 <kanban create="false" can_open="0" class="o_modules_kanban">
-                  <field name="icon"/>
-                  <field name="icon_flag"/>
                   <field name="to_buy"/>
                   <field name="name"/>
                   <field name="state"/>
@@ -162,36 +160,32 @@
                   <templates>
                     <t t-name="kanban-menu">
                         <t t-set="installed" t-value="record.state.raw_value == 'installed'"/>
-                        <a type="edit" class="dropdown-item">Module Info</a>
+                        <a type="open" class="dropdown-item">Module Info</a>
                         <a t-if="record.website.raw_value" role="menuitem" class="dropdown-item o-hidden-ios" t-att-href="record.website.raw_value" target="_blank">Learn More</a>
                         <a t-if="installed" name="button_immediate_upgrade" type="object" role="menuitem" class="dropdown-item" groups="base.group_system">Upgrade</a>
                         <a t-if="installed" name="button_uninstall_wizard" type="object" role="menuitem" class="dropdown-item" groups="base.group_system">Uninstall</a>
                     </t>
-                    <t t-name="kanban-box">
-                      <div class="oe_module_vignette">
-                        <div class="oe_module_icon">
-                            <img t-attf-src="#{record.icon.value}" class="w-100" alt="Icon"/>
-                            <span t-if="record.icon_flag" class="oe_module_flag"><t t-out="record.icon_flag.raw_value"/></span>
-                        </div>
-                        <div class="oe_module_desc" t-att-title="record.shortdesc.value">
-                          <h4 class="o_kanban_record_title">
-                            <field name="shortdesc"/>&amp;nbsp;
-                          </h4>
-                          <p class="oe_module_name">
-                            <field groups="!base.group_no_one" name="summary"/>
-                            <code groups="base.group_no_one"><field name="name"/></code>
-                          </p>
-                          <div class="oe_module_action d-flex flex-wrap justify-content-between">
-                            <button type="object" class="btn btn-primary btn-sm" name="button_immediate_install" invisible="state != 'uninstalled'" t-if="! record.to_buy.raw_value" groups="base.group_system">Activate</button>
-                            <div t-if="installed" class="d-flex align-items-center text-muted float-start">Installed</div>
-                            <a t-att-href="record.website.raw_value" target="_blank" invisible="website in (False, '')" class="btn btn-sm btn-secondary float-end o-hidden-ios" role="button">Learn More</a>
-                            <a type="edit" class="btn btn-secondary btn-sm float-end" role="button" invisible="website != ''">Module Info</a>
-                            <a href="https://odoo.com/pricing?utm_source=db&amp;utm_medium=module#hosting=on_premise" target="_blank" class="btn btn-info btn-sm" invisible="state not in ('uninstalled', 'uninstallable')" t-if="record.to_buy.raw_value" role="button" groups="base.group_system">Upgrade</a>
-                            <button invisible="state != 'to remove'" type="object" class="btn btn-sm btn-primary" name="button_uninstall_cancel" groups="base.group_system">Cancel Uninstall</button>
-                            <button invisible="state != 'to install'" type="object" class="btn btn-sm btn-primary" name="button_install_cancel" groups="base.group_system">Cancel Install</button>
-                          </div>
-                        </div>
-                      </div>
+                    <t t-name="kanban-card" class="flex-row align-items-center">
+                        <aside>
+                            <field name="icon" widget="image_url" options="{'size': [50, 50]}" alt="Icon"/>
+                            <field t-if="record.icon_flag" name="icon_flag" class="oe_module_flag"/>
+                        </aside>
+                        <main class="me-4" t-att-title="record.shortdesc.value">
+                            <field class="fw-bold fs-5" name="shortdesc"/>
+                            <p class="text-muted small my-0 lh-1">
+                                <field groups="!base.group_no_one" name="summary"/>
+                                <code groups="base.group_no_one"><field name="name"/></code>
+                            </p>
+                            <footer class="w-100 justify-content-between">
+                                <button type="object" class="btn btn-primary btn-sm" name="button_immediate_install" invisible="state != 'uninstalled'" t-if="! record.to_buy.raw_value" groups="base.group_system">Activate</button>
+                                <div t-if="installed" class="d-flex align-items-center text-muted float-start">Installed</div>
+                                <a t-att-href="record.website.raw_value" target="_blank" invisible="website in (False, '')" class="btn btn-sm btn-secondary float-end o-hidden-ios" role="button">Learn More</a>
+                                <a type="edit" class="btn btn-secondary btn-sm float-end" role="button" invisible="website != ''">Module Info</a>
+                                <a href="https://odoo.com/pricing?utm_source=db&amp;utm_medium=module#hosting=on_premise" target="_blank" class="btn btn-info btn-sm" invisible="state not in ('uninstalled', 'uninstallable')" t-if="record.to_buy.raw_value" role="button" groups="base.group_system">Upgrade</a>
+                                <button invisible="state != 'to remove'" type="object" class="btn btn-sm btn-primary" name="button_uninstall_cancel" groups="base.group_system">Cancel Uninstall</button>
+                                <button invisible="state != 'to install'" type="object" class="btn btn-sm btn-primary" name="button_install_cancel" groups="base.group_system">Cancel Install</button>
+                            </footer>
+                        </main>
                     </t>
                   </templates>
                 </kanban>

--- a/odoo/addons/base/views/res_company_views.xml
+++ b/odoo/addons/base/views/res_company_views.xml
@@ -76,39 +76,34 @@
             <field name="model">res.company</field>
             <field name="arch" type="xml">
                 <kanban>
-                    <field name="name"/>
-                    <field name="email"/>
-                    <field name="phone"/>
                     <templates>
-                        <t t-name="kanban-box">
-                            <div t-attf-class="oe_kanban_global_click">
-                                <div t-attf-class="#{!selection_mode ? 'text-center' : ''}">
-                                    <i class="fa fa-building" role="img" aria-label="Enterprise" title="Enterprise"></i> <strong><field name="name"/></strong>
+                        <t t-name="kanban-card">
+                            <div t-attf-class="#{!selection_mode ? 'text-center' : ''}">
+                                <i class="fa fa-building" role="img" aria-label="Enterprise" title="Enterprise"></i> <field class="fw-bold fs-5" name="name"/>
+                            </div>
+                            <hr class="mt4 mb4"/>
+                            <div class="row" t-if="!selection_mode">
+                                <div t-if="record.email.value" class="col-6 text-center">
+                                    <strong>Email:</strong>
                                 </div>
-                                <hr class="mt4 mb4"/>
-                                <div class="row" t-if="!selection_mode">
-                                    <div t-if="record.email.value" class="col-6 text-center">
-                                        <strong>Email:</strong>
-                                    </div>
-                                    <div t-if="record.phone.value" class="col-6 text-center">
-                                        <strong>Phone</strong>
-                                    </div>
-                                    <div t-if="record.email.value" class="col-6 text-center">
-                                        <field name="email"/>
-                                    </div>
-                                    <div t-if="record.phone.value" class="col-6 text-center o_force_ltr">
-                                        <field name="phone"/>
-                                    </div>
+                                <div t-if="record.phone.value" class="col-6 text-center">
+                                    <strong>Phone</strong>
                                 </div>
-                                <div t-else="">
-                                    <div t-if="record.email.value">
-                                        <strong>Email:</strong>
-                                        <field name="email"/>
-                                    </div>
-                                    <div t-if="record.phone.value" class="o_force_ltr">
-                                        <strong>Phone:</strong>
-                                        <field name="phone"/>
-                                    </div>
+                                <div t-if="record.email.value" class="col-6 text-center">
+                                    <field name="email"/>
+                                </div>
+                                <div t-if="record.phone.value" class="col-6 text-center o_force_ltr">
+                                    <field name="phone"/>
+                                </div>
+                            </div>
+                            <div t-else="">
+                                <div t-if="record.email.value">
+                                    <strong>Email:</strong>
+                                    <field name="email"/>
+                                </div>
+                                <div t-if="record.phone.value" class="o_force_ltr">
+                                    <strong>Phone:</strong>
+                                    <field name="phone"/>
                                 </div>
                             </div>
                         </t>

--- a/odoo/addons/base/views/res_currency_views.xml
+++ b/odoo/addons/base/views/res_currency_views.xml
@@ -100,19 +100,15 @@
             <field name="model">res.currency</field>
             <field name="arch" type="xml">
                 <kanban class="o_kanban_mobile">
-                    <field name="name"/>
-                    <field name="symbol"/>
-                    <field name="full_name"/>
                     <field name="active"/>
                     <templates>
-                        <t t-name="kanban-box">
-                            <div t-attf-class="oe_kanban_global_click">
+                        <t t-name="kanban-card">
                                 <div class="row mb4">
-                                    <div class="col-2">
-                                        <h3><t t-esc="record.name.value"/></h3>
+                                    <div class="col-2 text-nowrap">
+                                        <field class="fw-bold fs-3" name="name"/>
                                     </div>
                                     <div class="col-5">
-                                        <span class="badge rounded-pill"><t t-esc="record.symbol.value"/></span>
+                                        <span class="badge rounded-pill"><field name="symbol"/></span>
                                     </div>
                                     <div class="col-5 text-end">
                                         <t t-if="! record.active.raw_value"><span class="badge rounded-pill bg-light border">inactive</span></t>
@@ -124,7 +120,6 @@
                                         <t t-if="record.date.raw_value"><div>Last update: <field name="date"/></div></t>
                                     </div>
                                 </div>
-                            </div>
                         </t>
                     </templates>
                 </kanban>

--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -413,7 +413,7 @@
                             </aside>
                             <main class="ps-2 ps-md-0">
                                 <div class="mb-1">
-                                    <field name="display_name" class="mb-0 h5"/>
+                                    <field name="display_name" class="mb-0 fw-bold fs-5"/>
                                     <field t-if="record.parent_id.raw_value and !record.function.raw_value" class="text-muted" name="parent_id"/>
                                     <field t-elif="!record.parent_id.raw_value and record.function.raw_value" class="text-muted" name="function"/>
                                     <div t-elif="record.parent_id.raw_value and record.function.raw_value" class="text-muted">

--- a/odoo/addons/base/views/res_users_views.xml
+++ b/odoo/addons/base/views/res_users_views.xml
@@ -268,35 +268,31 @@
             <field name="model">res.users</field>
             <field name="arch" type="xml">
                 <kanban class="o_kanban_mobile">
-                    <field name="id"/>
-                    <field name="name"/>
-                    <field name="login"/>
-                    <field name="lang"/>
                     <field name="active"/>
                     <field name="login_date"/>
                     <templates>
-                        <t t-name="kanban-box">
-                            <div t-attf-class="oe_kanban_global_click">
-                                <div class="o_kanban_image">
-                                    <img alt="Avatar" t-att-src="kanban_image('res.users', 'avatar_128', record.id.raw_value)"/>
+                        <t t-name="kanban-card" class="flex-row">
+                            <aside class="w-25 p-1">
+                                <field name="avatar_128" widget="image" alt="Avatar"/>
+                            </aside>
+                            <main class="w-100 ps-2 pt-1">
+                                <div>
+                                    <div t-if="record.active.raw_value" class="text-success float-end mb4">
+                                        <i class="fa fa-circle" role="img" aria-label="Ok" title="Ok"></i>
+                                    </div>
+                                    <div t-else="" class="text-danger float-end mb4">
+                                        <i class="fa fa-circle" role="img" aria-label="Invalid" title="Invalid"></i>
+                                    </div>
+                                    <field class="fw-bold" name="name"/>
                                 </div>
-                                <div class="oe_kanban_details">
-                                    <ul>
-                                        <li class="text-success float-end mb4" t-if="record.active.raw_value"><i class="fa fa-circle" role="img" aria-label="Ok" title="Ok"></i></li>
-                                        <li class="text-danger float-end mb4" t-if="!record.active.raw_value"><i class="fa fa-circle" role="img" aria-label="Invalid" title="Invalid"></i></li>
-                                        <li class="mb4">
-                                            <strong><field name="name"/></strong>
-                                        </li>
-                                        <li class="d-flex flex-wrap">
-                                            <span class="mb4 text-truncate" title="Login">
-                                                <i class="fa fa-envelope me-1" role="img" aria-label="Login"/>
-                                                <field name="login"/>
-                                            </span>
-                                            <field class="badge rounded-pill mb4 ms-auto" name="lang"/>
-                                        </li>
-                                    </ul>
+                                <div>
+                                    <span class="mb4 text-truncate" title="Login">
+                                        <i class="fa fa-envelope me-1" role="img" aria-label="Login"></i>
+                                        <field name="login"/>
+                                    </span>
+                                    <field class="badge rounded-pill float-end" name="lang"/>
                                 </div>
-                            </div>
+                            </main>
                         </t>
                     </templates>
                 </kanban>

--- a/odoo/addons/base/wizard/base_module_uninstall_views.xml
+++ b/odoo/addons/base/wizard/base_module_uninstall_views.xml
@@ -18,25 +18,21 @@
                     </div>
                     <field name="module_ids" mode="kanban" class="o_modules_field">
                         <kanban create="false" class="o_modules_kanban">
-                            <field name="icon"/>
                             <field name="state"/>
-                            <field name="summary"/>
                                 <templates>
-                                    <t t-name="kanban-box">
-                                        <div class="oe_module_vignette">
-                                            <t t-set="installed" t-value="record.state.raw_value == 'installed'" />
-                                            <img t-attf-src="#{record.icon.value}" class="oe_module_icon" alt="Icon" />
-                                            <div class="oe_module_desc" t-att-title="record.shortdesc.value">
-                                                <h4 class="o_kanban_record_title">
-                                                    <field name="shortdesc" />&amp;nbsp;
-                                                </h4>
-                                                <p class="oe_module_name">
-                                                    <field groups="!base.group_no_one" name="summary" />
-                                                    <code groups="base.group_no_one">
-                                                        <field name="name" /></code>
-                                                </p>
-                                            </div>
-                                        </div>
+                                    <t t-name="kanban-card" class="flex-row align-items-center">
+                                        <aside>
+                                            <field name="icon" widget="image_url" options="{'size': [50, 50]}" alt="Icon"/>
+                                        </aside>
+                                        <main t-att-title="record.shortdesc.value">
+                                            <field class="fw-bold fs-5 mb-0" name="shortdesc" />
+                                            <p class="text-muted small my-1 lh-1">
+                                                <field groups="!base.group_no_one" name="summary" />
+                                                <code groups="base.group_no_one">
+                                                    <field name="name" />
+                                                </code>
+                                            </p>
+                                        </main>
                                     </t>
                                 </templates>
                         </kanban>


### PR DESCRIPTION
In this commit we have simplified the kanban arch for the base_import, base_import_module and base module. 
The goal is to simplify them, make them easier to read, and use bootstrap utility classnames.
- Previously, we used `kanban-box`, but now we are using `kanban-card` instead.
- Deprecated `oe_kanban_global_click` and `oe_kanban_global_click_edit`.
- More use of `<field/>` tags
- Removed the `oe_kanban_colorpicker` class and replaced it with the `kanban_color_picker` widget.
- Changed type='edit' to type='open' to open records. since version 16, records always open in edit mode by default.
- `kanban_image` from rendering context, is deprecated so we use `<field name=... widget=image/>` instead

Task-3992107

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
