### PR TITLE
[IMP] hr_contract, hr_expense: simplify kanban archs

### DIFF
--- a/addons/hr_contract/report/hr_contract_history_report_views.xml
+++ b/addons/hr_contract/report/hr_contract_history_report_views.xml
@@ -174,31 +174,13 @@
         <field name="name">hr.contract.history.view.kanban</field>
         <field name="model">hr.contract.history</field>
         <field name="arch" type="xml">
-            <kanban class="o_kanban_small_column" default_order="date_end" sample="1" create="0">
-                <field name="employee_id"/>
-                <field name="activity_state"/>
-                <field name="state"/>
+            <kanban default_order="date_end" sample="1" create="0">
                 <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}'/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div class="oe_kanban_card oe_kanban_global_click">
-                            <div class="oe_kanban_content">
-                                <div class="o_hr_contract_state">
-                                    <strong class="o_kanban_record_title">
-                                        <field name="display_name"/>
-                                    </strong>
-                                </div>
-                                <div class="text-muted o_kanban_record_subtitle o_hr_contract_job_id">
-                                    <field name="job_id"/>
-                                </div>
-                                <div class="oe_kanban_bottom_right">
-                                    <span class="float-end">
-                                        <field name="employee_id" widget="many2one_avatar_employee"/>
-                                    </span>
-                                </div>
-                            </div>
-                            <div class="clearfix"></div>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field class="fw-bold fs-5" name="display_name"/>
+                        <field class="text-muted" name="job_id"/>
+                        <field class="ms-auto" name="employee_id" widget="many2one_avatar_employee"/>
                     </t>
                 </templates>
             </kanban>

--- a/addons/hr_contract/views/hr_contract_views.xml
+++ b/addons/hr_contract/views/hr_contract_views.xml
@@ -280,60 +280,31 @@
             <field name="name">hr.contract.kanban</field>
             <field name="model">hr.contract</field>
             <field name="arch" type="xml">
-                <kanban class="o_kanban_small_column" default_order="date_end" sample="1">
-                    <field name="employee_id"/>
+                <kanban default_order="date_end" sample="1">
                     <field name="activity_state"/>
-                    <field name="state"/>
                     <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}'/>
                     <templates>
                     <t t-name="kanban-menu" groups="hr_contract.group_hr_contract_manager">
                         <t t-if="widget.editable"><a role="menuitem" type="edit" class="dropdown-item">Edit Contract</a></t>
                         <t t-if="widget.deletable"><a role="menuitem" type="delete" class="dropdown-item">Delete</a></t>
                     </t>
-                    <t t-name="kanban-box">
-                        <div class="oe_kanban_card oe_kanban_global_click">
-                            <div class="oe_kanban_content">
-                                <div class="o_hr_contract_state">
-                                    <strong class="o_kanban_record_title">
-                                        <field name="name"/>
-                                    </strong>
-                                </div>
-                                <div class="text-muted o_kanban_record_subtitle o_hr_contract_job_id" name="div_job_id">
-                                    <field name="job_id"/>
-                                </div>
-                                                                <div class="text-muted o_kanban_record_subtitle o_hr_contract_job_id" name="div_department_id">
-                                    <field name="department_id"/>
-                                </div>
-                                <div class="text-muted o_kanban_record_subtitle" name="div_date_id">
-                                    <span class="o_stat_text">
-                                        From
-                                    </span>
-                                    <span class="o_stat_value">
-                                        <field name="date_start"/>
-                                    </span>
-                                    <t t-if="record.date_end.raw_value">
-                                        <span class="o_stat_text">
-                                            To
-                                        </span>
-                                        <span class="o_stat_value">
-                                            <field name="date_end"/>
-                                        </span>
-                                    </t>
-                                </div>
-                                <div class="oe_kanban_bottom_right">
-                                    <span class="float-end">
-                                        <field name="employee_id" widget="many2one_avatar_employee"/>
-                                    </span>
-                                    <span class="float-end mr4">
-                                        <field name="kanban_state" widget="state_selection"/>
-                                    </span>
-                                </div>
-                                <div class="oe_kanban_bottom_left">
-                                    <field name="activity_ids" widget="kanban_activity"/>
-                                </div>
-                            </div>
-                            <div class="clearfix"></div>
+                    <t t-name="kanban-card">
+                        <field class="fw-bold fs-5" name="name"/>
+                        <field class="text-muted" name="job_id"/>
+                        <field class="text-muted" name="department_id"/>
+                        <div class="text-muted" name="div_date_id">
+                            From <field name="date_start"/>
+                            <t t-if="record.date_end.raw_value">
+                                To <field name="date_end"/>
+                            </t>
                         </div>
+                        <footer>
+                            <field name="activity_ids" widget="kanban_activity"/>
+                            <div class="d-flex ms-auto">
+                                <field class="mr4" name="kanban_state" widget="state_selection"/>
+                                <field name="employee_id" widget="many2one_avatar_employee"/>
+                            </div>
+                        </footer>
                     </t>
                     </templates>
                 </kanban>

--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -288,43 +288,25 @@
             <field name="name">hr.expense.kanban</field>
             <field name="model">hr.expense</field>
             <field name="arch" type="xml">
