### PR TITLE
[FIX] mrp: fix post production picking

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -855,14 +855,16 @@ class MrpProduction(models.Model):
             del vals['move_byproduct_ids']
         if 'workorder_ids' in self:
             production_to_replan = self.filtered(lambda p: p.is_planned)
-        if 'move_raw_ids' in vals and self.state not in ['draft', 'cancel', 'done']:
-            # When adding a move raw, it should have the source location's `warehouse_id`.
+        for move_str in ('move_raw_ids', 'move_finished_ids'):
+            if move_str not in vals or self.state in ['draft', 'cancel', 'done']:
+                continue
+            # When adding a move raw/finished, it should have the source location's `warehouse_id`.
             # Before, it was handle by an onchange, now it's forced if not already in vals.
             warehouse_id = self.location_src_id.warehouse_id.id
             if vals.get('location_src_id'):
                 location_source = self.env['stock.location'].browse(vals.get('location_src_id'))
                 warehouse_id = location_source.warehouse_id.id
-            for move_vals in vals['move_raw_ids']:
+            for move_vals in vals[move_str]:
                 command, _id, field_values = move_vals
                 if command == Command.CREATE and not field_values.get('warehouse_id', False):
                     field_values['warehouse_id'] = warehouse_id


### PR DESCRIPTION
Since the rule refactor, additional byproducts are not considered in the post production picking. The problem is when we add a new byproduct, the backend do not add the warehouse_id on the stock move, and without a warehouse id, it was impossible to find a stock rule for it. Now, with the correct warehouse and stock rule, the stock move is added on the transfers.

Testing steps:
---------------------
- go to configuration > settings > enable Multi-step routes 
- go to configuration > warehouses and enable either 2 or 3 step manufacture
- go to configuration > enable byproducts
- create a BOM with some components/byproducts
- create a MO with the BOM above, confirm it.
Now, we can see the 'transfers' button with 2 transfers, one by the components and another one for the final products and the byproducts.
- add a new byproduct with some produced quantity.

Problem:
-------------
No picking for the new byproduct when clicking on the transfer button

Expected behaviour:
------------------------------
The byproduct should be in the list

task: 3982566