### PR TITLE
[ADD] hw_drivers: allow iotbox to be used as a kiosk

### DIFF
--- a/addons/hw_drivers/browser.py
+++ b/addons/hw_drivers/browser.py
@@ -1,0 +1,116 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+import subprocess
+
+
+class Browser:
+    """Methods to interact with a browser"""
+
+    def __init__(self, url, _x_screen, env=None, kiosk=False):
+        """
+        :param url: URL to open in the browser
+        :param _x_screen: X screen number
+        :param env: Environment variables
+        :param kiosk: Whether the browser should be in kiosk mode
+        """
+        self.url = url
+        self.browser = 'chromium-browser'
+        self._x_screen = _x_screen
+        self.env = env
+        self.env['HOME'] = '/tmp/' + self._x_screen
+        self.kiosk_args = [
+            '--kiosk',
+            '--incognito',
+            '--disable-infobars',
+            '--noerrdialogs',
+            '--no-first-run',
+        ]
+        self.chromium_additional_args = self.kiosk_args if kiosk else []
+
+        self.instance = None
+
+    def open_browser(self, url=None):
+        """open the browser with the given URL, or reopen it if it is already open"""
+        self.url = url or self.url
+
+        # Reopen to take new url or additional args into account
+        if self.instance:
+            self.close_browser()
+
+        self.instance = subprocess.Popen(
+            [
+                self.browser,
+                self.url,
+                '--disk-cache-dir=/dev/null',
+                '--disk-cache-size=1',
+                *self.chromium_additional_args,
+            ],
+            env=self.env,
+            stdout=subprocess.DEVNULL,  # Chromium logs a lot of stuff, avoid contaminating Odoo logs
+            stderr=subprocess.DEVNULL,
+        )
+        return self.instance
+
+    def close_browser(self):
+        """close the browser"""
+        subprocess.run(['pkill', self.browser.split('-')[0] + '*'], check=False)
+        subprocess.run(['rm', '-rf', f'/tmp/{self._x_screen}/.cache'], check=False)  # Remove cached files to free space
+        self.instance = None
+
+    def xdotool_keystroke(self, keystroke):
+        """Execute a keystroke using xdotool"""
+        try:
+            subprocess.call([
+                'xdotool', 'search',
+                '--sync', '--onlyvisible',
+                '--screen', self._x_screen,
+                '--class', self.browser.capitalize(),
+                'key', keystroke,
+            ])
+            return "xdotool succeeded in stroking " + keystroke
+        except subprocess.SubprocessError:
+            return "xdotool failed in stroking " + keystroke
+
+    def xdotool_type(self, text):
+        """Type text using xdotool"""
+        try:
+            subprocess.call([
+                'xdotool', 'search',
+                '--sync', '--onlyvisible',
+                '--screen', self._x_screen,
+                '--class', self.browser.capitalize(),
+                'type', text,
+            ])
+            return "xdotool succeeded in typing " + text
+        except subprocess.SubprocessError:
+            return "xdotool failed in typing " + text
+
+    def open_new_tab(self, url):
+        """Open a new tab with the given URL"""
+        self.url = url
+        self.xdotool_keystroke('ctrl+t')
+        self.xdotool_type(self.url)
+        self.xdotool_keystroke('Return')
+
+    def fullscreen(self):
+        """Make the browser fullscreen"""
+        self.chromium_additional_args = ['--start-fullscreen']
+        self.open_browser()
+
+    def refresh(self):
+        """Refresh the current tab"""
+        self.xdotool_keystroke('ctrl+r')
+
+    def enable_kiosk_mode(self):
+        """Enable kiosk mode in browser with the given orientation"""
+        if not self.is_kiosk():
+            self.chromium_additional_args.extend(self.kiosk_args)
+            self.open_browser()
+
+    def disable_kiosk_mode(self):
+        """Disable kiosk mode in browser"""
+        if self.is_kiosk():
+            self.chromium_additional_args = [arg for arg in self.chromium_additional_args if arg not in self.kiosk_args]
+            self.open_browser()
+
+    def is_kiosk(self):
+        return '--kiosk' in self.chromium_additional_args

--- a/addons/hw_drivers/iot_handlers/drivers/DisplayDriver_L.py
+++ b/addons/hw_drivers/iot_handlers/drivers/DisplayDriver_L.py
@@ -12,13 +12,15 @@ import time
 
 import urllib3
 
