### PR TITLE
[FIX] website_slides: quiz question form generated upon page refresh

### DIFF
--- a/addons/website_slides/static/src/js/slides_course_quiz.js
+++ b/addons/website_slides/static/src/js/slides_course_quiz.js
@@ -427,7 +427,7 @@
          * @private
          */
         _checkLocationHref: function () {
-            if (window.location.href.includes('quiz_quick_create')) {
+            if (window.location.href.includes('quiz_quick_create') && this.quiz.questionsCount === 0) {
                 this._onCreateQuizClick();
             }
         },


### PR DESCRIPTION
### How to reproduce

1. Go to website slides.
2. Add a new Quiz content.
3. Add a question.
4. Save it.	​	​
5. Now refresh the page.

### Issue

It initialize a new QuestionFormWidget to input a new question.

### After this commit

The QuestionFormWidget should not initialize if the question is created and saved.

---

Task-3997404