### PR TITLE
[FIX] auth_password_policy: show correct error message

### DIFF
--- a/addons/auth_password_policy_portal/__init__.py
+++ b/addons/auth_password_policy_portal/__init__.py
@@ -1,2 +1,3 @@
 # -*- coding: utf-8 -*-
 from . import controllers
+from . import models

--- a/addons/auth_password_policy_portal/models/__init__.py
+++ b/addons/auth_password_policy_portal/models/__init__.py
@@ -1,0 +1,1 @@
+from . import ir_http

--- a/addons/auth_password_policy_portal/models/ir_http.py
+++ b/addons/auth_password_policy_portal/models/ir_http.py
@@ -1,0 +1,11 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import models
+
+
+class IrHttp(models.AbstractModel):
+    _inherit = 'ir.http'
+
+    @classmethod
+    def _get_translation_frontend_modules_name(cls):
+        mods = super()._get_translation_frontend_modules_name()
+        return mods + ['auth_password_policy']

--- a/addons/auth_password_policy_portal/views/templates.xml
+++ b/addons/auth_password_policy_portal/views/templates.xml
@@ -8,5 +8,8 @@
         <xpath expr="//input[@name='new1']" position="after">
             <owl-component name="password_meter" props='{"selector": "input[name=new1]"}'/>
         </xpath>
+        <xpath expr="//input[@name='new1']" position="attributes">
+            <attribute name="t-att-data-minlength">password_minimum_length</attribute>
+        </xpath>
     </template>
 </odoo>

--- a/addons/auth_password_policy_signup/__init__.py
+++ b/addons/auth_password_policy_signup/__init__.py
@@ -1,2 +1,3 @@
 # -*- coding: utf-8 -*-
 from . import controllers
+from . import models

--- a/addons/auth_password_policy_signup/models/__init__.py
+++ b/addons/auth_password_policy_signup/models/__init__.py
@@ -1,0 +1,1 @@
+from . import ir_http

--- a/addons/auth_password_policy_signup/models/ir_http.py
+++ b/addons/auth_password_policy_signup/models/ir_http.py
@@ -1,0 +1,11 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import models
+
+
+class IrHttp(models.AbstractModel):
+    _inherit = 'ir.http'
+
+    @classmethod
+    def _get_translation_frontend_modules_name(cls):
+        mods = super()._get_translation_frontend_modules_name()
+        return mods + ['auth_password_policy']

--- a/addons/auth_password_policy_signup/static/src/public/components/password_meter/password_meter.js
+++ b/addons/auth_password_policy_signup/static/src/public/components/password_meter/password_meter.js
@@ -22,7 +22,7 @@ class PasswordMeter extends Component {
             this.state.password = e.target.value || "";
         });
 
-        const minlength = Number(inputEl.getAttribute("minlength"));
+        const minlength = Number(inputEl.dataset?.minlength || inputEl.getAttribute("minlength"));
         this.hasMinlength = !isNaN(minlength);
         this.state = useState({
             password: inputEl.value || "",

--- a/addons/auth_password_policy_signup/views/signup_templates.xml
+++ b/addons/auth_password_policy_signup/views/signup_templates.xml
@@ -4,5 +4,8 @@
         <xpath expr="//input[@name='password']" position="after">
             <owl-component name="password_meter" props='{"selector": "input[name=password]"}'/>
         </xpath>
+        <xpath expr="//input[@name='password']" position="attributes">
+            <attribute name="t-att-data-minlength">password_minimum_length</attribute>
+        </xpath>
     </template>
 </odoo>


### PR DESCRIPTION
Fixes an issue introduced in c1f277a.
The issue was that the translation method wasn't correctly called leading to a formatting error to be raised instead of the correct failure, this is fixed so that the actual error message can be displayed to the user.

Ensure that the password_meter correctly displays a hint depending on the password policy in cases the password length is too small.

Ensure that translations can be applied for portal and signup `auth_password_policy_*` modules.

task-4013509
