### PR TITLE
[FIX] account_account: install stock after outstanding account removal

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -716,6 +716,12 @@ class AccountAccount(models.Model):
 
         return super(AccountAccount, self).write(vals)
 
+    def _load_records_write(self, values):
+        if 'prefix' in values:
+            del values['code_digits']
+            del values['prefix']
+        super()._load_records_write(values)
+
     @api.ondelete(at_uninstall=False)
     def _unlink_except_contains_journal_items(self):
         if self.env['account.move.line'].search([('account_id', 'in', self.ids)], limit=1):


### PR DESCRIPTION
### Steps to reproduce:

- Start with an empty DB
- Install account_accountant
- Open settings - Search "Default Accounts" - Clear Outstanding receipts - Save
- Go to Apps: Install stock

#### > traceback

### Cause of the issue:

The "_setup_utility_bank_accounts" method is called during the installation of the stock module. In this call, data about non-existing fields of the "account.account" model are added to the `account_data` dictionary, namely : `prefix` and `code_digits`:
https://github.com/odoo/odoo/blob/e80ff1c285ce633a75ce0de5a7cb8d3dcecd301f/addons/account/models/chart_template.py#L702-L708 Since the "Outstanding receipts" account was removed from the settings of the company, it is not removed from the `account_data` here: https://github.com/odoo/odoo/blob/e80ff1c285ce633a75ce0de5a7cb8d3dcecd301f/addons/account/models/chart_template.py#L749-L751 and the datas of these records will be loaded:
https://github.com/odoo/odoo/blob/e80ff1c285ce633a75ce0de5a7cb8d3dcecd301f/addons/account/models/chart_template.py#L756-L761 If the records were to be created, it would not be problematic because these datas are popped and used by the override of the `create` method of the `account.account` model:
https://github.com/odoo/odoo/blob/e80ff1c285ce633a75ce0de5a7cb8d3dcecd301f/addons/account/models/account_account.py#L701 However, in our case, the record linked to that xml_id already exists and is added to the list of the records to update. A `write` call will then be launched to update the non-existing `account.account` fields leading to the traceback:
https://github.com/odoo/odoo/blob/96d98792bb34772e7acc228dd093c56f2f18b483/odoo/models.py#L5045-L5046

opw-4007561
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
