### PR TITLE
[FIX] im_livechat: fix chatbot redirect loop

### DIFF
--- a/addons/im_livechat/static/src/embed/common/chatbot/chatbot_model.js
+++ b/addons/im_livechat/static/src/embed/common/chatbot/chatbot_model.js
@@ -134,6 +134,9 @@ export class Chatbot extends Record {
      * @returns {Promise<boolean>} Whether the script is ready to go to the next step.
      */
     async _processAnswerQuestionSelection(message) {
+        if (this.currentStep.selectedAnswer) {
+            return true;
+        }
         const answer = this.currentStep.answers.find(({ label }) => message.body.includes(label));
         this.currentStep.selectedAnswer = answer;
         await rpc("/chatbot/answer/save", {


### PR DESCRIPTION
Before this PR, redirecting the user to a page that would then be
rewritten according to the user's preferred language would make the
chatbot loop.

Steps to reproduce:
- Install website_helpdesk_livechat
- Install another language and translate the website
- Modify the /contactus rule to use the helpdesk live chat
- Create a question step that redirects the user to `/helpdesk/customer-
care-1`
- Navigate to the contactus page and change the website language to the
newly installed language
- Start the chatbot and proceed to the redirect step
- The chatbot gets stuck in a loop

This happens because the chatbot checks if the redirect link and the
URL are the same to determine if the redirection was already done.
However, since the URL is rewritten, it assumes it wasn't done and
redirects once again.

When a page is reloaded, the chatbot starts where it left off.
However, it should check that the step was not already processed
beforehand. This PR fixes this issue by skipping the already done
step.

opw-3987426