### PR TITLE
[FIX] point_of_sale: limited products loading priority

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -732,8 +732,8 @@ class PosConfig(models.Model):
         query = f"""
             WITH pm AS (
                   SELECT product_id,
-                         Max(write_date) date
-                    FROM stock_quant
+                         MAX(write_date) date
+                    FROM stock_move_line
                 GROUP BY product_id
             )
                SELECT product_product.id
@@ -741,17 +741,18 @@ class PosConfig(models.Model):
             LEFT JOIN pm ON product_product.id=pm.product_id
                 WHERE {where_clause}
              ORDER BY product_product__product_tmpl_id.is_favorite DESC,
-                      product_product__product_tmpl_id.type DESC,
-                      COALESCE(pm.date, product_product.write_date) DESC
+                      CASE WHEN product_product__product_tmpl_id.type = 'service' THEN 1 ELSE 0 END DESC,
+                      pm.date DESC NULLS LAST,
+                      product_product.write_date DESC
                 LIMIT %s
         """
         self.env.cr.execute(query, params + [self.get_limited_product_count()])
         product_ids = self.env.cr.fetchall()
-        products = self.env['product.product'].search([('id', 'in', product_ids)])
+        products = self.env['product.product'].browse([p[0] for p in product_ids])
         product_combo = products.filtered(lambda p: p['type'] == 'combo')
         product_in_combo = product_combo.combo_ids.combo_line_ids.product_id
         products_available = products | product_in_combo
-        return products_available.read(fields)
+        return products_available.read(fields, load=False)
 
     def get_limited_product_count(self):
         default_limit = 20000

--- a/addons/point_of_sale/models/product.py
+++ b/addons/point_of_sale/models/product.py
@@ -112,15 +112,18 @@ class ProductProduct(models.Model):
         ]
 
     def _load_pos_data(self, data):
-        domain = self._load_pos_data_domain(data)
-        fields = self._load_pos_data_fields(data['pos.config']['data'][0]['id'])
         config_id = self.env['pos.config'].browse(data['pos.config']['data'][0]['id'])
-        products = self.with_context({**self.env.context, 'display_default_code': False}).search_read(
-            domain,
-            fields,
-            limit=config_id.get_limited_product_count(),
-            order='sequence,default_code,name',
-            load=False)
+        limit_count = config_id.get_limited_product_count()
+        fields = self._load_pos_data_fields(data['pos.config']['data'][0]['id'])
+        if limit_count:
+            products = config_id.with_context({**self.env.context, 'display_default_code': False}).get_limited_products_loading(fields)
+        else:
+            domain = self._load_pos_data_domain(data)
+            products = self.with_context({**self.env.context, 'display_default_code': False}).search_read(
+                domain,
+                fields,
+                order='sequence,default_code,name',
+                load=False)
 
         self._process_pos_ui_product_product(products, config_id)
         return {


### PR DESCRIPTION
In this commit, we restore the feature that gives priority to products to load based on how recent the linked stock.move.line records are.

