### PR TITLE
[FIX] project: correctly pass the context

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -782,7 +782,7 @@ class Project(models.Model):
         favorite_projects.write({'favorite_user_ids': [(3, self.env.uid)]})
 
     def action_view_tasks(self):
-        action = self.env['ir.actions.act_window'].with_context({'active_id': self.id})._for_xml_id('project.act_project_project_2_project_task_all')
+        action = self.env['ir.actions.act_window'].with_context(active_id=self.id)._for_xml_id('project.act_project_project_2_project_task_all')
         action['display_name'] = _("%(name)s", name=self.name)
         context = action['context'].replace('active_id', str(self.id))
         context = ast.literal_eval(context)


### PR DESCRIPTION
Steps to reproduce: 
- install project app
- create project without any task
- change the language

Issue: The helper string is not being translated.
    
Reason: 
This issue occurs because the existing context is lost, particularly 
the `lang` variable, which impacts the translation functionality.
    
Solution:
In this commit, we have updated the method from 
with_context({'active_id': self.id}) to with_context(active_id=self.id).
This fix ensures that the previous context is retained.

task-3940540
