### PR TITLE
[IMP] hr_*: make buttons invisible until employee created

### DIFF
--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -60,7 +60,7 @@
                     <field name="work_contact_id" invisible="1"/>
                     <header>
                         <button name="%(plan_wizard_action)d" string="Launch Plan" type="action"
-                            groups="hr.group_hr_user" invisible="not active" context="{'sort_by_responsible': True}"/>
+                            groups="hr.group_hr_user" invisible="not active or not id" context="{'sort_by_responsible': True}"/>
                     </header>
                     <sheet>
                         <div name="button_box" class="oe_button_box">


### PR DESCRIPTION
Before this commit, the buttons `Launch Plan`, `Request Appraisal` and `Signature Request` were visible even before the record was saved, which is not ideal because as there are fields that need to be set before we can do the actions (like an e-mail for the signature request - or a manager for an onboarding plan)

This commit makes the buttons invisible until the record is saved.

task: 3999996

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
