### PR TITLE
[FIX] website: fix minor issues within the resource editor

### DIFF
--- a/addons/website/static/src/components/resource_editor/resource_editor.xml
+++ b/addons/website/static/src/components/resource_editor/resource_editor.xml
@@ -56,7 +56,7 @@
                         </Dropdown>
                     </div>
                 </label>
-                <div>
+                <div class="d-flex gap-2">
                     <button class="btn btn-primary" t-on-click="onSave"><i t-if="state.saving" class="fa fa-circle-o-notch fa-spin mr8"/>Save</button>
                     <button class="btn btn-secondary" t-on-click="this.props.close">Close</button>
                 </div>

--- a/addons/website/static/src/components/resource_editor/resource_editor_warning.xml
+++ b/addons/website/static/src/components/resource_editor/resource_editor_warning.xml
@@ -7,12 +7,14 @@
             <div class="d-flex flex-row gap-4">
                 <i class="fa fa-warning mb-4 fs-1 text-danger"/>
                 <div>
-                    <h1 class="fs-2 text-dark">Your changes might be lost during future Odoo upgrade.</h1>
+                    <h1 class="fs-2 text-dark mb-4">Your changes might be lost during future Odoo upgrade.</h1>
                     <p>If you need to add analytics or marketing tags, inject code in your &lt;head&gt; or &lt;body&gt; instead.</p>
                     <em>Note: To embed code in this specific page, use the "Embed Code" building block</em>
-                    <div class="d-flex flex-row gap-3 pt-4">
-                        <button type="button" class="btn btn-primary" t-on-click="onInjectCode">Inject code in &lt;head&gt; or &lt;body&gt;</button>
-                        <button type="button" class="btn btn-secondary" t-on-click="onCloseEditor">Close editor</button>
+                    <div class="d-flex justify-content-between mt-5">
+                        <div class="d-flex gap-2">
+                            <button type="button" class="btn btn-primary" t-on-click="onInjectCode">Inject code in &lt;head&gt; or &lt;body&gt;</button>
+                            <button type="button" class="btn btn-secondary" t-on-click="onCloseEditor">Close editor</button>
+                        </div>
                         <button type="button" class="btn btn-link" t-on-click="onHideWarning">Edit HTML anyway</button>
                     </div>
                 </div>

--- a/addons/website/static/tests/tours/html_editor.js
+++ b/addons/website/static/tests/tours/html_editor.js
@@ -277,7 +277,7 @@ registerWebsitePreviewTour(
         },
         {
             content: "Bypass warning",
-            trigger: ".o_resource_editor_wrapper div:nth-child(2) button:nth-child(3)",
+            trigger: ".o_resource_editor_wrapper div:nth-child(2) > button",
             run: "click",
         },
         // Test all 3 file type options


### PR DESCRIPTION
This PR aims to fix minor design issues within the resource editor
that require a small amount of changes for a high gain.

1) The `save` and `close` buttons in the top right corner are missing
a spacing, making them stick together ;

2) When opening the resource editor, a modal is displayed to indicate
that the changes applied here could be lost during an upgrade.

The content of that modal was missing a bit of spacing, and there was an
issue with the layout of the bottom buttons. This PR takes care of these changes while keeping the same content.

task-4008742

| //////// | Master | This PR |
|--------|--------|--------|
| Top-right buttons spacing | <img alt="image" src="https://github.com/odoo/odoo/assets/128030743/a410183e-14b6-4891-bb5c-880f4575d5a6"> | <img alt="image" src="https://github.com/odoo/odoo/assets/128030743/0ed96f9e-a9d8-4e7e-9ba1-fb116ed9c73f"> |
| Modal design | <img width="721" alt="image" src="https://github.com/user-attachments/assets/2ec0bc3b-91a6-451b-8620-f805f0a4b368"> | <img width="704" alt="image" src="https://github.com/user-attachments/assets/73723490-9348-4fec-9704-c02fcaa0b5ca" /> |

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr