### PR TITLE
[FIX] sale: price rules form behavior

### DIFF
--- a/addons/product/models/product.py
+++ b/addons/product/models/product.py
@@ -628,7 +628,7 @@ class ProductProduct(models.Model):
         return {
             'name': _('Price Rules'),
             'view_mode': 'tree,form',
-            'views': [(self.env.ref('product.product_pricelist_item_tree_view_from_product').id, 'tree'), (False, 'form')],
+            'views': [(self.env.ref('product.product_pricelist_item_tree_view_from_product').id, 'tree')],
             'res_model': 'product.pricelist.item',
             'type': 'ir.actions.act_window',
             'target': 'current',

--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -627,7 +627,7 @@ class ProductTemplate(models.Model):
         return {
             'name': _('Price Rules'),
             'view_mode': 'tree,form',
-            'views': [(self.env.ref('product.product_pricelist_item_tree_view_from_product').id, 'tree'), (False, 'form')],
+            'views': [(self.env.ref('product.product_pricelist_item_tree_view_from_product').id, 'tree')],
             'res_model': 'product.pricelist.item',
             'type': 'ir.actions.act_window',
             'target': 'current',


### PR DESCRIPTION
Steps :
- Set the company of the first pricelist in list view to false
- Create a product and set it's company and the go to extra price tab and group by product
- Now when adding a new, opens form view, try saving the record

Issue :
Returns a warning message not allowing to save

Cause :
The company for pricelist that is default selected and the product have different companies

Fix :
Updated the action so that it does not open form view as the pricelist tree view is multi-edit

opw-3943830
