### PR TITLE
[IMP]: improve seo of website pages

### DIFF
--- a/addons/http_routing/views/http_routing_template.xml
+++ b/addons/http_routing/views/http_routing_template.xml
@@ -109,7 +109,7 @@
                         <div class="container">
                             <div class="row align-items-center">
                                 <div class="col-lg-4 pb32">
-                                    <img class="img img-fluid mx-auto" src="/web_editor/shape/http_routing/404.svg?c2=o-color-2"/>
+                                    <img class="img img-fluid mx-auto" src="/web_editor/shape/http_routing/404.svg?c2=o-color-2" alt=""/>
                                 </div>
                                 <div class="col-lg-8 text-lg-start text-center my-auto">
                                     <h1 class="visually-hidden">Error 404</h1>

--- a/addons/website/i18n/website.pot
+++ b/addons/website/i18n/website.pot
@@ -3663,6 +3663,19 @@ msgid "Carousel Intro"
 msgstr ""
 
 #. module: website
+#. odoo-javascript
+#: code:addons/website/static/src/js/editor/snippets.options.js:0
+#: code:addons/website/static/src/snippets/s_image_gallery/001.xml:0
+#: model_terms:ir.ui.view,arch_db:website.new_page_template_team_s_image_gallery
+#: model_terms:ir.ui.view,arch_db:website.s_carousel
+#: model_terms:ir.ui.view,arch_db:website.s_carousel_intro
+#: model_terms:ir.ui.view,arch_db:website.s_image_gallery
+#: model_terms:ir.ui.view,arch_db:website.s_quotes_carousel
+#: model_terms:ir.ui.view,arch_db:website.s_quotes_carousel_minimal
+msgid "Carousel indicator"
+msgstr ""
+
+#. module: website
 #: model_terms:ir.ui.view,arch_db:website.s_product_catalog
 msgid "Carrot Cake"
 msgstr ""
@@ -5100,7 +5113,10 @@ msgid "Discard"
 msgstr ""
 
 #. module: website
+#: model_terms:ir.ui.view,arch_db:website.s_card
 #: model_terms:ir.ui.view,arch_db:website.s_framed_intro
+#: model_terms:ir.ui.view,arch_db:website.s_quadrant
+#: model_terms:ir.ui.view,arch_db:website.s_striped_top
 msgid "Discover"
 msgstr ""
 
@@ -6140,6 +6156,7 @@ msgstr ""
 #: code:addons/website/static/src/snippets/s_social_media/options.js:0
 #: model_terms:ir.ui.view,arch_db:website.footer_custom
 #: model_terms:ir.ui.view,arch_db:website.header_social_links
+#: model_terms:ir.ui.view,arch_db:website.s_facebook_page
 #: model_terms:ir.ui.view,arch_db:website.s_mega_menu_odoo_menu
 #: model_terms:ir.ui.view,arch_db:website.s_references_social
 #: model_terms:ir.ui.view,arch_db:website.s_share
@@ -8637,7 +8654,6 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:website.s_image_text_box
 #: model_terms:ir.ui.view,arch_db:website.s_image_text_overlap
 #: model_terms:ir.ui.view,arch_db:website.s_mockup_image
-#: model_terms:ir.ui.view,arch_db:website.s_quadrant
 #: model_terms:ir.ui.view,arch_db:website.s_shape_image
 #: model_terms:ir.ui.view,arch_db:website.s_text_image
 msgid "Learn more"
@@ -8800,6 +8816,11 @@ msgstr ""
 #. module: website
 #: model_terms:ir.ui.view,arch_db:website.color_combinations_debug_view
 msgid "Link text"
+msgstr ""
+
+#. module: website
+#: model_terms:ir.ui.view,arch_db:website.s_product_list
+msgid "Link to product"
 msgstr ""
 
 #. module: website
@@ -8981,6 +9002,8 @@ msgid "Management"
 msgstr ""
 
 #. module: website
+#. odoo-javascript
+#: code:addons/website/static/src/js/utils.js:0
 #: model_terms:ir.ui.view,arch_db:website.s_map
 #: model_terms:ir.ui.view,arch_db:website.snippets
 msgid "Map"
@@ -11316,18 +11339,8 @@ msgid "Reaching new heights together"
 msgstr ""
 
 #. module: website
-#: model_terms:ir.ui.view,arch_db:website.s_card
-msgid "Read More"
-msgstr ""
-
-#. module: website
 #: model_terms:ir.ui.view,arch_db:website.s_faq_horizontal
 msgid "Read More <i class=\"fa fa-angle-right\" role=\"img\"/>"
-msgstr ""
-
-#. module: website
-#: model_terms:ir.ui.view,arch_db:website.s_striped_top
-msgid "Read more"
 msgstr ""
 
 #. module: website

