### PR TITLE
[FIX] point_of_sale: handle traceback when the method is undefined

### DIFF
--- a/addons/point_of_sale/static/src/app/models/data_service.js
+++ b/addons/point_of_sale/static/src/app/models/data_service.js
@@ -168,7 +168,7 @@ export class PosData extends Reactive {
             return result;
         } catch (error) {
             if (queue) {
-                this.network.unsyncData.push({ type, model, ids, values });
+                this.network.unsyncData.push({ type, model, ids, values, method, args });
             }
 
             this.setOffline();


### PR DESCRIPTION
A traceback is occuring in the backend when the `method` is undefined while using the `POS`.

Error:- 
```
KeyError: 'method'
  File "odoo/http.py", line 2248, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1818, in _serve_db
    ro = ro(self.registry, request)
  File "addons/web/controllers/dataset.py", line 23, in _call_kw_readonly
    method_name = params['method']
```

During an `ORM` call with dynamic method and model, at some point somehow, 
`method` value getting undefined with the model as `pos.session`.

This leads to a traceback in the backend side.

After applying this commit it will resolve this issue by handling 
the traceback on the `JS` side when the method is undefined.

sentry-5285015466