### PR TITLE
[FIX] mass_mailing: fix mail template scroll

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
@@ -11,9 +11,11 @@ import { renderToElement } from "@web/core/utils/render";
 import { useService } from "@web/core/utils/hooks";
 import { HtmlField, htmlField } from "@web_editor/js/backend/html_field";
 import { MassMailingMobilePreviewDialog } from "./mass_mailing_mobile_preview";
+import { closestScrollableY } from "@web/core/utils/scrolling";
 import { getRangePosition } from '@web_editor/js/editor/odoo-editor/src/utils/utils';
+import { useThrottleForAnimation } from "@web/core/utils/timing";
 import { utils as uiUtils } from "@web/core/ui/ui_service";
-import { useSubEnv, status, markup } from "@odoo/owl";
+import { useSubEnv, status, markup, onWillUnmount } from "@odoo/owl";
 
 export class MassMailingHtmlField extends HtmlField {
     static props = {
@@ -33,6 +35,20 @@ export class MassMailingHtmlField extends HtmlField {
         this.action = useService('action');
         this.orm = useService('orm');
         this.dialog = useService('dialog');
+
+        const onIframeUpdated = this.onIframeUpdated;
+        this.onIframeUpdated = () => {
+            onIframeUpdated();
+            this._updateIframe();
+        };
+        const throttledOnResizeObserved = useThrottleForAnimation(() => {
+            this._resizeMailingEditorIframe();
+            this._repositionMailingEditorSidebar();
+        });
+        this._resizeObserver = new ResizeObserver(throttledOnResizeObserved);
+        onWillUnmount(() => {
+            this._resizeObserver.disconnect();
+        });
 
         useRecordObserver((record) => {
             if (record.data.mailing_model_id && this.wysiwyg) {
@@ -166,6 +182,98 @@ export class MassMailingHtmlField extends HtmlField {
         }
 
         await this._resetIframe();
+    }
+
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
+    /**
+     * Resize the given iframe so its height fits its contents and initialize a
+     * resize observer to resize on each size change in its contents.
+     * This also ensures the contents of the sidebar remain visible no matter
+     * how much we resize the iframe and scroll down.
+     *
+     * @private
+     */
+    _updateIframe() {
+        const iframe = this.wysiwyg.$iframe[0];
+        if (!iframe || !iframe.contentDocument) {
+            return;
+        }
+        const hasIframeChanged = !this.iframe || !this.iframe.contentDocument || iframe !== this.iframe;
+        this.iframe = iframe;
+        this._resizeMailingEditorIframe();
+
+        const iframeTarget = this.iframe.contentDocument.querySelector("#iframe_target");
+        if (hasIframeChanged && iframeTarget) {
+            this._resizeObserver.disconnect();
+            this._resizeObserver.observe(iframeTarget);
+        }
+        if (iframeTarget) {
+            const isFullscreen = this._isFullScreen();
+            iframeTarget.style.display = isFullscreen ? "" : "flex";
+            iframeTarget.style.flexDirection = isFullscreen ? "" : "column";
+        }
+    }
+
+    /**
+     * Return true if the mailing editor is in full screen mode, false otherwise.
+     *
+     * @private
+     * @returns {boolean}
+     */
+    _isFullScreen() {
+        return window.top.document.body.classList.contains("o_field_widgetTextHtml_fullscreen");
+    }
+
+    /**
+     * Resize the mailing editor's iframe container so its height fits its
+     * contents. This needs to be called whenever the iframe's contents might
+     * have changed, eg. when adding/removing content to/from it or when a
+     * template is picked.
+     *
+     * @private
+     */
+    _resizeMailingEditorIframe() {
+        if (!this.wysiwyg || !this.iframe) {
+            return;
+        }
+        const minHeight = window.innerHeight - Math.abs(this.iframe.getBoundingClientRect().y);
+        const themeSelectorNew = this.iframe.contentDocument.querySelector(".o_mail_theme_selector_new");
+        const iframeTarget = this.iframe.contentDocument.querySelector("#iframe_target");
+        const elementToResize = themeSelectorNew || iframeTarget;
+        if (elementToResize) {
+            this.iframe.parentNode.style.height = `${this._isFullScreen()
+                ? window.innerHeight
+                : Math.max(elementToResize.scrollHeight, minHeight)}px`;
+        }
+    }
+
+    /**
+     * Reposition the sidebar so it always occupies the full available visible
+     * height, no matter the scroll position. This way, the sidebar is always
+     * visible and as big as possible.
+     *
+     * @private
+     */
+    _repositionMailingEditorSidebar() {
+        const sidebar = document.querySelector("#oe_snippets");
+        if (!sidebar) {
+            return;
+        } else if (!this._isFullScreen()) {
+            const scrollableY = closestScrollableY(sidebar);
+            const top = scrollableY
+                ? `${-1 * (parseInt(getComputedStyle(scrollableY).paddingTop) || 0)}px`
+                : "0";
+            const maxHeight = this.iframe.parentNode.getBoundingClientRect().height;
+            const offsetHeight = window.innerHeight - document.querySelector(".o_content").getBoundingClientRect().y;
+            sidebar.style.height = `${Math.min(maxHeight, offsetHeight)}px`;
+            sidebar.style.top = top;
+        } else {
+            sidebar.style.height = "";
+            sidebar.style.top = "0";
+        }
     }
 
     async _resetIframe() {


### PR DESCRIPTION
Purpose
=======
Fix the height of the mail templates in the mailing form.

Specification
=============
For small templates / theme selector, there is a blank space below the editor
because the iframe's height is matching the full height of the website snippets on the side.
For big templates, the website snippets doesn't follow the template scrolling which
makes it difficult to drag and drop the snippets.

This happens following the removal of the full width view and a related js file which
was previously resizing the editor height accordingly (ref commit: https://github.com/odoo/odoo/commit/cf6cd5ef46287f4e71fe96ad6b404ba9b08c1066 )

Reverting a part of the old "mailing_mailing_view_form_full_width" file into
the "mass_mailing_html_field" one so that the editor iframe is correctly resized
depending on its content and the editor sidebar is correctly resized to follow
the scrolling behavior.
Concretely, introducting back the resize observer and the "_updateIframe", "_isFullScreen",
"_resizeMailingEditorIframe" and "_repositionMailingEditorSidebar" methods.

Task-4086341

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
