### PR TITLE
[FIX] project_todo: fixed task_split_activities_tour

### DIFF
--- a/addons/project_todo/static/tests/tours/project_task_activities_split.js
+++ b/addons/project_todo/static/tests/tours/project_task_activities_split.js
@@ -15,6 +15,7 @@ registry.category("web_tour.tours").add('project_task_activities_split', {
         }, {
             content: 'Task "New Task!" is listed in the activity view',
             trigger: '.o_activity_record .d-block:contains("New Task!")',
+            isCheck: true,
         }, {
             content: 'Task "New Sub-Task!" is listed in the activity view',
             trigger: '.o_activity_record .d-block:contains("New Sub-Task!")',

--- a/addons/project_todo/tests/test_todo_ui.py
+++ b/addons/project_todo/tests/test_todo_ui.py
@@ -17,6 +17,7 @@ class TestTodoUi(HttpCase):
                 - activities linked to records with either project_id set or
                   linked to a parent task are listed in the 'Task' category
         """
+        self.env.user.tz = "UTC"
         project = self.env['project.project'].create([{'name': 'Test project'}])
         stage = self.env['project.task.type'].create([{
             'name': 'Test Stage',


### PR DESCRIPTION
Here the error was due to timezone differences, so a frozentime wouldn't act indifferent irrespective of timezone. Also the isCheck is required in tour because a default run function is generated for every tour step for the specific I changed it is click. It is currently not affecting the tour because the tour is run with no delay.

task-4004285