+from enum import Enum
 from odoo import http
+from odoo.addons.hw_drivers.browser import Browser
 from odoo.addons.hw_drivers.connection_manager import connection_manager
 from odoo.addons.hw_drivers.driver import Driver
 from odoo.addons.hw_drivers.event_manager import event_manager
 from odoo.addons.hw_drivers.main import iot_devices
 from odoo.addons.hw_drivers.tools import helpers
-from odoo.tools.misc import file_open
+from odoo.tools.misc import file_open, file_path
 
 path = os.path.realpath(os.path.join(os.path.dirname(__file__), '../../views'))
 loader = jinja2.FileSystemLoader(path)
@@ -29,6 +31,14 @@ jinja_env.filters["json"] = json.dumps
 pos_display_template = jinja_env.get_template('pos_display.html')
 
 _logger = logging.getLogger(__name__)
+
+
+class Orientation(Enum):
+    """xrandr screen orientation for kiosk mode"""
+    NORMAL = 'normal'
+    INVERTED = 'inverted'
+    LEFT = 'left'
+    RIGHT = 'right'
 
 
 class DisplayDriver(Driver):
@@ -42,9 +52,16 @@ class DisplayDriver(Driver):
         self.event_data = threading.Event()
         self.owner = False
         self.rendered_html = ''
+        self.url = ''
         if self.device_identifier != 'distant_display':
             self._x_screen = device.get('x_screen', '0')
-            self.load_url()
+            self.browser = Browser(
+                'http://localhost:8069/point_of_sale/display/' + self.device_identifier,
+                self._x_screen,
+                self._set_environ(),
+            )
+            self.browser.close_browser()  # Close the browser if it was already open
+            self.update_url(self.load_url())
 
         self._actions.update({
             'update_url': self._action_update_url,
@@ -53,6 +70,8 @@ class DisplayDriver(Driver):
             'customer_facing_display': self._action_customer_facing_display,
             'get_owner': self._action_get_owner,
         })
+
+        self.set_orientation(Orientation.NORMAL)
 
     @classmethod
     def supported(cls, device):
@@ -68,18 +87,13 @@ class DisplayDriver(Driver):
             time.sleep(60)
             if self.url != 'http://localhost:8069/point_of_sale/display/' + self.device_identifier:
                 # Refresh the page every minute
-                self.call_xdotools('F5')
+                self.browser.refresh()
 
     def update_url(self, url=None):
-        os.environ['DISPLAY'] = ":0." + self._x_screen
-        os.environ['XAUTHORITY'] = '/run/lightdm/pi/xauthority'
-        firefox_env = os.environ.copy()
-        firefox_env['HOME'] = '/tmp/' + self._x_screen
         self.url = url or 'http://localhost:8069/point_of_sale/display/' + self.device_identifier
-        new_window = subprocess.call(['xdotool', 'search', '--onlyvisible', '--screen', self._x_screen, '--class', 'Firefox'])
-        subprocess.Popen(['firefox', self.url], env=firefox_env)
-        if new_window:
-            self.call_xdotools('F11')
+
+        if self.browser.open_browser(self.url):
+            self.browser.fullscreen()
 
     def load_url(self):
         url = None
@@ -88,7 +102,10 @@ class DisplayDriver(Driver):
             urllib3.disable_warnings()
             http = urllib3.PoolManager(cert_reqs='CERT_NONE')
             try:
-                response = http.request('GET', "%s/iot/box/%s/display_url" % (helpers.get_odoo_server_url(), helpers.get_mac_address()))
+                response = http.request(
+                    'GET',
+                    "%s/iot/box/%s/display_url" % (helpers.get_odoo_server_url(), helpers.get_mac_address())
+                )
                 if response.status == 200:
                     data = json.loads(response.data.decode('utf8'))
                     url = data[self.device_identifier]
@@ -96,16 +113,8 @@ class DisplayDriver(Driver):
                 url = response.data.decode('utf8')
             except Exception:
                 pass
-        return self.update_url(url)
 
