### PR TITLE
[IMP] account: Share accounts between companies.

### DIFF
--- a/addons/account/demo/account_demo.py
+++ b/addons/account/demo/account_demo.py
@@ -113,9 +113,9 @@ class AccountChartTemplate(models.AbstractModel):
             ],
             limit=1,
         )
-        default_receivable = self.env.ref('base.res_partner_3').with_company(company).property_account_receivable_id
-        income_account = self.env['account.account'].search([
-            ('company_id', '=', cid),
+        default_receivable = self.env.ref('base.res_partner_3').with_company(company or self.env.company).property_account_receivable_id
+        income_account = self.env['account.account'].with_company(company or self.env.company).search([
+            ('company_ids', '=', cid),
             ('account_type', '=', 'income'),
             ('id', '!=', (company or self.env.company).account_journal_early_pay_discount_gain_account_id.id)
         ], limit=1)
@@ -500,11 +500,11 @@ class AccountChartTemplate(models.AbstractModel):
                 ('model', '=', 'account.account'),
                 ('module', '=like', 'l10n%')
             ], limit=1).res_id)
-            or self.env['account.account'].search([
+            or self.env['account.account'].with_company(company).search([
                 *self.env['account.account']._check_company_domain(company),
                 ('account_type', '=', account_type),
             ], limit=1)
-            or self.env['account.account'].search([
+            or self.env['account.account'].with_company(company).search([
                 *self.env['account.account']._check_company_domain(company),
             ], limit=1)
         )

--- a/addons/account/models/__init__.py
+++ b/addons/account/models/__init__.py
@@ -6,6 +6,8 @@ from . import ir_http
 from . import res_partner_bank
 from . import account_account_tag
 from . import account_account
+from . import account_code_mapping
+from . import account_root
 from . import account_journal
 from . import account_lock_exception
 from . import account_tax

--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -1,28 +1,27 @@
-# -*- coding: utf-8 -*-
-from contextlib import nullcontext
-
-from odoo import api, fields, models, _, tools, Command
-from odoo.osv import expression
-from odoo.exceptions import UserError, ValidationError
-from odoo.tools import SQL, Query
 from bisect import bisect_left
 from collections import defaultdict
-import logging
+import itertools
 import re
 
-_logger = logging.getLogger(__name__)
+from odoo import api, fields, models, _, Command
+from odoo.osv import expression
+from odoo.exceptions import UserError, ValidationError, RedirectWarning
+from odoo.tools import SQL, Query
+from odoo.addons.base.models.ir_property import TYPE2FIELD
+
 
 ACCOUNT_REGEX = re.compile(r'(?:(\S*\d+\S*))?(.*)')
 ACCOUNT_CODE_REGEX = re.compile(r'^[A-Za-z0-9.]+$')
 ACCOUNT_CODE_NUMBER_REGEX = re.compile(r'(.*?)(\d*)(\D*?)$')
 
+
 class AccountAccount(models.Model):
     _name = "account.account"
     _inherit = ['mail.thread']
     _description = "Account"
-    _order = "code, company_id"
+    _order = "code"
     _check_company_auto = True
-    _check_company_domain = models.check_company_domain_parent_of
+    _check_company_domain = models.check_companies_domain_parent_of
 
     @api.constrains('account_type', 'reconcile')
     def _check_reconcile(self):
@@ -34,7 +33,7 @@ class AccountAccount(models.Model):
     def _check_account_type_unique_current_year_earning(self):
         result = self._read_group(
             domain=[('account_type', '=', 'equity_unaffected')],
-            groupby=['company_id'],
+            groupby=['company_ids'],
             aggregates=['id:recordset'],
             having=[('__count', '>', 1)],
         )
@@ -44,8 +43,8 @@ class AccountAccount(models.Model):
     name = fields.Char(string="Account Name", required=True, index='trigram', tracking=True, translate=True)
     currency_id = fields.Many2one('res.currency', string='Account Currency', tracking=True,
         help="Forces all journal items in this account to have a specific currency (i.e. bank journals). If no currency is set, entries can use any currency.")
-    company_currency_id = fields.Many2one(related='company_id.currency_id')
-    code = fields.Char(size=64, required=True, tracking=True, index=True)
+    company_currency_id = fields.Many2one('res.currency', compute='_compute_company_currency_id')
+    code = fields.Char(string="Code", size=64, tracking=True, compute='_compute_code', search='_search_code', inverse='_inverse_code')
     deprecated = fields.Boolean(default=False, tracking=True)
     used = fields.Boolean(compute='_compute_used', search='_search_used')
     account_type = fields.Selection(
@@ -100,8 +99,9 @@ class AccountAccount(models.Model):
         check_company=True,
         context={'append_type_to_tax_name': True})
     note = fields.Text('Internal Notes', tracking=True)
-    company_id = fields.Many2one('res.company', string='Company', required=True, readonly=False,
+    company_ids = fields.Many2many('res.company', string='Companies', required=True, readonly=False,
         default=lambda self: self.env.company)
+    code_mapping_ids = fields.One2many(comodel_name='account.code.mapping', inverse_name='account_id')
     tag_ids = fields.Many2many(
         comodel_name='account.account.tag',
         relation='account_account_account_tag',
@@ -111,9 +111,9 @@ class AccountAccount(models.Model):
         ondelete='restrict',
         tracking=True,
     )
-    group_id = fields.Many2one('account.group', compute='_compute_account_group', store=True, readonly=True,
+    group_id = fields.Many2one('account.group', compute='_compute_account_group',
                                help="Account prefixes can determine account groups.")
-    root_id = fields.Many2one('account.root', compute='_compute_account_root', store=True, precompute=True)
+    root_id = fields.Many2one('account.root', compute='_compute_account_root', search='_search_account_root')
     allowed_journal_ids = fields.Many2many(
         'account.journal',
         string="Allowed Journals",
@@ -134,29 +134,31 @@ class AccountAccount(models.Model):
     def _field_to_sql(self, alias: str, fname: str, query: (Query | None) = None, flush: bool = True) -> SQL:
         if fname == 'internal_group':
             return SQL("split_part(account_account.account_type, '_', 1)", to_flush=self._fields['account_type'])
-        return super()._field_to_sql(alias, fname, query, flush)
+        if fname == 'code':
+            field = self._fields.get(fname)
 
-    @api.constrains('company_id', 'code')
-    def _constrains_code(self):
-        # check for duplicates in each root company
-        by_root_company = self.grouped(lambda record: record.company_id.root_id)
-        for root_company, records in by_root_company.items():
-            by_code = records.grouped('code')
-            if len(by_code) < len(records):
-                # retrieve duplicates within self
-                duplicates = next(recs for recs in by_code.values() if len(recs) > 1)
-            else:
-                # search for duplicates of self in database
-                duplicates = self.search([
-                    ('company_id', 'child_of', root_company.id),
-                    ('code', 'in', list(by_code)),
-                    ('id', 'not in', records.ids),
-                ])
-            if duplicates:
-                raise ValidationError(
-                    _("The code of the account must be unique per company!")
-                    + "\n" + "\n".join(f"- {duplicate.code} in {duplicate.company_id.name}" for duplicate in duplicates)
+            company_dependent_field_alias = query.make_alias(alias, f'{field.name}_company_dependent')
+            query.add_join('LEFT JOIN', alias=company_dependent_field_alias, table='ir_property', condition=SQL(
+                    """
+                        %(ir_property_fields_id)s = %(field_id)s
+                        AND %(ir_property_company_id)s = %(root_company_id)s
+                        AND %(ir_property_res_id)s = 'account.account,' || %(account_id)s::text
+                    """,
+                    ir_property_fields_id=self.env['ir.property']._field_to_sql(company_dependent_field_alias, 'fields_id'),
+                    field_id=self.env['ir.model.fields']._get(self._name, field.name).id,
+                    ir_property_company_id=self.env['ir.property']._field_to_sql(company_dependent_field_alias, 'company_id'),
+                    root_company_id=self.env.company.root_id.id,
+                    ir_property_res_id=self.env['ir.property']._field_to_sql(company_dependent_field_alias, 'res_id'),
+                    account_id=SQL.identifier(alias, 'id'),
                 )
+            )
+
+            # This is the field on ir.property that will contain the value of 'code'.
+            value_field = self.env['ir.property']._fields[TYPE2FIELD[field.type]]
+
+            return self.env['ir.property']._field_to_sql(company_dependent_field_alias, value_field.name)
+
+        return super()._field_to_sql(alias, fname, query, flush)
 
     @api.constrains('reconcile', 'account_type', 'tax_ids')
     def _constrains_reconcile(self):
@@ -255,14 +257,19 @@ class AccountAccount(models.Model):
                 account=account.display_name
             ))
 
-    @api.constrains('company_id')
+    @api.constrains('company_ids')
     def _check_company_consistency(self):
-        for company, accounts in tools.groupby(self, lambda account: account.company_id):
-            if self.env['account.move.line'].search_count([
-                ('account_id', 'in', [account.id for account in accounts]),
-                '!', ('company_id', 'child_of', company.id)
+        if accounts_without_company := self.filtered(lambda a: not a.sudo().company_ids):
+            raise ValidationError(
+                _("The following accounts must be assigned to at least one company:")
+                + "\n" + "\n".join(f"- {account.display_name}" for account in accounts_without_company)
+            )
+        for companies, accounts in self.grouped(lambda a: a.company_ids).items():
+            if self.env['account.move.line'].sudo().search_count([
+                ('account_id', 'in', accounts.ids),
+                '!', ('company_id', 'child_of', companies.ids)
             ], limit=1):
-                raise UserError(_("You can't change the company of your account since there are some journal items linked to it."))
+                raise UserError(_("You can't unlink this company from this account since there are some journal items linked to it."))
 
     @api.constrains('account_type')
     def _check_account_type_sales_purchase_journal(self):
@@ -325,7 +332,7 @@ class AccountAccount(models.Model):
     @api.constrains('code')
     def _check_account_code(self):
         for account in self:
-            if not re.match(ACCOUNT_CODE_REGEX, account.code):
+            if account.code and not re.match(ACCOUNT_CODE_REGEX, account.code):
                 raise ValidationError(_(
                     "The account code can only contain alphanumeric characters and dots."
                 ))
@@ -346,20 +353,83 @@ class AccountAccount(models.Model):
         if self._cr.fetchone():
             raise ValidationError(_("You cannot change the type of an account set as Bank Account on a journal to Receivable or Payable."))
 
+    @api.depends_context('company')
+    def _compute_code(self):
+        values = self.env['ir.property'].with_company(self.env.company.root_id).sudo()._get_multi('code', 'account.account', self.ids)
+        for record in self:
+            # Need to set record.code with `company = self.env.company`, not `self.env.company.root_id`
+            record.code = values.get(record.id)
+
+    def _search_code(self, operator, value):
+        return self._fields['code']._search_company_dependent(self.with_company(self.env.company.root_id), operator, value)
+
+    def _inverse_code(self):
+        values = {
+            # Need to access record.code with `company = self.env.company`
+            record.id: self._fields['code'].convert_to_write(record.code, record)
+            for record in self
+        }
+        self.env['ir.property'].with_company(self.env.company.root_id).sudo()._set_multi('code', 'account.account', values)
+
+    @api.depends_context('company')
     @api.depends('code')
     def _compute_account_root(self):
-        # this computes the first 2 digits of the account.
-        # This field should have been a char, but the aim is to use it in a side panel view with hierarchy, and it's only supported by many2one fields so far.
-        # So instead, we make it a many2one to a psql view with what we need as records.
         for record in self:
-            record.root_id = (ord(record.code[0]) * 1000 + ord(record.code[1:2] or '\x00')) if record.code else False
+            record.root_id = self.env['account.root']._from_account_code(record.code)
 
+    def _search_account_root(self, operator, value):
+        if operator in ['=', 'child_of']:
+            root = self.env['account.root'].browse(value)
+            return [('code', '=like', root.name + ('' if operator == '=' and not root.parent_id else '%'))]
+        raise NotImplementedError
+
+    def _search_panel_domain_image(self, field_name, domain, set_count=False, limit=False):
+        if field_name != 'root_id' or set_count:
+            return super()._search_panel_domain_image(field_name, domain, set_count, limit)
+
+        if expression.is_false(self, domain):
+            return {}
+
+        query_account = self.env['account.account']._search(domain, limit=limit)
+        account_code_alias = self.env['account.account']._field_to_sql('account_account', 'code', query_account)
+
+        account_codes = self.env.execute_query(query_account.select(account_code_alias))
+        return {
+            (root := self.env['account.root']._from_account_code(code)).id: {'id': root.id, 'display_name': root.display_name}
+            for code, in account_codes if code
+        }
+
+    @api.depends_context('company')
     @api.depends('code')
     def _compute_account_group(self):
-        if self.ids:
-            self.env['account.group']._adapt_accounts_for_account_groups(self)
-        else:
-            self.group_id = False
+        accounts_with_code = self.filtered(lambda a: a.code)
+
+        (self - accounts_with_code).group_id = False
+
+        if not accounts_with_code:
+            return
+
+        codes = accounts_with_code.mapped('code')
+        account_code_values = SQL(','.join(['(%s)'] * len(codes)), *codes)
+        results = self.env.execute_query(SQL(
+            """
+                 SELECT DISTINCT ON (account_code.code)
+                        account_code.code,
+                        agroup.id AS group_id
+                   FROM (VALUES %(account_code_values)s) AS account_code (code)
+              LEFT JOIN account_group agroup
+                     ON agroup.code_prefix_start <= LEFT(account_code.code, char_length(agroup.code_prefix_start))
+                        AND agroup.code_prefix_end >= LEFT(account_code.code, char_length(agroup.code_prefix_end))
+                        AND agroup.company_id = %(root_company_id)s
+               ORDER BY account_code.code, char_length(agroup.code_prefix_start) DESC, agroup.id
+            """,
+            account_code_values=account_code_values,
+            root_company_id=self.env.company.root_id.id,
+        ))
+        group_by_code = dict(results)
+
+        for account in accounts_with_code:
+            account.group_id = group_by_code[account.code]
 
     def _search_used(self, operator, value):
         if operator not in ['=', '!='] or not isinstance(value, bool):
@@ -378,7 +448,7 @@ class AccountAccount(models.Model):
             record.used = record.id in ids
 
     @api.model
-    def _search_new_account_code(self, start_code, company, cache=None):
+    def _search_new_account_code(self, start_code, cache=None):
         """ Get an available account code by starting from an existing code
             and incrementing it until an available code is found.
 
@@ -394,7 +464,6 @@ class AccountAccount(models.Model):
                 |     9998     |  9999, 9998.copy, 9998.copy2, 9998.copy3, ...              |
 
             :param start_code str: the code to increment until an available one is found
-            :param res.company company: the company for which to find an available account code
             :param set[str] cache: a set of codes which you know are already used
                                     (optional, to speed up the method).
                                     If none is given, the method will use cache = {start_code}.
@@ -413,7 +482,7 @@ class AccountAccount(models.Model):
             cache = {start_code}
 
         def code_is_available(new_code):
-            return new_code not in cache and not self.search_count([('code', '=', new_code), ('company_id', 'child_of', company.root_id.id)], limit=1)
+            return new_code not in cache and not self.search_count([('code', '=', new_code)], limit=1)
 
         if code_is_available(start_code):
             return start_code
@@ -432,11 +501,12 @@ class AccountAccount(models.Model):
 
         raise UserError(_('Cannot generate an unused account code.'))
 
+    @api.depends_context('company')
     def _compute_current_balance(self):
         balances = {
             account.id: balance
             for account, balance in self.env['account.move.line']._read_group(
-                domain=[('account_id', 'in', self.ids), ('parent_state', '=', 'posted')],
+                domain=[('account_id', 'in', self.ids), ('parent_state', '=', 'posted'), ('company_id', '=', self.env.company.id)],
                 groupby=['account_id'],
                 aggregates=['balance:sum'],
             )
@@ -444,29 +514,40 @@ class AccountAccount(models.Model):
         for record in self:
             record.current_balance = balances.get(record.id, 0)
 
+    @api.depends_context('company')
     def _compute_related_taxes_amount(self):
         for record in self:
             record.related_taxes_amount = self.env['account.tax'].search_count([
+                *self.env['account.tax']._check_company_domain(self.env.company),
                 ('repartition_line_ids.account_id', '=', record.id),
             ])
 
+    @api.depends_context('company')
+    def _compute_company_currency_id(self):
+        self.company_currency_id = self.env.company.currency_id
+
+    @api.depends_context('company')
     def _compute_opening_debit_credit(self):
         self.opening_debit = 0
         self.opening_credit = 0
         self.opening_balance = 0
-        if not self.ids:
+        opening_move = self.env.company.account_opening_move_id
+        if not self.ids or not opening_move:
             return
-        self.env.cr.execute("""
+        self.env.cr.execute(SQL(
+            """
             SELECT line.account_id,
                    SUM(line.balance) AS balance,
                    SUM(line.debit) AS debit,
                    SUM(line.credit) AS credit
               FROM account_move_line line
-              JOIN res_company comp ON comp.id = line.company_id
-             WHERE line.move_id = comp.account_opening_move_id
-               AND line.account_id IN %s
+             WHERE line.move_id = %(opening_move_id)s
+               AND line.account_id IN %(account_ids)s
              GROUP BY line.account_id
-        """, [tuple(self.ids)])
+            """,
+            account_ids=tuple(self.ids),
+            opening_move_id=opening_move.id,
+        ))
         result = {r['account_id']: r for r in self.env.cr.dictfetchall()}
         for record in self:
             res = result.get(record.id) or {'debit': 0, 'credit': 0, 'balance': 0}
@@ -496,18 +577,18 @@ class AccountAccount(models.Model):
         assert field_name in self._fields
 
         all_accounts = self.search_read(
-            domain=[('company_id', 'in', accounts_to_process.company_id.ids)],
-            fields=['code', field_name, 'company_id'],
+            domain=self._check_company_domain(self.env.company),
+            fields=['code', field_name],
             order='code',
         )
-        accounts_with_codes = defaultdict(dict)
+        accounts_with_codes = {}
         # We want to group accounts by company to only search for account codes of the current company
         for account in all_accounts:
-            accounts_with_codes[account['company_id'][0]][account['code']] = account[field_name]
+            accounts_with_codes[account['code']] = account[field_name]
         for account in accounts_to_process:
-            codes_list = list(accounts_with_codes[account.company_id.id].keys())
+            codes_list = list(accounts_with_codes.keys())
             closest_index = bisect_left(codes_list, account.code) - 1
-            account[field_name] = accounts_with_codes[account.company_id.id][codes_list[closest_index]] if closest_index != -1 else default_value
+            account[field_name] = accounts_with_codes[codes_list[closest_index]] if closest_index != -1 else default_value
 
     @api.depends('account_type')
     def _compute_include_initial_balance(self):
@@ -572,9 +653,9 @@ class AccountAccount(models.Model):
             self._cr.precommit.add(self._load_precommit_update_opening_move)
         else:
             data = self._cr.precommit.data['import_account_opening_balance']
-        data.setdefault(self.id, [None, None])
+        data.setdefault(self.env.company.id, {}).setdefault(self.id, [None, None])
         index = 0 if field == 'debit' else 1
-        data[self.id][index] = amount
+        data[self.env.company.id][self.id][index] = amount
 
     @api.model
     def default_get(self, default_fields):
@@ -623,18 +704,22 @@ class AccountAccount(models.Model):
             _kind, rhs_table, condition = query._joins['account_move_line__account_id']
             query._joins['account_move_line__account_id'] = (SQL("RIGHT JOIN"), rhs_table, condition)
 
+        company = self.env['res.company'].browse(company_id)
+        code_sql = self.with_company(company)._field_to_sql('account_move_line__account_id', 'code', query)
+
         return [r[0] for r in self.env.execute_query(SQL(
             """
-            SELECT account_move_line__account_id.id
-              FROM %s
-             WHERE %s
-          GROUP BY account_move_line__account_id.id
-          ORDER BY COUNT(account_move_line.id) DESC, account_move_line__account_id.code
-                %s
+                SELECT account_move_line__account_id.id
+                  FROM %(from_clause)s
+                 WHERE %(where_clause)s
+              GROUP BY account_move_line__account_id.id
+              ORDER BY COUNT(account_move_line.id) DESC, MAX(%(code_sql)s)
+                %(limit_clause)s
             """,
-            query.from_clause,
-            query.where_clause or SQL("TRUE"),
-            SQL("LIMIT %s", limit) if limit else SQL(),
+            from_clause=query.from_clause,
+            where_clause=query.where_clause or SQL("TRUE"),
+            code_sql=code_sql,
+            limit_clause=SQL("LIMIT %s", limit) if limit else SQL(),
         ))]
 
     @api.model
@@ -679,24 +764,38 @@ class AccountAccount(models.Model):
             self.name = name
             self.code = code
 
+    @api.depends_context('company')
     @api.depends('code')
     def _compute_display_name(self):
         for account in self:
             account.display_name = f"{account.code} {account.name}"
 
     def copy_data(self, default=None):
-        default = dict(default or {})
         vals_list = super().copy_data(default)
-        cache_map = defaultdict(set)
+        default = default or {}
+
+        # We must restrict check_company fields to values available to the company of the new account.
+        fields_to_filter_by_company = {field for field in self._fields.values() if field.relational and field.check_company}
+        cache = defaultdict(set)
         for account, vals in zip(self, vals_list):
+            match vals.get('company_ids'):
+                case [(Command.LINK, company_id, 0)] | [(Command.SET, 0, [company_id])] | [company_id] if isinstance(company_id, int):
+                    company = self.env['res.company'].browse(company_id)
+                case _:
+                    raise ValueError(_("You may only give an account a single company at creation."))
             if 'code' not in default:
-                company = default.get('company_id', account.company_id)
-                company = company if isinstance(company, models.BaseModel) else account.env['res.company'].browse(company)
-                cache = cache_map[company.id]
-                vals['code'] = account._search_new_account_code(account.code, company, cache)
-                cache.add(vals['code'])
+                start_code = account.with_company(company).code or account.with_company(account.company_ids[0]).code
+                vals['code'] = account.with_company(company)._search_new_account_code(start_code, cache[company])
+                cache[company].add(vals['code'])
             if 'name' not in default:
                 vals['name'] = _("%s (copy)", account.name or '')
+
+            # For check_company fields, only keep values that are compatible with the new account's company.
+            for field in fields_to_filter_by_company:
+                if field.name not in default:
+                    corecord = account[field.name]
+                    filtered_corecord = corecord.filtered_domain(corecord._check_company_domain(company))
+                    vals[field.name] = filtered_corecord.id if field.type == 'many2one' else [Command.set(filtered_corecord.ids)]
         return vals_list
 
     def copy_translations(self, new, excluded=()):
@@ -718,14 +817,12 @@ class AccountAccount(models.Model):
         to update the opening move accordingly.
         """
         data = self._cr.precommit.data.pop('import_account_opening_balance', {})
-        accounts = self.browse(data.keys())
 
-        accounts_per_company = defaultdict(lambda: self.env['account.account'])
-        for account in accounts:
-            accounts_per_company[account.company_id] |= account
-
-        for company, company_accounts in accounts_per_company.items():
-            company._update_opening_move({account: data[account.id] for account in company_accounts})
+        for company_id, account_values in data.items():
+            self.env['res.company'].browse(company_id)._update_opening_move({
+                self.env['account.account'].browse(account_id): values
+                for account_id, values in account_values.items()
+            })
 
     def _toggle_reconcile_to_true(self):
         '''Toggle the `reconcile´ boolean from False -> True
@@ -783,16 +880,27 @@ class AccountAccount(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
-        cache_map = defaultdict(list)
-        for vals in vals_list:
-            if 'prefix' in vals:
-                company = self.env['res.company'].browse(vals.get('company_id')) or self.env.company
-                cache = cache_map[company.id]
-                prefix, digits = vals.pop('prefix'), vals.pop('code_digits')
-                start_code = prefix.ljust(digits-1, '0') + '1' if len(prefix) < digits else prefix
-                vals['code'] = self._search_new_account_code(start_code, company, cache)
-                cache.append(vals['code'])
-        return super().create(vals_list)
+        records_list = []
+        for company_ids, vals_list_for_company in itertools.groupby(vals_list, lambda v: v.get('company_ids')):
+            match company_ids:
+                case None:
+                    company = self.env.company
+                case [(Command.LINK, company_id, *_)] | [(Command.SET, 0, [company_id])] | [company_id] if isinstance(company_id, int):
+                    company = self.env['res.company'].browse(company_id)
+                case _:
+                    raise ValueError(_("You may only give an account a single company at creation."))
+            cache = set()
+            vals_list_for_company = list(vals_list_for_company)
+            for vals in vals_list_for_company:
+                if 'prefix' in vals:
+                    prefix, digits = vals.pop('prefix'), vals.pop('code_digits')
+                    start_code = prefix.ljust(digits - 1, '0') + '1' if len(prefix) < digits else prefix
+                    vals['code'] = self.with_company(company)._search_new_account_code(start_code, cache)
+                    cache.add(vals['code'])
+            records_list.append(super(AccountAccount, self.with_company(company)).create(vals_list_for_company))
+        records = self.env['account.account'].union(*records_list)
+        records.with_context(allowed_company_ids=records.company_ids.ids)._ensure_code_is_unique()
+        return records
 
     def write(self, vals):
         if 'reconcile' in vals:
@@ -805,8 +913,37 @@ class AccountAccount(models.Model):
             for account in self:
                 if self.env['account.move.line'].search_count([('account_id', '=', account.id), ('currency_id', 'not in', (False, vals['currency_id']))]):
                     raise UserError(_('You cannot set a currency on this account as it already has some journal entries having a different foreign currency.'))
+        res = super().write(vals)
+        if {'company_ids', 'code'} & vals.keys():
+            self._ensure_code_is_unique()
+        return res
 
-        return super(AccountAccount, self).write(vals)
+    def _ensure_code_is_unique(self):
+        """ Ensure that for each company to which the account belongs, the code is set
+        and that codes are unique per-company. """
+        accounts = self.sudo()
+        for account in accounts:
+            for company in account.company_ids:
+                if not account.with_company(company).code:
+                    raise ValidationError(_("The code must be set for every company to which this account belongs."))
+        accounts_with_code = accounts.filtered(lambda a: a.code)
+        accounts_by_code = accounts_with_code.grouped('code')
+        duplicate_codes = None
+        if len(accounts_by_code) < len(accounts_with_code):
+            duplicate_codes = [code for code, accounts in accounts_by_code.items() if len(accounts) > 1]
+        # search for duplicates of self in database
+        elif duplicates := self.sudo().search_fetch(
+            [
+                ('code', 'in', list(accounts_by_code)),
+                ('id', 'not in', self.ids),
+            ],
+            ['code'],
+        ):
+            duplicate_codes = duplicates.mapped('code')
+        if duplicate_codes:
+            raise ValidationError(
+                _("Account codes must be unique. You can't create accounts with these duplicate codes: %s", ", ".join(duplicate_codes))
+            )
 
     def _load_records_write(self, values):
         if 'prefix' in values:
@@ -863,6 +1000,195 @@ class AccountAccount(models.Model):
 
     def _merge_method(self, destination, source):
         raise UserError(_("You cannot merge accounts."))
+
+    def action_merge(self):
+        """ Merge the accounts in `self`:
+            - the first one is extended to each company of the accounts in `self`, keeping their codes and names;
+            - the others are deleted; and
+            - journal items and other references are retargeted to the first account.
+
+            If the companies of several accounts overlap, this is an accounting operation, so we check that no impacted entries are in a locked period.
+            If the companies don't overlap, from an accounting perspective, each company still has its own independent view of the account.
+        """
+        # Step 1: Perform checks and get account to merge into.
+        account_to_merge_into, code_by_company = self._check_action_merge_possible()
+
+        # Step 2: If needed, ask the user for confirmation.
+        self._action_merge_get_user_confirmation(account_to_merge_into)
+
+        # Step 3: Perform merge.
+        self._action_merge(account_to_merge_into, code_by_company)
+
+        return {
+            'type': 'ir.actions.client',
+            'tag': 'display_notification',
+            'params': {
+                'type': 'success',
+                'sticky': False,
+                'message': _("Accounts successfully merged!"),
+                'next': {'type': 'ir.actions.act_window_close'},
+            }
+        }
+
+    def _check_action_merge_possible(self):
+        """ Perform checks to determine whether the accounts in `self` can be merged,
+        and return an account to merge the others into.
+
+        :return: (account_to_merge_into, code_by_company)
+        where account_to_merge_into is the account that other accounts should be merged into,
+        and code_by_company is a dict of the codes that should be given to the merged account.
+        """
+        if len(self) < 2:
+            raise UserError(_("You must select at least 2 accounts to merge."))
+
+        for field in ['currency_id', 'deprecated', 'account_type', 'reconcile', 'non_trade']:
+            if len(set(self.mapped(field))) > 1:
+                raise UserError(_(
+                    "You may only merge accounts that have the same account type, currency, deprecated status, "
+                    "reconciliation status, and trade/non-trade receivable status."
+                ))
+
+        # If there are hashed entries in an account, then the merge must preserve that account's.
+        accounts_with_hashed_entries = self.filtered(
+            lambda a: self.env['account.move.line'].sudo().search_count([
+                ('account_id', '=', a.id),
+                ('parent_state', '=', 'posted'),
+                ('move_id.inalterable_hash', '!=', False)
+            ], limit=1)
+        )
+
+        match len(accounts_with_hashed_entries):
+            case 0:
+                account_to_merge_into = None
+                code_by_company = {}
+            case 1:
+                # If exactly one of the accounts contains hashed entries, we must merge the other ones into it,
+                # otherwise the hash will be broken.
+                account_to_merge_into = accounts_with_hashed_entries
+                code_by_company = {company: account_to_merge_into.with_company(company).sudo().code for company in account_to_merge_into.company_ids}
+            case _:
+                raise UserError(_(
+                    "Accounts %s contain hashed entries, so cannot be merged.",
+                    ", ".join(accounts_with_hashed_entries.mapped('display_name'))
+                ))
+
+        # If there are locked entries in an account, then the merge must preserve that account's code in the companies of those locked entries.
+        accounts_by_company = defaultdict(lambda: self.env['account.account'])
+        for account in self:
+            for company in account.company_ids:
+                accounts_by_company[company] |= account
+
+        for company, accounts in accounts_by_company.items():
+            if len(accounts) > 1 and (user_lock_date := max(company.user_fiscalyear_lock_date, company.user_hard_lock_date)):
+                locked_accounts = accounts.filtered(
+                    lambda a: self.env['account.move.line'].sudo().search_count([
+                        ('account_id', '=', a.id),
+                        ('company_id', '=', company.id),
+                        ('parent_state', '=', 'posted'),
+                        ('date', '<=', user_lock_date),
+                    ], limit=1)
+                )
+                if not locked_accounts:
+                    pass
+                elif company in code_by_company and locked_accounts != account_to_merge_into:
+                    raise UserError(_(
+                        "Company %(company_name)s (lock date %(lock_date)s): "
+                        "cannot merge account %(hashed_account_name)s that contains hashed entries "
+                        "with accounts %(locked_account_names)s that contain locked entries.",
+                        company_name=company.name,
+                        lock_date=user_lock_date,
+                        hashed_account_name=account_to_merge_into.display_name,
+                        locked_account_names=", ".join(a.display_name for a in locked_accounts - account_to_merge_into),
+                    ))
+                elif len(locked_accounts) == 1:
+                    code_by_company[company] = locked_accounts.with_company(company).sudo().code
+                else:
+                    raise UserError(_(
+                        "Company %(company_name)s (lock date %(lock_date)s): "
+                        "cannot merge accounts %(locked_account_names)s that both contain locked entries.",
+                        company_name=company.name,
+                        lock_date=user_lock_date,
+                        locked_account_names=", ".join(account.display_name for account in locked_accounts),
+                    ))
+            else:
+                code_by_company[company] = accounts[0].with_company(company).sudo().code
+
+        return account_to_merge_into or self[0], code_by_company
+
+    def _action_merge_get_user_confirmation(self, account_to_merge_into):
+        """ Open a RedirectWarning asking the user whether to proceed with the merge. """
+        if self.env.context.get('account_merge_confirm'):
+            return
+
+        is_irreversible = len(self.company_ids) != sum(len(account.company_ids) for account in self)
+        accounts_to_remove = self - account_to_merge_into
+
+        msg = _("Are you sure? This will perform the following operations:\n")
+        for account in accounts_to_remove:
+            msg += _(
+                "- %(account_1)s (company: %(companies_1)s) will be merged into %(account_2)s (company: %(companies_2)s)\n",
+                account_1=account.with_company(account.company_ids[:1]).display_name,
+                companies_1=",".join(account.company_ids.mapped('name')),
+                account_2=account_to_merge_into.with_company(account_to_merge_into.company_ids[:1]).display_name,
+                companies_2=",".join(account_to_merge_into.company_ids.mapped('name')),
+            )
+        if is_irreversible:
+            msg += _(
+                "This cannot be undone because you are merging accounts belonging to the same company.\n"
+                "After merging, we won't be able to separate journal items based on which account they originally referenced."
+            )
+        action = self.env['ir.actions.actions']._for_xml_id('account.action_merge_accounts')
+        raise RedirectWarning(msg, action, _("Merge"), additional_context={**self.env.context, 'account_merge_confirm': True})
+
+    def _action_merge(self, account_to_merge_into, code_by_company):
+        """ Perform the merge of the accounts in `self` into `account_to_merge_into`.
+        This will update the account codes of `account_to_merge_into` based on those of `self`,
+        and update keys in DB from `self` to `account_to_merge_into`.
+        This method expects checks to already have been performed.
+        """
+        # Step 1: Keep track of the company_ids we should write on the account.
+        # We will do so only at the end, to avoid triggering the constraint that prevents duplicate codes.
+        # Writing the codes will be handled by the update of ir_property.
+        company_ids_to_write = self.sudo().company_ids
+
+        # Step 2: Check that we have write access to all the accounts and access to all the companies
+        # of these accounts.
+        self.check_access_rights('write')
+        self.check_access_rule('write')
+        if forbidden_companies := (self.sudo().company_ids - self.env.user.company_ids):
+            raise UserError(_(
+                "You do not have the right to perform this operation as you do not have access to the following companies: %s.",
+                ", ".join(c.name for c in forbidden_companies)
+            ))
+
+        # Step 3: Update records in DB.
+        accounts_to_remove = self - account_to_merge_into
+
+        # 3.1: Update foreign keys in DB
+        wiz = self.env['base.partner.merge.automatic.wizard'].new()
+        wiz._update_foreign_keys_generic('account.account', accounts_to_remove, account_to_merge_into)
+
+        # 3.2: Update Reference and Many2OneReference fields that reference account.account
+        wiz._update_reference_fields_generic('account.account', accounts_to_remove, account_to_merge_into)
+
+        # Step 4: Remove merged accounts
+        self.env.invalidate_all()
+        self.env.cr.execute(SQL(
+            """
+             DELETE FROM account_account
+              WHERE id IN %(account_ids_to_delete)s
+            """,
+            account_ids_to_delete=tuple(accounts_to_remove.ids),
+        ))
+
+        # Clear ir.model.data ormcache
+        self.env.registry.clear_cache()
+
+        # Step 5: Write company_ids and codes on the account
+        for company, code in code_by_company.items():
+            account_to_merge_into.with_company(company).sudo().code = code
+
+        account_to_merge_into.sudo().company_ids = company_ids_to_write
 
 
 class AccountGroup(models.Model):
@@ -952,73 +1278,20 @@ class AccountGroup(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         groups = super().create([self._sanitize_vals(vals) for vals in vals_list])
-        groups._adapt_accounts_for_account_groups()
         groups._adapt_parent_account_group()
         return groups
 
     def write(self, vals):
         res = super(AccountGroup, self).write(self._sanitize_vals(vals))
         if 'code_prefix_start' in vals or 'code_prefix_end' in vals:
-            self._adapt_accounts_for_account_groups()
             self._adapt_parent_account_group()
         return res
 
     def unlink(self):
         for record in self:
-            account_ids = self.env['account.account'].search([('group_id', '=', record.id)])
-            account_ids.write({'group_id': record.parent_id.id})
-
             children_ids = self.env['account.group'].search([('parent_id', '=', record.id)])
             children_ids.write({'parent_id': record.parent_id.id})
         return super().unlink()
-
-    def _adapt_accounts_for_account_groups(self, account_ids=None, company=None):
-        """Ensure consistency between accounts and account groups.
-
-        Find and set the most specific group matching the code of the account.
-        The most specific is the one with the longest prefixes and with the starting
-        prefix being smaller than the account code and the ending prefix being greater.
-        """
-        if self.env.context.get('delay_account_group_sync'):
-            return
-
-        self.flush_model()
-        self.env['account.account'].flush_model(['code'])
-
-        if company:
-            company_ids = company.root_id.ids
-        elif account_ids:
-            company_ids = account_ids.company_id.root_id.ids
-            account_ids = account_ids.ids
-        else:
-            company_ids = self.company_id.ids
-            account_ids = []
-        if not company_ids and not account_ids:
-            return
-        account_where_clause = SQL('account.company_id IN %s', tuple(company_ids))
-        if account_ids:
-            account_where_clause = SQL('%s AND account.id IN %s', account_where_clause, tuple(account_ids))
-
-        self._cr.execute(SQL("""
-            WITH relation AS (
-                 SELECT DISTINCT ON (account.id)
-                        account.id AS account_id,
-                        agroup.id AS group_id
-                   FROM account_account account
-                   JOIN res_company account_company ON account_company.id = account.company_id
-              LEFT JOIN account_group agroup
-                     ON agroup.code_prefix_start <= LEFT(account.code, char_length(agroup.code_prefix_start))
-                    AND agroup.code_prefix_end >= LEFT(account.code, char_length(agroup.code_prefix_end))
-                    AND agroup.company_id = split_part(account_company.parent_path, '/', 1)::int
-                  WHERE %s
-               ORDER BY account.id, char_length(agroup.code_prefix_start) DESC, agroup.id
-            )
-            UPDATE account_account
-               SET group_id = rel.group_id
-              FROM relation rel
-             WHERE account_account.id = rel.account_id
-        """, account_where_clause))
-        self.env['account.account'].invalidate_model(['group_id'], flush=False)
 
     def _adapt_parent_account_group(self, company=None):
         """Ensure consistency of the hierarchy of account groups.
@@ -1062,31 +1335,3 @@ class AccountGroup(models.Model):
         updated_rows = self.env.cr.fetchall()
         if updated_rows:
             self.invalidate_model(['parent_id'])
-
-
-class AccountRoot(models.Model):
-    _name = 'account.root'
-    _description = 'Account codes first 2 digits'
-    _auto = False
-
-    name = fields.Char()
-    parent_id = fields.Many2one('account.root')
-    company_id = fields.Many2one('res.company')
-
-    def init(self):
-        tools.drop_view_if_exists(self.env.cr, self._table)
-        self.env.execute_query(SQL('''
-            CREATE OR REPLACE VIEW %s AS (
-            SELECT DISTINCT ASCII(code) * 1000 + ASCII(SUBSTRING(code,2,1)) AS id,
-                   LEFT(code,2) AS name,
-                   ASCII(code) AS parent_id,
-                   company_id
-            FROM account_account WHERE code != ''
-            UNION ALL
-            SELECT DISTINCT ASCII(code) AS id,
-                   LEFT(code,1) AS name,
-                   NULL::int AS parent_id,
-                   company_id
-            FROM account_account WHERE code != ''
-            )''', SQL.identifier(self._table)
-        ))

--- a/addons/account/models/account_bank_statement_line.py
+++ b/addons/account/models/account_bank_statement_line.py
@@ -505,7 +505,7 @@ class AccountBankStatementLine(models.Model):
     def _get_default_amls_matching_domain(self):
         self.ensure_one()
         all_reconcilable_account_ids = self.env['account.account'].search([
-            ("company_id", "child_of", self.company_id.root_id.id),
+            ("company_ids", "child_of", self.company_id.root_id.id),
             ('reconcile', '=', True),
         ]).ids
         return [

--- a/addons/account/models/account_cash_rounding.py
+++ b/addons/account/models/account_cash_rounding.py
@@ -26,18 +26,19 @@ class AccountCashRounding(models.Model):
         'account.account',
         string='Profit Account',
         company_dependent=True,
+        check_company=True,
         domain="[('deprecated', '=', False)]",
     )
     loss_account_id = fields.Many2one(
         'account.account',
         string='Loss Account',
         company_dependent=True,
+        check_company=True,
         domain="[('deprecated', '=', False)]",
     )
     rounding_method = fields.Selection(string='Rounding Method', required=True,
         selection=[('UP', 'UP'), ('DOWN', 'DOWN'), ('HALF-UP', 'HALF-UP')],
         default='HALF-UP', help='The tie-breaking rule used for float rounding operations')
-    company_id = fields.Many2one('res.company', related='profit_account_id.company_id')
 
     @api.constrains('rounding')
     def validate_rounding(self):

--- a/addons/account/models/account_code_mapping.py
+++ b/addons/account/models/account_code_mapping.py
@@ -1,0 +1,63 @@
+from odoo import fields, models
+from odoo.tools import Query
+
+
+class AccountCodeMapping(models.Model):
+    _name = 'account.code.mapping'
+    _description = "Mapping of account codes per company"
+    _auto = False
+    _table_query = '0'
+
+    account_id = fields.Many2one(
+        comodel_name='account.account',
+        string="Account",
+        compute='_compute_self',
+    )
+    company_id = fields.Many2one(
+        comodel_name='res.company',
+        string="Company",
+        compute='_compute_self',
+    )
+    code = fields.Char(
+        string="Code",
+        compute='_compute_self',
+        inverse='_inverse_code',
+    )
+
+    def browse(self, ids=None):
+        if isinstance(ids, str):
+            ids = (ids,)
+        return super().browse(ids)
+
+    def _search(self, domain, offset=0, limit=None, order=None) -> Query:
+        match domain:
+            case [('id', 'in', ids)]:
+                return self.browse(sorted(ids))._as_query()
+            case [('account_id', 'in', account_ids)]:
+                self_ids = {
+                    f'{account_id},{company.id}'
+                    for company in self.env.companies
+                    for account_id in account_ids
+                }
+                return self.browse(sorted(self_ids))._as_query()
+        raise NotImplementedError
+
+    def _compute_self(self):
+        for record in self:
+            (account_id, company_id) = record._origin.id.split(',')
+            # If record is a NewId, then record.account_id and record.company_id should be too
+            # in order to behave correctly in onchange.
+            if isinstance(record.id, models.NewId):
+                record.account_id = models.NewId(int(account_id))
+                record.company_id = models.NewId(int(company_id))
+            else:
+                record.account_id = int(account_id)
+                record.company_id = int(company_id)
+        # Do this in a separate loop, so that prefetching can happen if needed
+        for record in self:
+            account = record.account_id.with_company(record.company_id._origin)
+            record.code = account.code
+
+    def _inverse_code(self):
+        for record in self:
+            record.account_id.with_company(record.company_id._origin).code = record.code

--- a/addons/account/models/account_journal_dashboard.py
+++ b/addons/account/models/account_journal_dashboard.py
@@ -84,8 +84,7 @@ class account_journal(models.Model):
         today = fields.Date.context_today(self)
         activities = defaultdict(list)
         # search activity on move on the journal
-        lang = self.env.user.lang or get_lang(self.env).code
-        act_type_name = self.with_context(lang=lang).env['mail.activity.type']._field_to_sql('act_type', 'name')
+        act_type_name = self.env['mail.activity.type']._field_to_sql('act_type', 'name')
         sql_query = SQL(
             """
             SELECT activity.id,

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3188,23 +3188,29 @@ class AccountMove(models.Model):
             domain.append(('account_id.internal_group', '=', 'expense'))
 
         query = self.env['account.move.line']._where_calc(domain)
+        account_code = self.env['account.account']._field_to_sql('account_move_line__account_id', 'code', query)
         rows = self.env.execute_query(SQL("""
             SELECT COUNT(foo.id), foo.account_id, foo.taxes
               FROM (
                          SELECT account_move_line__account_id.id AS account_id,
-                                account_move_line__account_id.code,
+                                %(account_code)s AS code,
                                 account_move_line.id,
                                 ARRAY_AGG(tax_rel.account_tax_id) FILTER (WHERE tax_rel.account_tax_id IS NOT NULL) AS taxes
-                           FROM %s
+                           FROM %(from_clause)s
                       LEFT JOIN account_move_line_account_tax_rel tax_rel ON account_move_line.id = tax_rel.account_move_line_id
-                          WHERE %s
+                          WHERE %(where_clause)s
                        GROUP BY account_move_line__account_id.id,
+                                %(account_code)s,
                                 account_move_line.id
                    ) AS foo
-          GROUP BY foo.account_id, foo.code, foo.taxes
-          ORDER BY COUNT(foo.id) DESC, foo.code, taxes ASC NULLS LAST
+          GROUP BY foo.account_id, foo.taxes
+          ORDER BY COUNT(foo.id) DESC, taxes ASC NULLS LAST
              LIMIT 1
-        """, query.from_clause, query.where_clause or SQL("TRUE")))
+            """,
+            account_code=account_code,
+            from_clause=query.from_clause,
+            where_clause=query.where_clause or SQL("TRUE"),
+        ))
         return rows[0] if rows else (0, False, False)
 
     def _get_quick_edit_suggestions(self):

--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -573,7 +573,7 @@ class AccountPayment(models.Model):
                 if pay.partner_id:
                     pay.destination_account_id = pay.partner_id.with_company(pay.company_id).property_account_receivable_id
                 else:
-                    pay.destination_account_id = self.env['account.account'].search([
+                    pay.destination_account_id = self.env['account.account'].with_company(pay.company_id).search([
                         *self.env['account.account']._check_company_domain(pay.company_id),
                         ('account_type', '=', 'asset_receivable'),
                         ('deprecated', '=', False),
@@ -583,7 +583,7 @@ class AccountPayment(models.Model):
                 if pay.partner_id:
                     pay.destination_account_id = pay.partner_id.with_company(pay.company_id).property_account_payable_id
                 else:
-                    pay.destination_account_id = self.env['account.account'].search([
+                    pay.destination_account_id = self.env['account.account'].with_company(pay.company_id).search([
                         *self.env['account.account']._check_company_domain(pay.company_id),
                         ('account_type', '=', 'liability_payable'),
                         ('deprecated', '=', False),

--- a/addons/account/models/account_root.py
+++ b/addons/account/models/account_root.py
@@ -1,0 +1,37 @@
+
+from itertools import accumulate
+
+from odoo import api, fields, models
+from odoo.tools import Query
+
+
+class AccountRoot(models.Model):
+    _name = 'account.root'
+    _description = 'Account codes first 2 digits'
+    _auto = False
+    _table_query = '0'
+
+    name = fields.Char(compute='_compute_root')
+    parent_id = fields.Many2one('account.root', compute='_compute_root')
+
+    def browse(self, ids=None):
+        if isinstance(ids, str):
+            ids = (ids,)
+        return super().browse(ids)
+
+    def _search(self, domain, offset=0, limit=None, order=None) -> Query:
+        match domain:
+            case [('id', 'in', ids)]:
+                return self.browse(sorted(ids))._as_query()
+            case [('id', 'parent_of', ids)]:
+                return self.browse(sorted({s for _id in ids for s in accumulate(_id)}))._as_query()
+        raise NotImplementedError
+
+    @api.model
+    def _from_account_code(self, code):
+        return self.browse(code and code[:2])
+
+    def _compute_root(self):
+        for root in self:
+            root.name = root.id
+            root.parent_id = self.browse(root.id[:-1] if len(root.id) > 1 else False)

--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -91,7 +91,7 @@ class ResCompany(models.Model):
     user_hard_lock_date = fields.Date(compute='_compute_user_hard_lock_date')
     transfer_account_id = fields.Many2one('account.account',
         check_company=True,
-        domain="[('reconcile', '=', True), ('account_type', '=', 'asset_current'), ('deprecated', '=', False)]", string="Inter-Banks Transfer Account", help="Intermediary account used when moving money from a liqity account to another")
+        domain="[('reconcile', '=', True), ('account_type', '=', 'asset_current'), ('deprecated', '=', False)]", string="Inter-Banks Transfer Account", help="Intermediary account used when moving money from a liquidity account to another")
     expects_chart_of_accounts = fields.Boolean(string='Expects a Chart of Accounts', default=True)
     chart_template = fields.Selection(selection='_chart_template_selection')
     bank_account_code_prefix = fields.Char(string='Prefix of the bank accounts')
@@ -375,7 +375,7 @@ class ResCompany(models.Model):
     def reflect_code_prefix_change(self, old_code, new_code):
         if not old_code or new_code == old_code:
             return
-        accounts = self.env['account.account'].search([
+        accounts = self.env['account.account'].with_company(self).search([
             *self.env['account.account']._check_company_domain(self),
             ('code', '=like', old_code + '%'),
             ('account_type', 'in', ('asset_cash', 'liability_credit_card')),
@@ -717,19 +717,19 @@ class ResCompany(models.Model):
         if none has yet been defined.
         """
         unaffected_earnings_type = "equity_unaffected"
-        account = self.env['account.account'].search([
+        account = self.env['account.account'].with_company(self).search([
             *self.env['account.account']._check_company_domain(self),
             ('account_type', '=', unaffected_earnings_type),
-        ])
+        ], limit=1)
         if account:
-            return account[0]
+            return account
         # Do not assume '999999' doesn't exist since the user might have created such an account
         # manually.
         code = 999999
-        while self.env['account.account'].search([
+        while self.env['account.account'].with_company(self).search_count([
             *self.env['account.account']._check_company_domain(self),
             ('code', '=', str(code)),
-        ]):
+        ], limit=1):
             code -= 1
         return self.env['account.account']._load_records([
             {
@@ -738,7 +738,7 @@ class ResCompany(models.Model):
                               'code': str(code),
                               'name': _('Undistributed Profits/Losses'),
                               'account_type': unaffected_earnings_type,
-                              'company_id': self.id,
+                              'company_ids': [Command.link(self.id)],
                           },
                 'noupdate': True,
             }

--- a/addons/account/models/mail_message.py
+++ b/addons/account/models/mail_message.py
@@ -6,7 +6,7 @@ from odoo.osv.expression import OR
 bypass_token = object()
 DOMAINS = {
     'account.move': lambda operator, value: [('company_id.check_account_audit_trail', operator, value)],
-    'account.account': lambda operator, value: [('company_id.check_account_audit_trail', operator, value)],
+    'account.account': lambda operator, value: [('company_ids.check_account_audit_trail', operator, value)],
     'account.tax': lambda operator, value: [('company_id.check_account_audit_trail', operator, value)],
     'res.partner': lambda operator, value: [
         '|', ('company_id', '=', False), ('company_id.check_account_audit_trail', operator, value),

--- a/addons/account/populate/account_reconcile_model.py
+++ b/addons/account/populate/account_reconcile_model.py
@@ -69,7 +69,7 @@ class AccountReconcileModelLine(models.Model):
                 domain += [('account_type', '=', type)]
             if group:
                 domain += [('internal_group', '=', group)]
-            return self.env['account.account'].search(domain)
+            return self.env['account.account'].with_company(self.env['res.company'].browse(company_id)).search(domain)
 
         def get_amount(random, values, **kwargs):
             """Get an amount dending on the amount_type.

--- a/addons/account/security/account_security.xml
+++ b/addons/account/security/account_security.xml
@@ -152,19 +152,13 @@
     <record id="account_comp_rule" model="ir.rule">
         <field name="name">Account multi-company</field>
         <field name="model_id" ref="model_account_account"/>
-        <field name="domain_force">[('company_id', 'parent_of', company_ids)]</field>
+        <field name="domain_force">[('company_ids', 'parent_of', company_ids)]</field>
     </record>
 
     <record id="account_group_comp_rule" model="ir.rule">
         <field name="name">Account Group multi-company</field>
         <field name="model_id" ref="model_account_group"/>
         <field name="domain_force">[('company_id', 'parent_of', company_ids)]</field>
-    </record>
-
-    <record id="account_root_comp_rule" model="ir.rule">
-        <field name="name">Account Root multi-company</field>
-        <field name="model_id" ref="model_account_root"/>
-        <field name="domain_force">['|',('company_id','=',False), ('company_id', 'parent_of', company_ids)]</field>
     </record>
 
     <record id="tax_group_comp_rule" model="ir.rule">

--- a/addons/account/security/ir.model.access.csv
+++ b/addons/account/security/ir.model.access.csv
@@ -63,6 +63,8 @@ access_account_group_manager,account.group,model_account_group,account.group_acc
 access_account_group,account.group,model_account_group,account.group_account_readonly,1,0,0,0
 access_account_root_manager,account.root,model_account_root,account.group_account_manager,1,0,0,0
 access_account_root,account.root,model_account_root,account.group_account_readonly,1,0,0,0
+access_account_code_mapping,account.code.mapping,model_account_code_mapping,account.group_account_readonly,1,0,0,0
+access_account_code_mapping_manager,account.code.mapping,model_account_code_mapping,account.group_account_manager,1,1,0,0
 access_account_account_manager,account.account,model_account_account,account.group_account_manager,1,1,1,1
 access_account_account,account.account.readonly,model_account_account,account.group_account_readonly,1,0,0,0
 access_account_account_user,account.account user,model_account_account,base.group_user,1,0,0,0

--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -243,36 +243,38 @@ class AccountTestInvoicingCommon(ProductCommon):
 
     @classmethod
     def collect_company_accounting_data(cls, company):
+        # Need to have the right company when searching accounts with limit=1, since the ordering depends on the account code.
+        AccountAccount = cls.env['account.account'].with_company(company)
         return {
             'company': company,
             'currency': company.currency_id,
-            'default_account_revenue': cls.env['account.account'].search([
-                    ('company_id', '=', company.id),
+            'default_account_revenue': AccountAccount.search([
+                    ('company_ids', '=', company.id),
                     ('account_type', '=', 'income'),
                     ('id', '!=', company.account_journal_early_pay_discount_gain_account_id.id)
                 ], limit=1),
-            'default_account_expense': cls.env['account.account'].search([
-                    ('company_id', '=', company.id),
+            'default_account_expense': AccountAccount.search([
+                    ('company_ids', '=', company.id),
                     ('account_type', '=', 'expense'),
                     ('id', '!=', company.account_journal_early_pay_discount_loss_account_id.id)
                 ], limit=1),
             'default_account_receivable': cls.env['ir.property'].with_company(company)._get(
                 'property_account_receivable_id', 'res.partner'
             ),
-            'default_account_payable': cls.env['account.account'].search([
-                    ('company_id', '=', company.id),
+            'default_account_payable': AccountAccount.search([
+                    ('company_ids', '=', company.id),
                     ('account_type', '=', 'liability_payable')
                 ], limit=1),
-            'default_account_assets': cls.env['account.account'].search([
-                    ('company_id', '=', company.id),
+            'default_account_assets': AccountAccount.search([
+                    ('company_ids', '=', company.id),
                     ('account_type', '=', 'asset_fixed')
                 ], limit=1),
-            'default_account_deferred_expense': cls.env['account.account'].search([
-                    ('company_id', '=', company.id),
+            'default_account_deferred_expense': AccountAccount.search([
+                    ('company_ids', '=', company.id),
                     ('account_type', '=', 'asset_current')
                 ], limit=1),
-            'default_account_deferred_revenue': cls.env['account.account'].search([
-                    ('company_id', '=', company.id),
+            'default_account_deferred_revenue': AccountAccount.search([
+                    ('company_ids', '=', company.id),
                     ('account_type', '=', 'liability_current')
                 ], limit=1),
             'default_account_tax_sale': company.account_sale_tax_id.mapped('invoice_repartition_line_ids.account_id'),
@@ -306,7 +308,7 @@ class AccountTestInvoicingCommon(ProductCommon):
         suffix_nb = 1
         while True:
             new_code = '%s.%s' % (account.code, suffix_nb)
-            if account.search_count([('company_id', '=', account.company_id.id), ('code', '=', new_code)]):
+            if account.search_count([('code', '=', new_code)]):
                 suffix_nb += 1
             else:
                 return account.copy(default={'code': new_code, 'name': account.name, **(default or {})})

--- a/addons/account/tests/test_account_move_entry.py
+++ b/addons/account/tests/test_account_move_entry.py
@@ -562,19 +562,16 @@ class TestAccountMove(AccountTestInvoicingCommon):
             'code': 'TWAIT',
             'account_type': 'liability_current',
             'reconcile': True,
-            'company_id': self.company_data['company'].id,
         })
         tax_final_account = self.env['account.account'].create({
             'name': 'TAX_TO_DEDUCT',
             'code': 'TDEDUCT',
             'account_type': 'asset_current',
-            'company_id': self.company_data['company'].id,
         })
         tax_base_amount_account = self.env['account.account'].create({
             'name': 'TAX_BASE',
             'code': 'TBASE',
             'account_type': 'asset_current',
-            'company_id': self.company_data['company'].id,
         })
         self.env.company.account_cash_basis_base_account_id = tax_base_amount_account
         self.env.company.tax_exigibility = True
@@ -1033,43 +1030,6 @@ class TestAccountMove(AccountTestInvoicingCommon):
         move = move_form.save()
         tax_line = move.line_ids.filtered('tax_repartition_line_id')
         self.assertEqual(tax_line.debit, 721.43)
-
-    def test_account_root_multiple_companies(self):
-        account = self.env['account.account'].create({
-            'name': 'account',
-            'code': 'ZZ',
-            'account_type': 'asset_current',
-            'company_id': self.env.company.id,
-        })
-        other_company = self.env['res.company'].create({'name': 'other company'})
-        self.env['account.account'].create({
-            'name': 'other account',
-            'code': 'ZZ',
-            'account_type': 'asset_current',
-            'company_id': other_company.id,
-        })
-        self.env['account.move'].create({
-            'move_type': 'entry',
-            'date': fields.Date.from_string('2016-01-01'),
-            'line_ids': [
-                (0, None, {
-                    'name': 'revenue line 1',
-                    'account_id': account.id,
-                    'debit': 500.0,
-                    'credit': 0.0,
-                }),
-                (0, None, {
-                    'name': 'revenue line 1',
-                    'account_id': self.company_data['default_account_tax_sale'].id,
-                    'debit': 0.0,
-                    'credit': 500.0,
-                }),
-            ]
-        })
-        balance = self.env["account.move.line"].read_group(
-            [("account_id", "=", account.id)], ["balance:sum"], ["account_root_id"]
-        )[0]["balance"]
-        self.assertEqual(balance, 500)
 
     def test_line_steal(self):
         honest_move = self.env['account.move'].create({

--- a/addons/account/tests/test_account_move_in_invoice.py
+++ b/addons/account/tests/test_account_move_in_invoice.py
@@ -1979,19 +1979,16 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
             'code': 'TWAIT',
             'account_type': 'liability_current',
             'reconcile': True,
-            'company_id': self.company_data['company'].id,
         })
         tax_final_account = self.env['account.account'].create({
             'name': 'TAX_TO_DEDUCT',
             'code': 'TDEDUCT',
             'account_type': 'asset_current',
-            'company_id': self.company_data['company'].id,
         })
         tax_base_amount_account = self.env['account.account'].create({
             'name': 'TAX_BASE',
             'code': 'TBASE',
             'account_type': 'asset_current',
-            'company_id': self.company_data['company'].id,
         })
         self.env.company.account_cash_basis_base_account_id = tax_base_amount_account
         self.env.company.tax_exigibility = True
@@ -2105,20 +2102,17 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
             'code': 'TWAIT',
             'account_type': 'liability_current',
             'reconcile': True,
-            'company_id': self.company_data['company'].id,
         })
         tax_final_account = self.env['account.account'].create({
             'name': 'TAX_TO_DEDUCT',
             'code': 'TDEDUCT',
             'account_type': 'asset_current',
-            'company_id': self.company_data['company'].id,
         })
         default_expense_account = self.company_data['default_account_expense']
         not_default_expense_account = self.env['account.account'].create({
             'name': 'NOT_DEFAULT_EXPENSE',
             'code': 'NDE',
             'account_type': 'expense',
-            'company_id': self.company_data['company'].id,
         })
         self.env.company.tax_exigibility = True
         tax_tags = defaultdict(dict)

--- a/addons/account/tests/test_account_move_in_refund.py
+++ b/addons/account/tests/test_account_move_in_refund.py
@@ -1015,19 +1015,16 @@ class TestAccountMoveInRefundOnchanges(AccountTestInvoicingCommon):
             'code': 'TWAIT',
             'account_type': 'liability_current',
             'reconcile': True,
-            'company_id': self.company_data['company'].id,
         })
         tax_final_account = self.env['account.account'].create({
             'name': 'TAX_TO_DEDUCT',
             'code': 'TDEDUCT',
             'account_type': 'asset_current',
-            'company_id': self.company_data['company'].id,
         })
         tax_base_amount_account = self.env['account.account'].create({
             'name': 'TAX_BASE',
             'code': 'TBASE',
             'account_type': 'asset_current',
-            'company_id': self.company_data['company'].id,
         })
         self.env.company.account_cash_basis_base_account_id = tax_base_amount_account
         self.env.company.tax_exigibility = True
@@ -1141,20 +1138,17 @@ class TestAccountMoveInRefundOnchanges(AccountTestInvoicingCommon):
             'code': 'TWAIT',
             'account_type': 'liability_current',
             'reconcile': True,
-            'company_id': self.company_data['company'].id,
         })
         tax_final_account = self.env['account.account'].create({
             'name': 'TAX_TO_DEDUCT',
             'code': 'TDEDUCT',
             'account_type': 'asset_current',
-            'company_id': self.company_data['company'].id,
         })
         default_expense_account = self.company_data['default_account_expense']
         not_default_expense_account = self.env['account.account'].create({
             'name': 'NOT_DEFAULT_EXPENSE',
             'code': 'NDE',
             'account_type': 'expense',
-            'company_id': self.company_data['company'].id,
         })
         self.env.company.tax_exigibility = True
         tax_tags = defaultdict(dict)

--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -3235,19 +3235,16 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
             'code': 'TWAIT',
             'account_type': 'liability_current',
             'reconcile': True,
-            'company_id': self.company_data['company'].id,
         })
         tax_final_account = self.env['account.account'].create({
             'name': 'TAX_TO_DEDUCT',
             'code': 'TDEDUCT',
             'account_type': 'asset_current',
-            'company_id': self.company_data['company'].id,
         })
         tax_base_amount_account = self.env['account.account'].create({
             'name': 'TAX_BASE',
             'code': 'TBASE',
             'account_type': 'asset_current',
-            'company_id': self.company_data['company'].id,
         })
         self.env.company.account_cash_basis_base_account_id = tax_base_amount_account
         self.env.company.tax_exigibility = True
@@ -3361,20 +3358,17 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
             'code': 'TWAIT',
             'account_type': 'liability_current',
             'reconcile': True,
-            'company_id': self.company_data['company'].id,
         })
         tax_final_account = self.env['account.account'].create({
             'name': 'TAX_TO_DEDUCT',
             'code': 'TDEDUCT',
             'account_type': 'asset_current',
-            'company_id': self.company_data['company'].id,
         })
         default_income_account = self.company_data['default_account_revenue']
         not_default_income_account = self.env['account.account'].create({
             'name': 'NOT_DEFAULT_INCOME',
             'code': 'NDI',
             'account_type': 'income',
-            'company_id': self.company_data['company'].id,
         })
         self.env.company.tax_exigibility = True
         tax_tags = defaultdict(dict)

--- a/addons/account/tests/test_account_move_out_refund.py
+++ b/addons/account/tests/test_account_move_out_refund.py
@@ -965,19 +965,16 @@ class TestAccountMoveOutRefundOnchanges(AccountTestInvoicingCommon):
             'code': 'TWAIT',
             'account_type': 'liability_current',
             'reconcile': True,
-            'company_id': self.company_data['company'].id,
         })
         tax_final_account = self.env['account.account'].create({
             'name': 'TAX_TO_DEDUCT',
             'code': 'TDEDUCT',
             'account_type': 'asset_current',
-            'company_id': self.company_data['company'].id,
         })
         tax_base_amount_account = self.env['account.account'].create({
             'name': 'TAX_BASE',
             'code': 'TBASE',
             'account_type': 'asset_current',
-            'company_id': self.company_data['company'].id,
         })
         self.env.company.account_cash_basis_base_account_id = tax_base_amount_account
         self.env.company.tax_exigibility = True
@@ -1091,20 +1088,17 @@ class TestAccountMoveOutRefundOnchanges(AccountTestInvoicingCommon):
             'code': 'TWAIT',
             'account_type': 'liability_current',
             'reconcile': True,
-            'company_id': self.company_data['company'].id,
         })
         tax_final_account = self.env['account.account'].create({
             'name': 'TAX_TO_DEDUCT',
             'code': 'TDEDUCT',
             'account_type': 'asset_current',
-            'company_id': self.company_data['company'].id,
         })
         default_income_account = self.company_data['default_account_revenue']
         not_default_income_account = self.env['account.account'].create({
             'name': 'NOT_DEFAULT_INCOME',
             'code': 'NDI',
             'account_type': 'income',
-            'company_id': self.company_data['company'].id,
         })
         self.env.company.tax_exigibility = True
         tax_tags = defaultdict(dict)

--- a/addons/account/tests/test_account_move_reconcile.py
+++ b/addons/account/tests/test_account_move_reconcile.py
@@ -43,7 +43,6 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
             'code': 'cash.basis.base.account',
             'name': 'cash_basis_base_account',
             'account_type': 'income',
-            'company_id': cls.company_data['company'].id,
         })
         cls.company_data['company'].account_cash_basis_base_account_id = cls.cash_basis_base_account
 
@@ -52,21 +51,18 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
             'name': 'cash_basis_transfer_account',
             'account_type': 'income',
             'reconcile': True,
-            'company_id': cls.company_data['company'].id,
         })
 
         cls.tax_account_1 = cls.env['account.account'].create({
             'code': 'tax.account.1',
             'name': 'tax_account_1',
             'account_type': 'income',
-            'company_id': cls.company_data['company'].id,
         })
 
         cls.tax_account_2 = cls.env['account.account'].create({
             'code': 'tax.account.2',
             'name': 'tax_account_2',
             'account_type': 'income',
-            'company_id': cls.company_data['company'].id,
         })
 
         cls.fake_country = cls.env['res.country'].create({
@@ -3424,7 +3420,6 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
             'code': '209.01.01',
             'name': 'Cash Basis Transition Account',
             'account_type': 'liability_current',
-            'company_id': self.company_data['company'].id,
             'reconcile': True,
         })
         self.cash_basis_tax_a_third_amount.write({

--- a/addons/account/tests/test_chart_template.py
+++ b/addons/account/tests/test_chart_template.py
@@ -441,7 +441,6 @@ class TestChartTemplate(AccountTestInvoicingCommon):
         problematic_account = self.env['account.account'].create({
             'code': '222221',
             'name': 'problematic_account',
-            'company_id': self.company.id,
         })
 
         # remove an xmlid to see if it gets relinked and not duplicated
@@ -538,6 +537,8 @@ class TestChartTemplate(AccountTestInvoicingCommon):
         def get_domain(model):
             if model == 'account.account.tag':
                 return [('country_id', '=', self.company.country_id.id)]
+            elif model == 'account.account':
+                return [('company_ids', '=', self.company.id)]
             else:
                 return [('company_id', '=', self.company.id)]
 
@@ -658,7 +659,7 @@ class TestChartTemplate(AccountTestInvoicingCommon):
                     'name': 'Free Account',
                     'code': '333331',
                     'account_type': 'asset_current',
-                    'company_id': company.id,
+                    'company_ids': [Command.link(company.id)],
                 },
             },
             'account.tax': {
@@ -861,7 +862,7 @@ class TestChartTemplate(AccountTestInvoicingCommon):
             self.env['account.chart.template'].try_loading('test', company=self.company, install_demo=False)
 
         accounts = self.env['account.account'].search([
-            ('company_id', '=', self.company.id),
+            ('company_ids', '=', self.company.id),
             ('code', 'in', ('777777', '777778'))
         ], order='code asc')
         self.assertEqual(2, len(accounts))

--- a/addons/account/tests/test_digest.py
+++ b/addons/account/tests/test_digest.py
@@ -1,6 +1,6 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo import Command
 from odoo.addons.digest.tests.common import TestDigestCommon
 from odoo.tools import mute_logger
 from odoo.tests import tagged
@@ -13,8 +13,8 @@ class TestAccountDigest(TestDigestCommon):
     @mute_logger('odoo.models.unlink')
     def setUpClass(cls):
         super().setUpClass()
-        account1 = cls.env['account.account'].search([('internal_group', '=', 'income'), ('company_id', '=', cls.company_1.id)], limit=1)
-        account2 = cls.env['account.account'].search([('internal_group', '=', 'expense'), ('company_id', '=', cls.company_1.id)], limit=1)
+        account1 = cls.env['account.account'].search([('internal_group', '=', 'income'), ('company_ids', '=', cls.company_1.id)], limit=1)
+        account2 = cls.env['account.account'].search([('internal_group', '=', 'expense'), ('company_ids', '=', cls.company_1.id)], limit=1)
         cls.env['account.journal'].with_company(cls.company_2).create({
             'name': 'Test Journal',
             'code': 'code',
@@ -24,13 +24,13 @@ class TestAccountDigest(TestDigestCommon):
         comp2_account, comp2_account2 = cls.env['account.account'].create([{
             'name': 'Account 1 Company 2',
             'account_type': 'expense_depreciation',
-            'company_id': cls.company_2.id,
             'code': 'aaaaaa',
+            'company_ids': [Command.link(cls.company_2.id)],
         }, {
             'name': 'Account 2 Company 2',
             'account_type': 'income_other',
-            'company_id': cls.company_2.id,
             'code': 'bbbbbb',
+            'company_ids': [Command.link(cls.company_2.id)],
         }])
 
         cls.env['account.move'].search([]).state = 'draft'

--- a/addons/account/tests/test_tour.py
+++ b/addons/account/tests/test_tour.py
@@ -42,7 +42,7 @@ class TestUi(AccountTestInvoicingHttpCommon):
             'account_purchase_tax_id': None,
         })
 
-        account_with_taxes = self.env['account.account'].search([('tax_ids', '!=', False), ('company_id', '=', self.env.company.id)])
+        account_with_taxes = self.env['account.account'].search([('tax_ids', '!=', False), ('company_ids', '=', self.env.company.id)])
         account_with_taxes.write({
             'tax_ids': [Command.clear()],
         })

--- a/addons/account/tests/test_transfer_wizard.py
+++ b/addons/account/tests/test_transfer_wizard.py
@@ -17,7 +17,7 @@ class TestTransferWizard(AccountTestInvoicingCommon):
         cls.company = cls.company_data['company']
         cls.receivable_account = cls.company_data['default_account_receivable']
         cls.payable_account = cls.company_data['default_account_payable']
-        cls.accounts = cls.env['account.account'].search([('reconcile', '=', False), ('company_id', '=', cls.company.id)], limit=5)
+        cls.accounts = cls.env['account.account'].search([('reconcile', '=', False), ('company_ids', '=', cls.company.id)], limit=5)
         cls.journal = cls.company_data['default_journal_misc']
 
         # Set rate for base currency to 1

--- a/addons/account/views/account_account_views.xml
+++ b/addons/account/views/account_account_views.xml
@@ -32,7 +32,6 @@
                                 </div>
                             </button>
                         </div>
-                        <field name="company_id" invisible="1"/>
                         <div>
                             <h1 style="font-size: 1.9rem;">
                                 <div class="row">
@@ -53,7 +52,6 @@
                                         </div>
                                     </div>
                                 </div>
-                                <field name="company_id" invisible="1"/>
                             </h1>
                         </div>
                         <notebook>
@@ -70,9 +68,17 @@
                                         <field name="currency_id" options="{'no_create': True}" groups="base.group_multi_currency"/>
                                         <field name="deprecated"/>
                                         <field name="group_id"/>
-                                        <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>
+                                        <field name="company_ids" widget="many2many_tags" options="{'no_create': True}" groups="base.group_multi_company"/>
                                     </group>
                                 </group>
+                            </page>
+                            <page name="mapping" string="Mapping" groups="base.group_multi_company">
+                                <field name="code_mapping_ids" colspan="2" nolabel="1">
+                                    <tree editable="bottom">
+                                        <field name="company_id"/>
+                                        <field name="code"/>
+                                    </tree>
+                                </field>
                             </page>
                         </notebook>
                     </sheet>
@@ -87,7 +93,6 @@
             <field name="model">account.account</field>
             <field name="arch" type="xml">
                 <tree editable="top" create="1" delete="1" multi_edit="1" string="Chart of accounts"  open_form_view="True">
-                    <field name="company_id" column_invisible="True"/>
                     <field name="code"/>
                     <field name="name"/>
                     <field name="account_type" widget="account_type_selection"/>
@@ -99,7 +104,7 @@
                     <field name="tag_ids" domain="[('applicability', '=', 'accounts')]" optional="hide" widget="many2many_tags"/>
                     <field name="allowed_journal_ids" optional="hide" widget="many2many_tags"/>
                     <field name="currency_id" options="{'no_create': True}" groups="base.group_multi_currency"/>
-                    <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>
+                    <field name="company_ids" widget="many2many_tags" options="{'no_create': True}" groups="base.group_multi_company"/>
                 </tree>
             </field>
         </record>
@@ -178,5 +183,29 @@
             <field name="context">{'search_default_activeacc': True}</field>
         </record>
 
+        <record model="ir.actions.server" id="action_merge_accounts">
+            <field name="name">Merge accounts</field>
+            <field name="model_id" ref="model_account_account"/>
+            <field name="groups_id" eval="[(4, ref('account.group_account_manager'))]"/>
+            <field name="binding_model_id" ref="account.model_account_account" />
+            <field name="binding_view_types">tree</field>
+            <field name="state">code</field>
+            <field name="code">
+if records:
+    action = records.action_merge()
+            </field>
+        </record>
+        <record model="ir.actions.server" id="action_unmerge_accounts">
+            <field name="name">Unmerge account</field>
+            <field name="model_id" ref="model_account_account"/>
+            <field name="groups_id" eval="[(4, ref('account.group_account_manager'))]"/>
+            <field name="binding_model_id" ref="account.model_account_account" />
+            <field name="binding_view_types">form,tree</field>
+            <field name="state">code</field>
+            <field name="code">
+if record:
+    action = record.action_merge()
+            </field>
+        </record>
     </data>
 </odoo>

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -24,7 +24,7 @@
                             <page string="Information" name="information">
                                 <group>
                                     <group string="Amount">
-                                        <field name="account_id" options="{'no_create': True}" domain="[('company_id', 'parent_of', company_id), ('deprecated', '=', False)]" readonly="1"/>
+                                        <field name="account_id" options="{'no_create': True}" domain="[('deprecated', '=', False)]" readonly="1"/>
                                         <field name="debit" readonly="1"/>
                                         <field name="credit" readonly="1"/>
                                         <field name="balance" readonly="1"/>
@@ -168,7 +168,7 @@
                     <field name="company_id" groups="base.group_multi_company" readonly="1" optional="hide"/>
                     <field name="journal_id" readonly="1" options='{"no_open":True}' optional="hide"/>
                     <field name="move_name" string="Journal Entry" widget="open_move_widget"/>
-                    <field name="account_id" options="{'no_open': True, 'no_create': True}" domain="[('company_id', 'parent_of', company_id), ('deprecated', '=', False)]" groups="account.group_account_readonly"/>
+                    <field name="account_id" options="{'no_open': True, 'no_create': True}" domain="[('deprecated', '=', False)]" groups="account.group_account_readonly"/>
                     <field name="partner_id" optional="show" readonly="move_type != 'entry'"/>
                     <field name="ref" optional="hide" readonly="False"/>
                     <field name="product_id" readonly="1" optional="hide"/>
@@ -1087,7 +1087,7 @@
                                                context="{'partner_id': partner_id, 'move_type': parent.move_type}"
                                                groups="account.group_account_readonly"
                                                options="{'no_quick_create': True}"
-                                               domain="[('deprecated', '=', False), ('account_type', 'not in', ('asset_receivable', 'liability_payable', 'off_balance')), ('company_id', 'parent_of', parent.company_id)]"
+                                               domain="[('deprecated', '=', False), ('account_type', 'not in', ('asset_receivable', 'liability_payable', 'off_balance'))]"
                                                required="display_type not in ('line_note', 'line_section')"/>
                                         <field name="analytic_distribution" widget="analytic_distribution"
                                                groups="analytic.group_analytic_accounting"
@@ -1187,7 +1187,7 @@
                                                 <field name="discount" string="Disc.%"/>
                                             </group>
                                             <group>
-                                                <field name="account_id" domain="[('company_id', 'parent_of', company_id), ('deprecated', '=', False)]" options="{'no_create': True}" context="{'partner_id': partner_id, 'move_type': parent.move_type}"/>
+                                                <field name="account_id" domain="[('deprecated', '=', False)]" options="{'no_create': True}" context="{'partner_id': partner_id, 'move_type': parent.move_type}"/>
                                                 <field name="tax_ids" widget="many2many_tags"/>
                                                 <field name="analytic_distribution" widget="analytic_distribution" groups="analytic.group_analytic_accounting"/>
                                             </group>
@@ -1242,7 +1242,7 @@
                                         <field name="account_id"
                                                invisible="display_type in ('line_section', 'line_note')"
                                                required="display_type not in ('line_section', 'line_note')"
-                                               domain="[('company_id', 'parent_of', parent.company_id), ('deprecated', '=', False)]" />
+                                               domain="[('deprecated', '=', False)]" />
                                         <field name="partner_id"
                                                optional="show"
                                                domain="['|', ('parent_id', '=', False), ('is_company', '=', True)]"
@@ -1325,7 +1325,7 @@
                                     <!-- Form view to cover mobile use -->
                                     <form>
                                       <group>
-                                        <field name="account_id" domain="[('company_id', 'parent_of', parent.company_id), ('deprecated', '=', False)]"/>
+                                        <field name="account_id" domain="[('deprecated', '=', False)]"/>
                                         <field name="partner_id" domain="['|', ('parent_id', '=', False), ('is_company', '=', True)]"/>
                                         <field name="name"/>
                                         <field name="analytic_distribution" widget="analytic_distribution" groups="analytic.group_analytic_accounting"/>

--- a/addons/account/views/account_reconcile_model_views.xml
+++ b/addons/account/views/account_reconcile_model_views.xml
@@ -13,7 +13,7 @@
                     <field name="rule_type" invisible="1"/>
                     <group>
                         <group>
-                            <field name="account_id" options="{'no_create': True}" domain="[('company_id', '=', company_id)]"
+                            <field name="account_id" options="{'no_create': True}"
                                    required="rule_type != 'invoice_matching' or (rule_type == 'invoice_matching' and allow_payment_tolerance and payment_tolerance_param != 0.0)"/>
                             <field name="amount_type"/>
                             <field name="tax_ids"

--- a/addons/account/views/account_tax_views.xml
+++ b/addons/account/views/account_tax_views.xml
@@ -238,9 +238,9 @@
                     <field name="company_id" groups="base.group_multi_company"/>
                     <field name="country_code" column_invisible="True"/>
 
-                    <field name="tax_payable_account_id" domain="[('company_id', '=', company_id)]"/>
-                    <field name="tax_receivable_account_id" domain="[('company_id', '=', company_id)]"/>
-                    <field name="advance_tax_payment_account_id" domain="[('company_id', '=', company_id)]"/>
+                    <field name="tax_payable_account_id"/>
+                    <field name="tax_receivable_account_id"/>
+                    <field name="advance_tax_payment_account_id"/>
 
                     <field name="preceding_subtotal" optional="hide"/>
                 </tree>
@@ -263,9 +263,9 @@
                                 <field name="pos_receipt_label" string="Label on PoS Receipts" groups="base.group_no_one"/>
                             </group>
                             <group>
-                                <field name="tax_payable_account_id" domain="[('company_id', '=', company_id)]"/>
-                                <field name="tax_receivable_account_id" domain="[('company_id', '=', company_id)]"/>
-                                <field name="advance_tax_payment_account_id" domain="[('company_id', '=', company_id)]"/>
+                                <field name="tax_payable_account_id" domain="[('company_ids', '=', company_id)]"/>
+                                <field name="tax_receivable_account_id" domain="[('company_ids', '=', company_id)]"/>
+                                <field name="advance_tax_payment_account_id" domain="[('company_ids', '=', company_id)]"/>
                                 <field name="preceding_subtotal"/>
                             </group>
                         </group>

--- a/addons/account/views/partner_view.xml
+++ b/addons/account/views/partner_view.xml
@@ -90,12 +90,12 @@
                         <page name="account_mapping" string="Account Mapping" groups="account.group_account_readonly">
                             <field name="account_ids" widget="one2many" nolabel="1">
                                 <tree string="Account Mapping" editable="bottom">
-                                    <field name="account_src_id" domain="['|', '|', ('company_id', '=', False), ('company_id', '=', parent.company_id), ('account_type', '!=', 'off_balance')]"/>
-                                    <field name="account_dest_id" domain="['|', '|', ('company_id', '=', False), ('company_id', '=', parent.company_id), ('account_type', '!=', 'off_balance')]"/>
+                                    <field name="account_src_id" domain="['|', ('company_ids', '=', parent.company_id), ('account_type', '!=', 'off_balance')]"/>
+                                    <field name="account_dest_id" domain="['|', ('company_ids', '=', parent.company_id), ('account_type', '!=', 'off_balance')]"/>
                                 </tree>
                                 <form string="Account Mapping">
-                                    <field name="account_src_id" domain="['|', '|', ('company_id', '=', False), ('company_id', '=', parent.company_id), ('account_type', '!=', 'off_balance')]"/>
-                                    <field name="account_dest_id" domain="['|', '|', ('company_id', '=', False), ('company_id', '=', parent.company_id), ('account_type', '!=', 'off_balance')]"/>
+                                    <field name="account_src_id" domain="['|', ('company_ids', '=', parent.company_id), ('account_type', '!=', 'off_balance')]"/>
+                                    <field name="account_dest_id" domain="['|', ('company_ids', '=', parent.company_id), ('account_type', '!=', 'off_balance')]"/>
                                 </form>
                             </field>
                         </page>

--- a/addons/account/wizard/account_automatic_entry_wizard.py
+++ b/addons/account/wizard/account_automatic_entry_wizard.py
@@ -240,7 +240,7 @@ class AutomaticEntryWizard(models.TransientModel):
 
         # Get the lowest child company based on accounts used to avoid access error
         accounts = self.env['account.account'].browse([line['account_id'] for line in line_vals])
-        companies = accounts.company_id | self.env.company
+        companies = accounts.company_ids.filtered(lambda c: self.env.company in c.parent_ids) | self.env.company
         lowest_child_company = max(companies, key=lambda company: len(company.parent_ids))
 
         return [{

--- a/addons/account/wizard/account_automatic_entry_wizard_views.xml
+++ b/addons/account/wizard/account_automatic_entry_wizard_views.xml
@@ -30,7 +30,7 @@
                         </group>
                         <group invisible="action != 'change_account'">
                             <field name="date" string="Transfer Date"/>
-                            <field name="destination_account_id" required="action == 'change_account'" domain="[('company_id', '=', company_id)]"/>
+                            <field name="destination_account_id" required="action == 'change_account'"/>
                         </group>
                         <group>
                             <label for="total_amount" string="Adjusting Amount" invisible="action != 'change_period'"/>

--- a/addons/account/wizard/setup_wizards_view.xml
+++ b/addons/account/wizard/setup_wizards_view.xml
@@ -63,7 +63,7 @@
                 <tree editable="top" create="1" delete="1" decoration-muted="opening_debit == 0 and opening_credit == 0" open_form_view="True">
                     <field name="code"/>
                     <field name="name"/>
-                    <field name="company_id" column_invisible="True"/>
+                    <field name="company_ids" column_invisible="True"/>
                     <field name="account_type" widget="account_type_selection"/>
                     <field name="reconcile" widget="boolean_toggle"/>
                     <field name="opening_debit" options="{'no_symbol': True}"/>

--- a/addons/l10n_de/models/account_account.py
+++ b/addons/l10n_de/models/account_account.py
@@ -6,7 +6,7 @@ class AccountAccount(models.Model):
     _inherit = ['account.account']
 
     def write(self, vals):
-        if 'code' in vals and 'DE' in self.company_id.account_fiscal_country_id.mapped('code'):
+        if 'code' in vals and 'DE' in self.company_ids.account_fiscal_country_id.mapped('code'):
             if self.env['account.move.line'].search_count([('account_id', 'in', self.ids)], limit=1):
                 raise UserError(_("You can not change the code of an account."))
         return super().write(vals)

--- a/addons/l10n_de/models/datev.py
+++ b/addons/l10n_de/models/datev.py
@@ -19,7 +19,7 @@ class ProductTemplate(models.Model):
             if not self.property_account_income_id:
                 taxes = self.taxes_id.filtered_domain(self.env['account.tax']._check_company_domain(company))
                 if not result['income'] or (result['income'].tax_ids and taxes and taxes[0] not in result['income'].tax_ids):
-                    result['income'] = self.env['account.account'].search([
+                    result['income'] = self.env['account.account'].with_company(company).search([
                         *self.env['account.account']._check_company_domain(company),
                         ('internal_group', '=', 'income'),
                         ('deprecated', '=', False),
@@ -28,7 +28,7 @@ class ProductTemplate(models.Model):
             if not self.property_account_expense_id:
                 supplier_taxes = self.supplier_taxes_id.filtered_domain(self.env['account.tax']._check_company_domain(company))
                 if not result['expense'] or (result['expense'].tax_ids and supplier_taxes and supplier_taxes[0] not in result['expense'].tax_ids):
-                    result['expense'] = self.env['account.account'].search([
+                    result['expense'] = self.env['account.account'].with_company(company).search([
                         *self.env['account.account']._check_company_domain(company),
                         ('internal_group', '=', 'expense'),
                         ('deprecated', '=', False),

--- a/addons/l10n_in_withholding/models/res_company.py
+++ b/addons/l10n_in_withholding/models/res_company.py
@@ -7,8 +7,11 @@ class ResCompany(models.Model):
     l10n_in_withholding_account_id = fields.Many2one(
         comodel_name='account.account',
         string="TDS Account",
+        check_company=True,
+        domain="[('type', '=', 'general')]"
     )
     l10n_in_withholding_journal_id = fields.Many2one(
         comodel_name='account.journal',
         string="TDS Journal",
+        check_company=True,
     )

--- a/addons/l10n_in_withholding/views/res_config_settings_views.xml
+++ b/addons/l10n_in_withholding/views/res_config_settings_views.xml
@@ -9,11 +9,11 @@
                     <div class="content-group">
                         <div class="row mt8">
                             <label for="l10n_in_withholding_journal_id" class="col-lg-5 o_light_label" string="Journal"/>
-                            <field name="l10n_in_withholding_journal_id" domain="[('company_id', '=', company_id), ('type', '=', 'general')]"/>
+                            <field name="l10n_in_withholding_journal_id"/>
                         </div>
                         <div class="row mt8">
                             <label for="l10n_in_withholding_account_id" class="col-lg-5 o_light_label" string="Account"/>
-                            <field name="l10n_in_withholding_account_id" domain="[('company_id', '=', company_id)]"/>
+                            <field name="l10n_in_withholding_account_id"/>
                         </div>
                     </div>
                 </setting>

--- a/addons/l10n_mx/models/account_account.py
+++ b/addons/l10n_mx/models/account_account.py
@@ -11,7 +11,7 @@ class AccountAccount(models.Model):
         accounts = super().create(vals_list)
         debit_tag = self.env.ref('l10n_mx.tag_debit_balance_account')
         credit_tag = self.env.ref('l10n_mx.tag_credit_balance_account')
-        mx_account_no_tags = accounts.filtered(lambda a: a.company_id.country_code == 'MX' and not a.tag_ids & (credit_tag + debit_tag))
+        mx_account_no_tags = accounts.filtered(lambda a: 'MX' in a.company_ids.mapped('country_code') and not a.tag_ids & (credit_tag + debit_tag))
         DEBIT_CODES = ['1', '5', '6', '7']  # all other codes are considered "credit"
         for account in mx_account_no_tags:
             tag_id = debit_tag.id if account.code[0] in DEBIT_CODES else credit_tag.id

--- a/addons/l10n_pe/models/account_move.py
+++ b/addons/l10n_pe/models/account_move.py
@@ -1,6 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from odoo import api, models, fields
-from odoo.tools.sql import column_exists, create_column
+from odoo import api, models
 
 
 class AccountMove(models.Model):
@@ -35,23 +34,3 @@ class AccountMove(models.Model):
         for rec in to_review:
             number = rec.l10n_latam_document_number.split("-")
             rec.l10n_latam_document_number = "%s-%s" % (number[0], number[1].zfill(8))
-
-
-class AccountMoveLine(models.Model):
-    _inherit = "account.move.line"
-
-    l10n_pe_group_id = fields.Many2one("account.group", related="account_id.group_id", store=True)
-
-    def _auto_init(self):
-        """
-        Create column to stop ORM from computing it himself (too slow)
-        """
-        if not column_exists(self.env.cr, self._table, 'l10n_pe_group_id'):
-            create_column(self.env.cr, self._table, 'l10n_pe_group_id', 'int4')
-            self.env.cr.execute("""
-                UPDATE account_move_line line
-                SET l10n_pe_group_id = account.group_id
-                FROM account_account account
-                WHERE account.id = line.account_id
-            """)
-        return super()._auto_init()

--- a/addons/mrp_subcontracting_purchase/tests/test_mrp_subcontracting_purchase.py
+++ b/addons/mrp_subcontracting_purchase/tests/test_mrp_subcontracting_purchase.py
@@ -318,7 +318,6 @@ class MrpSubcontractingPurchaseTest(TestMrpSubcontractingCommon):
             'code': 'STOCKDIFF',
             'reconcile': True,
             'account_type': 'asset_current',
-            'company_id': self.env.company.id,
         })
         product_category_all.property_account_creditor_price_difference_categ = stock_price_diff_acc_id
 

--- a/addons/point_of_sale/tests/common.py
+++ b/addons/point_of_sale/tests/common.py
@@ -214,7 +214,7 @@ class TestPoSCommon(ValuationReconciliationTestCommon):
         # other basics
         cls.sale_account = cls.categ_basic.property_account_income_categ_id
         cls.other_sale_account = cls.env['account.account'].search([
-            ('company_id', '=', cls.company.id),
+            ('company_ids', '=', cls.company.id),
             ('account_type', '=', 'income'),
             ('id', '!=', cls.sale_account.id)
         ], limit=1)

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -624,7 +624,6 @@ class TestUi(TestPointOfSaleHttpCommon):
             'name': 'TAX_BASE',
             'code': 'TBASE',
             'account_type': 'asset_current',
-            'company_id': self.env.company.id,
         })
         fixed_tax = self.env['account.tax'].create({
             'name': 'fixed amount tax',

--- a/addons/point_of_sale/tests/test_point_of_sale_flow.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_flow.py
@@ -2053,9 +2053,9 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
             'chart_template': self.env.company.chart_template,
         })
 
-        outstanding_receipts = self.env.company.account_journal_payment_debit_account_id.copy()
-        outstanding_receipts.company_id = branch
-
+        outstanding_receipts = self.env.company.account_journal_payment_debit_account_id.with_company(branch).copy(
+            {'company_ids': [Command.set(branch.ids)]}
+        )
         self.env.cr.precommit.run()
         branch.account_journal_payment_debit_account_id = outstanding_receipts
 

--- a/addons/point_of_sale/tests/test_pos_products_with_tax.py
+++ b/addons/point_of_sale/tests/test_pos_products_with_tax.py
@@ -1,7 +1,6 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import tools
+from odoo import Command
 
 import odoo
 from odoo.addons.point_of_sale.tests.common import TestPoSCommon
@@ -649,10 +648,8 @@ class TestPoSProductsWithTax(TestPoSCommon):
             'name': 'Branch XX config',
             'company_id': branch_xx.id,
         })
-        xx_account_receivable = self.company_data['default_account_receivable'].copy()
-        xx_account_receivable.company_id = branch_xx
-        xx_cash_journal = self.company_data['default_journal_cash'].copy()
-        xx_cash_journal.company_id = branch_xx
+        xx_account_receivable = self.company_data['default_account_receivable'].copy({'company_ids': [Command.set(branch_xx.ids)]})
+        xx_cash_journal = self.company_data['default_journal_cash'].copy({'company_id': branch_xx.id})
         xx_cash_payment_method = self.env['pos.payment.method'].create({
             'name': 'XX Cash Payment',
             'receivable_account_id': xx_account_receivable.id,

--- a/addons/point_of_sale/views/res_config_settings_views.xml
+++ b/addons/point_of_sale/views/res_config_settings_views.xml
@@ -67,7 +67,7 @@
                                 <div class="content-group mt16" invisible="not pos_cash_rounding">
                                     <div class="row mt16">
                                         <label string="Rounding Method" for="pos_rounding_method" class="col-lg-3 o_light_label" />
-                                        <field name="pos_rounding_method" required="pos_cash_rounding" domain="[('company_id', '=', company_id)]" readonly="pos_has_active_session"/>
+                                        <field name="pos_rounding_method" required="pos_cash_rounding" readonly="pos_has_active_session"/>
                                     </div>
                                     <div class="row mt16">
                                         <div class="col">

--- a/addons/purchase_stock/tests/test_anglo_saxon_valuation_reconciliation.py
+++ b/addons/purchase_stock/tests/test_anglo_saxon_valuation_reconciliation.py
@@ -28,7 +28,6 @@ class TestValuationReconciliation(ValuationReconciliationTestCommon):
                 'code': 'STOCKDIFF',
                 'reconcile': True,
                 'account_type': 'asset_current',
-                'company_id': company_data['company'].id,
             }),
         })
         return company_data
@@ -295,7 +294,6 @@ class TestValuationReconciliation(ValuationReconciliationTestCommon):
             'code': 'cash.basis.base.account',
             'name': 'cash_basis_base_account',
             'account_type': 'income',
-            'company_id': self.company_data['company'].id,
         })
         self.company_data['company'].account_cash_basis_base_account_id = cash_basis_base_account
 
@@ -303,14 +301,12 @@ class TestValuationReconciliation(ValuationReconciliationTestCommon):
             'code': 'cash.basis.transfer.account',
             'name': 'cash_basis_transfer_account',
             'account_type': 'income',
-            'company_id': self.company_data['company'].id,
         })
 
         tax_account_1 = self.env['account.account'].create({
             'code': 'tax.account.1',
             'name': 'tax_account_1',
             'account_type': 'income',
-            'company_id': self.company_data['company'].id,
         })
 
         tax_tags = self.env['account.account.tag'].create({

--- a/addons/spreadsheet_account/tests/test_account_group.py
+++ b/addons/spreadsheet_account/tests/test_account_group.py
@@ -14,7 +14,7 @@ class SpreadsheetAccountGroupTest(AccountTestInvoicingCommon):
 
     def test_group_with_no_account(self):
         self.env['account.account']\
-            .search([('account_type', '=', 'income_other'), ('company_id', '=', self.env.company.id)])\
+            .search([('account_type', '=', 'income_other'), ('company_ids', '=', self.env.company.id)])\
             .unlink()
         self.assertEqual(self.env["account.account"].get_account_group(['income_other']), [[]])
 

--- a/addons/spreadsheet_account/tests/test_debit_credit.py
+++ b/addons/spreadsheet_account/tests/test_debit_credit.py
@@ -16,7 +16,7 @@ class SpreadsheetAccountingFunctionsTest(AccountTestInvoicingCommon):
 
         cls.account_revenue_c1 = cls.env["account.account"].create(
             {
-                "company_id": cls.company_data["company"].id,
+                "company_ids": [Command.link(cls.company_data["company"].id)],
                 "name": "spreadsheet revenue Company 1",
                 "account_type": "income",
                 "code": "sp1234566",
@@ -25,25 +25,26 @@ class SpreadsheetAccountingFunctionsTest(AccountTestInvoicingCommon):
 
         cls.account_expense_c1 = cls.env["account.account"].create(
             {
-                "company_id": cls.company_data["company"].id,
+                "company_ids": [Command.link(cls.company_data["company"].id)],
                 "name": "spreadsheet expense Company 1",
                 "account_type": "expense",
                 "code": "sp1234577",
             }
         )
 
-        cls.account_revenue_c2 = cls.env["account.account"].create(
+        company_2 = cls.company_data_2["company"]
+        cls.account_revenue_c2 = cls.env["account.account"].with_company(company_2).create(
             {
-                "company_id": cls.company_data_2["company"].id,
+                "company_ids": [Command.link(company_2.id)],
                 "name": "spreadsheet revenue Company 2",
                 "account_type": "income",
                 "code": "sp99887755",
             }
         )
 
-        cls.account_expense_c2 = cls.env["account.account"].create(
+        cls.account_expense_c2 = cls.env["account.account"].with_company(company_2).create(
             {
-                "company_id": cls.company_data_2["company"].id,
+                "company_ids": [Command.link(company_2.id)],
                 "name": "spreadsheet expense Company 2",
                 "account_type": "expense",
                 "code": "sp99887766",
@@ -925,7 +926,7 @@ class SpreadsheetAccountingFunctionsTest(AccountTestInvoicingCommon):
                     "year": 2022,
                 },
                 "codes": [self.account_revenue_c1.code],
-                "company_id": self.account_revenue_c1.company_id.id,
+                "company_id": self.account_revenue_c1.company_ids.id,
                 "include_unposted": True,
             }
         )
@@ -951,7 +952,7 @@ class SpreadsheetAccountingFunctionsTest(AccountTestInvoicingCommon):
                     ("account_id.include_initial_balance", "=", False),
                     ("date", ">=", date(2022, 1, 1)),
                     ("date", "<=", date(2022, 12, 31)),
-                    ("company_id", "=", self.account_revenue_c1.company_id.id),
+                    ("company_id", "=", self.account_revenue_c1.company_ids.id),
                     ("move_id.state", "!=", "cancel"),
                 ],
                 "name": "Journal items for account prefix sp1234566",

--- a/addons/stock_account/tests/test_anglo_saxon_valuation_reconciliation_common.py
+++ b/addons/stock_account/tests/test_anglo_saxon_valuation_reconciliation_common.py
@@ -61,26 +61,23 @@ class ValuationReconciliationTestCommon(AccountTestInvoicingCommon):
 
         # Create stock config.
         company_data.update({
-            'default_account_stock_in': cls.env['account.account'].create({
+            'default_account_stock_in': cls.env['account.account'].with_company(company).create({
                 'name': 'default_account_stock_in',
                 'code': 'STOCKIN',
                 'reconcile': True,
                 'account_type': 'asset_current',
-                'company_id': company.id,
             }),
-            'default_account_stock_out': cls.env['account.account'].create({
+            'default_account_stock_out': cls.env['account.account'].with_company(company).create({
                 'name': 'default_account_stock_out',
                 'code': 'STOCKOUT',
                 'reconcile': True,
                 'account_type': 'asset_current',
-                'company_id': company.id,
             }),
-            'default_account_stock_valuation': cls.env['account.account'].create({
+            'default_account_stock_valuation': cls.env['account.account'].with_company(company).create({
                 'name': 'default_account_stock_valuation',
                 'code': 'STOCKVAL',
                 'reconcile': True,
                 'account_type': 'asset_current',
-                'company_id': company.id,
             }),
             'default_warehouse': cls.env['stock.warehouse'].search(
                 [('company_id', '=', company.id)],

--- a/odoo/addons/base/models/ir_property.py
+++ b/odoo/addons/base/models/ir_property.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import functools
+
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
 from odoo.osv.expression import TERM_OPERATORS_NEGATION
@@ -18,19 +20,6 @@ TYPE2FIELD = {
     'datetime': 'value_datetime',
     'selection': 'value_text',
     'html': 'value_text',
-}
-
-TYPE2CLEAN = {
-    'boolean': bool,
-    'integer': lambda val: val or False,
-    'float': lambda val: val or False,
-    'char': lambda val: val or False,
-    'text': lambda val: val or False,
-    'selection': lambda val: val or False,
-    'binary': lambda val: val or False,
-    'date': lambda val: val.date() if val else False,
-    'datetime': lambda val: val or False,
-    'html': lambda val: val or False,
 }
 
 
@@ -299,7 +288,7 @@ class Property(models.Model):
                 ORDER BY p.company_id NULLS FIRST
             """.format(TYPE2FIELD[field.type])
             params = [model_pos, field_id, company_id]
-            clean = TYPE2CLEAN[field.type]
+            clean = functools.partial(field.convert_to_record, record=self.env[model].browse(ids))
 
         else:
             return dict.fromkeys(ids, False)

--- a/odoo/addons/test_new_api/models/test_new_api.py
+++ b/odoo/addons/test_new_api/models/test_new_api.py
@@ -353,6 +353,10 @@ class MixedModel(models.Model):
     _name = 'test_new_api.mixed'
     _description = 'Test New API Mixed'
 
+    foo = fields.Char()
+    text = fields.Text()
+    truth = fields.Boolean()
+    count = fields.Integer()
     number = fields.Float(digits=(10, 2), default=3.14)
     number2 = fields.Float(digits='New API Precision')
     date = fields.Date()
@@ -645,6 +649,7 @@ class CompanyDependent(models.Model):
     _description = 'Test New API Company'
 
     foo = fields.Char(company_dependent=True)
+    text = fields.Text(company_dependent=True)
     date = fields.Date(company_dependent=True)
     moment = fields.Datetime(company_dependent=True)
     tag_id = fields.Many2one('test_new_api.multi.tag', company_dependent=True)

--- a/odoo/addons/test_new_api/tests/test_new_fields.py
+++ b/odoo/addons/test_new_api/tests/test_new_fields.py
@@ -1452,6 +1452,34 @@ class TestFields(TransactionCaseWithUserDemo):
 
     def test_27_company_dependent(self):
         """ test company-dependent fields. """
+        # Company-dependent field variants should handle 0, '' and NULL database values
+        # in the same way as their 'normal' (non-company-dependent) variants.
+        # This section relies on there being no company defaults, so it needs to run first.
+        null_record = self.env['test_new_api.company'].create({})
+        null_record_normal = self.env['test_new_api.mixed'].create({})
+        null_record.invalidate_recordset()
+        null_record_normal.invalidate_recordset()
+        field_correspondence = [
+            ('foo', 'foo', ''),
+            ('text', 'text', ''),
+            ('date', 'date', False),
+            ('moment', 'moment', False),
+            ('truth', 'truth', False),
+            ('count', 'count', 0),
+            ('phi', 'number2', 0.0),
+            ('html1', 'comment1', ''),
+        ]
+        # Check null values
+        for field, normal_field, value_to_write in field_correspondence:
+            self.assertEqual(null_record[field], null_record_normal[normal_field])
+            null_record[field] = null_record_normal[normal_field] = value_to_write
+
+        # Check empty / 0 values
+        null_record.invalidate_recordset()
+        null_record_normal.invalidate_recordset()
+        for field, normal_field, _ in field_correspondence:
+            self.assertEqual(null_record[field], null_record_normal[normal_field])
+
         # consider three companies
         company0 = self.env.ref('base.main_company')
         company1 = self.env['res.company'].create({'name': 'A'})

--- a/odoo/addons/test_new_api/tests/test_views.py
+++ b/odoo/addons/test_new_api/tests/test_views.py
@@ -20,7 +20,7 @@ class TestDefaultView(common.TransactionCase):
         )
         self.assertEqual(
             etree.tostring(self.env['test_new_api.mixed']._get_default_form_view()),
-            b'<form><sheet string="Test New API Mixed"><group><group><field name="number"/><field name="date"/><field name="now"/><field name="reference"/></group><group><field name="number2"/><field name="moment"/><field name="lang"/></group></group><group><field name="comment1"/></group><group><field name="comment2"/></group><group><field name="comment3"/></group><group><field name="comment4"/></group><group><field name="comment5"/></group><group><group><field name="currency_id"/></group><group><field name="amount"/></group></group><group><separator/></group></sheet></form>'
+            b'<form><sheet string="Test New API Mixed"><group><group><field name="foo"/></group></group><group><field name="text"/></group><group><group><field name="truth"/><field name="number"/><field name="date"/><field name="now"/><field name="reference"/></group><group><field name="count"/><field name="number2"/><field name="moment"/><field name="lang"/></group></group><group><field name="comment1"/></group><group><field name="comment2"/></group><group><field name="comment3"/></group><group><field name="comment4"/></group><group><field name="comment5"/></group><group><group><field name="currency_id"/></group><group><field name="amount"/></group></group><group><separator/></group></sheet></form>'
         )
 
 

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -62,7 +62,7 @@ from .tools import (
     SQL, sql,
 )
 from .tools.lru import LRU
-from .tools.misc import CountingStream, LastOrderedSet, ReversedIterable
+from .tools.misc import CountingStream, LastOrderedSet, ReversedIterable, unquote
 from .tools.translate import _, _lt
 
 _logger = logging.getLogger(__name__)
@@ -170,14 +170,18 @@ def fix_import_export_id_paths(fieldname):
 def to_company_ids(companies):
     if isinstance(companies, BaseModel):
         return companies.ids
-    elif isinstance(companies, (list, tuple)):
+    elif isinstance(companies, (list, tuple, str)):
         return companies
     return [companies]
 
 
 def check_company_domain_parent_of(self, companies):
+    """ A `_check_company_domain` function that lets a record be used if either:
+        - record.company_id = False (which implies that it is shared between all companies), or
+        - record.company_id is a parent of any of the given companies.
+    """
     if isinstance(companies, str):
-        return ['|', ('company_id', '=', False), ('company_id', 'parent_of', [companies])]
+        return ['|', ('company_id', '=', False), ('company_id', 'parent_of', companies)]
 
     companies = [id for id in to_company_ids(companies) if id]
     if not companies:
@@ -188,6 +192,24 @@ def check_company_domain_parent_of(self, companies):
         for rec in self.env['res.company'].sudo().browse(companies)
         for parent in rec.parent_path.split('/')[:-1]
     ] + [False])]
+
+
+def check_companies_domain_parent_of(self, companies):
+    """ A `_check_company_domain` function that lets a record be used if
+        any company in record.company_ids is a parent of any of the given companies.
+    """
+    if isinstance(companies, str):
+        return [('company_ids', 'parent_of', companies)]
+
+    companies = [id_ for id_ in to_company_ids(companies) if id_]
+    if not companies:
+        return []
+
+    return [('company_ids', 'in', [
+        int(parent)
+        for rec in self.env['res.company'].sudo().browse(companies)
+        for parent in rec.parent_path.split('/')[:-1]
+    ])]
 
 
 class MetaModel(api.Meta):
@@ -4159,6 +4181,8 @@ class BaseModel(metaclass=MetaModel):
         """
         if not companies:
             return [('company_id', '=', False)]
+        if isinstance(companies, str):
+            return [('company_id', 'in', unquote(f'{companies} + [False]'))]
         return [('company_id', 'in', to_company_ids(companies) + [False])]
 
     def _check_company(self, fnames=None):
@@ -4175,15 +4199,14 @@ class BaseModel(metaclass=MetaModel):
         User with main company A, having access to company A and B, could be
         assigned or linked to records in company B.
         """
-        if fnames is None or 'company_id' in fnames:
+        if fnames is None or {'company_id', 'company_ids'} & set(fnames):
             fnames = self._fields
 
         regular_fields = []
         property_fields = []
         for name in fnames:
             field = self._fields[name]
-            if field.relational and field.check_company and \
-                    'company_id' in self.env[field.comodel_name]:
+            if field.relational and field.check_company:
                 if not field.company_dependent:
                     regular_fields.append(name)
                 else:
@@ -4194,15 +4217,28 @@ class BaseModel(metaclass=MetaModel):
 
         inconsistencies = []
         for record in self:
-            company = record.company_id if record._name != 'res.company' else record
             # The first part of the check verifies that all records linked via relation fields are compatible
             # with the company of the origin document, i.e. `self.account_id.company_id == self.company_id`
-            for name in regular_fields:
-                corecord = record.sudo()[name]
-                if corecord:
-                    domain = corecord._check_company_domain(company)
-                    if domain and not corecord.with_context(active_test=False).filtered_domain(domain):
-                        inconsistencies.append((record, name, corecord))
+            if regular_fields:
+                if self._name == 'res.company':
+                    companies = record
+                elif 'company_id' in self:
+                    companies = record.company_id
+                elif 'company_ids' in self:
+                    companies = record.company_ids
+                else:
+                    _logger.warning(_(
+                        "Skipping a company check for model %(model_name)s. Its fields %(field_names)s are set as company-dependent, "
+                        "but the model doesn't have a `company_id` or `company_ids` field!",
+                        model_name=self.model_name, field_names=regular_fields
+                    ))
+                    continue
+                for name in regular_fields:
+                    corecord = record.sudo()[name]
+                    if corecord:
+                        domain = corecord._check_company_domain(companies)
+                        if domain and not corecord.with_context(active_test=False).filtered_domain(domain):
+                            inconsistencies.append((record, name, corecord))
             # The second part of the check (for property / company-dependent fields) verifies that the records
             # linked via those relation fields are compatible with the company that owns the property value, i.e.
             # the company for which the value is being assigned, i.e:
@@ -5890,6 +5926,8 @@ class BaseModel(metaclass=MetaModel):
         """
         if 'company_id' in self:
             return self.company_id
+        elif 'company_ids' in self:
+            return (self.company_ids & self.env.user.company_ids)[:1]
         return False
 
     #
@@ -6281,12 +6319,12 @@ class BaseModel(metaclass=MetaModel):
             else:
                 (key, comparator, value) = leaf
                 if comparator in ('child_of', 'parent_of'):
-                    if key == 'company_id':  # avoid an explicit search
+                    if key in ['company_id', 'company_ids']:  # avoid an explicit search
                         value_companies = self.env['res.company'].browse(value)
                         if comparator == 'child_of':
-                            stack.append({record.id for record in self if record.company_id.parent_ids & value_companies})
+                            stack.append({record.id for record in self if record[key].parent_ids & value_companies})
                         else:
-                            stack.append({record.id for record in self if record.company_id & value_companies.parent_ids})
+                            stack.append({record.id for record in self if record[key] & value_companies.parent_ids})
                     else:
                         stack.append(set(self.with_context(active_test=False).search([('id', 'in', self.ids), leaf], order='id')._ids))
                     continue


### PR DESCRIPTION
#### In a nutshell

- At the moment, performing accounting duties needed for multi-company consolidation is a pain in Odoo. The central accountant typically has all companies active simultaneously, but because each company has a full set of accounts, this multiplication of accounts makes it particularly confusing to work with the CoA, accounting entries and reports. The CoA and reports list duplicate accounts indiscriminately, while for journal items it is difficult to see which account is actually used.

- This commit aims to simplify the central accountant's life by letting them manage a single chart of accounts that is shared between companies.

- Each account now defines one or more companies which it is active on. As previously, accounts active on a parent company may also be used in its branches.

- In addition, each account can now have a different code depending on the company. For the account name, variations are expected to be per-language rather than per-company, and should be handled via the existing translation mechanism.

- Starting from this commit, accounts should no longer be created specifying a company. Instead, when creating an account, the `company` context should be used to indicate which company the account starts active on, and the given code will be assigned to that company.

#### Changes
- Accounts no longer belong to a single company: we replace `company_id` by `company_ids`, which indicates which companies the account belongs to.
- `account.code` is now company-dependent.
- There is a constraint that forces `account.code` to be set for every company in `company_ids`. For this reason, if you need to create an account for 2 companies, first create it for one, then set the code for the second company using `account.with_company(...).code = ...`, then add the second company to `company_ids`.
- Account groups and account roots are now computed non-stored fields.
- Merge tool: Accounts that have the same type etc. can now be merged. Accounts belonging to different companies will keep their codes in their respective companies, and can be reversibly de-merged.
- De-merge tool: Accounts belonging to different companies can be de-merged.

Enterprise PR: https://github.com/odoo/enterprise/pull/66077
Upgrade PR: https://github.com/odoo/upgrade/pull/6372
taskid: 3698780