### PR TITLE
[REM] sale_margin: remove redundant view

### DIFF
--- a/addons/sale_margin/views/sale_order_views.xml
+++ b/addons/sale_margin/views/sale_order_views.xml
@@ -20,17 +20,6 @@
         </field>
     </record>
 
-    <record model="ir.ui.view" id="sale_margin_sale_order_line">
-        <field name="name">sale.order.line.margin.view.form</field>
-        <field name="model">sale.order</field>
-        <field name="inherit_id" ref="sale.view_order_form"/>
-        <field name="arch" type="xml">
-            <xpath expr="//field[@name='order_line']/form//field[@name='price_unit']" position="after">
-                <field name="purchase_price" groups="base.group_user"/>
-            </xpath>
-        </field>
-    </record>
-
     <record model="ir.ui.view" id="sale_margin_sale_order_line_form">
         <field name="name">sale.order.line.tree.margin.view.form</field>
         <field name="model">sale.order</field>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Remove redundant view which is still there from old days and introducing the same inheritance in the view underneath in the file. It is nowhere inherited in core code, but will create issues if you try to inherit purchase_price in the view underneath, namely not being visible (probably another issue in the framework).

**Current behavior before PR:**
Redundant view from old days creating issues

**Desired behavior after PR is merged:**
No issues based on redundant field / views

Info: @wt-io-it


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
