### PR TITLE
[FIX] stock: broken documentation link for packages

### DIFF
--- a/addons/stock/views/res_config_settings_views.xml
+++ b/addons/stock/views/res_config_settings_views.xml
@@ -19,7 +19,7 @@
                                 </div>
                                 <div class="o_setting_right_pane">
                                     <label for="group_stock_tracking_lot"/>
-                                    <a href="https://www.odoo.com/documentation/16.0/applications/inventory_and_mrp/inventory/management/products/usage.html#packages" title="Documentation" class="o_doc_link" target="_blank"></a>
+                                    <a href="https://www.odoo.com/documentation/16.0/applications/inventory_and_mrp/inventory/product_management/product_tracking/package.html" title="Documentation" class="o_doc_link" target="_blank"></a>
                                     <div class="text-muted">
                                         Put your products in packs (e.g. parcels, boxes) and track them
                                     </div>


### PR DESCRIPTION
Clicking on the doc link for the "Packages" setting returns a 404 error.

The structure of the Inventory documentation has been changed and it seems there was a missing redirection rule for this doc. This commit fixes the URL of the doc link.