### PR TITLE
[FIX] mass_mailing: fix new mailing on mobile

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
@@ -245,7 +245,7 @@ export class MassMailingHtmlField extends HtmlField {
             this._themeClassNames = "";
             const displayableThemes =
                 uiUtils.isSmall() ?
-                themesEls.filter(theme => !theme.dataset.hideFromMobile) :
+                Array.from(themesEls).filter(theme => !theme.dataset.hideFromMobile) :
                 themesEls;
             this._themeParams = Array.from(displayableThemes).map((theme) => {
                 const $theme = $(theme);


### PR DESCRIPTION
Purpose
=======
Fix the traceback appearing when creating a new mailing on mobile.

Specification
=============
There is no "filter" method on HTMLCollection.
Converting the HTMLCollection to an array so that the filtering can be performed.

related commit: 5a990d8d8ba2ec2999f84d2f1dae7aeec0f2d9b5

Task-4000990

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
