### PR TITLE
[FIX] web: update the selected input date after removing the existing date

### DIFF
--- a/addons/web/static/src/core/datetime/datetime_picker.js
+++ b/addons/web/static/src/core/datetime/datetime_picker.js
@@ -514,9 +514,15 @@ export class DateTimePicker extends Component {
     applyValueAtIndex(value, valueIndex) {
         const result = [...this.values];
         if (this.props.range) {
-            if (result[0] && value.endOf("day") < result[0].startOf("day")) {
+            if (
+                (result[0] && value.endOf("day") < result[0].startOf("day")) ||
+                (result[1] && !result[0])
+            ) {
                 valueIndex = 0;
-            } else if (result[1] && result[1].endOf("day") < value.startOf("day")) {
+            } else if (
+                (result[1] && result[1].endOf("day") < value.startOf("day")) ||
+                (result[0] && !result[1])
+            ) {
                 valueIndex = 1;
             }
         }

--- a/addons/web/static/tests/views/fields/daterange_field_tests.js
+++ b/addons/web/static/tests/views/fields/daterange_field_tests.js
@@ -1330,4 +1330,27 @@ QUnit.module("Fields", (hooks) => {
         assert.deepEqual(getValues(), ["02/19/2017 15:30:00", "02/19/2017 15:30:00"]);
         assert.verifySteps(["onchange"]);
     });
+
+    QUnit.test(
+        "update the selected input date after removing the existing date",
+        async (assert) => {
+            serverData.models.partner.fields.date_end = { string: "Date End", type: "date" };
+            serverData.models.partner.records[0].date_end = "2017-02-08";
+            await makeView({
+                type: "form",
+                resModel: "partner",
+                resId: 1,
+                serverData,
+                arch: `
+                        <form>
+                        <field name="date" widget="daterange" options="{'start_date_field': 'date_end'}" required="1" />
+                        </form>`,
+            });
+            await click(target, "input[data-field=date]");
+            await editInput(target, "input[data-field=date]", null);
+            await click(getPickerCell("12").at(0));
+
+            assert.strictEqual(target.querySelector("input[data-field=date]").value, "02/12/2017");
+        }
+    );
 });


### PR DESCRIPTION
before this commit:
When the user removes the end date and then selects a new date, that date is
update the start date.

after this commit:
When the user removes the end date and then selects a new date, that date should
update the end date.

Task-3899581