### PR TITLE
[FIX] project: singleton error and wrong resId when view history revision

### DIFF
--- a/addons/project/static/src/views/project_task_form/project_task_form_controller.js
+++ b/addons/project/static/src/views/project_task_form/project_task_form_controller.js
@@ -47,7 +47,7 @@ export class ProjectTaskFormController extends FormController {
         this.dialogService.add(
             HistoryDialog,
             {
-                recordId: this.props.resId,
+                recordId: record.resId,
                 recordModel: this.props.resModel,
                 versionedFieldName,
                 historyMetadata,

--- a/addons/project/static/tests/tours/project_task_history.js
+++ b/addons/project/static/tests/tours/project_task_history.js
@@ -113,6 +113,40 @@ registry.category("web_tour.tours").add("project_task_history_tour", {
             }
         }
     }, {
+        content: "Go back to projects view.",
+        trigger: 'a[data-menu-xmlid="project.menu_projects"]',
+    }, {
+        content: "Open Test History Project Without Tasks",
+        trigger: "div span.o_text_overflow[title='Without tasks project']",
+        extra_trigger: ".o_kanban_view",
+    }, {
+        content: "Switch to list view",
+        extra_trigger: "div .o_project_task_kanban_view",
+        trigger: ".o_switch_view.o_list",
+    }, {
+        content: "Create a new task.",
+        trigger: '.o_list_button_add',
+    }, {
+        trigger: 'textarea[id="name_0"]',
+        content: 'Set task name',
+        run: 'text New task',
+    },
+        ...changeDescriptionContentAndSave("0"),
+        ...changeDescriptionContentAndSave("1"),
+        ...changeDescriptionContentAndSave("2"),
+        ...changeDescriptionContentAndSave("3"),
+    {
+        content: "Open History Dialog",
+        trigger: ".o_cp_action_menus i.fa-cog",
+        extra_trigger: ".o_form_view",
+    }, {
+        content: "Open History Dialog",
+        trigger: ".o_cp_action_menus .o_menu_item i.fa-history",
+        extra_trigger: ".o_cp_action_menus .dropdown-menu",
+    }, {
+        content: "Close History Dialog",
+        trigger: ".modal-header .btn-close",
+    }, {
         content: "Go back to projects view. this step is added because Tour can't be finished with an open form view in edition mode.",
         trigger: 'a[data-menu-xmlid="project.menu_projects"]',
     }, {

--- a/addons/project/tests/test_project_ui.py
+++ b/addons/project/tests/test_project_ui.py
@@ -1,7 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import odoo.tests
-from odoo import Command
 
 
 @odoo.tests.tagged('post_install', '-at_install')
@@ -12,15 +11,19 @@ class TestUi(odoo.tests.HttpCase):
 
     def test_project_task_history(self):
         """This tour will check that the history works properly."""
-        project = self.env['project.project'].create({
+        stage = self.env['project.task.type'].create({'name': 'To Do'})
+        _dummy, project2 = self.env['project.project'].create([{
+            'name': 'Without tasks project',
+            'type_ids': stage.ids,
+        }, {
             'name': 'Test History Project',
-            'type_ids': [Command.create({'name': 'To Do'})],
-        })
+            'type_ids': stage.ids,
+        }])
 
         self.env['project.task'].create({
             'name': 'Test History Task',
-            'stage_id': project.type_ids[0].id,
-            'project_id': project.id,
+            'stage_id': stage.id,
+            'project_id': project2.id,
         })
 
         self.start_tour('/web', 'project_task_history_tour', login='admin')


### PR DESCRIPTION
This solve 2 problems:
--------------------

* Singleton Error:
  - STEP TO REPRODUCE: Go to tree view mode of task, press New to create
a new Task, input 'description' -> Save -> Then edit its
description again -> Save -> View history revision -> Error

  - Solution is to ensure 'recordId' has value when opening History
Dialog

* Wrong resId when switching task:
  - when you have 2 tasks, and you navigate between them,
this.props.resId will usually be the one for the first task, so the
history is wrong when we navigate between tasks, Instead we use
this.model.root.resId

Video to reproduce on runbot saas-17.1

https://github.com/odoo/odoo/assets/56789189/1cfd2dd8-a80e-4bdd-aac4-82856eadc8de




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
