### PR TITLE
[IMP] board,calendar,crm,website_crm_partner_assign: simplify kanban archs

### DIFF
--- a/addons/board/static/tests/board_test.js
+++ b/addons/board/static/tests/board_test.js
@@ -459,8 +459,8 @@ QUnit.module("Board", (hooks) => {
         serverData.views["partner,5,kanban"] = `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`;
@@ -539,9 +539,9 @@ QUnit.module("Board", (hooks) => {
         serverData.views["partner,false,kanban"] = `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
+                    <t t-name="kanban-card">
                         <div>
-                            <div><field name="foo"/></div>
+                            <field name="foo"/>
                             <button name="sitting_on_a_park_bench" type="object">Eying little girls with bad intent</button>
                         </div>
                     </t>

--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -257,23 +257,17 @@
                                     <button name="do_decline" string="Decline" invisible="state not in ('needsAction', 'tentative', 'accepted')" type="object" icon="fa-times-circle text-danger"/>
                                 </tree>
                                 <kanban class="o_kanban_mobile" create="false" delete="false">
-                                    <field name="partner_id" />
-                                    <field name="state" />
-                                    <field name="email" widget="email"/>
 
                                     <templates>
-                                        <t t-name="kanban-box">
-                                            <div class="d-flex flex-column justify-content-between">
-                                                <field name="partner_id"/>
-                                                <field name="email" widget="email"/>
-                                                <span>Status: <field name="state" /></span>
-
-                                                <div class="text-end">
-                                                    <button name="do_tentative" invisible="state not in ('needsAction', 'declined', 'accepted')" string="Uncertain" type="object" class="btn fa fa-asterisk"/>
-                                                    <button name="do_accept" invisible="state not in ('needsAction', 'tentative', 'declined')" string="Accept" type="object" class="btn fa fa-check text-success"/>
-                                                    <button name="do_decline" invisible="state not in ('needsAction', 'tentative', 'accepted')" string="Decline" type="object" class="btn fa fa-times-circle text-danger"/>
-                                                </div>
-                                            </div>
+                                        <t t-name="kanban-card">
+                                            <field name="partner_id"/>
+                                            <field name="email" widget="email"/>
+                                            <span>Status: <field name="state" /></span>
+                                            <footer class="justify-content-end">
+                                                <button name="do_tentative" invisible="state not in ('needsAction', 'declined', 'accepted')" string="Uncertain" type="object" class="btn fa fa-asterisk"/>
+                                                <button name="do_accept" invisible="state not in ('needsAction', 'tentative', 'declined')" string="Accept" type="object" class="btn fa fa-check text-success"/>
+                                                <button name="do_decline" invisible="state not in ('needsAction', 'tentative', 'accepted')" string="Decline" type="object" class="btn fa fa-times-circle text-danger"/>
+                                            </footer>
                                         </t>
                                     </templates>
                                 </kanban>

--- a/addons/crm/static/src/js/tours/crm.js
+++ b/addons/crm/static/src/js/tours/crm.js
@@ -52,7 +52,7 @@ registry.category("web_tour.tours").add('crm_tour', {
     trigger: ".o_opportunity_kanban",
 },
 {
-    trigger: ".o_opportunity_kanban .o_kanban_group:first-child .o_kanban_record:last-of-type .oe_kanban_content",
+    trigger: ".o_opportunity_kanban .o_kanban_group:first-child .o_kanban_record:last-of-type",
     content: markup(_t("<b>Drag &amp; drop opportunities</b> between columns as you progress in your sales cycle.")),
     tooltipPosition: "right",
     run: "drag_and_drop(.o_opportunity_kanban .o_kanban_group:eq(2))",

--- a/addons/crm/static/tests/crm_kanban_progress_bar_mrr_sum_field_tests.js
+++ b/addons/crm/static/tests/crm_kanban_progress_bar_mrr_sum_field_tests.js
@@ -77,15 +77,12 @@ QUnit.module('Crm Kanban Progressbar', {
             groupBy: ['stage_id'],
             arch: `
                 <kanban js_class="crm_kanban">
-                    <field name="stage_id"/>
-                    <field name="expected_revenue"/>
-                    <field name="recurring_revenue_monthly"/>
                     <field name="activity_state"/>
                     <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}' sum_field="expected_revenue" recurring_revenue_sum_field="recurring_revenue_monthly"/>
                     <templates>
-                        <t t-name="kanban-box">
-                            <div><field name="name"/></div>
-                            <div><field name="recurring_revenue_monthly"/></div>
+                        <t t-name="kanban-card" class="flex-row justify-content-between">
+                            <field name="name" class="p-2"/>
+                            <field name="recurring_revenue_monthly" class="p-2"/>
                         </t>
                     </templates>
                 </kanban>`,
@@ -106,15 +103,12 @@ QUnit.module('Crm Kanban Progressbar', {
             groupBy: ['stage_id'],
             arch: `
                 <kanban js_class="crm_kanban">
-                    <field name="stage_id"/>
-                    <field name="expected_revenue"/>
-                    <field name="recurring_revenue_monthly"/>
                     <field name="activity_state"/>
                     <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}' sum_field="expected_revenue" recurring_revenue_sum_field="recurring_revenue_monthly"/>
                     <templates>
-                        <t t-name="kanban-box">
-                            <div><field name="name"/></div>
-                            <div><field name="recurring_revenue_monthly"/></div>
+                        <t t-name="kanban-card" class="flex-row justify-content-between">
+                            <field name="name" class="p-2"/>
+                            <field name="recurring_revenue_monthly" class="p-2"/>
                         </t>
                     </templates>
                 </kanban>`,
@@ -137,16 +131,13 @@ QUnit.module('Crm Kanban Progressbar', {
             groupBy: ['bar'],
             arch: `
                 <kanban js_class="crm_kanban">
-                    <field name="stage_id"/>
-                    <field name="expected_revenue"/>
-                    <field name="recurring_revenue_monthly"/>
                     <field name="activity_state"/>
                     <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}' sum_field="expected_revenue" recurring_revenue_sum_field="recurring_revenue_monthly"/>
                     <templates>
-                        <t t-name="kanban-box">
-                            <div><field name="name"/></div>
-                            <div><field name="expected_revenue"/></div>
-                            <div><field name="recurring_revenue_monthly"/></div>
+                        <t t-name="kanban-card" class="flex-row justify-content-between">
+                            <field name="name" class="p-2"/>
+                            <field name="expected_revenue" class="p-2"/>
+                            <field name="recurring_revenue_monthly" class="p-2"/>
                         </t>
                     </templates>
                 </kanban>`,
@@ -188,16 +179,13 @@ QUnit.module('Crm Kanban Progressbar', {
             groupBy: ['stage_id'],
             arch: `
                 <kanban js_class="crm_kanban">
-                    <field name="stage_id"/>
-                    <field name="expected_revenue"/>
-                    <field name="recurring_revenue_monthly"/>
                     <field name="activity_state"/>
                     <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}' sum_field="expected_revenue" recurring_revenue_sum_field="recurring_revenue_monthly"/>
                     <templates>
