### PR TITLE
[IMP] mail: getter for post data

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -595,16 +595,21 @@ export class Composer extends Component {
             return;
         }
         await this.processMessage(async (value) => {
-            const postData = {
-                attachments: composer.attachments,
-                isNote: this.props.type === "note",
-                mentionedChannels: composer.mentionedChannels,
-                mentionedPartners: composer.mentionedPartners,
-                cannedResponseIds: composer.cannedResponses.map((c) => c.id),
-                parentId: this.props.messageToReplyTo?.message?.id,
-            };
-            await this._sendMessage(value, postData);
+            await this._sendMessage(value, this.postData);
         });
+    }
+
+    get postData() {
+        const composer = toRaw(this.props.composer);
+        return {
+            attachments: composer.attachments,
+            isNote: this.props.type === "note",
+            mentionedChannels: composer.mentionedChannels,
+            mentionedPartners: composer.mentionedPartners,
+            cannedResponseIds: composer.cannedResponses.map((c) => c.id),
+            parentId: this.props.messageToReplyTo?.message?.id,
+            extraData: {},
+        };
     }
 
     /**

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -501,6 +501,7 @@ export class Store extends BaseStore {
         mentionedChannels,
         mentionedPartners,
         thread,
+        extraData,
     }) {
         const subtype = isNote ? "mail.mt_note" : "mail.mt_comment";
         const validMentions =
@@ -546,6 +547,7 @@ export class Store extends BaseStore {
             partner_additional_values: recipientAdditionalValues,
             thread_id: thread.id,
             thread_model: thread.model,
+            ...extraData,
         };
     }
 

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -995,6 +995,7 @@ export class Thread extends Record {
             mentionedChannels = [],
             mentionedPartners = [],
             cannedResponseIds,
+            extraData,
         } = {}
     ) {
         let tmpMsg;
@@ -1007,6 +1008,7 @@ export class Thread extends Record {
             mentionedChannels,
             mentionedPartners,
             thread: this,
+            extraData,
         });
         const tmpId = this.store.getNextTemporaryId();
         params.context = { ...user.context, ...params.context, temporary_id: tmpId };


### PR DESCRIPTION
In the portal it's needed to send extra data (such as security params, rating value, project sharing id) in posting a message. This PR introduces a getter for preparing the data. There will be a new parameter as `extraDta` where it's possible to put other needed data in.

Part of task-2828744