### PR TITLE
[FIX] pos_viva_wallet: sent payment request for viva wallet

### DIFF
--- a/addons/pos_viva_wallet/models/pos_session.py
+++ b/addons/pos_viva_wallet/models/pos_session.py
@@ -7,7 +7,7 @@ from odoo import models
 class PosSession(models.Model):
     _inherit = 'pos.session'
 
-    def _loader_params_pos_payment_method(self):
-        result = super()._loader_params_pos_payment_method()
-        result['search_params']['fields'].append('viva_wallet_terminal_id')
+    def _load_data_params(self, config_id):
+        result = super()._load_data_params(config_id)
+        result['pos.payment.method']['fields'].append('viva_wallet_terminal_id')
         return result


### PR DESCRIPTION
Currently we are unable to pay using viva wallet as the terminalID is not sent during the request.

Steps to reproduce:
-------------------
* Go to **Point of Sale**
* Under **Configuration**, select **Payment Methods**
* Create a new payment method and configure it for viva wallet
* In the shop setting, add this payment method
* Open shop session
* Make an order and try to pay with viva wallet
> Observation: There are some issues between us and Viva Wallet, try again
later. [{'type': 'missing', 'loc': ['body', 'terminalId'], 'msg': 'Field required', 'input': {'sessionId': '00007-001-0001 - c9a31bfb-b517-4e65-a1ee-b00a1d86731b', 'cashRegisterId': 'Mitchell Admin', 'amount': 206885, 'currencyCode': 978, 'merchantReference': '00007-001-0001 - c9a31bfb-b517-4e65-a1ee-b00a1d86731b/7', 'customerTrns': ' ', 'preauth': False, 'maxInstalments': 0, 'tipAmount': 0}, 'url': 'https://errors.pydantic.dev/2.6/v/missing'}]

Why the fix:
------------
As the error states, the request is missing the information about the terminal ID. That is due to the fact that starting from saas-17.1 parameters are loaded through the function `_load_data_params` and not `_loader_params_(...)`.

opw-3983997