### PR TITLE
 [FIX] web: ControlPanel's TopBar spacing & animation 

### DIFF
--- a/addons/project/static/tests/tours/project_update_tour_tests.js
+++ b/addons/project/static/tests/tours/project_update_tour_tests.js
@@ -107,7 +107,7 @@ registry.category("web_tour.tours").add('project_update_tour', {
     content: 'Open embedded actions',
     run: "click",
 }, {
-    trigger: ".o_embedded_actions_buttons_wrapper button i.fa-sliders",
+    trigger: ".o_embedded_actions button i.fa-sliders",
     content: "Open embedded actions dropdown",
     run: "click",
 }, {
@@ -115,7 +115,7 @@ registry.category("web_tour.tours").add('project_update_tour', {
     content: "Put Project Updates in the embedded actions",
     run: "click",
 }, {
-    trigger: ".o_embedded_actions_buttons_wrapper button span:contains('Project Updates')",
+    trigger: ".o_embedded_actions button span:contains('Project Updates')",
     content: "Open Project Updates",
     run: "click",
 }, {

--- a/addons/sale_timesheet/static/tests/tours/sale_timesheet_tour.js
+++ b/addons/sale_timesheet/static/tests/tours/sale_timesheet_tour.js
@@ -282,7 +282,7 @@ registry.category("web_tour.tours").add('sale_timesheet_tour', {
     content: 'Open embedded actions',
     run: "click",
 }, {
-    trigger: ".o_embedded_actions_buttons_wrapper button i.fa-sliders",
+    trigger: ".o_embedded_actions button i.fa-sliders",
     content: "Open embedded actions dropdown",
     run: "click",
 }, {
@@ -290,7 +290,7 @@ registry.category("web_tour.tours").add('sale_timesheet_tour', {
     content: "Put Project Updates in the embedded actions",
     run: "click",
 }, {
-    trigger: ".o_embedded_actions_buttons_wrapper button span:contains('Project Updates')",
+    trigger: ".o_embedded_actions button span:contains('Project Updates')",
     content: "Open Project Updates",
     run: "click",
 }, {

--- a/addons/web/static/src/search/control_panel/control_panel.js
+++ b/addons/web/static/src/search/control_panel/control_panel.js
@@ -14,6 +14,7 @@ import { AccordionItem } from "@web/core/dropdown/accordion_item";
 import { CheckBox } from "@web/core/checkbox/checkbox";
 import { makeContext } from "@web/core/context";
 import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
+import { Transition } from "@web/core/transition";
 
 import { Component, useState, onMounted, useExternalListener, useRef, useEffect } from "@odoo/owl";
 
@@ -46,6 +47,7 @@ export class ControlPanel extends Component {
         DropdownItem,
         AccordionItem,
         CheckBox,
+        Transition,
     };
     static props = {
         display: { type: Object, optional: true },

--- a/addons/web/static/src/search/control_panel/control_panel.scss
+++ b/addons/web/static/src/search/control_panel/control_panel.scss
@@ -53,12 +53,6 @@
     }
 }
 
-.o_embedded_line {
-    flex: 1 1 0%;
-    height: 1px;
-    background-color: #ddd;
-}
-
 .o_dragged_embedded_action {
     transition: transform 0.5s;
     transform: rotate(2deg);
@@ -66,20 +60,20 @@
 }
 
 .o_embedded_actions {
-    opacity: 0;
-    max-height: 0;
-    align-self: center;
-    overflow: hidden;
-    transition: opacity 0.5s, max-height 1.0s ease;
-}
-
-.o_embedded_actions_buttons_wrapper {
-    max-width: 80%;
-}
-
-.o_embedded_actions.visible {
-    opacity: 1;
     max-height: 500px;
+    transition: opacity 0.5s, max-height 0.5s ease;
+
+    &.o-fade-leave, &.o-fade-enter {
+        opacity: 0;
+        max-height: 0;
+    }
+
+    &::before, &::after {
+        flex: 1 1 0;
+        height: 1px;
+        background-color: $border-color;
+        content: "";
+    }
 }
 
 .o_save_current_view {

--- a/addons/web/static/src/search/control_panel/control_panel.xml
+++ b/addons/web/static/src/search/control_panel/control_panel.xml
@@ -2,27 +2,23 @@
 <templates xml:space="preserve">
 
     <t t-name="web.ControlPanel">
-        <div class="o_control_panel d-flex flex-column gap-3 gap-lg-1 px-3 pt-2 pb-3" t-ref="root" data-command-category="actions">
-            <div class="o_embedded_actions d-flex w-100 align-items-center justify-content-center gap-2" t-attf-class="{{state.embeddedInfos.showEmbedded ? 'visible mb-2' : ''}}">
-                <div t-if="state.embeddedInfos.showEmbedded" class="d-none d-md-flex w-100 align-items-center justify-content-center gap-2">
-                    <div class="o_embedded_line" />
-                    <div class="d-none d-md-flex o_embedded_actions_buttons_wrapper gap-2 flex-wrap justify-content-center">
-                        <t t-foreach="state.embeddedInfos.embeddedActions" t-as="action" t-key="action.id">
-                            <t t-if="_checkValueLocalStorage(action)">
-                                <button class="btn btn-secondary"
-                                        t-att-class="{ 'active': state.embeddedInfos.currentEmbeddedAction?.id === action.id, 'o_draggable': !!action.id}"
-                                        t-on-click="() => this.onEmbeddedActionClick(action)"
-                                        t-att-data-id="action.id"
-                                >
-                                    <span t-out="action.name"/>
-                                </button>
-                            </t>
+        <div class="o_control_panel d-flex flex-column gap-3 px-3 pt-2 pb-3" t-ref="root" data-command-category="actions">
+            <Transition t-if="!env.isSmall" visible="state.embeddedInfos.showEmbedded" name="'o-fade'" t-slot-scope="transition" leaveDuration="500">
+                <div class="o_embedded_actions overflow-hidden d-flex flex-wrap w-100 align-items-center justify-content-center gap-2" t-att-class="transition.className">
+                    <t t-foreach="state.embeddedInfos.embeddedActions" t-as="action" t-key="action.id">
+                        <t t-if="_checkValueLocalStorage(action)">
+                            <button class="btn btn-secondary"
+                                    t-att-class="{ 'active': state.embeddedInfos.currentEmbeddedAction?.id === action.id, 'o_draggable': !!action.id}"
+                                    t-on-click="() => this.onEmbeddedActionClick(action)"
+                                    t-att-data-id="action.id"
+                            >
+                                <span t-out="action.name"/>
+                            </button>
                         </t>
-                        <t t-call="web.embeddedActionsDropdown" />
-                    </div>
-                    <div class="o_embedded_line" />
+                    </t>
+                    <t t-call="web.embeddedActionsDropdown" />
                 </div>
-            </div>
+            </Transition>
             <div class="o_control_panel_main d-flex flex-wrap flex-lg-nowrap justify-content-between align-items-lg-start gap-3 flex-grow-1">
                 <div class="o_control_panel_breadcrumbs d-flex align-items-center gap-1 order-0 h-lg-100">
                     <div class="o_control_panel_main_buttons d-flex gap-1 d-empty-none d-print-none" t-ref="mainButtons" t-on-keydown="onMainButtonsKeydown">
@@ -61,10 +57,10 @@
                     <t t-slot="control-panel-selection-actions"/>
                 </div>
 
-                <div class="o_control_panel_navigation d-flex flex-wrap flex-md-nowrap justify-content-end gap-3 gap-lg-1 gap-xl-3 order-1 order-lg-2 flex-grow-1">
-                    <div t-if="(state.embeddedInfos.showEmbedded || env.isSmall) and state.embeddedInfos.embeddedActions?.length" class="d-flex d-md-none">
+                <div class="o_control_panel_navigation d-flex flex-wrap flex-md-nowrap justify-content-end gap-1 gap-xl-3 order-1 order-lg-2 flex-grow-1">
+                    <t t-if="state.embeddedInfos.embeddedActions?.length and env.isSmall">
                         <t t-call="web.embeddedActionsDropdown" />
-                    </div>
+                    </t>
                     <div t-if="pagerProps and pagerProps.total > 0" class="o_cp_pager text-nowrap " role="search">
                         <Pager t-props="pagerProps"/>
                     </div>
@@ -110,11 +106,8 @@
 
     <t t-name="web.embeddedActionsDropdown">
         <Dropdown>
-            <button t-if="!env.isSmall" class="btn btn-secondary">
+            <button class="btn btn-secondary">
                 <i class="fa fa-sliders"/>
-            </button>
-            <button t-else="" class="btn btn-secondary o-dropdown-caret">
-                <span t-out="state.embeddedInfos.currentEmbeddedAction?.name || state.embeddedInfos.embeddedActions[0]?.name"/>
             </button>
             <t t-set-slot="content">
                 <t t-foreach="state.embeddedInfos.embeddedActions" t-as="action" t-key="action.id">

--- a/addons/web/static/tests/webclient/actions/embedded_action.test.js
+++ b/addons/web/static/tests/webclient/actions/embedded_action.test.js
@@ -173,7 +173,7 @@ test("can display embedded actions linked to the current action", async () => {
     });
     await contains(".o_control_panel_navigation > button > i.fa-sliders").click();
     expect(".o_embedded_actions").toHaveCount(1, { message: "should display the embedded" });
-    expect(".o_embedded_actions_buttons_wrapper > button > span").toHaveText("Partners Action 1", {
+    expect(".o_embedded_actions > button > span").toHaveText("Partners Action 1", {
         message:
             "The first embedded action should be the parent one and should be shown by default",
     });
@@ -184,7 +184,7 @@ test("can toggle visibility of embedded actions", async () => {
     await getService("action").doAction(1);
     browser.localStorage.clear();
     await contains(".o_control_panel_navigation > button > i.fa-sliders").click();
-    await contains(".o_embedded_actions_buttons_wrapper .dropdown").click();
+    await contains(".o_embedded_actions .dropdown").click();
     expect(".o_popover.dropdown-menu .dropdown-item").toHaveCount(4, {
         message: "Three embedded actions should be displayed in the dropdown + button 'Save View'",
     });
@@ -194,7 +194,7 @@ test("can toggle visibility of embedded actions", async () => {
     await contains(
         ".o_popover.dropdown-menu .dropdown-item > div > span:contains('Embedded Action 2')"
     ).click();
-    expect(".o_embedded_actions_buttons_wrapper > button").toHaveCount(3, {
+    expect(".o_embedded_actions > button").toHaveCount(3, {
         message: "Should have 2 embedded actions in the embedded + the dropdown button",
     });
 });
@@ -204,12 +204,12 @@ test("can click on a embedded action and execute the corresponding action (with 
     await getService("action").doAction(1);
     browser.localStorage.clear();
     await contains(".o_control_panel_navigation > button > i.fa-sliders").click();
-    await contains(".o_embedded_actions_buttons_wrapper .dropdown").click();
+    await contains(".o_embedded_actions .dropdown").click();
     await contains(
         ".o_popover.dropdown-menu .dropdown-item > div > span:contains('Embedded Action 2')"
     ).click();
     await contains(
-        ".o_embedded_actions_buttons_wrapper > button > span:contains('Embedded Action 2')"
+        ".o_embedded_actions > button > span:contains('Embedded Action 2')"
     ).click();
     await runAllTimers();
     expect(router.current.action).toBe(3, {
@@ -217,7 +217,7 @@ test("can click on a embedded action and execute the corresponding action (with 
     });
     expect(".o_list_view").toHaveCount(1, { message: "the view should be a list view" });
     expect(".o_embedded_actions").toHaveCount(1, { message: "the embedded should stay open" });
-    expect(".o_embedded_actions_buttons_wrapper > button.active").toHaveText("Embedded Action 2", {
+    expect(".o_embedded_actions > button.active").toHaveText("Embedded Action 2", {
         message: "The second embedded action should be active",
     });
 });
@@ -236,12 +236,12 @@ test("can click on a embedded action and execute the corresponding action (with 
     await getService("action").doAction(1);
     browser.localStorage.clear();
     await contains(".o_control_panel_navigation > button > i.fa-sliders").click();
-    await contains(".o_embedded_actions_buttons_wrapper .dropdown").click();
+    await contains(".o_embedded_actions .dropdown").click();
     await contains(
         ".o_popover.dropdown-menu .dropdown-item > div > span:contains('Embedded Action 3')"
     ).click();
     await contains(
-        ".o_embedded_actions_buttons_wrapper > button > span:contains('Embedded Action 3')"
+        ".o_embedded_actions > button > span:contains('Embedded Action 3')"
     ).click();
     await runAllTimers();
     expect(router.current.action).toBe(4, {
@@ -249,7 +249,7 @@ test("can click on a embedded action and execute the corresponding action (with 
     });
     expect(".o_kanban_view").toHaveCount(1, { message: "the view should be a kanban view" });
     expect(".o_embedded_actions").toHaveCount(1, { message: "the embedded should stay open" });
-    expect(".o_embedded_actions_buttons_wrapper > button.active").toHaveText("Embedded Action 3", {
+    expect(".o_embedded_actions > button.active").toHaveText("Embedded Action 3", {
         message: "The third embedded action should be active",
     });
 });
@@ -268,7 +268,7 @@ test("breadcrumbs are updated when clicking on embeddeds", async () => {
     await getService("action").doAction(1);
     browser.localStorage.clear();
     await contains(".o_control_panel_navigation > button > i.fa-sliders").click();
-    await contains(".o_embedded_actions_buttons_wrapper .dropdown").click();
+    await contains(".o_embedded_actions .dropdown").click();
     await contains(
         ".o_popover.dropdown-menu .dropdown-item > div > span:contains('Embedded Action 2')"
     ).click();
@@ -278,7 +278,7 @@ test("breadcrumbs are updated when clicking on embeddeds", async () => {
     expect(".o_control_panel .breadcrumb-item").toHaveCount(0);
     expect(".o_control_panel .o_breadcrumb .active").toHaveText("Partners Action 1");
     await contains(
-        ".o_embedded_actions_buttons_wrapper > button > span:contains('Embedded Action 2')"
+        ".o_embedded_actions > button > span:contains('Embedded Action 2')"
     ).click();
     await runAllTimers();
     expect(router.current.action).toBe(3, {
@@ -289,7 +289,7 @@ test("breadcrumbs are updated when clicking on embeddeds", async () => {
         "Favorite Ponies",
     ]);
     await contains(
-        ".o_embedded_actions_buttons_wrapper > button > span:contains('Embedded Action 3')"
+        ".o_embedded_actions > button > span:contains('Embedded Action 3')"
     ).click();
     await runAllTimers();
     expect(router.current.action).toBe(4, {
@@ -316,12 +316,12 @@ test("a view coming from a embedded can be saved in the embedded actions", async
     await getService("action").doAction(1);
     browser.localStorage.clear();
     await contains(".o_control_panel_navigation > button > i.fa-sliders").click();
-    await contains(".o_embedded_actions_buttons_wrapper .dropdown").click();
+    await contains(".o_embedded_actions .dropdown").click();
     await contains(
         ".o_popover.dropdown-menu .dropdown-item > div > span:contains('Embedded Action 2')"
     ).click();
     await contains(
-        ".o_embedded_actions_buttons_wrapper > button > span:contains('Embedded Action 2')"
+        ".o_embedded_actions > button > span:contains('Embedded Action 2')"
     ).click();
     await runAllTimers();
     expect(router.current.action).toBe(3, {
@@ -336,11 +336,11 @@ test("a view coming from a embedded can be saved in the embedded actions", async
     expect(".o_kanban_record:not(.o_kanban_ghost)").toHaveCount(1, {
         message: "There should be one record",
     });
-    await contains(".o_embedded_actions_buttons_wrapper .dropdown").click();
+    await contains(".o_embedded_actions .dropdown").click();
     await contains(".o_save_current_view ").click();
     await contains("input.form-check-input").click();
     await contains(".o_save_favorite ").click();
-    expect(".o_embedded_actions_buttons_wrapper > button").toHaveCount(4, {
+    expect(".o_embedded_actions > button").toHaveCount(4, {
         message: "Should have 2 embedded actions in the embedded + the dropdown button",
     });
 });


### PR DESCRIPTION
This commit applies some DOM and styling cleanup to the
TopBar/EmbeddedActions in the ControlPanel.

In a nutshell:
- less DOM nodes/CSS rules
- uses isSmall to actually removes elements from the DOM instead of
  hidding them with responsive classes.
- removes the unnecessary spacing at the top of the ControlPanel on
  small screens
- thin side lines' color match borders' (specially visible in dark mode)
- smoother animation using Transition component
- use same icon in desktop & mobile

task-3336242

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
