### PR TITLE
[FIX] point_of_sale: fix debug widget inputs

### DIFF
--- a/addons/point_of_sale/static/src/app/debug/debug_widget.js
+++ b/addons/point_of_sale/static/src/app/debug/debug_widget.js
@@ -52,6 +52,7 @@ export class DebugWidget extends Component {
         useDialogDraggable({
             ref: this.root,
             elements: ".debug-widget",
+            handle: ".drag-handle",
             onDrop: ({ left, top }) => {
                 this.position.left = left;
                 this.position.top = top;


### PR DESCRIPTION
The changes from e9a497340ba4bb558fdd596bb6b1ce4d931dc387 resulted in the input boxes in the `DebugWidget` component not working. The solution is to specify to the `useDraggable` hook to only use the top of the widget as a "handle".

Task: 4004651


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
