### PR TITLE
[IMP] portal, test_mail_full: thread id and model in portal_avatar params

### DIFF
--- a/addons/portal/models/mail_message.py
+++ b/addons/portal/models/mail_message.py
@@ -95,9 +95,9 @@ class MailMessage(models.Model):
                 values['attachment_ids'] = message_to_attachments.get(message.id, {})
             if 'author_avatar_url' in properties_names:
                 if options and 'token' in options:
-                    values['author_avatar_url'] = f'/mail/avatar/mail.message/{message.id}/author_avatar/50x50?access_token={options["token"]}'
+                    values['author_avatar_url'] = f'/mail/avatar/mail.message/{message.model}/{message.res_id}/{message.id}/author_avatar/50x50?access_token={options["token"]}'
                 elif options and options.keys() >= {"hash", "pid"}:
-                    values['author_avatar_url'] = f'/mail/avatar/mail.message/{message.id}/author_avatar/50x50?_hash={options["hash"]}&pid={options["pid"]}'
+                    values['author_avatar_url'] = f'/mail/avatar/mail.message/{message.model}/{message.res_id}/{message.id}/author_avatar/50x50?_hash={options["hash"]}&pid={options["pid"]}'
                 else:
                     values['author_avatar_url'] = f'/web/image/mail.message/{message.id}/author_avatar/50x50'
             if 'is_message_subtype_note' in properties_names:

--- a/addons/test_mail_full/tests/test_portal.py
+++ b/addons/test_mail_full/tests/test_portal.py
@@ -83,17 +83,17 @@ class TestPortalControllers(TestPortal):
             'model': self.record_portal._name,
             'res_id': self.record_portal.id,
         })
-        response = self.url_open(f'/mail/avatar/mail.message/{mail_record.id}/author_avatar/50x50?access_token={self.record_portal.access_token}')
+        response = self.url_open(f'/mail/avatar/mail.message/{mail_record.model}/{mail_record.res_id}/{mail_record.id}/author_avatar/50x50?access_token={self.record_portal.access_token}')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.headers.get('Content-Type'), 'image/png')
         self.assertRegex(response.headers.get('Content-Disposition', ''), r'mail_message-\d+-author_avatar\.png')
 
-        placeholder_response = self.url_open(f'/mail/avatar/mail.message/{mail_record.id}/author_avatar/50x50?access_token={self.record_portal.access_token + "a"}') # false token
+        placeholder_response = self.url_open(f'/mail/avatar/mail.message/{mail_record.model}/{mail_record.res_id}/{mail_record.id}/author_avatar/50x50?access_token={self.record_portal.access_token + "a"}')  # false token
         self.assertEqual(placeholder_response.status_code, 200)
         self.assertEqual(placeholder_response.headers.get('Content-Type'), 'image/png')
         self.assertRegex(placeholder_response.headers.get('Content-Disposition', ''), r'placeholder\.png')
 
-        no_token_response = self.url_open(f'/mail/avatar/mail.message/{mail_record.id}/author_avatar/50x50')
+        no_token_response = self.url_open(f'/mail/avatar/mail.message/{mail_record.model}/{mail_record.res_id}/{mail_record.id}/author_avatar/50x50')
         self.assertEqual(no_token_response.status_code, 200)
         self.assertEqual(no_token_response.headers.get('Content-Type'), 'image/png')
         self.assertRegex(no_token_response.headers.get('Content-Disposition', ''), r'placeholder\.png')
@@ -117,13 +117,13 @@ class TestPortalControllers(TestPortal):
         self.assertNotIn("error", res.json())
         message = self.record_portal.message_ids[0]
         response = self.url_open(
-            f'/mail/avatar/mail.message/{message.id}/author_avatar/50x50?_hash={self.record_portal._sign_token(self.partner_2.id)}&pid={self.partner_2.id}')
+            f'/mail/avatar/mail.message/{message.model}/{message.res_id}/{message.id}/author_avatar/50x50?_hash={self.record_portal._sign_token(self.partner_2.id)}&pid={self.partner_2.id}')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.headers.get('Content-Type'), 'image/png')
         self.assertRegex(response.headers.get('Content-Disposition', ''), r'mail_message-\d+-author_avatar\.png')
 
         placeholder_response = self.url_open(
-            f'/mail/avatar/mail.message/{message.id}/author_avatar/50x50?_hash={self.record_portal._sign_token(self.partner_2.id) + "a"}&pid={self.partner_2.id}')  # false hash
+            f'/mail/avatar/mail.message/{message.model}/{message.res_id}/{message.id}/author_avatar/50x50?_hash={self.record_portal._sign_token(self.partner_2.id) + "a"}&pid={self.partner_2.id}')  # false hash
         self.assertEqual(placeholder_response.status_code, 200)
         self.assertEqual(placeholder_response.headers.get('Content-Type'), 'image/png')
         self.assertRegex(placeholder_response.headers.get('Content-Disposition', ''), r'placeholder\.png')


### PR DESCRIPTION
In replacing the old portal chatter with the backend chatter, we're going to check portal access with a new decorator. This decorator checks the access to the thread using the `thread_model` and `thread_id` in the params. `_check_special_access` is going to be deleted after replacing the portal chatter and portal composer. To do so, we need `thread_model` and `thread_id` in this controller's params. 
This is a preparation PR to delete the `_check_special_access` and use a common decorator on all portal controllers.

Part of task-2828744

