### PR TITLE
[FIX] web: HOOT - prevented pointer events allow clicks

### DIFF
--- a/addons/web/static/lib/hoot-dom/helpers/events.js
+++ b/addons/web/static/lib/hoot-dom/helpers/events.js
@@ -1270,22 +1270,16 @@ const _pointerUp = (target, options) => {
         return;
     }
 
-    const prevented = dispatchEventSequence(
-        target,
-        ["pointerup", hasTouch() ? "touchend" : "mouseup"],
-        eventInit
-    );
+    dispatchEventSequence(target, ["pointerup", hasTouch() ? "touchend" : "mouseup"], eventInit);
 
-    if (!prevented) {
-        const clickEventInit = { ...eventInit, detail: runTime.currentClickCount + 1 };
-        const currentTarget = runTime.currentPointerDownTarget;
-        const parent = currentTarget && getFirstCommonParent(target, currentTarget);
-        if (parent) {
-            triggerClick(parent, clickEventInit);
-            runTime.currentClickCount++;
-            if (!hasTouch() && runTime.currentClickCount % 2 === 0) {
-                dispatch(parent, "dblclick", clickEventInit);
-            }
+    const clickEventInit = { ...eventInit, detail: runTime.currentClickCount + 1 };
+    const currentTarget = runTime.currentPointerDownTarget;
+    const parent = currentTarget && getFirstCommonParent(target, currentTarget);
+    if (parent) {
+        triggerClick(parent, clickEventInit);
+        runTime.currentClickCount++;
+        if (!hasTouch() && runTime.currentClickCount % 2 === 0) {
+            dispatch(parent, "dblclick", clickEventInit);
         }
     }
 

--- a/addons/web/static/lib/hoot/tests/hoot-dom/events.test.js
+++ b/addons/web/static/lib/hoot/tests/hoot-dom/events.test.js
@@ -281,6 +281,24 @@ describe(parseUrl(import.meta.url), () => {
         ]);
     });
 
+    test("click can be dispatched with pointer events prevented", async () => {
+        await mountOnFixture(/* xml */ `<button type="button">Click me</button>`);
+
+        const prevent = (ev) => ev.preventDefault();
+
+        on("button", "pointerdown", prevent);
+        on("button", "mousedown", prevent);
+        on("button", "pointerup", prevent);
+        on("button", "mouseup", prevent);
+
+        hover("button");
+        monitorEvents("button");
+
+        click("button");
+
+        expect.verifySteps(["button.pointerdown", "button.pointerup", "button.click"]);
+    });
+
     test("click: iframe", async () => {
         await mountOnFixture(/* xml */ `
             <button>Click me</button>


### PR DESCRIPTION
Before this commit, when using HOOT pointer event helpers such as `click`, preventing the `pointerup`, `mouseup` or `touchend` event would prevent the final `click` event to be dispatched.

Now, the `click` event can be dispatched regardless, as it would be during an actual user-triggered click.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
