### PR TITLE
[IMP] event, website_event, event_product: simplify kanban archs

### DIFF
--- a/addons/event/views/event_event_views.xml
+++ b/addons/event/views/event_event_views.xml
@@ -228,62 +228,46 @@
         <field name="model">event.event</field>
         <field name="arch" type="xml">
             <kanban class="o_event_kanban_view" default_group_by="stage_id" quick_create_view="event.event_event_view_form_quick_create" sample="1">
-                <field name="user_id"/>
-                <field name="name"/>
                 <field name="stage_id" options='{"group_by_tooltip": {"description": "Description"}}'/>
-                <field name="address_id"/>
                 <field name="date_begin"/>
                 <field name="date_end"/>
-                <field name="seats_reserved"/>
-                <field name="seats_used"/>
-                <field name="seats_taken"/>
-                <field name="legend_blocked"/>
-                <field name="legend_normal"/>
                 <field name="legend_done"/>
-                <field name="activity_ids"/>
-                <field name="activity_state"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div t-attf-class="d-flex flex-column p-0 oe_kanban_card oe_kanban_global_click">
-                            <div class="o_kanban_content p-0 m-0 position-relative row d-flex flex-fill">
-                                <div class="col-4 text-bg-primary p-2 text-center d-flex flex-column justify-content-center">
-                                    <div t-esc="luxon.DateTime.fromISO(record.date_begin.raw_value).toFormat('d')" class="o_event_fontsize_20"/>
-                                    <div>
-                                        <t t-esc="luxon.DateTime.fromISO(record.date_begin.raw_value).toFormat('MMM yyyy')"/>
-                                    </div>
-                                    <div><t t-esc="luxon.DateTime.fromISO(record.date_begin.raw_value).toFormat('t')"/></div>
-                                        <div t-if="record.date_begin.raw_value !== record.date_end.raw_value">
-                                            <i class="oi oi-arrow-right me-2 o_event_fontsize_09" title="End date"/>
-                                            <t t-esc="luxon.DateTime.fromISO(record.date_end.raw_value).toFormat('d MMM')"/>
-                                        </div>
+                    <t t-name="kanban-card" class="p-0 row">
+                        <aside class="col-4 text-bg-primary p-2 text-center d-flex flex-column justify-content-center">
+                            <div t-esc="luxon.DateTime.fromISO(record.date_begin.raw_value).toFormat('d')" class="fs-1"/>
+                            <div>
+                                <t t-esc="luxon.DateTime.fromISO(record.date_begin.raw_value).toFormat('MMM yyyy')"/>
+                            </div>
+                            <div><t t-esc="luxon.DateTime.fromISO(record.date_begin.raw_value).toFormat('t')"/></div>
+                                <div t-if="record.date_begin.raw_value !== record.date_end.raw_value">
+                                    <i class="oi oi-arrow-right me-2" title="End date"/>
+                                    <t t-esc="luxon.DateTime.fromISO(record.date_end.raw_value).toFormat('d MMM')"/>
                                 </div>
-                                <div class="col-8 py-2 px-3 d-flex flex-column justify-content-between pt-3">
-                                    <div>
-                                        <div class="o_kanban_record_title o_text_overflow" t-att-title="record.name.value">
-                                            <field name="name"/>
-                                        </div>
-                                        <div class="d-flex ps-1">
-                                            <i class="fa fa-map-marker mt-1 me-2 text-center ps-1" title="Location"/>
-                                            <span t-if="record.address_id.value" t-out="record.address_id.value" class="ms-1"/>
-                                            <span t-else="" class="ms-1">Online Event</span>
-                                        </div>
-                                        <div t-if="record.seats_taken.raw_value" class="d-flex ps-1">
-                                            <i class="fa fa-group mt-1 me-2 text-center" title="Attendees"/>
-                                            <span t-out="record.seats_taken.raw_value" class="me-1"/> Attendees
-                                        </div>
-                                    </div>
-                                    <div class="o_kanban_record_bottom">
-                                        <div class="oe_kanban_bottom_left">
-                                            <field name="activity_ids" widget="kanban_activity"/>
-                                        </div>
-                                        <div class="oe_kanban_bottom_right">
-                                            <field name="kanban_state" widget="state_selection"/>
-                                            <field name="user_id" widget="many2one_avatar_user"/>
-                                        </div>
-                                    </div>
+                        </aside>
+                        <main class="col pt-3 pb-2 px-3 justify-content-between">
+                            <div>
+                                <div class="fw-bold fs-5 o_text_overflow" t-att-title="record.name.value">
+                                    <field name="name"/>
+                                </div>
+                                <div class="d-flex ps-1">
+                                    <i class="fa fa-map-marker mt-1 me-2 text-center ps-1" title="Location"/>
+                                    <field t-if="record.address_id.value" name="address_id" class="ms-1"/>
+                                    <span t-else="" class="ms-1">Online Event</span>
+                                </div>
+                                <div t-if="record.seats_taken.raw_value" class="d-flex ps-1">
+                                    <i class="fa fa-group mt-1 me-2 text-center" title="Attendees"/>
+                                    <field name="seats_taken" class="me-1"/> Attendees
                                 </div>
                             </div>
