### PR TITLE
[FIX] event: prevent an error when open a event ticket with invalid url

### DIFF
--- a/addons/event/controllers/main.py
+++ b/addons/event/controllers/main.py
@@ -28,7 +28,7 @@ class EventController(Controller):
         ])
 
     @route(['/event/<int:event_id>/my_tickets'], type='http', auth='public')
-    def event_my_tickets(self, event_id, registration_ids, tickets_hash, badge_mode=False, responsive_html=False):
+    def event_my_tickets(self, event_id=False, registration_ids=False, tickets_hash=False, badge_mode=False, responsive_html=False):
         """ Returns a pdf response, containing all tickets for attendees in registration_ids for event_id.
 
         Throw Forbidden if no registration is valid / hash is invalid / parameters are missing.


### PR DESCRIPTION
Currently, an error occurs while opening an event ticket with an invalid URL.

Step To Produce:

- Install the 'event' module.
- And Open any booked event, click on 'Attendees', and open any record, Click on 'View Ticket' in chatter.
- Copy the ticket URL and try to open this ticket URL without 'registration_ids' which is included in it.

```
TypeError: EventController.event_my_tickets() missing 2 required positional
arguments: 'registration_ids' and 'tickets_hash'
```

An error occurs when the system tries to call a route '/event/<int:event_id>/my_tickets'' without certain parameters at [1].

Link [1]: https://github.com/odoo/odoo/blob/5945b8340ba4797c8224ab3464ec87e8f285d75a/addons/event/controllers/main.py#L31

To handle this issue, provide a default value to the parameter of the route method.

sentry-4952598215

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
