### PR TITLE
[FIX] pos*: consistent order/payment date with backend

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -3,7 +3,13 @@ import { Base } from "./related_models";
 import { _t } from "@web/core/l10n/translation";
 import { formatDate, formatDateTime } from "@web/core/l10n/dates";
 import { omit } from "@web/core/utils/objects";
-import { qrCodeSrc, random5Chars, uuidv4 } from "@point_of_sale/utils";
+import {
+    getUTCString,
+    parseUTCString,
+    qrCodeSrc,
+    random5Chars,
+    uuidv4,
+} from "@point_of_sale/utils";
 import { renderToElement } from "@web/core/utils/render";
 import { floatIsZero, roundPrecision } from "@web/core/utils/numbers";
 import { computeComboLines } from "./utils/compute_combo_lines";
@@ -19,7 +25,7 @@ export class PosOrder extends Base {
         super.setup(vals);
 
         // Data present in python model
-        this.date_order = vals.date_order || luxon.DateTime.now().toFormat("yyyy-MM-dd HH:mm:ss");
+        this.date_order = vals.date_order || getUTCString(luxon.DateTime.now());
         this.to_invoice = vals.to_invoice || false;
         this.shipping_date = vals.shipping_date || false;
         this.state = vals.state || "draft";
@@ -102,7 +108,7 @@ export class PosOrder extends Base {
             name: this.name,
             invoice_id: null, //TODO
             cashier: this.employee_id?.name || this.user_id?.name,
-            date: formatDateTime(luxon.DateTime.fromFormat(this.date_order, "yyyy-MM-dd HH:mm:ss")),
+            date: formatDateTime(parseUTCString(this.date_order)),
             pos_qr_code:
                 this.company.point_of_sale_use_ticket_qr_code &&
                 this.finalized &&

--- a/addons/point_of_sale/static/src/app/models/pos_payment.js
+++ b/addons/point_of_sale/static/src/app/models/pos_payment.js
@@ -1,7 +1,7 @@
 import { registry } from "@web/core/registry";
 import { Base } from "./related_models";
 import { roundDecimals } from "@web/core/utils/numbers";
-import { uuidv4 } from "@point_of_sale/utils";
+import { getUTCString, uuidv4 } from "@point_of_sale/utils";
 
 const { DateTime } = luxon;
 
@@ -10,7 +10,7 @@ export class PosPayment extends Base {
 
     setup(vals) {
         super.setup(...arguments);
-        this.payment_date = DateTime.now().toFormat("yyyy-MM-dd HH:mm:ss");
+        this.payment_date = getUTCString(DateTime.now());
         this.uuid = vals.uuid ? vals.uuid : uuidv4();
         this.amount = vals.amount || 0;
         this.ticket = vals.ticket || "";

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -17,6 +17,7 @@ import { floatIsZero } from "@web/core/utils/numbers";
 import { OrderReceipt } from "@point_of_sale/app/screens/receipt_screen/receipt/order_receipt";
 import { ask } from "@point_of_sale/app/store/make_awaitable_dialog";
 import { handleRPCError } from "@point_of_sale/app/errors/error_handlers";
+import { getUTCString } from "@point_of_sale/utils";
 
 export class PaymentScreen extends Component {
     static template = "point_of_sale.PaymentScreen";
@@ -244,7 +245,7 @@ export class PaymentScreen extends Component {
             this.hardwareProxy.openCashbox();
         }
 
-        this.currentOrder.date_order = luxon.DateTime.now().toFormat("yyyy-MM-dd HH:mm:ss");
+        this.currentOrder.date_order = getUTCString(luxon.DateTime.now());
         for (const line of this.paymentLines) {
             if (!line.amount === 0) {
                 this.currentOrder.remove_paymentline(line);

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -22,6 +22,7 @@ import {
 import { ask } from "@point_of_sale/app/store/make_awaitable_dialog";
 import { PosOrderLineRefund } from "@point_of_sale/app/models/pos_order_line_refund";
 import { fuzzyLookup } from "@web/core/utils/search";
+import { parseUTCString } from "@point_of_sale/utils";
 
 const { DateTime } = luxon;
 const NBR_BY_PAGE = 30;
@@ -408,9 +409,7 @@ export class TicketScreen extends Component {
         }
     }
     getDate(order) {
-        return DateTime.fromFormat(order.date_order, "yyyy-MM-dd HH:mm:ss").toFormat(
-            "MM/dd/yyyy HH:mm:ss"
-        );
+        return formatDateTime(parseUTCString(order.date_order));
     }
     getTotal(order) {
         return this.env.utils.formatCurrency(order.get_total_with_tax());
@@ -632,10 +631,7 @@ export class TicketScreen extends Component {
                 modelField: "pos_reference",
             },
             DATE: {
-                repr: (order) =>
-                    formatDateTime(
-                        luxon.DateTime.fromFormat(order.date_order, "yyyy-MM-dd HH:mm:ss")
-                    ),
+                repr: (order) => this.getDate(order),
                 displayName: _t("Date"),
                 modelField: "date_order",
             },

--- a/addons/point_of_sale/static/src/utils.js
+++ b/addons/point_of_sale/static/src/utils.js
@@ -1,3 +1,5 @@
+import { formatDateTime, parseDateTime } from "@web/core/l10n/dates";
+
 /*
  * comes from o_spreadsheet.js
  * https://stackoverflow.com/questions/105034/create-guid-uuid-in-javascript
@@ -117,4 +119,15 @@ export function loadImage(url, options = {}) {
 export function loadAllImages(el) {
     const images = el.querySelectorAll("img");
     return Promise.all(Array.from(images).map((img) => loadImage(img.src)));
+}
+
+export function getUTCString(datetimeObj) {
+    return formatDateTime(datetimeObj, {
+        format: "yyyy-MM-dd HH:mm:ss",
+        tz: "utc",
+    });
+}
+
+export function parseUTCString(utcStr) {
+    return parseDateTime(utcStr, { format: "yyyy-MM-dd HH:mm:ss", tz: "utc" });
 }


### PR DESCRIPTION
pos*: point_of_sale, pos_razorpay
    
In the frontend, date/payment datetime is generated. This value is interpreted
by the server as a utc date string.
    
This commit proposes consistency in representing datetimes for order and payment
objects.
    
1. `date_order` and `payment_date` fields are given with UTC strings
    (`getUTCString(date)`).
2. When shown in the screen or receipt, the values are parsed as utc string
    (`parsedUTCString`) then formatted using the user's locale
    (`formatDateTime`).
    
    task-3989663
