### PR TITLE
[FIX] website_slides: fix quiz saving traceback

### DIFF
--- a/addons/website_slides/static/src/js/slides_course_quiz_question_form.js
+++ b/addons/website_slides/static/src/js/slides_course_quiz_question_form.js
@@ -208,7 +208,7 @@ var QuestionFormWidget = publicWidget.Widget.extend({
                     'sequence': sequence++,
                     'text_value': value,
                     'is_correct': $(this).find('input[type=radio]').prop('checked') === true,
-                    'comment': $(this).find('.o_wslides_js_quiz_answer_comment > input[type=text]').val().trim()
+                    'comment': $(this).find('.o_wslides_js_quiz_answer_comment input[type=text]').val().trim()
                 };
                 answers.push(answer);
             }


### PR DESCRIPTION
Purpose
=======
Fix the traceback appearing when saving a quiz in the front-end.

Specification
=============
Following the addition of a div in the xml structure, the comment input element wasn't found in the dom anymore.
Fixing the selector so that the comment input is found again.

related commit: 53e4c0e462104d8c04bf31d5ce418034cd869a77

Task-4019133

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
