### PR TITLE
[IMP] web_editor: keep data of CORS protected images

### DIFF
--- a/addons/web_editor/controllers/main.py
+++ b/addons/web_editor/controllers/main.py
@@ -567,6 +567,16 @@ class Web_Editor(http.Controller):
 
         return files_data_by_bundle
 
+    @http.route('/web_editor/fetch_image', type="json", auth="user", website=True)
+    def fetch_image(self, url):
+        try:
+            req = requests.get(url, timeout=2.5)
+            req.raise_for_status()
+        except requests.exceptions.RequestException as error:
+            logger.warning("Could not get the image data at url %s: %s", url, error)
+            return {'mimetype': '', 'base64Data': ''}
+        return {'mimetype': req.headers['Content-Type'], 'base64Data': b64encode(req.content)}
+
     @http.route('/web_editor/modify_image/<model("ir.attachment"):attachment>', type="json", auth="user", website=True)
     def modify_image(self, attachment, res_model=None, res_id=None, name=None, data=None, original_id=None, mimetype=None, alt_data=None):
         """


### PR DESCRIPTION
[IMP] web_editor: keep data of CORS protected images

Since [1], the system tries to fetch the data when a url image is added through the media dialog. If it manages to do so, an attachment is created with the raw data. If the fetch operation fails (e.g. CORS protection), a url attachement is created instead.

The goal of this commit is to create a binary attachment even if the image is CORS protected.

[1]: https://github.com/odoo/odoo/commit/943944dd249c15de870d6800d89e48d54a422e5a

task-4011345


