### PR TITLE
[FIX] website_forum: fix navbar padding post bootstrap migration

### DIFF
--- a/addons/website_forum/views/forum_forum_templates_layout.xml
+++ b/addons/website_forum/views/forum_forum_templates_layout.xml
@@ -232,7 +232,7 @@
 <!-- User sidebar -->
 <template id="user_sidebar">
     <aside class="o_wforum_sidebar col-3 d-none d-lg-flex flex-column z-index-1">
-        <div class="flex-grow-1 px-2">
+        <div class="nav d-block flex-grow-1 px-2">
             <t t-call="website_forum.user_sidebar_header"/>
             <t t-call="website_forum.user_sidebar_body"/>
         </div>


### PR DESCRIPTION
This PR fixes a visual issue about the forum navbar not having a horizontal padding anymore, which is easily noticeable on when an item has the `.active` class.

With the migration to Bootstrap v5.3, we need to scope our `.nav-link` utility classes within a `.nav` one in order to inherit the CSS variables.

To handle this issue, we simply add the missing `.nav` utility class and a `d-block` to override de `d-flex` sets by the utility class.

task-4009043

| 17.3 | This PR |
|--------|--------|
| <img alt="image" src="https://github.com/odoo/odoo/assets/128030743/b2a9550f-7422-4c92-83d2-e3affe31c54d"> | <img alt="image" src="https://github.com/odoo/odoo/assets/128030743/e71c36ca-0e71-4969-a6db-6d086b3f3b77"> | 



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
