### PR TITLE
[FIX] pos_restaurant: _setup_main_restaurant_defaults only if closed

### DIFF
--- a/addons/pos_restaurant/models/pos_config.py
+++ b/addons/pos_restaurant/models/pos_config.py
@@ -112,7 +112,7 @@ class PosConfig(models.Model):
 
     def setup_defaults(self, company):
         main_restaurant = self.env.ref('pos_restaurant.pos_config_main_restaurant', raise_if_not_found=False)
-        main_restaurant_is_present = main_restaurant and self.filtered(lambda cfg: cfg.id == main_restaurant.id)
+        main_restaurant_is_present = main_restaurant and not main_restaurant.has_active_session and self.filtered(lambda cfg: cfg.id == main_restaurant.id)
         if main_restaurant_is_present:
             non_main_restaurant_configs = self - main_restaurant
             non_main_restaurant_configs.assign_payment_journals(company)


### PR DESCRIPTION
Ensure that _setup_main_restaurant_defaults is only called when the main restaurant does not have an active session. This prevents potential errors that could occur if the method is called while a session is active. E.g: https://runbot.odoo.com/runbot/build/64372543

opw-3937178