### PR TITLE
[FIX] point_of_sale,pos_online_payment: kitchen printer self order

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -317,6 +317,8 @@ class PosOrder(models.Model):
     tracking_number = fields.Char(string="Order Number", compute='_compute_tracking_number', search='_search_tracking_number')
     uuid = fields.Char(string='Uuid', readonly=True, copy=False)
 
+    kitchen_printed = fields.Boolean(string="Kitchen Printed", default=False)
+
     def _search_tracking_number(self, operator, value):
         #search is made over the pos_reference field
         #The pos_reference field is like 'Order 00001-001-0001'
@@ -1108,6 +1110,12 @@ class PosOrder(models.Model):
         orders.mapped('payment_ids').sudo().unlink()
         orders.sudo().unlink()
         return orders.ids
+
+    def should_print_kitchen(self):
+        if self.kitchen_printed:
+            return False
+        self.kitchen_printed = True
+        return True
 
     @api.model
     def search_paid_order_ids(self, config_id, domain, limit, offset):

--- a/addons/pos_self_order/models/pos_order.py
+++ b/addons/pos_self_order/models/pos_order.py
@@ -10,6 +10,7 @@ class PosOrderLine(models.Model):
     _inherit = "pos.order.line"
 
     combo_id = fields.Many2one('pos.combo', string='Combo line reference')
+    kitchen_printed = fields.Boolean('Kitchen Printed', default=False)
 
     @api.model_create_multi
     def create(self, vals_list):
@@ -60,6 +61,12 @@ class PosOrder(models.Model):
             self._send_notification(self)
 
         return res
+
+    def should_print_kitchen(self):
+        if self.kitchen_printed:
+            return False
+        self.kitchen_printed = True
+        return True
 
     @api.model
     def remove_from_ui(self, server_ids):


### PR DESCRIPTION
When ordering from a self order mobile and using the online payment method, the order was not sent to the kitchen printer

Steps to reproduce:
-------------------
* Setup an online payment method to be used in the self order
* Setup a kitchen printer for any PoS, to print all orders
* Setup the PoS to use the mobile self ordering
* Open the PoS
* Open the self order on another tab
* Make any order on the self order and pay for it using the online payment
> Observation: Nothing is printed on the kitchen printer

Why the fix:
------------
When the payment is finalized nothing was done to send it to the kitchen printer. To fix this, when the order is paid we send a notification to the PoS. When the PoS receive this notification it will retrieve the order that has been paid and send it to the kitchen printer.

opw-3974742
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
