### PR TITLE
[FIX] requirements: adapt werkzeug versions for noble

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -63,7 +63,9 @@ rjsmin==1.1.0
 urllib3==1.26.5 ; python_version < '3.12' # indirect / min version = 1.25.8 (Focal with security backports)
 urllib3==2.0.7  ; python_version >= '3.12'  # (Noble) Compatibility with cryptography
 vobject==0.9.6.1
-Werkzeug==2.0.2
+Werkzeug==2.0.2 ; python_version <= '3.10' 
+Werkzeug==2.2.2 ; python_version > '3.10' and python_version < '3.12'
+Werkzeug==3.0.1 ; python_version >= '3.12'  # (Noble) Avoid deprecation warnings
 xlrd==1.2.0
 XlsxWriter==3.0.2
 xlwt==1.3.0


### PR DESCRIPTION
Adapt [werkzeug version for Ubuntu Noble](https://packages.ubuntu.com/noble/python3-werkzeug) mainly to avoid deprecation warnings in python 3.12.

While at it, adapt for Bookworm as it provides [python 3.11](https://packages.debian.org/bookworm/python3).

