### PR TITLE
[FIX] hr_timesheet: fix timesheet link in task portal page.

### DIFF
--- a/addons/hr_timesheet/controllers/portal.py
+++ b/addons/hr_timesheet/controllers/portal.py
@@ -58,7 +58,11 @@ class TimesheetCustomerPortal(CustomerPortal):
         if search_in in ('task', 'all'):
             search_domain = OR([search_domain, [('task_id', 'ilike', search)]])
         if search_in == 'parent_task_id':
-            search_domain = OR([search_domain, [('parent_task_id', '=', int(search))]])
+            parent_task_id = int(search)
+            if parent_task_id:
+                sub_task_ids = request.env['project.task'].browse(parent_task_id)._get_subtask_ids_per_task_id()[parent_task_id]
+                sub_task_ids.append(parent_task_id)
+                search_domain = OR([search_domain, [('parent_task_id', 'in', sub_task_ids)]])
         return search_domain
 
     def _get_groupby_mapping(self):

--- a/addons/hr_timesheet/controllers/project.py
+++ b/addons/hr_timesheet/controllers/project.py
@@ -51,4 +51,9 @@ class ProjectCustomerPortal(CustomerPortal):
         values['allow_timesheets'] = task.allow_timesheets
         values['timesheets'] = timesheets
         values['is_uom_day'] = request.env['account.analytic.line']._is_timesheet_encode_uom_day()
+        parent_task = values['task']
+        sub_task_ids = parent_task._get_subtask_ids_per_task_id()[parent_task.id]
+        sub_task_ids.append(parent_task.id)
+        search_domain = expression.AND([domain, [('parent_task_id', 'in', sub_task_ids)]])
+        values['enable_sub_task_link'] = request.env['account.analytic.line'].sudo().search_count(search_domain, limit=1)
         return values

--- a/addons/hr_timesheet/views/hr_timesheet_portal_templates.xml
+++ b/addons/hr_timesheet/views/hr_timesheet_portal_templates.xml
@@ -179,13 +179,19 @@
                         <tr>
                             <div t-if="task.subtask_effective_hours">
                                 <t t-if="is_uom_day">
-                                    <td><a t-att-href="'/my/timesheets?search_in=parent_task_id&amp;search=%s' % task.id"><strong>Days recorded on sub-tasks: </strong></a></td>
+                                    <td>
+                                        <a t-if="enable_sub_task_link" t-att-href="'/my/timesheets?search_in=parent_task_id&amp;search=%s' % task.id"><strong>Days recorded on sub-tasks: </strong></a>
+                                        <strong t-else="">Days recorded on sub-tasks: </strong>
+                                    </td>
                                     <td class="text-end">
                                         <span t-esc="timesheets._convert_hours_to_days(task.subtask_effective_hours)" t-options='{"widget": "timesheet_uom"}'/>
                                     </td>
                                 </t>
                                 <t t-else="">
-                                    <td><a t-att-href="'/my/timesheets?search_in=parent_task_id&amp;search=%s' % task.id"><strong>Hours recorded on sub-tasks: </strong></a></td>
+                                    <td>
+                                        <a t-if="enable_sub_task_link" t-att-href="'/my/timesheets?search_in=parent_task_id&amp;search=%s' % task.id"><strong>Hours recorded on sub-tasks: </strong></a>
+                                        <strong t-else="">Hours recorded on sub-tasks: </strong>
+                                    </td>
                                     <td class="text-end">
                                         <span t-esc="task.subtask_effective_hours" t-options='{"widget": "float_time"}'/>
                                     </td>


### PR DESCRIPTION
Currently, when a user has a limited access to timesheets, it is possible that he has access to a task, but that he has no access to the timesheets of its children task. This make a strange use case where the user clicks on the link to be redirected to a page without any timesheet.
This fix aims to change that.

Solution : change the link to the timesheets into a span if none of the timesheets are accessible by the current user.

task - 3978484

version saas-17.2

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
