### PR TITLE
[FIX] website, tools: translate the highlight effects as a whole

### DIFF
--- a/addons/website/static/src/js/editor/snippets.editor.js
+++ b/addons/website/static/src/js/editor/snippets.editor.js
@@ -744,7 +744,7 @@ const wSnippetMenu = weSnippetEditor.SnippetsMenu.extend({
         };
         this._handleTextOptions(
             target,
-            [this._getOptionTextClass(target), "o_text_highlight_underline"],
+            [this._getOptionTextClass(target), "o_text_highlight_underline", "o_translate_inline"],
         );
         delete this.__handleTextOptionsPostActivate;
     },

--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -199,7 +199,13 @@ def translate_xml_node(node, callback, parse, serialize):
     def translatable(node):
         """ Return whether the given node can be translated as a whole. """
         return (
-            node.tag in TRANSLATED_ELEMENTS
+            # Some specific nodes (e.g., text highlights) have an auto-updated
+            # DOM structure that makes them impossible to translate.
+            # The introduction of a translation `<span>` in the middle of their
+            # hierarchy breaks their functionalities. We need to force them to
+            # be translated as a whole using the `o_translate_inline` class.
+            "o_translate_inline" in node.attrib.get("class", "").split()
+            or node.tag in TRANSLATED_ELEMENTS
             and not any(key.startswith("t-") for key in node.attrib)
             and all(translatable(child) for child in node)
         )


### PR DESCRIPTION
Steps to reproduce:

- Go to website (in "Edit" mode) > Drop a "Title" block > Add a
highlight effect to the title text.

- Select a word in the title text > Transform it to a link, and save.

- Try to translate the title into another language in the editor > You
cannot update the text or remove it.

The highlight effects have an auto-updated DOM structure handled by JS.
Having an element that is not inline translated (the `<a/>` tag in this
case) inside a highlight structure will wrap the link content in
`<span data-oe-translation-initial-sha="...">` elements that are
considered "UNREMOVABLE" and, as a consequence, cannot be adapted as
normal content inside the highlight DOM.

Also, we cannot translate `<a>` elements inline to fix this issue, since
there is a reason why this was prevented (see more details in the commit
message from [1]).

The goal of this commit is to fix this behaviour by forcing the
highlight content to always be translated as a whole. This should wrap
all the text highlight DOM in one global `<span>` so it can be
translated correctly.

[1]: https://github.com/odoo/odoo/commit/9bd60ca93510e410a0136b8b433f596330900593

opw-3980975