### PR TITLE
[FIX] mrp_subcontracting: use the right uom

### DIFF
--- a/addons/mrp_subcontracting/models/stock_move.py
+++ b/addons/mrp_subcontracting/models/stock_move.py
@@ -325,7 +325,7 @@ class StockMove(models.Model):
         if wip_production:
             self.env['change.production.qty'].with_context(skip_activity=True).create({
                 'mo_id': wip_production.id,
-                'product_qty': wip_production.product_uom_qty + quantity_to_remove
+                'product_qty': wip_production.product_qty + quantity_to_remove
             }).change_prod_qty()
 
         # Cancel productions until reach new_quantity
@@ -336,7 +336,7 @@ class StockMove(models.Model):
             else:
                 self.env['change.production.qty'].with_context(skip_activity=True).create({
                     'mo_id': production.id,
-                    'product_qty': production.product_uom_qty - quantity_to_remove
+                    'product_qty': production.product_qty - quantity_to_remove
                 }).change_prod_qty()
                 break
 

--- a/addons/mrp_subcontracting/tests/test_subcontracting.py
+++ b/addons/mrp_subcontracting/tests/test_subcontracting.py
@@ -925,6 +925,12 @@ class TestSubcontractingFlows(TestMrpSubcontractingCommon):
     def test_decrease_quantity_done(self):
         self.bom.consumption = 'flexible'
         supplier_location = self.env.ref('stock.stock_location_suppliers')
+        uom_duo = self.env['uom.uom'].create({
+            'category_id': self.finished.uom_id.category_id.id,
+            'name': 'Duos',
+            'uom_type': 'bigger',
+            'factor_inv': 2.0,
+        })
 
         receipt = self.env['stock.picking'].create({
             'partner_id': self.subcontractor_partner1.id,
@@ -935,7 +941,7 @@ class TestSubcontractingFlows(TestMrpSubcontractingCommon):
                 'name': self.finished.name,
                 'product_id': self.finished.id,
                 'product_uom_qty': 10.0,
-                'product_uom': self.finished.uom_id.id,
+                'product_uom': uom_duo.id,
                 'location_id': supplier_location.id,
                 'location_dest_id': self.warehouse.lot_stock_id.id,
             })],


### PR DESCRIPTION
When reducing the quantity to produce in the subcontracted manufacturing orders, we use the wrong quantity for the call to `change_prod_qty()`.

Instead of `production.product_uom_qty` (which is in the **product** uom), use `production.product_qty` (which is in the **production** uom), itself set from the move's uom.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
