### PR TITLE
[FIX] web_editor: restore vAlignment fix

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -3169,7 +3169,11 @@ var SnippetsMenu = Widget.extend({
      * @private
      * @param {jQuery}
      */
-    _patchForComputeSnippetTemplates($html) {},
+    _patchForComputeSnippetTemplates($html) {
+        // TODO: Remove in master and add it back in the template.
+        const $vAlignOption = $html.find("#row_valign_snippet_option");
+        $vAlignOption[0].dataset.js = "vAlignment";
+    },
     /**
      * Creates a snippet editor to associated to the given snippet. If the given
      * snippet already has a linked snippet editor, the function only returns


### PR DESCRIPTION
Commit [1] introduced a fix which selects the last button of the Vert. Alignment option when switching back from grid mode.

However, commit [2] removed the XML's data-js attribute which linked the JS code to the option in 16.1, and this was not caught in commit [1]'s forward-ports.

Therefore, the fix was no longer working in 16.1+.

This commit restores the data-js attribute in JS for a stable fix, and in master, will add it back on the template.

[1]: https://github.com/odoo/odoo/commit/cdf0870e1f81a5ec5096ddd062cf699e98681880
[2]: https://github.com/odoo/odoo/commit/c6561929f339ac1451cc998b2d2b399253db0016

Related to task-3142615