### PR TITLE
[REF] mail: flatten store data sent on network (part 3 - member)

### DIFF
--- a/addons/hr_holidays/tests/test_out_of_office.py
+++ b/addons/hr_holidays/tests/test_out_of_office.py
@@ -48,13 +48,17 @@ class TestOutOfOffice(TestHrHolidaysCommon):
             'channel_type': 'chat',
             'name': 'test'
         })
-        all_members_data = Store(channel).get_result()["ChannelMember"]
-        members_data = [member for member in all_members_data if member["thread"]["id"] == channel.id]
-        self.assertEqual(len(members_data), 2, "Channel info should get info for the 2 members")
-        partner_info = next(member for member in members_data if member['persona']['email'] == partner.email)
-        partner2_info = next(member for member in members_data if member['persona']['email'] == partner2.email)
-        self.assertFalse(partner2_info['persona']['out_of_office_date_end'], "current user should not be out of office")
-        self.assertEqual(partner_info['persona']['out_of_office_date_end'], fields.Date.to_string(leave_date_end), "correspondent should be out of office")
+        data = Store(channel).get_result()
+        partner_info = next(p for p in data["Persona"] if p["id"] == partner.id)
+        partner2_info = next(p for p in data["Persona"] if p["id"] == partner2.id)
+        self.assertFalse(
+            partner2_info["out_of_office_date_end"], "current user should not be out of office"
+        )
+        self.assertEqual(
+            partner_info["out_of_office_date_end"],
+            fields.Date.to_string(leave_date_end),
+            "correspondent should be out of office",
+        )
 
 
 @tagged('out_of_office')

--- a/addons/im_livechat/tests/test_get_discuss_channel.py
+++ b/addons/im_livechat/tests/test_get_discuss_channel.py
@@ -51,8 +51,8 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
             [
                 {
                     "id": guest.id,
-                    "name": "Visitor",
                     "im_status": "offline",
+                    "name": "Visitor",
                     "type": "guest",
                     "write_date": fields.Datetime.to_string(guest.write_date),
                 },
@@ -120,22 +120,22 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
             data["ChannelMember"],
             [
                 {
-                    "thread": {"id": channel_info["id"], "model": "discuss.channel"},
                     "create_date": fields.Datetime.to_string(visitor_member.create_date),
+                    "fetched_message_id": False,
                     "id": visitor_member.id,
                     "last_interest_dt": fields.Datetime.to_string(visitor_member.last_interest_dt),
                     "new_message_separator": 0,
                     "persona": {"id": test_user.partner_id.id, "type": "partner"},
-                    "fetched_message_id": False,
                     "seen_message_id": False,
+                    "thread": {"id": channel_info["id"], "model": "discuss.channel"},
                 },
                 {
-                    "thread": {"id": channel_info["id"], "model": "discuss.channel"},
                     "create_date": fields.Datetime.to_string(operator_member.create_date),
+                    "fetched_message_id": False,
                     "id": operator_member.id,
                     "persona": {"id": operator.partner_id.id, "type": "partner"},
-                    "fetched_message_id": False,
                     "seen_message_id": False,
+                    "thread": {"id": channel_info["id"], "model": "discuss.channel"},
                 },
             ],
         )
@@ -181,14 +181,14 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
             data["ChannelMember"],
             [
                 {
-                    "thread": {"id": channel_info["id"], "model": "discuss.channel"},
                     "create_date": fields.Datetime.to_string(operator_member.create_date),
+                    "fetched_message_id": False,
                     "id": operator_member.id,
                     "last_interest_dt": fields.Datetime.to_string(operator_member.last_interest_dt),
                     "new_message_separator": 0,
                     "persona": {"id": operator.partner_id.id, "type": "partner"},
-                    "fetched_message_id": False,
                     "seen_message_id": False,
+                    "thread": {"id": channel_info["id"], "model": "discuss.channel"},
                 },
             ],
         )

--- a/addons/mail/controllers/discuss/channel.py
+++ b/addons/mail/controllers/discuss/channel.py
@@ -31,7 +31,7 @@ class ChannelController(http.Controller):
         channel = request.env["discuss.channel"].search([("id", "=", channel_id)])
         if not channel:
             raise NotFound()
