### PR TITLE
[FIX] mail: fix failing user profile tour

### DIFF
--- a/addons/mail/static/tests/tours/user_modify_own_profile_tour.js
+++ b/addons/mail/static/tests/tours/user_modify_own_profile_tour.js
@@ -23,14 +23,17 @@ registry.category("web_tour.tours").add("mail/static/tests/tours/user_modify_own
         },
         {
             trigger: "body.modal-open",
+            in_modal: false,
         },
         {
             content: "Save the form",
             trigger: 'button[name="preference_save"]',
+            run: "click",
         },
         {
             content: "Wait until the modal is closed",
             trigger: "body:not(.modal-open)",
+            in_modal: false,
         },
     ],
 });


### PR DESCRIPTION
With recent tour compiler changes, the `user_modify_own_profile` tour was consistently failing.

Before those changes, the default action for steps that didn't define one was click which is not the cased anymore. In addition, the `in_modal` step key was added to help finding elements in modals. However two steps of this tour are looking for elements outside the modal.

This PR fixes both issues.

runbot-69023
