### PR TITLE
[FIX] l10n_cl: use correct attribute in invoice template

### DIFF
--- a/addons/l10n_cl/views/report_invoice.xml
+++ b/addons/l10n_cl/views/report_invoice.xml
@@ -162,7 +162,7 @@
 
         <xpath expr="//span[@t-field='line.price_unit']" position="attributes">
             <attribute name="t-field"></attribute>
-            <attribute t-if="not o.l10n_latam_document_type_id._is_doc_type_electronic_ticket()" name="t-out">line_amounts['price_item_document']</attribute>
+            <attribute name="t-out">line_amounts['price_item_document']</attribute>
             <attribute name="t-options">{"widget": "float", "precision": 2}</attribute>
         </xpath>
 


### PR DESCRIPTION
We should add the price_unit via a `t-out` attribute, using a condition inside, rather than trying to use `t-if`. This was missed in resolving fw-port issues.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