-                        <t t-name="kanban-box">
-                            <div><field name="name"/></div>
-                            <div><field name="expected_revenue"/></div>
-                            <div><field name="recurring_revenue_monthly"/></div>
+                        <t t-name="kanban-card" class="flex-row justify-content-between">
+                            <field name="name" class="p-2"/>
+                            <field name="expected_revenue" class="p-2"/>
+                            <field name="recurring_revenue_monthly" class="p-2"/>
                         </t>
                     </templates>
                 </kanban>`,

--- a/addons/crm/static/tests/crm_rainbowman_tests.js
+++ b/addons/crm/static/tests/crm_rainbowman_tests.js
@@ -101,8 +101,8 @@ QUnit.module('Crm Rainbowman Triggers', {
             arch: `
                 <kanban js_class="crm_kanban">
                     <templates>
-                        <t t-name="kanban-box">
-                            <div><field name="name"/></div>
+                        <t t-name="kanban-card">
+                            <field name="name"/>
                         </t>
                     </templates>
                 </kanban>`,

--- a/addons/crm/static/tests/forecast_kanban_tests.js
+++ b/addons/crm/static/tests/forecast_kanban_tests.js
@@ -20,11 +20,9 @@ QUnit.module('Crm Forecast Model Extension', {
         this.testKanbanView = {
             arch: `
                 <kanban js_class="forecast_kanban">
-                    <field name="date_deadline"/>
-                    <field name="date_closed"/>
                     <templates>
