### PR TITLE
[FIX] sale_stock: only consider moves strictly delivered to the customer

### DIFF
--- a/addons/sale_stock/models/sale_order_line.py
+++ b/addons/sale_stock/models/sale_order_line.py
@@ -288,7 +288,7 @@ class SaleOrderLine(models.Model):
                (not strict and move.rule_id.id in triggering_rule_ids and move.location_final_id.usage == "customer"):
                 if not move.origin_returned_move_id or (move.origin_returned_move_id and move.to_refund):
                     outgoing_moves |= move
-            elif move.location_dest_id.usage != "customer" and move.to_refund:
+            elif move.location_id.usage == "customer" and move.to_refund:
                 incoming_moves |= move
 
         return outgoing_moves, incoming_moves

--- a/addons/sale_stock/tests/test_sale_stock.py
+++ b/addons/sale_stock/tests/test_sale_stock.py
@@ -1881,3 +1881,60 @@ class TestSaleStock(TestSaleStockCommon, ValuationReconciliationTestCommon):
         self.assertEqual(pick_return.move_ids.product_uom_qty, 1)
         self.assertEqual(pick_return.location_dest_id, warehouse.lot_stock_id)
         self.assertEqual(pick_return.state, 'assigned')
+
+    def test_return_partial_delivery(self):
+        """
+        Test that the qty_delivered is correctly computed when a return of backorder delivery is validated:
+        - Set the delivery process to three steps.
+        - Update the quantity of the product to 10.
+        - Create a sales order to deliver 3 units.
+        - Validate a pick for 1 unit and create a backorder.
+        - Validate the pack for 1 unit.
+        - Validate the backorder for 2 units.
+        - Create and validate a return.
+        Check that the qty_delivered is 0.
+        """
+        warehouse = self.company_data['default_warehouse']
+        warehouse.delivery_steps = 'pick_pack_ship'
+        product = self.env['product.product'].create({
+            'name': 'To be delivered',
+            'type': 'product',
+        })
+        self.env['stock.quant']._update_available_quantity(product, warehouse.lot_stock_id, 10)
+        with Form(self.env['sale.order']) as so_form:
+            so_form.partner_id = self.partner_a
+            with so_form.order_line.new() as line:
+                line.product_id = product
+                line.product_uom_qty = 3
+            sale_order = so_form.save()
+        sale_order.action_confirm()
+        self.assertEqual(len(sale_order.picking_ids), 1)
+        pick = sale_order.picking_ids
+        self.assertEqual(pick.picking_type_id, warehouse.pick_type_id)
+        pick.move_ids.write({'quantity': 1, 'picked': True})
+        # Create backorder for missing qty
+        pick._action_done()
+        pick_backorder = pick.backorder_ids
+        self.assertEqual(pick_backorder.move_ids.product_uom_qty, 2)
+        # validate the pack for one unit
+        pack_1 = sale_order.picking_ids - pick
+        pack_1.move_ids.write({'quantity': 1, 'picked': True})
+        pack_1._action_done()
+        # validate the pick_backorder and then create the return
+        pick_backorder.move_ids.write({'quantity': 2, 'picked': True})
+        pick_backorder._action_done()
+        self.assertEqual(pick_backorder.state, 'done')
+        # Create return picking
+        stock_return_picking_form = Form(self.env['stock.return.picking']
+            .with_context(active_ids=pick_backorder.ids, active_id=pick_backorder.sorted().ids[0],
+            active_model='stock.picking'))
+        return_wiz = stock_return_picking_form.save()
+        return_wiz.product_return_moves.quantity = 2.0
+        return_wiz.product_return_moves.to_refund = True
+        res = return_wiz.create_returns()
+        return_pick = self.env['stock.picking'].browse(res['res_id'])
+        # Validate the return
+        return_pick.move_ids.write({'quantity': 2, 'picked': True})
+        return_pick.button_validate()
+        # check the qty delivered in the SOL
+        self.assertEqual(sale_order.order_line.qty_delivered, 0)


### PR DESCRIPTION
**Steps to reproduce the bug:**
- Enable multi-step routes in the general settings.
- Go to the warehouse settings:
    - Select 3 steps for Outgoing Shipments.
- Create a storable product “P1”.
- Create a sales order with the following details:
    - Customer: Azure Interior
    - Product: 3 units of P1
- Confirm the sales order

- Go to the pick picking
- Set the quantity to 1 unit
- Validate the pick and create a backorder
- Go to the pack step and validate it

- Return to the pick backorder and validate it for 2 units
- Create a return from this backorder
- Validate the return
- Go back to the sales order

**Problem:**
The delivered quantity is set to -2 instead of 0. When the return is validated, the “_compute_qty_delivered” function is triggered, which uses both outgoing and incoming moves. The “_get_outgoing_incoming_moves” method is called to retrieve these moves. However, for return moves, we only check if the `location_dest` is not set to customer usage and if `move.to_refund` is not false, without verifying that the source location is from the customer.

opw-3962062
