### PR TITLE
[IMP] analytic,base_automation: simplify kanban archs

### DIFF
--- a/addons/analytic/views/analytic_account_views.xml
+++ b/addons/analytic/views/analytic_account_views.xml
@@ -83,23 +83,15 @@
             <field name="model">account.analytic.account</field>
             <field name="arch" type="xml">
                <kanban class="o_kanban_mobile">
-                   <field name="display_name"/>
-                   <field name="balance"/>
                    <field name="currency_id"/>
                    <templates>
-                        <t t-name="kanban-box">
-                            <div t-attf-class="oe_kanban_card oe_kanban_global_click">
-                                <div t-attf-class="#{!selection_mode ? 'text-center' : ''}">
-                                   <strong><span><field name="display_name"/></span></strong>
-                                </div>
-                                <hr class="mt8 mb8"/>
-                                <div class="row">
-                                    <div t-attf-class="col-12 #{!selection_mode ? 'text-center' : ''}">
-                                        <span>
-                                            Balance: <field name="balance" widget="monetary"/>
-                                        </span>
-                                    </div>
-                                </div>
+                        <t t-name="kanban-card">
+                            <div t-attf-class="#{!selection_mode ? 'text-center' : ''}">
+                                <field class="fw-bold fs-5" name="display_name"/>
+                            </div>
+                            <hr class="mt-2 mb-2"/>
+                            <div t-attf-class="#{!selection_mode ? 'text-center' : ''}">
+                                Balance: <field name="balance" widget="monetary"/>
                             </div>
                         </t>
                     </templates>

--- a/addons/analytic/views/analytic_line_views.xml
+++ b/addons/analytic/views/analytic_line_views.xml
@@ -121,32 +121,17 @@
         <field name="model">account.analytic.line</field>
         <field name="arch" type="xml">
             <kanban class="o_kanban_mobile">
-                <field name="date"/>
-                <field name="name"/>
                 <field name="account_id"/>
                 <field name="currency_id"/>
-                <field name="amount"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div t-attf-class="oe_kanban_card oe_kanban_global_click">
-                            <div class="row">
-                                <div class="col-6">
-                                    <strong><span><t t-out="record.name.value"/></span></strong>
-                                </div>
-                                <div class="col-6 text-end">
-                                    <strong><t t-out="record.date.value"/></strong>
-                                </div>
-                            </div>
-                            <div class="row">
-                                <div class="col-6 text-muted">
-                                    <span><t t-out="record.account_id.value"/></span>
-                                </div>
-                                <div class="col-6">
-                                    <span class="float-end text-end">
-                                        <field name="amount" widget="monetary"/>
-                                    </span>
-                                </div>
-                            </div>
+                    <t t-name="kanban-card">
+                        <div class="d-flex justify-content-between" >
+                            <field class="fw-bold fs-5" name="name"/>
+                            <field class="text-end fw-bold fs-5" name="date"/>
+                        </div>
+                        <div class="d-flex justify-content-between">
+                            <field class="text-muted" name="account_id"/>
+                            <field class="justify-content-end" name="amount" widget="monetary"/>
                         </div>
                     </t>
                 </templates>

--- a/addons/base_automation/static/src/base_automation.scss
+++ b/addons/base_automation/static/src/base_automation.scss
@@ -10,19 +10,7 @@
             &.o_kanban_ghost {
                 display: none;
             }
-
         }
-        @include media-breakpoint-up(md) {
-            .o_automation_base_info {
-                width: 25%;
-                min-width: 200px;
-                min-height: 90px
-            };
-            .o_automation_actions {
-                display: flex !important;
-            }
-        }
-    
     }
 }
 

