### PR TITLE
[FIX] point_of_sale,pos_online_payment: kitchen printer self order

### DIFF
--- a/addons/point_of_sale/static/src/app/bus/pos_bus_service.js
+++ b/addons/point_of_sale/static/src/app/bus/pos_bus_service.js
@@ -1,6 +1,7 @@
 /** @odoo-module */
 
 import { registry } from "@web/core/registry";
+import { Order } from "@point_of_sale/app/store/models";
 
 export class PosBus {
     static serviceDependencies = ["pos", "orm", "bus_service"];
@@ -21,7 +22,18 @@ export class PosBus {
         });
     }
 
-    dispatch(message) {}
+    async dispatch(message) {
+        if (message.type === "POS_SELF_ORDER_PAID") {
+            const fetchedOrders = await this.orm.call("pos.order", "export_for_ui", [
+                message.payload,
+            ]);
+            const order = new Order(
+                { env: this.pos.env },
+                { pos: this.pos, json: fetchedOrders[0] }
+            );
+            this.pos.sendOrderInPreparation(order);
+        }
+    }
 }
 
 export const posBusService = {


### PR DESCRIPTION
When ordering from a self order mobile and using the online payment method, the order was not sent to the kitchen printer

Steps to reproduce:
-------------------
* Setup an online payment method to be used in the self order
* Setup a kitchen printer for any PoS, to print all orders
* Setup the PoS to use the mobile self ordering
* Open the PoS
* Open the self order on another tab
* Make any order on the self order and pay for it using the online payment
> Observation: Nothing is printed on the kitchen printer

Why the fix:
------------
When the payment is finalized nothing was done to send it to the kitchen printer. To fix this, when the order is paid we send a notification to the PoS. When the PoS receive this notification it will retrieve the order that has been paid and send it to the kitchen printer.

opw-3974742
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
