### PR TITLE
[IMP] hr_holidays : employee departure

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -975,51 +975,32 @@ Attempting to double-book your time off won't magically make your vacation 2x be
     def _get_leaves_on_public_holiday(self):
         return self.filtered(lambda l: l.employee_id and not l.number_of_days)
 
-    def _split_leaves(self, split_date_from, split_date_to):
+    def _split_leaves(self, split_date_from, split_date_to=False):
         """
-        Split leaves on the given full-day interval. The leaves will be split
-        into two new leaves: the period up until (but not including)
-        split_date_from and the period starting at (and including)
-        split_date_to.
+        This method splits an original leave in two leaves and returns the new one for each leave in self.
+        E.g. (start, stop) -> (start, split_date_from - 1day), (split_date_to, stop)
+        :param split_date_from: The starting date of the splicing interval (includes)
+        :param split_date_to: The ending date of the splicing interval. (not includes)
+        :param changes_message: The message will be translated and posted in the first leave's chatter
 
-        This means that the period in between split_date_from and split_date_to
-        will no longer be covered by the new leaves. In order to split a leave
-        without losing any leave coverage, split_date_from and split_date_to
-        should therefore be the same.
-
-        Another important note to make is that this method only splits leaves
-        on full-day intervals. Logic to split leaves on partial days or hours
-        is not straightforward as you have to take into account working hours
-        and timezones. It's also not clear that we would want to handle this
-        automatically. The method will therefore also only work on leaves that
-        are taken in full or half days (Though a half day leave in the interval
-        will simply be refused - there are no multi-day spanning half-day
-        leaves)
-
-        The method creates one or two new leaves per leave that needs to be
-        split and refuses the original leave.
+        If split_date_to is not set; the splicing interval will be equals to [split_date_form, split_date_from -1]
+        to avoid one day leave.
         """
-        # Keep track of the original states before refusing the leaves and creating new ones
-        original_states = {l.id: l.state for l in self}
-
-        # Refuse all original leaves
-        self.action_refuse()
-        split_leaves_vals = []
+        new_leaves_vals = []
+        if not split_date_to:
+            split_date_to = split_date_from
 
         # Only leaves that span a period outside of the split interval need
         # to be split.
         multi_day_leaves = self.filtered(lambda l: l.request_date_from < split_date_from or l.request_date_to >= split_date_to)
-
         for leave in multi_day_leaves:
-            # Leaves in days
             new_leave_vals = []
-
-            # Get the values to create the leave before the split
+            target_leave_vals = []
             if leave.request_date_from < split_date_from:
                 new_leave_vals.append(leave.copy_data({
                     'request_date_from': leave.request_date_from,
                     'request_date_to': split_date_from + timedelta(days=-1),
-                    'state': original_states[leave.id],
+                    'state': leave.state
                 })[0])
 
             # Do the same for the new leave after the split
@@ -1027,35 +1008,33 @@ Attempting to double-book your time off won't magically make your vacation 2x be
                 new_leave_vals.append(leave.copy_data({
                     'request_date_from': split_date_to,
                     'request_date_to': leave.request_date_to,
-                    'state': original_states[leave.id],
+                    'state': leave.state,
                 })[0])
 
-            # For those two new leaves, only create them if they actually
-            # have a non-zero duration.
+            # For those two new leaves, only create them if they actually have a non-zero duration.
             for leave_vals in new_leave_vals:
                 new_leave = self.env['hr.leave'].new(leave_vals)
                 new_leave._compute_date_from_to()
-                # Could happen for part-time contract, that time off is not necessary
-                # anymore.
-                # Imagine you work on monday-wednesday-friday only.
-                # You take a time off on friday.
-                # We create a company time off on friday.
-                # By looking at the last attendance before the company time off
-                # start date to compute the date_to, you would have a date_from > date_to.
-                # Just don't create the leave at that time. That's the reason why we use
-                # new instead of create. As the leave is not actually created yet, the sql
-                # constraint didn't check date_from < date_to yet.
                 if new_leave.date_from < new_leave.date_to:
