### PR TITLE
[FIX] point_of_sale, pos_loyalty: correctly handle ui state in models

### DIFF
--- a/addons/point_of_sale/static/src/app/models/data_service.js
+++ b/addons/point_of_sale/static/src/app/models/data_service.js
@@ -91,9 +91,8 @@ export class PosData extends Reactive {
         // This methods will add uiState to the serialized object
         const dataFormatter = (record) => {
             const serializedData = record.serialize();
-            const uiState =
-                typeof record.uiState === "object" ? JSON.stringify(record.uiState) : "{}";
-            return { ...serializedData, JSONuiState: uiState, id: record.id };
+            const uiState = typeof record.uiState === "object" ? record.serializeState() : "{}";
+            return { ...serializedData, JSONuiState: JSON.stringify(uiState), id: record.id };
         };
 
         for (const model of this.opts.databaseTable) {
@@ -149,7 +148,7 @@ export class PosData extends Reactive {
                     const loadedRecords = this.models[model].find((r) => r.uuid === record.uuid);
 
                     if (loadedRecords) {
-                        loadedRecords.uiState = JSON.parse(record.raw.JSONuiState);
+                        loadedRecords.setupState(JSON.parse(record.raw.JSONuiState));
                     }
                 }
             }

--- a/addons/point_of_sale/static/src/app/models/related_models.js
+++ b/addons/point_of_sale/static/src/app/models/related_models.js
@@ -155,6 +155,15 @@ export class Base {
             }
         }
     }
+
+    setupState(vals) {
+        this.uiState = vals;
+    }
+
+    serializeState() {
+        return { ...this.uiState };
+    }
+
     update(vals) {
         this.model.update(this, vals);
     }
@@ -767,7 +776,7 @@ export function createRelatedModels(modelDefs, modelClasses = {}, indexes = {}) 
             const newRec = this.loadData({ [model]: data });
             for (const record of newRec[model]) {
                 if (uiState[record[key]]) {
-                    record.uiState = uiState[record[key]];
+                    record.setupState(uiState[record[key]]);
                 }
             }
 

--- a/addons/pos_loyalty/static/src/overrides/models/pos_order.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_order.js
@@ -94,7 +94,15 @@ patch(PosOrder.prototype, {
             }
         }
     },
-
+    setupState(vals) {
+        super.setupState(...arguments);
+        this.uiState.disabledRewards = new Set(vals.disabledRewards);
+    },
+    serializeState() {
+        const state = super.serializeState(...arguments);
+        state.disabledRewards = [...this.uiState.disabledRewards];
+        return state;
+    },
     /** @override */
     getEmailItems() {
         return super


### PR DESCRIPTION
When a model is created in the client side, it can sometime contain Set which isn't JSON serializable. So we need to process the state of the model before sending it to IndexedDB.

This commit fix this issue by adding a method to the base model to process the state of the model before sending it to IndexedDB.


