### PR TITLE
[IMP] pos_restaurant: show amount per guest if more than one guest

### DIFF
--- a/addons/pos_restaurant/static/src/overrides/components/payment_screen/payment_screen.xml
+++ b/addons/pos_restaurant/static/src/overrides/components/payment_screen/payment_screen.xml
@@ -23,7 +23,7 @@
     </t>
     <t t-name="pos_restaurant.PaymentScreenDue" t-inherit="point_of_sale.PaymentScreenDue" t-inherit-mode="extension">
         <xpath expr="//section[hasclass('paymentlines-container')]" position="inside">
-            <div t-if="currentOrder.getCustomerCount()" class="message text-center fs-4">
+            <div t-if="currentOrder.getCustomerCount() > 1" class="message text-center fs-4">
                 <t t-esc="this.env.utils.formatCurrency(currentOrder.amountPerGuest())" /> / Guest
             </div>
         </xpath>


### PR DESCRIPTION
Before this commit
-------------------------
The amount per guest was displayed for every case even if the customer is only one on the table.

After this commit
----------------------
If the customer-count is more than one than only show the per guest amount because for only one guest total amount and per guest amount will be same and makes no sense to show again.

task: 4002199