### PR TITLE
[FIX] hr_holidays: correct accrued levels kanban display logic

### DIFF
--- a/addons/hr_holidays/i18n/hr_holidays.pot
+++ b/addons/hr_holidays/i18n/hr_holidays.pot
@@ -99,6 +99,20 @@ msgstr ""
 
 #. module: hr_holidays
 #. odoo-python
+#: code:addons/hr_holidays/models/hr_leave_allocation.py:0
+#, python-format
+msgid "%(name)s (%(duration)s day(s))"
+msgstr ""
+
+#. module: hr_holidays
+#. odoo-python
+#: code:addons/hr_holidays/models/hr_leave_allocation.py:0
+#, python-format
+msgid "%(name)s (%(duration)s hour(s))"
+msgstr ""
+
+#. module: hr_holidays
+#. odoo-python
 #: code:addons/hr_holidays/models/hr_leave.py:0
 #, python-format
 msgid "%(person)s on %(leave_type)s: %(duration).2f days (%(start)s)"
@@ -151,13 +165,6 @@ msgstr ""
 #: code:addons/hr_holidays/models/hr_leave_allocation.py:0
 #, python-format
 msgid "%s (from %s to No Limit)"
-msgstr ""
-
-#. module: hr_holidays
-#. odoo-python
-#: code:addons/hr_holidays/models/hr_leave_allocation.py:0
-#, python-format
-msgid "%s allocation request (%s %s)"
 msgstr ""
 
 #. module: hr_holidays
@@ -3671,6 +3678,7 @@ msgstr ""
 #. module: hr_holidays
 #. odoo-python
 #: code:addons/hr_holidays/models/hr_leave.py:0
+#: code:addons/hr_holidays/models/hr_leave.py:0
 #, python-format
 msgid "There is no valid allocation to cover that request."
 msgstr ""
@@ -3894,7 +3902,6 @@ msgstr ""
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_leave_report__holiday_status_id
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_leave_type__name
 #: model_terms:ir.ui.view,arch_db:hr_holidays.edit_holiday_status_form
-#: model_terms:ir.ui.view,arch_db:hr_holidays.hr_accrual_plan_view_search
 #: model_terms:ir.ui.view,arch_db:hr_holidays.report_holidayssummary
 #: model_terms:ir.ui.view,arch_db:hr_holidays.view_holiday_status_normal_tree
 #: model_terms:ir.ui.view,arch_db:hr_holidays.view_hr_leave_allocation_filter
@@ -4447,6 +4454,15 @@ msgstr ""
 #, python-format
 msgid ""
 "You cannot have a cap on accrued time without setting a maximum amount."
+msgstr ""
+
+#. module: hr_holidays
+#. odoo-python
+#: code:addons/hr_holidays/models/hr_leave_allocation.py:0
+#, python-format
+msgid ""
+"You cannot reduce the duration below the duration of leaves already taken by"
+" the employee."
 msgstr ""
 
 #. module: hr_holidays

--- a/addons/hr_holidays/views/hr_leave_accrual_views.xml
+++ b/addons/hr_holidays/views/hr_leave_accrual_views.xml
@@ -165,7 +165,7 @@
                                     <div t-name="kanban-box" class="border-0 bg-transparent">
                                         <div class="o_hr_holidays_body oe_kanban_global_click">
                                             <div class="o_hr_holidays_timeline text-center">
-                                                <t t-if="record.start_count.value > 0">
+                                                <t t-if="record.start_count.raw_value > 0">
                                                     after <t t-esc="record.start_count.value"/> <t t-esc="record.start_type.value"/>
                                                 </t>
                                                 <t t-else="">
@@ -213,7 +213,7 @@
                                                         Cap:
                                                     </div>
                                                     <div class="col-3 m-0 ps-1">
-                                                        <t t-if="record.cap_accrued_time.value &amp;&amp; record.maximum_leave.value > 0">
+                                                        <t t-if="record.cap_accrued_time.raw_value &amp;&amp; record.maximum_leave.raw_value > 0">
                                                             <field name="maximum_leave" widget="FloatWithoutTrailingZeros"/> <field name="added_value_type"/>
                                                         </t>
                                                         <t t-else="">


### PR DESCRIPTION
Use of the record.{field}.value was causing the displayed (string) values
to be used in the kanban card's t-if logic rather than the actual value
of the field. This resulted in

- `record.cap_accrued_time.value` ALWAYS being evaluated as True (since
  "False" is True)
- `record.maximum_leave.value > 0` evaluating as True when the language
  wasn't a language that uses "." as it's decimal separator. e.g.
  "5.00" > 0 == True but "5,00" > 0 == False

opw-3999753

Also, re-export the pot file since it was noticed that it's no longer correct.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
