### PR TITLE
[FIX] account: perf of journal item search panel

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1638,10 +1638,9 @@ class AccountMoveLine(models.Model):
         query_str, query_param = query.select()
         self.env.cr.execute(f"""
             SELECT account.root_id
-              FROM account_account account,
-                   LATERAL ({query_str}) line
-             WHERE account.company_id IN %s
-        """, query_param + [tuple(self.env.companies.ids)])
+              FROM account_account account
+             WHERE EXISTS ({query_str})
+        """, query_param)
         return {
             root.id: {'id': root.id, 'display_name': root.display_name}
             for root in self.env['account.root'].browse(id for [id] in self.env.cr.fetchall())


### PR DESCRIPTION
The LATERAL was destroying perfs to compute the account roots. 
It took more than 7 sec on a db that only had 660k move lines. 
Replaced it by a simple JOIN which reduced it to 1.2 sec.





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
