### PR TITLE
[REF] web_tour: remove consumeVisibleOnly

### DIFF
--- a/addons/web_tour/static/src/tour_service/tour_service.js
+++ b/addons/web_tour/static/src/tour_service/tour_service.js
@@ -49,7 +49,6 @@ import { callWithUnloadCheck } from "./tour_utils";
  * @property {number} [width]
  * @property {number} [timeout] By default, when the trigger node isn't found after 10000 milliseconds, it throws an error.
  * You can change this value to lengthen or shorten the time before the error occurs [ms].
- * @property {boolean} [consumeVisibleOnly] TODO: Still used ???
  * @property {string} [consumeEvent] Only in manual mode (onboarding tour). It's the event we want the customer to do.
  * @property {boolean} [mobile] When true, step will only trigger in mobile view.
  * @property {string} [title]
@@ -78,7 +77,6 @@ function checkTourStepKeyValues(tourStep) {
         in_modal: { type: Boolean, optional: true },
         width: { type: Number, optional: true },
         timeout: { type: Number, optional: true },
-        consumeVisibleOnly: { type: Boolean, optional: true },
         consumeEvent: { type: String, optional: true },
         title: { type: String, optional: true },
         debugHelp: { type: String, optional: true },

--- a/addons/website/static/tests/tours/rte.js
+++ b/addons/website/static/tests/tours/rte.js
@@ -54,7 +54,6 @@ wTourUtils.goToTheme(),
 {
     content: "Open new page menu",
     trigger: ".o_menu_systray .o_new_content_container > a",
-    consumeVisibleOnly: true,
     run: "click",
 }, {
     content: "click on new page",
@@ -87,7 +86,6 @@ wTourUtils.goToTheme(),
 }, {
     content: "Open new page menu",
     trigger: ".o_menu_systray .o_new_content_container > a",
-    consumeVisibleOnly: true,
     run: "click",
 }, {
     content: "click on new page",

--- a/addons/website_blog/static/src/js/tours/website_blog.js
+++ b/addons/website_blog/static/src/js/tours/website_blog.js
@@ -10,7 +10,6 @@
     }, () => [{
         trigger: "body:not(:has(#o_new_content_menu_choices)) .o_new_content_container > a",
         content: _t("Click here to add new content to your website."),
-        consumeVisibleOnly: true,
         position: 'bottom',
         run: "click",
     }, {

--- a/addons/website_event/static/tests/tours/website_event.js
+++ b/addons/website_event/static/tests/tours/website_event.js
@@ -11,7 +11,6 @@
     }, () => [{
         content: _t("Click here to add new content to your website."),
         trigger: ".o_menu_systray .o_new_content_container > a",
-        consumeVisibleOnly: true,
         position: 'bottom',
         run: "click",
     }, {

--- a/addons/website_sale/static/src/js/tours/website_sale_shop.js
+++ b/addons/website_sale/static/src/js/tours/website_sale_shop.js
@@ -17,7 +17,6 @@
     {
         trigger: ".o_menu_systray .o_new_content_container > a",
         content: _t("Let's create your first product."),
-        consumeVisibleOnly: true,
         position: "bottom",
         run: "click",
     }, {

--- a/addons/website_slides/static/src/js/tours/slides_tour.js
+++ b/addons/website_slides/static/src/js/tours/slides_tour.js
@@ -10,7 +10,6 @@ wTourUtils.registerWebsitePreviewTour('slides_tour', {
 }, () => [{
     trigger: "body:not(.editor_has_snippets) .o_new_content_container > a",
     content: markup(_t("Welcome on your course's home page. It's still empty for now. Click on \"<b>New</b>\" to write your first course.")),
-    consumeVisibleOnly: true,
     position: 'bottom',
     run: "click",
 }, {


### PR DESCRIPTION
In this commit, the key consumeVisibleOnly is removed from step tour structure because it is no longer used.

task~3974087