### PR TITLE
[FIX] mass_mailing: fix mail template undo

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
@@ -379,6 +379,8 @@ export class MassMailingHtmlField extends HtmlField {
             // the Odoo editor before resetting the history.
             setTimeout(() => {
                 this.wysiwyg.historyReset();
+                // Update undo/redo buttons
+                this.wysiwyg.odooEditor.dispatchEvent(new Event('historyStep'));
 
                 // The selection has been lost when switching theme.
                 const document = this.wysiwyg.odooEditor.document;


### PR DESCRIPTION
Purpose
=======
Fix the undo button in the website snippets which is enabled after choosing a template from the theme selector. The undo button shouldn't be enabled as the first selected theme is meant to be the first history step.

Specification
=============
After selecting a theme in the theme selector, the history steps are reset. However the undo/redo buttons of the website snippets aren't being updated with the reset.

This happens because the method which updates the undo/redo buttons is triggered on the 'historyStep' event and this event is only trigerred when adding a new step in the history, not when resetting the history.

Fixing the issue by trigerring the 'historyStep' event after reseting the history so that the undo/redo buttons are correctly being updated with the reset.

Task-4000990

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
