### PR TITLE
[FIX] website_sale: display correctly the selected quantity in the cart

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -971,7 +971,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
                 { # For the cart_notification
                     'id': line.id,
                     'image_url': order.website_id.image_url(line.product_id, 'image_128'),
-                    'quantity': line.product_uom_qty,
+                    'quantity': line._get_displayed_quantity(),
                     'name': line.name_short,
                     'description': line._get_sale_order_line_multiline_description_variants(),
                     'line_price_total': line.price_total if show_tax else line.price_subtotal,

--- a/addons/website_sale/models/sale_order_line.py
+++ b/addons/website_sale/models/sale_order_line.py
@@ -78,6 +78,11 @@ class SaleOrderLine(models.Model):
             self.price_unit, self.currency_id, 1, self.product_id, self.order_partner_id,
         )[tax_display]
 
+    def _get_displayed_quantity(self):
+        rounded_uom_qty = round(self.product_uom_qty,
+                                self.env['decimal.precision'].precision_get('Product Unit of Measure'))
+        return int(rounded_uom_qty) == rounded_uom_qty and int(rounded_uom_qty) or rounded_uom_qty
+
     def _show_in_cart(self):
         self.ensure_one()
         # Exclude delivery & section/note lines from showing up in the cart

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1567,7 +1567,7 @@
                                            class="js_quantity quantity form-control border-start-0 border-end-0"
                                            t-att-data-line-id="line.id"
                                            t-att-data-product-id="line.product_id.id"
-                                           t-att-value="int(line.product_uom_qty) == line.product_uom_qty and int(line.product_uom_qty) or line.product_uom_qty"/>
+                                           t-att-value="line._get_displayed_quantity()"/>
                                     <t t-if="line._get_shop_warning(clear=False)">
                                         <a href="#" class="btn btn-link">
                                         <i class='fa fa-warning text-warning'
@@ -1589,7 +1589,7 @@
                                            class="js_quantity form-control quantity"
                                            t-att-data-line-id="line.id"
                                            t-att-data-product-id="line.product_id.id"
-                                           t-att-value="int(line.product_uom_qty) == line.product_uom_qty and int(line.product_uom_qty) or line.product_uom_qty"/>
+                                           t-att-value="line._get_displayed_quantity()"/>
                                 </t>
                             </t>
                             <t t-else="">
@@ -1598,7 +1598,7 @@
                                        class="js_quantity quantity form-control"
                                        t-att-data-line-id="line.id"
                                        t-att-data-product-id="line.product_id.id"
-                                       t-att-value="line.product_uom_qty"/>
+                                       t-att-value="line._get_displayed_quantity()"/>
                             </t>
                         </div>
                         <div class="mb-0 h6 fw-bold text-end" name="website_sale_cart_line_price">


### PR DESCRIPTION
To reproduce the bug:
1. On Runbot, set the decimal accuracy of "Product Unit of Measure" to 5.
2. Go to the website and add a product to the cart.
3. Go to the cart and click on the "+" button.

Some decimals may appear due to issues related to floating-point numbers. This issue is being addressed and will be fixed in the future (see: https://github.com/odoo/odoo/pull/152709). In the meantime, we can apply a fix on the frontend.

opw-3990565