### PR TITLE
[FIX] website_profile: reorder conditions accessing users profile

### DIFF
--- a/addons/website_profile/controllers/main.py
+++ b/addons/website_profile/controllers/main.py
@@ -45,12 +45,15 @@ class WebsiteProfile(http.Controller):
         # User can access - no matter what - his own profile
         if user_sudo.id == request.env.user.id:
             return user_sudo, False
-        if request.env.user.karma < request.website.karma_profile_min:
-            return False, _("Not have enough karma to view other users' profile.")
+
+        # Profile being published is more specific than general karma requirement (check it first!)
+        if not user_sudo.website_published:
+            return False, _('This profile is private!')
         elif not user_sudo.exists():
             raise request.not_found()
-        elif user_sudo.karma == 0 or not user_sudo.website_published:
-            return False, _('This profile is private!')
+
+        elif request.env.user.karma < request.website.karma_profile_min:
+            return False, _("Not have enough karma to view other users' profile.")
         return user_sudo, False
 
     def _prepare_user_values(self, **kwargs):


### PR DESCRIPTION
[FIX] website_profile: reorder conditions accessing users profile

Before we were checking for karma requirenment even if for unpublished websites
now we don't.

[Reproduce]
- Install website_forum
- Set karma to 100 for a website
- Open a profile page on a forum, unselect "Public Profile"
- BUG: Opening a profile page as another user render msg:
	   "Not have enough karma to view other users's profile"
	   Instead of a message about profile beeing private

opw-3972165