### PR TITLE
[FIX] web_editor: remove dead code

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -3181,14 +3181,6 @@ export class OdooEditor extends EventTarget {
                     this.options.convertNumericToUnit
                 ));
             }
-
-            const table = getInSelection(this.document, 'table');
-            const toolbarButton = this.toolbar.querySelector('.toolbar-edit-table');
-            if (toolbarButton) {
-                this.toolbar.querySelector('.toolbar-edit-table').style.display = table
-                    ? 'block'
-                    : 'none';
-            }
         }
         this.updateColorpickerLabels();
         const listUIClasses = {UL: 'fa-list-ul', OL: 'fa-list-ol', CL: 'fa-tasks'};


### PR DESCRIPTION
Description of the issue this PR addresses:

Commit [1] removed dead code related to table creation/edition via the toolbar but missed a portion in `_updateToolbar`. This PR removes the remaining code.

[1]: https://github.com/odoo/odoo/commit/82dfb82b21a00c640c7c6e3c6dc3eb7d65069e1e

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr