### PR TITLE
[IMP] sale,website_sale: no automatic invoice for zero amount orders

### DIFF
--- a/addons/sale/controllers/portal.py
+++ b/addons/sale/controllers/portal.py
@@ -286,7 +286,7 @@ class CustomerPortal(payment_portal.PaymentPortal):
             return {'error': _('Invalid signature data.')}
 
         if not order_sudo._has_to_be_paid():
-            order_sudo.with_context(send_email=True).action_confirm()
+            order_sudo._validate_order()
 
         pdf = request.env['ir.actions.report'].sudo()._render_qweb_pdf('sale.action_report_saleorder', [order_sudo.id])[0]
 

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -2022,3 +2022,11 @@ class SaleOrder(models.Model):
             return self.partner_id.lang
 
         return self.env.lang
+
+    def _validate_order(self):
+        """
+        Confirm the sale order and send a confirmation email.
+
+        :return: None
+        """
+        self.with_context(send_email=True).action_confirm()

--- a/addons/sale_loyalty/tests/__init__.py
+++ b/addons/sale_loyalty/tests/__init__.py
@@ -11,3 +11,4 @@ from . import test_program_with_code_operations
 from . import test_program_without_code_operations
 from . import test_sale_invoicing
 from . import test_unlink_reward
+from . import test_sale_auto_invoice

--- a/addons/sale_loyalty/tests/test_sale_auto_invoice.py
+++ b/addons/sale_loyalty/tests/test_sale_auto_invoice.py
@@ -1,0 +1,43 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.fields import Command
+from odoo.tests import tagged
+
+from odoo.addons.sale_loyalty.tests.common import TestSaleCouponCommon
+
+
+@tagged('post_install', '-at_install')
+class TestSaleAutoInvoice(TestSaleCouponCommon):
+
+    def test_automatic_invoice_on_zero_amount_order(self):
+        self.env['ir.config_parameter'].sudo().set_param('sale.automatic_invoice', 'True')
+        # Create a loyalty program with 100% discount
+        self.env['loyalty.program'].sudo().create({
+            'name': '100discount',
+            'program_type': 'promo_code',
+            'rule_ids': [
+                Command.create({
+                    'code': "100dis",
+                    'minimum_amount': 0,
+                })
+            ],
+            'reward_ids': [
+                Command.create({
+                    'discount': 100,
+                }),
+            ],
+        })
+        # Add order line to order
+        self.env["sale.order.line"].create({
+            'order_id': self.empty_order.id,
+            'product_id': self.product_A.id,
+            'product_uom_qty': 1,
+            'price_unit': 200,
+        })
+        # Apply discount
+        self._apply_promo_code(self.empty_order, '100dis')
+        self.empty_order._validate_order()
+        self.assertTrue(
+            self.empty_order.invoice_ids,
+            "Invoices should be generated for orders with zero total amount",
+        )

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1836,7 +1836,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
 
         if order and not order.amount_total and not tx_sudo:
             if order.state != 'sale':
-                order._validate_zero_amount_cart()
+                order._validate_order()
 
             # clean context and session, then redirect to the portal page
             request.website.sale_reset()

--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -479,9 +479,6 @@ class SaleOrder(models.Model):
         self.ensure_one()
         order_line.write(update_values)
 
-    def _validate_zero_amount_cart(self):
-        self.with_context(send_email=True).with_user(SUPERUSER_ID).action_confirm()
-
     def _cart_accessories(self):
         """ Suggest accessories based on 'Accessory Products' of products in cart """
         product_ids = set(self.website_order_line.product_id.ids)

--- a/addons/website_sale_loyalty/models/sale_order.py
+++ b/addons/website_sale_loyalty/models/sale_order.py
@@ -7,7 +7,6 @@ from odoo import api, fields, models
 from odoo.exceptions import UserError
 from odoo.http import request
 from odoo.osv import expression
-from odoo.tools import str2bool
 
 
 class SaleOrder(models.Model):
@@ -246,11 +245,3 @@ class SaleOrder(models.Model):
         lines = super()._cart_find_product_line(product_id, line_id, **kwargs)
         lines = lines.filtered(lambda l: not l.is_reward_line) if not line_id else lines
         return lines
-
-    def _validate_zero_amount_cart(self):
-        super()._validate_zero_amount_cart()
-        auto_invoice = self.env['ir.config_parameter'].get_param('sale.automatic_invoice')
-        if str2bool(auto_invoice) and self.reward_amount:
-            # create an invoice for order with zero total amount and automatic invoice enabled
-            invoice = self._create_invoices(final=True)
-            invoice.action_post()

--- a/addons/website_sale_loyalty/tests/test_website_sale_auto_invoice.py
+++ b/addons/website_sale_loyalty/tests/test_website_sale_auto_invoice.py
@@ -44,4 +44,6 @@ class TestWebsiteSaleAutoInvoice(WebsiteSaleCommon):
 
         with MockRequest(self.env, sale_order_id=self.cart.id, website=self.website):
             self.Controller.shop_payment_validate()
-        self.assertTrue(self.cart.invoice_ids, "No invoices were created for orders with zero total amount.")
+        self.assertTrue(
+            self.cart.invoice_ids, "Invoices should be generated for orders with zero total amount",
+        )


### PR DESCRIPTION
Steps:
- enable automatic invoice from setting
- in sale :
- create a quotation and use a loyalty coupon to reduce price to 0
- enable online signature
- click on preview and then click on accept and sign
- in ecom :
- create a new cart with products that have invoicing policy delivered
- confirm the cart

Issue:
No invoice in generated in case of sale. The invoice generated in ecom for product with invoicing policy delivered is RINV

Cause:
When price is set to 0 there is no pay button and since automatic invoicing is linked to payment transaction that logic is not executed and for ecom since we get a negative line in the order and for product line

Fix:
added the automatic invoicing logic in portal_quote_accept controller and shop_payment_validate controller to generate invoice when price is zero

opw-3935250

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
