### PR TITLE
[FIX] pos_loyalty: add language to default context when loading data

### DIFF
--- a/addons/pos_loyalty/models/pos_session.py
+++ b/addons/pos_loyalty/models/pos_session.py
@@ -33,6 +33,7 @@ class PosSession(models.Model):
                     'discount', 'discount_mode', 'discount_applicability', 'all_discount_product_ids', 'is_global_discount',
                     'discount_max_amount', 'discount_line_product_id',
                     'multi_product', 'reward_product_ids', 'reward_product_qty', 'reward_product_uom_id', 'reward_product_domain'],
+                'context': {**self.env.context},
             },
             'loyalty.card': {
                 'domain': lambda data: [('program_id', 'in', [program["id"] for program in data["loyalty.program"]])],

--- a/addons/pos_loyalty/static/tests/tours/PosLoyaltyTour.js
+++ b/addons/pos_loyalty/static/tests/tours/PosLoyaltyTour.js
@@ -459,3 +459,21 @@ registry.category("web_tour.tours").add("PosLoyaltyPointsGlobalDiscountProgramNo
             PosLoyalty.finalizeOrder("Cash", "90"),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add('ChangeRewardValueWithLanguage', {
+    test: true,
+    url: '/pos/web',
+    steps: () =>
+        [
+            Dialog.confirm("Open session"),
+
+            ProductScreen.clickDisplayedProduct('Desk Organizer'),
+            ProductScreen.selectedOrderlineHas('Desk Organizer', '1.00', '5.10'),
+            ProductScreen.clickPartnerButton(),
+            ProductScreen.clickCustomer('Colleen Diaz'),
+            PosLoyalty.isRewardButtonHighlighted(true),
+            PosLoyalty.claimReward('$ 2 on your order'),
+            PosLoyalty.hasRewardLine('$ 2 on your order', '-2.00'),
+            PosLoyalty.orderTotalIs('3.10'),
+        ].flat(),
+});

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -2069,3 +2069,46 @@ class TestUi(TestPointOfSaleHttpCommon):
             login="pos_user",
         )
         self.assertEqual(loyalty_card.points, 100)
+
+    def test_change_reward_value_with_language(self):
+        """
+        Verify that the displayed language is not en_US.
+        When a user has another language than en_US set,
+        he shouldn't have the en_US message displayed but the message of the active language.
+        For this test, we shouldn't have the description displayed for selecting the reward in en_US but in en_GB.
+        Description in en_US (unexpected): 'A en_US name which should not be displayed'
+        Description in en_GB (expected): '$ 2 on your order'
+        """
+
+        self.env['loyalty.program'].search([]).write({'active': False})
+        self.env['res.lang']._activate_lang('en_GB')
+        env_gb = self.env(context={'lang': 'en_GB'})
+        self.pos_user.write({'lang': 'en_GB'})
+
+        loyalty_program = env_gb['loyalty.program'].create({
+            'name': 'Loyalty Program',
+            'program_type': 'loyalty',
+            'applies_on': 'both',
+            'trigger': 'auto',
+            'rule_ids': [(0, 0, {
+                'reward_point_amount': 1,
+                'reward_point_mode': 'money',
+                'minimum_qty': 0,
+            })],
+            'reward_ids': [(0, 0, {
+                'reward_type': 'discount',
+                'discount': 2,
+                'discount_mode': 'per_order',
+                'discount_applicability': 'order',
+                'required_points': 1,
+            })],
+        })
+
+        loyalty_program.reward_ids.update_field_translations('description', {'en_US': 'A en_US name which should not be displayed'})
+
+        self.main_pos_config.open_ui()
+        self.start_tour(
+            "/pos/web?config_id=%d" % self.main_pos_config.id,
+            "ChangeRewardValueWithLanguage",
+            login="pos_user",
+        )


### PR DESCRIPTION
Problem:
en_US data is loaded while the user uses another language

Steps to reproduce:
- Install "point_of_sale" app and "pos_loyalty" module
- Change the language (e.g. to french)
- Go to POS -> Products -> Discount & Loyalty
- Create a new Loyalty Card
- In Rewards, set a discount of 20 $ on order and save
- Go to the shop and select a partner and a product (price must be expensive enough for the loyalty card to be applicable)
- Click on "Reward", the earlier created reward is there
- Go back to the form of the loyalty card and change the value and save
- Go back to the shop
- Click on "Reward" and the name of the loyalty card is still the same as before while it should be for the new price

Cause:
When loading the data, the record environment have language set to None so by default it is loaded in en_US which didn't recompute its value after the modification of the price.

opw-3987961


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
