### PR TITLE
[FIX] website: fix rounded boxed header template megamenu issues

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -1593,6 +1593,11 @@ header {
     background-color: transparent; // In order to allow the mega menu to be transparent
     border: $border-width solid $border-color; // Prevent to see the color of the block behind.
 
+    // Needed to space the megamenu on this specific header
+    @if o-website-value('header-template') == 'boxed' {
+        margin-top: $navbar-padding-y !important;
+    }
+
     .container, .container-fluid {
         // Need to reforce those because they are removed since its a container
         // inside another container (the one in the navbar)

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -29,7 +29,7 @@
         <!-- Avoid rendering the mega menu element twice (Desktop + Mobile) -->
         <div
             t-if="submenu.is_mega_menu and not is_mobile"
-            t-attf-class="o_mega_menu dropdown-menu border-top-0 #{submenu.mega_menu_classes}"
+            t-attf-class="o_mega_menu dropdown-menu #{submenu.mega_menu_classes} #{_extra_megamenu_classes or 'border-top-0'}"
             data-name="Mega Menu"
             t-field="submenu.mega_menu_content"
             role="menuitem"
@@ -1509,7 +1509,7 @@
     <xpath expr="//header//nav" position="replace">
         <div class="container py-3 px-0">
             <t t-call="website.navbar">
-                <t t-set="_navbar_classes" t-valuef="o_full_border d-none d-lg-block rounded-pill py-2 px-3 shadow-sm"/>
+                <t t-set="_navbar_classes" t-valuef="o_full_border d-none d-lg-block rounded-pill px-3 shadow-sm"/>
 
                 <div id="o_main_nav" class="o_main_nav container">
                     <!-- Brand -->
@@ -1525,6 +1525,7 @@
                             <t t-call="website.submenu">
                                 <t t-set="item_class" t-valuef="nav-item"/>
                                 <t t-set="link_class" t-valuef="nav-link"/>
+                                <t t-set="_extra_megamenu_classes" t-valuef="rounded-2"/>
                             </t>
                         </t>
                     </t>


### PR DESCRIPTION
This PR aims to solve two issues within the `rounded box` header
templates, especially in the megamenu design:

1- The megamenu is missing a border at the top. As all our header have
sharp edges, our meganumenu doesn't have a `border-top` by default to
render it correctly. This works well for all the headers except this one
as it has rounded edges.

2- The megamenu should be spaced from the header. Similar to above, our
megamenu are currently sticked to the header, for design purpose and to
ease the navigation. In the case of this specific header, it should be
spaced.

To handle these issues, we remove the border-top if we are not in the case
of the rounded box header. For the spacing issue, we rely on the navbar
padding and move the megamenu down of the same value.

task-3608124

| Master | This PR |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/386bfdd6-0483-41f6-a7fc-2f27c0be3226) | ![image](https://github.com/user-attachments/assets/19a6c442-f8ad-4729-aace-c0f2c831611e) | 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
