### PR TITLE
[FIX] l10n_gcc_pos: remove colon and number for non-GCC countries

### DIFF
--- a/addons/l10n_gcc_pos/static/src/overrides/app/screens/receipt_screen/receipt/order_receipt.xml
+++ b/addons/l10n_gcc_pos/static/src/overrides/app/screens/receipt_screen/receipt/order_receipt.xml
@@ -81,7 +81,9 @@
             </t>
         </xpath>
         <xpath expr="//Orderline">
-            <div t-if="props.data.is_gcc_country" style="display: inline-flex;" t-translation="off">Taxes / الضرائب</div>:<span t-esc="line.tax " style="margin-left: 5px"/>
+            <t t-if="props.data.is_gcc_country">
+                <div style="display: inline-flex;" t-translation="off">Taxes / الضرائب</div>:<span t-esc="line.tax " style="margin-left: 5px"/>
+            </t>
         </xpath>
     </t>
 </templates>


### PR DESCRIPTION
Before this commit, when is_gcc_country was false, a colon followed by a number would appear in the receipt, which was confusing. This commit removes this misleading information for receipts in non-GCC countries.

opw-3992612

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
