### PR TITLE
[FIX] account: keep is_move_sent value when move reverted to draft 

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4609,7 +4609,7 @@ class AccountMove(models.Model):
             move.mapped('line_ids.analytic_line_ids').unlink()
 
         self.mapped('line_ids').remove_move_reconcile()
-        self.write({'state': 'draft', 'is_move_sent': False})
+        self.state = 'draft'
 
     def button_hash(self):
         self._hash_moves(force_hash=True)

--- a/addons/account/tests/test_account_move_send.py
+++ b/addons/account/tests/test_account_move_send.py
@@ -1057,3 +1057,20 @@ class TestAccountMoveSend(TestAccountMoveSendCommon):
 
         self.assertTrue(self._get_mail_message(invoice))  # email was sent
         self.assertEqual(res['type'], 'ir.actions.act_window_close')  # the download which is a default value didn't happen
+
+    def test_is_move_sent_state(self):
+        # Post a move, nothing sent yet
+        invoice = self.init_invoice("out_invoice", amounts=[1000], post=True)
+        self.assertFalse(invoice.is_move_sent)
+        # Send via send & print
+        wizard = self.create_send_and_print(invoice)
+        wizard.action_send_and_print()
+        self.assertTrue(invoice.is_move_sent)
+        # Revert move to draft
+        invoice.button_draft()
+        self.assertTrue(invoice.is_move_sent)
+        # Unlink PDF
+        pdf_report = invoice.invoice_pdf_report_id
+        self.assertTrue(pdf_report)
+        invoice.invoice_pdf_report_id.unlink()
+        self.assertTrue(invoice.is_move_sent)


### PR DESCRIPTION
Current Behavior:
When an invoice is sent via Send & Print, is_move_sent is set to True. If the move is reverted to draft, is_move_sent is set to False. After that, if the invoice is resent via Send & Print, is_move_sent is not set to True again.

To reproduce:
1. Optional: add the field is_move_sent to the view, to see its value
2. Create and confirm an invoice (is_move_sent = False)
3. Send it via the Send & Print button (is_move_sent = True)
4. Reset move to draft (is_move_sent = False)
5. Confirm and send it again (is_move_sent = False)

Desired behavior:
is_move_sent should be set to True after being sent via Send & Print, even if it is not the first time the invoice is being sent.

Fix:
Update is_send_move in account_move_send.py, in function _process_send_and_print. This function already loops through the moves and, if there was no error in sending, updates send_and_print_values. After that, we can also update is_move_sent.

task-3997538

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
