### PR TITLE
[FIX] point_of_sale, l10n_ch_pos: missing bank recipient pos invoice

### DIFF
--- a/addons/l10n_ch_pos/__init__.py
+++ b/addons/l10n_ch_pos/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models

--- a/addons/l10n_ch_pos/__manifest__.py
+++ b/addons/l10n_ch_pos/__manifest__.py
@@ -1,0 +1,14 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+{
+    'name': 'Swiss - Point of Sale',
+    'author': 'Odoo PS',
+    'category': 'Accounting/Localizations/Point of Sale',
+    'description': """
+Swiss POS Localization
+=======================================================
+    """,
+    'depends': ['l10n_ch', 'point_of_sale'],
+    'auto_install': True,
+    'installable': True,
+    'license': 'LGPL-3',
+}

--- a/addons/l10n_ch_pos/models/__init__.py
+++ b/addons/l10n_ch_pos/models/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import pos_order

--- a/addons/l10n_ch_pos/models/pos_order.py
+++ b/addons/l10n_ch_pos/models/pos_order.py
@@ -1,0 +1,15 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import models
+
+
+class PosOrder(models.Model):
+    _name = "pos.order"
+    _inherit = ["pos.order"]
+
+    def _get_partner_bank_id(self):
+        bank_partner_id = super()._get_partner_bank_id()
+        swiss_order = self.filtered(lambda o: o.company_id.country_code == 'CH')
+        if swiss_order:
+            has_pay_later = any(not pm.journal_id for pm in swiss_order.payment_ids.mapped('payment_method_id'))
+            bank_partner_id = bank_partner_id if has_pay_later else False
+        return bank_partner_id

--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -511,12 +511,10 @@ class PosOrder(models.Model):
 
     def _get_partner_bank_id(self):
         bank_partner_id = False
-        has_pay_later = any(not pm.journal_id for pm in self.payment_ids.mapped('payment_method_id'))
-        if has_pay_later:
-            if self.amount_total <= 0 and self.partner_id.bank_ids:
-                bank_partner_id = self.partner_id.bank_ids[0].id
-            elif self.amount_total >= 0 and self.company_id.partner_id.bank_ids:
-                bank_partner_id = self.company_id.partner_id.bank_ids[0].id
+        if self.amount_total <= 0 and self.partner_id.bank_ids:
+            bank_partner_id = self.partner_id.bank_ids[0].id
+        elif self.amount_total >= 0 and self.company_id.partner_id.bank_ids:
+            bank_partner_id = self.company_id.partner_id.bank_ids[0].id
         return bank_partner_id
 
     def _create_invoice(self, move_vals):


### PR DESCRIPTION
Steps:

- Install l10n_fr and make sure fr company has tax id filled
- Go to bank journal and set a bank account number
- Go to Customer invoice journal and check `Factur-X` in the
  Advenced Settings tab
- Create a french customer F with an email address
- Open a pos session, and make an invoice forF for a product with tax,
  select Bank payment method and confirm
- Go to invoices and select the newly created invoice
-> "Error occured while creating the EDI document"

Cause:

The field `partner_bank_id` is not set from the pos order to the invoice

cbe1cf5b1044827a058a4cde5d0492a545ac6da4 added a condition specifically
for swiss localisation.

Fix:

Movr the condition to a bridge module for swiss localisation

opw-3992498
