### PR TITLE
[REF] web_tour: remove extra_trigger

### DIFF
--- a/odoo/addons/test_new_api/static/tests/tours/x2many.js
+++ b/odoo/addons/test_new_api/static/tests/tours/x2many.js
@@ -35,10 +35,10 @@
         content: "click on 'Create and Edit...'",
         trigger: '.o_field_widget[name=moderator] .o-autocomplete--dropdown-menu .o_m2o_dropdown_option_create_edit a',
         run: "click",
-    }, {
+    },
+    {
         content: "insert a name into the modal form",
-        trigger: '.o_field_widget[name=name] input',
-        extra_trigger: '.modal',
+        trigger: '.modal .o_field_widget[name=name] input',
         run: `edit user_test_${(inc = new Date().getTime())}`,
     }, {
         content: "insert an email into the modal form",
@@ -66,14 +66,20 @@
         content: "select Admin",
         trigger: 'tr:has(td:contains(/^Mitchell Admin$/)) .o_list_record_selector input[type="checkbox"]',
         run: "click",
-    }, {
+    },
+    {
+        trigger: 'tr:has(td:contains(/^Mitchell Admin$/)) .o_list_record_selector input[type="checkbox"]:checked',
+    },
+    {
         content: "save selected participants",
         trigger: '.o_select_button',
-        extra_trigger: 'tr:has(td:contains(/^Mitchell Admin$/)) .o_list_record_selector input[type="checkbox"]:checked',
         run: "click",
-    }, ...stepUtils.saveForm({
+    },
+    {
+        trigger: '.o_field_widget[name=participants] .o_data_cell:contains(/^Mitchell Admin$/)',
+    },
+    ...stepUtils.saveForm({
         content: "save discussion",
-        extra_trigger: '.o_field_widget[name=participants] .o_data_cell:contains(/^Mitchell Admin$/)',
     }), { // add message a
         content: "Select First Tab",
         trigger: '.o_notebook_headers .nav-item a:contains(Messages)',
@@ -90,10 +96,13 @@
         content: "save new message a",
         trigger: '.modal-footer .o_form_button_save',
         run: "click",
-    }, { // add message b
+    },
+    {
+        trigger: '.o_field_widget[name="message_concat"] textarea:value([test] Mitchell Admin:a)',
+    },
+    { // add message b
         content: "create new message b",
         trigger: '.o_field_widget[name=messages] .o_field_x2many_list_row_add a',
-        extra_trigger: '.o_field_widget[name="message_concat"] textarea:value([test] Mitchell Admin:a)',
         run: "click",
     }, {
         content: "insert body b",
@@ -103,18 +112,21 @@
         content: "save new message b",
         trigger: '.modal-footer .o_form_button_save',
         run: "click",
-    }, { // change content to trigger on change
+    },
+    {
+        trigger: '.o_field_widget[name="message_concat"] textarea:value([test] Mitchell Admin:a\n[test] Mitchell Admin:b)',
+    },
+    { // change content to trigger on change
         content: "insert content",
         trigger: '.o_field_widget[name=name] input',
-        extra_trigger: '.o_field_widget[name="message_concat"] textarea:value([test] Mitchell Admin:a\n[test] Mitchell Admin:b)',
         run: "edit test_trigger && press Enter",
     }, {
         content: "check onchange",
         trigger: '.o_field_widget[name="message_concat"] textarea:value([test_trigger] Mitchell Admin:a\n[test_trigger] Mitchell Admin:b)',
-    }, { // change message b
+    },
+    { // change message b
         content: "edit message b",
         trigger: '.o_field_widget[name=messages] .o_data_cell:contains(/^b$/)',
-        // extra_trigger: 'body:not(:has(.tab-pane:eq(0) .o_field_widget tbody .o_data_row:eq(2))) .tab-pane:eq(0) .o_field_widget tbody tr td:contains([test_trigger] )',
         run: "click",
     }, {
         content: "change the body",
@@ -124,10 +136,13 @@
         content: "save changes",
         trigger: '.modal-footer .o_form_button_save',
         run: "click",
-    }, { // add message c
+    },
+    {
+        trigger: '.o_field_widget[name="message_concat"] textarea:value([test_trigger] Mitchell Admin:a\n[test_trigger] Mitchell Admin:bbb)',
+    },
+    { // add message c
         content: "create new message c",
         trigger: '.o_field_widget[name=messages] .o_field_x2many_list_row_add a',
-        extra_trigger: '.o_field_widget[name="message_concat"] textarea:value([test_trigger] Mitchell Admin:a\n[test_trigger] Mitchell Admin:bbb)',
         run: "click",
     }, {
         content: "insert body",
@@ -137,10 +152,13 @@
         content: "save new message c",
         trigger: '.modal-footer .o_form_button_save',
         run: "click",
-    }, { // add participants
+    },
+    {
+        trigger: '.o_field_widget[name=messages] .o_data_row:eq(2)',
+    },
+    { // add participants
         content: "change tab to Participants",
         trigger: '.o_notebook_headers .nav-item a:contains(Participants)',
-        extra_trigger: '.o_field_widget[name=messages] .o_data_row:eq(2)',
         run: "click",
     }, {
         content: "click to add participants",
@@ -150,10 +168,13 @@
         content: "select Demo User",
         trigger: 'tr:has(td:contains(/^Marc Demo$/)) .o_list_record_selector input[type="checkbox"]',
         run: "click",
-    }, {
+    },
+    {
+        trigger: 'tr:has(td:contains(/^Marc Demo$/)) .o_list_record_selector input[type="checkbox"]:checked',
+    },
+    {
         content: "save selected participants",
         trigger: '.o_select_button',
-        extra_trigger: 'tr:has(td:contains(/^Marc Demo$/)) .o_list_record_selector input[type="checkbox"]:checked',
         run: "click",
     }, { // save
         content: "save discussion",
@@ -163,10 +184,13 @@
         content: "go back to tab 1",
         trigger: '.o_notebook_headers .nav-item a:contains(Messages)',
         run: "click",
-    }, { // check saved data
+    },
+    {
+        trigger: 'body:not(:has(.o_field_widget[name=messages] tbody .o_data_row:eq(3)))',
+    },
+    { // check saved data
         content: "check data 1",
         trigger: '.o_content:has(.o_field_widget[name=messages] tbody .o_data_row:eq(2))',
-        extra_trigger: 'body:not(:has(.o_field_widget[name=messages] tbody .o_data_row:eq(3)))',
     }, {
         content: "check data 2",
         trigger: `.o_content:has(.o_field_widget[name=messages] tr:has(td:contains(/^bbb$/)):has(td:contains(/^\\[test_trigger\\] Mitchell Admin$/)))`,
@@ -174,19 +198,28 @@
         content: "go to tab 3",
         trigger: '.o_notebook_headers .nav-item a:contains(Participants)',
         run: "click",
-    }, {
+    },
+    {
+        trigger: 'body:not(:has(.o_field_widget[name=participants] tbody .o_data_row:eq(3)))',
+    },
+    {
         content: "check data 3",
         trigger: '.o_content:has(.o_field_widget[name=participants] tbody .o_data_row:eq(2))',
-        extra_trigger: 'body:not(:has(.o_field_widget[name=participants] tbody .o_data_row:eq(3)))',
-    }, {
+    },
+    {
+        trigger: '.o_form_editable',
+    },
+    {
         content: "change tab to Messages",
         trigger: '.o_notebook_headers .nav-item a:contains(Messages)',
-        extra_trigger: '.o_form_editable',
         run: "click",
-    }, { // add message d
+    },
+    {
+        trigger: '.o_notebook_headers .nav-link.active:contains(Messages)',
+    },
+    { // add message d
         content: "create new message d",
         trigger: '.o_field_widget[name=messages] .o_field_x2many_list_row_add a',
-        extra_trigger: '.o_notebook_headers .nav-link.active:contains(Messages)',
         run: "click",
     }, {
         content: "insert body",
@@ -196,10 +229,13 @@
         content: "save new message d",
         trigger: '.modal-footer .o_form_button_save',
         run: "click",
-    }, { // add message e
+    },
+    {
+        trigger: '.o_field_widget[name=messages] .o_data_cell:contains(/^d$/)',
+    },
+    { // add message e
         content: "create new message e",
         trigger: '.o_field_widget[name=messages] .o_field_x2many_list_row_add a',
-        extra_trigger: '.o_field_widget[name=messages] .o_data_cell:contains(/^d$/)',
         run: "click",
     }, {
         content: "insert body",
@@ -209,10 +245,13 @@
         content: "save new message e",
         trigger: '.modal-footer .o_form_button_save',
         run: "click",
-    }, { // change message a
+    },
+    {
+        trigger: '.o_field_widget[name=messages] .o_data_cell:contains(/^e$/)',
+    },
+    { // change message a
         content: "edit message a",
         trigger: '.o_field_widget[name=messages] .o_data_cell:contains(/^a$/)',
-        extra_trigger: '.o_field_widget[name=messages] .o_data_cell:contains(/^e$/)',
         run: "click",
     }, {
         content: "change the body",
@@ -222,10 +261,13 @@
         content: "save changes",
         trigger: '.modal-footer .o_form_button_save',
         run: "click",
-    }, { // change message e
+    },
+    {
+        trigger: '.o_field_widget[name=messages] .o_data_cell:contains(/^aaa$/)',
+    },
+    { // change message e
         content: "edit message e",
         trigger: '.o_field_widget[name=messages] .o_data_cell:contains(/^e$/)',
-        extra_trigger: '.o_field_widget[name=messages] .o_data_cell:contains(/^aaa$/)',
         run: "click",
     }, {
         content: "open the many2one to select another user",
@@ -260,10 +302,13 @@
         content: "remove e",
         trigger: '.o_field_widget[name=messages] .o_data_row:has(.o_data_cell:contains(/^e$/)) .o_list_record_remove',
         run: "click",
-    }, { // save
+    },
+    {
+        trigger: 'body:not(:has(tr:has(td:contains(/^e$/))))',
+    },
+    { // save
         content: "save discussion",
         trigger: 'button.o_form_button_save',
-        extra_trigger: 'body:not(:has(tr:has(td:contains(/^e$/))))',
         run: "click",
     }, { // check saved data
         content: "check data 4",
@@ -278,18 +323,24 @@
         content: "go to Participants",
         trigger: '.o_notebook_headers .nav-item a:contains(Participants)',
         run: "click",
-    }, {
+    },
+    {
+        trigger: '.o_content:not(:has(.o_field_widget[name=participants] tbody .o_data_row:eq(3)))',
+    },
+    {
         content: "check data 7",
         trigger: '.o_content:has(.o_field_widget[name=participants] tbody .o_data_row:eq(2))',
-        extra_trigger: '.o_content:not(:has(.o_field_widget[name=participants] tbody .o_data_row:eq(3)))',
     }, {
         content: "go to Messages",
         trigger: '.o_notebook_headers .nav-item a:contains(Messages)',
         run: "click",
-    }, { // add message ddd
+    },
+    {
+        trigger: '.o_form_editable .o_field_widget[name=messages] tbody tr:has(td:contains(/^d$/))',
+    },
+    { // add message ddd
         content: "create new message ddd",
         trigger: '.o_field_widget[name=messages] .o_field_x2many_list_row_add a',
-        extra_trigger: '.o_form_editable .o_field_widget[name=messages] tbody tr:has(td:contains(/^d$/))',
         run: "click",
     }, {
         content: "select another user",
@@ -313,13 +364,19 @@
     }, { // check onchange data
         content: "check data 8",
         trigger: '.o_field_widget[name="message_concat"] textarea:value([test_trigger] Mitchell Admin:aaa\n[test_trigger] Mitchell Admin:c\n[test_trigger] Mitchell Admin:d\n[test_trigger] Marc Demo:ddd)',
-    }, {
+    },
+    {
+        trigger: 'body:not(:has(.o_field_widget[name=messages] .o_data_row:eq(4)))',
+    },
+    {
         content: "check data 9",
         trigger: '.o_content:has(.o_field_widget[name=messages] .o_data_row:eq(3))',
-        extra_trigger: 'body:not(:has(.o_field_widget[name=messages] .o_data_row:eq(4)))',
-    }, ...stepUtils.discardForm({ // cancel
+    },
+    {
+        trigger: '.o_field_widget[name=messages]:has(tr td:contains(/^ddd$/))',
+    },
+    ...stepUtils.discardForm({ // cancel
         content: "cancel change",
-        extra_trigger: '.o_field_widget[name=messages]:has(tr td:contains(/^ddd$/))',
     }),
 
     /////////////////////////////////////////////////////////////////////////////////////////////
@@ -334,24 +391,33 @@
         content: "switch to the second form view to test one2many with editable list (open submenu)",
         trigger: '.dropdown-item[data-menu-xmlid="test_new_api.menu_discussions_2"]',
         run: "click",
-    }, {
+    },
+    {
+        trigger: '.o_breadcrumb:contains(Discussions 2)',
+    },
+    {
         content: "select previous created record",
         trigger: 'td:contains(test_trigger):last',
-        extra_trigger: '.o_breadcrumb:contains(Discussions 2)',
         run: "click",
-    }, {
+    },
+    {
+        trigger: ".o_form_editable",
+    },
+    {
         content: "edit content",
         trigger: '.o_field_widget[name=name] input',
-        extra_trigger: ".o_form_editable",
         run: "edit test_trigger2 && click body",
     }, {
         content: "click outside to trigger onchange",
         trigger: '.o_form_sheet',
         run: "click",
-    }, {
+    },
+    {
+        trigger: '.o_field_widget[name=messages]:contains(test_trigger2)',
+    },
+    {
         content: "click on a field of the editable list to edit content",
         trigger: '.o_field_widget[name=messages] .o_data_row:eq(1) td',
-        extra_trigger: '.o_field_widget[name=messages]:contains(test_trigger2)',
         run: "click",
     }, {
         content: "change text value",
@@ -401,45 +467,61 @@
     }, {
         content: "test one2many onchange after delete",
         trigger: '.o_content:not(:has(.o_field_widget[name="message_concat"] textarea:value(Mitchell Admin:d)))',
-    }, ...stepUtils.saveForm({ // save
+    },
+    {
+        trigger: 'body:not(:has(tr:has(td:contains(/^d$/))))',
+    },
+    ...stepUtils.saveForm({ // save
         content: "save discussion",
-        extra_trigger: 'body:not(:has(tr:has(td:contains(/^d$/))))',
     }), { // check saved data
         content: "check data 10",
         trigger: '.o_field_widget[name=message_concat] textarea:value([test_trigger2] Mitchell Admin:aaa\n[test_trigger2] Marc Demo:ccccc)',
-    }, {
+    },
+    {
+        trigger: 'body:not(:has(.o_field_widget[name=messages] tbody .o_data_row:eq(2)))',
+    },
+    {
         content: "check data 11",
         trigger: '.o_field_widget[name=messages] tbody .o_data_row:eq(1)',
-        extra_trigger: 'body:not(:has(.o_field_widget[name=messages] tbody .o_data_row:eq(2)))',
-    }, { // add message eee
+    },
+    {
+        trigger: '.o_form_editable .nav-link.active:contains(Messages)',
+    },
+    { // add message eee
         content: "create new message eee",
         trigger: '.o_field_widget[name=messages] .o_field_x2many_list_row_add a',
-        extra_trigger: '.o_form_editable .nav-link.active:contains(Messages)',
         run: "click",
     }, {
         content: "change text value",
         trigger: '.o_field_widget[name="body"] textarea',
         run: "edit eee",
-    }, ...stepUtils.saveForm({ // save
+    },
+    {
+        trigger: '.o_field_widget[name="body"] textarea:value(eee)',
+    },
+    ...stepUtils.saveForm({ // save
         content: "save discussion",
-        extra_trigger: '.o_field_widget[name="body"] textarea:value(eee)',
     }), { // check saved data
         content: "check data 12",
         trigger: '.o_field_widget[name="message_concat"] textarea:value([test_trigger2] Mitchell Admin:aaa\n[test_trigger2] Marc Demo:ccccc\n[test_trigger2] Mitchell Admin:eee)',
-    }, {
+    },
+    {
+        trigger: 'body:not(:has(.o_field_widget[name=messages] .o_data_row:eq(3)))',
+    },
+    {
         content: "check data 13",
         trigger: '.o_field_widget[name=messages] .o_data_row:eq(2)',
-        extra_trigger: 'body:not(:has(.o_field_widget[name=messages] .o_data_row:eq(3)))',
     },
 
     /////////////////////////////////////////////////////////////////////////////////////////////
     // Discussions 3
     /////////////////////////////////////////////////////////////////////////////////////////////
-
+    {
+        trigger: '.tab-pane:eq(0) .o_field_widget tbody .o_data_row:eq(2)',
+    },
     {
         content: "switch to the third form view to test onchange changing one2many (toggle menu dropdown)",
         trigger: 'button[data-menu-xmlid="test_new_api.menu_main"], li.o_extra_menu_items a i.fa-plus',
-        extra_trigger: '.tab-pane:eq(0) .o_field_widget tbody .o_data_row:eq(2)',
         run: "click",
     }, {
         content: "switch to the thied form view to test onchange changing one2many (open submenu)",
@@ -457,10 +539,13 @@
         content: "set discussion title to generate dummy message",
         trigger: '.o_field_widget[name=name] input',
         run:     "edit {generate_dummy_message} && click body",
-    }, {
+    },
+    {
+        trigger: '.o_field_widget[name=important_messages] .o_data_row .o_list_number:contains(/^13$/)',
+    },
+    {
         content: "check new dummy message happened",
         trigger: '.o_field_widget[name=messages] .o_data_row .o_list_number:contains(/^13$/)',
-        extra_trigger: '.o_field_widget[name=important_messages] .o_data_row .o_list_number:contains(/^13$/)',
     }, {
         content: "check field not in embedded view received correctly",
         trigger: '.o_field_widget[name=messages] .o_data_row input[type="checkbox"]:checked',
@@ -476,10 +561,13 @@
         content: "set discussion title to generate dummy message",
         trigger: '.o_field_widget[name=name] input',
         run:     "edit {generate_dummy_message} && click body",
-    }, {
+    },
+    {
+        trigger: '.o_field_widget[name=important_messages] .o_data_row .o_list_number:contains(/^22$/)',
+    },
+    {
         content: "check update and new dummy message happened",
         trigger: '.o_field_widget[name=messages] .o_data_row .o_list_number:contains(/^22$/)',
-        extra_trigger: '.o_field_widget[name=important_messages] .o_data_row .o_list_number:contains(/^22$/)',
     },
     ...stepUtils.discardForm(),
     ]});


### PR DESCRIPTION
In order to simplify the tours API, it was decided to remove the extra_trigger key from the steps.
To check that an element is in the DOM, simply create a step with a trigger.

task~3974087
