### PR TITLE
[IMP] product: improve pricelist report

### DIFF
--- a/addons/product/controllers/__init__.py
+++ b/addons/product/controllers/__init__.py
@@ -1,2 +1,3 @@
 from . import catalog
 from . import product_document
+from . import pricelist_report

--- a/addons/product/controllers/pricelist_report.py
+++ b/addons/product/controllers/pricelist_report.py
@@ -1,0 +1,78 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import csv
+import io
+import json
+
+import xlsxwriter
+
+from odoo import _
+from odoo.http import Controller, request, route, content_disposition
+
+
+class ProductPricelistExportController(Controller):
+
+    @route('/product/export/pricelist/', type='http', auth='user')
+    def export_pricelist(self, report_data, export_format):
+        json_data = json.loads(report_data)
+        report_data = request.env['report.product.report_pricelist']._get_report_data(json_data)
+        pricelist_name = report_data['pricelist']['name']
+        quantities = report_data['quantities']
+        products = report_data['products']
+        headers = [
+            _("Product"),
+            _("UOM"),
+        ] + [_("Quantity (%s UoM)", qty) for qty in quantities]
+        if export_format == 'csv':
+            return self._generate_csv(pricelist_name, quantities, products, headers)
+        else:
+            return self._generate_xlsx(pricelist_name, quantities, products, headers)
+
+    def _generate_rows(self, products, quantities):
+        rows = []
+        for product in products:
+            variants = product.get('variants', [product])
+            for variant in variants:
+                row = [
+                    variant['name'],
+                    variant['uom']
+                ] + [variant['price'].get(qty, 0.0) for qty in quantities]
+                rows.append(row)
+        return rows
+
+    def _generate_csv(self, pricelist_name, quantities, products, headers):
+        buffer = io.StringIO()
+        writer = csv.writer(buffer)
+        writer.writerow(headers)
+        rows = self._generate_rows(products, quantities)
+        writer.writerows(rows)
+        content = buffer.getvalue()
+        buffer.close()
+        headers = [
+            ('Content-Type', 'text/csv'),
+            ('Content-Disposition', content_disposition(f'Pricelist - {pricelist_name}.csv'))
+        ]
+        return request.make_response(content, headers)
+
+    def _generate_xlsx(self, pricelist_name, quantities, products, headers):
+        buffer = io.BytesIO()
+        workbook = xlsxwriter.Workbook(buffer, {'in_memory': True})
+        worksheet = workbook.add_worksheet()
+        worksheet.write_row(0, 0, headers)
+        rows = self._generate_rows(products, quantities)
+        column_widths = [len(header) for header in headers]
+        for row_idx, row in enumerate(rows, start=1):
+            worksheet.write_row(row_idx, 0, row)
+            for col_idx, cell_value in enumerate(row):
+                column_widths[col_idx] = max(column_widths[col_idx], len(str(cell_value)))
+
+        for col_idx, width in enumerate(column_widths):
+            worksheet.set_column(col_idx, col_idx, width)
+        workbook.close()
+        content = buffer.getvalue()
+        buffer.close()
+        headers = [
+            ('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'),
+            ('Content-Disposition', content_disposition(f'Pricelist - {pricelist_name}.xlsx'))
+        ]
+        return request.make_response(content, headers)

--- a/addons/product/models/product_pricelist.py
+++ b/addons/product/models/product_pricelist.py
@@ -371,3 +371,11 @@ class Pricelist(models.Model):
                 pricelists='\n'.join(linked_items.base_pricelist_id.mapped('display_name')),
                 other_pricelists='\n'.join(linked_items.pricelist_id.mapped('display_name')),
             ))
+
+    def action_open_pricelist_report(self):
+        self.ensure_one()
+        return {
+            'name': _("Pricelist Report Preview"),
+            'type': 'ir.actions.client',
+            'tag': 'generate_pricelist_report',
+        }

--- a/addons/product/report/product_pricelist_report.py
+++ b/addons/product/report/product_pricelist_report.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, models
@@ -18,7 +17,6 @@ class ProductPricelistReport(models.AbstractModel):
 
     def _get_report_data(self, data, report_type='html'):
         quantities = data.get('quantities', [1])
-
         data_pricelist_id = data.get('pricelist_id')
         pricelist_id = data_pricelist_id and int(data_pricelist_id)
         pricelist = self.env['product.pricelist'].browse(pricelist_id).exists()