-                        <t t-name="kanban-box">
-                            <div><field name="name"/></div>
+                        <t t-name="kanban-card">
+                            <field name="name"/>
                         </t>
                     </templates>
                 </kanban>`,
@@ -140,10 +138,9 @@ QUnit.module('Crm Fill Temporal Service', {
         this.testKanbanView = {
             arch: `
                 <kanban js_class="forecast_kanban">
-                    <field name="date_deadline"/>
                     <templates>
-                        <t t-name="kanban-box">
-                            <div><field name="name"/></div>
+                        <t t-name="kanban-card">
+                            <field name="name"/>
                         </t>
                     </templates>
                 </kanban>`,
@@ -286,12 +283,9 @@ QUnit.module('Crm Forecast main flow with progressBars', (hooks) => {
             arch: `
                 <kanban js_class="forecast_kanban">
                     <progressbar field="color" colors='{"s": "success", "w": "warning", "d": "danger"}'  sum_field="int_field"/>
-                    <field name="date_deadline"/>
                     <templates>
-                        <t t-name="kanban-box">
-                            <div>
-                                <field name="name"/>
-                            </div>
+                        <t t-name="kanban-card">
+                            <field name="name"/>
                         </t>
                     </templates>
                 </kanban>`,

--- a/addons/crm/static/tests/tours/crm_email_and_phone_propagation.js
+++ b/addons/crm/static/tests/tours/crm_email_and_phone_propagation.js
@@ -13,7 +13,7 @@
             content: 'open crm app',
             run: "click",
         }, {
-            trigger: '.o_kanban_record .o_kanban_record_title span:contains(Test Lead Propagation)',
+            trigger: '.o_kanban_record:contains(Test Lead Propagation)',
             content: 'Open the first lead',
             run: 'click',
         },
@@ -37,7 +37,7 @@
             content: 'open crm app',
             run: "click",
         }, {
-            trigger: '.o_kanban_record .o_kanban_record_title span:contains(Test Lead Propagation)',
+            trigger: '.o_kanban_record:contains(Test Lead Propagation)',
             content: 'Open the first lead',
             run: 'click',
         },

--- a/addons/crm/static/tests/tours/crm_forecast_tour.js
+++ b/addons/crm/static/tests/tours/crm_forecast_tour.js
@@ -54,14 +54,14 @@ registry.category("web_tour.tours").add('crm_forecast', {
         tooltipPosition: "bottom",
         run: "click"
     }, {
-        trigger: ".o_kanban_record .o_kanban_record_title:contains('Test Opportunity 1')",
+        trigger: ".o_kanban_record:contains('Test Opportunity 1')",
         content: "move to the next month",
         async run(helpers) {
             const undefined_groups = queryAll('.o_column_title:contains("None")').length;
             await helpers.drag_and_drop(`.o_opportunity_kanban .o_kanban_group:eq(${1 + undefined_groups})`);
         },
     }, {
-        trigger: ".o_kanban_record .o_kanban_record_title:contains('Test Opportunity 1')",
+        trigger: ".o_kanban_record:contains('Test Opportunity 1')",
         content: "edit lead",
         run: "click"
     }, {

--- a/addons/crm/static/tests/tours/crm_rainbowman.js
+++ b/addons/crm/static/tests/tours/crm_rainbowman.js
@@ -34,7 +34,7 @@ registry.category("web_tour.tours").add("crm_rainbowman", {
             run: "click",
         },
         {
-            trigger: ".o_kanban_record .o_kanban_record_title:contains('Test Lead 1')",
+            trigger: ".o_kanban_record:contains('Test Lead 1')",
             content: "move to won stage",
             run: "drag_and_drop (.o_opportunity_kanban .o_kanban_group:eq(3))",
         },
@@ -75,16 +75,16 @@ registry.category("web_tour.tours").add("crm_rainbowman", {
             run: "click",
         },
         {
-            trigger: ".o_kanban_record .o_kanban_record_title:contains('Test Lead 2')",
+            trigger: ".o_kanban_record:contains('Test Lead 2')",
         },
         {
             // move first test back to new stage to be able to test rainbowman a second time
-            trigger: ".o_kanban_record .o_kanban_record_title:contains('Test Lead 1')",
+            trigger: ".o_kanban_record:contains('Test Lead 1')",
             content: "move back to new stage",
             run: "drag_and_drop .o_opportunity_kanban .o_kanban_group:eq(0) ",
         },
         {
-            trigger: ".o_kanban_record .o_kanban_record_title:contains('Test Lead 2')",
+            trigger: ".o_kanban_record:contains('Test Lead 2')",
             content: "click on second lead",
             run: "click",
         },

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -389,38 +389,19 @@
             <field name="priority" eval="100"/>
             <field name="arch" type="xml">
                 <kanban class="o_kanban_mobile" archivable="false" js_class="crm_kanban" sample="1">
-                    <field name="name"/>
-                    <field name="contact_name"/>
-                    <field name="priority"/>
-                    <field name="tag_ids"/>
-                    <field name="user_id"/>
-                    <field name="activity_ids"/>
-                    <field name="activity_state"/>
                     <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}'/>
                     <templates>
-                        <t t-name="kanban-box">
-                            <div t-attf-class="oe_kanban_content oe_kanban_global_click">
-                                <div>
-                                    <strong class="o_kanban_record_title"><span><field name="name"/></span></strong>
+                        <t t-name="kanban-card">
+                            <field name="name" class="fw-bold fs-5"/>
+                            <field name="contact_name"/>
+                            <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                            <footer class="pt-1 mt-0 fs-6">
+                                <div class="d-flex mt-auto">
+                                    <field name="priority" widget="priority" class="me-2"/>
+                                    <field name="activity_ids" widget="kanban_activity"/>
                                 </div>
-                                <div>
-                                    <span class="o_kanban_record_subtitle"><field name="contact_name"/></span>
-                                </div>
-                                <div>
-                                  <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
-                                </div>
-                                <div class="o_kanban_record_bottom">
-                                    <div class="oe_kanban_bottom_left">
-                                        <field name="priority" widget="priority"/>
-                                        <div class="o_kanban_inline_block">
-                                            <field name="activity_ids" widget="kanban_activity"/>
-                                        </div>
-                                    </div>
-                                    <div class="oe_kanban_bottom_right">
-                                        <field name="user_id" widget="many2one_avatar_user" domain="[('share', '=', False)]"/>
-                                    </div>
-                                </div>
-                            </div>
+                                <field name="user_id" widget="many2one_avatar_user" domain="[('share', '=', False)]" class="ms-auto"/>
+                            </footer>
                         </t>
                     </templates>
                 </kanban>
@@ -535,21 +516,11 @@
             <field name="model">crm.lead</field>
             <field name="priority" eval="1"/>
             <field name="arch" type="xml">
-                <kanban default_group_by="stage_id" class="o_kanban_small_column o_opportunity_kanban" on_create="quick_create" quick_create_view="crm.quick_create_opportunity_form"
+                <kanban  highlight_color="color" default_group_by="stage_id" class="o_kanban_small_column o_opportunity_kanban" on_create="quick_create" quick_create_view="crm.quick_create_opportunity_form"
                     archivable="false" sample="1" js_class="crm_kanban">
-                    <field name="stage_id" options='{"group_by_tooltip": {"requirements": "Description"}}'/>
                     <field name="probability"/>
-                    <field name="color"/>
-                    <field name="priority"/>
-                    <field name="expected_revenue"/>
-                    <field name="activity_date_deadline"/>
-                    <field name="user_id"/>
-                    <field name="partner_id"/>
-                    <field name="activity_summary"/>
                     <field name="active"/>
                     <field name="company_currency"/>
-                    <field name="activity_state" />
-                    <field name="activity_ids" />
                     <field name="recurring_revenue_monthly"/>
                     <field name="team_id"/>
                     <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}'
@@ -557,55 +528,34 @@
                         help="This bar allows to filter the opportunities based on scheduled activities."/>
                     <templates>
                         <t t-name="kanban-menu">
-                            <t t-if="widget.editable"><a role="menuitem" type="edit" class="dropdown-item">Edit</a></t>
+                            <t t-if="widget.editable"><a role="menuitem" type="open" class="dropdown-item">Edit</a></t>
                             <t t-if="widget.deletable"><a role="menuitem" type="delete" class="dropdown-item">Delete</a></t>
-                            <ul class="oe_kanban_colorpicker" data-field="color"/>
+                            <field name="color" widget="kanban_color_picker"/>
                         </t>
-                        <t t-name="kanban-box">
+                        <t t-name="kanban-card">
                             <t t-set="lost_ribbon" t-value="!record.active.raw_value and record.probability and record.probability.raw_value == 0"/>
-                            <div t-attf-class="#{!selection_mode ? kanban_color(record.color.raw_value) : ''} #{lost_ribbon ? 'oe_kanban_card_ribbon' : ''} oe_kanban_global_click oe_kanban_card d-flex flex-column">
-                                <div class="ribbon ribbon-top-right"
-                                    invisible="probability &gt; 0 or active">
-                                    <span class="text-bg-danger">Lost</span>
-                                </div>
-
-                                <div class="oe_kanban_content flex-grow-1">
-                                    <div class="oe_kanban_details">
-                                        <strong class="o_kanban_record_title"><field name="name"/></strong>
-                                    </div>
-                                    <div class="o_kanban_record_subtitle">
-                                        <t t-if="record.expected_revenue.raw_value">
-                                            <field name="expected_revenue" widget="monetary" options="{'currency_field': 'company_currency'}"/>
-                                            <span t-if="record.recurring_revenue and record.recurring_revenue.raw_value" groups="crm.group_use_recurring_revenues"> + </span>
-                                        </t>
-                                        <t t-if="record.recurring_revenue and record.recurring_revenue.raw_value">
-                                            <field class="me-1" name="recurring_revenue" widget="monetary" options="{'currency_field': 'company_currency'}" groups="crm.group_use_recurring_revenues"/>
-                                            <field name="recurring_plan" groups="crm.group_use_recurring_revenues"/>
-                                        </t>
-                                    </div>
-                                    <div>
-                                        <span class="o_text_overflow" t-if="record.partner_id.value" t-esc="record.partner_id.value"></span>
-                                    </div>
-                                    <div>
-                                        <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
-                                    </div>
-                                    <div>
-                                        <field name="lead_properties" widget="properties"/>
-                                    </div>
-                                </div>
-                                <div class="oe_kanban_footer">
-                                    <div class="o_kanban_record_bottom">
-                                        <div class="oe_kanban_bottom_left">
-                                            <field name="priority" widget="priority" groups="base.group_user"/>
-                                            <field name="activity_ids" widget="kanban_activity"/>
-                                        </div>
-                                        <div class="oe_kanban_bottom_right">
-                                            <field name="user_id" widget="many2one_avatar_user" domain="[('share', '=', False)]"/>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div class="clearfix"/>
+                            <widget name="web_ribbon" title="lost" bg_color="text-bg-danger" invisible="probability &gt; 0 or active"/>
+                            <field class="fw-bold fs-5" name="name"/>
+                            <div>
+                                <t t-if="record.expected_revenue.raw_value">
+                                    <field name="expected_revenue" widget="monetary" options="{'currency_field': 'company_currency'}"/>
+                                    <span t-if="record.recurring_revenue and record.recurring_revenue.raw_value" groups="crm.group_use_recurring_revenues"> + </span>
+                                </t>
+                                <t t-if="record.recurring_revenue and record.recurring_revenue.raw_value">
+                                    <field class="me-1" name="recurring_revenue" widget="monetary" options="{'currency_field': 'company_currency'}" groups="crm.group_use_recurring_revenues"/>
+                                    <field name="recurring_plan" groups="crm.group_use_recurring_revenues"/>
+                                </t>
                             </div>
+                            <field name="partner_id" class="text-truncate" />
+                            <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                            <field name="lead_properties" widget="properties"/>
+                            <footer class="fs-6 pt-1">
+                                <div class="d-flex mt-auto align-items-center">
+                                    <field name="priority" widget="priority" groups="base.group_user" class="me-2"/>
+                                    <field name="activity_ids" widget="kanban_activity"/>
+                                </div>
+                                <field name="user_id" widget="many2one_avatar_user" domain="[('share', '=', False)]" class="ms-auto"/>
+                            </footer>
                         </t>
                     </templates>
                 </kanban>
@@ -640,22 +590,12 @@
                 <xpath expr="//t[@t-set='lost_ribbon']" position="after">
                     <t t-set="won_ribbon" t-value="record.active.raw_value and record.probability and record.probability.raw_value == 100"/>
                 </xpath>
-                <xpath expr="//div[contains(@t-attf-class, 'oe_kanban_card')]" position="attributes">
-                    <attribute name="t-attf-class">
-                        #{!selection_mode ? kanban_color(record.color.raw_value) : ''}
-                        #{lost_ribbon || won_ribbon ? 'oe_kanban_card_ribbon' : ''}
-                        oe_kanban_global_click oe_kanban_card d-flex flex-column
-                    </attribute>
+                <xpath expr="//widget" position="replace">
+                    <widget t-if="won_ribbon" name="web_ribbon" title="Won" bg_color="text-bg-success" invisible="(probability &gt; 0 or active) and (probability &lt; 100 or not active)"/>
+                    <widget t-if="lost_ribbon" name="web_ribbon" title="Lost" bg_color="text-bg-danger" invisible="(probability &gt; 0 or active) and (probability &lt; 100 or not active)"/>
                 </xpath>
-                <xpath expr="//div[hasclass('ribbon')]" position="replace">
-                    <div class="ribbon ribbon-top-right"
-                        invisible="(probability &gt; 0 or active) and (probability &lt; 100 or not active)">
-                        <span t-if="won_ribbon" class="text-bg-success">Won</span>
-                        <span t-elif="lost_ribbon" class="text-bg-danger">Lost</span>
-                    </div>
-                </xpath>
-                <xpath expr="//div[hasclass('o_kanban_record_subtitle')]" position="replace">
-                    <div class="o_kanban_record_subtitle">
+                <xpath expr="//div" position="replace">
+                    <div>
                         <t t-if="record.prorated_revenue.raw_value">
                             <field name="prorated_revenue" widget="monetary" options="{'currency_field': 'company_currency'}"/>
                             <span t-if="record.recurring_revenue and record.recurring_revenue.raw_value" groups="crm.group_use_recurring_revenues"> + </span>

--- a/addons/website_crm_partner_assign/views/crm_lead_views.xml
+++ b/addons/website_crm_partner_assign/views/crm_lead_views.xml
@@ -181,18 +181,13 @@
             <field name="model">crm.lead</field>
             <field name="inherit_id" ref="crm.crm_case_kanban_view_leads"/>
             <field name="arch" type="xml">
-                <field name="user_id" position="after">
-                    <field name="partner_assigned_id"/>
-                </field>
-                <xpath expr="//span[@t-esc='record.partner_id.value']" position="replace">
-                    <span class="o_text_overflow"
-                        t-esc="record.partner_id.value"
-                        t-att-title="record.partner_id.value"
-                        t-if="record.partner_id.value"/>
-                    <span class="o_text_overflow ms-1" t-if="record.partner_assigned_id.value">
+                <xpath expr="//field[@name='partner_id']" position="replace">
+                    <span t-att-title="record.partner_id.value">
+                        <field class="text-truncate" name="partner_id"/>
+                    </span>
+                    <span class="text-truncate ms-1" t-if="record.partner_assigned_id.value">
                         (<i class="fa fa-long-arrow-right me-1" aria-label="Assigned Partner" title="Assigned Partner"/>
-                        <span t-att-title="record.partner_assigned_id.value"
-                            t-esc="record.partner_assigned_id.value"/>)
+                        <span t-att-title="record.partner_assigned_id.value"><field name="partner_assigned_id"/></span>)
                     </span>
                 </xpath>
             </field>


### PR DESCRIPTION

In this commit we have simplified the kanban arch for the board,calendar, crm and website_crm_partner_assign module.the goal is to simplify them, make them easier to read,and use bootstrap utility classnames.
- Previously, we used `kanban-box`, but now we are using `kanban-card` instead.
- Deprecated `oe_kanban_global_click` and `oe_kanban_global_click_edit`.
- More use of `<field/>` tags
- Removed the `oe_kanban_colorpicker` class and replaced it with the `kanban_color_picker` widget.
- Changed type='edit' to type='open' to open records. since version 16, records always open in edit mode by default.
- `kanban_image` from rendering context, is deprecated so we use `<field name="..." widget="image"/>` instead
- `kanban_color`, `kanban_getcolor` and `kanban_getcolorname` are deprecated use new attribute `highlight_color="color_field_name"` on root node
- `oe_kanban_colorpicker` is deprecated, use kanban_color_picker widget instead

Task-3992107

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
