### PR TITLE
[FIX] account: normalize tax_tag_invert on early payment discount

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3215,6 +3215,7 @@ class AccountMove(models.Model):
                         **vals,
                         'amount_currency': 0.0,
                         'balance': 0.0,
+                        'display_type': 'epd',  # Used to compute tax_tag_invert for early payment discount lines
                     })
                     line_vals['amount_currency'] += vals['amount_currency']
                     line_vals['balance'] += vals['balance']

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -768,7 +768,10 @@ class AccountMoveLine(models.Model):
                 tax = record.tax_repartition_line_id.tax_id or record.tax_ids[:1]
                 is_refund = record.is_refund
                 tax_type = tax.type_tax_use
-                record.tax_tag_invert = (tax_type == 'purchase' and is_refund) or (tax_type == 'sale' and not is_refund)
+                if record.display_type == 'epd':  # In case of early payment, tax_tag_invert is independent of the balance of the line
+                    record.tax_tag_invert = tax_type == 'purchase'
+                else:
+                    record.tax_tag_invert = (tax_type == 'purchase' and is_refund) or (tax_type == 'sale' and not is_refund)
             else:
                 # For invoices with taxes
                 record.tax_tag_invert = origin_move_id.is_inbound()

--- a/addons/account/tests/test_early_payment_discount.py
+++ b/addons/account/tests/test_early_payment_discount.py
@@ -882,3 +882,86 @@ class TestAccountEarlyPaymentDiscount(AccountTestInvoicingCommon):
                 'display_type': 'payment_term',
             },
         ])
+
+    def test_epd_entry_tag_invert_with_distinct_negative_invoice_line(self):
+        """
+        `tax_tag_invert` should be the same for all Early Payment Discount lines of a single entry
+        """
+
+        analytic_plan = self.env['account.analytic.plan'].create({
+            'name': 'existential plan',
+        })
+        analytic_account_a = self.env['account.analytic.account'].create({
+            'name': 'positive_account',
+            'plan_id': analytic_plan.id,
+        })
+        analytic_account_b = self.env['account.analytic.account'].create({
+            'name': 'negative_account',
+            'plan_id': analytic_plan.id,
+        })
+
+        invoice = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'partner_id': self.partner_a.id,
+            'invoice_date': '2019-01-10',
+            'date': '2019-01-10',
+            'invoice_line_ids': [
+                Command.create({
+                    'name': 'line',
+                    'price_unit': 2000,
+                    'tax_ids': self.tax_sale_a,
+                    'analytic_distribution': {str(analytic_account_a.id): 100},
+                }),
+                Command.create({
+                    'name': 'line',
+                    'price_unit': -1500,
+                    'tax_ids': self.tax_sale_a,
+                    'analytic_distribution': {str(analytic_account_b.id): 100},
+                }),
+            ],
+            'invoice_payment_term_id': self.early_pay_10_percents_10_days.id,
+        })
+        invoice.action_post()
+
+        bill = self.env['account.move'].create({
+            'move_type': 'in_invoice',
+            'partner_id': self.partner_b.id,
+            'invoice_date': '2019-01-10',
+            'date': '2019-01-10',
+            'invoice_line_ids': [
+                Command.create({
+                    'name': 'line',
+                    'price_unit': 3000,
+                    'tax_ids': self.tax_purchase_a,
+                    'analytic_distribution': {str(analytic_account_a.id): 100},
+                }),
+                Command.create({
+                    'name': 'line',
+                    'price_unit': -2250,
+                    'tax_ids': self.tax_purchase_a,
+                    'analytic_distribution': {str(analytic_account_b.id): 100},
+                }),
+            ],
+            'invoice_payment_term_id': self.early_pay_10_percents_10_days.id,
+        })
+        bill.action_post()
+
+        payments = self.env['account.payment.register'].with_context(
+            active_model='account.move',
+            active_ids=invoice.ids,
+        ).create({
+            'payment_date': '2019-01-01',
+        })._create_payments()
+
+        for line in payments.line_ids.filtered(lambda line: line.tax_repartition_line_id or line.tax_ids):
+            self.assertFalse(line.tax_tag_invert)
+
+        payments = self.env['account.payment.register'].with_context(
+            active_model='account.move',
+            active_ids=bill.ids,
+        ).create({
+            'payment_date': '2019-01-01',
+        })._create_payments()
+
+        for line in payments.line_ids.filtered(lambda line: line.tax_repartition_line_id or line.tax_ids):
+            self.assertTrue(line.tax_tag_invert)


### PR DESCRIPTION
### Steps to reproduce the issue:

1. Create a Customer Invoice with two product lines
2. Give a negative price to one of those lines, the total must remain positive
3. Add distinct analytic accounts to each line's analytic_distribution
4. Add a payment term with applicable early discount
5. Confirm and Register Payment
6. Go to the Journal Entry related to the Invoice
7. Check the Invert Tags (developer mode), one of them is set to True, which should not be the case

### Explanation:

In the current situation, `_compute_is_refund` and `_compute_tax_tag_invert` will assign a value to `tax_tag_invert` depending on the `account.move.line.balance`. Because of the distinct analytic accounts, the negative line is separated from the others and because of the logic behind the computes, `tax_tag_invert` is set to the opposite value.

### Fix reasoning:

While `account.payment` are restricted to `account.move` with the same direction, `account.bank.statement.line` are not. In the current case, the affected lines all have `tax_ids` values. Thanks to this, we can use `account.tax.type_tax_use` independently of the line's balance to differentiate in and out transactions and assign `tax_tag_invert` consistently.
We must also consider the case where `account.bank.statement.line`. To target the Early Payment Discount lines, we will separate them from the other values using `display_type`.

opw-3989174