### PR TITLE
[IMP] account: export analytic_distribution into plans

### DIFF
--- a/addons/account/controllers/__init__.py
+++ b/addons/account/controllers/__init__.py
@@ -5,3 +5,4 @@ from . import portal
 from . import terms
 from . import download_docs
 from . import tests_shared_js_python
+from . import export

--- a/addons/account/controllers/export.py
+++ b/addons/account/controllers/export.py
@@ -1,0 +1,41 @@
+import json
+
+from odoo import http
+from odoo.addons.web.controllers.export import CSVExport, ExcelExport
+
+
+def adapt_analytic_distribution_into_analytic_lines_data(data):
+
+    def get_analytic_fields_to_add():
+        project_plan, other_plans = http.request.env['account.analytic.plan']._get_all_plans()
+        return (
+            [{'name': 'analytic_line_ids/amount', 'label': 'Analytic Amount'}]
+            + [{'name': 'analytic_line_ids/account_id', 'label': project_plan.name}]
+            + [{'name': f'analytic_line_ids/{plan_field.name}', 'label': plan_field.field_description} for plan_field in other_plans._find_plan_column()]
+        )
+
+    data_dic = json.loads(data)
+    if data_dic.get('model') != 'account.move.line':
+        return data
+
+    fields_data_lst = data_dic['fields']
+    for i, field_data_dic in enumerate(fields_data_lst):
+        if field_data_dic['name'] == 'analytic_distribution':
+            data_dic['fields'] = fields_data_lst[:i] + get_analytic_fields_to_add() + fields_data_lst[i + 1:]
+            return json.dumps(data_dic)
+
+    return data
+
+
+class CSVExportAccountMoveLine(CSVExport):
+
+    def base(self, data):
+        data = adapt_analytic_distribution_into_analytic_lines_data(data)
+        return super().base(data)
+
+
+class ExcelExportAccountMoveLine(ExcelExport):
+
+    def base(self, data):
+        data = adapt_analytic_distribution_into_analytic_lines_data(data)
+        return super().base(data)


### PR DESCRIPTION
Currently, when you export the `analytic_distribution` field of journal items, you get the content of the json field.  Which doesn't mean anything to the user.

With this commit, exporting `analytic_distribution` will be equivalent to exporting the amount and all the plans of the `analytic_line_ids`.

task-3977961
