### PR TITLE
[FIX] website_slides: prevent traceback on new tag and upload

### DIFF
--- a/addons/website_slides/static/src/js/slides_course_tag_add.js
+++ b/addons/website_slides/static/src/js/slides_course_tag_add.js
@@ -106,8 +106,9 @@ var TagCourseDialog = Dialog.extend({
                 return fmt(data.text);
             },
             createSearchChoice: function (term, data) {
-                var addedTags = $(this.opts.element).select2('data');
-                if (addedTags.concat(data).filter(tag => {
+                var addedTags = $(this.opts.element).select2('data') || [];
+                addedTags = Array.isArray(addedTags) ? addedTags : [addedTags];
+                if (addedTags.concat(data || []).filter(tag => {
                     return tag.text.toLowerCase().localeCompare(term.toLowerCase()) === 0;
                 }).length === 0) {
                     if (this.opts.can_create) {

--- a/addons/website_slides/static/src/js/slides_upload.js
+++ b/addons/website_slides/static/src/js/slides_upload.js
@@ -297,8 +297,9 @@ var SlideUploadDialog = Dialog.extend({
                 return fmt(data.text);
             },
             createSearchChoice: function (term, data) {
-                var addedTags = $(this.opts.element).select2('data');
-                if (addedTags.concat(data).filter(tag => {
+                var addedTags = $(this.opts.element).select2('data') || [];
+                addedTags = Array.isArray(addedTags) ? addedTags : [addedTags];
+                if (addedTags.concat(data || []).filter(tag => {
                     return tag.text.toLowerCase().localeCompare(term.toLowerCase()) === 0;
                 }).length === 0) {
                     if (this.opts.can_create) {


### PR DESCRIPTION
In 76d328624fecaed5167b0e4fc1210014309d59a9, the underscore methods were removed. Following this change, a traceback occurs because concat is supposed to be used on an Array. When no element is in existing tags, addedTags is null, and if there is a single tag, it is not an array but an object.

In order to fix this, we format properly the addedTags to have an array, allowing the use of the concat method.

Task-3527175
