### PR TITLE
[IMP] mail: allow image deletion in composer on mobile

### DIFF
--- a/addons/mail/static/src/core/common/attachment_list.xml
+++ b/addons/mail/static/src/core/common/attachment_list.xml
@@ -34,15 +34,15 @@
                     <div t-if="attachment.uploading" class="position-absolute top-0 bottom-0 start-0 end-0 d-flex align-items-center justify-content-center" title="Uploading">
                         <i class="fa fa-spin fa-spinner"/>
                     </div>
-                    <div class="position-absolute top-0 bottom-0 start-0 end-0 p-2 text-white opacity-0 opacity-100-hover d-flex align-items-end flax-wrap flex-column">
-                        <div t-if="showDelete and !ui.isSmall"
+                    <div class="position-absolute top-0 bottom-0 start-0 end-0 p-2 text-white o-opacity-hoverable opacity-0 opacity-100-hover d-flex align-items-end flax-wrap flex-column">
+                        <button t-if="showDelete"
                              class="btn btn-sm btn-dark rounded opacity-75 opacity-100-hover"
                              tabindex="0" aria-label="Remove" role="menuitem" t-on-click.stop="() => this.onClickUnlink(attachment)" title="Remove">
                             <i class="fa fa-trash"/>
-                        </div>
-                        <div t-if="canDownload(attachment) and !ui.isSmall" class="btn btn-sm btn-dark rounded opacity-75 opacity-100-hover mt-auto" t-on-click.stop="() => this.onClickDownload(attachment)" title="Download">
+                        </button>
+                        <button t-if="canDownload(attachment)" class="btn btn-sm btn-dark rounded opacity-75 opacity-100-hover mt-auto" t-on-click.stop="() => this.onClickDownload(attachment)" title="Download">
                             <i class="fa fa-download"/>
-                        </div>
+                        </button>
                     </div>
                 </div>
             </div>

--- a/addons/mail/static/src/core/common/core.scss
+++ b/addons/mail/static/src/core/common/core.scss
@@ -102,3 +102,11 @@ a.o-discuss-mention {
         visibility: visible;
     }
 }
+
+// .o-opacity-hoberable class disable the opacity effect (see opacity-100-hover) on
+// device that dont support the hover effect (mainly touch device).
+@media (hover: none) {
+    .o-opacity-hoverable {
+        opacity: 100 !important;
+    }
+}

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -1128,7 +1128,7 @@ test("allow attachment delete on authored message", async () => {
     });
     await start();
     await openDiscuss(channelId);
-    await click(".o-mail-AttachmentImage div[title='Remove']");
+    await click(".o-mail-AttachmentImage [title='Remove']");
     await contains(".modal-dialog .modal-body", { text: 'Do you really want to delete "BLAH"?' });
     await click(".modal-footer .btn-primary");
     await contains(".o-mail-AttachmentCard", { count: 0 });


### PR DESCRIPTION
This PR removes the hover effect for touch device on attachment meaning:

* Touch device can now use the download button on image
* Touch device can now delete attachment images from the composer

![image](https://github.com/odoo/odoo/assets/1810149/bf791de0-b42e-4c7e-a58f-aecdea8da7ce)