--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -2143,6 +2143,7 @@ options.registry.Carousel = options.registry.CarouselHandler.extend({
         this.$indicators.append($('<button>', {
             'data-bs-target': '#' + this.$target.attr('id'),
             'data-bs-slide-to': $items.length,
+            'aria-label': _t('Carousel indicator'),
         }));
         this.$indicators.append(' ');
         // Need to remove editor data from the clone so it gets its own.

--- a/addons/website/static/src/js/utils.js
+++ b/addons/website/static/src/js/utils.js
@@ -381,6 +381,7 @@ export function generateGMapIframe() {
     iframeEl.setAttribute('marginheight', '0');
     iframeEl.setAttribute('marginwidth', '0');
     iframeEl.setAttribute('src', 'about:blank');
+    iframeEl.setAttribute('aria-label', _t("Map"));
     return iframeEl;
 }
 

--- a/addons/website/static/src/snippets/s_image_gallery/001.xml
+++ b/addons/website/static/src/snippets/s_image_gallery/001.xml
@@ -16,7 +16,7 @@
                 </button>
                 <div class="carousel-indicators s_image_gallery_indicators_bars">
                     <t t-foreach="images" t-as="image" t-key="image_index">
-                        <button type="button" t-attf-data-bs-target="##{id}" t-att-data-bs-slide-to="image_index" t-att-class="image_index == index and 'active' or None" t-attf-style="background-image: url(#{image.getAttribute('src')})"/>
+                        <button type="button" aria-label="Carousel indicator" t-attf-data-bs-target="##{id}" t-att-data-bs-slide-to="image_index" t-att-class="image_index == index and 'active' or None" t-attf-style="background-image: url(#{image.getAttribute('src')})"/>
                     </t>
                 </div>
                 <button class="carousel-control-next o_we_no_overlay o_not_editable" contenteditable="false" t-attf-data-bs-target="##{id}" data-bs-slide="next" aria-label="Next" title="Next">

--- a/addons/website/views/new_page_template_templates.xml
+++ b/addons/website/views/new_page_template_templates.xml
@@ -995,9 +995,9 @@ overridden by modules), because:
     </xpath>
     <xpath expr="//div[hasclass('carousel-indicators')]" position="replace">
         <div class="carousel-indicators">
-            <button data-bs-target="#slideshow_sample" data-bs-slide-to="0" style="background-image: url(/web/image/website.s_company_team_image_1)" class="active"/>
-            <button data-bs-target="#slideshow_sample" data-bs-slide-to="1" style="background-image: url(/web/image/website.s_company_team_image_2)"/>
-            <button data-bs-target="#slideshow_sample" data-bs-slide-to="2" style="background-image: url(/web/image/website.s_company_team_image_3)"/>
+            <button data-bs-target="#slideshow_sample" data-bs-slide-to="0" style="background-image: url(/web/image/website.s_company_team_image_1)" class="active" aria-label="Carousel indicator"/>
+            <button data-bs-target="#slideshow_sample" data-bs-slide-to="1" style="background-image: url(/web/image/website.s_company_team_image_2)" aria-label="Carousel indicator"/>
+            <button data-bs-target="#slideshow_sample" data-bs-slide-to="2" style="background-image: url(/web/image/website.s_company_team_image_3)" aria-label="Carousel indicator"/>
         </div>
     </xpath>
 </template>

--- a/addons/website/views/snippets/s_card.xml
+++ b/addons/website/views/snippets/s_card.xml
@@ -4,12 +4,12 @@
 <template id="s_card" name="Card">
     <div class="s_card o_card_img_top card o_cc o_cc1" data-vxml="001">
         <figure class="o_card_img_wrapper ratio ratio-16x9 mb-0">
-            <img class="o_card_img card-img-top" src="/web/image/website.s_card_default_image_1"/>
+            <img class="o_card_img card-img-top" src="/web/image/website.s_card_default_image_1" alt=""/>
         </figure>
         <div class="card-body">
             <h5 class="card-title">Card title</h5>
             <p class="card-text">A card is a flexible and extensible content container. It includes options for headers and footers, a wide variety of content, contextual background colors, and powerful display options.</p>
-            <a t-att-href="cta_btn_href">Read More</a>
+            <a t-att-href="cta_btn_href">Discover</a>
         </div>
     </div>
 </template>

--- a/addons/website/views/snippets/s_carousel.xml
+++ b/addons/website/views/snippets/s_carousel.xml
@@ -56,15 +56,15 @@
                 <span class="carousel-control-prev-icon" aria-hidden="true"/>
                 <span class="visually-hidden">Previous</span>
             </button>
-            <button class="carousel-control-next o_not_editable" contenteditable="false" t-attf-data-bs-target="#myCarousel{{uniq}}" data-bs-slide="next" role="img" aria-label="Next" title="Next">
+            <button class="carousel-control-next o_not_editable" contenteditable="false" t-attf-data-bs-target="#myCarousel{{uniq}}" data-bs-slide="next" aria-label="Next" title="Next">
                 <span class="carousel-control-next-icon" aria-hidden="true"/>
                 <span class="visually-hidden">Next</span>
             </button>
             <!-- Indicators -->
             <div class="carousel-indicators o_not_editable">
-                <button type="button" t-attf-data-bs-target="#myCarousel{{uniq}}" data-bs-slide-to="0" class="active"/>
-                <button type="button" t-attf-data-bs-target="#myCarousel{{uniq}}" data-bs-slide-to="1"/>
-                <button type="button" t-attf-data-bs-target="#myCarousel{{uniq}}" data-bs-slide-to="2"/>
+                <button type="button" t-attf-data-bs-target="#myCarousel{{uniq}}" data-bs-slide-to="0" class="active" aria-label="Carousel indicator"/>
+                <button type="button" t-attf-data-bs-target="#myCarousel{{uniq}}" data-bs-slide-to="1" aria-label="Carousel indicator"/>
+                <button type="button" t-attf-data-bs-target="#myCarousel{{uniq}}" data-bs-slide-to="2" aria-label="Carousel indicator"/>
             </div>
         </div>
     </section>

--- a/addons/website/views/snippets/s_carousel_intro.xml
+++ b/addons/website/views/snippets/s_carousel_intro.xml
@@ -64,16 +64,16 @@
                             <span class="carousel-control-prev-icon" aria-hidden="true"/>
                             <span class="visually-hidden">Previous</span>
                         </button>
-                        <button class="carousel-control-next o_not_editable" contenteditable="false" t-attf-data-bs-target="#myCarouselIntro{{uniq}}" data-bs-slide="next" role="img" aria-label="Next" title="Next">
+                        <button class="carousel-control-next o_not_editable" contenteditable="false" t-attf-data-bs-target="#myCarouselIntro{{uniq}}" data-bs-slide="next" aria-label="Next" title="Next">
                             <span class="carousel-control-next-icon" aria-hidden="true"/>
                             <span class="visually-hidden">Next</span>
                         </button>
                     </div>
                     <!-- Indicators -->
                     <div class="s_carousel_indicators_numbers carousel-indicators align-items-center flex-shrink-1 w-auto">
-                        <button type="button" t-attf-data-bs-target="#myCarouselIntro{{uniq}}" data-bs-slide-to="0" class="active"/>
-                        <button type="button" t-attf-data-bs-target="#myCarouselIntro{{uniq}}" data-bs-slide-to="1"/>
-                        <button type="button" t-attf-data-bs-target="#myCarouselIntro{{uniq}}" data-bs-slide-to="2"/>
+                        <button type="button" t-attf-data-bs-target="#myCarouselIntro{{uniq}}" data-bs-slide-to="0" class="active" aria-label="Carousel indicator"/>
+                        <button type="button" t-attf-data-bs-target="#myCarouselIntro{{uniq}}" data-bs-slide-to="1" aria-label="Carousel indicator"/>
+                        <button type="button" t-attf-data-bs-target="#myCarouselIntro{{uniq}}" data-bs-slide-to="2" aria-label="Carousel indicator"/>
                     </div>
                 </div>
             </div>

--- a/addons/website/views/snippets/s_closer_look.xml
+++ b/addons/website/views/snippets/s_closer_look.xml
@@ -13,7 +13,7 @@
             <p>
                 <br/>
             </p>
-            <img class="img-fluid mx-auto" data-shape="web_editor/devices/macbook_front" data-file-name="s_closer_look.jpg" data-original-mimetype="image/jpeg" src="/web_editor/image_shape/website.s_closer_look_default_image/web_editor/devices/macbook_front.svg"/>
+            <img class="img-fluid mx-auto" data-shape="web_editor/devices/macbook_front" data-file-name="s_closer_look.jpg" data-original-mimetype="image/jpeg" src="/web_editor/image_shape/website.s_closer_look_default_image/web_editor/devices/macbook_front.svg" alt=""/>
         </div>
     </section>
 </template>

--- a/addons/website/views/snippets/s_cta_box.xml
+++ b/addons/website/views/snippets/s_cta_box.xml
@@ -6,7 +6,7 @@
         <div class="container">
             <div class="s_card o_card_img_horizontal flex-lg-row-reverse card o_cc o_cc4" data-snippet="s_card" data-vxml="001" data-name="Card" style="--card-spacer-x: 64px; --card-spacer-y: 64px; border-width: 0px !important;">
                 <figure class="o_card_img_wrapper ratio ratio-1x1 mb-0">
-                    <img class="o_card_img rounded-end" src="/web/image/website.s_cta_box_default_image"/>
+                    <img class="o_card_img rounded-end" src="/web/image/website.s_cta_box_default_image" alt=""/>
                 </figure>
                 <div class="card-body">
                     <h2 class="card-title">50,000+ companies run Odoo<br/>to grow their businesses.</h2>

--- a/addons/website/views/snippets/s_cta_mockups.xml
+++ b/addons/website/views/snippets/s_cta_mockups.xml
@@ -6,7 +6,7 @@
         <div class="container">
             <div class="row o_grid_mode" data-row-count="9">
                 <div class="o_grid_item o_grid_item_image g-height-9 g-col-lg-7 col-lg-7" style="grid-area: 1 / 6 / 10 / 13; z-index: 1;">
-                    <img src="web_editor/image_shape/website.s_cta_mockups_default_image/web_editor/devices/macbook_front.svg" class="img img-fluid" data-shape="web_editor/devices/macbook_front" data-original-mimetype="image/jpeg" data-file-name="s_cta_mockups.jpg"/>
+                    <img src="web_editor/image_shape/website.s_cta_mockups_default_image/web_editor/devices/macbook_front.svg" class="img img-fluid" data-shape="web_editor/devices/macbook_front" data-original-mimetype="image/jpeg" data-file-name="s_cta_mockups.jpg" alt=""/>
                 </div>
                 <div class="o_grid_item g-height-6 g-col-lg-4 col-lg-4" style="grid-area: 3 / 1 / 9 / 5; z-index: 2;">
                     <h3>50,000+ companies trust Odoo.</h3>
@@ -14,7 +14,7 @@
                     <a t-att-href="cta_btn_href" class="btn btn-primary btn-lg"><t t-out="cta_btn_text">Contact us</t></a>
                 </div>
                 <div class="o_grid_item o_grid_item_image o_snippet_mobile_invisible g-height-8 g-col-lg-2 col-lg-2 d-none d-lg-block" style="grid-area: 2 / 6 / 10 / 8; z-index: 3;">
-                    <img src="web_editor/image_shape/website.s_cta_mockups_default_image_1/web_editor/devices/iphone_front_portrait.svg" class="img img-fluid" data-shape="web_editor/devices/iphone_front_portrait" data-original-mimetype="image/jpeg" data-file-name="s_cta_mockups_1.jpg"/>
+                    <img src="web_editor/image_shape/website.s_cta_mockups_default_image_1/web_editor/devices/iphone_front_portrait.svg" class="img img-fluid" data-shape="web_editor/devices/iphone_front_portrait" data-original-mimetype="image/jpeg" data-file-name="s_cta_mockups_1.jpg" alt=""/>
                 </div>
             </div>
         </div>

--- a/addons/website/views/snippets/s_empowerment.xml
+++ b/addons/website/views/snippets/s_empowerment.xml
@@ -17,7 +17,7 @@
                     </p>
                 </div>
                 <div class="o_grid_item o_grid_item_image g-height-12 g-col-lg-5 col-lg-5 o_snippet_mobile_invisible d-none d-lg-block" style="grid-area: 1 / 8 / 13 / 13; --grid-item-padding-x: 24px; --grid-item-padding-y: 0px;">
-                    <img class="img img-fluid mx-auto rounded" style="width: 100% !important;" src="/web/image/website.s_empowerment_default_image"/>
+                    <img class="img img-fluid mx-auto rounded" style="width: 100% !important;" src="/web/image/website.s_empowerment_default_image" alt=""/>
                 </div>
             </div>
         </div>

--- a/addons/website/views/snippets/s_facebook_page.xml
+++ b/addons/website/views/snippets/s_facebook_page.xml
@@ -4,7 +4,7 @@
 <!-- Snippet template -->
 <template id="s_facebook_page" name="Facebook">
     <div class="o_facebook_page">
-        <iframe class="mw-100 o_facebook_page_preview" src="https://www.facebook.com/plugins/page.php?height=70&amp;hide_cover=true&amp;href=https%3A%2F%2Fwww.facebook.com%2FOdoo&amp;show_facepile=false&amp;small_header=true&amp;tabs=&amp;width=500" style="width: 500px; height: 70px; border: medium none; overflow: hidden;"/>
+        <iframe class="mw-100 o_facebook_page_preview" src="https://www.facebook.com/plugins/page.php?height=70&amp;hide_cover=true&amp;href=https%3A%2F%2Fwww.facebook.com%2FOdoo&amp;show_facepile=false&amp;small_header=true&amp;tabs=&amp;width=500" style="width: 500px; height: 70px; border: medium none; overflow: hidden;" aria-label="Facebook"/>
     </div>
 </template>
 

--- a/addons/website/views/snippets/s_faq_horizontal.xml
+++ b/addons/website/views/snippets/s_faq_horizontal.xml
@@ -13,7 +13,7 @@
             <div class="row s_col_no_resize">
                 <div data-name="Topic" class="s_faq_horizontal_entry col-12 mb-2 pt16 pb32">
                     <article class="row">
-                        <hgroup class="col-lg-4" role="heading">
+                        <hgroup class="col-lg-4" role="heading" aria-level="3">
                             <div class="s_faq_horizontal_entry_title position-lg-sticky pb-lg-3 transition-base overflow-auto" style="top: 16px">
                                 <h3 class="h5-fs">Getting Started</h3>
                                 <p class="o_small text-muted">Getting started with our product is a breeze, thanks to our well-structured and comprehensive onboarding process.</p>
@@ -30,7 +30,7 @@
                 </div>
                 <div data-name="Topic" class="s_faq_horizontal_entry col-12 mb-2 pt16 pb32">
                     <article class="row">
-                        <hgroup class="col-lg-4" role="heading">
+                        <hgroup class="col-lg-4" role="heading" aria-level="3">
                             <div class="s_faq_horizontal_entry_title position-lg-sticky pb-lg-3 transition-base overflow-auto" style="top: 16px">
                                 <h3 class="h5-fs">Updates and Improvements</h3>
                                 <p class="o_small text-muted">We are committed to continuous improvement, regularly releasing updates and new features based on user feedback and technological advancements.</p>
@@ -43,7 +43,7 @@
                                 <canvas height="0"/>
                             </div>
                             <!-- Graph's preview: removed automatically on drop  -->
-                            <img src="/website/static/src/img/snippets_previews/s_faq_horizontal_2_preview.jpg" class="s_dialog_preview w-100"/>
+                            <img src="/website/static/src/img/snippets_previews/s_faq_horizontal_2_preview.jpg" class="s_dialog_preview w-100" alt=""/>
                             <!-- ==============================================  -->
                             <p><br/>Users can participate in beta testing programs, providing feedback on upcoming releases and influencing the future direction of the platform. By staying current with updates, you can take advantage of the latest tools and features, ensuring your business remains competitive and efficient.</p>
                         </span>
@@ -51,7 +51,7 @@
                 </div>
                 <div data-name="Topic" class="s_faq_horizontal_entry col-12 mb-2 pt16 pb32">
                     <article class="row">
-                        <hgroup class="col-lg-4" role="heading">
+                        <hgroup class="col-lg-4" role="heading" aria-level="3">
                             <div class="s_faq_horizontal_entry_title position-lg-sticky pb-lg-3 transition-base overflow-auto" style="top: 16px">
                                 <h3 class="h5-fs">Support and Resources</h3>
                                 <p class="o_small text-muted">We are committed to providing exceptional support and resources to help you succeed with our platform.</p>

--- a/addons/website/views/snippets/s_features_wall.xml
+++ b/addons/website/views/snippets/s_features_wall.xml
@@ -11,21 +11,21 @@
                     <p class="lead">Write one or two paragraphs describing your product or services. To be successful your content needs to be useful to your readers.</p>
                 </div>
                 <div class="o_grid_item o_grid_item_image g-height-6 g-col-lg-3 col-lg-3" style="z-index: 2; grid-area: 1 / 7 / 7 / 10; --grid-item-padding-y: 0px; --grid-item-padding-x: 16px;">
-                    <img class="img img-fluid" src="/web/image/website.library_image_16"/>
+                    <img class="img img-fluid" src="/web/image/website.library_image_16" alt=""/>
                 </div>
                 <div class="o_grid_item g-height-4 g-col-lg-3 col-lg-3 s_col_no_bgcolor" style="z-index: 3; grid-area: 7 / 7 / 11 / 10; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px;">
                     <h3 class="h5-fs">Expertise and Knowledge</h3>
                     <p>We offer cutting-edge products and services to tackle modern challenges. Leveraging the latest technology, we help you achieve your goals.</p>
                 </div>
                 <div class="o_grid_item o_grid_item_image g-height-6 g-col-lg-3 col-lg-3" style="z-index: 4; grid-area: 12 / 7 / 18 / 10; --grid-item-padding-y: 0px; --grid-item-padding-x: 16px;">
-                    <img class="img img-fluid" src="/web/image/website.library_image_03"/>
+                    <img class="img img-fluid" src="/web/image/website.library_image_03" alt=""/>
                 </div>
                 <div class="o_grid_item g-height-4 g-col-lg-3 col-lg-3 s_col_no_bgcolor" style="z-index: 5; grid-area: 18 / 7 / 22 / 10; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px;">
                     <h3 class="h5-fs">Tailored Solutions</h3>
                     <p>Customer satisfaction is our priority. Our support team is always ready to assist, ensuring you have a smooth and successful experience.</p>
                 </div>
                 <div class="o_grid_item o_grid_item_image g-height-6 g-col-lg-3 col-lg-3" style="z-index: 6; grid-area: 6 / 10 / 12 / 13; --grid-item-padding-y: 0px; --grid-item-padding-x: 16px;">
-                    <img class="img img-fluid" src="/web/image/website.library_image_13"/>
+                    <img class="img img-fluid" src="/web/image/website.library_image_13" alt=""/>
                 </div>
                 <div class="o_grid_item g-height-4 g-col-lg-3 col-lg-3 s_col_no_bgcolor" style="z-index: 7; grid-area: 12 / 10 / 16 / 13; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px;">
                     <h3 class="h5-fs">Quality and Excellence</h3>

--- a/addons/website/views/snippets/s_image_gallery.xml
+++ b/addons/website/views/snippets/s_image_gallery.xml
@@ -7,13 +7,13 @@
             <div id="slideshow_sample" class="carousel carousel-dark slide" data-bs-ride="true">
                 <div class="carousel-inner">
                     <div class="carousel-item active">
-                        <img class="img img-fluid d-block mh-100 mw-100 mx-auto rounded object-fit-cover" src="/web/image/website.library_image_08" data-name="Image" data-index="0" alt=" "/>
+                        <img class="img img-fluid d-block mh-100 mw-100 mx-auto rounded object-fit-cover" src="/web/image/website.library_image_08" data-name="Image" data-index="0" alt=""/>
                     </div>
                     <div class="carousel-item">
-                        <img class="img img-fluid d-block mh-100 mw-100 mx-auto rounded object-fit-cover" src="/web/image/website.library_image_03" data-name="Image" data-index="1" alt=" "/>
+                        <img class="img img-fluid d-block mh-100 mw-100 mx-auto rounded object-fit-cover" src="/web/image/website.library_image_03" data-name="Image" data-index="1" alt=""/>
                     </div>
                     <div class="carousel-item">
-                        <img class="img img-fluid d-block mh-100 mw-100 mx-auto rounded object-fit-cover" src="/web/image/website.library_image_02" data-name="Image" data-index="2" alt=" "/>
+                        <img class="img img-fluid d-block mh-100 mw-100 mx-auto rounded object-fit-cover" src="/web/image/website.library_image_02" data-name="Image" data-index="2" alt=""/>
                     </div>
                 </div>
                 <div class="o_carousel_controllers">
@@ -22,9 +22,9 @@
                         <span class="visually-hidden">Previous</span>
                     </button>
                     <div class="carousel-indicators">
-                        <button type="button" data-bs-target="#slideshow_sample" data-bs-slide-to="0" style="background-image: url(/web/image/website.library_image_08)" class="active"/>
-                        <button type="button" style="background-image: url(/web/image/website.library_image_03)" data-bs-target="#slideshow_sample" data-bs-slide-to="1"/>
-                        <button type="button" style="background-image: url(/web/image/website.library_image_02)" data-bs-target="#slideshow_sample" data-bs-slide-to="2"/>
+                        <button type="button" data-bs-target="#slideshow_sample" data-bs-slide-to="0" style="background-image: url(/web/image/website.library_image_08)" class="active" aria-label="Carousel indicator"/>
+                        <button type="button" style="background-image: url(/web/image/website.library_image_03)" data-bs-target="#slideshow_sample" data-bs-slide-to="1" aria-label="Carousel indicator"/>
+                        <button type="button" style="background-image: url(/web/image/website.library_image_02)" data-bs-target="#slideshow_sample" data-bs-slide-to="2" aria-label="Carousel indicator"/>
                     </div>
                     <button class="carousel-control-next o_not_editable" contenteditable="false" t-attf-data-bs-target="#slideshow_sample" data-bs-slide="next" aria-label="Next" title="Next">
                         <span class="carousel-control-next-icon" aria-hidden="true"/>
@@ -41,16 +41,16 @@
         <div class="container">
             <div class="row s_nb_column_fixed">
                 <div class="o_masonry_col o_snippet_not_selectable col-lg-4">
-                    <img class="img img-fluid d-block rounded" src="/web/image/website.library_image_03" data-index="0" data-name="Image" alt=" "/>
-                    <img class="img img-fluid d-block rounded" src="/web/image/website.library_image_10" data-index="3" data-name="Image" alt=" "/>
+                    <img class="img img-fluid d-block rounded" src="/web/image/website.library_image_03" data-index="0" data-name="Image" alt=""/>
+                    <img class="img img-fluid d-block rounded" src="/web/image/website.library_image_10" data-index="3" data-name="Image" alt=""/>
                 </div>
                 <div class="o_masonry_col o_snippet_not_selectable col-lg-4">
-                    <img class="img img-fluid d-block rounded" src="/web/image/website.library_image_13" data-index="1" data-name="Image" alt=" "/>
-                    <img class="img img-fluid d-block rounded" src="/web/image/website.library_image_05" data-index="4" data-name="Image" alt=" "/>
+                    <img class="img img-fluid d-block rounded" src="/web/image/website.library_image_13" data-index="1" data-name="Image" alt=""/>
+                    <img class="img img-fluid d-block rounded" src="/web/image/website.library_image_05" data-index="4" data-name="Image" alt=""/>
                 </div>
                 <div class="o_masonry_col o_snippet_not_selectable col-lg-4">
-                    <img class="img img-fluid d-block rounded" src="/web/image/website.library_image_14" data-index="2" data-name="Image" alt=" "/>
-                    <img class="img img-fluid d-block rounded" src="/web/image/website.library_image_16" data-index="5" data-name="Image" alt=" "/>
+                    <img class="img img-fluid d-block rounded" src="/web/image/website.library_image_14" data-index="2" data-name="Image" alt=""/>
+                    <img class="img img-fluid d-block rounded" src="/web/image/website.library_image_16" data-index="5" data-name="Image" alt=""/>
                 </div>
             </div>
         </div>

--- a/addons/website/views/snippets/s_intro_pill.xml
+++ b/addons/website/views/snippets/s_intro_pill.xml
@@ -7,7 +7,7 @@
             <div class="row o_grid_mode" data-row-count="11">
                 <div class="o_grid_item oe_img_bg o_grid_item_image g-col-lg-5 g-height-9 col-lg-5 order-lg-0" style="order: 2; z-index: 1; grid-area: 1 / 1 / 10 / 6; --grid-item-padding-y: 0px; --grid-item-padding-x: 0px;">
                     <img class="img-fluid mx-auto" data-shape="web_editor/geometric_round/geo_round_pill" data-file-name="s_intro_pill_default_image.jpg"
-                    data-original-mimetype="image/jpeg" src="/web_editor/image_shape/website.s_intro_pill_default_image/web_editor/geometric_round/geo_round_pill.svg"/>
+                    data-original-mimetype="image/jpeg" src="/web_editor/image_shape/website.s_intro_pill_default_image/web_editor/geometric_round/geo_round_pill.svg" alt=""/>
                 </div>
                 <div class="o_grid_item g-height-11 g-col-lg-8 col-lg-8 order-lg-0" data-name="Box" style="order: 1; z-index: 3; grid-area: 1 / 3 / 12 / 11; --grid-item-padding-y: 120px;">
                     <h1 class="display-3" style="text-align: center;">Experience the<br/>best quality services</h1>
@@ -19,7 +19,7 @@
                     </p>
                 </div>
                 <div class="o_grid_item o_grid_item_image g-col-lg-5 g-height-10 d-none d-lg-block col-lg-5 order-lg-0" style="order: 3; z-index: 2; grid-area: 2 / 8 / 12 / 13; --grid-item-padding-y: 0px; --grid-item-padding-x: 0px;">
-                    <img class="img-fluid mx-auto" data-shape="web_editor/geometric_round/geo_round_pill" data-file-name="s_intro_pill_default_image_2.jpg" data-original-mimetype="image/jpeg" src="/web_editor/image_shape/website.s_intro_pill_default_image_2/web_editor/geometric_round/geo_round_pill.svg"/>
+                    <img class="img-fluid mx-auto" data-shape="web_editor/geometric_round/geo_round_pill" data-file-name="s_intro_pill_default_image_2.jpg" data-original-mimetype="image/jpeg" src="/web_editor/image_shape/website.s_intro_pill_default_image_2/web_editor/geometric_round/geo_round_pill.svg" alt=""/>
                 </div>
             </div>
         </div>

--- a/addons/website/views/snippets/s_mockup_image.xml
+++ b/addons/website/views/snippets/s_mockup_image.xml
@@ -13,7 +13,7 @@
                     <p><a href="#" class="btn btn-primary">Learn more</a></p>
                 </div>
                 <div class="col-lg-8 pt16 pb16">
-                    <img src="/web_editor/image_shape/website.s_mockup_image_default_image/web_editor/devices/macbook_front.svg" class="img-fluid ms-auto" data-shape="web_editor/devices/macbook_front" data-shape-colors=";;#F3F2F2;;" data-file-name="s_text_image.jpg" data-original-mimetype="image/jpeg"/>
+                    <img src="/web_editor/image_shape/website.s_mockup_image_default_image/web_editor/devices/macbook_front.svg" class="img-fluid ms-auto" data-shape="web_editor/devices/macbook_front" data-shape-colors=";;#F3F2F2;;" data-file-name="s_text_image.jpg" data-original-mimetype="image/jpeg" alt=""/>
                 </div>
             </div>
         </div>

--- a/addons/website/views/snippets/s_numbers_charts.xml
+++ b/addons/website/views/snippets/s_numbers_charts.xml
@@ -14,8 +14,8 @@
                     <p>Clients saved $32 million with our services.</p>
                     <div class="s_progress_bar s_progress_bar_label_hidden" data-display="inline" data-vcss="001" data-snippet="s_progress_bar">
                         <div class="s_progress_bar_wrapper d-flex gap-2">
-                            <div class="progress" role="progressbar" aria-valuenow="80" aria-valuemin="0" aria-valuemax="100">
-                                <div class="progress-bar overflow-visible bg-o-color-2" style="width: 80%; min-width: 3%" aria-label="Progress bar"/>
+                            <div class="progress" role="progressbar" aria-label="Progress bar" aria-valuenow="80" aria-valuemin="0" aria-valuemax="100">
+                                <div class="progress-bar overflow-visible bg-o-color-2" style="width: 80%; min-width: 3%"/>
                             </div>
                         </div>
                     </div>
@@ -25,8 +25,8 @@
                     <p>We proudly serves over 25,000 clients.</p>
                     <div class="s_progress_bar s_progress_bar_label_hidden" data-display="inline" data-vcss="001" data-snippet="s_progress_bar">
                         <div class="s_progress_bar_wrapper d-flex gap-2">
-                            <div class="progress" role="progressbar" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100">
-                                <div class="progress-bar overflow-visible bg-o-color-2" style="width: 45%; min-width: 3%" aria-label="Progress bar"/>
+                            <div class="progress" role="progressbar" aria-label="Progress bar" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100">
+                                <div class="progress-bar overflow-visible bg-o-color-2" style="width: 45%; min-width: 3%"/>
                             </div>
                         </div>
                     </div>

--- a/addons/website/views/snippets/s_product_list.xml
+++ b/addons/website/views/snippets/s_product_list.xml
@@ -12,7 +12,7 @@
                 <div data-name="Card" class="col-lg-2 col-6">
                     <div class="s_card o_card_img_top card o_cc o_cc1" data-snippet="s_card" data-vxml="001" data-name="Card">
                         <figure class="o_card_img_wrapper ratio ratio-4x3 mb-0">
-                            <a t-att-href="url">
+                            <a t-att-href="url" aria-label="Link to product">
                                 <img src="/web/image/website.s_product_list_default_image_1" alt="" class="o_card_img card-img-top"/>
                             </a>
                         </figure>
@@ -24,7 +24,7 @@
                 <div data-name="Card" class="col-lg-2 col-6">
                     <div class="s_card o_card_img_top card o_cc o_cc1" data-snippet="s_card" data-vxml="001" data-name="Card">
                         <figure class="o_card_img_wrapper ratio ratio-4x3 mb-0">
-                            <a t-att-href="url">
+                            <a t-att-href="url" aria-label="Link to product">
                                 <img src="/web/image/website.s_product_list_default_image_2" alt="" class="o_card_img card-img-top"/>
                             </a>
                         </figure>
@@ -36,7 +36,7 @@
                 <div data-name="Card" class="col-lg-2 col-6">
                     <div class="s_card o_card_img_top card o_cc o_cc1" data-snippet="s_card" data-vxml="001" data-name="Card">
                         <figure class="o_card_img_wrapper ratio ratio-4x3 mb-0">
-                            <a t-att-href="url">
+                            <a t-att-href="url" aria-label="Link to product">
                                 <img src="/web/image/website.s_product_list_default_image_3" alt="" class="o_card_img card-img-top"/>
                             </a>
                         </figure>
@@ -48,7 +48,7 @@
                 <div data-name="Card" class="col-lg-2 col-6">
                     <div class="s_card o_card_img_top card o_cc o_cc1" data-snippet="s_card" data-vxml="001" data-name="Card">
                         <figure class="o_card_img_wrapper ratio ratio-4x3 mb-0">
-                            <a t-att-href="url">
+                            <a t-att-href="url" aria-label="Link to product">
                                 <img src="/web/image/website.s_product_list_default_image_4" alt="" class="o_card_img card-img-top"/>
                             </a>
                         </figure>
@@ -60,7 +60,7 @@
                 <div data-name="Card" class="col-lg-2 col-6">
                     <div class="s_card o_card_img_top card o_cc o_cc1" data-snippet="s_card" data-vxml="001" data-name="Card">
                         <figure class="o_card_img_wrapper ratio ratio-4x3 mb-0">
-                            <a t-att-href="url">
+                            <a t-att-href="url" aria-label="Link to product">
                                 <img src="/web/image/website.s_product_list_default_image_5" alt="" class="o_card_img card-img-top"/>
                             </a>
                         </figure>
@@ -72,7 +72,7 @@
                 <div data-name="Card" class="col-lg-2 col-6">
                     <div class="s_card o_card_img_top card o_cc o_cc1" data-snippet="s_card" data-vxml="001" data-name="Card">
                         <figure class="o_card_img_wrapper ratio ratio-4x3 mb-0">
-                            <a t-att-href="url">
+                            <a t-att-href="url" aria-label="Link to product">
                                 <img src="/web/image/website.s_product_list_default_image_6" alt="" class="o_card_img card-img-top"/>
                             </a>
                         </figure>

--- a/addons/website/views/snippets/s_progress_bar.xml
+++ b/addons/website/views/snippets/s_progress_bar.xml
@@ -5,8 +5,8 @@
     <div class="s_progress_bar s_progress_bar_label_inline mb-2" data-display="inline" data-vcss="001">
         <h4 class="h6-fs">We are almost done!</h4>
         <div class="s_progress_bar_wrapper d-flex gap-2">
-            <div class="progress" role="progressbar" aria-valuenow="80" aria-valuemin="0" aria-valuemax="100">
-                <div class="progress-bar overflow-visible" style="width: 80%; min-width: 3%" aria-label="Progress bar">
+            <div class="progress" role="progressbar" aria-label="Progress bar" aria-valuenow="80" aria-valuemin="0" aria-valuemax="100">
+                <div class="progress-bar overflow-visible" style="width: 80%; min-width: 3%">
                     <span class="s_progress_bar_text small">80%</span>
                 </div>
             </div>

--- a/addons/website/views/snippets/s_quadrant.xml
+++ b/addons/website/views/snippets/s_quadrant.xml
@@ -21,7 +21,7 @@
                     <h2 style="text-align: center;">Understanding the Innovation</h2>
                     <p class="lead" style="text-align: center;">Explore how our cutting-edge solutions redefine industry standards. To achieve excellence, we focus on what truly matters to our customers. <br/><br/> Begin by identifying their needs and exceed their expectations.</p>
                     <p style="text-align: center;">
-                        <a t-att-href="cta_btn_href" class="btn btn-primary btn-lg"><t t-out="cta_btn_text">Learn more</t></a>
+                        <a t-att-href="cta_btn_href" class="btn btn-primary btn-lg"><t t-out="cta_btn_text">Discover</t></a>
                     </p>
                 </div>
             </div>

--- a/addons/website/views/snippets/s_quotes_carousel.xml
+++ b/addons/website/views/snippets/s_quotes_carousel.xml
@@ -76,9 +76,9 @@
             </button>
             <!-- Indicators -->
             <div class="carousel-indicators s_carousel_indicators_dots o_not_editable">
-                <button type="button" t-attf-data-bs-target="#myQuoteCarousel{{uniq}}" data-bs-slide-to="0" class="active"/>
-                <button type="button" t-attf-data-bs-target="#myQuoteCarousel{{uniq}}" data-bs-slide-to="1"/>
-                <button type="button" t-attf-data-bs-target="#myQuoteCarousel{{uniq}}" data-bs-slide-to="2"/>
+                <button type="button" t-attf-data-bs-target="#myQuoteCarousel{{uniq}}" data-bs-slide-to="0" class="active" aria-label="Carousel indicator"/>
+                <button type="button" t-attf-data-bs-target="#myQuoteCarousel{{uniq}}" data-bs-slide-to="1" aria-label="Carousel indicator"/>
+                <button type="button" t-attf-data-bs-target="#myQuoteCarousel{{uniq}}" data-bs-slide-to="2" aria-label="Carousel indicator"/>
             </div>
         </div>
     </section>

--- a/addons/website/views/snippets/s_quotes_carousel_minimal.xml
+++ b/addons/website/views/snippets/s_quotes_carousel_minimal.xml
@@ -76,9 +76,9 @@
             </button>
             <!-- Indicators -->
             <div class="carousel-indicators s_carousel_indicators_dots">
-                <button type="button" t-attf-data-bs-target="#myQuoteCarouselMinimal{{uniq}}" data-bs-slide-to="0" class="active"/>
-                <button type="button" t-attf-data-bs-target="#myQuoteCarouselMinimal{{uniq}}" data-bs-slide-to="1"/>
-                <button type="button" t-attf-data-bs-target="#myQuoteCarouselMinimal{{uniq}}" data-bs-slide-to="2"/>
+                <button type="button" t-attf-data-bs-target="#myQuoteCarouselMinimal{{uniq}}" data-bs-slide-to="0" class="active" aria-label="Carousel indicator"/>
+                <button type="button" t-attf-data-bs-target="#myQuoteCarouselMinimal{{uniq}}" data-bs-slide-to="1" aria-label="Carousel indicator"/>
+                <button type="button" t-attf-data-bs-target="#myQuoteCarouselMinimal{{uniq}}" data-bs-slide-to="2" aria-label="Carousel indicator"/>
             </div>
         </div>
     </section>

--- a/addons/website/views/snippets/s_shape_image.xml
+++ b/addons/website/views/snippets/s_shape_image.xml
@@ -6,7 +6,7 @@
         <div class="container">
             <div class="row align-items-center">
                 <div class="col-lg-5 pt16 pb16">
-                    <img class="img img-fluid" data-shape="web_editor/composite/composite_double_pill" data-file-name="s_shape_image_default_image.jpg" data-original-mimetype="image/jpeg" src="/web_editor/image_shape/website.s_shape_image_default_image/web_editor/composite/composite_double_pill.svg"/>
+                    <img class="img img-fluid" data-shape="web_editor/composite/composite_double_pill" data-file-name="s_shape_image_default_image.jpg" data-original-mimetype="image/jpeg" src="/web_editor/image_shape/website.s_shape_image_default_image/web_editor/composite/composite_double_pill.svg" alt=""/>
                 </div>
                 <div class="col-lg-6 offset-lg-1 pt16 pb16">
                     <h2 class="h3-fs">About our product line</h2>

--- a/addons/website/views/snippets/s_striped_top.xml
+++ b/addons/website/views/snippets/s_striped_top.xml
@@ -12,7 +12,7 @@
                 <div class="col-lg-6 pt24 pb24 order-lg-0" style="order: 1;">
                     <h1>Experience the Future of Innovation in Every Interaction</h1>
                     <p class="lead">Innovation transforms possibilities into reality.</p>
-                    <a t-att-href="cta_btn_href" class="btn btn-primary"><t t-out="cta_btn_text">Read more</t></a>
+                    <a t-att-href="cta_btn_href" class="btn btn-primary"><t t-out="cta_btn_text">Discover</t></a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
[IMP] http_routing, website: improve seo of website pages

The goal of this commit is to improve the seo of website pages. To do
so:
- An `aria-label` has been added on generated iframe map.
- The `role="img"` has been removed from the next icon of the carousel
snippet to avoid an aria error of type `Uses ARIA roles on incompatible
elements`.
- Since [this commit] `alt=" "` has been added on images of the
`image gallery` and `images wall` snippet. The idea was to force screen
readers to not skip those images when describing the snippet. The
problem is that it raises an accessibility error of type `Image elements
do not have [alt] attributes`. They are so replaced by `alt=""` as those
images are default images meant to be changed.
- An aria label has been added on the facebook preview iframe.
- An aria label has been added on anchors to avoid an error of type
"Links do not have a discernible name".
- An `aria-level` attribute has been added on elements with the
"heading" role to follow the [heading role documentation].
- The `aria-label` attribute has been moved on elements with the
`progressbar` role.
- The `img` role has been removed from the 'next' icon of the "carousel
intro" snippet.
- An `aria-label` has been added on the carousel indicators.
- An `alt` attribute has been added on images when missiging.
- The link text of some anchors has been adapted in order to avoid an
error of type "Links do not have descriptive text". Indeed, as per
[the link text documentation], `more` is flagged as generic link text by
the performance tool.

[this commit]: https://github.com/odoo/odoo/commit/fb2296adec1fd151397da3b73ed882058f1ecdfc
[heading role documentation]: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/heading_role
[the link text documentation]: https://developer.chrome.com/docs/lighthouse/seo/link-text/?utm_source=lighthouse&utm_medium=devtoo

task-3866469
