### PR TITLE
[FIX] web, *: dropdown and searchbar colors

### DIFF
--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -397,7 +397,7 @@
                                 </a>
                             </t>
                         </div>
-                        <input type="text" class="form-control border-0 bg-light" placeholder="Search" t-att-value='search' name="search"/>
+                        <input type="search" class="form-control border-0 bg-light" placeholder="Search" t-att-value='search' name="search"/>
                         <button class="btn btn-light" type="submit">
                             <span class="oi oi-search"/>
                         </button>

--- a/addons/web/static/src/scss/bootstrap_overridden_frontend.scss
+++ b/addons/web/static/src/scss/bootstrap_overridden_frontend.scss
@@ -18,6 +18,10 @@ $primary: $blue !default;
 // See https://www.w3.org/TR/WCAG20/#visual-audio-contrast-contrast
 $min-contrast-ratio: $o-frontend-min-contrast-ratio !default;
 
+// Color contrast variables used in the color-contrast function
+$color-contrast-dark: $black !default; // BS Default
+$color-contrast-light: $white !default; // BS Default
+
 // Body
 
 $body-bg: $white !default; // BS Default
@@ -31,6 +35,7 @@ $body-emphasis-color: $black !default; // BS Default
 $border-width: 1px !default; // BS Default
 
 $component-active-bg: $primary !default;
+$component-active-color: color-contrast($component-active-bg) !default;
 
 // Fonts
 //
@@ -92,6 +97,11 @@ $form-range-thumb-disabled-bg: $input-disabled-bg !default;
 
 $form-file-button-bg: mix($input-color, $input-bg, $btn-hover-bg-shade-amount * 0.3) !default;
 $form-file-button-hover-bg: mix($input-color, $input-bg, $btn-hover-bg-shade-amount) !default;
+
+// Dropdowns
+$dropdown-bg: $body-bg !default;
+$dropdown-link-active-bg: rgba(color-contrast($dropdown-bg), .2) !default;
+$dropdown-link-active-color: color-contrast($dropdown-link-active-bg) !default;
 
 // Figures
 

--- a/addons/web/static/src/scss/bootstrap_review_frontend.scss
+++ b/addons/web/static/src/scss/bootstrap_review_frontend.scss
@@ -195,7 +195,14 @@ $o-navbar-nav-pills-link-border-radius: $nav-pills-border-radius !default;
     color: inherit;
 }
 .form-control.bg-light {
+    @include o-search-cancel-button(adjust-color-to-background($input-color, $light));
+
     color: adjust-color-to-background($input-color, $light);
+}
+
+// Default style inputs
+input[type="search"] {
+    @include o-search-cancel-button($input-color);
 }
 
 $-color-for-gray-200-bg: adjust-color-to-background($body-color, $gray-200);
@@ -248,9 +255,18 @@ $-color-for-gray-200-bg: adjust-color-to-background($body-color, $gray-200);
 }
 
 // Dropdown
-.dropdown .dropdown-menu {
+.dropdown-menu {
     .text-muted {
         color: adjust-color-to-background($text-muted, $dropdown-bg, mute-color($color-contrast-light), mute-color($color-contrast-dark)) !important;
+    }
+
+    // Since we define the $dropdown-link-active-bg variable, we need to
+    // redefine the .active state of the dropdown items to differentiate
+    // an active class from the active state. This allows a discreet effect for
+    // the active state while keeping an active navigation element prominent.
+    .dropdown-item.active {
+        --dropdown-link-active-bg: #{$component-active-bg};
+        --dropdown-link-active-color: #{$component-active-color};
     }
 }
 

--- a/addons/web/static/src/scss/utils.scss
+++ b/addons/web/static/src/scss/utils.scss
@@ -375,3 +375,19 @@
         @warn "'media-only()' - missing argument"
     }
 }
