### PR TITLE
[FIX] mrp: fix reservation on split

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1945,6 +1945,7 @@ class MrpProduction(models.Model):
         # reserve new backorder moves depending on the picking type
         self.env['stock.move'].browse(assigned_moves).write({'state': 'assigned'})
         self.env['stock.move'].browse(partially_assigned_moves).write({'state': 'partially_available'})
+        self.env['stock.move.line'].create(move_lines_vals)
         move_to_assign = move_to_assign.filtered(
             lambda move: move.state in ('confirmed', 'partially_available')
             and (move._should_bypass_reservation()
@@ -1955,7 +1956,6 @@ class MrpProduction(models.Model):
         # Avoid triggering a useless _recompute_state
         self.env['stock.move.line'].browse(move_lines_to_unlink).write({'move_id': False})
         self.env['stock.move.line'].browse(move_lines_to_unlink).unlink()
-        self.env['stock.move.line'].create(move_lines_vals)
 
         moves_to_consume.write({'picked': True})
 


### PR DESCRIPTION
When splitting MO there's a bug which causes more items
to be reserved than we have on hand.

Steps to reproduce:

- Create a product TEST
- Create BoM of a product (e.g. COMP1)
- Set quantity of COMP1 to X
- Create MO of TEST with quantity set to X + 1 (or more)
- Split the MO

It will cause X + 1 COMP1's to be reserved even though we only
have X COMP1's on hand.

To fix this we need to create move lines before reserving.

Task: 3962125