### PR TITLE
[FIX] web, board, stock: update action state from controllers components

### DIFF
--- a/addons/board/static/src/board_controller.js
+++ b/addons/board/static/src/board_controller.js
@@ -19,7 +19,6 @@ export class BoardController extends Component {
     static props = {
         ...standardViewProps,
         board: Object,
-        updateResId: { type: Function, optional: true },
     };
 
     setup() {

--- a/addons/stock/static/src/client_actions/stock_traceability_report_backend.js
+++ b/addons/stock/static/src/client_actions/stock_traceability_report_backend.js
@@ -59,10 +59,14 @@ export class TraceabilityReport extends Component {
         Object.assign(this.context, {
             active_id: active_id || this.props.action.params.active_id,
             auto_unfold: auto_unfold || false,
-            model: active_model || false,
+            model: active_model || this.props.action.context.params?.active_model || false,
             lot_name: lot_name || false,
             ttype: ttype || false,
         });
+
+        if (this.context.model) {
+            this.props.updateActionState({ active_model: this.context.model });
+        }
 
         this.display = {
             controlPanel: {},

--- a/addons/web/static/src/views/form/form_controller.js
+++ b/addons/web/static/src/views/form/form_controller.js
@@ -135,12 +135,11 @@ export class FormController extends Component {
         preventEdit: { type: Boolean, optional: true },
         onDiscard: { type: Function, optional: true },
         onSave: { type: Function, optional: true },
-        updateResId: { type: Function, optional: true },
     };
     static defaultProps = {
         preventCreate: false,
         preventEdit: false,
-        updateResId: () => {},
+        updateActionState: () => {},
     };
 
     setup() {
@@ -191,7 +190,7 @@ export class FormController extends Component {
             effect(
                 (model) => {
                     if (status(this) === "mounted") {
-                        this.props.updateResId(model.root.resId);
+                        this.props.updateActionState({ resId: model.root.resId });
                     }
                 },
                 [this.model]

--- a/addons/web/static/src/views/standard_view_props.js
+++ b/addons/web/static/src/views/standard_view_props.js
@@ -36,4 +36,5 @@ export const standardViewProps = {
     selectRecord: { type: Function, optional: true },
     state: { type: Object, optional: true },
     useSampleModel: { type: Boolean },
+    updateActionState: { type: Function, optional: true },
 };

--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -27,7 +27,7 @@ import {
     reactive,
 } from "@odoo/owl";
 import { downloadReport, getReportUrl } from "./reports/utils";
-import { pick } from "@web/core/utils/objects";
+import { omit, pick, shallowEqual } from "@web/core/utils/objects";
 import { zip } from "@web/core/utils/arrays";
 
 class BlankComponent extends Component {
@@ -84,7 +84,7 @@ export const standardActionServiceProps = {
     globalState: { type: Object, optional: true }, // prop added by _updateUI
     state: { type: Object, optional: true }, // prop added by _updateUI
     resId: { type: [Number, Boolean], optional: true },
-    updateResId: { type: Function, optional: true },
+    updateActionState: { type: Function, optional: true },
 };
 
 function parseActiveIds(ids) {
@@ -171,6 +171,7 @@ export function makeActionManager(env, router = _router) {
                     action: {},
                     props: {},
                     state: { ...actionState, actionStack: state.actionStack.slice(0, index + 1) },
+                    currentState: {},
                 };
                 if (actionState.action) {
                     controller.action.id = actionState.action;
@@ -193,6 +194,7 @@ export function makeActionManager(env, router = _router) {
                     }
                     if (actionState.active_id) {
                         controller.action.context = { active_id: actionState.active_id };
+                        controller.currentState.active_id = actionState.active_id;
                     }
                 }
                 if (actionState.model) {
@@ -202,7 +204,7 @@ export function makeActionManager(env, router = _router) {
                 if (actionState.resId) {
                     controller.action.type ||= "ir.actions.act_window";
                     controller.props.resId = actionState.resId;
-                    controller.resId = () => actionState.resId;
+                    controller.currentState.resId = actionState.resId;
                     controller.props.type = "form";
                 }
                 return controller;
@@ -555,19 +557,21 @@ export function makeActionManager(env, router = _router) {
      */
     function _getActionInfo(action, props) {
         const actionProps = Object.assign({}, props, { action, actionId: action.id });
-        actionProps.updateResId = (newId) => {
-            const changed = resId !== newId;
-            resId = newId;
-            if (changed && action.target !== "new") {
-                // It's possible that the ControllerComponent is not mounted yet, so we
-                // need to wait for the next microtask to push the state.
-                Promise.resolve().then(() => pushState());
+        const currentState = {
+            resId: actionProps.resId || false,
+            active_id: action.context.active_id || false,
+        };
+        actionProps.updateActionState = (controller, patchState) => {
+            const oldState = { ...currentState };
+            Object.assign(currentState, patchState);
+            const changed = !shallowEqual(currentState, oldState);
+            if (changed && action.target !== "new" && controller.isMounted) {
+                pushState();
             }
         };
-        let resId = actionProps.resId || false;
         return {
             props: actionProps,
-            resId: () => resId,
+            currentState,
             config: {
                 actionId: action.id,
                 actionType: "ir.actions.client",
@@ -648,15 +652,19 @@ export function makeActionManager(env, router = _router) {
                 }
             },
         });
-
+        const currentState = {
+            resId: viewProps.resId,
+            active_id: action.context.active_id || false,
+        };
+        viewProps.updateActionState = (controller, patchState) => {
+            const oldState = { ...currentState };
+            Object.assign(currentState, patchState);
+            const changed = !shallowEqual(currentState, oldState);
+            if (changed && target !== "new" && controller.isMounted) {
+                pushState();
+            }
+        };
         if (view.type === "form") {
-            viewProps.updateResId = (newId) => {
-                const changed = resId !== newId;
-                resId = newId;
-                if (changed && target !== "new") {
-                    pushState();
-                }
-            };
             if (target === "new") {
                 viewProps.mode = "edit";
                 if (!viewProps.onSave) {
@@ -700,10 +708,9 @@ export function makeActionManager(env, router = _router) {
             "no_breadcrumbs" in action.context ? action.context.no_breadcrumbs : target === "new";
         delete action.context.no_breadcrumbs;
 
-        let resId = viewProps.resId;
         return {
             props: viewProps,
-            resId: () => resId,
+            currentState,
             config: {
                 actionId: action.id,
                 actionType: "ir.actions.act_window",
@@ -907,12 +914,15 @@ export function makeActionManager(env, router = _router) {
                 this.isMounted = true;
             }
             onWillUnmount() {
+                this.isMounted = false;
                 if (action.target === "new" && dialogCloseResolve) {
                     dialogCloseResolve();
                 }
             }
             get componentProps() {
                 const componentProps = { ...this.props };
+                const updateActionState = componentProps.updateActionState;
+                componentProps.updateActionState = (newState) => updateActionState(this, newState);
                 if (this.constructor.Component === View) {
                     componentProps.__beforeLeave__ = this.__beforeLeave__;
                     componentProps.__getGlobalState__ = this.__getGlobalState__;
@@ -1530,6 +1540,9 @@ export function makeActionManager(env, router = _router) {
     }
 
     function pushState() {
+        if (!controllerStack.length) {
+            return;
+        }
         const actions = controllerStack.map((controller) => {
             const { action, props, displayName } = controller;
             const actionState = { displayName };
@@ -1543,38 +1556,35 @@ export function makeActionManager(env, router = _router) {
             if (action.type === "ir.actions.act_window") {
                 actionState.view_type = props.type;
                 if (props.type === "form" && action.res_model !== "res.config.settings") {
-                    actionState.resId = controller.resId() || "new";
+                    actionState.resId = controller.currentState.resId || "new";
                 }
             }
-            if (action.type === "ir.actions.client" && controller.resId?.()) {
-                actionState.resId = controller.resId();
+            if (action.type === "ir.actions.client" && controller.currentState?.resId) {
+                actionState.resId = controller.currentState.resId;
             }
 
-            if (action.context) {
-                const activeId = action.context.active_id;
+            if (controller.currentState?.active_id) {
+                const activeId = controller.currentState.active_id;
                 if (activeId) {
                     actionState.active_id = activeId;
                 }
-                const activeIds = action.context.active_ids;
-                // we don't push active_ids if it's a single element array containing
-                // the active_id to make the url shorter in most cases
-                if (activeIds && !(activeIds.length === 1 && activeIds[0] === activeId)) {
-                    actionState.active_ids = activeIds.join(",");
-                }
             }
+            Object.assign(actionState, omit(controller.currentState || {}, ...PATH_KEYS));
             return actionState;
         });
-        const newState = {};
-        if (actions.length) {
-            newState.actionStack = actions;
-            const stateKeys = [...PATH_KEYS, "active_ids"];
-            const { action, props } = controllerStack.at(-1);
-            if (props.type !== "form" && props.type !== action.views?.[0][1]) {
-                // add view_type only when it's not already known implicitly
-                stateKeys.push("view_type");
-            }
-            Object.assign(newState, pick(newState.actionStack.at(-1), ...stateKeys));
+        const newState = {
+            actionStack: actions,
+        };
+        const stateKeys = [...PATH_KEYS];
+        const { action, props, currentState } = controllerStack.at(-1);
+        if (props.type !== "form" && props.type !== action.views?.[0][1]) {
+            // add view_type only when it's not already known implicitly
+            stateKeys.push("view_type");
         }
+        if (currentState) {
+            stateKeys.push(...Object.keys(omit(currentState, ...PATH_KEYS)));
+        }
+        Object.assign(newState, pick(newState.actionStack.at(-1), ...stateKeys));
 
         controllerStack.at(-1).state = newState;
         router.pushState(newState, { replace: true });

--- a/addons/web/static/tests/legacy/webclient/actions/load_state_tests.js
+++ b/addons/web/static/tests/legacy/webclient/actions/load_state_tests.js
@@ -214,8 +214,7 @@ QUnit.module("ActionManager", (hooks) => {
     });
 
     QUnit.test("correctly sends additional context", async (assert) => {
-        // %2C is a URL-encoded comma
-        redirect("/odoo/4/action-1001?active_ids=4%2C8");
+        redirect("/odoo/4/action-1001");
         logHistoryInteractions(assert);
         function mockRPC(route, params) {
             if (route === "/web/action/load") {
@@ -223,7 +222,7 @@ QUnit.module("ActionManager", (hooks) => {
                     action_id: 1001,
                     context: {
                         active_id: 4, // aditional context
-                        active_ids: [4, 8], // aditional context
+                        active_ids: [4], // aditional context
                         lang: "en", // user context
                         tz: "taht", // user context
                         uid: 7, // user context
@@ -234,11 +233,11 @@ QUnit.module("ActionManager", (hooks) => {
         await createWebClient({ serverData, mockRPC });
         assert.strictEqual(
             browser.location.href,
-            "http://example.com/odoo/4/action-1001?active_ids=4%2C8",
+            "http://example.com/odoo/4/action-1001",
             "url did not change"
         );
         assert.verifySteps([
-            "Update the state without updating URL, nextState: actionStack,action,active_id,active_ids",
+            "Update the state without updating URL, nextState: actionStack,action,active_id",
         ]);
     });
 
@@ -397,7 +396,7 @@ QUnit.module("ActionManager", (hooks) => {
         );
     });
 
-    QUnit.test("properly load client actions with updateResId", async function (assert) {
+    QUnit.test("properly load client actions with updateActionState", async function (assert) {
         class ClientAction extends Component {
             static template = xml`<ControlPanel/><div class="o_client_action_test">Hello World</div>`;
             static props = ["*"];
@@ -406,7 +405,7 @@ QUnit.module("ActionManager", (hooks) => {
 
             setup() {
                 onMounted(() => {
-                    this.props.updateResId(12);
+                    this.props.updateActionState({ resId: 12 });
                 });
             }
         }


### PR DESCRIPTION
- In the Inventory app, go to Lots/Serial Numbers;
- Open any record;
- Click on the Traceability stat button;
- reload the page;

Before this commit, the message "No operation made on this lot." was
shown, even if there are operations. This occurs because the
TraceabilityReport lost the current model at reload (active_model).

Since [1] a new prop (a function called updateResId) was give to the
controllers components of the window actions to update the resId on the
action state and url, when needed. For instance, the form view after
saving a new record, will update the state and the url with the newly
created id.

Since [2], the prop was also given to the controllers components of the
client actions to update the resId.

There is a need to update more than the resId. This PR will introduce a
new prop with the aim to update the action state (updateActionState).
This props will allow the controller components to update the state and
push the new state to the router (updating the url).

In practical, this allows to push a new state in the url, keeping the
action service in sync. This synchronization between the router and the
action service allows the browser back/forward/reload to work as
expected.

Now, the TraceabilityReport can update the state, to add the
active_model to the url (as a query param), and be able to restore the
full state at reload.

[1]: https://github.com/odoo/odoo/commit/c63d14a0485a553b74a8457aee158384e9ae6d3f
[2]: https://github.com/odoo/odoo/commit/3ad4fd65387f60b524e5f786556963ead8ae9dfe
