### PR TITLE
[FIX] mrp_subcontracting: prevent error when Replenish product

### DIFF
--- a/addons/mrp_subcontracting/i18n/mrp_subcontracting.pot
+++ b/addons/mrp_subcontracting/i18n/mrp_subcontracting.pot
@@ -366,6 +366,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/mrp_subcontracting/models/stock_warehouse.py:0
 #: code:addons/mrp_subcontracting/models/stock_warehouse.py:0
+#: code:addons/mrp_subcontracting/wizard/product_replenish.py:0
 #: model:stock.route,name:mrp_subcontracting.route_resupply_subcontractor_mto
 #, python-format
 msgid "Resupply Subcontractor on Order"

--- a/addons/mrp_subcontracting/wizard/product_replenish.py
+++ b/addons/mrp_subcontracting/wizard/product_replenish.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import models
+from odoo import models, _
 from odoo.osv import expression
 
 
@@ -10,4 +10,5 @@ class ProductReplenish(models.TransientModel):
 
     def _get_allowed_route_domain(self):
         domains = super()._get_allowed_route_domain()
-        return expression.AND([domains, [('id', '!=', self.env.ref('mrp_subcontracting.route_resupply_subcontractor_mto', raise_if_not_found=False).id)]])
+        route_id = self.env['stock.warehouse']._find_or_create_global_route('mrp_subcontracting.route_resupply_subcontractor_mto', _('Resupply Subcontractor on Order')).id
+        return expression.AND([domains, [('id', '!=', route_id)]])


### PR DESCRIPTION
This error occurs when we delete the specific ``Resupply Subcontractor on Order`` route and subsequently attempt to replenish the product.

Steps to reproduce:
- Install the ``stock`` and ``mrp_subcontracting`` module
- Inventory > Configuration > Settings > Warehouse > Activate Multi-Step Routes
- Go to routes and delete ``Resupply Subcontractor on Order``
- Now go to any product > Click on ``Replenish``

Traceback: 
``AttributeError 'NoneType' object has no attribute 'id'``

At [1], this error occurs when we try to access an attribute called ``id`` on an object that is actually None.

This commit will fix the above error by returning the value of ``domains`` if the route is not present in the ``_get_allowed_route_domain`` method.

[1]: https://github.com/odoo/odoo/blob/731766aa03ad4cf14349169faab3957c710bc002/addons/mrp_subcontracting/wizard/product_replenish.py#L13

sentry-5514962307

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
