### PR TITLE
[IMP] fleet: simplify kanban archs

### DIFF
--- a/addons/fleet/views/fleet_vehicle_cost_views.xml
+++ b/addons/fleet/views/fleet_vehicle_cost_views.xml
@@ -95,27 +95,16 @@
         <field name="model">fleet.vehicle.log.contract</field>
         <field name="arch" type="xml">
             <kanban class="o_kanban_mobile" sample="1">
-                <field name="activity_state"/>
                 <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}'/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div t-attf-class="oe_kanban_global_click">
-                            <div>
-                                <strong>
-                                    <field name="vehicle_id" widget="res_partner_many2one"/>
-                                    <span class="float-end badge text-bg-secondary">
-                                        <field name="state"/>
-                                    </span>
-                                </strong>
-                            </div>
-                            <div>
-                                <t t-if="luxon.DateTime.fromISO(record.expiration_date.raw_value) &lt; luxon.DateTime.local()" t-set="expiration_class" t-value="'oe_kanban_text_red'"/>
-                                <span t-att-class="expiration_class"><field name="start_date"/> - <field name="expiration_date"/></span>
-                            </div>
-                            <div>
-                                <field name="insurer_id" widget="res_partner_many2one"/>
-                            </div>
+                    <t t-name="kanban-card">
+                        <div class="d-flex justify-content-between align-items-center">
+                            <field name="vehicle_id" class="fw-bold" widget="res_partner_many2one"/>
+                            <field class="badge text-bg-secondary" name="state"/>
                         </div>
+                        <t t-if="luxon.DateTime.fromISO(record.expiration_date.raw_value) &lt; luxon.DateTime.local()" t-set="expiration_class" t-value="'text-danger fw-bold'"/>
+                        <span t-att-class="expiration_class"><field name="start_date"/> - <field name="expiration_date"/></span>
+                        <field name="insurer_id" widget="res_partner_many2one"/>
                     </t>
                 </templates>
             </kanban>
@@ -274,49 +263,30 @@
         <field name="arch" type="xml">
             <kanban default_group_by="state">
                 <field name="currency_id"/>
-                <field name="activity_ids"/>
-                <field name="activity_state"/>
-                <field name="purchaser_id"/>
-                <field name="vendor_id"/>
-                <field name="amount"/>
                 <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}'/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div t-attf-class="oe_kanban_global_click container" class="o_kanban_record_has_image_fill">
-                            <div class="oe_kanban_details">
-                                <div class="o_kanban_record_top">
-                                    <img t-att-src="kanban_image('fleet.vehicle', 'image_128', record.vehicle_id.raw_value)" t-att-alt="record.vehicle_id.value" class="o_image_24_cover float-start"/>
-                                    <div class="o_kanban_record_headings ps-2 pe-2">
-                                        <div class="text-truncate">
-                                            <strong class="o_kanban_record_title">
-                                                <field name="vehicle_id"/>
-                                                <span t-attf-class="float-end badge #{['todo', 'running'].indexOf(record.state.raw_value) > -1 ? 'text-bg-secondary' : ['cancelled'].indexOf(record.state.raw_value) > -1 ? 'text-bg-danger' : 'text-bg-success'}">
-                                                    <field name="state"/>
-                                                </span>
-                                            </strong>
-                                        </div>
-                                        <div class="text-truncate">
-                                            <em><field name="service_type_id"/></em>
-                                        </div>
-                                    </div>
-                                </div>
+                    <t t-name="kanban-card">
+                        <div class="flex-row">
+                            <field name="vehicle_id" widget="image" options="{'preview_image': 'image_128'}" t-att-alt="record.vehicle_id.value" class="float-start col-2 pe-2"/>
+                            <div class="col-10 pe-2 text-truncate">
+                                <field class="fw-bolder" name="vehicle_id"/>
+                                <span t-attf-class="float-end badge #{['todo', 'running'].indexOf(record.state.raw_value) > -1 ? 'text-bg-secondary' : ['cancelled'].indexOf(record.state.raw_value) > -1 ? 'text-bg-danger' : 'text-bg-success'}">
+                                    <field name="state"/>
+                                </span>
                                 <div class="text-truncate">
