### PR TITLE
[FIX] stock: Remove empty column on delivery slip report

### DIFF
--- a/addons/stock/report/report_deliveryslip.xml
+++ b/addons/stock/report/report_deliveryslip.xml
@@ -168,7 +168,6 @@
                             <thead>
                                 <tr>
                                     <th name="th_sb_product"><strong>Product</strong></th>
-                                    <th/>
                                     <th name="th_sb_quantity" class="text-center"><strong>Quantity</strong></th>
                                 </tr>
                             </thead>
@@ -182,7 +181,6 @@
                                                 <span t-field="bo_line.description_picking"/>
                                             </p>
                                         </td>
-                                        <td/>
                                         <td class="text-center w-auto">
                                             <span t-field="bo_line.product_uom_qty"/>
                                             <span t-field="bo_line.product_uom"/>


### PR DESCRIPTION
Versions: 16.0+

Issue:
Empty column on delivery slip report for transfers with unfinished backorders.

Purpose of this PR:
Remove the empty column.

Steps to reproduce on Runbot:
1) Validate a transfer with less than demanded quantity. 
2) Create the backorder when prompted.
3) Print the transfer.

Notes:
Affects all document layouts

opw-4014770