### PR TITLE
[IMP] website_event{_*}: set specific SEO data for sub-pages

### DIFF
--- a/addons/test_event_full/tests/__init__.py
+++ b/addons/test_event_full/tests/__init__.py
@@ -7,4 +7,5 @@ from . import test_event_event
 from . import test_event_mail
 from . import test_event_security
 from . import test_performance
+from . import test_wevent_menu
 from . import test_wevent_register

--- a/addons/test_event_full/tests/test_wevent_menu.py
+++ b/addons/test_event_full/tests/test_wevent_menu.py
@@ -1,0 +1,41 @@
+from odoo.addons.test_event_full.tests.common import TestWEventCommon
+from odoo.tests import tagged
+from odoo.tests.common import users
+
+
+@tagged('event_online', 'post_install', '-at_install')
+class TestWEventMenu(TestWEventCommon):
+
+    @users('admin')
+    def test_seo_data(self):
+        """Test SEO data for submenus on event website page"""
+
+        self.assertFalse(self.event.website_meta_title, 'Event should initially have no meta title')
+        self.event.write({
+            'website_meta_title': 'info',
+        })
+        self.assertTrue(self.event.website_meta_title, 'Event should have a meta title after writing')
+
+        menus = [
+            ('booth_menu_ids', 'Get a Booth'),
+            ('exhibitor_menu_ids', 'Exhibitor'),
+            ('community_menu_ids', 'Community'),
+            ('track_menu_ids', 'Talks'),
+            ('track_menu_ids', 'Agenda'),
+            ('track_proposal_menu_ids', 'Talk Proposal'),
+        ]
+
+        for menu_field, menu_name in menus:
+            menu = self.event[menu_field]
+
+            if menu_field == 'track_menu_ids':
+                menu_url = '/track' if menu_name == 'Talks' else '/agenda'
+                menu = self.event[menu_field].filtered(lambda menu: menu.menu_id.url.endswith(menu_url))
+
+            self.assertFalse(menu.website_meta_title, f"{menu_name} page should initially have no meta title")
+            menu.write({'website_meta_title': menu_name})
+
+            web_page = self.url_open(menu.menu_id.url)
+
+            self.assertTrue(menu.website_meta_title, f"{menu_name} page should have a meta title after writing")
+            self.assertIn(f"<title>{menu.website_meta_title}</title>", web_page.text)

--- a/addons/website_event/models/website_event_menu.py
+++ b/addons/website_event/models/website_event_menu.py
@@ -6,6 +6,7 @@ from odoo import fields, models
 
 class WebsiteEventMenu(models.Model):
     _name = 'website.event.menu'
+    _inherit = 'website.seo.metadata'
     _description = "Website Event Menu"
     _rec_name = "menu_id"
 

