### PR TITLE
[FIX] mrp_account: kit Cogs

### DIFF
--- a/addons/sale_mrp/models/account_move.py
+++ b/addons/sale_mrp/models/account_move.py
@@ -26,12 +26,12 @@ class AccountMoveLine(models.Model):
                 components_qty = so_line._get_bom_component_qty(bom)
                 storable_components = self.env['product.product'].search([('id', 'in', list(components_qty.keys())), ('type', '=', 'product')])
                 for product in storable_components:
-                    factor = components_qty[product.id]['qty']
+                    factor = components_qty[product.id]['qty'] / bom.product_qty
                     prod_moves = moves.filtered(lambda m: m.product_id == product)
                     prod_qty_invoiced = factor * qty_invoiced
                     prod_qty_to_invoice = factor * qty_to_invoice
                     product = product.with_company(self.company_id).with_context(is_returned=is_line_reversing)
                     average_price_unit += factor * product._compute_average_price(prod_qty_invoiced, prod_qty_to_invoice, prod_moves)
-                price_unit = average_price_unit / bom.product_qty or price_unit
+                price_unit = average_price_unit or price_unit
                 price_unit = self.product_id.uom_id._compute_price(price_unit, self.product_uom_id)
         return price_unit


### PR DESCRIPTION
Steps to reproduce
1) Create a dropshipped kit
​- Set it to automated inventory valuation
​- Add a dropshipped product with automated inventory valuation to the kit
2) Create a Sale Order for the kit with quantity greater than 1
3) Confirm the sale order -> Purchase -> Confirm Order -> Dropship -> Validate
4) Check the inventory valuation of the dropship picking
5) Go back to the Sale Order and create and view the invoice
6) Confirm the invoice and notice the discrepency between the stock valuation and stock interim value

Bug:
when the picking for the components is created from a seperate rule
e.g. dropshiping the moves will not have a bom_line set on them

Fix:
instead of relying on the move qty to determine the corresponding qty for the components which only works for 1 kit 
group generated bom_lines from bom_explode by product
(note that the same product could be on seperate lines that's why I did `+=`)

opw-3878025

nb: also correctly account for product qty of the bom
when generating cogs line in the invoice