### PR TITLE
[PERF] point of sale: speed attribut selection in pop-up

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_info_popup/product_info_popup.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_info_popup/product_info_popup.js
@@ -20,7 +20,7 @@ export class ProductInfoPopup extends AbstractAwaitablePopup {
     }
     searchProduct(productName) {
         this.pos.setSelectedCategoryId(0);
-        this.pos.searchProductWord = productName;
+        this.pos.searchProductWord = productName + ";product_tmpl_id:" + this.props.product.product_tmpl_id;
         this.cancel();
     }
     _hasMarginsCostsAccessRights() {

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_list/product_list.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_list/product_list.js
@@ -126,13 +126,14 @@ export class ProductsWidget extends Component {
             this.state.currentOffset = 0;
         }
         const result = await this.loadProductFromDB();
+        const cleanedProductWord = searchProductWord.replace(/;product_tmpl_id:\d+$/, '');
         if (result.length > 0) {
             this.notification.add(
-                _t('%s product(s) found for "%s".', result.length, searchProductWord),
+                _t('%s product(s) found for "%s".', result.length, cleanedProductWord),
                 3000
             );
         } else {
-            this.notification.add(_t('No more product found for "%s".', searchProductWord), 3000);
+            this.notification.add(_t('No more product found for "%s".', cleanedProductWord), 3000);
         }
         if (this.state.previousSearchWord === searchProductWord) {
             this.state.currentOffset += result.length;
@@ -146,12 +147,13 @@ export class ProductsWidget extends Component {
         if (!searchProductWord) {
             return;
         }
+        const cleanedProductWord = searchProductWord.replace(/;product_tmpl_id:\d+$/, '');
         const domain = [
             "|",
             "|",
-            ["name", "ilike", searchProductWord],
-            ["default_code", "ilike", searchProductWord],
-            ["barcode", "ilike", searchProductWord],
+            ["name", "ilike", cleanedProductWord],
+            ["default_code", "ilike", cleanedProductWord],
+            ["barcode", "ilike", cleanedProductWord],
             ["available_in_pos", "=", true],
             ["sale_ok", "=", true],
         ];
@@ -166,7 +168,17 @@ export class ProductsWidget extends Component {
             const ProductIds = await this.orm.call(
                 "product.product",
                 "search",
-                [domain],
+                [
+                    [
+                        "&",
+                        ["available_in_pos", "=", true],
+                        "|",
+                        "|",
+                        ["name", "ilike", searchProductWord],
+                        ["default_code", "ilike", searchProductWord],
+                        ["barcode", "ilike", searchProductWord],
+                    ],
+                ],
                 {
                     offset: this.state.currentOffset,
                     limit: limit,


### PR DESCRIPTION
Before the commit:
To reproduce the error: In POS, when we go to the information page of a product and select an attribute, we perform a search to match the product name with the category_search_string (a long string). If the string is too long, the page freezes.

After the commit:
We pass the product.tmpl.id in the query so we can retrieve all products with the same product_tmpl_id and perform the match only within this list.

opw-3992954

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
