### PR TITLE
[FIX] l10n_gcc_invoice: html entity in payment terms

### DIFF
--- a/addons/l10n_gcc_invoice/models/account_move.py
+++ b/addons/l10n_gcc_invoice/models/account_move.py
@@ -24,7 +24,7 @@ class AccountMove(models.Model):
         moves_to_fix = self.env['account.move']
         for move in self.filtered(lambda m: m.company_id.country_id in gcc_countries and m.is_sale_document(include_receipts=True) and m.narration):
             lang = move.partner_id.lang or self.env.user.lang
-            if move.company_id.terms_type == 'html' or move.narration != move.company_id.with_context(lang=lang).invoice_terms:
+            if move.company_id.terms_type == 'html' or move.narration.unescape() != move.company_id.with_context(lang=lang).invoice_terms.unescape():
                 continue
             moves_to_fix |= move
         if not moves_to_fix:


### PR DESCRIPTION
Payment terms will be shown twice when using the English language, once as `move.narration` the other as part of the `company_id.invoice_terms`.

This occurs because the check that should ensure they are different before printing both, doesn't take into account that:
- `&nbsp;` in `company_id.invoice_terms` field gets encoded while retrieving the translation string, (`&nbsp;` -> `\xa0`) 
- `move.narration` will contains the original `html` entity instead.

To reproduce:
- Install the Saudi Arabian localization
- Select the Saudi Arabian demo company as your current one.
- In Accounting Settings, activate the invoice terms flag.
- Add a Payment Terms string in English (example `TEST ENGLISH`)
- Add the Arabic translation with an `html` entity in between (example `TEST&nbsp;ARABIC`)
- Create an invoice with a partner that has his language set to Arabic.
- Activate the Arabic (ar_001) language
- Click the Preview button

Ticket link: https://www.odoo.com/odoo/project.task/3530811
opw-3530811