### PR TITLE
[FIX] web: avoid updating controllers when target is "new"

### DIFF
--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -774,6 +774,9 @@ export function makeActionManager(env, router = _router) {
             reject = _rej;
         });
         const action = controller.action;
+        if (action.target !== "new" && "newStack" in options) {
+            controllerStack = options.newStack;
+        }
         const index = _computeStackIndex(options);
         const nextStack = [...controllerStack.slice(0, index), controller];
         // Compute breadcrumbs
@@ -1088,14 +1091,7 @@ export function makeActionManager(env, router = _router) {
         };
         action.controllers[view.type] = controller;
 
-        return _updateUI(controller, {
-            index: options.index,
-            clearBreadcrumbs: options.clearBreadcrumbs,
-            onClose: options.onClose,
-            stackPosition: options.stackPosition,
-            onActionReady: options.onActionReady,
-            noEmptyTransition: options.noEmptyTransition,
-        });
+        return _updateUI(controller, options);
     }
 
     /**
@@ -1140,15 +1136,7 @@ export function makeActionManager(env, router = _router) {
                 ..._getActionInfo(action, options.props),
             };
             controller.displayName ||= clientAction.displayName?.toString() || "";
-            const updateUIOptions = {
-                index: options.index,
-                clearBreadcrumbs: options.clearBreadcrumbs,
-                stackPosition: options.stackPosition,
-                onClose: options.onClose,
-                onActionReady: options.onActionReady,
-                noEmptyTransition: options.noEmptyTransition,
-            };
-            return _updateUI(controller, updateUIOptions);
+            return _updateUI(controller, options);
         } else {
             const next = await clientAction(env, action);
             if (next) {
@@ -1179,13 +1167,7 @@ export function makeActionManager(env, router = _router) {
             ..._getActionInfo(action, props),
         };
 
-        const updateUIOptions = {
-            clearBreadcrumbs: options.clearBreadcrumbs,
-            stackPosition: options.stackPosition,
-            onClose: options.onClose,
-            index: options.index,
-        };
-        return _updateUI(controller, updateUIOptions);
+        return _updateUI(controller, options);
     }
 
     /**
@@ -1519,11 +1501,12 @@ export function makeActionManager(env, router = _router) {
      * @returns {Promise<boolean>} true if doAction was performed
      */
     async function loadState() {
-        controllerStack = await _controllersFromState();
+        const newStack = await _controllersFromState();
         const actionParams = _getActionParams();
         if (actionParams) {
             // Params valid => performs a "doAction"
             const { actionRequest, options } = actionParams;
+            options.newStack = newStack;
             await doAction(actionRequest, options);
             return true;
         }

--- a/addons/web/static/tests/legacy/webclient/actions/load_state_tests.js
+++ b/addons/web/static/tests/legacy/webclient/actions/load_state_tests.js
@@ -1063,6 +1063,58 @@ QUnit.module("ActionManager", (hooks) => {
         }
     );
 
+    QUnit.test("don't load controllers when load action new", async function (assert) {
+        const mockRPC = async function (route, { method }) {
+            assert.step(method || route);
+        };
+        redirect("/odoo/action-3/2");
+
+        serverData.views = {
+            ...serverData.views,
+            "partner,false,form": `
+                <form>
+                    <a href="http://example.com/odoo/action-5" class="clickMe">clickMe</a>
+                    <group>
+                        <field name="display_name"/>
+                        <field name="foo"/>
+                    </group>
+                </form>`,
+        };
+
+        await createWebClient({ serverData, mockRPC });
+        assert.containsOnce(target, ".o_form_view");
+        assert.deepEqual(getBreadCrumbTexts(target), ["Partners", "Second record"]);
+        assert.verifySteps([
+            "/web/webclient/load_menus",
+            "/web/action/load",
+            "get_views",
+            "web_read",
+        ]);
+        assert.strictEqual(
+            browser.location.href,
+            "http://example.com/odoo/action-3/2",
+            "the url did not change"
+        );
+
+        await click(target, ".clickMe");
+        assert.containsOnce(target, ".o_dialog .o_form_view");
+        assert.verifySteps(["/web/action/load", "get_views", "onchange"]);
+        assert.strictEqual(
+            browser.location.href,
+            "http://example.com/odoo/action-3/2",
+            "the url did not change"
+        );
+
+        // Close the dialog
+        await click(target, ".o_dialog .o_form_button_cancel");
+
+        //Go back to the multi-record view
+        await click(target, ".breadcrumb-item");
+        await nextTick();
+        assert.containsOnce(target, ".o_list_view");
+        assert.verifySteps(["web_search_read"]);
+    });
+
     QUnit.module("Load State: legacy urls");
 
     QUnit.test("action loading", async (assert) => {


### PR DESCRIPTION
- Open the Employees app;
- Open the record of an employee, that have the onbording plan link in
    the chatter (for instance Abigail Peterson in runbot);
- Click on the onbording plan;
- Close the onbording plan dialog;
- Click on the Employees link in the breadcrumb to came back to the
    employees multi-record view;

Before this commit, a traceback was raised : `Invalid controller to
restore`. This issue occurs because when we load from a link/URL
(loadState), the controllers list is updated from the actions found in
the URL, this is done to be able to recreate the controllers (the
breadcrumb) from the URL.
This behavior is correct when the action has a target other than “new”
(i.e., when it's not a dialog). In the case of a target "new" (a dialog)
the controllers shouldn't be modified, to be able to interact with the
breadcrumb when the dialog is closed.

Now, only when the action has a target different from "new", the
controllers are updated from the URL.