-        return channel.load_more_members(known_member_ids)
+        return channel._load_more_members(known_member_ids)
 
     @http.route("/discuss/channel/update_avatar", methods=["POST"], type="json")
     def discuss_channel_avatar_update(self, channel_id, data):

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -423,7 +423,6 @@ class Channel(models.Model):
                 store = Store(
                     "Thread",
                     {
-                        "channelMembers": [("ADD", [{"id": member.id} for member in new_members])],
                         "id": channel.id,
                         "memberCount": channel.member_count,
                         "model": "discuss.channel",
@@ -438,9 +437,6 @@ class Channel(models.Model):
                 user_store = Store(
                     "Thread",
                     {
-                        "channelMembers": [
-                            ("ADD", [{"id": member.id} for member in existing_members])
-                        ],
                         "id": channel.id,
                         "memberCount": channel.member_count,
                         "model": "discuss.channel",
@@ -1248,7 +1244,6 @@ class Channel(models.Model):
             {
                 "id": self.id,
                 "model": "discuss.channel",
-                "channelMembers": [("ADD", [{"id": member.id} for member in unknown_members])],
                 "memberCount": count,
             },
         )

--- a/addons/mail/models/discuss/discuss_channel_member.py
+++ b/addons/mail/models/discuss/discuss_channel_member.py
@@ -191,7 +191,7 @@ class ChannelMember(models.Model):
         """
         notifications = []
         for member in self:
-            store = Store("ChannelMember", member._discuss_channel_member_format().get(member))
+            store = Store(member)
             store.add("ChannelMember", {"id": member.id, "isTyping": is_typing})
             notifications.append([member.channel_id, "mail.record/insert", store.get_result()])
         self.env['bus.bus']._sendmany(notifications)
@@ -211,7 +211,7 @@ class ChannelMember(models.Model):
             notifications.append((member.partner_id, "mail.record/insert", {"Thread": channel_data}))
         self.env["bus.bus"]._sendmany(notifications)
 
-    def _discuss_channel_member_format(self, fields=None, extra_fields=None):
+    def _to_store(self, store: Store, fields=None, extra_fields=None):
         if not fields:
             fields = {
                 "channel": {},
@@ -228,7 +228,6 @@ class ChannelMember(models.Model):
         if "message_unread_counter" in fields:
             # sudo: bus.bus: reading non-sensitive last id
             bus_last_id = self.env["bus.bus"].sudo()._bus_last_id()
-        members_formatted_data = {}
         for member in self:
             data = {}
             if 'id' in fields:
@@ -259,8 +258,7 @@ class ChannelMember(models.Model):
                 data["thread"].update(message_unread_counter=member.message_unread_counter, message_unread_counter_bus_id=bus_last_id)
             if fields.get("last_interest_dt"):
                 data['last_interest_dt'] = odoo.fields.Datetime.to_string(member.last_interest_dt)
-            members_formatted_data[member] = data
-        return members_formatted_data
+            store.add("ChannelMember", data)
 
     def _get_partner_data(self, fields=None):
         self.ensure_one()
@@ -438,19 +436,15 @@ class ChannelMember(models.Model):
             }
             store = Store("Thread", channel_data)
             store.add(
-                "ChannelMember",
-                list(
-                    members._discuss_channel_member_format(
-                        fields={
-                            "id": True,
-                            "channel": {},
-                            "persona": {
-                                "partner": {"id": True, "name": True, "im_status": True},
-                                "guest": {"id": True, "name": True, "im_status": True},
-                            },
-                        }
-                    ).values()
-                ),
+                members,
+                fields={
+                    "id": True,
+                    "channel": {},
+                    "persona": {
+                        "partner": {"id": True, "name": True, "im_status": True},
+                        "guest": {"id": True, "name": True, "im_status": True},
+                    },
+                },
             )
             self.env["bus.bus"]._sendone(self.channel_id, "mail.record/insert", store.get_result())
         return members
@@ -496,20 +490,16 @@ class ChannelMember(models.Model):
         if self.channel_id.channel_type in self.channel_id._types_allowing_seen_infos():
             target = self.channel_id
         store = Store(
-            "ChannelMember",
-            list(
-                self._discuss_channel_member_format(
-                    fields={
-                        "id": True,
-                        "channel": {},
-                        "persona": {
-                            "partner": {"id": True, "name": True},
-                            "guest": {"id": True, "name": True},
-                        },
-                        "seen_message_id": True,
-                    }
-                ).values()
-            ),
+            self,
+            fields={
+                "id": True,
+                "channel": {},
+                "persona": {
+                    "partner": {"id": True, "name": True},
+                    "guest": {"id": True, "name": True},
+                },
+                "seen_message_id": True,
+            },
         )
         self.env["bus.bus"]._sendone(target, "mail.record/insert", store.get_result())
 
@@ -525,7 +515,9 @@ class ChannelMember(models.Model):
         if message_id == self.new_message_separator:
             return
         self.new_message_separator = message_id
-        member_data = self._discuss_channel_member_format(
+        target = self.partner_id or self.guest_id
+        store = Store(
+            self,
             fields={
                 "id": True,
                 "channel": {},
@@ -536,8 +528,6 @@ class ChannelMember(models.Model):
                     "guest": {"id": True, "name": True},
                 },
             },
-        )[self]
-        member_data.update(syncUnread=sync)
-        target = self.partner_id or self.guest_id
-        store = Store("ChannelMember", member_data)
+        )
+        store.add("ChannelMember", {"id": self.id, "syncUnread": sync})
         self.env["bus.bus"]._sendone(target, "mail.record/insert", store.get_result())

--- a/addons/mail/models/discuss/discuss_channel_member.py
+++ b/addons/mail/models/discuss/discuss_channel_member.py
@@ -243,7 +243,8 @@ class ChannelMember(models.Model):
                 if member.guest_id:
                     # sudo: mail.guest - reading _guest_format related to a member is considered acceptable
                     persona = member.guest_id.sudo()._guest_format(fields=fields.get('persona', {}).get('guest')).get(member.guest_id)
-                data['persona'] = persona
+                store.add("Persona", persona)
+                data['persona'] = {"id": persona["id"], "type": persona["type"]}
             if 'custom_notifications' in fields:
                 data['custom_notifications'] = member.custom_notifications
             if 'mute_until_dt' in fields:

--- a/addons/mail/models/discuss/discuss_channel_member.py
+++ b/addons/mail/models/discuss/discuss_channel_member.py
@@ -525,10 +525,19 @@ class ChannelMember(models.Model):
         if message_id == self.new_message_separator:
             return
         self.new_message_separator = message_id
-        persona_fields = {"partner": {"id": True, "name": True}, "guest": {"id": True, "name": True}}
         member_data = self._discuss_channel_member_format(
-            fields={"id": True, "channel": {}, "message_unread_counter": True, "new_message_separator": True, "persona": persona_fields},
+            fields={
+                "id": True,
+                "channel": {},
+                "message_unread_counter": True,
+                "new_message_separator": True,
+                "persona": {
+                    "partner": {"id": True, "name": True},
+                    "guest": {"id": True, "name": True},
+                },
+            },
         )[self]
         member_data.update(syncUnread=sync)
         target = self.partner_id or self.guest_id
-        self.env["bus.bus"]._sendone(target, "mail.record/insert", {"ChannelMember": member_data})
+        store = Store("ChannelMember", member_data)
+        self.env["bus.bus"]._sendone(target, "mail.record/insert", store.get_result())

--- a/addons/mail/models/discuss/discuss_channel_rtc_session.py
+++ b/addons/mail/models/discuss/discuss_channel_rtc_session.py
@@ -153,19 +153,15 @@ class MailRtcSession(models.Model):
 
     def _to_store(self, store: Store, extra=False):
         store.add(
-            "ChannelMember",
-            list(
-                self.channel_member_id._discuss_channel_member_format(
-                    fields={
-                        "id": True,
-                        "channel": {},
-                        "persona": {
-                            "partner": {"id": True, "name": True, "im_status": True},
-                            "guest": {"id": True, "name": True, "im_status": True},
-                        },
-                    }
-                ).values()
-            ),
+            self.channel_member_id,
+            fields={
+                "id": True,
+                "channel": {},
+                "persona": {
+                    "partner": {"id": True, "name": True, "im_status": True},
+                    "guest": {"id": True, "name": True, "im_status": True},
+                },
+            },
         )
         for rtc_session in self:
             vals = {

--- a/addons/mail/models/discuss/res_partner.py
+++ b/addons/mail/models/discuss/res_partner.py
@@ -76,16 +76,12 @@ class ResPartner(models.Model):
             ]
         )
         store = Store(
-            "ChannelMember",
-            list(
-                members._discuss_channel_member_format(
-                    fields={
-                        "id": True,
-                        "channel": {"id": True},
-                        "persona": {"partner": {"id": True}},
-                    }
-                ).values()
-            ),
+            members,
+            fields={
+                "id": True,
+                "channel": {"id": True},
+                "persona": {"partner": {"id": True}},
+            },
         )
         store.add("Persona", list(partners.mail_partner_format().values()))
         return store.get_result()

--- a/addons/mail/models/ir_attachment.py
+++ b/addons/mail/models/ir_attachment.py
@@ -85,8 +85,8 @@ class IrAttachment(models.Model):
             "size": attachment.file_size,
             'res_name': attachment.res_name,
             'mimetype': 'application/octet-stream' if safari and attachment.mimetype and 'video' in attachment.mimetype else attachment.mimetype,
-            'thread': [('ADD', {
+            'thread': {
                 'id': attachment.res_id,
                 'model': attachment.res_model,
-            })],
+            },
         } for attachment in self]

--- a/addons/mail/models/res_partner.py
+++ b/addons/mail/models/res_partner.py
@@ -6,6 +6,7 @@ import re
 import odoo
 from odoo import _, api, fields, models, tools
 from odoo.osv import expression
+from odoo.addons.mail.tools.discuss import Store
 
 class Partner(models.Model):
     """ Update partner to add a field about notification preferences. Add a generic opt-out field that can be used
@@ -215,9 +216,7 @@ class Partner(models.Model):
         if not fields:
             fields = {'id': True, 'name': True, 'email': True, 'active': True, 'im_status': True, 'is_company': True, 'user': {}, "write_date": True}
         for partner in self:
-            data = {}
-            if 'id' in fields:
-                data['id'] = partner.id
+            data = {"id": partner.id}
             if 'name' in fields:
                 data['name'] = partner.name
             if 'email' in fields:
@@ -250,7 +249,7 @@ class Partner(models.Model):
         """
         domain = self._get_mention_suggestions_domain(search)
         partners = self._search_mention_suggestions(domain, limit)
-        return list(partners.mail_partner_format().values())
+        return Store("Persona", list(partners.mail_partner_format().values())).get_result()
 
     @api.model
     def _get_mention_suggestions_domain(self, search):

--- a/addons/mail/static/src/core/common/suggestion_service.js
+++ b/addons/mail/static/src/core/common/suggestion_service.js
@@ -43,7 +43,7 @@ export class SuggestionService {
         if (thread?.model === "discuss.channel") {
             kwargs.channel_id = thread.id;
         }
-        const suggestedPartners = await this.orm.silent.call(
+        const data = await this.orm.silent.call(
             "res.partner",
             thread?.model === "discuss.channel"
                 ? "get_mention_suggestions_from_channel"
@@ -51,7 +51,7 @@ export class SuggestionService {
             [],
             kwargs
         );
-        this.store.Persona.insert(suggestedPartners);
+        this.store.insert(data);
     }
 
     /**

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -626,9 +626,9 @@ export class Thread extends Record {
         const previousState = this.fetchMembersState;
         this.fetchMembersState = "pending";
         const known_member_ids = this.channelMembers.map((channelMember) => channelMember.id);
-        let results;
+        let data;
         try {
-            results = await rpc("/discuss/channel/members", {
+            data = await rpc("/discuss/channel/members", {
                 channel_id: this.id,
                 known_member_ids: known_member_ids,
             });
@@ -637,7 +637,7 @@ export class Thread extends Record {
             throw e;
         }
         this.fetchMembersState = "fetched";
-        this.update(results);
+        this.store.insert(data);
     }
 
     /** @param {{after: Number, before: Number}} */

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -85,6 +85,7 @@ export class Thread extends Record {
         return this.channel_type === "chat" && this.importantCounter === 0;
     }
     channelMembers = Record.many("ChannelMember", {
+        inverse: "thread",
         onDelete: (r) => r.delete(),
         sort: (m1, m2) => m1.id - m2.id,
     });

--- a/addons/mail/static/tests/legacy/helpers/mock_server/models/discuss_channel.js
+++ b/addons/mail/static/tests/legacy/helpers/mock_server/models/discuss_channel.js
@@ -143,7 +143,7 @@ patch(MockServer.prototype, {
             const ids = args.args[0];
             return this._mockDiscussChannelWriteImage128(ids[0]);
         }
-        if (args.model === "discuss.channel" && args.method === "load_more_members") {
+        if (args.model === "discuss.channel" && args.method === "_load_more_members") {
             const [channel_ids] = args.args;
             const { known_member_ids } = args.kwargs;
             return this._mockDiscussChannelloadOlderMembers(channel_ids, known_member_ids);
@@ -908,7 +908,7 @@ patch(MockServer.prototype, {
         });
     },
     /**
-     * Simulates `load_more_members` on `discuss.channel`.
+     * Simulates `_load_more_members` on `discuss.channel`.
      *
      * @private
      * @param {integer[]} channel_ids

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -299,7 +299,7 @@ async function discuss_channel_members(request) {
     const DiscussChannel = this.env["discuss.channel"];
 
     const { channel_id, known_member_ids } = await parseRequestParams(request);
-    return DiscussChannel.load_more_members([channel_id], known_member_ids);
+    return DiscussChannel._load_more_members([channel_id], known_member_ids);
 }
 
 registerRoute("/discuss/channel/messages", discuss_channel_messages);

--- a/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
+++ b/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
@@ -161,16 +161,10 @@ export class DiscussChannel extends models.ServerModel {
             ]) > 0;
         if (isSelfMember) {
             BusBus._sendone(channel, "mail.record/insert", {
+                ChannelMember:
+                    DiscussChannelMember._discuss_channel_member_format(insertedChannelMembers),
                 Thread: {
                     id: channel.id,
-                    channelMembers: [
-                        [
-                            "ADD",
-                            DiscussChannelMember._discuss_channel_member_format(
-                                insertedChannelMembers
-                            ),
-                        ],
-                    ],
                     memberCount: DiscussChannelMember.search_count([
                         ["channel_id", "=", channel.id],
                     ]),
@@ -800,7 +794,6 @@ export class DiscussChannel extends models.ServerModel {
             ),
             Thread: [
                 {
-                    channelMembers: [["ADD", members.map((member) => ({ id: member.id }))]],
                     id: ids[0],
                     memberCount,
                     model: "discuss.channel",

--- a/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
+++ b/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
@@ -777,7 +777,7 @@ export class DiscussChannel extends models.ServerModel {
      * @param {number[]} ids
      * @param {number[]} known_member_ids
      */
-    load_more_members(ids, known_member_ids) {
+    _load_more_members(ids, known_member_ids) {
         const kwargs = getKwArgs(arguments, "ids", "known_member_ids");
         ids = kwargs.ids;
         delete kwargs.ids;
@@ -795,13 +795,17 @@ export class DiscussChannel extends models.ServerModel {
         );
         const memberCount = DiscussChannelMember.search_count([["channel_id", "in", ids]]);
         return {
-            channelMembers: [
-                [
-                    "ADD",
-                    DiscussChannelMember._discuss_channel_member_format(members.map((m) => m.id)),
-                ],
+            ChannelMember: DiscussChannelMember._discuss_channel_member_format(
+                members.map((member) => member.id)
+            ),
+            Thread: [
+                {
+                    channelMembers: [["ADD", members.map((member) => ({ id: member.id }))]],
+                    id: ids[0],
+                    memberCount,
+                    model: "discuss.channel",
+                },
             ],
-            memberCount,
         };
     }
 

--- a/addons/mail/static/tests/mock_server/mock_models/ir_attachment.js
+++ b/addons/mail/static/tests/mock_server/mock_models/ir_attachment.js
@@ -44,7 +44,7 @@ export class IrAttachment extends webModels.IrAttachment {
                 name: attachment.name,
                 size: attachment.file_size,
             };
-            res["thread"] = [["ADD", { id: attachment.res_id, model: attachment.res_model }]];
+            res["thread"] = { id: attachment.res_id, model: attachment.res_model };
             const voice = DiscussVoiceMetadata._filter([["attachment_id", "=", attachment.id]])[0];
             if (voice) {
                 res.voice = true;

--- a/addons/mail/static/tests/mock_server/mock_models/res_partner.js
+++ b/addons/mail/static/tests/mock_server/mock_models/res_partner.js
@@ -87,7 +87,7 @@ export class ResPartner extends webModels.ResPartner {
             ]);
             extraMatchingPartners = mentionSuggestionsFilter(partners, search, remainingLimit);
         }
-        return mainMatchingPartners.concat(extraMatchingPartners);
+        return { Persona: mainMatchingPartners.concat(extraMatchingPartners) };
     }
 
     /**
@@ -174,7 +174,7 @@ export class ResPartner extends webModels.ResPartner {
             ]);
             extraMatchingPartners = mentionSuggestionsFilter(partners, search, remainingLimit);
         }
-        return mainMatchingPartners.concat(extraMatchingPartners);
+        return { Persona: mainMatchingPartners.concat(extraMatchingPartners) };
     }
 
     /**

--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -921,8 +921,12 @@ class MailCase(MockEmail):
             self.assertEqual(self._new_notifs, done_notifs, 'Mail: invalid notification creation (%s) / expected (%s)' % (len(self._new_notifs), len(done_notifs)))
 
     @contextmanager
-    def assertBus(self, channels, message_items=None):
-        """ Check content of bus notifications. """
+    def assertBus(self, channels=None, message_items=None, get_params=None):
+        """Check content of bus notifications.
+        Params might not be determined in advance (newly created id, create_date, ...), in this case
+        the `get_params` function can be given to return the expected values, called after the
+        execution of the tested code.
+        """
         def format_notif(notif):
             if not notif.message:
                 return ""
@@ -931,6 +935,8 @@ class MailCase(MockEmail):
             with self.mock_bus():
                 yield
         finally:
+            if get_params:
+                channels, message_items = get_params()
             found_bus_notifs = self.assertBusNotifications(channels, message_items=message_items)
             new_line = "\n"
             self.assertEqual(

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -133,11 +133,14 @@ class TestChannelInternals(MailCommon, HttpCase):
                     {
                         "type": "mail.record/insert",
                         "payload": {
-                            "Thread": [
+                            "ChannelMember": [
                                 {
-                                    "id": channel.id,
-                                    "memberCount": 2,
-                                    "model": "discuss.channel",
+                                    "id": member.id,
+                                    "thread": {"id": channel.id, "model": "discuss.channel"},
+                                    "create_date": fields.Datetime.to_string(member.create_date),
+                                    "persona": {"id": self.test_partner.id, "type": "partner"},
+                                    "fetched_message_id": False,
+                                    "seen_message_id": False,
                                 },
                             ],
                             "Persona": [
@@ -155,14 +158,11 @@ class TestChannelInternals(MailCommon, HttpCase):
                                     "out_of_office_date_end": False,
                                 },
                             ],
-                            "ChannelMember": [
+                            "Thread": [
                                 {
-                                    "id": member.id,
-                                    "thread": {"id": channel.id, "model": "discuss.channel"},
-                                    "create_date": fields.Datetime.to_string(member.create_date),
-                                    "persona": {"id": self.test_partner.id, "type": "partner"},
-                                    "fetched_message_id": False,
-                                    "seen_message_id": False,
+                                    "id": channel.id,
+                                    "memberCount": 2,
+                                    "model": "discuss.channel",
                                 },
                             ],
                         },
@@ -183,11 +183,14 @@ class TestChannelInternals(MailCommon, HttpCase):
                     {
                         "type": "mail.record/insert",
                         "payload": {
-                            "Thread": [
+                            "ChannelMember": [
                                 {
-                                    "id": channel.id,
-                                    "memberCount": 2,
-                                    "model": "discuss.channel",
+                                    "id": member.id,
+                                    "thread": {"id": channel.id, "model": "discuss.channel"},
+                                    "create_date": fields.Datetime.to_string(member.create_date),
+                                    "persona": {"id": self.test_partner.id, "type": "partner"},
+                                    "fetched_message_id": False,
+                                    "seen_message_id": False,
                                 }
                             ],
                             "Persona": [
@@ -205,14 +208,11 @@ class TestChannelInternals(MailCommon, HttpCase):
                                     "out_of_office_date_end": False,
                                 },
                             ],
-                            "ChannelMember": [
+                            "Thread": [
                                 {
-                                    "id": member.id,
-                                    "thread": {"id": channel.id, "model": "discuss.channel"},
-                                    "create_date": fields.Datetime.to_string(member.create_date),
-                                    "persona": {"id": self.test_partner.id, "type": "partner"},
-                                    "fetched_message_id": False,
-                                    "seen_message_id": False,
+                                    "id": channel.id,
+                                    "memberCount": 2,
+                                    "model": "discuss.channel",
                                 }
                             ],
                         },
@@ -406,13 +406,6 @@ class TestChannelInternals(MailCommon, HttpCase):
                 {
                     "type": "mail.record/insert",
                     "payload": {
-                        "Persona": [
-                            {
-                                "id": self.user_admin.partner_id.id,
-                                "name": self.user_admin.partner_id.name,
-                                "type": "partner",
-                            },
-                        ],
                         "ChannelMember": {
                             "id": member.id,
                             "thread": {
@@ -425,11 +418,6 @@ class TestChannelInternals(MailCommon, HttpCase):
                             "new_message_separator": msg_1.id + 1,
                             "syncUnread": False,
                         },
-                    },
-                },
-                {
-                    "type": "mail.record/insert",
-                    "payload": {
                         "Persona": [
                             {
                                 "id": self.user_admin.partner_id.id,
@@ -437,12 +425,24 @@ class TestChannelInternals(MailCommon, HttpCase):
                                 "type": "partner",
                             },
                         ],
+                    },
+                },
+                {
+                    "type": "mail.record/insert",
+                    "payload": {
                         "ChannelMember": {
                             "id": member.id,
                             "thread": {"id": chat.id, "model": "discuss.channel"},
                             "persona": {"id": self.user_admin.partner_id.id, "type": "partner"},
                             "seen_message_id": {"id": msg_1.id},
                         },
+                        "Persona": [
+                            {
+                                "id": self.user_admin.partner_id.id,
+                                "name": self.user_admin.partner_id.name,
+                                "type": "partner",
+                            },
+                        ],
                     },
                 },
             ],

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -135,7 +135,6 @@ class TestChannelInternals(MailCommon, HttpCase):
                         "payload": {
                             "Thread": [
                                 {
-                                    "channelMembers": [["ADD", [{"id": member.id}]]],
                                     "id": channel.id,
                                     "memberCount": 2,
                                     "model": "discuss.channel",
@@ -186,7 +185,6 @@ class TestChannelInternals(MailCommon, HttpCase):
                         "payload": {
                             "Thread": [
                                 {
-                                    "channelMembers": [["ADD", [{"id": member.id}]]],
                                     "id": channel.id,
                                     "memberCount": 2,
                                     "model": "discuss.channel",

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -135,27 +135,27 @@ class TestChannelInternals(MailCommon, HttpCase):
                         "payload": {
                             "ChannelMember": [
                                 {
-                                    "id": member.id,
-                                    "thread": {"id": channel.id, "model": "discuss.channel"},
                                     "create_date": fields.Datetime.to_string(member.create_date),
-                                    "persona": {"id": self.test_partner.id, "type": "partner"},
                                     "fetched_message_id": False,
+                                    "id": member.id,
+                                    "persona": {"id": self.test_partner.id, "type": "partner"},
                                     "seen_message_id": False,
+                                    "thread": {"id": channel.id, "model": "discuss.channel"},
                                 },
                             ],
                             "Persona": [
                                 {
-                                    "id": self.test_partner.id,
-                                    "name": "Test Partner",
-                                    "email": "test_customer@example.com",
                                     "active": True,
+                                    "email": "test_customer@example.com",
+                                    "id": self.test_partner.id,
                                     "im_status": "im_partner",
-                                    "is_company": False,
-                                    "write_date": test_partner_write_date,
-                                    "userId": False,
                                     "isInternalUser": False,
-                                    "type": "partner",
+                                    "is_company": False,
+                                    "name": "Test Partner",
                                     "out_of_office_date_end": False,
+                                    "type": "partner",
+                                    "userId": False,
+                                    "write_date": test_partner_write_date,
                                 },
                             ],
                             "Thread": [
@@ -185,27 +185,27 @@ class TestChannelInternals(MailCommon, HttpCase):
                         "payload": {
                             "ChannelMember": [
                                 {
-                                    "id": member.id,
-                                    "thread": {"id": channel.id, "model": "discuss.channel"},
                                     "create_date": fields.Datetime.to_string(member.create_date),
-                                    "persona": {"id": self.test_partner.id, "type": "partner"},
                                     "fetched_message_id": False,
+                                    "id": member.id,
+                                    "persona": {"id": self.test_partner.id, "type": "partner"},
                                     "seen_message_id": False,
+                                    "thread": {"id": channel.id, "model": "discuss.channel"},
                                 }
                             ],
                             "Persona": [
                                 {
-                                    "id": self.test_partner.id,
-                                    "name": "Test Partner",
-                                    "email": "test_customer@example.com",
                                     "active": True,
+                                    "email": "test_customer@example.com",
+                                    "id": self.test_partner.id,
                                     "im_status": "im_partner",
-                                    "is_company": False,
-                                    "write_date": test_partner_write_date,
-                                    "userId": False,
                                     "isInternalUser": False,
-                                    "type": "partner",
+                                    "is_company": False,
+                                    "name": "Test Partner",
                                     "out_of_office_date_end": False,
+                                    "type": "partner",
+                                    "userId": False,
+                                    "write_date": test_partner_write_date,
                                 },
                             ],
                             "Thread": [
@@ -406,18 +406,20 @@ class TestChannelInternals(MailCommon, HttpCase):
                 {
                     "type": "mail.record/insert",
                     "payload": {
-                        "ChannelMember": {
-                            "id": member.id,
-                            "thread": {
-                                "id": chat.id,
-                                "model": "discuss.channel",
-                                "message_unread_counter": 0,
-                                "message_unread_counter_bus_id": last_bus_id + 1,
+                        "ChannelMember": [
+                            {
+                                "id": member.id,
+                                "new_message_separator": msg_1.id + 1,
+                                "persona": {"id": self.user_admin.partner_id.id, "type": "partner"},
+                                "syncUnread": False,
+                                "thread": {
+                                    "id": chat.id,
+                                    "model": "discuss.channel",
+                                    "message_unread_counter": 0,
+                                    "message_unread_counter_bus_id": last_bus_id + 1,
+                                },
                             },
-                            "persona": {"id": self.user_admin.partner_id.id, "type": "partner"},
-                            "new_message_separator": msg_1.id + 1,
-                            "syncUnread": False,
-                        },
+                        ],
                         "Persona": [
                             {
                                 "id": self.user_admin.partner_id.id,
@@ -430,12 +432,14 @@ class TestChannelInternals(MailCommon, HttpCase):
                 {
                     "type": "mail.record/insert",
                     "payload": {
-                        "ChannelMember": {
-                            "id": member.id,
-                            "thread": {"id": chat.id, "model": "discuss.channel"},
-                            "persona": {"id": self.user_admin.partner_id.id, "type": "partner"},
-                            "seen_message_id": {"id": msg_1.id},
-                        },
+                        "ChannelMember": [
+                            {
+                                "id": member.id,
+                                "persona": {"id": self.user_admin.partner_id.id, "type": "partner"},
+                                "seen_message_id": {"id": msg_1.id},
+                                "thread": {"id": chat.id, "model": "discuss.channel"},
+                            },
+                        ],
                         "Persona": [
                             {
                                 "id": self.user_admin.partner_id.id,

--- a/addons/mail/tests/discuss/test_rtc.py
+++ b/addons/mail/tests/discuss/test_rtc.py
@@ -52,14 +52,6 @@ class TestChannelRTC(MailCommon):
                 {
                     "type": "mail.record/insert",
                     "payload": {
-                        "Persona": [
-                            {
-                                "id": channel_member.partner_id.id,
-                                "name": channel_member.partner_id.name,
-                                "im_status": channel_member.partner_id.im_status,
-                                "type": "partner",
-                            },
-                        ],
                         "ChannelMember": [
                             {
                                 "id": channel_member.id,
@@ -68,6 +60,14 @@ class TestChannelRTC(MailCommon):
                                     "model": "discuss.channel",
                                 },
                                 "persona": {"id": channel_member.partner_id.id, "type": "partner"},
+                            },
+                        ],
+                        "Persona": [
+                            {
+                                "id": channel_member.partner_id.id,
+                                "name": channel_member.partner_id.name,
+                                "im_status": channel_member.partner_id.im_status,
+                                "type": "partner",
                             },
                         ],
                         "RtcSession": [
@@ -95,14 +95,6 @@ class TestChannelRTC(MailCommon):
         self.assertEqual(
             res,
             {
-                "Persona": [
-                    {
-                        "id": channel_member.partner_id.id,
-                        "name": channel_member.partner_id.name,
-                        "im_status": channel_member.partner_id.im_status,
-                        "type": "partner",
-                    },
-                ],
                 "ChannelMember": [
                     {
                         "id": channel_member.id,
@@ -111,6 +103,14 @@ class TestChannelRTC(MailCommon):
                             "model": "discuss.channel",
                         },
                         "persona": {"id": channel_member.partner_id.id, "type": "partner"},
+                    },
+                ],
+                "Persona": [
+                    {
+                        "id": channel_member.partner_id.id,
+                        "name": channel_member.partner_id.name,
+                        "im_status": channel_member.partner_id.im_status,
+                        "type": "partner",
                     },
                 ],
                 "Rtc": {
@@ -163,14 +163,6 @@ class TestChannelRTC(MailCommon):
                 {
                     "type": "mail.record/insert",
                     "payload": {
-                        "Persona": [
-                            {
-                                "id": channel_member.partner_id.id,
-                                "name": channel_member.partner_id.name,
-                                "im_status": channel_member.partner_id.im_status,
-                                "type": "partner",
-                            },
-                        ],
                         "ChannelMember": [
                             {
                                 "id": channel_member.id,
@@ -179,6 +171,14 @@ class TestChannelRTC(MailCommon):
                                     "model": "discuss.channel",
                                 },
                                 "persona": {"id": channel_member.partner_id.id, "type": "partner"},
+                            },
+                        ],
+                        "Persona": [
+                            {
+                                "id": channel_member.partner_id.id,
+                                "name": channel_member.partner_id.name,
+                                "im_status": channel_member.partner_id.im_status,
+                                "type": "partner",
                             },
                         ],
                         "RtcSession": [
@@ -199,21 +199,6 @@ class TestChannelRTC(MailCommon):
                 {
                     "type": "mail.record/insert",
                     "payload": {
-                        "Thread": [
-                            {
-                                "id": channel.id,
-                                "model": "discuss.channel",
-                                "invitedMembers": [("ADD", [{"id": channel_member_test_user.id}])],
-                            }
-                        ],
-                        "Persona": [
-                            {
-                                "id": channel_member_test_user.partner_id.id,
-                                "name": channel_member_test_user.partner_id.name,
-                                "im_status": channel_member_test_user.partner_id.im_status,
-                                "type": "partner",
-                            },
-                        ],
                         "ChannelMember": [
                             {
                                 "id": channel_member_test_user.id,
@@ -226,6 +211,21 @@ class TestChannelRTC(MailCommon):
                                     "type": "partner",
                                 },
                             },
+                        ],
+                        "Persona": [
+                            {
+                                "id": channel_member_test_user.partner_id.id,
+                                "name": channel_member_test_user.partner_id.name,
+                                "im_status": channel_member_test_user.partner_id.im_status,
+                                "type": "partner",
+                            },
+                        ],
+                        "Thread": [
+                            {
+                                "id": channel.id,
+                                "model": "discuss.channel",
+                                "invitedMembers": [("ADD", [{"id": channel_member_test_user.id}])],
+                            }
                         ],
                     },
                 },
@@ -265,14 +265,6 @@ class TestChannelRTC(MailCommon):
                 {
                     "type": "mail.record/insert",
                     "payload": {
-                        "Persona": [
-                            {
-                                "id": channel_member.partner_id.id,
-                                "name": channel_member.partner_id.name,
-                                "im_status": channel_member.partner_id.im_status,
-                                "type": "partner",
-                            },
-                        ],
                         "ChannelMember": [
                             {
                                 "id": channel_member.id,
@@ -281,6 +273,14 @@ class TestChannelRTC(MailCommon):
                                     "model": "discuss.channel",
                                 },
                                 "persona": {"id": channel_member.partner_id.id, "type": "partner"},
+                            },
+                        ],
+                        "Persona": [
+                            {
+                                "id": channel_member.partner_id.id,
+                                "name": channel_member.partner_id.name,
+                                "im_status": channel_member.partner_id.im_status,
+                                "type": "partner",
                             },
                         ],
                         "RtcSession": [
@@ -301,14 +301,6 @@ class TestChannelRTC(MailCommon):
                 {
                     "type": "mail.record/insert",
                     "payload": {
-                        "Persona": [
-                            {
-                                "id": channel_member.partner_id.id,
-                                "name": channel_member.partner_id.name,
-                                "im_status": channel_member.partner_id.im_status,
-                                "type": "partner",
-                            },
-                        ],
                         "ChannelMember": [
                             {
                                 "id": channel_member.id,
@@ -317,6 +309,14 @@ class TestChannelRTC(MailCommon):
                                     "model": "discuss.channel",
                                 },
                                 "persona": {"id": channel_member.partner_id.id, "type": "partner"},
+                            },
+                        ],
+                        "Persona": [
+                            {
+                                "id": channel_member.partner_id.id,
+                                "name": channel_member.partner_id.name,
+                                "im_status": channel_member.partner_id.im_status,
+                                "type": "partner",
                             },
                         ],
                         "RtcSession": [
@@ -337,35 +337,6 @@ class TestChannelRTC(MailCommon):
                 {
                     "type": "mail.record/insert",
                     "payload": {
-                        "Thread": [
-                            {
-                                "id": channel.id,
-                                "model": "discuss.channel",
-                                "invitedMembers": [
-                                    (
-                                        "ADD",
-                                        [
-                                            {"id": channel_member_test_user.id},
-                                            {"id": channel_member_test_guest.id},
-                                        ],
-                                    )
-                                ],
-                            },
-                        ],
-                        "Persona": [
-                            {
-                                "id": channel_member_test_user.partner_id.id,
-                                "name": channel_member_test_user.partner_id.name,
-                                "im_status": channel_member_test_user.partner_id.im_status,
-                                "type": "partner",
-                            },
-                            {
-                                "id": channel_member_test_guest.guest_id.id,
-                                "name": channel_member_test_guest.guest_id.name,
-                                "im_status": channel_member_test_guest.guest_id.im_status,
-                                "type": "guest",
-                            },
-                        ],
                         "ChannelMember": [
                             {
                                 "id": channel_member_test_user.id,
@@ -388,6 +359,35 @@ class TestChannelRTC(MailCommon):
                                     "id": channel_member_test_guest.guest_id.id,
                                     "type": "guest",
                                 },
+                            },
+                        ],
+                        "Persona": [
+                            {
+                                "id": channel_member_test_user.partner_id.id,
+                                "name": channel_member_test_user.partner_id.name,
+                                "im_status": channel_member_test_user.partner_id.im_status,
+                                "type": "partner",
+                            },
+                            {
+                                "id": channel_member_test_guest.guest_id.id,
+                                "name": channel_member_test_guest.guest_id.name,
+                                "im_status": channel_member_test_guest.guest_id.im_status,
+                                "type": "guest",
+                            },
+                        ],
+                        "Thread": [
+                            {
+                                "id": channel.id,
+                                "model": "discuss.channel",
+                                "invitedMembers": [
+                                    (
+                                        "ADD",
+                                        [
+                                            {"id": channel_member_test_user.id},
+                                            {"id": channel_member_test_guest.id},
+                                        ],
+                                    )
+                                ],
                             },
                         ],
                     },
@@ -432,6 +432,27 @@ class TestChannelRTC(MailCommon):
                 {
                     "type": "mail.record/insert",
                     "payload": {
+                        "ChannelMember": [
+                            {
+                                "id": channel_member_test_user.id,
+                                "thread": {
+                                    "id": channel_member_test_user.channel_id.id,
+                                    "model": "discuss.channel",
+                                },
+                                "persona": {
+                                    "id": channel_member_test_user.partner_id.id,
+                                    "type": "partner",
+                                },
+                            },
+                        ],
+                        "Persona": [
+                            {
+                                "id": channel_member_test_user.partner_id.id,
+                                "name": channel_member_test_user.partner_id.name,
+                                "im_status": channel_member_test_user.partner_id.im_status,
+                                "type": "partner",
+                            },
+                        ],
                         "Thread": [
                             {
                                 "id": channel.id,
@@ -441,40 +462,11 @@ class TestChannelRTC(MailCommon):
                                 ],
                             },
                         ],
-                        "Persona": [
-                            {
-                                "id": channel_member_test_user.partner_id.id,
-                                "name": channel_member_test_user.partner_id.name,
-                                "im_status": channel_member_test_user.partner_id.im_status,
-                                "type": "partner",
-                            },
-                        ],
-                        "ChannelMember": [
-                            {
-                                "id": channel_member_test_user.id,
-                                "thread": {
-                                    "id": channel_member_test_user.channel_id.id,
-                                    "model": "discuss.channel",
-                                },
-                                "persona": {
-                                    "id": channel_member_test_user.partner_id.id,
-                                    "type": "partner",
-                                },
-                            },
-                        ],
                     },
                 },
                 {
                     "type": "mail.record/insert",
                     "payload": {
-                        "Persona": [
-                            {
-                                "id": channel_member_test_user.partner_id.id,
-                                "name": channel_member_test_user.partner_id.name,
-                                "im_status": channel_member_test_user.partner_id.im_status,
-                                "type": "partner",
-                            },
-                        ],
                         "ChannelMember": [
                             {
                                 "id": channel_member_test_user.id,
@@ -486,6 +478,14 @@ class TestChannelRTC(MailCommon):
                                     "id": channel_member_test_user.partner_id.id,
                                     "type": "partner",
                                 },
+                            },
+                        ],
+                        "Persona": [
+                            {
+                                "id": channel_member_test_user.partner_id.id,
+                                "name": channel_member_test_user.partner_id.name,
+                                "im_status": channel_member_test_user.partner_id.im_status,
+                                "type": "partner",
                             },
                         ],
                         "RtcSession": [
@@ -533,6 +533,27 @@ class TestChannelRTC(MailCommon):
                 {
                     "type": "mail.record/insert",
                     "payload": {
+                        "ChannelMember": [
+                            {
+                                "id": channel_member_test_guest.id,
+                                "thread": {
+                                    "id": channel_member_test_guest.channel_id.id,
+                                    "model": "discuss.channel",
+                                },
+                                "persona": {
+                                    "id": channel_member_test_guest.guest_id.id,
+                                    "type": "guest",
+                                },
+                            },
+                        ],
+                        "Persona": [
+                            {
+                                "id": channel_member_test_guest.guest_id.id,
+                                "name": channel_member_test_guest.guest_id.name,
+                                "im_status": channel_member_test_guest.guest_id.im_status,
+                                "type": "guest",
+                            },
+                        ],
                         "Thread": [
                             {
                                 "id": channel.id,
@@ -542,40 +563,11 @@ class TestChannelRTC(MailCommon):
                                 ],
                             },
                         ],
-                        "Persona": [
-                            {
-                                "id": channel_member_test_guest.guest_id.id,
-                                "name": channel_member_test_guest.guest_id.name,
-                                "im_status": channel_member_test_guest.guest_id.im_status,
-                                "type": "guest",
-                            },
-                        ],
-                        "ChannelMember": [
-                            {
-                                "id": channel_member_test_guest.id,
-                                "thread": {
-                                    "id": channel_member_test_guest.channel_id.id,
-                                    "model": "discuss.channel",
-                                },
-                                "persona": {
-                                    "id": channel_member_test_guest.guest_id.id,
-                                    "type": "guest",
-                                },
-                            },
-                        ],
                     },
                 },
                 {
                     "type": "mail.record/insert",
                     "payload": {
-                        "Persona": [
-                            {
-                                "id": channel_member_test_guest.guest_id.id,
-                                "name": channel_member_test_guest.guest_id.name,
-                                "im_status": channel_member_test_guest.guest_id.im_status,
-                                "type": "guest",
-                            },
-                        ],
                         "ChannelMember": [
                             {
                                 "id": channel_member_test_guest.id,
@@ -587,6 +579,14 @@ class TestChannelRTC(MailCommon):
                                     "id": channel_member_test_guest.guest_id.id,
                                     "type": "guest",
                                 },
+                            },
+                        ],
+                        "Persona": [
+                            {
+                                "id": channel_member_test_guest.guest_id.id,
+                                "name": channel_member_test_guest.guest_id.name,
+                                "im_status": channel_member_test_guest.guest_id.im_status,
+                                "type": "guest",
                             },
                         ],
                         "RtcSession": [
@@ -643,23 +643,6 @@ class TestChannelRTC(MailCommon):
                 {
                     "type": "mail.record/insert",
                     "payload": {
-                        "Thread": [
-                            {
-                                "id": channel.id,
-                                "model": "discuss.channel",
-                                "invitedMembers": [
-                                    ("DELETE", [{"id": channel_member_test_user.id}]),
-                                ],
-                            },
-                        ],
-                        "Persona": [
-                            {
-                                "id": channel_member_test_user.partner_id.id,
-                                "name": channel_member_test_user.partner_id.name,
-                                "im_status": channel_member_test_user.partner_id.im_status,
-                                "type": "partner",
-                            },
-                        ],
                         "ChannelMember": [
                             {
                                 "id": channel_member_test_user.id,
@@ -671,6 +654,23 @@ class TestChannelRTC(MailCommon):
                                     "id": channel_member_test_user.partner_id.id,
                                     "type": "partner",
                                 },
+                            },
+                        ],
+                        "Persona": [
+                            {
+                                "id": channel_member_test_user.partner_id.id,
+                                "name": channel_member_test_user.partner_id.name,
+                                "im_status": channel_member_test_user.partner_id.im_status,
+                                "type": "partner",
+                            },
+                        ],
+                        "Thread": [
+                            {
+                                "id": channel.id,
+                                "model": "discuss.channel",
+                                "invitedMembers": [
+                                    ("DELETE", [{"id": channel_member_test_user.id}]),
+                                ],
                             },
                         ],
                     },
@@ -702,23 +702,6 @@ class TestChannelRTC(MailCommon):
                 {
                     "type": "mail.record/insert",
                     "payload": {
-                        "Thread": [
-                            {
-                                "id": channel.id,
-                                "model": "discuss.channel",
-                                "invitedMembers": [
-                                    ("DELETE", [{"id": channel_member_test_guest.id}]),
-                                ],
-                            },
-                        ],
-                        "Persona": [
-                            {
-                                "id": channel_member_test_guest.guest_id.id,
-                                "name": channel_member_test_guest.guest_id.name,
-                                "im_status": channel_member_test_guest.guest_id.im_status,
-                                "type": "guest",
-                            },
-                        ],
                         "ChannelMember": [
                             {
                                 "id": channel_member_test_guest.id,
@@ -730,6 +713,23 @@ class TestChannelRTC(MailCommon):
                                     "id": channel_member_test_guest.guest_id.id,
                                     "type": "guest",
                                 },
+                            },
+                        ],
+                        "Persona": [
+                            {
+                                "id": channel_member_test_guest.guest_id.id,
+                                "name": channel_member_test_guest.guest_id.name,
+                                "im_status": channel_member_test_guest.guest_id.im_status,
+                                "type": "guest",
+                            },
+                        ],
+                        "Thread": [
+                            {
+                                "id": channel.id,
+                                "model": "discuss.channel",
+                                "invitedMembers": [
+                                    ("DELETE", [{"id": channel_member_test_guest.id}]),
+                                ],
                             },
                         ],
                     },
@@ -793,35 +793,6 @@ class TestChannelRTC(MailCommon):
                 {
                     "type": "mail.record/insert",
                     "payload": {
-                        "Thread": [
-                            {
-                                "id": channel.id,
-                                "model": "discuss.channel",
-                                "invitedMembers": [
-                                    (
-                                        "DELETE",
-                                        [
-                                            {"id": channel_member_test_user.id},
-                                            {"id": channel_member_test_guest.id},
-                                        ],
-                                    )
-                                ],
-                            },
-                        ],
-                        "Persona": [
-                            {
-                                "id": channel_member_test_user.partner_id.id,
-                                "name": channel_member_test_user.partner_id.name,
-                                "im_status": channel_member_test_user.partner_id.im_status,
-                                "type": "partner",
-                            },
-                            {
-                                "id": channel_member_test_guest.guest_id.id,
-                                "name": channel_member_test_guest.guest_id.name,
-                                "im_status": channel_member_test_guest.guest_id.im_status,
-                                "type": "guest",
-                            },
-                        ],
                         "ChannelMember": [
                             {
                                 "id": channel_member_test_user.id,
@@ -844,6 +815,35 @@ class TestChannelRTC(MailCommon):
                                     "id": channel_member_test_guest.guest_id.id,
                                     "type": "guest",
                                 },
+                            },
+                        ],
+                        "Persona": [
+                            {
+                                "id": channel_member_test_user.partner_id.id,
+                                "name": channel_member_test_user.partner_id.name,
+                                "im_status": channel_member_test_user.partner_id.im_status,
+                                "type": "partner",
+                            },
+                            {
+                                "id": channel_member_test_guest.guest_id.id,
+                                "name": channel_member_test_guest.guest_id.name,
+                                "im_status": channel_member_test_guest.guest_id.im_status,
+                                "type": "guest",
+                            },
+                        ],
+                        "Thread": [
+                            {
+                                "id": channel.id,
+                                "model": "discuss.channel",
+                                "invitedMembers": [
+                                    (
+                                        "DELETE",
+                                        [
+                                            {"id": channel_member_test_user.id},
+                                            {"id": channel_member_test_guest.id},
+                                        ],
+                                    )
+                                ],
                             },
                         ],
                     },
@@ -904,21 +904,6 @@ class TestChannelRTC(MailCommon):
                 {
                     "type": "mail.record/insert",
                     "payload": {
-                        "Thread": [
-                            {
-                                "id": channel.id,
-                                "model": "discuss.channel",
-                                "rtcInvitingSession": {"id": channel_member.rtc_session_ids.id},
-                            },
-                        ],
-                        "Persona": [
-                            {
-                                "id": channel_member.partner_id.id,
-                                "name": channel_member.partner_id.name,
-                                "im_status": channel_member.partner_id.im_status,
-                                "type": "partner",
-                            },
-                        ],
                         "ChannelMember": [
                             {
                                 "id": channel_member.id,
@@ -929,24 +914,6 @@ class TestChannelRTC(MailCommon):
                                 "persona": {"id": channel_member.partner_id.id, "type": "partner"},
                             },
                         ],
-                        "RtcSession": [
-                            {
-                                "id": channel_member.rtc_session_ids.id,
-                                "channelMember": {"id": channel_member.id},
-                            },
-                        ],
-                    },
-                },
-                {
-                    "type": "mail.record/insert",
-                    "payload": {
-                        "Thread": [
-                            {
-                                "id": channel.id,
-                                "model": "discuss.channel",
-                                "rtcInvitingSession": {"id": channel_member.rtc_session_ids.id},
-                            },
-                        ],
                         "Persona": [
                             {
                                 "id": channel_member.partner_id.id,
@@ -955,6 +922,24 @@ class TestChannelRTC(MailCommon):
                                 "type": "partner",
                             },
                         ],
+                        "RtcSession": [
+                            {
+                                "id": channel_member.rtc_session_ids.id,
+                                "channelMember": {"id": channel_member.id},
+                            },
+                        ],
+                        "Thread": [
+                            {
+                                "id": channel.id,
+                                "model": "discuss.channel",
+                                "rtcInvitingSession": {"id": channel_member.rtc_session_ids.id},
+                            },
+                        ],
+                    },
+                },
+                {
+                    "type": "mail.record/insert",
+                    "payload": {
                         "ChannelMember": [
                             {
                                 "id": channel_member.id,
@@ -965,10 +950,25 @@ class TestChannelRTC(MailCommon):
                                 "persona": {"id": channel_member.partner_id.id, "type": "partner"},
                             },
                         ],
+                        "Persona": [
+                            {
+                                "id": channel_member.partner_id.id,
+                                "name": channel_member.partner_id.name,
+                                "im_status": channel_member.partner_id.im_status,
+                                "type": "partner",
+                            },
+                        ],
                         "RtcSession": [
                             {
                                 "id": channel_member.rtc_session_ids.id,
                                 "channelMember": {"id": channel_member.id},
+                            },
+                        ],
+                        "Thread": [
+                            {
+                                "id": channel.id,
+                                "model": "discuss.channel",
+                                "rtcInvitingSession": {"id": channel_member.rtc_session_ids.id},
                             },
                         ],
                     },
@@ -976,35 +976,6 @@ class TestChannelRTC(MailCommon):
                 {
                     "type": "mail.record/insert",
                     "payload": {
-                        "Thread": [
-                            {
-                                "id": channel.id,
-                                "model": "discuss.channel",
-                                "invitedMembers": [
-                                    (
-                                        "ADD",
-                                        [
-                                            {"id": channel_member_test_user.id},
-                                            {"id": channel_member_test_guest.id},
-                                        ],
-                                    )
-                                ],
-                            }
-                        ],
-                        "Persona": [
-                            {
-                                "id": channel_member_test_user.partner_id.id,
-                                "name": channel_member_test_user.partner_id.name,
-                                "im_status": channel_member_test_user.partner_id.im_status,
-                                "type": "partner",
-                            },
-                            {
-                                "id": channel_member_test_guest.guest_id.id,
-                                "name": channel_member_test_guest.guest_id.name,
-                                "im_status": channel_member_test_guest.guest_id.im_status,
-                                "type": "guest",
-                            },
-                        ],
                         "ChannelMember": [
                             {
                                 "id": channel_member_test_user.id,
@@ -1028,6 +999,35 @@ class TestChannelRTC(MailCommon):
                                     "type": "guest",
                                 },
                             },
+                        ],
+                        "Persona": [
+                            {
+                                "id": channel_member_test_user.partner_id.id,
+                                "name": channel_member_test_user.partner_id.name,
+                                "im_status": channel_member_test_user.partner_id.im_status,
+                                "type": "partner",
+                            },
+                            {
+                                "id": channel_member_test_guest.guest_id.id,
+                                "name": channel_member_test_guest.guest_id.name,
+                                "im_status": channel_member_test_guest.guest_id.im_status,
+                                "type": "guest",
+                            },
+                        ],
+                        "Thread": [
+                            {
+                                "id": channel.id,
+                                "model": "discuss.channel",
+                                "invitedMembers": [
+                                    (
+                                        "ADD",
+                                        [
+                                            {"id": channel_member_test_user.id},
+                                            {"id": channel_member_test_guest.id},
+                                        ],
+                                    )
+                                ],
+                            }
                         ],
                     },
                 },

--- a/addons/mail/tests/discuss/test_rtc.py
+++ b/addons/mail/tests/discuss/test_rtc.py
@@ -24,8 +24,8 @@ class TestChannelRTC(MailCommon):
         self.env['bus.bus'].sudo().search([]).unlink()
         with self.assertBus(
             [
-                (self.cr.dbname, 'res.partner', self.user_employee.partner_id.id),  # end of previous session
                 (self.cr.dbname, 'discuss.channel', channel.id),  # update sessions
+                (self.cr.dbname, 'res.partner', self.user_employee.partner_id.id),  # end of previous session
                 (self.cr.dbname, 'discuss.channel', channel.id),  # update sessions
             ],
             [
@@ -686,11 +686,11 @@ class TestChannelRTC(MailCommon):
         self.env['bus.bus'].sudo().search([]).unlink()
         with self.assertBus(
             [
-                (self.cr.dbname, 'res.partner', self.user_employee.partner_id.id),  # end session
                 (self.cr.dbname, 'res.partner', test_user.partner_id.id),  # update invitation
                 (self.cr.dbname, 'mail.guest', test_guest.id),  # update invitation
                 (self.cr.dbname, 'discuss.channel', channel.id),  # update list of invitations
                 (self.cr.dbname, 'discuss.channel', channel.id),  # update sessions
+                (self.cr.dbname, 'res.partner', self.user_employee.partner_id.id),  # end session
             ],
             [
                 {
@@ -809,19 +809,19 @@ class TestChannelRTC(MailCommon):
         channel_member_test_guest = channel.sudo().channel_member_ids.filtered(lambda member: member.guest_id == test_guest)
         found_bus_notifs = self.assertBusNotifications(
             [
-                (self.cr.dbname, 'res.partner', test_user.partner_id.id),  # channel joined  -- last_interest (not asserted below)
                 (self.cr.dbname, 'discuss.channel', channel.id),  # message_post -- new_message (not asserted below)
                 (self.cr.dbname, 'res.partner', self.user_employee.partner_id.id),  # update new message separator
                 (self.cr.dbname, 'discuss.channel', channel.id, "members"),  # update of pin state (not asserted below)
                 (self.cr.dbname, 'discuss.channel', channel.id),  # message_post -- last_interest (not asserted below)
                 (self.cr.dbname, 'res.partner', self.user_employee.partner_id.id),  # update new message separator
+                (self.cr.dbname, 'discuss.channel', channel.id, "members"),  # update of pin state (not asserted below)
                 (self.cr.dbname, 'discuss.channel', channel.id),  # new members (not asserted below)
-                (self.cr.dbname, 'res.partner', test_user.partner_id.id),  # incoming invitation
+                (self.cr.dbname, 'res.partner', test_user.partner_id.id),  # channel joined  -- last_interest (not asserted below)
                 (self.cr.dbname, 'mail.guest', test_guest.id),  # incoming invitation
                 (self.cr.dbname, 'discuss.channel', channel.id),  # update list of invitations
-                (self.cr.dbname, 'discuss.channel', channel.id, "members"),  # update of pin state (not asserted below)
-                (self.cr.dbname, 'discuss.channel', channel.id),  # new member (guest) (not asserted below)
+                (self.cr.dbname, 'res.partner', test_user.partner_id.id),  # incoming invitation
                 (self.cr.dbname, 'mail.guest', test_guest.id),  # channel joined for guest (not asserted below)
+                (self.cr.dbname, 'discuss.channel', channel.id),  # new member (guest) (not asserted below)
             ],
             message_items=[
                 {
@@ -951,8 +951,8 @@ class TestChannelRTC(MailCommon):
         self.env['bus.bus'].sudo().search([]).unlink()
         with self.assertBus(
             [
-                (self.cr.dbname, 'res.partner', self.user_employee.partner_id.id),  # end session
                 (self.cr.dbname, 'discuss.channel', channel.id),  # update list of sessions
+                (self.cr.dbname, 'res.partner', self.user_employee.partner_id.id),  # end session
             ],
             [
                 {
@@ -993,8 +993,8 @@ class TestChannelRTC(MailCommon):
         self.env['bus.bus'].sudo().search([]).unlink()
         with self.assertBus(
             [
-                (self.cr.dbname, 'res.partner', self.user_employee.partner_id.id),  # session ended
                 (self.cr.dbname, 'discuss.channel', channel.id),  # update list of sessions
+                (self.cr.dbname, 'res.partner', self.user_employee.partner_id.id),  # session ended
             ],
             [
                 {
@@ -1031,8 +1031,8 @@ class TestChannelRTC(MailCommon):
         self.env['bus.bus'].sudo().search([]).unlink()
         with self.assertBus(
             [
-                (self.cr.dbname, 'res.partner', self.user_employee.partner_id.id),  # session ended
                 (self.cr.dbname, 'discuss.channel', channel.id),  # update list of sessions
+                (self.cr.dbname, 'res.partner', self.user_employee.partner_id.id),  # session ended
             ],
             [
                 {
@@ -1080,8 +1080,8 @@ class TestChannelRTC(MailCommon):
         self.env['bus.bus'].sudo().search([]).unlink()
         with self.assertBus(
             [
-                (self.cr.dbname, 'mail.guest', test_guest.id),  # session ended
                 (self.cr.dbname, 'discuss.channel', channel.id),  # update list of sessions
+                (self.cr.dbname, 'mail.guest', test_guest.id),  # session ended
             ],
             [
                 {

--- a/addons/mail/tests/discuss/test_rtc.py
+++ b/addons/mail/tests/discuss/test_rtc.py
@@ -55,25 +55,25 @@ class TestChannelRTC(MailCommon):
                         "ChannelMember": [
                             {
                                 "id": channel_member.id,
+                                "persona": {"id": channel_member.partner_id.id, "type": "partner"},
                                 "thread": {
                                     "id": channel_member.channel_id.id,
                                     "model": "discuss.channel",
                                 },
-                                "persona": {"id": channel_member.partner_id.id, "type": "partner"},
                             },
                         ],
                         "Persona": [
                             {
                                 "id": channel_member.partner_id.id,
-                                "name": channel_member.partner_id.name,
                                 "im_status": channel_member.partner_id.im_status,
+                                "name": channel_member.partner_id.name,
                                 "type": "partner",
                             },
                         ],
                         "RtcSession": [
                             {
-                                "id": channel_member.rtc_session_ids.id + 1,
                                 "channelMember": {"id": channel_member.id},
+                                "id": channel_member.rtc_session_ids.id + 1,
                             },
                         ],
                         "Thread": [
@@ -98,18 +98,18 @@ class TestChannelRTC(MailCommon):
                 "ChannelMember": [
                     {
                         "id": channel_member.id,
+                        "persona": {"id": channel_member.partner_id.id, "type": "partner"},
                         "thread": {
                             "id": channel_member.channel_id.id,
                             "model": "discuss.channel",
                         },
-                        "persona": {"id": channel_member.partner_id.id, "type": "partner"},
                     },
                 ],
                 "Persona": [
                     {
                         "id": channel_member.partner_id.id,
-                        "name": channel_member.partner_id.name,
                         "im_status": channel_member.partner_id.im_status,
+                        "name": channel_member.partner_id.name,
                         "type": "partner",
                     },
                 ],
@@ -120,8 +120,8 @@ class TestChannelRTC(MailCommon):
                 },
                 "RtcSession": [
                     {
-                        "id": channel_member.rtc_session_ids.id,
                         "channelMember": {"id": channel_member.id},
+                        "id": channel_member.rtc_session_ids.id,
                     },
                 ],
                 "Thread": [
@@ -166,25 +166,25 @@ class TestChannelRTC(MailCommon):
                         "ChannelMember": [
                             {
                                 "id": channel_member.id,
+                                "persona": {"id": channel_member.partner_id.id, "type": "partner"},
                                 "thread": {
                                     "id": channel_member.channel_id.id,
                                     "model": "discuss.channel",
                                 },
-                                "persona": {"id": channel_member.partner_id.id, "type": "partner"},
                             },
                         ],
                         "Persona": [
                             {
                                 "id": channel_member.partner_id.id,
-                                "name": channel_member.partner_id.name,
                                 "im_status": channel_member.partner_id.im_status,
+                                "name": channel_member.partner_id.name,
                                 "type": "partner",
                             },
                         ],
                         "RtcSession": [
                             {
-                                "id": last_rtc_session_id + 1,
                                 "channelMember": {"id": channel_member.id},
+                                "id": last_rtc_session_id + 1,
                             },
                         ],
                         "Thread": [
@@ -202,29 +202,29 @@ class TestChannelRTC(MailCommon):
                         "ChannelMember": [
                             {
                                 "id": channel_member_test_user.id,
-                                "thread": {
-                                    "id": channel_member_test_user.channel_id.id,
-                                    "model": "discuss.channel",
-                                },
                                 "persona": {
                                     "id": channel_member_test_user.partner_id.id,
                                     "type": "partner",
+                                },
+                                "thread": {
+                                    "id": channel_member_test_user.channel_id.id,
+                                    "model": "discuss.channel",
                                 },
                             },
                         ],
                         "Persona": [
                             {
                                 "id": channel_member_test_user.partner_id.id,
-                                "name": channel_member_test_user.partner_id.name,
                                 "im_status": channel_member_test_user.partner_id.im_status,
+                                "name": channel_member_test_user.partner_id.name,
                                 "type": "partner",
                             },
                         ],
                         "Thread": [
                             {
                                 "id": channel.id,
-                                "model": "discuss.channel",
                                 "invitedMembers": [("ADD", [{"id": channel_member_test_user.id}])],
+                                "model": "discuss.channel",
                             }
                         ],
                     },
@@ -268,25 +268,25 @@ class TestChannelRTC(MailCommon):
                         "ChannelMember": [
                             {
                                 "id": channel_member.id,
+                                "persona": {"id": channel_member.partner_id.id, "type": "partner"},
                                 "thread": {
                                     "id": channel_member.channel_id.id,
                                     "model": "discuss.channel",
                                 },
-                                "persona": {"id": channel_member.partner_id.id, "type": "partner"},
                             },
                         ],
                         "Persona": [
                             {
                                 "id": channel_member.partner_id.id,
-                                "name": channel_member.partner_id.name,
                                 "im_status": channel_member.partner_id.im_status,
+                                "name": channel_member.partner_id.name,
                                 "type": "partner",
                             },
                         ],
                         "RtcSession": [
                             {
-                                "id": last_rtc_session_id + 1,
                                 "channelMember": {"id": channel_member.id},
+                                "id": last_rtc_session_id + 1,
                             },
                         ],
                         "Thread": [
@@ -304,25 +304,25 @@ class TestChannelRTC(MailCommon):
                         "ChannelMember": [
                             {
                                 "id": channel_member.id,
+                                "persona": {"id": channel_member.partner_id.id, "type": "partner"},
                                 "thread": {
                                     "id": channel_member.channel_id.id,
                                     "model": "discuss.channel",
                                 },
-                                "persona": {"id": channel_member.partner_id.id, "type": "partner"},
                             },
                         ],
                         "Persona": [
                             {
                                 "id": channel_member.partner_id.id,
-                                "name": channel_member.partner_id.name,
                                 "im_status": channel_member.partner_id.im_status,
+                                "name": channel_member.partner_id.name,
                                 "type": "partner",
                             },
                         ],
                         "RtcSession": [
                             {
-                                "id": last_rtc_session_id + 1,
                                 "channelMember": {"id": channel_member.id},
+                                "id": last_rtc_session_id + 1,
                             },
                         ],
                         "Thread": [
@@ -340,45 +340,44 @@ class TestChannelRTC(MailCommon):
                         "ChannelMember": [
                             {
                                 "id": channel_member_test_user.id,
-                                "thread": {
-                                    "id": channel_member_test_user.channel_id.id,
-                                    "model": "discuss.channel",
-                                },
                                 "persona": {
                                     "id": channel_member_test_user.partner_id.id,
                                     "type": "partner",
                                 },
+                                "thread": {
+                                    "id": channel_member_test_user.channel_id.id,
+                                    "model": "discuss.channel",
+                                },
                             },
                             {
                                 "id": channel_member_test_guest.id,
-                                "thread": {
-                                    "id": channel_member_test_guest.channel_id.id,
-                                    "model": "discuss.channel",
-                                },
                                 "persona": {
                                     "id": channel_member_test_guest.guest_id.id,
                                     "type": "guest",
+                                },
+                                "thread": {
+                                    "id": channel_member_test_guest.channel_id.id,
+                                    "model": "discuss.channel",
                                 },
                             },
                         ],
                         "Persona": [
                             {
                                 "id": channel_member_test_user.partner_id.id,
-                                "name": channel_member_test_user.partner_id.name,
                                 "im_status": channel_member_test_user.partner_id.im_status,
+                                "name": channel_member_test_user.partner_id.name,
                                 "type": "partner",
                             },
                             {
                                 "id": channel_member_test_guest.guest_id.id,
-                                "name": channel_member_test_guest.guest_id.name,
                                 "im_status": channel_member_test_guest.guest_id.im_status,
+                                "name": channel_member_test_guest.guest_id.name,
                                 "type": "guest",
                             },
                         ],
                         "Thread": [
                             {
                                 "id": channel.id,
-                                "model": "discuss.channel",
                                 "invitedMembers": [
                                     (
                                         "ADD",
@@ -388,6 +387,7 @@ class TestChannelRTC(MailCommon):
                                         ],
                                     )
                                 ],
+                                "model": "discuss.channel",
                             },
                         ],
                     },
@@ -435,31 +435,31 @@ class TestChannelRTC(MailCommon):
                         "ChannelMember": [
                             {
                                 "id": channel_member_test_user.id,
-                                "thread": {
-                                    "id": channel_member_test_user.channel_id.id,
-                                    "model": "discuss.channel",
-                                },
                                 "persona": {
                                     "id": channel_member_test_user.partner_id.id,
                                     "type": "partner",
+                                },
+                                "thread": {
+                                    "id": channel_member_test_user.channel_id.id,
+                                    "model": "discuss.channel",
                                 },
                             },
                         ],
                         "Persona": [
                             {
                                 "id": channel_member_test_user.partner_id.id,
-                                "name": channel_member_test_user.partner_id.name,
                                 "im_status": channel_member_test_user.partner_id.im_status,
+                                "name": channel_member_test_user.partner_id.name,
                                 "type": "partner",
                             },
                         ],
                         "Thread": [
                             {
                                 "id": channel.id,
-                                "model": "discuss.channel",
                                 "invitedMembers": [
                                     ("DELETE", [{"id": channel_member_test_user.id}]),
                                 ],
+                                "model": "discuss.channel",
                             },
                         ],
                     },
@@ -470,28 +470,28 @@ class TestChannelRTC(MailCommon):
                         "ChannelMember": [
                             {
                                 "id": channel_member_test_user.id,
-                                "thread": {
-                                    "id": channel_member_test_user.channel_id.id,
-                                    "model": "discuss.channel",
-                                },
                                 "persona": {
                                     "id": channel_member_test_user.partner_id.id,
                                     "type": "partner",
+                                },
+                                "thread": {
+                                    "id": channel_member_test_user.channel_id.id,
+                                    "model": "discuss.channel",
                                 },
                             },
                         ],
                         "Persona": [
                             {
                                 "id": channel_member_test_user.partner_id.id,
-                                "name": channel_member_test_user.partner_id.name,
                                 "im_status": channel_member_test_user.partner_id.im_status,
+                                "name": channel_member_test_user.partner_id.name,
                                 "type": "partner",
                             },
                         ],
                         "RtcSession": [
                             {
-                                "id": channel_member.rtc_session_ids.id + 1,
                                 "channelMember": {"id": channel_member_test_user.id},
+                                "id": channel_member.rtc_session_ids.id + 1,
                             },
                         ],
                         "Thread": [
@@ -536,31 +536,31 @@ class TestChannelRTC(MailCommon):
                         "ChannelMember": [
                             {
                                 "id": channel_member_test_guest.id,
-                                "thread": {
-                                    "id": channel_member_test_guest.channel_id.id,
-                                    "model": "discuss.channel",
-                                },
                                 "persona": {
                                     "id": channel_member_test_guest.guest_id.id,
                                     "type": "guest",
+                                },
+                                "thread": {
+                                    "id": channel_member_test_guest.channel_id.id,
+                                    "model": "discuss.channel",
                                 },
                             },
                         ],
                         "Persona": [
                             {
                                 "id": channel_member_test_guest.guest_id.id,
-                                "name": channel_member_test_guest.guest_id.name,
                                 "im_status": channel_member_test_guest.guest_id.im_status,
+                                "name": channel_member_test_guest.guest_id.name,
                                 "type": "guest",
                             },
                         ],
                         "Thread": [
                             {
                                 "id": channel.id,
-                                "model": "discuss.channel",
                                 "invitedMembers": [
                                     ("DELETE", [{"id": channel_member_test_guest.id}]),
                                 ],
+                                "model": "discuss.channel",
                             },
                         ],
                     },
@@ -571,28 +571,28 @@ class TestChannelRTC(MailCommon):
                         "ChannelMember": [
                             {
                                 "id": channel_member_test_guest.id,
-                                "thread": {
-                                    "id": channel_member_test_guest.channel_id.id,
-                                    "model": "discuss.channel",
-                                },
                                 "persona": {
                                     "id": channel_member_test_guest.guest_id.id,
                                     "type": "guest",
+                                },
+                                "thread": {
+                                    "id": channel_member_test_guest.channel_id.id,
+                                    "model": "discuss.channel",
                                 },
                             },
                         ],
                         "Persona": [
                             {
                                 "id": channel_member_test_guest.guest_id.id,
-                                "name": channel_member_test_guest.guest_id.name,
                                 "im_status": channel_member_test_guest.guest_id.im_status,
+                                "name": channel_member_test_guest.guest_id.name,
                                 "type": "guest",
                             },
                         ],
                         "RtcSession": [
                             {
-                                "id": channel_member.rtc_session_ids.id + 2,
                                 "channelMember": {"id": channel_member_test_guest.id},
+                                "id": channel_member.rtc_session_ids.id + 2,
                             },
                         ],
                         "Thread": [
@@ -646,31 +646,31 @@ class TestChannelRTC(MailCommon):
                         "ChannelMember": [
                             {
                                 "id": channel_member_test_user.id,
-                                "thread": {
-                                    "id": channel_member_test_user.channel_id.id,
-                                    "model": "discuss.channel",
-                                },
                                 "persona": {
                                     "id": channel_member_test_user.partner_id.id,
                                     "type": "partner",
+                                },
+                                "thread": {
+                                    "id": channel_member_test_user.channel_id.id,
+                                    "model": "discuss.channel",
                                 },
                             },
                         ],
                         "Persona": [
                             {
                                 "id": channel_member_test_user.partner_id.id,
-                                "name": channel_member_test_user.partner_id.name,
                                 "im_status": channel_member_test_user.partner_id.im_status,
+                                "name": channel_member_test_user.partner_id.name,
                                 "type": "partner",
                             },
                         ],
                         "Thread": [
                             {
                                 "id": channel.id,
-                                "model": "discuss.channel",
                                 "invitedMembers": [
                                     ("DELETE", [{"id": channel_member_test_user.id}]),
                                 ],
+                                "model": "discuss.channel",
                             },
                         ],
                     },
@@ -705,31 +705,31 @@ class TestChannelRTC(MailCommon):
                         "ChannelMember": [
                             {
                                 "id": channel_member_test_guest.id,
-                                "thread": {
-                                    "id": channel_member_test_guest.channel_id.id,
-                                    "model": "discuss.channel",
-                                },
                                 "persona": {
                                     "id": channel_member_test_guest.guest_id.id,
                                     "type": "guest",
+                                },
+                                "thread": {
+                                    "id": channel_member_test_guest.channel_id.id,
+                                    "model": "discuss.channel",
                                 },
                             },
                         ],
                         "Persona": [
                             {
                                 "id": channel_member_test_guest.guest_id.id,
-                                "name": channel_member_test_guest.guest_id.name,
                                 "im_status": channel_member_test_guest.guest_id.im_status,
+                                "name": channel_member_test_guest.guest_id.name,
                                 "type": "guest",
                             },
                         ],
                         "Thread": [
                             {
                                 "id": channel.id,
-                                "model": "discuss.channel",
                                 "invitedMembers": [
                                     ("DELETE", [{"id": channel_member_test_guest.id}]),
                                 ],
+                                "model": "discuss.channel",
                             },
                         ],
                     },
@@ -796,45 +796,44 @@ class TestChannelRTC(MailCommon):
                         "ChannelMember": [
                             {
                                 "id": channel_member_test_user.id,
-                                "thread": {
-                                    "id": channel_member_test_user.channel_id.id,
-                                    "model": "discuss.channel",
-                                },
                                 "persona": {
                                     "id": channel_member_test_user.partner_id.id,
                                     "type": "partner",
                                 },
+                                "thread": {
+                                    "id": channel_member_test_user.channel_id.id,
+                                    "model": "discuss.channel",
+                                },
                             },
                             {
                                 "id": channel_member_test_guest.id,
-                                "thread": {
-                                    "id": channel_member_test_guest.channel_id.id,
-                                    "model": "discuss.channel",
-                                },
                                 "persona": {
                                     "id": channel_member_test_guest.guest_id.id,
                                     "type": "guest",
+                                },
+                                "thread": {
+                                    "id": channel_member_test_guest.channel_id.id,
+                                    "model": "discuss.channel",
                                 },
                             },
                         ],
                         "Persona": [
                             {
                                 "id": channel_member_test_user.partner_id.id,
-                                "name": channel_member_test_user.partner_id.name,
                                 "im_status": channel_member_test_user.partner_id.im_status,
+                                "name": channel_member_test_user.partner_id.name,
                                 "type": "partner",
                             },
                             {
                                 "id": channel_member_test_guest.guest_id.id,
-                                "name": channel_member_test_guest.guest_id.name,
                                 "im_status": channel_member_test_guest.guest_id.im_status,
+                                "name": channel_member_test_guest.guest_id.name,
                                 "type": "guest",
                             },
                         ],
                         "Thread": [
                             {
                                 "id": channel.id,
-                                "model": "discuss.channel",
                                 "invitedMembers": [
                                     (
                                         "DELETE",
@@ -844,6 +843,7 @@ class TestChannelRTC(MailCommon):
                                         ],
                                     )
                                 ],
+                                "model": "discuss.channel",
                             },
                         ],
                     },
@@ -907,25 +907,25 @@ class TestChannelRTC(MailCommon):
                         "ChannelMember": [
                             {
                                 "id": channel_member.id,
+                                "persona": {"id": channel_member.partner_id.id, "type": "partner"},
                                 "thread": {
                                     "id": channel_member.channel_id.id,
                                     "model": "discuss.channel",
                                 },
-                                "persona": {"id": channel_member.partner_id.id, "type": "partner"},
                             },
                         ],
                         "Persona": [
                             {
                                 "id": channel_member.partner_id.id,
-                                "name": channel_member.partner_id.name,
                                 "im_status": channel_member.partner_id.im_status,
+                                "name": channel_member.partner_id.name,
                                 "type": "partner",
                             },
                         ],
                         "RtcSession": [
                             {
-                                "id": channel_member.rtc_session_ids.id,
                                 "channelMember": {"id": channel_member.id},
+                                "id": channel_member.rtc_session_ids.id,
                             },
                         ],
                         "Thread": [
@@ -943,25 +943,25 @@ class TestChannelRTC(MailCommon):
                         "ChannelMember": [
                             {
                                 "id": channel_member.id,
+                                "persona": {"id": channel_member.partner_id.id, "type": "partner"},
                                 "thread": {
                                     "id": channel_member.channel_id.id,
                                     "model": "discuss.channel",
                                 },
-                                "persona": {"id": channel_member.partner_id.id, "type": "partner"},
                             },
                         ],
                         "Persona": [
                             {
                                 "id": channel_member.partner_id.id,
-                                "name": channel_member.partner_id.name,
                                 "im_status": channel_member.partner_id.im_status,
+                                "name": channel_member.partner_id.name,
                                 "type": "partner",
                             },
                         ],
                         "RtcSession": [
                             {
-                                "id": channel_member.rtc_session_ids.id,
                                 "channelMember": {"id": channel_member.id},
+                                "id": channel_member.rtc_session_ids.id,
                             },
                         ],
                         "Thread": [
@@ -979,45 +979,44 @@ class TestChannelRTC(MailCommon):
                         "ChannelMember": [
                             {
                                 "id": channel_member_test_user.id,
-                                "thread": {
-                                    "id": channel_member_test_user.channel_id.id,
-                                    "model": "discuss.channel",
-                                },
                                 "persona": {
                                     "id": channel_member_test_user.partner_id.id,
                                     "type": "partner",
                                 },
+                                "thread": {
+                                    "id": channel_member_test_user.channel_id.id,
+                                    "model": "discuss.channel",
+                                },
                             },
                             {
                                 "id": channel_member_test_guest.id,
-                                "thread": {
-                                    "id": channel_member_test_guest.channel_id.id,
-                                    "model": "discuss.channel",
-                                },
                                 "persona": {
                                     "id": channel_member_test_guest.guest_id.id,
                                     "type": "guest",
+                                },
+                                "thread": {
+                                    "id": channel_member_test_guest.channel_id.id,
+                                    "model": "discuss.channel",
                                 },
                             },
                         ],
                         "Persona": [
                             {
                                 "id": channel_member_test_user.partner_id.id,
-                                "name": channel_member_test_user.partner_id.name,
                                 "im_status": channel_member_test_user.partner_id.im_status,
+                                "name": channel_member_test_user.partner_id.name,
                                 "type": "partner",
                             },
                             {
                                 "id": channel_member_test_guest.guest_id.id,
-                                "name": channel_member_test_guest.guest_id.name,
                                 "im_status": channel_member_test_guest.guest_id.im_status,
+                                "name": channel_member_test_guest.guest_id.name,
                                 "type": "guest",
                             },
                         ],
                         "Thread": [
                             {
                                 "id": channel.id,
-                                "model": "discuss.channel",
                                 "invitedMembers": [
                                     (
                                         "ADD",
@@ -1027,6 +1026,7 @@ class TestChannelRTC(MailCommon):
                                         ],
                                     )
                                 ],
+                                "model": "discuss.channel",
                             }
                         ],
                     },

--- a/addons/mail/tests/discuss/test_rtc.py
+++ b/addons/mail/tests/discuss/test_rtc.py
@@ -52,6 +52,14 @@ class TestChannelRTC(MailCommon):
                 {
                     "type": "mail.record/insert",
                     "payload": {
+                        "Persona": [
+                            {
+                                "id": channel_member.partner_id.id,
+                                "name": channel_member.partner_id.name,
+                                "im_status": channel_member.partner_id.im_status,
+                                "type": "partner",
+                            },
+                        ],
                         "ChannelMember": [
                             {
                                 "id": channel_member.id,
@@ -59,12 +67,7 @@ class TestChannelRTC(MailCommon):
                                     "id": channel_member.channel_id.id,
                                     "model": "discuss.channel",
                                 },
-                                "persona": {
-                                    "id": channel_member.partner_id.id,
-                                    "name": channel_member.partner_id.name,
-                                    "im_status": channel_member.partner_id.im_status,
-                                    "type": "partner",
-                                },
+                                "persona": {"id": channel_member.partner_id.id, "type": "partner"},
                             },
                         ],
                         "RtcSession": [
@@ -92,6 +95,14 @@ class TestChannelRTC(MailCommon):
         self.assertEqual(
             res,
             {
+                "Persona": [
+                    {
+                        "id": channel_member.partner_id.id,
+                        "name": channel_member.partner_id.name,
+                        "im_status": channel_member.partner_id.im_status,
+                        "type": "partner",
+                    },
+                ],
                 "ChannelMember": [
                     {
                         "id": channel_member.id,
@@ -99,12 +110,7 @@ class TestChannelRTC(MailCommon):
                             "id": channel_member.channel_id.id,
                             "model": "discuss.channel",
                         },
-                        "persona": {
-                            "id": channel_member.partner_id.id,
-                            "name": channel_member.partner_id.name,
-                            "im_status": channel_member.partner_id.im_status,
-                            "type": "partner",
-                        },
+                        "persona": {"id": channel_member.partner_id.id, "type": "partner"},
                     },
                 ],
                 "Rtc": {
@@ -157,6 +163,14 @@ class TestChannelRTC(MailCommon):
                 {
                     "type": "mail.record/insert",
                     "payload": {
+                        "Persona": [
+                            {
+                                "id": channel_member.partner_id.id,
+                                "name": channel_member.partner_id.name,
+                                "im_status": channel_member.partner_id.im_status,
+                                "type": "partner",
+                            },
+                        ],
                         "ChannelMember": [
                             {
                                 "id": channel_member.id,
@@ -164,12 +178,7 @@ class TestChannelRTC(MailCommon):
                                     "id": channel_member.channel_id.id,
                                     "model": "discuss.channel",
                                 },
-                                "persona": {
-                                    "id": channel_member.partner_id.id,
-                                    "name": channel_member.partner_id.name,
-                                    "im_status": channel_member.partner_id.im_status,
-                                    "type": "partner",
-                                },
+                                "persona": {"id": channel_member.partner_id.id, "type": "partner"},
                             },
                         ],
                         "RtcSession": [
@@ -197,6 +206,14 @@ class TestChannelRTC(MailCommon):
                                 "invitedMembers": [("ADD", [{"id": channel_member_test_user.id}])],
                             }
                         ],
+                        "Persona": [
+                            {
+                                "id": channel_member_test_user.partner_id.id,
+                                "name": channel_member_test_user.partner_id.name,
+                                "im_status": channel_member_test_user.partner_id.im_status,
+                                "type": "partner",
+                            },
+                        ],
                         "ChannelMember": [
                             {
                                 "id": channel_member_test_user.id,
@@ -206,8 +223,6 @@ class TestChannelRTC(MailCommon):
                                 },
                                 "persona": {
                                     "id": channel_member_test_user.partner_id.id,
-                                    "name": channel_member_test_user.partner_id.name,
-                                    "im_status": channel_member_test_user.partner_id.im_status,
                                     "type": "partner",
                                 },
                             },
@@ -250,6 +265,14 @@ class TestChannelRTC(MailCommon):
                 {
                     "type": "mail.record/insert",
                     "payload": {
+                        "Persona": [
+                            {
+                                "id": channel_member.partner_id.id,
+                                "name": channel_member.partner_id.name,
+                                "im_status": channel_member.partner_id.im_status,
+                                "type": "partner",
+                            },
+                        ],
                         "ChannelMember": [
                             {
                                 "id": channel_member.id,
@@ -257,12 +280,7 @@ class TestChannelRTC(MailCommon):
                                     "id": channel_member.channel_id.id,
                                     "model": "discuss.channel",
                                 },
-                                "persona": {
-                                    "id": channel_member.partner_id.id,
-                                    "name": channel_member.partner_id.name,
-                                    "im_status": channel_member.partner_id.im_status,
-                                    "type": "partner",
-                                },
+                                "persona": {"id": channel_member.partner_id.id, "type": "partner"},
                             },
                         ],
                         "RtcSession": [
@@ -283,6 +301,14 @@ class TestChannelRTC(MailCommon):
                 {
                     "type": "mail.record/insert",
                     "payload": {
+                        "Persona": [
+                            {
+                                "id": channel_member.partner_id.id,
+                                "name": channel_member.partner_id.name,
+                                "im_status": channel_member.partner_id.im_status,
+                                "type": "partner",
+                            },
+                        ],
                         "ChannelMember": [
                             {
                                 "id": channel_member.id,
@@ -290,12 +316,7 @@ class TestChannelRTC(MailCommon):
                                     "id": channel_member.channel_id.id,
                                     "model": "discuss.channel",
                                 },
-                                "persona": {
-                                    "id": channel_member.partner_id.id,
-                                    "name": channel_member.partner_id.name,
-                                    "im_status": channel_member.partner_id.im_status,
-                                    "type": "partner",
-                                },
+                                "persona": {"id": channel_member.partner_id.id, "type": "partner"},
                             },
                         ],
                         "RtcSession": [
@@ -329,7 +350,21 @@ class TestChannelRTC(MailCommon):
                                         ],
                                     )
                                 ],
-                            }
+                            },
+                        ],
+                        "Persona": [
+                            {
+                                "id": channel_member_test_user.partner_id.id,
+                                "name": channel_member_test_user.partner_id.name,
+                                "im_status": channel_member_test_user.partner_id.im_status,
+                                "type": "partner",
+                            },
+                            {
+                                "id": channel_member_test_guest.guest_id.id,
+                                "name": channel_member_test_guest.guest_id.name,
+                                "im_status": channel_member_test_guest.guest_id.im_status,
+                                "type": "guest",
+                            },
                         ],
                         "ChannelMember": [
                             {
@@ -340,8 +375,6 @@ class TestChannelRTC(MailCommon):
                                 },
                                 "persona": {
                                     "id": channel_member_test_user.partner_id.id,
-                                    "name": channel_member_test_user.partner_id.name,
-                                    "im_status": channel_member_test_user.partner_id.im_status,
                                     "type": "partner",
                                 },
                             },
@@ -353,8 +386,6 @@ class TestChannelRTC(MailCommon):
                                 },
                                 "persona": {
                                     "id": channel_member_test_guest.guest_id.id,
-                                    "name": channel_member_test_guest.guest_id.name,
-                                    "im_status": channel_member_test_guest.guest_id.im_status,
                                     "type": "guest",
                                 },
                             },
@@ -410,6 +441,14 @@ class TestChannelRTC(MailCommon):
                                 ],
                             },
                         ],
+                        "Persona": [
+                            {
+                                "id": channel_member_test_user.partner_id.id,
+                                "name": channel_member_test_user.partner_id.name,
+                                "im_status": channel_member_test_user.partner_id.im_status,
+                                "type": "partner",
+                            },
+                        ],
                         "ChannelMember": [
                             {
                                 "id": channel_member_test_user.id,
@@ -419,8 +458,6 @@ class TestChannelRTC(MailCommon):
                                 },
                                 "persona": {
                                     "id": channel_member_test_user.partner_id.id,
-                                    "name": channel_member_test_user.partner_id.name,
-                                    "im_status": channel_member_test_user.partner_id.im_status,
                                     "type": "partner",
                                 },
                             },
@@ -430,6 +467,14 @@ class TestChannelRTC(MailCommon):
                 {
                     "type": "mail.record/insert",
                     "payload": {
+                        "Persona": [
+                            {
+                                "id": channel_member_test_user.partner_id.id,
+                                "name": channel_member_test_user.partner_id.name,
+                                "im_status": channel_member_test_user.partner_id.im_status,
+                                "type": "partner",
+                            },
+                        ],
                         "ChannelMember": [
                             {
                                 "id": channel_member_test_user.id,
@@ -439,8 +484,6 @@ class TestChannelRTC(MailCommon):
                                 },
                                 "persona": {
                                     "id": channel_member_test_user.partner_id.id,
-                                    "name": channel_member_test_user.partner_id.name,
-                                    "im_status": channel_member_test_user.partner_id.im_status,
                                     "type": "partner",
                                 },
                             },
@@ -499,6 +542,14 @@ class TestChannelRTC(MailCommon):
                                 ],
                             },
                         ],
+                        "Persona": [
+                            {
+                                "id": channel_member_test_guest.guest_id.id,
+                                "name": channel_member_test_guest.guest_id.name,
+                                "im_status": channel_member_test_guest.guest_id.im_status,
+                                "type": "guest",
+                            },
+                        ],
                         "ChannelMember": [
                             {
                                 "id": channel_member_test_guest.id,
@@ -508,8 +559,6 @@ class TestChannelRTC(MailCommon):
                                 },
                                 "persona": {
                                     "id": channel_member_test_guest.guest_id.id,
-                                    "name": channel_member_test_guest.guest_id.name,
-                                    "im_status": channel_member_test_guest.guest_id.im_status,
                                     "type": "guest",
                                 },
                             },
@@ -519,6 +568,14 @@ class TestChannelRTC(MailCommon):
                 {
                     "type": "mail.record/insert",
                     "payload": {
+                        "Persona": [
+                            {
+                                "id": channel_member_test_guest.guest_id.id,
+                                "name": channel_member_test_guest.guest_id.name,
+                                "im_status": channel_member_test_guest.guest_id.im_status,
+                                "type": "guest",
+                            },
+                        ],
                         "ChannelMember": [
                             {
                                 "id": channel_member_test_guest.id,
@@ -528,8 +585,6 @@ class TestChannelRTC(MailCommon):
                                 },
                                 "persona": {
                                     "id": channel_member_test_guest.guest_id.id,
-                                    "name": channel_member_test_guest.guest_id.name,
-                                    "im_status": channel_member_test_guest.guest_id.im_status,
                                     "type": "guest",
                                 },
                             },
@@ -597,6 +652,14 @@ class TestChannelRTC(MailCommon):
                                 ],
                             },
                         ],
+                        "Persona": [
+                            {
+                                "id": channel_member_test_user.partner_id.id,
+                                "name": channel_member_test_user.partner_id.name,
+                                "im_status": channel_member_test_user.partner_id.im_status,
+                                "type": "partner",
+                            },
+                        ],
                         "ChannelMember": [
                             {
                                 "id": channel_member_test_user.id,
@@ -606,8 +669,6 @@ class TestChannelRTC(MailCommon):
                                 },
                                 "persona": {
                                     "id": channel_member_test_user.partner_id.id,
-                                    "name": channel_member_test_user.partner_id.name,
-                                    "im_status": channel_member_test_user.partner_id.im_status,
                                     "type": "partner",
                                 },
                             },
@@ -650,6 +711,14 @@ class TestChannelRTC(MailCommon):
                                 ],
                             },
                         ],
+                        "Persona": [
+                            {
+                                "id": channel_member_test_guest.guest_id.id,
+                                "name": channel_member_test_guest.guest_id.name,
+                                "im_status": channel_member_test_guest.guest_id.im_status,
+                                "type": "guest",
+                            },
+                        ],
                         "ChannelMember": [
                             {
                                 "id": channel_member_test_guest.id,
@@ -659,8 +728,6 @@ class TestChannelRTC(MailCommon):
                                 },
                                 "persona": {
                                     "id": channel_member_test_guest.guest_id.id,
-                                    "name": channel_member_test_guest.guest_id.name,
-                                    "im_status": channel_member_test_guest.guest_id.im_status,
                                     "type": "guest",
                                 },
                             },
@@ -741,6 +808,20 @@ class TestChannelRTC(MailCommon):
                                 ],
                             },
                         ],
+                        "Persona": [
+                            {
+                                "id": channel_member_test_user.partner_id.id,
+                                "name": channel_member_test_user.partner_id.name,
+                                "im_status": channel_member_test_user.partner_id.im_status,
+                                "type": "partner",
+                            },
+                            {
+                                "id": channel_member_test_guest.guest_id.id,
+                                "name": channel_member_test_guest.guest_id.name,
+                                "im_status": channel_member_test_guest.guest_id.im_status,
+                                "type": "guest",
+                            },
+                        ],
                         "ChannelMember": [
                             {
                                 "id": channel_member_test_user.id,
@@ -750,8 +831,6 @@ class TestChannelRTC(MailCommon):
                                 },
                                 "persona": {
                                     "id": channel_member_test_user.partner_id.id,
-                                    "name": channel_member_test_user.partner_id.name,
-                                    "im_status": channel_member_test_user.partner_id.im_status,
                                     "type": "partner",
                                 },
                             },
@@ -763,8 +842,6 @@ class TestChannelRTC(MailCommon):
                                 },
                                 "persona": {
                                     "id": channel_member_test_guest.guest_id.id,
-                                    "name": channel_member_test_guest.guest_id.name,
-                                    "im_status": channel_member_test_guest.guest_id.im_status,
                                     "type": "guest",
                                 },
                             },
@@ -834,6 +911,14 @@ class TestChannelRTC(MailCommon):
                                 "rtcInvitingSession": {"id": channel_member.rtc_session_ids.id},
                             },
                         ],
+                        "Persona": [
+                            {
+                                "id": channel_member.partner_id.id,
+                                "name": channel_member.partner_id.name,
+                                "im_status": channel_member.partner_id.im_status,
+                                "type": "partner",
+                            },
+                        ],
                         "ChannelMember": [
                             {
                                 "id": channel_member.id,
@@ -841,12 +926,7 @@ class TestChannelRTC(MailCommon):
                                     "id": channel_member.channel_id.id,
                                     "model": "discuss.channel",
                                 },
-                                "persona": {
-                                    "id": channel_member.partner_id.id,
-                                    "name": channel_member.partner_id.name,
-                                    "im_status": channel_member.partner_id.im_status,
-                                    "type": "partner",
-                                },
+                                "persona": {"id": channel_member.partner_id.id, "type": "partner"},
                             },
                         ],
                         "RtcSession": [
@@ -867,6 +947,14 @@ class TestChannelRTC(MailCommon):
                                 "rtcInvitingSession": {"id": channel_member.rtc_session_ids.id},
                             },
                         ],
+                        "Persona": [
+                            {
+                                "id": channel_member.partner_id.id,
+                                "name": channel_member.partner_id.name,
+                                "im_status": channel_member.partner_id.im_status,
+                                "type": "partner",
+                            },
+                        ],
                         "ChannelMember": [
                             {
                                 "id": channel_member.id,
@@ -874,12 +962,7 @@ class TestChannelRTC(MailCommon):
                                     "id": channel_member.channel_id.id,
                                     "model": "discuss.channel",
                                 },
-                                "persona": {
-                                    "id": channel_member.partner_id.id,
-                                    "name": channel_member.partner_id.name,
-                                    "im_status": channel_member.partner_id.im_status,
-                                    "type": "partner",
-                                },
+                                "persona": {"id": channel_member.partner_id.id, "type": "partner"},
                             },
                         ],
                         "RtcSession": [
@@ -908,6 +991,20 @@ class TestChannelRTC(MailCommon):
                                 ],
                             }
                         ],
+                        "Persona": [
+                            {
+                                "id": channel_member_test_user.partner_id.id,
+                                "name": channel_member_test_user.partner_id.name,
+                                "im_status": channel_member_test_user.partner_id.im_status,
+                                "type": "partner",
+                            },
+                            {
+                                "id": channel_member_test_guest.guest_id.id,
+                                "name": channel_member_test_guest.guest_id.name,
+                                "im_status": channel_member_test_guest.guest_id.im_status,
+                                "type": "guest",
+                            },
+                        ],
                         "ChannelMember": [
                             {
                                 "id": channel_member_test_user.id,
@@ -917,8 +1014,6 @@ class TestChannelRTC(MailCommon):
                                 },
                                 "persona": {
                                     "id": channel_member_test_user.partner_id.id,
-                                    "name": channel_member_test_user.partner_id.name,
-                                    "im_status": channel_member_test_user.partner_id.im_status,
                                     "type": "partner",
                                 },
                             },
@@ -930,8 +1025,6 @@ class TestChannelRTC(MailCommon):
                                 },
                                 "persona": {
                                     "id": channel_member_test_guest.guest_id.id,
-                                    "name": channel_member_test_guest.guest_id.name,
-                                    "im_status": channel_member_test_guest.guest_id.im_status,
                                     "type": "guest",
                                 },
                             },

--- a/addons/mail/tests/test_res_partner.py
+++ b/addons/mail/tests/test_res_partner.py
@@ -121,7 +121,7 @@ class TestPartner(MailCommon):
         for i in range(0, 2):
             mail_new_test_user(self.env, login=f'{name}-{i}-portal-user', groups='base.group_portal')
             mail_new_test_user(self.env, login=f'{name}-{i}-internal-user', groups='base.group_user')
-        partners_format = self.env['res.partner'].get_mention_suggestions(name, limit=5)
+        partners_format = self.env['res.partner'].get_mention_suggestions(name, limit=5)["Persona"]
         self.assertEqual(len(partners_format), 5, "should have found limit (5) partners")
         # return format for user is either a dict (there is a user and the dict is data) or a list of command (clear)
         self.assertEqual(list(map(lambda p: p['isInternalUser'], partners_format)), [True, True, False, False, False], "should return internal users in priority")

--- a/addons/mail/tools/discuss.py
+++ b/addons/mail/tools/discuss.py
@@ -110,7 +110,7 @@ class Store:
     def get_result(self):
         """Gets resulting data built from adding all data together."""
         res = {}
-        for model_name, records in self.data.items():
+        for model_name, records in sorted(self.data.items()):
             if not ids_by_model[model_name]:  # singleton
                 res[model_name] = records
             else:

--- a/addons/mail/tools/discuss.py
+++ b/addons/mail/tools/discuss.py
@@ -112,7 +112,7 @@ class Store:
         res = {}
         for model_name, records in sorted(self.data.items()):
             if not ids_by_model[model_name]:  # singleton
-                res[model_name] = records
+                res[model_name] = dict(sorted(records.items()))
             else:
-                res[model_name] = list(records.values())
+                res[model_name] = [dict(sorted(record.items())) for record in records.values()]
         return res

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -231,16 +231,19 @@ class TestDiscussFullPerformance(HttpCase):
         # sudo: bus.bus: reading non-sensitive last id
         bus_last_id = self.env["bus.bus"].sudo()._bus_last_id()
         return {
-            "Persona": [
-                self._expected_result_for_persona(self.users[2], only_inviting=True),
-                self._expected_result_for_persona(self.users[0]),
-                self._expected_result_for_persona(self.users[14]),
-            ],
             "ChannelMember": [
                 self._expected_result_for_channel_member(self.channel_channel_group_1, self.users[2].partner_id),
                 self._expected_result_for_channel_member(self.channel_channel_group_1, self.users[0].partner_id),
                 self._expected_result_for_channel_member(self.channel_chat_1, self.users[0].partner_id),
                 self._expected_result_for_channel_member(self.channel_chat_1, self.users[14].partner_id),
+            ],
+            "Persona": [
+                self._expected_result_for_persona(self.users[2], only_inviting=True),
+                self._expected_result_for_persona(self.users[0]),
+                self._expected_result_for_persona(self.users[14]),
+            ],
+            "RtcSession": [
+                self._expected_result_for_rtc_session(self.channel_channel_group_1, self.users[2]),
             ],
             "Store": {
                 "discuss": {
@@ -261,9 +264,6 @@ class TestDiscussFullPerformance(HttpCase):
                 "initChannelsUnreadCounter": 1,
                 "odoobotOnboarding": False,
             },
-            "RtcSession": [
-                self._expected_result_for_rtc_session(self.channel_channel_group_1, self.users[2]),
-            ],
             "Thread": [
                 self._expected_result_for_channel(self.channel_channel_group_1),
                 self._expected_result_for_channel(self.channel_chat_1),
@@ -289,16 +289,6 @@ class TestDiscussFullPerformance(HttpCase):
         The point of having a separate getter is to allow it to be overriden.
         """
         return {
-            "Persona": [
-                self._expected_result_for_persona(self.users[2]),
-                self._expected_result_for_persona(self.users[0], also_livechat=True),
-                self._expected_result_for_persona(self.users[12]),
-                self._expected_result_for_persona(self.users[14]),
-                self._expected_result_for_persona(self.users[15]),
-                self._expected_result_for_persona(self.users[3]),
-                self._expected_result_for_persona(self.users[1]),
-                self._expected_result_for_persona(guest=True),
-            ],
             "ChannelMember": [
                 self._expected_result_for_channel_member(self.channel_channel_group_1, self.users[2].partner_id),
                 self._expected_result_for_channel_member(self.channel_general, self.users[0].partner_id),
@@ -328,6 +318,16 @@ class TestDiscussFullPerformance(HttpCase):
                 self._expected_result_for_message(self.channel_channel_group_2),
                 self._expected_result_for_message(self.channel_livechat_1),
                 self._expected_result_for_message(self.channel_livechat_2),
+            ],
+            "Persona": [
+                self._expected_result_for_persona(self.users[2]),
+                self._expected_result_for_persona(self.users[0], also_livechat=True),
+                self._expected_result_for_persona(self.users[12]),
+                self._expected_result_for_persona(self.users[14]),
+                self._expected_result_for_persona(self.users[15]),
+                self._expected_result_for_persona(self.users[3]),
+                self._expected_result_for_persona(self.users[1]),
+                self._expected_result_for_persona(guest=True),
             ],
             "RtcSession": [
                 self._expected_result_for_rtc_session(self.channel_channel_group_1, self.users[2]),

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -113,7 +113,7 @@ class TestDiscussFullPerformance(HttpCase):
                 'channel_id': self.im_livechat_channel.id,
                 'previous_operator_id': self.users[0].partner_id.id,
             })["Thread"][0]['id'])
-        guest_sudo = self.channel_livechat_2.channel_member_ids.filtered(lambda m: m.guest_id).guest_id.sudo()
+        self.guest = self.channel_livechat_2.channel_member_ids.guest_id.sudo()
         self.make_jsonrpc_request("/mail/message/post", {
             "post_data": {
                 "body": "test",
@@ -121,7 +121,7 @@ class TestDiscussFullPerformance(HttpCase):
             },
             "thread_id": self.channel_livechat_2.id,
             "thread_model": "discuss.channel",
-        }, headers={"Cookie": f"{guest_sudo._cookie_name}={guest_sudo._format_auth_cookie()};"})
+        }, headers={"Cookie": f"{self.guest._cookie_name}={self.guest._format_auth_cookie()};"})
         # add needaction
         self.users[0].notification_type = 'inbox'
         message = self.channel_channel_public_1.message_post(body='test', message_type='comment', author_id=self.users[2].partner_id.id, partner_ids=self.users[0].partner_id.ids)
