### PR TITLE
[FIX] project: fixed tour step with incorrect trigger

### DIFF
--- a/addons/project/static/src/js/tours/project.js
+++ b/addons/project/static/src/js/tours/project.js
@@ -118,13 +118,14 @@ registry.category("web_tour.tours").add('project_tour', {
     position: "bottom",
     run: "click",
 }, {
-    trigger: ".o_field_widget[name='user_ids'] input",
+    trigger: ".o_field_widget[name='user_ids']",
     extra_trigger: '.o_form_project_tasks',
     content: _t("Assign a responsible to your task"),
     position: "right",
-    run(helpers) {
-        this.anchor.click();
-    }, 
+    run() {
+        this.anchor = document.querySelector(".o_field_widget[name='user_ids'] input"); //passing an HTML Element for hoot click
+        this.anchor.click()
+    }
 }, {
     trigger: ".ui-autocomplete > li > a:not(:has(i.fa))",
     auto: true,


### PR DESCRIPTION
Steps to reproduce:

- Start the project tour
- Follow the steps till the tour step comes to selecting Assignee's(user_ids)
- Now click on the drop-down and select an user.

Issue:

- The step is not completed even though we have selected an user.
- Now type something the Assignee's the step is completed

Fix:

- Incorrect trigger causes to generate incorrect consumeEvent (i.e., an input consume type) which is not satisfied by click event we initiate

Solution:

- Change the trigger and rewrite the run function.

task-3906723

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
