### PR TITLE
[IMP] l10n_nl_reports: tax closing rounding

### DIFF
--- a/addons/l10n_nl/models/__init__.py
+++ b/addons/l10n_nl/models/__init__.py
@@ -2,3 +2,4 @@
 from . import template_nl
 from . import account_journal
 from . import account_chart_template
+from . import res_company

--- a/addons/l10n_nl/models/res_company.py
+++ b/addons/l10n_nl/models/res_company.py
@@ -1,0 +1,10 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+    _inherit = 'res.company'
+
+    l10n_nl_rounding_difference_loss_account_id = fields.Many2one('account.account', check_company=True)
+    l10n_nl_rounding_difference_profit_account_id = fields.Many2one('account.account', check_company=True)

--- a/addons/l10n_nl/models/template_nl.py
+++ b/addons/l10n_nl/models/template_nl.py
@@ -33,6 +33,8 @@ class AccountChartTemplate(models.AbstractModel):
                 'expense_currency_exchange_account_id': '4920',
                 'account_journal_early_pay_discount_loss_account_id': '7065',
                 'account_journal_early_pay_discount_gain_account_id': '8065',
+                'l10n_nl_rounding_difference_loss_account_id': '4960',
+                'l10n_nl_rounding_difference_profit_account_id': '4950',
                 'account_sale_tax_id': 'btw_21',
                 'account_purchase_tax_id': 'btw_21_buy',
             },


### PR DESCRIPTION
Add the tax report integer rounding in the tax closing.

Also, add the support to a `total` key in the `vat_results_summary` of `_vat_closing_entry_results_rounding`.
That key is used when reports have a single line with the payable/reclaimable vat.

task-3691312

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
