### PR TITLE
[FIX] pos_sale: cancel down-payment reflate in SOL

### DIFF
--- a/addons/pos_sale/models/__init__.py
+++ b/addons/pos_sale/models/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import account_move
 from . import pos_config
 from . import pos_order
 from . import product_template

--- a/addons/pos_sale/models/account_move.py
+++ b/addons/pos_sale/models/account_move.py
@@ -1,0 +1,25 @@
+from odoo import models, _
+
+
+class AccountMove(models.Model):
+    _inherit = 'account.move'
+
+    def reflect_cancelled_sol(self, isCancelled):
+        if self.env.user.has_group('point_of_sale.group_pos_user'):
+            for invoice in self:
+                for pos_order_line in invoice.pos_order_ids.mapped('lines'):
+                    if isCancelled and "(Cancelled)" not in pos_order_line.sale_order_line_id.name:
+                        name = _("%(old_name)s (Cancelled)", old_name=pos_order_line.sale_order_line_id.name)
+                        pos_order_line.sale_order_line_id.name = name
+                    elif not isCancelled:
+                        pos_order_line.sale_order_line_id.name = pos_order_line.sale_order_line_id.name.replace(" (Cancelled)", "")
+
+    def button_cancel(self):
+        res = super().button_cancel()
+        self.reflect_cancelled_sol(True)
+        return res
+
+    def action_post(self):
+        res = super().action_post()
+        self.reflect_cancelled_sol(False)
+        return res

--- a/addons/pos_sale/models/sale_order.py
+++ b/addons/pos_sale/models/sale_order.py
@@ -149,3 +149,13 @@ class SaleOrderLine(models.Model):
         return super()._get_downpayment_line_price_unit(invoices) + sum(
             pol.price_unit for pol in self.sudo().pos_order_line_ids
         )
+
+    @api.depends('product_id', 'pos_order_line_ids')
+    def _compute_name(self):
+        for sol in self:
+            if sol.pos_order_line_ids:
+                downpayment_sols = sol.pos_order_line_ids.mapped('refunded_orderline_id.sale_order_line_id')
+                for downpayment_sol in downpayment_sols:
+                    downpayment_sol.name = _("%(line_description)s (Cancelled)", line_description=downpayment_sol.name)
+            else:
+                super()._compute_name()


### PR DESCRIPTION
Before this commit :
---------------------------
Previously, when recording a down payment from the Point of Sale (POS), the amount was correctly reflected and visible in the Sale Order line. However, if the down payment was canceled from the POS, the cancellation was not properly reflected in the Sale Order line name(description).

After this commit :
------------------------
With this commit, the issue is addressed, and the cancellation of down payments from the POS is now accurately reflected in the Sale Order line.

task: 3514218