### PR TITLE
[FIX] sale: deduct downpayment on the same account

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -1160,6 +1160,8 @@ class SaleOrderLine(models.Model):
             'is_downpayment': self.is_downpayment,
         }
         self._set_analytic_distribution(res, **optional_values)
+        if self.is_downpayment:
+            res['account_id'] = self.invoice_lines.filtered('is_downpayment').account_id[:1].id
         if optional_values:
             res.update(optional_values)
         if self.display_type:


### PR DESCRIPTION
Previously, the down payment invoice used the account related to the product.
The final invoice used the default computed account instead.
This resulted in two different accounts being billed for the same client and the same sale.

This commit makes the final invoice use the same account as its down payment.

To verify:
- Create a sale order with a product which have an income account different from default one
- Create Downpayment => Invoice will have the income account of the product
- Fully invoice the sale order => Line to deduce the payment will use the default account

[Ticket link](https://www.odoo.com/odoo/project.task/3887331)
opw-3887331