### PR TITLE
[IMP] mail: getter for chatter's fetch root

### DIFF
--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -787,6 +787,10 @@ export class Thread extends Record {
         if (this.model === "mail.box") {
             return `/mail/${this.id}/messages`;
         }
+        return this.chatterFetchRoute;
+    }
+
+    get chatterFetchRoute() {
         return "/mail/thread/messages";
     }
 


### PR DESCRIPTION
Since the fetch root of chatter is different in the portal from the backend, this commit defines a `getter` for this root, so it'd be possible to change it in the portal.

Part of task-2828744