### PR TITLE
[FIX] tools: prevent traceback when uploading corrupted image

### DIFF
--- a/odoo/tools/image.py
+++ b/odoo/tools/image.py
@@ -422,7 +422,10 @@ def image_fix_orientation(image):
     """
     getexif = getattr(image, 'getexif', None) or getattr(image, '_getexif', None)  # support PIL < 6.0
     if getexif:
-        exif = getexif()
+        try:
+            exif = getexif()
+        except SyntaxError:
+            raise UserError(_("This file could not be decoded as an image file. Please try with a different file."))
         if exif:
             orientation = exif.get(EXIF_TAG_ORIENTATION, 0)
             for method in EXIF_TAG_ORIENTATION_TO_TRANSPOSE_METHODS.get(orientation, []):


### PR DESCRIPTION
When user uploads the corrupted image in product.
a traceback will appear.

Steps to reproduce the issue.
- Create a new product > Upload a corrupted file in the product image
  ex.(https://tinyurl.com/2mazelw3)
- Save

Error: A traceback appears:
'SyntaxError: not a TIFF file (header b'Exif\x00\x00MM' not valid)'

Try-catch is added to catch the syntaxerror when the user tries
to upload the corrupted image.

sentry-5528394249

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
