### PR TITLE
[FIX] base: load demo data with a company and accounting

### DIFF
--- a/odoo/addons/base/models/res_company.py
+++ b/odoo/addons/base/models/res_company.py
@@ -3,6 +3,7 @@
 
 import base64
 import logging
+import threading
 import warnings
 
 from odoo import api, fields, models, tools, _, Command, SUPERUSER_ID
@@ -224,6 +225,7 @@ class Company(models.Model):
         is_ready_and_not_test = (
             not tools.config['test_enable']
             and (self.env.registry.ready or not self.env.registry._init)
+            and not getattr(threading.current_thread(), 'testing', False)
         )
         if uninstalled_modules and is_ready_and_not_test:
             return uninstalled_modules.button_immediate_install()


### PR DESCRIPTION
Use case to reproduce:
- Install stock and accounting without demo data
- Load demo data

Current behavior:
RuntimeError: Module operations inside tests are not transactional and thus forbidden...

It happens due to commit [1]. However, when loading the demo data the current thread has the attribute 'testing' set to True and prevent the installation of new modules.

The solution would be to prevent the installation of l10n when loading demo data as before the patch

[1] 0d4fac7fe0a356cbaf40f71587c78765ce50fc1e

