### PR TITLE
[IMP] account_edi,l10n_in_*: force-cancel button if request cancellation fails

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4873,6 +4873,13 @@ class AccountMove(models.Model):
         self.ensure_one()
         return True
 
+    def _can_force_cancel(self):
+        """ Hook to indicate whether it should be possible to force-cancel this invoice,
+        that is, cancel it without waiting for the cancellation request to succeed.
+        """
+        self.ensure_one()
+        return False
+
     @contextmanager
     def _send_only_when_ready(self):
         moves_not_ready = self.filtered(lambda x: not x._is_ready_to_be_sent())

--- a/addons/account_edi/models/account_move.py
+++ b/addons/account_edi/models/account_move.py
@@ -36,6 +36,8 @@ class AccountMove(models.Model):
         compute='_compute_edi_show_cancel_button')
     edi_show_abandon_cancel_button = fields.Boolean(
         compute='_compute_edi_show_abandon_cancel_button')
+    edi_show_force_cancel_button = fields.Boolean(
+        compute='_compute_edi_show_force_cancel_button')
 
     @api.depends('edi_document_ids.state')
     def _compute_edi_state(self):
@@ -51,6 +53,11 @@ class AccountMove(models.Model):
                 move.edi_state = 'to_cancel'
             else:
                 move.edi_state = False
+
+    @api.depends('edi_document_ids.state')
+    def _compute_edi_show_force_cancel_button(self):
+        for move in self:
+            move.edi_show_force_cancel_button = move._can_force_cancel()
 
     @api.depends('edi_document_ids.error')
     def _compute_edi_error_count(self):
@@ -267,6 +274,14 @@ class AccountMove(models.Model):
         if not self.env.context.get('skip_account_edi_cron_trigger'):
             self.env.ref('account_edi.ir_cron_edi_network')._trigger()
         return posted
+
+    def button_force_cancel(self):
+        """ Cancel the invoice without waiting for the cancellation request to succeed.
+        """
+        for move in self:
+            to_cancel_edi_documents = move.edi_document_ids.filtered(lambda doc: doc.state == 'to_cancel')
+            move.message_post(body=_("This invoice was canceled while the EDIs %s still had a pending cancellation request.", ", ".join(to_cancel_edi_documents.mapped('edi_format_id.name'))))
+        self.button_cancel()
 
     def button_cancel(self):
         # OVERRIDE

--- a/addons/account_edi/views/account_move_views.xml
+++ b/addons/account_edi/views/account_move_views.xml
@@ -71,6 +71,7 @@
                 <xpath expr="//button[@name='button_cancel']" position="after">
                     <field name="edi_show_cancel_button" invisible="1"/>
                     <field name="edi_show_abandon_cancel_button" invisible="1"/>
+                    <field name="edi_show_force_cancel_button" invisible="1"/>
                     <button name="button_cancel_posted_moves"
                             string="Request EDI Cancellation"
                             type="object"
@@ -96,6 +97,12 @@
                         invisible="edi_error_count == 0 or edi_blocking_level != 'error'">
                         <div class="o_row">
                             <field name="edi_error_message" />
+                            <button name="button_force_cancel"
+                                string="Force Cancel"
+                                type="object"
+                                groups="account.group_account_invoice"
+                                confirm="Are you sure you want to cancel this invoice without waiting for the EDI document to be canceled?"
+                                invisible="not edi_show_force_cancel_button" />
                             <button name="%(account_edi.action_open_edi_documents)d" string="⇒ See errors" type="action" class="oe_link" invisible="edi_error_count == 1" />
                             <button name="action_retry_edi_documents_error" type="object" class="oe_link oe_inline" string="Retry" />
                         </div>

--- a/addons/l10n_in_edi/models/account_move.py
+++ b/addons/l10n_in_edi/models/account_move.py
@@ -61,3 +61,8 @@ class AccountMove(models.Model):
         """
         param_name = 'l10n_in_edi.manage_invoice_negative_lines'
         return bool(self.env['ir.config_parameter'].sudo().get_param(param_name))
+
+    def _can_force_cancel(self):
+        # OVERRIDE
+        self.ensure_one()
+        return any(document.edi_format_id.code == 'in_einvoice_1_03' and document.state == 'to_cancel' for document in self.edi_document_ids) or super()._can_force_cancel()

--- a/addons/l10n_in_edi_ewaybill/models/account_move.py
+++ b/addons/l10n_in_edi_ewaybill/models/account_move.py
@@ -124,3 +124,8 @@ class AccountMove(models.Model):
                 })
         self.env['account.edi.document'].create(edi_document_vals_list)
         self.env.ref('account_edi.ir_cron_edi_network')._trigger()
+
+    def _can_force_cancel(self):
+        # OVERRIDE
+        self.ensure_one()
+        return any(document.edi_format_id.code == 'in_ewaybill_1_03' and document.state == 'to_cancel' for document in self.edi_document_ids) or super()._can_force_cancel()


### PR DESCRIPTION
l10n_in_* = l10n_in_edi,l10n_in_edi_ewaybill

In the context of Indian EDI and e-waybill regulations, the cancellation service
fails if more than 24 hours have passed since the document was submitted.
However, these documents can still be canceled through other channels. To ensure
users can cancel their invoices in Odoo even if the initial cancellation request
fails, we've implemented a new feature.

A 'Force Cancel' button has been added to the EDI cancellation flow. If a
cancellation request fails, the user can click this button to cancel the invoice
immediately. Additionally, we have provided a hook that can be inherited to
specify whether this force-cancellation option is applicable to each invoice.

**task**-3997285