### PR TITLE
[FIX] web_editor: handle grid columns with video only

### DIFF
--- a/addons/web_editor/static/src/js/common/grid_layout_utils.js
+++ b/addons/web_editor/static/src/js/common/grid_layout_utils.js
@@ -163,28 +163,28 @@ function _placeColumns(columnEls, rowSize, rowGap, columnSize, columnGap) {
     let maxRowEnd = 0;
     const columnSpans = [];
     let zIndex = 1;
-    const imageColumns = []; // array of boolean telling if it is a column with only an image.
+    const mediaColumns = []; // array of boolean telling if it is a column with only an image/video.
 
     // Checking if all the columns have a background color to take that into
     // account when computing their size and padding (to make them look good).
     const allBackgroundColor = [...columnEls].every(columnEl => columnEl.classList.contains('o_cc'));
 
     for (const columnEl of columnEls) {
-        // Finding out if the images are alone in their column.
-        let isImageColumn = _checkIfImageColumn(columnEl);
-        const imageEl = columnEl.querySelector('img');
+        // Finding out if the images/videos are alone in their column.
+        let isMediaColumn = _checkIfImageColumn(columnEl);
+        const mediaEl = columnEl.querySelector("img, .media_iframe_video");
 
         // Placing the column.
         const style = window.getComputedStyle(columnEl);
         // Horizontal placement.
         const borderLeft = parseFloat(style.borderLeft);
-        const columnLeft = isImageColumn && !borderLeft ? imageEl.offsetLeft : columnEl.offsetLeft;
+        const columnLeft = isMediaColumn && !borderLeft ? mediaEl.offsetLeft : columnEl.offsetLeft;
         // Getting the width of the column.
         const paddingLeft = parseFloat(style.paddingLeft);
-        let width = isImageColumn ? parseFloat(imageEl.scrollWidth)
+        let width = isMediaColumn ? parseFloat(mediaEl.scrollWidth)
             : parseFloat(columnEl.scrollWidth) - (allBackgroundColor ? 0 : 2 * paddingLeft);
         const borderX = borderLeft + parseFloat(style.borderRight);
-        width += borderX + (allBackgroundColor || isImageColumn ? 0 : 2 * defaultGridPadding);
+        width += borderX + (allBackgroundColor || isMediaColumn ? 0 : 2 * defaultGridPadding);
         let columnSpan = Math.round((width + columnGap) / (columnSize + columnGap));
         if (columnSpan < 1) {
             columnSpan = 1;
@@ -194,18 +194,18 @@ function _placeColumns(columnEls, rowSize, rowGap, columnSize, columnGap) {
 
         // Vertical placement.
         const borderTop = parseFloat(style.borderTop);
-        const columnTop = isImageColumn && !borderTop ? imageEl.offsetTop : columnEl.offsetTop;
+        const columnTop = isMediaColumn && !borderTop ? mediaEl.offsetTop : columnEl.offsetTop;
         // Getting the top and bottom paddings and computing the row offset.
         const paddingTop = parseFloat(style.paddingTop);
         const paddingBottom = parseFloat(style.paddingBottom);
         const rowOffsetTop = Math.floor((paddingTop + rowGap) / (rowSize + rowGap));
         // Getting the height of the column.
-        let height = isImageColumn ? parseFloat(imageEl.scrollHeight)
+        let height = isMediaColumn ? parseFloat(mediaEl.scrollHeight)
             : parseFloat(columnEl.scrollHeight) - (allBackgroundColor ? 0 : paddingTop + paddingBottom);
         const borderY = borderTop + parseFloat(style.borderBottom);
-        height += borderY + (allBackgroundColor || isImageColumn ? 0 : 2 * defaultGridPadding);
+        height += borderY + (allBackgroundColor || isMediaColumn ? 0 : 2 * defaultGridPadding);
         const rowSpan = Math.ceil((height + rowGap) / (rowSize + rowGap));
-        const rowStart = Math.round(columnTop / (rowSize + rowGap)) + 1 + (allBackgroundColor || isImageColumn ? 0 : rowOffsetTop);
+        const rowStart = Math.round(columnTop / (rowSize + rowGap)) + 1 + (allBackgroundColor || isMediaColumn ? 0 : rowOffsetTop);
         const rowEnd = rowStart + rowSpan;
 
         columnEl.style.gridArea = `${rowStart} / ${columnStart} / ${rowEnd} / ${columnEnd}`;
@@ -222,7 +222,7 @@ function _placeColumns(columnEls, rowSize, rowGap, columnSize, columnGap) {
 
         maxRowEnd = Math.max(rowEnd, maxRowEnd);
         columnSpans.push(columnSpan);
-        imageColumns.push(isImageColumn);
+        mediaColumns.push(isMediaColumn);
     }
 
     // If all the columns have a background color, set their padding to the
@@ -245,8 +245,8 @@ function _placeColumns(columnEls, rowSize, rowGap, columnSize, columnGap) {
         columnEl.classList.remove(...toRemove);
         columnEl.classList.add('col-lg-' + columnSpans[i]);
 
-        // If the column only has an image, convert it.
-        if (imageColumns[i]) {
+        // If the column only has an image/video, convert it.
+        if (mediaColumns[i]) {
             _convertImageColumn(columnEl);
         }
     }
@@ -280,7 +280,7 @@ export function _reloadLazyImages(columnEl) {
  * @returns {Object}
  */
 export function _convertColumnToGrid(rowEl, columnEl, columnWidth, columnHeight) {
-    // First, checking if the column only contains an image and if it is the
+    // First, checking if the column only contains an image/video and if it is the
     // case, converting it.
     if (_checkIfImageColumn(columnEl)) {
         _convertImageColumn(columnEl);
@@ -309,40 +309,42 @@ export function _convertColumnToGrid(rowEl, columnEl, columnWidth, columnHeight)
     return {columnColCount: columnColCount, columnRowCount: columnRowCount};
 }
 /**
- * Checks whether the column only contains an image or not. An image is
+ * Checks whether the column only contains an image/video or not. It is
  * considered alone if the column only contains empty textnodes and line breaks
- * in addition to the image. Note that "image" also refers to an image link
+ * in addition to the image/video. Note that "image" also refers to an image link
  * (i.e. `a > img`).
+ * TODO master: rename to _checkIfMediaColumn
  *
  * @private
  * @param {Element} columnEl
  * @returns {Boolean}
  */
 export function _checkIfImageColumn(columnEl) {
-    let isImageColumn = false;
-    const imageEls = columnEl.querySelectorAll(":scope > img, :scope > a > img");
+    let isMediaColumn = false;
+    const mediaEls = columnEl.querySelectorAll(":scope > img, :scope > a > img, :scope > .media_iframe_video");
     const columnChildrenEls = [...columnEl.children].filter(el => el.nodeName !== 'BR');
-    if (imageEls.length === 1 && columnChildrenEls.length === 1) {
-        // If there is only one image and if this image is the only "real"
+    if (mediaEls.length === 1 && columnChildrenEls.length === 1) {
+        // If there is only one image/video and if it is the only "real"
         // child of the column, we need to check if there is text in it.
         const textNodeEls = [...columnEl.childNodes].filter(el => el.nodeType === Node.TEXT_NODE);
         const areTextNodesEmpty = [...textNodeEls].every(textNodeEl => textNodeEl.nodeValue.trim() === '');
-        isImageColumn = areTextNodesEmpty;
+        isMediaColumn = areTextNodesEmpty;
     }
-    return isImageColumn;
+    return isMediaColumn;
 }
 /**
  * Removes the line breaks and textnodes of the column, adds the grid class and
- * sets the image width to default so it can be displayed as expected.
+ * sets the image/video width to default so it can be displayed as expected.
+ * TODO master: rename to _convertMediaColumn
  *
  * @private
- * @param {Element} columnEl a column containing only an image.
+ * @param {Element} columnEl a column containing only an image/video.
  */
 function _convertImageColumn(columnEl) {
     columnEl.querySelectorAll('br').forEach(el => el.remove());
     const textNodeEls = [...columnEl.childNodes].filter(el => el.nodeType === Node.TEXT_NODE);
     textNodeEls.forEach(el => el.remove());
-    const imageEl = columnEl.querySelector('img');
+    const mediaEl = columnEl.querySelector("img, .media_iframe_video");
     columnEl.classList.add('o_grid_item_image');
-    imageEl.style.removeProperty('width');
+    mediaEl.style.removeProperty("width");
 }


### PR DESCRIPTION
Commit [1] made it so that, in grid mode, a video alone in its column would take the whole width/height of the column, just like was already the case for images since commit [2].
However, it did not adapt the part of the code that checks whether the image is alone in its column (which then adds the `.o_grid_item_image` class to the column). That check only happens when toggling the grid mode.
This commit makes sure that, upon toggling the grid mode, the check is also run for video-only columns.

Steps to reproduce:
- Drop a Text - Image snippet
- Set it to full-width
- Replace the image with a video
- Toggle grid mode
- Save
=> the video takes more space than it should, it sticks out further than its section.

Note that the same bug may still happen if you use a text column, toggle grid mode, and only after that place a video or an image and remove any text from the column: because the check isn't run after toggling, the proper class is not set, and the size of the image/video doesn't match what would be expected.

[1]: https://github.com/odoo/odoo/commit/b54b34e6c34f435b2923e7b571b2bb2e4e9e0f08
[2]: https://github.com/odoo/odoo/commit/e9c7e020daf88022d6e02de0a5620074e8417b5a

opw-3959262