### PR TITLE
[FIX] web, *: Prevent crashes when using JS APIs with sr@latin language

### DIFF
--- a/addons/payment_adyen/static/src/js/payment_form.js
+++ b/addons/payment_adyen/static/src/js/payment_form.js
@@ -3,6 +3,7 @@ odoo.define('payment_adyen.payment_form', require => {
     'use strict';
 
     const core = require('web.core');
+    const { pyToJsLocale } = require('@web/core/l10n/utils');
     const checkoutForm = require('payment.checkout_form');
     const manageForm = require('payment.manage_form');
 
@@ -159,7 +160,7 @@ odoo.define('payment_adyen.payment_form', require => {
                         paymentMethodsResponse: paymentMethodsResult['payment_methods_data'],
                         amount: paymentMethodsResult['amount_formatted'],
                         clientKey: acquirerInfo.client_key,
-                        locale: (this._getContext().lang || 'en-US').replace('_', '-'),
+                        locale: pyToJsLocale(this._getContext().lang || 'en-US'),
                         environment: acquirerInfo.state === 'enabled' ? 'live' : 'test',
                         onAdditionalDetails: this._dropinOnAdditionalDetails.bind(this),
                         onError: this._dropinOnError.bind(this),

--- a/addons/web/static/src/core/l10n/utils.js
+++ b/addons/web/static/src/core/l10n/utils.js
@@ -1,0 +1,33 @@
+/** @odoo-module **/
+
+/**
+ * Converts a locale from Python to JavaScript format.
+ *
+ * Most of the time the conversion is simply to replace _ with -.
+ * Example: fr_BE → fr-BE
+ *
+ * Exception: Serbian can be written in both Latin and Cyrillic scripts
+ * interchangeably, therefore its locale includes a special modifier
+ * to indicate which script to use.
+ * Example: sr@latin → sr-Latn
+ *
+ * BCP 47 (JS):
+ *  language[-extlang][-script][-region][-variant][-extension][-privateuse]
+ * XPG syntax (Python):
+ *  language[_territory][.codeset][@modifier]
+ *
+ * @param {string} locale The locale formatted for use on the Python-side.
+ * @returns {string} The locale formatted for use on the JavaScript-side.
+ */
+export function pyToJsLocale(locale) {
+    const regex = /^([a-z]+)(_[A-Z\d]+)?(@.+)?$/;
+    const [, language, territory, modifier] = locale.match(regex);
+    const subtags = [language];
+    if (modifier === "@latin") {
+        subtags.push("Latn");
+    }
+    if (territory) {
+        subtags.push(territory.slice(1));
+    }
+    return subtags.join("-");
+}

--- a/addons/web/static/tests/l10n/utils_tests.js
+++ b/addons/web/static/tests/l10n/utils_tests.js
@@ -1,0 +1,14 @@
+/** @odoo-module **/
+
+import { pyToJsLocale } from "@web/core/l10n/utils";
+
+QUnit.module("utils");
+
+QUnit.test("pyToJsLocale", (assert) => {
+    assert.strictEqual(pyToJsLocale("kab"), "kab");
+    assert.strictEqual(pyToJsLocale("fr_BE"), "fr-BE");
+    assert.strictEqual(pyToJsLocale("es_419"), "es-419");
+    assert.strictEqual(pyToJsLocale("sr@latin"), "sr-Latn");
+    assert.strictEqual(pyToJsLocale("sr_RS@latin"), "sr-Latn-RS");
+    assert.strictEqual(pyToJsLocale("en-US"), "en-US");
+});


### PR DESCRIPTION
Serbian is a rare example of "synchronic digraphia", meaning that it has two writing systems that coexist and are used interchangeably by its speakers: Cyrillic and Latin.

To handle this feature of Serbian in Odoo, we use a locale with a special modifier to specify the script to use: sr@latin.

Problem: This locale is not recognized by the JavaScript APIs that implement the BCP 47 format, which leads to errors when trying to use them with the sr@latin locale.

This PR provides a helper to convert the locales from the Python side for use on the JavaScript side.

*: payment_adyen

Task-4014022