### PR TITLE
[16.0][REF] stock_account: refactoring for finding candidates

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -321,16 +321,23 @@ class ProductProduct(models.Model):
         if account_moves:
             account_moves._post()
 
+    def _get_fifo_candidates_domain(self, company):
+        return [
+            ("product_id", "=", self.id),
+            ("remaining_qty", ">", 0),
+            ("company_id", "=", company.id),
+        ]
+
+    def _get_fifo_candidates(self, company):
+        candidates_domain = self._get_fifo_candidates_domain(company)
+        return self.env["stock.valuation.layer"].sudo().search(candidates_domain)
+
     def _run_fifo(self, quantity, company):
         self.ensure_one()
 
         # Find back incoming stock valuation layers (called candidates here) to value `quantity`.
         qty_to_take_on_candidates = quantity
-        candidates = self.env['stock.valuation.layer'].sudo().search([
-            ('product_id', '=', self.id),
-            ('remaining_qty', '>', 0),
-            ('company_id', '=', company.id),
-        ])
+        candidates = self._get_fifo_candidates(company)
         new_standard_price = 0
         tmp_value = 0  # to accumulate the value taken on the candidates
         for candidate in candidates:


### PR DESCRIPTION
This PR refactors the process of finding candidates (SVL) in the FIFO run of the stock account. With the current Odoo standard behavior, we can't update the domain to find candidates or adjust the candidates' values, and we have to override `def _run_fifo.` This PR addresses this issue.

@qrtl QT4657