### PR TITLE
[FIX] google_calendar: prevent duplicate event cancellation

### DIFF
--- a/addons/google_calendar/models/google_sync.py
+++ b/addons/google_calendar/models/google_sync.py
@@ -178,7 +178,7 @@ class GoogleSync(models.AbstractModel):
             google_ids_to_remove = [event.full_recurring_event_id() for event in rescheduled_events]
             cancelled_odoo += self.env['calendar.event'].search([('google_id', 'in', google_ids_to_remove)])
 
-        cancelled_odoo._cancel()
+        cancelled_odoo.exists()._cancel()
         synced_records = new_odoo + cancelled_odoo
         for gevent in existing - cancelled:
             # Last updated wins.


### PR DESCRIPTION
This commit addresses an issue where events removed due to changes in their recurrence rules from Google, and those cancelled separately on Google, could be attempted to be cancelled twice in Odoo.

opw-3997021

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
