### PR TITLE
[REF] web_tour: remove extra_trigger

### DIFF
--- a/addons/hr_recruitment/static/src/js/tours/hr_recruitment.js
+++ b/addons/hr_recruitment/static/src/js/tours/hr_recruitment.js
@@ -28,15 +28,23 @@ registry.category("web_tour.tours").add('hr_recruitment_tour',{
     position: "bottom",
     width: 195,
     run: "click",
-}, {
+}, 
+{
+    isActive: ["auto"],
+    trigger: ".o_hr_job_simple_form",
+},
+{
     trigger: ".o_job_name",
-    extra_trigger: '.o_hr_job_simple_form',
     content: _t("What do you want to recruit today? Choose a job title..."),
     position: "right",
     run: "click",
-}, {
+}, 
+{
+    isActive: ["auto"],
+    trigger: '.o_hr_job_simple_form',
+},
+{
     trigger: ".o_job_alias",
-    extra_trigger: '.o_hr_job_simple_form',
     content: _t("Choose an application email."),
     position: "right",
     width: 195,
@@ -51,60 +59,96 @@ registry.category("web_tour.tours").add('hr_recruitment_tour',{
     content: _t("Copy this email address, to paste it in your email composer, to apply."),
     position: "bottom",
     run: "click",
-}, {
+}, 
+{
+    isActive: ["auto"],
+    trigger: ".o_kanban_applicant",
+},
+{
     trigger: ".breadcrumb-item:not(.active):last",
-    extra_trigger: '.o_kanban_applicant',
     content: _t("Let’s go back to the dashboard."),
     position: "bottom",
     width: 195,
     run: "click",
-}, {
+}, 
+{
+    isActive: ["auto"],
+    trigger: ".o_hr_recruitment_kanban",
+},
+{
     trigger: ".oe_kanban_action_button",
-    extra_trigger: '.o_hr_recruitment_kanban',
     content: markup(_t("<b>Did you apply by sending an email?</b> Check incoming applications.")),
     position: "bottom",
     run: "click",
-}, {
+}, 
+{
+    isActive: ["auto"],
+    trigger: ".o_kanban_applicant",
+},
+{
     trigger: ".oe_kanban_card",
-    extra_trigger: '.o_kanban_applicant',
     content: markup(_t("<b>Drag this card</b>, to qualify him for a first interview.")),
     position: "bottom",
     run: "drag_and_drop(.o_kanban_group:eq(1))",
-}, {
+}, 
+{
+    isActive: ["auto"],
+    trigger: ".o_kanban_applicant",
+},
+{
     trigger: ".oe_kanban_card",
-    extra_trigger: '.o_kanban_applicant',
     content: markup(_t("<b>Click to view</b> the application.")),
     position: "bottom",
     width: 195,
     run: "click",
-}, {
+}, 
+{
+    isActive: ["auto"],
+    trigger: ".o_applicant_form",
+},
+{
     trigger: "button:contains(Send message)",
-    extra_trigger: '.o_applicant_form',
     content: markup(_t("<div><b>Try to send an email</b> to the applicant.</div><div><i>Tips: All emails sent or received are saved in the history here</i>")),
     position: "bottom",
     run: "click",
-}, {
+}, 
+{
+    isActive: ["auto"],
+    trigger: ".o_applicant_form",
+},
+{
     trigger: ".o-mail-Chatter .o-mail-Composer button[aria-label='Send']",
-    extra_trigger: '.o_applicant_form',
     content: _t("Send your email. Followers will get a copy of the communication."),
     position: "bottom",
     run: "click",
-}, {
+}, 
+{
+    isActive: ["auto"],
+    trigger: ".o_applicant_form",
+},
+{
     trigger: "button:contains(Log note)",
-    extra_trigger: '.o_applicant_form',
     content: _t("Or talk about this applicant privately with your colleagues."),
     position: "bottom",
     run: "click",
-}, {
+}, 
+{
+    isActive: ["auto"],
+    trigger: ".o_applicant_form",
+},
+{
     trigger: ".o_create_employee",
-    extra_trigger: '.o_applicant_form',
     content: _t("Let’s create this new employee now."),
     position: "bottom",
     width: 225,
     run: "click",
-}, {
+}, 
+{
+    isActive: ["auto"],
+    trigger: ".o_hr_employee_form_view",
+},
+{
     trigger: ".o_form_button_save",
-    extra_trigger: ".o_hr_employee_form_view",
     content: _t("Save it!"),
     position: "bottom",
     width: 80,

--- a/addons/project/static/src/js/tours/project.js
+++ b/addons/project/static/src/js/tours/project.js
@@ -22,9 +22,13 @@ registry.category("web_tour.tours").add('project_tour', {
     content: markup(_t('Want a better way to <b>manage your projects</b>? <i>It starts here.</i>')),
     position: 'bottom',
     run: "click",
-}, {
+}, 
+{
+    isActive: ["auto"],
+    trigger: ".o_project_kanban",
+},
+{
     trigger: '.o-kanban-button-new',
-    extra_trigger: '.o_project_kanban',
     content: markup(_t('Let\'s create your first <b>project</b>.')),
     position: 'bottom',
     width: 200,
@@ -49,9 +53,13 @@ registry.category("web_tour.tours").add('project_tour', {
     content: markup(_t('Let\'s create your first <b>stage</b>.')),
     position: 'right',
     run: "click",
-}, {
+}, 
+{
+    isActive: ["auto"],
+    trigger: ".o_kanban_group",
+},
+{
     trigger: ".o_kanban_project_tasks .o_column_quick_create .o_kanban_header input",
-    extra_trigger: '.o_kanban_group',
     content: markup(_t("Add columns to organize your tasks into <b>stages</b> <i>e.g. New - In Progress - Done</i>.")),
     position: 'bottom',
     run: "edit Test",
@@ -60,58 +68,95 @@ registry.category("web_tour.tours").add('project_tour', {
     content: markup(_t('Let\'s create your second <b>stage</b>.')),
     position: 'right',
     run: "click",
-}, {
+}, 
+{
+    isActive: ["auto"],
+    trigger: ".o_kanban_group:eq(1)",
+},
+{
     trigger: '.o-kanban-button-new',
-    extra_trigger: '.o_kanban_group:eq(1)',
     content: markup(_t("Let's create your first <b>task</b>.")),
     position: 'bottom',
     width: 200,
     run: "click",
-}, {
+}, 
+{
+    isActive: ["auto"],
+    trigger: ".o_kanban_project_tasks",
+},
+{
     trigger: '.o_kanban_quick_create div.o_field_char[name=display_name] input',
-    extra_trigger: '.o_kanban_project_tasks',
     content: markup(_t('Choose a task <b>name</b> <i>(e.g. Website Design, Purchase Goods...)</i>')),
     position: 'right',
     run: "edit Test",
-}, {
+}, 
+{
+    isActive: ["auto"],
+    trigger: ".o_kanban_project_tasks",
+},
+{
     trigger: '.o_kanban_quick_create .o_kanban_add',
-    extra_trigger: '.o_kanban_project_tasks',
     content: _t("Add your task once it is ready."),
     position: "bottom",
     run: "click",
-}, {
+}, 
+{
+    isActive: ["auto"],
+    trigger: ".o_kanban_project_tasks",
+},
+{
     trigger: ".o_kanban_record .oe_kanban_content",
-    extra_trigger: '.o_kanban_project_tasks',
     content: markup(_t("<b>Drag &amp; drop</b> the card to change your task from stage.")),
     position: "bottom",
     run: "drag_and_drop(.o_kanban_group:eq(1))",
-}, {
+}, 
+{
+    isActive: ["auto"],
+    trigger: ".o_kanban_project_tasks",
+},
+{
     trigger: ".o_kanban_record:first",
-    extra_trigger: '.o_kanban_project_tasks',
     content: _t("Let's start working on your task."),
     position: "bottom",
     run: "click",
-}, {
+}, 
+{
+    isActive: ["auto"],
+    trigger: ".o_form_project_tasks",
+},
+{
     trigger: ".o-mail-Chatter-topbar button:contains(Send message)",
-    extra_trigger: '.o_form_project_tasks',
     content: markup(_t("Use the chatter to <b>send emails</b> and communicate efficiently with your customers. Add new people to the followers' list to make them aware of the main changes about this task.")),
     width: 350,
     position: "bottom",
     run: "click",
-}, {
+}, 
+{
+    isActive: ["auto"],
+    trigger: ".o_form_project_tasks",
+},
+{
     trigger: "button:contains(Log note)",
-    extra_trigger: '.o_form_project_tasks',
     content: markup(_t("<b>Log notes</b> for internal communications <i>(the people following this task won't be notified of the note you are logging unless you specifically tag them)</i>. Use @ <b>mentions</b> to ping a colleague or # <b>mentions</b> to reach an entire team.")),
     width: 350,
     position: "bottom",
     run: "click",
-}, {
+}, 
+{
+    isActive: ["auto"],
+    trigger: ".o_form_project_tasks",
+},
+{
     trigger: ".o-mail-Chatter-topbar button:contains(Activities)",
-    extra_trigger: '.o_form_project_tasks',
     content: markup(_t("Create <b>activities</b> to set yourself to-dos or to schedule meetings.")),
     position: "bottom",
     run: "click",
 }, 
+{
+    trigger: ".o_form_project_tasks",
+    isActive: ["auto"],
+},
+
 {
     trigger: ".o_form_project_tasks",
 },
@@ -120,6 +165,11 @@ registry.category("web_tour.tours").add('project_tour', {
     content: _t("Schedule your activity once it is ready."),
     position: "bottom",
     run: "click",
+},
+
+{
+    trigger: ".o_form_project_tasks",
+    isActive: ["auto"],
 },
 {
     trigger: ".o_field_widget[name='user_ids'] input",
@@ -148,15 +198,23 @@ registry.category("web_tour.tours").add('project_tour', {
     trigger: '.o_field_subtasks_one2many div[name="name"] input',
     content: markup(_t('Give the sub-task a <b>name</b>')),
     run: "edit New Sub-task",
-}, {
+}, 
+{
+    isActive: ["auto"],
+    trigger: ".o_form_project_tasks .o_form_dirty",
+},
+{
     trigger: ".o_form_button_save",
-    extra_trigger: '.o_form_project_tasks .o_form_dirty',
     content: markup(_t("You have unsaved changes - no worries! Odoo will automatically save it as you navigate.<br/> You can discard these changes from here or manually save your task.<br/>Let's save it manually.")),
     position: "bottom",
     run: "click",
-}, {
+}, 
+{
+    isActive: ["auto"],
+    trigger: ".o_form_project_tasks",
+},
+{
     trigger: ".o_breadcrumb .o_back_button",
-    extra_trigger: '.o_form_project_tasks',
     content: markup(_t("Let's go back to the <b>kanban view</b> to have an overview of your next tasks.")),
     position: "right",
     run: 'click',
@@ -164,23 +222,35 @@ registry.category("web_tour.tours").add('project_tour', {
     trigger: ".o_kanban_record .oe_kanban_content .o_widget_subtask_counter .subtask_list_button",
     content: _t("You can open sub-tasks from the kanban card!"),
     run: "click",
-}, {
+}, 
+{
+    isActive: ["auto"],
+    trigger: ".o_widget_subtask_kanban_list .subtask_list",
+},
+{
     trigger: ".o_kanban_record .o_widget_subtask_kanban_list .subtask_create",
-    extra_trigger: ".o_widget_subtask_kanban_list .subtask_list",
     content: _t("Create a new sub-task"),
     run: "click",
-}, {
+}, 
+{
+    isActive: ["auto"],
+    trigger: ".subtask_create_input",
+},
+{
     trigger: ".o_kanban_record .o_widget_subtask_kanban_list .subtask_create_input input",
-    extra_trigger: ".subtask_create_input",
     content: markup(_t("Give the sub-task a <b>name</b>")),
     run: "edit Newer Sub-task && click body",
 }, {
     trigger: ".o_kanban_record .o_widget_subtask_kanban_list .subtask_list_row:first-child .o_field_project_task_state_selection button",
     content: _t("You can change the sub-task state here!"),
     run: "click",
-}, {
+}, 
+{
+    isActive: ["auto"],
+    trigger: ".dropdown-menu",
+},
+{
     trigger: ".dropdown-menu span.text-danger",
-    extra_trigger: ".dropdown-menu",
     content: markup(_t("Mark the task as <b>Cancelled</b>")),
     run: "click",
 }, {

--- a/addons/project/static/tests/tours/project_update_tour_tests.js
+++ b/addons/project/static/tests/tours/project_update_tour_tests.js
@@ -9,9 +9,12 @@ registry.category("web_tour.tours").add('project_update_tour', {
     steps: () => [stepUtils.showAppsMenuItem(), {
     trigger: '.o_app[data-menu-xmlid="project.menu_main_pm"]',
     run: "click",
-}, {
+}, 
+{
+    trigger: ".o_project_kanban",
+},
+{
     trigger: '.o-kanban-button-new',
-    extra_trigger: '.o_project_kanban',
     width: 200,
     run: "click",
 }, {
@@ -27,37 +30,58 @@ registry.category("web_tour.tours").add('project_update_tour', {
     isActive: ["auto"],
     trigger: ".o_kanban_project_tasks .o_column_quick_create .o_kanban_add",
     run: "click",
-}, {
+}, 
+{
+    trigger: ".o_kanban_group",
+},
+{
     trigger: ".o_kanban_project_tasks .o_column_quick_create .input-group input",
-    extra_trigger: '.o_kanban_group',
     run: "edit Done",
 }, {
     isActive: ["auto"],
     trigger: ".o_kanban_project_tasks .o_column_quick_create .o_kanban_add",
     run: "click",
-}, {
+}, 
+{
+    trigger: ".o_kanban_group:eq(0)",
+},
+{
     trigger: '.o-kanban-button-new',
-    extra_trigger: '.o_kanban_group:eq(0)',
     run: "click",
-}, {
+}, 
+{
+    trigger: ".o_kanban_project_tasks",
+},
+{
     trigger: '.o_kanban_quick_create div.o_field_char[name=display_name] input',
-    extra_trigger: '.o_kanban_project_tasks',
     run: "edit New task",
-}, {
+}, 
+{
+    trigger: ".o_kanban_project_tasks",
+},
+{
     trigger: '.o_kanban_quick_create .o_kanban_add',
-    extra_trigger: '.o_kanban_project_tasks',
     run: "click",
-}, {
+}, 
+{
+    trigger: ".o_kanban_group:eq(0)",
+},
+{
     trigger: '.o-kanban-button-new',
-    extra_trigger: '.o_kanban_group:eq(0)',
     run: "click",
-}, {
+}, 
+{
+    trigger: ".o_kanban_project_tasks",
+},
+{
     trigger: '.o_kanban_quick_create div.o_field_char[name=display_name] input',
-    extra_trigger: '.o_kanban_project_tasks',
     run: "edit Second task",
-}, {
+}, 
+{
+    trigger: ".o_kanban_project_tasks",
+},
+{
     trigger: '.o_kanban_quick_create .o_kanban_add',
-    extra_trigger: '.o_kanban_project_tasks',
     run: "click",
 }, {
     trigger: '.o_kanban_group:nth-child(2) .o_kanban_header .o_kanban_config .dropdown-toggle',
@@ -71,9 +95,12 @@ registry.category("web_tour.tours").add('project_update_tour', {
 }, {
     trigger: ".modal-footer button",
     run: "click",
-}, {
+}, 
+{
+    trigger: '.o_kanban_project_tasks',
+},
+{
     trigger: ".o_kanban_record .oe_kanban_content",
-    extra_trigger: '.o_kanban_project_tasks',
     run: "drag_and_drop(.o_kanban_group:eq(1))",
 }, {
     trigger: ".o_control_panel_navigation button i.fa-sliders",
@@ -153,10 +180,13 @@ registry.category("web_tour.tours").add('project_update_tour', {
     trigger: '.o_switch_view.o_list',
     content: 'Open List View of Project Updates',
     run: "click",
-}, {
+}, 
+{
+    trigger: '.o_list_view',
+},
+{
     trigger: '.o_back_button',
     content: 'Go back to the kanban view the project',
-    extra_trigger: '.o_list_view',
     run: "click",
 },
 ]});

--- a/addons/purchase_product_matrix/static/tests/tours/purchase_product_matrix_tour.js
+++ b/addons/purchase_product_matrix/static/tests/tours/purchase_product_matrix_tour.js
@@ -9,9 +9,12 @@ registry.category("web_tour.tours").add('purchase_matrix_tour', {
     steps: () => [stepUtils.showAppsMenuItem(), {
     trigger: '.o_app[data-menu-xmlid="purchase.menu_purchase_root"]',
     run: "click",
-}, {
+}, 
+{
+    trigger: ".o_purchase_order",
+},
+{
     trigger: ".o_list_button_add",
-    extra_trigger: ".o_purchase_order",
     run: "click",
 }, {
     trigger: '.o_required_modifier[name=partner_id] input',
@@ -44,8 +47,10 @@ registry.category("web_tour.tours").add('purchase_matrix_tour', {
 },
 // Open the matrix through the pencil button next to the product in line edit mode.
 {
+    trigger: ".o_form_status_indicator_buttons.invisible", // wait for save to be finished
+},
+{
     trigger: 'span:contains("Matrix (PAV11, PAV22, PAV31)\nPA4: PAV41")',
-    extra_trigger: '.o_form_status_indicator_buttons.invisible', // wait for save to be finished
     run: "click",
 }, {
     trigger: '[name=product_template_id] button.fa-pencil', // edit the matrix
@@ -61,15 +66,20 @@ registry.category("web_tour.tours").add('purchase_matrix_tour', {
 }, {
     trigger: 'button:contains("Confirm")',
     run: 'click' // apply the matrix
-}, {
+}, 
+{
+    trigger: '.o_field_cell.o_data_cell.o_list_number:contains("4.00")',
+},
+{
     trigger: '.o_form_button_save',
-    extra_trigger: '.o_field_cell.o_data_cell.o_list_number:contains("4.00")',
     run: 'click' // SAVE Sales Order, after matrix has been applied (extra_trigger).
 },
 // Ensures the matrix is opened with the values, when adding the same product.
 {
+    trigger: '.o_form_status_indicator_buttons.invisible',
+},
+{
     trigger: 'a:contains("Add a product")',
-    extra_trigger: '.o_form_status_indicator_buttons.invisible',
     run: "click",
 }, {
     trigger: 'div[name="product_template_id"] input',

--- a/addons/purchase_stock/static/src/js/tours/purchase_stock.js
+++ b/addons/purchase_stock/static/src/js/tours/purchase_stock.js
@@ -8,9 +8,12 @@ import { patch } from "@web/core/utils/patch";
 patch(PurchaseAdditionalTourSteps.prototype, {
 
     _get_purchase_stock_steps: function () {
-        return [{
+        return [
+            {
+                trigger: ".o-form-buttonbox button[name='action_view_picking']",
+            },
+        {
             trigger: ".o-form-buttonbox button[name='action_view_picking']",
-            extra_trigger: ".o-form-buttonbox button[name='action_view_picking']",
             content: _t("Receive the ordered products."),
             position: "bottom",
             run: 'click',
@@ -19,9 +22,12 @@ patch(PurchaseAdditionalTourSteps.prototype, {
             content: _t("Validate the receipt of all ordered products."),
             position: "bottom",
             run: 'click',
-        }, {
+        }, 
+        {
+            trigger: ".modal-dialog",
+        },
+        {
             trigger: ".modal-footer .btn-primary",
-            extra_trigger: ".modal-dialog",
             content: _t("Process all the receipt quantities."),
             position: "bottom",
             run: "click",

--- a/addons/test_event_full/static/src/js/tours/wevent_performance_tour.js
+++ b/addons/test_event_full/static/src/js/tours/wevent_performance_tour.js
@@ -48,9 +48,12 @@ var registerSteps = [{
             document.querySelector("textarea[name*='question_answer']").textContent =
                 "Random answer from random guy";
     },
-}, {
+}, 
+{
+    trigger: "input[name*='1-name'], input[name*='2-name'], input[name*='3-name']",
+},
+{
     content: "Validate attendees details",
-    extra_trigger: "input[name*='1-name'], input[name*='2-name'], input[name*='3-name']",
     trigger: 'button[type=submit]',
     run: 'click',
 },

--- a/addons/test_event_full/static/src/js/tours/wevent_register_tour.js
+++ b/addons/test_event_full/static/src/js/tours/wevent_register_tour.js
@@ -103,9 +103,12 @@ var registerSteps = [{
             document.querySelector("textarea[name*='text_box']").textContent =
                 "An unicorn told me about you. I ate it afterwards.";
     },
-}, {
+}, 
+{
+    trigger: "input[name*='1-name'], input[name*='2-name'], input[name*='3-name']",
+},
+{
     content: "Validate attendees details",
-    extra_trigger: "input[name*='1-name'], input[name*='2-name'], input[name*='3-name']",
     trigger: 'button[type=submit]',
     run: 'click',
 }, {

--- a/addons/test_sale_product_configurators/static/tests/tours/event_sale_with_product_configurator_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/event_sale_with_product_configurator_ui.js
@@ -10,9 +10,12 @@ registry.category("web_tour.tours").add('event_sale_with_product_configurator_to
     steps: () => [stepUtils.showAppsMenuItem(), {
     trigger: '.o_app[data-menu-xmlid="sale.sale_menu_root"]',
     run: "click",
-}, {
+}, 
+{
+    trigger: ".o_sale_order",
+},
+{
     trigger: '.o_list_button_add',
-    extra_trigger: ".o_sale_order",
     run: "click",
 }, {
     trigger: '.o_required_modifier[name=partner_id] input',
@@ -36,34 +39,38 @@ registry.category("web_tour.tours").add('event_sale_with_product_configurator_to
 }, {
     trigger: 'button:contains(Confirm)',
     run: "click",
-}, {
-    trigger: '.o_input_dropdown input',
-    extra_trigger: '.o_technical_modal',  // to be in the event wizard
+}, 
+{
+    trigger: ".modal .o_input_dropdown input",
     run: "edit Test",
 }, {
-    trigger: 'div[name="event_id"] input',
+    trigger: '.modal div[name="event_id"] input',
     run: "click",
 }, {
-    trigger: 'ul.ui-autocomplete a:contains("TestEvent")',
-    in_modal: false,
+    trigger: "ul.ui-autocomplete a:contains(TestEvent)",
     run: "click",
 }, {
-    trigger: 'div[name="event_ticket_id"] input',
+    trigger: '.modal div[name="event_ticket_id"] input',
     run: 'click',
 }, {
-    trigger: 'ul.ui-autocomplete a:contains("Kid + meal")',
-    in_modal: false,
+    trigger: "ul.ui-autocomplete a:contains(Kid + meal)",
     run: "click",
 }, {
-    trigger: '.o_event_sale_js_event_configurator_ok',
+    trigger: ".modal .o_event_sale_js_event_configurator_ok",
     run: "click",
-}, {
+}, 
+{
+    trigger: 'td[name="price_subtotal"]:contains("16.50")', // wait for the optional product line
+},
+{
     trigger: 'a:contains("Add a product")',
-    extra_trigger: 'td[name="price_subtotal"]:contains("16.50")',  // wait for the optional product line
     run: "click",
-}, {
+}, 
+{
+    trigger: ".o_data_row:nth-child(3)", // wait for the new row to be created
+},
+{
     trigger: 'div[name="product_template_id"] input',
-    extra_trigger: '.o_data_row:nth-child(3)',  // wait for the new row to be created
     run: "edit event (",
 }, {
     trigger: 'ul.ui-autocomplete a:contains("Registration Event (TEST variants)")',
@@ -79,34 +86,38 @@ registry.category("web_tour.tours").add('event_sale_with_product_configurator_to
 {
     trigger: 'button:contains(Confirm)',
     run: "click",
-}, {
-    trigger: '.o_input_dropdown input',
-    extra_trigger: '.o_technical_modal',
+}, 
+{
+    trigger: ".modal .o_input_dropdown input",
     run: "edit Test",
 }, {
-    trigger: 'div[name="event_id"] input',
+    trigger: '.modal div[name="event_id"] input',
     run: "click",
 }, {
     trigger: 'ul.ui-autocomplete a:contains("TestEvent")',
-    in_modal: false,
     run: "click",
 }, {
-    trigger: 'div[name="event_ticket_id"] input',
+    trigger: '.modal div[name="event_ticket_id"] input',
     run: 'click',
 }, {
     trigger: 'ul.ui-autocomplete a:contains("Adult")',
-    in_modal: false,
     run: "click",
 }, {
-    trigger: '.o_event_sale_js_event_configurator_ok',
+    trigger: ".modal .o_event_sale_js_event_configurator_ok",
     run: "click",
-}, {
+}, 
+{
+    trigger: 'td[name="price_subtotal"]:contains("150.00")', // wait for the adult tickets line
+},
+{
     trigger: 'a:contains("Add a product")',
-    extra_trigger: 'td[name="price_subtotal"]:contains("150.00")',  // wait for the adult tickets line
     run: "click",
-}, {
+}, 
+{
+    trigger: ".o_data_row:nth-child(4)", // wait for the new row to be created
+},
+{
     trigger: 'div[name="product_template_id"] input',
-    extra_trigger: '.o_data_row:nth-child(4)',  // wait for the new row to be created
     run: "edit event (",
 }, {
     trigger: 'ul.ui-autocomplete a:contains("Registration Event (TEST variants)")',
@@ -119,26 +130,28 @@ registry.category("web_tour.tours").add('event_sale_with_product_configurator_to
 {
     trigger: 'button:contains(Confirm)',
     run: "click",
-}, {
-    trigger: '.o_input_dropdown input',
-    extra_trigger: '.o_technical_modal',
+}, 
+{
+    trigger: ".modal .o_input_dropdown input",
     run: "edit Test",
 }, {
     trigger: 'div[name="event_id"] input',
     run: "click",
 }, {
     trigger: 'ul.ui-autocomplete a:contains("TestEvent")',
-    in_modal: false,
     run: "click",
 }, {
-    trigger: 'div[name="event_ticket_id"] input',
+    trigger: '.modal div[name="event_ticket_id"] input',
     run: 'click',
 }, {
     trigger: 'ul.ui-autocomplete a:contains("VIP")',
-    in_modal: false,
     run: "click",
 }, {
-    trigger: '.o_event_sale_js_event_configurator_ok',
+    trigger: ".modal .o_event_sale_js_event_configurator_ok",
     run: "click",
-}, ...stepUtils.saveForm({ extra_trigger: '.o_field_cell.o_data_cell.o_list_number:contains("60.00")' }),
+},
+{
+    trigger: '.o_field_cell.o_data_cell.o_list_number:contains("60.00")',
+},
+...stepUtils.saveForm(),
 ]});

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_advanced_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_advanced_ui.js
@@ -13,9 +13,12 @@ registry.category("web_tour.tours").add('sale_product_configurator_advanced_tour
     steps: () => [stepUtils.showAppsMenuItem(), {
     trigger: '.o_app[data-menu-xmlid="sale.sale_menu_root"]',
     run: "click",
-},  {
+},  
+{
+    trigger: ".o_sale_order",
+},
+{
     trigger: '.o_list_button_add',
-    extra_trigger: '.o_sale_order',
     run: "click",
 }, {
     trigger: '.o_required_modifier[name=partner_id] input',
@@ -24,9 +27,12 @@ registry.category("web_tour.tours").add('sale_product_configurator_advanced_tour
     isActive: ["auto"],
     trigger: '.ui-menu-item > a:contains("Tajine Saucisse")',
     run: "click",
-}, {
+}, 
+{
+    trigger: ".o_field_widget[name=partner_shipping_id] .o_external_button", // Wait for onchange_partner_id
+},
+{
     trigger: 'a:contains("Add a product")',
-    extra_trigger: '.o_field_widget[name=partner_shipping_id] .o_external_button', // Wait for onchange_partner_id
     run: "click",
 }, {
     trigger: 'div[name="product_template_id"] input',

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_custom_value_update_tour.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_custom_value_update_tour.js
@@ -49,9 +49,12 @@ configuratorTourUtils.assertProductNameContains("Customizable Desk (TEST) (Custo
 {
     trigger: 'div[name="product_template_id"]',
     run: "click",
-}, {
+}, 
+{
+    trigger: ".o_external_button",
+},
+{
     trigger: '.fa-pencil',
-    extra_trigger: '.o_external_button',
     run: "click",
 },
 configuratorTourUtils.setCustomAttribute("Customizable Desk (TEST)", "Legs", "123456"),

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_edition_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_edition_ui.js
@@ -11,9 +11,12 @@ registry.category("web_tour.tours").add('sale_product_configurator_edition_tour'
     steps: () => [stepUtils.showAppsMenuItem(), {
     trigger: '.o_app[data-menu-xmlid="sale.sale_menu_root"]',
     run: "click",
-}, {
+}, 
+{
+    trigger: ".o_sale_order",
+},
+{
     trigger: '.o_list_button_add',
-    extra_trigger: '.o_sale_order',
     run: "click",
 }, {
     trigger: '.o_required_modifier[name=partner_id] input',
@@ -39,10 +42,13 @@ registry.category("web_tour.tours").add('sale_product_configurator_edition_tour'
 }, {
     trigger: 'button:contains(Confirm)',
     run: "click",
-}, {
+}, 
+{
+    trigger: 'div[name="order_line"]',
+},
+{
     // check added product
     trigger: 'td.o_data_cell:contains("Customizable Desk (TEST) (Aluminium, White)")',
-    extra_trigger: 'div[name="order_line"]',
 }, {
     trigger: 'div[name="product_template_id"]',
     run: "click",
@@ -70,14 +76,20 @@ registry.category("web_tour.tours").add('sale_product_configurator_edition_tour'
 }, {
     trigger: 'button:contains(Confirm)',
     run: "click",
-}, {
+}, 
+{
+    trigger: 'div[name="order_line"]',
+},
+{
     // check updated product
     trigger: 'td.o_data_cell:contains("Customizable Desk (TEST) (Custom, Black)")',
-    extra_trigger: 'div[name="order_line"]',
-}, {
+}, 
+{
+    trigger: 'div[name="order_line"]',
+},
+{
     // check custom value
     trigger: 'td.o_data_cell:contains("Custom: nice custom value")',
-    extra_trigger: 'div[name="order_line"]',
 }, {
     trigger: 'div[name="product_template_id"]',
     run: "click",
@@ -89,10 +101,13 @@ registry.category("web_tour.tours").add('sale_product_configurator_edition_tour'
 {
     trigger: 'button:contains(Confirm)',
     run: "click",
-}, {
+}, 
+{
+    trigger: 'div[name="order_line"]',
+},
+{
     // check custom value
     trigger: 'td.o_data_cell:contains("Custom: another nice custom value")',
-    extra_trigger: 'div[name="order_line"]',
 }, {
     trigger: 'div[name="product_template_id"]',
     run: "click",
@@ -124,9 +139,12 @@ registry.category("web_tour.tours").add('sale_product_configurator_edition_tour'
             el.textContent = "tour success";
         }
     }
-}, {
+}, 
+{
+    trigger: 'div[name="order_line"]',
+},
+{
     trigger: 'td.o_data_cell:contains("tour success")',
-    extra_trigger: 'div[name="order_line"]',
 },
     ...stepUtils.saveForm(),
 ]});

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_optional_products_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_optional_products_ui.js
@@ -9,9 +9,12 @@ registry.category("web_tour.tours").add('sale_product_configurator_optional_prod
     steps: () => [stepUtils.showAppsMenuItem(), {
     trigger: '.o_app[data-menu-xmlid="sale.sale_menu_root"]',
     run: "click",
-}, {
+}, 
+{
+    trigger: ".o_sale_order",
+},
+{
     trigger: '.o_list_button_add',
-    extra_trigger: '.o_sale_order',
     run: "click",
 }, {
     trigger: '.o_required_modifier[name=partner_id] input',
@@ -50,9 +53,12 @@ registry.category("web_tour.tours").add('sale_product_configurator_optional_prod
 }, {
     trigger: 'button:contains(Confirm)',
     run: "click",
-}, {
+}, 
+{
+    trigger: ".modal-title:contains(Warning for Conference Chair (TEST))",
+},
+{
     trigger: '.o-default-button',
-    extra_trigger: '.modal-title:contains(Warning for Conference Chair (TEST))',
     run: "click",
 }, {
     trigger: 'tr:has(td.o_data_cell:contains("Customizable Desk")) td.o_data_cell:contains("2.0")',

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_pricelist_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_pricelist_ui.js
@@ -13,10 +13,13 @@ stepUtils.showAppsMenuItem(),
     content: "navigate to the sale app",
     trigger: '.o_app[data-menu-xmlid="sale.sale_menu_root"]',
     run: "click",
-}, {
+}, 
+{
+    trigger: ".o_sale_order",
+},
+{
     content: "create a new order",
     trigger: '.o_list_button_add',
-    extra_trigger: ".o_sale_order",
     run: "click",
 }, {
     content: "search the partner",
@@ -26,11 +29,14 @@ stepUtils.showAppsMenuItem(),
     content: "select the partner",
     trigger: 'ul.ui-autocomplete > li > a:contains(Azure)',
     run: "click",
-}, {
+}, 
+{
+    trigger: "[name=partner_id]:contains(Fremont)",
+},
+{
     content: "search the pricelist",
     trigger: 'input[id="pricelist_id_0"]',
     // Wait for onchange to come back
-    extra_trigger: "[name=partner_id]:contains(Fremont)",
     run: "edit Test",
 }, {
     content: "search the pricelist",

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_recursive_optional_products.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_recursive_optional_products.js
@@ -10,9 +10,12 @@ registry.category("web_tour.tours").add('sale_product_configurator_recursive_opt
     steps: () => [stepUtils.showAppsMenuItem(), {
     trigger: '.o_app[data-menu-xmlid="sale.sale_menu_root"]',
     run: "click",
-}, {
+}, 
+{
+    trigger: ".o_sale_order",
+},
+{
     trigger: '.o_list_button_add',
-    extra_trigger: '.o_sale_order',
     run: "click",
 }, {
     trigger: 'a:contains("Add a product")',

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_single_custom_attribute_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_single_custom_attribute_ui.js
@@ -11,9 +11,12 @@ registry.category("web_tour.tours").add('sale_product_configurator_single_custom
     steps: () => [stepUtils.showAppsMenuItem(), {
     trigger: '.o_app[data-menu-xmlid="sale.sale_menu_root"]',
     run: "click",
-}, {
+}, 
+{
+    trigger: ".o_sale_order",
+},
+{
     trigger: '.o_list_button_add',
-    extra_trigger: '.o_sale_order',
     run: "click",
 }, {
     trigger: 'a:contains("Add a product")',
@@ -29,9 +32,12 @@ registry.category("web_tour.tours").add('sale_product_configurator_single_custom
 {
     trigger: 'button:contains(Confirm)',
     run: "click",
-}, {
+}, 
+{
+    trigger: 'div[name="order_line"]',
+},
+{
     trigger: 'td.o_data_cell:contains("single product attribute value: great single custom value")',
-    extra_trigger: 'div[name="order_line"]',
 }, {
     trigger: 'div[name="product_template_id"]',
     run: "click",

--- a/addons/test_sale_product_configurators/static/tests/tours/product_matrix_tour.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_matrix_tour.js
@@ -24,9 +24,12 @@ registry.category("web_tour.tours").add('sale_matrix_tour', {
     steps: () => [stepUtils.showAppsMenuItem(), {
     trigger: '.o_app[data-menu-xmlid="sale.sale_menu_root"]',
     run: "click",
-}, {
+}, 
+{
+    trigger: ".o_sale_order",
+},
+{
     trigger: '.o_list_button_add',
-    extra_trigger: '.o_sale_order',
     run: "click",
 }, {
     trigger: '.o_required_modifier[name=partner_id] input',
@@ -53,14 +56,20 @@ registry.category("web_tour.tours").add('sale_matrix_tour', {
 }, {
     trigger: 'button:contains("Confirm")',
     run: "click",
-}, {
+}, 
+{
+    trigger: '.oe_subtotal_footer_separator:contains("248.40")',
+},
+{
     trigger: '.o_sale_order',
     // wait for qty to be 1 => check the total to be sure all qties are set to 1
-    extra_trigger: '.oe_subtotal_footer_separator:contains("248.40")',
     run: "click",
-}, {
+}, 
+{
+    trigger: ".o_form_editable",
+},
+{
     trigger: 'span:contains("Matrix (PAV11, PAV22, PAV31)\n\nPA4: PAV41")',
-    extra_trigger: '.o_form_editable',
     run: "click",
 }, {
     trigger: '[name=product_template_id] button.fa-pencil',  // edit the matrix
@@ -85,14 +94,20 @@ registry.category("web_tour.tours").add('sale_matrix_tour', {
 }, {
     trigger: 'button:contains("Confirm")',  // apply the matrix
     run: "click",
-}, {
+}, 
+{
+    trigger: '.oe_subtotal_footer_separator:contains("745.20")',
+},
+{
     trigger: '.o_sale_order',
     // wait for qty to be 3 => check the total to be sure all qties are set to 3
-    extra_trigger: '.oe_subtotal_footer_separator:contains("745.20")',
     run: "click",
-}, {
+}, 
+{
+    trigger: ".o_form_editable",
+},
+{
     trigger: 'span:contains("Matrix (PAV11, PAV22, PAV31)\n\nPA4: PAV41")',
-    extra_trigger: '.o_form_editable',
     run: "click",
 }, {
     trigger: '[name=product_template_id] button.fa-pencil',  // edit the matrix
@@ -106,10 +121,13 @@ registry.category("web_tour.tours").add('sale_matrix_tour', {
 }, {
     trigger: 'button:contains("Confirm")',  // apply the matrix
     run: "click",
-}, {
+}, 
+{
+    trigger: '.oe_subtotal_footer_separator:contains("248.40")',
+},
+{
     trigger: '.o_sale_order',
     // wait for qty to be 1 => check the total to be sure all qties are set to 1
-    extra_trigger: '.oe_subtotal_footer_separator:contains("248.40")',
     run: "click",
 }, {
     trigger: '.o_form_button_save',  // SAVE Sales Order.
@@ -117,10 +135,13 @@ registry.category("web_tour.tours").add('sale_matrix_tour', {
 },
 // Open the matrix through the pencil button next to the product in line edit mode.
 {
+    trigger: ".o_form_status_indicator_buttons.invisible", // wait for save to be finished
+},
+{
     trigger: 'span:contains("Matrix (PAV11, PAV22, PAV31)\n\nPA4: PAV41")',
-    extra_trigger: '.o_form_status_indicator_buttons.invisible', // wait for save to be finished
     run: "click",
-}, {
+}, 
+{
     trigger: '[name=product_template_id] button.fa-pencil',  // edit the matrix
     run: "click",
 }, {
@@ -134,15 +155,20 @@ registry.category("web_tour.tours").add('sale_matrix_tour', {
 }, {
     trigger: 'button:contains("Confirm")',  // apply the matrix
     run: "click",
-}, {
+}, 
+{
+    trigger: '.o_field_cell.o_data_cell.o_list_number:contains("4.00")',
+},
+{
     trigger: '.o_form_button_save',
-    extra_trigger: '.o_field_cell.o_data_cell.o_list_number:contains("4.00")',
-    run: 'click', // SAVE Sales Order, after matrix has been applied (extra_trigger).
+    run: 'click', // SAVE Sales Order, after matrix has been applied.
 },
 // Ensures the matrix is opened with the values, when adding the same product.
 {
+    trigger: ".o_form_status_indicator_buttons.invisible",
+},
+{
     trigger: 'a:contains("Add a product")',
-    extra_trigger: '.o_form_status_indicator_buttons.invisible',
     run: "click",
 }, {
     trigger: 'div[name="product_template_id"] input',

--- a/addons/test_website_modules/static/tests/tours/configurator_flow.js
+++ b/addons/test_website_modules/static/tests/tours/configurator_flow.js
@@ -59,16 +59,22 @@ registry.category("web_tour.tours").add('configurator_flow', {
         content: "select Pricing",
         trigger: '.card:contains("Pricing")',
         run: "click",
-    }, {
+    }, 
+    {
+        trigger: '.card.border-success:contains("Pricing")',
+    },
+    {
         content: "Events should be selected (module already installed)",
-        extra_trigger: '.card.border-success:contains("Pricing")',
         trigger: '.card.card_installed:contains("Events")',
     }, {
         content: "Slides should be selected (module already installed)",
         trigger: '.card.card_installed:contains("eLearning")',
-    }, {
+    }, 
+    {
+        trigger: '.card.card_installed:contains("Success Stories")',
+    },
+    {
         content: "Success Stories (Blog) and News (Blog) should be selected (module already installed)",
-        extra_trigger: '.card.card_installed:contains("Success Stories")',
         trigger: '.card.card_installed:contains("News")',
     }, {
         content: "Click on build my website",

--- a/addons/website/static/tests/tours/snippet_popup_display_on_click.js
+++ b/addons/website/static/tests/tours/snippet_popup_display_on_click.js
@@ -88,9 +88,11 @@ wTourUtils.registerWebsitePreviewTour("snippet_popup_display_on_click", {
     ...wTourUtils.clickOnSave(),
     wTourUtils.clickOnElement("text image snippet button", ":iframe .s_text_image .btn-secondary"),
     {
+        trigger: ".o_website_preview[data-view-xmlid='website.homepage']",
+    },
+    {
         content: "Verify that the popup opens when the homepage page loads.",
         in_modal: false,
-        extra_trigger: ".o_website_preview[data-view-xmlid='website.homepage']",
         trigger: ":iframe .s_popup .modal[id='Win-%2420'].show",
     },
 ]);

--- a/addons/website/static/tests/tours/snippet_social_media.js
+++ b/addons/website/static/tests/tours/snippet_social_media.js
@@ -8,10 +8,13 @@ import wTourUtils from '@website/js/tours/tour_utils';
 // would actually "ignore" the result of the click on the toggle and would just
 // consider the action of focusing out the input.
 const socialRaceConditionClass = 'social_media_race_condition';
-const preventRaceConditionStep = [{
+const preventRaceConditionStep = [
+    {
+        trigger: `body:not(.${socialRaceConditionClass})`,
+    },
+    {
     content: "Wait a few ms to avoid race condition",
     // Ensure the class is remove from previous call of those steps
-    extra_trigger: `body:not(.${socialRaceConditionClass})`,
     trigger: ':iframe .s_social_media',
     run() {
         setTimeout(() => {

--- a/addons/website/static/tests/tours/snippet_version.js
+++ b/addons/website/static/tests/tours/snippet_version.js
@@ -40,18 +40,30 @@ wTourUtils.registerWebsitePreviewTour("snippet_version_2", {
     content: "Edit s_test_snip",
     trigger: ':iframe #wrap.o_editable .s_test_snip',
     run: "click",
-}, {
+}, 
+{
+    trigger:
+        "we-customizeblock-options:contains(Test snip) .snippet-option-VersionControl > we-alert",
+},
+{
     content: "Edit text_image",
-    extra_trigger: 'we-customizeblock-options:contains(Test snip) .snippet-option-VersionControl > we-alert',
     trigger: ':iframe #wrap.o_editable .s_text_image',
     run: "click",
-}, {
+}, 
+{
+    trigger:
+        "we-customizeblock-options:contains(Text - Image) .snippet-option-VersionControl  > we-alert",
+},
+{
     content: "Edit s_share",
-    extra_trigger: 'we-customizeblock-options:contains(Text - Image) .snippet-option-VersionControl  > we-alert',
     trigger: ':iframe #wrap.o_editable .s_share',
     run: "click",
-}, {
+}, 
+{
+    trigger:
+        "we-customizeblock-options:contains(Share) .snippet-option-VersionControl > we-alert",
+},
+{
     content: "s_share is outdated",
-    extra_trigger: 'we-customizeblock-options:contains(Share) .snippet-option-VersionControl > we-alert',
     trigger: ':iframe body',
 }]);

--- a/addons/website/static/tests/tours/snippets_all_drag_and_drop.js
+++ b/addons/website/static/tests/tours/snippets_all_drag_and_drop.js
@@ -52,9 +52,12 @@ for (const snippet of snippetsNames) {
         content: `Remove the ${snippet} snippet`, // Avoid bad perf if many snippets
         trigger: "we-button.oe_snippet_remove:last",
         run: "click",
-    }, {
+    }, 
+    {
+        trigger: "body[test-dd-snippet-removed]",
+    },
+    {
         content: `click on 'BLOCKS' tab (${snippet})`,
-        extra_trigger: 'body[test-dd-snippet-removed]',
         trigger: ".o_we_add_snippet_btn",
         run: function (actions) {
             document.body.removeAttribute("test-dd-snippet-removed");

--- a/addons/website/static/tests/tours/website_no_dirty_page.js
+++ b/addons/website/static/tests/tours/website_no_dirty_page.js
@@ -41,10 +41,13 @@ const makeSteps = (steps = []) => [
                 }, 999);
             });
         },
-    }, {
+    }, 
+    {
+        trigger: "body.o_test_delay",
+    },
+    {
         content: "Click on Discard",
         trigger: '.o_we_website_top_actions [data-action="cancel"]',
-        extra_trigger: 'body.o_test_delay',
         run: "click",
     }, {
         content: "Confirm we are not in edit mode anymore",
@@ -102,21 +105,30 @@ wTourUtils.registerWebsitePreviewTour('website_no_dirty_lazy_image', {
     wTourUtils.dragNDrop({
         id: 's_text_image',
         name: 'Text - Image',
-    }), {
-        content: "Replace first paragraph, to insert a new link",
+    }), 
+    {
         // Ensure the test keeps testing what it should test (eg if we ever
+        trigger: ':iframe img.o_lang_flag[loading="lazy"]',
+    },
+    {
+        content: "Replace first paragraph, to insert a new link",
         // remove the lazy loading on those language img))
-        extra_trigger: ':iframe img.o_lang_flag[loading="lazy"]',
         trigger: ':iframe #wrap .s_text_image p',
         run: 'editor SomeTestText',
-    }, {
+    }, 
+    {
+        trigger: ':iframe #wrap .s_text_image p:contains("SomeTestText")',
+    },
+    {
         content: "Click elsewhere to be sure the editor fully process the new content",
-        extra_trigger: ':iframe #wrap .s_text_image p:contains("SomeTestText")',
         trigger: ':iframe #wrap .s_text_image img',
         run: "click",
-    }, {
+    }, 
+    {
+        trigger: '.o_we_user_value_widget[data-replace-media="true"]',
+    },
+    {
         content: "Check that there is no more than one dirty flag",
-        extra_trigger: '.o_we_user_value_widget[data-replace-media="true"]',
         trigger: ':iframe body',
         run: function () {
             const dirtyCount = this.anchor.querySelectorAll('.o_dirty').length;

--- a/addons/website/static/tests/tours/website_snippets_menu_tabs.js
+++ b/addons/website/static/tests/tours/website_snippets_menu_tabs.js
@@ -9,8 +9,10 @@ wTourUtils.registerWebsitePreviewTour("website_snippets_menu_tabs", {
 }, () => [
     wTourUtils.goToTheme(),
     {
+        trigger: "we-customizeblock-option.snippet-option-ThemeColors",
+    },
+    {
         content: "Click on the empty 'DRAG BUILDING BLOCKS HERE' area.",
-        extra_trigger: 'we-customizeblock-option.snippet-option-ThemeColors',
         trigger: ':iframe main > .oe_structure.oe_empty',
         run: 'click',
     },

--- a/addons/website/static/tests/tours/website_text_font_size.js
+++ b/addons/website/static/tests/tours/website_text_font_size.js
@@ -80,11 +80,14 @@ function getFontSizeTestSteps(fontSizeClass) {
             content: `Check that the setting of ${fontSizeClass} has been updated`,
             trigger: `we-input[data-variable="${classNameInfo.get(fontSizeClass).scssVariableName}"]`
                 + ` input:value("${classNameInfo.get(fontSizeClass).end}")`,
-        }, {
+        }, 
+        {
+            trigger: `body:not(:has(.o_we_ui_loading))`,
+        },
+        {
             content: `Close the collapse to hide the font size of ${fontSizeClass}`,
             trigger: `we-collapse:has(we-input[data-variable=` +
                 `"${classNameInfo.get(fontSizeClass).scssVariableName}"]) we-toggler`,
-            extra_trigger: `body:not(:has(.o_we_ui_loading))`,
             run: "click",
         },
         checkComputedFontSize(fontSizeClass, "end"),

--- a/addons/website/static/tests/tours/website_update_column_count.js
+++ b/addons/website/static/tests/tours/website_update_column_count.js
@@ -113,11 +113,14 @@ wTourUtils.clickOnSnippet({
     content: "Change the orders of the 2nd and 3rd items",
     trigger: ":iframe .o_overlay_move_options [data-name='move_right_opt']",
     run: "click",
-}, {
+}, 
+{
+    trigger: `${columnsSnippetRow}:has([style*='order: 2;'].order-lg-0:nth-child(2) + [style*='order: 1;'].order-lg-0:nth-child(3))`,
+},
+{
     content: "Check that the 1st item now has order: 0 and a class .order-lg-0 " +
              "and that order: 1, .order-lg-0 is set on the 3rd item, and order: 2, .order-lg-0 on the 2nd",
     trigger: `${columnsSnippetRow}:has([style*='order: 0;'].order-lg-0:first-child)`,
-    extra_trigger: `${columnsSnippetRow}:has([style*='order: 2;'].order-lg-0:nth-child(2) + [style*='order: 1;'].order-lg-0:nth-child(3))`,
 }, {
     content: "Toggle desktop view",
     trigger: ".o_we_website_top_actions [data-action='mobile']",

--- a/addons/website_blog/static/tests/tours/blog_search_with_date.js
+++ b/addons/website_blog/static/tests/tours/blog_search_with_date.js
@@ -12,14 +12,20 @@ registry.category("web_tour.tours").add("blog_autocomplete_with_date", {
     content: "Select first month",
     trigger: 'select[name=archive]',
     run: "selectByIndex 1",
-}, {
+}, 
+{
+    trigger: '#o_wblog_posts_loop span:has(i.fa-calendar-o):has(a[href="/blog"])',
+},
+{
     content: "Enter search term",
     trigger: '.o_searchbar_form input',
-    extra_trigger: '#o_wblog_posts_loop span:has(i.fa-calendar-o):has(a[href="/blog"])',
     run: "edit a",
-}, {
+}, 
+{
+    trigger: ".o_searchbar_form .o_dropdown_menu .o_search_result_item",
+},
+{
     content: "Wait for suggestions then click on search icon",
-    extra_trigger: '.o_searchbar_form .o_dropdown_menu .o_search_result_item',
     trigger: '.o_searchbar_form button:has(i.oi-search)',
     run: "click",
 }, {

--- a/addons/website_crm/static/tests/tours/website_crm.js
+++ b/addons/website_crm/static/tests/tours/website_crm.js
@@ -11,10 +11,13 @@
         content: "Select contact form",
         trigger: ":iframe #wrap.o_editable section.s_website_form",
         run: "click",
-    }, {
+    },
+    {
+        trigger: "#oe_snippets .o_we_customize_snippet_btn.active",
+    },
+    {
         content: "Open action select",
         trigger: "we-select:has(we-button:contains('Create an Opportunity')) we-toggler",
-        extra_trigger: "#oe_snippets .o_we_customize_snippet_btn.active",
         run: "click",
     }, {
         content: "Select 'Create an Opportunity' as form action",

--- a/addons/website_event/static/src/js/tours/event_tour.js
+++ b/addons/website_event/static/src/js/tours/event_tour.js
@@ -30,15 +30,21 @@ patch(EventAdditionalTourSteps.prototype, {
                 content: markup(_t("Don't forget to click <b>save</b> when you're done.")),
                 position: 'bottom',
                 run: "click",
-            }, {
+            },
+            {
+                trigger: ":iframe body:not(.editor_enable) .o_wevent_event",
+            },
+            {
                 trigger: '.o_menu_systray_item.o_website_publish_container a',
-                extra_trigger: ':iframe body:not(.editor_enable) .o_wevent_event',
                 content: markup(_t("Looking great! Let's now <b>publish</b> this page so that it becomes <b>visible</b> on your website!")),
                 position: 'bottom',
                 run: "click",
-            }, {
+            },
+            {
+                trigger: ":iframe .o_wevent_event",
+            },
+            {
                 trigger: '.o_website_edit_in_backend > a',
-                extra_trigger: ':iframe .o_wevent_event',
                 content: _t("This shortcut will bring you right back to the event form."),
                 position: 'bottom',
                 run: "click",

--- a/addons/website_event/static/tests/tours/website_event_pages_seo.js
+++ b/addons/website_event/static/tests/tours/website_event_pages_seo.js
@@ -2,36 +2,45 @@
 
 import { registry } from "@web/core/registry";
 
-registry.category("web_tour.tours").add('website_event_pages_seo', {
+registry.category("web_tour.tours").add("website_event_pages_seo", {
     test: true,
     // The tour must start on an event's custom page (not register page)
     // url: `/event/openwood-collection-online-reveal-8/page/introduction-openwood-collection-online-reveal`,
     steps: () => [
-    {
-        content: "Open the site menu",
-        trigger: '[data-menu-xmlid="website.menu_site"]',
-        extra_trigger: ':iframe #o_wevent_event_submenu', // Ensure we landed on the event page
-        run: "click",
-    },
-    {
-        content: "Open the optimize SEO dialog",
-        trigger: '[data-menu-xmlid="website.menu_optimize_seo"]',
-        run: "click",
-    },
-    {
-        content: "Fill in the title input",
-        trigger: '[for="website_meta_title"] + input',
-        run: "edit Hello, world!",
-    },
-    {
-        content: "Save the dialog",
-        trigger: '.modal-footer .btn-primary',
-        run: "click",
-    },
-    {
-        content: "Check that the page title is adapted, inside and outside the iframe",
-        trigger: "head:has(title:contains(/^Hello, world!$/))",
-        extra_trigger: ":iframe head:has(title:contains(/^Hello, world!$/))",
-        allowInvisible: true,
-    },
-]});
+        {
+            trigger: ":iframe #o_wevent_event_submenu", // Ensure we landed on the event page
+        },
+        {
+            content: "Open the site menu",
+            trigger: '[data-menu-xmlid="website.menu_site"]',
+            run: "click",
+        },
+        {
+            content: "Open the optimize SEO dialog",
+            trigger: '[data-menu-xmlid="website.menu_optimize_seo"]',
+            run: "click",
+        },
+        {
+            content: "Fill in the title input",
+            trigger: '.modal [for="website_meta_title"] + input',
+            run: "edit Hello, world!",
+        },
+        {
+            content: "Save the dialog",
+            trigger: ".modal .modal-footer .btn-primary",
+            run: "click",
+        },
+        {
+            trigger: "body:not(:has(.modal))",
+        },
+        {
+            trigger: ":iframe head:has(title:contains(/^Hello, world!$/))",
+            allowInvisible: true,
+        },
+        {
+            content: "Check that the page title is adapted, inside and outside the iframe",
+            trigger: "head:has(title:contains(/^Hello, world!$/))",
+            allowInvisible: true,
+        },
+    ],
+});

--- a/addons/website_event_booth_exhibitor/static/tests/tours/website_event_booth_exhibitor.js
+++ b/addons/website_event_booth_exhibitor/static/tests/tours/website_event_booth_exhibitor.js
@@ -40,9 +40,12 @@
             document.querySelector("input[name='sponsor_slogan']").value = "Patrick is Your Sponsor";
             document.querySelector("textarea[name='sponsor_description']").textContent = "Really eager to meet you !";
         },
-    }, {
+    }, 
+    {
+        trigger: "input[name='sponsor_name'], input[name='sponsor_email'], input[name='sponsor_phone']",
+    },
+    {
         content: "Validate booth details",
-        extra_trigger: "input[name='sponsor_name'], input[name='sponsor_email'], input[name='sponsor_phone']",
         trigger: 'button.o_wbooth_registration_confirm',
         run: 'click',
     }, ...new FinalSteps()._getSteps()].filter(Boolean)});

--- a/addons/website_event_sale/static/tests/tours/website_event_sale.js
+++ b/addons/website_event_sale/static/tests/tours/website_event_sale.js
@@ -18,20 +18,26 @@ registry.category("web_tour.tours").add('event_buy_tickets', {
             run: "click",
         },
         {
+            trigger: '#wrap:not(:has(a[href*="/event"]:contains("Conference for Architects")))',
+        },
+        {
             content: "Select 1 unit of `Standard` ticket type",
-            extra_trigger: '#wrap:not(:has(a[href*="/event"]:contains("Conference for Architects")))',
             trigger: 'select:eq(0)',
             run: "select 1",
         },
         {
+            trigger: "select:eq(0):has(option:contains(1):selected)",
+        },
+        {
             content: "Select 2 units of `VIP` ticket type",
-            extra_trigger: 'select:eq(0):has(option:contains(1):selected)',
             trigger: 'select:eq(1)',
             run: "select 2",
         },
         {
+            trigger: "select:eq(1):has(option:contains(2):selected)",
+        },
+        {
             content: "Click on `Order Now` button",
-            extra_trigger: 'select:eq(1):has(option:contains(2):selected)',
             trigger: '.btn-primary:contains("Register")',
             run: "click",
         },
@@ -51,8 +57,10 @@ registry.category("web_tour.tours").add('event_buy_tickets', {
             },
         },
         {
+            trigger: "input[name*='1-name'], input[name*='2-name'], input[name*='3-name']",
+        },
+        {
             content: "Validate attendees details",
-            extra_trigger: "input[name*='1-name'], input[name*='2-name'], input[name*='3-name']",
             trigger: 'button[type=submit]',
             run: "click",
         },

--- a/addons/website_event_sale/static/tests/tours/website_event_sale_pricelists.js
+++ b/addons/website_event_sale/static/tests/tours/website_event_sale_pricelists.js
@@ -33,8 +33,10 @@
             },
         },
         {
+            trigger: "input[name*='1-name'], input[name*='2-name']",
+        },
+        {
             content: "Validate attendees details",
-            extra_trigger: "input[name*='1-name'], input[name*='2-name']",
             trigger: 'button[type=submit]',
             run: "click",
         },

--- a/addons/website_forum/static/src/js/tours/website_forum.js
+++ b/addons/website_forum/static/src/js/tours/website_forum.js
@@ -39,8 +39,7 @@
         run: "click",
     }, {
         isActive: ["auto"],
-        extra_trigger: 'div.modal.modal_shown',
-        trigger: ".modal-header button.btn-close",
+        trigger: ".modal .modal-header button.btn-close",
         run: "click",
     },
     {
@@ -62,8 +61,7 @@
         run: "click",
     }, {
         isActive: ["auto"],
-        extra_trigger: 'div.modal.modal_shown',
-        trigger: ".modal-header button.btn-close",
+        trigger: ".modal .modal-header button.btn-close",
         run: "click",
     }, {
         trigger: ".o_wforum_validate_toggler[data-karma]:first",

--- a/addons/website_forum/static/tests/tours/website_forum_question.js
+++ b/addons/website_forum/static/tests/tours/website_forum_question.js
@@ -14,28 +14,37 @@ registry.category("web_tour.tours").add('forum_question', {
         content: "Give your question content.",
         trigger: 'input[name=post_name]',
         run: "edit First Question Title",
-    }, {
+    },
+    {
+        trigger: "#wrap:not(:has(input[name=post_name]:value('')))",
+    },
+    {
         content: "Put your question here.",
-        extra_trigger: "#wrap:not(:has(input[name=post_name]:value('')))",
         trigger: '.note-editable p',
         run: "editor First Question",
-    }, {
+    },
+    {
+        trigger: ".note-editable:not(:has(br))",
+    },
+    {
         content: "Insert tags related to your question.",
-        extra_trigger: '.note-editable:not(:has(br))',
         trigger: '.select2-choices',
         run: "editor Tag",
-    }, {
+    },
+    {
+        trigger: "#wrap:not(:has(input[id=s2id_autogen2]:value('')))",
+    },
+    {
         content: "Click to post your question.",
-        extra_trigger: "#wrap:not(:has(input[id=s2id_autogen2]:value('')))",
         trigger: 'button:contains("Post")',
         run: "click",
     }, {
         content: "This page contain new created question.",
         trigger: '#wrap:has(.fa-star)',
-    }, {
+    },
+    {
         content: "Close modal once modal animation is done.",
-        extra_trigger: 'div.modal.modal_shown',
-        trigger: ".modal-header button.btn-close",
+        trigger: ".modal .modal-header button.btn-close",
         run: "click",
     },
     {
@@ -48,15 +57,18 @@ registry.category("web_tour.tours").add('forum_question', {
         content: "Put your answer here.",
         trigger: '.note-editable p',
         run: "editor First Answer",
-    }, {
+    },
+    {
+        trigger: ".note-editable:not(:has(br))",
+    },
+    {
         content: "Click to post your answer.",
-        extra_trigger: '.note-editable:not(:has(br))',
         trigger: 'button:contains("Post Answer")',
         run: "click",
-    }, {
+    },
+    {
         content: "Close modal once modal animation is done.",
-        extra_trigger: 'div.modal.modal_shown',
-        trigger: ".modal-header button.btn-close",
+        trigger: ".modal .modal-header button.btn-close",
         run: "click",
     }, {
         content: "Congratulations! You just created and post your first question and answer.",

--- a/addons/website_links/static/tests/tours/website_links.js
+++ b/addons/website_links/static/tests/tours/website_links.js
@@ -67,8 +67,10 @@ registry.category("web_tour.tours").add('website_links_tour', {
         },
         // 2. Visit it
         {
+            trigger: '#o_website_links_recent_links .truncate_text:first():contains("Contact Us")',
+        },
+        {
             content: "check that link was created and visit it",
-            extra_trigger: '#o_website_links_recent_links .truncate_text:first():contains("Contact Us")',
             trigger: '#o_website_links_link_tracker_form #generated_tracked_link:contains("/r/")',
             run: function () {
                 window.location.href = $('#generated_tracked_link').text();
@@ -98,8 +100,10 @@ registry.category("web_tour.tours").add('website_links_tour', {
             run: "click",
         },
         {
+            trigger: '.website_links_click_chart .title:contains("1 clicks")',
+        },
+        {
             content: "check click number and ensure graphs are initialized",
-            extra_trigger: '.website_links_click_chart .title:contains("1 clicks")',
             trigger: 'canvas',
         },
         {

--- a/addons/website_mass_mailing/static/tests/tours/snippet_newsletter_block_with_edit.js
+++ b/addons/website_mass_mailing/static/tests/tours/snippet_newsletter_block_with_edit.js
@@ -20,9 +20,11 @@ wTourUtils.registerWebsitePreviewTour('snippet_newsletter_block_with_edit', {
     ...wTourUtils.clickOnSave(),
     // Subscribe to the newsletter.
     {
+        trigger: ':iframe .s_newsletter_block input:value("admin@yourcompany.example.com")',
+    },
+    {
         content: 'Wait for the email to be loaded in the newsletter input',
         trigger: ':iframe .s_newsletter_block .js_subscribe_btn',
-        extra_trigger: ':iframe .s_newsletter_block input:value("admin@yourcompany.example.com")',
         run: "click",
     },
     // Change the link style.
@@ -53,9 +55,11 @@ wTourUtils.registerWebsitePreviewTour('snippet_newsletter_block_with_edit', {
         run: "click",
     },
     {
+        trigger: 'we-customizeblock-option:has([name="link_style_size"])',
+    },
+    {
         content: 'Verify that the shape option is not available for primary while the size option appeared',
         trigger: 'we-customizeblock-option:not(:has([name="link_style_shape"]))',
-        extra_trigger: 'we-customizeblock-option:has([name="link_style_size"])',
     },
     {
         content: 'Click on the link style button',

--- a/addons/website_sale/static/tests/tours/website_sale_google_analytics.js
+++ b/addons/website_sale/static/tests/tours/website_sale_google_analytics.js
@@ -40,8 +40,10 @@ registry.category("web_tour.tours").add('google_analytics_view_item', {
         }
     },
     {
+        trigger: 'body:not([view-event-id])',
+    },
+    {
         content: 'select another variant',
-        extra_trigger: 'body:not([view-event-id])',
         trigger: 'ul.js_add_cart_variants ul.list-inline li:has(label.active) + li:has(label) input',
         run: "click",
     },
@@ -59,8 +61,10 @@ registry.category("web_tour.tours").add('google_analytics_add_to_cart', {
     steps: () => [
     ...tourUtils.addToCart({productName: 'Acoustic Bloc Screens', search: false}),
     {
+        trigger: "body[cart-event-id]",
+    },
+    {
         content: 'check add to cart event',
-        extra_trigger: 'body[cart-event-id]',
         trigger: "a:has(.my_cart_quantity:contains(/^1$/))",
         timeout: 25000,
     },

--- a/addons/website_sale/static/tests/tours/website_sale_preconfigured_variant_price.js
+++ b/addons/website_sale/static/tests/tours/website_sale_preconfigured_variant_price.js
@@ -4,17 +4,23 @@ import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add('website_sale_product_configurator_optional_products_tour', {
     test: true,
-    steps: () => [{
+    steps: () => [
+        {
+            trigger: 'ul.js_add_cart_variants span:contains("Aluminium") ~ span.badge:contains("50.40")',
+        },
+        {
     content: 'Click Aluminium Option',
     trigger: 'ul.js_add_cart_variants span:contains("Aluminium")',
-    extra_trigger: 'ul.js_add_cart_variants span:contains("Aluminium") ~ span.badge:contains("50.40")',
     run: "click",
 }, {
     content: 'Add to cart',
     trigger: '#add_to_cart',
     run: "click",
-}, {
+}, 
+{
+    trigger: 'main.oe_advanced_configurator_modal span:contains("800.40")',
+},
+{
     content: 'Check that modal was opened with the correct variant price',
     trigger: 'main.oe_advanced_configurator_modal',
-    extra_trigger: 'main.oe_advanced_configurator_modal span:contains("800.40")',
 }]});

--- a/addons/website_sale/static/tests/tours/website_sale_restricted_editor_ui.js
+++ b/addons/website_sale/static/tests/tours/website_sale_restricted_editor_ui.js
@@ -20,10 +20,12 @@ wTourUtils.registerWebsitePreviewTour('website_sale_restricted_editor_ui', {
         run: "click",
     },
     {
+        // Wait for the possibility to edit to appear
+        trigger: ".o_menu_systray .o_edit_website_container a",
+    },
+    {
         content: "Ensure the publish and 'edit-in-backend' buttons are not shown",
         trigger: '.o_menu_systray:not(:has(.form-switch)):not(:has(.o_website_edit_in_backend))',
-        // Wait for the possibility to edit to appear
-        extra_trigger: '.o_menu_systray .o_edit_website_container a',
         run: "click",
     },
     stepUtils.waitIframeIsReady(),
@@ -38,9 +40,12 @@ wTourUtils.registerWebsitePreviewTour('website_sale_restricted_editor_ui', {
         run: "click",
     },
     {
+        trigger:
+            ".o_menu_systray_item:not([data-processing]) .form-switch:has(input:not(:checked))",
+    },
+    {
         content: "Click on edit-in-backend",
         trigger: '.o_menu_systray .o_website_edit_in_backend a',
-        extra_trigger: '.o_menu_systray_item:not([data-processing]) .form-switch:has(input:not(:checked))',
         run: "click",
     },
     {

--- a/addons/website_sale/static/tests/tours/website_sale_shop_cart_recovery.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_cart_recovery.js
@@ -69,8 +69,10 @@ registry.category("web_tour.tours").add('shop_cart_recovery', {
         },
     },
     {
+        trigger: 'p:contains("This is your current cart")',
+    },
+    {
         content: "check the page is working, click on restore",
-        extra_trigger: 'p:contains("This is your current cart")',
         trigger: 'p:contains("restore") a:contains("Click here")',
         run: "click",
     },

--- a/addons/website_sale/static/tests/tours/website_sale_shop_custom_attribute_value.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_custom_attribute_value.js
@@ -9,9 +9,12 @@
         content: "click on Customizable Desk",
         trigger: '.oe_product_cart a:contains("Customizable Desk (TEST)")',
         run: "click",
-    }, {
+    }, 
+    {
+        trigger: "li.js_attribute_value",
+    },
+    {
         trigger: 'li.js_attribute_value span:contains(Custom)',
-        extra_trigger: 'li.js_attribute_value',
         run: 'click',
     }, {
         trigger: 'input.variant_custom_value',
@@ -26,7 +29,9 @@
         run: 'click',
     },
     {
+        trigger: "#cart_products",
+    },
+    {
         trigger: 'span:contains(Custom: Wood)',
-        extra_trigger: '#cart_products',
         run: function (){}, // check
     }]});

--- a/addons/website_sale/static/tests/tours/website_sale_shop_custom_attributes_value.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_custom_attributes_value.js
@@ -41,20 +41,31 @@ registry.category("web_tour.tours").add("a_shop_custom_attribute_value", {
             $('<p>').text('image variant option src changed').insertAfter('.oe_advanced_configurator_modal .js_product:eq(1) .product-name');
         }
     }
-}, {
-    extra_trigger: '.oe_advanced_configurator_modal .js_product:eq(1) div:contains("image variant option src changed")',
+}, 
+{
+    trigger: '.oe_advanced_configurator_modal .js_product:eq(1) div:contains("image variant option src changed")',
+},
+{
     trigger: '.oe_advanced_configurator_modal .js_product:eq(1) input[data-value_name="Steel"]',
     run: "click",
 }, {
     trigger: '.oe_price span:contains(22.90)',
     run: function (){}, // check
-}, {
+}, 
+{
+    trigger:
+        ".oe_advanced_configurator_modal .js_product:has(strong:contains(Conference Chair))",
+},
+{
     trigger: '.oe_advanced_configurator_modal .js_product:has(strong:contains(Conference Chair)) .js_add',
-    extra_trigger: '.oe_advanced_configurator_modal .js_product:has(strong:contains(Conference Chair))',
     run: 'click'
-}, {
+},
+{
+    trigger:
+        ".oe_advanced_configurator_modal .js_product:has(strong:contains(Chair floor protection))",
+},
+{
     trigger: '.oe_advanced_configurator_modal .js_product:has(strong:contains(Chair floor protection)) .js_add',
-    extra_trigger: '.oe_advanced_configurator_modal .js_product:has(strong:contains(Chair floor protection))',
     run: 'click'
 }, {
     trigger: 'span:contains(1,557.00)',

--- a/addons/website_sale/static/tests/tours/website_sale_shop_editor_tour.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_editor_tour.js
@@ -10,14 +10,20 @@ wTourUtils.registerWebsitePreviewTour("shop_editor", {
     content: "Click on pricelist dropdown",
     trigger: ":iframe div.o_pricelist_dropdown a[data-bs-toggle=dropdown]",
     run: "click",
-}, {
+}, 
+{
+    trigger: ":iframe div.o_pricelist_dropdown a[data-bs-toggle=dropdown][aria-expanded=true]",
+},
+{
     trigger: ":iframe input[name=search]",
-    extra_trigger: ":iframe div.o_pricelist_dropdown a[data-bs-toggle=dropdown][aria-expanded=true]",
     content: "Click somewhere else in the shop.",
     run: "click",
-}, {
+}, 
+{
+    trigger: ":iframe div.o_pricelist_dropdown a[data-bs-toggle=dropdown][aria-expanded=false]",
+},
+{
     trigger: ":iframe div.o_pricelist_dropdown a[data-bs-toggle=dropdown]",
-    extra_trigger: ":iframe div.o_pricelist_dropdown a[data-bs-toggle=dropdown][aria-expanded=false]",
     content: "Click on the pricelist again.",
     run: "click",
 }, {

--- a/addons/website_sale_loyalty/static/tests/tours/test_promo_main_tour.js
+++ b/addons/website_sale_loyalty/static/tests/tours/test_promo_main_tour.js
@@ -10,8 +10,10 @@ registry.category("web_tour.tours").add('shop_sale_loyalty', {
     steps: () => [
         /* 1. Buy 1 Small Cabinet, enable coupon code & insert 10% code */
         {
+            trigger: ".oe_search_found",
+        },
+        {
             content: "select Small Cabinet",
-            extra_trigger: '.oe_search_found',
             trigger: '.oe_product_cart a:contains("Small Cabinet")',
             run: "click",
         },
@@ -27,8 +29,10 @@ registry.category("web_tour.tours").add('shop_sale_loyalty', {
         },
             tourUtils.goToCart({quantity: 2}),
         {
+            trigger: 'form[name="coupon_code"]',
+        },
+        {
             content: "insert promo code 'testcode'",
-            extra_trigger: 'form[name="coupon_code"]',
             trigger: 'form[name="coupon_code"] input[name="promo"]',
             run: "edit testcode",
         },
@@ -78,8 +82,10 @@ registry.category("web_tour.tours").add('shop_sale_loyalty', {
             ...tourUtils.addToCart({productName: "Taxed Product"}),
             tourUtils.goToCart({quantity: 3}),
         {
+            trigger: ".oe_currency_value:contains(/74.00/):not(#cart_total)",
+        },
+        {
             content: "check reduction amount got recomputed and merged both discount lines into one only",
-            extra_trigger: ".oe_currency_value:contains(/74.00/):not(#cart_total)",
             trigger: '.oe_website_sale .oe_cart',
         },
         /* 3. Add some cabinet to get a free one, play with quantity */

--- a/addons/website_sale_stock/static/tests/tours/website_sale_stock_message_after_close_configurator_modal.js
+++ b/addons/website_sale_stock/static/tests/tours/website_sale_stock_message_after_close_configurator_modal.js
@@ -18,9 +18,12 @@ registry.category("web_tour.tours").add('website_sale_stock_message_after_close_
         content: "Add to cart",
         trigger: '#add_to_cart',
         run: "click",
-    }, {
+    }, 
+    {
+        trigger: ".oe_advanced_configurator_modal",
+    },
+    {
         content: "Continue shoppping",
-        extra_trigger: '.oe_advanced_configurator_modal',
         trigger: 'button span:contains(Continue Shopping)',
         run: 'click'
     }, {

--- a/addons/website_sale_wishlist/static/tests/tours/website_sale_wishlist_admin.js
+++ b/addons/website_sale_wishlist/static/tests/tours/website_sale_wishlist_admin.js
@@ -13,9 +13,11 @@ wTourUtils.registerWebsitePreviewTour('shop_wishlist_admin', {
             run: "click",
         },
         {
+            trigger: ":iframe #product_details",
+        },
+        {
             content: "check list view of variants is disabled initially (when on /product page)",
             trigger: ':iframe body:not(:has(.js_product_change))',
-            extra_trigger: ':iframe #product_details',
             run: "click",
         },
         ...wTourUtils.clickOnEditAndWaitEditMode(),
@@ -25,8 +27,10 @@ wTourUtils.registerWebsitePreviewTour('shop_wishlist_admin', {
             run: "click",
         },
         {
+            trigger: "#oe_snippets .o_we_customize_panel",
+        },
+        {
             content: "open 'Variants' selector",
-            extra_trigger: '#oe_snippets .o_we_customize_panel',
             trigger: '[data-name="variants_opt"] we-toggler',
             run: "click",
         },
@@ -83,8 +87,10 @@ wTourUtils.registerWebsitePreviewTour('shop_wishlist_admin', {
             }
         },
         {
+            trigger: ':iframe #o_comparelist_table tr:contains("red")',
+        },
+        {
             content: "Check wishlist contains both variants",
-            extra_trigger: ':iframe #o_comparelist_table tr:contains("red")',
             trigger: ':iframe #o_comparelist_table tr:contains("black")',
         },
     ]

--- a/addons/website_slides/static/tests/tours/slide_course_publisher_standard.js
+++ b/addons/website_slides/static/tests/tours/slide_course_publisher_standard.js
@@ -60,10 +60,13 @@ wTourUtils.registerWebsitePreviewTour('course_publisher_standard', {
     content: 'eLearning: add a bioutifoul URL',
     trigger: 'input.o_we_url_input',
     run: "edit https://upload.wikimedia.org/wikipedia/commons/thumb/1/12/ThreeTimeAKCGoldWinnerPembrookeWelshCorgi.jpg/800px-ThreeTimeAKCGoldWinnerPembrookeWelshCorgi.jpg",
-}, {
+}, 
+{
+    trigger: ".o_we_url_success",
+},
+{
     content: 'eLearning: click "Add URL" really adding image',
     trigger: '.o_upload_media_url_button',
-    extra_trigger: '.o_we_url_success',
     run: "click",
 }, {
     content: 'eLearning: is the Corgi set ?',
@@ -73,9 +76,12 @@ wTourUtils.registerWebsitePreviewTour('course_publisher_standard', {
     content: 'eLearning: save course edition',
     trigger: 'button[data-action="save"]',
     run: "click",
-}, {
+}, 
+{
+    trigger: ":iframe body:not(.editor_enable)", // wait for editor to close
+},
+{
     content: 'eLearning: course create with current member',
-    extra_trigger: ':iframe body:not(.editor_enable)',  // wait for editor to close
     trigger: ':iframe .o_wslides_js_course_join:contains("You\'re enrolled")',
 }
 ].concat(

--- a/addons/website_slides/static/tests/tours/slides_course_member.js
+++ b/addons/website_slides/static/tests/tours/slides_course_member.js
@@ -1,6 +1,5 @@
 /** @odoo-module **/
 
-import { queryAll } from "@odoo/hoot-dom";
 import { registry } from "@web/core/registry";
 
 /**
@@ -55,73 +54,31 @@ registry.category("web_tour.tours").add('course_member', {
 // eLeaning: course completion
 {
     trigger: '.o_wslides_fs_sidebar_header',
-    run(helpers) {
-        // check navigation with arrow keys
-        // go back once
-        helpers.press("ArrowLeft");
-        // check that it selected the previous tab
-        if (
-            queryAll(
-                '.o_wslides_fs_sidebar_list_item.active:contains("Gardening: The Know-How")'
-            ).length === 0
-        ) {
-            return;
-        }
-        // getting here means that navigation worked
-        document
-            .querySelector(".o_wslides_fs_sidebar_header")
-            .classList.add("navigation-success-1");
-    }
-}, {
-    trigger: '.o_wslides_fs_sidebar_header.navigation-success-1',
-    extra_trigger: '.o_wslides_progress_percentage:contains("40")',
-    run(helpers) {
-        // check navigation with arrow keys
-        helpers.press("ArrowRight");
-        // check that it selected the next/next tab
-        if (
-            queryAll('.o_wslides_fs_sidebar_list_item.active:contains("Home Gardening")')
-                .length === 0
-        ) {
-            return;
-        }
-        // getting here means that navigation worked
-        document
-            .querySelector(".o_wslides_fs_sidebar_header")
-            .classList.add("navigation-success-2");
-    }
-}, {
+    run: "press ArrowLeft",
+}, 
+{
+    trigger: ".o_wslides_fs_sidebar_list_item.active:contains(Gardening: The Know-How)",
+},
+{
+    trigger: '.o_wslides_progress_percentage:contains("40")',
+    run: "press ArrowRight",
+},
+{
+    trigger: ".o_wslides_fs_sidebar_list_item.active:contains(Home Gardening)",
+},
+{
     // check progression
     trigger: '.o_wslides_progress_percentage:contains("40")',
-}, {
-    trigger: '.o_wslides_fs_sidebar_header.navigation-success-2',
-    extra_trigger: '.o_wslides_progress_percentage:contains("40")',
-    run(helpers) {
-        // check navigation with arrow keys
-        setTimeout(function () {
-            helpers.press("ArrowRight");
-            // check that it selected the next/next tab
-            if (
-                queryAll(
-                    '.o_wslides_fs_sidebar_list_item.active:contains("Mighty Carrots")'
-                ).length === 0
-            ) {
-                return;
-            }
-            // getting here means that navigation worked
-            document
-                .querySelector(".o_wslides_fs_sidebar_header")
-                .classList.add("navigation-success-3");
-        }, 300);
-    }
-}, {
+    run: "press ArrowRight",
+},
+{
+    trigger: ".o_wslides_fs_sidebar_list_item.active:contains(Mighty Carrots)",
+},
+{
     // check progression
     trigger: '.o_wslides_progress_percentage:contains("60")',
-}, {
-    // check that previous step succeeded
-    trigger: '.o_wslides_fs_sidebar_header.navigation-success-3',
-    extra_trigger: '.o_wslides_progress_percentage:contains("60")',
-}, {
+}, 
+{
     trigger: '.o_wslides_fs_slide_name:contains("How to Grow and Harvest The Best Strawberries | Basics")',
     run: 'click',
 }, {
@@ -161,26 +118,31 @@ registry.category("web_tour.tours").add('course_member', {
 {
     trigger: 'a:contains("Basics of Gardening")',
     run: "click",
-}, {
+},
+{
     trigger: 'button[data-bs-target="#ratingpopupcomposer"]',
     run: "click",
-}, {
-    trigger: 'div.o_portal_chatter_composer_input i.fa:eq(2)',
-    extra_trigger: 'div.modal_shown',
+},
+{
+    in_modal: false,
+    trigger: ".modal .modal-body i.fa.fa-star:eq(2)",
     run: 'click',
+},
+{
     in_modal: false,
-}, {
-    trigger: 'div.o_portal_chatter_composer_input textarea',
+    trigger: ".modal .modal-body textarea",
     run: "edit This is a great course. Top !",
+},
+{
     in_modal: false,
-}, {
-    trigger: 'button.o_portal_chatter_composer_btn',
-    in_modal: false,
+    trigger: ".modal button:contains(review)",
     run: "click",
-}, {
+},
+{
     trigger: 'a[id="review-tab"]',
     run: "click",
-}, {
+},
+{
     // check review is correctly added
     trigger: '.o_portal_chatter_message:contains("This is a great course. Top !")',
 }

--- a/addons/website_slides/static/tests/tours/slides_course_publisher.js
+++ b/addons/website_slides/static/tests/tours/slides_course_publisher.js
@@ -64,10 +64,13 @@ wTourUtils.registerWebsitePreviewTour('course_publisher', {
     content: 'eLearning: add a bioutifoul URL',
     trigger: 'input.o_we_url_input',
     run: "edit https://upload.wikimedia.org/wikipedia/commons/thumb/1/12/ThreeTimeAKCGoldWinnerPembrookeWelshCorgi.jpg/800px-ThreeTimeAKCGoldWinnerPembrookeWelshCorgi.jpg",
-}, {
+}, 
+{
+    trigger: ".o_we_url_success",
+},
+{
     content: 'eLearning: click "Add URL" really adding image',
     trigger: '.o_upload_media_url_button',
-    extra_trigger: '.o_we_url_success',
     run: "click",
 }, {
     content: 'eLearning: is the Corgi set ?',
@@ -77,10 +80,13 @@ wTourUtils.registerWebsitePreviewTour('course_publisher', {
     content: 'eLearning: save course edition',
     trigger: 'button[data-action="save"]',
     run: "click",
-}, {
+},
+{
+    trigger: ":iframe body:not(.editor_enable)", // wait for editor to close
+},
+{
     // check membership
     content: 'eLearning: course create with current member',
-    extra_trigger: ':iframe body:not(.editor_enable)',  // wait for editor to close
     trigger: ':iframe .o_wslides_js_course_join:contains("You\'re enrolled")',
 }
 ].concat(

--- a/addons/website_slides/static/tests/tours/slides_course_reviews.js
+++ b/addons/website_slides/static/tests/tours/slides_course_reviews.js
@@ -1,48 +1,55 @@
 /** @odoo-module **/
 
-import { registry } from '@web/core/registry';
+import { registry } from "@web/core/registry";
 
 /**
  * This tour test that a log note isn't considered
  * as a course review. And also that a member can
  * add only one review.
  */
-registry.category('web_tour.tours').add('course_reviews', {
-    url: '/slides',
+registry.category("web_tour.tours").add("course_reviews", {
+    url: "/slides",
     test: true,
     steps: () => [
-{
-    trigger: 'a:contains("Basics of Gardening - Test")',
-    run: "click",
-}, {
-    trigger: 'a[id="review-tab"]',
-    run: "click",
-}, {
-    trigger: '.o_portal_chatter_message:contains("Log note")',
-}, {
-    trigger: 'span:contains("Add Review")',
-    run: "click",
-    // If it fails here, it means the log note is considered as a review
-}, {
-    trigger: 'div.o_portal_chatter_composer_body textarea',
-    extra_trigger: 'div.modal_shown',
-    in_modal: false,
-    run: "edit Great course!",
-}, {
-    trigger: 'button.o_portal_chatter_composer_btn',
-    in_modal: false,
-    run: "click",
-}, {
-    trigger: 'a[id="review-tab"]',
-    run: "click",
-}, {
-    trigger: 'label:contains("Public")',
-    run: "click",
-}, {
-    trigger: 'span:contains("Edit Review")',
-    run: "click",
-    // If it fails here, it means the system is allowing you to add another review.
-}, {
-    trigger: "div.o_portal_chatter_composer_body textarea:value(Great course!)",
-}
-]});
+        {
+            trigger: "a:contains(Basics of Gardening - Test)",
+            run: "click",
+        },
+        {
+            trigger: "a[id=review-tab]",
+            run: "click",
+        },
+        {
+            trigger: ".o_portal_chatter_message:contains(Log note)",
+        },
+        {
+            // If it fails here, it means the log note is considered as a review
+            trigger: "span:contains(Add Review)",
+            run: "click",
+        },
+        {
+            trigger: ".modal div.o_portal_chatter_composer_body textarea",
+            run: "edit Great course!",
+        },
+        {
+            trigger: ".modal button.o_portal_chatter_composer_btn",
+            run: "click",
+        },
+        {
+            trigger: "a[id=review-tab]",
+            run: "click",
+        },
+        {
+            trigger: "label:contains(Public)",
+            run: "click",
+        },
+        {
+            // If it fails here, it means the system is allowing you to add another review.
+            trigger: "span:contains(Edit Review)",
+            run: "click",
+        },
+        {
+            trigger: "div.o_portal_chatter_composer_body textarea:value(Great course!)",
+        },
+    ],
+});


### PR DESCRIPTION
In order to simplify the towers API, it was decided to remove the extra_trigger key from the steps.
To check that an element is in the DOM, simply create a step with a trigger.

task~3974087
