### PR TITLE
[REF] web_tour: remove extra_trigger

### DIFF
--- a/addons/hr_expense/static/src/js/tours/hr_expense.js
+++ b/addons/hr_expense/static/src/js/tours/hr_expense.js
@@ -64,10 +64,12 @@ registry.category("web_tour.tours").add('hr_expense_tour' , {
 }, ...stepUtils.statusbarButtonsSteps(_t("Attach Receipt"), _t("Attach a receipt - usually an image or a PDF file.")),
 ...stepUtils.statusbarButtonsSteps(_t("Create Report"), _t("Create a report to submit one or more expenses to your manager.")),
 ...stepUtils.statusbarButtonsSteps(_t("Submit to Manager"), markup(_t('Once your <b>Expense Report</b> is ready, you can submit it to your manager and wait for approval.'))),
+{
+    isActive: ["mobile"],
+    trigger: ".o_hr_expense_form_view_view",
+},
 ...stepUtils.goBackBreadcrumbsMobile(
     _t("Use the breadcrumbs to go back to the list of expenses."),
-    undefined,
-    ".o_hr_expense_form_view_view",
 ),
 {
     trigger: ".o_hr_expense_form_view_view",
@@ -83,7 +85,13 @@ registry.category("web_tour.tours").add('hr_expense_tour' , {
     position: 'bottom',
     run: "click",
 },
-stepUtils.openBurgerMenu(),
+{
+    isActive: ["mobile"],
+    trigger: ".o_mobile_menu_toggle",
+    content: _t("Open bugger menu."),
+    position: "bottom",
+    run: "click",
+},
 {
     trigger: ".o_main_navbar",
 },

--- a/addons/purchase/static/src/js/tours/purchase.js
+++ b/addons/purchase/static/src/js/tours/purchase.js
@@ -103,10 +103,13 @@ registry.category("web_tour.tours").add("purchase_tour", {
             position: "right",
             run: "edit 12.0",
         },
+        {
+            isActive: ["auto", "mobile"],
+            trigger: ".o_statusbar_buttons .o_arrow_button_current[name='action_rfq_send']",
+        },
         ...stepUtils.statusbarButtonsSteps(
             "Send by Email",
-            _t("Send the request for quotation to your vendor."),
-            ".o_statusbar_buttons .o_arrow_button_current[name='action_rfq_send']"
+            _t("Send the request for quotation to your vendor.")
         ),
         {
             trigger: ".modal-content input[name='email']",

--- a/addons/sale/static/src/js/tours/sale.js
+++ b/addons/sale/static/src/js/tours/sale.js
@@ -106,10 +106,13 @@ registry.category("web_tour.tours").add("sale_tour", {
             trigger: ".o_field_monetary[name='price_subtotal']:contains(10.00)",
             run: "click",
         },
+        {
+            isActive: ["auto", "mobile"],
+            trigger: ".o_statusbar_buttons button[name='action_quotation_send']",
+        },
         ...stepUtils.statusbarButtonsSteps(
             "Send by Email",
             markup(_t("<b>Send the quote</b> to yourself and check what the customer will receive.")),
-            ".o_statusbar_buttons button[name='action_quotation_send']",
         ),
         {
             isActive: ["body:not(:has(.modal-footer button[name='action_send_mail']))"],

--- a/addons/test_sale_product_configurators/static/tests/tours/product_matrix_tour.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_matrix_tour.js
@@ -187,5 +187,10 @@ registry.category("web_tour.tours").add('sale_matrix_tour', {
 }, {
     trigger: 'button:contains("Confirm")',  // apply the matrix
     run: "click",
-}, ...stepUtils.saveForm('.o_field_cell.o_data_cell.o_list_number:contains("8.20")'),
-]});
+        },
+        {
+            trigger: ".o_field_cell.o_data_cell.o_list_number:contains(8.20)",
+        },
+        ...stepUtils.saveForm(),
+    ],
+});

--- a/addons/web_tour/static/src/tour_service/tour_utils.js
+++ b/addons/web_tour/static/src/tour_service/tour_utils.js
@@ -148,13 +148,12 @@ export const stepUtils = {
         };
     },
 
