### PR TITLE
[15.0][FIX] calendar: Singleton error to read private events

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -611,8 +611,9 @@ class Meeting(models.Model):
                     value = []
                 elif field_name in ('name', 'display_name'):
                     value = _('Busy')
-                replacement = field.convert_to_cache(value, private_events)
-                self.env.cache.update(private_events, field, repeat(replacement))
+                for private_event in private_events:
+                    replacement = field.convert_to_cache(value, private_event)
+                    self.env.cache.update(private_event, field, repeat(replacement))
         return records
 
     @api.model


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

Singleton errror when try to read private events because the convert_to_cache does not accept multiple records

**Current behavior before PR:**

Create some private events for marc demo and with admin user go to calendar and change to list view. The singleton error appears.
This error is cause by this commit https://github.com/odoo/odoo/commit/764f18f18a45175142f56161f6eb9e8b5aa4086c but the real probles is the convert_to_cache call

**Desired behavior after PR is merged:**
Admin can access to all records without error


cc @Tecnativa

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