-                        </div>
+                            <footer class="pt-1 p-0 m-0">
+                                <field name="activity_ids" widget="kanban_activity"/>
+                                <div class="d-flex ms-auto">
+                                    <field class="mt-1 mr4" name="kanban_state" widget="state_selection"/>
+                                    <field name="user_id" widget="many2one_avatar_user"/>
+                                </div>
+                            </footer>
+                        </main>
                     </t>
                 </templates>
             </kanban>

--- a/addons/event/views/event_registration_views.xml
+++ b/addons/event/views/event_registration_views.xml
@@ -96,25 +96,15 @@
                                 </tree>
                                 <kanban class="o_kanban_mobile" create="false" delete="false">
                                     <field name="event_id"/>
-                                    <field name="question_id"/>
                                     <field name="question_type"/>
-                                    <field name="value_answer_id"/>
-                                    <field name="value_text_box"/>
-
                                     <templates>
-                                        <t t-name="kanban-box">
-                                            <div class="d-flex flex-column justify-content-between">
-                                                <div class="o_kanban_record_title oe_kanban_details">
-                                                    <strong>
-                                                        <field name="question_id" domain="[('event_id', '=', event_id)]"/>
-                                                    </strong>
-                                                </div>
-                                                <field name="value_answer_id"
-                                                    invisible="question_type != 'simple_choice'"
-                                                    domain="[('question_id', '=', question_id)]" options="{'no_create': True}"/>
-                                                <field name="value_text_box"
-                                                    invisible="question_type == 'simple_choice'"/>
-                                            </div>
+                                        <t t-name="kanban-card" class="justify-content-between">
+                                            <field class="fw-bold fs-5" name="question_id" domain="[('event_id', '=', event_id)]"/>
+                                            <field name="value_answer_id"
+                                                invisible="question_type != 'simple_choice'"
+                                                domain="[('question_id', '=', question_id)]" options="{'no_create': True}"/>
+                                            <field name="value_text_box"
+                                                invisible="question_type == 'simple_choice'"/>
                                         </t>
                                     </templates>
                                 </kanban>
@@ -134,10 +124,7 @@
         <field name="arch" type="xml">
             <kanban class="o_event_attendee_kanban_view" default_order="name, create_date desc" sample="1">
                 <field name="name"/>
-                <field name="partner_id"/>
                 <field name="state"/>
-                <field name="email"/>
-                <field name="event_ticket_id"/>
                 <field name="active"/>
                 <templates>
                     <t t-name="event_attendees_kanban_icons_desktop">
@@ -170,37 +157,27 @@
                             </t>
                         </div>
                     </t>
-                    <t t-name="kanban-box">
-                        <div t-attf-class="#{!record.active.raw_value ? 'oe_kanban_card_ribbon' : ''} oe_kanban_global_click o_event_registration_kanban container-fluid">
-                            <div t-if="!record.active.raw_value" class="ribbon ribbon-top-right">
-                                <span class="text-bg-danger">Archived</span>
+                    <t t-name="kanban-card" class="row g-0">
+                        <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
+                        <div class="col-8 col-md-9">
+                            <field class="d-block fw-bold fs-5" name="name"/>
+                            <div class="o_kanban_event_registration_event_name">
+                                <field class="text-truncate text-primary" name="event_id" invisible="context.get('default_event_id')"/>
                             </div>
-                            <div class="row g-0 h-100">
-                                <div class="col-8 col-md-9">
-                                    <div class="oe_kanban_content h-100">
-                                        <div class="o_kanban_record_body h-100 d-flex flex-column">
-                                            <b class="o_kanban_record_title"><field name="name"/></b>
-                                            <div class="o_kanban_event_registration_event_name">
-                                                <field class="o_text_overflow text-primary" name="event_id" invisible="context.get('default_event_id')"/>
-                                            </div>
-                                            <span class="o_text_overflow" invisible="not company_name">
-                                                <i class="fa fa-building" title="Attendee Company"/> <field name="company_name"/>
-                                            </span>
-                                            <div id="event_ticket_id" class="o_field_many2many_tags o_field_widget d-flex mt-auto align-items-center">
-                                                <field name="registration_properties"/>
-                                                <t t-if="record.event_ticket_id.raw_value">
-                                                    <i class="fa fa-ticket" title="Ticket type"/>
-                                                    <b><span class="o_badge_text o_text_overflow ms-1"><t t-out="record.event_ticket_id.value"/></span></b>
-                                                </t>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div id="event_attendees_kanban_icons" class="col-4 col-md-3">
-                                    <t t-call="event_attendees_kanban_icons_desktop"/>
-                                    <t t-call="event_attendees_kanban_icons_mobile"/>
-                                </div>
+                            <span class="text-truncate" invisible="not company_name">
+                                <i class="fa fa-building" title="Attendee Company"/> <field name="company_name"/>
+                            </span>
+                            <div id="event_ticket_id">
+                                <field name="registration_properties"/>
+                                <t t-if="record.event_ticket_id.raw_value">
+                                    <i class="fa fa-ticket" title="Ticket type"/>
+                                    <field name="event_ticket_id" class="fw-bold text-truncate ms-1"/>
+                                </t>
                             </div>
