### PR TITLE
[IMP] base: using str2bool for boolean field with config parameter

### DIFF
--- a/odoo/addons/base/models/res_config.py
+++ b/odoo/addons/base/models/res_config.py
@@ -10,7 +10,7 @@ from lxml import etree
 
 from odoo import api, models, _
 from odoo.exceptions import AccessError, RedirectWarning, UserError
-from odoo.tools import ustr
+from odoo.tools import str2bool
 
 _logger = logging.getLogger(__name__)
 
@@ -317,7 +317,7 @@ class ResConfigSettings(models.TransientModel, ResConfigModuleInstallationMixin)
                         _logger.warning(WARNING_MESSAGE, value, field, icp)
                         value = 0.0
                 elif field.type == 'boolean':
-                    value = bool(value)
+                    value = str2bool(value, True)
             res[name] = value
 
         res.update(self.get_values())


### PR DESCRIPTION
-PROBLEM: install account where we will have `use_invoice_term` as one of `ir.config.parameter `-> Set it to `True` in setting -> Go to `system parameter` and try to edit its key `account.use_invoice_term` to hold value `'False'` -> Go back in see it in Account setting, The checkbox is still ticked while we expect it not
-Solution: instead of using `bool(value)` we check the condition more precisely with `tools.str2bool` because `bool("False") return True`

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
