### PR TITLE
[IMP] bus, hr, mail: edit IM status

### DIFF
--- a/addons/bus/models/bus_presence.py
+++ b/addons/bus/models/bus_presence.py
@@ -109,7 +109,7 @@ class BusPresence(models.Model):
                 self.env["bus.bus"]._sendone(
                     target,
                     "bus.bus/im_status_updated",
-                    {"im_status": im_status or presence.status, **identity_data},
+                    {"im_status": im_status or presence.user_id.forced_im_status or presence.status, **identity_data},
                 )
 
     @api.autovacuum

--- a/addons/bus/models/res_partner.py
+++ b/addons/bus/models/res_partner.py
@@ -13,6 +13,9 @@ class ResPartner(models.Model):
         status_by_partner = {}
         for presence in self.env["bus.presence"].search([("user_id", "in", self.user_ids.ids)]):
             partner = presence.user_id.partner_id
+            if forced_im_status := presence.user_id.forced_im_status:
+                status_by_partner[partner] = forced_im_status
+                continue
             if (
                 status_by_partner.get(partner, "offline") == "offline"
                 or presence.status == "online"

--- a/addons/bus/models/res_users.py
+++ b/addons/bus/models/res_users.py
@@ -12,7 +12,7 @@ class ResUsers(models.Model):
     def _compute_im_status(self):
         """Compute the im_status of the users"""
         presence_by_user = {
-            presence.user_id: presence.status
+            presence.user_id: presence.user_id.forced_im_status or presence.status
             for presence in self.env["bus.presence"].search([("user_id", "in", self.ids)])
         }
         for user in self:

--- a/addons/hr/models/hr_employee_base.py
+++ b/addons/hr/models/hr_employee_base.py
@@ -73,6 +73,7 @@ class HrEmployeeBase(models.AbstractModel):
         ('presence_undetermined', 'Undetermined')], compute='_compute_presence_icon')
     show_hr_icon_display = fields.Boolean(compute='_compute_presence_icon')
     im_status = fields.Char(related="user_id.im_status")
+    custom_status = fields.Char(related="user_id.custom_status")
     newly_hired = fields.Boolean('Newly Hired', compute='_compute_newly_hired', search='_search_newly_hired')
 
     @api.model

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -319,6 +319,7 @@
                                     </div>
                                 </div>
                                 <field t-if="record.job_title.raw_value" name="job_title"/>
+                                <field name="custom_status" />
                                 <div t-if="record.work_email.raw_value" class="o_text_overflow">
                                     <i class="fa fa-fw me-2 fa-envelope text-primary" title="Email"/>
                                     <field name="work_email" />

