### PR TITLE
[FIX] mail: test - fix non deterministic create channel test

### DIFF
--- a/addons/mail/static/tests/discuss/core/web/discuss.test.js
+++ b/addons/mail/static/tests/discuss/core/web/discuss.test.js
@@ -22,7 +22,7 @@ defineMailModels();
 test("can create a new channel [REQUIRE FOCUS]", async () => {
     const pyEnv = await startServer();
     onRpcBefore((route, args) => {
-        if (route.startsWith("/mail") || route.startsWith("/discuss")) {
+        if (route.startsWith("/mail") || route.includes("/discuss/channel/messages")) {
             step(`${route} - ${JSON.stringify(args)}`);
         }
     });


### PR DESCRIPTION
Before this PR, the `can create a new channel` test was sometimes failing.

This test asserts that the `/discuss/channel/messages` route is called using the step API. However, creating a new channel also sets the last seen message of the user. Most of the time, the test ended before this step but when it didn't, the test would fail as this step is not verified.

This PR ignore this step as it is not relevant for the current test.

runbot-68993