### PR TITLE
[IMP] mail: deleting attachment card in composer on mobile device.

### DIFF
--- a/addons/mail/static/src/core/common/attachment_list.scss
+++ b/addons/mail/static/src/core/common/attachment_list.scss
@@ -1,5 +1,10 @@
-.o-mail-AttachmentCard-unlink.o-inComposer {
-    transform: translateX(100%);
+@media (hover: hover) {
+    .o-mail-AttachmentCard-unlink.o-inComposer {
+        transform: translateX(100%);
+    }
+    .o-mail-AttachmentCard-aside:hover .o-mail-AttachmentCard-unlink.o-inComposer {
+        transform: translateX(0);
+    }
 }
 
 .o-mail-AttachmentCard-aside {
@@ -10,10 +15,6 @@
     &.o-hasMultipleActions {
         min-width: 30px;
     }
-}
-
-.o-mail-AttachmentCard-aside:hover .o-mail-AttachmentCard-unlink.o-inComposer {
-    transform: translateX(0);
 }
 
 .o-mail-AttachmentList-in-composer {


### PR DESCRIPTION
Before this PR and attachments (other than an image) could not be deleted from the composer.
This is because touch device cannot trigger the animation that shows the delete button.

This PR removes the animation and always shows the delete button on touch device.

![image](https://github.com/odoo/odoo/assets/1810149/2ceae79e-335b-4bf4-9f85-19041a68d74a)