--- a/addons/base_automation/static/tests/kanban_header_patch.test.js
+++ b/addons/base_automation/static/tests/kanban_header_patch.test.js
@@ -67,10 +67,8 @@ test.tags("desktop")("basic grouped rendering with automations", async () => {
             <kanban class="o_kanban_test">
                 <field name="bar" />
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo" />
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo" />
                     </t>
                 </templates>
             </kanban>`,

--- a/addons/base_automation/views/base_automation_views.xml
+++ b/addons/base_automation/views/base_automation_views.xml
@@ -133,64 +133,58 @@
                                         <control>
                                             <create string="Add an action" />
                                         </control>
+                                        <field name="state"/>
+                                        <field name="evaluation_type"/>
+                                        <field name="value"/>
+                                        <field name="value_field_to_show"/>
+                                        <field name="update_field_type"/>
+                                        <field name="update_m2m_operation"/>
                                         <templates>
-                                            <t t-name="kanban-box">
-                                                <div class="oe_kanban_global_click row g-0 align-items-center">
-                                                    <div class="d-flex align-items-center gap-1">
-                                                        <field name="sequence" widget="handle" class="px-1" />
-                                                        <field name="state" invisible="1" />
-                                                        <field name="evaluation_type" invisible="1" />
-                                                        <field name="value" invisible="1" />
-                                                        <field name="selection_value" invisible="1" />
-                                                        <field name="value_field_to_show" invisible="1"/>
-                                                        <field name="update_field_type" invisible="1"/>
-                                                        <field name="update_m2m_operation" invisible="1"/>
-
-                                                        <!-- Icon section -->
-                                                        <i
-                                                            data-name="server_action_icon"
-                                                            t-att-title="record.state.value"
-                                                            class="fa fa-fw"
-                                                            t-att-class="{
-                                                                'code': 'fa-file-code-o',
-                                                                'object_create': 'fa-edit',
-                                                                'object_write': 'fa-refresh',
-                                                                'multi': 'fa-list-ul',
-                                                                'mail_post': 'fa-envelope',
-                                                                'followers': 'fa-user-o',
-                                                                'remove_followers': 'fa-user-times',
-                                                                'next_activity': 'fa-clock-o',
-                                                                'sms': 'fa-comments-o',
-                                                                'webhook': 'fa-paper-plane',
-                                                            }[record.state.raw_value]"
-                                                        />
-                                                        <field name="name" class="text-truncate" />
-                                                        <t invisible="state != 'object_write'">
-                                                            <t invisible="not (update_field_type == 'many2many' and update_m2m_operation == 'clear') or evaluation_type != 'value'">
-                                                                <span>by clearing it</span>
-                                                            </t>
-                                                            <t invisible="not (update_field_type == 'many2many' and update_m2m_operation == 'add') or evaluation_type != 'value'">
-                                                                <span>by adding</span><field name="resource_ref"/>
-                                                            </t>
-                                                            <t invisible="not (update_field_type == 'many2many' and update_m2m_operation == 'remove') or evaluation_type != 'value'">
-                                                               <span>by removing</span><field name="resource_ref"/>
-                                                            </t>
-                                                            <t invisible="not (update_field_type == 'many2many' and update_m2m_operation == 'set') or evaluation_type != 'value'">
-                                                                <span>by setting it to</span><field name="resource_ref"/>
-                                                             </t>
-                                                            <t invisible="update_field_type == 'many2many' and evaluation_type == 'value'">
-                                                                <span invisible="evaluation_type != 'value'">to</span>
-                                                                <span invisible="evaluation_type != 'equation'">as</span>
-                                                                <field name="resource_ref" invisible="not (value_field_to_show == 'resource_ref' and evaluation_type == 'value')" />
-                                                                <field name="selection_value" invisible="not (value_field_to_show == 'selection_value' and evaluation_type == 'value')" class="d-inline"/>
-                                                                <field name="update_boolean_value" invisible="not (value_field_to_show == 'update_boolean_value' and evaluation_type == 'value')" class="d-inline"/>
-                                                                <em invisible="not (value_field_to_show == 'value' and evaluation_type == 'value')" t-out="record.value.raw_value" class="d-inline"/>
-                                                                <code invisible="not (evaluation_type == 'equation')" t-out="record.value.raw_value"/>
-                                                            </t>
+                                            <t t-name="kanban-card" class="flex-row align-items-center gap-1">
+                                                <field name="sequence" widget="handle" class="px-1" />
+                                                <!-- Icon section -->
+                                                <i
+                                                    data-name="server_action_icon"
+                                                    t-att-title="record.state.value"
+                                                    class="fa fa-fw"
+                                                    t-att-class="{
+                                                        'code': 'fa-file-code-o',
+                                                        'object_create': 'fa-edit',
+                                                        'object_write': 'fa-refresh',
+                                                        'multi': 'fa-list-ul',
+                                                        'mail_post': 'fa-envelope',
+                                                        'followers': 'fa-user-o',
+                                                        'remove_followers': 'fa-user-times',
+                                                        'next_activity': 'fa-clock-o',
+                                                        'sms': 'fa-comments-o',
+                                                        'webhook': 'fa-paper-plane',
+                                                    }[record.state.raw_value]"
+                                                />
+                                                <field name="name" class="text-truncate" />
+                                                <t invisible="state != 'object_write'">
+                                                    <t invisible="not (update_field_type == 'many2many' and update_m2m_operation == 'clear') or evaluation_type != 'value'">
+                                                        <span>by clearing it</span>
+                                                    </t>
+                                                    <t invisible="not (update_field_type == 'many2many' and update_m2m_operation == 'add') or evaluation_type != 'value'">
+                                                        <span>by adding</span><field name="resource_ref"/>
+                                                    </t>
+                                                    <t invisible="not (update_field_type == 'many2many' and update_m2m_operation == 'remove') or evaluation_type != 'value'">
+                                                        <span>by removing</span><field name="resource_ref"/>
+                                                    </t>
+                                                    <t invisible="not (update_field_type == 'many2many' and update_m2m_operation == 'set') or evaluation_type != 'value'">
+                                                        <span>by setting it to</span><field name="resource_ref"/>
                                                         </t>
-                                                        <button type="delete" name="delete" class="btn fa fa-trash fa-xl px-3 ms-auto" title="Delete Action" />
-                                                    </div>
-                                                </div>
+                                                    <t invisible="update_field_type == 'many2many' and evaluation_type == 'value'">
+                                                        <span invisible="evaluation_type != 'value'">to</span>
+                                                        <span invisible="evaluation_type != 'equation'">as</span>
+                                                        <field name="resource_ref" invisible="not (value_field_to_show == 'resource_ref' and evaluation_type == 'value')" />
+                                                        <field name="selection_value" invisible="not (value_field_to_show == 'selection_value' and evaluation_type == 'value')" class="d-inline"/>
+                                                        <field name="update_boolean_value" invisible="not (value_field_to_show == 'update_boolean_value' and evaluation_type == 'value')" class="d-inline"/>
+                                                        <em invisible="not (value_field_to_show == 'value' and evaluation_type == 'value')" class="d-inline"><field name="value"/></em>
+                                                        <code invisible="not (evaluation_type == 'equation')"><field name="value" /></code>
+                                                    </t>
+                                                </t>
+                                                <button type="delete" name="delete" class="btn fa fa-trash fa-xl px-3 ms-auto" title="Delete Action" />
                                             </t>
                                         </templates>
                                     </kanban>
@@ -233,45 +227,40 @@
                     group_edit="false"
                     group_delete="false"
                 >
+                    <field name="active"/>
                     <templates>
-                        <t t-name="kanban-box">
-                            <div class="oe_kanban_global_click">
-                                <field name="active" invisible="1" />
-                                <field name="model_name" invisible="1" />
-                                <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active" />
-                                <div class="d-flex flex-column flex-md-row gap-3 flex-grow-1">
-                                    <div class="d-flex align-items-center o_automation_base_info">
-                                        <div class="d-flex flex-column">
-                                            <field name="name" class="fs-2 fw-bold"/>
-                                            <field name="model_id" invisible="context.get('default_model_id')"/>
-                                            <div class="d-flex align-items-center gap-1" invisible="trigger in ['on_time', 'on_time_created', 'on_time_updated']">
-                                                <field name="trigger" />
-                                                <field name="on_change_field_ids" invisible="trigger != 'on_change'" class="my-1" />
-                                                <field name="trg_selection_field_id" invisible="trigger not in ['on_state_set', 'on_priority_set']" class="o_tag o_tag_color_0 rounded-pill p-1 px-2" />
-                                                <field name="trg_field_ref" invisible="trigger not in ['on_stage_set', 'on_tag_set']" class="o_tag o_tag_color_0 rounded-pill p-1 px-2" />
-                                                <field name="trigger_field_ids" invisible="trigger not in ['on_create_or_write']" class="my-1" />
-                                            </div>
-                                            <div class="d-flex align-items-center gap-1" invisible="trigger != 'on_time'">
-                                                <field name="trg_date_range"/>
-                                                <field name="trg_date_range_type" class="text-lowercase" />
-                                                <span class="flex-shrink-0">
-                                                    based on <field name="trg_date_id" invisible="trigger != 'on_time'"  class="o_tag o_tag_color_0 rounded-pill p-1 px-2" />
-                                                </span>
-                                            </div>
-                                            <div class="d-flex align-items-center gap-1" invisible="trigger not in ['on_time_created', 'on_time_updated']">
-                                                <field name="trg_date_range"/>
-                                                <field name="trg_date_range_type" class="text-lowercase" />
-                                                <field name="trigger" class="text-lowercase" />
-                                                <field name="trg_date_id" invisible="trigger != 'on_time'"  class="o_tag o_tag_color_0 rounded-pill p-1 px-2" />
-                                            </div>
-                                            <field name="trg_date_calendar_id" invisible="not trg_date_id or trg_date_range_type != 'day'" />
-                                        </div>
+                        <t t-name="kanban-card" class="flex-md-row">
+                            <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active" />
+                            <div class="d-flex align-items-center w-100 w-md-25 o_automation_base_info">
+                                <div class="d-flex flex-column">
+                                    <field name="name" class="fs-2 fw-bold"/>
+                                    <field name="model_id" invisible="context.get('default_model_id')"/>
+                                    <div class="d-flex align-items-center gap-1" invisible="trigger in ['on_time', 'on_time_created', 'on_time_updated']">
+                                        <field name="trigger" />
+                                        <field name="on_change_field_ids" invisible="trigger != 'on_change'" class="my-1" />
+                                        <field name="trg_selection_field_id" invisible="trigger not in ['on_state_set', 'on_priority_set']" class="o_tag o_tag_color_0 rounded-pill p-1 px-2" />
+                                        <field name="trg_field_ref" invisible="trigger not in ['on_stage_set', 'on_tag_set']" class="o_tag o_tag_color_0 rounded-pill p-1 px-2" />
+                                        <field name="trigger_field_ids" invisible="trigger not in ['on_create_or_write']" class="my-1" />
                                     </div>
-                                    <div class="d-none flex-grow-1 align-items-center gap-3 o_automation_actions" data-name="more-info">
-                                        <i class="fa fa-2x fa-arrow-right text-primary" title="Actions" />
-                                        <field name="action_server_ids" widget="base_automation_actions_one2many" class="align-self-center w-100 me-md-3" />
+                                    <div class="d-flex align-items-center gap-1" invisible="trigger != 'on_time'">
+                                        <field name="trg_date_range"/>
+                                        <field name="trg_date_range_type" class="text-lowercase text-nowrap" />
+                                        <span class="flex-shrink-0">
+                                            based on <field name="trg_date_id" invisible="trigger != 'on_time'"  class="o_tag o_tag_color_0 rounded-pill p-1 px-2" />
+                                        </span>
                                     </div>
+                                    <div class="d-flex align-items-center gap-1" invisible="trigger not in ['on_time_created', 'on_time_updated']">
+                                        <field name="trg_date_range"/>
+                                        <field name="trg_date_range_type" class="text-lowercase" />
+                                        <field name="trigger" class="text-lowercase" />
+                                        <field name="trg_date_id" invisible="trigger != 'on_time'"  class="o_tag o_tag_color_0 rounded-pill p-1 px-2" />
+                                    </div>
+                                    <field name="trg_date_calendar_id" invisible="not trg_date_id or trg_date_range_type != 'day'" />
                                 </div>
+                            </div>
+                            <div class="d-none d-md-flex flex-grow-1 align-items-center gap-3 o_automation_actions" data-name="more-info">
+                                <i class="fa fa-2x fa-arrow-right text-primary" title="Actions" />
+                                <field name="action_server_ids" widget="base_automation_actions_one2many" class="align-self-center w-100 me-md-3" />
                             </div>
                         </t>
                     </templates>


### PR DESCRIPTION
In this commit we have simplified the kanban arch for the analytic and base_automation module.the goal is to simplify them, make them easier to read, and use bootstrap utility classnames.
- Previously, we used `kanban-box`, but now we are using `kanban-card` instead.
- Deprecated `oe_kanban_global_click` and `oe_kanban_global_click_edit`.
- More use of `<field/>` tags
- Removed the `oe_kanban_colorpicker` class and replaced it with the `kanban_color_picker` widget.
- Changed type='edit' to type='open' to open records. since version 16, records always open in edit mode by default.
- `kanban_image` from rendering context, is deprecated so we use `<field name=... widget=image/>` instead

Task:3992107

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
