### PR TITLE
[IMP] account, (*_)sale(_*): use the new description widget

### DIFF
--- a/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.xml
+++ b/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.xml
@@ -82,7 +82,7 @@
                         <Many2XAutocomplete t-props="Many2XAutocompleteProps"/>
                         <button t-if="hasExternalButton"
                                 aria-label="Internal link"
-                                class="btn btn-link text-action oi o_external_button"
+                                class="btn btn-link text-action oi o_external_button px-2"
                                 data-tooltip="Internal link"
                                 draggable="false"
                                 tabindex="-1"
@@ -92,7 +92,7 @@
                         />
                         <button t-if="hasBarcodeButton"
                                 aria-label="Scan barcode"
-                                class="btn ms-3 o_barcode o_external_button"
+                                class="btn ms-3 o_barcode o_external_button px-2"
                                 data-tooltip="Scan barcode"
                                 draggable="false"
                                 tabindex="-1"

--- a/addons/event_booth_sale/views/sale_order_views.xml
+++ b/addons/event_booth_sale/views/sale_order_views.xml
@@ -14,9 +14,9 @@
                 </button>
             </xpath>
             <xpath expr="//field[@name='order_line']//tree//field[@name='event_ticket_id']" position="after">
-                <field name="is_event_booth" optional="hide"/>
-                <field name="event_booth_category_id" optional="hide"/>
-                <field name="event_booth_pending_ids" optional="hide"/>
+                <field name="is_event_booth" column_invisible="True"/>
+                <field name="event_booth_category_id" column_invisible="True"/>
+                <field name="event_booth_pending_ids" column_invisible="True"/>
             </xpath>
             <xpath expr="//field[@name='order_line']//tree//field[@name='product_uom_qty']" position="attributes">
                 <attribute name="readonly">is_event_booth</attribute>

--- a/addons/event_sale/static/tests/tours/event_configurator_ui.js
+++ b/addons/event_sale/static/tests/tours/event_configurator_ui.js
@@ -2,35 +2,16 @@
 
 import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
+import tourUtils from "@sale/js/tours/tour_utils";
 
 registry.category("web_tour.tours").add("event_configurator_tour", {
     url: "/odoo",
     test: true,
     steps: () => [
-        stepUtils.showAppsMenuItem(),
-        {
-            trigger: '.o_app[data-menu-xmlid="sale.sale_menu_root"]',
-            run: "click",
-        },
-        {
-            trigger: ".o_sale_order",
-        },
-        {
-            trigger: ".o_list_button_add",
-            run: "click",
-        },
-        {
-            trigger: "a:contains(Add a product)",
-            run: "click",
-        },
-        {
-            trigger: 'div[name="product_id"] input, div[name="product_template_id"] input',
-            run: "edit Event Registration",
-        },
-        {
-            trigger: "ul.ui-autocomplete a:contains(Event Registration)",
-            run: "click",
-        },
+        ...stepUtils.goToAppSteps("sale.sale_menu_root", "Go to the Sales App"),
+        ...tourUtils.createNewSalesOrder(),
+        ...tourUtils.selectCustomer("Azure"),
+        ...tourUtils.addProduct("Event Registration"),
         {
             trigger: 'div[name="event_id"] input',
             run: "click",
@@ -55,36 +36,9 @@ registry.category("web_tour.tours").add("event_configurator_tour", {
             content: "Wait the modal is closed",
             trigger: "body:not(:has(.modal))",
         },
-        {
-            content: "click somewhere else to exit cell focus",
-            trigger: "label:contains(Untaxed Amount)",
-            run: "click",
-        },
-        {
-            trigger: "td[name='name'] span:contains(VIP)",
-        },
-        {
-            trigger: "ul.nav a:contains(Order Lines)",
-            run: "click",
-        },
-        {
-            content: "search the partner",
-            trigger: 'div[name="partner_id"] input',
-            run: "edit Azure",
-        },
-        {
-            content: "select the partner",
-            trigger: "ul.ui-autocomplete > li > a:contains(Azure)",
-            run: "click",
-        },
-        {
-            trigger: "td:contains(Event)",
-            run: "click",
-        },
-        {
-            trigger: "button.fa-pencil",
-            run: "click",
-        },
+        ...tourUtils.clickSomewhereElse(),
+        tourUtils.editLineMatching("Event Registration", "VIP"),
+        tourUtils.editConfiguration(),
         {
             trigger: 'div[name="event_ticket_id"] input',
             run: "click",
@@ -101,14 +55,8 @@ registry.category("web_tour.tours").add("event_configurator_tour", {
             content: "Wait the modal is closed",
             trigger: "body:not(:has(.modal))",
         },
-        {
-            content: "click somewhere else to exit cell focus",
-            trigger: "label:contains(Untaxed Amount)",
-            run: "click",
-        },
-        {
-            trigger: "td[name='name'] span:contains(Standard)",
-        },
+        ...tourUtils.clickSomewhereElse(),
+        tourUtils.checkSOLDescriptionContains("Event Registration", "Standard"),
         ...stepUtils.saveForm(),
     ],
 });

--- a/addons/event_sale/views/sale_order_views.xml
+++ b/addons/event_sale/views/sale_order_views.xml
@@ -33,7 +33,8 @@
                     options="{'no_open': True, 'no_create': True}"/>
             </xpath>
             <xpath expr="//field[@name='order_line']//tree//field[@name='product_template_id']" position="after">
-                <field name="event_id" optional="hide"
+                <field name="event_id"
+                    column_invisible="True"
                     domain="[
                         ('event_ticket_ids.product_id','=', product_id),
                         ('date_end','&gt;=',time.strftime('%Y-%m-%d 00:00:00')),
@@ -42,7 +43,8 @@
                     invisible="service_tracking != 'event'"
                     required="service_tracking == 'event'"
                     options="{'no_open': True, 'no_create': True}"/>
-                <field name="event_ticket_id" optional="hide"
+                <field name="event_ticket_id"
+                    column_invisible="True"
                     domain="[
                         ('event_id', '=', event_id), ('product_id','=',product_id),
                          '|', ('company_id', '=', False), ('company_id', '=', parent.company_id)

--- a/addons/event_sale/views/sale_order_views.xml
+++ b/addons/event_sale/views/sale_order_views.xml
@@ -40,7 +40,6 @@
                         ('date_end','&gt;=',time.strftime('%Y-%m-%d 00:00:00')),
                         '|', ('company_id', '=', False), ('company_id', '=', parent.company_id)
                     ]"
-                    invisible="service_tracking != 'event'"
                     required="service_tracking == 'event'"
                     options="{'no_open': True, 'no_create': True}"/>
                 <field name="event_ticket_id"
@@ -49,7 +48,6 @@
                         ('event_id', '=', event_id), ('product_id','=',product_id),
                          '|', ('company_id', '=', False), ('company_id', '=', parent.company_id)
                     ]"
-                    invisible="service_tracking != 'event' or not event_id"
                     required="service_tracking == 'event' and event_id"
                     options="{'no_open': True, 'no_create': True}"/>
             </xpath>

--- a/addons/purchase_product_matrix/static/src/js/purchase_product_field.xml
+++ b/addons/purchase_product_matrix/static/src/js/purchase_product_field.xml
@@ -7,7 +7,7 @@
             <button
                 t-if="isConfigurableTemplate"
                 type="button"
-                class="btn btn-link fa fa-pencil"
+                class="btn btn-link fa fa-pencil px-2"
                 tabindex="-1"
                 draggable="false"
                 t-att-aria-label="configurationButtonHelp"

--- a/addons/sale/__manifest__.py
+++ b/addons/sale/__manifest__.py
@@ -76,6 +76,7 @@ This module contains all the common features of Sales Management and eCommerce.
             'sale/static/src/js/sale_progressbar_field.js',
             'sale/static/src/js/tours/sale.js',
             'sale/static/src/js/sale_product_field.js',
+            'sale/static/src/js/sale_product_field.scss',
             'sale/static/src/xml/**/*',
             'sale/static/src/views/**/*',
         ],

--- a/addons/sale/static/src/js/sale_product_field.scss
+++ b/addons/sale/static/src/js/sale_product_field.scss
@@ -1,0 +1,4 @@
+.o_field_sol_o2m ~ .row.o_group {
+    clear: both;
+    justify-content: space-between;
+}

--- a/addons/sale/static/src/js/tours/product_configurator_tour_utils.js
+++ b/addons/sale/static/src/js/tours/product_configurator_tour_utils.js
@@ -192,6 +192,18 @@ function assertFooterButtonsDisabled() {
     };
 }
 
