### PR TITLE
[FIX] website: fix webp-converted cover image's related record

### DIFF
--- a/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
+++ b/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
@@ -980,8 +980,7 @@ export class WysiwygAdapterComponent extends Wysiwyg {
                     name: `${modelName} ${recordName} cover image.${groups.mimetype.split("/")[1]}`,
                     data: groups.imageData,
                     is_image: true,
-                    res_model: resModel,
-                    res_id: resID,
+                    res_model: 'ir.ui.view',
                 },
             );
             cssBgImage = `url(${attachment.image_src})`;


### PR DESCRIPTION
Since [1] cover images are implicitly converted to webp. Those converted images were stored related to their record (e.g. a given blog post). Because of this, the created attachment was not made public, and therefore not available for visitors.

This commit fixes this by linking the cover image to the general concept of `ir.ui.view` - as it was the case before images were converted. Doing this makes the image attachments public.

Steps to reproduce:
- Upload a JPG image as a published blog post cover.
- Save => a WEBP version of the image is uploaded.

=> Visitors could not see the image when viewing the blog post.

[1]: https://github.com/odoo/odoo/commit/068dcc27e417d52b51d274c44497f4388fed780a

opw-4009916
