### PR TITLE
[IMP][draft] project: allow project manager to delete all tasks from a project

### DIFF
--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -526,7 +526,7 @@ class Project(models.Model):
             if project.analytic_account_id and not project.analytic_account_id.line_ids:
                 analytic_accounts_to_delete |= project.analytic_account_id
         result = super(Project, self).unlink()
-        tasks.unlink()
+        tasks.sudo().unlink()
         analytic_accounts_to_delete.unlink()
         return result
 

--- a/addons/project/tests/test_project_base.py
+++ b/addons/project/tests/test_project_base.py
@@ -478,3 +478,10 @@ class TestProjectBase(TestProjectCommon):
         } for x in range(10)])
         projects._create_analytic_account()
         self.assertEqual(projects.mapped("name"), projects.analytic_account_id.mapped("name"), "The analytic accounts names should match with the projects.")
+
+    def test_project_deletion_not_blocked_by_unfollowed_tasks(self):
+        """ This test ensures that when a user with project.manager access rights delete a project, all of its tasks are also correctly deleted
+         even if the tasks that user is not a follower of."""
+        # This line just ensure that the user_projectmanager is not following the task. If the test data were to be updated, this line ensure this test is failing.
+        self.assertNotIn(self.task_1.message_partner_ids, self.user_projectmanager.partner_id)
+        self.project_pigs.with_user(self.user_projectmanager).unlink()


### PR DESCRIPTION
This commit's purpose is to make the deletion of a project easier for project manager. Currently, when a project manager wants to delete a project, he has to first delete manually each tasks that he's not following.

This commit adds a 'sudo' in the unlink of project to ensure tasks are all deleted.

task - 4002254
