### PR TITLE
[FIX] point_of_sale: fix fields reading in data_service.js

### DIFF
--- a/addons/point_of_sale/static/src/app/models/data_service.js
+++ b/addons/point_of_sale/static/src/app/models/data_service.js
@@ -121,9 +121,16 @@ export class PosData extends Reactive {
         this.network.loading = true;
         try {
             let result = true;
-
+            let limitedFields = false;
             if (fields.length === 0) {
-                fields = this.fields[model];
+                fields = this.fields[model] || [];
+            }
+
+            if (
+                this.fields[model] &&
+                fields.sort().join(",") !== this.fields[model].sort().join(",")
+            ) {
+                limitedFields = true;
             }
 
             switch (type) {
@@ -155,6 +162,55 @@ export class PosData extends Reactive {
                 const response = await this.orm.create(model, values);
                 values[0].id = response[0];
                 result = values;
+            }
+
+            if (limitedFields) {
+                const X2MANY_TYPES = new Set(["many2many", "one2many"]);
+                const nonExistentRecords = [];
+
+                for (const record of result) {
+                    const localRecord = this.models[model].get(record.id);
+
+                    if (localRecord) {
+                        const formattedForUpdate = {};
+                        for (const [field, value] of Object.entries(record)) {
+                            const fieldsParams = this.relations[model][field];
+
+                            if (!fieldsParams) {
+                                console.info("Warning, attempt to load a non-existent field.");
+                                continue;
+                            }
+
+                            if (X2MANY_TYPES.has(fieldsParams.type)) {
+                                formattedForUpdate[field] = value
+                                    .filter((id) => this.models[fieldsParams.relation].get(id))
+                                    .map((id) => [
+                                        "link",
+                                        this.models[fieldsParams.relation].get(id),
+                                    ]);
+                            } else if (fieldsParams.type === "many2one") {
+                                if (this.models[fieldsParams.relation].get(value)) {
+                                    formattedForUpdate[field] = [
+                                        "link",
+                                        this.models[fieldsParams.relation].get(value),
+                                    ];
+                                }
+                            } else {
+                                formattedForUpdate[field] = value;
+                            }
+                        }
+                        localRecord.update(formattedForUpdate);
+                    } else {
+                        nonExistentRecords.push(record);
+                    }
+                }
+
+                if (nonExistentRecords.length) {
+                    console.warn(
+                        "Warning, attempt to load a non-existent record with limited fields."
+                    );
+                    result = nonExistentRecords;
+                }
             }
 
             if (this.models[model] && LOADED_ORM_METHODS.includes(type)) {


### PR DESCRIPTION
Before when read or search_read was called on a model with specific fields, the server was returning only these fields which is normal.

But when data_service was loading these fields, it was replacing the old record with the new one, which was missing all the other fields.

This commit fixes this by updating only the fields that were returned by the server when there is specific fields in the context.

taskId: 4005114

