### PR TITLE
[IMP] account, sale: Hide tax column for US & BR based companies

### DIFF
--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -190,6 +190,11 @@ class ResCompany(models.Model):
             ('out_and_in_invoices', 'Customer Invoices and Vendor Bills')],
         string="Quick encoding")
 
+    show_invoice_tax = fields.Boolean(
+        compute='_compute_show_invoice_tax',
+        export_string_translation=False,
+    )
+
     # Separate account for allocation of discounts
     account_discount_income_allocation_id = fields.Many2one(comodel_name='account.account', string='Separate account for income discount')
     account_discount_expense_allocation_id = fields.Many2one(comodel_name='account.account', string='Separate account for expense discount')
@@ -210,6 +215,12 @@ class ResCompany(models.Model):
         invalidation_fields = super().cache_invalidation_fields()
         invalidation_fields.add('check_account_audit_trail')
         return invalidation_fields
+
+    @api.depends('account_fiscal_country_id')
+    def _compute_show_invoice_tax(self):
+        """To override in order to make 'show_invoice_tax' used by different localization package e.g,. USA and Brazil"""
+        for record in self:
+            record.show_invoice_tax = True
 
     @api.constrains('account_opening_move_id', 'fiscalyear_last_day', 'fiscalyear_last_month')
     def _check_fiscalyear_last_day(self):

--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -102,6 +102,7 @@
                             </div>
                         </div>
 
+                        <t t-set="show_tax" t-value="o.company_id.show_invoice_tax"/>
                         <t t-set="display_discount" t-value="any(l.discount for l in o.invoice_line_ids)"/>
                         <div class="oe_structure"></div>
                         <table class="table table-sm o_main_table table-borderless" name="invoice_line_table">
@@ -113,7 +114,7 @@
                                     <th name="th_discount" t-if="display_discount" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
                                         <span>Disc.%</span>
                                     </th>
-                                    <th name="th_taxes" t-attf-class="text-start {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}"><span>Taxes</span></th>
+                                    <th t-if="show_tax" name="th_taxes" t-attf-class="text-start {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}"><span>Taxes</span></th>
                                     <th name="th_subtotal" class="text-end">
                                         <span>Amount</span>
                                     </th>
@@ -143,10 +144,12 @@
                                             <td name="td_discount" t-if="display_discount" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
                                                 <span class="text-nowrap" t-field="line.discount">0</span>
                                             </td>
-                                            <t t-set="taxes" t-value="', '.join([(tax.invoice_label or tax.name) for tax in line.tax_ids])"/>
-                                            <td name="td_taxes" t-attf-class="text-start {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }} {{ 'text-nowrap' if len(taxes) &lt; 10 else '' }}">
-                                                <span t-out="taxes" id="line_tax_ids">Tax 15%</span>
-                                            </td>
+                                            <t t-if="show_tax">
+                                                <t t-set="taxes" t-value="', '.join([(tax.invoice_label or tax.name) for tax in line.tax_ids])"/>
+                                                <td name="td_taxes" t-attf-class="text-start {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }} {{ 'text-nowrap' if len(taxes) &lt; 10 else '' }}">
+                                                    <span t-out="taxes" id="line_tax_ids">Tax 15%</span>
+                                                </td>
+                                            </t>
                                             <td name="td_subtotal" class="text-end o_price_total">
                                                 <span class="text-nowrap" t-field="line.price_subtotal">27.00</span>
                                             </td>

--- a/addons/sale/report/ir_actions_report_templates.xml
+++ b/addons/sale/report/ir_actions_report_templates.xml
@@ -67,6 +67,7 @@
 
             <!-- Is there a discount on at least one line? -->
             <t t-set="lines_to_report" t-value="doc._get_order_lines_to_report()"/>
+            <t t-set="show_tax" t-value="doc.company_id.show_invoice_tax"/>
             <t t-set="display_discount" t-value="any(l.discount for l in lines_to_report)"/>
 
             <div class="oe_structure"></div>
@@ -80,7 +81,7 @@
                         <th name="th_discount" t-if="display_discount" class="text-end">
                             <span>Disc.%</span>
                         </th>
-                        <th name="th_taxes" class="text-end">Taxes</th>
+                        <th t-if="show_tax" name="th_taxes" class="text-end">Taxes</th>
                         <th name="th_subtotal" class="text-end">
                             <span>Amount</span>
                         </th>
@@ -110,10 +111,12 @@
                                 <td t-if="display_discount" class="text-end">
                                     <span t-field="line.discount">-</span>
                                 </td>
-                                <t t-set="taxes" t-value="', '.join([(tax.invoice_label or tax.name) for tax in line.tax_id])"/>
-                                <td name="td_taxes" t-attf-class="text-end {{ 'text-nowrap' if len(taxes) &lt; 10 else '' }}">
-                                    <span t-out="taxes">Tax 15%</span>
-                                </td>
+                                <t t-if="show_tax">
+                                    <t t-set="taxes" t-value="', '.join([(tax.invoice_label or tax.name) for tax in line.tax_id])"/>
+                                    <td name="td_taxes" t-attf-class="text-end {{ 'text-nowrap' if len(taxes) &lt; 10 else '' }}">
+                                        <span t-out="taxes">Tax 15%</span>
+                                    </td>
+                                </t>
                                 <td t-if="not line.is_downpayment" name="td_subtotal" class="text-end o_price_total">
                                     <span t-field="line.price_subtotal">27.00</span>
                                 </td>

--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -515,6 +515,7 @@
                     </div>
                 </t>
 
+                <t t-set="show_tax" t-value="sale_order.company_id.show_invoice_tax"/>
                 <t t-set="display_discount" t-value="True in [line.discount > 0 for line in sale_order.order_line]"/>
 
                 <div class="table-responsive">
@@ -529,7 +530,7 @@
                                 <th t-if="display_discount" t-attf-class="text-end {{ 'd-none d-sm-table-cell' if report_type == 'html' else '' }}">
                                     <span>Disc.%</span>
                                 </th>
-                                <th t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}" id="taxes_header">
+                                <th t-if="show_tax" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}" id="taxes_header">
                                     <span>Taxes</span>
                                 </th>
                                 <th class="text-end" id="subtotal_header">
@@ -573,7 +574,7 @@
                                                 <t t-out="((line.discount % 1) and '%s' or '%d') % line.discount"/>%
                                             </strong>
                                         </td>
-                                        <td t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}" id="taxes">
+                                        <td t-if="show_tax" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}" id="taxes">
                                             <span t-out="', '.join(map(lambda x: (x.name), line.tax_id))"/>
                                         </td>
                                         <td t-if="not line.is_downpayment" class="text-end" id="subtotal">


### PR DESCRIPTION
[IMP] account, sale: Hide tax column for US & BR based companies

in some scenarios users can see several taxes listed in the "Taxes" column in the PDF report (for SO, quotes, invoices, etc).
Having the column oversaturated with all the taxes can represent a problem for our users.

it's a pain currently and we predict that we are going to receive this kind of request also for other countries
and in case of mutlti-company we enforce the company be a USA/Brazil country base

Solution:
1- Add new stored column to control showing the tax column through allowing any module to overwrite it.
2- Use the new column 'show_tax_column' to hide the tax column in portal preview and PDF report for US/BR that has avatax active

Task-3864811

enterprise-pr#https://github.com/odoo/enterprise/pull/65409

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr