### PR TITLE
[IMP] website_event{_*}: set specific SEO data for sub-pages

### DIFF
--- a/addons/website_event/controllers/community.py
+++ b/addons/website_event/controllers/community.py
@@ -7,7 +7,7 @@ from odoo.http import request
 
 class EventCommunityController(http.Controller):
 
-    @http.route('/event/<model("event.event"):event>/community', type="http", auth="public", website=True, sitemap=False)
-    def community(self, event, lang=None, **kwargs):
+    @http.route('/event/<model("event.event"):event>/community/<path:page_seo>', type="http", auth="public", website=True, sitemap=False)
+    def community(self, event, page_seo, lang=None, **kwargs):
         """ This skeleton route will be overriden in website_event_track_quiz, website_event_meet and website_event_meet_quiz. """
         return request.render('website.page_404')

--- a/addons/website_event/models/event_event.py
+++ b/addons/website_event/models/event_event.py
@@ -276,11 +276,10 @@ class Event(models.Model):
 
         :return list: list of fields, each of which triggering a menu update
           like website_menu, website_track, ... """
-        return ['community_menu', 'introduction_menu', 'location_menu', 'register_menu']
+        return ['introduction_menu', 'location_menu', 'register_menu']
 
     def _get_menu_type_field_matching(self):
         return {
-            'community': 'community_menu',
             'introduction': 'introduction_menu',
             'location': 'location_menu',
             'register': 'register_menu',
@@ -346,7 +345,6 @@ class Event(models.Model):
             (_('Introduction'), False, 'website_event.template_intro', 1, 'introduction'),
             (_('Location'), False, 'website_event.template_location', 50, 'location'),
             (_('Info'), '/event/%s/register' % slug(self), False, 100, 'register'),
-            (_('Community'), '/event/%s/community' % slug(self), False, 80, 'community'),
         ]
 
     def _update_website_menus(self, menus_update_by_field=None):
@@ -361,8 +359,6 @@ class Event(models.Model):
             elif event.website_menu and not event.menu_id:
                 root_menu = self.env['website.menu'].sudo().create({'name': event.name, 'website_id': event.website_id.id})
                 event.menu_id = root_menu
-            if event.menu_id and (not menus_update_by_field or event in menus_update_by_field.get('community_menu')):
-                event._update_website_menu_entry('community_menu', 'community_menu_ids', 'community')
             if event.menu_id and (not menus_update_by_field or event in menus_update_by_field.get('introduction_menu')):
                 event._update_website_menu_entry('introduction_menu', 'introduction_menu_ids', 'introduction')
             if event.menu_id and (not menus_update_by_field or event in menus_update_by_field.get('location_menu')):
@@ -414,6 +410,13 @@ class Event(models.Model):
         """
         self.check_access_rights('write')
         view_id = False
+
+        if url and xml_id:
+            page_result = self.env['website'].sudo().new_page(
+                name=f'{name} {self.name}', template=xml_id,
+                add_menu=False, ispage=False)
+            url = url + page_result['url']
+
         if not url:
             # add_menu=False, ispage=False -> simply create a new ir.ui.view with name
             # and template

--- a/addons/website_event/tests/common.py
+++ b/addons/website_event/tests/common.py
@@ -32,7 +32,7 @@ class OnlineEventCase(EventCase):
         })
 
     def _get_menus(self):
-        return {'Introduction', 'Community', 'Info', 'Location'}
+        return {'Introduction', 'Info', 'Location'}
 
     def _assert_website_menus(self, event, menus_in=None, menus_out=None):
         self.assertTrue(event.menu_id)

--- a/addons/website_event/tests/test_event_menus.py
+++ b/addons/website_event/tests/test_event_menus.py
@@ -17,17 +17,14 @@ class TestEventMenus(OnlineEventCase):
             'date_begin': fields.Datetime.to_string(datetime.today() + timedelta(days=1)),
             'date_end': fields.Datetime.to_string(datetime.today() + timedelta(days=15)),
             'website_menu': True,
-            'community_menu': False,
         })
         self.assertTrue(event.website_menu)
         self.assertTrue(event.introduction_menu)
         self.assertTrue(event.location_menu)
         self.assertTrue(event.register_menu)
-        self.assertFalse(event.community_menu)
-        self._assert_website_menus(event, ['Introduction', 'Location', 'Info'], menus_out=['Community'])
+        self._assert_website_menus(event, ['Introduction', 'Location', 'Info'])
 
