### PR TITLE
[FIX] web: pushing the global state to the correct state

### DIFF
--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -989,7 +989,16 @@ export function makeActionManager(env, router = _router) {
             );
 
             currentController.action.globalState = globalState;
-            router.pushState({ globalState }, { sync: true });
+            // Avoid pushing the globalState, if the state on the router was changed.
+            // For instance, if a link was clicked, the state of the router will be the one of the link and not the one of the currentController.
+            // Or when using the back or forward buttons on the browser.
+            if (
+                currentController.state.action === router.current.action &&
+                currentController.state.active_id === router.current.active_id &&
+                currentController.state.resId === router.current.resId
+            ) {
+                router.pushState({ globalState }, { sync: true });
+            }
         }
         if (controller.action.globalState) {
             controller.props.globalState = controller.action.globalState;

--- a/addons/web/static/tests/legacy/webclient/actions/load_state_tests.js
+++ b/addons/web/static/tests/legacy/webclient/actions/load_state_tests.js
@@ -1067,6 +1067,7 @@ QUnit.module("ActionManager", (hooks) => {
             assert.step(method || route);
         };
         redirect("/odoo/action-3/2");
+        logHistoryInteractions(assert);
 
         serverData.views = {
             ...serverData.views,
@@ -1088,6 +1089,7 @@ QUnit.module("ActionManager", (hooks) => {
             "/web/action/load",
             "get_views",
             "web_read",
+            "Update the state without updating URL, nextState: actionStack,resId,action",
         ]);
         assert.strictEqual(
             browser.location.href,
@@ -1111,7 +1113,7 @@ QUnit.module("ActionManager", (hooks) => {
         await click(target, ".breadcrumb-item");
         await nextTick();
         assert.containsOnce(target, ".o_list_view");
-        assert.verifySteps(["web_search_read"]);
+        assert.verifySteps(["web_search_read", "pushState http://example.com/odoo/action-3"]);
     });
 
     QUnit.module("Load State: legacy urls");


### PR DESCRIPTION
Since [1], the global state was pushed before opening a new controller. For instance, when opening a record in a kanban view. An issue could happen, because the code didn't assure that the current state of the router, was the same as the state of the current controller, before pushing. The state of the router could be modified previously, for instance, clicking on an internal link, so the state of the router will be different as the state of the current controller.

This commit, will ensure that the pushed global state is done to the correct state.

[1] : https://github.com/odoo/odoo/commit/f26256f566840ff252886b7383f3685720da9a6e
