### PR TITLE
[FIX] l10n_es_edi_tbai: correctly handle lines without description

### DIFF
--- a/addons/l10n_es_edi_tbai/models/account_edi_format.py
+++ b/addons/l10n_es_edi_tbai/models/account_edi_format.py
@@ -357,7 +357,7 @@ class AccountEdiFormat(models.Model):
                 'discount': discount * refund_sign,
                 'unit_price': (line.balance + discount) / line.quantity * refund_sign,
                 'total': total,
-                'description': regex_sub(r'[^0-9a-zA-Z ]', '', line.name)[:250]
+                'description': regex_sub(r'[^0-9a-zA-Z ]', '', line.name or '')[:250]
             })
         values['invoice_lines'] = invoice_lines
         # Tax details (desglose)


### PR DESCRIPTION
The TicketBAI EDI integration will pre-process invoice lines to make sure that the description in the EDI is properly encoded/striped of non-supported characters.

However this pre-processing step does not take into account the fact that the `name` field of an `account.move.line` record is not required and can thus be Falsy.

This causes the EDI pre-processing to crash with a traceback for invoices with empty lines. This also prevents the cron from going any further than such an invoice in its queue.

This fix solves this issue.

Note that the generated XML will not pass the XLD validation, since the presence of at least one alpha-numeric character is required - but at least the problem will now be explained with an actual error flow and not a complete crash.

opw-3974117