### PR TITLE
[FIX] web: fix colorpicker position in iframe

### DIFF
--- a/addons/web/static/lib/popper/popper.js
+++ b/addons/web/static/lib/popper/popper.js
@@ -23,7 +23,7 @@
 
   function isElement(node) {
     var OwnElement = getWindow(node).Element;
-    return node instanceof OwnElement || node instanceof Element;
+    return node instanceof OwnElement || node.nodeType === Node.ELEMENT_NODE;
   }
 
   function isHTMLElement(node) {


### PR DESCRIPTION
Issue:
======
Half of the colorpicker isn't visible in the sidebar toolbar.

Steps to reproduce the issue:
=============================
- Go to mass mailing and choose any template with a button.
- Click on the button, make it a link.
- Choose style as custom in the sidebar
- Click on the circles for text color or fill color
- Colorpicker is not position correctly.

Origin of the issue:
====================
See commit: https://github.com/odoo/odoo/commit/88c16966b6b2d29d464ac3b43cc4998d3f4fe0e2

Solution:
=========
Fixing this issue properly would require huge changes to how the
SnippetsMenu is constructed and would most likely require going
back to the slow iframe with all the assets inside. That would not
be a desirable outcome, especially in a stable version. With that
in mind, and considering the issue doesn't exist in saas-17.1, we
decided it was a prime example where a local change in the popper.js
library was actually the best fix. The library is very unlikely to
be updated in a stable version and the change won't reach saas-17.1.

co-authored with dmo-odoo

opw-3984170