### PR TITLE
[IMP] payment, *: track payment methods' support for manual capture

### DIFF
--- a/addons/payment/data/payment_method_data.xml
+++ b/addons/payment/data/payment_method_data.xml
@@ -11,6 +11,7 @@
         <field name="image" type="base64" file="payment/static/img/7eleven.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -32,6 +33,7 @@
         <field name="image" type="base64" file="payment/static/img/ach_direct_debit.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -54,6 +56,7 @@
         <field name="image" type="base64" file="payment/static/img/affirm.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">full_only</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -77,6 +80,7 @@
         <field name="image" type="base64" file="payment/static/img/afterpay.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">partial</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -104,6 +108,7 @@
         <field name="image" type="base64" file="payment/static/img/afterpay_riverty.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">partial</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -129,6 +134,7 @@
         <field name="image" type="base64" file="payment/static/img/akulaku.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -150,6 +156,7 @@
         <field name="image" type="base64" file="payment/static/img/alipay.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">partial</field>
     </record>
 
@@ -161,6 +168,7 @@
         <field name="image" type="base64" file="payment/static/img/alipay_hk.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -182,6 +190,7 @@
         <field name="image" type="base64" file="payment/static/img/alipay_plus.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -251,6 +260,7 @@
         <field name="image" type="base64" file="payment/static/img/alma.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">partial</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -272,6 +282,7 @@
         <field name="image" type="base64" file="payment/static/img/amazon_pay.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">partial</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -313,6 +324,7 @@
         <field name="image" type="base64" file="payment/static/img/atome.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -336,6 +348,7 @@
         <field name="image" type="base64" file="payment/static/img/axis.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -357,6 +370,7 @@
         <field name="image" type="base64" file="payment/static/img/bacs_direct_debit.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -378,6 +392,7 @@
         <field name="image" type="base64" file="payment/static/img/bancnet.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -399,6 +414,7 @@
         <field name="image" type="base64" file="payment/static/img/bancomat_pay.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -420,6 +436,7 @@
         <field name="image" type="base64" file="payment/static/img/bancontact.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -441,6 +458,7 @@
         <field name="image" type="base64" file="payment/static/img/bank.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -462,6 +480,7 @@
         <field name="image" type="base64" file="payment/static/img/bank.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
     </record>
 
@@ -473,6 +492,7 @@
         <field name="image" type="base64" file="payment/static/img/bank_bca.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -494,6 +514,7 @@
         <field name="image" type="base64" file="payment/static/img/bank.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -515,6 +536,7 @@
         <field name="image" type="base64" file="payment/static/img/bank_permata.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -536,6 +558,7 @@
         <field name="image" type="base64" file="payment/static/img/bank.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
     </record>
 
@@ -547,6 +570,7 @@
         <field name="image" type="base64" file="payment/static/img/bank.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_currency_ids"
                eval="[Command.set([
@@ -564,6 +588,7 @@
         <field name="image" type="base64" file="payment/static/img/becs_direct_debit.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -585,6 +610,7 @@
         <field name="image" type="base64" file="payment/static/img/belfius.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -606,6 +632,7 @@
         <field name="image" type="base64" file="payment/static/img/benefit.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -627,6 +654,7 @@
         <field name="image" type="base64" file="payment/static/img/bharatqr.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -648,6 +676,7 @@
         <field name="image" type="base64" file="payment/static/img/billease.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
               eval="[Command.set([
@@ -669,6 +698,7 @@
         <field name="image" type="base64" file="payment/static/img/billink.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -691,6 +721,7 @@
         <field name="image" type="base64" file="payment/static/img/bizum.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -712,6 +743,7 @@
         <field name="image" type="base64" file="payment/static/img/blik.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -733,6 +765,7 @@
         <field name="image" type="base64" file="payment/static/img/bni.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -754,6 +787,7 @@
         <field name="image" type="base64" file="payment/static/img/boleto.png"/>
         <field name="support_tokenization">True</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -775,6 +809,7 @@
         <field name="image" type="base64" file="payment/static/img/boost.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -796,6 +831,7 @@
        <field name="image" type="base64" file="payment/static/img/bank.png"/>
        <field name="support_tokenization">False</field>
        <field name="support_express_checkout">False</field>
+       <field name="support_manual_capture">none</field>
        <field name="support_refund">none</field>
        <field name="supported_country_ids"
               eval="[Command.set([