-        event.community_menu = True
-        self._assert_website_menus(event, ['Introduction', 'Location', 'Info', 'Community'])
+        self._assert_website_menus(event, ['Introduction', 'Location', 'Info'])
 
         # test create without any requested menus
         event = self.env['event.event'].create({
@@ -40,12 +37,11 @@ class TestEventMenus(OnlineEventCase):
         self.assertFalse(event.introduction_menu)
         self.assertFalse(event.location_menu)
         self.assertFalse(event.register_menu)
-        self.assertFalse(event.community_menu)
         self.assertFalse(event.menu_id)
 
         # test update of website_menu triggering 3 sub menus
         event.write({'website_menu': True})
-        self._assert_website_menus(event, ['Introduction', 'Location', 'Info'], menus_out=['Community'])
+        self._assert_website_menus(event, ['Introduction', 'Location', 'Info'])
 
     @users('user_event_web_manager')
     def test_menu_management_frontend(self):
@@ -54,16 +50,15 @@ class TestEventMenus(OnlineEventCase):
             'date_begin': fields.Datetime.to_string(datetime.today() + timedelta(days=1)),
             'date_end': fields.Datetime.to_string(datetime.today() + timedelta(days=15)),
             'website_menu': True,
-            'community_menu': False,
         })
-        self._assert_website_menus(event, ['Introduction', 'Location', 'Info'], menus_out=['Community'])
+        self._assert_website_menus(event, ['Introduction', 'Location', 'Info'])
 
         # simulate menu removal from frontend: aka unlinking a menu
         event.menu_id.child_id.filtered(lambda menu: menu.name == 'Introduction').unlink()
 
         self.assertTrue(event.website_menu)
-        self._assert_website_menus(event, ['Location', 'Info'], menus_out=['Introduction', 'Community'])
+        self._assert_website_menus(event, ['Location', 'Info'], menus_out=['Introduction'])
 
         # re-created from backend
         event.introduction_menu = True
-        self._assert_website_menus(event, ['Introduction', 'Location', 'Info'], menus_out=['Community'])
+        self._assert_website_menus(event, ['Introduction', 'Location', 'Info'])

--- a/addons/website_event_booth/__init__.py
+++ b/addons/website_event_booth/__init__.py
@@ -3,3 +3,4 @@
 
 from . import controllers
 from . import models
+from . import tests

--- a/addons/website_event_booth/controllers/event_booth.py
+++ b/addons/website_event_booth/controllers/event_booth.py
@@ -12,18 +12,19 @@ from odoo.addons.website_event.controllers.main import WebsiteEventController
 
 class WebsiteEventBoothController(WebsiteEventController):
 
-    @http.route('/event/<model("event.event"):event>/booth', type='http', auth='public', website=True, sitemap=False)
-    def event_booth_main(self, event, booth_category_id=False, booth_ids=False):
+    @http.route('/event/<model("event.event"):event>/booth/<path:page>', type='http', auth='public', website=True, sitemap=False)
+    def event_booth_main(self, event, page, booth_category_id=False, booth_ids=False):
         try:
             event.check_access_rights('read')
             event.check_access_rule('read')
         except exceptions.AccessError:
             raise Forbidden()
 
+        seo_object = request.website.get_template('website_event_booth.' + page)
         booth_category_id = int(booth_category_id) if booth_category_id else False
         return request.render(
             'website_event_booth.event_booth_registration',
-            self._prepare_booth_main_values(event, booth_category_id=booth_category_id, booth_ids=booth_ids)
+            self._prepare_booth_main_values(event, seo_object, booth_category_id=booth_category_id, booth_ids=booth_ids)
         )
 
     @http.route('/event/<model("event.event"):event>/booth/register',
@@ -101,7 +102,7 @@ class WebsiteEventBoothController(WebsiteEventController):
             return request.env['event.booth']
         return booths
 
-    def _prepare_booth_main_values(self, event, booth_category_id=False, booth_ids=False):
+    def _prepare_booth_main_values(self, event, seo_object, booth_category_id=False, booth_ids=False):
         event_sudo = event.sudo()
         available_booth_categories = event_sudo.event_booth_category_available_ids
         chosen_booth_category = available_booth_categories.filtered(lambda cat: cat.id == booth_category_id)
@@ -112,6 +113,7 @@ class WebsiteEventBoothController(WebsiteEventController):
             'event_booths': event_sudo.event_booth_ids,
             'hide_sponsors': True,
             'main_object': event_sudo,
+            'seo_object': seo_object,
             'selected_booth_category_id': (chosen_booth_category or default_booth_category).id,
             'selected_booth_ids': booth_ids if booth_category_id == chosen_booth_category.id and booth_ids else False,
         }

--- a/addons/website_event_booth/models/event_event.py
+++ b/addons/website_event_booth/models/event_event.py
@@ -51,5 +51,5 @@ class Event(models.Model):
     def _get_website_menu_entries(self):
         self.ensure_one()
         return super(Event, self)._get_website_menu_entries() + [
-            (_('Get A Booth'), '/event/%s/booth' % slug(self), False, 90, 'booth')
+            (_('Get A Booth'), '/event/%s/booth' % slug(self), 'website_event_booth.event_booth_registration', 90, 'booth')
         ]

--- a/addons/website_event_booth/tests/__init__.py
+++ b/addons/website_event_booth/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_event_seo_data

