### PR TITLE
[FIX] hr_contract: Missing props for validation in debug mode

### DIFF
--- a/addons/hr_contract/static/src/widgets/tooltip_warning_widget.js
+++ b/addons/hr_contract/static/src/widgets/tooltip_warning_widget.js
@@ -3,10 +3,11 @@
 import { registry } from "@web/core/registry";
 import { _t } from "@web/core/l10n/translation";
 import { Component } from "@odoo/owl";
+import { standardWidgetProps } from "@web/views/widgets/standard_widget_props";
 
 export class ContractWarningTooltip extends Component {
     static template = "hr_contract.ContractWarningTooltip";
-    static props = {};
+    static props = { ...standardWidgetProps };
     get tooltipInfo() {
         return JSON.stringify({
             "text" : _t("Calendar Mismatch: The employee's calendar does not match this contract's calendar. This could lead to unexpected behaviors."),


### PR DESCRIPTION
Steps to reproduce:
-------------------

- Install `Employee Contracts` module
- Go to `Employees` and open any employee with a contract
- Click on `Work Information` tab
- Set `Working Hours` to nothing and save
- Activate debug mode
- Click again on `Work Information` tab

Issue:
------

Error : `Invalid props for component 'ContractWarningTooltip'`.

Cause:
------

In debug mode, we activate the validation of the props, and since there are not declared on the widget component, it is raising an error.

Solution:
---------

Set the default props (`standardWidgetProps`) on the widget component.

opw-3972488