### PR TITLE
[FIX] hr_holidays : fix approval's filter

### DIFF
--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -66,7 +66,7 @@
                     name="waiting_for_me_manager"
                     groups="hr_holidays.group_hr_holidays_user"/>
                 <separator/>
-                <filter domain="[('state','in',('confirm','validate1'))]" string="First Approval" name="approve"/>
+                <filter domain="[('state','=','confirm')]" string="First Approval" name="approve"/>
                 <filter domain="[('state', '=', 'validate1')]" string="Second Approval" name="second_approval"/>
                 <filter string="Approved" domain="[('state', '=', 'validate')]" name="validated"/>
                 <separator/>


### PR DESCRIPTION
STEP TO REPRODUCE:
==================

    1- Go on Time off Application
    2- Select First Approval filter

You will see two records: one with "second approval" status and one with "to approve" status.

With this commit only leaves with "to approve status" will appears with this filter.

task-4005045

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
