### PR TITLE
[PERF] hr_recruitement_survey: add missing index on `applicant_id`

### DIFF
--- a/addons/hr_recruitment_survey/models/survey_user_input.py
+++ b/addons/hr_recruitment_survey/models/survey_user_input.py
@@ -6,7 +6,7 @@ from odoo import fields, models, _
 class SurveyUserInput(models.Model):
     _inherit = "survey.user_input"
 
-    applicant_id = fields.Many2one('hr.applicant', string='Applicant')
+    applicant_id = fields.Many2one('hr.applicant', string='Applicant', index='btree_not_null')
 
     def _mark_done(self):
         odoobot = self.env.ref('base.partner_root')


### PR DESCRIPTION
## Description
Following a1bc13b39559fa82763a9f0b3b603f6026b8a151 the field `One2many: applicant_ids` becomes `Many2one: applicant_id`. The field is used in lookups (ir.rules) and is also the inverse of `hr.applicant.response_ids`, and is present on the model `survey.user_input`, which is a large table, therefor should be indexed.

## Reference
task-4011294

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