-                    split_leaves_vals.append(new_leave._convert_to_write(new_leave._cache))
+                    target_leave_vals.append(new_leave._convert_to_write(new_leave._cache))
 
-        split_leaves = self.env['hr.leave'].with_context(
+            if target_leave_vals:
+                vals = target_leave_vals.pop(0)
+                leave.with_context(leave_skip_state_check=True).write({
+                    'request_date_from': vals['request_date_from'],
+                    'request_date_to': vals['request_date_to'],
+                })
+                if target_leave_vals:
+                    new_leaves_vals.extend(target_leave_vals)
+
+        if not new_leaves_vals:
+            return self.env['hr.leave']
+        return self.env['hr.leave'].with_context(
             tracking_disable=True,
             mail_activity_automation_skip=True,
             leave_fast_create=True,
             leave_skip_state_check=True
-        ).create(split_leaves_vals)
-
-        split_leaves.filtered(lambda l: l.state in 'validate')._validate_leave_request()
+        ).create(new_leaves_vals)
 
     def action_validate(self, check_state=True):
         current_employee = self.env.user.employee_id

--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -811,7 +811,7 @@ Attempting to double-book your time off won't magically make your vacation 2x be
 
     def copy_data(self, default=None):
         vals_list = super().copy_data(default=default)
-        if default and 'request_date_from' in default and 'request_date_to' in default:
+        if self.env.context.get('skip_copy_check'):
             return vals_list
         if all(leave.state in ['cancel', 'refuse'] for leave in self):  # No overlap constraint in these cases
             return vals_list
@@ -997,18 +997,16 @@ Attempting to double-book your time off won't magically make your vacation 2x be
             new_leave_vals = []
             target_leave_vals = []
             if leave.request_date_from < split_date_from:
