### PR TITLE
[IMP] gamification: simplify kanban archs

### DIFF
--- a/addons/gamification/views/gamification_badge_user_views.xml
+++ b/addons/gamification/views/gamification_badge_user_views.xml
@@ -6,29 +6,17 @@
         <field name="model">gamification.badge.user</field>
         <field name="arch" type="xml">
             <kanban action="action_open_badge" type="object">
-                <field name="badge_name"/>
-                <field name="badge_id"/>
-                <field name="user_id"/>
-                <field name="comment"/>
                 <field name="create_date"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div class="oe_kanban_card oe_kanban_global_click oe_kanban_badge oe_kanban_color_white o_kanban_gamification">
-                            <div class="o_kanban_content">
-                                <div class="o_kanban_image">
-                                    <a type="open"><img t-att-src="kanban_image('gamification.badge', 'image_1024', record.badge_id.raw_value)" t-att-title="record.badge_name.value" t-att-alt="record.badge_name.value" /></a>
-                                </div>
-                                <div class="oe_kanban_details">
-                                    <h4 class="mt0 mb0">
-                                        <a class="o_kanban_record_title" type="open"><t t-esc="record.badge_name.raw_value" /></a>
-                                    </h4>
-                                    <t t-if="record.comment.raw_value">
-                                        <p class="o_kanban_record_subtitle"><em><field name="comment"/></em></p>
-                                    </t>
-                                    <p>Granted by <a type="open"><field name="create_uid" /></a> the <t t-esc="luxon.DateTime.fromISO(record.create_date.raw_value).toFormat('D')" /></p>
-                                </div>
-                            </div>
-                        </div>
+                    <t t-name="kanban-card" class="row g-0">
+                        <aside class="col-2">
+                            <field name="badge_id" widget="image" options="{'preview_image': 'image_1024'}" t-att-title="badge_name" t-att-alt="badge_name" />
+                        </aside>
+                        <main class="col ps-2">
+                            <field class="fw-bold fs-5 mt0 mb0" type="open" name="badge_name"/>
+                            <field name="comment"/>
+                            <p>Granted by <field name="create_uid" /> the <t t-esc="luxon.DateTime.fromISO(record.create_date.raw_value).toFormat('D')" /></p>
+                        </main>
                     </t>
                 </templates>
             </kanban>

--- a/addons/gamification/views/gamification_badge_views.xml
+++ b/addons/gamification/views/gamification_badge_views.xml
@@ -114,50 +114,35 @@
         <field name="model">gamification.badge</field>
         <field name="arch" type="xml">
             <kanban>
-                <field name="id"/>
-                <field name="name"/>
-                <field name="description"/>
-                <field name="stat_my"/>
-                <field name="granted_count"/>
-                <field name="stat_this_month"/>
-                <field name="unique_owner_ids"/>
-                <field name="stat_my_monthly_sending"/>
                 <field name="remaining_sending" />
-                <field name="rule_max_number" />
                 <templates>
-                    <t t-name="kanban-box">
-                        <div t-attf-class="o_kanban_gamification oe_kanban_global_click #{record.stat_my.raw_value ? 'oe_kanban_color_5' : 'oe_kanban_color_white'}">
-                            <div class="o_kanban_image">
-                                <img t-att-src="kanban_image('gamification.badge', 'image_1024', record.id.raw_value)" t-att-title="record.name.value" t-att-alt="record.name.value"/>
+                    <t t-name="kanban-card" class="row g-0">
+                        <aside class="col-2">
+                            <field name="image_1024" widget="image" t-att-title="name" t-att-alt="name"/>
+                        </aside>
+                        <main class="col ps-2">
+                            <span>
+                                <field class="fw-bold fs-5" name="name"/>
+                                <t t-if="record.remaining_sending.value != -1">
+                                    <field name="stat_my_monthly_sending"/>/<field name="rule_max_number"/>
+                                </t>
+                                <t t-else="">
+                                    <field name="stat_my_monthly_sending"/>/∞
+                                </t>
+                            </span>
+                            <div t-if="record.remaining_sending.value == 0">Can not grant</div>
+                            <div>
+                                <field class="fw-bold" name="granted_count"/> granted,
+                                <field class="fw-bold" name="stat_this_month"/> this month
                             </div>
