### PR TITLE
[FIX] purchase_edi_ubl_bis3: pdf report issue with orders missing tax

### DIFF
--- a/addons/purchase_edi_ubl_bis3/data/bis3_templates.xml
+++ b/addons/purchase_edi_ubl_bis3/data/bis3_templates.xml
@@ -148,7 +148,7 @@
             <cac:StandardItemIdentification>
                 <cbc:ID t-out="vals.get('standard_item_identification')" />
             </cac:StandardItemIdentification>
-            <cac:ClassifiedTaxCategory>
+            <cac:ClassifiedTaxCategory t-if="vals.get('classified_tax_category_vals')" >
                 <t t-call="purchase_edi_ubl_bis3.bis3_TaxCategoryType">
                     <t t-set="vals" t-value="vals.get('classified_tax_category_vals')" />
                 </t>

--- a/addons/purchase_edi_ubl_bis3/models/purchase_edi_xml_ubl_bis3.py
+++ b/addons/purchase_edi_ubl_bis3/models/purchase_edi_xml_ubl_bis3.py
@@ -86,6 +86,8 @@ class PurchaseEdiXmlUBLBIS3(models.AbstractModel):
         }
 
     def _get_tax_category_vals(self, order, order_line):
+        if not order_line.taxes_id:
+            return None
         tax = order_line.taxes_id[0]
         tax_unece_codes = self.env['account.edi.common'].get_tax_unece_codes_order(order, tax)
         return {


### PR DESCRIPTION
    Step to produce:
    ===================
    1. Install the purchase module and then install the l10n_in module and
       select IN COMPANY.
    2. Create a PO with one or more order lines that do not have any tax data
       associated.
    3. Attempt to generate a PDF report for this order.
    4. Observe that the report generation fails with an index error due to the
       missing tax data.

    Resolution:
    ==============
    - handle cases where an order line has no associated tax data.

    Expected Behavior After the Fix:
    ===================================
    - The PDF report generation process should be completed successfully, even
      if some order lines lack tax data. Empty values will be used in place of the
      missing tax information, ensuring that the report is generated without errors.