--- a/addons/website_event_booth/tests/test_event_seo_data.py
+++ b/addons/website_event_booth/tests/test_event_seo_data.py
@@ -1,0 +1,37 @@
+from datetime import datetime, timedelta
+
+from odoo import fields
+from odoo.addons.website_event.tests.common import OnlineEventCase
+from odoo.tests.common import users
+
+
+class TestEventSeoData(OnlineEventCase):
+
+    @users('user_event_web_manager')
+    def test_seo_data_booth(self):
+        """Test SEO data for event and booth page"""
+
+        # Create an event
+        event = self.env['event.event'].create({
+            'name': 'TestEvent',
+            'date_begin': fields.Datetime.to_string(datetime.today() + timedelta(days=1)),
+            'date_end': fields.Datetime.to_string(datetime.today() + timedelta(days=15)),
+            'website_menu': True,
+            'booth_menu': True,
+        })
+
+        self.assertFalse(event.website_meta_title, "Event should initially have no meta title")
+        event.write({
+            'website_meta_title': "info",
+        })
+        self.assertTrue(event.website_meta_title, "Event should have a meta title after writing")
+
+        view_model = self.env['ir.ui.view'].search([('name', '=', 'Get A Booth TestEvent')])
+
+        self.assertFalse(view_model.website_meta_title, "Booth page should initially have no meta title")
+        view_model.write({
+            'website_meta_title': "booth",
+        })
+        self.assertTrue(view_model.website_meta_title, "Booth page should have a meta title after writing")
+
+        self.assertNotEqual(event.website_meta_title, view_model.website_meta_title, "Event and booth page should have different meta titles")

--- a/addons/website_event_booth_sale/controllers/event_booth.py
+++ b/addons/website_event_booth_sale/controllers/event_booth.py
@@ -45,8 +45,8 @@ class WebsiteEventBoothController(WebsiteEventController):
             values.get('booth_category', request.env['event.booth.category']).price
         return values
 
-    def _prepare_booth_main_values(self, event, booth_category_id=False, booth_ids=False):
-        values = super()._prepare_booth_main_values(event, booth_category_id=booth_category_id, booth_ids=booth_ids)
+    def _prepare_booth_main_values(self, event, seo_object, booth_category_id=False, booth_ids=False):
+        values = super()._prepare_booth_main_values(event, seo_object, booth_category_id=booth_category_id, booth_ids=booth_ids)
         values['has_payment_step'] = request.website.sale_get_order().amount_total or \
             any(booth_category.price for booth_category in values.get('available_booth_category_ids', request.env['event.booth.category']))
         return values

--- a/addons/website_event_exhibitor/controllers/exhibitor.py
+++ b/addons/website_event_exhibitor/controllers/exhibitor.py
@@ -30,17 +30,20 @@ class ExhibitorController(WebsiteEventController):
 
     @http.route([
         # TDE BACKWARD: exhibitors is actually a typo
-        '/event/<model("event.event"):event>/exhibitors',
+        '/event/<model("event.event"):event>/exhibitors/<path:page>',
         # TDE BACKWARD: matches event/event-1/exhibitor/exhib-1 sub domain
-        '/event/<model("event.event"):event>/exhibitor'
+        '/event/<model("event.event"):event>/exhibitor/<path:page>'
     ], type='http', auth="public", website=True, sitemap=False, methods=['GET', 'POST'])
-    def event_exhibitors(self, event, **searches):
+    def event_exhibitors(self, event, page, **searches):
+
+        seo_object = request.website.get_template('website_event_exhibitor.' + page)
+
         return request.render(
             "website_event_exhibitor.event_exhibitors",
-            self._event_exhibitors_get_values(event, **searches)
+            self._event_exhibitors_get_values(event, seo_object, **searches)
         )
 
-    def _event_exhibitors_get_values(self, event, **searches):
+    def _event_exhibitors_get_values(self, event, seo_object, **searches):
         # init and process search terms
         searches.setdefault('search', '')
         searches.setdefault('countries', '')
@@ -106,6 +109,7 @@ class ExhibitorController(WebsiteEventController):
             # event information
             'event': event,
             'main_object': event,
+            'seo_object': seo_object,
             'sponsor_categories': sponsor_categories,
             'hide_sponsors': True,
             # search information

--- a/addons/website_event_exhibitor/models/event_event.py
+++ b/addons/website_event_exhibitor/models/event_event.py
@@ -59,5 +59,5 @@ class EventEvent(models.Model):
     def _get_website_menu_entries(self):
         self.ensure_one()
         return super(EventEvent, self)._get_website_menu_entries() + [
-            (_('Exhibitors'), '/event/%s/exhibitors' % slug(self), False, 60, 'exhibitor')
+            (_('Exhibitors'), '/event/%s/exhibitors' % slug(self), 'website_event_exhibitor.event_exhibitors', 60, 'exhibitor')
         ]

--- a/addons/website_event_exhibitor/tests/__init__.py
+++ b/addons/website_event_exhibitor/tests/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import test_event_seo_data
 from . import test_sponsor_internals

