### PR TITLE
[FIX] website_sale: enable zoom-on-click on mobile

### DIFF
--- a/addons/website_sale/static/src/js/website_sale.js
+++ b/addons/website_sale/static/src/js/website_sale.js
@@ -336,15 +336,14 @@ export const WebsiteSale = publicWidget.Widget.extend(VariantMixin, cartHandlerM
      * @private
      */
     _startZoom: function () {
-        // Do not activate image zoom on hover for mobile devices
         const salePage = document.querySelector(".o_wsale_product_page");
-        if (!salePage || uiUtils.isSmall() || this._getProductImageWidth() === "none") {
+        if (!salePage || this._getProductImageWidth() === "none") {
             return;
         }
         this._cleanupZoom();
         this.zoomCleanup = [];
-        // Zoom on hover
-        if (salePage.dataset.ecomZoomAuto) {
+        // Zoom on hover (except on mobile)
+        if (salePage.dataset.ecomZoomAuto && !uiUtils.isSmall()) {
             const images = salePage.querySelectorAll("img[data-zoom]");
             for (const image of images) {
                 const $image = $(image);


### PR DESCRIPTION
Versions
--------
- 17.0+

Steps
-----
1. Go to Website / Shop;
2. click on a product;
3. click on the phone icon to get mobile view;
4. open the editor;
5. click on the product image;
6. set Layout / Image Zoom to Both;
7. save.

Issue
-----
Clicking on the product image doesn't zoom it.

Cause
-----
Commit 75cb82490200 improved zoom features. In the `_startZoom` function it added a comment to an early return, explaining zoom-on-hover should be ignored on mobile:

https://github.com/odoo/odoo/blob/75cb824902000b2c05716c8992ec486cf7102cea/addons/website_sale/static/src/js/website_sale.js#L490-L495

The issue is that this function also handles zoom-on-click, which gets skipped as well with the early return.

This early return didn't fire in the editor before commit 55f182291164, because it checked the value of `config.device.mobile`, which was `undefined`. After this commit, it checks `uiUtils.isSmall()` instead, which does return true in the editor, fully disabling the ability to zoom-on-click:

https://github.com/odoo/odoo/blob/55f1822911641a63309078dbc6dadf0c9fdc0796/addons/website_sale/static/src/js/website_sale.js#L341-L343

Solution
--------
Move the check on `uiUtils.isSmall()` from the early return to the `salePage.dataset.ecomZoomAuto` check, so that only zoom-on-hover gets skipped on mobile.

opw-3880081