### PR TITLE
[FIX] mail: speed up partner mention

### DIFF
--- a/addons/mail/static/src/discuss/core/common/partner_compare.js
+++ b/addons/mail/static/src/discuss/core/common/partner_compare.js
@@ -5,7 +5,8 @@ import { partnerCompareRegistry } from "@mail/core/common/partner_compare";
 partnerCompareRegistry.add(
     "discuss.recent-chats",
     (p1, p2, { env, context }) => {
-        const recentChatPartnerIds = context.recentChatPartnerIds || env.services["mail.persona"].getRecentChatPartnerIds();
+        const recentChatPartnerIds =
+            context.recentChatPartnerIds || env.services["mail.persona"].getRecentChatPartnerIds();
         const recentChatIndex_p1 = recentChatPartnerIds.findIndex(
             (partnerId) => partnerId === p1.id
         );
@@ -27,10 +28,10 @@ partnerCompareRegistry.add(
 
 partnerCompareRegistry.add(
     "discuss.members",
-    (p1, p2, { thread }) => {
+    (p1, p2, { thread, memberPartnerIds }) => {
         if (thread?.model === "discuss.channel") {
-            const isMember1 = thread.channelMembers.some((member) => p1.eq(member.persona));
-            const isMember2 = thread.channelMembers.some((member) => p2.eq(member.persona));
+            const isMember1 = memberPartnerIds.has(p1.id);
+            const isMember2 = memberPartnerIds.has(p2.id);
             if (isMember1 && !isMember2) {
                 return -1;
             }


### PR DESCRIPTION
Before this PR, searching for a partner using a mention ("@") could take up to 18 seconds on a channel with 200 members. As a result, the UI would freeze while waiting for the search function to return partners to display.

After this PR, trying to mention a partner on the same channel only takes 80ms.

Most of the time was consumed by the `sortPartnerSuggestions` function, specifically by the `discuss.members` compare function that looped over every channel member twice per comparison.

The rest of the time was consumed by owl's `reactive` (~1/3 of the time).

To solve this issue, this PR focuses on two points:
- Providing a set of member partner IDs to the compare functions to speed up membership tests.
- Removing unnecessary reactive callbacks by using `toRaw` (searching partners is not coupled to rendering).