### PR TITLE
[FIX] resource: make duration days editable again

### DIFF
--- a/addons/resource/models/resource_calendar_attendance.py
+++ b/addons/resource/models/resource_calendar_attendance.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import math
@@ -74,7 +73,7 @@ class ResourceCalendarAttendance(models.Model):
         for attendance in self:
             attendance.duration_hours = (attendance.hour_to - attendance.hour_from) if attendance.day_period != 'lunch' else 0
 
-    @api.depends('day_period', 'duration_hours', 'calendar_id.hours_per_day')
+    @api.depends('day_period', 'duration_hours')
     def _compute_duration_days(self):
         for attendance in self:
             if attendance.day_period == 'lunch':


### PR DESCRIPTION
Versions
--------
- 17.0+

Steps
-----
1. Go to working schedules;
2. try to modify duration days.

Issue
-----
Any change gets undone immediately.

Cause
-----
Commit https://github.com/odoo/odoo/commit/bbae19cc630cb629adabbc54e7fa96f23a4359d8 added `calendar_id.hours_per_day` to the dependent fields of the `_compute_duration_days` method. Because modifications happen on temporary records, any modification will now trigger a recompute, overwriting the manual values.

Solution
--------
Remove `calendar_id.hours_per_day` from `api.depends`. Having the fields editable is preferable over triggering recomputes ASAP.

opw-3999825