### PR TITLE
[FIX] stock_picking_batch: keep picking on batch after validation

### DIFF
--- a/addons/stock_picking_batch/models/stock_picking.py
+++ b/addons/stock_picking_batch/models/stock_picking.py
@@ -140,7 +140,7 @@ class StockPicking(models.Model):
     def _create_backorder(self):
         for picking in self:
             # Avoid inconsistencies in states of the same batch when validating a single picking in a batch.
-            if picking.batch_id and picking.state != 'done':
+            if picking.batch_id and picking.state != 'done' and any(p not in self for p in picking.batch_id.picking_ids):
                 picking.batch_id = None
         return super()._create_backorder()
 


### PR DESCRIPTION
### Steps to reproduce:

- Create and mark as to do a delivery order for a partner with a move: - 2 x Product P
- Set the quantity of the move to 1
- Create and confirm a batch transfer containing your picking
- Validate the batch transfer and create a backorder

#### > The picking is removed from the batch

### Cause of the issue:

The pickings are removed from the batch by these lines: https://github.com/odoo/odoo/blob/b4872364f9f8926bbf5b843db014f33652124cb9/addons/stock_picking_batch/models/stock_picking.py#L141-L145 However, they should only be removed if at least one of the pickings is not backordered.

opw-4001981
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