--- a/addons/im_livechat/tests/test_get_discuss_channel.py
+++ b/addons/im_livechat/tests/test_get_discuss_channel.py
@@ -70,6 +70,7 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
                 },
                 {
                     "active": False,
+                    "custom_status": False,
                     "id": self.user_root.partner_id.id,
                     "im_status": "bot",
                     "isInternalUser": True,
@@ -133,6 +134,7 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
                 },
                 {
                     "active": False,
+                    "custom_status": False,
                     "email": "odoobot@example.com",
                     "id": self.user_root.partner_id.id,
                     "im_status": "bot",
@@ -214,6 +216,7 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
                 },
                 {
                     "active": False,
+                    "custom_status": False,
                     "email": "odoobot@example.com",
                     "id": self.user_root.partner_id.id,
                     "im_status": "bot",

--- a/addons/mail/controllers/__init__.py
+++ b/addons/mail/controllers/__init__.py
@@ -10,6 +10,7 @@ from . import message_reaction
 from . import thread
 from . import webclient
 from . import webmanifest
+from . import im_status
 
 # after mail specifically as discuss module depends on mail
 from . import discuss

--- a/addons/mail/controllers/im_status.py
+++ b/addons/mail/controllers/im_status.py
@@ -1,0 +1,38 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import http
+from odoo.http import request
+
+from datetime import datetime, timedelta, time
+
+
+class ImStatusController(http.Controller):
+    @http.route("/mail/im_status", methods=["POST"], type="json", auth="user")
+    def set_im_status(self, action):
+        user = request.env.user
+        user.forced_im_status = None if action == "online" else action
+        user._bus_send(
+            "bus.bus/im_status_updated",
+            {"im_status": action, "partner_id": user.partner_id.id},
+            subchannel="presence",
+        )
+
+    @http.route("/mail/custom_status", methods=["POST"], type="json", auth="user")
+    def set_custom_status(self, custom_status, reset_after):
+        user = request.env.user
+        user.custom_status = custom_status
+        match reset_after:
+            case "today":
+                user.reset_custom_status_datetime = datetime.combine(
+                    datetime.utcnow().date() + timedelta(days=1), time()
+                )
+            case "1_hour":
+                user.reset_custom_status_datetime = datetime.utcnow() + timedelta(hours=1)
+            case "4_hour":
+                user.reset_custom_status_datetime = datetime.utcnow() + timedelta(hours=4)
+            case "never":
+                user.reset_custom_status_datetime = None
+        if reset_after != "never":
+            request.env.ref("mail.ir_cron_reset_custom_statuses")._trigger(
+                user.reset_custom_status_datetime
+            )

--- a/addons/mail/data/ir_cron_data.xml
+++ b/addons/mail/data/ir_cron_data.xml
@@ -93,5 +93,14 @@
             <field name="code">model._cleanup_expired_mutes()</field>
             <field name="state">code</field>
         </record>
+
+        <record id="ir_cron_reset_custom_statuses" model="ir.cron">
+            <field name="name">Notification: reset custom statuses</field>
+            <field name="interval_number">1</field>
+            <field name="interval_type">hours</field>
+            <field name="model_id" ref="model_res_users"/>
+            <field name="code">model._reset_custom_status_cron()</field>
+            <field name="state">code</field>
+        </record>
     </data>
 </odoo>

--- a/addons/mail/models/discuss/discuss_channel_member.py
+++ b/addons/mail/models/discuss/discuss_channel_member.py
@@ -440,11 +440,12 @@ class ChannelMember(models.Model):
             ('channel_id', '=', self.channel_id.id),
             ('rtc_inviting_session_id', '=', False),
             ('rtc_session_ids', '=', False),
+            ('partner_id.im_status', '!=', 'busy'),
         ]
         if member_ids:
             channel_member_domain = expression.AND([channel_member_domain, [('id', 'in', member_ids)]])
         members = self.env['discuss.channel.member'].search(channel_member_domain)
