### PR TITLE
[FIX] project: fix traceback when sharing project in SO

### DIFF
--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -646,6 +646,8 @@ class Project(models.Model):
         local_context = self.env.context | {
             'default_template_id': template.id if template else False,
             'default_email_layout_xmlid': 'mail.mail_notification_light',
+            'active_id': self.id,
+            'active_model': 'project.project',
         }
         action = self.env["ir.actions.actions"]._for_xml_id("project.project_share_wizard_action")
         if self.env.context.get('default_access_mode'):


### PR DESCRIPTION
After this commit:
fixes the traceback issue when sharing the project from SO. The issue is due to the wrong active_model and active_id, by passing the `active_model`, `active_id` in `action_open_share_project_wizard` the issue will be fixed.

Effected commit -https://github.com/odoo/odoo/commit/606f710ebd611f33c677f89ca25effd691290a15

task-3998576
