### PR TITLE
[IMP] mrp(_workorder): produce partial qty

### DIFF
--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -157,20 +157,13 @@ class MrpWorkorder(models.Model):
         # cyclic depends with the mo.state, mo.reservation_state and wo.state and avoid recursion error
         self.mapped('production_availability')
         for workorder in self:
-            if workorder.state == 'pending':
-                if all([wo.state in ('done', 'cancel') for wo in workorder.blocked_by_workorder_ids]):
-                    workorder.state = 'ready' if workorder.production_availability == 'assigned' else 'waiting'
-                    continue
-            if workorder.state not in ('waiting', 'ready'):
+            if workorder.state not in ('pending', 'waiting', 'ready'):
                 continue
-            if not all([wo.state in ('done', 'cancel') for wo in workorder.blocked_by_workorder_ids]):
+            if workorder._are_previous_workorder_blocking():
                 workorder.state = 'pending'
-                continue
-            if workorder.production_availability not in ('waiting', 'confirmed', 'assigned'):
-                continue
-            if workorder.production_availability == 'assigned' and workorder.state == 'waiting':
+            elif workorder.production_availability == 'assigned':
                 workorder.state = 'ready'
-            elif workorder.production_availability != 'assigned' and workorder.state == 'ready':
+            else:
                 workorder.state = 'waiting'
 
     @api.depends('production_state', 'date_start', 'date_finished')
@@ -897,3 +890,6 @@ class MrpWorkorder(models.Model):
 
     def _compute_current_operation_cost(self):
         return (self.get_duration() / 60.0) * (self.costs_hour or self.workcenter_id.costs_hour)
+
+    def _are_previous_workorder_blocking(self):
+        return any(w.state not in ('done', 'cancel') for w in self.blocked_by_workorder_ids)

--- a/addons/mrp/tests/test_backorder.py
+++ b/addons/mrp/tests/test_backorder.py
@@ -937,7 +937,7 @@ class TestMrpWorkorderBackorder(TransactionCase):
         bo_1 = mo.procurement_group_id.mrp_production_ids - mo
         self.assertRecordValues(bo_1.workorder_ids, [
             {'state': 'cancel', 'qty_remaining': 0.0, 'workcenter_id': op_1.workcenter_id.id},
-            {'state': 'waiting', 'qty_remaining': 6.0, 'workcenter_id': op_2.workcenter_id.id},
+            {'state': 'ready', 'qty_remaining': 6.0, 'workcenter_id': op_2.workcenter_id.id},
         ])
         with Form(bo_1) as form_bo_1:
             form_bo_1.qty_producing = 2
@@ -951,7 +951,7 @@ class TestMrpWorkorderBackorder(TransactionCase):
         bo_2 = mo.procurement_group_id.mrp_production_ids - mo - bo_1
         self.assertRecordValues(bo_2.workorder_ids, [
             {'state': 'cancel', 'qty_remaining': 0.0, 'workcenter_id': op_1.workcenter_id.id},
-            {'state': 'waiting', 'qty_remaining': 4.0, 'workcenter_id': op_2.workcenter_id.id},
+            {'state': 'ready', 'qty_remaining': 4.0, 'workcenter_id': op_2.workcenter_id.id},
         ])
         op_6 = bo_2.workorder_ids.filtered(lambda wo: wo.state != 'cancel')
         with Form(bo_2) as form_bo_2:

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -3433,7 +3433,7 @@ class TestMrpOrder(TestMrpCommon):
         mo_backorder.button_plan()
 
         self.assertEqual(mo_backorder.workorder_ids[0].state, 'cancel')
-        self.assertEqual(mo_backorder.workorder_ids[1].state, 'waiting')
+        self.assertEqual(mo_backorder.workorder_ids[1].state, 'ready')
         self.assertEqual(mo_backorder.workorder_ids[2].state, 'pending')
         self.assertFalse(mo_backorder.workorder_ids[0].date_start)
         self.assertEqual(mo_backorder.workorder_ids[1].date_start, datetime(2023, 3, 1, 12, 0))

--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -77,6 +77,7 @@
                 <field name="workcenter_id" readonly="state in ['cancel', 'done', 'progress']"/>
                 <field name="product_id" optional="show"/>
                 <field name="qty_remaining" optional="show" string="Quantity Remaining"/>
+                <field name="qty_ready" optional="hide"/>
                 <field name="finished_lot_id" optional="hide" string="Lot/Serial"/>
                 <field name="date_start" optional="hide" readonly="state in ['progress', 'done', 'cancel']"/>
                 <field name="date_finished" optional="hide" readonly="state in ['progress', 'done', 'cancel']"/>
@@ -109,6 +110,9 @@
         <field name="inherit_id" ref="mrp_production_workorder_tree_editable_view"/>
         <field name="arch" type="xml">
             <xpath expr="//list/field[@name='qty_remaining']" position="attributes">
+                <attribute name="column_invisible">parent.state == 'done'</attribute>
+            </xpath>
+            <xpath expr="//list/field[@name='qty_ready']" position="attributes">
                 <attribute name="column_invisible">parent.state == 'done'</attribute>
             </xpath>
             <xpath expr="//list/field[@name='qty_remaining']" position="after">


### PR DESCRIPTION
Allow operators to register partial production on work orders, thereby liberating work orders in the queue before marking operations as done.
This will make it much more flexible for users and also reduce the need for creating backorders, which can be quite messy and difficult to understand. 

Task [3504085](https://www.odoo.com/odoo/project/966/tasks/3504085)
odoo/enterprise#65638

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
