### PR TITLE
[FIX] mail: download all attachments from message in chatter

### DIFF
--- a/addons/mail/static/src/core/common/message_actions.js
+++ b/addons/mail/static/src/core/common/message_actions.js
@@ -86,7 +86,7 @@ messageActionsRegistry
                     file_ids: component.message.attachments.map((rec) => rec.id),
                     zip_name: `attachments_${DateTime.local().toFormat("HHmmddMMyyyy")}.zip`,
                 },
-                url: "mail/attachment/zip",
+                url: "/mail/attachment/zip",
             }),
         sequence: 55,
     })


### PR DESCRIPTION
Steps to reproduce:
-------------------

- Install `Project` module (for test purpose)
- Open any project and create a task
- Post a message with multiple attachments
- Select "Download Files" in the message options

Issue:
------

Traceback

Cause:
------

Calling directly the route without starting with `/`. The issue started since the following commit [1] because we changed how the URLs are generated;

Before: `localhost/web#id=55&...`
After: `localhost/odoo/project/5/tasks/55`

With these changes, since the download URL don't start with `/`, the browser will try to download the file from the current URL who, combined with the download URL, is not a real route.

[1] https://github.com/odoo/odoo/commit/c63d14a0485a553b74a8457aee158384e9ae6d3f

Solution:
---------

Add `/` at the beginning of the download URL.

opw-4009021