+function saveConfigurator() {
+    return [
+        {
+            trigger: '.modal button:contains(Confirm)',
+            run: 'click',
+        }, {
+            content: "Wait until the modal is closed",
+            trigger: 'body:not(:has(.modal))',
+        }
+    ]
+}
+
 export default {
     productSelector,
     optionalProductSelector,
@@ -210,4 +222,5 @@ export default {
     assertOptionalProductPriceInfo,
     assertProductNameContains,
     assertFooterButtonsDisabled,
+    saveConfigurator,
 };

--- a/addons/sale/static/src/js/tours/sale.js
+++ b/addons/sale/static/src/js/tours/sale.js
@@ -88,10 +88,6 @@ registry.category("web_tour.tours").add("sale_tour", {
         },
         {
             isActive: ["auto"],
-            trigger: ".o_field_text[name='name'] textarea:value(DESK0001)",
-        },
-        {
-            isActive: ["auto"],
             trigger: ".oi-arrow-right", // Wait for product creation
         },
         {

--- a/addons/sale/static/src/xml/sale_product_field.xml
+++ b/addons/sale/static/src/xml/sale_product_field.xml
@@ -2,20 +2,13 @@
 
 <templates xml:space="preserve">
 
-    <t t-name="sale.SaleProductField" t-inherit="web.Many2OneField" t-inherit-mode="primary">
-        <!-- Make the product label clickable (to open its form view) when the user cannot
-            access it through the external button (because the product/line is readonly) -->
-        <xpath expr="//t[@t-if='!props.canOpen']" position="attributes">
-            <attribute name="t-if">
-                !isProductClickable
-            </attribute>
-        </xpath>
+    <t t-name="sale.SaleProductField" t-inherit="account.ProductLabelSectionAndNoteField" t-inherit-mode="primary">
         <!-- Show configuration button for custom lines/products -->
-        <xpath expr="//t[@t-if='hasExternalButton']" position="before">
+        <xpath expr="//button[@t-if='hasExternalButton']" position="before">
             <t t-if="hasConfigurationButton">
                 <button
                     type="button"
-                    t-att-class="configurationButtonIcon"
+                    class="btn btn-secondary fa fa-pencil px-2"
                     tabindex="-1"
                     draggable="false"
                     t-att-aria-label="configurationButtonHelp"

--- a/addons/sale/static/tests/sale_product_field_tests.js
+++ b/addons/sale/static/tests/sale_product_field_tests.js
@@ -51,9 +51,17 @@ QUnit.module("Fields", (hooks) => {
                             type: "many2one",
                             relation: "product.template",
                         },
+                        product_id: {
+                            string: "Product",
+                            type: "many2one",
+                            relation: "product.product",
+                        },
+                        name: {
+                            string: "Description",
+                            type: "char",
+                        }
                     },
-                    records: [
-                    ],
+                    records: [],
                 },
                 'product.template': {
                     fields: {
@@ -65,9 +73,18 @@ QUnit.module("Fields", (hooks) => {
                     ],
                     methods:  {
                         get_single_product_variant() {
-                            return Promise.resolve({product_id: 12});
+                            return Promise.resolve({product_id: 14, product_name: 'desk'});
                         }
                     }
+                },
+                'product.product': {
+                    fields: {
+                        display_name: { string: "Partner Type", type: "char" },
+                        name: { string: "Partner Type", type: "char" },
+                    },
+                    records: [
+                        { id: 14, display_name: "desk" },
+                    ],
                 },
                 user: {
                     fields: {
@@ -104,8 +121,10 @@ QUnit.module("Fields", (hooks) => {
                 <form>
                     <sheet>
                         <field name="order_line">
-                            <tree editable="bottom" >
-                                <field name="product_template_id" widget="sol_product_many2one" />
+                            <tree editable="bottom">
+                                <field name="product_template_id" widget="sol_product_many2one"/>
+                                <field name="product_id" optional="hide"/>
+                                <field name="name" optional="show"/>
                             </tree>
                         </field>
                     </sheet>

--- a/addons/sale/static/tests/tours/product_attribute_value_tour.js
+++ b/addons/sale/static/tests/tours/product_attribute_value_tour.js
@@ -2,7 +2,7 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
 
 const openProductAttribute = (product_attribute) => [
-    ...stepUtils.goToAppSteps("sale.sale_menu_root", 'Go to the Sales App'),
+    ...stepUtils.goToAppSteps("sale.sale_menu_root", "Go to the Sales App"),
     {
         content: 'Open configuration menu',
         trigger: '.o-dropdown[data-menu-xmlid="sale.menu_sale_config"]',

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -593,10 +593,12 @@
                                     context="{'company_id': parent.company_id}"
                                     groups="uom.group_uom"
                                     options='{"no_open": True}'
+                                    width="60px"
                                     optional="show"/>
                                 <field
                                     name="customer_lead"
                                     optional="hide"
+                                    width="80px"
                                     readonly="parent.state not in ['draft', 'sent', 'sale'] or is_downpayment"/>
                                 <field name="product_packaging_qty" invisible="not product_id or not product_packaging_id" groups="product.group_stock_packaging" optional="show"/>
                                 <field name="product_packaging_id" invisible="not product_id" context="{'default_product_id': product_id, 'tree_view_ref':'product.product_packaging_tree_view', 'form_view_ref':'product.product_packaging_form_view'}" groups="product.group_stock_packaging" optional="show"/>
@@ -611,7 +613,12 @@
                                     context="{'active_test': True}"
                                     readonly="qty_invoiced &gt; 0 or is_downpayment"
                                     optional="show"/>
-                                <field name="discount" string="Disc.%" groups="sale.group_discount_per_so_line" optional="show"/>
+                                <field
+                                    name="discount"
+                                    string="Disc.%"
+                                    groups="sale.group_discount_per_so_line"
+                                    width="60px"
+                                    optional="show"/>
                                 <field name="is_downpayment" column_invisible="True"/>
                                 <field name="price_subtotal" string="Tax excl." invisible="is_downpayment"/>
                                 <field name="price_total"

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -378,7 +378,7 @@
                     <page string="Order Lines" name="order_lines">
                         <field
                             name="order_line"
-                            widget="section_and_note_one2many"
+                            widget="sol_o2m"
                             mode="tree,kanban"
                             readonly="state == 'cancel' or locked">
                             <form>
@@ -516,7 +516,6 @@
                                         'uom':product_uom,
                                         'company_id': parent.company_id,
                                         'default_lst_price': price_unit,
-                                        'default_description_sale': name
                                     }"
                                     options="{
                                         'no_open': True,
@@ -535,11 +534,11 @@
                                         'uom':product_uom,
                                         'company_id': parent.company_id,
                                         'default_list_price': price_unit,
-                                        'default_description_sale': name
                                     }"
                                     options="{
                                         'no_open': True,
                                     }"
+                                    optional="show"
                                     domain="[('sale_ok', '=', True)]"
                                     widget="sol_product_many2one"
                                     placeholder="Type to find a product..."/>

--- a/addons/sale_stock/data/sale_order_demo.xml
+++ b/addons/sale_stock/data/sale_order_demo.xml
@@ -42,19 +42,15 @@
 
         <record id="sale_order_line_42" model="sale.order.line">
             <field name="order_id" ref="sale_order_19"/>
-            <field name="name" model="sale.order.line" eval="obj().env.ref('product.product_product_25').get_product_multiline_description_sale()"/>
             <field name="product_id" ref="product.product_product_25"/>
             <field name="product_uom_qty">5</field>
-            <field name="product_uom" ref="uom.product_uom_unit"/>
             <field name="price_unit">295.00</field>
         </record>
 
         <record id="sale_order_line_43" model="sale.order.line">
             <field name="order_id" ref="sale_order_19"/>
-            <field name="name" model="sale.order.line" eval="obj().env.ref('product.product_product_10').get_product_multiline_description_sale()"/>
             <field name="product_id" ref="product.product_product_10"/>
             <field name="product_uom_qty">5</field>
-            <field name="product_uom" ref="uom.product_uom_unit"/>
             <field name="price_unit">140.00</field>
         </record>
 
@@ -73,10 +69,8 @@
 
         <record id="sale_order_line_44" model="sale.order.line">
             <field name="order_id" ref="sale_order_20"/>
-            <field name="name" model="sale.order.line" eval="obj().env.ref('product.product_product_25').get_product_multiline_description_sale()"/>
             <field name="product_id" ref="product.product_product_25"/>
             <field name="product_uom_qty">5</field>
-            <field name="product_uom" ref="uom.product_uom_unit"/>
             <field name="price_unit">295.00</field>
         </record>
 
@@ -95,19 +89,15 @@
 
         <record id="sale_order_line_45" model="sale.order.line">
             <field name="order_id" ref="sale_order_21"/>
-            <field name="name" model="sale.order.line" eval="obj().env.ref('product.product_product_25').get_product_multiline_description_sale()"/>
             <field name="product_id" ref="product.product_product_25"/>
             <field name="product_uom_qty">10</field>
-            <field name="product_uom" ref="uom.product_uom_unit"/>
             <field name="price_unit">295.00</field>
         </record>
 
         <record id="sale_order_line_46" model="sale.order.line">
             <field name="order_id" ref="sale_order_21"/>
-            <field name="name" model="sale.order.line" eval="obj().env.ref('product.product_product_10').get_product_multiline_description_sale()"/>
             <field name="product_id" ref="product.product_product_10"/>
             <field name="product_uom_qty">10</field>
-            <field name="product_uom" ref="uom.product_uom_unit"/>
             <field name="price_unit">140.00</field>
         </record>
 
@@ -126,10 +116,8 @@
 
         <record id="sale_order_line_47" model="sale.order.line">
             <field name="order_id" ref="sale_order_22"/>
-            <field name="name" model="sale.order.line" eval="obj().env.ref('product.product_product_5').get_product_multiline_description_sale()"/>
             <field name="product_id" ref="product.product_product_5"/>
             <field name="product_uom_qty">10</field>
-            <field name="product_uom" ref="uom.product_uom_unit"/>
             <field name="price_unit">199.00</field>
         </record>
 

--- a/addons/sale_timesheet/data/sale_service_demo.xml
+++ b/addons/sale_timesheet/data/sale_service_demo.xml
@@ -61,9 +61,7 @@
 
         <record id="sale_line_services" model="sale.order.line">
             <field name="order_id" ref="sale.sale_order_3"/>
-            <field name="name" model="sale.order.line" eval="obj().env.ref('sale.advance_product_0').get_product_multiline_description_sale()"/>
             <field name="product_id" ref="sale.advance_product_0"/>
-            <field name="product_uom" ref="uom.product_uom_unit"/>
             <field name="price_unit">150.0</field>
             <field name="product_uom_qty">5.0</field>
         </record>

--- a/addons/sale_timesheet/static/tests/tours/sale_timesheet_tour.js
+++ b/addons/sale_timesheet/static/tests/tours/sale_timesheet_tour.js
@@ -2,6 +2,7 @@
 
 import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
+import tourUtils from "@sale/js/tours/tour_utils";
 
 import { markup } from "@odoo/owl";
 import { queryText } from "@odoo/hoot-dom";
@@ -9,41 +10,22 @@ import { queryText } from "@odoo/hoot-dom";
 registry.category("web_tour.tours").add('sale_timesheet_tour', {
     test: true,
     url: '/odoo',
-    steps: () => [...stepUtils.goToAppSteps("sale.sale_menu_root", 'Go to the Sales App'),
+    steps: () => [
+        ...stepUtils.goToAppSteps("sale.sale_menu_root", "Go to the Sales App"),
+        ...tourUtils.createNewSalesOrder(),
+        ...tourUtils.selectCustomer("Brandon Freeman"),
+        ...tourUtils.addProduct("Service Product (Prepaid Hours)"),
 {
-    trigger: 'button.o_list_button_add',
-    content: 'Click on CREATE button to create a quotation with service products.',
-    run: "click",
-}, {
-    trigger: 'div[name="partner_id"] input',
-    content: 'Add the customer for this quotation (e.g. Brandon Freeman)',
-    run: "edit Brandon Freeman",
-}, {
-    trigger: 'div[name="partner_id"] ul > li:first-child > a:contains(Freeman)',
-    content: 'Select the first item on the autocomplete dropdown',
-    run: "click",
-},
-{
-    trigger: 'td.o_field_x2many_list_row_add > a:first-child',
-    content: 'Click on "Add a product" to add a new product. We will add a service product.',
-    run: "click",
-}, {
-    trigger: '.o_field_html[name="product_id"], .o_field_widget[name="product_template_id"] input',
-    content: markup('Select a prepaid service product <i>(e.g. Service Product (Prepaid Hours))</i>'),
-    run: "edit Service Product (Prepaid Hours)",
-}, {
-    trigger: 'ul.ui-autocomplete a:contains(Service Product (Prepaid Hours))',
-    content: 'Select the prepaid service product in the autocomplete dropdown',
-    run: "click",
-}, {
     trigger: 'div[name="product_uom_qty"] input',
     content: "Add 10 hours as ordered quantity for this product.",
-    run: "edit 10 && press Tab",
-}, {
-    trigger: '.o_field_widget[name=price_subtotal]:contains(2,500.00)',
-}, {
-    trigger: 'div[name="name"] textarea:value(Service Product)',
-}, {
+    run: "edit 10",
+},
+...tourUtils.clickSomewhereElse(),
+{
+    trigger: '.o_field_cell[name=price_subtotal]:contains(2,500.00)',
+},
+tourUtils.checkSOLDescriptionContains("Service Product (Prepaid Hours)", ""),
+{
     trigger: "button[name=action_confirm]:enabled",
     content: 'Click on Confirm button to create a sale order with this quotation.',
     run: "click",

--- a/addons/sale_timesheet/tests/test_sale_timesheet_ui.py
+++ b/addons/sale_timesheet/tests/test_sale_timesheet_ui.py
@@ -9,7 +9,7 @@ _logger = logging.getLogger(__name__)
 
 
 @tagged('-at_install', 'post_install')
-class TestUi(HttpCase):
+class TestSaleTimesheetUi(HttpCase):
 
     @classmethod
     def setUpClass(cls):

--- a/addons/test_sale_product_configurators/static/tests/tours/event_sale_with_product_configurator_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/event_sale_with_product_configurator_ui.js
@@ -3,47 +3,19 @@
 import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
 import configuratorTourUtils from "@sale/js/tours/product_configurator_tour_utils";
+import tourUtils from "@sale/js/tours/tour_utils";
 
 registry.category("web_tour.tours").add("event_sale_with_product_configurator_tour", {
     url: "/odoo",
     test: true,
     steps: () => [
-        stepUtils.showAppsMenuItem(),
-        {
-            trigger: '.o_app[data-menu-xmlid="sale.sale_menu_root"]',
-            run: "click",
-        },
-        {
-            trigger: ".o_sale_order",
-        },
-        {
-            trigger: ".o_list_button_add",
-            run: "click",
-        },
-        {
-            trigger: ".o_required_modifier[name=partner_id] input",
-            run: "edit Tajine Saucisse",
-        },
-        {
-            isActive: ["auto"],
-            trigger: '.ui-menu-item > a:contains("Tajine Saucisse")',
-            run: "click",
-        },
-        {
-            trigger: 'a:contains("Add a product")',
-            run: "click",
-        },
-        {
-            trigger: 'div[name="product_template_id"] input',
-            run: "edit event (",
-        },
-        {
-            trigger: 'ul.ui-autocomplete a:contains("Registration Event (TEST variants)")',
-            run: "click",
-        },
+        ...stepUtils.goToAppSteps("sale.sale_menu_root", "Go to the Sales App"),
+        ...tourUtils.createNewSalesOrder(),
+        ...tourUtils.selectCustomer("Tajine Saucisse"),
+        ...tourUtils.addProduct("Registration Event (TEST variants)"),
         {
             trigger:
-                'tr:has(div[name="o_sale_product_configurator_name"]:contains("Memorabilia")) button:has(i.fa-plus)',
+            'tr:has(div[name="o_sale_product_configurator_name"]:contains("Memorabilia")) button:has(i.fa-plus)',
             run: "click",
         },
         {
@@ -81,29 +53,15 @@ registry.category("web_tour.tours").add("event_sale_with_product_configurator_to
         {
             trigger: 'td[name="price_subtotal"]:contains("16.50")', // wait for the optional product line
         },
+        ...tourUtils.addProduct("Registration Event (TEST variants)"),
         {
-            trigger: 'a:contains("Add a product")',
-            run: "click",
-        },
-        {
-            trigger: ".o_data_row:nth-child(3)", // wait for the new row to be created
-        },
-        {
-            trigger: 'div[name="product_template_id"] input',
-            run: "edit event (",
-        },
-        {
-            trigger: 'ul.ui-autocomplete a:contains("Registration Event (TEST variants)")',
+            trigger:
+            'tr:has(div[name="o_sale_product_configurator_name"]:contains("Registration Event (TEST variants)")) label:contains("Adult")',
             run: "click",
         },
         {
             trigger:
-                'tr:has(div[name="o_sale_product_configurator_name"]:contains("Registration Event (TEST variants)")) label:contains("Adult")',
-            run: "click",
-        },
-        {
-            trigger:
-                'tr:has(div[name="o_sale_product_configurator_name"]:contains("Registration Event (TEST variants)")) .o_sale_product_configurator_qty input',
+            'tr:has(div[name="o_sale_product_configurator_name"]:contains("Registration Event (TEST variants)")) .o_sale_product_configurator_qty input',
             run: "edit 5 && click body",
         },
         configuratorTourUtils.assertPriceTotal("150.00"),
@@ -142,24 +100,10 @@ registry.category("web_tour.tours").add("event_sale_with_product_configurator_to
         {
             trigger: 'td[name="price_subtotal"]:contains("150.00")', // wait for the adult tickets line
         },
-        {
-            trigger: 'a:contains("Add a product")',
-            run: "click",
-        },
-        {
-            trigger: ".o_data_row:nth-child(4)", // wait for the new row to be created
-        },
-        {
-            trigger: 'div[name="product_template_id"] input',
-            run: "edit event (",
-        },
-        {
-            trigger: 'ul.ui-autocomplete a:contains("Registration Event (TEST variants)")',
-            run: "click",
-        },
+        ...tourUtils.addProduct("Registration Event (TEST variants)"),
         {
             trigger:
-                'tr:has(div[name="o_sale_product_configurator_name"]:contains("Registration Event (TEST variants)")) label:contains("VIP")',
+            'tr:has(div[name="o_sale_product_configurator_name"]:contains("Registration Event (TEST variants)")) label:contains("VIP")',
             run: "click",
         },
         configuratorTourUtils.assertPriceTotal(60.0),

--- a/addons/test_sale_product_configurators/static/tests/tours/product_attribute_with_multi_type.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_attribute_with_multi_type.js
@@ -2,49 +2,19 @@
 
 import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
+import configuratorTourUtils from "@sale/js/tours/product_configurator_tour_utils";
+import tourUtils from "@sale/js/tours/tour_utils";
 
 registry.category("web_tour.tours").add("product_attribute_multi_type", {
     url: "/odoo",
     test: true,
-    steps: () => [stepUtils.showAppsMenuItem(),
-    {
-        content: "navigate to the sale app",
-        trigger: '.o_app[data-menu-xmlid="sale.sale_menu_root"]',
-        run: "click",
-    }, 
-    {
-        trigger: ".o_sale_order",
-    },
-    {
-        content: "create a new order",
-        trigger: '.o_list_button_add',
-        run: "click",
-    }, {
-        content: "search the partner",
-        trigger: 'div[name="partner_id"] input',
-        run: "edit Azure",
-    }, {
-        content: "select the partner",
-        trigger: 'ul.ui-autocomplete > li > a:contains(Azure)',
-        run: "click",
-    }, {
-        content: "Add a product",
-        trigger: "a:contains('Add a product')",
-        run: "click",
-    }, {
-        trigger: 'div[name="product_template_id"] input',
-        run: 'edit Big Burger'
-    }, {
-        content: "Choose item",
-        trigger: '.ui-menu-item-wrapper:contains("Big Burger")',
-        run: "click",
-    }, {
-        content: "Select the attribute value",
-        trigger: 'main.modal-body input[type="checkbox"]',
-        run: "click",
-    }, {
-        content: "Click on Confirm",
-        trigger: ".modal button:contains(Confirm)",
-        run: "click",
-    }, ...stepUtils.saveForm()
-]});
+    steps: () => [
+        ...stepUtils.goToAppSteps("sale.sale_menu_root", "Go to the Sales App"),
+        ...tourUtils.createNewSalesOrder(),
+        ...tourUtils.selectCustomer("Azure"),
+        ...tourUtils.addProduct("Big Burger"),
+        configuratorTourUtils.selectAttribute("Big Burger", "Toppings", "Cheese", "multi"),
+        ...configuratorTourUtils.saveConfigurator(),
+        ...stepUtils.saveForm(),
+    ],
+});

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_advanced_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_advanced_ui.js
@@ -3,81 +3,49 @@
 import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
 import configuratorTourUtils from "@sale/js/tours/product_configurator_tour_utils";
+import tourUtils from "@sale/js/tours/tour_utils";
 
 let optionVariantImage;
 
 registry.category("web_tour.tours").add('sale_product_configurator_advanced_tour', {
     url: '/odoo',
     test: true,
-    steps: () => [stepUtils.showAppsMenuItem(), {
-    trigger: '.o_app[data-menu-xmlid="sale.sale_menu_root"]',
-    run: "click",
-},
-{
-    trigger: ".o_sale_order",
-},
-{
-    trigger: '.o_list_button_add',
-    run: "click",
-}, {
-    trigger: '.o_required_modifier[name=partner_id] input',
-    run: "edit Tajine Saucisse",
-}, {
-    isActive: ["auto"],
-    trigger: '.ui-menu-item > a:contains("Tajine Saucisse")',
-    run: "click",
-},
-{
-    trigger: ".o_field_widget[name=partner_shipping_id] .o_external_button", // Wait for onchange_partner_id
-},
-{
-    trigger: 'a:contains("Add a product")',
-    run: "click",
-}, {
-    trigger: 'div[name="product_template_id"] input',
-    run: "edit Custo",
-}, {
-    trigger: 'ul.ui-autocomplete a:contains("Customizable Desk (TEST)")',
-    run: "click",
-},
-    ...configuratorTourUtils.selectAndSetCustomAttribute("Customizable Desk", "Legs", "Custom", "Custom 1"),
-    ...configuratorTourUtils.selectAndSetCustomAttribute("Customizable Desk", "PA1", "PAV9", "Custom 2"),
-    configuratorTourUtils.selectAttribute("Customizable Desk", "PA2", "PAV5"),
-    ...configuratorTourUtils.selectAndSetCustomAttribute("Customizable Desk", "PA4", "PAV9", "Custom 3", "select"),
-    configuratorTourUtils.assertProductNameContains("Custom, White, PAV9, PAV5, PAV1"),
-{
-    trigger: configuratorTourUtils.optionalProductSelector("Conference Chair (TEST) (Steel)"),
-    run: function () {
-        optionVariantImage =
-            configuratorTourUtils.optionalProductImageSrc("Conference Chair (TEST) (Steel)")
-    }
-},
-    configuratorTourUtils.selectAttribute("Conference Chair", "Legs", "Aluminium"),
-{
-    trigger: configuratorTourUtils.optionalProductSelector("Conference Chair (TEST) (Aluminium)"),
-    run: function () {
-        const newOptionVariantImage =
-            configuratorTourUtils.optionalProductImageSrc("Conference Chair (TEST) (Aluminium)")
-        if (newOptionVariantImage === optionVariantImage) {
-            console.error("The variant image wasn't updated");
-        }
-    }
-}, {
-    trigger: '.modal button:contains(Confirm)',
-    run: "click",
-}, {
-    trigger: 'td.o_data_cell:contains("Customizable Desk (TEST) (Custom, White, PAV9, PAV5, PAV1)"):not(:contains("PA9: Single PAV"))',
-}, {
-    trigger: 'td.o_data_cell:contains("Legs: Custom: Custom 1")',
-}, {
-    trigger: 'td.o_data_cell:contains("PA1: PAV9: Custom 2")',
-}, {
-    trigger: 'td.o_data_cell:contains("PA4: PAV9: Custom 3")',
-}, {
-    trigger: 'td.o_data_cell:contains("PA5: PAV1")',
-}, {
-    trigger: 'td.o_data_cell:contains("PA7: PAV1")',
-}, {
-    trigger: 'td.o_data_cell:contains("PA8: PAV1")',
-}, ...stepUtils.saveForm()
-]});
+    steps: () => [
+        ...stepUtils.goToAppSteps("sale.sale_menu_root", "Go to the Sales App"),
+        ...tourUtils.createNewSalesOrder(),
+        ...tourUtils.selectCustomer("Tajine Saucisse"),
+        {
+            trigger: ".o_field_widget[name=partner_shipping_id] .o_external_button", // Wait for onchange_partner_id
+        },
+        ...tourUtils.addProduct("Customizable Desk (TEST)"),
+        ...configuratorTourUtils.selectAndSetCustomAttribute("Customizable Desk", "Legs", "Custom", "Custom 1"),
+        ...configuratorTourUtils.selectAndSetCustomAttribute("Customizable Desk", "PA1", "PAV9", "Custom 2"),
+        configuratorTourUtils.selectAttribute("Customizable Desk", "PA2", "PAV5"),
+        ...configuratorTourUtils.selectAndSetCustomAttribute("Customizable Desk", "PA4", "PAV9", "Custom 3", "select"),
+        configuratorTourUtils.assertProductNameContains("Custom, White, PAV9, PAV5, PAV1"),
+        {
+            trigger: configuratorTourUtils.optionalProductSelector("Conference Chair (TEST) (Steel)"),
+            run: function () {
+                optionVariantImage =
+                    configuratorTourUtils.optionalProductImageSrc("Conference Chair (TEST) (Steel)")
+            }
+        },
+        configuratorTourUtils.selectAttribute("Conference Chair", "Legs", "Aluminium"),
+        {
+            trigger: configuratorTourUtils.optionalProductSelector("Conference Chair (TEST) (Aluminium)"),
+            run: function () {
+                const newOptionVariantImage =
+                    configuratorTourUtils.optionalProductImageSrc("Conference Chair (TEST) (Aluminium)")
+                if (newOptionVariantImage === optionVariantImage) {
+                    console.error("The variant image wasn't updated");
+                }
+            }
+        },
+        ...configuratorTourUtils.saveConfigurator(),
+        tourUtils.checkSOLDescriptionContains(
+            "Customizable Desk (TEST) (Custom, White, PAV9, PAV5, PAV1)",
+            "PA5: PAV1\nPA7: PAV1\nPA8: PAV1\nLegs: Custom: Custom 1\nPA1: PAV9: Custom 2\nPA4: PAV9: Custom 3",
+        ),
+        ...stepUtils.saveForm(),
+    ],
+});

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_custom_value_update_tour.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_custom_value_update_tour.js
@@ -3,66 +3,26 @@
 import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
 import configuratorTourUtils from "@sale/js/tours/product_configurator_tour_utils";
+import tourUtils from "@sale/js/tours/tour_utils";
 
 registry.category("web_tour.tours").add('sale_product_configurator_custom_value_update_tour', {
     url: '/odoo',
     test: true,
-    steps: () => [stepUtils.showAppsMenuItem(), {
-    trigger: '.o_app[data-menu-xmlid="sale.sale_menu_root"]',
-    run: "click",
-}, 
-{
-    trigger: ".o_sale_order",
-},
-{
-    trigger: '.o_list_button_add',
-    run: "click",
-}, {
-    trigger: '.o_required_modifier[name=partner_id] input',
-    run: "edit Tajine Saucisse",
-}, {
-    isActive: ["auto"],
-    trigger: '.ui-menu-item > a:contains("Tajine Saucisse")',
-    run: "click",
-}, {
-    trigger: 'a:contains("Add a product")',
-    run: "click",
-}, {
-    trigger: 'div[name="product_template_id"] input',
-    run: "edit Custo",
-}, {
-    trigger: 'ul.ui-autocomplete a:contains("Customizable Desk (TEST)")',
-    run: "click",
-},
-...configuratorTourUtils.selectAndSetCustomAttribute("Customizable Desk (TEST)", "Legs", "Custom", "123"),
-configuratorTourUtils.assertProductNameContains("Customizable Desk (TEST) (Custom, White)"),
-{
-    trigger: ".modal button:contains(Confirm)",
-    run: "click",
-}, {
-    trigger: 'td.o_data_cell:contains("Legs: Custom: 123")',
-},
-...stepUtils.saveForm(),
-{
-    trigger: 'td.o_data_cell:contains("Legs: Custom: 123")',
-},
-{
-    trigger: 'div[name="product_template_id"]',
-    run: "click",
-}, 
-{
-    trigger: ".o_external_button",
-},
-{
-    trigger: '.fa-pencil',
-    run: "click",
-},
-configuratorTourUtils.setCustomAttribute("Customizable Desk (TEST)", "Legs", "123456"),
-{
-    trigger: ".modal button:contains(Confirm)",
-    run: "click",
-}, {
-    trigger: 'td.o_data_cell:contains("Legs: Custom: 123456")',
-},
-...stepUtils.saveForm(),
-]});
+    steps: () => [
+        ...stepUtils.goToAppSteps("sale.sale_menu_root", "Go to the Sales App"),
+        ...tourUtils.createNewSalesOrder(),
+        ...tourUtils.selectCustomer("Tajine Saucisse"),
+        ...tourUtils.addProduct("Customizable Desk (TEST)"),
+        ...configuratorTourUtils.selectAndSetCustomAttribute("Customizable Desk (TEST)", "Legs", "Custom", "123"),
+        configuratorTourUtils.assertProductNameContains("Customizable Desk (TEST) (Custom, White)"),
+        ...configuratorTourUtils.saveConfigurator(),
+        tourUtils.checkSOLDescriptionContains("Customizable Desk (TEST) (Custom, White)", "Legs: Custom: 123"),
+        ...stepUtils.saveForm(),
+        tourUtils.editLineMatching("Customizable Desk (TEST) (Custom, White)", "Legs: Custom: 123"),
+        tourUtils.editConfiguration(),
+        configuratorTourUtils.setCustomAttribute("Customizable Desk (TEST)", "Legs", "123456"),
+        ...configuratorTourUtils.saveConfigurator(),
+        tourUtils.checkSOLDescriptionContains("Customizable Desk (TEST) (Custom, White)", "Legs: Custom: 123456"),
+        ...stepUtils.saveForm(),
+    ],
+});

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_edition_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_edition_ui.js
@@ -1,150 +1,74 @@
 /** @odoo-module **/
 
-import { queryAll, queryOne } from "@odoo/hoot-dom";
 import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
 import configuratorTourUtils from "@sale/js/tours/product_configurator_tour_utils";
+import tourUtils from "@sale/js/tours/tour_utils";
 
 registry.category("web_tour.tours").add('sale_product_configurator_edition_tour', {
     url: '/odoo',
     test: true,
-    steps: () => [stepUtils.showAppsMenuItem(), {
-    trigger: '.o_app[data-menu-xmlid="sale.sale_menu_root"]',
-    run: "click",
-}, 
-{
-    trigger: ".o_sale_order",
-},
-{
-    trigger: '.o_list_button_add',
-    run: "click",
-}, {
-    trigger: '.o_required_modifier[name=partner_id] input',
-    run: "edit Tajine Saucisse",
-}, {
-    isActive: ["auto"],
-    trigger: '.ui-menu-item > a:contains("Tajine Saucisse")',
-    run: "click",
-}, {
-    trigger: 'a:contains("Add a product")',
-    run: "click",
-}, {
-    trigger: 'div[name="product_template_id"] input',
-    run: "edit Custo",
-}, {
-    trigger: 'ul.ui-autocomplete a:contains("Customizable Desk (TEST)")',
-    run: "click",
-}, {
-    trigger: 'tr:has(div[name="o_sale_product_configurator_name"]:contains("Customizable Desk")) label:contains("Aluminium")',
-    run: "click",
-}, {
-    trigger: 'tr:has(div[name="o_sale_product_configurator_name"]:contains("Customizable Desk (TEST) (Aluminium, White)"))',
-}, {
-    trigger: ".modal button:contains(Confirm)",
-    run: "click",
-}, 
-{
-    trigger: 'div[name="order_line"]',
-},
-{
-    // check added product
-    trigger: 'td.o_data_cell:contains("Customizable Desk (TEST) (Aluminium, White)")',
-}, {
-    trigger: 'div[name="product_template_id"]',
-    run: "click",
-}, {
-    trigger: '.fa-pencil',
-    run: "click",
-}, {
-    // check updated legs
-    trigger: 'table.o_sale_product_configurator_table tr:has(td>div[name="o_sale_product_configurator_name"] span:contains("Customizable Desk")) td>div[name="ptal"]:has(div>label:contains("Legs")) label:has(span:contains("Aluminium")) ~ input:checked',
-}, {
-    // check updated price
-    trigger: 'table.o_sale_product_configurator_table tr:has(td>div[name="o_sale_product_configurator_name"] span:contains("Customizable Desk")) td[name="price"] span:contains("800.40")',
-}, {
-    trigger: 'table.o_sale_product_configurator_table tr:has(td>div[name="o_sale_product_configurator_name"] span:contains("Customizable Desk")) td>div[name="ptal"]:has(div>label:contains("Legs")) label:has(span:contains("Custom")) ~ input',
-    run: "click",
-}, {
-    trigger: 'table.o_sale_product_configurator_table tr:has(td>div[name="o_sale_product_configurator_name"] span:contains("Customizable Desk")) td>div[name="ptal"]:has(div>label:contains("Legs")) input[type="text"]',
-    run: "edit nice custom value && click .modal-body",
-}, {
-    trigger: 'tr:has(div[name="o_sale_product_configurator_name"]:contains("Customizable Desk")) label[style="background-color:#000000"] input',
-    run: "click", 
-}, {
-    // used to sync with server
-    trigger: 'div[name="o_sale_product_configurator_name"]:contains("Customizable Desk (TEST) (Custom, Black)")',
-}, {
-    trigger: ".modal button:contains(Confirm)",
-    run: "click",
-}, 
-{
-    trigger: 'div[name="order_line"]',
-},
-{
-    // check updated product
-    trigger: 'td.o_data_cell:contains("Customizable Desk (TEST) (Custom, Black)")',
-}, 
-{
-    trigger: 'div[name="order_line"]',
-},
-{
-    // check custom value
-    trigger: 'td.o_data_cell:contains("Custom: nice custom value")',
-}, {
-    trigger: 'div[name="product_template_id"]',
-    run: "click",
-}, {
-    trigger: '.fa-pencil',
-    run: "click",
-},
-    configuratorTourUtils.setCustomAttribute("Customizable Desk", "Legs", "another nice custom value"),
-{
-    trigger: ".modal button:contains(Confirm)",
-    run: "click",
-}, 
-{
-    trigger: 'div[name="order_line"]',
-},
-{
-    // check custom value
-    trigger: 'td.o_data_cell:contains("Custom: another nice custom value")',
-}, {
-    trigger: 'div[name="product_template_id"]',
-    run: "click",
-}, {
-    trigger: '.fa-pencil',
-    run: "click",
-}, {
-    trigger: 'table.o_sale_product_configurator_table tr:has(td>div[name="o_sale_product_configurator_name"] span:contains("Customizable Desk")) td>div[name="ptal"]:has(div>label:contains("Legs")) label:has(span:contains("Steel")) ~ input',
-    run: "click",
-},
-    configuratorTourUtils.assertProductNameContains("Customizable Desk (TEST) (Steel, Black)"),
-    configuratorTourUtils.increaseProductQuantity("Customizable Desk"),
-    // Mr Tajine Saucisse uses the pricelist that has a rule when 2 or more products. Price is 600
-    configuratorTourUtils.assertPriceTotal("1,200.00"),
-{
-    trigger: ".modal button:contains(Confirm)",
-    run: "click",
-}, {
-    // check quantity
-    trigger: 'td.o_data_cell:contains("2.00")',
-}, {
-    trigger: 'div[name="product_template_id"]',
-    run: function () {
-        // used to check that the description does not contain a custom value anymore
-        if (queryAll(`td.o_data_cell:contains("Custom: another nice custom value")`).length === 0){
-            const el = queryOne(
-                'td.o_data_cell:contains("Customizable Desk (TEST) (Steel, Black)")'
-            )
-            el.textContent = "tour success";
-        }
-    }
-}, 
-{
-    trigger: 'div[name="order_line"]',
-},
-{
-    trigger: 'td.o_data_cell:contains("tour success")',
-},
-    ...stepUtils.saveForm(),
-]});
+    steps: () => [
+        ...stepUtils.goToAppSteps("sale.sale_menu_root", "Go to the Sales App"),
+        ...tourUtils.createNewSalesOrder(),
+        ...tourUtils.selectCustomer("Tajine Saucisse"),
+        ...tourUtils.addProduct("Customizable Desk (TEST)"),
+        {
+            trigger: 'tr:has(div[name="o_sale_product_configurator_name"]:contains("Customizable Desk")) label:contains("Aluminium")',
+            run: "click",
+        },
+        {
+            trigger: 'tr:has(div[name="o_sale_product_configurator_name"]:contains("Customizable Desk (TEST) (Aluminium, White)"))',
+        },
+        ...configuratorTourUtils.saveConfigurator(),
+        tourUtils.editLineMatching("Customizable Desk (TEST) (Aluminium, White)", ""),
+        tourUtils.editConfiguration(),
+        {
+            // check updated legs
+            trigger: 'table.o_sale_product_configurator_table tr:has(td>div[name="o_sale_product_configurator_name"] span:contains("Customizable Desk")) td>div[name="ptal"]:has(div>label:contains("Legs")) label:has(span:contains("Aluminium")) ~ input:checked',
+        },
+        {
+            // check updated price
+            trigger: 'table.o_sale_product_configurator_table tr:has(td>div[name="o_sale_product_configurator_name"] span:contains("Customizable Desk")) td[name="price"] span:contains("800.40")',
+        },
+        {
+            trigger: 'table.o_sale_product_configurator_table tr:has(td>div[name="o_sale_product_configurator_name"] span:contains("Customizable Desk")) td>div[name="ptal"]:has(div>label:contains("Legs")) label:has(span:contains("Custom")) ~ input',
+            run: "click",
+        },
+        {
+            trigger: 'table.o_sale_product_configurator_table tr:has(td>div[name="o_sale_product_configurator_name"] span:contains("Customizable Desk")) td>div[name="ptal"]:has(div>label:contains("Legs")) input[type="text"]',
+            run: "edit nice custom value && click .modal-body",
+        },
+        {
+            trigger: 'tr:has(div[name="o_sale_product_configurator_name"]:contains("Customizable Desk")) label[style="background-color:#000000"] input',
+            run: "click",
+        },
+        {
+            // used to sync with server
+            trigger: 'div[name="o_sale_product_configurator_name"]:contains("Customizable Desk (TEST) (Custom, Black)")',
+        },
+        ...configuratorTourUtils.saveConfigurator(),
+        tourUtils.editLineMatching("Customizable Desk (TEST) (Custom, Black)", "Custom: nice custom value"),
+        tourUtils.editConfiguration(),
+        configuratorTourUtils.setCustomAttribute("Customizable Desk", "Legs", "another nice custom value"),
+        ...configuratorTourUtils.saveConfigurator(),
+        tourUtils.editLineMatching("Customizable Desk (TEST) (Custom, Black)", "Custom: another nice custom value"),
+        tourUtils.editConfiguration(),
+        {
+            trigger: 'table.o_sale_product_configurator_table tr:has(td>div[name="o_sale_product_configurator_name"] span:contains("Customizable Desk")) td>div[name="ptal"]:has(div>label:contains("Legs")) label:has(span:contains("Steel")) ~ input',
+            run: "click",
+        },
+        configuratorTourUtils.assertProductNameContains("Customizable Desk (TEST) (Steel, Black)"),
+        configuratorTourUtils.increaseProductQuantity("Customizable Desk"),
+        // Mr Tajine Saucisse uses the pricelist that has a rule when 2 or more products. Price is 600
+        configuratorTourUtils.assertPriceTotal("1,200.00"),
+        ...configuratorTourUtils.saveConfigurator(),
+        {
+            // check quantity
+            trigger: 'td.o_data_cell:contains("2.00")',
+        },
+        // make sure the custom value was removed on product change
+        tourUtils.checkSOLDescriptionContains("Customizable Desk (TEST) (Steel, Black)", ""),
+        ...stepUtils.saveForm(),
+    ],
+});

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_optional_products_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_optional_products_ui.js
@@ -2,71 +2,63 @@
 
 import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
+import tourUtils from "@sale/js/tours/tour_utils";
 
 registry.category("web_tour.tours").add('sale_product_configurator_optional_products_tour', {
     url: '/odoo',
     test: true,
-    steps: () => [stepUtils.showAppsMenuItem(), {
-    trigger: '.o_app[data-menu-xmlid="sale.sale_menu_root"]',
-    run: "click",
-}, 
-{
-    trigger: ".o_sale_order",
-},
-{
-    trigger: '.o_list_button_add',
-    run: "click",
-}, {
-    trigger: '.o_required_modifier[name=partner_id] input',
-    run: "edit Tajine Saucisse",
-}, {
-    isActive: ["auto"],
-    trigger: '.ui-menu-item > a:contains("Tajine Saucisse")',
-    run: "click",
-}, {
-    trigger: 'a:contains("Add a product")',
-    run: "click",
-}, {
-    trigger: 'div[name="product_template_id"] input',
-    run: "edit Custo",
-}, {
-    trigger: 'ul.ui-autocomplete a:contains("Customizable Desk (TEST)")',
-    run: "click",
-}, {
-    trigger: 'tr:has(div[name="o_sale_product_configurator_name"]:contains("Office Chair Black")) button:has(i.fa-plus)',
-    run: "click",
-}, {
-    trigger: 'tr:has(div[name="o_sale_product_configurator_name"]:contains("Customizable Desk")) button:has(i.fa-plus)',
-    run: "click",
-}, {
-    trigger: 'tr:has(div[name="o_sale_product_configurator_name"]:contains("Chair floor protection")) button:has(i.fa-plus)',
-    run: "click",
-}, {
-    trigger: 'tr:has(div[name="o_sale_product_configurator_name"]:contains("Conference Chair")) button:has(i.fa-plus)',
-    run: "click",
-}, {
-    trigger: 'tr:has(div[name="o_sale_product_configurator_name"]:contains("Conference Chair")) a:contains("Remove")',
-    run: "click",
-}, {
-    trigger: 'tr:has(div[name="o_sale_product_configurator_name"]:contains("Conference Chair")) button:has(i.fa-plus)',
-    run: "click",
-}, {
-    trigger: ".modal button:contains(Confirm)",
-    run: "click",
-}, 
-{
-    trigger: ".modal-title:contains(Warning for Conference Chair (TEST))",
-},
-{
-    trigger: '.o-default-button',
-    run: "click",
-}, {
-    trigger: 'tr:has(td.o_data_cell:contains("Customizable Desk")) td.o_data_cell:contains("2.0")',
-}, {
-    trigger: 'tr:has(td.o_data_cell:contains("Office Chair Black")) td.o_data_cell:contains("1.0")',
-}, {
-    trigger: 'tr:has(td.o_data_cell:contains("Conference Chair")) td.o_data_cell:contains("1.0")',
-}, {
-    trigger: 'tr:has(td.o_data_cell:contains("Chair floor protection")) td.o_data_cell:contains("1.0")',
-}, ...stepUtils.saveForm()
-]});
+    steps: () => [
+        ...stepUtils.goToAppSteps("sale.sale_menu_root", "Go to the Sales App"),
+        ...tourUtils.createNewSalesOrder(),
+        ...tourUtils.selectCustomer("Tajine Saucisse"),
+        ...tourUtils.addProduct("Customizable Desk (TEST)"),
+        {
+            trigger: 'tr:has(div[name="o_sale_product_configurator_name"]:contains("Office Chair Black")) button:has(i.fa-plus)',
+            run: "click",
+        },
+        {
+            trigger: 'tr:has(div[name="o_sale_product_configurator_name"]:contains("Customizable Desk")) button:has(i.fa-plus)',
+            run: "click",
+        },
+        {
+            trigger: 'tr:has(div[name="o_sale_product_configurator_name"]:contains("Chair floor protection")) button:has(i.fa-plus)',
+            run: "click",
+        },
+        {
+            trigger: 'tr:has(div[name="o_sale_product_configurator_name"]:contains("Conference Chair")) button:has(i.fa-plus)',
+            run: "click",
+        },
+        {
+            trigger: 'tr:has(div[name="o_sale_product_configurator_name"]:contains("Conference Chair")) a:contains("Remove")',
+            run: "click",
+        },
+        {
+            trigger: 'tr:has(div[name="o_sale_product_configurator_name"]:contains("Conference Chair")) button:has(i.fa-plus)',
+            run: "click",
+        },
+        {
+            trigger: ".modal button:contains(Confirm)",
+            run: "click",
+        },
+        {
+            trigger: ".modal-title:contains(Warning for Conference Chair (TEST))",
+        },
+        {
+            trigger: '.o-default-button',
+            run: "click",
+        },
+        {
+            trigger: 'tr:has(td.o_data_cell:contains("Customizable Desk")) td.o_data_cell:contains("2.0")',
+        },
+        {
+            trigger: 'tr:has(td.o_data_cell:contains("Office Chair Black")) td.o_data_cell:contains("1.0")',
+        },
+        {
+            trigger: 'tr:has(td.o_data_cell:contains("Conference Chair")) td.o_data_cell:contains("1.0")',
+        },
+        {
+            trigger: 'tr:has(td.o_data_cell:contains("Chair floor protection")) td.o_data_cell:contains("1.0")',
+        },
+        ...stepUtils.saveForm()
+    ],
+});

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_pricelist_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_pricelist_ui.js
@@ -3,85 +3,73 @@
 import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
 import configuratorTourUtils from "@sale/js/tours/product_configurator_tour_utils";
+import tourUtils from "@sale/js/tours/tour_utils";
 
 registry.category("web_tour.tours").add('sale_product_configurator_pricelist_tour', {
     url: '/odoo',
     test: true,
     steps: () => [
-stepUtils.showAppsMenuItem(),
-{
-    content: "navigate to the sale app",
-    trigger: '.o_app[data-menu-xmlid="sale.sale_menu_root"]',
-    run: "click",
-}, 
-{
-    trigger: ".o_sale_order",
-},
-{
-    content: "create a new order",
-    trigger: '.o_list_button_add',
-    run: "click",
-}, {
-    content: "search the partner",
-    trigger: 'div[name="partner_id"] input',
-    run: "edit Azure",
-}, {
-    content: "select the partner",
-    trigger: 'ul.ui-autocomplete > li > a:contains(Azure)',
-    run: "click",
-}, 
-{
-    trigger: "[name=partner_id]:contains(Fremont)",
-},
-{
-    content: "search the pricelist",
-    trigger: 'input[id="pricelist_id_0"]',
-    // Wait for onchange to come back
-    run: "edit Test",
-}, {
-    content: "search the pricelist",
-    trigger: 'input[id="pricelist_id_0"]',
-    run: "edit Custo",
-}, {
-    content: "select the pricelist",
-    trigger: 'ul.ui-autocomplete > li > a:contains(Custom pricelist (TEST))',
-    run: "click",
-}, {
-    trigger: 'a:contains("Add a product")',
-    run: "click",
-}, {
-    trigger: 'div[name="product_template_id"] input',
-    run: "edit Custo",
-}, {
-    trigger: 'ul.ui-autocomplete a:contains("Customizable Desk (TEST)")',
-    run: "click",
-}, {
-    content: "check price is correct (USD)",
-    trigger: 'main.modal-body>table:nth-child(1)>tbody>tr:nth-child(1)>td:nth-child(4) span:contains("750.00")',
-}, {
-    content: "add one more",
-    trigger: 'main.modal-body>table:nth-child(1)>tbody>tr:nth-child(1)>td:nth-child(3)>div>button:has(i.fa-plus)',
-    run: "click",
-}, {
-    content: "check price for 2",
-    trigger: 'main.modal-body>table:nth-child(1)>tbody>tr:nth-child(1)>td:nth-child(4) span:contains("600.00")',
-},
-    configuratorTourUtils.addOptionalProduct("Conference Chair"),
-    configuratorTourUtils.increaseProductQuantity("Conference Chair"),
-    configuratorTourUtils.addOptionalProduct("Chair floor protection"),
-    configuratorTourUtils.increaseProductQuantity("Chair floor protection"),
-    configuratorTourUtils.assertPriceTotal("1,257.00"),
-{
-    content: "add to SO",
-    trigger: ".modal button:contains(Confirm)",
-    run: "click",
-}, {
-    content: "verify SO final price excluded",
-    trigger: 'span[name="Untaxed Amount"]:contains("1,257.00")',
-    run: "click",
-}, {
-    content: "verify SO final price included",
-    trigger: 'span[name="amount_total"]:contains("1,437.00")',
-    run: "click",
-}, ...stepUtils.saveForm()
-]});
+        ...stepUtils.goToAppSteps("sale.sale_menu_root", "Go to the Sales App"),
+        ...tourUtils.createNewSalesOrder(),
+        {
+            content: "search the partner",
+            trigger: 'div[name="partner_id"] input',
+            run: "edit Azure",
+        },
+        {
+            content: "select the partner",
+            trigger: 'ul.ui-autocomplete > li > a:contains(Azure)',
+            run: "click",
+        },
+        {
+            trigger: "[name=partner_id]:contains(Fremont)",
+        },
+        {
+            content: "search the pricelist",
+            trigger: 'input[id="pricelist_id_0"]',
+            // Wait for onchange to come back
+            run: "edit Test",
+        },
+        {
+            content: "search the pricelist",
+            trigger: 'input[id="pricelist_id_0"]',
+            run: "edit Custo",
+        },
+        {
+            content: "select the pricelist",
+            trigger: 'ul.ui-autocomplete > li > a:contains(Custom pricelist (TEST))',
+            run: "click",
+        },
+        ...tourUtils.addProduct("Customizable Desk (TEST)"),
+        {
+            content: "check price is correct (USD)",
+            trigger: 'main.modal-body>table:nth-child(1)>tbody>tr:nth-child(1)>td:nth-child(4) span:contains("750.00")',
+        },
+        {
+            content: "add one more",
+            trigger: 'main.modal-body>table:nth-child(1)>tbody>tr:nth-child(1)>td:nth-child(3)>div>button:has(i.fa-plus)',
+            run: "click",
+        },
+        {
+            content: "check price for 2",
+            trigger: 'main.modal-body>table:nth-child(1)>tbody>tr:nth-child(1)>td:nth-child(4) span:contains("600.00")',
+        },
+        configuratorTourUtils.addOptionalProduct("Conference Chair"),
+        configuratorTourUtils.increaseProductQuantity("Conference Chair"),
+        configuratorTourUtils.addOptionalProduct("Chair floor protection"),
+        configuratorTourUtils.increaseProductQuantity("Chair floor protection"),
+        configuratorTourUtils.assertPriceTotal("1,257.00"),
+        ...configuratorTourUtils.saveConfigurator(),
+        {
+            content: "verify SO final price excluded",
+            trigger: 'span[name="Untaxed Amount"]:contains("1,257.00")',
+            run: "click",
+        },
+        {
+            content: "verify SO final price included",
+            trigger: 'span[name="amount_total"]:contains("1,437.00")',
+            run: "click",
+        },
+        ...stepUtils.saveForm()
+    ]
+});

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_recursive_optional_products.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_recursive_optional_products.js
@@ -3,35 +3,22 @@
 import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
 import configuratorTourUtils from "@sale/js/tours/product_configurator_tour_utils";
+import tourUtils from "@sale/js/tours/tour_utils";
 
 registry.category("web_tour.tours").add('sale_product_configurator_recursive_optional_products_tour', {
     url: '/odoo',
     test: true,
-    steps: () => [stepUtils.showAppsMenuItem(), {
-    trigger: '.o_app[data-menu-xmlid="sale.sale_menu_root"]',
-    run: "click",
-}, 
-{
-    trigger: ".o_sale_order",
-},
-{
-    trigger: '.o_list_button_add',
-    run: "click",
-}, {
-    trigger: 'a:contains("Add a product")',
-    run: "click",
-}, {
-    trigger: 'div[name="product_template_id"] input',
-    run: "edit Custo",
-}, {
-    trigger: 'ul.ui-autocomplete a:contains("Customizable Desk (TEST)")',
-    run: "click",
-},
-    configuratorTourUtils.selectAttribute("Customizable Desk", "Legs", "Aluminium"),
-    configuratorTourUtils.addOptionalProduct("Conference Chair"),
-    configuratorTourUtils.addOptionalProduct("Chair floor protection"),
-{
-    trigger: 'button:contains(Confirm)',
-    run: "click",
-}, ...stepUtils.discardForm()
-]});
+    steps: () => [
+        ...stepUtils.goToAppSteps("sale.sale_menu_root", "Go to the Sales App"),
+        ...tourUtils.createNewSalesOrder(),
+        ...tourUtils.addProduct("Customizable Desk (TEST)"),
+        configuratorTourUtils.selectAttribute("Customizable Desk", "Legs", "Aluminium"),
+        configuratorTourUtils.addOptionalProduct("Conference Chair"),
+        configuratorTourUtils.addOptionalProduct("Chair floor protection"),
+        {
+            trigger: 'button:contains(Confirm)',
+            run: "click",
+        },
+        ...stepUtils.discardForm(),
+    ],
+});

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_single_custom_attribute_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_single_custom_attribute_ui.js
@@ -4,61 +4,36 @@ import { queryOne } from "@odoo/hoot-dom";
 import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
 import configuratorTourUtils from "@sale/js/tours/product_configurator_tour_utils";
+import tourUtils from "@sale/js/tours/tour_utils";
 
 registry.category("web_tour.tours").add('sale_product_configurator_single_custom_attribute_tour', {
     url: '/odoo',
     test: true,
-    steps: () => [stepUtils.showAppsMenuItem(), {
-    trigger: '.o_app[data-menu-xmlid="sale.sale_menu_root"]',
-    run: "click",
-},
-{
-    trigger: ".o_sale_order",
-},
-{
-    trigger: '.o_list_button_add',
-    run: "click",
-}, {
-    trigger: 'a:contains("Add a product")',
-    run: "click",
-}, {
-    trigger: 'div[name="product_template_id"] input',
-    run: "edit Custo",
-}, {
-    trigger: 'ul.ui-autocomplete a:contains("Customizable Desk (TEST)")',
-    run: "click",
-},
-    configuratorTourUtils.setCustomAttribute("Customizable Desk (TEST)", "product attribute", "great single custom value"),
-{
-    trigger: ".modal button:contains(Confirm)",
-    run: "click",
-},
-{
-    trigger: 'div[name="order_line"]',
-},
-{
-    trigger: 'td.o_data_cell:contains("single product attribute value: great single custom value")',
-}, {
-    trigger: 'div[name="product_template_id"]',
-    run: "click",
-}, {
-    trigger: '.fa-pencil',
-    run: "click",
-}, {
-    trigger: 'table.o_sale_product_configurator_table tr:has(td>div[name="o_sale_product_configurator_name"] *:contains("Customizable Desk (TEST)")) td>div[name="ptal"]:has(div>label:contains("product attribute")) input[type="text"]',
-    run: function () {
-        // check custom value initialized
-        if (
-            queryOne(
-                'table.o_sale_product_configurator_table tr:has(td>div[name="o_sale_product_configurator_name"] *:contains("Customizable Desk (TEST)")) td>div[name="ptal"]:has(div>label:contains("product attribute")) input[type="text"]'
-            ).value !== "great single custom value"
-        ) {
-            console.error("The value of custom product attribute should be 'great single custom value'.");
-        }
-    }
-}, {
-    trigger: 'button:contains("Cancel")',
-    run: "click",
-},
-    ...stepUtils.discardForm()
-]});
+    steps: () => [
+        ...stepUtils.goToAppSteps("sale.sale_menu_root", "Go to the Sales App"),
+        ...tourUtils.createNewSalesOrder(),
+        ...tourUtils.addProduct("Customizable Desk (TEST)"),
+        configuratorTourUtils.setCustomAttribute("Customizable Desk (TEST)", "product attribute", "great single custom value"),
+        ...configuratorTourUtils.saveConfigurator(),
+        tourUtils.editLineMatching("Customizable Desk (TEST)", "single product attribute value: great single custom value"),
+        tourUtils.editConfiguration(),
+        {
+            trigger: 'table.o_sale_product_configurator_table tr:has(td>div[name="o_sale_product_configurator_name"] *:contains("Customizable Desk (TEST)")) td>div[name="ptal"]:has(div>label:contains("product attribute")) input[type="text"]',
+            run: function () {
+                // check custom value initialized
+                if (
+                    queryOne(
+                        'table.o_sale_product_configurator_table tr:has(td>div[name="o_sale_product_configurator_name"] *:contains("Customizable Desk (TEST)")) td>div[name="ptal"]:has(div>label:contains("product attribute")) input[type="text"]'
+                    ).value !== "great single custom value"
+                ) {
+                    console.error("The value of custom product attribute should be 'great single custom value'.");
+                }
+            }
+        },
+        {
+            trigger: '.modal button:contains("Cancel")',
+            run: "click",
+        },
+        ...stepUtils.discardForm(),
+    ],
+});

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_ui.js
@@ -3,6 +3,7 @@
 import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
 import configuratorTourUtils from "@sale/js/tours/product_configurator_tour_utils";
+import tourUtils from "@sale/js/tours/tour_utils";
 
 // Note: please keep this test without pricelist for maximum coverage.
 // The pricelist is tested on the other tours.
@@ -10,81 +11,68 @@ import configuratorTourUtils from "@sale/js/tours/product_configurator_tour_util
 registry.category("web_tour.tours").add('sale_product_configurator_tour', {
     url: '/odoo',
     test: true,
-    steps: () => [stepUtils.showAppsMenuItem(), {
-    trigger: '.o_app[data-menu-xmlid="sale.sale_menu_root"]',
-    run: "click",
-}, 
-{
-    trigger: ".o_sale_order",
-},
-{
-    trigger: '.o_list_button_add',
-    run: "click",
-}, {
-    trigger: '.o_required_modifier[name=partner_id] input',
-    run: "edit Tajine Saucisse",
-}, {
-    isActive: ["auto"],
-    trigger: '.ui-menu-item > a:contains("Tajine Saucisse")',
-    run: "click",
-}, {
-    trigger: 'a:contains("Add a product")',
-    run: "click",
-}, {
-    trigger: 'div[name="product_template_id"] input',
-    run: "edit Custo",
-}, {
-    trigger: 'ul.ui-autocomplete a:contains("Customizable Desk (TEST)")',
-    run: "click",
-}, {
-    trigger: '.o_sale_product_configurator_table tr:has(td>div[name="o_sale_product_configurator_name"] span:contains("Customizable Desk")) label:contains("Steel")',
-    run: "click",
-}, {
-    trigger: '.o_sale_product_configurator_table tr:has(td>div[name="o_sale_product_configurator_name"] span:contains("Customizable Desk")) label:contains("Aluminium")',
-    run: "click",
-}, {
-    trigger: '.o_sale_product_configurator_table tr:has(td>div[name="o_sale_product_configurator_name"] span:contains("Customizable Desk")) td[name="price"] span:contains("800.40")',
-}, {
-    trigger: 'label[style="background-color:#000000"] input',
-    run: "click",
-}, {
-    trigger: '.btn-primary:disabled:contains("Confirm")',
-}, {
-    trigger: 'label[style="background-color:#FFFFFF"] input',
-    run: "click",
-}, 
-{
-    trigger: ".modal-footer",
-},
-{
-    trigger: '.btn-primary:not(:disabled):contains("Confirm")',
-}, {
-    trigger: '.o_sale_product_configurator_table_optional span:contains("Aluminium")',
-    run: "click",
-},
-    configuratorTourUtils.addOptionalProduct("Conference Chair"),
-    configuratorTourUtils.addOptionalProduct("Chair floor protection"),
-{
-    trigger: ".modal button:contains(Confirm)",
-    id: 'quotation_product_selected',
-    run: "click",
-},
-// check that 3 products were added to the SO
-{
-    trigger: 'td.o_data_cell:contains("Customizable Desk (TEST) (Aluminium, White)")',
-}, {
-    trigger: 'td.o_data_cell:contains("Conference Chair (TEST) (Aluminium)")',
-},
-// check that additional line is kept if selected but not edited with a click followed by a check
-{
-    trigger: 'td.o_data_cell:contains("Chair floor protection")',
-    run: 'click',
-}, {
-    trigger: 'div[name="tax_totals"]',
-    run: 'click',
-}, {
-    trigger: 'td.o_data_cell:contains("Chair floor protection")',
-}, {
-    trigger: 'span[name=amount_total]:contains("960.60")',
-}, ...stepUtils.saveForm(),
-]});
+    steps: () => [
+        ...stepUtils.goToAppSteps("sale.sale_menu_root", "Go to the Sales App"),
+        ...tourUtils.createNewSalesOrder(),
+        ...tourUtils.selectCustomer("Tajine Saucisse"),
+        ...tourUtils.addProduct("Customizable Desk (TEST)"),
+        {
+            trigger: '.o_sale_product_configurator_table tr:has(td>div[name="o_sale_product_configurator_name"] span:contains("Customizable Desk")) label:contains("Steel")',
+            run: "click",
+        },
+        {
+            trigger: '.o_sale_product_configurator_table tr:has(td>div[name="o_sale_product_configurator_name"] span:contains("Customizable Desk")) label:contains("Aluminium")',
+            run: "click",
+        },
+        {
+            trigger: '.o_sale_product_configurator_table tr:has(td>div[name="o_sale_product_configurator_name"] span:contains("Customizable Desk")) td[name="price"] span:contains("800.40")',
+        },
+        {
+            trigger: 'label[style="background-color:#000000"] input',
+            run: "click",
+        },
+        {
+            trigger: '.btn-primary:disabled:contains("Confirm")',
+        },
+        {
+            trigger: 'label[style="background-color:#FFFFFF"] input',
+            run: "click",
+        },
+        {
+            trigger: ".modal-footer",
+        },
+        {
+            trigger: '.btn-primary:not(:disabled):contains("Confirm")',
+        },
+        {
+            trigger: '.o_sale_product_configurator_table_optional span:contains("Aluminium")',
+            run: "click",
+        },
+        configuratorTourUtils.addOptionalProduct("Conference Chair"),
+        configuratorTourUtils.addOptionalProduct("Chair floor protection"),
+        ...configuratorTourUtils.saveConfigurator(),
+        // check that 3 products were added to the SO
+        {
+            trigger: 'td.o_data_cell:contains("Customizable Desk (TEST) (Aluminium, White)")',
+        },
+        {
+            trigger: 'td.o_data_cell:contains("Conference Chair (TEST) (Aluminium)")',
+        },
+        // check that additional line is kept if selected but not edited with a click followed by a check
+        {
+            trigger: 'td.o_data_cell:contains("Chair floor protection")',
+            run: 'click',
+        },
+        {
+            trigger: 'div[name="tax_totals"]',
+            run: 'click',
+        },
+        {
+            trigger: 'td.o_data_cell:contains("Chair floor protection")',
+        },
+        {
+            trigger: 'span[name=amount_total]:contains("960.60")',
+        },
+        ...stepUtils.saveForm(),
+    ],
+});

