### PR TITLE
[FIX] point_of_sale,pos_loyalty: apply taxes on gift card rewards

### DIFF
--- a/addons/pos_loyalty/static/src/js/Loyalty.js
+++ b/addons/pos_loyalty/static/src/js/Loyalty.js
@@ -1393,9 +1393,13 @@ const PosLoyaltyOrder = (Order) => class PosLoyaltyOrder extends Order {
         // These are considered payments and do not require to be either taxed or split by tax
         const discountProduct = reward.discount_line_product_id;
         if (['ewallet', 'gift_card'].includes(reward.program_id.program_type)) {
+            const taxes_to_apply = discountProduct.taxes_id.map(id => { return { ...this.pos.taxes_by_id[id], price_include:true } })
+            const tax_res = this.pos.compute_all(taxes_to_apply, -Math.min(maxDiscount, discountable), 1, this.pos.currency.rounding)
+            let new_price = tax_res['total_excluded']
+            new_price += tax_res.taxes.filter(tax => this.pos.taxes_by_id[tax.id].price_include).reduce((sum,tax) => sum += tax.amount,0)
             return [{
                 product: discountProduct,
-                price: -Math.min(maxDiscount, discountable),
+                price: new_price,
                 quantity: 1,
                 reward_id: reward.id,
                 is_reward_line: true,
@@ -1403,6 +1407,7 @@ const PosLoyaltyOrder = (Order) => class PosLoyaltyOrder extends Order {
                 points_cost: pointCost,
                 reward_identifier_code: rewardCode,
                 merge: false,
+                taxIds: discountProduct.taxes_id
             }];
         }
         const discountFactor = discountable ? Math.min(1, (maxDiscount / discountable)) : 1;

--- a/addons/pos_loyalty/static/src/tours/GiftCardProgramTours.js
+++ b/addons/pos_loyalty/static/src/tours/GiftCardProgramTours.js
@@ -1,5 +1,6 @@
 /** @odoo-module **/
 
+import { Chrome } from "point_of_sale.tour.ChromeTourMethods";
 import { PosLoyalty } from 'pos_loyalty.tour.PosCouponTourMethods';
 import { ProductScreen } from 'point_of_sale.tour.ProductScreenTourMethods';
 import { TextInputPopup } from 'point_of_sale.tour.TextInputPopupTourMethods';
@@ -67,3 +68,13 @@ PosLoyalty.check.orderTotalIs("50.00");
 PosLoyalty.check.pointsAwardedAre("100"),
 PosLoyalty.exec.finalizeOrder("Cash", "50");
 Tour.register("PosLoyaltyPointsGiftcard", { test: true, url: "/pos/web" }, getSteps());
+
+startSteps();
+ProductScreen.do.confirmOpeningPopup();
+ProductScreen.do.clickHomeCategory();
+ProductScreen.do.clickDisplayedProduct("Test Product A");
+PosLoyalty.do.enterCode("044123456");
+Chrome.do.confirmPopup();
+PosLoyalty.check.orderTotalIs("50.00");
+ProductScreen.check.checkTaxAmount("-6.52");
+Tour.register("PosLoyaltyGiftCardTaxes", { test: true }, getSteps());

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -1915,3 +1915,38 @@ class TestUi(TestPointOfSaleHttpCommon):
             login="accountman",
         )
         self.assertEqual(loyalty_card.points, 100)
+
+    def test_gift_card_rewards_using_taxes(self):
+        """
+        Check the gift card value when the reward has taxes
+        """
+        self.env['loyalty.program'].search([]).write({'active': False})
+        self.env.ref('loyalty.gift_card_product_50').write({'active': True})
+
+        gift_card_program = self.create_programs([('arbitrary_name', 'gift_card')])['arbitrary_name']
+        self.product_a = self.env["product.product"].create({
+            "name": "Test Product A",
+            "type": "product",
+            "list_price": 100,
+            "available_in_pos": True,
+            "taxes_id": False,
+        })
+
+        self.tax01 = self.env["account.tax"].create({
+            "name": "C01 Tax",
+            "amount": "15.00",
+        })
+        gift_card_program.payment_program_discount_product_id.taxes_id = self.tax01
+        self.main_pos_config.write({'gift_card_settings': 'scan_use'})
+        self.env["loyalty.generate.wizard"].with_context(
+            {"active_id": gift_card_program.id}
+        ).create({"coupon_qty": 1, 'points_granted': 50}).generate_coupons()
+        gift_card_program.coupon_ids.code = '044123456'
+
+        self.main_pos_config.open_ui()
+        self.start_tour(
+            "/pos/web?config_id=%d" % self.main_pos_config.id,
+            "PosLoyaltyGiftCardTaxes",
+            login="accountman",
+        )
+        self.main_pos_config.current_session_id.close_session_from_ui()


### PR DESCRIPTION
If for some reason you want to apply taxes on the gift card reward, they were not correctly applied.

Steps to reproduce:
-------------------
* Create a gift card program
* Find the gift card reward product in the program
* Add some taxes to it
* Open a PoS session, add some product and use a gift card
> Observation: The tax on the gift card product is not taken into
  account

Why the fix:
------------
When generating the gift card we force all taxes to be included in price this way the value of the gift card is not modified, but the taxes are applied

opw-3916989
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
