### PR TITLE
[FIX] web: restore card background to white

### DIFF
--- a/addons/web/static/src/scss/bootstrap_overridden.scss
+++ b/addons/web/static/src/scss/bootstrap_overridden.scss
@@ -300,7 +300,7 @@ $badge-padding-x: 0.82em !default;
 $input-placeholder-color: mix($gray-400, $gray-500) !default;
 
 // Card
-
+$card-bg: $o-view-background-color !default;
 $card-spacer-y: $spacer !default; // BS Default
 $card-cap-padding-y: $card-spacer-y !default;
 


### PR DESCRIPTION
- Requires https://github.com/odoo/enterprise/pull/65166
- task-4004392
- part of task-3883628
---------


This PR aims to restore the previous `background-color` of our cards
prior to the Bootstrap v5.3 migration.

Before we migrated to a newer version of Bootstrap, our cards were using
the default. value from the library, which was set to white.

Within our dark mode files, we'd then override it to another value.
As Bootstrap v5.3 defines the background of card as `$body-bg`, we need
to replace that value with white.

We also take that opportunity to simplify the declaration of our variables
removing a useless declaration within a `.dark` file.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
