### PR TITLE
[IMP] sale: Extract copiable order lines

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -824,6 +824,10 @@ class SaleOrder(models.Model):
 
         return super().create(vals_list)
 
+    def _get_copiable_order_lines(self):
+        """Returns the order lines that can be copied to a new order."""
+        return self.order_line.filtered(lambda l: not l.is_downpayment)
+
     def copy_data(self, default=None):
         default = dict(default or {})
         default_has_no_order_line = 'order_line' not in default
@@ -833,7 +837,7 @@ class SaleOrder(models.Model):
             for order, vals in zip(self, vals_list):
                 vals['order_line'] = [
                     Command.create(line_vals)
-                    for line_vals in order.order_line.filtered(lambda l: not l.is_downpayment).copy_data()
+                    for line_vals in order._get_copiable_order_lines().copy_data()
                 ]
         return vals_list
 

--- a/doc/cla/corporate/akretion.md
+++ b/doc/cla/corporate/akretion.md
@@ -33,6 +33,7 @@ Cilene Oliveira cilene.oliveira@akretion.com https://github.com/cileneoliveira
 Clément Mombereau clement.mombereau@akretion.com.br https://github.com/clementmbr
 David Beal david.beal@akretion.com https://github.com/bealdav
 Florian da Costa florian.dacosta@akretion.com https://github.com/florian-dacosta
+Florian Mounier florian.mounier@akretion.com https://github.com/paradoxxxzero
 Magno Barcelo da Costa magno.costa@akretion.com.br https://github.com/mbcosta
 Mourad El Hadj Mimoune mourad.elhadj.mimoune@akretion.com https://github.com/mourad-ehm
 Pierrick Brun pierrick.brun@akretion.com https://github.com/PierrickBrun


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

This PR extracts the sale order line filter on sale copy in an extendable method `_get_copiable_order_lines`

Current behavior before PR:

Sale order lines are copied except for downpayment lines.

Desired behavior after PR is merged:

Sale order lines are copied except for downpayment lines through an extendable method.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
