### PR TITLE
[FIX] stock: avoid reservation by setting quantity on done move

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -375,6 +375,8 @@ class StockMove(models.Model):
 
         err = []
         for move in self:
+            if move.state == 'done':
+                continue
             uom_qty = float_round(move.quantity, precision_rounding=move.product_uom.rounding, rounding_method='HALF-UP')
             precision_digits = self.env['decimal.precision'].precision_get('Product Unit of Measure')
             qty = float_round(move.quantity, precision_digits=precision_digits, rounding_method='HALF-UP')


### PR DESCRIPTION
### Steps to reproduce:

- Create a product P
- Click on "on hand" and add 10 units in stock
- Create and validate picking for 1 x any other product
- Unlock the delivery
- Add a line (stock move) for 1 x P
- Set the quantity of the move to 5
- Save the picking
- Go to the on hand quantity of P

#### > only 5 units remain in stock

### Cause of the issue:

Updating the quantity of a stock move will trigger the `_set_quantity` inverse method which is going to create stock move lines according to the change of quantity:
https://github.com/odoo/odoo/blob/ea39f5f8e9e86ad8138acaf8e95f057e7d97e3cd/addons/stock/models/stock_move.py#L388-L391

Follow up of commit f9b1329

opw-3906472
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
