### PR TITLE
[FIX] maintenance: error ensure_one

### DIFF
--- a/addons/maintenance/models/maintenance.py
+++ b/addons/maintenance/models/maintenance.py
@@ -367,7 +367,7 @@ class MaintenanceRequest(models.Model):
                 date_deadline=date_dl,
                 new_user_id=request.user_id.id or request.owner_user_id.id or self.env.uid)
             if not updated:
-                note = self._get_activity_note()
+                note = request._get_activity_note()
                 request.activity_schedule(
                     'maintenance.mail_act_maintenance_request',
                     fields.Datetime.from_string(request.schedule_date).date(),

--- a/doc/cla/corporate/VillaGroup.md
+++ b/doc/cla/corporate/VillaGroup.md
@@ -1,0 +1,15 @@
+México, 2024-06-28
+
+Villa Group agrees to the terms of the Odoo Corporate Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Diego Pelayo diego.pelayo@villagroup.com https://github.com/DiegoVGV
+
+List of contributors:
+
+Diego Pelayo diego.pelayo@villagroup.com https://github.com/DiegoVGV


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
call to _get_activity_note should be request not self

Current behavior before PR:
When creating more than one maintenance you get the error:
"raise ValueError("Expected singleton: %s" % self)" on
note = self._get_activity_note()

Desired behavior after PR is merged:
create the note for each request correctly



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