-    def call_xdotools(self, keystroke):
-        os.environ['DISPLAY'] = ":0." + self._x_screen
-        os.environ['XAUTHORITY'] = "/run/lightdm/pi/xauthority"
-        try:
-            subprocess.call(['xdotool', 'search', '--sync', '--onlyvisible', '--screen', self._x_screen, '--class', 'Firefox', 'key', keystroke])
-            return "xdotool succeeded in stroking " + keystroke
-        except:
-            return "xdotool threw an error, maybe it is not installed on the IoTBox"
+        return url
 
     def update_customer_facing_display(self, origin, html=None):
         if origin == self.owner:
@@ -137,7 +146,7 @@ class DisplayDriver(Driver):
 
     def _action_display_refresh(self, data):
         if self.device_identifier != 'distant_display':
-            self.call_xdotools('F5')
+            self.browser.refresh()
 
     def _action_take_control(self, data):
         self.take_control(self.data.get('owner'), data.get('html'))
@@ -151,6 +160,17 @@ class DisplayDriver(Driver):
             'owner': self.owner,
         }
         event_manager.device_changed(self)
+
+    def _set_environ(self):
+        os.environ['DISPLAY'] = ":0." + self._x_screen
+        os.environ['XAUTHORITY'] = '/run/lightdm/pi/xauthority'
+
+        return os.environ.copy()
+
+    def set_orientation(self, orientation=Orientation.NORMAL):
+        subprocess.run(['xrandr', '-o', orientation.value], check=True)
+        subprocess.run([file_path('hw_drivers/tools/sync_touchscreen.sh'), str(int(self._x_screen) + 1)], check=False)
+
 
 class DisplayController(http.Controller):
 
@@ -170,7 +190,7 @@ class DisplayController(http.Controller):
 
     @http.route('/hw_proxy/take_control', type='json', auth='none', cors='*')
     def take_control(self, html=None):
-        display = DisplayDriver.get_default_display()
+        display: DisplayDriver = DisplayDriver.get_default_display()
         if display:
             display.take_control(http.request.httprequest.remote_addr, html)
             return {
@@ -188,12 +208,13 @@ class DisplayController(http.Controller):
     @http.route(['/point_of_sale/get_serialized_order', '/point_of_sale/get_serialized_order/<string:display_identifier>'], type='json', auth='none')
     def get_serialized_order(self, display_identifier=None):
         if display_identifier:
-            display = iot_devices.get(display_identifier)
+            display: DisplayDriver = iot_devices.get(display_identifier)
         else:
             display = DisplayDriver.get_default_display()
 
         if display:
             return display.get_serialized_order()
+
         return {
             'rendered_html': False,
             'error': "No display found",
@@ -242,3 +263,42 @@ class DisplayController(http.Controller):
         } for device in iot_devices]
 
         return json.dumps({'iot_device_status': iot_device})
+
+    @http.route('/kiosk/display', type='json', auth='none', methods=['POST'])
+    def kiosk_display(self, pos_id, access_token):
+        if not pos_id or not access_token:
+            return json.dumps({'status': 'failed', 'message': 'No id or access_token provided'})
+
+        display: DisplayDriver = DisplayDriver.get_default_display()
+        if not display:
+            return json.dumps({'status': 'failed', 'message': 'No display found'})
+
+        uri = f'{helpers.get_odoo_server_url()}/pos-self/{pos_id}?access_token={access_token}'
+
+        display.set_orientation(Orientation.RIGHT)  # default orientation for kiosk mode
+        display.update_url(uri)
+        display.browser.enable_kiosk_mode()
+
+        return json.dumps({'status': 'success'})
+
+    @http.route(['/hw_proxy/display_pos_display'], type='http', auth='none')
+    def display_pos_display(self):
+        """Display the POS display on the screen: may be useful for debugging purposes?"""
+        display: DisplayDriver = DisplayDriver.get_default_display()
+        if not display:
+            return json.dumps({'status': 'failed', 'message': 'No display found'})
+
+        display.update_url(display.load_url())
+        display.browser.disable_kiosk_mode()
+
+        return json.dumps({'status': 'success'})
+
+    @http.route(['/hw_proxy/rotate_screen'], type='json', auth='none', methods=['POST'])
+    def rotate_screen(self, orientation=Orientation.NORMAL):
+        """Rotate screen: use by 'iot.box' model when is_kiosk is checked"""
+        display: DisplayDriver = DisplayDriver.get_default_display()
+        if not display:
+            return json.dumps({'status': 'failed', 'message': 'No display found'})
+
+        display.set_orientation(Orientation(orientation))
+        return json.dumps({'status': 'success'})