--- a/addons/website_event_exhibitor/tests/test_event_seo_data.py
+++ b/addons/website_event_exhibitor/tests/test_event_seo_data.py
@@ -1,0 +1,37 @@
+from datetime import datetime, timedelta
+
+from odoo import fields
+from odoo.addons.website_event.tests.common import OnlineEventCase
+from odoo.tests.common import users
+
+
+class TestEventSeoData(OnlineEventCase):
+
+    @users('user_event_web_manager')
+    def test_seo_data_exhibitor(self):
+        """Test SEO data for event and exhibitors page"""
+
+        # Create an event
+        event = self.env['event.event'].create({
+            'name': 'TestEvent',
+            'date_begin': fields.Datetime.to_string(datetime.today() + timedelta(days=1)),
+            'date_end': fields.Datetime.to_string(datetime.today() + timedelta(days=15)),
+            'website_menu': True,
+            'exhibitor_menu': True,
+        })
+
+        self.assertFalse(event.website_meta_title, "Event should initially have no meta title")
+        event.write({
+            'website_meta_title': "info",
+        })
+        self.assertTrue(event.website_meta_title, "Event should have a meta title after writing")
+
+        view_model = self.env['ir.ui.view'].search([('name', '=', 'Exhibitors TestEvent')])
+
+        self.assertFalse(view_model.website_meta_title, "Exhibitors page should initially have no meta title")
+        view_model.write({
+            'website_meta_title': "exhibitors",
+        })
+        self.assertTrue(view_model.website_meta_title, "Exhibitors page should have a meta title after writing")
+
+        self.assertNotEqual(event.website_meta_title, view_model.website_meta_title, "Event and Exhibitors page should have different meta titles")

--- a/addons/website_event_exhibitor/views/event_exhibitor_templates_page.xml
+++ b/addons/website_event_exhibitor/views/event_exhibitor_templates_page.xml
@@ -5,7 +5,7 @@
     <t t-set="no_header" t-value="option_widescreen"/>
     <t t-set="no_footer" t-value="option_widescreen"/>
     <t t-call="website_event.layout">
-        <t t-set="navbar__back_url" t-value="'/event/%s/exhibitors' % (slug(event))"/>
+        <t t-set="navbar__back_url" t-value="'/event/%s/exhibitors/exhibitors-%s' % (slug(event), event.name.replace(' ','-').lower())"/>
         <t t-set="navbar__back_title">Back to all Exhibitors</t>
         <t t-set="navbar__back_text">All Exhibitors</t>
 

--- a/addons/website_event_meet/controllers/community.py
+++ b/addons/website_event_meet/controllers/community.py
@@ -29,18 +29,19 @@ class WebsiteEventMeetController(EventCommunityController):
     # ------------------------------------------------------------
 
     @http.route()
-    def community(self, event, page=1, lang=None, **kwargs):
+    def community(self, event, page_seo, page=1, lang=None, **kwargs):
         """Display the meeting rooms of the event on the frontend side.
 
         :param event: event for which we display the meeting rooms
         :param lang: lang id used to perform a search
         """
+        seo_object = request.website.get_template('website_event_meet.' + page_seo)
         return request.render(
             "website_event_meet.event_meet",
-            self._event_meeting_rooms_get_values(event, lang=lang)
+            self._event_meeting_rooms_get_values(event, seo_object, page_seo, lang=lang)
         )
 
-    def _event_meeting_rooms_get_values(self, event, lang=None):
+    def _event_meeting_rooms_get_values(self, event, seo_object, page_seo, lang=None):
         search_domain = self._get_event_rooms_base_domain(event)
         meeting_rooms_all = request.env['event.meeting.room'].sudo().search(search_domain)
         if lang:
@@ -61,6 +62,8 @@ class WebsiteEventMeetController(EventCommunityController):
             # event information
             "event": event,
             'main_object': event,
+            'seo_object': seo_object,
+            'page': page_seo,
             # rooms
             "meeting_rooms": meeting_rooms,
             "current_lang": request.env["res.lang"].browse(int(lang)) if lang else False,

--- a/addons/website_event_meet/controllers/website_event_main.py
+++ b/addons/website_event_meet/controllers/website_event_main.py
@@ -10,7 +10,7 @@ from odoo.addons.website_event.controllers import main
 
 class WebsiteEventController(main.WebsiteEventController):
     def _prepare_event_register_values(self, event, **post):
-        values = super(WebsiteEventController, self)._prepare_event_register_values(event, **post)
+        values = super()._prepare_event_register_values(event, **post)
 
         if "from_room_id" in post and not event.is_ongoing:
             meeting_room = request.env["event.meeting.room"].browse(int(post["from_room_id"])).sudo().exists()

--- a/addons/website_event_meet/tests/__init__.py
+++ b/addons/website_event_meet/tests/__init__.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import test_event_menus
+from . import test_event_seo_data
 from . import test_website_event_meet

