### PR TITLE
[FIX] sale: update hotkey for create invoice

### DIFF
--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -247,10 +247,10 @@
                         confirm="Are you sure you want to void the authorized transaction? This action can't be undone."
                         invisible="not authorized_transaction_ids"/>
                 <button id="create_invoice" name="%(sale.action_view_sale_advance_payment_inv)d" string="Create Invoice"
-                    type="action" class="btn-primary" data-hotkey="i"
+                    type="action" class="btn-primary" data-hotkey="q"
                     invisible="invoice_status != 'to invoice'"/>
                 <button id="create_invoice_percentage" name="%(sale.action_view_sale_advance_payment_inv)d" string="Create Invoice"
-                    type="action" context="{'default_advance_payment_method': 'percentage'}" data-hotkey="i"
+                    type="action" context="{'default_advance_payment_method': 'percentage'}" data-hotkey="q"
                     invisible="invoice_status != 'no' or state != 'sale'"/>
                 <button name="action_quotation_send" id="send_by_email_primary" string="Send by Email" type="object" data-hotkey="g"
                     invisible="state != 'draft'" class="btn-primary"


### PR DESCRIPTION
Steps:
- In Studio, add a many2one field with the widget "many2one_avatar_user" in SO form
- Create a SO and confirm it
- Press Alt+I

Actual result:
- Alt+I is related to "Create Invoice" in UI
- Alt+I open the user choice for the added field

Expected result:
- Alt+Q for "Create Invoice"
- Alt+I open the user choice for the added field

`q` used to be aligned with [sale_subscription](https://github.com/odoo/enterprise/blob/17.0/sale_subscription/views/sale_order_views.xml#L28)
`q` used for "Confirm" action in the same view, should not be a conflict

opw-4004869



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