--- a/addons/website_event_booth/controllers/event_booth.py
+++ b/addons/website_event_booth/controllers/event_booth.py
@@ -20,7 +20,7 @@ class WebsiteEventBoothController(WebsiteEventController):
         booth_category_id = int(booth_category_id) if booth_category_id else False
         return request.render(
             'website_event_booth.event_booth_registration',
-            self._prepare_booth_main_values(event, booth_category_id=booth_category_id, booth_ids=booth_ids)
+            self._prepare_booth_main_values(event, booth_category_id=booth_category_id, booth_ids=booth_ids) | {'seo_object': event.booth_menu_ids}
         )
 
     @http.route('/event/<model("event.event"):event>/booth/register',

--- a/addons/website_event_exhibitor/controllers/exhibitor.py
+++ b/addons/website_event_exhibitor/controllers/exhibitor.py
@@ -37,7 +37,7 @@ class ExhibitorController(WebsiteEventController):
     def event_exhibitors(self, event, **searches):
         return request.render(
             "website_event_exhibitor.event_exhibitors",
-            self._event_exhibitors_get_values(event, **searches)
+            self._event_exhibitors_get_values(event, **searches) | {'seo_object': event.exhibitor_menu_ids}
         )
 
     def _event_exhibitors_get_values(self, event, **searches):

--- a/addons/website_event_meet/controllers/community.py
+++ b/addons/website_event_meet/controllers/community.py
@@ -36,7 +36,7 @@ class WebsiteEventMeetController(EventCommunityController):
         """
         return request.render(
             "website_event_meet.event_meet",
-            self._event_meeting_rooms_get_values(event, lang=lang)
+            self._event_meeting_rooms_get_values(event, lang=lang) | {'seo_object': event.community_menu_ids}
         )
 
     def _event_meeting_rooms_get_values(self, event, lang=None):

--- a/addons/website_event_meet_quiz/controllers/community.py
+++ b/addons/website_event_meet_quiz/controllers/community.py
@@ -15,5 +15,5 @@ class WebsiteEventTrackQuizMeetController(EventCommunityController):
         values = self._get_community_leaderboard_render_values(event, kwargs.get('search'), page)
 
         # website_event_meet
-        values.update(self._event_meeting_rooms_get_values(event, lang=lang))
+        values.update(self._event_meeting_rooms_get_values(event, lang=lang) | {'seo_object': event.community_menu_ids})
         return request.render('website_event_meet.event_meet', values)

--- a/addons/website_event_track/controllers/event_track.py
+++ b/addons/website_event_track/controllers/event_track.py
@@ -80,10 +80,11 @@ class EventTrackController(http.Controller):
             # TODO: remove in a few stable versions (v19?), including the "prevent_redirect" param in templates
             slug = request.env['ir.http']._slug
             return request.redirect(f'/event/{slug(event)}/track', code=301)
+        seo_object = event.track_menu_ids.filtered(lambda menu: menu.menu_id.url.endswith('/track'))
 
         return request.render(
             "website_event_track.tracks_session",
-            self._event_tracks_get_values(event, tag=tag, **searches)
+            self._event_tracks_get_values(event, tag=tag, **searches) | {'seo_object': seo_object}
         )
 
     def _event_tracks_get_values(self, event, tag=None, **searches):
@@ -188,9 +189,11 @@ class EventTrackController(http.Controller):
     @http.route(['''/event/<model("event.event"):event>/agenda'''], type='http', auth="public", website=True, sitemap=False)
     def event_agenda(self, event, tag=None, **post):
         event = event.with_context(tz=event.date_tz or 'UTC')
+        seo_object = event.track_menu_ids.filtered(lambda menu: menu.menu_id.url.endswith('/agenda'))
         vals = {
             'event': event,
             'main_object': event,
+            'seo_object': seo_object,
             'tag': tag,
             'is_event_user': request.env.user.has_group('event.group_event_user'),
         }
@@ -426,7 +429,11 @@ class EventTrackController(http.Controller):
 
     @http.route(['''/event/<model("event.event"):event>/track_proposal'''], type='http', auth="public", website=True, sitemap=False)
     def event_track_proposal(self, event, **post):
-        return request.render("website_event_track.event_track_proposal", {'event': event, 'main_object': event})
+        return request.render("website_event_track.event_track_proposal", {
+            'event': event,
+            'main_object': event,
+            'seo_object': event.track_proposal_menu_ids,
+        })
 
     @http.route(['''/event/<model("event.event"):event>/track_proposal/post'''], type='http', auth="public", methods=['POST'], website=True)
     def event_track_proposal_post(self, event, **post):


### PR DESCRIPTION
\* = booth, booth_sale, exhibitor, meet, meet_quiz, track, track_quiz

**How to reproduce:**
- Create an event and activate the submenu
- Open Talk Proposal page and set specific SEO discription and title
- Open Exhibitors page and set another one

**Specifications:**
- They are currently synced.
- All the sub-pages except 'Introduction' and 'Location' page are synced.
- SEO data of all the pages should be different from one another.

**After this PR:**
SEO data for all sub-pages will be different.

Task-3874050