--- a/addons/website_event_meet/tests/test_event_menus.py
+++ b/addons/website_event_meet/tests/test_event_menus.py
@@ -1,0 +1,49 @@
+from datetime import datetime, timedelta
+
+from odoo import fields
+from odoo.addons.website_event.tests.common import OnlineEventCase
+from odoo.tests.common import users
+
+
+class TestEventWebsiteMeet(OnlineEventCase):
+
+    def _get_menus(self):
+        return super()._get_menus() | {'Community'}
+
+    @users('user_eventmanager')
+    def test_create_menu(self):
+        event = self.env['event.event'].create({
+            'name': 'TestEvent',
+            'date_begin': fields.Datetime.to_string(datetime.today() + timedelta(days=1)),
+            'date_end': fields.Datetime.to_string(datetime.today() + timedelta(days=15)),
+            'website_menu': True,
+            'community_menu': True,
+        })
+        self._assert_website_menus(event)
+
+        event.write({
+            'community_menu': False,
+        })
+        self._assert_website_menus(event, ['Introduction', 'Location', 'Info'], menus_out=['Community'])
+
+    @users('user_event_web_manager')
+    def test_menu_management_frontend(self):
+        event = self.env['event.event'].create({
+            'name': 'TestEvent',
+            'date_begin': fields.Datetime.to_string(datetime.today() + timedelta(days=1)),
+            'date_end': fields.Datetime.to_string(datetime.today() + timedelta(days=15)),
+            'website_menu': True,
+            'community_menu': True,
+        })
+        self.assertTrue(event.community_menu)
+        self._assert_website_menus(event, self._get_menus())
+
+        menu = event.menu_id.child_id.filtered(lambda menu: menu.name == 'Community')
+        menu.unlink()
+        self.assertFalse(event.community_menu)
+
+        self._assert_website_menus(event, ['Introduction', 'Location', 'Info'], menus_out=['Community'])
+
+        event.write({'community_menu': True})
+        self.assertTrue(event.community_menu)
+        self._assert_website_menus(event, self._get_menus())

--- a/addons/website_event_meet/tests/test_event_seo_data.py
+++ b/addons/website_event_meet/tests/test_event_seo_data.py
@@ -1,0 +1,37 @@
+from datetime import datetime, timedelta
+
+from odoo import fields
+from odoo.addons.website_event.tests.common import OnlineEventCase
+from odoo.tests.common import users
+
+
+class TestEventSeoData(OnlineEventCase):
+
+    @users('user_event_web_manager')
+    def test_seo_data_meet(self):
+        """Test SEO data for event and community page"""
+
+        # Create an event
+        event = self.env['event.event'].create({
+            'name': 'TestEvent',
+            'date_begin': fields.Datetime.to_string(datetime.today() + timedelta(days=1)),
+            'date_end': fields.Datetime.to_string(datetime.today() + timedelta(days=15)),
+            'website_menu': True,
+            'community_menu': True,
+        })
+
+        self.assertFalse(event.website_meta_title, "Event should initially have no meta title")
+        event.write({
+            'website_meta_title': "info",
+        })
+        self.assertTrue(event.website_meta_title, "Event should have a meta title after writing")
+
+        view_model = self.env['ir.ui.view'].search([('name', '=', 'Community TestEvent')])
+
+        self.assertFalse(view_model.website_meta_title, "Community page should initially have no meta title")
+        view_model.write({
+            'website_meta_title': "community",
+        })
+        self.assertTrue(view_model.website_meta_title, "Community page should have a meta title after writing")
+
+        self.assertNotEqual(event.website_meta_title, view_model.website_meta_title, "Event and Community page should have different meta titles")

--- a/addons/website_event_meet/views/event_meet_templates_list.xml
+++ b/addons/website_event_meet/views/event_meet_templates_list.xml
@@ -37,9 +37,9 @@
                     aria-label="Dropdown menu" data-bs-display="static" data-bs-toggle="dropdown" href="#" role="button">
                     <span t-out="current_lang.name if current_lang else 'All Languages'"/></a>
                 <div class="dropdown-menu" role="menu">
-                    <a class="dropdown-item" role="menuitem" t-attf-href="/event/#{slug(event)}/community">All Languages
+                    <a class="dropdown-item" role="menuitem" t-attf-href="/event/#{slug(event)}/community/#{page}">All Languages
                        </a>
-                    <a class="dropdown-item" role="menuitem" t-as="language" t-attf-href="/event/#{slug(event)}/community?lang=#{language.id}" t-out="language.name" t-foreach="available_languages"/>
+                    <a class="dropdown-item" role="menuitem" t-as="language" t-attf-href="/event/#{slug(event)}/community/#{page}?lang=#{language.id}" t-out="language.name" t-foreach="available_languages"/>
                 </div>
             </div>
         </div>

--- a/addons/website_event_meet/views/event_meet_templates_page.xml
+++ b/addons/website_event_meet/views/event_meet_templates_page.xml
@@ -5,7 +5,7 @@
     <t t-set="no_header" t-value="option_widescreen"/>
     <t t-set="no_footer" t-value="option_widescreen"/>
     <t t-call="website_event.layout">
-        <t t-set="navbar__back_url" t-value="'/event/%s/community' % (slug(event))"/>
+        <t t-set="navbar__back_url" t-value="'/event/%s/community/community-%s' % (slug(event), event.name.replace(' ', '-').lower())"/>
         <t t-set="navbar__back_title">Back to all Rooms</t>
         <t t-set="navbar__back_text">All Rooms</t>
 

