### PR TITLE
[FIX] mass_mailing: only traces belonging to mailing

### DIFF
--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -735,6 +735,7 @@ class MassMailing(models.Model):
 
     def _action_view_documents_filtered(self, view_filter):
         def _fetch_trace_res_ids(trace_domain):
+            trace_domain.append(('mass_mailing_id', '=', self.id))
             result = self.env['mailing.trace'].search_read(
                 domain=trace_domain, fields=['res_id'])
             return [line['res_id'] for line in result]


### PR DESCRIPTION
The smart buttons on mass mailings were tracking all mailing traces on the database instead of only mailing traces belonging to the mass mailing in question. Adding a filter on each of these cases to only track traces belonging to the mass mailing in question fixes this issue.

opw-3950732

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