-                <kanban class="o_kanban_mobile hr_expense" sample="1" js_class="hr_expense_kanban" quick_create="false">
-                    <field name="name"/>
-                    <field name="employee_id"/>
-                    <field name="total_amount_currency"/>
-                    <field name="date"/>
-                    <field name="state"/>
-                    <field name="activity_state"/>
+                <kanban class="o_kanban_mobile" sample="1" js_class="hr_expense_kanban" quick_create="false">
                     <field name="currency_id"/>
                     <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}'/>
                     <templates>
-                        <t t-name="kanban-box">
-                            <div t-attf-class="oe_kanban_card oe_kanban_global_click">
-                                <div class="row">
-                                    <div class="col-12">
-                                        <strong class="o_kanban_record_title"><span><t t-out="record.name.value"/></span></strong>
-                                        <strong class="o_kanban_record_subtitle float-end"><span class="text-end">
-                                            <field name="total_amount_currency" widget="monetary"/></span>
-                                        </strong>
-                                    </div>
-                                </div>
-                                <div class="row mt8">
-                                    <div class="col-6 text-muted">
-                                        <field name="employee_id" widget="many2one_avatar_user"
-                                               options="{'display_avatar_name': True}"
-                                               readonly="True"/><br/>
-                                        <t t-out="record.date.value"/>
-                                    </div>
-                                    <div class="col-6">
-                                        <span class="float-end text-end">
-                                            <field name="state" widget="label_selection"
-                                                   options="{'classes': {'draft': 'default', 'reported': 'primary',
-                                                                         'submitted': 'warning', 'refused': 'danger',
-                                                                         'done': 'warning', 'approved': 'success'}}"/>
-                                        </span>
-                                    </div>
-                                </div>
+                        <t t-name="kanban-card">
+                            <div class="d-flex">
+                                <field class="fw-bold fs-5" name="name"/>
+                                <field class="fw-bold ms-auto" name="total_amount_currency" widget="monetary"/>
                             </div>
+                            <div class="d-flex mt8 text-muted">
+                                <field name="employee_id" widget="many2one_avatar_user"
+                                       options="{'display_avatar_name': True}"
+                                       readonly="True"/>
+                                <field class="ms-auto" name="state" widget="label_selection"
+                                        options="{'classes': {'draft': 'default', 'reported': 'primary',
+                                                            'submitted': 'warning', 'refused': 'danger',
+                                                            'done': 'warning', 'approved': 'success'}}"/>
+                            </div>
+                            <field class="mt8 text-muted" name="date"/>
                         </t>
                     </templates>
                 </kanban>
@@ -954,37 +936,21 @@
             <field name="model">hr.expense.sheet</field>
             <field name="arch" type="xml">
                 <kanban class="o_kanban_mobile" sample="1">
-                    <field name="name"/>
-                    <field name="employee_id"/>
-                    <field name="total_amount"/>
-                    <field name="accounting_date"/>
-                    <field name="state"/>
                     <field name="currency_id"/>
                     <templates>
-                        <t t-name="kanban-box">
-                            <div t-attf-class="oe_kanban_card oe_kanban_global_click">
-                                <div class="row">
-                                    <div class="col-12">
-                                        <strong class="o_kanban_record_title"><span><t t-out="record.name.value"/></span></strong>
-                                        <strong class="o_kanban_record_subtitle float-end">
-                                            <span class="text-end"><field name="total_amount" widget="monetary"/></span>
-                                        </strong>
-                                    </div>
-                                </div>
-                                <div class="row mt8">
-                                    <div class="col-6 text-muted">
-                                        <field name="employee_id" widget="many2one_avatar_user"  options="{'display_avatar_name': True}" readonly="state != 'draft'"/><t t-out="record.accounting_date.value"/>
-                                    </div>
-                                    <div class="col-6">
-                                        <span class="float-end text-end">
-                                            <field name="state" widget="label_selection"
-                                                   options="{'classes': {'draft': 'default', 'submit': 'default',
-                                                                         'cancel': 'danger', 'post': 'warning',
-                                                                         'done': 'success'}}"/>
-                                        </span>
-                                    </div>
-                                </div>
+                        <t t-name="kanban-card">
+                            <div class="d-flex">
+                                <field class="fw-bold fs-5" name="name"/>
+                                <field class="fw-bold ms-auto" name="total_amount" widget="monetary"/>
                             </div>
+                            <div class="d-flex text-muted mt8">
+                                <field name="employee_id" widget="many2one_avatar_user"  options="{'display_avatar_name': True}" readonly="state != 'draft'"/>
+                                <field class="ms-auto" name="state" widget="label_selection"
+                                       options="{'classes': {'draft': 'default', 'submit': 'default',
+                                                             'cancel': 'danger', 'post': 'warning',
+                                                             'done': 'success'}}"/>
+                            </div>
+                            <field class="mt8 text-muted" name="accounting_date"/>
                         </t>
                     </templates>
                 </kanban>


### PR DESCRIPTION
In this commit we have simplified the kanban arch for the hr_contract and hr_expense module. The goal is to simplify them, make them easier to read, and use bootstrap utility classnames.
- Previously, we used `kanban-box`, but now we are using `kanban-card` instead.
- Deprecated `oe_kanban_global_click` and `oe_kanban_global_click_edit`.
- More use of `<field/>` tags
- Removed the `oe_kanban_colorpicker` class and replaced it with the `kanban_color_picker` widget.
- Changed type='edit' to type='open' to open records. since version 16, records always open in edit mode by default.
- `kanban_image` from rendering context, is deprecated so we use `<field name=... widget=image/>` instead

Task-3992107

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
