### PR TITLE
[FIX] mrp_bom kanban view. Typo : clatt instead of class

### DIFF
--- a/addons/mrp/views/mrp_bom_views.xml
+++ b/addons/mrp/views/mrp_bom_views.xml
@@ -185,7 +185,7 @@
                             <div t-attf-class="oe_kanban_global_click">
                                 <div class="o_kanban_record_top">
                                     <div class="o_kanban_record_headings mt4">
-                                        <strong class="o_kanban_record_title"><span clatt="mt4"><field name="product_tmpl_id"/></span></strong>
+                                        <strong class="o_kanban_record_title"><span class="mt4"><field name="product_tmpl_id"/></span></strong>
                                     </div>
                                     <span class="float-end badge rounded-pill"><t t-esc="record.product_qty.value"/> <small><t t-esc="record.product_uom_id.value"/></small></span>
                                 </div>

--- a/doc/cla/corporate/grap.md
+++ b/doc/cla/corporate/grap.md
@@ -9,7 +9,9 @@ declaration.
 Signed,
 
 Sylvain LE GAL sylvain.legal@grap.coop https://github.com/legalsylvain
+Quentin DUPONT quentin.dupont@grap.coop https://github.com/quentinDupont
 
 List of contributors:
 
 Sylvain LE GAL sylvain.legal@grap.coop https://github.com/legalsylvain
+Quentin DUPONT quentin.dupont@grap.coop https://github.com/quentinDupont


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Trivial commit that fixes typo

Current behavior before PR: class "mt4" is not used as it's written "clatt" and not "class"

Desired behavior after PR is merged: class "mt4" will be used 




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
