### PR TITLE
[FIX] core: fix html_translate nbsp

### DIFF
--- a/odoo/addons/base/tests/test_translate.py
+++ b/odoo/addons/base/tests/test_translate.py
@@ -314,6 +314,12 @@ class TranslationToolsTestCase(BaseCase):
         result = html_translate(lambda term: term, source)
         self.assertEqual(result, source)
 
+    def test_translate_html_nbsp(self):
+        """ Test html_translate(). """
+        source = """<blockquote>A&nbsp;<h2>B&#160</h2>\xa0C</blockquote>"""
+        result = html_translate(lambda term: term, source)
+        self.assertEqual(result, '<blockquote>A&nbsp;<h2>B&nbsp;</h2>&nbsp;C</blockquote>')
+
     def test_translate_html_i(self):
         """ Test xml_translate() and html_translate() with <i> elements. """
         source = """<p>A <i class="fa-check"></i> B</p>"""

--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -344,7 +344,7 @@ def html_translate(callback, value):
         root = parse_html("<div>%s</div>" % value)
         result = translate_xml_node(root, callback, parse_html, serialize_html)
         # remove tags <div> and </div> from result
-        value = serialize_html(result)[5:-6]
+        value = serialize_html(result)[5:-6].replace('\xa0', '&nbsp;')
     except ValueError:
         _logger.exception("Cannot translate malformed HTML, using source value instead")
 


### PR DESCRIPTION
the fix replaces the `\xa0` with `&nbsp;` for html translated values and keeps the consistent logic as odoo/odoo#110148

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
