### PR TITLE
[PERF] hr_recruitment: add index on `active`

### DIFF
--- a/addons/hr_recruitment/models/hr_applicant.py
+++ b/addons/hr_recruitment/models/hr_applicant.py
@@ -33,7 +33,7 @@ class Applicant(models.Model):
     _primary_email = 'email_from'
 
     name = fields.Char("Subject / Application", required=True, help="Email subject for applications sent via email", index='trigram')
-    active = fields.Boolean("Active", default=True, help="If the active field is set to false, it will allow you to hide the case without removing it.")
+    active = fields.Boolean("Active", default=True, help="If the active field is set to false, it will allow you to hide the case without removing it.", index=True)
     description = fields.Html("Description")
     email_from = fields.Char("Email", size=128, compute='_compute_partner_phone_email',
         inverse='_inverse_partner_email', store=True, index='trigram')


### PR DESCRIPTION
## Description
The `web_read_group` done when loading the "All Applicants" view is slow when having a large quantity of `hr.applicant`

## Analysis
The query done by the `web_read_group` will get all the `active` `hr.applicant`, but the field isn't indexed, so even if only a small portion of applicants are active, we are still scanning the whole table to filter out the applicants.

## Solution
Index the `active` field.

## Benchmark
On a DB with 900k `hr_applicant`, where only 80k are `active`, the main query for the `web_read_group` takes

|         | Before | After |
|---------|--------|-------|
| Timings | 320ms  | 80ms  |

## Reference
task-4011294

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
