### PR TITLE
[IMP] base: enable WS during tests

### DIFF
--- a/addons/bus/models/bus.py
+++ b/addons/bus/models/bus.py
@@ -191,6 +191,8 @@ class ImDispatch(threading.Thread):
     def _clear_outdated_channels(self, websocket, outdated_channels):
         """ Remove channels from channel to websocket map. """
         for channel in outdated_channels:
+            if channel not in self._channels_to_ws:
+                continue
             self._channels_to_ws[channel].remove(websocket)
             if not self._channels_to_ws[channel]:
                 self._channels_to_ws.pop(channel)

--- a/addons/bus/tests/common.py
+++ b/addons/bus/tests/common.py
@@ -25,8 +25,6 @@ class WebsocketCase(HttpCase):
             cls._logger.warning("websocket-client module is not installed")
             raise unittest.SkipTest("websocket-client module is not installed")
         cls._WEBSOCKET_URL = f"ws://{HOST}:{odoo.tools.config['http_port']}/websocket"
-        websocket_allowed_patch = patch.object(WebsocketConnectionHandler, "websocket_allowed", return_value=True)
-        cls.startClassPatcher(websocket_allowed_patch)
 
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
Until now, websockets were disabled during tests. However, applications such as discuss cannot properly be tested without receiving messages from the bus.

This PR enables the websockets during tests.

task-3970199
