### PR TITLE
[FIX] website_sale: make accordion button not disapearing when selected

### DIFF
--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -818,3 +818,7 @@ a.no-decoration {
         pointer-events: none;
     }
 }
+
+.accordion-button:not(.collapsed).bg-transparent::after {
+    background-image: escape-svg($accordion-button-icon);
+}


### PR DESCRIPTION
To reproduce the bug:
- Go to website(eCommerce)
- Click on the Shop tab.
- Once you are in the store tab, click on the 'Edit' option to edit the website and select Categories: Left and Collapse Categories: enable.
- Go to the theme, in the light and dark themes select a darker version like black or gray for the first option.
- The drop down appears for categories which are not selected but when selected the up arrow disappears.

This problem was due to the superposition of the .accordion-button and .bg-transparent CSS classes. When the accordion button is clicked, it switches its body and background colors, changing the body color from black to white. However, since the background becomes black, we can still see the button. The issue arises when the background is transparent; in this case, the button becomes invisible.

opw-4009051
