### PR TITLE
[FIX] website_sale_loyalty: show discount button in web editor

### DIFF
--- a/addons/website_sale_loyalty/controllers/delivery.py
+++ b/addons/website_sale_loyalty/controllers/delivery.py
@@ -19,13 +19,13 @@ class WebsiteSaleLoyaltyDelivery(WebsiteSaleDelivery):
                     'new_amount_delivery_discount': Monetary.value_to_html(
                         amount_free_shipping, {'display_currency': currency}
                     ),
-                    'new_amount_order_discounted': Monetary.value_to_html(order.reward_amount - amount_free_shipping, {'display_currency': currency}),
                     'delivery_discount_minor_amount': payment_utils.to_minor_currency_units(
                         amount_free_shipping, currency
                     ),
                 })
-            else:
-                result.update({'new_amount_order_discounted': Monetary.value_to_html(
+            result.update({
+                'new_amount_order_discounted': Monetary.value_to_html(
                     order.reward_amount, {'display_currency': currency}
-                )})
+                )
+            })
         return result

--- a/addons/website_sale_loyalty/i18n/website_sale_loyalty.pot
+++ b/addons/website_sale_loyalty/i18n/website_sale_loyalty.pot
@@ -95,18 +95,13 @@ msgid "Disabled Auto Rewards"
 msgstr ""
 
 #. module: website_sale_loyalty
+#: model_terms:ir.ui.view,arch_db:website_sale_loyalty.cart_discount
+msgid "Discount"
+msgstr ""
+
+#. module: website_sale_loyalty
 #: model:ir.ui.menu,name:website_sale_loyalty.menu_discount_loyalty_type_config
 msgid "Discount & Loyalty"
-msgstr ""
-
-#. module: website_sale_loyalty
-#: model_terms:ir.ui.view,arch_db:website_sale_loyalty.cart_discount
-msgid "Discount:"
-msgstr ""
-
-#. module: website_sale_loyalty
-#: model_terms:ir.ui.view,arch_db:website_sale_loyalty.cart_discount
-msgid "Discounted amount"
 msgstr ""
 
 #. module: website_sale_loyalty

--- a/addons/website_sale_loyalty/static/src/js/website_sale_loyalty_delivery.js
+++ b/addons/website_sale_loyalty/static/src/js/website_sale_loyalty_delivery.js
@@ -22,10 +22,8 @@ publicWidget.registry.websiteSaleDelivery.include({
                 cart_summary_discount_line.innerHTML = this.result.new_amount_delivery_discount;
             }
         }
-        else if (this.result.new_amount_order_discounted) {
-             const cart_summary_discount_line = document.querySelector(
-                '[data-reward-type="discount"]'
-            );
+        if (this.result.new_amount_order_discounted) {
+            const cart_summary_discount_line = document.querySelector('#order_discount .monetary_field');
             if (cart_summary_discount_line) {
                 cart_summary_discount_line.innerHTML = this.result.new_amount_order_discounted;
             }

--- a/addons/website_sale_loyalty/views/snippets.xml
+++ b/addons/website_sale_loyalty/views/snippets.xml
@@ -3,7 +3,7 @@
 
 <template id="snippet_options" inherit_id="website.snippet_options" name="Coupon Snippet Options">
     <xpath expr="." position="inside">
-        <div data-selector="main:has(.oe_website_sale .wizard)" data-page-options="true" groups="website.group_website_designer" data-no-check="true">
+        <div data-selector="main:has(.oe_website_sale .o_wizard)" data-page-options="true" groups="website.group_website_designer" data-no-check="true">
             <we-checkbox string="Show Discount in Subtotal"
                          data-customize-website-views="website_sale_loyalty.cart_discount"
                          data-no-preview="true"

--- a/addons/website_sale_loyalty/views/website_sale_templates.xml
+++ b/addons/website_sale_loyalty/views/website_sale_templates.xml
@@ -133,16 +133,16 @@
 
     <template id="cart_discount" name="Show Discount in Subtotal" active="False" inherit_id="website_sale.total">
         <xpath expr="//tr[@id='order_total_untaxed']" position="before">
-            <tr t-if="website_sale_order and website_sale_order.reward_amount">
-            <td class="text-end border-0 text-muted" title="Discounted amount">Discount:</td>
-            <td class="text-xl-end border-0 text-muted">
-                <span t-field="website_sale_order.reward_amount" style="white-space: nowrap;"
-                    class="monetary_field"
-                    t-options='{
-                            "widget": "monetary",
-                            "display_currency": website_sale_order.currency_id,
-                    }'/>
-            </td>
+            <tr id="order_discount">
+                <td colspan="2" class="text-muted border-0 ps-0 pt-0 pb-2">Discount</td>
+                <td class="text-end border-0 pe-0 pt-0 pb-2" name="order_discount">
+                    <span
+                        t-field="website_sale_order.reward_amount"
+                        class="monetary_field"
+                        style="white-space: nowrap;"
+                        t-options="{'widget': 'monetary', 'display_currency': website_sale_order.currency_id}"
+                    />
+                </td>
             </tr>
         </xpath>
     </template>


### PR DESCRIPTION
Since 0750eb6, enabling or disabling the discount subtotal in the
checkout pages is impossible.

Now, the settings will be shown again in the website editor.

opw-3995547