--- a/addons/hw_drivers/main.py
+++ b/addons/hw_drivers/main.py
@@ -34,12 +34,13 @@ iot_devices = {}
 
 
 class Manager(Thread):
+    server_url = None
+
     def send_alldevices(self, iot_client=None):
         """
         This method send IoT Box and devices informations to Odoo database
         """
-        server = helpers.get_odoo_server_url()
-        if server:
+        if self.server_url:
             subject = helpers.read_file_first_line('odoo-subject.conf')
             if subject:
                 domain = helpers.get_ip().replace('.', '-') + subject.strip('*')
@@ -68,7 +69,7 @@ class Manager(Thread):
             try:
                 resp = http.request(
                     'POST',
-                    server + "/iot/setup",
+                    self.server_url + "/iot/setup",
                     body=json.dumps(data).encode('utf8'),
                     headers={
                         'Content-type': 'application/json',
@@ -88,10 +89,11 @@ class Manager(Thread):
         """
         Thread that will load interfaces and drivers and contact the odoo server with the updates
         """
+        self.server_url = helpers.get_odoo_server_url()
 
         helpers.start_nginx_server()
         _logger.info("IoT Box Image version: %s", helpers.get_version(detailed_version=True))
-        if platform.system() == 'Linux' and helpers.get_odoo_server_url():
+        if platform.system() == 'Linux' and self.server_url:
             helpers.check_git_branch()
             helpers.generate_password()
         is_certificate_ok, certificate_details = helpers.get_certificate_status()
@@ -99,7 +101,7 @@ class Manager(Thread):
             _logger.warning("An error happened when trying to get the HTTPS certificate: %s",
                             certificate_details)
 
-        iot_client = helpers.get_odoo_server_url() and WebsocketClient(helpers.get_odoo_server_url())
+        iot_client = self.server_url and WebsocketClient(self.server_url)
         # We first add the IoT Box to the connected DB because IoT handlers cannot be downloaded if
         # the identifier of the Box is not found in the DB. So add the Box to the DB.
         self.send_alldevices(iot_client)
@@ -118,10 +120,10 @@ class Manager(Thread):
         # Set scheduled actions
         schedule and schedule.every().day.at("00:00").do(helpers.get_certificate_status)
 
-        #Setup the websocket connection
-        if helpers.get_odoo_server_url():
+        # Set up the websocket connection
+        if self.server_url:
             iot_client.start()
-        # Check every 3 secondes if the list of connected devices has changed and send the updated
+        # Check every 3 seconds if the list of connected devices has changed and send the updated
         # list to the connected DB.
         self.previous_iot_devices = []
         while 1:

--- a/addons/hw_drivers/tools/helpers.py
+++ b/addons/hw_drivers/tools/helpers.py
@@ -262,12 +262,15 @@ def get_ssid():
     process_grep = subprocess.Popen(['grep', 'ESSID:"'], stdin=process_iwconfig.stdout, stdout=subprocess.PIPE)
     return subprocess.check_output(['sed', 's/.*"\\(.*\\)"/\\1/'], stdin=process_grep.stdout).decode('utf-8').rstrip()
 
+
 def get_odoo_server_url():
     if platform.system() == 'Linux':
         ap = subprocess.call(['systemctl', 'is-active', '--quiet', 'hostapd']) # if service is active return 0 else inactive
         if not ap:
             return False
-    return read_file_first_line('odoo-remote-server.conf')
+
+    return read_file_first_line('/home/pi/odoo-remote-server.conf', absolute=True)
+
 
 def get_token():
     return read_file_first_line('token')
@@ -439,11 +442,13 @@ def path_file(filename):
     elif platform_os == 'Windows':
         return Path().absolute().parent.joinpath('server/' + filename)
 
-def read_file_first_line(filename):
-    path = path_file(filename)
+
+def read_file_first_line(filename, absolute=False):
+    path = Path(filename) if absolute else file_path(filename)
     if path.exists():
         with path.open('r') as f:
             return f.readline().strip('\n')
+
 
 def unlink_file(filename):
     with writable():

--- a/addons/hw_drivers/tools/sync_touchscreen.sh
+++ b/addons/hw_drivers/tools/sync_touchscreen.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+if [ $# -eq 0 ]; then
+    echo "No output screen specified, assuming :0.0"
+    screen=1
+else
+    screen="$1"
+fi
+
+# Get touchscreen name
+touchscreen_name=$(udevadm info --export-db | awk '/ID_INPUT_TOUCHSCREEN=1/' RS= | grep "^E: NAME=" | cut -d '"' -f2)
+if [ -z "$touchscreen_name" ]; then
+    echo "No touchscreen found"
+    exit 1
+fi
+
+# Get touchscreen device ids (Elo Touchscreen appears twice in the list)
+device_id_0=$(xinput list | grep "$touchscreen_name" | head -1 | cut -d "=" -f2 | cut -d$'\t' -f1)
+device_id_1=$(xinput list | grep "$touchscreen_name" | tail -1 | cut -d "=" -f2 | cut -d$'\t' -f1)
+
+# Get screen name: default will return the 1st line (e.g. HDMI-1)
+output_name=$(xrandr --listactivemonitors | awk '{print $NF}' | tail -n +2 | awk -v screen="$screen" 'NR==screen')
+
+# Map touchscreen matrix to screen configuration (orientation)
+xinput map-to-output $device_id_0 "$output_name"
+xinput map-to-output $device_id_1 "$output_name"

--- a/addons/pos_self_order/static/src/app/self_order_index.js
+++ b/addons/pos_self_order/static/src/app/self_order_index.js
@@ -39,6 +39,15 @@ class selfOrderIndex extends Component {
 
     setup() {
         this.selfOrder = useSelfOrder();
+
+        // Disable cursor on touch devices (required on IoT Box Kiosk)
+        if (
+            "ontouchstart" in window ||
+            navigator.maxTouchPoints > 0 ||
+            navigator.msMaxTouchPoints > 0
+        ) {
+            document.body.classList.add("touch-device");
+        }
     }
     get selfIsReady() {
         return Object.values(this.selfOrder.productByIds).length > 0;

--- a/addons/pos_self_order/static/src/app/self_order_index.scss
+++ b/addons/pos_self_order/static/src/app/self_order_index.scss
@@ -4,6 +4,10 @@
 
     --btn-group-gap: 0;
 
+    // Disable zoom
+    touch-action: pan-x pan-y;
+    height: 100%;
+
     // Target 4K devices
     @media #{screen and (min-width: 3839px), (min-height: 3839px)} {
         --root-font-size: #{$o-so-font-size-4k};
@@ -13,6 +17,7 @@
 html, body {
     height: 100%;
     overflow: hidden;
+    overscroll-behavior: none;  // disable swipe to go back
 }
 
 body {
@@ -75,4 +80,8 @@ ul, ol {
 }
 li {
     list-style-type: none;
+}
+
+.touch-device * {
+    cursor: none !important;
 }

--- a/addons/pos_self_order/views/point_of_sale_dashboard.xml
+++ b/addons/pos_self_order/views/point_of_sale_dashboard.xml
@@ -5,9 +5,11 @@
         <field name="model">pos.config</field>
         <field name="arch" type="xml">
             <form>
-                <div class="text-center">
+                <div>
                     <div class="fs-2 mb-2">From your Kiosk, open this URL:</div>
-                    <field name="self_ordering_url" readonly="1" />
+                    <group>
+                        <field name="self_ordering_url"  widget="CopyClipboardChar" readonly="1" string="Kiosk URL" />
+                    </group>
                 </div>
                 <footer class="justify-content-end">
                     <button class="btn btn-secondary" special="cancel">Close</button>


### PR DESCRIPTION
- Moved browser logic inside of a class (Browser),
- Added support for touchscreens:
    - Screen matrix sync with screen orientation,
    - Cursor hiding in kiosk,
    - Disabled zoom in kiosk,
- Added screen rotation logic,
- fixed chromium cache taking too much space in `/tmp/0`,
- Added copy button to `pos_self_order` open kiosk url.

Enterprise PR: [https://github.com/odoo/enterprise/pull/65747](https://github.com/odoo/enterprise/pull/65747)
Task: 3598744