### PR TITLE
[FIX] point_of_sale: correctly load partner from server by barcode

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -234,7 +234,8 @@ export class ProductScreen extends Component {
     async _getPartnerByBarcode(code) {
         let partner = this.pos.models["res.partner"].getBy("barcode", code.code);
         if (!partner) {
-            partner = this.pos.data.searchRead("res.partner", ["barcode", "=", code.code]);
+            partner = await this.pos.data.searchRead("res.partner", [["barcode", "=", code.code]]);
+            partner = partner.length > 0 && partner[0];
         }
         return partner;
     }


### PR DESCRIPTION
Before this commit, scanning a partner's barcode did not successfully load the partner from the server, leading to functionality issues.

opw-3986674

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
