### PR TITLE
FIX kanban dropdown button and IMP field/widget documentation

### DIFF
--- a/addons/web/static/src/views/fields/field.js
+++ b/addons/web/static/src/views/fields/field.js
@@ -14,28 +14,31 @@ const isSmall = utils.isSmall;
 const viewRegistry = registry.category("views");
 const fieldRegistry = registry.category("fields");
 
+const supportedInfoValidation = {
+    type: Array,
+    element: Object,
+    shape: {
+        label: String,
+        name: String,
+        type: String,
+        availableTypes: { type: Array, element: String, optional: true },
+        default: { type: String, optional: true },
+        help: { type: String, optional: true },
+        choices: /* choices if type == selection */ {
+            type: Array,
+            element: Object,
+            shape: { label: String, value: String },
+            optional: true,
+        },
+    },
+    optional: true,
+};
+
 fieldRegistry.addValidation({
     component: { validate: (c) => c.prototype instanceof Component },
     displayName: { type: String, optional: true },
-    supportedOptions: {
-        type: Array,
-        element: Object,
-        shape: {
-            label: String,
-            name: String,
-            type: String,
-            availableTypes: { type: Array, element: String, optional: true },
-            default: { type: String, optional: true },
-            help: { type: String, optional: true },
-            choices: /* choices if type == selection */ {
-                type: Array,
-                element: Object,
-                shape: { label: String, value: String },
-                optional: true,
-            },
-        },
-        optional: true,
-    },
+    supportedAttributes: supportedInfoValidation,
+    supportedOptions: supportedInfoValidation,
     supportedTypes: { type: Array, element: String, optional: true },
     extractProps: { type: Function, optional: true },
     isEmpty: { type: Function, optional: true },

--- a/addons/web/static/src/views/fields/image/image_field.js
+++ b/addons/web/static/src/views/fields/image/image_field.js
@@ -207,6 +207,13 @@ export class ImageField extends Component {
 export const imageField = {
     component: ImageField,
     displayName: _t("Image"),
+    supportedAttributes: [
+        {
+            label: _t("Alternative text"),
+            name: "alt",
+            type: "string",
+        },
+    ],
     supportedOptions: [
         {
             label: _t("Reload"),

--- a/addons/web/static/src/views/fields/kanban_color_picker/kanban_color_picker_field.js
+++ b/addons/web/static/src/views/fields/kanban_color_picker/kanban_color_picker_field.js
@@ -1,3 +1,4 @@
+import { _t } from "@web/core/l10n/translation";
 import { ColorList } from "@web/core/colorlist/colorlist";
 import { registry } from "@web/core/registry";
 import { standardFieldProps } from "../standard_field_props";
@@ -19,6 +20,7 @@ class KanbanColorPickerField extends Component {
 
 export const kanbanColorPickerField = {
     component: KanbanColorPickerField,
+    displayName: _t("Color Picker"),
     extractProps(fieldInfo, dynamicInfo) {
         return {
             readonly: dynamicInfo.readonly,

--- a/addons/web/static/src/views/kanban/kanban_record.xml
+++ b/addons/web/static/src/views/kanban/kanban_record.xml
@@ -14,7 +14,7 @@
     </t>
 
     <t t-name="web.KanbanRecordMenu">
-        <div t-if="showMenu" class="o_dropdown_kanban bg-transparent position-absolute end-0">
+        <div t-if="showMenu" class="o_dropdown_kanban bg-transparent position-absolute end-0 top-0 w-auto">
             <Dropdown menuClass="'o-dropdown--kanban-record-menu'" position="'bottom-end'">
                 <button class="btn o-no-caret rounded-0" title="Dropdown menu">
                     <span class="fa fa-ellipsis-v"/>

--- a/addons/web/static/src/views/widgets/ribbon/ribbon.js
+++ b/addons/web/static/src/views/widgets/ribbon/ribbon.js
@@ -1,3 +1,4 @@
+import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { standardWidgetProps } from "../standard_widget_props";
 
@@ -49,6 +50,23 @@ export const ribbonWidget = {
             bgClass: attrs.bg_color,
         };
     },
+    supportedAttributes: [
+        {
+            label: _t("Title"),
+            name: "title",
+            type: "string",
+        },
+        {
+            label: _t("Background color"),
+            name: "bg_color",
+            type: "string",
+        },
+        {
+            label: _t("Tooltip"),
+            name: "tooltip",
+            type: "string",
+        },
+    ],
 };
 
 registry.category("view_widgets").add("web_ribbon", ribbonWidget);

--- a/addons/web/static/src/views/widgets/widget.js
+++ b/addons/web/static/src/views/widgets/widget.js
@@ -4,6 +4,26 @@ import { registry } from "@web/core/registry";
 import { Component, xml } from "@odoo/owl";
 const viewWidgetRegistry = registry.category("view_widgets");
 
+const supportedInfoValidation = {
+    type: Array,
+    element: Object,
+    shape: {
+        label: String,
+        name: String,
+        type: String,
+        availableTypes: { type: Array, element: String, optional: true },
+        default: { type: String, optional: true },
+        help: { type: String, optional: true },
+        choices: /* choices if type == selection */ {
+            type: Array,
+            element: Object,
+            shape: { label: String, value: String },
+            optional: true,
+        },
+    },
+    optional: true,
+};
+
 viewWidgetRegistry.addValidation({
     component: { validate: (c) => c.prototype instanceof Component },
     extractProps: { type: Function, optional: true },
@@ -12,6 +32,8 @@ viewWidgetRegistry.addValidation({
         type: [Function, { type: Array, element: Object, shape: { name: String, type: String } }],
         optional: true,
     },
+    supportedAttributes: supportedInfoValidation,
+    supportedOptions: supportedInfoValidation,
 });
 
 /**


### PR DESCRIPTION
This PR fixes the display of the dropdown button in a kanban card.

The second commit allow to document field and widgets attributes, and improves
the documentation on some of them (display name, supportedAttributes and supportedOptions)