### PR TITLE
[IMP] payment, _*: add emi for razorpay

### DIFF
--- a/addons/payment/data/payment_method_data.xml
+++ b/addons/payment/data/payment_method_data.xml
@@ -1003,9 +1003,9 @@
         />
     </record>
 
-    <record id="payment_method_emi" model="payment.method">
+    <record id="payment_method_emi_india" model="payment.method">
         <field name="name">EMI</field>
-        <field name="code">emi</field>
+        <field name="code">emi_india</field>
         <field name="sequence">1000</field>
         <field name="active">False</field>
         <field name="image" type="base64" file="payment/static/img/card.png"/>

--- a/addons/payment/data/payment_provider_data.xml
+++ b/addons/payment/data/payment_provider_data.xml
@@ -302,6 +302,7 @@
                          ref('payment.payment_method_upi'),
                          ref('payment.payment_method_wallets_india'),
                          ref('payment.payment_method_paylater_india'),
+                         ref('payment.payment_method_emi_india'),
                      ])]"
         />
     </record>

--- a/addons/payment_payumoney/data/payment_provider_data.xml
+++ b/addons/payment_payumoney/data/payment_provider_data.xml
@@ -13,7 +13,7 @@
                eval="[(6, 0, [
                    ref('payment.payment_method_card'),
                    ref('payment.payment_method_netbanking'),
-                   ref('payment.payment_method_emi'),
+                   ref('payment.payment_method_emi_india'),
                    ref('payment.payment_method_upi'),
                ])]"/>
         <field name="code">payumoney</field>

--- a/addons/payment_razorpay/const.py
+++ b/addons/payment_razorpay/const.py
@@ -115,12 +115,14 @@ DEFAULT_PAYMENT_METHOD_CODES = {
 FALLBACK_PAYMENT_METHOD_CODES = {
     'wallets_india',
     'paylater_india',
+    'emi_india',
 }
 
 # Mapping of payment method codes to Razorpay codes.
 PAYMENT_METHODS_MAPPING = {
     'wallets_india': 'wallet',
     'paylater_india': 'paylater',
+    'emi_india': 'emi',
 }
 
 # The maximum amount in INR that can be paid through an eMandate.


### PR DESCRIPTION
_* = payment_razorpay

This commit adds support for EMI as a payment method to Razorpay.

Why this solution?
The `orders` API does not accept `emi` as a method key in the payload even though it is mentioned in their docs. Even though Razorpay responds with `method: emi` when we pay via emi, the `orders` API does not recognize it as a valid method.

What is the solution?
We have added the `emi` to the `FALLBACK_PAYMENT_METHOD_CODES`. This ensures that no method is passed in the payload, which opens the Razorpay form with all the methods listed, and the user can choose `emi` from there.

task-3958299