### PR TITLE
[IMP] hr_holidays: improve the department configuration link

### DIFF
--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -8,6 +8,7 @@
             <field name="arch" type="xml">
                 <search string="Employees">
                     <field name="name" string="Employee" filter_domain="['|', ('work_email', 'ilike', self), ('name', 'ilike', self)]"/>
+                    <field name="department_id"/>
                     <searchpanel>
                         <field name="company_id" groups="base.group_multi_company" icon="fa-building" enable_counters="1"/>
                         <field name="department_id" icon="fa-users" enable_counters="1"/>

--- a/addons/hr_holidays/models/hr_department.py
+++ b/addons/hr_holidays/models/hr_department.py
@@ -35,7 +35,7 @@ class Department(models.Model):
              ('state', '=', 'confirm')],
             ['department_id'], ['__count'])
         absence_data = Requests._read_group(
-            [('department_id', 'in', self.ids), ('state', 'not in', ['cancel', 'refuse']),
+            [('department_id', 'in', self.ids), ('state', '=', 'validate'),
              ('date_from', '<=', today_end), ('date_to', '>=', today_start)],
             ['department_id'], ['__count'])
 

--- a/addons/hr_holidays/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays/views/hr_leave_allocation_views.xml
@@ -9,6 +9,7 @@
                 <field name="employee_id"/>
                 <field name="name"/>
                 <field name="allocation_type"/>
+                <field name="department_id"/>
                 <filter domain="[
                         ('state','in',['confirm']),
                         '|',

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -66,7 +66,7 @@
                     name="waiting_for_me_manager"
                     groups="hr_holidays.group_hr_holidays_user"/>
                 <separator/>
-                <filter domain="[('state','in',('confirm','validate1'))]" string="First Approval" name="approve"/>
+                <filter domain="[('state', '=', 'confirm')]" string="First Approval" name="approve"/>
                 <filter domain="[('state', '=', 'validate1')]" string="Second Approval" name="second_approval"/>
                 <filter string="Approved" domain="[('state', '=', 'validate')]" name="validated"/>
                 <separator/>
@@ -572,6 +572,9 @@
         <field name="mode">primary</field>
         <field name="priority">33</field>
         <field name="arch" type="xml">
+            <field name='employee_id' position="after">
+                <field name="department_id"/>
+            </field>
             <xpath expr="//filter[@name='my_leaves']" position="attributes">
                 <attribute name="invisible">1</attribute>
             </xpath>

--- a/addons/hr_holidays/views/hr_views.xml
+++ b/addons/hr_holidays/views/hr_views.xml
@@ -8,6 +8,7 @@
        <field name="context">{
            'search_default_on_timeoff': 1,
            'searchpanel_default_department_id': active_id,
+           'search_default_department_id': active_id,
            'default_department_id': active_id}
        </field>
        <field name="search_view_id" ref="hr.view_employee_filter"/>


### PR DESCRIPTION
In this PR,
- Both "Time Off Requests" and "Allocation Requests" links now display the records according to the selected department.

Task - 3872574