-        for member in members:
+        for member in members.filtered(lambda m: m.partner_id.im_status != "busy"):
             member.rtc_inviting_session_id = self.rtc_session_ids.id
             member._bus_send_store(
                 self.channel_id, {"rtcInvitingSession": Store.one(member.rtc_inviting_session_id)}

--- a/addons/mail/static/src/core/common/im_status.xml
+++ b/addons/mail/static/src/core/common/im_status.xml
@@ -13,6 +13,7 @@
                 <t t-if="(!props.member or !props.member.isTyping) and persona">
                     <i t-if="persona.im_status === 'online'" class="fa fa-circle text-success" title="Online" role="img" aria-label="User is online"/>
                     <i t-elif="persona.im_status === 'away'" class="fa fa-circle o-away" title="Idle" role="img" aria-label="User is idle"/>
+                    <i t-elif="persona.im_status === 'busy'" class="fa fa-minus-circle text-danger" title="Busy" role="img" aria-label="User is busy"/>
                     <i t-elif="persona.im_status === 'offline'" class="fa fa-circle-o text-700" title="Offline" role="img" aria-label="User is offline"/>
                     <i t-elif="persona.im_status === 'bot'" class="fa fa-heart text-success" title="Bot" role="img" aria-label="User is a bot"/>
                     <i t-else="" class="fa fa-fw fa-question-circle" title="No IM status available"/>

--- a/addons/mail/static/src/core/common/persona_model.js
+++ b/addons/mail/static/src/core/common/persona_model.js
@@ -3,7 +3,7 @@ import { imageUrl } from "@web/core/utils/urls";
 import { rpc } from "@web/core/network/rpc";
 
 /**
- * @typedef {'offline' | 'bot' | 'online' | 'away' | 'im_partner' | undefined} ImStatus
+ * @typedef {'offline' | 'bot' | 'online' | 'away' | 'busy' | 'im_partner' | undefined} ImStatus
  * @typedef Data
  * @property {number} id
  * @property {string} name

--- a/addons/mail/static/src/core/common/thread_icon.xml
+++ b/addons/mail/static/src/core/common/thread_icon.xml
@@ -14,6 +14,7 @@
                         <div t-if="correspondent.persona.im_status === 'online'" class="fa fa-fw fa-circle text-success" title="Online"/>
                         <div t-elif="correspondent.persona.im_status === 'offline'" class="fa fa-fw fa-circle-o" title="Offline"/>
                         <div t-elif="correspondent.persona.im_status === 'away'" class="fa fa-fw fa-circle o-yellow" title="Away"/>
+                        <div t-elif="correspondent.persona.im_status === 'busy'" class="fa fa-fw fa-minus-circle text-danger" title="Busy"/>
                         <div t-elif="correspondent.persona.im_status === 'bot'" class="fa fa-fw fa-heart text-success" title="Bot"/>
                         <div t-else="" class="fa-fw" t-att-class="largeClass" t-attf-class="#{ defaultChatIcon.class }" t-att-title="defaultChatIcon.title"/>
                     </t>

--- a/addons/mail/static/src/core/public_web/custom_status_editor.js
+++ b/addons/mail/static/src/core/public_web/custom_status_editor.js
@@ -1,0 +1,44 @@
+import { Component, useRef, useState } from "@odoo/owl";
+import { rpc } from "@web/core/network/rpc";
+import { useService } from "@web/core/utils/hooks";
+import { useEmojiPicker } from "@web/core/emoji_picker/emoji_picker";
+
+export class CustomStatusEditor extends Component {
+    // static props = ["close"];
+    static template = "discuss.StatusSettings";
+
+    setup() {
+        this.store = useState(useService("mail.store"));
+        this.emojiButton = useRef("emoji-button");
+        this.emojiPicker = useEmojiPicker(this.emojiButton, {
+            onSelect: (emoji) => {
+                this.state.customStatus += emoji;
+            },
+        });
+        this.state = useState({
+            customStatus: this.store.self.custom_status || "",
+            resetAfter: "today",
+        });
+    }
+
+    async setStatus(to) {
+        rpc("/mail/im_status", { action: to });
+        rpc("/discuss/settings/mute", { minutes: to == "busy" ? -1 : false });
+        this.store.self.im_status = to;
+    }
+
+    onConfirm() {
+        rpc("/mail/custom_status", {
+            custom_status: this.state.customStatus,
+            reset_after: this.state.resetAfter,
+        });
+        this.store.self.custom_status = this.state.customStatus;
+        // this.props.close();
+    }
+
+    onClear() {
+        this.state.customStatus = "";
+        rpc("/mail/custom_status", { custom_status: "", reset_after: "never" });
+        this.store.self.custom_status = "";
+    }
+}

--- a/addons/mail/static/src/core/public_web/custom_status_editor.xml
+++ b/addons/mail/static/src/core/public_web/custom_status_editor.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="discuss.CustomStatusEditor">
+        <div class="d-flex flex-column p-3">
+            <label for="custom-status-input" class="form-label">Custom Status</label>
+            <div class="input-group">
+                <button class="btn btn-outline-secondary" type="button" t-ref="emoji-button">
+                    <i class="fa fa-lg fa-smile-o"/>
+                </button>
+                <input type="text" class="form-control" id="custom-status-input" placeholder="Status message" t-model="state.customStatus" />
+                <button class="btn btn-outline-success" type="button" t-on-click="onConfirm"><i class="fa fa-check"/></button>
+                <button class="btn btn-outline-danger" type="button" t-on-click="onClear"><i class="fa fa-times"/></button>
+            </div>
+            <label for="reset-after-select" class="form-label mt-3">Reset after</label>
+            <div class="input-group">
+                <select class="form-control" id="reset-after-select" t-model="state.resetAfter">
+                    <option value="today">Today</option>
+                    <option value="1_hour">1 hour</option>
+                    <option value="4_hour">4 hour</option>
+                    <option value="never">Never</option>
+                </select>
+            </div>
+        </div>
+    </t>
+
+</templates>

--- a/addons/mail/static/src/core/public_web/discuss.xml
+++ b/addons/mail/static/src/core/public_web/discuss.xml
@@ -34,6 +34,7 @@
                             onValidate.bind="renameThread"
                             value="thread.displayName"
                         />
+                        <span t-if="thread.correspondent?.persona.custom_status" t-esc="thread.correspondent.persona.custom_status" class="text-truncate text-muted" />
                         <t t-if="thread.allowDescription and (thread.is_editable or (!thread.is_editable and thread.description))">
                             <div class="flex-shrink-0 mx-1 py-2 border-start"/>
                             <t t-set="autogrowDescriptionPlaceholder">Add a description</t>

--- a/addons/mail/static/src/core/public_web/discuss_sidebar.js
+++ b/addons/mail/static/src/core/public_web/discuss_sidebar.js
@@ -6,6 +6,7 @@ import { _t } from "@web/core/l10n/translation";
 
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
+import { UserStatusPanel } from "@mail/core/public_web/user_status_panel";
 
 export const discussSidebarItemsRegistry = registry.category("mail.discuss_sidebar_items");
 
@@ -16,7 +17,7 @@ export const discussSidebarItemsRegistry = registry.category("mail.discuss_sideb
 export class DiscussSidebar extends Component {
     static template = "mail.DiscussSidebar";
     static props = {};
-    static components = { Dropdown };
+    static components = { Dropdown, UserStatusPanel };
 
     setup() {
         super.setup();

--- a/addons/mail/static/src/core/public_web/discuss_sidebar.xml
+++ b/addons/mail/static/src/core/public_web/discuss_sidebar.xml
@@ -17,6 +17,7 @@
                 </div>
             </div>
             <t t-foreach="discussSidebarItems" t-as="item" t-key="item_index" t-component="item"/>
+            <UserStatusPanel t-if="!store.inPublicPage"/>
         </div>
     </t>
 </templates>

--- a/addons/mail/static/src/core/public_web/status_settings.js
+++ b/addons/mail/static/src/core/public_web/status_settings.js
@@ -1,0 +1,27 @@
+import { Component, useState } from "@odoo/owl";
+import { Dropdown } from "@web/core/dropdown/dropdown";
+import { DropdownItem } from "@web/core/dropdown/dropdown_item";
+import { useService } from "@web/core/utils/hooks";
+import { CustomStatusEditor } from "./custom_status_editor";
+
+export class StatusSettings extends Component {
+    static components = { Dropdown, DropdownItem, CustomStatusEditor };
+    static props = ["close"];
+    static template = "discuss.StatusSettings";
+
+    setup() {
+        this.store = useState(useService("mail.store"));
+        this.actionService = useService("action");
+    }
+
+    onClickViewProfile() {
+        const action = {
+            res_id: this.store.self.id,
+            res_model: "res.partner",
+            type: "ir.actions.act_window",
+            views: [[false, "form"]],
+            target: "new",
+        };
+        this.actionService.doAction(action);
+    }
+}

--- a/addons/mail/static/src/core/public_web/status_settings.xml
+++ b/addons/mail/static/src/core/public_web/status_settings.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="discuss.StatusSettings">
+        <div class="o-discuss-NotificationSettings">
+            <button class="btn d-flex w-100 px-1 py-0 opacity-75 opacity-100-hover" t-on-click="onClickViewProfile">
+                <div class="d-flex flex-grow-1 align-items-center p-2 rounded">
+                    <i class="fa fa-user me-2"/> View Profile
+                </div>
+            </button>
+            <hr class="solid mx-2 my-0"/>
+            <Dropdown position="'right-start'" menuClass="'o-mail-NotificationSettings-submenu d-flex flex-column py-0 my-0'">
+                <button class="btn w-100 d-flex p-1 opacity-75 opacity-100-hover">
+                    <div class="d-flex flex-grow-1 align-items-center px-2 py-1 w-100 rounded">
+                        <span class="me-2">
+                            <i t-if="store.self.im_status === 'online'" class="fa fa-circle text-success" title="Online" role="img" aria-label="User is online"/>
+                            <i t-elif="store.self.im_status === 'away'" class="fa fa-circle o-yellow" title="Idle" role="img" aria-label="User is idle"/>
+                            <i t-elif="store.self.im_status === 'busy'" class="fa fa-minus-circle text-danger" title="Busy" aria-label="User is busy"/>
+                            <i t-elif="store.self.im_status === 'offline'" class="fa fa-circle-o text-700" title="Offline" role="img" aria-label="User is offline"/>
+                            <i t-elif="!store.self.im_status" class="fa fa-fw fa-question-circle" title="No IM status available"/>
+                        </span>
+                        <span class="text-wrap text-start text-break">
+                            <t t-if="store.self.im_status === 'online'" t-esc="'Online'"/>
+                            <t t-elif="store.self.im_status === 'away'" t-esc="'Away'"/>
+                            <t t-elif="store.self.im_status === 'busy'" t-esc="'Busy'"/>
+                            <t t-elif="store.self.im_status === 'offline'" t-esc="'Offline'"/>
+                            <t t-else="" t-esc="'Offline'"/>
+                        </span>
+                        <i class="fa fa-arrow-right ps-2 ms-auto"/>
+                    </div>
+                </button>
+                <t t-set-slot="content">
+                    <DropdownItem class="'btn rounded-0 d-flex align-items-center px-2 py-2 m-0 opacity-75 opacity-100-hover border-bottom'" onSelected="() => this.setStatus('online')"><i class="fa fa-circle text-success mx-2"/><button class="btn p-0 text-wrap text-start text-break" t-esc="'Online'"/></DropdownItem>
+                    <DropdownItem class="'btn rounded-0 d-flex align-items-center px-2 py-2 m-0 opacity-75 opacity-100-hover'" onSelected="() => this.setStatus('away')"><i class="fa fa-circle o-yellow mx-2"/><button class="btn p-0 text-wrap text-start text-break" t-esc="'Away'"/></DropdownItem>
+                    <DropdownItem class="'btn rounded-0 d-flex px-2 py-2 m-0 opacity-75 opacity-100-hover flex-column align-items-start'" onSelected="() => this.setStatus('busy')">
+                        <div>
+                            <i class="fa fa-minus-circle text-danger mx-2"/>
+                            <button class="btn p-0 text-wrap text-start text-break" t-esc="'Busy'"/>
+                        </div>
+                        <span style="margin-left: 30px">You will not receive any notifications</span>
+                    </DropdownItem>
+                    <DropdownItem class="'btn rounded-0 d-flex align-items-center px-2 py-2 m-0 opacity-75 opacity-100-hover'" onSelected="() => this.setStatus('offline')"><i class="fa fa-circle-o text-700 mx-2"/><button class="btn p-0 text-wrap text-start text-break" t-esc="'Offline'"/></DropdownItem>
+                </t>
+            </Dropdown>
+            <Dropdown position="'right-start'" menuClass="'o-mail-NotificationSettings-submenu d-flex flex-column py-0 my-0'">
+                <button class="btn w-100 d-flex p-1 opacity-75 opacity-100-hover">
+                    <div class="d-flex flex-grow-1 align-items-center px-2 py-1 w-100 rounded">
+                        <i class="fa fa-pencil me-2"/> Set Custom Status <i class="fa fa-arrow-right ps-2 ms-auto"/>
+                    </div>
+                </button>
+                <t t-set-slot="content">
+                    <CustomStatusEditor />
+                </t>
+            </Dropdown>
+        </div>
+    </t>
+
+</templates>

--- a/addons/mail/static/src/core/public_web/user_status_panel.js
+++ b/addons/mail/static/src/core/public_web/user_status_panel.js
@@ -1,0 +1,34 @@
+import { Component, useRef, useState } from "@odoo/owl";
+import { usePopover } from "@web/core/popover/popover_hook";
+
+import { registry } from "@web/core/registry";
+import { useService } from "@web/core/utils/hooks";
+import { StatusSettings } from "@mail/core/public_web/status_settings";
+
+export const discussSidebarItemsRegistry = registry.category("mail.discuss_sidebar_items");
+
+/**
+ * @typedef {Object} Props
+ * @extends {Component<Props, Env>}
+ */
+export class UserStatusPanel extends Component {
+    static template = "mail.UserStatusPanel";
+
+    setup() {
+        super.setup();
+        this.store = useState(useService("mail.store"));
+        this.statusRef = useRef("status");
+        this.statusSettingsPopover = usePopover(StatusSettings, {
+            position: "bottom-start",
+            fixedPosition: true,
+        });
+    }
+
+    onStatusClicked() {
+        if (this.statusSettingsPopover.isOpen) {
+            this.statusSettingsPopover.close();
+        } else {
+            this.statusSettingsPopover.open(this.statusRef.el);
+        }
+    }
+}

--- a/addons/mail/static/src/core/public_web/user_status_panel.scss
+++ b/addons/mail/static/src/core/public_web/user_status_panel.scss
@@ -1,0 +1,25 @@
+.o-mail-UserStatusPanel {
+    &:hover {
+        background-color: mix($o-gray-100, $o-gray-200);
+    }
+    &.o-active {
+        background-color: mix($o-gray-100, $o-gray-200);
+    }
+}
+
+.o-mail-UserStatusPanel-avatar {
+    width: 42px;
+    height: 42px;
+    &.o-compact {
+        width: 32px;
+        height: 32px;
+    }
+}
+
+.o-mail-UserStatusPanel-imStatus {
+    bottom: -4px;
+    right: -4px;
+    border-radius: 2rem;
+    height: 18px;
+    width: 18px;
+}

--- a/addons/mail/static/src/core/public_web/user_status_panel.xml
+++ b/addons/mail/static/src/core/public_web/user_status_panel.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="mail.UserStatusPanel">
+        <div class="py-2 mt-auto position-sticky bottom-0 o-mail-discussSidebarBgColor border-top" t-att-class="{ 'px-2': !store.discuss.isSidebarCompact }">
+            <button class="py-2 w-100 btn border-0 rounded-0 text-reset d-flex align-items-center o-mail-UserStatusPanel" t-attf-class="{{ store.discuss.isSidebarCompact ? 'p-0 mx-auto' : 'w-100' }}" t-ref="status" t-on-click="onStatusClicked">
+                <div class="bg-inherit position-relative flex-shrink-0 o-mail-UserStatusPanel-avatar" t-att-class="{ 'o-compact': store.discuss.isSidebarCompact }">
+                    <img class="w-100 h-100 rounded" t-att-src="store.self.avatarUrl" alt="Avatar of user" />
+                    <span name="icon" class="o-mail-UserStatusPanel-imStatus position-absolute d-flex align-items-center justify-content-center o-mail-discussSidebarBgColor">
+                        <i t-if="store.self.im_status === 'online'" class="fa fa-fw fa-circle text-success" title="Online" role="img" aria-label="User is online"/>
+                        <i t-elif="store.self.im_status === 'away'" class="fa fa-fw fa-circle o-yellow" title="Idle" role="img" aria-label="User is idle"/>
+                        <i t-elif="store.self.im_status === 'busy'" class="fa fa-minus-circle text-danger" title="Busy" aria-label="User is busy"/>
+                        <i t-elif="store.self.im_status === 'offline'" class="fa fa-fw fa-circle-o text-700" title="Offline" role="img" aria-label="User is offline"/>
+                        <i t-elif="!store.self.im_status" class="fa fa-fw fa-question-circle" title="No IM status available"/>
+                    </span>
+                </div>
+                <div t-if="!store.discuss.isSidebarCompact" class="d-flex flex-column ms-2 text-start min-w-0">
+                    <span class="text-truncate w-100" t-esc="store.self.name"/>
+                    <span class="text-truncate w-100 text-muted">
+                        <t t-if="store.self.custom_status" t-out="store.self.custom_status" />
+                        <t t-elif="store.self.im_status === 'online'" t-esc="'Online'"/>
+                        <t t-elif="store.self.im_status === 'away'" t-esc="'Away'"/>
+                        <t t-elif="store.self.im_status === 'busy'" t-esc="'Busy'"/>
+                        <t t-elif="store.self.im_status === 'offline'" t-esc="'Offline'"/>
+                        <t t-else="" t-esc="'Offline'"/>
+                    </span>
+                </div>
+            </button>
+        </div>
+    </t>
+</templates>

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
@@ -96,6 +96,8 @@
                     <t t-set-slot="content">
                         <div class="overflow-hidden" t-ref="floating">
                             <span class="fw-bolder user-select-none" t-esc="thread.displayName"/>
+                            <t t-set="customStatus" t-value="thread.correspondent?.persona.custom_status" />
+                            <span t-if="customStatus" class="text-muted text-truncate" t-att-title="customStatus" t-esc="customStatus" />
                             <t t-call="mail.DiscussSidebarChannel.commands"/>
                         </div>
                     </t>
@@ -166,6 +168,8 @@
                 </div>
                 <span t-if="!store.discuss.isSidebarCompact" class="mx-2 text-truncate" t-att-class="thread.selfMember?.message_unread_counter > 0 and !thread.isMuted ? 'o-item-unread fw-bolder' : 'text-muted'">
                     <t t-esc="thread.displayName"/>
+                    <t t-set="customStatus" t-value="thread.correspondent?.persona.custom_status" />
+                    <span t-if="customStatus" class="ms-1 fw-normal text-muted w-100 text-truncate" t-att-title="customStatus" t-esc="customStatus" />
                 </span>
             </div>
             <t t-if="!store.discuss.isSidebarCompact">

--- a/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.xml
+++ b/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.xml
@@ -11,7 +11,8 @@
                         />
                         <span t-if="user.im_status" name="icon" class="o_card_avatar_im_status position-absolute d-flex align-items-center justify-content-center">
                             <i t-if="user.im_status === 'online'" class="fa fa-fw fa-circle text-success" title="Online" role="img" aria-label="User is online"/>
-                            <i t-elif="user.im_status === 'away'" class="fa fa-fw fa-circle text-warning" title="Idle" role="img" aria-label="User is idle"/>
+                            <i t-elif="user.im_status === 'away'" class="fa fa-fw fa-circle o-yellow" title="Idle" role="img" aria-label="User is idle"/>
+                            <i t-elif="user.im_status === 'busy'" class="fa fa-fw fa-minus-circle text-danger" title="Busy" role="img" aria-label="User is busy"/>
                             <i t-elif="user.im_status === 'offline'" class="fa fa-fw fa-circle-o text-700" title="Offline" role="img" aria-label="User is offline"/>
                             <i t-elif="user.im_status === 'bot'" class="fa fa-fw fa-heart text-success" title="Bot" role="img" aria-label="User is a bot"/>
                             <i t-elif="!user.im_status" class="fa fa-fw fa-question-circle" title="No IM status available"/>

--- a/addons/mail/static/tests/discuss_app/sidebar.test.js
+++ b/addons/mail/static/tests/discuss_app/sidebar.test.js
@@ -929,10 +929,10 @@ test("chat - states: open manually by clicking the title", async () => {
     await start();
     await openDiscuss();
     await contains(".o-mail-DiscussSidebarCategory-chat .oi-chevron-right");
-    await contains(".o-mail-DiscussSidebar button", { count: 0, text: "Mitchell Admin" });
+    await contains(".o-mail-DiscussSidebar-item button", { count: 0, text: "Mitchell Admin" });
     await click(".o-mail-DiscussSidebarCategory-chat .btn", { text: "Direct messages" });
     await contains(".o-mail-DiscussSidebarCategory-chat .oi-chevron-down");
-    await contains(".o-mail-DiscussSidebar button", { text: "Mitchell Admin" });
+    await contains(".o-mail-DiscussSidebar-item button", { text: "Mitchell Admin" });
 });
 
 test("chat - states: close should call update server data", async () => {
@@ -1012,14 +1012,14 @@ test("chat - states: close from the bus", async () => {
     await start();
     await openDiscuss();
     await contains(".o-mail-DiscussSidebarCategory-chat .oi-chevron-down");
-    await contains(".o-mail-DiscussSidebar button", { text: "Mitchell Admin" });
+    await contains(".o-mail-DiscussSidebar-item button", { text: "Mitchell Admin" });
     const [partner] = pyEnv["res.partner"].read(serverState.partnerId);
     pyEnv["bus.bus"]._sendone(partner, "res.users.settings", {
         id: userSettingsId,
         is_discuss_sidebar_category_chat_open: false,
     });
     await contains(".o-mail-DiscussSidebarCategory-chat .oi-chevron-right");
-    await contains(".o-mail-DiscussSidebar button", { count: 0, text: "Mitchell Admin" });
+    await contains(".o-mail-DiscussSidebar-item button", { count: 0, text: "Mitchell Admin" });
 });
 
 test("chat - states: open from the bus", async () => {
@@ -1046,14 +1046,14 @@ test("chat - states: open from the bus", async () => {
     // send after init_messaging because bus subscription is done after init_messaging
     await openDiscuss();
     await contains(".o-mail-DiscussSidebarCategory-chat .oi-chevron-right");
-    await contains(".o-mail-DiscussSidebar button", { count: 0, text: "Mitchell Admin" });
+    await contains(".o-mail-DiscussSidebar-item button", { count: 0, text: "Mitchell Admin" });
     const [partner] = pyEnv["res.partner"].read(serverState.partnerId);
     pyEnv["bus.bus"]._sendone(partner, "res.users.settings", {
         id: userSettingsId,
         is_discuss_sidebar_category_chat_open: true,
     });
     await contains(".o-mail-DiscussSidebarCategory-chat .oi-chevron-down");
-    await contains(".o-mail-DiscussSidebar button", { text: "Mitchell Admin" });
+    await contains(".o-mail-DiscussSidebar-item button", { text: "Mitchell Admin" });
 });
 
 test("chat - states: the active category item should be visible even if the category is closed", async () => {
@@ -1062,15 +1062,15 @@ test("chat - states: the active category item should be visible even if the cate
     await start();
     await openDiscuss();
     await contains(".o-mail-DiscussSidebarCategory-chat .oi-chevron-down");
-    await contains(".o-mail-DiscussSidebar button", { text: "Mitchell Admin" });
+    await contains(".o-mail-DiscussSidebar-item button", { text: "Mitchell Admin" });
     await click("button", { text: "Mitchell Admin" });
     await contains("button.o-active", { text: "Mitchell Admin" });
     await click(".o-mail-DiscussSidebarCategory-chat .btn", { text: "Direct messages" });
     await contains(".o-mail-DiscussSidebarCategory-chat .oi-chevron-right");
-    await contains(".o-mail-DiscussSidebar button", { text: "Mitchell Admin" });
+    await contains(".o-mail-DiscussSidebar-item button", { text: "Mitchell Admin" });
     await click("button", { text: "Inbox" });
     await contains(".o-mail-DiscussSidebarCategory-chat .oi-chevron-right");
-    await contains(".o-mail-DiscussSidebar button", { count: 0, text: "Mitchell Admin" });
+    await contains(".o-mail-DiscussSidebar-item button", { count: 0, text: "Mitchell Admin" });
 });
 
 test("chat - avatar: should have correct avatar", async () => {

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -159,6 +159,7 @@ class TestChannelInternals(MailCommon, HttpCase):
                             "res.partner": self._filter_partners_fields(
                                 {
                                     "active": True,
+                                    "custom_status": False,
                                     "email": "test_customer@example.com",
                                     "id": self.test_partner.id,
                                     "im_status": "im_partner",
@@ -203,6 +204,7 @@ class TestChannelInternals(MailCommon, HttpCase):
                             "res.partner": self._filter_partners_fields(
                                 {
                                     "active": True,
+                                    "custom_status": False,
                                     "email": "test_customer@example.com",
                                     "id": self.test_partner.id,
                                     "im_status": "im_partner",

--- a/addons/mail/views/res_partner_views.xml
+++ b/addons/mail/views/res_partner_views.xml
@@ -29,6 +29,9 @@
             <field name="model">res.partner</field>
             <field name="inherit_id" ref="base.res_partner_kanban_view"/>
             <field name="arch" type="xml">
+                <field name="email" position="before">
+                    <field name="custom_status" class="text-muted"/>
+                </field>
                 <xpath expr="//footer" position="inside">
                     <field name="activity_ids" widget="kanban_activity" class="ms-auto mt-auto"/>
                 </xpath>

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -368,6 +368,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                     "email": "odoobot@example.com",
                     "id": self.user_root.partner_id.id,
                     "im_status": "bot",
+                    "custom_status": False,
                     "isInternalUser": True,
                     "is_company": False,
                     "name": "OdooBot",
@@ -1557,6 +1558,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
         if user == self.users[0]:
             res = {
                 "active": True,
+                "custom_status": False,
                 "email": "e.e@example.com",
                 "id": user.partner_id.id,
                 "im_status": "online",
@@ -1606,6 +1608,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 }
             return {
                 "active": True,
+                "custom_status": False,
                 "email": "test2@example.com",
                 "id": user.partner_id.id,
                 "im_status": "offline",
@@ -1619,6 +1622,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
         if user == self.users[3]:
             return {
                 "active": True,
+                "custom_status": False,
                 "email": False,
                 "id": user.partner_id.id,
                 "im_status": "offline",
@@ -1632,6 +1636,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
         if user == self.users[12]:
             return {
                 "active": True,
+                "custom_status": False,
                 "email": False,
                 "id": user.partner_id.id,
                 "im_status": "offline",
@@ -1645,6 +1650,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
         if user == self.users[14]:
             return {
                 "active": True,
+                "custom_status": False,
                 "email": False,
                 "id": user.partner_id.id,
                 "im_status": "offline",
@@ -1658,6 +1664,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
         if user == self.users[15]:
             return {
                 "active": True,
+                "custom_status": False,
                 "email": False,
                 "id": user.partner_id.id,
                 "im_status": "offline",


### PR DESCRIPTION
Introduced two new fields on `res.users`:
- forced_im_status
- custom_status

The IM status set by the user will take precedence over the IM status computed by the system.

task-3208257