-                            <div class="oe_kanban_details">
-                                <strong class="o_kanban_record_title"><field name="name"/></strong>
-                                <span class="oe_grey">
-                                    <t t-if="record.remaining_sending.value != -1">
-                                        <t t-esc="record.stat_my_monthly_sending.value"/>/<t t-esc="record.rule_max_number.value"/>
-                                    </t>
-                                    <t t-if="record.remaining_sending.value == -1">
-                                        <t t-esc="record.stat_my_monthly_sending.value"/>/∞
-                                    </t>
-                                </span>
-                                <div t-if="record.remaining_sending.value == 0" class="oe_grey">Can not grant</div>
-                                <div>
-                                    <strong><t t-esc="record.granted_count.raw_value"/></strong> granted,
-                                    <strong><t t-esc="record.stat_this_month.raw_value"/></strong> this month
-                                </div>
-                                <div t-if="!widget.isHtmlEmpty(record.description.value)" class="o_kanban_badge_description pb-3">
-                                    <em t-out="record.description.value"/>
-                                    <div>
-                                        <t t-foreach="record.unique_owner_ids.raw_value.slice(0,11)" t-as="owner" t-key="owner">
-                                            <img class="oe_kanban_avatar o_avatar rounded" t-att-src="kanban_image('res.users', 'avatar_128', owner)" t-att-data-member_id="owner" alt="Owner"/>
-                                        </t>
-                                    </div>
-                                </div>
-                                <div t-if="record.remaining_sending.value != 0 and !selection_mode" class="o_kanban_button">
-                                    <button type="action" name="%(action_grant_wizard)d" class="oe_highlight btn btn-primary">Grant</button>
-                                </div>
+                            <div t-if="!widget.isHtmlEmpty(record.description.value)">
+                                <field class="fst-italic" name="description"/>
+                                <field name="unique_owner_ids" widget="many2many_avatar_user"/>
                             </div>
-                        </div>
+                            <footer t-if="record.remaining_sending.value != 0 and !selection_mode">
+                                <button type="action" name="%(action_grant_wizard)d" class="btn btn-primary ms-auto">Grant</button>
+                            </footer>
+                        </main>
                     </t>
                 </templates>
             </kanban>

--- a/addons/gamification/views/gamification_challenge_views.xml
+++ b/addons/gamification/views/gamification_challenge_views.xml
@@ -129,24 +129,14 @@
             <kanban string="Challenges">
                 <field name="line_ids"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div t-attf-class="oe_kanban_card o_kanban_gamification oe_kanban_global_click">
-                            <div class="o_kanban_content">
-                               <strong>
-                                   <h4 class="o_kanban_record_title"><field name="name"/></h4>
-                                   <div class="o_kanban_record_subtitle">
-                                        <a type="action" name="%(goals_from_challenge_act)d"
-                                           style="margin-right: 10px" tabindex="-1">
-                                            <span><t t-esc="record.line_ids.raw_value.length"/> Goals</span>
-                                        </a><br />
-                                        <a type="object" name="action_view_users"
-                                           style="margin-right: 10px" tabindex="-1">
-                                            <span><field name="user_count"/> Participants</span>
-                                        </a>
-                                   </div>
-                               </strong>
-                            </div>
-                        </div>
+                    <t t-name="kanban-card" class="fw-bold">
+                        <field class="fs-5" name="name"/>
+                        <a type="action" name="%(goals_from_challenge_act)d" class="me-2" tabindex="-1">
+                            <t t-esc="record.line_ids.raw_value.length"/> Goals
+                        </a>
+                        <a type="object" name="action_view_users" class="me-2" tabindex="-1">
+                            <field name="user_count"/> Participants
+                        </a>
                     </t>
                 </templates>
             </kanban>

--- a/addons/gamification/views/gamification_goal_views.xml
+++ b/addons/gamification/views/gamification_goal_views.xml
@@ -145,58 +145,44 @@
         <field name="name">Goal Kanban View</field>
         <field name="model">gamification.goal</field>
         <field name="arch" type="xml">
-            <kanban create="false">
-                <field name="definition_id"/>
-                <field name="user_id"/>
-                <field name="current"/>
-                <field name="completeness"/>
+            <kanban highlight_color="color" create="false">
                 <field name="state"/>
-                <field name="target_goal"/>
-                <field name="definition_description"/>
+                <field name="color"/>
                 <field name="definition_condition"/>
                 <field name="definition_suffix"/>
                 <field name="definition_display"/>
-                <field name="start_date"/>
-                <field name="end_date"/>
                 <field name="last_update"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div t-attf-class="oe_kanban_card oe_kanban_global_click o_kanban_gamification #{record.end_date.raw_value &lt; record.last_update.raw_value and record.state.raw_value == 'failed' ? 'oe_kanban_color_2' : ''} #{record.end_date.raw_value &lt; record.last_update.raw_value and record.state.raw_value == 'reached' ? 'oe_kanban_color_5' : ''}">
