### PR TITLE
[FIX] sale: remove wrong claim in reinvoice expense helper

### DIFF
--- a/addons/sale/models/product_template.py
+++ b/addons/sale/models/product_template.py
@@ -31,7 +31,7 @@ class ProductTemplate(models.Model):
         ],
         string="Re-Invoice Expenses", default='no',
         compute='_compute_expense_policy', store=True, readonly=False,
-        help="Validated expenses and vendor bills can be re-invoiced to a customer at its cost or sales price.")
+        help="Validated expenses can be re-invoiced to a customer at its cost or sales price.")
     visible_expense_policy = fields.Boolean(
         string="Re-Invoice Policy visible", compute='_compute_visible_expense_policy')
     sales_count = fields.Float(


### PR DESCRIPTION
Steps to reproduce:

- Go to a product's page where re-invoice expense appears (e.g. [EXP_GEN] Others)
- Click on "Sales" tab
- Hover mouse over "?" next to "Re-Invoice Expenses"
- Helper text says vendor bills can be reinvoiced which is false

This commit removes the mention of "vendor bills" from this text

task-3997879