-                                    <field name="purchaser_id"/>
-                                    <span class="float-end"><field name="date"/></span>
-                                </div>
-                                <div class="text-truncate">
-                                    <field name="vendor_id"/>
-                                </div>
-                                <div class="o_kanban_record_bottom">
-                                    <div class="oe_kanban_bottom_left">
-                                        <field name="amount" widget="monetary" options="{'currency_field': 'currency_id'}"/>
-                                    </div>
-                                    <div class="oe_kanban_bottom_right">
-                                        <field name="activity_ids" widget="kanban_activity"/>
-                                    </div>
+                                    <em><field name="service_type_id"/></em>
                                 </div>
                             </div>
                         </div>
+                        <div class="text-truncate">
+                            <field name="purchaser_id"/>
+                            <field class="float-end" name="date"/>
+                        </div>
+                        <field class="text-truncate" name="vendor_id"/>
+                        <footer class="fs-6 pt-0">
+                            <field name="amount" widget="monetary" options="{'currency_field': 'currency_id'}"/>
+                            <field name="activity_ids" widget="kanban_activity" class="ms-auto"/>
+                        </footer>
                     </t>
                 </templates>
             </kanban>

--- a/addons/fleet/views/fleet_vehicle_model_views.xml
+++ b/addons/fleet/views/fleet_vehicle_model_views.xml
@@ -72,23 +72,12 @@
                         <page string="Vendors" name="vendors">
                             <field name="vendors">
                                 <kanban quick_create="false" create="true">
-                                    <field name="name"/>
-                                    <field name="phone"/>
-                                    <field name="email"/>
                                     <templates>
-                                        <t t-name="kanban-box">
-                                            <div style="position: relative" class="oe_kanban_global_click">
-                                                <div>
-                                                    <div class="o_kanban_record_title">
-                                                        <field name="name"/>
-                                                        <div class="o_kanban_details float-end">
-                                                            <span class="text-muted">
-                                                                <t t-if="record.phone.raw_value"><field name="phone"/><br/></t>
-                                                                <t t-if="record.email.raw_value"><field name="email"/></t>
-                                                            </span>
-                                                        </div>
-                                                    </div>
-                                                </div>
+                                        <t t-name="kanban-card" class="flex-row fw-bold">
+                                            <field name="name"/>
+                                            <div class="text-muted ms-auto">
+                                                <t t-if="record.phone.raw_value"><field name="phone"/><br/></t>
+                                                <t t-if="record.email.raw_value"><field name="email"/></t>
                                             </div>
                                         </t>
                                     </templates>
@@ -123,11 +112,9 @@
         <field name="arch" type="xml">
             <kanban string="Models">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div class="oe_kanban_global_click oe_kanban_details">
-                            <div><strong><field name="name"/></strong></div>
-                            <div><field name="brand_id"/></div>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field class="fw-bold" name="name"/>
+                        <field name="brand_id"/>
                     </t>
                 </templates>
             </kanban>
@@ -206,9 +193,7 @@
         <field name="name">fleet.vehicle.model.brandkanban</field>
         <field name="model">fleet.vehicle.model.brand</field>
         <field name="arch" type="xml">
-            <kanban default_order="name" action="action_brand_model" type="object">
-                <field name="id"/>
-                <field name="name"/>
+            <kanban default_order="name">
                 <field name="active"/>
                 <templates>
                     <t t-name="kanban-menu">
@@ -219,22 +204,16 @@
                         </a>
                         <a role="menuitem" t-if="widget.deletable" type="delete" class="dropdown-item">Delete</a>
                     </t>
