### PR TITLE
[FIX] account: fix lines of reverse move

### DIFF
--- a/addons/account/wizard/account_move_reversal.py
+++ b/addons/account/wizard/account_move_reversal.py
@@ -135,7 +135,7 @@ class AccountMoveReversal(models.TransientModel):
                 moves_vals_list = []
                 for move in moves.with_context(include_business_fields=True):
                     data = move.copy_data({'date': self.date})[0]
-                    data['line_ids'] = [line for line in data['line_ids'] if line[2]['display_type'] == 'product']
+                    data['line_ids'] = [line for line in data['line_ids'] if line[2]['display_type'] in ('product', 'line_section', 'line_note')]
                     moves_vals_list.append(data)
                 new_moves = self.env['account.move'].create(moves_vals_list)
 


### PR DESCRIPTION
[FIX] account: fix lines of reverse move

The button "Reverse and Create Invoice" allows the user to reverse the current Invoice, and create a copy in one button. When pressing it, all Notes and Sections are lost

Solution: Include 'line_section' & 'line_note' in creating the reverse move

task-id#3940541

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr