### PR TITLE
[FIX] mail: long channel names do not overflow in discuss sidebar

### DIFF
--- a/addons/mail/static/src/discuss/core/web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/web/discuss_sidebar_categories.xml
@@ -54,7 +54,7 @@
                     }"
              t-on-click="(ev) => this.openThread(ev, thread)"
         >
-            <button class="btn border-0 rounded-0 text-reset d-flex align-items-center px-0 py-2">
+            <button class="btn border-0 rounded-0 text-reset overflow-hidden d-flex align-items-center px-0 py-2">
                 <div class="bg-inherit position-relative d-flex ms-3 flex-shrink-0" style="width:26px;height:26px">
                     <img class="w-100 h-100 rounded" t-att-src="thread.avatarUrl" alt="Thread Image"/>
                     <ThreadIcon t-if="thread.channel_type === 'chat' or (thread.channel_type === 'channel' and !thread.authorizedGroupFullName)" thread="thread" size="'small'" className="'o-mail-DiscussSidebarChannel-threadIcon position-absolute bottom-0 end-0 p-1 me-n1 mb-n1 d-flex align-items-center justify-content-center rounded-circle bg-inherit'"/>


### PR DESCRIPTION
Before this commit, when a channel had a long name, the Discuss app sidebar was horizontally scrollable.

This happens because the channel item were not properly managing overflow, due to recent subtle layout change [1].
The inner span of `button` is `text-truncate`, but the button can still overflow by default. So in the end, the button was not truncated at all.

This commit fixes the issue by setting `overflow-hidden` on this button, to ensure that if it theoretically overflows, this is truncated. The inner-text still keeps `text-truncate` so that it visually puts the ellipsis/`...` when the button overflows.

[1]: https://github.com/odoo/odoo/pull/169751

Before / After
<img width="302" alt="before" src="https://github.com/odoo/odoo/assets/6569390/3c8baca9-cb43-4d53-8f4a-f74b7517ae60"> <img width="300" alt="after" src="https://github.com/odoo/odoo/assets/6569390/5aafe600-7046-4a29-9ac9-11c39e47d7cd">