@@ -30,7 +28,7 @@ class ProductPricelistReport(models.AbstractModel):
         is_product_tmpl = active_model == 'product.template'
         ProductClass = self.env[active_model]
 
-        products = ProductClass.browse(active_ids) if active_ids else ProductClass.search([('sale_ok', '=', True)])
+        products = ProductClass.browse(active_ids) if active_ids else []
         products_data = [
             self._get_product_data(is_product_tmpl, product, pricelist, quantities)
             for product in products

--- a/addons/product/report/product_pricelist_report_templates.xml
+++ b/addons/product/report/product_pricelist_report_templates.xml
@@ -4,16 +4,18 @@
     <template id="report_pricelist_page">
         <div class="container bg-white p-4 my-4">
             <div class="oe_structure"></div>
-            <div class="row my-3" t-if="display_pricelist_title">
+            <div class="row my-3">
                 <div class="col-12">
                     <h2 t-if="is_html_type">
-                        Pricelist:
-                        <a href="#" class="o_action" data-model="product.pricelist" t-att-data-res-id="pricelist.id">
+                        Pricelist <span t-if="display_pricelist_title">:</span>
+                        <a t-if="display_pricelist_title" href="#" class="o_action"
+                            data-model="product.pricelist" t-att-data-res-id="pricelist.id">
                             <span t-field="pricelist.display_name">Gold Member Pricelist</span>
                         </a>
                     </h2>
                     <h2 t-else="">
-                        Pricelist: <span t-field="pricelist.display_name">Gold Member Pricelist</span>
+                        Pricelist <span t-if="display_pricelist_title">:</span>
+                        <span t-if="display_pricelist_title" t-field="pricelist.display_name">Gold Member Pricelist</span>
                     </h2>
                 </div>
             </div>
@@ -22,42 +24,42 @@
                 <div class="col-12">
                     <table class="table table-sm">
                         <thead>
-                            <th class="text-end" colspan="100%">Quantities (Price)</th>
+                            <th class="text-end px-1" colspan="100%">Quantities (Price)</th>
                             <tr>
-                                <th>Products</th>
-                                <th groups="uom.group_uom">UOM</th>
+                                <th class="px-1">Products</th>
+                                <th class="px-1" groups="uom.group_uom">UOM</th>
                                 <t t-foreach="quantities" t-as="qty">
-                                    <th class="text-end"><span t-out="qty">10 Units</span></th>
+                                    <th class="text-end px-1"><span t-out="qty">10 Units</span></th>
                                 </t>
                             </tr>
                         </thead>
                         <tbody>
                             <t t-foreach="products" t-as="product">
                                 <tr>
-                                    <td t-att-class="is_product_tmpl and 'fw-bold' or None">
+                                    <td t-att-class="is_product_tmpl and 'fw-bold px-1' or None">
                                         <a t-if="is_html_type" href="#" class="o_action" t-att-data-model="is_product_tmpl and 'product.template' or 'product.product'" t-att-data-res-id="product['id']">
                                             <span t-out="product['name']">Virtual Interior Design</span>
                                         </a>
                                         <span t-else="" t-out="product['name']">Acme Widget</span>
                                     </td>
-                                    <td groups="uom.group_uom" t-out="product['uom']"/>
+                                    <td groups="uom.group_uom" class="px-1" t-out="product['uom']"/>
                                     <t t-foreach="quantities" t-as="qty">
-                                        <td class="text-end">
+                                        <td class="text-end px-1">
                                             <span t-out="product['price'][qty]" t-options='{"widget": "monetary", "display_currency": pricelist.currency_id}'>$15.00</span>
                                         </td>
                                     </t>
                                 </tr>
                                 <t t-if="is_product_tmpl and 'variants' in product">
                                     <tr t-foreach="product['variants']" t-as="variant">
-                                        <td>
+                                        <td class="px-1">
                                             <a t-if="is_html_type" href="#" class="o_action ms-4" data-model="product.product" t-att-data-res-id="variant['id']">
                                                 <span t-out="variant['name']">Acme Widget - Blue</span>
                                             </a>
                                             <span t-else="" class="ms-4" t-out="variant['name']">Acme Widget - Blue</span>
                                         </td>
-                                        <td groups="uom.group_uom" t-out="product['uom']"/>
+                                        <td groups="uom.group_uom" class="px-1" t-out="product['uom']"/>
                                         <t t-foreach="quantities" t-as="qty">
-                                            <td class="text-end">
+                                            <td class="text-end px-1">
                                                 <span t-out="variant['price'][qty]" t-options='{"widget": "monetary", "display_currency": pricelist.currency_id}'>$14.00</span>
                                             </td>
                                         </t>
@@ -73,9 +75,16 @@
     </template>
 
     <template id="report_pricelist">
-        <t t-call="web.basic_layout">
+        <t t-call="web.html_container">
             <div class="page">
-                <t t-call="product.report_pricelist_page"/>
+                <t t-if="is_html_type">
+                    <t t-call="product.report_pricelist_page"/>
+                </t>
+                <t t-else="">
+                    <t t-call="web.external_layout">
+                        <t t-call="product.report_pricelist_page"/>
+                    </t>
+                </t>
             </div>
             <p style="page-break-before:always;"> </p>
             <div class="oe_structure"></div>

--- a/addons/product/static/src/js/pricelist_report/product_pricelist_report.xml
+++ b/addons/product/static/src/js/pricelist_report/product_pricelist_report.xml
@@ -7,24 +7,31 @@
             <Layout display="{ controlPanel: {} }">
                 <t t-set-slot="control-panel-always-buttons">
                     <button t-on-click="onClickPrint" type="button" class="btn btn-primary" title="Print">Print</button>
+                    <select name="formats" id="formats" class="form-select border-1 w-auto">
+                        <option value="pdf">pdf</option>
+                        <option value="csv">csv</option>
+                        <option value="xlsx">xlsx</option>
+                    </select>
                 </t>
                 <t t-set-slot="layout-actions">
-                    <form class="o_pricelist_report_form d-flex flex-column gap-1">
+                    <form class="o_pricelist_report_form d-flex flex-row gap-1">
                         <div class="d-flex align-items-center gap-3 w-100">
                             <label class="visually-hidden" for="pricelists">Username</label>
                             <div class="input-group w-auto">
                                 <div class="input-group-text fw-bold">Pricelist</div>
-                                <select name="pricelists"
-                                            id="pricelists"
-                                            class="o_select form-select border-0"
-                                            t-on-change="onSelectPricelist">
-                                        <option t-out="selectedPricelist.name" t-att-value="selectedPricelist.id"/>
-                                        <t t-foreach="pricelists" t-as="pricelist" t-key="pricelist.id">
-                                            <t t-if="pricelist.id != selectedPricelist.id">
-                                                <option t-out="pricelist.name" t-att-value="pricelist.id"/>
-                                            </t>
+                                <select
+                                    name="pricelists"
+                                    id="pricelists"
+                                    class="o_select form-select border-0"
+                                    t-on-change="onSelectPricelist"
+                                >
+                                    <option t-out="selectedPricelist.name" t-att-value="selectedPricelist.id"/>
+                                    <t t-foreach="pricelists" t-as="pricelist" t-key="pricelist.id">
+                                        <t t-if="pricelist.id != selectedPricelist.id">
+                                            <option t-out="pricelist.name" t-att-value="pricelist.id"/>
+                                        </t>
                                     </t>
-                                    </select>
+                                </select>
                             </div>
                             <div class="form-check w-auto">
                                 <input class="o_display_pricelist_title form-check-input ms-0 me-2"
@@ -32,12 +39,12 @@
                                     type="checkbox"
                                     t-att-checked="displayPricelistTitle"
                                     t-on-click="onToggleDisplayPricelist"/>
-                                <label for="display_pricelist_title" class="form-check-label">Display Pricelist</label>
+                                <label for="display_pricelist_title" class="form-check-label">Show Name</label>
                             </div>
                         </div>
                         <div class="d-flex align-items-center gap-3 w-100">
                             <div class="input-group d-flex flex-nowrap w-50" style="min-width:210px;">
-                                <span class="input-group-text fw-bold"> 
+                                <span class="input-group-text fw-bold">
                                     Quantities
                                 </span>
                                 <input type="number"
@@ -50,7 +57,7 @@
                                         title="Add a quantity"/>
                             </div>
                             <div class="d-flex align-items-center w-50">
-                                <span class="o_badges_list">
+                                <span class="o_badges_list d-flex">
                                     <t t-foreach="quantities" t-as="qty" t-key="qty">
                                         <span class="o_field_badge o_remove_qty badge rounded-pill me-2 py-1 border " t-att-value="qty">
                                             <t class="me-2" t-esc="qty"/>
@@ -63,10 +70,29 @@
                             </div>
                         </div>
                     </form>
+                    <div style="margin-left:300px;">
+                        <button t-on-click="onClickAddProducts" string="All Products" class="btn btn-link">
+                            <i class="fa fa-pencil"/>
+                            Add Products
+                        </button>
+                    </div>
                 </t>
                 <div t-on-click="onClickLink">
                     <t t-out="html"/>
                 </div>
+                <t t-if="noProducts">
+                    <div class="o_view_nocontent" role="alert">
+                        <div class="o_nocontent_help">
+                            <p class="o_view_nocontent_smiling_face">
+                                No products found in the report
+                            </p>
+                            <p class="fs-5">
+                                Add products using the "Add Products" button at the top right to
+                                include them in the report.
+                            </p>
+                        </div>
+                    </div>
+                </t>
            </Layout>
         </div>
     </t>

--- a/addons/product/static/tests/product_pricelist_report_test.js
+++ b/addons/product/static/tests/product_pricelist_report_test.js
@@ -75,12 +75,11 @@ QUnit.module('Product Pricelist Report', {
             tag: 'generate_pricelist_report',
             type: 'ir.actions.client',
             context: {
-                'default_pricelist': 1,
                 'active_ids': [42],
-                'active_model': 'product.product'
+                'active_model': 'product.product',
             }
         });
-        const selectElement = findElement(target, 'select');
+        const selectElement = findElement(target, 'select#pricelists');
         const badgesElement = findElement(target, '.o_badges_list');
         const inputElement = findElement(target, '.add-quantity-input');
         const addQtyButton = findElement(target, '.o_add_qty');

--- a/addons/product/views/product_pricelist_views.xml
+++ b/addons/product/views/product_pricelist_views.xml
@@ -51,6 +51,9 @@
         <field name="model">product.pricelist</field>
         <field name="arch" type="xml">
             <form string="Products Price List">
+                <header>
+                    <button name="action_open_pricelist_report" type="object" string="Print"/>
+                </header>
                 <sheet>
                     <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
                     <div class="oe_title">

--- a/addons/product/views/product_template_views.xml
+++ b/addons/product/views/product_template_views.xml
@@ -167,19 +167,17 @@
     </record>
 
     <record id="action_product_template_price_list_report" model="ir.actions.server">
-        <field name="name">Generate Pricelist Report</field>
+        <field name="name">Pricelist Report</field>
         <field name="groups_id" eval="[(4, ref('product.group_product_pricelist'))]"/>
         <field name="model_id" ref="product.model_product_template"/>
         <field name="binding_model_id" ref="product.model_product_template"/>
         <field name="state">code</field>
         <field name="code">
-ctx = env.context
-ctx.update({'default_pricelist': env['product.pricelist'].search([], limit=1).id})
 action = {
     'name': 'Pricelist Report',
     'type': 'ir.actions.client',
     'tag': 'generate_pricelist_report',
-    'context': ctx,
+    'context': env.context,
 }
         </field>
     </record>

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -607,19 +607,17 @@
         </record>
 
     <record id="action_product_price_list_report" model="ir.actions.server">
-        <field name="name">Generate Pricelist Report</field>
+        <field name="name">Pricelist Report</field>
         <field name="groups_id" eval="[(4, ref('group_product_pricelist'))]"/>
         <field name="model_id" ref="product.model_product_product"/>
         <field name="binding_model_id" ref="product.model_product_product"/>
         <field name="state">code</field>
         <field name="code">
-ctx = env.context
-ctx.update({'default_pricelist': env['product.pricelist'].search([], limit=1).id})
 action = {
     'name': 'Pricelist Report',
     'type': 'ir.actions.client',
     'tag': 'generate_pricelist_report',
-    'context': ctx,
+    'context': env.context,
 }
         </field>
     </record>


### PR DESCRIPTION
Before this commit:
- The print report layout was misaligned and unattractive.
- Reports could not be downloaded in CSV or XLSX formats.
- Printed reports lacked headers.
- Users could not print pricelist reports from the pricelist form view, making
  it difficult for them to find out how to print pricelists.

After this commit:
- Introduced a new action and a button in the form view of the product
  pricelist. When the button is clicked, it takes the user to the print
  pricelist report screen.
- Enhanced the overall UI of the pricelist report layout.
- Added functionality to export reports in CSV and XLSX formats.
- Added a button which opens a dialog containing list of all products to add
  more products in the report.
- Renamed some action strings.
- Added headers to reports to give them a professional appearance.

task-3956664