### PR TITLE
[FIX] test_new_api: make test_onchange_one2many_default robust

### DIFF
--- a/odoo/addons/test_new_api/tests/test_onchange.py
+++ b/odoo/addons/test_new_api/tests/test_onchange.py
@@ -372,7 +372,7 @@ class TestOnchange(SavepointCaseWithUserDemo):
         }
         result = model.onchange(values, ['name'], fields_spec)
         self.assertEqual(result['value'], {
-            'messages': [Command.update('virtual1', {'name': '[Stuff] OdooBot'})],
+            'messages': [Command.update('virtual1', {'name': f'[Stuff] {self.env.user.name}'})],
         })
 
     def test_fields_specific(self):


### PR DESCRIPTION
We assert a hardcoded string with the name of the base.partner_root data inside test_onchange_one2many_default(). Without mail this name is "System", with the mail module it becomes "OdooBot". Then the test works if we have mail installed