-                new_leave_vals.append(leave.copy_data({
-                    'request_date_from': leave.request_date_from,
+                new_leave_vals.append(leave.with_context(skip_copy_check=True).copy_data({
                     'request_date_to': split_date_from + timedelta(days=-1),
                     'state': leave.state
                 })[0])
 
             # Do the same for the new leave after the split
             if leave.request_date_to >= split_date_to:
-                new_leave_vals.append(leave.copy_data({
+                new_leave_vals.append(leave.with_context(skip_copy_check=True).copy_data({
                     'request_date_from': split_date_to,
-                    'request_date_to': leave.request_date_to,
-                    'state': leave.state,
+                    'state': leave.state
                 })[0])
 
             # For those two new leaves, only create them if they actually have a non-zero duration.

--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -724,6 +724,8 @@ class HolidaysAllocation(models.Model):
 
     @api.ondelete(at_uninstall=False)
     def _unlink_if_correct_states(self):
+        if self.env.context.get('allocation_skip_state_check'):
+            return
         state_description_values = {elem[0]: elem[1] for elem in self._fields['state']._description_selection(self.env)}
         for allocation in self.filtered(lambda allocation: allocation.state not in ['confirm', 'refuse']):
             raise UserError(_('You cannot delete an allocation request which is in %s state.', state_description_values.get(allocation.state)))

--- a/addons/hr_holidays/tests/__init__.py
+++ b/addons/hr_holidays/tests/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_access_rights
@@ -26,3 +25,4 @@ from . import test_timeoff_event
 from . import test_working_hours
 from . import test_dashboard
 from . import test_expiring_leaves
+from . import test_hr_departure_wizard

--- a/addons/hr_holidays/tests/test_company_leave.py
+++ b/addons/hr_holidays/tests/test_company_leave.py
@@ -64,24 +64,22 @@ class TestCompanyLeave(TransactionCase):
         company_leave.action_generate_time_off()
 
         all_leaves = self.env['hr.leave'].search([('employee_id', '=', self.employee.id)], order='id')
-        self.assertEqual(len(all_leaves), 4)
-        # Original Time Off
-        self.assertEqual(leave.state, 'refuse')
+        self.assertEqual(len(all_leaves), 3)
         # Before Time Off
-        self.assertEqual(all_leaves[1].date_from, datetime(2020, 1, 7, 7, 0))
-        self.assertEqual(all_leaves[1].date_to, datetime(2020, 1, 7, 16, 0))
+        self.assertEqual(all_leaves[0].date_from, datetime(2020, 1, 7, 7, 0))
+        self.assertEqual(all_leaves[0].date_to, datetime(2020, 1, 7, 16, 0))
+        self.assertEqual(all_leaves[0].number_of_days, 1)
+        self.assertEqual(all_leaves[0].state, 'confirm')
+        # After Time Off
+        self.assertEqual(all_leaves[1].date_from, datetime(2020, 1, 9, 7, 0))
+        self.assertEqual(all_leaves[1].date_to, datetime(2020, 1, 9, 16, 0))
         self.assertEqual(all_leaves[1].number_of_days, 1)
         self.assertEqual(all_leaves[1].state, 'confirm')
-        # After Time Off
-        self.assertEqual(all_leaves[2].date_from, datetime(2020, 1, 9, 7, 0))
-        self.assertEqual(all_leaves[2].date_to, datetime(2020, 1, 9, 16, 0))
-        self.assertEqual(all_leaves[2].number_of_days, 1)
-        self.assertEqual(all_leaves[2].state, 'confirm')
         # Company Time Off
-        self.assertEqual(all_leaves[3].date_from, datetime(2020, 1, 8, 7, 0))
-        self.assertEqual(all_leaves[3].date_to, datetime(2020, 1, 8, 16, 0))
-        self.assertEqual(all_leaves[3].number_of_days, 1)
-        self.assertEqual(all_leaves[3].state, 'validate')
+        self.assertEqual(all_leaves[2].date_from, datetime(2020, 1, 8, 7, 0))
+        self.assertEqual(all_leaves[2].date_to, datetime(2020, 1, 8, 16, 0))
+        self.assertEqual(all_leaves[2].number_of_days, 1)
+        self.assertEqual(all_leaves[2].state, 'validate')
 
     def test_02_leave_whole_company(self):
         # TEST CASE 2: Leaves taken in half-days. Take a 3 days leave
@@ -110,24 +108,22 @@ class TestCompanyLeave(TransactionCase):
         company_leave.action_generate_time_off()
 
         all_leaves = self.env['hr.leave'].search([('employee_id', '=', self.employee.id)], order='id')
-        self.assertEqual(len(all_leaves), 4)
-        # Original Time Off
-        self.assertEqual(leave.state, 'refuse')
+        self.assertEqual(len(all_leaves), 3)
         # Before Time Off
-        self.assertEqual(all_leaves[1].date_from, datetime(2020, 1, 7, 7, 0))
-        self.assertEqual(all_leaves[1].date_to, datetime(2020, 1, 7, 16, 0))
+        self.assertEqual(all_leaves[0].date_from, datetime(2020, 1, 7, 7, 0))
+        self.assertEqual(all_leaves[0].date_to, datetime(2020, 1, 7, 16, 0))
+        self.assertEqual(all_leaves[0].number_of_days, 1)
+        self.assertEqual(all_leaves[0].state, 'confirm')
+        # After Time Off
+        self.assertEqual(all_leaves[1].date_from, datetime(2020, 1, 9, 7, 0))
+        self.assertEqual(all_leaves[1].date_to, datetime(2020, 1, 9, 16, 0))
         self.assertEqual(all_leaves[1].number_of_days, 1)
         self.assertEqual(all_leaves[1].state, 'confirm')
-        # After Time Off
-        self.assertEqual(all_leaves[2].date_from, datetime(2020, 1, 9, 7, 0))
-        self.assertEqual(all_leaves[2].date_to, datetime(2020, 1, 9, 16, 0))
-        self.assertEqual(all_leaves[2].number_of_days, 1)
-        self.assertEqual(all_leaves[2].state, 'confirm')
         # Company Time Off
-        self.assertEqual(all_leaves[3].date_from, datetime(2020, 1, 8, 7, 0))
-        self.assertEqual(all_leaves[3].date_to, datetime(2020, 1, 8, 16, 0))
-        self.assertEqual(all_leaves[3].number_of_days, 1)
-        self.assertEqual(all_leaves[3].state, 'validate')
+        self.assertEqual(all_leaves[2].date_from, datetime(2020, 1, 8, 7, 0))
+        self.assertEqual(all_leaves[2].date_to, datetime(2020, 1, 8, 16, 0))
+        self.assertEqual(all_leaves[2].number_of_days, 1)
+        self.assertEqual(all_leaves[2].state, 'validate')
 
     def test_03_leave_whole_company(self):
         # TEST CASE 3: Time Off taken in half-days. Take a 0.5 days leave
@@ -242,19 +238,17 @@ class TestCompanyLeave(TransactionCase):
         company_leave.action_generate_time_off()
 
         all_leaves = self.env['hr.leave'].search([('employee_id', '=', self.employee.id)], order='id')
-        self.assertEqual(len(all_leaves), 3)
-        # Original Time Off
-        self.assertEqual(leave.state, 'refuse')
+        self.assertEqual(len(all_leaves), 2)
         # Before Time Off
-        self.assertEqual(all_leaves[1].date_from, datetime(2020, 1, 6, 7, 0))
-        self.assertEqual(all_leaves[1].date_to, datetime(2020, 1, 9, 16, 0))
-        self.assertEqual(all_leaves[1].number_of_days, 2)
-        self.assertEqual(all_leaves[1].state, 'confirm')
+        self.assertEqual(all_leaves[0].date_from, datetime(2020, 1, 6, 7, 0))
+        self.assertEqual(all_leaves[0].date_to, datetime(2020, 1, 9, 16, 0))
+        self.assertEqual(all_leaves[0].number_of_days, 2)
+        self.assertEqual(all_leaves[0].state, 'confirm')
         # Company Time Off
-        self.assertEqual(all_leaves[2].date_from, datetime(2020, 1, 10, 7, 0))
-        self.assertEqual(all_leaves[2].date_to, datetime(2020, 1, 10, 16, 0))
-        self.assertEqual(all_leaves[2].number_of_days, 1)
-        self.assertEqual(all_leaves[2].state, 'validate')
+        self.assertEqual(all_leaves[1].date_from, datetime(2020, 1, 10, 7, 0))
+        self.assertEqual(all_leaves[1].date_to, datetime(2020, 1, 10, 16, 0))
+        self.assertEqual(all_leaves[1].number_of_days, 1)
+        self.assertEqual(all_leaves[1].state, 'validate')
 
     @warmup
     def test_07_leave_whole_company(self):

--- a/addons/hr_holidays/tests/test_hr_departure_wizard.py
+++ b/addons/hr_holidays/tests/test_hr_departure_wizard.py
@@ -1,0 +1,143 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from datetime import date, timedelta
+
+from odoo.addons.hr_holidays.tests.common import TestHrHolidaysCommon
+
+
+class TestHolidaysFlow(TestHrHolidaysCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.employee = cls.env['hr.employee'].create({
+            'name': 'Sky'
+        })
+        cls.departure_date = date.today()
+        departure_reason = cls.env['hr.departure.reason'].create({'name': "Fired"})
+        cls.departure_wizard = cls.env['hr.departure.wizard'].create({
+            'departure_reason_id': departure_reason.id,
+            'departure_date': cls.departure_date,
+            'employee_id': cls.employee.id,
+        })
+        cls.leave_type = cls.env['hr.leave.type'].create({
+            'name': 'Paid Time Off',
+            'time_type': 'leave',
+            'requires_allocation': 'no',
+        })
+
+    def test_departure_without_leave_and_allocation_employee(self):
+        self._check_action_departure()
+
+    def test_departure_leave_before_departure_date(self):
+        leave = self.env['hr.leave'].with_context(leave_fast_create=True).create({
+            'employee_id': self.employee.id,
+            'holiday_status_id': self.leave_type.id,
+            'request_date_from': self.departure_date + timedelta(days=-6),
+            'request_date_to': self.departure_date,
+        })
+        leave.state = 'validate'
+
+        self._check_action_departure()
+
+    def test_departure_leave_after_departure_date(self):
+        leave = self.env['hr.leave'].with_context(leave_fast_create=True).create({
+            'employee_id': self.employee.id,
+            'holiday_status_id': self.leave_type.id,
+            'request_date_from': self.departure_date + timedelta(days=6),
+            'request_date_to': self.departure_date + timedelta(days=8),
+        })
+        leave.state = 'validate'
+
+        self._check_action_departure()
+
+    def test_departure_leave_with_departure_date(self):
+        leave = self.env['hr.leave'].with_context(leave_fast_create=True).create({
+            'employee_id': self.employee.id,
+            'holiday_status_id': self.leave_type.id,
+            'request_date_from': self.departure_date + timedelta(days=-6),
+            'request_date_to': self.departure_date + timedelta(days=8),
+        })
+        leave.state = 'validate'
+
+        self._check_action_departure()
+        message = "<p>End date has been updated because the employee will leave the company on %(departure_date)s.</p>" % {
+            'departure_date': self.departure_date}
+        self.assertTrue(message in leave.message_ids.mapped('body'))
+
+        cancel_message = "<p>The time off has been cancelled: The employee will leave the company on %(departure_date)s.</p>" % {
+            'departure_date': self.departure_date
+        }
+        self.assertTrue(cancel_message in self.env['hr.leave'].search([
+            ('request_date_from', '=', self.departure_date + timedelta(days=1)),
+            ('request_date_to', '=', self.departure_date + timedelta(days=8)),
+            ("employee_id", "=", self.employee.id)
+        ]).message_ids.mapped('body'))
+
+    def test_departure_allocation_before_departure_date(self):
+        self.env['hr.leave.allocation'].create([{
+            'name': 'allocation',
+            'holiday_status_id': self.leave_type.id,
+            'number_of_days': 15,
+            'employee_id': self.employee.id,
+            'state': 'confirm',
+            'date_from': self.departure_date + timedelta(days=-10),
+            'date_to': self.departure_date,
+        }]).action_validate()
+        self._check_action_departure()
+
+    def test_departure_allocation_after_departure_date(self):
+        self.env['hr.leave.allocation'].create([{
+            'name': 'allocation',
+            'holiday_status_id': self.leave_type.id,
+            'number_of_days': 15,
+            'employee_id': self.employee.id,
+            'state': 'confirm',
+            'date_from': self.departure_date + timedelta(days=1),
+            'date_to': self.departure_date + timedelta(days=10),
+        }]).action_validate()
+        self._check_action_departure()
+
+    def test_departure_allocation_with_departure_date(self):
+        allocation = self.env['hr.leave.allocation'].create([{
+            'name': 'allocation',
+            'holiday_status_id': self.leave_type.id,
+            'number_of_days': 15,
+            'employee_id': self.employee.id,
+            'state': 'confirm',
+            'date_from': self.departure_date + timedelta(days=-10),
+            'date_to': self.departure_date + timedelta(days=10),
+        }])
+        allocation.action_validate()
+        self._check_action_departure()
+
+        allocation_msg = '<p>Validity End date has been updated because the employee will leave the company on %(departure_date)s.</p>' % {
+            'departure_date': self.departure_date
+        }
+        self.assertTrue(allocation_msg in allocation.message_ids.mapped('body'))
+
+    def _check_action_departure(self):
+        self.departure_wizard.action_register_departure()
+        self._check_employee_allocation()
+        self._check_employee_leave()
+
+    def _check_employee_leave(self):
+        leaves_after_departure_date = self.env['hr.leave'].search([
+            ('employee_id', '=', self.employee.id),
+            ('date_from', '>', self.departure_date),
+            ('state', '!=', 'cancel')
+        ])
+
+        self.assertFalse(leaves_after_departure_date)
+        leaves_before_departure_date = self.env['hr.leave'].search([
+            ('employee_id', '=', self.employee.id),
+            ('date_from', '<=', self.departure_date),
+        ])
+        self.assertFalse(any(leave.date_to.date() > self.departure_date for leave in leaves_before_departure_date))
+
+    def _check_employee_allocation(self):
+        allocations = self.env['hr.leave.allocation'].search([
+            ('employee_id', '=', self.employee.id),
+            '|',
+                ('date_from', '>', self.departure_date),
+                ('date_to', '>', self.departure_date),
+        ])
+        self.assertFalse(allocations)

--- a/addons/hr_holidays/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays/views/hr_leave_allocation_views.xml
@@ -183,13 +183,13 @@
         <field name="arch" type="xml">
             <field name="state" position="before">
                 <button string="Approve" name="action_approve"
-                    invisible="not can_approve or state != 'confirm'" type="object" class="oe_highlight"/>
+                    invisible="not can_approve or state != 'confirm' or not active_employee" type="object" class="oe_highlight"/>
                 <button string="Validate" name="action_validate"
-                    invisible="state != 'validate1'" type="object" class="oe_highlight"/>
+                    invisible="state != 'validate1' or not active_employee" type="object" class="oe_highlight"/>
                 <button string="Refuse" name="action_refuse" type="object"
-                    invisible="not can_approve or state not in ('confirm', 'validate1','validate')"/>
+                    invisible="not can_approve or state not in ('confirm', 'validate1','validate') or not active_employee"/>
                 <button string="Mark as ready to approve" name="action_set_to_confirm" type="object"
-                        invisible="not can_approve or state != 'refuse'"/>
+                        invisible="not can_approve or state != 'refuse' or not active_employee"/>
             </field>
             <div id="title" position="replace">
                 <div class="oe_title">

--- a/addons/hr_holidays/wizard/hr_departure_wizard.py
+++ b/addons/hr_holidays/wizard/hr_departure_wizard.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from datetime import datetime, timedelta
@@ -14,17 +13,33 @@ class HrDepartureWizard(models.TransientModel):
         employee_leaves = self.env['hr.leave'].search([
             ('employee_id', '=', self.employee_id.id),
             ('date_to', '>', self.departure_date),
-            ('state', '!=', 'refuse')
         ])
-        to_delete = self.env['hr.leave']
-        to_cancel = self.env['hr.leave']
-        for leave in employee_leaves:
-            if leave.state == 'validate':
-                to_cancel |= leave
-            else:
-                to_delete |= leave
-        to_delete.unlink()
-        to_cancel._force_cancel(_('The employee no longer works in the company'), notify_responsibles=False)
+        if employee_leaves:
+            leaves_with_departure = employee_leaves.filtered(
+                lambda leave: leave.date_from.date() <= self.departure_date)
+            leaves_after_departure = employee_leaves - leaves_with_departure
+
+            new_leaves = leaves_with_departure._split_leaves(
+                split_date_from=(self.departure_date + timedelta(days=1)))
+            # Post message for changes leaves
+            changes_leaves = leaves_with_departure.filtered(lambda leave: leave.date_to.date() <= self.departure_date)
+            changes_msg = _('End date has been updated because '
+                'the employee will leave the company on %(departure_date)s.',
+                departure_date=self.departure_date
+            )
+            for leave in changes_leaves:
+                leave.message_post(body=changes_msg, message_type="comment", subtype_xmlid="mail.mt_comment")
+
+            # Cancel approved leaves
+            leaves_after_departure |= leaves_with_departure - changes_leaves
+            leaves_after_departure |= new_leaves
+            leaves_to_cancel = leaves_after_departure.filtered(lambda leave: leave.state in ['validate', 'validate1'])
+            cancel_msg = _('The employee will leave the company on %(departure_date)s.',
+                departure_date=self.departure_date)
+            leaves_to_cancel._force_cancel(cancel_msg, notify_responsibles=False)
+            # Delete others leaves
+            leaves_to_delete = leaves_after_departure - leaves_to_cancel
+            leaves_to_delete.with_context(leave_skip_state_check=True).unlink()
 
         employee_allocations = self.env['hr.leave.allocation'].search([
             ('employee_id', '=', self.employee_id.id),
@@ -32,17 +47,20 @@ class HrDepartureWizard(models.TransientModel):
                 ('date_to', '=', False),
                 ('date_to', '>', self.departure_date),
         ])
+        if not employee_allocations:
+            return
         to_delete = self.env['hr.leave.allocation']
         to_modify = self.env['hr.leave.allocation']
+        allocation_msg = _('Validity End date has been updated because '
+            'the employee will leave the company on %(departure_date)s.',
+            departure_date=self.departure_date
+        )
         for allocation in employee_allocations:
             if allocation.date_from > self.departure_date:
                 to_delete |= allocation
             else:
                 to_modify |= allocation
-                allocation.message_post(
-                    body=_('Validity End date has been updated because Employee no longer works in the company'),
-                    subtype_xmlid='mail.mt_comment'
-                )
+                allocation.message_post(body=allocation_msg, subtype_xmlid='mail.mt_comment')
         to_delete.write({'state': 'confirm'}) # Needs to be confirmed before it can be unlinked
         to_delete.unlink()
         to_modify.date_to = self.departure_date

--- a/addons/hr_holidays/wizard/hr_departure_wizard.py
+++ b/addons/hr_holidays/wizard/hr_departure_wizard.py
@@ -61,6 +61,5 @@ class HrDepartureWizard(models.TransientModel):
             else:
                 to_modify |= allocation
                 allocation.message_post(body=allocation_msg, subtype_xmlid='mail.mt_comment')
-        to_delete.write({'state': 'confirm'}) # Needs to be confirmed before it can be unlinked
-        to_delete.unlink()
+        to_delete.with_context(allocation_skip_state_check=True).unlink()
         to_modify.date_to = self.departure_date

--- a/addons/hr_holidays/wizard/hr_leave_generate_multi_wizard.py
+++ b/addons/hr_holidays/wizard/hr_leave_generate_multi_wizard.py
@@ -82,8 +82,9 @@ class HrLeaveGenerateMultiWizard(models.TransientModel):
             invalid_time_off = conflicting_leaves.filtered(lambda l: l.leave_type_request_unit == 'hour')
             if invalid_time_off:
                 raise UserError(_('Automatic time off spliting during batch generation is not managed for ovelapping time off declared in hours. Conflicting time off:\n%s', '\n'.join(f"- {l.display_name}" for l in invalid_time_off)))
-
-            conflicting_leaves._split_leaves(self.date_from, self.date_to + timedelta(days=1))
+            one_day_leaves = conflicting_leaves.filtered(lambda leave: leave.request_date_from == leave.request_date_to)
+            one_day_leaves.action_refuse()
+            (conflicting_leaves - one_day_leaves)._split_leaves(self.date_from, self.date_to + timedelta(days=1))
 
         vals_list = self._prepare_employees_holiday_values(employees, date_from_tz, date_to_tz)
         leaves = self.env['hr.leave'].with_context(


### PR DESCRIPTION
When an employee will be archived, his leaves/allocation after the departure date will be automatically cancelled.
If a leave/allocation starts before the departure date and ends after the departure date; this leave/allocation will be cut in two leaves/allocations. [leave (start, stop) -- > leaves (start, departure date) (departure date +1 day, stop)]

task-3946565

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
