### PR TITLE
[FIX] project : Remove followers if they are not related to the project

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -2088,6 +2088,13 @@ class Task(models.Model):
                 task._portal_ensure_token()
             if current_partner not in task.message_partner_ids:
                 task.message_subscribe(current_partner.ids)
+            for follower in task.message_follower_ids:
+                if (
+                        (follower.partner_id.user_ids != task.project_id.user_id)
+                        and (follower.partner_id.user_ids.id not in task.user_ids.ids)
+                        and follower.partner_id != current_partner
+                ):
+                    task.message_unsubscribe(follower.partner_id.ids)
         return tasks
 
     def write(self, vals):

--- a/addons/project/tests/test_task_follow.py
+++ b/addons/project/tests/test_task_follow.py
@@ -13,3 +13,14 @@ class TestTaskFollow(TestProjectCommon):
         # Tests that the user is follower of the task upon writing new assignees
         self.task_2.user_ids += self.user_projectmanager
         self.assertTrue(self.user_projectmanager.partner_id in self.task_2.message_partner_ids)
+
+    def test_follow_after_change_project_manager(self):
+        # Change the manager to create a mail_follower for user_projectmanager linked to the project_goats
+        self.project_goats.user_id = self.user_projectmanager
+        # Change the manager again to create a mail_follower for user_projectuser linked to the project_goats
+        self.project_goats.user_id = self.user_projectuser
+        task = self.env['project.task'].create({
+            'name': 'Test Task',
+            'project_id': self.project_goats.id,
+        })
+        self.assertFalse(self.user_projectmanager.partner_id in task.message_follower_ids.partner_id)


### PR DESCRIPTION
### Steps to reproduce:
	- Install Project module
	- Create a project and a task inside this project
	- Change the project manager
	- Create a new task in the project

### Current behavior before PR:
The previous project manager will still be added as a follower even though he is not assigned to this task and he is not the one created it. This is happening because when assigning a user to be a project manager we create 'mail.follower' record for this user linked to this project and even when he is no longer the project manager this record doesn't get deleted so when getting the followers data this record will still be fetched from the database and we add him as follower. https://github.com/odoo/odoo/blob/17.0/addons/mail/models/mail_followers.py#L368:L382

### Desired behavior after PR is merged:
After creating a task we filter the followers that have been added and remove any follower who is not the creator of the task or the project manager or one of the assignees.

### Other Solution:
Delete the 'mail.followers' record from the database when changing the project manager. The only issue in this fix is that it won't affect already existed projects that has already changed the project manager before this commit.

opw-3980595