### PR TITLE
[FIX] purchase: prevent planned date reset on order line creation

### DIFF
--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -185,7 +185,9 @@ class PurchaseOrder(models.Model):
     def _compute_date_planned(self):
         """ date_planned = the earliest date_planned across all order lines. """
         for order in self:
-            dates_list = order.order_line.filtered(lambda x: not x.display_type and x.date_planned).mapped('date_planned')
+            relevant_lines = order.order_line.filtered(lambda x: not x.display_type and x.date_planned)
+            relevant_lines = relevant_lines.filtered(lambda x: x._origin) or relevant_lines
+            dates_list = relevant_lines.mapped('date_planned')
             if dates_list:
                 order.date_planned = min(dates_list)
             else:


### PR DESCRIPTION
### Steps to reproduce:

- Create a purchase order with 1 sale order line: 1 x Product P1 and planned date to tomorrow (> this updates the planned date of the PO)
- Save the PO
- Add a sale order line and set a Product

#### > All planned_date are updated to today

### Cause of the issue:

The `date_planned` fields of the `purchase.order` and `purchase.order.line` are both computed and stored. Adding a new line on the PO will trigger the creation of a `New` sale order line associated with the `New` purchase order (created so that the change on the originial PO are not applied untill the record is saved). When a product is set on the line, the `date_planned` of the new line is set by its compute method here:
https://github.com/odoo/odoo/blob/5d8c8f3d01c3c633bcacbdb9e42419e11eb802d9/addons/purchase/models/purchase_order_line.py#L331 Since the `date_planned` of the line changed it triggers the compute method of the `date_planned` of the purchase order: https://github.com/odoo/odoo/blob/5d8c8f3d01c3c633bcacbdb9e42419e11eb802d9/addons/purchase/models/purchase_order.py#L184-L190 Since the `date_planned` of the new line is "smaller" than the `date_planned` of the other already existing line, the `date_planned` of the PO will be changed to that min value. This will in turn trigger the `onchange_date_planned` of the purchase order since we are in the Form view of that model and will update the "planned_date" of every other existing line accordingly:
https://github.com/odoo/odoo/blob/5d8c8f3d01c3c633bcacbdb9e42419e11eb802d9/addons/purchase/models/purchase_order.py#L229-L232

### Fix:

The `date_planned` of the purchase order should only be computed regarding the values the lines that are already existing (hence having an origin). As such, the onchange will not be applied by the creation of the new line. However, the `date_planed` of the PO will be correclty updated since, when the record will be saved, the new line will be created and will retrigger the `_compute_date_planned` of the PO.

### Note:

If you change the `date_planned` of an already existing line in the Form view it will update the values of every other lines because of the `onchange_date_planned` of the PO model.

opw-4000019
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
