### PR TITLE
[REV] loyalty: Correct duplicate view rendering

### DIFF
--- a/addons/loyalty/tests/test_loyalty.py
+++ b/addons/loyalty/tests/test_loyalty.py
@@ -114,7 +114,7 @@ class TestLoyalty(TransactionCase):
         self.assertTrue(all(r.reward_type == 'product' for r in self.program.reward_ids))
 
     def test_loyalty_program_preserve_reward_with_always_edit(self):
-        with Form(self.env['loyalty.program'], 'loyalty.loyalty_program_view_form') as program_form:
+        with Form(self.env['loyalty.program']) as program_form:
             program_form.name = 'Test'
             program_form.program_type = 'buy_x_get_y'
             program_form.reward_ids.remove(0)

--- a/addons/loyalty/views/loyalty_program_views.xml
+++ b/addons/loyalty/views/loyalty_program_views.xml
@@ -116,13 +116,21 @@
                         </group>
                     </group>
                     <notebook>
-                        <page string="Rules &amp; Rewards" name="rules_rewards">
+                        <page string="Rules &amp; Rewards" name="rules_rewards" invisible="program_type in ('gift_card', 'ewallet')">
                             <group>
                                 <group>
                                     <field name="rule_ids" colspan="2" mode="kanban" nolabel="1" add-label="Add a rule"
                                         class="o_loyalty_kanban_inline" widget="loyalty_one2many" context="{'currency_symbol': currency_symbol, 'program_type': program_type}"/>
                                 </group>
                                 <group>
+                                    <field name="reward_ids" colspan="2" mode="kanban" nolabel="1" add-label="Add a reward"
+                                      class="o_loyalty_kanban_inline" widget="loyalty_one2many" context="{'currency_symbol': currency_symbol, 'program_type': program_type}"/>
+                                </group>
+                            </group>
+                        </page>
+                        <page string="Rewards" name="rewards" groups="base.group_no_one" invisible="program_type not in ('gift_card', 'ewallet')">
+                            <group>
+                                <group groups="base.group_no_one">
                                     <field name="reward_ids" colspan="2" mode="kanban" nolabel="1" add-label="Add a reward"
                                       class="o_loyalty_kanban_inline" widget="loyalty_one2many" context="{'currency_symbol': currency_symbol, 'program_type': program_type}"/>
                                 </group>
@@ -197,12 +205,6 @@
         <field name="inherit_id" ref="loyalty_program_view_form"/>
         <field name="mode">primary</field>
         <field name="arch" type="xml">
-            <notebook position="attributes">
-                <attribute name="groups">base.group_no_one</attribute>
-            </notebook>
-            <xpath expr="//field[@name='rule_ids']/.." position="attributes">
-                <attribute name="invisible">program_type in ('gift_card', 'ewallet')</attribute>
-            </xpath>
             <form position="attributes">
                 <attribute name="string">Gift &amp; Ewallet</attribute>
             </form>


### PR DESCRIPTION
This reverts commit ac93012e3cf954b5b3bcd4475b63ab027d461355. The gift card/ewallet programs were created without rewards or rules, and the issue is not present in 17 so no need to keep this forward-ported commit.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
