### PR TITLE
[FIX] base: allow readonly on write actions

### DIFF
--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -661,8 +661,6 @@ class IrActionsServer(models.Model):
                     raise ValidationError(_("The path to the field to update contains a non-relational field (%s) that is not the last field in the path. You can't traverse non-relational fields (even in the quantum realm). Make sure only the last field in the path is non-relational.", field_name))
                 if isinstance(field, fields.Json):
                     raise ValidationError(_("I'm sorry to say that JSON fields (such as %s) are currently not supported.", field_name))
-                elif field.readonly:
-                    raise ValidationError(_("The field to update (%s) is read-only. You can't update a read-only field - even when asking nicely.", field_name))
         target_records = None
         if record is not None:
             target_records = reduce(getitem, path[:-1], record)

--- a/odoo/addons/base/tests/test_ir_actions.py
+++ b/odoo/addons/base/tests/test_ir_actions.py
@@ -293,20 +293,25 @@ ZeroDivisionError: division by zero""" % self.test_server_action.id
         # Test: partner updated
         self.assertEqual(self.test_partner.country_id.name, 'TestUpdatedCountry', 'ir_actions_server: country name should have been updated through relation')
 
+        # update a readonly field
+        self.action.write({
+            'state': 'object_write',
+            'update_path': 'country_id.image_url',
+            'value': "/base/static/img/country_flags/be.png",
+        })
+        self.assertEqual(self.test_partner.country_id.image_url, "/base/static/img/country_flags/ty.png", 'ir_actions_server: country flag has this value before the update')
+        run_res = self.action.with_context(self.context).run()
+        self.assertFalse(run_res, 'ir_actions_server: update record action correctly finished should return False')
+        # Test: partner updated
+        self.assertEqual(self.test_partner.country_id.image_url, "/base/static/img/country_flags/be.png", 'ir_actions_server: country should have been updated through a readonly field')
+        self.assertEqual(self.test_partner.country_id.code, "TY", 'ir_actions_server: country code is still TY')
+
         # input an invalid path
         with self.assertRaises(ValidationError):
             self.action.write({
                 'state': 'object_write',
                 'update_path': 'country_id.name.foo',
                 'value': 'DoesNotMatter',
-            })
-            self.action.flush_recordset(['update_path', 'update_field_id'])
-
-        # update a readonly field
-            self.action.write({
-                'state': 'object_write',
-                'update_path': 'country_id.id',
-                'value': 0,
             })
             self.action.flush_recordset(['update_path', 'update_field_id'])
 


### PR DESCRIPTION
Since the automation revamp, it is not possible to update read-only fields without executing Python code.

This commit removes this limitation as some use-cases are useful:
- Automatically update the invoice status of SO when an action is executed.
- Force the SO status to "sent" without sending the email.

Task: 3983645