### PR TITLE
[IMP] event_booth, event_product: simplify kanban archs

### DIFF
--- a/addons/event_booth/views/event_booth_views.xml
+++ b/addons/event_booth/views/event_booth_views.xml
@@ -98,22 +98,12 @@
             <kanban default_group_by="state" quick_create_view="event_booth.event_booth_view_form_quick_create" sample="1">
                 <field name="name"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div class="o_kanban_content oe_kanban_global_click">
-                            <div class="o_kanban_record_title">
-                                <field name="name"/>
-                            </div>
-                            <div class="d-flex flex-column">
-                                <div class="o_kanban_record_bottom">
-                                    <div class="oe_kanban_bottom_left">
-                                        <field name="booth_category_id"/>
-                                    </div>
-                                    <div class="oe_kanban_bottom_right">
-                                        <field name="activity_ids" widget="kanban_activity"/>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field class="fw-bold fs-5" name="name"/>
+                        <footer class="p-0 fs-6">
+                            <field name="booth_category_id"/>
+                            <field class="ms-auto" name="activity_ids" widget="kanban_activity"/>
+                        </footer>
                     </t>
                 </templates>
             </kanban>
@@ -127,7 +117,7 @@
         <field name="mode">primary</field>
         <field name="priority">16</field>
         <field name="arch" type="xml">
-            <xpath expr="//div[hasclass('o_kanban_record_bottom')]" position="before">
+            <xpath expr="//footer" position="before">
                 <field name="event_id"/>
             </xpath>
         </field>


### PR DESCRIPTION
In this commit we have simplified the kanban arch for the event_booth and event_product module. The goal is to simplify them, make them easier to read, and use bootstrap utility classnames.
- Previously, we used `kanban-box`, but now we are using `kanban-card` instead.
- Deprecated `oe_kanban_global_click` and `oe_kanban_global_click_edit`.
- More use of `<field/>` tags
- Removed the `oe_kanban_colorpicker` class and replaced it with the `kanban_color_picker` widget.
- Changed type='edit' to type='open' to open records. since version 16, records always open in edit mode by default.
- `kanban_image` from rendering context, is deprecated so we use `<field name=... widget=image/>` instead

Task-3992107

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