@@ -817,6 +853,7 @@
         <field name="image" type="base64" file="payment/static/img/brankas.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -838,6 +875,7 @@
         <field name="image" type="base64" file="payment/static/img/bri.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -859,6 +897,7 @@
         <field name="image" type="base64" file="payment/static/img/bsi.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -880,6 +919,7 @@
         <field name="image" type="base64" file="payment/static/img/card.png"/>
         <field name="support_tokenization">True</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">partial</field>
         <field name="support_refund">partial</field>
     </record>
 
@@ -891,6 +931,7 @@
         <field name="image" type="base64" file="payment/static/img/cash_app_pay.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">partial</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -912,6 +953,7 @@
         <field name="image" type="base64" file="payment/static/img/cashalo.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -933,6 +975,7 @@
         <field name="image" type="base64" file="payment/static/img/cebuana.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -954,6 +997,7 @@
         <field name="image" type="base64" file="payment/static/img/cimb_niaga.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -975,6 +1019,7 @@
         <field name="image" type="base64" file="payment/static/img/clearpay.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">partial</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -996,6 +1041,7 @@
         <field name="image" type="base64" file="payment/static/img/clearpay.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -1018,6 +1064,7 @@
         <field name="image" type="base64" file="payment/static/img/dana.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -1039,6 +1086,7 @@
         <field name="image" type="base64" file="payment/static/img/dolfin.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -1060,6 +1108,7 @@
         <field name="image" type="base64" file="payment/static/img/duitnow.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -1081,6 +1130,7 @@
         <field name="image" type="base64" file="payment/static/img/card.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">partial</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -1102,6 +1152,7 @@
         <field name="image" type="base64" file="payment/static/img/enets.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -1123,6 +1174,7 @@
         <field name="image" type="base64" file="payment/static/img/eps.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -1144,6 +1196,7 @@
         <field name="image" type="base64" file="payment/static/img/floa_bank.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -1169,6 +1222,7 @@
         <field name="image" type="base64" file="payment/static/img/card.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -1190,6 +1244,7 @@
         <field name="image" type="base64" file="payment/static/img/fpx.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -1211,6 +1266,7 @@
         <field name="image" type="base64" file="payment/static/img/frafinance.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -1232,6 +1288,7 @@
         <field name="image" type="base64" file="payment/static/img/gcash.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -1253,6 +1310,7 @@
         <field name="image" type="base64" file="payment/static/img/giropay.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -1274,6 +1332,7 @@
         <field name="image" type="base64" file="payment/static/img/gopay.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -1295,6 +1354,7 @@
         <field name="image" type="base64" file="payment/static/img/grabpay.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -1320,6 +1380,7 @@
         <field name="image" type="base64" file="payment/static/img/bank.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -1341,6 +1402,7 @@
         <field name="image" type="base64" file="payment/static/img/bank.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -1362,6 +1424,7 @@
         <field name="image" type="base64" file="payment/static/img/hoolah.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -1389,6 +1452,7 @@
         <field name="image" type="base64" file="payment/static/img/humm.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -1416,6 +1480,7 @@
         <field name="image" type="base64" file="payment/static/img/ideal.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -1437,6 +1502,7 @@
         <field name="image" type="base64" file="payment/static/img/in3.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -1458,6 +1524,7 @@
         <field name="image" type="base64" file="payment/static/img/jeniuspay.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -1479,6 +1546,7 @@
         <field name="image" type="base64" file="payment/static/img/jkopay.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -1500,6 +1568,7 @@
         <field name="image" type="base64" file="payment/static/img/kakaopay.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -1521,6 +1590,7 @@
         <field name="image" type="base64" file="payment/static/img/bank.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -1542,6 +1612,7 @@
         <field name="image" type="base64" file="payment/static/img/kbc.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -1563,6 +1634,7 @@
         <field name="image" type="base64" file="payment/static/img/klarna.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">partial</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -1616,6 +1688,7 @@
         <field name="image" type="base64" file="payment/static/img/klarna.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">partial</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -1642,6 +1715,7 @@
         <field name="image" type="base64" file="payment/static/img/klarna.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">partial</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -1688,6 +1762,7 @@
         <field name="image" type="base64" file="payment/static/img/knet.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -1709,6 +1784,7 @@
         <field name="image" type="base64" file="payment/static/img/kredivo.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -1730,6 +1806,7 @@
         <field name="image" type="base64" file="payment/static/img/bank.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -1751,6 +1828,7 @@
         <field name="image" type="base64" file="payment/static/img/linepay.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -1776,6 +1854,7 @@
         <field name="image" type="base64" file="payment/static/img/linkaja.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -1797,6 +1876,7 @@
         <field name="image" type="base64" file="payment/static/img/lydia.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -1819,6 +1899,7 @@
         <field name="image" type="base64" file="payment/static/img/lyfpay.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -1840,6 +1921,7 @@
         <field name="image" type="base64" file="payment/static/img/mada.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -1862,6 +1944,7 @@
         <field name="image" type="base64" file="payment/static/img/mandiri.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -1883,6 +1966,7 @@
         <field name="image" type="base64" file="payment/static/img/maya.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -1904,6 +1988,7 @@
         <field name="image" type="base64" file="payment/static/img/maybank.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -1925,6 +2010,7 @@
         <field name="image" type="base64" file="payment/static/img/mbway.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -1946,6 +2032,7 @@
         <field name="image" type="base64" file="payment/static/img/mtn-mobile-money.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -1979,6 +2066,7 @@
         <field name="image" type="base64" file="payment/static/img/mobile_pay.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">partial</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -2004,6 +2092,7 @@
         <field name="image" type="base64" file="payment/static/img/momo.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -2025,6 +2114,7 @@
         <field name="image" type="base64" file="payment/static/img/mpesa.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -2046,6 +2136,7 @@
         <field name="image" type="base64" file="payment/static/img/multibanco.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -2067,6 +2158,7 @@
         <field name="image" type="base64" file="payment/static/img/mybank.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -2089,6 +2181,7 @@
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
         <field name="support_refund">none</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">full_only</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -2110,6 +2203,7 @@
         <field name="image" type="base64" file="payment/static/img/naver_pay.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -2131,6 +2225,7 @@
         <field name="image" type="base64" file="payment/static/img/bank.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">partial</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -2152,6 +2247,7 @@
         <field name="image" type="base64" file="payment/static/img/octopus.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -2173,6 +2269,7 @@
         <field name="image" type="base64" file="payment/static/img/bank.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -2194,6 +2291,7 @@
         <field name="image" type="base64" file="payment/static/img/bank.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="support_refund">full_only</field>
         <field name="supported_country_ids"
