### PR TITLE
[PERF] mrp: speed up `onchange` on MO's `lot_producing_id`

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -168,6 +168,10 @@ class MrpProduction(models.Model):
         'stock.move', 'production_id', 'Finished Products', readonly=False,
         compute='_compute_move_finished_ids', store=True, copy=False,
         domain=[('scrapped', '=', False)])
+    # technical field: inverse field for `stock.move.raw_material_production_id`
+    all_move_raw_ids = fields.One2many('stock.move', 'raw_material_production_id')
+    # technical field: inverse field for `stock.move.production_id`
+    all_move_ids = fields.One2many('stock.move', 'production_id')
     move_byproduct_ids = fields.One2many('stock.move', compute='_compute_move_byproduct_ids', inverse='_set_move_byproduct_ids')
     finished_move_line_ids = fields.One2many(
         'stock.move.line', compute='_compute_lines', inverse='_inverse_lines', string="Finished Product"


### PR DESCRIPTION
## Description
On large MOs with many lines, the `onchange` triggered when setting the `lot_producing_id` can be really slow.

## Analysis
In `_set_quantity_done`, the `__set__` on `move_line_ids` triggers the computation of fields that depends on it.
This necessitates the creation of a trigger tree, to know what fields on what model with what records needs to be recomputed. In this context, because some of the frequent dependencies, `raw_material_production_id` and `production_id` on `stock.move` don't have a respective inverse *without* a domain on it, in `_modified_triggers`, we fall back on a generic lookup of cache entries + filtering, which can be costly, as it's `O(n)` in complexity, and `n` can be large, in this case it's over 18k records of `stock.move`, that's done 4 times (the tree has 2 instances for each of the above-mentionned `Many2one`)
The process of resolution of the dependencies tree is repeated for each line of the MO, accentuating the bottleneck.

## Solution
Adding two `One2many` fields to be the generic inverse of `raw_material_production_id` and `production_id` on `mrp.production`, so the ORM can use those to fall into the fast-path when resolving these dependencies.
There are already two `One2many` on this model that are inverse of these `Many2one` (`move_raw_ids` and `move_finished_ids`), but they each have a domain, therefor the ORM cannot use them as an inverse during creation of the trigger tree.

## Benchmarks

|         | Before | After |
|---------|--------|-------|
| Timings | 91.8s  | 14.1s |

## Reference
opw-4003495

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
