### PR TITLE
[FIX] mail: make setup() have precedence over instance field def.

### DIFF
--- a/addons/mail/static/src/model/make_store.js
+++ b/addons/mail/static/src/model/make_store.js
@@ -40,6 +40,7 @@ export function makeStore(env, { localRegistry } = {}) {
             [OgClass.name]: class extends OgClass {
                 constructor() {
                     super();
+                    this.setup();
                     const record = this;
                     record._raw = record;
                     record.Model = Model;
@@ -148,6 +149,7 @@ export function makeStore(env, { localRegistry } = {}) {
         store[name] = Model;
         // Detect fields with a dummy record and setup getter/setters on them
         const obj = new OgClass();
+        obj.setup();
         for (const [name, val] of Object.entries(obj)) {
             if (isFieldDefinition(val)) {
                 Model._.prepareField(name, val);

--- a/addons/mail/static/src/model/record.js
+++ b/addons/mail/static/src/model/record.js
@@ -359,10 +359,6 @@ export class Record {
     /** @type {this} */
     _proxy;
 
-    constructor() {
-        this.setup();
-    }
-
     setup() {}
 
     update(data) {

--- a/addons/mail/static/tests/core/record.test.js
+++ b/addons/mail/static/tests/core/record.test.js
@@ -877,3 +877,18 @@ test("Record lists methods are bound to the record list", async () => {
     expect(general.messages.length).toBe(1);
     expect(general.messages.map((msg) => msg.content)).toEqual(["1"]);
 });
+
+test("setup() has precedence over instance class field definition", async () => {
+    class Test extends Record {}
+    Test.register(localRegistry);
+    (class Test2 extends Test {
+        x = false;
+        setup() {
+            super.setup();
+            this.x = true;
+        }
+    }).register(localRegistry);
+    const store = await start();
+    const test = store.Test2.insert();
+    expect(test.x).toBe(true);
+});


### PR DESCRIPTION
Before this commit, when defining an attribute field on a JS record in the class definition and assigning it in `setup()`, the resulting value was the one at class definition rather than the `setup()` value.

Steps to reproduce:

```js
class MyRecord extends Record {
	isSetup = false;
	setup() {
		super.setup();
		this.isSetup = true;
	}
}
MyRecord.register();

const myRecord = store.MyRecord.insert();
myRecord.isSetup; // 'false' instead of 'true'
```

This happens because the `setup()` was implemented as an extension of the original `constructor` of the class of model. Due to this implementation, instance field definition from extended classes were applied after `setup()`.

This behavior is both unintended and unnatural. `setup()` is supposed to be used as an extension of class `constructor`.

This commit fixes the issue by calling `setup()` after whole constructor() rather than inside `constructor()` of original class.