--- a/addons/test_sale_product_configurators/static/tests/tours/product_matrix_tour.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_matrix_tour.js
@@ -2,6 +2,7 @@
 
 import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
+import tourUtils from "@sale/js/tours/tour_utils";
 
 let EXPECTED = [
     "Matrix", "PAV11", "PAV12 + $ 50.00",
@@ -21,172 +22,136 @@ for (let no of ['PAV41', 'PAV42']) {
 registry.category("web_tour.tours").add('sale_matrix_tour', {
     url: '/odoo',
     test: true,
-    steps: () => [stepUtils.showAppsMenuItem(), {
-    trigger: '.o_app[data-menu-xmlid="sale.sale_menu_root"]',
-    run: "click",
-}, 
-{
-    trigger: ".o_sale_order",
-},
-{
-    trigger: '.o_list_button_add',
-    run: "click",
-}, {
-    trigger: '.o_required_modifier[name=partner_id] input',
-    run: "edit Agrolait",
-}, {
-    isActive: ["auto"],
-    trigger: '.ui-menu-item > a:contains("Agrolait")',
-    run: "click",
-}, {
-    trigger: 'a:contains("Add a product")',
-    run: "click",
-}, {
-    trigger: 'div[name="product_template_id"] input',
-    run: "edit Matrix",
-}, {
-    trigger: 'ul.ui-autocomplete a:contains("Matrix")',
-    run: "click",
-}, {
-    trigger: ".modal .o_matrix_input_table",
-    run: function () {
-        // fill the whole matrix with 1's
-        [...document.querySelectorAll(".o_matrix_input")].forEach((el) => (el.value = 1));
-    }
-}, {
-    trigger: ".modal button:contains(Confirm)",
-    run: "click",
-}, 
-{
-    trigger: '.oe_subtotal_footer_separator:contains("248.40")',
-},
-{
-    trigger: '.o_sale_order',
-    // wait for qty to be 1 => check the total to be sure all qties are set to 1
-    run: "click",
-}, 
-{
-    trigger: ".o_form_editable",
-},
-{
-    trigger: 'span:contains("Matrix (PAV11, PAV22, PAV31)\n\nPA4: PAV41")',
-    run: "click",
-}, {
-    trigger: '[name=product_template_id] button.fa-pencil',  // edit the matrix
-    run: "click",
-}, {
-    trigger: ".modal .o_matrix_input_table",
-    run: function () {
-        // whitespace normalization: removes newlines around text from markup
-        // content, then collapse & convert internal whitespace to regular
-        // spaces.
-        const tds = [...this.anchor.querySelectorAll('th, td')];
-        const texts = tds.map((el) => el.innerText.trim().replace(/\s+/g, ' '))
-
-        for (let i=0; i<EXPECTED.length; ++i) {
-            if (EXPECTED[i] !== texts[i]) {
-                throw new Error(`${EXPECTED[i]} != ${texts[i]}`)
+    steps: () => [
+        ...stepUtils.goToAppSteps("sale.sale_menu_root", "Go to the Sales App"),
+        ...tourUtils.createNewSalesOrder(),
+        ...tourUtils.selectCustomer("Agrolait"),
+        ...tourUtils.addProduct("Matrix"),
+        {
+            trigger: ".modal .o_matrix_input_table",
+            run: function () {
+                // fill the whole matrix with 1's
+                [...document.querySelectorAll(".o_matrix_input")].forEach((el) => (el.value = 1));
             }
-        }
-        // set all qties to 3
-        [...document.querySelectorAll(".o_matrix_input")].forEach((el) => (el.value = 3));
-    }
-}, {
-    trigger: ".modal button:contains(Confirm)", // apply the matrix
-    run: "click",
-}, 
-{
-    trigger: '.oe_subtotal_footer_separator:contains("745.20")',
-},
-{
-    trigger: '.o_sale_order',
-    // wait for qty to be 3 => check the total to be sure all qties are set to 3
-    run: "click",
-}, 
-{
-    trigger: ".o_form_editable",
-},
-{
-    trigger: 'span:contains("Matrix (PAV11, PAV22, PAV31)\n\nPA4: PAV41")',
-    run: "click",
-}, {
-    trigger: '[name=product_template_id] button.fa-pencil',  // edit the matrix
-    run: "click",
-}, {
-    trigger: ".modal .o_matrix_input_table",
-    run: function () {
-        // reset all qties to 1
-        [...document.querySelectorAll(".o_matrix_input")].forEach((el) => (el.value = 1));
-    }
-}, {
-    trigger: ".modal button:contains(Confirm)", // apply the matrix
-    run: "click",
-}, 
-{
-    trigger: '.oe_subtotal_footer_separator:contains("248.40")',
-},
-{
-    trigger: '.o_sale_order',
-    // wait for qty to be 1 => check the total to be sure all qties are set to 1
-    run: "click",
-}, {
-    trigger: '.o_form_button_save',  // SAVE Sales Order.
-    run: "click",
-},
-// Open the matrix through the pencil button next to the product in line edit mode.
-{
-    trigger: ".o_form_status_indicator_buttons.invisible", // wait for save to be finished
-},
-{
-    trigger: 'span:contains("Matrix (PAV11, PAV22, PAV31)\n\nPA4: PAV41")',
-    run: "click",
-}, 
-{
-    trigger: '[name=product_template_id] button.fa-pencil',  // edit the matrix
-    run: "click",
-}, {
-    trigger: ".modal .o_matrix_input_table",
-    run: function () {
-        // update some of the matrix values.
-        [...document.querySelectorAll(".o_matrix_input")]
-            .slice(8, 16)
-            .forEach((el) => (el.value = 4));
-    } // set the qty to 4 for half of the matrix products.
-}, {
-    trigger: ".modal button:contains(Confirm)", // apply the matrix
-    run: "click",
-}, 
-{
-    trigger: '.o_field_cell.o_data_cell.o_list_number:contains("4.00")',
-},
-{
-    trigger: '.o_form_button_save',
-    run: 'click', // SAVE Sales Order, after matrix has been applied.
-},
-// Ensures the matrix is opened with the values, when adding the same product.
-{
-    trigger: ".o_form_status_indicator_buttons.invisible",
-},
-{
-    trigger: 'a:contains("Add a product")',
-    run: "click",
-}, {
-    trigger: 'div[name="product_template_id"] input',
-    run: "edit Matrix",
-}, {
-    trigger: 'ul.ui-autocomplete a:contains("Matrix")',
-    run: "click",
-}, {
-    trigger: 'input[value="4"]',
-    run: function () {
-        // update some values of the matrix
-        [...document.querySelectorAll("input[value='4']")]
-            .slice(0, 4)
-            .forEach((el) => (el.value = 8.2));
-    }
-}, {
-    trigger: ".modal button:contains(Confirm)", // apply the matrix
-    run: "click",
+        },
+        {
+            trigger: ".modal button:contains(Confirm)",
+            run: "click",
+        },
+        {
+            trigger: '.oe_subtotal_footer_separator:contains("248.40")',
+        },
+        {
+            trigger: '.o_sale_order',
+            // wait for qty to be 1 => check the total to be sure all qties are set to 1
+            run: "click",
+        },
+        {
+            trigger: ".o_form_editable",
+        },
+        tourUtils.editLineMatching("Matrix (PAV11, PAV22, PAV31)", "PA4: PAV41"),
+        tourUtils.editConfiguration(),
+        {
+            trigger: ".modal .o_matrix_input_table",
+            run: function () {
+                // whitespace normalization: removes newlines around text from markup
+                // content, then collapse & convert internal whitespace to regular
+                // spaces.
+                const tds = [...this.anchor.querySelectorAll('th, td')];
+                const texts = tds.map((el) => el.innerText.trim().replace(/\s+/g, ' '))
+
+                for (let i=0; i<EXPECTED.length; ++i) {
+                    if (EXPECTED[i] !== texts[i]) {
+                        throw new Error(`${EXPECTED[i]} != ${texts[i]}`)
+                    }
+                }
+                // set all qties to 3
+                [...document.querySelectorAll(".o_matrix_input")].forEach((el) => (el.value = 3));
+            }
+        },
+        {
+            trigger: ".modal button:contains(Confirm)", // apply the matrix
+            run: "click",
+        },
+        {
+            trigger: '.oe_subtotal_footer_separator:contains("745.20")',
+        },
+        {
+            trigger: '.o_sale_order',
+            // wait for qty to be 3 => check the total to be sure all qties are set to 3
+            run: "click",
+        },
+        {
+            trigger: ".o_form_editable",
+        },
+        tourUtils.editLineMatching("Matrix (PAV11, PAV22, PAV31)", "PA4: PAV41"),
+        tourUtils.editConfiguration(),
+        {
+            trigger: ".modal .o_matrix_input_table",
+            run: function () {
+                // reset all qties to 1
+                [...document.querySelectorAll(".o_matrix_input")].forEach((el) => (el.value = 1));
+            }
+        },
+        {
+            trigger: ".modal button:contains(Confirm)", // apply the matrix
+            run: "click",
+        },
+        {
+            trigger: '.oe_subtotal_footer_separator:contains("248.40")',
+        },
+        {
+            trigger: '.o_sale_order',
+            // wait for qty to be 1 => check the total to be sure all qties are set to 1
+            run: "click",
+        },
+        {
+            trigger: '.o_form_button_save',  // SAVE Sales Order.
+            run: "click",
+        },
+        // Open the matrix through the pencil button next to the product in line edit mode.
+        {
+            trigger: ".o_form_status_indicator_buttons.invisible", // wait for save to be finished
+        },
+        tourUtils.editLineMatching("Matrix (PAV11, PAV22, PAV31)", "PA4: PAV41"),
+        tourUtils.editConfiguration(),
+        {
+            trigger: ".modal .o_matrix_input_table",
+            run: function () {
+                // update some of the matrix values.
+                [...document.querySelectorAll(".o_matrix_input")]
+                    .slice(8, 16)
+                    .forEach((el) => (el.value = 4));
+            } // set the qty to 4 for half of the matrix products.
+        },
+        {
+            trigger: ".modal button:contains(Confirm)", // apply the matrix
+            run: "click",
+        },
+        {
+            trigger: '.o_field_cell.o_data_cell.o_list_number:contains("4.00")',
+        },
+        {
+            trigger: '.o_form_button_save',
+            run: 'click', // SAVE Sales Order, after matrix has been applied.
+        },
+        // Ensures the matrix is opened with the values, when adding the same product.
+        {
+            trigger: ".o_form_status_indicator_buttons.invisible",
+        },
+        ...tourUtils.addProduct("Matrix"),
+        {
+            trigger: 'input[value="4"]',
+            run: function () {
+                // update some values of the matrix
+                [...document.querySelectorAll("input[value='4']")]
+                    .slice(0, 4)
+                    .forEach((el) => (el.value = 8.2));
+            }
+        },
+        {
+            trigger: ".modal button:contains(Confirm)", // apply the matrix
+            run: "click",
         },
         {
             trigger: ".o_field_cell.o_data_cell.o_list_number:contains(8.20)",

--- a/addons/website_sale/data/demo.xml
+++ b/addons/website_sale/data/demo.xml
@@ -332,10 +332,7 @@
 
         <record id="website_sale_order_line_1" model="sale.order.line">
             <field name="order_id" ref="website_sale_order_1"/>
-            <field name="name" model="sale.order.line" eval="obj().env.ref('product.product_product_6').get_product_multiline_description_sale()"/>
             <field name="product_id" ref="product.product_product_6"/>
-            <field name="product_uom_qty">1</field>
-            <field name="product_uom" ref="uom.product_uom_unit"/>
             <field name="price_unit">599.0</field>
         </record>
 
@@ -352,10 +349,7 @@
 
         <record id="website_sale_order_line_2" model="sale.order.line">
             <field name="order_id" ref="website_sale_order_2"/>
-            <field name="name" model="sale.order.line" eval="obj().env.ref('product.product_product_4').get_product_multiline_description_sale()"/>
             <field name="product_id" ref="product.product_product_4"/>
-            <field name="product_uom_qty">1</field>
-            <field name="product_uom" ref="uom.product_uom_unit"/>
             <field name="price_unit">900</field>
         </record>
 
@@ -373,10 +367,7 @@
 
         <record id="website_sale_order_line_3" model="sale.order.line">
             <field name="order_id" ref="website_sale_order_3"/>
-            <field name="name" model="sale.order.line" eval="obj().env.ref('product.product_product_4').get_product_multiline_description_sale()"/>
             <field name="product_id" ref="product.product_product_4"/>
-            <field name="product_uom_qty">1</field>
-            <field name="product_uom" ref="uom.product_uom_unit"/>
             <field name="price_unit">750</field>
         </record>
 
@@ -393,10 +384,7 @@
 
         <record id="website_sale_order_line_4" model="sale.order.line">
             <field name="order_id" ref="website_sale_order_4"/>
-            <field name="name" model="sale.order.line" eval="obj().env.ref('product.product_product_8').get_product_multiline_description_sale()"/>
             <field name="product_id" ref="product.product_product_8"/>
-            <field name="product_uom_qty">1</field>
-            <field name="product_uom" ref="uom.product_uom_unit"/>
             <field name="price_unit">1199.0</field>
         </record>
 
@@ -413,10 +401,8 @@
 
         <record id="website_sale_order_line_5" model="sale.order.line">
             <field name="order_id" ref="website_sale_order_5"/>
-            <field name="name" model="sale.order.line" eval="obj().env.ref('product.product_product_4').get_product_multiline_description_sale()"/>
             <field name="product_id" ref="product.product_product_4"/>
             <field name="product_uom_qty">3</field>
-            <field name="product_uom" ref="uom.product_uom_unit"/>
             <field name="price_unit">349.0</field>
         </record>
 
@@ -433,10 +419,7 @@
 
         <record id="website_sale_order_line_6" model="sale.order.line">
             <field name="order_id" ref="website_sale_order_6"/>
-            <field name="name" model="sale.order.line" eval="obj().env.ref('product.product_product_8').get_product_multiline_description_sale()"/>
             <field name="product_id" ref="product.product_product_8"/>
-            <field name="product_uom_qty">1</field>
-            <field name="product_uom" ref="uom.product_uom_unit"/>
             <field name="price_unit">1599.00</field>
         </record>
 
@@ -454,10 +437,7 @@
 
         <record id="website_sale_order_line_7" model="sale.order.line">
             <field name="order_id" ref="website_sale_order_7"/>
-            <field name="name" model="sale.order.line" eval="obj().env.ref('product.product_product_8').get_product_multiline_description_sale()"/>
             <field name="product_id" ref="product.product_product_8"/>
-            <field name="product_uom_qty">1</field>
-            <field name="product_uom" ref="uom.product_uom_unit"/>
             <field name="price_unit">1349.00</field>
         </record>
 
@@ -475,10 +455,7 @@
 
         <record id="website_sale_order_line_8" model="sale.order.line">
             <field name="order_id" ref="website_sale_order_8"/>
-            <field name="name" model="sale.order.line" eval="obj().env.ref('product.product_product_8').get_product_multiline_description_sale()"/>
             <field name="product_id" ref="product.product_product_8"/>
-            <field name="product_uom_qty">1</field>
-            <field name="product_uom" ref="uom.product_uom_unit"/>
             <field name="price_unit">1799.00</field>
         </record>
 
@@ -494,19 +471,13 @@
 
         <record id="website_sale_order_line_9" model="sale.order.line">
             <field name="order_id" ref="website_sale_order_9"/>
-            <field name="name" model="sale.order.line" eval="obj().env.ref('product.product_product_25').get_product_multiline_description_sale()"/>
             <field name="product_id" ref="product.product_product_25"/>
-            <field name="product_uom_qty">1</field>
-            <field name="product_uom" ref="uom.product_uom_unit"/>
             <field name="price_unit">295.00</field>
         </record>
 
         <record id="website_sale_order_line_10" model="sale.order.line">
             <field name="order_id" ref="website_sale_order_9"/>
-            <field name="name" model="sale.order.line" eval="obj().env.ref('product.product_product_12').get_product_multiline_description_sale()"/>
             <field name="product_id" ref="product.product_product_12"/>
-            <field name="product_uom_qty">1</field>
-            <field name="product_uom" ref="uom.product_uom_unit"/>
             <field name="price_unit">120.50</field>
         </record>
 
@@ -524,10 +495,8 @@
 
         <record id="website_sale_order_line_11" model="sale.order.line">
             <field name="order_id" ref="website_sale_order_10"/>
-            <field name="name" model="sale.order.line" eval="obj().env.ref('product.product_product_11').get_product_multiline_description_sale()"/>
             <field name="product_id" ref="product.product_product_11"/>
             <field name="product_uom_qty">2</field>
-            <field name="product_uom" ref="uom.product_uom_unit"/>
             <field name="price_unit">33</field>
         </record>
 
@@ -544,10 +513,7 @@
 
         <record id="website_sale_order_line_12" model="sale.order.line">
             <field name="order_id" ref="website_sale_order_11"/>
-            <field name="name" model="sale.order.line" eval="obj().env.ref('product.product_product_9').get_product_multiline_description_sale()"/>
             <field name="product_id" ref="product.product_product_9"/>
-            <field name="product_uom_qty">1</field>
-            <field name="product_uom" ref="uom.product_uom_unit"/>
             <field name="price_unit">47.0</field>
         </record>
 
@@ -566,10 +532,7 @@
 
         <record id="website_sale_order_line_14" model="sale.order.line">
             <field name="order_id" ref="website_sale_order_13"/>
-            <field name="name" model="sale.order.line" eval="obj().env.ref('product.product_product_8').get_product_multiline_description_sale()"/>
             <field name="product_id" ref="product.product_product_8"/>
-            <field name="product_uom_qty">1</field>
-            <field name="product_uom" ref="uom.product_uom_unit"/>
             <field name="price_unit">1799.0</field>
         </record>
 
@@ -585,10 +548,7 @@
 
         <record id="website_sale_order_line_15" model="sale.order.line">
             <field name="order_id" ref="website_sale_order_14"/>
-            <field name="name" model="sale.order.line" eval="obj().env.ref('product.product_product_16').get_product_multiline_description_sale()"/>
             <field name="product_id" ref="product.product_product_16"/>
-            <field name="product_uom_qty">1</field>
-            <field name="product_uom" ref="uom.product_uom_unit"/>
             <field name="price_unit">25.0</field>
         </record>
 
@@ -606,10 +566,8 @@
 
         <record id="website_sale_order_line_16" model="sale.order.line">
             <field name="order_id" ref="website_sale_order_16"/>
-            <field name="name" model="sale.order.line" eval="obj().env.ref('product.product_product_8').get_product_multiline_description_sale()"/>
             <field name="product_id" ref="product.product_product_8"/>
             <field name="product_uom_qty">2</field>
-            <field name="product_uom" ref="uom.product_uom_unit"/>
             <field name="price_unit">1799.0</field>
         </record>
 
@@ -626,10 +584,8 @@
 
         <record id="website_sale_order_line_17" model="sale.order.line">
             <field name="order_id" ref="website_sale_order_17"/>
-            <field name="name" model="sale.order.line" eval="obj().env.ref('product.product_product_9').get_product_multiline_description_sale()"/>
             <field name="product_id" ref="product.product_product_9"/>
             <field name="product_uom_qty">7</field>
-            <field name="product_uom" ref="uom.product_uom_unit"/>
             <field name="price_unit">47.0</field>
             <field name="invoice_status">to invoice</field>
         </record>
@@ -647,10 +603,8 @@
 
         <record id="website_sale_order_line_18" model="sale.order.line">
             <field name="order_id" ref="website_sale_order_18"/>
-            <field name="name" model="sale.order.line" eval="obj().env.ref('product.product_product_9').get_product_multiline_description_sale()"/>
             <field name="product_id" ref="product.product_product_9"/>
             <field name="product_uom_qty">3</field>
-            <field name="product_uom" ref="uom.product_uom_unit"/>
             <field name="price_unit">47.0</field>
             <field name="invoice_status">to invoice</field>
         </record>

--- a/addons/website_sale_slides/data/sale_order_demo.xml
+++ b/addons/website_sale_slides/data/sale_order_demo.xml
@@ -17,10 +17,7 @@
     </record>
     <record id="sale_order_course_1_line_1" model="sale.order.line">
         <field name="order_id" ref="sale_order_course_1"/>
-        <field name="name" model="sale.order.line" eval="obj().env.ref('website_sale_slides.product_course_channel_6').get_product_multiline_description_sale()"/>
         <field name="product_id" ref="website_sale_slides.product_course_channel_6"/>
-        <field name="product_uom_qty">1</field>
-        <field name="product_uom" ref="uom.product_uom_unit"/>
         <field name="price_unit">100.0</field>
     </record>
 
@@ -36,18 +33,12 @@
     </record>
     <record id="sale_order_course_2_line_1" model="sale.order.line">
         <field name="order_id" ref="sale_order_course_2"/>
-        <field name="name" model="sale.order.line" eval="obj().env.ref('website_sale_slides.product_course_channel_1').get_product_multiline_description_sale()"/>
         <field name="product_id" ref="website_sale_slides.product_course_channel_1"/>
-        <field name="product_uom_qty">1</field>
-        <field name="product_uom" ref="uom.product_uom_unit"/>
         <field name="price_unit">150.0</field>
     </record>
     <record id="sale_order_course_2_line_2" model="sale.order.line">
         <field name="order_id" ref="sale_order_course_2"/>
-        <field name="name" model="sale.order.line" eval="obj().env.ref('website_sale_slides.product_course_channel_6').get_product_multiline_description_sale()"/>
         <field name="product_id" ref="website_sale_slides.product_course_channel_6"/>
-        <field name="product_uom_qty">1</field>
-        <field name="product_uom" ref="uom.product_uom_unit"/>
         <field name="price_unit">100.0</field>
     </record>
 
@@ -66,10 +57,7 @@
     </record>
     <record id="sale_order_course_3_line_1" model="sale.order.line">
         <field name="order_id" ref="sale_order_course_3"/>
-        <field name="name" model="sale.order.line" eval="obj().env.ref('website_sale_slides.product_course_channel_5').get_product_multiline_description_sale()"/>
         <field name="product_id" ref="website_sale_slides.product_course_channel_5"/>
-        <field name="product_uom_qty">1</field>
-        <field name="product_uom" ref="uom.product_uom_unit"/>
         <field name="price_unit">200.0</field>
     </record>
 

--- a/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
+++ b/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
@@ -730,12 +730,6 @@ stepUtils.autoExpandMoreButtons(),
     isActive: ["desktop"],
     trigger: ".ui-menu-item > a:contains('the_flow.product')",
     run: "click",
-}, {
-    isActive: ["desktop"],
-    trigger: "td[name='product_id'][data-tooltip*='the_flow.product'], td[name='product_template_id'][data-tooltip*='the_flow.product']",
-}, {
-    isActive: ["desktop"],
-    trigger: "td[name='product_uom'][data-tooltip='Units']",
 },
 {
     isActive: ["mobile"],
@@ -790,12 +784,6 @@ stepUtils.autoExpandMoreButtons(),
     isActive: ["desktop"],
     trigger: ".ui-menu-item > a:contains('the_flow.service')",
     run: "click",
-}, {
-    isActive: ["desktop"],
-    trigger: "td[name='product_id'][data-tooltip*='the_flow.service'], td[name='product_template_id'][data-tooltip*='the_flow.service']",
-}, {
-    isActive: ["desktop"],
-    trigger: "td[name='product_uom'][data-tooltip='Hours']",
 }, {
     isActive: ["desktop"],
     content: "click somewhere else to exit cell focus",


### PR DESCRIPTION
A new widget has been recently introduced by 4f325ef620263c27e095eb49026a677ac617a0ee
to improve the display of information on Account Move lines by combining
the product and description in a custom field.

This commit adapts and integrates this new widget to the Sales Order Lines.

The specificity of Sales Order Lines is that the user has to choose
either a product template or a product variant on the line, depending
on whether variants are enabled, whether the product configurator/grid
is needed, ...

Following the logic of this new widget, from now on, the product name
won't be included in the stored SOL description. Existing reports &
qweb templates have been adapted to still display the full information.

Specific to the Sales Order logic, the user will choose either a product
template or a product product (variant) depending on the columns he chose
to show, but he won't be able to see both columns anymore.

To make sure the full product information is displayed, even if the
chosen column is the product template, the display name of the selected
variant will be shown.

While fixing the impacted tests, this commit also cleans and factorize most
existing tours targeting the sale scope.

task-3970677

See also odoo/enterprise#65772