### PR TITLE
[IMP] mail: UI/UX improvements in mail templates

### DIFF
--- a/addons/mail/views/mail_template_views.xml
+++ b/addons/mail/views/mail_template_views.xml
@@ -25,7 +25,7 @@
                         <button string="Add Context Action"
                                 class="btn btn-secondary"
                                 name="create_action" type="object"
-                                groups="base.group_no_one"
+                                groups="base.group_system"
                                 invisible="ref_ir_act_window"
                                 help="Display an option on related documents to open a composition wizard with this template"/>
                         <button string="Remove Context Action"

--- a/addons/mail/wizard/mail_template_reset.py
+++ b/addons/mail/wizard/mail_template_reset.py
@@ -23,7 +23,7 @@ class MailTemplateReset(models.TransientModel):
             'tag': 'display_notification',
             'params': {
                 'type': 'success',
-                'message': _('Mail Templates have been reset'),
+                'message': _('The email template(s) have been restored to their original settings.'),
                 'next': next_action,
             }
         }


### PR DESCRIPTION
**Specifications:**
- 'Add Context Button' in mail templates is visible to every user, even if they do not have access of action window 
  (ir.actions.act_window), thus it gives an Access Error traceback.
- Change the reset template message.

**After this PR:**
- 'Add Context Button' will only be visible to those user who comes under group 'group_system'.
- Will change from 'Mail Templates have been reset' to 'The email template(s) have been restored to their original settings.'

Task-3524281