### PR TITLE
[FIX] payment_stripe: add webhook event

### DIFF
--- a/addons/payment_stripe/const.py
+++ b/addons/payment_stripe/const.py
@@ -39,6 +39,7 @@ HANDLED_WEBHOOK_EVENTS = [
     'payment_intent.amount_capturable_updated',
     'payment_intent.succeeded',
     'payment_intent.payment_failed',
+    'payment_intent.canceled',
     'setup_intent.succeeded',
     'charge.refunded',  # A refund has been issued.
     'charge.refund.updated',  # The refund status has changed, possibly from succeeded to failed.


### PR DESCRIPTION
When the authorization of the payment expires. Happens when you do not capture manually tx in 7 days (by default). Stripe sends a webhook that payment is canceled which was not captured before this PR, hence the changes were not applied for the corresponding payment.
With this PR the cancel webhook is captured and  the corresponding payment is canceled odoo-side.


opw-3957346
