### PR TITLE
[IMP] hr_holidays: change state to `confirm` on record duplicate

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -627,6 +627,11 @@ class HolidaysAllocation(models.Model):
         if any(allocation.holiday_status_id.requires_allocation == 'yes' and allocation.leaves_taken > 0 for allocation in self):
             raise UserError(_('You cannot delete an allocation request which has some validated leaves.'))
 
+    def copy(self, default=None):
+        new_allocations = super().copy(default)
+        new_allocations.state = 'confirm'
+        return new_allocations
+
     def _get_redirect_suggested_company(self):
         return self.holiday_status_id.company_id
 


### PR DESCRIPTION
For a time off type that don't require a validation, if you create an allocation, as soon as it will be saved, it will be approved because no validation is needed. If you duplicate it, the new allocation will have the same state, and you can't do anything with it anymore.

This commit reverts the state back to `confirm` so that the copy can be changed before saving.

task: 4014280

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
