### PR TITLE
[IMP] sale.order.line: Update price_unit compute

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -512,7 +512,7 @@ class SaleOrderLine(models.Model):
                     date=line.order_id.date_order,
                 )
 
-    @api.depends('product_id', 'product_uom', 'product_uom_qty')
+    @api.depends('product_id', 'product_uom')
     def _compute_price_unit(self):
         for line in self:
             # check if there is already invoiced amount. if so, the price shouldn't change as it might have been


### PR DESCRIPTION
Remove dependency on product_uom_qty to avoid resetting prices when updating quantity

Description of the issue/feature this PR addresses:

Current behavior before PR:
Edit a sale order line.
- Update the price_unit from value A to value B
- Update the product_uom_qty
- price_unit resets to value A

Desired behavior after PR is merged:
- price_unit should keep value A



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
