### PR TITLE
[IMP] web, *: Beautiful CopyClipboard

### DIFF
--- a/addons/spreadsheet/static/src/components/share_button/share_button.xml
+++ b/addons/spreadsheet/static/src/components/share_button/share_button.xml
@@ -26,7 +26,7 @@
           <div class=" px-3 o_field_widget o_readonly_modifier o_field_CopyClipboardChar">
             <div class="d-grid rounded-2 overflow-hidden">
               <span t-out="state.url"/>
-              <CopyButton className="'o_btn_char_copy btn-sm'" content="state.url" successText="copiedText"/>
+              <CopyButton className="'o_btn_char_copy btn-sm'" content="state.url" successText="copiedText" icon="'fa-clone'"/>
             </div>
           </div>
         </t>

--- a/addons/spreadsheet_dashboard/static/tests/dashboard/dashboard_action.test.js
+++ b/addons/spreadsheet_dashboard/static/tests/dashboard/dashboard_action.test.js
@@ -269,7 +269,7 @@ test("share dashboard from dashboard view", async function () {
     expect(target.querySelector(".o_field_CopyClipboardChar").innerText).toBe(
         "localhost:8069/share/url/132465"
     );
-    await contains(".fa-clipboard").click();
+    await contains(".fa-clone").click();
     expect.verifySteps(["share url copied"]);
 });
 

--- a/addons/web/static/src/core/copy_button/copy_button.js
+++ b/addons/web/static/src/core/copy_button/copy_button.js
@@ -10,6 +10,7 @@ export class CopyButton extends Component {
         copyText: { type: String, optional: true },
         disabled: { type: Boolean, optional: true },
         successText: { type: String, optional: true },
+        icon: { type: String, optional: true },
         content: { type: [String, Object], optional: true },
     };
 

--- a/addons/web/static/src/core/copy_button/copy_button.xml
+++ b/addons/web/static/src/core/copy_button/copy_button.xml
@@ -6,11 +6,11 @@
             class="text-nowrap"
             t-ref="button"
             t-att-disabled="props.disabled"
-            t-attf-class="btn btn-primary o_clipboard_button {{ props.className || '' }}"
+            t-attf-class="btn o_clipboard_button {{ props.className || '' }}"
             t-on-click.stop="onClick"
         >
-            <span class="fa fa-clipboard mx-1"/>
-            <span t-esc="props.copyText"/>
+            <span class="mx-1" t-attf-class="fa {{ props.icon || 'fa-clipboard' }}"/>
+            <span t-if="props.copyText" t-esc="props.copyText"/>
         </button>
     </t>
 

--- a/addons/web/static/src/views/fields/copy_clipboard/copy_clipboard_field.js
+++ b/addons/web/static/src/views/fields/copy_clipboard/copy_clipboard_field.js
@@ -47,16 +47,24 @@ export class CopyClipboardButtonField extends CopyClipboardField {
     static components = { CopyButton };
 
     get copyButtonClassName() {
-        return `o_btn_${this.type}_copy rounded-2`;
+        return `o_btn_${this.type}_copy btn-primary rounded-2`;
     }
 }
 
 export class CopyClipboardCharField extends CopyClipboardField {
     static components = { Field: CharField, CopyButton };
+
+    get copyButtonIcon() {
+        return "fa-clone";
+    }
 }
 
 export class CopyClipboardURLField extends CopyClipboardField {
     static components = { Field: UrlField, CopyButton };
+
+    get copyButtonIcon() {
+        return "fa-link";
+    }
 }
 
 // ----------------------------------------------------------------------------

