### PR TITLE
[FIX] web_editor: consider t-out/esc as visible content

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
@@ -1882,6 +1882,8 @@ export function isWhitespace(value) {
 export function isVisible(node) {
     return !!node && (
         (node.nodeType === Node.TEXT_NODE && isVisibleTextNode(node)) ||
+        (node.nodeType === Node.ELEMENT_NODE &&
+            (node.getAttribute("t-esc") || node.getAttribute("t-out"))) ||
         isSelfClosingElement(node) ||
         isFontAwesome(node) ||
         hasVisibleContent(node)


### PR DESCRIPTION
The `isVisible` function did not consider those as visible. This had the side effect that they would be removed when they were the only child of a link since we remove links that do not have visible content.

Steps to reproduce:
- Go to Email Templates in debug mode
- Open the code view and add `<a href="#"><t t-out="object.name"></t></a>`
- Save
- Notice that the link and the t-out have been lost

opw-3990415
