### PR TITLE
[ADD] delivery_fedex_rest: FedEx integration using new REST API

### DIFF
--- a/odoo/addons/base/i18n/base.pot
+++ b/odoo/addons/base/i18n/base.pot
@@ -13615,7 +13615,7 @@ msgstr ""
 
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_delivery_fedex
-msgid "Fedex Shipping"
+msgid "Fedex Shipping (Legacy)"
 msgstr ""
 
 #. module: base
@@ -23873,7 +23873,8 @@ msgstr ""
 
 #. module: base
 #: model:ir.module.module,description:base.module_delivery_fedex
-msgid "Send your shippings through Fedex and track them online"
+msgid "This is the legacy integration with FedEx that is no longer supported."
+      "Please install the new \"Fedex Shipping\" module and uninstall this one as soon as possible. This integration will stop working in 2024"
 msgstr ""
 
 #. module: base


### PR DESCRIPTION
The existing FedEx implementation used the old FedEx SOAP API which is no longer in development. This new version makes use of the current REST APIs available at developer.fedex.com

task-3759206

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
