### PR TITLE
[REF] discuss: Peer to peer service

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_context_menu.js
+++ b/addons/mail/static/src/discuss/call/common/call_context_menu.js
@@ -23,6 +23,7 @@ export class CallContextMenu extends Component {
             downloadStats: {},
             uploadStats: {},
             producerStats: {},
+            peerStats: {},
         });
         onMounted(() => {
             if (!this.env.debug) {
@@ -42,7 +43,7 @@ export class CallContextMenu extends Component {
         const candidateType =
             this.rtc.state.connectionType === CONNECTION_TYPES.SERVER
                 ? this.state.downloadStats.remoteCandidateType
-                : this.props.rtcSession.remoteCandidateType;
+                : this.state.peerStats.remoteCandidateType;
         return this.formatProtocol(candidateType);
     }
 
@@ -50,7 +51,7 @@ export class CallContextMenu extends Component {
         const candidateType =
             this.rtc.state.connectionType === CONNECTION_TYPES.SERVER
                 ? this.state.uploadStats.localCandidateType
-                : this.props.rtcSession.localCandidateType;
+                : this.state.peerStats.localCandidateType;
         return this.formatProtocol(candidateType);
     }
 
@@ -130,7 +131,9 @@ export class CallContextMenu extends Component {
             }
             return;
         }
-        await this.props.rtcSession.updateStats();
+        this.state.peerStats = await this.rtc.p2pService.getFormattedStats(
+            this.props.rtcSession.id
+        );
     }
 
     onChangeVolume(ev) {

--- a/addons/mail/static/src/discuss/call/common/call_context_menu.xml
+++ b/addons/mail/static/src/discuss/call/common/call_context_menu.xml
@@ -2,23 +2,24 @@
 <templates xml:space="preserve">
     <t t-name="discuss.CallContextMenu">
         <div class="d-flex flex-column p-3">
+            <div class="text-center pb-2 fw-bolder" t-out="props.rtcSession.name"/>
             <input t-if="!isSelf" type="range" min="0.0" max="1" step="0.01" t-att-value="volume" t-on-change="onChangeVolume" class="form-range"/>
             <t t-if="env.debug and !isSelf and rtc.state.connectionType === rtcConnectionTypes.P2P">
                 <hr class="w-100 border-top"/>
                 <div><span class="fw-bolder">Connection type: </span><t t-out="rtc.state.connectionType"/></div>
                 <div><span class="fw-bolder">To peer: </span><t t-out="outboundConnectionTypeText"/></div>
                 <div><span class="fw-bolder">From peer: </span><t t-out="inboundConnectionTypeText"/></div>
-                <div><span class="fw-bolder">Connection: </span><t t-out="props.rtcSession.connectionState"/></div>
-                <div><span class="fw-bolder">ICE: </span><t t-out="props.rtcSession.iceState"/></div>
-                <div><span class="fw-bolder">DTLS: </span><t t-out="props.rtcSession.dtlsState"/></div>
-                <div><span class="fw-bolder">Data channel: </span><t t-out="props.rtcSession.dataChannelState"/></div>
+                <div><span class="fw-bolder">Connection: </span><t t-out="state.peerStats.connectionState"/></div>
+                <div><span class="fw-bolder">ICE: </span><t t-out="state.peerStats.iceState"/></div>
+                <div><span class="fw-bolder">DTLS: </span><t t-out="state.peerStats.dtlsState"/></div>
+                <div><span class="fw-bolder">Data channel: </span><t t-out="state.peerStats.dataChannelState"/></div>
                 <div t-if="props.rtcSession.audioError"><span class="fw-bolder">Audio player: </span><t t-out="props.rtcSession.audioError"/></div>
                 <div t-if="props.rtcSession.videoError"><span class="fw-bolder">Video player: </span><t t-out="props.rtcSession.videoError"/></div>
                 <hr class="w-100 border-top"/>
-                <div><span class="fw-bolder">ICE gathering: </span><t t-out="props.rtcSession.iceGatheringState"/></div>
-                <div><span class="fw-bolder">Packets sent: </span><t t-out="props.rtcSession.packetsSent"/></div>
-                <div><span class="fw-bolder">Packets received: </span><t t-out="props.rtcSession.packetsReceived"/></div>
-                <div><span class="fw-bolder">Log step: </span><t t-out="props.rtcSession.logStep"/></div>
+                <div><span class="fw-bolder">ICE gathering: </span><t t-out="state.peerStats.iceGatheringState"/></div>
+                <div><span class="fw-bolder">Packets sent: </span><t t-out="state.peerStats.packetsSent"/></div>
+                <div><span class="fw-bolder">Packets received: </span><t t-out="state.peerStats.packetsReceived"/></div>
+                <div><span class="fw-bolder">Log step: </span><t t-out="state.peerStats.logStep"/></div>
             </t>
             <t t-elif="env.debug and isSelf and rtc.state.connectionType === rtcConnectionTypes.SERVER">
                 <div><span class="fw-bolder">Connection type: </span><t t-out="rtc.state.connectionType"/></div>

--- a/addons/mail/static/src/discuss/call/common/call_participant_card.js
+++ b/addons/mail/static/src/discuss/call/common/call_participant_card.js
@@ -1,5 +1,6 @@
 import { CallContextMenu } from "@mail/discuss/call/common/call_context_menu";
 import { CallParticipantVideo } from "@mail/discuss/call/common/call_participant_video";
+import { CONNECTION_TYPES } from "@mail/discuss/call/common/rtc_service";
 import { useHover } from "@mail/utils/common/hooks";
 import { isEventHandled, markEventHandled } from "@web/core/utils/misc";
 import { browser } from "@web/core/browser/browser";
@@ -16,7 +17,7 @@ import { usePopover } from "@web/core/popover/popover_hook";
 import { useService } from "@web/core/utils/hooks";
 import { rpc } from "@web/core/network/rpc";
 
-const HIDDEN_CONNECTION_STATES = new Set(["connected", "completed"]);
+const HIDDEN_CONNECTION_STATES = new Set([undefined, "connected", "completed"]);
 
 export class CallParticipantCard extends Component {
     static props = ["className", "cardData", "thread", "minimized?", "inset?"];
@@ -56,10 +57,10 @@ export class CallParticipantCard extends Component {
         if (!this.rtcSession) {
             return false;
         }
-        if (this.env.debug) {
-            return true;
-        }
-        return !this.rtcSession?.eq(this.rtc.selfSession);
+        return (
+            !this.rtcSession.eq(this.rtc.selfSession) ||
+            (this.env.debug && this.rtc.state.connectionType === CONNECTION_TYPES.SERVER)
+        );
     }
 
     get rtcSession() {
@@ -76,9 +77,7 @@ export class CallParticipantCard extends Component {
 
     get showConnectionState() {
         return Boolean(
-            this.isOfActiveCall &&
-                this.rtcSession?.peerConnection &&
-                !HIDDEN_CONNECTION_STATES.has(this.rtcSession.connectionState)
+            this.isOfActiveCall && !HIDDEN_CONNECTION_STATES.has(this.rtcSession.connectionState)
         );
     }
 

--- a/addons/mail/static/src/discuss/call/common/discuss_p2p_service.js
+++ b/addons/mail/static/src/discuss/call/common/discuss_p2p_service.js
@@ -1,0 +1,24 @@
+import { registry } from "@web/core/registry";
+import { PeerToPeer } from "@mail/discuss/call/common/peer_to_peer";
+
+export const discussP2P = {
+    dependencies: ["bus_service"],
+    /**
+     * @param {import("@web/env").OdooEnv} env
+     * @param {Partial<import("services").Services>} services
+     */
+    start(env, services) {
+        const p2p = new PeerToPeer({ notificationRoute: "/mail/rtc/session/notify_call_members" });
+        services["bus_service"].subscribe(
+            "discuss.channel.rtc.session/peer_notification",
+            ({ sender, notifications }) => {
+                for (const content of notifications) {
+                    p2p.handleNotification(sender, content);
+                }
+            }
+        );
+        return p2p;
+    },
+};
+
+registry.category("services").add("discuss.p2p", discussP2P);

--- a/addons/mail/static/src/discuss/call/common/peer_to_peer.js
+++ b/addons/mail/static/src/discuss/call/common/peer_to_peer.js
@@ -1,0 +1,859 @@
+import { rpc } from "@web/core/network/rpc";
+import { browser } from "@web/core/browser/browser";
+
+export const STREAM_TYPE = Object.freeze({
+    AUDIO: "audio",
+    CAMERA: "camera",
+    SCREEN: "screen",
+});
+export const UPDATE_EVENT = Object.freeze({
+    BROADCAST: "broadcast",
+    CONNECTION_CHANGE: "connection_change",
+    DISCONNECT: "disconnect",
+    INFO_CHANGE: "info_change",
+    TRACK: "track",
+});
+const LOG_LEVEL = Object.freeze({
+    NONE: "none",
+    DEBUG: "debug",
+    INFO: "info",
+    WARN: "warn",
+    ERROR: "error",
+});
+const INTERNAL_EVENT = Object.freeze({
+    ANSWER: "answer",
+    BROADCAST: "broadcast",
+    DISCONNECT: "disconnect",
+    ICE_CANDIDATE: "ice-candidate",
+    INFO: "info",
+    OFFER: "offer",
+    TRACK_CHANGE: "trackChange",
+});
+const ORDERED_TRANSCEIVER_TYPES = [STREAM_TYPE.AUDIO, STREAM_TYPE.CAMERA, STREAM_TYPE.SCREEN];
+const DEFAULT_BUS_BATCH_DELAY = 100;
+const INITIAL_RECONNECT_DELAY = 2_000 + Math.random() * 1_000; // the initial delay between reconnection attempts
+const MAXIMUM_RECONNECT_DELAY = 25_000 + Math.random() * 5_000; // the longest delay possible between reconnection attempts
+const INVALID_ICE_CONNECTION_STATES = new Set(["disconnected", "failed", "closed"]);
+const IS_CLIENT_RTC_COMPATIBLE = Boolean(window.RTCPeerConnection && window.MediaStream);
+const DEFAULT_ICE_SERVERS = [
+    { urls: ["stun:stun1.l.google.com:19302", "stun:stun2.l.google.com:19302"] },
+];
+const DEFAULT_NOTIFICATION_ROUTE = "/mail/rtc/session/notify_call_members";
+
+/**
+ * @typedef {Object} Media
+ * @property {MediaStreamTrack | null} track the track of the associated RtcRtpTransceiver, its presence does not
+ *     imply active streaming as it exists for the whole lifetime transceiver (since webRTC 'unified plan').
+ * @property {boolean} active represents whether the remote (peer) is actively streaming this track
+ * @property {boolean} accepted represents whether the local (current user) wants to download this track
+ */
+
+/**
+ * @typedef {Object} Info (sealed)
+ * @property {boolean} isSelfMuted
+ * @property {boolean} isRaisingHand
+ * @property {boolean} isDeaf
+ * @property {boolean} isTalking
+ * @property {boolean} isCameraOn
+ * @property {boolean} isScreenSharingOn
+ */
+
+export class Peer {
+    /** @type {number} */
+    id;
+    /** @type {RTCPeerConnection} */
+    connection;
+    /** @type {number} */
+    connectRetryDelay = INITIAL_RECONNECT_DELAY;
+    /** @type {RTCDataChannel} */
+    dataChannel;
+    hasPriority = false;
+    isBuildingOffer = false;
+    isBuildingAnswer = false;
+    /** @type {Object<STREAM_TYPE[keyof STREAM_TYPE], Media>} */
+    medias = Object.seal({
+        [STREAM_TYPE.AUDIO]: {
+            track: null,
+            active: false,
+            accepted: true,
+        },
+        [STREAM_TYPE.SCREEN]: {
+            track: null,
+            active: false,
+            accepted: true,
+        },
+        [STREAM_TYPE.CAMERA]: {
+            track: null,
+            active: false,
+            accepted: true,
+        },
+    });
+    /**
+     * @param {number} id
+     * @param {Object} param2
+     * @param {RTCPeerConnection} param2.connection
+     * @param {RTCDataChannel} param2.dataChannel
+     * @param {boolean} hasPriority true if this peer offers should have priority in case of collisions
+     * @param {number} [connectRetryDelay=INITIAL_RECONNECT_DELAY]
+     */
+    constructor(
+        id,
+        {
+            connection,
+            dataChannel,
+            hasPriority = false,
+            connectRetryDelay = INITIAL_RECONNECT_DELAY,
+        }
+    ) {
+        this.id = id;
+        this.connection = connection;
+        this.dataChannel = dataChannel;
+        this.hasPriority = hasPriority;
+        this.connectRetryDelay = connectRetryDelay;
+        this.ready = new Promise((resolve) => {
+            this.dataChannel.addEventListener("open", resolve);
+        });
+    }
+    disconnect() {
+        if (this.connection) {
+            const RTCRtpSenders = this.connection.getSenders();
+            for (const sender of RTCRtpSenders) {
+                try {
+                    this.connection.removeTrack(sender);
+                } catch {
+                    // ignore error
+                }
+            }
+            for (const transceiver of this.connection.getTransceivers()) {
+                try {
+                    transceiver.stop();
+                } catch {
+                    // transceiver may already be stopped by the remote.
+                }
+            }
+        }
+        this.connection?.close();
+        this.connection = undefined;
+        this.dataChannel?.close();
+        this.dataChannel = undefined;
+        for (const media of Object.values(this.medias)) {
+            media.track?.stop();
+        }
+    }
+    /**
+     * @param {{STREAM_TYPE[keyof STREAM_TYPE]}} streamType
+     * @param {boolean} canUpload whether this transceiver needs upload capability (outbound stream)
+     * @returns {RTCRtpTransceiverDirection}
+     */
+    getRecommendedTransceiverDirection(streamType, canUpload = false) {
+        if (this.medias[streamType].accepted) {
+            return canUpload ? "sendrecv" : "recvonly";
+        } else {
+            return canUpload ? "sendonly" : "inactive";
+        }
+    }
+    /**
+     * @param {STREAM_TYPE[keyof STREAM_TYPE]} streamType
+     * @returns {RTCRtpTransceiver | undefined} the transceiver used for this trackKind.
+     */
+    getTransceiver(streamType) {
+        if (!this.connection) {
+            // may be disconnected
+            return;
+        }
+        const transceivers = this.connection.getTransceivers();
+        return transceivers[ORDERED_TRANSCEIVER_TYPES.indexOf(streamType)];
+    }
+    /**
+     * @param {RTCRtpTransceiver} transceiver
+     * @returns {STREAM_TYPE[keyof STREAM_TYPE]}
+     */
+    getTransceiverStreamType(transceiver) {
+        const transceivers = this.connection.getTransceivers();
+        return ORDERED_TRANSCEIVER_TYPES[transceivers.indexOf(transceiver)];
+    }
+}
+
+/**
+ * This class represents a network of peers and handles peer to peer connections.
+ *
+ *  @fires PeerToPeer#update
+ */
+export class PeerToPeer extends EventTarget {
+    /** @type {number} */
+    selfId;
+    /** @type {number}*/
+    channelId;
+    /** @type {Map<number, Peer>}*/
+    peers = new Map();
+    /** @type {number} */
+    _batchDelay = DEFAULT_BUS_BATCH_DELAY;
+    /** @type {Info} */
+    _localInfo = Object.seal({
+        isSelfMuted: false,
+        isRaisingHand: false,
+        isDeaf: false,
+        isTalking: false,
+        isCameraOn: false,
+        isScreenSharingOn: false,
+    });
+    /** @type {String[]} */
+    _iceServers;
+    _isPendingNotify = false;
+    _notificationsToSend = new Map();
+    _isAntiGlareEnabled = true;
+    /**
+     * id of notification transaction
+     * @type {number}
+     */
+    _tmpNotificationId = 0;
+    /**
+     * by peer ID
+     * @type {Map<timeoutID>}
+     */
+    _recoverTimeouts = new Map();
+    /** @type {String} */
+    _notificationRoute;
+    /** @type {boolean} */
+    _isStreamingEnabled = true;
+    /** @type {Object<STREAM_TYPE[keyof STREAM_TYPE], MediaStreamTrack | null>} */
+    _tracks = Object.seal({
+        [STREAM_TYPE.AUDIO]: null,
+        [STREAM_TYPE.SCREEN]: null,
+        [STREAM_TYPE.CAMERA]: null,
+    });
+    _loggingFunctions = {
+        [LOG_LEVEL.DEBUG]: () => {},
+        [LOG_LEVEL.INFO]: () => {},
+        [LOG_LEVEL.WARN]: () => {},
+        [LOG_LEVEL.ERROR]: () => {},
+    };
+    /**
+     * @param {object} [options]
+     * @param {String} [options.notificationRoute] the route used to communicate with the odoo server
+     * @param {LOG_LEVEL[keyof LOG_LEVEL]} [options.logLevel=LOG_LEVEL.NONE]
+     * @param {boolean} [options.antiGlare=true] whether or not to use the rollback feature to manage offer collisions,
+     *        ids provided for peers should be comparable for this feature to work.
+     * @param {number} [options.batchDelay=DEFAULT_BUS_BATCH_DELAY]
+     * @param {boolean} [options.enableStreaming=true] whether or not setting the peer connections with audio and video
+     *        transceivers to allow streaming features.
+     */
+    constructor({
+        notificationRoute = DEFAULT_NOTIFICATION_ROUTE,
+        logLevel = LOG_LEVEL.NONE,
+        batchDelay = DEFAULT_BUS_BATCH_DELAY,
+        antiGlare = true,
+        enableStreaming = true,
+    } = {}) {
+        super();
+        this._isStreamingEnabled = enableStreaming;
+        this._isAntiGlareEnabled = antiGlare;
+        this._notificationRoute = notificationRoute;
+        this._batchDelay = batchDelay;
+        this.setLoggingLevel(logLevel);
+    }
+
+    /**
+     * @param {any} selfId should be comparable to benefit from the anti glare (offer collisions)
+     * @param {any} channelId
+     * @param {object} [options]
+     * @param {Info} [options.info={}]
+     * @param {array} [options.iceServers=DEFAULT_ICE_SERVERS]
+     */
+    connect(selfId, channelId, { info = {}, iceServers = DEFAULT_ICE_SERVERS } = {}) {
+        if (!IS_CLIENT_RTC_COMPATIBLE) {
+            throw new Error("RTCPeerConnection is not supported");
+        }
+        this.selfId = selfId;
+        this.channelId = channelId;
+        this._iceServers = iceServers;
+        this._localInfo = Object.assign(this._localInfo, info);
+    }
+
+    removeALlPeers() {
+        for (const peer of this.peers.values()) {
+            this.removePeer(peer.id);
+        }
+        this.peers.clear();
+    }
+
+    disconnect() {
+        this.removeALlPeers();
+        this.selfId = undefined;
+        this.channelId = undefined;
+        this._localInfo = Object.assign(this._localInfo, {
+            isSelfMuted: false,
+            isRaisingHand: false,
+            isDeaf: false,
+            isTalking: false,
+            isCameraOn: false,
+            isScreenSharingOn: false,
+        });
+    }
+    /**
+     * Adds a peer and starts the process of connection establishment. From this point the whole
+     * peer lifecycle is handled internally, including connection recovery attempts, until
+     * `removePeer()` or `disconnect()` is called.
+     * If a peer of that id already exists, it is returned without being re-created.
+     * This allows `addPeer` to be called to ensure that all of them are registered without fear
+     * of resetting connections (removePeer() should be called explicitly if that is the intention).
+     *
+     * @param {number} id
+     * @param {object} [options={}] options for the Peer constructor
+     * @returns {Peer} resolved when the dataChannel is open
+     */
+    async addPeer(id, options = {}) {
+        const peer = this.peers.get(id);
+        if (peer) {
+            return peer;
+        }
+        const newPeer = this._createPeer(id, options);
+        await newPeer.ready;
+        return newPeer;
+    }
+    removePeer(id) {
+        const recoverTimeoutId = this._recoverTimeouts.get(id);
+        browser.clearTimeout(recoverTimeoutId);
+        this._recoverTimeouts.delete(id);
+        const peer = this.peers.get(id);
+        if (!peer) {
+            return;
+        }
+        this.peers.delete(id);
+        peer.disconnect();
+    }
+
+    /**
+     * Broadcast a message to all peers
+     * @param message any JSON serializable
+     */
+    broadcast(message) {
+        this._dataChannelBroadcast(INTERNAL_EVENT.BROADCAST, message);
+    }
+    /**
+     * @param id
+     * @return {{
+     *     connectionState: RTCPeerConnection.connectionState
+     *     iceConnectionState: RTCPeerConnection.iceConnectionState
+     *     iceGatheringState: RTCPeerConnection.iceGatheringState
+     *     localCandidateType: RTCIceCandidatePairStats.candidateType
+     *     remoteCandidateType: RTCIceCandidatePairStats.candidateType
+     *     dataChannelState:  RTCDataChannelStats.state
+     *     dtlsState: RTCTransportStats.dtpsState,
+     *     iceState: RTCTransportStats.iceState,
+     *     packetsReceived: RTCTransportStats.packetsReceived,
+     *     packetsSent: RTCTransportStats.packetsSent,
+     * } | {}}
+     */
+    async getFormattedStats(id) {
+        const peer = this.peers.get(id);
+        const formattedStats = {};
+        if (!peer) {
+            return formattedStats;
+        }
+        formattedStats.connectionState = peer.connection.connectionState;
+        formattedStats.iceConnectionState = peer.connection.iceConnectionState;
+        formattedStats.iceGatheringState = peer.connection.iceGatheringState;
+        const stats = await peer.connection.getStats();
+        for (const value of stats?.values() || []) {
+            switch (value.type) {
+                case "candidate-pair":
+                    if (value.state === "succeeded" && value.localCandidateId) {
+                        formattedStats.localCandidateType =
+                            stats.get(value.localCandidateId)?.candidateType || "";
+                        formattedStats.remoteCandidateType =
+                            stats.get(value.remoteCandidateId)?.candidateType || "";
+                    }
+                    break;
+                case "data-channel":
+                    formattedStats.dataChannelState = value.state;
+                    break;
+                case "transport":
+                    formattedStats.dtlsState = value.dtlsState;
+                    formattedStats.iceState = value.iceState;
+                    formattedStats.packetsReceived = value.packetsReceived;
+                    formattedStats.packetsSent = value.packetsSent;
+                    break;
+            }
+        }
+        return formattedStats;
+    }
+    /**
+     * Stop or resume the consumption of tracks from the other call participants.
+     *
+     * @param {number} id
+     * @param {Object<[STREAM_TYPE[keyof STREAM_TYPE], boolean]>} states e.g: { screen: true, camera: false }
+     */
+    updateDownload(id, states) {
+        const peer = this.peers.get(id);
+        if (!peer) {
+            return;
+        }
+        for (const [streamType, accepted] of Object.entries(states)) {
+            peer.medias[streamType].accepted = accepted;
+            const transceiver = peer.getTransceiver(streamType);
+            if (!transceiver) {
+                this._recover(id, `no transceiver available when updating direction`);
+                return;
+            }
+            // changing the direction triggers a negotiation-needed
+            transceiver.direction = peer.getRecommendedTransceiverDirection(
+                streamType,
+                Boolean(this._tracks[streamType])
+            );
+        }
+    }
+
+    /**
+     * @param {STREAM_TYPE[keyof STREAM_TYPE]} streamType
+     * @param {MediaStreamTrack | null} [track] track to be sent to the other call participants
+     */
+    async updateUpload(streamType, track) {
+        this._tracks[streamType] = track || null;
+        this.updateInfo({
+            isScreenSharingOn: Boolean(this._tracks[STREAM_TYPE.SCREEN]),
+            isCameraOn: Boolean(this._tracks[STREAM_TYPE.CAMERA]),
+        });
+        const proms = [];
+        for (const peer of this.peers.values()) {
+            proms.push(this._updateRemote(peer, streamType));
+        }
+        await Promise.all(proms);
+    }
+    /**
+     * @param {Info} info
+     */
+    updateInfo(info) {
+        this._localInfo = Object.assign(this._localInfo, info);
+        this._dataChannelBroadcast(INTERNAL_EVENT.INFO, this._localInfo);
+    }
+    /**
+     * @param id id of the peer sending the notification
+     * @param {string} content JSON
+     */
+    async handleNotification(id, content) {
+        /** @type {{ event: INTERNAL_EVENT[keyof INTERNAL_EVENT], channelId, payload: Object }} */
+        const { event, channelId, payload } = JSON.parse(content);
+        this._emitLog(id, `received notification: ${event}`, LOG_LEVEL.DEBUG);
+        if (channelId !== this.channelId) {
+            return;
+        }
+        let peer = this.peers.get(id);
+        if (event !== INTERNAL_EVENT.OFFER && !peer?.connection) {
+            this._emitLog(id, `received ${event} for missing peer ${id}`, LOG_LEVEL.WARN);
+            return;
+        }
+        switch (event) {
+            case INTERNAL_EVENT.ANSWER: {
+                this._emitLog(id, `received answer`, LOG_LEVEL.DEBUG);
+                if (
+                    INVALID_ICE_CONNECTION_STATES.has(peer.connection.iceConnectionState) ||
+                    peer.connection.signalingState === "stable" ||
+                    peer.connection.signalingState === "have-remote-offer"
+                ) {
+                    return;
+                }
+                const description = new window.RTCSessionDescription(payload.sdp);
+                try {
+                    await peer.connection.setRemoteDescription(description);
+                } catch {
+                    this._recover(id, "answer handling: Failed at setting remoteDescription");
+                    // ignored the transaction may have been resolved by another concurrent offer.
+                }
+                break;
+            }
+            case INTERNAL_EVENT.BROADCAST: {
+                this._emitUpdate({
+                    name: UPDATE_EVENT.BROADCAST,
+                    payload: { senderId: id, message: payload },
+                });
+                break;
+            }
+            case INTERNAL_EVENT.DISCONNECT: {
+                this.removePeer(id);
+                this._emitUpdate({ name: UPDATE_EVENT.DISCONNECT, payload: { sessionId: id } });
+                break;
+            }
+            case INTERNAL_EVENT.ICE_CANDIDATE: {
+                if (INVALID_ICE_CONNECTION_STATES.has(peer.connection.iceConnectionState)) {
+                    return;
+                }
+                const rtcIceCandidate = new window.RTCIceCandidate(payload.candidate);
+                try {
+                    await peer.connection.addIceCandidate(rtcIceCandidate);
+                } catch {
+                    this._recover(id, "failed at adding ice candidate");
+                }
+                break;
+            }
+            case INTERNAL_EVENT.INFO: {
+                const { isTalking, isCameraOn, isScreenSharingOn } = payload;
+                peer.medias[STREAM_TYPE.AUDIO].active = isTalking;
+                peer.medias[STREAM_TYPE.CAMERA].active = isCameraOn;
+                peer.medias[STREAM_TYPE.SCREEN].active = isScreenSharingOn;
+                this._emitUpdate({
+                    name: UPDATE_EVENT.INFO_CHANGE,
+                    payload: { [id]: payload },
+                });
+                break;
+            }
+            case INTERNAL_EVENT.OFFER: {
+                if (!peer) {
+                    peer = this._createPeer(id);
+                }
+                if (
+                    INVALID_ICE_CONNECTION_STATES.has(peer.connection.iceConnectionState) ||
+                    peer.connection.signalingState === "have-remote-offer"
+                ) {
+                    return;
+                }
+                const isStable =
+                    peer.connection.signalingState === "stable" || peer.isBuildingAnswer;
+                const hasOfferCollision = !isStable || peer.isBuildingOffer;
+                if (hasOfferCollision && peer.hasPriority && this._isAntiGlareEnabled) {
+                    this._emitLog(
+                        peer.id,
+                        `rolling back due to offer collision: ${peer.connection.signalingState}`,
+                        LOG_LEVEL.WARN
+                    );
+                    try {
+                        await peer.connection.setLocalDescription({ type: "rollback" });
+                    } catch {
+                        this._recover(id, `failed rollback`);
+                    }
+                }
+                const description = new window.RTCSessionDescription(payload.sdp);
+                try {
+                    await peer.connection.setRemoteDescription(description);
+                } catch {
+                    this._recover(id, "failed at setting remoteDescription");
+                    return;
+                }
+                if (this._isStreamingEnabled) {
+                    if (peer.connection.getTransceivers().length === 0) {
+                        for (const streamType of ORDERED_TRANSCEIVER_TYPES) {
+                            const type = streamType === STREAM_TYPE.AUDIO ? "audio" : "video";
+                            peer.connection.addTransceiver(type);
+                        }
+                    }
+                    for (const transceiverName of ORDERED_TRANSCEIVER_TYPES) {
+                        await this._updateRemote(peer, transceiverName);
+                    }
+                }
+                peer.isBuildingAnswer = true;
+                try {
+                    await peer.connection.setLocalDescription(await peer.connection.createAnswer());
+                } catch {
+                    peer.isBuildingAnswer = false;
+                    this._recover(id, "offer handling: failed at setting answer localDescription");
+                    return;
+                }
+                peer.isBuildingAnswer = false;
+                this._emitLog(id, `sending answer`, LOG_LEVEL.DEBUG);
+                await this._busNotify(INTERNAL_EVENT.ANSWER, {
+                    payload: {
+                        sdp: peer.connection.localDescription,
+                    },
+                    targets: [peer.id],
+                });
+                this._recover(peer.id, "standard answer timeout");
+                break;
+            }
+        }
+    }
+    /**
+     * @param {LOG_LEVEL[keyof LOG_LEVEL]} logLevel
+     */
+    setLoggingLevel(logLevel) {
+        const makeLog = (level) => {
+            return (id, message) => {
+                this.dispatchEvent(new CustomEvent("log", { detail: { id, level, message } }));
+            };
+        };
+        this._loggingFunctions = {
+            [LOG_LEVEL.DEBUG]: () => {},
+            [LOG_LEVEL.INFO]: () => {},
+            [LOG_LEVEL.WARN]: () => {},
+            [LOG_LEVEL.ERROR]: () => {},
+        };
+        switch (logLevel) {
+            case LOG_LEVEL.DEBUG:
+                this._loggingFunctions[LOG_LEVEL.DEBUG] = makeLog(LOG_LEVEL.DEBUG);
+            // eslint-disable-next-line no-fallthrough
+            case LOG_LEVEL.INFO:
+                this._loggingFunctions[LOG_LEVEL.INFO] = makeLog(LOG_LEVEL.INFO);
+            // eslint-disable-next-line no-fallthrough
+            case LOG_LEVEL.WARN:
+                this._loggingFunctions[LOG_LEVEL.WARN] = makeLog(LOG_LEVEL.WARN);
+            // eslint-disable-next-line no-fallthrough
+            case LOG_LEVEL.ERROR:
+                this._loggingFunctions[LOG_LEVEL.ERROR] = makeLog(LOG_LEVEL.ERROR);
+        }
+    }
+    /**
+     * @param {INTERNAL_EVENT[keyof INTERNAL_EVENT]} internalEvent
+     * @param message any JSON serializable
+     */
+    _dataChannelBroadcast(internalEvent, message) {
+        for (const peer of this.peers.values()) {
+            if (!peer?.dataChannel || peer?.dataChannel.readyState !== "open") {
+                continue;
+            }
+            peer.dataChannel.send(
+                JSON.stringify({
+                    event: internalEvent,
+                    channelId: this.channelId,
+                    payload: message,
+                })
+            );
+        }
+    }
+    /**
+     * @param {any} detail
+     */
+    _emitUpdate(detail) {
+        this.dispatchEvent(new CustomEvent("update", { detail }));
+    }
+    /**
+     * @param id
+     * @param {string} message
+     * @param {LOG_LEVEL[keyof LOG_LEVEL]} [level=LOG_LEVEL.DEBUG]
+     */
+    _emitLog(id, message, level = LOG_LEVEL.DEBUG) {
+        this._loggingFunctions[level](id, message);
+    }
+    /**
+     * @param id
+     * @param {string} reason
+     */
+    _recover(id, reason = "") {
+        if (this._recoverTimeouts.get(id)) {
+            return;
+        }
+        const peer = this.peers.get(id);
+        if (!peer) {
+            return;
+        }
+        // Retry connecting with an exponential backoff.
+        const delay =
+            Math.min(peer.connectRetryDelay * 1.5, MAXIMUM_RECONNECT_DELAY) + 1000 * Math.random();
+        this._recoverTimeouts.set(
+            id,
+            browser.setTimeout(async () => {
+                const peer = this.peers.get(id);
+                this._recoverTimeouts.delete(id);
+                if (
+                    !peer?.connection ||
+                    !this.channelId ||
+                    peer.connection.iceConnectionState === "connected" ||
+                    peer.connection.iceConnectionState === "completed"
+                ) {
+                    return;
+                }
+                this._emitLog(id, `attempting to recover connection: ${reason}`, LOG_LEVEL.WARN);
+                this._busNotify(INTERNAL_EVENT.DISCONNECT, { targets: [peer.id] });
+                this.removePeer(peer.id);
+                this.addPeer(peer.id, { connectRetryDelay: delay });
+            }, delay)
+        );
+    }
+    async _sendNotifications() {
+        if (this._isPendingNotify) {
+            return;
+        }
+        this._isPendingNotify = true;
+        await new Promise((resolve) => setTimeout(resolve, this._batchDelay));
+        const ids = [];
+        const notifications = [];
+        this._notificationsToSend.forEach((notification, id) => {
+            ids.push(id);
+            notifications.push([
+                notification.sender,
+                notification.targets,
+                JSON.stringify({
+                    event: notification.event,
+                    channelId: notification.channelId,
+                    payload: notification.payload,
+                }),
+            ]);
+        });
+        try {
+            await rpc(
+                this._notificationRoute,
+                {
+                    peer_notifications: notifications,
+                },
+                { silent: true }
+            );
+            for (const id of ids) {
+                this._notificationsToSend.delete(id);
+            }
+        } finally {
+            this._isPendingNotify = false;
+            if (this._notificationsToSend.size > 0) {
+                await this._sendNotifications();
+            }
+        }
+    }
+    /**
+     * @param {INTERNAL_EVENT[keyof INTERNAL_EVENT]} event
+     * @param {Object} [options]
+     * @param {Object} [options.payload]
+     * @param {number[]} [options.targets] list of the ids of peers to send the message to,
+     * sends to all peers if no specified target(s)
+     */
+    async _busNotify(event, { payload, targets } = {}) {
+        targets = targets || Array.from(this.peers.keys());
+        let id;
+        if (event === INTERNAL_EVENT.OFFER) {
+            // offers are always single-target, ensures that only 1 offer (the latest) per target is kept
+            id = `latestOffer_to:${targets[0]}`;
+        } else {
+            id = ++this._tmpNotificationId;
+        }
+        this._notificationsToSend.set(id, {
+            channelId: this.channelId,
+            event,
+            payload,
+            sender: this.selfId,
+            targets,
+        });
+        await this._sendNotifications();
+    }
+    /**
+     * @param {Peer} peer
+     * @param {STREAM_TYPE[keyof STREAM_TYPE]} streamType
+     */
+    async _updateRemote(peer, streamType) {
+        const track = this._tracks[streamType];
+        const transceiver = peer.getTransceiver(streamType);
+        if (!transceiver) {
+            return;
+        }
+        try {
+            await transceiver.sender.replaceTrack(track);
+            transceiver.direction = peer.getRecommendedTransceiverDirection(
+                streamType,
+                Boolean(track)
+            );
+        } catch (error) {
+            this._recover(
+                peer.id,
+                `failed to update ${streamType} transceiver for peer ${peer.id}: ${error}`
+            );
+        }
+    }
+    /**
+     * Creates a new peer.
+     * If a peer of this id already exists, it is cleared.
+     *
+     * @param {number} id
+     * @param {object} [options={}]
+     * @returns {Peer}
+     */
+    _createPeer(id, options = {}) {
+        this.removePeer(id);
+        const peerConnection = new window.RTCPeerConnection({ iceServers: this._iceServers });
+        const dataChannel = peerConnection.createDataChannel("notifications", {
+            negotiated: true,
+            id: 1,
+        });
+        const peer = new Peer(id, {
+            ...options,
+            connection: peerConnection,
+            dataChannel,
+            hasPriority: id > this.selfId,
+        });
+        this.peers.set(id, peer);
+        peerConnection.addEventListener("icecandidate", async (event) => {
+            if (!event.candidate) {
+                return;
+            }
+            await this._busNotify(INTERNAL_EVENT.ICE_CANDIDATE, {
+                payload: {
+                    candidate: event.candidate,
+                },
+                targets: [id],
+            });
+        });
+        peerConnection.addEventListener("iceconnectionstatechange", async () => {
+            this._emitUpdate({
+                name: UPDATE_EVENT.CONNECTION_CHANGE,
+                payload: { id, peer, state: peerConnection.iceConnectionState },
+            });
+            switch (peerConnection.iceConnectionState) {
+                case "closed":
+                    this.removePeer(id);
+                    break;
+                case "failed":
+                case "disconnected":
+                    this._recover(peer.id, 1000, "ice connection disconnected");
+                    break;
+            }
+        });
+        peerConnection.addEventListener("icegatheringstatechange", () => {
+            this._emitLog(
+                id,
+                `gathering state change: ${peerConnection.iceGatheringState}`,
+                LOG_LEVEL.INFO
+            );
+        });
+        peerConnection.addEventListener("connectionstatechange", async () => {
+            this._emitLog(
+                id,
+                `connection state change: ${peerConnection.connectionState}`,
+                LOG_LEVEL.INFO
+            );
+        });
+        peerConnection.addEventListener("icecandidateerror", async (error) => {
+            this._recover(id, `ice candidate error: ${error.errorText}`);
+        });
+        peerConnection.addEventListener("negotiationneeded", async () => {
+            peer.isBuildingOffer = true;
+            try {
+                await peerConnection.setLocalDescription(await peerConnection.createOffer());
+            } catch (error) {
+                this._recover(id, `failed to set local Description for offer: ${error}`);
+                peer.isBuildingOffer = false;
+                return;
+            }
+            peer.isBuildingOffer = false;
+            await this._busNotify(INTERNAL_EVENT.OFFER, {
+                payload: {
+                    sdp: peerConnection.localDescription,
+                },
+                targets: [id],
+            });
+        });
+        peerConnection.addEventListener("track", ({ transceiver, track }) => {
+            const streamType = peer.getTransceiverStreamType(transceiver);
+            peer.medias[streamType].track = track;
+            this._emitUpdate({
+                name: UPDATE_EVENT.TRACK,
+                payload: {
+                    sessionId: id,
+                    type: streamType,
+                    track,
+                    active: peer.medias[streamType].active,
+                },
+            });
+        });
+        dataChannel.addEventListener("message", async (event) => {
+            await this.handleNotification(id, event.data);
+        });
+        dataChannel.addEventListener("open", () => {
+            if (dataChannel.readyState !== "open") {
+                // can be closed by the time the event is emitted
+                return;
+            }
+            dataChannel.send(
+                JSON.stringify({
+                    event: INTERNAL_EVENT.INFO,
+                    channelId: this.channelId,
+                    payload: this._localInfo,
+                })
+            );
+        });
+        return peer;
+    }
+}

--- a/addons/mail/static/src/discuss/call/common/rtc_session_model.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_session_model.js
@@ -193,48 +193,6 @@ export class RtcSession extends Record {
             this.isScreenSharingOn = state;
         }
     }
-
-    async updateStats() {
-        delete this.localCandidateType;
-        delete this.remoteCandidateType;
-        delete this.dataChannelState;
-        delete this.packetsReceived;
-        delete this.packetsSent;
-        delete this.dtlsState;
-        delete this.iceState;
-        delete this.iceGatheringState;
-        if (!this.peerConnection) {
-            return;
-        }
-        let stats;
-        try {
-            stats = await this.peerConnection.getStats();
-        } catch {
-            return;
-        }
-        this.iceGatheringState = this.peerConnection.iceGatheringState;
-        for (const value of stats.values() || []) {
-            switch (value.type) {
-                case "candidate-pair":
-                    if (value.state === "succeeded" && value.localCandidateId) {
-                        this.localCandidateType =
-                            stats.get(value.localCandidateId)?.candidateType || "";
-                        this.remoteCandidateType =
-                            stats.get(value.remoteCandidateId)?.candidateType || "";
-                    }
-                    break;
-                case "data-channel":
-                    this.dataChannelState = value.state;
-                    break;
-                case "transport":
-                    this.dtlsState = value.dtlsState;
-                    this.iceState = value.iceState;
-                    this.packetsReceived = value.packetsReceived;
-                    this.packetsSent = value.packetsSent;
-                    break;
-            }
-        }
-    }
 }
 
 RtcSession.register();

--- a/addons/mail/static/src/js/tooling/types/services.d.ts
+++ b/addons/mail/static/src/js/tooling/types/services.d.ts
@@ -9,6 +9,7 @@ declare module "services" {
     import { mailCoreWeb } from "@mail/core/web/mail_core_web_service";
     import { notificationPermissionService } from "@mail/core/common/notification_permission_service";
     import { outOfFocusService } from "@mail/core/common/out_of_focus_service";
+    import { discussP2P } from "@mail/discuss/call/common/discuss_p2p_service";
     import { rtcService } from "@mail/discuss/call/common/rtc_service";
     import { soundEffects } from "@mail/core/common/sound_effects_service";
     import { storeService } from "@mail/core/common/store_service";
@@ -18,6 +19,7 @@ declare module "services" {
         "discuss.core.common": typeof discussCoreCommon;
         "discuss.core.public": typeof discussCorePublic;
         "discuss.core.web": typeof discussCoreWeb;
+        "discuss.p2p": typeof discussP2P;
         "discuss.rtc": typeof rtcService;
         "discuss.typing": typeof discussTypingService;
         "mail.attachment_upload": typeof attachmentUploadService;

--- a/addons/mail/static/tests/discuss/call/peer_to_peer.test.js
+++ b/addons/mail/static/tests/discuss/call/peer_to_peer.test.js
@@ -1,0 +1,195 @@
+import { describe, expect, test } from "@odoo/hoot";
+import { advanceTime } from "@odoo/hoot-mock";
+import { browser } from "@web/core/browser/browser";
+import { onRpc, mountWebClient } from "@web/../tests/web_test_helpers";
+import { defineMailModels, mockGetMedia } from "@mail/../tests/mail_test_helpers";
+import { PeerToPeer, STREAM_TYPE, UPDATE_EVENT } from "@mail/discuss/call/common/peer_to_peer";
+
+describe.current.tags("desktop");
+defineMailModels();
+
+class Network {
+    _peerToPeerInstances = new Map();
+    _notificationRoute;
+    constructor(route) {
+        this._notificationRoute = route || "/any/mock/notification";
+        onRpc(this._notificationRoute, async (req) => {
+            const {
+                params: { peer_notifications },
+            } = await req.json();
+            for (const notification of peer_notifications) {
+                const [sender_session_id, target_session_ids, content] = notification;
+                for (const id of target_session_ids) {
+                    const p2p = this._peerToPeerInstances.get(id);
+                    p2p.handleNotification(sender_session_id, content);
+                }
+            }
+        });
+    }
+    /**
+     * @param id
+     * @return {{id, p2p: PeerToPeer}}
+     */
+    register(id) {
+        const p2p = new PeerToPeer({ notificationRoute: this._notificationRoute });
+        this._peerToPeerInstances.set(id, p2p);
+        return { id, p2p };
+    }
+    close() {
+        for (const p2p of this._peerToPeerInstances.values()) {
+            p2p.disconnect();
+        }
+    }
+}
+
+test("basic peer to peer connection", async () => {
+    await mountWebClient();
+    const channelId = 1;
+    const network = new Network();
+    const user1 = network.register(1);
+    const user2 = network.register(2);
+    user2.remoteStates = new Map();
+    user2.p2p.addEventListener("update", ({ detail: { name, payload } }) => {
+        if (name === UPDATE_EVENT.CONNECTION_CHANGE) {
+            user2.remoteStates.set(payload.id, payload.state);
+        }
+    });
+
+    user2.p2p.connect(user2.id, channelId);
+    user1.p2p.connect(user1.id, channelId);
+    await user1.p2p.addPeer(user2.id);
+    expect(user2.remoteStates.get(user1.id)).toBe("connected");
+    network.close();
+});
+
+test("mesh peer to peer connections", async () => {
+    await mountWebClient();
+    const channelId = 2;
+    const network = new Network();
+    const userCount = 10;
+    const users = Array.from({ length: userCount }, (_, i) => network.register(i));
+    const promises = [];
+    for (const user of users) {
+        user.p2p.connect(user.id, channelId);
+        for (let i = 0; i < user.id; i++) {
+            promises.push(user.p2p.addPeer(i));
+        }
+    }
+    await Promise.all(promises);
+
+    let connectionsCount = 0;
+    for (const user of users) {
+        connectionsCount += user.p2p.peers.size;
+    }
+    expect(connectionsCount).toBe(userCount * (userCount - 1));
+    connectionsCount = 0;
+    network.close();
+    for (const user of users) {
+        connectionsCount += user.p2p.peers.size;
+    }
+    expect(connectionsCount).toBe(0);
+});
+
+test("connection recovery", async () => {
+    await mountWebClient();
+    const channelId = 1;
+    const network = new Network();
+    const user1 = network.register(1);
+    const user2 = network.register(2);
+    user2.remoteStates = new Map();
+    user2.p2p.addEventListener("update", ({ detail: { name, payload } }) => {
+        if (name === UPDATE_EVENT.CONNECTION_CHANGE) {
+            user2.remoteStates.set(payload.id, payload.state);
+        }
+    });
+
+    user1.p2p.connect(user1.id, channelId);
+    user1.p2p.addPeer(user2.id);
+    // only connecting user2 after user1 has called addPeer so that user2 ignores notifications
+    // from user1, which simulates a connection drop that should be recovered.
+    user2.p2p.connect(user2.id, channelId);
+    expect(user2.remoteStates.get(user1.id)).toBe(undefined);
+    const openPromise = new Promise((resolve) => {
+        user1.p2p.peers.get(2).dataChannel.onopen = resolve;
+    });
+    advanceTime(5_000); // recovery timeout
+    await openPromise;
+    expect(user2.remoteStates.get(user1.id)).toBe("connected");
+    network.close();
+});
+
+test("can broadcast a stream and control download", async () => {
+    mockGetMedia();
+    await mountWebClient();
+    const channelId = 3;
+    const network = new Network();
+    const user1 = network.register(1);
+    const user2 = network.register(2);
+    user2.remoteMedia = new Map();
+    const trackPromise = new Promise((resolve) => {
+        user2.p2p.addEventListener("update", ({ detail: { name, payload } }) => {
+            if (name === UPDATE_EVENT.TRACK) {
+                user2.remoteMedia.set(payload.sessionId, {
+                    [payload.type]: {
+                        track: payload.track,
+                        active: payload.active,
+                    },
+                });
+                resolve();
+            }
+        });
+    });
+
+    user2.p2p.connect(user2.id, channelId);
+    user1.p2p.connect(user1.id, channelId);
+    await user1.p2p.addPeer(user2.id);
+    const videoStream = await browser.navigator.mediaDevices.getUserMedia({
+        video: true,
+    });
+    const videoTrack = videoStream.getVideoTracks()[0];
+    await user1.p2p.updateUpload(STREAM_TYPE.CAMERA, videoTrack);
+    await trackPromise;
+    const user2RemoteMedia = user2.remoteMedia.get(user1.id);
+    const user2CameraTransceiver = user2.p2p.peers.get(user1.id).getTransceiver(STREAM_TYPE.CAMERA);
+    expect(user2CameraTransceiver.direction).toBe("recvonly");
+    expect(user2RemoteMedia[STREAM_TYPE.CAMERA].track.kind).toBe("video");
+    expect(user2RemoteMedia[STREAM_TYPE.CAMERA].active).toBe(true);
+    user2.p2p.updateDownload(user1.id, { camera: false });
+    expect(user2CameraTransceiver.direction).toBe("inactive");
+    network.close();
+});
+
+test("can broadcast arbitrary messages (dataChannel)", async () => {
+    await mountWebClient();
+    const channelId = 4;
+    const network = new Network();
+    const user1 = network.register(1);
+    const user2 = network.register(2);
+    user1.inbox = [];
+    const pongPromise = new Promise((resolve) => {
+        user1.p2p.addEventListener("update", ({ detail: { name, payload } }) => {
+            if (name === UPDATE_EVENT.BROADCAST) {
+                user1.inbox.push(payload);
+                resolve();
+            }
+        });
+    });
+    user2.inbox = [];
+    user2.p2p.addEventListener("update", ({ detail: { name, payload } }) => {
+        if (name === UPDATE_EVENT.BROADCAST) {
+            user2.inbox.push(payload);
+            user2.p2p.broadcast("pong");
+        }
+    });
+
+    user2.p2p.connect(user2.id, channelId);
+    user1.p2p.connect(user1.id, channelId);
+    await user1.p2p.addPeer(user2.id);
+    user1.p2p.broadcast("ping");
+    await pongPromise;
+    expect(user2.inbox[0].senderId).toBe(user1.id);
+    expect(user2.inbox[0].message).toBe("ping");
+    expect(user1.inbox[0].senderId).toBe(user2.id);
+    expect(user1.inbox[0].message).toBe("pong");
+    network.close();
+});


### PR DESCRIPTION
Adds a `PeerToPeer` class and service with an API that is almost
identical to the SFU API:
`connect()`, `disconnect()`, `updateUpload()`, `updateState()`,
`updateDownload()`, `broadcast()` and emits `update` events.
The main differences being that the API has additional tools to deal
with the p2p aspect of the connections:
`addPeer()` and `removePeer()`, and an `update` event of the type
`connectionChange` to notify changes of the connection on a peer basis.

Besides the following changes, all the features of the former
webRTC implementation are conserved:

behavioral changes:
* 'offer' events are now squashed, which means that only the last
offer will be sent per notification batch.

* Now waiting that the `dataChannel` is open before sending eventual
local streams to the remote.

* The recovery system does not longer differentiate between outgoing
and incoming connections and will attempt to recover all of them, while
no bug could be traced back to this, unforeseen race conditions could
in theory get a connection stuck in a state where no peer is trying
to recover it.

* The `offer` handing now checks for offer collisions to avoid glare by
rolling back the state of the connection.

* `hasPendingRequest` is now set to `false` earlier so that it does
not wait for device input promises.

* Dual (p2p/sfu) connections are now possible, which enables calls
to manage a mix of peer-to-peer and sfu connections simultaneously:
Users that cannot connect to the SFU will establish p2p connections
with the other participants.