### PR TITLE
[FIX] mail: new message separator not shown 

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -683,7 +683,7 @@ class Channel(models.Model):
         self._set_last_seen_message(message, notify=False)
         current_channel_member = self.env["discuss.channel.member"].search([("channel_id", "=", self.id), ("is_self", "=", True)])
         if current_channel_member:
-            current_channel_member._set_new_message_separator(message.id + 1)
+            current_channel_member._set_new_message_separator(message.id + 1, sync=True)
         return super()._message_post_after_hook(message, msg_vals)
 
     def _check_can_update_message_content(self, message):

--- a/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
@@ -187,9 +187,7 @@ export class DiscussCoreCommon {
                 channel.pendingNewMessages.push(message);
             }
             if (message.isSelfAuthored && channel.selfMember) {
-                channel.selfMember.syncUnread = true;
                 channel.selfMember.seen_message_id = message;
-                channel.selfMember.new_message_separator = message.id + 1;
             } else {
                 if (!channel.isDisplayed && channel.selfMember) {
                     channel.selfMember.syncUnread = true;


### PR DESCRIPTION
When sending a lot of messages, it can happen that the new message
separator does not appear anymore.

Steps to reproduce the issue:
- Open two browsers: one logged in as admin, and the other as demo.
- Send a bunch of messages to demo very quickly.
- Send a message to admin.
- Notice that the unread message banner does not appear.

When the user first accesses the thread, the separator is kept locally
and is displayed until the user sends a message.

From a technical standpoint, the server tells the client when to sync
the separator value when certain actions occur (e.g., message sent,
explicitly marking a message as read).

In this case, the server sends the wrong information, indicating that
the separator should not be synced when it actually should be. This PR
fixes that issue.