### PR TITLE
[FIX] mrp_subcontracting: keep flexible consumption

### DIFF
--- a/addons/mrp_subcontracting/models/stock_move.py
+++ b/addons/mrp_subcontracting/models/stock_move.py
@@ -334,6 +334,9 @@ class StockMove(models.Model):
                 quantity_to_remove -= production.product_qty
                 production.with_context(skip_activity=True).action_cancel()
             else:
+                if float_is_zero(quantity_to_remove, precision_rounding=production.product_uom_id.rounding):
+                    # No need to do change_prod_qty for no change at all.
+                    break
                 self.env['change.production.qty'].with_context(skip_activity=True).create({
                     'mo_id': production.id,
                     'product_qty': production.product_uom_qty - quantity_to_remove

--- a/addons/mrp_subcontracting/tests/test_subcontracting.py
+++ b/addons/mrp_subcontracting/tests/test_subcontracting.py
@@ -568,6 +568,48 @@ class TestSubcontractingFlows(TestMrpSubcontractingCommon):
         avail_qty_comp1 = self.env['stock.quant']._get_available_quantity(self.comp1, self.subcontractor_partner1.property_stock_subcontractor, allow_negative=True)
         self.assertEqual(avail_qty_comp1, -2)
 
+    def test_flow_warning_bom_2(self):
+        """ For an initial demand of 10 subcontracted products
+            - The production of 3 is recorded, with an over-consumption of its components
+            After the picking is validated, check that the over-consumption stays as-is.
+        """
+        self.bom.consumption = 'warning'
+        # Create reception picking
+        with Form(self.env['stock.picking']) as picking_form:
+            picking_form.picking_type_id = self.warehouse.in_type_id
+            picking_form.partner_id = self.subcontractor_partner1
+            with picking_form.move_ids_without_package.new() as move:
+                move.product_id = self.finished
+                move.product_uom_qty = 10
+            receipt = picking_form.save()
+        receipt.action_confirm()
+
+        # Record the over-consumption of a component
+        self.assertTrue(receipt._get_subcontract_production())
+        action_record = receipt.action_record_components()
+        sbc_mo = self.env['mrp.production'].browse(action_record['res_id'])
+        with Form(sbc_mo.with_context(**action_record['context']), view=action_record['view_id']) as mo_form:
+            mo_form.qty_producing = 3
+            with mo_form.move_line_raw_ids.edit(0) as ml:
+                self.assertEqual(ml.product_id, self.comp1)
+                self.assertEqual(ml.qty_done, 3)
+                ml.qty_done = 5
+            sbc_mo = mo_form.save()
+        # Confirm the over-consumption through the warning
+        action_warning = sbc_mo.subcontracting_record_component()
+        wizard_warning = Form(self.env['mrp.consumption.warning'].with_context(**action_warning['context'])).save()
+        wizard_warning.action_confirm()
+
+        self.assertEqual(sbc_mo.move_raw_ids[0].move_line_ids.qty_done, 5)
+
+        # Validate the picking without backorders
+        action_backorder = receipt.button_validate()
+        wizard_backorder = Form(self.env[action_backorder['res_model']].with_context(action_backorder['context'])).save()
+        wizard_backorder.process_cancel_backorder()
+
+        # Check that the over-consumption is still present
+        self.assertEqual(sbc_mo.move_raw_ids[0].move_line_ids.qty_done, 5)
+
     def test_mrp_report_bom_structure_subcontracting(self):
         self.comp2_bom.write({'type': 'subcontract', 'subcontractor_ids': [Command.link(self.subcontractor_partner1.id)]})
         self.env['product.supplierinfo'].create({


### PR DESCRIPTION
Steps to reproduce:
- Create a subcontracted bom for a product with:
  - Flexible consumption (with warning)
  - One component requiring 1 qty
- Create a receipt for 10 for that product from the recorded subcontractor
- Click on 'Record Component' and set:
  - Quantity (subcontracted product) to 3
  - Done (component) to 5
- Record Production and validate the warning
- Discard the wizard
- Validate the picking and select 'No backorder'

Issue:
Once validated, the subcontracted consumption will be back to 3 instead of 5.

During the subcontracted move's `_action_done()`, as the move is incomplete, it will be split in two. After doing the split, the `product_uom_qty` of the initial move will be changed to its done quantity, which will trigger the update of the subcontracted demand.

This will end up triggering `change_prod_qty()` of the recorded production, but to change its quantity to the same quantity. However, doing that will reset the consumption of its components to what would be expected from the bom.

Instead of doing that, we can simply stop if there is no quantity to remove anymore before calling `change_prod_qty()`.

opw-4032052

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