+
+
+// ----------------------------------------------------------------------------
+// Webkit Search Cancel Button
+// ----------------------------------------------------------------------------
+// Define the webkit cancel button used for search inputs to match bootstrap
+// btn-close style with a color parameter to allow contextual override.
+
+@mixin o-search-cancel-button($search-cancel-button-color, $button-height: $font-size-sm) {
+    &::-webkit-search-cancel-button {
+        -webkit-appearance: none;
+        content: escape-svg(url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='#{$search-cancel-button-color}'><path d='M.293.293a1 1 0 0 1 1.414 0L8 6.586 14.293.293a1 1 0 1 1 1.414 1.414L9.414 8l6.293 6.293a1 1 0 0 1-1.414 1.414L8 9.414l-6.293 6.293a1 1 0 0 1-1.414-1.414L6.586 8 .293 1.707a1 1 0 0 1 0-1.414z'/></svg>"));
+        height: $button-height;
+        cursor: pointer;
+    }
+}

--- a/addons/web_editor/static/src/scss/web_editor.common.scss
+++ b/addons/web_editor/static/src/scss/web_editor.common.scss
@@ -589,6 +589,11 @@ pre {
                 &:hover, &:focus {
                     color: $dropdown-link-hover-color !important;
                 }
+                &.active, &:active {
+                    // Restore BS default custom property to allow contextual
+                    // active state. (see bootstrap_review_frontend.scss)
+                    color: var(--dropdown-link-active-color, #{$dropdown-link-active-color}) !important;
+                }
             }
             &.disabled,
             &:disabled {
@@ -716,20 +721,6 @@ pre {
                 .show > .nav-link {
                     background-color: $-btn-primary-color;
                     color: color-contrast($-btn-primary-color);
-                }
-            }
-            .dropdown-menu .dropdown-item { // Need to add +1 priority thanks to
-                                            // .dropdown-menu (see .o_cc).
-                &.active,
-                &:active {
-                    &, h6 { // Quick fix: sometimes we use h6 in dropdowns
-                        @include gradient-bg($-btn-primary-color);
-                        color: color-contrast($-btn-primary-color) !important;
-
-                        &:hover, &:focus {
-                            color: color-contrast($-btn-primary-color) !important;
-                        }
-                    }
                 }
             }
             a.list-group-item {

--- a/addons/website/static/src/scss/bootstrap_overridden.scss
+++ b/addons/website/static/src/scss/bootstrap_overridden.scss
@@ -70,6 +70,9 @@ $spacers: (
 $body-bg: o-color('o-cc1-bg') !default;
 $body-color: o-color('o-cc1-text') or color-contrast($body-bg) !default;
 
+// Bootstrap's default value on hover on some components eg. dropdown-item.
+$body-tertiary-bg: mix(color-contrast($body-bg), $body-bg, 10%) !default;
+
 // Links
 //
 // Style anchor elements.

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -1673,6 +1673,10 @@ $ribbon-padding: 100px;
 .o_search_result_item_detail {
     flex: 1;
     word-break: normal !important;
+
+    button:disabled {
+        color: inherit;
+    }
 }
 
 .o_cookies_bar_toggle {

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -1040,12 +1040,22 @@ $-transition-duration: 200ms;
 .navbar .o_extra_menu_items > .show {
     > li {
         + li {
-            border-top: 1px solid map-get($grays, '200');
+            border-top: $border-width solid $border-color;
         }
         > a.dropdown-toggle {
-            background-color: map-get($grays, '200');
-            color: inherit; // Useful when the toggle is active
+            background-color: $body-tertiary-bg;
             pointer-events: none; // hack to prevent clicking on it because dropdown always opened
+
+            &.active {
+                color: inherit !important;
+            }
+        }
+        > .dropdown-menu {
+            border-radius: 0;
+
+            .dropdown-item {
+                padding-left: $dropdown-item-padding-x + map-get($spacers, 2);
+            }
         }
         > ul, > .o_mega_menu { // remove dropdown-menu default style as it is nested in another one
             position: static;


### PR DESCRIPTION
*: portal, website, web_editor

Enhance user experience by resolving UI inconsistencies and ensuring readability and contrast between the dropdown active / hover states and their inner text. 

**Global**
 - Updated hover effects to use `body-tertiary-bg` instead of `gray-100`, aligning with Bootstrap 5.3's styling approach.
- Added color-contrast function's variables to allow easier use in `bootstrap_overridden_frontend`

**Dropdowns**
- Adjusted active state colors to prevent conflicts between the primary active color and dropdown item text color.
- Differentiate two active states: 
  - Active menu entries (current page) ➡️  Primary color
  - Active feedback on click ➡️  color-contrast of background color
- Updated the `o_extra_menu_items` dropdown to adapt the borders to the user theme settings, removing the hardcoded `gray-200` value.

**Search & Misc**
 - Replaced `-webkit-search-cancel-button` with Bootstrap's `btn-close` design introducing a mixin for contextual color adjustments to match the input color.
- Changed portal search input type from `text` to `search` ensuring proper styling and semantic.

task-3969685

| Before | After |
| --- | --- | 
| ![image](https://github.com/odoo/odoo/assets/118886338/aae9ce72-62e9-44a9-87de-8914bd06bb7a) |  ![image](https://github.com/user-attachments/assets/1bb428b9-1d22-4607-9d2d-9abfb87ba311) |
|![image](https://github.com/odoo/odoo/assets/118886338/ed891c37-11bd-4f69-82a2-45d4a235abd1) | ![image](https://github.com/odoo/odoo/assets/118886338/89db4343-9042-43c8-a338-e2f1f50e7b54) |
| ![image](https://github.com/odoo/odoo/assets/118886338/ae95a96c-8243-46f7-981e-dcc0b1f63e43) | ![image](https://github.com/odoo/odoo/assets/118886338/c8c24097-8e6b-47d5-a0bc-aff3c3841a73) |




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
