### PR TITLE
[FIX] mrp: improve compute BoM days warning message

### DIFF
--- a/addons/mrp/i18n/mrp.pot
+++ b/addons/mrp/i18n/mrp.pot
@@ -674,13 +674,6 @@ msgid "Assign Serial Numbers"
 msgstr ""
 
 #. module: mrp
-#. odoo-python
-#: code:addons/mrp/models/product.py:0
-#, python-format
-msgid "At least one component can not be resupplied."
-msgstr ""
-
-#. module: mrp
 #: model_terms:ir.ui.view,arch_db:mrp.mrp_bom_form_view
 msgid "At the creation of a Manufacturing Order."
 msgstr ""
@@ -1084,6 +1077,15 @@ msgstr ""
 #: model:ir.model.fields.selection,name:mrp.selection__mrp_workorder__state__cancel
 #: model_terms:ir.ui.view,arch_db:mrp.view_mrp_production_filter
 msgid "Cancelled"
+msgstr ""
+
+#. module: mrp
+#. odoo-python
+#: code:addons/mrp/models/product.py:0
+#, python-format
+msgid ""
+"Cannot compute days to prepare due to missing route info for at least 1 "
+"component or for the final product."
 msgstr ""
 
 #. module: mrp

--- a/addons/mrp/models/product.py
+++ b/addons/mrp/models/product.py
@@ -353,7 +353,7 @@ class ProductProduct(models.Model):
                 'type': 'ir.actions.client',
                 'tag': 'display_notification',
                 'params': {
-                    'title': _('At least one component can not be resupplied.'),
+                    'title': _('Cannot compute days to prepare due to missing route info for at least 1 component or for the final product.'),
                     'sticky': False,
                     }
                 }


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a product “Finished product”
    - Route: do not set the manufacturing route
    - BoM:
        - Component: C1 Route: Buy
        Purchase tab: Azure interior, days 10
- Go back to the finished product form and try to
 calculate the Days to prepare the Manufacturing
 Order

Problem:

The following warning is displayed: “At least one component cannot be
resupplied.” This is incorrect because it is actually the finished
product that does not have a route. Therefore, we change the warning
message to make it more explicit.
Original warning: https://github.com/odoo/odoo/pull/167136/commits/64a0d4c9a755e0f31a874aaad6bd7fc09420e49d