### PR TITLE
[FIX] whatsapp: Assign to correct UTMs

### DIFF
--- a/addons/crm_livechat_whatsapp/__init__.py
+++ b/addons/crm_livechat_whatsapp/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/addons/crm_livechat_whatsapp/__manifest__.py
+++ b/addons/crm_livechat_whatsapp/__manifest__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    'name': 'CRM Livechat whatsapp',
+    'category': 'Sales/CRM',
+    'summary': 'Create lead from whatsapp conversation',
+    'data': [
+        'data/utm_data.xml',
+    ],
+    'depends': [
+        'crm',
+        'im_livechat',
+        'whatsapp'
+    ],
+    'description': 'Create new lead with using /lead command in the channel',
+    'auto_install': True,
+    'license': 'LGPL-3',
+}

--- a/addons/crm_livechat_whatsapp/data/utm_data.xml
+++ b/addons/crm_livechat_whatsapp/data/utm_data.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record model="utm.source" id="utm_source_whatsapp">
+        <field name="name">WhatsApp Account</field>
+    </record>
+
+    <record model="utm.medium" id="utm_medium_whatsapp">
+        <field name="name">WhatsApp</field>
+    </record>
+</odoo>

--- a/addons/crm_livechat_whatsapp/models/__init__.py
+++ b/addons/crm_livechat_whatsapp/models/__init__.py
@@ -1,0 +1,1 @@
+from . import discuss_channel

--- a/addons/crm_livechat_whatsapp/models/discuss_channel.py
+++ b/addons/crm_livechat_whatsapp/models/discuss_channel.py
@@ -1,0 +1,13 @@
+from odoo import models
+
+
+class DiscussChannel(models.Model):
+    _inherit = 'discuss.channel'
+
+    def get_crm_lead_vals(self, partner, key, customers):
+        lead_vals = super().get_crm_lead_vals(partner, key, customers)
+        utm_source = self.env.ref('crm_livechat_whatsapp.utm_source_whatsapp', raise_if_not_found=False)
+        utm_medium = self.env.ref('crm_livechat_whatsapp.utm_medium_whatsapp', raise_if_not_found=False)
+        lead_vals['source_id'] = utm_source and utm_source.id,
+        lead_vals['medium_id'] = utm_medium and utm_medium.id
+        return lead_vals


### PR DESCRIPTION
The creation of lead is corrected when conversation happens via whatsapp channel. After this commit, the correct UTM source and medium is set after the lead is created

task-3964124

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
