### PR TITLE
[FIX] stock: prevent a traceback if product is empty in stock move

### DIFF
--- a/addons/stock/i18n/stock.pot
+++ b/addons/stock/i18n/stock.pot
@@ -5147,6 +5147,12 @@ msgid "No operations found. Let's create a transfer!"
 msgstr ""
 
 #. module: stock
+#. odoo-python
+#: code:addons/stock/models/stock_move.py:0
+msgid "No product found to generate Serials/Lots for."
+msgstr ""
+
+#. module: stock
 #: model_terms:ir.actions.act_window,help:stock.product_template_action_product
 msgid "No product found. Let's create one!"
 msgstr ""

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -192,11 +192,12 @@ class StockMove(models.Model):
         for move in self:
             move.product_uom = move.product_id.uom_id.id
 
-    @api.depends('has_tracking', 'picking_type_id.use_create_lots', 'picking_type_id.use_existing_lots')
+    @api.depends('has_tracking', 'picking_type_id.use_create_lots', 'picking_type_id.use_existing_lots', 'product_id')
     def _compute_display_assign_serial(self):
         for move in self:
             move.display_import_lot = (
                 move.has_tracking != 'none' and
+                move.product_id and
                 move.picking_type_id.use_create_lots and
                 not move.origin_returned_move_id.id and
                 move.state not in ('done', 'cancel')
@@ -888,6 +889,8 @@ Please change the quantity done or the rounding precision of your unit of measur
 
     @api.model
     def action_generate_lot_line_vals(self, context, mode, first_lot, count, lot_text):
+        if not context.get('default_product_id'):
+            raise UserError(_("No product found to generate Serials/Lots for."))
         assert mode in ('serial', 'import')
         default_vals = {}
         # Get default values


### PR DESCRIPTION
This error occurs when we keep the product name empty in the stock move and try to generate the Serials/Lots by clicking on ``Generate Serials/Lots``.

Steps to reproduce:
- Install the ``stock`` module
- Create a new product(eg: test) and set its tracking ``By Lots`` in Traceability
- Create a new receipt and add ``test`` as product and ``Mark as ToDo``
- Again add ``test`` as the product and on the right, click on ``bars(fa-icon)``
- Remove the product name > click on ``Generate Serials/Lots``
- Click on ``Generate``

Traceback: 
``KeyError 'product_id'``

This error occurs at [1] because ``product_id`` is not present in the default values.

This commit will fix the above error by not showing the ``Generate Serials/Lots`` and ``Import Serials/Lots`` buttons when ``product`` is empty and also will raise an error if ``product`` is not found.

[1]: https://github.com/odoo/odoo/blob/b1ba4018f91f1fd788f48180bd5fc4656ab1e35c/addons/stock/models/stock_move.py#L930

sentry-5072366645

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
