### PR TITLE
[IMP] web: lazy load views

### DIFF
--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -883,7 +883,7 @@
             <field name="name">project.task.activity</field>
             <field name="model">project.task</field>
             <field name="arch" type="xml">
-                <activity string="Project Tasks" js_class="project_activity">
+                <activity string="Project Tasks">
                     <field name="user_ids"/>
                     <field name="project_id"/>
                     <templates>

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -125,7 +125,7 @@
             <field name="model">stock.picking</field>
             <field eval="12" name="priority"/>
             <field name="arch" type="xml">
-                <form string="Transfer" js_class="picking_form">
+                <form string="Transfer">
                 <header>
                     <button name="action_confirm" invisible="state != 'draft'" string="Mark as Todo" type="object" class="oe_highlight" groups="base.group_user" data-hotkey="q"/>
                     <button name="action_assign" invisible="not show_check_availability" string="Check Availability" type="object" class="oe_highlight" groups="base.group_user" data-hotkey="w"/>

--- a/addons/web/__manifest__.py
+++ b/addons/web/__manifest__.py
@@ -128,6 +128,13 @@ This module provides the core of the Odoo Web Client.
             # Don't include dark mode files in light mode
             ('remove', 'web/static/src/**/*.dark.scss'),
         ],
+        'web.assets_backend_lazy': [
+            ('include', 'web._assets_helpers'),
+            'web/static/src/scss/pre_variables.scss',
+            'web/static/lib/bootstrap/scss/_variables.scss',
+            'web/static/lib/bootstrap/scss/_variables-dark.scss',
+            'web/static/lib/bootstrap/scss/_maps.scss',
+        ],
         'web.assets_web': [
             ('include', 'web.assets_backend'),
             'web/static/src/main.js',
@@ -422,6 +429,7 @@ This module provides the core of the Odoo Web Client.
             # Assets for features to test (views, services, fields, ...)
             # Typically includes most files in 'web.web.assets_backend'
             ('include', 'web.assets_backend'),
+            ('include', 'web.assets_backend_lazy'),
 
             'web/static/src/public/public_component_service.js',
             'web/static/src/webclient/clickbot/clickbot.js',
@@ -435,6 +443,7 @@ This module provides the core of the Odoo Web Client.
         ],
         'web.tests_assets': [
             ('include', 'web.assets_backend'),
+            ('include', 'web.assets_backend_lazy'),
 
             'web/static/src/public/public_component_service.js',
             'web/static/tests/legacy/patch_translations.js',

--- a/addons/web/static/src/views/view.js
+++ b/addons/web/static/src/views/view.js
@@ -10,6 +10,7 @@ import { WithSearch } from "@web/search/with_search/with_search";
 import { OnboardingBanner } from "@web/views/onboarding_banner";
 import { useActionLinks } from "@web/views/view_hook";
 import { computeViewClassName } from "./utils";
+import { loadBundle } from "@web/core/assets";
 import {
     Component,
     markRaw,
@@ -25,6 +26,7 @@ viewRegistry.addValidation({
     Controller: { validate: (c) => c.prototype instanceof Component },
     "*": true,
 });
+const DEFAULT_LAZY_BUNDLE = "web.assets_backend_lazy";
 
 /** @typedef {Object} Config
  *  @property {integer|false} actionId
@@ -310,7 +312,9 @@ export class View extends Component {
             }
         }
 
-        let subType = archXmlDoc.getAttribute("js_class");
+        const jsClass = archXmlDoc.hasAttribute("js_class")
+            ? archXmlDoc.getAttribute("js_class")
+            : type;
         const bannerRoute = archXmlDoc.getAttribute("banner_route");
         const sample = archXmlDoc.getAttribute("sample");
         const className = computeViewClassName(type, archXmlDoc, [
@@ -318,22 +322,17 @@ export class View extends Component {
             ...(props.className || "").split(" "),
         ]);
 
-        let descr = viewRegistry.get(type);
-        // determine ViewClass to instantiate (if not already done)
-        if (subType) {
-            if (viewRegistry.contains(subType)) {
-                descr = viewRegistry.get(subType);
-            } else {
-                subType = null;
-            }
+        if (!viewRegistry.contains(jsClass)) {
+            await loadBundle(DEFAULT_LAZY_BUNDLE);
         }
+        const descr = viewRegistry.get(jsClass);
 
         Object.assign(this.env.config, {
             rawArch: arch,
             viewArch: archXmlDoc,
             viewId: viewDescription.id,
             viewType: type,
-            viewSubType: subType,
+            viewSubType: jsClass,
             bannerRoute,
             noBreadcrumbs: props.noBreadcrumbs,
             ...extractLayoutComponents(descr),

--- a/addons/web/static/src/views/view.js
+++ b/addons/web/static/src/views/view.js
@@ -20,9 +20,12 @@ import {
     useSubEnv,
     reactive,
 } from "@odoo/owl";
+import { session } from "@web/session";
+
 const viewRegistry = registry.category("views");
 
 viewRegistry.addValidation({
+    type: { validate: (t) => t in session.view_info },
     Controller: { validate: (c) => c.prototype instanceof Component },
     "*": true,
 });

--- a/addons/web/static/tests/views/view.test.js
+++ b/addons/web/static/tests/views/view.test.js
@@ -1,4 +1,4 @@
-import { expect, test } from "@odoo/hoot";
+import { before, expect, test } from "@odoo/hoot";
 import { click, queryOne } from "@odoo/hoot-dom";
 import { Deferred, animationFrame, runAllTimers } from "@odoo/hoot-mock";
 import { Component, onWillStart, onWillUpdateProps, useState, xml } from "@odoo/owl";
@@ -12,6 +12,7 @@ import {
     mountWithCleanup,
     onRpc,
     patchWithCleanup,
+    serverState,
 } from "@web/../tests/web_test_helpers";
 
 import { registry } from "@web/core/registry";
@@ -44,8 +45,13 @@ class ToyControllerImp extends ToyController {
     }
 }
 
-viewRegistry.add("toy", toyView);
-viewRegistry.add("toy_imp", { ...toyView, Controller: ToyControllerImp });
+before(() => {
+    patchWithCleanup(serverState.view_info, {
+        toy: { multi_record: true, display_name: "Toy", icon: "fab fa-android" },
+    });
+    viewRegistry.add("toy", toyView);
+    viewRegistry.add("toy_imp", { ...toyView, Controller: ToyControllerImp });
+});
 
 class Animal extends models.Model {
     birthday = fields.Date();


### PR DESCRIPTION
We make possible to lazy load views. The logic is simple.
- a bundle "web.assets_backend_lazy" has been added in web.
  Basically, it contains what is needed to compile scss files.
  A view that should be lazy loaded has to be addded to that bundle.
- when a view (a js_class) has to be rendered, the view component tries to
  find it in the registry. It it can't, the lazy bundle is loaded and the
  view component tries again to find the view. A crash occurs at that
  time if the view is still not in the registry.

Task ID: `3546321`