@@ -2216,6 +2314,7 @@
         <field name="image" type="base64" file="payment/static/img/bank.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -2237,6 +2336,7 @@
         <field name="image" type="base64" file="payment/static/img/bank.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -2258,6 +2358,7 @@
         <field name="image" type="base64" file="payment/static/img/bank.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -2279,6 +2380,7 @@
         <field name="image" type="base64" file="payment/static/img/ovo.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -2300,6 +2402,7 @@
         <field name="image" type="base64" file="payment/static/img/paybright.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">partial</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -2321,6 +2424,7 @@
         <field name="image" type="base64" file="payment/static/img/pace.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -2352,6 +2456,7 @@
         <field name="image" type="base64" file="payment/static/img/pay_later.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">partial</field>
         <field name="support_refund">none</field>
         <field name="support_refund">full_only</field>
         <field name="supported_country_ids"
@@ -2374,6 +2479,7 @@
         <field name="image" type="base64" file="payment/static/img/pay_easy.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -2395,6 +2501,7 @@
         <field name="image" type="base64" file="payment/static/img/pay_id.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -2418,6 +2525,7 @@
         <field name="image" type="base64" file="payment/static/img/paylib.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -2439,6 +2547,7 @@
         <field name="image" type="base64" file="payment/static/img/payme.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -2460,6 +2569,7 @@
         <field name="image" type="base64" file="payment/static/img/paynow.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -2481,6 +2591,7 @@
         <field name="image" type="base64" file="payment/static/img/paypal.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">partial</field>
         <field name="support_refund">partial</field>
     </record>
 
@@ -2492,6 +2603,7 @@
         <field name="image" type="base64" file="payment/static/img/paypay.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">partial</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -2513,6 +2625,7 @@
         <field name="image" type="base64" file="payment/static/img/paysafecard.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="support_refund">full_only</field>
         <field name="supported_country_ids"
