### PR TITLE
[17.0][FIX] project: Cannot cancel filter in burndown chart

### DIFF
--- a/addons/project/static/src/views/burndown_chart/burndown_chart_search_model.js
+++ b/addons/project/static/src/views/burndown_chart/burndown_chart_search_model.js
@@ -43,7 +43,7 @@ export class BurndownChartSearchModel extends SearchModel {
      */
     deactivateGroup(groupId) {
         // Prevent removing Date & Stage group by from the search
-        if (this.searchItems[this.stageIdSearchItemId].groupId == groupId && this.searchItems[this.dateSearchItemId].groupId) {
+        if (this.stageIdSearchItemId && this.searchItems[this.stageIdSearchItemId].groupId == groupId && this.searchItems[this.dateSearchItemId].groupId) {
             this._addGroupByNotification(_t("Date and Stage"));
             return;
         }


### PR DESCRIPTION


Description of the issue/feature this PR addresses:
- When a user cancels a filter on a burndown chart, if stageIdSearchItemId is undefined, an error is raised.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
