### PR TITLE
[FIX] web: fix breadcrumb mobile flex behaviour

### DIFF
--- a/addons/web/static/src/search/control_panel/control_panel.xml
+++ b/addons/web/static/src/search/control_panel/control_panel.xml
@@ -82,7 +82,7 @@
         <t t-set="collapsedBreadcrumbs" t-value="breadcrumbs.slice(0, -3).reverse()"/>
         <t t-set="breadcrumb" t-value="currentBreadcrumbs[0] || {}"/>
 
-        <div t-if="collapsedBreadcrumbs.length || visiblePathBreadcrumbs.length" class="o_breadcrumb d-flex flex-row flex-md-column align-self-stretch justify-content-between min-w-0">
+        <div t-if="collapsedBreadcrumbs.length || visiblePathBreadcrumbs.length" class="o_breadcrumb d-flex flex-row flex-md-column align-self-stretch justify-content-between min-w-0" t-att-class="!env.isSmall? 'flex-column' : 'flex-row'">
             <t t-if="env.isSmall">
                 <t t-set="previousBreadcrumb" t-value="visiblePathBreadcrumbs.slice(-1)"/>
                 <button class="o_back_button btn btn-link px-1" t-on-click.prevent="() => this.onBreadcrumbClicked(previousBreadcrumb.jsId)">


### PR DESCRIPTION
This commit fixes an issue about the breadcrumb having the wrong `flex-direction:` property on mobile devices.

This change seems to be linked to the fact that we have different breadcrumbs behaviour on smaller devices. If there is a possibility to go back, an arrow is displayed. When this arrow is existing, the flex direction should indeed be `row`, but if it doesn't exists, it should remains `column`.

This commit addresses this issue by setting a conditional class on the breadcrumb.

task-4016743

| 17.0 and higher | This PR |
|--------|--------|
| ![image](https://github.com/odoo/odoo/assets/128030743/756786b6-cef8-4f19-b092-c62d4fb1b97e) | ![image](https://github.com/odoo/odoo/assets/128030743/82e2bb06-a921-422c-849d-55386fa49dc2) |
| ![image](https://github.com/odoo/odoo/assets/128030743/6873c19d-8f46-4aeb-809e-9480d1051b81) | ![image](https://github.com/odoo/odoo/assets/128030743/1f9e3f89-21c7-4f5e-afd2-05d73772f1c3) |

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