@@ -2610,6 +2723,7 @@
         <field name="image" type="base64" file="payment/static/img/paytm.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -2631,6 +2745,7 @@
         <field name="image" type="base64" file="payment/static/img/paytrail.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -2652,6 +2767,7 @@
         <field name="image" type="base64" file="payment/static/img/payu.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -2673,6 +2789,7 @@
         <field name="image" type="base64" file="payment/static/img/pix.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -2694,6 +2811,7 @@
         <field name="image" type="base64" file="payment/static/img/poli.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -2717,6 +2835,7 @@
         <field name="image" type="base64" file="payment/static/img/pf_pay.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -2767,6 +2886,7 @@
         <field name="image" type="base64" file="payment/static/img/poste_pay.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -2788,6 +2908,7 @@
         <field name="image" type="base64" file="payment/static/img/card.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -2809,6 +2930,7 @@
         <field name="image" type="base64" file="payment/static/img/promptpay.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -2830,6 +2952,7 @@
         <field name="image" type="base64" file="payment/static/img/card.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -2851,6 +2974,7 @@
         <field name="image" type="base64" file="payment/static/img/p24.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -2873,6 +2997,7 @@
         <field name="image" type="base64" file="payment/static/img/qris.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -2894,6 +3019,7 @@
         <field name="image" type="base64" file="payment/static/img/rabbit_line_pay.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -2915,6 +3041,7 @@
         <field name="image" type="base64" file="payment/static/img/ratepay.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">partial</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -2940,6 +3067,7 @@
         <field name="image" type="base64" file="payment/static/img/revolut_pay.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">full_only</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -2961,6 +3089,7 @@
         <field name="image" type="base64" file="payment/static/img/samsung_pay.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">partial</field>
         <field name="support_refund">partial</field>
     </record>
 
@@ -2973,6 +3102,7 @@
         <field name="image" type="base64" file="payment/static/img/bank.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -2994,6 +3124,7 @@
         <field name="image" type="base64" file="payment/static/img/sepa.png"/>
         <field name="support_tokenization">True</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -3043,6 +3174,7 @@
         <field name="image" type="base64" file="payment/static/img/shopback.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -3064,6 +3196,7 @@
         <field name="image" type="base64" file="payment/static/img/shopeepay.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -3087,6 +3220,7 @@
         <field name="image" type="base64" file="payment/static/img/sofort.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -3117,6 +3251,7 @@
         <field name="image" type="base64" file="payment/static/img/swish.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -3138,6 +3273,7 @@
         <field name="image" type="base64" file="payment/static/img/techcom.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -3159,6 +3295,7 @@
         <field name="image" type="base64" file="payment/static/img/tendopay.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -3180,6 +3317,7 @@
         <field name="image" type="base64" file="payment/static/img/tenpay.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -3201,6 +3339,7 @@
         <field name="image" type="base64" file="payment/static/img/bank.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -3222,6 +3361,7 @@
         <field name="image" type="base64" file="payment/static/img/tinka.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -3243,6 +3383,7 @@
         <field name="image" type="base64" file="payment/static/img/tmb.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -3264,6 +3405,7 @@
         <field name="image" type="base64" file="payment/static/img/toss_pay.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -3285,6 +3427,7 @@
         <field name="image" type="base64" file="payment/static/img/touch_n_go.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -3306,6 +3449,7 @@
         <field name="image" type="base64" file="payment/static/img/truemoney.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -3327,6 +3471,7 @@
         <field name="image" type="base64" file="payment/static/img/trustly.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -3364,6 +3509,7 @@
         <field name="image" type="base64" file="payment/static/img/card.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -3385,6 +3531,7 @@
         <field name="image" type="base64" file="payment/static/img/twint.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">partial</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -3406,6 +3553,7 @@
         <field name="image" type="base64" file="payment/static/img/uatp.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
     </record>
 
@@ -3417,6 +3565,7 @@
         <field name="image" type="base64" file="payment/static/img/unknown.png"/>
         <field name="support_tokenization">True</field>
         <field name="support_express_checkout">True</field>
+        <field name="support_manual_capture">partial</field>
         <field name="support_refund">partial</field>
     </record>
 
@@ -3428,6 +3577,7 @@
         <field name="image" type="base64" file="payment/static/img/bank.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -3449,6 +3599,7 @@
         <field name="image" type="base64" file="payment/static/img/upi.png"/>
         <field name="support_tokenization">True</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -3470,6 +3621,7 @@
         <field name="image" type="base64" file="payment/static/img/flutterwave.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
     </record>
 
@@ -3481,6 +3633,7 @@
         <field name="image" type="base64" file="payment/static/img/venmo.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -3502,6 +3655,7 @@
         <field name="image" type="base64" file="payment/static/img/vietcom.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -3523,6 +3677,7 @@
         <field name="image" type="base64" file="payment/static/img/vipps.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">partial</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -3544,6 +3699,7 @@
         <field name="image" type="base64" file="payment/static/img/vpay.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_currency_ids"
                eval="[Command.set([
