### PR TITLE
[CLN] website: fix await on trigger_up in s_instagram_page options

### DIFF
--- a/addons/website/static/src/snippets/s_instagram_page/options.js
+++ b/addons/website/static/src/snippets/s_instagram_page/options.js
@@ -62,9 +62,13 @@ options.registry.InstagramPage = options.Class.extend({
         this.$target[0].dataset.instagramPage = widgetValue || "";
         // As the public widget restart is disabled for instagram, we have to
         // manually restart the widget.
-        await this.trigger_up("widgets_start_request", {
-            $target: this.$target,
-            editableMode: true,
+        await new Promise((resolve, reject) => {
+            this.trigger_up("widgets_start_request", {
+                $target: this.$target,
+                editableMode: true,
+                onSuccess: () => resolve(),
+                onFailure: () => reject(),
+            });
         });
     },
 


### PR DESCRIPTION
trigger_up never returns a Promise, this commit therefore awaits onSuccess/onFailure of the event trigger