@@ -231,6 +231,11 @@ class TestDiscussFullPerformance(HttpCase):
         # sudo: bus.bus: reading non-sensitive last id
         bus_last_id = self.env["bus.bus"].sudo()._bus_last_id()
         return {
+            "Persona": [
+                self._expected_result_for_persona(self.users[2], only_inviting=True),
+                self._expected_result_for_persona(self.users[0]),
+                self._expected_result_for_persona(self.users[14]),
+            ],
             "ChannelMember": [
                 self._expected_result_for_channel_member(self.channel_channel_group_1, self.users[2].partner_id),
                 self._expected_result_for_channel_member(self.channel_channel_group_1, self.users[0].partner_id),
@@ -284,6 +289,16 @@ class TestDiscussFullPerformance(HttpCase):
         The point of having a separate getter is to allow it to be overriden.
         """
         return {
+            "Persona": [
+                self._expected_result_for_persona(self.users[2]),
+                self._expected_result_for_persona(self.users[0], also_livechat=True),
+                self._expected_result_for_persona(self.users[12]),
+                self._expected_result_for_persona(self.users[14]),
+                self._expected_result_for_persona(self.users[15]),
+                self._expected_result_for_persona(self.users[3]),
+                self._expected_result_for_persona(self.users[1]),
+                self._expected_result_for_persona(guest=True),
+            ],
             "ChannelMember": [
                 self._expected_result_for_channel_member(self.channel_channel_group_1, self.users[2].partner_id),
                 self._expected_result_for_channel_member(self.channel_general, self.users[0].partner_id),
@@ -763,32 +778,16 @@ class TestDiscussFullPerformance(HttpCase):
         member_12 = members.filtered(lambda m: m.partner_id == self.users[12].partner_id)
         member_14 = members.filtered(lambda m: m.partner_id == self.users[14].partner_id)
         member_15 = members.filtered(lambda m: m.partner_id == self.users[15].partner_id)
-        write_date_0 = fields.Datetime.to_string(self.users[0].partner_id.write_date)
         last_message = channel._get_last_messages()
         member_g = members.filtered(lambda m: m.guest_id)
         guest = member_g.guest_id
         if channel == self.channel_general and partner == self.users[0].partner_id:
             return {
                 "create_date": member_0_create_date,
-                "thread": {
-                    "id": channel.id,
-                    "model": "discuss.channel",
-                },
+                "thread": {"id": channel.id, "model": "discuss.channel"},
                 "id": member_0.id,
                 "last_interest_dt": member_0_last_interest_dt,
-                "persona": {
-                    "active": True,
-                    "email": "e.e@example.com",
-                    "id": self.users[0].partner_id.id,
-                    "im_status": "online",
-                    "is_company": False,
-                    "name": "Ernest Employee",
-                    "out_of_office_date_end": False,
-                    "type": "partner",
-                    "userId": self.users[0].id,
-                    "isInternalUser": True,
-                    "write_date": write_date_0,
-                },
+                "persona": {"id": self.users[0].partner_id.id, "type": "partner"},
                 "fetched_message_id": False,
                 "seen_message_id": False,
                 "new_message_separator": 0,
@@ -796,25 +795,10 @@ class TestDiscussFullPerformance(HttpCase):
         if channel == self.channel_channel_public_1 and partner == self.users[0].partner_id:
             return {
                 "create_date": member_0_create_date,
-                "thread": {
-                    "id": channel.id,
-                    "model": "discuss.channel",
-                },
+                "thread": {"id": channel.id, "model": "discuss.channel"},
                 "id": member_0.id,
                 "last_interest_dt": member_0_last_interest_dt,
-                "persona": {
-                    "active": True,
-                    "email": "e.e@example.com",
-                    "id": self.users[0].partner_id.id,
-                    "im_status": "online",
-                    "is_company": False,
-                    "name": "Ernest Employee",
-                    "out_of_office_date_end": False,
-                    "type": "partner",
-                    "userId": self.users[0].id,
-                    "isInternalUser": True,
-                    "write_date": write_date_0,
-                },
+                "persona": {"id": self.users[0].partner_id.id, "type": "partner"},
                 "fetched_message_id": {"id": last_message.id},
                 "seen_message_id": {"id": last_message.id},
                 "new_message_separator": last_message.id + 1,
@@ -822,25 +806,10 @@ class TestDiscussFullPerformance(HttpCase):
         if channel == self.channel_channel_public_2 and partner == self.users[0].partner_id:
             return {
                 "create_date": member_0_create_date,
-                "thread": {
-                    "id": channel.id,
-                    "model": "discuss.channel",
-                },
+                "thread": {"id": channel.id, "model": "discuss.channel"},
                 "id": member_0.id,
                 "last_interest_dt": member_0_last_interest_dt,
-                "persona": {
-                    "active": True,
-                    "email": "e.e@example.com",
-                    "id": self.users[0].partner_id.id,
-                    "im_status": "online",
-                    "is_company": False,
-                    "name": "Ernest Employee",
-                    "out_of_office_date_end": False,
-                    "type": "partner",
-                    "userId": self.users[0].id,
-                    "isInternalUser": True,
-                    "write_date": write_date_0,
-                },
+                "persona": {"id": self.users[0].partner_id.id, "type": "partner"},
                 "fetched_message_id": {"id": last_message.id},
                 "seen_message_id": {"id": last_message.id},
                 "new_message_separator": last_message.id + 1,
@@ -848,26 +817,10 @@ class TestDiscussFullPerformance(HttpCase):
         if channel == self.channel_channel_group_1 and partner == self.users[0].partner_id:
             return {
                 "create_date": member_0_create_date,
-                "thread": {
-                    "id": channel.id,
-                    "model": "discuss.channel",
-                },
+                "thread": {"id": channel.id, "model": "discuss.channel"},
                 "id": member_0.id,
                 "last_interest_dt": member_0_last_interest_dt,
-                "persona": {
-                    # FIXME: invited_members overriding values
-                    # "active": True,
-                    # "email": "e.e@example.com",
-                    "id": self.users[0].partner_id.id,
-                    "im_status": "online",
-                    # "is_company": False,
-                    "name": "Ernest Employee",
-                    # "out_of_office_date_end": False,
-                    "type": "partner",
-                    # "userId": self.users[0].id,
-                    # "isInternalUser": True,
-                    # "write_date": write_date_0,
-                },
+                "persona": {"id": self.users[0].partner_id.id, "type": "partner"},
                 "fetched_message_id": {"id": last_message.id},
                 "seen_message_id": {"id": last_message.id},
                 "new_message_separator": last_message.id + 1,
@@ -875,39 +828,16 @@ class TestDiscussFullPerformance(HttpCase):
         if channel == self.channel_channel_group_1 and partner == self.users[2].partner_id:
             return {
                 "id": member_2.id,
-                "thread": {
-                    "id": channel.id,
-                    "model": "discuss.channel",
-                },
-                "persona": {
-                    "id": self.users[2].partner_id.id,
-                    "im_status": "offline",
-                    "name": "test2",
-                    "type": "partner",
-                },
+                "thread": {"id": channel.id, "model": "discuss.channel"},
+                "persona": {"id": self.users[2].partner_id.id, "type": "partner"},
             }
         if channel == self.channel_channel_group_2 and partner == self.users[0].partner_id:
             return {
                 "create_date": member_0_create_date,
-                "thread": {
-                    "id": channel.id,
-                    "model": "discuss.channel",
-                },
+                "thread": {"id": channel.id, "model": "discuss.channel"},
                 "id": member_0.id,
                 "last_interest_dt": member_0_last_interest_dt,
-                "persona": {
-                    "active": True,
-                    "email": "e.e@example.com",
-                    "id": self.users[0].partner_id.id,
-                    "im_status": "online",
-                    "is_company": False,
-                    "name": "Ernest Employee",
-                    "out_of_office_date_end": False,
-                    "type": "partner",
-                    "userId": self.users[0].id,
-                    "isInternalUser": True,
-                    "write_date": write_date_0,
-                },
+                "persona": {"id": self.users[0].partner_id.id, "type": "partner"},
                 "fetched_message_id": {"id": last_message.id},
                 "seen_message_id": {"id": last_message.id},
                 "new_message_separator": last_message.id + 1,
@@ -915,338 +845,140 @@ class TestDiscussFullPerformance(HttpCase):
         if channel == self.channel_group_1 and partner == self.users[0].partner_id:
             return {
                 "create_date": member_0_create_date,
-                "thread": {
-                    "id": channel.id,
-                    "model": "discuss.channel",
-                },
+                "thread": {"id": channel.id, "model": "discuss.channel"},
                 "id": member_0.id,
                 "last_interest_dt": member_0_last_interest_dt,
                 "new_message_separator": 0,
-                "persona": {
-                    "active": True,
-                    "email": "e.e@example.com",
-                    "id": self.users[0].partner_id.id,
-                    "im_status": "online",
-                    "is_company": False,
-                    "name": "Ernest Employee",
-                    "out_of_office_date_end": False,
-                    "type": "partner",
-                    "userId": self.users[0].id,
-                    "isInternalUser": True,
-                    "write_date": write_date_0,
-                },
+                "persona": {"id": self.users[0].partner_id.id, "type": "partner"},
                 "fetched_message_id": False,
                 "seen_message_id": False,
             }
         if channel == self.channel_group_1 and partner == self.users[12].partner_id:
             return {
                 "create_date": fields.Datetime.to_string(member_12.create_date),
-                "thread": {
-                    "id": channel.id,
-                    "model": "discuss.channel",
-                },
+                "thread": {"id": channel.id, "model": "discuss.channel"},
                 "id": member_12.id,
-                "persona": {
-                    "active": True,
-                    "email": False,
-                    "id": self.users[12].partner_id.id,
-                    "im_status": "offline",
-                    "is_company": False,
-                    "name": "test12",
-                    "out_of_office_date_end": False,
-                    "type": "partner",
-                    "userId": self.users[12].id,
-                    "isInternalUser": True,
-                    "write_date": write_date_0,
-                },
+                "persona": {"id": self.users[12].partner_id.id, "type": "partner"},
                 "fetched_message_id": False,
                 "seen_message_id": False,
             }
         if channel == self.channel_chat_1 and partner == self.users[0].partner_id:
             return {
                 "create_date": member_0_create_date,
-                "thread": {
-                    "id": channel.id,
-                    "model": "discuss.channel",
-                },
+                "thread": {"id": channel.id, "model": "discuss.channel"},
                 "id": member_0.id,
                 "last_interest_dt": member_0_last_interest_dt,
                 "new_message_separator": 0,
-                "persona": {
-                    "active": True,
-                    "email": "e.e@example.com",
-                    "id": self.users[0].partner_id.id,
-                    "im_status": "online",
-                    "is_company": False,
-                    "name": "Ernest Employee",
-                    "out_of_office_date_end": False,
-                    "type": "partner",
-                    "userId": self.users[0].id,
-                    "isInternalUser": True,
-                    "write_date": write_date_0,
-                },
+                "persona": {"id": self.users[0].partner_id.id, "type": "partner"},
                 "fetched_message_id": False,
                 "seen_message_id": False,
             }
         if channel == self.channel_chat_1 and partner == self.users[14].partner_id:
             return {
                 "create_date": fields.Datetime.to_string(member_14.create_date),
-                "thread": {
-                    "id": channel.id,
-                    "model": "discuss.channel",
-                },
+                "thread": {"id": channel.id, "model": "discuss.channel"},
                 "id": member_14.id,
-                "persona": {
-                    "active": True,
-                    "email": False,
-                    "id": self.users[14].partner_id.id,
-                    "im_status": "offline",
-                    "is_company": False,
-                    "name": "test14",
-                    "out_of_office_date_end": False,
-                    "type": "partner",
-                    "userId": self.users[14].id,
-                    "isInternalUser": True,
-                    "write_date": write_date_0,
-                },
+                "persona": {"id": self.users[14].partner_id.id, "type": "partner"},
                 "fetched_message_id": False,
                 "seen_message_id": False,
             }
         if channel == self.channel_chat_2 and partner == self.users[0].partner_id:
             return {
                 "create_date": member_0_create_date,
-                "thread": {
-                    "id": channel.id,
-                    "model": "discuss.channel",
-                },
+                "thread": {"id": channel.id, "model": "discuss.channel"},
                 "id": member_0.id,
                 "last_interest_dt": member_0_last_interest_dt,
                 "new_message_separator": 0,
-                "persona": {
-                    "active": True,
-                    "email": "e.e@example.com",
-                    "id": self.users[0].partner_id.id,
-                    "im_status": "online",
-                    "is_company": False,
-                    "name": "Ernest Employee",
-                    "out_of_office_date_end": False,
-                    "type": "partner",
-                    "userId": self.users[0].id,
-                    "isInternalUser": True,
-                    "write_date": write_date_0,
-                },
+                "persona": {"id": self.users[0].partner_id.id, "type": "partner"},
                 "fetched_message_id": False,
                 "seen_message_id": False,
             }
         if channel == self.channel_chat_2 and partner == self.users[15].partner_id:
             return {
                 "create_date": fields.Datetime.to_string(member_15.create_date),
-                "thread": {
-                    "id": channel.id,
-                    "model": "discuss.channel",
-                },
+                "thread": {"id": channel.id, "model": "discuss.channel"},
                 "id": member_15.id,
-                "persona": {
-                    "active": True,
-                    "email": False,
-                    "id": self.users[15].partner_id.id,
-                    "im_status": "offline",
-                    "is_company": False,
-                    "name": "test15",
-                    "out_of_office_date_end": False,
-                    "type": "partner",
-                    "userId": self.users[15].id,
-                    "isInternalUser": True,
-                    "write_date": write_date_0,
-                },
+                "persona": {"id": self.users[15].partner_id.id, "type": "partner"},
                 "fetched_message_id": False,
                 "seen_message_id": False,
             }
         if channel == self.channel_chat_3 and partner == self.users[0].partner_id:
             return {
                 "create_date": member_0_create_date,
-                "thread": {
-                    "id": channel.id,
-                    "model": "discuss.channel",
-                },
+                "thread": {"id": channel.id, "model": "discuss.channel"},
                 "id": member_0.id,
                 "last_interest_dt": member_0_last_interest_dt,
                 "new_message_separator": 0,
-                "persona": {
-                    "active": True,
-                    "email": "e.e@example.com",
-                    "id": self.users[0].partner_id.id,
-                    "im_status": "online",
-                    "is_company": False,
-                    "name": "Ernest Employee",
-                    "out_of_office_date_end": False,
-                    "type": "partner",
-                    "userId": self.users[0].id,
-                    "isInternalUser": True,
-                    "write_date": write_date_0,
-                },
+                "persona": {"id": self.users[0].partner_id.id, "type": "partner"},
                 "fetched_message_id": False,
                 "seen_message_id": False,
             }
         if channel == self.channel_chat_3 and partner == self.users[2].partner_id:
             return {
                 "create_date": fields.Datetime.to_string(member_2.create_date),
-                "thread": {
-                    "id": channel.id,
-                    "model": "discuss.channel",
-                },
+                "thread": {"id": channel.id, "model": "discuss.channel"},
                 "id": member_2.id,
-                "persona": {
-                    "active": True,
-                    "email": "test2@example.com",
-                    "id": self.users[2].partner_id.id,
-                    "im_status": "offline",
-                    "is_company": False,
-                    "name": "test2",
-                    "out_of_office_date_end": False,
-                    "type": "partner",
-                    "userId": self.users[2].id,
-                    "isInternalUser": True,
-                    "write_date": write_date_0,
-                },
+                "persona": {"id": self.users[2].partner_id.id, "type": "partner"},
                 "fetched_message_id": False,
                 "seen_message_id": False,
             }
         if channel == self.channel_chat_4 and partner == self.users[0].partner_id:
             return {
                 "create_date": member_0_create_date,
-                "thread": {
-                    "id": channel.id,
-                    "model": "discuss.channel",
-                },
+                "thread": {"id": channel.id, "model": "discuss.channel"},
                 "id": member_0.id,
                 "last_interest_dt": member_0_last_interest_dt,
                 "new_message_separator": 0,
-                "persona": {
-                    "active": True,
-                    "email": "e.e@example.com",
-                    "id": self.users[0].partner_id.id,
-                    "im_status": "online",
-                    "is_company": False,
-                    "name": "Ernest Employee",
-                    "out_of_office_date_end": False,
-                    "type": "partner",
-                    "userId": self.users[0].id,
-                    "isInternalUser": True,
-                    "write_date": write_date_0,
-                },
+                "persona": {"id": self.users[0].partner_id.id, "type": "partner"},
                 "fetched_message_id": False,
                 "seen_message_id": False,
             }
         if channel == self.channel_chat_4 and partner == self.users[3].partner_id:
             return {
                 "create_date": fields.Datetime.to_string(member_3.create_date),
-                "thread": {
-                    "id": channel.id,
-                    "model": "discuss.channel",
-                },
+                "thread": {"id": channel.id, "model": "discuss.channel"},
                 "id": member_3.id,
-                "persona": {
-                    "active": True,
-                    "email": False,
-                    "id": self.users[3].partner_id.id,
-                    "im_status": "offline",
-                    "is_company": False,
-                    "name": "test3",
-                    "out_of_office_date_end": False,
-                    "type": "partner",
-                    "userId": self.users[3].id,
-                    "isInternalUser": True,
-                    "write_date": fields.Datetime.to_string(
-                        self.users[3].partner_id.write_date
-                    ),
-                },
+                "persona": {"id": self.users[3].partner_id.id, "type": "partner"},
                 "fetched_message_id": False,
                 "seen_message_id": False,
             }
         if channel == self.channel_livechat_1 and partner == self.users[0].partner_id:
             return {
                 "create_date": member_0_create_date,
-                "thread": {
-                    "id": channel.id,
-                    "model": "discuss.channel",
-                },
+                "thread": {"id": channel.id, "model": "discuss.channel"},
                 "id": member_0.id,
                 "last_interest_dt": member_0_last_interest_dt,
                 "new_message_separator": 0,
-                "persona": {
-                    "active": True,
-                    "country": False,
-                    "id": self.users[0].partner_id.id,
-                    "is_bot": False,
-                    "is_public": False,
-                    "name": "Ernest Employee",
-                    "type": "partner",
-                },
+                "persona": {"id": self.users[0].partner_id.id, "type": "partner"},
                 "fetched_message_id": False,
                 "seen_message_id": False,
             }
         if channel == self.channel_livechat_1 and partner == self.users[1].partner_id:
             return {
                 "create_date": fields.Datetime.to_string(member_1.create_date),
-                "thread": {
-                    "id": channel.id,
-                    "model": "discuss.channel",
-                },
+                "thread": {"id": channel.id, "model": "discuss.channel"},
                 "id": member_1.id,
-                "persona": {
-                    "active": True,
-                    "country": {
-                        "code": "IN",
-                        "id": self.env.ref("base.in").id,
-                        "name": "India",
-                    },
-                    "id": self.users[1].partner_id.id,
-                    "is_bot": False,
-                    "is_public": False,
-                    "name": "test1",
-                    "type": "partner",
-                },
+                "persona": {"id": self.users[1].partner_id.id, "type": "partner"},
                 "fetched_message_id": {"id": last_message.id},
                 "seen_message_id": {"id": last_message.id},
             }
         if channel == self.channel_livechat_2 and partner == self.users[0].partner_id:
             return {
                 "create_date": member_0_create_date,
-                "thread": {
-                    "id": channel.id,
-                    "model": "discuss.channel",
-                },
+                "thread": {"id": channel.id, "model": "discuss.channel"},
                 "id": member_0.id,
                 "last_interest_dt": member_0_last_interest_dt,
                 "new_message_separator": 0,
-                "persona": {
-                    "active": True,
-                    "country": False,
-                    "id": self.users[0].partner_id.id,
-                    "is_bot": False,
-                    "is_public": False,
-                    "name": "Ernest Employee",
-                    "type": "partner",
-                },
+                "persona": {"id": self.users[0].partner_id.id, "type": "partner"},
                 "fetched_message_id": False,
                 "seen_message_id": False,
             }
         if channel == self.channel_livechat_2 and guest:
             return {
                 "create_date": fields.Datetime.to_string(member_g.create_date),
-                "thread": {
-                    "id": channel.id,
-                    "model": "discuss.channel",
-                },
+                "thread": {"id": channel.id, "model": "discuss.channel"},
                 "id": member_g.id,
-                "persona": {
-                    "id": guest.id,
-                    "im_status": "offline",
-                    "name": "Visitor",
-                    "type": "guest",
-                    "write_date": fields.Datetime.to_string(guest.write_date),
-                },
+                "persona": {"id": guest.id, "type": "guest"},
                 "fetched_message_id": {"id": last_message.id},
                 "seen_message_id": {"id": last_message.id},
             }
@@ -1535,6 +1267,133 @@ class TestDiscussFullPerformance(HttpCase):
                 "subtype_description": False,
                 "trackingValues": [],
                 "write_date": write_date,
+            }
+        return {}
+
+    def _expected_result_for_persona(
+        self, user=None, guest=None, only_inviting=False, also_livechat=False
+    ):
+        if user == self.users[0]:
+            res = {
+                "active": True,
+                "email": "e.e@example.com",
+                "id": user.partner_id.id,
+                "im_status": "online",
+                "is_company": False,
+                "name": "Ernest Employee",
+                "out_of_office_date_end": False,
+                "type": "partner",
+                "userId": user.id,
+                "isInternalUser": True,
+                "write_date": fields.Datetime.to_string(user.partner_id.write_date),
+            }
+            if also_livechat:
+                res.update(
+                    {
+                        "country": False,
+                        "is_bot": False,
+                        "is_public": False,
+                    }
+                )
+            return res
+        if user == self.users[1]:
+            return {
+                "active": True,
+                "country": {
+                    "code": "IN",
+                    "id": self.env.ref("base.in").id,
+                    "name": "India",
+                },
+                "id": user.partner_id.id,
+                "is_bot": False,
+                "is_public": False,
+                "name": "test1",
+                "type": "partner",
+            }
+        if user == self.users[2]:
+            if only_inviting:
+                return {
+                    "id": user.partner_id.id,
+                    "im_status": "offline",
+                    "name": "test2",
+                    "type": "partner",
+                }
+            return {
+                "active": True,
+                "email": "test2@example.com",
+                "id": user.partner_id.id,
+                "im_status": "offline",
+                "is_company": False,
+                "name": "test2",
+                "out_of_office_date_end": False,
+                "type": "partner",
+                "userId": user.id,
+                "isInternalUser": True,
+                "write_date": fields.Datetime.to_string(user.partner_id.write_date),
+            }
+        if user == self.users[3]:
+            return {
+                "active": True,
+                "email": False,
+                "id": user.partner_id.id,
+                "im_status": "offline",
+                "is_company": False,
+                "name": "test3",
+                "out_of_office_date_end": False,
+                "type": "partner",
+                "userId": user.id,
+                "isInternalUser": True,
+                "write_date": fields.Datetime.to_string(self.users[3].partner_id.write_date),
+            }
+        if user == self.users[12]:
+            return {
+                "active": True,
+                "email": False,
+                "id": user.partner_id.id,
+                "im_status": "offline",
+                "is_company": False,
+                "name": "test12",
+                "out_of_office_date_end": False,
+                "type": "partner",
+                "userId": user.id,
+                "isInternalUser": True,
+                "write_date": fields.Datetime.to_string(user.partner_id.write_date),
+            }
+        if user == self.users[14]:
+            return {
+                "active": True,
+                "email": False,
+                "id": user.partner_id.id,
+                "im_status": "offline",
+                "is_company": False,
+                "name": "test14",
+                "out_of_office_date_end": False,
+                "type": "partner",
+                "userId": user.id,
+                "isInternalUser": True,
+                "write_date": fields.Datetime.to_string(user.partner_id.write_date),
+            }
+        if user == self.users[15]:
+            return {
+                "active": True,
+                "email": False,
+                "id": user.partner_id.id,
+                "im_status": "offline",
+                "is_company": False,
+                "name": "test15",
+                "out_of_office_date_end": False,
+                "type": "partner",
+                "userId": user.id,
+                "isInternalUser": True,
+                "write_date": fields.Datetime.to_string(user.partner_id.write_date),
+            }
+        if guest:
+            return {
+                "id": self.guest.id,
+                "im_status": "offline",
+                "name": "Visitor",
+                "type": "guest",
+                "write_date": fields.Datetime.to_string(self.guest.write_date),
             }
         return {}
 

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -784,203 +784,203 @@ class TestDiscussFullPerformance(HttpCase):
         if channel == self.channel_general and partner == self.users[0].partner_id:
             return {
                 "create_date": member_0_create_date,
-                "thread": {"id": channel.id, "model": "discuss.channel"},
+                "fetched_message_id": False,
                 "id": member_0.id,
                 "last_interest_dt": member_0_last_interest_dt,
-                "persona": {"id": self.users[0].partner_id.id, "type": "partner"},
-                "fetched_message_id": False,
-                "seen_message_id": False,
                 "new_message_separator": 0,
+                "persona": {"id": self.users[0].partner_id.id, "type": "partner"},
+                "seen_message_id": False,
+                "thread": {"id": channel.id, "model": "discuss.channel"},
             }
         if channel == self.channel_channel_public_1 and partner == self.users[0].partner_id:
             return {
                 "create_date": member_0_create_date,
-                "thread": {"id": channel.id, "model": "discuss.channel"},
+                "fetched_message_id": {"id": last_message.id},
                 "id": member_0.id,
                 "last_interest_dt": member_0_last_interest_dt,
-                "persona": {"id": self.users[0].partner_id.id, "type": "partner"},
-                "fetched_message_id": {"id": last_message.id},
-                "seen_message_id": {"id": last_message.id},
                 "new_message_separator": last_message.id + 1,
+                "persona": {"id": self.users[0].partner_id.id, "type": "partner"},
+                "seen_message_id": {"id": last_message.id},
+                "thread": {"id": channel.id, "model": "discuss.channel"},
             }
         if channel == self.channel_channel_public_2 and partner == self.users[0].partner_id:
             return {
                 "create_date": member_0_create_date,
-                "thread": {"id": channel.id, "model": "discuss.channel"},
+                "fetched_message_id": {"id": last_message.id},
                 "id": member_0.id,
                 "last_interest_dt": member_0_last_interest_dt,
-                "persona": {"id": self.users[0].partner_id.id, "type": "partner"},
-                "fetched_message_id": {"id": last_message.id},
-                "seen_message_id": {"id": last_message.id},
                 "new_message_separator": last_message.id + 1,
+                "persona": {"id": self.users[0].partner_id.id, "type": "partner"},
+                "seen_message_id": {"id": last_message.id},
+                "thread": {"id": channel.id, "model": "discuss.channel"},
             }
         if channel == self.channel_channel_group_1 and partner == self.users[0].partner_id:
             return {
                 "create_date": member_0_create_date,
-                "thread": {"id": channel.id, "model": "discuss.channel"},
+                "fetched_message_id": {"id": last_message.id},
                 "id": member_0.id,
                 "last_interest_dt": member_0_last_interest_dt,
-                "persona": {"id": self.users[0].partner_id.id, "type": "partner"},
-                "fetched_message_id": {"id": last_message.id},
-                "seen_message_id": {"id": last_message.id},
                 "new_message_separator": last_message.id + 1,
+                "persona": {"id": self.users[0].partner_id.id, "type": "partner"},
+                "seen_message_id": {"id": last_message.id},
+                "thread": {"id": channel.id, "model": "discuss.channel"},
             }
         if channel == self.channel_channel_group_1 and partner == self.users[2].partner_id:
             return {
                 "id": member_2.id,
-                "thread": {"id": channel.id, "model": "discuss.channel"},
                 "persona": {"id": self.users[2].partner_id.id, "type": "partner"},
+                "thread": {"id": channel.id, "model": "discuss.channel"},
             }
         if channel == self.channel_channel_group_2 and partner == self.users[0].partner_id:
             return {
                 "create_date": member_0_create_date,
-                "thread": {"id": channel.id, "model": "discuss.channel"},
+                "fetched_message_id": {"id": last_message.id},
                 "id": member_0.id,
                 "last_interest_dt": member_0_last_interest_dt,
-                "persona": {"id": self.users[0].partner_id.id, "type": "partner"},
-                "fetched_message_id": {"id": last_message.id},
-                "seen_message_id": {"id": last_message.id},
                 "new_message_separator": last_message.id + 1,
+                "persona": {"id": self.users[0].partner_id.id, "type": "partner"},
+                "seen_message_id": {"id": last_message.id},
+                "thread": {"id": channel.id, "model": "discuss.channel"},
             }
         if channel == self.channel_group_1 and partner == self.users[0].partner_id:
             return {
                 "create_date": member_0_create_date,
-                "thread": {"id": channel.id, "model": "discuss.channel"},
+                "fetched_message_id": False,
                 "id": member_0.id,
                 "last_interest_dt": member_0_last_interest_dt,
                 "new_message_separator": 0,
                 "persona": {"id": self.users[0].partner_id.id, "type": "partner"},
-                "fetched_message_id": False,
                 "seen_message_id": False,
+                "thread": {"id": channel.id, "model": "discuss.channel"},
             }
         if channel == self.channel_group_1 and partner == self.users[12].partner_id:
             return {
                 "create_date": fields.Datetime.to_string(member_12.create_date),
-                "thread": {"id": channel.id, "model": "discuss.channel"},
+                "fetched_message_id": False,
                 "id": member_12.id,
                 "persona": {"id": self.users[12].partner_id.id, "type": "partner"},
-                "fetched_message_id": False,
                 "seen_message_id": False,
+                "thread": {"id": channel.id, "model": "discuss.channel"},
             }
         if channel == self.channel_chat_1 and partner == self.users[0].partner_id:
             return {
                 "create_date": member_0_create_date,
-                "thread": {"id": channel.id, "model": "discuss.channel"},
+                "fetched_message_id": False,
                 "id": member_0.id,
                 "last_interest_dt": member_0_last_interest_dt,
                 "new_message_separator": 0,
                 "persona": {"id": self.users[0].partner_id.id, "type": "partner"},
-                "fetched_message_id": False,
                 "seen_message_id": False,
+                "thread": {"id": channel.id, "model": "discuss.channel"},
             }
         if channel == self.channel_chat_1 and partner == self.users[14].partner_id:
             return {
                 "create_date": fields.Datetime.to_string(member_14.create_date),
-                "thread": {"id": channel.id, "model": "discuss.channel"},
+                "fetched_message_id": False,
                 "id": member_14.id,
                 "persona": {"id": self.users[14].partner_id.id, "type": "partner"},
-                "fetched_message_id": False,
                 "seen_message_id": False,
+                "thread": {"id": channel.id, "model": "discuss.channel"},
             }
         if channel == self.channel_chat_2 and partner == self.users[0].partner_id:
             return {
                 "create_date": member_0_create_date,
-                "thread": {"id": channel.id, "model": "discuss.channel"},
+                "fetched_message_id": False,
                 "id": member_0.id,
                 "last_interest_dt": member_0_last_interest_dt,
                 "new_message_separator": 0,
                 "persona": {"id": self.users[0].partner_id.id, "type": "partner"},
-                "fetched_message_id": False,
                 "seen_message_id": False,
+                "thread": {"id": channel.id, "model": "discuss.channel"},
             }
         if channel == self.channel_chat_2 and partner == self.users[15].partner_id:
             return {
                 "create_date": fields.Datetime.to_string(member_15.create_date),
-                "thread": {"id": channel.id, "model": "discuss.channel"},
+                "fetched_message_id": False,
                 "id": member_15.id,
                 "persona": {"id": self.users[15].partner_id.id, "type": "partner"},
-                "fetched_message_id": False,
                 "seen_message_id": False,
+                "thread": {"id": channel.id, "model": "discuss.channel"},
             }
         if channel == self.channel_chat_3 and partner == self.users[0].partner_id:
             return {
                 "create_date": member_0_create_date,
-                "thread": {"id": channel.id, "model": "discuss.channel"},
+                "fetched_message_id": False,
                 "id": member_0.id,
                 "last_interest_dt": member_0_last_interest_dt,
                 "new_message_separator": 0,
                 "persona": {"id": self.users[0].partner_id.id, "type": "partner"},
-                "fetched_message_id": False,
                 "seen_message_id": False,
+                "thread": {"id": channel.id, "model": "discuss.channel"},
             }
         if channel == self.channel_chat_3 and partner == self.users[2].partner_id:
             return {
                 "create_date": fields.Datetime.to_string(member_2.create_date),
-                "thread": {"id": channel.id, "model": "discuss.channel"},
+                "fetched_message_id": False,
                 "id": member_2.id,
                 "persona": {"id": self.users[2].partner_id.id, "type": "partner"},
-                "fetched_message_id": False,
                 "seen_message_id": False,
+                "thread": {"id": channel.id, "model": "discuss.channel"},
             }
         if channel == self.channel_chat_4 and partner == self.users[0].partner_id:
             return {
                 "create_date": member_0_create_date,
-                "thread": {"id": channel.id, "model": "discuss.channel"},
+                "fetched_message_id": False,
                 "id": member_0.id,
                 "last_interest_dt": member_0_last_interest_dt,
                 "new_message_separator": 0,
                 "persona": {"id": self.users[0].partner_id.id, "type": "partner"},
-                "fetched_message_id": False,
                 "seen_message_id": False,
+                "thread": {"id": channel.id, "model": "discuss.channel"},
             }
         if channel == self.channel_chat_4 and partner == self.users[3].partner_id:
             return {
                 "create_date": fields.Datetime.to_string(member_3.create_date),
-                "thread": {"id": channel.id, "model": "discuss.channel"},
+                "fetched_message_id": False,
                 "id": member_3.id,
                 "persona": {"id": self.users[3].partner_id.id, "type": "partner"},
-                "fetched_message_id": False,
                 "seen_message_id": False,
+                "thread": {"id": channel.id, "model": "discuss.channel"},
             }
         if channel == self.channel_livechat_1 and partner == self.users[0].partner_id:
             return {
                 "create_date": member_0_create_date,
-                "thread": {"id": channel.id, "model": "discuss.channel"},
+                "fetched_message_id": False,
                 "id": member_0.id,
                 "last_interest_dt": member_0_last_interest_dt,
                 "new_message_separator": 0,
                 "persona": {"id": self.users[0].partner_id.id, "type": "partner"},
-                "fetched_message_id": False,
                 "seen_message_id": False,
+                "thread": {"id": channel.id, "model": "discuss.channel"},
             }
         if channel == self.channel_livechat_1 and partner == self.users[1].partner_id:
             return {
                 "create_date": fields.Datetime.to_string(member_1.create_date),
-                "thread": {"id": channel.id, "model": "discuss.channel"},
+                "fetched_message_id": {"id": last_message.id},
                 "id": member_1.id,
                 "persona": {"id": self.users[1].partner_id.id, "type": "partner"},
-                "fetched_message_id": {"id": last_message.id},
                 "seen_message_id": {"id": last_message.id},
+                "thread": {"id": channel.id, "model": "discuss.channel"},
             }
         if channel == self.channel_livechat_2 and partner == self.users[0].partner_id:
             return {
                 "create_date": member_0_create_date,
-                "thread": {"id": channel.id, "model": "discuss.channel"},
+                "fetched_message_id": False,
                 "id": member_0.id,
                 "last_interest_dt": member_0_last_interest_dt,
                 "new_message_separator": 0,
                 "persona": {"id": self.users[0].partner_id.id, "type": "partner"},
-                "fetched_message_id": False,
                 "seen_message_id": False,
+                "thread": {"id": channel.id, "model": "discuss.channel"},
             }
         if channel == self.channel_livechat_2 and guest:
             return {
                 "create_date": fields.Datetime.to_string(member_g.create_date),
-                "thread": {"id": channel.id, "model": "discuss.channel"},
+                "fetched_message_id": {"id": last_message.id},
                 "id": member_g.id,
                 "persona": {"id": guest.id, "type": "guest"},
-                "fetched_message_id": {"id": last_message.id},
                 "seen_message_id": {"id": last_message.id},
+                "thread": {"id": channel.id, "model": "discuss.channel"},
             }
         return {}
 
@@ -1280,11 +1280,11 @@ class TestDiscussFullPerformance(HttpCase):
                 "id": user.partner_id.id,
                 "im_status": "online",
                 "is_company": False,
+                "isInternalUser": True,
                 "name": "Ernest Employee",
                 "out_of_office_date_end": False,
                 "type": "partner",
                 "userId": user.id,
-                "isInternalUser": True,
                 "write_date": fields.Datetime.to_string(user.partner_id.write_date),
             }
             if also_livechat:
@@ -1324,11 +1324,11 @@ class TestDiscussFullPerformance(HttpCase):
                 "id": user.partner_id.id,
                 "im_status": "offline",
                 "is_company": False,
+                "isInternalUser": True,
                 "name": "test2",
                 "out_of_office_date_end": False,
                 "type": "partner",
                 "userId": user.id,
-                "isInternalUser": True,
                 "write_date": fields.Datetime.to_string(user.partner_id.write_date),
             }
         if user == self.users[3]:
@@ -1338,11 +1338,11 @@ class TestDiscussFullPerformance(HttpCase):
                 "id": user.partner_id.id,
                 "im_status": "offline",
                 "is_company": False,
+                "isInternalUser": True,
                 "name": "test3",
                 "out_of_office_date_end": False,
                 "type": "partner",
                 "userId": user.id,
-                "isInternalUser": True,
                 "write_date": fields.Datetime.to_string(self.users[3].partner_id.write_date),
             }
         if user == self.users[12]:
@@ -1352,11 +1352,11 @@ class TestDiscussFullPerformance(HttpCase):
                 "id": user.partner_id.id,
                 "im_status": "offline",
                 "is_company": False,
+                "isInternalUser": True,
                 "name": "test12",
                 "out_of_office_date_end": False,
                 "type": "partner",
                 "userId": user.id,
-                "isInternalUser": True,
                 "write_date": fields.Datetime.to_string(user.partner_id.write_date),
             }
         if user == self.users[14]:
@@ -1366,11 +1366,11 @@ class TestDiscussFullPerformance(HttpCase):
                 "id": user.partner_id.id,
                 "im_status": "offline",
                 "is_company": False,
+                "isInternalUser": True,
                 "name": "test14",
                 "out_of_office_date_end": False,
                 "type": "partner",
                 "userId": user.id,
-                "isInternalUser": True,
                 "write_date": fields.Datetime.to_string(user.partner_id.write_date),
             }
         if user == self.users[15]:
@@ -1380,11 +1380,11 @@ class TestDiscussFullPerformance(HttpCase):
                 "id": user.partner_id.id,
                 "im_status": "offline",
                 "is_company": False,
+                "isInternalUser": True,
                 "name": "test15",
                 "out_of_office_date_end": False,
                 "type": "partner",
                 "userId": user.id,
-                "isInternalUser": True,
                 "write_date": fields.Datetime.to_string(user.partner_id.write_date),
             }
         if guest:
@@ -1403,8 +1403,8 @@ class TestDiscussFullPerformance(HttpCase):
         if channel == self.channel_channel_group_1 and user == self.users[2]:
             return {
                 # sudo: discuss.channel.rtc.session - reading a session in a test file
-                "id": member_2.sudo().rtc_session_ids.id,
                 "channelMember": {"id": member_2.id},
+                "id": member_2.sudo().rtc_session_ids.id,
                 "isCameraOn": False,
                 "isDeaf": False,
                 "isScreenSharingOn": False,

--- a/addons/test_mail_sms/tests/test_sms_management.py
+++ b/addons/test_mail_sms/tests/test_sms_management.py
@@ -141,7 +141,7 @@ class TestSMSWizards(TestSMSActionsCommon):
             {'partner': self.partner_1, 'state': 'pending'},
             {'partner': self.partner_2, 'state': 'pending'}
         ], 'TEST BODY', self.msg, check_sms=True)
-        self.assertMessageBusNotifications(self.msg)
+        self.assertMessageBusNotifications(self.msg, count=2)
 
     @mute_logger('odoo.addons.sms.models.sms_sms')
     def test_sms_resend_update_number(self):
@@ -157,7 +157,7 @@ class TestSMSWizards(TestSMSActionsCommon):
             {'partner': self.partner_1, 'state': 'pending', 'number': self.random_numbers_san[0]},
             {'partner': self.partner_2, 'state': 'pending', 'number': self.random_numbers_san[1]}
         ], 'TEST BODY', self.msg, check_sms=True)
-        self.assertMessageBusNotifications(self.msg)
+        self.assertMessageBusNotifications(self.msg, count=2)
 
     def test_sms_resend_cancel(self):
         self._reset_bus()
@@ -201,4 +201,4 @@ class TestSMSWizards(TestSMSActionsCommon):
 
         self.assertSMSNotification([{'partner': self.partner_1, 'state': 'pending'}], 'TEST BODY', self.msg, check_sms=True)
         self.assertSMSNotification([{'partner': self.partner_2, 'state': 'canceled', 'number': self.notif_p2.sms_number, 'failure_type': 'sms_credit'}], 'TEST BODY', self.msg, check_sms=False)
-        self.assertMessageBusNotifications(self.msg)
+        self.assertMessageBusNotifications(self.msg, count=2)


### PR DESCRIPTION
This will reduce data transferred to the client and processed in JS when the same persona was appearing multiple times in members.

This also makes more clear what is transferred by avoiding nested values.

This is part 3, focusing on channel member and related persona.

Formatting code eventually becomes simpler too, by always adding data to the store rather than updating pre-existing dict manually.

Part of task-3605717

https://github.com/odoo/enterprise/pull/65199