### PR TITLE
[FIX] mail: no crash on opening channel member panel

### DIFF
--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -600,7 +600,9 @@ export class Thread extends Record {
         compute() {
             return this.channelMembers.filter((member) => member.persona.im_status === "online");
         },
-        sort: (m1, m2) => this.store.Thread.sortOnlineMembers(m1, m2),
+        sort(m1, m2) {
+            return this.store.Thread.sortOnlineMembers(m1, m2);
+        },
     });
 
     static sortOnlineMembers(m1, m2) {


### PR DESCRIPTION
Before this commit, opening channel member resulted in the following crash:

`TypeError: Cannot read properties of undefined (reading 'Model')`

Steps to reproduce:
- Go to Discuss app
- Select a channel or chat in left sidebar
- Click on member icon on top-right corner (2 users icon)

This happens because a sorted field `onlineMembers` was computing using `this`, which is intended to refer to the Thread record. However, as it was using arrow function, `this` is refering to a dummy Thread record used internally and crashes.

Arrow function on `sort` and `compute` options on fields are fine as long as `this` is not used. When that's the case, the non-arrow syntax should be used to ensure proper `this`.