### PR TITLE
[FIX] point_of_sale: correct currency check for balancing line

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -646,7 +646,7 @@ class PosSession(models.Model):
             pickings.write({'pos_session_id': self.id, 'origin': self.name})
 
     def _create_balancing_line(self, data, balancing_account, amount_to_balance):
-        if (not float_is_zero(amount_to_balance, precision_rounding=self.currency_id.rounding)):
+        if not self.company_id.currency_id.is_zero(amount_to_balance):
             balancing_vals = self._prepare_balancing_line_vals(amount_to_balance, self.move_id, balancing_account)
             MoveLine = data.get('MoveLine')
             MoveLine.create(balancing_vals)


### PR DESCRIPTION
Prior to this commit, when adding a balancing line, it was incorrectly
checked with the session currency instead of the company currency.

opw-3985175

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
