### PR TITLE
[FIX] l10n_co_edi_pos: bridge colombian edi for pos compatibility

### DIFF
--- a/addons/l10n_co_pos/__init__.py
+++ b/addons/l10n_co_pos/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/addons/l10n_co_pos/models/__init__.py
+++ b/addons/l10n_co_pos/models/__init__.py
@@ -1,0 +1,1 @@
+from . import pos_order

--- a/addons/l10n_co_pos/models/pos_order.py
+++ b/addons/l10n_co_pos/models/pos_order.py
@@ -1,0 +1,10 @@
+from odoo import models
+
+class PosOrder(models.Model):
+    _inherit = "pos.order"
+
+    def _prepare_invoice_vals(self):
+        move_vals = super()._prepare_invoice_vals()
+        if "l10n_co_edi_description_code_credit" in self.env["account.move"] and move_vals.get("move_type") == "out_refund" and move_vals.get("reversed_entry_id"):
+            move_vals["l10n_co_edi_description_code_credit"] = move_vals.get("l10n_co_edi_description_code_credit", "1")
+        return move_vals


### PR DESCRIPTION
With restriction imposed by Colombian EDI, the PoS is not 100% compatible and usable as such features are not adapted for such restrictions.

---

Description of the issue this commit addresses:

When trying to issue a credit note via the POS (refund with invoice) and the colombian EDI module is installed, a traceback shows up as it is required to have a description code on the the credit note invoice but nothing in the UI makes it possible to add such data.

---

Steps to reproduce:

1-Install l10n_co_pos and l10n_co_edi
2-Setup all the fun stuff for the edi to work (credentials, VAT, journals, ...) 3-Go in the POS and post an order
4-Now refund that order and make sure to make an invoice with that refund, post 5-An error message shows up to inform that some data is missing.

---

Desired behavior after the commit is merged:

This commit makes it so that when a credit note is created from the PoS, if it is linked to Colombia, the description code is set to 1 if no code is already set.

---

Note on the fix:

It is currently not possible to already have a description code when the invoice is created so the default could be replaced by an assignation but I figured that if we add the possibility in the future, it would be great not to override it.

---

task-3977188

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
