### PR TITLE
[FIX] web: tests - fix memory leaks

### DIFF
--- a/addons/web/static/lib/hoot/mock/window.js
+++ b/addons/web/static/lib/hoot/mock/window.js
@@ -261,7 +261,8 @@ export function watchListeners() {
     }
 
     return function unwatchAllListeners() {
-        for (const [target, args] of remaining) {
+        while (remaining.length) {
+            const [target, args] = remaining.pop();
             target.removeEventListener(...args);
         }
 

--- a/addons/web/static/tests/_framework/module_set.hoot.js
+++ b/addons/web/static/tests/_framework/module_set.hoot.js
@@ -491,7 +491,6 @@ const WHITE_LISTED_KEYS = [
     "Chart", // Chart.js
     "L", // Leaflet
     "lamejs", // LameJS
-    "clickEverywhere", // Odoo ClickBot
 ];
 
 /** @type {Record<string, string[]} */


### PR DESCRIPTION
This PR clears a few retainers that would leak memory during the execution of JS unit tests.

This fix will be backported in saas-17.2 by https://github.com/odoo/odoo/pull/170887

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
