### PR TITLE
[FIX] web: duplicate favorite crash with enter

### DIFF
--- a/addons/web/static/src/search/favorite_menu/custom_favorite_item.js
+++ b/addons/web/static/src/search/favorite_menu/custom_favorite_item.js
@@ -81,7 +81,7 @@ export class CustomFavoriteItem extends Component {
         switch (ev.key) {
             case "Enter":
                 ev.preventDefault();
-                this.saveFavorite();
+                this.saveFavorite(ev);
                 break;
             case "Escape":
                 // Gives the focus back to the component.

--- a/addons/web/static/tests/search/custom_favorite_item_tests.js
+++ b/addons/web/static/tests/search/custom_favorite_item_tests.js
@@ -347,6 +347,56 @@ QUnit.module("Search", (hooks) => {
         }
     );
 
+    QUnit.test("add favorite with enter which already exists", async function (assert) {
+        serviceRegistry.add(
+            "notification",
+            {
+                start() {
+                    return {
+                        add(message, options) {
+                            assert.strictEqual(message, "A filter with same name already exists.");
+                            assert.deepEqual(options, { type: "danger" });
+                            assert.step("warning dialog");
+                        },
+                    };
+                },
+            },
+            { force: true }
+        );
+        const controlPanel = await makeWithSearch({
+            serverData,
+            resModel: "foo",
+            Component: ControlPanel,
+            searchMenuTypes: ["favorite"],
+            searchViewId: false,
+            config: {
+                displayName: "Action Name",
+            },
+            irFilters: [
+                {
+                    context: "{}",
+                    domain: "[]",
+                    id: 1,
+                    is_default: false,
+                    name: "My favorite",
+                    sort: "[]",
+                    user_id: [2, "Mitchell Admin"],
+                },
+            ],
+        });
+
+        await toggleFavoriteMenu(controlPanel);
+        await toggleSaveFavorite(controlPanel);
+        await editFavoriteName(controlPanel, "My favorite");
+        triggerEvent(
+            controlPanel.el,
+            `.o_favorite_menu .o_add_favorite .dropdown-menu input[type="text"]`,
+            "keydown",
+            { key: "Enter" }
+        );
+        assert.verifySteps(["warning dialog"]);
+    });
+
     QUnit.skip("save search filter in modal", async function (assert) {
         /** @todo I don't know yet how to convert this test */
         // assert.expect(5);


### PR DESCRIPTION
This commit fixes a bug where there would be a traceback occuring when the user would either create a favorite with a name that already exists or one with an empty name by pressing enter instead of save. The crash occurs because the keydown event is not passed to saveFavorite and in these cases, saveFavorite will invoke stopPropagation on an undefined event. Solution: pass the event to saveFavorite.