@@ -3567,6 +3723,7 @@
         <field name="image" type="base64" file="payment/static/img/wallet.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="support_refund">full_only</field>
         <field name="supported_country_ids"
@@ -3589,6 +3746,7 @@
         <field name="image" type="base64" file="payment/static/img/walley.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">full_only</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -3616,6 +3774,7 @@
         <field name="image" type="base64" file="payment/static/img/wechat_pay.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">partial</field>
         <field name="supported_currency_ids"
                eval="[Command.set([
@@ -3641,6 +3800,7 @@
         <field name="image" type="base64" file="payment/static/img/welend.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -3662,6 +3822,7 @@
         <field name="image" type="base64" file="payment/static/img/zalopay.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
         <field name="supported_country_ids"
                eval="[Command.set([
@@ -3683,6 +3844,7 @@
         <field name="image" type="base64" file="payment/static/img/zip.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">partial</field>
         <field name="supported_country_ids"
                eval="[Command.set([

--- a/addons/payment/models/payment_provider.py
+++ b/addons/payment/models/payment_provider.py
@@ -294,6 +294,21 @@ class PaymentProvider(models.Model):
                 "You cannot change the company of a payment provider with existing transactions."
             ))
 
+    # === CONSTRAINT METHODS === #
+
+    @api.constrains('capture_manually')
+    def _check_manual_capture_supported_by_payment_methods(self):
+        if self.capture_manually:
+            incompatible_pms = self.payment_method_ids.filtered(
+                lambda method: method.active and method.support_manual_capture == 'none'
+            )
+            if incompatible_pms:
+                raise ValidationError(_(
+                    "The following payment methods must be disabled in order to enable manual"
+                    " capture: %s", ", ".join(incompatible_pms.mapped('name'))
+                ))
+
+
     #=== CRUD METHODS ===#
 
     @api.model_create_multi

--- a/addons/payment/views/payment_method_views.xml
+++ b/addons/payment/views/payment_method_views.xml
@@ -63,6 +63,7 @@
                             </div>
                             <group>
                                 <field name="support_tokenization"/>
+                                <field name="support_manual_capture"/>
                                 <field name="support_express_checkout"/>
                                 <field name="support_refund" />
                                 <field name="supported_country_ids"

--- a/addons/payment/wizards/payment_capture_wizard.py
+++ b/addons/payment/wizards/payment_capture_wizard.py
@@ -87,7 +87,9 @@ class PaymentCaptureWizard(models.TransientModel):
     def _compute_support_partial_capture(self):
         for wizard in self:
             wizard.support_partial_capture = all(
-                tx.provider_id.support_manual_capture == 'partial' for tx in wizard.transaction_ids
+                tx.provider_id.support_manual_capture == 'partial'
+                and tx.payment_method_id.support_manual_capture == 'partial'
+                for tx in wizard.transaction_ids
             )
 
     @api.depends('transaction_ids')

--- a/addons/payment_custom/data/payment_method_data.xml
+++ b/addons/payment_custom/data/payment_method_data.xml
@@ -9,6 +9,7 @@
         <field name="image" type="base64" file="payment_custom/static/img/wire_transfer.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
     </record>
 

--- a/addons/payment_demo/data/payment_method_data.xml
+++ b/addons/payment_demo/data/payment_method_data.xml
@@ -8,6 +8,7 @@
         <field name="image" type="base64" file="payment_demo/static/img/demo.png"/>
         <field name="support_tokenization">True</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">partial</field>
         <field name="support_refund">partial</field>
     </record>
 

--- a/addons/website_sale_collect/data/payment_method_data.xml
+++ b/addons/website_sale_collect/data/payment_method_data.xml
@@ -8,6 +8,7 @@
         <field name="image" type="base64" file="website_sale_collect/static/img/pay_on_site.png"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
         <field name="support_refund">none</field>
     </record>
 


### PR DESCRIPTION
Prior to this commit
- Certain payment methods did not support manual capture, leading to an empty traceback and a warning when users attempted payments with these methods.

Post this commit
- Added a new field to the payment method form, visible in the config tab, indicating whether the method supports manual capture.
- updated the data for PM based on documentations and testing of PM
- user error when user tries to activate capture manually in provider which contains payment methods with support manual capture false

task-3949151

See also:
- https://github.com/odoo/enterprise/pull/71305
- https://github.com/odoo/upgrade/pull/6810