### PR TITLE
[FIX] web_editor: force new twitter icon

### DIFF
--- a/addons/web_editor/controllers/main.py
+++ b/addons/web_editor/controllers/main.py
@@ -94,6 +94,12 @@ class Web_Editor(http.Controller):
         if icon.isdigit():
             if int(icon) == 57467:
                 font = "/web/static/fonts/tiktok_only.woff"
+            elif int(icon) == 61593:  # F099
+                icon = "59392"  # E800
+                font = "/web/static/fonts/twitter_x_only.woff"
+            elif int(icon) == 61569:  # F081
+                icon = "59395"  # E803
+                font = "/web/static/fonts/twitter_x_only.woff"
 
         size = max(width, height, 1) if width else size
         width = width or size


### PR DESCRIPTION
Current behaviour:
---
When sending an email through Email Marketing,
the icon is right in the preview, but wrong in the received email.

Steps to reproduce:
---
1. Install mass_mailing
2. Create a new mailing
3. Select a template with a twitter icon
4. The icon is the new one
5. Click on Test
6. Open the email
7. Wrong icon

Cause of the issue:
---
Twitter icons have been overriden in fontawesome_overridden.scss 
However this css is not loaded when writing the src in fontToImg in convert_inline.js

Fix:
---
Same fix as for tiktok, forcing a custom font and changing the icon code to match the font
(ie: one icon is F099 in FA but E800 in the custom font)

opw-3963437

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
