### PR TITLE
[FIX] pos_loyalty: underterministic error

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/models/loyalty.js
+++ b/addons/pos_loyalty/static/src/overrides/models/loyalty.js
@@ -695,7 +695,7 @@ patch(Order.prototype, {
      */
     async _couponForProgram(program) {
         if (program.is_nominative) {
-            return this.pos.fetchLoyaltyCard(program.id, this.get_partner().id);
+            return await this.pos.fetchLoyaltyCard(program.id, this.get_partner().id);
         }
         // This type of coupons don't need to really exist up until validating the order, so no need to cache
         return new PosLoyaltyCard(null, null, program.id, (this.get_partner() || { id: -1 }).id, 0);


### PR DESCRIPTION
An indeterministic error was present in the pos_loyalty module. This was
due to the fact that when the user changed the partner a request to
retrieve the loyaltyCards already existing for this partner was made by
a different series of function calls.

In fine, the call was not awaited, so when another method wanted to
retrieve the loyaltyCards for the same partner, a new card was created
and then overridden to null by the result of the call to the server.

To correct this error, the call to the server to retrieve the cards
is made when the partner is changed. At this point the request is
awaited.

Runbot Error: [57047](https://runbot.odoo.com/web/#id=57047&view_type=form&model=runbot.build.error&menu_id=405&cids=1)