### PR TITLE
[IMP] website_forum: owlify select post tags

### DIFF
--- a/addons/website_forum/__manifest__.py
+++ b/addons/website_forum/__manifest__.py
@@ -76,6 +76,7 @@ Ask questions, get answers, no distractions
             'website_forum/static/src/js/website_forum.share.js',
             'website_forum/static/src/xml/public_templates.xml',
             'website_forum/static/src/components/flag_mark_as_offensive/**/*',
+            'website_forum/static/src/components/forum_post_select_tags/*',
         ],
     },
     'license': 'LGPL-3',

--- a/addons/website_forum/controllers/website_forum.py
+++ b/addons/website_forum/controllers/website_forum.py
@@ -193,18 +193,6 @@ class WebsiteForum(WebsiteProfile):
     # Tags
     # --------------------------------------------------
 
-    @http.route('/forum/get_tags', type='http', auth="public", methods=['GET'], website=True, sitemap=False)
-    def tag_read(self, forum_id, query='', limit=25, **post):
-        data = request.env['forum.tag'].search_read(
-            domain=[('forum_id', '=', int(forum_id)), ('name', '=ilike', (query or '') + "%")],
-            fields=['id', 'name'],
-            limit=int(limit),
-        )
-        return request.make_response(
-            json.dumps(data),
-            headers=[("Content-Type", "application/json")]
-        )
-
     @http.route(['/forum/<model("forum.forum"):forum>/tag',
                  '/forum/<model("forum.forum"):forum>/tag/<string:tag_char>',
                  ], type='http', auth="public", website=True, sitemap=False)

