### PR TITLE
[FIX] iap: add club-internet.fr to generic emails

### DIFF
--- a/addons/iap/tools/iap_tools.py
+++ b/addons/iap/tools/iap_tools.py
@@ -61,7 +61,7 @@ _MAIL_PROVIDERS = {
     'freemail.hu', 'live.it', 'blackwaretech.com', 'byom.de', 'dispostable.com', 'dayrep.com', 'aim.com', 'prixgen.com', 'gmail.om',
     'asterisk-tech.mn', 'in.com', 'aliceadsl.fr', 'lycos.com', 'topnet.tn', 'teleworm.us', 'kedgebs.com', 'supinfo.com', 'posteo.de',
     'yahoo.com ', 'op.pl', 'gmail.fr', 'grr.la', 'oci.fr', 'aselcis.com', 'optusnet.com.au', 'mailcatch.com', 'rambler.ru', 'protonmail.ch',
-    'prisme.ch', 'bbox.fr', 'orbitalu.com', 'netcourrier.com', 'iinet.net.au', 'cegetel.net', 'proton.me', 'dbmail.com',
+    'prisme.ch', 'bbox.fr', 'orbitalu.com', 'netcourrier.com', 'iinet.net.au', 'cegetel.net', 'proton.me', 'dbmail.com', 'club-internet.fr',
     # Dummy entries
     'example.com',
 }


### PR DESCRIPTION
same as: https://github.com/odoo/odoo/pull/159321

opw-3786308

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
