### PR TITLE
[IMP] mail: avoid emoji conflicts with canned responses

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -367,6 +367,8 @@ export class Composer extends Component {
             case "CannedResponse":
                 return {
                     ...props,
+                    autoSelectFirst: false,
+                    hint: _t("Tab to select"),
                     optionTemplate: "mail.Composer.suggestionCannedResponse",
                     options: suggestions.map((suggestion) => {
                         return {

--- a/addons/mail/static/src/core/common/navigable_list.js
+++ b/addons/mail/static/src/core/common/navigable_list.js
@@ -13,7 +13,9 @@ export class NavigableList extends Component {
     static template = "mail.NavigableList";
     static props = {
         anchorRef: { optional: true },
+        autoSelectFirst: { type: Boolean, optional: true },
         class: { type: String, optional: true },
+        hint: { type: String, optional: true },
         onSelect: { type: Function },
         options: { type: Array },
         optionTemplate: { type: String, optional: true },
@@ -21,7 +23,7 @@ export class NavigableList extends Component {
         position: { type: String, optional: true },
         isLoading: { type: Boolean, optional: true },
     };
-    static defaultProps = { position: "bottom", isLoading: false };
+    static defaultProps = { position: "bottom", isLoading: false, autoSelectFirst: true };
 
     setup() {
         super.setup();
@@ -66,7 +68,9 @@ export class NavigableList extends Component {
     open() {
         this.state.open = true;
         this.state.activeIndex = null;
-        this.navigate("first");
+        if (this.props.autoSelectFirst) {
+            this.navigate("first");
+        }
     }
 
     close() {
@@ -87,6 +91,9 @@ export class NavigableList extends Component {
     }
 
     navigate(direction) {
+        if (this.props.options.length === 0) {
+            return;
+        }
         const activeOptionId = this.state.activeIndex !== null ? this.state.activeIndex : 0;
         let targetId = undefined;
         switch (direction) {
@@ -123,10 +130,11 @@ export class NavigableList extends Component {
         const hotkey = getActiveHotkey(ev);
         switch (hotkey) {
             case "enter":
-                if (!this.show || this.state.activeIndex === null) {
+                markEventHandled(ev, "NavigableList.select");
+                if (this.state.activeIndex === null) {
+                    this.close();
                     return;
                 }
-                markEventHandled(ev, "NavigableList.select");
                 this.selectOption(ev, this.state.activeIndex);
                 break;
             case "escape":
@@ -134,13 +142,13 @@ export class NavigableList extends Component {
                 this.close();
                 break;
             case "tab":
-                this.navigate("next");
+                this.navigate(this.state.activeIndex === null ? "first" : "next");
                 break;
             case "arrowup":
-                this.navigate("previous");
+                this.navigate(this.state.activeIndex === null ? "first" : "previous");
                 break;
             case "arrowdown":
-                this.navigate("next");
+                this.navigate(this.state.activeIndex === null ? "first" : "next");
                 break;
             default:
                 return;

--- a/addons/mail/static/src/core/common/navigable_list.xml
+++ b/addons/mail/static/src/core/common/navigable_list.xml
@@ -3,7 +3,7 @@
 
     <t t-name="mail.NavigableList">
         <div class="o-mail-NavigableList bg-view m-0 p-0" t-ref="root" t-att-class="props.class">
-            <div t-if="show" class="o-open border" t-on-mousedown.prevent="">
+            <div t-if="show" class="o-open border d-flex flex-column" t-on-mousedown.prevent="">
                 <div t-if="props.isLoading" class="o-mail-NavigableList-item">
                     <a href="#" class="d-flex align-items-center w-100 py-2 px-4 gap-1">
                         <i class="fa fa-spin fa-circle-o-notch"/>
@@ -27,6 +27,7 @@
                         <t t-set="lastGroup" t-value="option.group"/>
                     </div>
                 </t>
+                <span t-if="props.hint" class="text-muted fst-italic form-text align-self-end m-0 me-1" t-esc="props.hint"/>
             </div>
         </div>
     </t>


### PR DESCRIPTION
Canned responses are triggered by the ":" shortcut, which can be cumbersome as it conflicts with emojis. This also leads to mistakes since the first canned response in the list is automatically focused, causing the insertion of the canned response when pressing enter to send a message.

This PR addresses this usability issue by removing the auto-focus behavior for canned response suggestions. Users can still easily access canned responses using the same shortcut, but the risk of inserting a canned response by mistake is significantly reduced.

task-356389