### PR TITLE
[IMP] mail: introduce a getter for picker popover settings

### DIFF
--- a/addons/mail/static/src/core/common/picker.js
+++ b/addons/mail/static/src/core/common/picker.js
@@ -58,14 +58,7 @@ export class Picker extends Component {
 
     setup() {
         this.ui = useState(useService("ui"));
-        this.popover = usePopover(PickerContent, {
-            position: this.props.position,
-            fixedPosition: true,
-            onClose: () => this.close(),
-            closeOnClickAway: false,
-            animation: false,
-            arrow: false,
-        });
+        this.popover = usePopover(PickerContent, this.popoverSettings);
         useExternalListener(
             browser,
             "click",
@@ -87,6 +80,17 @@ export class Picker extends Component {
                 async (ev) => this.toggle(this.props.anchor?.el ?? button.el, ev)
             );
         }
+    }
+
+    get popoverSettings() {
+        return {
+            position: this.props.position,
+            fixedPosition: true,
+            onClose: () => this.close(),
+            closeOnClickAway: false,
+            animation: false,
+            arrow: false,
+        };
     }
 
     get contentProps() {


### PR DESCRIPTION
The picker location in the backend is fixed, and it makes sense to set its `fixedPosition` to `true`. Since we're going to replace the portal chatter with the backend chatter and because the position of the composer in the portal chatter is not fixed (it's scrollable) the picker position for this usage shouldn't be fixed as well.
This commit introduces a getter for popover settings, so it'd be possible to change the picker popover settings when it's needed.

Part of task-2828744
