### PR TITLE
[FIX] account: always show sales tax on product form

### DIFF
--- a/addons/account/views/product_view.xml
+++ b/addons/account/views/product_view.xml
@@ -71,8 +71,8 @@
                     </page>
                 </page>
                 <div name="list_price_uom" position="after">
-                    <label for="taxes_id" invisible="not sale_ok"/>
-                    <div name="taxes_div" class="o_row" invisible="not sale_ok">
+                    <label for="taxes_id"/>
+                    <div name="taxes_div" class="o_row">
                         <field name="taxes_id"
                             widget="many2many_tags"
                             class="oe_inline"


### PR DESCRIPTION
Before this fix:
Sales tax was only shown on products marked as 'saleable', causing issues for products used for discounts, shipping, etc., which need default tax regardless of sales status.

After this fix:
Sales Tax is always displayed on the product form.

Task:4008793

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr