### PR TITLE
[FIX] point_of_sale: compatibility fix for invoice_line name from PoS

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -8,6 +8,7 @@ from collections import defaultdict
 
 import psycopg2
 import pytz
+import re
 
 from odoo import api, fields, models, tools, _
 from odoo.tools import float_is_zero, float_round, float_repr, float_compare
@@ -1456,6 +1457,10 @@ class PosOrderLine(models.Model):
             product_name = line.product_id\
                 .with_context(lang=line.order_id.partner_id.lang or self.env.user.lang)\
                 .get_product_multiline_description_sale()
+            if line.product_id.display_name:
+                product_name = re.sub(re.escape(line.product_id.display_name), '', product_name)
+                product_name = re.sub(r'^\n', '', product_name)
+                product_name = re.sub(r'(?<=\n) ', '', product_name)
             base_line_vals_list.append(
                 {
                     **self.env['account.tax']._convert_to_tax_base_line_dict(


### PR DESCRIPTION
Description of the issue this commit addresses:

Since the redesign of the description column of the invoice lines, that column is not supposed to contain the name of the product anymore. At the moment, the computation of the line name still uses it in the PoS.
Referenced commit is:
https://github.com/odoo/odoo/pull/152869/commits/216634fd048c568d5b398134ba948a301bf76e3c

---

Desired behavior after the commit is merged:

When creating an invoice from the PoS, the invoice lines' description only contain the custom description of the product and not the name of the product.

---

task-4013483

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
