### PR TITLE
[FIX] pos_loyalty: prevent error when reward product is archived

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/models/loyalty.js
+++ b/addons/pos_loyalty/static/src/overrides/models/loyalty.js
@@ -1015,6 +1015,9 @@ patch(Order.prototype, {
                 if (reward.reward_type === "product") {
                     if (!reward.multi_product) {
                         const product = this.pos.db.get_product_by_id(reward.reward_product_ids[0]);
+                        if (!product) {
+                            continue;
+                        }
                         unclaimedQty = this._computeUnclaimedFreeProductQty(
                             reward,
                             couponProgram.coupon_id,


### PR DESCRIPTION
This commit adds a check to prevent errors when a reward product is archived.

opw-4012282

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
