### PR TITLE
[FIX] account: python expression ruined by translation

### DIFF
--- a/addons/account/i18n/sv.po
+++ b/addons/account/i18n/sv.po
@@ -1074,7 +1074,7 @@ msgid ""
 "                                        A second payment will be created in the destination journal.\n"
 "                                    </span>"
 msgstr ""
-"<span invisible=\"paired_internal_transfer_payment_id or not is_internal_transfer or state != ’draft’\" class=\"fst-italic\">\n"
+"<span invisible=\"paired_internal_transfer_payment_id or not is_internal_transfer or state != 'draft'\" class=\"fst-italic\">\n"
 "En andra betalning kommer att skapas i måljournalen.\n"
 "</span>"
 


### PR DESCRIPTION
Issue
----

Quote is erroneously changed in the translation of python-expression-containing xml.

Steps
-----

- Change the language of the current user to swedish.
- Try creating a new payment from Accounting -> Customers -> Payments -> New.
- A parse error is thrown.

Cause
-----

The translated value of a xml snippet containing a python expression changed `'` to `’`, which has no meaning in python.

opw-3989869
