### PR TITLE
[FIX] hr_holidays: disable preview of attachments on hr leave

### DIFF
--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -356,7 +356,6 @@
                     <span >You can only take this time off in whole days, so if your schedule has half days, it won't be used efficiently.</span>
                 </div>
             </sheet>
-            <div class="o_attachment_preview"/>
             <div class="oe_chatter">
                 <field name="message_follower_ids"/>
                 <field name="activity_ids"/>


### PR DESCRIPTION
Steps to reproduce:
- Install "Time Off"
- Go to "Employees" pick the first one
- Click on "Time Off" smart button
- New and in supported attachments add a .jpg or a .png
- Click on "Save & Close"

Issues:
The preview blocks the entire window from being usable.

opw-3997812