### PR TITLE
[FIX] web: Set extend to optional for flat button style

### DIFF
--- a/addons/web/static/src/scss/bootstrap_review_frontend.scss
+++ b/addons/web/static/src/scss/bootstrap_review_frontend.scss
@@ -53,7 +53,8 @@ $o-btn-outline-border-width-defaults: () !default;
         } @else {
             @extend .btn-fill-#{$color};
             @if index($o-btn-flat-defaults, $color) {
-                @extend .btn.flat;
+                // TODO In master: move definition to web_editor
+                @extend .btn.flat !optional;
             }
         }
     }


### PR DESCRIPTION
Steps to reproduce:
-------------------

- Install `Sign` and `Website` (for test purpose)
- Go to the website and enable the web editor
- Click on Theme tab, and set Button -> Primary Style to `Flat`
- Go to Sign module and copy the Share link of a document
- Open it in an incognito window

Issue:
------

Error: `The target selector was not found`

Cause:
------

Trying to extend `.btn.flat` selector while it is not declared in the dependencies of the `sign.assets_public_sign` assets.

Solution:
---------

Set the `extend` to `optional`.

opw-3989063