-                    <t t-name="kanban-box">
-                        <div class="oe_kanban_vignette oe_semantic_html_override oe_kanban_global_click">
-                            <div class="o_kanban_image">
-                                <img alt="img" t-att-src="kanban_image('fleet.vehicle.model.brand', 'image_128', record.id.raw_value)" class="o_image_64_max" height="52"/>
-                            </div>
-                            <div class="oe_kanban_details">
-                                <h4 class="oe_partner_heading">
-                                    <a type="open" class="o_kanban_record_title">
-                                        <field name="name"/>
-                                    </a>
-                                </h4>
-                                <div>
-                                    <field name="model_count"/> MODELS
-                                </div>
-                            </div>
-                        </div>
+                    <t t-name="kanban-card" class="flex-row p-1">
+                        <aside>
+                            <field name="image_128" widget="image" options="{'img_class': 'object-fit-contain'}"/>
+                        </aside>
+                        <main class="ms-2 mt-1">
+                            <field class="fw-bold fs-5" name="name"/>
+                            <a type="object" name="action_brand_model" class="mt-2 text-black">
+                                <field name="model_count"/> MODELS
+                            </a>
+                        </main>
                     </t>
                 </templates>
             </kanban>

--- a/addons/fleet/views/fleet_vehicle_views.xml
+++ b/addons/fleet/views/fleet_vehicle_views.xml
@@ -256,67 +256,46 @@
         <field name="model">fleet.vehicle</field>
         <field name="arch" type="xml">
             <kanban default_group_by="state_id" sample="1">
-                <field name="license_plate" />
-                <field name="model_id" />
-                <field name="driver_id" />
-                <field name="future_driver_id" />
-                <field name="location" />
-                <field name="state_id" />
-                <field name="id" />
-                <field name="tag_ids" />
                 <field name="contract_renewal_due_soon" />
                 <field name="contract_renewal_overdue" />
-                <field name="contract_count" />
-                <field name="activity_ids"/>
-                <field name="activity_state"/>
                 <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}'/>
 
                 <templates>
-                    <t t-name="kanban-box">
-                        <div class="oe_kanban_global_click o_kanban_record_has_image_fill">
-                            <div class="o_kanban_image">
-                                <img t-attf-src="#{kanban_image('fleet.vehicle', 'image_128', record.id.raw_value)}" t-att-alt="record.id.value"/>
+                    <t t-name="kanban-card" class="flex-row">
+                        <aside class="d-flex align-items-center me-2">
+                            <field name="image_128" widget="image" options="{'img_class': 'object-fit-cover'}"/>
+                        </aside>
+                        <main>
+                            <div>
+                                <t t-if="record.license_plate.raw_value">
+                                    <field class="fw-bolder fs-5" name="license_plate"/>:
+                                </t>
+                                <field class="fw-bolder fs-5" name="model_id"/>
                             </div>
-                            <div class="oe_kanban_details">
-                                <strong class="o_kanban_record_title">
-                                    <t t-if="record.license_plate.raw_value"><field name="license_plate"/>:</t> <field name="model_id"/>
-                                </strong>
-                                <div class="o_kanban_tags_section">
-                                    <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
-                                </div>
-                                <ul>
-                                    <li>
-                                        <t t-if="record.driver_id.raw_value"><field name="driver_id" widget="many2one_avatar" options="{'display_avatar_name': True}"/></t>
-                                    </li>
-                                    <li>
-                                        <t t-if="record.future_driver_id.raw_value">Future Driver : <field name="future_driver_id"/></t>
-                                    </li>
-                                    <li>
-                                        <t t-if="record.location.raw_value"><small><i class="fa fa-map-marker" title="Location"></i> <field name="location"/></small></t>
-                                    </li>
-                                    <li>
-                                        <field name="vehicle_properties" widget="properties"/>
-                                    </li>
-                                </ul>
-                                <div class="o_kanban_record_bottom" t-if="!selection_mode">
-                                    <div class="oe_kanban_bottom_left">
-                                        <a t-if="record.contract_count.raw_value>0" data-type="object"
-                                           data-name="return_action_to_open" href="#" class="oe_kanban_action oe_kanban_action_a"
-                                           data-context='{"xml_id":"fleet_vehicle_log_contract_action"}'>
-                                            <field name="contract_count"/>
-                                            Contract(s)
-                                            <span t-if="record.contract_renewal_due_soon.raw_value and !record.contract_renewal_overdue.raw_value"
-                                                class="fa fa-exclamation-triangle text-warning" role="img" aria-label="Warning: renewal due soon" title="Warning: renewal due soon">
-                                            </span>
-                                             <span t-if="record.contract_renewal_overdue.raw_value"
-                                                class="fa fa-exclamation-triangle text-danger" role="img" aria-label="Attention: renewal overdue" title="Attention: renewal overdue">
-                                            </span>
-                                        </a>
-                                        <field name="activity_ids" widget="kanban_activity"/>
-                                    </div>
-                                </div>
+                            <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                            <field t-if="record.driver_id.raw_value" name="driver_id" widget="many2one_avatar" options="{'display_avatar_name': True}" class="small pt-1 pb-1"/>
+                            <div class="small">
+                                <t t-if="record.future_driver_id.raw_value">Future Driver : <field name="future_driver_id"/></t>
                             </div>