--- a/addons/website_event_meet_quiz/controllers/community.py
+++ b/addons/website_event_meet_quiz/controllers/community.py
@@ -10,10 +10,11 @@ from odoo.http import request, route
 class WebsiteEventTrackQuizMeetController(EventCommunityController):
 
     @route()
-    def community(self, event, page=1, lang=None, **kwargs):
+    def community(self, event, page_seo, page=1, lang=None, **kwargs):
         # website_event_track_quiz
         values = self._get_community_leaderboard_render_values(event, kwargs.get('search'), page)
+        seo_object = request.website.get_template('website_event_meet.' + page_seo)
 
         # website_event_meet
-        values.update(self._event_meeting_rooms_get_values(event, lang=lang))
+        values.update(self._event_meeting_rooms_get_values(event, seo_object, page_seo, lang=lang))
         return request.render('website_event_meet.event_meet', values)

--- a/addons/website_event_track/controllers/event_track.py
+++ b/addons/website_event_track/controllers/event_track.py
@@ -56,10 +56,10 @@ class EventTrackController(http.Controller):
     # ------------------------------------------------------------
 
     @http.route([
-        '''/event/<model("event.event"):event>/track''',
-        '''/event/<model("event.event"):event>/track/tag/<model("event.track.tag"):tag>'''
+        '''/event/<model("event.event"):event>/track/<path:page>''',
+        '''/event/<model("event.event"):event>/track/<path:page>/tag/<model("event.track.tag"):tag>'''
     ], type='http', auth="public", website=True, sitemap=False)
-    def event_tracks(self, event, tag=None, **searches):
+    def event_tracks(self, event, page, tag=None, **searches):
         """ Main route
 
         :param event: event whose tracks are about to be displayed;
@@ -69,12 +69,13 @@ class EventTrackController(http.Controller):
           * 'search': search string;
           * 'tags': list of tag IDs for filtering;
         """
+        seo_object = request.website.get_template('website_event_track.' + page)
         return request.render(
             "website_event_track.tracks_session",
-            self._event_tracks_get_values(event, tag=tag, **searches)
+            self._event_tracks_get_values(event, seo_object, tag=tag, **searches)
         )
 
-    def _event_tracks_get_values(self, event, tag=None, **searches):
+    def _event_tracks_get_values(self, event, seo_object, tag=None, **searches):
         # init and process search terms
         searches.setdefault('search', '')
         searches.setdefault('search_wishlist', '')
@@ -150,6 +151,7 @@ class EventTrackController(http.Controller):
             # event information
             'event': event,
             'main_object': event,
+            'seo_object': seo_object,
             # tracks display information
             'tracks': tracks_sudo,
             'tracks_by_day': tracks_by_day,
@@ -173,12 +175,14 @@ class EventTrackController(http.Controller):
     # AGENDA VIEW
     # ------------------------------------------------------------
 
-    @http.route(['''/event/<model("event.event"):event>/agenda'''], type='http', auth="public", website=True, sitemap=False)
-    def event_agenda(self, event, tag=None, **post):
+    @http.route(['''/event/<model("event.event"):event>/agenda/<path:page>'''], type='http', auth="public", website=True, sitemap=False)
+    def event_agenda(self, event, page, tag=None, **post):
         event = event.with_context(tz=event.date_tz or 'UTC')
+        seo_object = request.website.get_template('website_event_track.' + page)
         vals = {
             'event': event,
             'main_object': event,
+            'seo_object': seo_object,
             'tag': tag,
             'is_event_user': request.env.user.has_group('event.group_event_user'),
         }
@@ -412,9 +416,12 @@ class EventTrackController(http.Controller):
     # TRACK PROPOSAL
     # ------------------------------------------------------------
 
-    @http.route(['''/event/<model("event.event"):event>/track_proposal'''], type='http', auth="public", website=True, sitemap=False)
-    def event_track_proposal(self, event, **post):
-        return request.render("website_event_track.event_track_proposal", {'event': event, 'main_object': event})
+    @http.route(['''/event/<model("event.event"):event>/track_proposal/<path:page>'''], type='http', auth="public", website=True, sitemap=False)
+    def event_track_proposal(self, event, page, **post):
+
+        seo_object = request.website.get_template('website_event_track.' + page)
+
+        return request.render("website_event_track.event_track_proposal", {'event': event, 'main_object': event, 'seo_object': seo_object})
 
     @http.route(['''/event/<model("event.event"):event>/track_proposal/post'''], type='http', auth="public", methods=['POST'], website=True)
     def event_track_proposal_post(self, event, **post):

