### PR TITLE
[IMP] mail: remove border on discuss category toggle

### DIFF
--- a/addons/mail/static/src/discuss/core/web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/web/discuss_sidebar_categories.xml
@@ -12,11 +12,11 @@
 
     <t t-name="mail.DiscussSidebarCategory">
         <div class="o-mail-DiscussSidebarCategory d-flex align-items-center my-1" t-att-class="category.extraClass">
-            <div t-attf-class="flex-grow-1 d-flex align-items-baseline mx-1 btn p-0 text-start opacity-100-hover opacity-75" t-on-click="() => this.toggleCategory(category)">
+            <button class="btn btn-link text-reset flex-grow-1 d-flex align-items-baseline mx-1 p-0 text-start opacity-100-hover opacity-75" t-on-click="() => this.toggleCategory(category)">
                 <span t-if="store.channels.status === 'fetching'" class="o-visible-short-delay"><i class="o-mail-DiscussSidebarCategory-icon o-smaller me-1 fa fa-fw fa-circle-o-notch fa-spin opacity-50"/></span>
                 <i t-else="" class="o-mail-DiscussSidebarCategory-icon o-smaller me-1" t-att-class="category.open ? 'oi oi-chevron-down' : 'oi oi-chevron-right'"/>
                 <span class="btn-sm p-0 text-uppercase text-break fw-bolder o-smaller"><t t-esc="category.name"/></span>
-            </div>
+            </button>
             <div class="d-flex me-3" t-ref="actions">
                 <div class="btn-group btn-group-sm">
                     <button t-if="category.canView" class="btn btn-light" t-on-click="() => this.openCategory(category)" title="View or join channels">


### PR DESCRIPTION
Before this PR, when folding or unfolding a discuss category from the sidebar, a border would briefly appear. This is because only `.btn` is set on the link.

This PR adds `.btn-link` and `text-reset` to keep the same styling and improve the html of the sidebar by using a button tag and removing a useless `t-attf-class`.
