### PR TITLE
[FIX] mail: fix non deterministic starred counter test

### DIFF
--- a/addons/mail/static/tests/crosstab/crosstab.test.js
+++ b/addons/mail/static/tests/crosstab/crosstab.test.js
@@ -45,6 +45,8 @@ test("Delete starred message updates counter", async () => {
     const env2 = await start({ asTab: true });
     await openDiscuss(channelId, { target: env1 });
     await openDiscuss(channelId, { target: env2 });
+    await contains(".o-mail-Message", { target: env1, text: "Hello World!" });
+    await contains(".o-mail-Message", { target: env2, text: "Hello World!" });
     await contains("button", { target: env2, text: "Starred1" });
     rpc("/mail/message/update_content", {
         message_id: messageId,


### PR DESCRIPTION
Before this PR, the `delete starred message updates counter` test was sometimes failing. It occurs when the message is deleted before it is loaded. This PR ensures we wait for the message to be loaded before deleting it.

runbot-61305,62004