### PR TITLE
[FIX] web: scope kanban_record background within :not(.o_kanban_ghost)

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_controller.scss
+++ b/addons/web/static/src/views/kanban/kanban_controller.scss
@@ -76,7 +76,6 @@
         align-items: stretch;
         min-width: 150px;
         margin: 0 0 (-$border-width);
-        background-color: $o-view-background-color;
         overflow-wrap: break-word;
         word-wrap: break-word;
         word-break: break-word;
@@ -84,6 +83,7 @@
         &:not(.o_kanban_ghost) {
             padding: var(--KanbanRecord-padding-v) var(--KanbanRecord-padding-h);
             border: $border-width solid $border-color;
+            background-color: $o-view-background-color;
         }
         &:not(.row) {
             flex-flow: column;


### PR DESCRIPTION
task-4004259

----------
There is currently an issue with `o_kanban_record` that have the `o_kanban_ghost` class and a `min-height` CSS property applied.

Currently, the `background-color` of our kanban records is set on the record directly, and to ensure that `o_kanban_ghost` don't have that background, we applied a `max-height` on them.

Unfortunately, in some modules, there are some custom `min-height` applied to kanban_record, resulting in a visible kanban_ghost with a white background.

Commit[1] solved this issue but within the `mrp_plm` module by adding a `:not(.o_kanban_ghost)` rule but it appears the issue is widespread to all the `kanban_record` that are `.o_kanban_ghost` and have a `min-height` property applied.

With that in mind, it's easier to fix the issue globally within the kanban_controller directly.

Commit[1]: https://github.com/odoo/enterprise/commit/01250ba51e37625f2175605a72e09c23060aa763

| Master | This PR |
|--------|--------|
| ![image](https://github.com/odoo/enterprise/assets/128030743/af453316-7fe8-408c-a4e9-521b07e2689a) | ![image](https://github.com/odoo/enterprise/assets/128030743/c0d04a0a-c1c7-4d0b-a657-1ed53a8744a1) | 


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