--- a/addons/website_event_track/models/event_event.py
+++ b/addons/website_event_track/models/event_event.py
@@ -85,7 +85,7 @@ class Event(models.Model):
     def _get_website_menu_entries(self):
         self.ensure_one()
         return super(Event, self)._get_website_menu_entries() + [
-            (_('Talks'), '/event/%s/track' % slug(self), False, 10, 'track'),
-            (_('Agenda'), '/event/%s/agenda' % slug(self), False, 70, 'track'),
-            (_('Talk Proposals'), '/event/%s/track_proposal' % slug(self), False, 15, 'track_proposal')
+            (_('Talks'), '/event/%s/track' % slug(self), 'website_event_track.tracks_session', 10, 'track'),
+            (_('Agenda'), '/event/%s/agenda' % slug(self), 'website_event_track.agenda_online', 70, 'track'),
+            (_('Talk Proposals'), '/event/%s/track_proposal' % slug(self), 'website_event_track.event_track_proposal', 15, 'track_proposal')
         ]

--- a/addons/website_event_track/tests/__init__.py
+++ b/addons/website_event_track/tests/__init__.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_event_menus
+from . import test_event_seo_data
 from . import test_track_internals
 from . import test_website_event
 from . import test_website_visitor

--- a/addons/website_event_track/tests/test_event_menus.py
+++ b/addons/website_event_track/tests/test_event_menus.py
@@ -24,7 +24,6 @@ class TestEventWebsiteTrack(OnlineEventCase):
                 'name': 'test_reg',
             })],
             'website_menu': True,
-            'community_menu': True,
             'website_track': True,
             'website_track_proposal': True,
         }
@@ -35,7 +34,7 @@ class TestEventWebsiteTrack(OnlineEventCase):
             'website_track': False,
             'website_track_proposal': False,
         })
-        self._assert_website_menus(event, ['Introduction', 'Location', 'Info', 'Community'], menus_out=['Talks', 'Agenda', 'Talk Proposals'])
+        self._assert_website_menus(event, ['Introduction', 'Location', 'Info'], menus_out=['Talks', 'Agenda', 'Talk Proposals'])
 
     @users('user_event_web_manager')
     def test_menu_management_frontend(self):
@@ -44,7 +43,6 @@ class TestEventWebsiteTrack(OnlineEventCase):
             'date_begin': fields.Datetime.to_string(datetime.today() + timedelta(days=1)),
             'date_end': fields.Datetime.to_string(datetime.today() + timedelta(days=15)),
             'website_menu': True,
-            'community_menu': True,
             'website_track': True,
             'website_track_proposal': True,
         }
@@ -55,7 +53,7 @@ class TestEventWebsiteTrack(OnlineEventCase):
 
         introduction_menu = event.menu_id.child_id.filtered(lambda menu: menu.name == 'Introduction')
         introduction_menu.unlink()
-        self._assert_website_menus(event, ['Location', 'Info', 'Community', 'Talks', 'Agenda', 'Talk Proposals'], menus_out=["Introduction"])
+        self._assert_website_menus(event, ['Location', 'Info', 'Talks', 'Agenda', 'Talk Proposals'], menus_out=["Introduction"])
 
         menus = event.menu_id.child_id.filtered(lambda menu: menu.name in ['Agenda', 'Talk Proposals'])
         menus.unlink()
@@ -67,14 +65,14 @@ class TestEventWebsiteTrack(OnlineEventCase):
         self.assertFalse(event.website_track)
         self.assertFalse(event.website_track_proposal)
 
-        self._assert_website_menus(event, ['Location', 'Info', 'Community'], menus_out=["Introduction", "Talks", "Agenda", "Talk Proposals"])
+        self._assert_website_menus(event, ['Location', 'Info'], menus_out=["Introduction", "Talks", "Agenda", "Talk Proposals"])
 
         event.write({'website_track_proposal': True})
         self.assertFalse(event.website_track)
         self.assertTrue(event.website_track_proposal)
-        self._assert_website_menus(event, ['Location', 'Info', 'Community', 'Talk Proposals'], menus_out=["Introduction", "Talks", "Agenda"])
+        self._assert_website_menus(event, ['Location', 'Info', 'Talk Proposals'], menus_out=["Introduction", "Talks", "Agenda"])
 
         event.write({'website_track': True})
         self.assertTrue(event.website_track)
         self.assertTrue(event.website_track_proposal)
-        self._assert_website_menus(event, ['Location', 'Info', 'Community', 'Talks', 'Agenda', 'Talk Proposals'], menus_out=["Introduction"])
+        self._assert_website_menus(event, ['Location', 'Info', 'Talks', 'Agenda', 'Talk Proposals'], menus_out=["Introduction"])

