### PR TITLE
[IMP] stock,purchase: b2b 2106

### DIFF
--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -916,4 +916,17 @@
         <field name="target">main</field>
     </record>
 
-</odoo>
+    <record id="action_confirm_rfqs" model="ir.actions.server">
+        <field name="name">Confirm RFQ</field>
+        <field name="model_id" ref="purchase.model_purchase_order"/>
+        <field name="binding_model_id" ref="purchase.model_purchase_order"/>
+        <field name="binding_view_types">tree</field>
+        <field name="state">code</field>
+        <field name="code">
+if records:
+    res = records.button_confirm()
+if isinstance(res, dict):
+    action = res
+        </field>
+    </record>
+ </odoo>

--- a/addons/purchase_stock/tests/test_purchase_order.py
+++ b/addons/purchase_stock/tests/test_purchase_order.py
@@ -504,7 +504,7 @@ class TestPurchaseOrder(ValuationReconciliationTestCommon):
         orderpoint_form = Form(self.env['stock.warehouse.orderpoint'])
         orderpoint_form.product_id = product
         orderpoint_form.product_min_qty = 1
-        orderpoint_form.product_max_qty = 0.000
+        orderpoint_form.product_max_qty = 1.000
         orderpoint_form.save()
 
         self.env['procurement.group'].run_scheduler()

--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -54,10 +54,12 @@ class StockWarehouseOrderpoint(models.Model):
     product_uom_name = fields.Char(string='Product unit of measure label', related='product_uom.display_name', readonly=True)
     product_min_qty = fields.Float(
         'Min Quantity', digits='Product Unit of Measure', required=True, default=0.0,
+        compute='_compute_product_min_qty', readonly=False, store=True,
         help="When the virtual stock goes below the Min Quantity specified for this field, Odoo generates "
              "a procurement to bring the forecasted quantity above of this Min Quantity.")
     product_max_qty = fields.Float(
         'Max Quantity', digits='Product Unit of Measure', required=True, default=0.0,
+        compute='_compute_product_max_qty', readonly=False, store=True,
         help="When the virtual stock goes below the Min Quantity, Odoo generates "
              "a procurement to bring the forecasted quantity up to (or near to) the Max Quantity specified for this field (or to Min Quantity, whichever is bigger).")
     qty_multiple = fields.Float(
@@ -127,6 +129,18 @@ class StockWarehouseOrderpoint(models.Model):
                 continue
             orderpoint.rule_ids = orderpoint.product_id._get_rules_from_location(orderpoint.location_id, route_ids=orderpoint.route_id)
 
+    @api.depends('product_max_qty')
+    def _compute_product_min_qty(self):
+        for orderpoint in self:
+            if orderpoint.product_max_qty < orderpoint.product_min_qty or not orderpoint.product_min_qty:
+                orderpoint.product_min_qty = orderpoint.product_max_qty
+
+    @api.depends('product_min_qty')
+    def _compute_product_max_qty(self):
+        for orderpoint in self:
+            if orderpoint.product_max_qty < orderpoint.product_min_qty or not orderpoint.product_max_qty:
+                orderpoint.product_max_qty = orderpoint.product_min_qty
+
     @api.depends('route_id', 'product_id')
     def _compute_visibility_days(self):
         self.visibility_days = 0
@@ -143,6 +157,11 @@ class StockWarehouseOrderpoint(models.Model):
         ''' Check if the UoM has the same category as the product standard UoM '''
         if any(orderpoint.product_id.uom_id.category_id != orderpoint.product_uom.category_id for orderpoint in self):
             raise ValidationError(_('You have to select a product unit of measure that is in the same category as the default unit of measure of the product'))
+
+    @api.constrains('product_min_qty', 'product_max_qty')
+    def _check_min_max_qty(self):
+        if any(orderpoint.product_min_qty > orderpoint.product_max_qty for orderpoint in self):
+            raise ValidationError(_('The minimum quantity must be less than or equal to the maximum quantity.'))
 
     @api.depends('location_id', 'company_id')
     def _compute_warehouse_id(self):

--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -69,7 +69,7 @@ class StockQuant(models.Model):
     sn_duplicated = fields.Boolean(string="Duplicated Serial Number", compute='_compute_sn_duplicated', help="If the same SN is in another Quant")
     package_id = fields.Many2one(
         'stock.quant.package', 'Package',
-        domain="[('location_id', '=', location_id)]",
+        domain="['|', ('location_id', '=', location_id), '&', ('location_id', '=', False), '&', ('package_use', '=', 'reusable'), ('quant_ids', '=', False)]",
         help='The package containing this quant', ondelete='restrict', check_company=True, index=True)
     owner_id = fields.Many2one(
         'res.partner', 'Owner',

--- a/addons/stock/views/stock_location_views.xml
+++ b/addons/stock/views/stock_location_views.xml
@@ -99,7 +99,7 @@
         <field name="model">stock.location</field>
         <field name="priority" eval="2"/>
         <field name="arch" type="xml">
-            <tree string="Stock Location" decoration-info="usage=='view'" decoration-danger="usage=='internal'" multi_edit="1">
+            <tree string="Stock Location" decoration-info="usage=='view'" multi_edit="1">
                 <field name="company_id" column_invisible="True"/>
                 <field name="active" column_invisible="True"/>
                 <field name="complete_name" string="Location"/>

--- a/addons/stock/views/stock_quant_views.xml
+++ b/addons/stock/views/stock_quant_views.xml
@@ -145,6 +145,7 @@
                 <field name="inventory_quantity_auto_apply" string="On Hand Quantity" readonly="0" sum="Total On Hand"/>
                 <button name="%(action_view_inventory_tree)d" title="Inventory Adjustment" type="action" class="btn-link" icon="fa-pencil" context="{'search_default_product_id': product_id, 'default_product_id': product_id}"/>
                 <field name="reserved_quantity" optional="show" sum="Total Reserved"/>
+                <field name="available_quantity" optional="hide" sum="Total Available"/>
                 <field name="product_uom_id" string="Unit" groups="uom.group_uom"/>
                 <field name="lot_properties" optional="hide"/>
                 <button name="action_view_stock_moves" string="History" type="object" class="btn-link" icon="fa-history"/>


### PR DESCRIPTION
This PR adds miscallaneous changes to `stock` and `purchase` modules:

#### `stock`:
- Reordering rules now are required to have their minimum quantity less than or equal to the maximum quantity.
- `available_quantity` column is added to the tree view of `stock.quant` that is used in "Locations" report and "On Hand" smart button.

#### `purchase`:
- A new server action is added to confirm multiple RFQs at once from the tree view of `purchase.order`.

Enterprise: odoo/enterprise#65210

Task-4004274

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
