### PR TITLE
[FIX] (website_)sale: double confirmation mail

### DIFF
--- a/addons/sale/controllers/portal.py
+++ b/addons/sale/controllers/portal.py
@@ -283,8 +283,7 @@ class CustomerPortal(payment_portal.PaymentPortal):
             return {'error': _('Invalid signature data.')}
 
         if not order_sudo._has_to_be_paid():
-            order_sudo.action_confirm()
-            order_sudo._send_order_confirmation_mail()
+            order_sudo.with_context(send_email=True).action_confirm()
 
         pdf = request.env['ir.actions.report'].sudo()._render_qweb_pdf('sale.action_report_saleorder', [order_sudo.id])[0]
 

--- a/addons/sale/models/payment_transaction.py
+++ b/addons/sale/models/payment_transaction.py
@@ -94,7 +94,6 @@ class PaymentTransaction(models.Model):
         """ Override of payment to confirm the quotations automatically. """
         txs_to_process = super()._set_authorized(state_message=state_message, **kwargs)
         confirmed_orders = txs_to_process._check_amount_and_confirm_order()
-        confirmed_orders._send_order_confirmation_mail()
         (txs_to_process.sale_order_ids - confirmed_orders)._send_payment_succeeded_for_order_mail()
 
     def _log_message_on_linked_documents(self, message):
@@ -113,7 +112,6 @@ class PaymentTransaction(models.Model):
     def _reconcile_after_done(self):
         """ Override of payment to automatically confirm quotations and generate invoices. """
         confirmed_orders = self._check_amount_and_confirm_order()
-        confirmed_orders._send_order_confirmation_mail()
         (self.sale_order_ids - confirmed_orders)._send_payment_succeeded_for_order_mail()
 
         auto_invoice = str2bool(

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -947,6 +947,9 @@ class SaleOrder(models.Model):
 
         self.filtered(lambda so: so._should_be_locked()).action_lock()
 
+        if self.env.context.get('send_email'):
+            self._send_order_confirmation_mail()
+
         return True
 
     def _should_be_locked(self):

--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -475,13 +475,6 @@ class SaleOrder(models.Model):
                 access_opt['url'] = '%s/shop/cart?access_token=%s' % (self.get_base_url(), self.access_token)
         return groups
 
-    def action_confirm(self):
-        res = super().action_confirm()
-        for order in self:
-            if not order.transaction_ids and not order.amount_total and self._context.get('send_email'):
-                order._send_order_confirmation_mail()
-        return res
-
     def _action_confirm(self):
         for order in self:
             order_location = order.access_point_address


### PR DESCRIPTION
If a quotation template is set on an order, and that template
has a "Confirmation mail", it'll be used to send quotes on
confirmation, regardless of the flow (backend/frontend).

For frontend flows (portal/ecommerce), a confirmation mail
is sent after the order confirmation:

* after SO signature on portal (if no payment is required)
* on payment post processing (payment on portal or ecommerce)
* on free order confirmation (ecommerce)

Issue:

If a template (with confirmation mail) is used in on the quote
in one of those flows, two mails would be sent on confirmation:

* the template confirmation mail
* the default confirmation mail (could be the same mail)

Solution:

Harmonize and factorize a bit the behavior, to only send 1 mail maximum.

In backend, only send a confirmation mail if there is one configured on
the quotation template (as before).

In frontend, always send one unique mail, either the default one, or the
quotation template one if one is set.

opw-3997315