--- a/addons/website_event_track/tests/test_event_seo_data.py
+++ b/addons/website_event_track/tests/test_event_seo_data.py
@@ -1,0 +1,56 @@
+from datetime import datetime, timedelta
+
+from odoo import fields
+from odoo.addons.website_event.tests.common import OnlineEventCase
+from odoo.tests.common import users
+
+
+class TestEventSeoData(OnlineEventCase):
+
+    @users('user_event_web_manager')
+    def test_seo_data_track(self):
+        """Test SEO data for event and talks, talk proposals and agenda page"""
+
+        # Create an event
+        event = self.env['event.event'].create({
+            'name': 'TestEvent',
+            'date_begin': fields.Datetime.to_string(datetime.today() + timedelta(days=1)),
+            'date_end': fields.Datetime.to_string(datetime.today() + timedelta(days=15)),
+            'website_menu': True,
+            'website_track': True,
+            'website_track_proposal': True,
+        })
+
+        self.assertFalse(event.website_meta_title, "Event should initially have no meta title")
+        event.write({
+            'website_meta_title': "info",
+        })
+        self.assertTrue(event.website_meta_title, "Event should have a meta title after writing")
+
+        view_model_track = self.env['ir.ui.view'].search([('name', '=', 'Talks TestEvent')])
+        self.assertFalse(view_model_track.website_meta_title, "Talks page should initially have no meta title")
+        view_model_track.write({
+            'website_meta_title': "talks",
+        })
+        self.assertTrue(view_model_track.website_meta_title, "Talks page should have a meta title after writing")
+        self.assertNotEqual(event.website_meta_title, view_model_track.website_meta_title, "Event and Talks page should have different meta titles")
+
+        view_model_agenda = self.env['ir.ui.view'].search([('name', '=', 'Agenda TestEvent')])
+        self.assertFalse(view_model_agenda.website_meta_title, "Agenda page should initially have no meta title")
+        view_model_agenda.write({
+            'website_meta_title': "agenda",
+        })
+        self.assertTrue(view_model_agenda.website_meta_title, "Agenda page should have a meta title after writing")
+        self.assertNotEqual(event.website_meta_title, view_model_agenda.website_meta_title, "Event and Agenda page should have different meta titles")
+
+        view_model_track_proposal = self.env['ir.ui.view'].search([('name', '=', 'Talk Proposals TestEvent')])
+        self.assertFalse(view_model_track_proposal.website_meta_title, "Talk Proposals page should initially have no meta title")
+        view_model_track_proposal.write({
+            'website_meta_title': "talk proposals",
+        })
+        self.assertTrue(view_model_track_proposal.website_meta_title, "Talk Proposals page should have a meta title after writing")
+        self.assertNotEqual(event.website_meta_title, view_model_track_proposal.website_meta_title, "Event and Talk Proposals page should have different meta titles")
+
+        self.assertNotEqual(view_model_track.website_meta_title, view_model_agenda.website_meta_title, "Talks and Agenda page should have different meta titles")
+        self.assertNotEqual(view_model_track.website_meta_title, view_model_track_proposal.website_meta_title, "Talks and Talk Proposals page should have different meta titles")
+        self.assertNotEqual(view_model_agenda.website_meta_title, view_model_track_proposal.website_meta_title, "Agenda and Talk Proposals page should have different meta titles")

--- a/addons/website_event_track/views/event_templates.xml
+++ b/addons/website_event_track/views/event_templates.xml
@@ -8,7 +8,7 @@
             <div class="col-12">
                 <h3>Book your seats to the best talks</h3>
                 <p>Get prepared and
-                    <a t-att-href="'/event/%s/track' % (slug(event))">register to your favorites talks now.</a>
+                    <a t-att-href="'/event/%s/track/talks-%s' % (slug(event), event.name.replace(' ','-').lower())">register to your favorites talks now.</a>
                 </p>
             </div>
         </div>

--- a/addons/website_event_track/views/event_track_templates_page.xml
+++ b/addons/website_event_track/views/event_track_templates_page.xml
@@ -3,7 +3,7 @@
 
 <template id="event_track_main" name="Event Exhibitor">
     <t t-call="website_event.layout">
-        <t t-set="navbar__back_url" t-value="'/event/%s/track' % (slug(event))"/>
+        <t t-set="navbar__back_url" t-value="'/event/%s/track/talks-%s' % (slug(event), event.name.replace(' ','-').lower())"/>
         <t t-set="navbar__back_title">Back to All Talks</t>
         <t t-set="navbar__back_text">All Talks</t>
 

--- a/addons/website_event_track_quiz/controllers/community.py
+++ b/addons/website_event_track_quiz/controllers/community.py
@@ -28,7 +28,7 @@ class WebsiteEventTrackQuizCommunityController(EventCommunityController):
         return request.render('website_event_track_quiz.event_leaderboard', values)
 
     @http.route()
-    def community(self, event, **kwargs):
+    def community(self, event, page_seo, **kwargs):
         values = self._get_community_leaderboard_render_values(event, None, None)
         return request.render('website_event_track_quiz.event_leaderboard', values)
 


### PR DESCRIPTION
* = booth, booth_sale, exhibitor, meet, meet_quiz, track, track_quiz

**How to reproduce:**
- Create an event and activate the submenu
- Open Talk Proposal page and set specific SEO discription and title
- Open Exhibitors page and set another one

**Specifications:**
- They are currently synced.
- All the sub-pages except 'Introduction' and 'Location' page are synced.
- SEO data of all the pages should be different from one another.

**After this PR:**
SEO data for all sub-pages will be different.

Task-3874050