### PR TITLE
[FIX] project: traceback when duplicating projects in batch

### DIFF
--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -416,7 +416,7 @@ class Project(models.Model):
                 new_project.milestone_ids = self.milestone_ids.copy().ids
             if 'tasks' not in default:
                 old_project.map_tasks(new_project.id)
-            if not self.active:
+            if not old_project.active:
                 new_project.with_context(active_test=False).tasks.active = True
         return new_projects
 


### PR DESCRIPTION
'self' could be a recordset, in which case accessing the 'active' field results in ValueError: too many values to unpack. We then need to make the check individually for each copied project.

task-4008123
version-17.3

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
