### PR TITLE
[FIX] mail: minor messageToReply UI adjustment

### DIFF
--- a/addons/mail/static/src/core/common/thread.js
+++ b/addons/mail/static/src/core/common/thread.js
@@ -454,7 +454,7 @@ export class Thread extends Component {
 
     getMessageClassName(message) {
         return this.messageHighlight?.highlightedMessageId === message.id
-            ? "o-highlighted bg-view shadow-lg"
+            ? "o-highlighted bg-view shadow-lg pb-1"
             : "";
     }
 


### PR DESCRIPTION
Before this commit, when the parent was highlighted upon clicking the 
messageInReply block of the replied message, the highlighted message 
had a minor padding-bottom issue. This class was removed in [1]. 

Reintroducing the pb-1 class with all highlighted classes so that it is 
safely removed when the highlight is not active and does not accidentally 
reintroduce the unwanted padding.


![image](https://github.com/odoo/odoo/assets/120459796/94747e03-9adf-4b8f-bc18-9067250c84e8)


[1]: https://github.com/odoo/odoo/pull/168159



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
