### PR TITLE
[FIX] website_sale: sort by alignment issue when search bar is disabled

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -343,7 +343,7 @@
                                 </t>
 
                                 <t t-if="is_view_active('website_sale.sort')" t-call="website_sale.sort">
-                                    <t t-set="_classes" t-valuef="d-none d-lg-inline-block"/>
+                                    <t t-set="_classes" t-valuef="d-none me-auto d-lg-inline-block"/>
                                 </t>
 
                                 <div t-if="category" class="d-flex align-items-center d-lg-none me-auto">


### PR DESCRIPTION
Steps:
-Go to your /shop page.
-Disable the search bar from the editor.
-Configure several pricelists as selectable.

Issue:
When the search bar is disabled and multiple pricelists are selectable,'Sort by'
dropdown does not align correctly, causing it to appear in the middle of the
page instead of to the left, just after the pricelists.

Fix:
Applied the me-auto class to the 'Sort by' dropdown, ensuring it aligns
correctly to the left within its container.

opw-3994784

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
