### PR TITLE
[FIX] hr_expense: handle reversal_move_id as One2many when computing payment state

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -1036,7 +1036,10 @@ class HrExpenseSheet(models.Model):
             sheet_move = sheet.account_move_id
             if not sheet_move:
                 sheet.payment_state = 'not_paid'
-            elif sheet_move.currency_id.compare_amounts(sheet_move.reversal_move_id.amount_total, sheet_move.amount_total) == 0:
+            elif sheet_move.currency_id.compare_amounts(
+                sum(sheet_move.reversal_move_id.mapped('amount_total')),
+                sheet_move.amount_total
+            ) == 0:
                 sheet.payment_state = 'reversed'
             else:
                 sheet.payment_state = sheet_move.payment_state


### PR DESCRIPTION
**Issue:**
When computing payment state of an expense, we check the amount of "reversal_move_id" field as if it was a Many2one, which triggers a traceback when it contains several records.

**Steps to reproduce:**
Unable to reproduce 2 reversal moves for a sheet move directly from version 16.0.
However, it was possible to reverse the sheet move several times in version 14.0.
If upgrading a 14.0 database to 16.0 with such moves, a traceback is raised in "_compute_payment_state" method.

opw-3997248



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
