### PR TITLE
[IMP] web: add hoot matchers

### DIFF
--- a/addons/web/static/lib/hoot/core/expect.js
+++ b/addons/web/static/lib/hoot/core/expect.js
@@ -806,6 +806,29 @@ export class Matchers {
     }
 
     /**
+     * Expects the received value to be null.
+     *
+     * @param {ExpectOptions} [options]
+     * @example
+     *  expect(null).toBeNull();
+     */
+    toBeNull(options) {
+        this._saveStack();
+
+        ensureArguments([[options, ["object", null]]]);
+
+        return this._resolve({
+            name: "toBeNull",
+            acceptedType: "any",
+            predicate: (actual) => actual === null,
+            message: (pass) =>
+                options?.message ||
+                (pass ? `%actual% is[! not] null` : `expected value to be null`),
+            details: (actual) => [[Markup.red("Received:"), actual]],
+        });
+    }
+
+    /**
      * Expects the received value to be of the given type.
      *
      * @param {ArgumentType} type
@@ -836,6 +859,29 @@ export class Matchers {
                 [Markup.green("Expected type:"), type],
                 [Markup.red("Received value:"), actual],
             ],
+        });
+    }
+
+    /**
+     * Expects the received value to be undefined.
+     *
+     * @param {ExpectOptions} [options]
+     * @example
+     *  expect(undefined).toBeUndefined();
+     */
+    toBeUndefined(options) {
+        this._saveStack();
+
+        ensureArguments([[options, ["object", null]]]);
+
+        return this._resolve({
+            name: "toBeUndefined",
+            acceptedType: "any",
+            predicate: (actual) => actual === undefined,
+            message: (pass) =>
+                options?.message ||
+                (pass ? `%actual% is[! not] undefined` : `expected value to be undefined`),
+            details: (actual) => [[Markup.red("Received:"), actual]],
         });
     }
 

--- a/addons/web/static/lib/hoot/tests/core/expect.test.js
+++ b/addons/web/static/lib/hoot/tests/core/expect.test.js
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "@odoo/hoot";
+import { Suite } from "../../core/suite";
+import { parseUrl } from "../local_helpers";
+
+describe(parseUrl(import.meta.url), () => {
+    test("toBeUndefined", () => {
+        expect(undefined).toBeUndefined();
+        expect(null).not.toBeUndefined();
+        expect(0).not.toBeUndefined();
+        expect("").not.toBeUndefined();
+        expect(false).not.toBeUndefined();
+        expect({ a: 1 }).not.toBeUndefined();
+        expect(new Suite(null, "a suite", []).id).toMatch(/^\w{8}$/);
+    });
+
+    test("toBeNull", () => {
+        expect(null).toBeNull();
+        expect(undefined).not.toBeNull();
+        expect(0).not.toBeNull();
+        expect("").not.toBeNull();
+        expect(false).not.toBeNull();
+        expect({ a: 1 }).not.toBeNull();
+    });
+});

--- a/addons/web/static/lib/hoot/tests/index.js
+++ b/addons/web/static/lib/hoot/tests/index.js
@@ -1,6 +1,7 @@
 import { start } from "@odoo/hoot";
 import { whenReady } from "@odoo/owl";
 
+import "./core/expect.test.js";
 import "./core/runner.test.js";
 import "./core/suite.test.js";
 import "./core/test.test.js";


### PR DESCRIPTION
This commit adds two new matchers to the hoot testing framework:
- toBeUndefined, to check if a value is undefined
- toBeNull, to check if a value is null

This commit also adds tests for these matchers.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
