### PR TITLE
[FIX] account: fix _compute_max_tax_lock_date depends

### DIFF
--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -259,7 +259,7 @@ class ResCompany(models.Model):
             if html:
                 company.invoice_terms_html = html
 
-    @api.depends('parent_id.max_tax_lock_date')
+    @api.depends('tax_lock_date', 'parent_id.max_tax_lock_date')
     def _compute_max_tax_lock_date(self):
         for company in self:
             company.max_tax_lock_date = max(company.tax_lock_date or date.min, company.parent_id.sudo().max_tax_lock_date or date.min)


### PR DESCRIPTION
The field `max_tax_lock_date` is not always computed correctly. This is since the compute function does not depend on the `tax_lock_date` field.

It should not happen in production since the `tax_lock_date` and the check of `max_tax_lock_date` should not happen in the same transaction. But it can still cause issues in tests.

The missing dependency is added in this commit.

enterprise PR (fixing a test): https://github.com/odoo/enterprise/pull/65262