### PR TITLE
[FIX] l10n_es_edi_tbai: traceback on invoice process

### DIFF
--- a/addons/l10n_es_edi_tbai/i18n/es.po
+++ b/addons/l10n_es_edi_tbai/i18n/es.po
@@ -115,6 +115,16 @@ msgid "Hacienda Foral de Gipuzkoa"
 msgstr "Diputación Foral de Gipuzkoa"
 
 #. module: l10n_es_edi_tbai
+#. odoo-python
+#: code:addons/l10n_es_edi_tbai/models/account_edi_format.py:0
+#, python-format
+msgid ""
+"In case of a foreign customer, you need to configure the tax scope on taxes:\n"
+"%s"
+msgstr "En el caso de un cliente extranjero, es necesario configurar el ámbito fiscal en impuestos:\n"
+"%s"
+
+#. module: l10n_es_edi_tbai
 #: model:ir.model.fields,field_description:l10n_es_edi_tbai.field_account_bank_statement_line__l10n_es_tbai_refund_reason
 #: model:ir.model.fields,field_description:l10n_es_edi_tbai.field_account_move__l10n_es_tbai_refund_reason
 #: model:ir.model.fields,field_description:l10n_es_edi_tbai.field_account_move_reversal__l10n_es_tbai_refund_reason

--- a/addons/l10n_es_edi_tbai/i18n/l10n_es_edi_tbai.pot
+++ b/addons/l10n_es_edi_tbai/i18n/l10n_es_edi_tbai.pot
@@ -109,6 +109,15 @@ msgid "Hacienda Foral de Gipuzkoa"
 msgstr ""
 
 #. module: l10n_es_edi_tbai
+#. odoo-python
+#: code:addons/l10n_es_edi_tbai/models/account_edi_format.py:0
+#, python-format
+msgid ""
+"In case of a foreign customer, you need to configure the tax scope on taxes:\n"
+"%s"
+msgstr ""
+
+#. module: l10n_es_edi_tbai
 #: model:ir.model.fields,field_description:l10n_es_edi_tbai.field_account_bank_statement_line__l10n_es_tbai_refund_reason
 #: model:ir.model.fields,field_description:l10n_es_edi_tbai.field_account_move__l10n_es_tbai_refund_reason
 #: model:ir.model.fields,field_description:l10n_es_edi_tbai.field_account_move_reversal__l10n_es_tbai_refund_reason

--- a/addons/l10n_es_edi_tbai/models/account_edi_format.py
+++ b/addons/l10n_es_edi_tbai/models/account_edi_format.py
@@ -115,6 +115,15 @@ class AccountEdiFormat(models.Model):
             if invoice.move_type == 'out_refund' and not invoice.reversed_entry_id._l10n_es_tbai_is_in_chain():
                 error_msg = _("TicketBAI: Cannot post a reversal move while the source document (%s) has not been posted", invoice.reversed_entry_id.name)
 
+            # Tax configuration check: In case of foreign customer we need the tax scope to be set
+            com_partner = invoice.commercial_partner_id
+            if (com_partner.country_id.code not in ('ES', False) or (com_partner.vat or '').startswith("ESN")) and\
+                    invoice.line_ids.tax_ids.filtered(lambda t: not t.tax_scope):
+                error_msg = _(
+                    "In case of a foreign customer, you need to configure the tax scope on taxes:\n%s",
+                    "\n".join(invoice.line_ids.tax_ids.mapped('name'))
+                )
+
             if error_msg:
                 return {
                     invoice: {


### PR DESCRIPTION
Open tax "IVA 0% Entregas Intracomunitarias exentas"
Set Tax Scope to False
Create an invoice to an EU partner
Add an invoice line (select the mentioned tax)
Confirm
Send for Validation

Traceback:
odoo.addons.base.models.ir_qweb.QWebException: Error while render the template
KeyError: 'DesgloseTipoOperacion'
Template: l10n_es_edi_tbai.template_invoice_factura
Path: /t/TipoDesglose/DesgloseTipoOperacion/PrestacionServicios
Node: <PrestacionServicios t-if="invoice_info.get(\'PrestacionServicios\')"/>

This occurs because tax info was not fetched properly
When invoicing to a foreign partner the tax scope needs to be properly
configured

opw-3877924