### PR TITLE
[FIX] spreadsheet: restore copy of mapIterator

### DIFF
--- a/addons/spreadsheet/static/src/pivot/pivot_model.js
+++ b/addons/spreadsheet/static/src/pivot/pivot_model.js
@@ -585,7 +585,7 @@ export class SpreadsheetPivotModel extends PivotModel {
             indent,
         });
 
-        const subTreeKeys = tree.sortedKeys || tree.directSubTrees.keys();
+        const subTreeKeys = tree.sortedKeys || [...tree.directSubTrees.keys()];
         subTreeKeys.forEach((subTreeKey) => {
             const subTree = tree.directSubTrees.get(subTreeKey);
             rows.push(...this._getSpreadsheetRows(subTree));


### PR DESCRIPTION
This commit fixes an issue introduced by https://github.com/odoo/odoo/pull/170159. forEach is not available for mapIterator on non-chromium based browser.

opw-4008053

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
