### PR TITLE
[FIX] sale_timesheet: correct costs expected value in a project update form view

### DIFF
--- a/addons/sale_timesheet/views/project_update_templates.xml
+++ b/addons/sale_timesheet/views/project_update_templates.xml
@@ -84,13 +84,13 @@
 <td t-out="profitability['labels'][cost['id']]"/>
 <td class="text-end" t-out="format_monetary(cost['billed'])"/>
 <td class="text-end" t-out="format_monetary(cost['to_bill'])"/>
-<td class="text-end" t-out="format_monetary(cost['billed'] - cost['to_bill'])"/>
+<td class="text-end" t-out="format_monetary(cost['billed'] + cost['to_bill'])"/>
 </tr>
 <tfoot>
 <td class="fw-bolder text-end">Total</td>
 <td class="fw-bolder text-end" t-out="format_monetary(profitability['costs']['total']['billed'])"/>
 <td class="fw-bolder text-end" t-out="format_monetary(profitability['costs']['total']['to_bill'])"/>
-<td class="fw-bolder text-end" t-out="format_monetary(profitability['costs']['total']['billed'] - profitability['costs']['total']['to_bill'])"/>
+<td class="fw-bolder text-end" t-out="format_monetary(profitability['costs']['total']['billed'] + profitability['costs']['total']['to_bill'])"/>
 </tfoot>
 </tbody>
 </table>


### PR DESCRIPTION
- saas-17.1

### Steps to reproduce:
- Install sales timesheet, accounting, and purchase.
- Select Analytic Accounting from the accounting setting.
- Create a billable project.
- Create a purchase order, select a service product, add a project in analytic distribution, and add quantity 10.
- While confirming PO, add received quantity 5.
- Open project updates, on the right side under the profitability heading. Observe the expected value of cost.
- Click on a new button, in the description tab, and check the expected value.
- There is a wrong value in the form view.

### Issue:
Wrong value of costs expected in project update form view.

### Solution:
Calculate the value in the same way in the project update right side.


task-3996848


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
