### PR TITLE
[FIX] l10n_eg_edi_eta: check current status before cancelling

### DIFF
--- a/addons/l10n_eg_edi_eta/models/account_edi_format.py
+++ b/addons/l10n_eg_edi_eta/models/account_edi_format.py
@@ -132,6 +132,11 @@ class AccountEdiFormat(models.Model):
         access_data = self._l10n_eg_eta_get_access_token(invoice)
         if access_data.get('error'):
             return access_data
+        # Check current status. It may already be cancelled or rejected.
+        if invoice.l10n_eg_submission_number:
+            document_summary = self._l10n_eg_get_einvoice_document_summary(invoice)
+            if document_summary.get('doc_data') and document_summary['doc_data'][0].get('status') in ('Cancelled', 'Rejected'):
+                return {'success': True}
         request_url = f'/api/v1/documents/state/{url_quote(invoice.l10n_eg_uuid)}/state'
         request_data = {
             'body': json.dumps({'status': 'cancelled', 'reason': 'Cancelled'}),
@@ -148,7 +153,7 @@ class AccountEdiFormat(models.Model):
         }
 
     @api.model
-    def _l10n_eg_get_einvoice_status(self, invoice):
+    def _l10n_eg_get_einvoice_document_summary(self, invoice):
         access_data = self._l10n_eg_eta_get_access_token(invoice)
         if access_data.get('error'):
             return access_data
@@ -162,6 +167,11 @@ class AccountEdiFormat(models.Model):
             return response_data
         response_data = response_data.get('response').json()
         document_summary = [doc for doc in response_data.get('documentSummary', []) if doc.get('uuid') == invoice.l10n_eg_uuid]
+        return {'doc_data': document_summary}
+
+    @api.model
+    def _l10n_eg_get_einvoice_status(self, invoice):
+        document_summary = self._l10n_eg_get_einvoice_document_summary(invoice)
         return_dict = {
             'Invalid': {
                 'error': _("This invoice has been marked as invalid by the ETA. Please check the ETA website for more information"),
@@ -174,8 +184,8 @@ class AccountEdiFormat(models.Model):
             'Valid': {'success': True},
             'Cancelled': {'error': _('Document Canceled'), 'blocking_level': 'error'},
         }
-        if document_summary and return_dict.get(document_summary[0].get('status')):
-            return return_dict.get(document_summary[0]['status'])
+        if document_summary.get('doc_data') and return_dict.get(document_summary['doc_data'][0].get('status')):
+            return return_dict.get(document_summary['doc_data'][0]['status'])
         return {'error': _('an Unknown error has occured'), 'blocking_level': 'warning'}
 
     def _l10n_eg_eta_get_access_token(self, invoice):


### PR DESCRIPTION
**Steps to reproduce:** (Require credentials)
- Install l10n_eg_edi_eta
- Switch to an Egyptian company
- Configure the Egyption localization
- Create an invoice and post it to ETA
- Go to ETA portal and reject the invoice
- From invoice in Odoo, request EDI cancellation

**Issue:**
The following error is displayed:
{
    'code': 'ValidationError',
    'message': None,
    'target': 'Update Document Status',
    'details': [{
        'code': None,
        'target': 'Document.UUID',
        'message': 'Provided Status is invalid, based on the current document status.'
    }]
}

**Solution:**
Before cancelling an invoice, check submission status.
If it's cancelled or rejected, do not send the cancellation EDI request and responds to the method with a success.

opw-3884519



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
