### PR TITLE
[FIX] sale: avoid loosing tx state on failure

### DIFF
--- a/addons/sale/models/payment_transaction.py
+++ b/addons/sale/models/payment_transaction.py
@@ -93,6 +93,8 @@ class PaymentTransaction(models.Model):
     def _set_authorized(self, state_message=None, **kwargs):
         """ Override of payment to confirm the quotations automatically. """
         txs_to_process = super()._set_authorized(state_message=state_message, **kwargs)
+        # Commit transaction changes to avoid loosing it if other processes fails.
+        self.env.cr.commit()
         confirmed_orders = txs_to_process._check_amount_and_confirm_order()
         confirmed_orders._send_order_confirmation_mail()
         (txs_to_process.sale_order_ids - confirmed_orders)._send_payment_succeeded_for_order_mail()


### PR DESCRIPTION
Steps:
- Install sale app.
- Enable any provider which support manual capture and enable it.
- Do something wrong in flow in SO confirmation flow after payment.
- Make payment from portal.

Issue:
- Transaction stays in draft state it should be in `Authorize` state like it work for non manual capture flow.

Cause:
- Override of `_set_authorize` method in sale send mail and do other post-processing so when other processing fail `authorize` state set on tx from super revert back to draft state.

Fix:
- Commit changes on tx before doing post-processing on SO.

task-3957553

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