--- a/addons/web/static/src/views/fields/copy_clipboard/copy_clipboard_field.scss
+++ b/addons/web/static/src/views/fields/copy_clipboard/copy_clipboard_field.scss
@@ -1,20 +1,9 @@
 .o_field_CopyClipboardURL, .o_field_CopyClipboardChar {
     > div {
         grid-template-columns: auto min-content;
-        border: 1px solid $primary;
-        font-size: $font-size-sm;
-        color: o-text-color('primary');
-        font-weight: $badge-font-weight;
-
-        .o_input {
-            border: none;
-            padding-left: 4px;
-        }
         .o_clipboard_button {
-            border-top-left-radius: 0;
-            border-bottom-left-radius: 0;
+            border: none;
         }
-
         > span:first-child, a {
             margin-left: 4px;
             margin-right: 4px;
@@ -23,6 +12,23 @@
             overflow: hidden;
             text-overflow: ellipsis;
             white-space: nowrap;
+        }
+    }
+}
+
+.o_field_CopyClipboardURL, .o_field_CopyClipboardChar {
+    &.o_readonly_modifier > div {
+        border: 1px solid #e6e6e6;
+        > span {
+            padding-left: 4px;
+        }
+    }
+}
+
+body:not(.o_touch_device) .o_field_CopyClipboardURL, .o_field_CopyClipboardChar {
+    &:not(.o_readonly_modifier) {
+        &:not(:hover):not(:focus-within) button {
+            opacity: 0 !important;
         }
     }
 }

--- a/addons/web/static/src/views/fields/copy_clipboard/copy_clipboard_field.xml
+++ b/addons/web/static/src/views/fields/copy_clipboard/copy_clipboard_field.xml
@@ -4,7 +4,7 @@
     <t t-name="web.CopyClipboardField">
         <div class="d-grid rounded-2 overflow-hidden">
             <Field t-props="fieldProps"/>
-            <CopyButton className="copyButtonClassName" content="props.record.data[props.name]" copyText="copyText" successText="successText"/>
+            <CopyButton className="copyButtonClassName" content="props.record.data[props.name]" icon="copyButtonIcon" successText="successText"/>
         </div>
     </t>
 

--- a/addons/web/static/tests/views/fields/copy_clipboard_field.test.js
+++ b/addons/web/static/tests/views/fields/copy_clipboard_field.test.js
@@ -82,7 +82,6 @@ test("Show copy button even on readonly empty field", async () => {
 test("Display a tooltip on click", async () => {
     mockService("popover", {
         add(el, comp, params) {
-            expect(el).toHaveText("Copy");
             expect(params).toEqual({ tooltip: "Copied" });
             expect.step("copied tooltip");
             return () => {};
@@ -102,7 +101,7 @@ test("Display a tooltip on click", async () => {
     });
 
     await expect(".o_clipboard_button.o_btn_char_copy").toHaveCount(1);
-    await contains(".o_clipboard_button").click();
+    await contains(".o_clipboard_button", { visible: false }).click();
     expect.verifySteps(["char value", "copied tooltip"]);
 });
 

--- a/addons/website_slides/static/src/js/public/components/slide_share_dialog/slide_share_dialog.xml
+++ b/addons/website_slides/static/src/js/public/components/slide_share_dialog/slide_share_dialog.xml
@@ -11,7 +11,7 @@
                     <div class="input-group">
                         <input type="text" class="form-control text-center" t-att-value="this.props.url"
                                readonly="readonly" onClick="this.select();"/>
-                        <CopyButton content="this.props.url" copyText="copyUrlText" successText="successText"/>
+                        <CopyButton content="this.props.url" copyText="copyUrlText" className="'btn-primary'" successText="successText"/>
                     </div>
                 </div>
                 <div class="col-12 mt-4">


### PR DESCRIPTION
This commit adapts the base design of the CopyClipboard char and url widgets to a lighter design that is more inclined with the milk design. It now consists in adding a single icon next to the field which only appears on hover and does the same job as before without the unnecessary additional styling that was before added to the field. In readonly, the copy button icon is always visible and the input is highlighted by a small surrounding border for clarity purposes. Other utilisations of the CopyButton component and CopyClipboardButton widget remain unchanged.

task-3964629
