### PR TITLE
[FIX] account_edi_ubl_cii: change for X-Rechnung version 3.0.1 (on Odoo 16.0)

### DIFF
--- a/addons/account_edi_ubl_cii/data/ubl_20_templates.xml
+++ b/addons/account_edi_ubl_cii/data/ubl_20_templates.xml
@@ -29,6 +29,9 @@
             <cbc:EndpointID
                     t-att="vals.get('endpoint_id_attrs', {})"
                     t-out="vals.get('endpoint_id')"/>
+            <t t-if="not partner.vat and partner.email" >
+                <cbc:EndpointID schemeID="EM" t-out="partner.email"/>
+            </t>
             <t t-foreach="vals.get('party_identification_vals', [])" t-as="party_vals">
                 <cac:PartyIdentification>
                     <cbc:ID

--- a/addons/l10n_sa_edi/tests/compliance/standard/credit.xml
+++ b/addons/l10n_sa_edi/tests/compliance/standard/credit.xml
@@ -36,6 +36,7 @@
             <cac:PartyIdentification>
                 <cbc:ID schemeID="CRN">2525252525252</cbc:ID>
             </cac:PartyIdentification>
+            <cac:EndpointID schemeID="9930">\</cbc:EndpointID>
             <cac:PartyName>
                 <cbc:Name>SA Company Test</cbc:Name>
             </cac:PartyName>

--- a/addons/l10n_sa_edi/tests/compliance/standard/debit.xml
+++ b/addons/l10n_sa_edi/tests/compliance/standard/debit.xml
@@ -36,6 +36,7 @@
             <cac:PartyIdentification>
                 <cbc:ID schemeID="CRN">2525252525252</cbc:ID>
             </cac:PartyIdentification>
+            <cac:EndpointID schemeID="9930">\</cbc:EndpointID>
             <cac:PartyName>
                 <cbc:Name>SA Company Test</cbc:Name>
             </cac:PartyName>

--- a/doc/cla/corporate/mundialis.md
+++ b/doc/cla/corporate/mundialis.md
@@ -1,0 +1,15 @@
+Germany, 2024-06-26
+
+mundialis agrees to the terms of the Odoo Corporate Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Markus Eichhorn eichhorn@mundialis.de https://github.com/Jarmin81
+
+List of contributors:
+
+Anika Weinmann weinmann@mundialis.de https://github.com/anikaweinmann

--- a/doc/cla/corporate/terrestris.md
+++ b/doc/cla/corporate/terrestris.md
@@ -1,0 +1,15 @@
+Germany, 2024-06-26
+
+terrestris agrees to the terms of the Odoo Corporate Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Marc Jansen jansen@terrestris.de https://github.com/marcjansen
+
+List of contributors:
+
+Michael Holthausen mholthausen@terrestris.de https://github.com/mholthausen


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

- The PR addresses the problem described in https://github.com/odoo/odoo/issues/167219. 

Current behavior before PR:

- The current behavior is that the created XRechnung is not valide because of the missing `Buyer electronic address MUST be provided (val-sch.2.1; PEPPOL-EN16931-RO-10)` if the customer does not have a VAT number.

Desired behavior after PR is merged:

- Getting a valide XRechnung also without a VAT number of the customer.


Co-authored-by: [Michael Holthausen](@mholthausen)
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
