### PR TITLE
[IMP] crm: improve wording and include today activities

### DIFF
--- a/addons/crm/report/crm_activity_report_views.xml
+++ b/addons/crm/report/crm_activity_report_views.xml
@@ -57,7 +57,7 @@
                     <separator/>
                     <filter string="Trailing 12 months" name="completion_date" domain="[
                         ('date', '>=', (datetime.datetime.combine(context_today() + relativedelta(days=-365), datetime.time(0,0,0)).to_utc()).strftime('%Y-%m-%d %H:%M:%S')),
-                        ('date', '&lt;=', (datetime.datetime.combine(context_today(), datetime.time(0,0,0)).to_utc()).strftime('%Y-%m-%d %H:%M:%S'))]"/>
+                        ('date', '&lt;=', (datetime.datetime.combine(context_today(), datetime.time(23, 59, 59)).to_utc()).strftime('%Y-%m-%d %H:%M:%S'))]"/>
                     <separator/>
                     <filter name="filter_date" date="date"/>
                     <separator/>
@@ -94,9 +94,9 @@
             <field name="domain">[]</field>
             <field name="help" type="html">
                 <p class="o_view_nocontent_smiling_face">
-                    No data yet!
+                    Let's get to work!
                 </p><p>
-                    Start scheduling activities on your opportunities
+                    Activities marked as Done on Leads will appear here, providing an overview of lead interactions.
                 </p>
             </field>
        </record>
@@ -109,9 +109,9 @@
             <field name="domain">[]</field>
             <field name="help" type="html">
                 <p class="o_view_nocontent_smiling_face">
-                    No data yet!
+                    Let's get to work!
                 </p><p>
-                    Start scheduling activities on your opportunities
+                    Activities marked as Done on Leads will appear here, providing an overview of lead interactions.
                 </p>
             </field>
         </record>

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -128,7 +128,7 @@
                             <group name="opportunity_partner" invisible="type == 'lead'">
                                 <field name="partner_id"
                                     widget="res_partner_many2one"
-                                    string="Customer"
+                                    string="Contact"
                                     context="{'res_partner_search_mode': type == 'opportunity' and 'customer' or False,
                                         'default_name': contact_name or partner_name,
                                         'default_street': street,
@@ -451,7 +451,7 @@
                     <group>
                         <field name="partner_id" widget="res_partner_many2one"
                             class="o_field_highlight"
-                            string='Organization / Contact'
+                            string='Contact'
                             context="{
                             'res_partner_search_mode': type == 'opportunity' and 'customer' or False,
                             'default_name': contact_name or partner_name,

--- a/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
+++ b/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
@@ -635,7 +635,7 @@ stepUtils.autoExpandMoreButtons(),
 },
 {
     isActive: ["mobile"],
-    trigger: ".modal:not(.o_inactive_modal) .modal-title:contains(Organization / Contact)",
+    trigger: ".modal:not(.o_inactive_modal) .modal-title:contains(Contact)",
 },
 {
     isActive: ["mobile"],
@@ -650,7 +650,7 @@ stepUtils.autoExpandMoreButtons(),
 },
 {
     isActive: ["mobile"],
-    trigger: ".modal:not(.o_inactive_modal) .modal-title:contains(Organization / Contact)",
+    trigger: ".modal:not(.o_inactive_modal) .modal-title:contains(Contact)",
 },
 {
     isActive: ["mobile"],


### PR DESCRIPTION
- Harmonize wording on lead form for partner_id: 'Contact' as the contact is not yet a customer.
- Include today as well in the activity filter 'Trailing 12 months'
- Reword activity helper

Task-4008792