--- a/addons/website_forum/static/src/components/forum_post_select_tags/forum_post_select_tags.js
+++ b/addons/website_forum/static/src/components/forum_post_select_tags/forum_post_select_tags.js
@@ -1,0 +1,154 @@
+/** @odoo-module **/
+
+import { Component, onWillStart, onWillUpdateProps, useState } from "@odoo/owl";
+import { DropdownItem } from "@web/core/dropdown/dropdown_item";
+import { registry } from "@web/core/registry";
+import { SelectMenu } from "@web/core/select_menu/select_menu";
+import { _t } from "@web/core/l10n/translation";
+import { useService } from "@web/core/utils/hooks";
+import { useDebounced } from "@web/core/utils/timing";
+
+export class ForumPostSelectMenu extends SelectMenu {
+    static template = "website_forum.ForumPostSelectMenu";
+    static props = {
+        ...super.props,
+        getErrorMessage: { type: Function },
+        hasTokenSeparator: { type: Boolean },
+    };
+
+    setup() {
+        super.setup();
+        this.debouncedOnInput = useDebounced(
+            () => this.onInput(this.inputRef.el ? this.inputRef.el.value : ""),
+            250
+        );
+        onWillUpdateProps((nextProps) => {
+            if (nextProps.hasTokenSeparator) {
+                this.inputRef.el.value = "";
+                this.state.searchValue = "";
+            }
+        });
+    }
+}
+
+registry
+    .category("public_components")
+    .add("website_forum.ForumPostSelectMenu", ForumPostSelectMenu);
+
+export class ForumPostSelectTags extends Component {
+    static components = { DropdownItem, ForumPostSelectMenu };
+    static defaultProps = {
+        maximumInputLength: 35,
+        minimumInputLength: 2,
+        maximumSelectionSize: 5,
+        tokenSeparators: [",", " ", "_"],
+    };
+    static props = {
+        forumId: { type: Number },
+        initValue: { type: String | null, optional: true },
+        karma: { type: Number },
+        karmaEditRetag: { type: Number },
+        maximumInputLength: { type: Number, optional: true },
+        minimumInputLength: { type: Number, optional: true },
+        maximumSelectionSize: { type: Number, optional: true },
+        tokenSeparators: { type: Array, optional: true },
+    };
+    static template = "website_forum.ForumPostSelectTags";
+
+    setup() {
+        this.createdTags = [];
+        this.orm = useService("orm");
+        this.state = useState({
+            value: [],
+            choices: [],
+            hasTokenSeparator: false,
+        });
+        this.token = "";
+
+        onWillStart(async () => {
+            if (this.props.initValue) {
+                this.state.value = JSON.parse(this.props.initValue).map((choice) => {
+                    return choice.id;
+                });
+            }
+            this.getForumTags();
+        });
+    }
+
+    getErrorMessage(input) {
+        if (this.props.karma < this.props.karmaEditRetag) {
+            return _t("You need to have sufficient karma to edit tags");
+        }
+        if (this.state.value.length >= this.props.maximumSelectionSize) {
+            return _t("You can only select %s items", this.props.maximumSelectionSize);
+        }
+        if (input.length < this.props.minimumInputLength) {
+            return _t("Please enter at least %s characters", this.props.minimumInputLength);
+        }
+        if (input.length >= this.props.maximumInputLength) {
+            return _t("Please enter at most %s characters", this.props.maximumInputLength);
+        }
+        return "";
+    }
+
+    async getForumTags() {
+        const results = await this.orm.call("forum.tag", "search_read", [], {
+            domain: [["forum_id", "=", this.props.forumId]],
+            fields: ["id", "name"],
+        });
+
+        this.state.choices = results.map((choice) => {
+            return { value: choice.id, label: choice.name };
+        });
+    }
+
+    onInput(searchString) {
+        this.state.hasTokenSeparator = false;
+        this.token = searchString.split(new RegExp(this.props.tokenSeparators.join("|")))[0];
+
+        if (this.token !== searchString) {
+            const label = this.token.trim();
+            const tag = this.state.choices.find(
+                (choice) => choice.label.toLowerCase() === label.toLowerCase()
+            );
+
+            if (tag) {
+                this.onTagsSelect([...this.state.value, tag.value]);
+            } else if (this.canCreateTag(label, this.state.choices)) {
+                this.onClickCreateTagBtn(label);
+            }
+            this.state.hasTokenSeparator = true;
+        }
+    }
+
+    onTagsSelect(values) {
+        this.state.value = values;
+    }
+
+    onClickCreateTagBtn(tagName) {
+        const newTag = tagName.trim();
+        this.state.choices = [...this.state.choices, { value: `_${newTag}`, label: newTag }];
+        this.state.value = [...this.state.value, `_${newTag}`];
+    }
+
+    /**
+     * To figure when to propose/allow users to create a new category or tag:
+     * users need to have the required level of karma
+     * input length should be comprised between a min and a max number of characters
+     * input should not match any existing choice
+     * current selection should not exceed the limit number of tags
+     */
+    canCreateTag(input, choices) {
+        return (
+            this.props.karma >= this.props.karmaEditRetag &&
+            input.length >= this.props.minimumInputLength &&
+            input.length < this.props.maximumInputLength &&
+            this.state.value.length < this.props.maximumSelectionSize &&
+            !choices.some((choice) => input.toLowerCase() === choice.label.toLowerCase())
+        );
+    }
+}
+
+registry
+    .category("public_components")
+    .add("website_forum.ForumPostSelectTags", ForumPostSelectTags);

--- a/addons/website_forum/static/src/components/forum_post_select_tags/forum_post_select_tags.xml
+++ b/addons/website_forum/static/src/components/forum_post_select_tags/forum_post_select_tags.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+
+  <t t-name="website_forum.ForumPostSelectMenu" t-inherit="web.SelectMenu" t-inherit-mode="primary">
+    <xpath expr="//button" position="attributes">
+      <attribute name="onclick">return false</attribute>
+    </xpath>
+    <xpath expr="//t[@t-set-slot='content']" position="replace">
+      <t t-set-slot="content" t-slot-scope="select">
+        <input
+            t-if="props.searchable"
+            type="text"
+            class="dropdown-item o_select_menu_sticky px-3 py-3 position-sticky top-0 start-0 border-bottom"
+            t-ref="inputRef"
+            t-on-input="debouncedOnInput"
+            t-att-placeholder="props.searchPlaceholder"
+            autocomplete="selectMenuAutocompleteOff"
+            autocorrect="off"
+            spellcheck="false"
+        />
+        <span 
+          t-if="props.getErrorMessage(state.searchValue)"
+          class="text-muted fst-italic ms-3"
+          t-out="props.getErrorMessage(state.searchValue)"/>
+        <t t-elif="state.displayedOptions.length gt 0">
+          <t t-foreach="state.displayedOptions" t-as="choice" t-key="choice_index">
+            <t t-call="{{ this.constructor.choiceItemTemplate }}">
+                <t t-set="choice" t-value="choice" />
+            </t>
+          </t>
+        </t>
+        <t t-else="">
+          <span class="text-muted fst-italic ms-3">No matches found</span>
+        </t>
+        <t t-if="props.slots and props.slots.bottomArea" t-slot="bottomArea" data="state"/>
+      </t>
+    </xpath>
+    <xpath expr="//TagsList" position="after">
+      <t t-if="props.value.length === 0">Select or create tags</t>
+    </xpath>
+  </t>
+
+  <t t-name="website_forum.ForumPostSelectTags">
+    <input t-model="state.value" type="hidden" name="post_tags"/>
+    <ForumPostSelectMenu
+        choices= "state.choices"
+        class="'p-O'"
+        getErrorMessage.bind="getErrorMessage"
+        multiSelect= "true"
+        onInput.bind="onInput"
+        onSelect.bind="onTagsSelect"
+        searchable= "true"
+        searchPlaceholder= "'Tags...'"
+        togglerClass="'bg-transparent border-0'"
+        value= "state.value"
+        hasTokenSeparator="state.hasTokenSeparator"
+    >
+      <t t-set-slot="bottomArea" t-slot-scope="select">
+        <DropdownItem
+            t-if="select.data.searchValue and this.canCreateTag(select.data.searchValue, select.data.choices)"
+            class="'btn text-primary'"
+            onSelected="() => this.onClickCreateTagBtn(select.data.searchValue)"
+        >
+            Create New Tag "<i t-out="select.data.searchValue"/>"
+        </DropdownItem>
+      </t>
+    </ForumPostSelectMenu>
+  </t>
+</templates>

