### PR TITLE
[FIX] project: button to assign should be visible on line being hovered

### DIFF
--- a/addons/project/static/src/components/subtask_kanban_list/subtask_kanban_list.scss
+++ b/addons/project/static/src/components/subtask_kanban_list/subtask_kanban_list.scss
@@ -17,5 +17,10 @@
 
     .subtask_list_row:hover {
         background-color: $table-hover-bg;
+        @include media-breakpoint-up(sm) {
+            .o_field_widget.o_field_many2many_tags_avatar .o_quick_assign {
+                visibility: visible !important;
+            }
+        }
     }
 }

--- a/addons/project/static/src/views/project_task_kanban/project_task_kanban_view.scss
+++ b/addons/project/static/src/views/project_task_kanban/project_task_kanban_view.scss
@@ -10,6 +10,26 @@
         font-size: 16px;
     }
 
+    .o_kanban_record {
+        @include media-breakpoint-up(sm) {
+            &:hover {
+                .o_field_widget.o_field_many2many_tags_avatar .o_quick_assign {
+                    visibility: hidden;
+                }
+            }
+        }
+    }
+
+    .oe_kanban_content {
+        @include media-breakpoint-up(sm) {
+            &:hover {
+                .o_field_widget.o_field_many2many_tags_avatar .o_quick_assign {
+                    visibility: visible;
+                }
+            }
+        }
+    }
+
     .o_kanban_header .o_column_progress .bg-success-done {
         --bs-bg-opacity: 1;
         background-color: rgba(25, 135, 84, var(--bs-bg-opacity)) !important;

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -723,8 +723,8 @@
                                         <field name="state" widget="project_task_state_selection" options="{'is_toggle_mode': false}"/>
                                     </div>
                                 </div>
-                                <widget name="subtask_kanban_list" />
                             </div>
+                            <widget name="subtask_kanban_list" />
                             <div class="clearfix"></div>
                         </div>
                     </t>


### PR DESCRIPTION
Steps to reproduce:
- Navigate to the 'project.task' kanban card.
- click on the checkbox of the sub-task which is on card of the task. -hover the subtask.

Issue:
- The 'Assign People' button is currently always visible for each sub-task, which may lead to cluttered UI.

Solution:
- Modify the UI behavior to display the 'Assign People' button only when hovering over a sub-task line in the 'project.task' kanban card's sub-tasks list.

task-3549267


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
