### PR TITLE
[FIX] sale_mrp: transfer description from SO to MO in MTO

### DIFF
--- a/addons/sale_stock/models/sale_order_line.py
+++ b/addons/sale_stock/models/sale_order_line.py
@@ -256,6 +256,7 @@ class SaleOrderLine(models.Model):
         # Use the delivery date if there is else use date_order and lead time
         date_deadline = self.order_id.commitment_date or self._expected_date()
         date_planned = date_deadline - timedelta(days=self.order_id.company_id.security_lead)
+        lang = self.order_id.partner_id.lang
         values.update({
             'group_id': group_id,
             'sale_line_id': self.id,
@@ -264,7 +265,8 @@ class SaleOrderLine(models.Model):
             'route_ids': self.route_id,
             'warehouse_id': self.order_id.warehouse_id or False,
             'partner_id': self.order_id.partner_shipping_id.id,
-            'product_description_variants': self.with_context(lang=self.order_id.partner_id.lang)._get_sale_order_line_multiline_description_variants(),
+            'product_description_variants': self.name if self.name != self.product_id.with_context(lang=lang).display_name
+                 else self.with_context(lang=lang)._get_sale_order_line_multiline_description_variants(),
             'company_id': self.order_id.company_id,
             'product_packaging_id': self.product_packaging_id,
             'sequence': self.sequence,


### PR DESCRIPTION
### Steps to reproduce:

- Enable multi-step routes in the settings
- Go to Inventory > Configuration > Warehouse Management > Routes
- Unarchive the MTO route
- Create a storable product P with a BOM and routes: MTO, manufacture
- Create and confirm a sale order with one SOL: 1 x P: and add a custom description

#### > An MO is created but the custom description is not present.

### Cause of the issue:

Confirming the SO triggers the `_action_launch_stock_rule` on the SOL. During this call, procurments will be created and run: https://github.com/odoo/odoo/blob/0b4b30231ea4c1d254b5b120e749a947a568f4aa/addons/sale_stock/models/sale_order_line.py#L351-L359 However, the datas used to generate the MO are fetched from the `_prepare_mo_vals`:
https://github.com/odoo/odoo/blob/0b4b30231ea4c1d254b5b120e749a947a568f4aa/addons/mrp/models/stock_rule.py#L52 and that method does not take the custom description of the SOL into account.

opw-3998861
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
