### PR TITLE
[FIX] web: tests - fix memory leaks

### DIFF
--- a/addons/web/static/lib/hoot/mock/window.js
+++ b/addons/web/static/lib/hoot/mock/window.js
@@ -261,7 +261,8 @@ export function watchListeners() {
     }
 
     return function unwatchAllListeners() {
-        for (const [target, args] of remaining) {
+        while (remaining.length) {
+            const [target, args] = remaining.pop();
             target.removeEventListener(...args);
         }
 


### PR DESCRIPTION
This PR clears a few retainers that would leak memory during the execution of JS unit tests.

Backport of https://github.com/odoo/odoo/pull/170885

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
