### PR TITLE
[PERF] point_of_sale: move load call out of loop

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -353,9 +353,9 @@ export class PosStore extends Reactive {
                     product.cachedPricelistRules[pricelistId] = applicableRules[pricelistId];
                 }
             }
-            if (data && data.length > 0 && data[0].model.modelName === "product.product") {
-                this._loadMissingPricelistItems(products);
-            }
+        }
+        if (data && data.length > 0 && data[0].model.modelName === "product.product") {
+            this._loadMissingPricelistItems(products);
         }
     }
 


### PR DESCRIPTION
This commit moves a call to `_loadMissingPricelistItems` within the `computeProductPricelistCache` method of `PosStore` outside of a for loop. This is done because it only needs to be called once for the products, not once for each product.

`_loadMissingPricelistItems` calls `pos.session/get_pos_ui_product_pricelist_item_by_product`, which can be an expensive call. This commit minimizes how many times it's called.

opw-3928634