### PR TITLE
[IMP] hr_timesheet: improve the kanban view of timesheets

### DIFF
--- a/addons/hr_timesheet/static/src/components/time_hour_field/time_hour_field.js
+++ b/addons/hr_timesheet/static/src/components/time_hour_field/time_hour_field.js
@@ -1,0 +1,18 @@
+import { registry } from "@web/core/registry";
+import {_t} from "@web/core/l10n/translation";
+import { FloatTimeField } from "@web/views/fields/float_time/float_time_field";
+
+export class TimeHourField extends FloatTimeField {
+    get formattedValue() {
+        const unitAmount = super.formattedValue;
+        const [hourStr, minuteStr] = unitAmount.split(":");
+        const hours = parseInt(hourStr, 10);
+        const minutes = parseInt(minuteStr, 10);
+        return minutes ? _t("%(hours)sh%(minutes)s", { hours, minutes }) : _t("%(hours)sh", { hours });
+    }
+}
+export const timeHourField = {
+    component: TimeHourField,
+};
+
+registry.category("fields").add("time_hour_uom", timeHourField);

--- a/addons/hr_timesheet/static/src/components/timesheet_duration_uom/timesheet_duration_uom.js
+++ b/addons/hr_timesheet/static/src/components/timesheet_duration_uom/timesheet_duration_uom.js
@@ -1,0 +1,22 @@
+import { registry } from "@web/core/registry";
+import { TimesheetUOM } from "../timesheet_uom/timesheet_uom";
+import { TimeHourField } from "../time_hour_field/time_hour_field";
+
+export class TimesheetDurationUOM extends TimesheetUOM {
+    static components = {
+        ...TimesheetUOM.components,
+        TimeHourField,
+    };
+    get timesheetComponent() {
+        if (this.timesheetUOMService.timesheetWidget === "float_time") {
+            return this.timesheetUOMService.getTimesheetComponent("time_hour_uom");
+        }
+        return super.timesheetComponent;
+    }
+}
+
+export const timesheetDurationUOM = {
+    component: TimesheetDurationUOM,
+};
+
+registry.category("fields").add("timesheet_duration_uom", timesheetDurationUOM);

--- a/addons/hr_timesheet/views/hr_timesheet_views.xml
+++ b/addons/hr_timesheet/views/hr_timesheet_views.xml
@@ -291,20 +291,26 @@
                         <t t-name="kanban-card">
                             <div class="d-flex flex-row">
                                 <span t-att-title="record.employee_id.value">
-                                    <field name="employee_id" widget="image" options="{'preview_image': 'avatar_128'}" class="o_image_40_cover me-2 float-start"/>
+                                    <field name="employee_id" widget="image" options="{'preview_image': 'avatar_128'}" class="o_image_64_cover me-2 float-start"/>
                                 </span>
                                 <div class="d-flex flex-column text-truncate lh-sm col-10">
-                                    <span class="text-truncate" t-att-title="record.project_id.value"><field name="project_id" class="p-0 fw-bold fs-5"/></span>
-                                    <span class="text-truncate" t-att-title="record.task_id.value"><field name="task_id" class="fst-italic"/></span>
-                                    <span class="text-truncate" t-att-title="record.name.value"><field name="name"/></span>
+                                    <span class="text-truncate" invisible="context.get('default_project_id')" t-att-title="record.project_id.value">
+                                        <field name="project_id" class="p-0 fw-bold fs-5"/>
+                                    </span>
+                                    <span class="text-truncate" t-att-title="record.task_id.value">
+                                        <field name="task_id" invisible="context.get('default_project_id')"/>
+                                        <field name="task_id" invisible="not context.get('default_project_id')" class="p-0 fw-bold fs-5"/>
+                                    </span>
+                                    <span class="text-truncate">
+                                        <i class="fa fa-calendar me-1" role="img" aria-label="Date" title="Date"></i>
+                                        <field name="date"/><span invisible="context.get('is_my_timesheets')"> - <field name="employee_id"/></span>
+                                    </span>
+                                    <span class="text-truncate" t-att-title="record.name.value"><field name="name" class="fst-italic"/></span>
                                 </div>
                             </div>
-                            <hr class="mt4 mb4"/>
                             <footer class="mt-0 pt-0 fs-6">
-                                <i class="fa fa-calendar me-1" role="img" aria-label="Date" title="Date"></i>
-                                <field name="date"/>
                                 <div class="d-flex ms-auto">
-                                    <strong>Duration:</strong><field name="unit_amount" widget="timesheet_uom" decoration-danger="unit_amount &gt; 24" decoration-muted="unit_amount == 0" class="ms-1"/>
+                                    <strong><field name="unit_amount" widget="timesheet_duration_uom" decoration-danger="unit_amount &gt; 24" decoration-muted="unit_amount == 0" class="ms-1"/></strong>
                                 </div>
                             </footer>
                         </t>
@@ -335,6 +341,7 @@
             <field name="context">{
                 "search_default_week":1,
                 "is_timesheet": 1,
+                "is_my_timesheets": 1,
             }</field>
             <field name="search_view_id" ref="hr_timesheet_line_my_timesheet_search"/>
             <field name="help" type="html">


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Desired behavior after PR is merged:

- hide the project and display the task in bold on the first line in kanban in timesheet kanban view.
- Remove hr between the text and the date.
- Remove the italic for the task.
- Display the description in italic.
- Move the date on the right of the avatar.
- Display the name of the employee on the right of the date. e.g. 06/06/2024 - Mitchell Admin

task-3996705

Enterprise PR: odoo/enterprise#65148


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
