### PR TITLE
[IMP] hr_expense: remove term "Or" in expense mobile view

### DIFF
--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -432,7 +432,7 @@
                     <h2 class="d-none d-md-block">
                         Drag and drop files to create expenses
                     </h2>
-                    <p>
+                    <p class="d-none d-md-block">
                         Or
                     </p>
                     <h2 class="d-none d-md-block">


### PR DESCRIPTION
-Before this commit, when user has no expense at all and in mobile view of expense, it will display term "Or" alongside with "Snap pictures of your receipts..."
-After this commit, remove term "Or".

Description of the issue/feature this PR addresses:

Current behavior before PR:
![image](https://github.com/odoo/odoo/assets/56789189/fba82ba0-f2ab-4b87-8a65-618eca3b5e3a)


Desired behavior after PR is merged:
![image](https://github.com/odoo/odoo/assets/56789189/d549a497-e39f-4c55-bd3a-be8e8a8e4640)




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
