### PR TITLE
[REF] pos_loyalty: prefix local fields with underscore

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/components/control_buttons/control_buttons.js
+++ b/addons/pos_loyalty/static/src/overrides/components/control_buttons/control_buttons.js
@@ -53,7 +53,7 @@ patch(ControlButtons.prototype, {
                 this.pos.addLineToCurrentOrder(
                     {
                         product_id: selectedProgram.trigger_product_ids[0],
-                        e_wallet_program_id: selectedProgram,
+                        _e_wallet_program_id: selectedProgram,
                         price_unit: -orderTotal,
                     },
                     {}

--- a/addons/pos_loyalty/static/src/overrides/components/product_screen/order_summary/order_summary.js
+++ b/addons/pos_loyalty/static/src/overrides/components/product_screen/order_summary/order_summary.js
@@ -12,7 +12,7 @@ patch(OrderSummary.prototype, {
     async updateSelectedOrderline({ buffer, key }) {
         const selectedLine = this.currentOrder.get_selected_orderline();
         if (key === "-") {
-            if (selectedLine && selectedLine.e_wallet_program_id) {
+            if (selectedLine && selectedLine._e_wallet_program_id) {
                 // Do not allow negative quantity or price in a gift card or ewallet orderline.
                 // Refunding gift card or ewallet is not supported.
                 this.notification.add(
@@ -69,7 +69,7 @@ patch(OrderSummary.prototype, {
             if (
                 coupon &&
                 coupon.id > 0 &&
-                this.currentOrder.code_activated_coupon_ids.find((c) => c.code === coupon.code)
+                this.currentOrder._code_activated_coupon_ids.find((c) => c.code === coupon.code)
             ) {
                 coupon.delete();
             }

--- a/addons/pos_loyalty/static/src/overrides/models/pos_order_line.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_order_line.js
@@ -5,29 +5,29 @@ import { patch } from "@web/core/utils/patch";
 patch(PosOrderline, {
     extraFields: {
         ...(PosOrderline.extraFields || {}),
-        e_wallet_program_id: {
+        _e_wallet_program_id: {
             model: "pos.order.line",
-            name: "e_wallet_program_id",
+            name: "_e_wallet_program_id",
             relation: "loyalty.program",
             type: "many2one",
             local: true,
         },
-        gift_barcode: {
+        _gift_barcode: {
             model: "pos.order.line",
-            name: "gift_barcode",
+            name: "_gift_barcode",
             type: "char",
             local: true,
         },
-        gift_card_id: {
+        _gift_card_id: {
             model: "pos.order.line",
-            name: "gift_card_id",
+            name: "_gift_card_id",
             relation: "loyalty.card",
             type: "many2one",
             local: true,
         },
-        reward_product_id: {
+        _reward_product_id: {
             model: "pos.order.line",
-            name: "reward_product_id",
+            name: "_reward_product_id",
             relation: "product.product",
             type: "many2one",
             local: true,
@@ -45,23 +45,23 @@ patch(PosOrderline.prototype, {
     },
     setOptions(options) {
         if (options.eWalletGiftCardProgram) {
-            this.update({ e_wallet_program_id: options.eWalletGiftCardProgram });
+            this.update({ _e_wallet_program_id: options.eWalletGiftCardProgram });
         }
         if (options.giftBarcode) {
-            this.update({ gift_barcode: options.giftBarcode });
+            this.update({ _gift_barcode: options.giftBarcode });
         }
         if (options.giftCardId) {
-            this.update({ gift_card_id: this.models["loyalty.card"].get(options.giftCardId) });
+            this.update({ _gift_card_id: this.models["loyalty.card"].get(options.giftCardId) });
         }
         return super.setOptions(...arguments);
     },
     getEWalletGiftCardProgramType() {
-        return this.e_wallet_program_id && this.e_wallet_program_id.program_type;
+        return this._e_wallet_program_id && this._e_wallet_program_id.program_type;
     },
     ignoreLoyaltyPoints({ program }) {
         return (
             ["gift_card", "ewallet"].includes(program.program_type) &&
-            this.e_wallet_program_id?.id !== program.id
+            this._e_wallet_program_id?.id !== program.id
         );
     },
     isGiftCardOrEWalletReward() {

--- a/addons/pos_loyalty/static/src/overrides/models/pos_store.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_store.js
@@ -139,7 +139,7 @@ patch(PosStore.prototype, {
             }
             changesPerProgram[pe.program_id].push(pe);
         }
-        for (const coupon of order.code_activated_coupon_ids) {
+        for (const coupon of order._code_activated_coupon_ids) {
             programsToCheck.add(coupon.program_id.id);
         }
         const programs = [...programsToCheck].map((programId) =>
@@ -182,8 +182,8 @@ patch(PosStore.prototype, {
             }
         }
 
-        // Also remove coupons from code_activated_coupon_ids if their program applies_on current orders and the program does not give any points
-        const toUnlink = order.code_activated_coupon_ids.filter(
+        // Also remove coupons from _code_activated_coupon_ids if their program applies_on current orders and the program does not give any points
+        const toUnlink = order._code_activated_coupon_ids.filter(
             inverted((coupon) => {
                 const program = coupon.program_id;
                 if (
@@ -195,7 +195,7 @@ patch(PosStore.prototype, {
                 return true;
             })
         );
-        order.update({ code_activated_coupon_ids: [["unlink", ...toUnlink]] });
+        order.update({ _code_activated_coupon_ids: [["unlink", ...toUnlink]] });
     },
     async activateCode(code) {
         const order = this.get_order();
@@ -229,7 +229,7 @@ patch(PosStore.prototype, {
             await this.orderUpdateLoyaltyPrograms();
             claimableRewards = order.getClaimableRewards(false, rule.program_id.id);
         } else {
-            if (order.code_activated_coupon_ids.find((coupon) => coupon.code === code)) {
+            if (order._code_activated_coupon_ids.find((coupon) => coupon.code === code)) {
                 return _t("That coupon code has already been scanned and activated.");
             }
             const customerId = order.get_partner() ? order.get_partner().id : false;
@@ -265,7 +265,7 @@ patch(PosStore.prototype, {
                     // TODO JCB: make the expiration_date work.
                     // expiration_date: payload.expiration_date,
                 });
-                order.update({ code_activated_coupon_ids: [["link", coupon]] });
+                order.update({ _code_activated_coupon_ids: [["link", coupon]] });
                 await this.orderUpdateLoyaltyPrograms();
                 claimableRewards = order.getClaimableRewards(coupon.id);
             } else {
@@ -304,7 +304,7 @@ patch(PosStore.prototype, {
                     allCoupons.push(pe.coupon_id);
                 }
             }
-            allCoupons.push(...order.code_activated_coupon_ids.map((coupon) => coupon.id));
+            allCoupons.push(...order._code_activated_coupon_ids.map((coupon) => coupon.id));
             const couponsToFetch = allCoupons.filter(
                 (elem) => !this.models["loyalty.card"].get(elem)
             );
@@ -498,7 +498,7 @@ patch(PosStore.prototype, {
                 };
             })
             .concat(
-                order.code_activated_coupon_ids.map((coupon) => {
+                order._code_activated_coupon_ids.map((coupon) => {
                     return {
                         program_id: coupon.program_id.id,
                         coupon_id: coupon.id,
@@ -696,8 +696,8 @@ patch(PosStore.prototype, {
             Object.assign(
                 this.rewardProductByLineUuidCache,
                 order.lines.reduce((agg, line) => {
-                    if (line.reward_product_id) {
-                        return { ...agg, [line.uuid]: line.reward_product_id.id };
+                    if (line._reward_product_id) {
+                        return { ...agg, [line.uuid]: line._reward_product_id.id };
                     } else {
                         return agg;
                     }
@@ -721,7 +721,7 @@ patch(PosStore.prototype, {
             for (const line of order.lines) {
                 if (line.uuid in this.rewardProductByLineUuidCache) {
                     line.update({
-                        reward_product_id: this.models["product.product"].get(
+                        _reward_product_id: this.models["product.product"].get(
                             this.rewardProductByLineUuidCache[line.uuid]
                         ),
                     });


### PR DESCRIPTION
This commit prefixes local fields with underscore in order to avoid conflicts with Odoo fields.

This allow us to easily identify local fields.

