### PR TITLE
[FIX] base: validate timezones again

### DIFF
--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -200,7 +200,7 @@ class Partner(models.Model):
     lang = fields.Selection(_lang_get, string='Language',
                             help="All the emails and documents sent to this contact will be translated in this language.")
     active_lang_count = fields.Integer(compute='_compute_active_lang_count')
-    tz = fields.Selection(_tz_get, string='Timezone', default=lambda self: self._context.get('tz'),
+    tz = fields.Selection(_tzs, string='Timezone', default=lambda self: self._context.get('tz'),
                           help="When printing documents and exporting/importing data, time values are computed according to this timezone.\n"
                                "If the timezone is not set, UTC (Coordinated Universal Time) is used.\n"
                                "Anywhere else, time values are computed according to the time offset of your web client.")


### PR DESCRIPTION
In odoo/odoo#154177 it was apparently decided that validating callable selections is unnecessary, leading to the lang and timezone fields not being validated anymore.

Nothing to be done for the lang as it relies on the installed langs and thus the corresponding database, however the tz list has effectively been static / global since
odoo/odoo#26496 (f11d143f00add145f1a05b51968108e46b96ca87). So initialise `tz` with the precomputed value instead of the function which returns the precomputed value.

cherry-pick of ff8ac5d13cd6bb

