### PR TITLE
[IMP] project: add "Close" button to project sharing wizard

### DIFF
--- a/addons/project/wizard/project_share_wizard_views.xml
+++ b/addons/project/wizard/project_share_wizard_views.xml
@@ -29,7 +29,8 @@
                     <li>Edit: collaborators can view and edit all tasks in the Kanban view. Additionally, they can choose which tasks they want to follow.</li>
                 </ul>
                 <footer>
-                    <button string="Share Project" name="action_share_record" type="object" class="btn-primary" data-hotkey="q"/>
+                    <button string="Share Project" name="action_share_record" type="object" class="btn-primary" data-hotkey="q" invisible="not collaborator_ids" />
+                    <button string="Save" class="btn-primary" special="save" data-hotkey="q" invisible="collaborator_ids" />
                     <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="x" />
                 </footer>
             </form>


### PR DESCRIPTION
Currently, when there are no collaborators in the project sharing wizard and you click on the "Share Project" button, a toast will get displayed indicating that the project was shared with the collaborators, which is misleading.

This PR adds a "Close" button that is displayed instead of the "Share Project" and "Discard" button when there are no collaborators.

task-4004946