### PR TITLE
Fix an error that occurs when opening the salary configurator as an applicant.

### DIFF
--- a/addons/hr_contract/models/hr_contract.py
+++ b/addons/hr_contract/models/hr_contract.py
@@ -107,7 +107,7 @@ class Contract(models.Model):
             return default_structure
 
         for contract in self:
-            if not contract.structure_type_id or contract.structure_type_id.country_id != contract.company_id.country_id:
+            if not contract.structure_type_id or (contract.structure_type_id.country_id and contract.structure_type_id.country_id != contract.company_id.country_id):
                 contract.structure_type_id = _default_salary_structure(contract.company_id.country_id.id)
 
     @api.onchange('structure_type_id')


### PR DESCRIPTION
Description of the issue/feature this PR addresses: 
- Fix an error that occurs when opening the salary configurator as an applicant. task-3958678

- To reproduce (on runbot):

  1. Go to: Recruitment / Configuration / Contracts / Contract Templates
  2. Create a new contract template:
     1. Name: Employee contract template
     2. Salary structure: Employee
     3. HR Responsible: Mitchell Admin
  3. Create a new applicant for any job position:
     1. Applicant's Name: John Doe
     2. Email: john@example.com
  4. Click "Generate Offer":
     1. Contract Template: Employee contract template
     2. Click "Save"
  5. On the offer, click "Salary Configurator"
  6. An error occurs."

This occurs because the `salary structure type` on the contract is reset to the country's default if it isn't related to a specific country.

To fix the issue, Prevent the `salary structure type` from resetting to the country's default if the `salary structure type` of the contract is generic (isn't related to a specific country) such as Employee​.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