--- a/addons/website_forum/static/src/js/tours/website_forum.js
+++ b/addons/website_forum/static/src/js/tours/website_forum.js
@@ -31,17 +31,18 @@
         trigger: `.note-editable p:not(:contains(/^<br>$/))`,
     },
     {
-        trigger: ".select2-choices",
+        trigger: "button.o_select_menu_toggler",
         content: _t("Insert tags related to your question."),
         position: "top",
+        run: "click",
     }, 
     {
-        trigger: "input[id=s2id_autogen2]",
+        trigger: "input.dropdown-item.o_select_menu_sticky",
         run: "editor Test",
     },
     {
         isActive: ["auto"],
-        trigger: `input[id=s2id_autogen2]:not(:contains(Tags))`,
+        trigger: `input.dropdown-item.o_select_menu_sticky:not(:contains(Tags))`,
     },
     {
         trigger: "button:contains(/^Post/)",

--- a/addons/website_forum/static/src/js/website_forum.js
+++ b/addons/website_forum/static/src/js/website_forum.js
@@ -8,7 +8,6 @@ import { loadWysiwygFromTextarea } from "@web_editor/js/frontend/loadWysiwygFrom
 import publicWidget from "@web/legacy/js/public/public_widget";
 import { session } from "@web/session";
 import { rpc } from "@web/core/network/rpc";
-import { escape } from "@web/core/utils/strings";
 import { _t } from "@web/core/l10n/translation";
 import { renderToElement } from "@web/core/utils/render";
 
@@ -59,67 +58,6 @@ publicWidget.registry.websiteForum = publicWidget.Widget.extend({
         // Initialize forum's tooltips
         this.$('[data-bs-toggle="tooltip"]').tooltip({delay: 0});
         this.$('[data-bs-toggle="popover"]').popover({offset: '8'});
-
-        $('input.js_select2').select2({
-            tags: true,
-            tokenSeparators: [',', ' ', '_'],
-            maximumInputLength: 35,
-            minimumInputLength: 2,
-            maximumSelectionSize: 5,
-            lastsearch: [],
-            createSearchChoice: function (term) {
-                if (self.lastsearch.filter(s => s.text.localeCompare(term) === 0).length === 0) {
-                    //check Karma
-                    if (parseInt($('#karma').val()) >= parseInt($('#karma_edit_retag').val())) {
-                        return {
-                            id: '_' + $.trim(term),
-                            text: $.trim(term) + ' *',
-                            isNew: true,
-                        };
-                    }
-                }
-            },
-            createSearchChoicePosition: "bottom",
-            formatResult: function (term) {
-                if (term.isNew) {
-                    return '<span class="badge bg-primary">New</span> ' + escape(term.text);
-                } else {
-                    return escape(term.text);
-                }
-            },
-            ajax: {
-                url: '/forum/get_tags',
-                dataType: 'json',
-                data: function (term) {
-                    return {
-                        query: term,
-                        limit: 50,
-                        forum_id: $('#wrapwrap').data('forum_id'),
-                    };
-                },
-                results: function (data) {
-                    var ret = [];
-                    data.forEach((x) => {
-                        ret.push({
-                            id: x.id,
-                            text: x.name,
-                            isNew: false,
-                        });
-                    });
-                    self.lastsearch = ret;
-                    return {results: ret};
-                }
-            },
-            // Take default tags from the input value
-            initSelection: function (element, callback) {
-                var data = [];
-                element.data("init-value").forEach((x) => {
-                    data.push({id: x.id, text: x.name, isNew: false});
-                });
-                element.val('');
-                callback(data);
-            },
-        });
 
         $('textarea.o_wysiwyg_loader').toArray().forEach((textarea) => {
             var $textarea = $(textarea);

--- a/addons/website_forum/static/tests/tours/website_forum_question.js
+++ b/addons/website_forum/static/tests/tours/website_forum_question.js
@@ -28,11 +28,15 @@ registry.category("web_tour.tours").add('forum_question', {
     },
     {
         content: "Insert tags related to your question.",
-        trigger: '.select2-choices',
+        trigger: 'button.o_select_menu_toggler',
+        run:"click",
+    },
+    {
+        trigger: 'input.dropdown-item.o_select_menu_sticky',
         run: "editor Tag",
     },
     {
-        trigger: "#wrap:not(:has(input[id=s2id_autogen2]:value('')))",
+        trigger: "#wrap:not(:has(input.dropdown-item.o_select_menu_sticky:value('')))",
     },
     {
         content: "Click to post your question.",

--- a/addons/website_forum/views/forum_forum_templates.xml
+++ b/addons/website_forum/views/forum_forum_templates.xml
@@ -116,7 +116,12 @@
                 <div class="col">
                     <input type="hidden" name="karma_tag_create" t-att-value="forum.karma_tag_create" id="karma_tag_create"/>
                     <input type="hidden" name="karma_edit_retag" t-att-value="forum.karma_edit_retag" id="karma_edit_retag"/>
-                    <input type="hidden" name="post_tags" placeholder="Tags" class="form-control js_select2"/>
+                    <owl-component name="website_forum.ForumPostSelectTags" t-att-props="json.dumps({
+                        'initValue': tags,
+                        'karma': user.karma,
+                        'karmaEditRetag': forum.karma_edit_retag,
+                        'forumId': forum.id
+                    })"/>
                 </div>
             </div>
             <div class="row mb-5">
@@ -206,11 +211,12 @@
                 <div class="col">
                     <input type="hidden" name="karma_tag_create" t-att-value="forum.karma_tag_create" id="karma_tag_create"/>
                     <input type="hidden" name="karma_edit_retag" t-att-value="forum.karma_edit_retag" id="karma_edit_retag"/>
-                    <t t-set="edit_tags_karma_fail" t-value="user.karma &lt; forum.karma_edit_retag"/>
-                    <t t-set="edit_tags_karma_error_message">You need to have sufficient karma to edit tags</t>
-                    <input type="text" name="post_tags" class="form-control js_select2" placeholder="Tags" t-attf-data-init-value="#{tags}" value="Tags"
-                        t-att-readonly="edit_tags_karma_fail and 'readonly'"
-                        t-att-title="edit_tags_karma_fail and edit_tags_karma_error_message"/>
+                    <owl-component name="website_forum.ForumPostSelectTags" t-att-props="json.dumps({
+                        'initValue': tags,
+                        'karma': user.karma,
+                        'karmaEditRetag': forum.karma_edit_retag,
+                        'forumId': forum.id
+                    })"/>
                </div>
             </div>
             <div class="row mb-5">


### PR DESCRIPTION
Select2 is replaced by OWL wherever possible.

The current form for creating or editing a Forum post uses 'select2' for selecting/creating Post tags. This commit replaces 'select2' with 'OWL.js' components derived from the 'SelectMenu' component.

These components mimic the characteristics of the current tag selector:
- Display of the option list according to the user's search criteria
- Limit on the number of tags that can be assigned to a forum post
- Minimum/maximum number of characters for tag creation 
- Display message error when one of the constrains above is broken
- Add/create tags using token separators.

task-3945088

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