-                            <div class="o_kanban_content text-center">
-                                <p><strong><h4 class="oe_goal_name"><field name="definition_id" /></h4></strong></p>
-                                <img class="o_image_24_cover me-1 rounded" t-att-src="kanban_image('res.users', 'avatar_128', record.user_id.raw_value)" t-att-title="record.user_id.value" t-att-alt="record.user_id.value"/>
-                                <field name="user_id" class="fw-bold"/>
-                                <div class="o_goal_state_block pt-3 fs-1 fw-bolder">
-                                    <t t-if="record.definition_display.raw_value == 'boolean'">
-                                        <div class="o_goal_state">
-                                            <t t-if="record.state.raw_value=='reached'"><i role="img" class="text-success fa fa-check fa-3x" title="Goal Reached" aria-label="Goal Reached"/></t>
-                                            <t t-if="record.state.raw_value=='inprogress'"><i role="img" class="text-700 fa fa-clock-o fa-3x" title="Goal in Progress" aria-label="Goal in Progress"/></t>
-                                            <t t-if="record.state.raw_value=='failed'"><i role="img" class="text-danger fa fa-times fa-3x" title="Goal Failed" aria-label="Goal Failed"/></t>
-                                        </div>
-                                    </t>
-                                    <t t-if="record.definition_display.raw_value == 'progress'">
-                                        <t t-if="record.definition_condition.raw_value =='higher'">
-                                            <field name="current" widget="gauge" options="{'max_field': 'target_goal', 'label_field': 'definition_suffix', 'style': 'width:160px; height: 120px;'}" />
-                                        </t>
-                                        <t t-if="record.definition_condition.raw_value != 'higher'">
-                                            <div t-attf-class="o_goal_state #{record.current.raw_value == record.target_goal.raw_value+1 ? 'text-warning' : record.current.raw_value &gt; record.target_goal.raw_value ? 'text-danger' : 'text-success'}">
-                                                <t t-esc="record.current.raw_value" />
-                                            </div>
-                                            <em>Target: less than <t t-esc="record.target_goal.raw_value" /></em>
-                                        </t>
-                                    </t>
-
-                                </div>
-                                <p>
-                                    <t t-if="record.start_date.value">
-                                        From <t t-esc="record.start_date.value" />
-                                    </t>
-                                    <t t-if="record.end_date.value">
-                                        To <t t-esc="record.end_date.value" />
-                                    </t>
-                                </p>
-                            </div>
+                    <t t-name="kanban-card" class="text-center">
+                        <field class="fw-bold fs-4" name="definition_id" />
+                        <div class="d-flex justify-content-center mt-3">
+                            <field class="o_image_24_cover me-1 rounded" name="user_id" widget="image" options="{'preview_image': 'avatar_128'}" t-att-title="record.user_id.value" t-att-alt="record.user_id.value"/>
+                            <field name="user_id" class="fw-bold"/>
                         </div>
+                        <div class="pt-3 fs-1 fw-bolder">
+                            <t t-if="record.definition_display.raw_value == 'boolean'">
+                                <t t-if="record.state.raw_value=='reached'"><i role="img" class="text-success fa fa-check fa-3x" title="Goal Reached" aria-label="Goal Reached"/></t>
+                                <t t-if="record.state.raw_value=='inprogress'"><i role="img" class="text-700 fa fa-clock-o fa-3x" title="Goal in Progress" aria-label="Goal in Progress"/></t>
+                                <t t-if="record.state.raw_value=='failed'"><i role="img" class="text-danger fa fa-times fa-3x" title="Goal Failed" aria-label="Goal Failed"/></t>
+                            </t>
+                            <t t-if="record.definition_display.raw_value == 'progress'">
+                                <t t-if="record.definition_condition.raw_value =='higher'">
+                                    <field name="current" widget="gauge" options="{'max_field': 'target_goal', 'label_field': 'definition_suffix', 'style': 'width:160px; height: 120px;'}" />
+                                </t>
+                                <t t-if="record.definition_condition.raw_value != 'higher'">
+                                    <field class="#{record.current.raw_value == record.target_goal.raw_value+1 ? 'text-warning' : record.current.raw_value &gt; record.target_goal.raw_value ? 'text-danger' : 'text-success'}" name="current" />
+                                    <em>Target: less than <field name="target_goal"/></em>
+                                </t>
+                            </t>
+                        </div>
+                        <p>
+                            <t t-if="record.start_date.value">
+                                From <field name="start_date" />
+                            </t>
+                            <t t-if="record.end_date.value">
+                                To <field name="end_date" />
+                            </t>
+                        </p>
                     </t>
                 </templates>
             </kanban>


### PR DESCRIPTION
In this commit we have simplified the kanban arch for the gamification module. The goal is to simplify them, make them easier to read, and use bootstrap utility classnames.
- Previously, we used `kanban-box`, but now we are using `kanban-card` instead.
- Deprecated `oe_kanban_global_click` and `oe_kanban_global_click_edit`.
- More use of `<field/>` tags
- Removed the `oe_kanban_colorpicker` class and replaced it with the `kanban_color_picker` widget.
- Changed type='edit' to type='open' to open records. since version 16, records always open in edit mode by default.
- `kanban_image` from rendering context, is deprecated so we use `<field name=... widget=image/>` instead

Task-3992107

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