+                        </div>
+                        <div id="event_attendees_kanban_icons" class="col-4 col-md-3">
+                            <t t-call="event_attendees_kanban_icons_desktop"/>
+                            <t t-call="event_attendees_kanban_icons_mobile"/>
                         </div>
                     </t>
                 </templates>

--- a/addons/event/views/event_ticket_views.xml
+++ b/addons/event/views/event_ticket_views.xml
@@ -112,21 +112,12 @@
         <field name="priority" eval="20"/>
         <field name="arch" type="xml">
             <kanban class="o_kanban_mobile">
-                <field name="name"/>
-                <field name="seats_max"/>
-                <field name="seats_reserved"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div t-attf-class="oe_kanban_card oe_kanban_global_click">
-                            <div class="row">
-                                <div class="col-8">
-                                    <strong><t t-out="record.name.value"/></strong>
-                                </div>
-                            </div>
-                            <div><i>
-                            <t t-out="record.seats_reserved.value"/> reserved
-                            </i></div>
+                    <t t-name="kanban-card">
+                        <div class="d-flex">
+                            <field class="fw-bolder" name="name"/>
                         </div>
+                        <i><field name="seats_reserved"/> reserved</i>
                     </t>
                 </templates>
             </kanban>

--- a/addons/event_product/views/event_ticket_views.xml
+++ b/addons/event_product/views/event_ticket_views.xml
@@ -90,15 +90,11 @@
         <field name="model">event.event.ticket</field>
         <field name="inherit_id" ref="event.event_event_ticket_view_kanban_from_event"/>
         <field name="arch" type="xml">
-            <field name="name" position="before">
-                <field name="product_id"/>
-                <field name="price"/>
+            <field name="name" position="after">
+                <field class="fw-bold ms-auto" name="price"/>
             </field>
-            <xpath expr="//div[hasclass('col-8')]" position="after">
-                <div class="col-4 text-end"><strong> <t t-out="record.price.value"/></strong></div>
-            </xpath>
-            <xpath expr="//div[hasclass('row')]" position="after">
-                <div t-out="record.product_id.value"/>
+            <xpath expr="//div[hasclass('d-flex')]" position="after">
+                <field name="product_id"/>
             </xpath>
         </field>
     </record>

--- a/addons/website_event/views/website_pages_views.xml
+++ b/addons/website_event/views/website_pages_views.xml
@@ -51,14 +51,14 @@
         <xpath expr="//kanban" position="inside">
             <field name="website_url" invisible="1"/>
         </xpath>
-        <xpath expr="//div[hasclass('o_kanban_record_title')]" position="inside">
+        <xpath expr="//main" position="inside">
             <div class="text-muted" t-if="record.website_id.value" groups="website.group_multi_website">
                 <i class="fa fa-globe me-1" title="Website"/>
                 <field name="website_id"/>
             </div>
         </xpath>
-        <xpath expr="//div[hasclass('o_kanban_record_bottom')]" position="after">
-            <div class="border-top mt-2 pt-2">
+        <xpath expr="//main" position="inside">
+            <div class="d-flex border-top mt-2 pt-2">
                 <field name="is_published" widget="boolean_toggle"/>
                 <t t-if="record.is_published.raw_value">Published</t>
                 <t t-else="">Not Published</t>


### PR DESCRIPTION
In this commit we have simplified the kanban arch for the event, event_product and website_event module. The goal is to simplify them, make them easier to read, and use bootstrap utility classnames.
- Previously, we used `kanban-box`, but now we are using `kanban-card` instead.
- Deprecated `oe_kanban_global_click` and `oe_kanban_global_click_edit`.
- More use of `<field/>` tags
- Removed the `oe_kanban_colorpicker` class and replaced it with the `kanban_color_picker` widget.
- Changed type='edit' to type='open' to open records. since version 16, records always open in edit mode by default.
- `kanban_image` from rendering context, is deprecated so we use `<field name=... widget=image/>` instead

Task-3992107

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
