### PR TITLE
[IMP] l10n_co: default to anglo-saxon accounting

### DIFF
--- a/addons/l10n_co/models/template_co.py
+++ b/addons/l10n_co/models/template_co.py
@@ -19,6 +19,7 @@ class AccountChartTemplate(models.AbstractModel):
     def _get_co_res_company(self):
         return {
             self.env.company.id: {
+                'anglo_saxon_accounting': True,
                 'account_fiscal_country_id': 'base.co',
                 'bank_account_code_prefix': '1110',
                 'cash_account_code_prefix': '1105',


### PR DESCRIPTION
Anglo-Saxon accounting is the main system used in Colombia, this commit enables it by default when installing `l10n_co`.

This configuration is only accessible in Debug mode in the `Settings` -> `Bank and Cash` section, so during the implementation it doesn't get much visibility. 

Setting the correct default for the localization helps prevent re-implementations and reduces accounting errors for companies. At present, the impact of this configuration can only be assessed after going live.

[Task link](https://www.odoo.com/odoo/project.task/3990709)
task-3990709