### PR TITLE
[IMP] crm: preventing stages to reappear after updating module

### DIFF
--- a/addons/crm/data/crm_stage_data.xml
+++ b/addons/crm/data/crm_stage_data.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo noupdate="1">
-    <record model="crm.stage" id="stage_lead1">
+    <record model="crm.stage" id="stage_lead1" forcecreate="False">
         <field name="name">New</field>
         <field name="sequence">1</field>
     </record>
-    <record model="crm.stage" id="stage_lead2">
+    <record model="crm.stage" id="stage_lead2" forcecreate="False">
         <field name="name">Qualified</field>
         <field name="sequence">2</field>
     </record>
-    <record model="crm.stage" id="stage_lead3">
+    <record model="crm.stage" id="stage_lead3" forcecreate="False">
         <field name="name">Proposition</field>
         <field name="sequence">3</field>
     </record>
-    <record model="crm.stage" id="stage_lead4">
+    <record model="crm.stage" id="stage_lead4" forcecreate="False">
         <field name="name">Won</field>
         <field name="fold" eval="False"/>
         <field name="is_won">True</field>

--- a/addons/crm/tests/test_crm_ui.py
+++ b/addons/crm/tests/test_crm_ui.py
@@ -1,11 +1,12 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo.addons.crm.tests.common import TestCrmCommon
 from odoo.tests import HttpCase
 from odoo.tests.common import tagged
 
 
 @tagged('post_install', '-at_install')
-class TestUi(HttpCase):
+class TestUi(HttpCase, TestCrmCommon):
 
     def test_01_crm_tour(self):
         # TODO: The tour is raising a JS error when selecting Brandon Freeman
@@ -21,13 +22,13 @@ class TestUi(HttpCase):
             'name': "Zizizbroken",
             'type': 'opportunity',
             'partner_id': brandon.id,
-            'stage_id': self.env.ref('crm.stage_lead1').id,
+            'stage_id': self.stage_team1_1.id,
             'user_id': self.env.ref('base.user_admin').id,
         }, {
             'name': "Zizizbroken 2",
             'type': 'opportunity',
             'partner_id': brandon.id,
-            'stage_id': self.env.ref('crm.stage_lead2').id,
+            'stage_id': self.stage_gen_1.id,
             'user_id': self.env.ref('base.user_admin').id,
         }])
         self.start_tour("/odoo", 'crm_tour', login="admin")


### PR DESCRIPTION
**How to reproduce:**
- Create a db with crm
- Delete the stages
- Update the module
- Stages will reappear

**Specifications:**
Once deleted stages should not appear again after updating module.

**After this PR:**
Stages will not reappear after a module update.

Task-4008997