### PR TITLE
[FIX] mail: allow tests to pass without hr_holidays

### DIFF
--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -1507,3 +1507,11 @@ class MailCommon(common.TransactionCase, MailCase):
             'res_id': res_id,
             **attach_values,
         } for x in range(count)]
+
+    def _filter_persona_fields(self, data):
+        """ Remove store persona data dependant on other modules if they are not not installed.
+        Not written in a modular way to avoid complex override for a simple test tool.
+        """
+        if "hr.leave" not in self.env:
+            data.pop("out_of_office_date_end")
+        return data

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -144,7 +144,7 @@ class TestChannelInternals(MailCommon, HttpCase):
                                 },
                             ],
                             "Persona": [
-                                {
+                                self._filter_persona_fields({
                                     "active": True,
                                     "email": "test_customer@example.com",
                                     "id": self.test_partner.id,
@@ -156,7 +156,7 @@ class TestChannelInternals(MailCommon, HttpCase):
                                     "type": "partner",
                                     "userId": False,
                                     "write_date": test_partner_write_date,
-                                },
+                                }),
                             ],
                             "Thread": [
                                 {
@@ -194,7 +194,7 @@ class TestChannelInternals(MailCommon, HttpCase):
                                 }
                             ],
                             "Persona": [
-                                {
+                                self._filter_persona_fields({
                                     "active": True,
                                     "email": "test_customer@example.com",
                                     "id": self.test_partner.id,
@@ -206,7 +206,7 @@ class TestChannelInternals(MailCommon, HttpCase):
                                     "type": "partner",
                                     "userId": False,
                                     "write_date": test_partner_write_date,
-                                },
+                                }),
                             ],
                             "Thread": [
                                 {


### PR DESCRIPTION
Solves dependency issue with `out_of_office_date_end` the simplest possible way.

runbot-69894
Part of task-3605717