-                        </div>
+                            <t t-if="record.location.raw_value"><small><i class="fa fa-map-marker" title="Location"></i> <field name="location"/></small></t>
+                            <field name="vehicle_properties" widget="properties"/>
+                            <footer class="pt-0 mt-0" t-if="!selection_mode">
+                                <div class="d-flex fs-6">
+                                    <a t-if="record.contract_count.raw_value>0" data-type="object"
+                                        data-name="return_action_to_open" href="#" data-context='{"xml_id":"fleet_vehicle_log_contract_action"}'>
+                                        <field name="contract_count"/>
+                                        Contract(s)
+                                        <span t-if="record.contract_renewal_due_soon.raw_value and !record.contract_renewal_overdue.raw_value"
+                                            class="fa fa-exclamation-triangle text-warning" role="img" aria-label="Warning: renewal due soon" title="Warning: renewal due soon">
+                                        </span>
+                                        <span t-if="record.contract_renewal_overdue.raw_value"
+                                            class="fa fa-exclamation-triangle text-danger" role="img" aria-label="Attention: renewal overdue" title="Attention: renewal overdue">
+                                        </span>
+                                    </a>
+                                    <field name="activity_ids" widget="kanban_activity" class="ms-2"/>
+                                </div>
+                            </footer>
+                        </main>
                     </t>
                 </templates>
             </kanban>
@@ -415,18 +394,14 @@
         <field name="arch" type="xml">
             <kanban class="o_kanban_mobile">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div t-attf-class="oe_kanban_global_click">
-                            <div>
-                                <strong>
-                                    <field name="vehicle_id"/>
-                                    <span class="float-end"><field name="date"/></span>
-                                </strong>
-                            </div>
-                            <div>
-                                <span><field name="driver_id"/></span>
-                                <span class="float-end"><field name="value"/> Km</span>
-                            </div>
+                    <t t-name="kanban-card">
+                        <div class="d-flex">
+                            <field class="fw-bold" name="vehicle_id"/>
+                            <field class="fw-bold ms-auto" name="date"/>
+                        </div>
+                        <div class="d-flex">
+                            <field name="driver_id"/>
+                            <span class="ms-auto"><field name="value"/> Km</span>
                         </div>
                     </t>
                 </templates>


### PR DESCRIPTION
In this commit we have simplified the kanban arch for the fleet module.the goal is to simplify them, make them easier to read and use bootstrap utility classnames.
- Previously, we used `kanban-box`, but now we are using `kanban-card` instead.
- Deprecated `oe_kanban_global_click` and `oe_kanban_global_click_edit`.
- More use of `<field/>` tags
- Removed the `oe_kanban_colorpicker` class and replaced it with the `kanban_color_picker` widget.
- Changed type='edit' to type='open' to open records. since version 16, records always open in edit mode by default.
- `kanban_image` from rendering context, is deprecated so we use `<field name="..." widget="image"/>` instead
- `kanban_color`, `kanban_getcolor` and `kanban_getcolorname` are deprecated use new attribute `highlight_color="color_field_name"` on root node
- `oe_kanban_colorpicker` is deprecated, use kanban_color_picker widget instead

Task-3992107


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
