### PR TITLE
[IMP] payment_worldline: add idempotency_key for worldline

### DIFF
--- a/addons/payment_worldline/models/payment_provider.py
+++ b/addons/payment_worldline/models/payment_provider.py
@@ -47,7 +47,7 @@ class PaymentProvider(models.Model):
 
     # === BUSINESS METHODS === #
 
-    def _worldline_make_request(self, endpoint, payload=None, method='POST'):
+    def _worldline_make_request(self, endpoint, payload=None, method='POST', idempotency_key=None):
         """ Make a request to Worldline API at the specified endpoint.
 
         Note: self.ensure_one()
@@ -55,6 +55,7 @@ class PaymentProvider(models.Model):
         :param str endpoint: The endpoint to be reached by the request.
         :param dict payload: The payload of the request.
         :param str method: The HTTP method of the request.
+        :param str idempotency_key: The idempotency key to pass in the request.
         :return: The JSON-formatted content of the response.
         :rtype: dict
         :raise ValidationError: If an HTTP error occurs.
@@ -72,6 +73,7 @@ class PaymentProvider(models.Model):
             'Authorization': authorization_header,
             'Date': dt,
             'Content-Type': content_type,
+            'X-GCS-Idempotence-Key': idempotency_key,
         }
         try:
             response = requests.request(method, url, json=payload, headers=headers, timeout=10)

--- a/addons/payment_worldline/models/payment_transaction.py
+++ b/addons/payment_worldline/models/payment_transaction.py
@@ -156,7 +156,13 @@ class PaymentTransaction(models.Model):
         }
 
         # Make the payment request to Worldline.
-        response_content = self.provider_id._worldline_make_request('payments', payload=payload)
+        response_content = self.provider_id._worldline_make_request(
+            'payments',
+            payload=payload,
+            idempotency_key=payment_utils.generate_idempotency_key(
+                self, scope='payment_request_token'
+            ),
+        )
 
         # Handle the payment request response.
         _logger.info(


### PR DESCRIPTION
This commit add idempotency_key for worldline to avoid charging
customer multiple time.

Cause:
When response from webhook cause SQL concurrent update then
odoo retry request towards Worldline and it create multiple
request to Worldline.

Fix:
Set idempotency_key in request header with the hash of the
transaction reference and the database UUID, which will
prevent duplicate payments to happen.

task-2894752