-    autoExpandMoreButtons(extra_trigger) {
+    autoExpandMoreButtons() {
         return {
             isActive: ["auto"],
             content: `autoExpandMoreButtons`,
             trigger: ".o-form-buttonbox",
-            extra_trigger: extra_trigger,
-            run: (actions) => {
+            run() {
                 const more = hoot.queryFirst(".o-form-buttonbox .o_button_more");
                 if (more) {
                     hoot.click(more);
@@ -163,20 +162,16 @@ export const stepUtils = {
         };
     },
 
-    goBackBreadcrumbsMobile(description, ...extraTrigger) {
-        return extraTrigger.map((element) => ({
-            isActive: ["mobile"],
-            trigger: ".o_back_button",
-            extra_trigger: element,
-            content: description,
-            position: "bottom",
-            run: "click",
-            debugHelp: this._getHelpMessage(
-                "goBackBreadcrumbsMobile",
-                description,
-                ...extraTrigger
-            ),
-        }));
+    goBackBreadcrumbsMobile(description) {
+        return [
+            {
+                isActive: ["mobile"],
+                trigger: ".o_back_button",
+                content: description,
+                position: "bottom",
+                run: "click",
+            },
+        ];
     },
 
     goToAppSteps(dataMenuXmlid, description) {
@@ -201,24 +196,19 @@ export const stepUtils = {
         );
     },
 
-    openBurgerMenu(extraTrigger) {
-        return {
-            isActive: ["mobile"],
-            trigger: ".o_mobile_menu_toggle",
-            extra_trigger: extraTrigger,
-            content: _t("Open bugger menu."),
-            position: "bottom",
-            run: "click",
-            debugHelp: this._getHelpMessage("openBurgerMenu", extraTrigger),
-        };
-    },
-
-    statusbarButtonsSteps(innerTextButton, description, extraTrigger) {
-        return [
+    statusbarButtonsSteps(innerTextButton, description, trigger) {
+        const steps = [];
+        if (trigger) {
+            steps.push({
+                isActive: ["auto", "mobile"],
+                trigger,
+                allowDisabled: true,
+            });
+        }
+        steps.push(
             {
                 isActive: ["auto", "mobile"],
                 trigger: ".o_statusbar_buttons",
-                extra_trigger: extraTrigger,
                 run: (actions) => {
                     const node = hoot.queryFirst(
                         ".o_statusbar_buttons .btn.dropdown-toggle:contains(Action)"
@@ -233,29 +223,14 @@ export const stepUtils = {
                 content: description,
                 position: "bottom",
                 run: "click",
-            },
-        ].map((step) =>
+            }
+        );
+        return steps.map((step) =>
             this.addDebugHelp(
-                this._getHelpMessage(
-                    "statusbarButtonsSteps",
-                    innerTextButton,
-                    description,
-                    extraTrigger
-                ),
+                this._getHelpMessage("statusbarButtonsSteps", innerTextButton, description),
                 step
             )
         );
-    },
-
-    simulateEnterKeyboardInSearchModal() {
-        return {
-            isActive: ["mobile"],
-            trigger: ".o_searchview_input",
-            extra_trigger: ".dropdown-menu.o_searchview_autocomplete",
-            position: "bottom",
-            run: "press Enter",
-            debugHelp: this._getHelpMessage("simulateEnterKeyboardInSearchModal"),
-        };
     },
 
     mobileKanbanSearchMany2X(modalTitle, valueSearched) {
@@ -269,11 +244,19 @@ export const stepUtils = {
             {
                 isActive: ["mobile"],
                 trigger: ".o_searchview_input",
-                extra_trigger: `.modal:not(.o_inactive_modal) .modal-title:contains('${modalTitle}')`,
                 position: "bottom",
                 run: `edit ${valueSearched}`,
             },
-            this.simulateEnterKeyboardInSearchModal(),
+            {
+                isActive: ["mobile"],
+                trigger: ".dropdown-menu.o_searchview_autocomplete",
+            },
+            {
+                isActive: ["mobile"],
+                trigger: ".o_searchview_input",
+                position: "bottom",
+                run: "press Enter",
+            },
             {
                 isActive: ["mobile"],
                 trigger: `.o_kanban_record:contains('${valueSearched}')`,
@@ -289,18 +272,13 @@ export const stepUtils = {
     },
     /**
      * Utility steps to save a form and wait for the save to complete
-     *
-     * @param {object} [options]
-     * @param {string} [options.content]
-     * @param {string} [options.extra_trigger] additional save-condition selector
      */
-    saveForm(options = {}) {
+    saveForm() {
         return [
             {
                 isActive: ["auto"],
-                content: options.content || "save form",
+                content: "save form",
                 trigger: ".o_form_button_save",
-                extra_trigger: options.extra_trigger,
                 run: "click",
             },
             {
@@ -316,13 +294,12 @@ export const stepUtils = {
      * Supports creation/edition from either a form or a list view (so checks
      * for both states).
      */
-    discardForm(options = {}) {
+    discardForm() {
         return [
             {
                 isActive: ["auto"],
-                content: options.content || "exit the form",
+                content: "discard the form",
                 trigger: ".o_form_button_cancel",
-                extra_trigger: options.extra_trigger,
                 run: "click",
             },
             {

--- a/addons/website_slides/static/tests/tours/slides_tour_tools.js
+++ b/addons/website_slides/static/tests/tours/slides_tour_tools.js
@@ -55,23 +55,34 @@ var addVideoToSection = function (sectionName, saveAsDraft, backend = false) {
     trigger: prefix + 'div.o_w_slide_upload_modal_container',
     run: "click",
 }];
-	if (saveAsDraft) {
-		base_steps = [].concat(base_steps, [{
-    content: 'eLearning: save as draft slide',
-    extra_trigger: prefix + 'div.o_slide_preview img:not([src="/website_slides/static/src/img/document.png"])',  // wait for onchange to perform its duty
-    trigger: prefix + 'footer.modal-footer button:contains("Save as Draft")',
-    run: "click",
-}]);
-	}
-	else {
-		base_steps = [].concat(base_steps, [{
-    content: 'eLearning: create and publish slide',
-    extra_trigger: prefix + 'div.o_slide_preview img:not([src="/website_slides/static/src/img/document.png"])',  // wait for onchange to perform its duty
-    trigger: prefix + 'footer.modal-footer button:contains("Publish")',
-    run: "click",
-}]);
-	}
-	return base_steps;
+    if (saveAsDraft) {
+        base_steps = [].concat(base_steps, [
+            {
+                trigger:
+                    prefix +
+                    'div.o_slide_preview img:not([src="/website_slides/static/src/img/document.png"])', // wait for onchange to perform its duty
+            },
+            {
+                content: "eLearning: save as draft slide",
+                trigger: prefix + 'footer.modal-footer button:contains("Save as Draft")',
+                run: "click",
+            },
+        ]);
+    } else {
+        base_steps = [].concat(base_steps, [
+            {
+                trigger:
+                    prefix +
+                    'div.o_slide_preview img:not([src="/website_slides/static/src/img/document.png"])', // wait for onchange to perform its duty
+            },
+            {
+                content: "eLearning: create and publish slide",
+                trigger: prefix + 'footer.modal-footer button:contains("Publish")',
+                run: "click",
+            },
+        ]);
+    }
+    return base_steps;
 };
 
 var addArticleToSection = function (sectionName, pageName, backend) {

--- a/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
+++ b/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
@@ -12,7 +12,17 @@ registry.category("web_tour.tours").add('main_flow_tour', {
     url: "/web",
     steps: () => [
 ...stepUtils.goToAppSteps('sale.sale_menu_root', markup(_t('Organize your sales activities with the <b>Sales app</b>.'))),
-stepUtils.openBurgerMenu(".o_breadcrumb .active:contains('Quotations')"),
+{
+    isActive: ["mobile"],
+    trigger: ".o_breadcrumb .active:contains('Quotations')",
+},
+{
+    isActive: ["mobile"],
+    trigger: ".o_mobile_menu_toggle",
+    content: _t("Open bugger menu."),
+    position: "bottom",
+    run: "click",
+},
 {
     isActive: ["desktop"],
     trigger: ".o_main_navbar",
@@ -96,7 +106,10 @@ stepUtils.openBurgerMenu(".o_breadcrumb .active:contains('Quotations')"),
     position: 'bottom',
     run: "click",
 },
-stepUtils.autoExpandMoreButtons('.o_form_saved'),
+{
+    trigger: ".o_form_saved",
+},
+stepUtils.autoExpandMoreButtons(),
 {
     trigger: '.o_form_saved',
 },
@@ -856,7 +869,17 @@ stepUtils.autoExpandMoreButtons('.o_form_saved'),
     run: "click",
 },
 ...stepUtils.goToAppSteps('stock.menu_stock_root', _t('Go to Inventory')),
-stepUtils.openBurgerMenu(".o_breadcrumb .active:contains('Inventory Overview')"),
+{
+    isActive: ["mobile"],
+    trigger: ".o_breadcrumb .active:contains('Inventory Overview')",
+},
+{
+    isActive: ["mobile"],
+    trigger: ".o_mobile_menu_toggle",
+    content: _t("Open bugger menu."),
+    position: "bottom",
+    run: "click",
+},
 {
     isActive: ["desktop"],
     trigger: '.o_main_navbar',
@@ -973,7 +996,17 @@ stepUtils.openBurgerMenu(".o_breadcrumb .active:contains('Inventory Overview')")
     run: "click",
 },
 ...stepUtils.goToAppSteps('mrp.menu_mrp_root', _t('Go to Manufacturing')),
-stepUtils.openBurgerMenu(".o_breadcrumb .active:contains('Manufacturing Orders'), .o_breadcrumb .active:contains('Work Centers Overview')"),
+{
+    isActive: ["mobile"],
+    trigger: ".o_breadcrumb .active:contains('Manufacturing Orders'), .o_breadcrumb .active:contains('Work Centers Overview')",
+},
+{
+    isActive: ["mobile"],
+    trigger: ".o_mobile_menu_toggle",
+    content: _t("Open bugger menu."),
+    position: "bottom",
+    run: "click",
+},
 {
     isActive: ["desktop"],
     trigger: ".o_menu_sections button[data-menu-xmlid='mrp.menu_mrp_manufacturing']",
@@ -1018,7 +1051,17 @@ stepUtils.openBurgerMenu(".o_breadcrumb .active:contains('Manufacturing Orders')
     run: "click",
 },
 ...stepUtils.goToAppSteps('sale.sale_menu_root', markup(_t('Organize your sales activities with the <b>Sales app</b>.'))),
-stepUtils.openBurgerMenu(".o_breadcrumb .active:contains('Quotations')"),
+{
+    isActive: ["mobile"],
+    trigger: ".o_breadcrumb .active:contains('Quotations')",
+},
+{
+    isActive: ["mobile"],
+    trigger: ".o_mobile_menu_toggle",
+    content: _t("Open bugger menu."),
+    position: "bottom",
+    run: "click",
+},
 {
     isActive: ["desktop"],
     trigger: ".o_menu_sections button[data-menu-xmlid='sale.sale_order_menu']",
@@ -1054,7 +1097,11 @@ stepUtils.openBurgerMenu(".o_breadcrumb .active:contains('Quotations')"),
     position: "bottom",
     run: "click",
 },
-stepUtils.mobileModifier(stepUtils.autoExpandMoreButtons('.o_control_panel .o_breadcrumb:contains("S0")')),
+{
+    isActive: ["mobile"],
+    trigger: '.o_control_panel .o_breadcrumb:contains("S0")',
+},
+stepUtils.mobileModifier(stepUtils.autoExpandMoreButtons()),
 {
     isActive: ["desktop"],
     trigger: '.oe_stat_button:has(div[name=tasks_count])',
@@ -1117,10 +1164,12 @@ stepUtils.mobileModifier(stepUtils.autoExpandMoreButtons('.o_control_panel .o_br
     trigger: ".o_form_button_save",
     run: "click",
 },
+{
+    isActive: ["mobile"],
+    trigger: ".o_breadcrumb .active:contains('the_flow.service')",
+},
 ...stepUtils.goBackBreadcrumbsMobile(
-        _t('Back to the sale order'),
-        undefined,
-        ".o_breadcrumb .active:contains('the_flow.service')"
+        _t('Back to the sale order')
     ),
 {
     isActive: ["desktop"],

--- a/odoo/addons/test_new_api/static/tests/tours/x2many.js
+++ b/odoo/addons/test_new_api/static/tests/tours/x2many.js
@@ -78,9 +78,8 @@
     {
         trigger: '.o_field_widget[name=participants] .o_data_cell:contains(/^Mitchell Admin$/)',
     },
-    ...stepUtils.saveForm({
-        content: "save discussion",
-    }), { // add message a
+    ...stepUtils.saveForm(),
+    { // add message a
         content: "Select First Tab",
         trigger: '.o_notebook_headers .nav-item a:contains(Messages)',
         run: "click",
@@ -471,9 +470,8 @@
     {
         trigger: 'body:not(:has(tr:has(td:contains(/^d$/))))',
     },
-    ...stepUtils.saveForm({ // save
-        content: "save discussion",
-    }), { // check saved data
+    ...stepUtils.saveForm(),
+    { // check saved data
         content: "check data 10",
         trigger: '.o_field_widget[name=message_concat] textarea:value([test_trigger2] Mitchell Admin:aaa\n[test_trigger2] Marc Demo:ccccc)',
     },
@@ -499,9 +497,8 @@
     {
         trigger: '.o_field_widget[name="body"] textarea:value(eee)',
     },
-    ...stepUtils.saveForm({ // save
-        content: "save discussion",
-    }), { // check saved data
+    ...stepUtils.saveForm(),
+    { // check saved data
         content: "check data 12",
         trigger: '.o_field_widget[name="message_concat"] textarea:value([test_trigger2] Mitchell Admin:aaa\n[test_trigger2] Marc Demo:ccccc\n[test_trigger2] Mitchell Admin:eee)',
     },


### PR DESCRIPTION
In order to simplify the tours API, it was decided to remove the extra_trigger key from the steps.
To check that an element is in the DOM, simply create a step with a trigger.

task~3974087