### PR TITLE
[FIX] stock: optimize the _get_weight method

### DIFF
--- a/addons/stock/models/stock_location.py
+++ b/addons/stock/models/stock_location.py
@@ -426,17 +426,28 @@ class Location(models.Model):
         result = defaultdict(lambda: defaultdict(float))
         if not excluded_sml_ids:
             excluded_sml_ids = set()
-        for location in self:
-            quants = location.quant_ids
-            incoming_move_lines = location.incoming_move_line_ids.filtered(lambda ml: ml.state not in ['draft', 'done', 'cancel'] and ml.id not in excluded_sml_ids)
-            outgoing_move_lines = location.outgoing_move_line_ids.filtered(lambda ml: ml.state not in ['draft', 'done', 'cancel'] and ml.id not in excluded_sml_ids)
-            for quant in quants:
-                result[location]['net_weight'] += quant.product_id.weight * quant.quantity
-            result[location]['forecast_weight'] = result[location]['net_weight']
-            for line in incoming_move_lines:
-                result[location]['forecast_weight'] += line.product_id.weight * line.reserved_qty
-            for line in outgoing_move_lines:
-                result[location]['forecast_weight'] -= line.product_id.weight * line.reserved_qty
+        Product = self.env['product.product']
+        StockMoveLine = self.env['stock.move.line']
+
+        quants = self.env['stock.quant'].read_group([('location_id', 'in', self.ids)], ['quantity'], ['location_id', 'product_id'], lazy=False)
+        base_domain = [('state', 'not in', ['draft', 'done', 'cancel']), ('id', 'not in', tuple(excluded_sml_ids))]
+        outgoing_move_lines = StockMoveLine.read_group(expression.AND([[('location_id', 'in', self.ids)], base_domain]), ['reserved_qty'], ['location_id', 'product_id'], lazy=False)
+        incoming_move_lines = StockMoveLine.read_group(expression.AND([[('location_dest_id', 'in', self.ids)], base_domain]), ['reserved_qty'], ['location_dest_id', 'product_id'], lazy=False)
+
+        product_ids = {record['product_id'][0] for record in quants + outgoing_move_lines + incoming_move_lines}
+        weight_per_product = {weight['id']: weight['weight'] for weight in Product.browse(product_ids).read(['weight'])}
+
+        for quant in quants:
+            weight = quant['quantity'] * weight_per_product[quant['product_id'][0]]
+            result[self.browse(quant['location_id'][0])]['net_weight'] += weight
+            result[self.browse(quant['location_id'][0])]['forecast_weight'] += weight
+
+        for line in outgoing_move_lines:
+            result[self.browse(line['location_id'][0])]['forecast_weight'] -= line['reserved_qty'] * weight_per_product[line['product_id'][0]]
+
+        for line in incoming_move_lines:
+            result[self.browse(line['location_dest_id'][0])]['forecast_weight'] += line['reserved_qty'] * weight_per_product[line['product_id'][0]]
+
         return result
 
 


### PR DESCRIPTION
Issue:
The `_get_weight` method is called for each location to compute the weight and it sums up all the incoming and outgoing lines for forecasted weight. Using filtered for each record is compute intensive and gets slower over time.

While returning a delivery with 30 stock moves the _create_return took 7:41 minutes most of which were on `_get_weight`. Here filtered alone was taking over 6 minutes.
![image](https://github.com/odoo/odoo/assets/111344786/52f2bdef-f486-4e07-aab3-0ced1d68bd1c)

For a single run, 
|| Before| 
| --------- | ------------- | 
|Quants| 5474  | 
|Outgoing Move Lines| 38020  | 
|Incoming Move Lines| 150935 |
|Time| 246.05s |

Solution:
Optimized the `_get_weight` method to use `read_group` to get the sum of incoming and outgoing lines. This reduces the number of reads. Total time for the same return reduced to 28s.

![image](https://github.com/odoo/odoo/assets/111344786/9cc83c93-3502-44a2-af54-9a269a98394a)
For a single run:
|| After| 
| --------- | ------------- | 
|Quants| 5474  | 
|Outgoing Move Lines| 38020  | 
|Incoming Move Lines| 150935 |
|Time| 0.4s |
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
