### PR TITLE
[PERF] account: speed up _inverse_product_id

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1113,10 +1113,10 @@ class AccountMoveLine(models.Model):
 
     @api.onchange('product_id')
     def _inverse_product_id(self):
-        self._conditional_add_to_compute('account_id', lambda line: (
-            (self.product_id or not self.account_id) and
-            line.display_type == 'product' and line.move_id.is_invoice(True)
-        ))
+        if self.product_id or not self.account_id:
+            self._conditional_add_to_compute('account_id', lambda line: (
+                line.display_type == 'product' and line.move_id.is_invoice(True)
+            ))
 
     @api.onchange('amount_currency', 'currency_id')
     def _inverse_amount_currency(self):


### PR DESCRIPTION
Currently the condition on `self.product_id or not self.account_id` is inside the lambda passed to `_conditional_add_to_compute`. `_conditional_add_to_compute` calls the lambda in a filtered so this condition will be evaluated for all the lines in self. As it only depends on self, i.e. not the current line, we can move it outside of the implicit for-loop.

#### speedup

Customer database. Calling `_inverse_product_id` increasing the cardinality of self.

| self size | Before PR | After PR |
|:----------:|:---------------:|:-----------:|
|     10    |    5ms    |   5ms    |
|     100   |    14ms   |   11ms   |
|     1000  |    271ms  |   36ms   |
|     10000 |    28.7s  |   300ms  |
|     50000 |    16min  |   1.5s   |

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
