### PR TITLE
[FIX] web_editor: selection preserve on applying color

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/color_palette.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/color_palette.js
@@ -100,16 +100,16 @@ export class ColorPalette extends Component {
             this.$ = $el.find.bind($el);
 
             $el.on('click', '.o_we_color_btn', this._onColorButtonClick.bind(this));
-            $el.on('mouseenter', '.o_we_color_btn', this._onColorButtonEnter.bind(this));
-            $el.on('mouseleave', '.o_we_color_btn', this._onColorButtonLeave.bind(this));
+            $el.on('mouseenter', '.o_we_color_btn:not(.o_custom_gradient_btn):not(.selected)', this._onColorButtonEnter.bind(this));
+            $el.on('mouseleave', '.o_we_color_btn:not(.o_custom_gradient_btn):not(.selected)', this._onColorButtonLeave.bind(this));
 
             $el.on('click', '.o_custom_gradient_editor .o_custom_gradient_btn', this._onGradientCustomButtonClick.bind(this));
             $el.on('click', '.o_custom_gradient_editor', this._onPanelClick.bind(this));
             $el.on('change', '.o_custom_gradient_editor input[type="text"]', this._onGradientInputChange.bind(this));
             $el.on('keypress', '.o_custom_gradient_editor input[type="text"]', this._onGradientInputKeyPress.bind(this));
             $el.on('click', '.o_custom_gradient_editor we-button:not(.o_remove_color)', this._onGradientButtonClick.bind(this));
-            $el.on('mouseenter', '.o_custom_gradient_editor we-button:not(.o_remove_color)', this._onGradientButtonEnter.bind(this));
-            $el.on('mouseleave', '.o_custom_gradient_editor we-button:not(.o_remove_color)', this._onGradientButtonLeave.bind(this));
+            $el.on('mouseenter', '.o_custom_gradient_editor we-button:not(.o_remove_color):not(.active)', this._onGradientButtonEnter.bind(this));
+            $el.on('mouseleave', '.o_custom_gradient_editor we-button:not(.o_remove_color):not(.active)', this._onGradientButtonLeave.bind(this));
 
             $el.on('click', '.o_custom_gradient_scale', this._onGradientPreviewClick.bind(this));
             // Note: _onGradientSliderClick on slider is attached at slider creation.

--- a/addons/website/static/tests/tours/website_colorpicker.js
+++ b/addons/website/static/tests/tours/website_colorpicker.js
@@ -1,0 +1,72 @@
+/** @odoo-module **/
+
+import wTourUtils from "@website/js/tours/tour_utils";
+const TARGET_BODY_DATA_COLOR = "linear-gradient(135deg, rgb(255, 204, 51) 0%, rgb(226, 51, 255) 100%)";
+wTourUtils.registerWebsitePreviewTour(
+    "custom_gradient_on_contactus_button",
+    {
+        test: true,
+        url: "/",
+        edition: true,
+    },
+    () => [
+        {
+            content: "Click the 'Contact Us' button in the navigation bar",
+            trigger: "iframe .o_main_nav a.btn-primary[href='/contactus']",
+        },
+        {
+            content: "Click on 'Edit Link' to customize the button",
+            trigger: "iframe .o_edit_menu_popover .o_we_edit_link",
+        },
+        {
+            content: "Open the foreground colorpicker",
+            trigger: "#toolbar:not(.oe-floating) #oe-text-color",
+        },
+        {
+            content: "Go to the 'Gradient' tab",
+            trigger: ".o_we_colorpicker_switch_pane_btn[data-target='gradients']",
+        },
+        {
+            content: "Click on the custom button to apply a custom gradient",
+            trigger: ".o_custom_gradient_btn",
+        },
+        {
+            content: "Trigger the mouseleave event on the 'Custom' button",
+            trigger: ".o_custom_gradient_btn",
+            run() {
+                this.$anchor.trigger("mouseleave");
+            },
+        },
+        {
+            content: "Check if font tag is applied to 'Contact Us'",
+            trigger: "iframe .o_main_nav a.btn-primary[href='/contactus'] font:contains('Contact Us')",
+            run: () => {}, // It's a check.
+        },
+        {
+            content: "Trigger 'mouseenter' and 'mouseleave' on selected gradient",
+            trigger: `.o_we_color_btn[data-color='${TARGET_BODY_DATA_COLOR}'].selected`,
+            run() {
+                this.$anchor.trigger("mouseenter");
+                this.$anchor.trigger("mouseleave");
+            },
+        },
+        {
+            content: "Check if font tag is applied to 'Contact Us' after hovering on selected gradient",
+            trigger: "iframe .o_main_nav a.btn-primary[href='/contactus'] font:contains('Contact Us')",
+            run: () => {}, // It's a check.
+        },
+        {
+            content: "Trigger 'mouseenter' and 'mouseleave' on linear-gradient",
+            trigger: ".colorpicker we-button[data-gradient-type='linear-gradient'].active",
+            run() {
+                this.$anchor.trigger("mouseeenter");
+                this.$anchor.trigger("mouseleave");
+            },
+        },
+        {
+            content: "Check if font tag is applied to 'Contact Us' after hovering on linear-gradient",
+            trigger: "iframe .o_main_nav a.btn-primary[href='/contactus'] font:contains('Contact Us')",
+            run: () => {}, // It's a check.
+        },
+    ]
+);

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -629,3 +629,6 @@ class TestUi(odoo.tests.HttpCase):
             self.env['website'].with_context(website_id=website.id).viewref(key).active = active
 
         self.start_tour('/', 'website_no_dirty_lazy_image', login='admin')
+
+    def test_custom_gradient_on_contactus_button(self):
+        self.start_tour(self.env['website'].get_client_action_url('/'), 'custom_gradient_on_contactus_button', login='admin')


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

Applying custom gradient to the Contact Us button leads to unexpected selection shifts due to a recent 
website header redesign in commit [1]. This redesign introduced separate navbars for desktop and mobile, 
resulting in duplication of the Contact Us field in the DOM. The `onColorLeave` function, triggered during 
mouse events, reverts current history step, causing mutations in the mobile view button and replacing the 
desktop button's innerHTML. This results in change in selection and the introduction of a zero-width space 
(ZWS) node, which causes display issues for the button.

**Desired behavior after PR is merged:**

Selection remains consistent, and the position of the Contact Us button is maintained.

[1]: https://github.com/odoo/odoo/commit/df64fed894bbf9630b33fd6a20882f294982f8e3

task-3871537