### PR TITLE
[FIX] pos_restaurant: floating order fix

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -162,10 +162,8 @@ export class PosOrder extends Base {
                 const printingChanges = {
                     new: changes["new"],
                     cancelled: changes["cancelled"],
-                    table_name: this.config.module_pos_restaurant ? this.table_id.name : false,
-                    floor_name: this.config.module_pos_restaurant
-                        ? this.table_id.floor_id.name
-                        : false,
+                    table_name: this.table_id?.name,
+                    floor_name: this.table_id?.floor_id?.name,
                     name: this.name || "unknown order",
                     time: {
                         hours,

--- a/addons/point_of_sale/static/tests/tours/utils/chrome_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/chrome_util.js
@@ -27,6 +27,12 @@ export function isCashMoveButtonHidden() {
         },
     ];
 }
+export function newOrder() {
+    return {
+        content: "create new order",
+        trigger: ".pos-topheader button i.fa-plus-circle",
+    };
+}
 export function endTour() {
     return {
         content: "Last tour step that avoids error mentioned in commit 443c209",

--- a/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.js
+++ b/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.js
@@ -101,7 +101,7 @@ export class FloorScreen extends Component {
     }
     getTablesSelectedByDefault() {
         const oToTrans = this.pos.models["pos.order"].getBy("uuid", this.pos.orderToTransferUuid);
-        return oToTrans ? [oToTrans.table_id.id] : [];
+        return oToTrans?.table_id ? [oToTrans.table_id.id] : [];
     }
     async onWillStart() {
         this.pos.searchProductWord = "";

--- a/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.xml
+++ b/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.xml
@@ -6,7 +6,10 @@
             <div t-if="pos.orderToTransferUuid" class="d-flex align-items-center justify-content-between px-3 border-bottom bg-view overflow-x-auto w-100">
                 <button t-attf-class="ms-auto {{editButtonClass}}" t-att-class="{active: !pos.isTableToMerge}" t-on-click="() => this.pos.isTableToMerge = false">
                     <i class="fa fa-arrow-right" role="img" aria-label="Transfer" title="Transfer" />Transfer</button>
-                <button t-attf-class="{{editButtonClass}}" t-att-class="{active: pos.isTableToMerge}" t-on-click="() => this.pos.isTableToMerge = true">
+                <button
+                    t-if="pos.models['pos.order'].find(o => o.uuid === pos.orderToTransferUuid).table_id"
+                    t-attf-class="{{editButtonClass}}" t-att-class="{active: pos.isTableToMerge}"
+                    t-on-click="() => this.pos.isTableToMerge = true">
                     <i class="fa fa-link" role="img" aria-label="Merge" title="Merge" />Merge</button>
                 <button t-attf-class="ms-auto {{editButtonClass}}" t-on-click.stop="stopOrderTransfer">
                     <i class="fa fa-times" role="img" aria-label="Close" title="Close" />Discard</button>

--- a/addons/pos_restaurant/static/src/overrides/components/payment_screen/payment_screen.js
+++ b/addons/pos_restaurant/static/src/overrides/components/payment_screen/payment_screen.js
@@ -17,7 +17,7 @@ patch(PaymentScreen.prototype, {
     async afterOrderValidation(suggestToSync = true) {
         // After the order has been validated the tables have no reason to be merged anymore.
         const changedTables = this.pos.models["restaurant.table"]?.filter(
-            (t) => t.parent_id && t.parent_id.id === this.currentOrder.table_id.id
+            (t) => t.parent_id && t.parent_id.id === this.currentOrder.table_id?.id
         );
         if (changedTables?.length) {
             for (const table of changedTables) {

--- a/addons/pos_restaurant/static/src/overrides/components/ticket_screen/ticket_screen.js
+++ b/addons/pos_restaurant/static/src/overrides/components/ticket_screen/ticket_screen.js
@@ -55,7 +55,7 @@ patch(TicketScreen.prototype, {
             this.pos.config.module_pos_restaurant &&
             this.pos.selectedTable &&
             !this.pos.models["pos.order"].some(
-                (order) => order.table_id.id === this.pos.selectedTable.id
+                (order) => order.table_id?.id === this.pos.selectedTable.id
             )
         ) {
             return this.pos.showScreen("FloorScreen");

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -68,6 +68,13 @@ registry.category("web_tour.tours").add("pos_restaurant_sync", {
         [
             Dialog.confirm("Open session"),
 
+            // Create a floating order. The idea is to have one of the draft orders be a floating order during the tour.
+            Chrome.newOrder(),
+            ProductScreen.clickDisplayedProduct("Coca-Cola"),
+            ProductScreen.clickDisplayedProduct("Coca-Cola"),
+            ProductScreen.clickDisplayedProduct("Coca-Cola"),
+            ProductScreen.back(),
+
             // Create first order
             FloorScreen.clickTable("5"),
             ProductScreen.orderBtnIsPresent(),
@@ -154,7 +161,9 @@ registry.category("web_tour.tours").add("pos_restaurant_sync", {
             FloorScreen.clickTable("5"),
             ProductScreen.isShown(),
             Chrome.clickMenuOption("Orders"),
-            TicketScreen.deleteOrder("-0001"),
+            // The order ref ends with -0002 because it is actually the 2nd order made in the session.
+            // The first order made in the session is a floating order.
+            TicketScreen.deleteOrder("-0002"),
             Dialog.confirm(),
             {
                 ...Dialog.confirm(),
@@ -162,7 +171,7 @@ registry.category("web_tour.tours").add("pos_restaurant_sync", {
                     "acknowledge printing error ( because we don't have printer in the test. )",
             },
             isSyncStatusConnected(),
-            TicketScreen.selectOrder("-0004"),
+            TicketScreen.selectOrder("-0005"),
             TicketScreen.loadSelectedOrder(),
             ProductScreen.isShown(),
             ProductScreen.back(),


### PR DESCRIPTION
After the introduction of floating orders ( orders not linked to a table ) in `pos_restaurant`, there were still methods that did not account for this change.

In this commit we adapt the code such that we now always handle the case where an order is not linked to a table.

Ex of issue caused by this problem:
Steps:

1. open pos restaurant
2. create a floating order ( by clicking on the "+" button in the top left )
3. create an order on a table
4. try to pay for the order on the table
5. observe the traceback

Task-id: "4009094"





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
