### PR TITLE
[FIX] website_crm_partner_assign: fix sitemap grades

### DIFF
--- a/addons/website_crm_partner_assign/controllers/main.py
+++ b/addons/website_crm_partner_assign/controllers/main.py
@@ -11,7 +11,6 @@ from odoo import fields
 from odoo import http
 from odoo.http import request
 from odoo.addons.http_routing.models.ir_http import slug, unslug
-from odoo.addons.website.models.ir_http import sitemap_qs2dom
 from odoo.addons.portal.controllers.portal import CustomerPortal
 from odoo.addons.website_partner.controllers.main import WebsitePartnerPage
 
@@ -185,19 +184,20 @@ class WebsiteCrmPartnerAssign(WebsitePartnerPage):
     def sitemap_partners(env, rule, qs):
         if not qs or qs.lower() in '/partners':
             yield {'loc': '/partners'}
-
-        Grade = env['res.partner.grade']
-        dom = [('website_published', '=', True)]
-        dom += sitemap_qs2dom(qs=qs, route='/partners/grade/', field=Grade._rec_name)
-        for grade in env['res.partner.grade'].search(dom):
-            loc = '/partners/grade/%s' % slug(grade)
+        base_partner_domain = [
+            ('is_company', '=', True),
+            ('grade_id', '!=', False),
+            ('website_published', '=', True),
+            ('grade_id.website_published', '=', True),
+            ('grade_id.active', '=', True),
+        ]
+        grades = env['res.partner'].sudo().read_group(base_partner_domain, fields=['id', 'grade_id'], groupby='grade_id')
+        for grade in grades:
+            loc = '/partners/grade/%s' % slug(grade['grade_id'])
             if not qs or qs.lower() in loc:
                 yield {'loc': loc}
-
-        partners_dom = [('is_company', '=', True), ('grade_id', '!=', False), ('website_published', '=', True),
-                        ('grade_id.website_published', '=', True), ('country_id', '!=', False)]
-        dom += sitemap_qs2dom(qs=qs, route='/partners/country/')
-        countries = env['res.partner'].sudo().read_group(partners_dom, fields=['id', 'country_id'], groupby='country_id')
+        country_partner_domain = base_partner_domain + [('country_id', '!=', False)]
+        countries = env['res.partner'].sudo().read_group(country_partner_domain, fields=['id', 'country_id'], groupby='country_id')
         for country in countries:
             loc = '/partners/country/%s' % slug(country['country_id'])
             if not qs or qs.lower() in loc:
@@ -222,7 +222,7 @@ class WebsiteCrmPartnerAssign(WebsitePartnerPage):
         country_obj = request.env['res.country']
         search = post.get('search', '')
 
-        base_partner_domain = [('is_company', '=', True), ('grade_id', '!=', False), ('website_published', '=', True)]
+        base_partner_domain = [('is_company', '=', True), ('grade_id', '!=', False), ('website_published', '=', True), ('grade_id.active', '=', True)]
         if not request.env['res.users'].has_group('website.group_website_publisher'):
             base_partner_domain += [('grade_id.website_published', '=', True)]
         if search:


### PR DESCRIPTION
[FIX] website_crm_partner_assign: fix sitemap grades

Context: when visiting the `/partners` url, the user has access to the
"silver", "gold" and "platinum" grades. However, when generating the
sitemap, the `/partners/grade/bronze-4` url is part of it but trying to
access it leads to a 404 server answer. Another problematic behavior is
that if the user deactivates a grade ("gold" for example), the grade is
still accessible from `/partners` (but the `/partners/grade/gold-2` url
is not on the sitemap anymore).

This can be explained as:
- When visiting the `/partners` url, the `partners` route searches for
grades from `request.env['res.partner']`. By doing so, it ensures that
grades are linked to at least one partner; this explains why the
"bronze" grade (not linked to any partner) is not shown at the
`/partners` url and why the deactivated "gold" grade is still
accessible (as a partner is still related to it).
- When the user tries to reach a `/partners` route, a 404 server answer
is returned if no partners are found for the route (e.g.
`/partners/grade/bronze-4`).
- When generating the sitemap, the system is searching for grades from
`env['res.partner.grade']`. Due to it, inactive grades (e.g. "gold") are
not shown on the sitemap and grades that are not linked to a partner
(e.g. "bronze") are shown on the sitemap.

The goal of this commit is to:
- Correct the `/partners` route so that it does not show inactive
grades.
- Generate the sitemap coherently from what is done in the `/partners`
route.

In the end, the `/partner` route only shows company website published
partners linked to active website published grades. The user has then
the possibility to filter the partners by grades or by country.

opw-3992340
