### PR TITLE
[FIX] l10n_din5008_stock: show the delivery address on German delivery slip

### DIFF
--- a/addons/l10n_din5008_stock/i18n/l10n_din5008_stock.pot
+++ b/addons/l10n_din5008_stock/i18n/l10n_din5008_stock.pot
@@ -23,6 +23,13 @@ msgid "Customer Address:"
 msgstr ""
 
 #. module: l10n_din5008_stock
+#. odoo-python
+#: code:addons/l10n_din5008_stock/models/stock.py:0
+#, python-format
+msgid "Delivery Address:"
+msgstr ""
+
+#. module: l10n_din5008_stock
 #: model:ir.model.fields,field_description:l10n_din5008_stock.field_stock_picking__l10n_din5008_addresses
 msgid "L10N Din5008 Addresses"
 msgstr ""

--- a/addons/l10n_din5008_stock/models/stock.py
+++ b/addons/l10n_din5008_stock/models/stock.py
@@ -18,6 +18,8 @@ class StockPicking(models.Model):
                 if record.picking_type_id.code == 'outgoing' and record.move_ids_without_package and record.move_ids_without_package[0].partner_id \
                         and record.move_ids_without_package[0].partner_id.id != record.partner_id.id:
                     data.append((_('Customer Address:'), record.partner_id))
+                if record.picking_type_id.code == 'outgoing' and record.partner_id.id != record.partner_id.commercial_partner_id.id:
+                    data.append((_('Delivery Address:'), record.move_ids_without_package[0].partner_id))
 
     def check_field_access_rights(self, operation, field_names):
         field_names = super().check_field_access_rights(operation, field_names)


### PR DESCRIPTION
The German delivery slips only show the company address, not the actual delivery address.

### Steps to reproduce:
- Install l10n_de and switch to a German company
- Create a delivery address to a company
- Create a new SO, select the company as the customer and validate
- Go to the created Delivery order, the delivery address should be the one you created before
- Validate and print the delivery slip

### Cause:
The German document format is DIN 5008 and this format does not include the delivery address on the slips.

### Solution:
Add the delivery address in the additional addresses that should be printed.

opw-3961185