### PR TITLE
[FIX] account,l10n_{be,in}: tracking of journal items

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -101,7 +101,14 @@ class AccountAccount(models.Model):
     note = fields.Text('Internal Notes', tracking=True)
     company_id = fields.Many2one('res.company', string='Company', required=True, readonly=False,
         default=lambda self: self.env.company)
-    tag_ids = fields.Many2many('account.account.tag', 'account_account_account_tag', string='Tags', help="Optional tags you may want to assign for custom reporting", ondelete='restrict')
+    tag_ids = fields.Many2many(
+        comodel_name='account.account.tag',
+        relation='account_account_account_tag',
+        string='Tags',
+        help="Optional tags you may want to assign for custom reporting",
+        ondelete='restrict',
+        tracking=True,
+    )
     group_id = fields.Many2one('account.group', compute='_compute_account_group', store=True, readonly=True,
                                help="Account prefixes can determine account groups.")
     root_id = fields.Many2one('account.root', compute='_compute_account_root', store=True, precompute=True)

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -114,6 +114,7 @@ class AccountMoveLine(models.Model):
         string='Balance',
         compute='_compute_balance', store=True, readonly=False, precompute=True,
         currency_field='company_currency_id',
+        tracking=True,
     )
     cumulated_balance = fields.Monetary(
         string='Cumulated Balance',
@@ -180,6 +181,7 @@ class AccountMoveLine(models.Model):
         compute='_compute_tax_ids', store=True, readonly=False, precompute=True,
         context={'active_test': False},
         check_company=True,
+        tracking=True,
     )
     group_tax_id = fields.Many2one(
         comodel_name='account.tax',
@@ -1557,6 +1559,21 @@ class AccountMoveLine(models.Model):
             if line.move_id.state == 'posted':
                 line._check_tax_lock_date()
 
+        if not self.env.context.get('tracking_disable'):
+            # Log changes to move lines on each move
+            tracked_fields = [fname for fname, f in self._fields.items() if hasattr(f, 'tracking') and f.tracking and not (hasattr(f, 'related') and f.related)]
+            ref_fields = self.env['account.move.line'].fields_get(tracked_fields)
+            empty_values = dict.fromkeys(tracked_fields)
+            for move_id, modified_lines in lines.grouped('move_id').items():
+                if not move_id.posted_before:
+                    continue
+                for line in modified_lines:
+                    if tracking_value_ids := line._mail_track(ref_fields, empty_values)[1]:
+                        line.move_id._message_log(
+                            body=_("Journal Item %s created", line._get_html_link(title=f"#{line.id}")),
+                            tracking_value_ids=tracking_value_ids
+                        )
+
         lines.move_id._synchronize_business_models(['line_ids'])
         lines._check_constrains_account_id_journal_id()
         return lines
@@ -1688,6 +1705,21 @@ class AccountMoveLine(models.Model):
 
         # Check the tax lock date.
         self._check_tax_lock_date()
+
+        if not self.env.context.get('tracking_disable'):
+            # Log changes to move lines on each move
+            tracked_fields = [fname for fname, f in self._fields.items() if hasattr(f, 'tracking') and f.tracking and not (hasattr(f, 'related') and f.related)]
+            ref_fields = self.env['account.move.line'].fields_get(tracked_fields)
+            empty_line = self.browse([False])  # all falsy fields but not failing `ensure_one` checks
+            for move_id, modified_lines in self.grouped('move_id').items():
+                if not move_id.posted_before:
+                    continue
+                for line in modified_lines:
+                    if tracking_value_ids := empty_line._mail_track(ref_fields, line)[1]:
+                        line.move_id._message_log(
+                            body=_("Journal Item %s deleted", line._get_html_link(title=f"#{line.id}")),
+                            tracking_value_ids=tracking_value_ids
+                        )
 
         move_container = {'records': self.move_id}
         with self.move_id._check_balanced(move_container),\

--- a/addons/account/wizard/account_move_send.py
+++ b/addons/account/wizard/account_move_send.py
@@ -473,6 +473,7 @@ class AccountMoveSend(models.TransientModel):
             )
 
         # Prevent duplicated attachments linked to the invoice.
+        self.env.cr.execute("UPDATE ir_attachment SET res_id = NULL WHERE id IN %s", [tuple(new_message.attachment_ids.ids)])
         new_message.attachment_ids.write({
             'res_model': new_message._name,
             'res_id': new_message.id,

--- a/addons/account_audit_trail/__init__.py
+++ b/addons/account_audit_trail/__init__.py
@@ -2,3 +2,9 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import models
+from odoo.exceptions import UserError
+
+
+def uninstall_hook(env):
+    if not env.ref('base.module_base').demo:
+        raise UserError("This module cannot be uninstalled.")

--- a/addons/account_audit_trail/__manifest__.py
+++ b/addons/account_audit_trail/__manifest__.py
@@ -10,5 +10,6 @@
         'report/audit_trail_report_views.xml',
         'views/res_config_settings_views.xml',
     ],
+    'uninstall_hook': 'uninstall_hook',
     'license': 'LGPL-3',
 }

--- a/addons/account_audit_trail/i18n/account_audit_trail.pot
+++ b/addons/account_audit_trail/i18n/account_audit_trail.pot
@@ -16,6 +16,19 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: account_audit_trail
+#: model:ir.model.fields,field_description:account_audit_trail.field_mail_mail__account_audit_log_account_id
+#: model:ir.model.fields,field_description:account_audit_trail.field_mail_message__account_audit_log_account_id
+#: model_terms:ir.ui.view,arch_db:account_audit_trail.view_message_tree_audit_log_search
+msgid "Account"
+msgstr ""
+
+#. module: account_audit_trail
+#: model:ir.model.fields,field_description:account_audit_trail.field_mail_mail__account_audit_log_display_name
+#: model:ir.model.fields,field_description:account_audit_trail.field_mail_message__account_audit_log_display_name
+msgid "Account Audit Log Display Name"
+msgstr ""
+
+#. module: account_audit_trail
 #: model_terms:ir.ui.view,arch_db:account_audit_trail.res_config_settings_view_form_inherit_account_audit_trail
 msgid "Activate Audit Trail"
 msgstr ""
@@ -27,6 +40,11 @@ msgstr ""
 #: model:ir.ui.menu,name:account_audit_trail.account_audit_trail_menu
 #: model_terms:ir.ui.view,arch_db:account_audit_trail.res_config_settings_view_form_inherit_account_audit_trail
 msgid "Audit Trail"
+msgstr ""
+
+#. module: account_audit_trail
+#: model:ir.model,name:account_audit_trail.model_account_bank_statement_line
+msgid "Bank Statement Line"
 msgstr ""
 
 #. module: account_audit_trail
@@ -49,8 +67,24 @@ msgid "Companies"
 msgstr ""
 
 #. module: account_audit_trail
+#: model_terms:ir.ui.view,arch_db:account_audit_trail.view_message_tree_audit_log_search
+msgid "Company"
+msgstr ""
+
+#. module: account_audit_trail
+#: model:ir.model.fields,field_description:account_audit_trail.field_mail_mail__account_audit_log_company_id
+#: model:ir.model.fields,field_description:account_audit_trail.field_mail_message__account_audit_log_company_id
+msgid "Company "
+msgstr ""
+
+#. module: account_audit_trail
 #: model:ir.model,name:account_audit_trail.model_res_config_settings
 msgid "Config Settings"
+msgstr ""
+
+#. module: account_audit_trail
+#: model_terms:ir.ui.view,arch_db:account_audit_trail.view_message_tree_audit_log_search
+msgid "Create Only"
 msgstr ""
 
 #. module: account_audit_trail
@@ -83,6 +117,11 @@ msgid "Journal Entry"
 msgstr ""
 
 #. module: account_audit_trail
+#: model:ir.model,name:account_audit_trail.model_mail_tracking_value
+msgid "Mail Tracking Value"
+msgstr ""
+
+#. module: account_audit_trail
 #: model:ir.model,name:account_audit_trail.model_mail_message
 msgid "Message"
 msgstr ""
@@ -90,6 +129,11 @@ msgstr ""
 #. module: account_audit_trail
 #: model_terms:ir.ui.view,arch_db:account_audit_trail.view_message_tree_audit_log_search
 msgid "Messages Search"
+msgstr ""
+
+#. module: account_audit_trail
+#: model_terms:ir.ui.view,arch_db:account_audit_trail.view_message_tree_audit_log
+msgid "Name"
 msgstr ""
 
 #. module: account_audit_trail
@@ -101,9 +145,36 @@ msgid "Operation not supported"
 msgstr ""
 
 #. module: account_audit_trail
+#: model:ir.model.fields,field_description:account_audit_trail.field_mail_mail__account_audit_log_partner_id
+#: model:ir.model.fields,field_description:account_audit_trail.field_mail_message__account_audit_log_partner_id
+msgid "Partner"
+msgstr ""
+
+#. module: account_audit_trail
+#: model_terms:ir.ui.view,arch_db:account_audit_trail.view_message_tree_audit_log_search
+msgid "Partners"
+msgstr ""
+
+#. module: account_audit_trail
+#: model_terms:ir.ui.view,arch_db:account_audit_trail.view_message_tree_audit_log_search
+msgid "Record"
+msgstr ""
+
+#. module: account_audit_trail
 #: model:ir.model.fields,field_description:account_audit_trail.field_mail_mail__show_audit_log
 #: model:ir.model.fields,field_description:account_audit_trail.field_mail_message__show_audit_log
 msgid "Show Audit Log"
+msgstr ""
+
+#. module: account_audit_trail
+#: model:ir.model.fields,field_description:account_audit_trail.field_mail_mail__account_audit_log_tax_id
+#: model:ir.model.fields,field_description:account_audit_trail.field_mail_message__account_audit_log_tax_id
+msgid "Tax"
+msgstr ""
+
+#. module: account_audit_trail
+#: model_terms:ir.ui.view,arch_db:account_audit_trail.view_message_tree_audit_log_search
+msgid "Taxes"
 msgstr ""
 
 #. module: account_audit_trail
@@ -134,6 +205,9 @@ msgid "Updated"
 msgstr ""
 
 #. module: account_audit_trail
-#: model_terms:ir.ui.view,arch_db:account_audit_trail.view_message_tree_audit_log_search
-msgid "date"
+#. odoo-python
+#: code:addons/account_audit_trail/models/mail_message.py:0
+#, python-format
+msgid ""
+"You cannot remove parts of the audit trail. Archive the record instead."
 msgstr ""

--- a/addons/account_audit_trail/models/__init__.py
+++ b/addons/account_audit_trail/models/__init__.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import mail_message
+from . import account_bank_statement_line
 from . import account_move
-from . import res_config_settings
+from . import mail_message
+from . import mail_tracking_value
 from . import res_company
+from . import res_config_settings

--- a/addons/account_audit_trail/models/account_bank_statement_line.py
+++ b/addons/account_audit_trail/models/account_bank_statement_line.py
@@ -1,0 +1,10 @@
+from odoo import models
+
+
+class AccountBankStatementLine(models.Model):
+    _inherit = "account.bank.statement.line"
+
+    def unlink(self):
+        tracked_lines = self.filtered(lambda stl: stl.company_id.check_account_audit_trail)
+        super(AccountBankStatementLine, tracked_lines.with_context(soft_delete=True)).unlink()
+        return super(AccountBankStatementLine, self - tracked_lines).unlink()

--- a/addons/account_audit_trail/models/account_move.py
+++ b/addons/account_audit_trail/models/account_move.py
@@ -22,6 +22,9 @@ class AccountMove(models.Model):
             raise UserError(_("To keep the audit trail, you can not delete journal entries once they have been posted.\nInstead, you can cancel the journal entry."))
 
     def unlink(self):
+        if self.env.context.get('soft_delete'):
+            self.button_cancel()
+            return True
         # Add logger here because in api ondelete account.move.line is deleted and we can't get total amount
         logger_msg = False
         if any(m.posted_before and m.company_id.check_account_audit_trail for m in self):

--- a/addons/account_audit_trail/models/mail_message.py
+++ b/addons/account_audit_trail/models/mail_message.py
@@ -3,8 +3,9 @@
 
 from markupsafe import Markup
 
-from odoo import fields, models, _
+from odoo import api, fields, models, _
 from odoo.exceptions import UserError
+from odoo.osv.expression import OR
 
 
 class Message(models.Model):
@@ -17,7 +18,32 @@ class Message(models.Model):
         compute="_compute_account_audit_log_move_id",
         search="_search_account_audit_log_move_id",
     )
-    show_audit_log = fields.Boolean(compute="_compute_account_audit_log_move_id", search="_search_show_audit_log")
+    account_audit_log_partner_id = fields.Many2one(
+        comodel_name='res.partner',
+        string="Partner",
+        compute="_compute_account_audit_log_partner_id",
+        search="_search_account_audit_log_partner_id",
+    )
+    account_audit_log_account_id = fields.Many2one(
+        comodel_name='account.account',
+        string="Account",
+        compute="_compute_account_audit_log_account_id",
+        search="_search_account_audit_log_account_id",
+    )
+    account_audit_log_tax_id = fields.Many2one(
+        comodel_name='account.tax',
+        string="Tax",
+        compute="_compute_account_audit_log_tax_id",
+        search="_search_account_audit_log_tax_id",
+    )
+    account_audit_log_company_id = fields.Many2one(
+        comodel_name='res.company',
+        string="Company ",
+        compute="_compute_account_audit_log_company_id",
+        search="_search_account_audit_log_company_id",
+    )
+    account_audit_log_display_name = fields.Char(compute='_compute_account_audit_log_display_name')
+    show_audit_log = fields.Boolean(compute="_compute_show_audit_log", search="_search_show_audit_log")
 
     def _compute_account_audit_log_preview(self):
         for message in self:
@@ -43,32 +69,116 @@ class Message(models.Model):
             message.account_audit_log_preview = audit_log_preview
 
     def _compute_account_audit_log_move_id(self):
-        messages_of_account_move = self.filtered(lambda m: m.model == 'account.move' and m.res_id)
-        recordset_difference = (self - messages_of_account_move)
-        recordset_difference.update({
-            'account_audit_log_move_id': False,
-            'show_audit_log': False,
-        })
-        moves = self.env['account.move'].sudo().search([
-            ('id', 'in', messages_of_account_move.mapped('res_id')),
+        self._compute_audit_log_related_record_id('account.move', 'account_audit_log_move_id', [
             ('company_id.check_account_audit_trail', '=', True),
         ])
-        moves_by_id = {m.id: m for m in moves}
-        for message in messages_of_account_move:
-            message.account_audit_log_move_id = moves_by_id.get(message.res_id, False)
-            message.show_audit_log = bool(moves_by_id.get(message.res_id))
 
     def _search_account_audit_log_move_id(self, operator, value):
-        if operator in ['=', 'like', 'ilike', '!=', 'not ilike', 'not like'] and isinstance(value, str):
-            res_id_domain = [('res_id', 'in', self.env['account.move']._name_search(value, operator=operator))]
-        elif operator in ['=', 'in', '!=', 'not in']:
-            res_id_domain = [('res_id', operator, value)]
-        else:
-            raise UserError(_('Operation not supported'))
-        return [('model', '=', 'account.move')] + res_id_domain
+        return self._search_audit_log_related_record_id('account.move', operator, value)
+
+    def _compute_account_audit_log_account_id(self):
+        self._compute_audit_log_related_record_id('account.account', 'account_audit_log_account_id', [
+            ('company_id.check_account_audit_trail', '=', True),
+        ])
+
+    def _search_account_audit_log_account_id(self, operator, value):
+        return self._search_audit_log_related_record_id('account.account', operator, value)
+
+    def _compute_account_audit_log_tax_id(self):
+        self._compute_audit_log_related_record_id('account.tax', 'account_audit_log_tax_id', [
+            ('company_id.check_account_audit_trail', '=', True),
+        ])
+
+    def _search_account_audit_log_tax_id(self, operator, value):
+        return self._search_audit_log_related_record_id('account.tax', operator, value)
+
+    def _compute_account_audit_log_company_id(self):
+        self._compute_audit_log_related_record_id('res.company', 'account_audit_log_company_id', [
+            ('check_account_audit_trail', '=', True),
+        ])
+
+    def _search_account_audit_log_company_id(self, operator, value):
+        return self._search_audit_log_related_record_id('res.company', operator, value)
+
+    def _compute_account_audit_log_partner_id(self):
+        self._compute_audit_log_related_record_id('res.partner', 'account_audit_log_partner_id', [
+            '|', ('company_id', '=', False), ('company_id.check_account_audit_trail', '=', True),
+            '|', ('customer_rank', '>', 0), ('supplier_rank', '>', 0),
+        ])
+
+    def _search_account_audit_log_partner_id(self, operator, value):
+        return self._search_audit_log_related_record_id('res.partner', operator, value)
+
+    def _compute_account_audit_log_display_name(self):
+        for message in self:
+            message.account_audit_log_display_name = (
+                message.account_audit_log_move_id
+                or message.account_audit_log_account_id
+                or message.account_audit_log_tax_id
+                or message.account_audit_log_partner_id
+                or message.account_audit_log_company_id
+            ).display_name
+
+    def _compute_show_audit_log(self):
+        for message in self:
+            message.show_audit_log = message.message_type == 'notification' and (
+                message.account_audit_log_move_id
+                or message.account_audit_log_account_id
+                or message.account_audit_log_tax_id
+                or message.account_audit_log_partner_id
+                or message.account_audit_log_company_id
+            )
 
     def _search_show_audit_log(self, operator, value):
         if operator not in ['=', '!='] or not isinstance(value, bool):
             raise UserError(_('Operation not supported'))
-        move_query = self.env['account.move']._search([('company_id.check_account_audit_trail', operator, value)])
-        return [('model', '=', 'account.move'), ('res_id', 'in', move_query)]
+        return [('message_type', '=', 'notification')] + OR([
+            [('model', '=', 'account.move'), ('res_id', 'in', self.env['account.move']._search([
+                ('company_id.check_account_audit_trail', operator, value),
+            ]))],
+            [('model', '=', 'account.account'), ('res_id', 'in', self.env['account.account']._search([
+                ('company_id.check_account_audit_trail', operator, value),
+            ]))],
+            [('model', '=', 'account.tax'), ('res_id', 'in', self.env['account.tax']._search([
+                ('company_id.check_account_audit_trail', operator, value),
+            ]))],
+            [('model', '=', 'res.partner'), ('res_id', 'in', self.env['res.partner']._search([
+                '|', ('company_id', '=', False), ('company_id.check_account_audit_trail', operator, value),
+                '|', ('customer_rank', '>', 0), ('supplier_rank', '>', 0),
+            ]))],
+            [('model', '=', 'res.company'), ('res_id', 'in', self.env['res.company']._search([
+                ('check_account_audit_trail', operator, value),
+            ]))],
+        ])
+
+    def _compute_audit_log_related_record_id(self, model, fname, domain):
+        messages_of_related = self.filtered(lambda m: m.model == model and m.res_id)
+        (self - messages_of_related)[fname] = False
+        if messages_of_related:
+            related_recs = self.env[model].sudo().search([('id', 'in', messages_of_related.mapped('res_id'))] + domain)
+            recs_by_id = {record.id: record for record in related_recs}
+            for message in messages_of_related:
+                message[fname] = recs_by_id.get(message.res_id, False)
+
+    def _search_audit_log_related_record_id(self, model, operator, value):
+        if operator in ['=', 'like', 'ilike', '!=', 'not ilike', 'not like'] and isinstance(value, str):
+            res_id_domain = [('res_id', 'in', self.env[model]._name_search(value, operator=operator))]
+        elif operator in ['=', 'in', '!=', 'not in']:
+            res_id_domain = [('res_id', operator, value)]
+        else:
+            raise UserError(_('Operation not supported'))
+        return [('model', '=', model)] + res_id_domain
+
+    @api.ondelete(at_uninstall=True)
+    def _except_audit_log(self):
+        for message in self:
+            if message.show_audit_log and not (
+                message.account_audit_log_move_id
+                and not message.account_audit_log_move_id.posted_before
+            ):
+                raise UserError(_("You cannot remove parts of the audit trail. Archive the record instead."))
+
+    def write(self, vals):
+        if vals.keys() & {'res_id', 'res_model', 'subject', 'message_type', 'subtype_id'}:
+            self._except_audit_log()
+        return super().write(vals)

--- a/addons/account_audit_trail/models/mail_tracking_value.py
+++ b/addons/account_audit_trail/models/mail_tracking_value.py
@@ -1,0 +1,15 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, models
+
+
+class MailTrackingValues(models.Model):
+    _inherit = 'mail.tracking.value'
+
+    @api.ondelete(at_uninstall=True)
+    def _except_audit_log(self):
+        self.mail_message_id._except_audit_log()
+
+    def write(self, vals):
+        self._except_audit_log()
+        return super().write(vals)

--- a/addons/account_audit_trail/report/audit_trail_report_views.xml
+++ b/addons/account_audit_trail/report/audit_trail_report_views.xml
@@ -11,7 +11,7 @@
                 <field name="res_id" column_invisible="True"/>
                 <field name="date"/>
                 <field name="author_id" widget="many2one_avatar"/>
-                <field name="account_audit_log_move_id"/>
+                <field name="account_audit_log_display_name" string="Name"/>
                 <field name="account_audit_log_preview"/>
             </tree>
         </field>
@@ -25,12 +25,25 @@
         <field name="arch" type="xml">
             <search string="Messages Search">
                 <field name="account_audit_log_move_id"/>
+                <field name="account_audit_log_account_id"/>
+                <field name="account_audit_log_tax_id"/>
+                <field name="account_audit_log_partner_id"/>
+                <field name="account_audit_log_company_id"/>
                 <field name="author_id"/>
-                <field name="date" string="Date"/>
+                <field name="date"/>
+                <filter string="Journal Entry" name="account_move" domain="[('model', '=', 'account.move')]"/>
+                <filter string="Account" name="account_account" domain="[('model', '=', 'account.account')]"/>
+                <filter string="Taxes" name="account_tax" domain="[('model', '=', 'account.tax')]"/>
+                <filter string="Partners" name="res_partner" domain="[('model', '=', 'res.partner')]"/>
+                <filter string="Company" name="res_company" domain="[('model', '=', 'res.company')]"/>
+                <separator/>
                 <filter string="Update Only" name="update_only" domain="[('tracking_value_ids', '!=', False)]" groups="base.group_system"/>
+                <filter string="Create Only" name="create_only" domain="[('tracking_value_ids', '=', False)]" groups="base.group_system"/>
+                <separator/>
+                <filter name="date" string="Date" date="date"/>
                 <group expand="0" string="Group By">
-                    <filter string="date" name="group_by_date" domain="[]" context="{'group_by': 'date'}"/>
-                    <filter string="Journal Entry" name="group_by_log_move_id" domain="[]" context="{'group_by': 'res_id'}"/>
+                    <filter string="Date" name="group_by_date" domain="[]" context="{'group_by': 'date'}"/>
+                    <filter string="Record" name="group_by_log_move_id" domain="[]" context="{'group_by': 'res_id'}"/>
                 </group>
             </search>
         </field>
@@ -47,9 +60,7 @@
             </p>
         </field>
         <field name="domain">[
-            ('model', '=', 'account.move'),
             ('message_type', '=', 'notification'),
-            ('account_audit_log_move_id', '!=', False),
             ('show_audit_log', '=', True),
         ]</field>
         <field name="search_view_id" ref="view_message_tree_audit_log_search"/>

--- a/addons/account_audit_trail/tests/__init__.py
+++ b/addons/account_audit_trail/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_audit_trail

--- a/addons/account_audit_trail/tests/test_audit_trail.py
+++ b/addons/account_audit_trail/tests/test_audit_trail.py
@@ -1,0 +1,123 @@
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.exceptions import UserError
+from odoo.fields import Command
+from odoo.tests import tagged
+from odoo.tools.mail import html2plaintext
+
+
+@tagged('post_install', '-at_install')
+class TestAuditTrail(AccountTestInvoicingCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env.company.check_account_audit_trail = True
+        cls.move = cls.create_move()
+
+    @classmethod
+    def create_move(cls):
+        return cls.env['account.move'].create({
+            'line_ids': [
+                Command.create({
+                    'balance': 100,
+                    'account_id': cls.company_data['default_account_revenue'].id
+                }),
+                Command.create({
+                    'balance': -100,
+                    'account_id': cls.company_data['default_account_revenue'].id
+                }),
+            ],
+        })
+
+    def get_trail(self, move):
+        self.env.cr.precommit.run()
+        return self.env['mail.message'].search([
+            ('model', '=', 'account.move'),
+            ('res_id', '=', move.id),
+        ])
+
+    def assertTrail(self, trail, expected):
+        self.assertEqual(len(trail), len(expected))
+        for message, expected in zip(trail, expected[::-1]):
+            self.assertRegex(
+                html2plaintext(message.account_audit_log_preview),
+                expected
+            )
+
+    def test_can_unlink_draft(self):
+        self.move.unlink()
+
+    def test_cant_unlink_posted(self):
+        self.move.action_post()
+        self.move.button_draft()
+        with self.assertRaisesRegex(UserError, "remove parts of the audit trail"):
+            self.move.unlink()
+
+    def test_cant_unlink_message(self):
+        self.move.action_post()
+        audit_trail = self.get_trail(self.move)
+        with self.assertRaisesRegex(UserError, "remove parts of the audit trail"):
+            audit_trail.unlink()
+
+    def test_cant_unown_message(self):
+        self.move.action_post()
+        audit_trail = self.get_trail(self.move)
+        with self.assertRaisesRegex(UserError, "remove parts of the audit trail"):
+            audit_trail.res_id = 0
+
+    def test_cant_unlink_tracking_value(self):
+        self.move.action_post()
+        self.env.cr.precommit.run()
+        self.move.name = 'track this!'
+        audit_trail = self.get_trail(self.move)
+        trackings = audit_trail.tracking_value_ids.sudo()
+        self.assertTrue(trackings)
+        with self.assertRaisesRegex(UserError, "remove parts of the audit trail"):
+            trackings.unlink()
+
+    def test_content(self):
+        messages = ["Journal Entry created"]
+        self.assertTrail(self.get_trail(self.move), messages)
+
+        self.move.action_post()
+        messages.append(r"Updated Draft Posted \(Status\)")
+        self.assertTrail(self.get_trail(self.move), messages)
+
+        self.move.button_draft()
+        messages.append(r"Updated Posted Draft \(Status\)")
+        self.assertTrail(self.get_trail(self.move), messages)
+
+        self.move.name = "nawak"
+        messages.append(r"Updated MISC/\d+/\d+/0001 nawak \(Number\)")
+        self.assertTrail(self.get_trail(self.move), messages)
+
+        self.move.line_ids = [
+            Command.update(self.move.line_ids[0].id, {'balance': 300}),
+            Command.update(self.move.line_ids[1].id, {'credit': 200}),  # writing on debit/credit or balance both log
+            Command.create({
+                'balance': -100,
+                'account_id': self.company_data['default_account_revenue'].id,
+            })
+        ]
+        messages.extend([
+            r"updated 100.0 300.0",
+            r"updated -100.0 -200.0",
+            r"created  400000 Product Sales \(Account\) 0.0 -100.0 \(Balance\)",
+        ])
+        self.assertTrail(self.get_trail(self.move), messages)
+
+        self.move.line_ids[0].tax_ids = self.env.company.account_purchase_tax_id
+        messages.extend([
+            r"updated  15% \(Taxes\)",
+            r"created  131000 Tax Paid \(Account\) 0.0 45.0 \(Balance\) False 15% \(Label\)",
+            r"created  101402 Bank Suspense Account \(Account\) 0.0 -45.0 \(Balance\) False Automatic Balancing Line \(Label\)",
+        ])
+        self.assertTrail(self.get_trail(self.move), messages)
+        self.move.with_context(dynamic_unlink=True).line_ids.unlink()
+        messages.extend([
+            r"deleted 400000 Product Sales  \(Account\) 300.0 0.0 \(Balance\) 15%  \(Taxes\)",
+            r"deleted 400000 Product Sales  \(Account\) -200.0 0.0 \(Balance\)",
+            r"deleted 400000 Product Sales  \(Account\) -100.0 0.0 \(Balance\)",
+            r"deleted 131000 Tax Paid  \(Account\) 45.0 0.0 \(Balance\) 15% False \(Label\)",
+            r"deleted 101402 Bank Suspense Account  \(Account\) -45.0 0.0 \(Balance\) Automatic Balancing Line False \(Label\)",
+        ])
+        self.assertTrail(self.get_trail(self.move), messages)

--- a/addons/account_lock/__init__.py
+++ b/addons/account_lock/__init__.py
@@ -1,3 +1,8 @@
 # -*- coding: utf-8 -*-
 
 from . import models
+from odoo.exceptions import UserError
+
+def uninstall_hook(env):
+    if not env.ref('base.module_base').demo:
+        raise UserError("This module cannot be uninstalled.")

--- a/addons/account_lock/__init__.py
+++ b/addons/account_lock/__init__.py
@@ -3,6 +3,7 @@
 from . import models
 from odoo.exceptions import UserError
 
+
 def uninstall_hook(env):
     if not env.ref('base.module_base').demo:
         raise UserError("This module cannot be uninstalled.")

--- a/addons/account_lock/__manifest__.py
+++ b/addons/account_lock/__manifest__.py
@@ -12,5 +12,6 @@ Make the lock date irreversible:
 * Any new All Users Lock Date must be posterior (or equal) to the previous one.
     """,
     'depends': ['account'],
+    'uninstall_hook': 'uninstall_hook',
     'license': 'LGPL-3',
 }

--- a/addons/l10n_de/__manifest__.py
+++ b/addons/l10n_de/__manifest__.py
@@ -10,8 +10,8 @@
     'website': 'https://www.odoo.com/documentation/17.0/applications/finance/fiscal_localizations/germany.html',
     'category': 'Accounting/Localizations/Account Charts',
     'description': """
-Dieses  Modul beinhaltet einen deutschen Kontenrahmen basierend auf dem SKR03.
-==============================================================================
+Dieses  Modul beinhaltet einen deutschen Kontenrahmen basierend auf dem SKR03 oder SKR04.
+=========================================================================================
 
 German accounting chart and localization.
     """,

--- a/addons/l10n_de/i18n/de.po
+++ b/addons/l10n_de/i18n/de.po
@@ -18,6 +18,13 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 
 #. module: l10n_de
+#. odoo-python
+#: code:addons/l10n_de/models/ir_attachment.py:0
+#, python-format
+msgid "%(attachment_name)s (detached by %(user)s on %(date)s)"
+msgstr "%(attachment_name)s (getrennt von %(user)s am %(date)s)"
+
+#. module: l10n_de
 #: model:account.report.line,name:l10n_de.tax_report_de_tag_21
 msgid "21. non-taxable other services (line 34)"
 msgstr "21. Nicht steuerbare sonstige Leistungen (zeile 34)"
@@ -251,6 +258,11 @@ msgid "98. at other tax rates (line 27)"
 msgstr "98. zu anderen Steuersatzen (zeile 27)"
 
 #. module: l10n_de
+#: model:ir.model,name:l10n_de.model_account_account
+msgid "Account"
+msgstr "Konto"
+
+#. module: l10n_de
 #: model:ir.model,name:l10n_de.model_account_chart_template
 msgid "Account Chart Template"
 msgstr "Kontenplan Vorlage"
@@ -259,6 +271,11 @@ msgstr "Kontenplan Vorlage"
 #: model:account.report.line,name:l10n_de.tax_report_de_tag_01
 msgid "Assessment basis"
 msgstr "Bemessungsgrundlage"
+
+#. module: l10n_de
+#: model:ir.model,name:l10n_de.model_ir_attachment
+msgid "Attachment"
+msgstr "Dateianhang"
 
 #. module: l10n_de
 #: model:account.report.column,name:l10n_de.tax_report_balance
@@ -754,27 +771,26 @@ msgstr "W-IdNr."
 #. odoo-python
 #: code:addons/l10n_de/models/account_account.py:0
 #, python-format
-msgid ""
-"You can not change the code/name of an account if it contains hashed "
-"entries."
-msgstr ""
-"Sie können den Code/Namen eines Kontos nicht ändern, wenn es Hash-Einträge "
-"enthält."
+msgid "You can not change the code of an account."
+msgstr "Sie können den Code eines Kontos nicht ändern."
 
-#. module: l10n_de_reports
-#: code:addons/l10n_de_reports/models/account_generic_tax_report.py:0
+#. module: l10n_de
+#. odoo-python
+#: code:addons/l10n_de/models/ir_attachment.py:0
+#, python-format
+msgid "You cannot remove parts of the audit trail."
+msgstr "Sie können keine Teile des Prüfpfads entfernen."
+
+#. module: l10n_de
+#. odoo-python
+#: code:addons/l10n_de/models/res_company.py:0
 #, python-format
 msgid "Your company's SteuerNummer is not compatible with your state"
-msgstr ""
-"Die Steuernummer Ihres Unternehmens ist nicht mit Ihrem Bundesland kompatibel."
+msgstr "Die Steuernummer Ihres Unternehmens ist nicht mit Ihrem Bundesland kompatibel."
 
-#. module: l10n_de_reports
-#: code:addons/l10n_de_reports/models/account_generic_tax_report.py:0
+#. module: l10n_de
+#. odoo-python
+#: code:addons/l10n_de/models/res_company.py:0
 #, python-format
 msgid "Your company's SteuerNummer is not valid"
 msgstr "Die Steuernummer Ihres Unternehmens ist nicht gültig."
-
-#. module: l10n_de
-#: model:ir.model.fields,field_description:l10n_de.field_base_document_layout__zip
-msgid "Zip"
-msgstr "Postleitzahl"

--- a/addons/l10n_de/i18n/l10n_de.pot
+++ b/addons/l10n_de/i18n/l10n_de.pot
@@ -16,6 +16,13 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: l10n_de
+#. odoo-python
+#: code:addons/l10n_de/models/ir_attachment.py:0
+#, python-format
+msgid "%(attachment_name)s (detached by %(user)s on %(date)s)"
+msgstr ""
+
+#. module: l10n_de
 #: model:account.report.line,name:l10n_de.tax_report_de_tag_21
 msgid "21. non-taxable other services (line 34)"
 msgstr ""
@@ -276,6 +283,11 @@ msgid "98. at other tax rates (line 27)"
 msgstr ""
 
 #. module: l10n_de
+#: model:ir.model,name:l10n_de.model_account_account
+msgid "Account"
+msgstr ""
+
+#. module: l10n_de
 #: model:ir.model,name:l10n_de.model_account_chart_template
 msgid "Account Chart Template"
 msgstr ""
@@ -283,6 +295,11 @@ msgstr ""
 #. module: l10n_de
 #: model:account.report.line,name:l10n_de.tax_report_de_tag_01
 msgid "Assessment basis"
+msgstr ""
+
+#. module: l10n_de
+#: model:ir.model,name:l10n_de.model_ir_attachment
+msgid "Attachment"
 msgstr ""
 
 #. module: l10n_de
@@ -810,24 +827,26 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_de/models/account_account.py:0
 #, python-format
-msgid ""
-"You can not change the code/name of an account if it contains hashed "
-"entries."
+msgid "You can not change the code of an account."
 msgstr ""
 
-#. module: l10n_de_reports
-#: code:addons/l10n_de_reports/models/account_generic_tax_report.py:0
+#. module: l10n_de
+#. odoo-python
+#: code:addons/l10n_de/models/ir_attachment.py:0
+#, python-format
+msgid "You cannot remove parts of the audit trail."
+msgstr ""
+
+#. module: l10n_de
+#. odoo-python
+#: code:addons/l10n_de/models/res_company.py:0
 #, python-format
 msgid "Your company's SteuerNummer is not compatible with your state"
 msgstr ""
 
-#. module: l10n_de_reports
-#: code:addons/l10n_de_reports/models/account_generic_tax_report.py:0
+#. module: l10n_de
+#. odoo-python
+#: code:addons/l10n_de/models/res_company.py:0
 #, python-format
 msgid "Your company's SteuerNummer is not valid"
-msgstr ""
-
-#. module: l10n_de
-#: model:ir.model.fields,field_description:l10n_de.field_base_document_layout__zip
-msgid "Zip"
 msgstr ""

--- a/addons/l10n_de/models/__init__.py
+++ b/addons/l10n_de/models/__init__.py
@@ -7,6 +7,7 @@ from . import account_move
 from . import datev
 from . import chart_template
 from . import ir_actions_report
+from . import ir_attachment
 from . import res_company
 from . import template_de_skr03
 from . import template_de_skr04

--- a/addons/l10n_de/models/account_account.py
+++ b/addons/l10n_de/models/account_account.py
@@ -6,11 +6,7 @@ class AccountAccount(models.Model):
     _inherit = ['account.account']
 
     def write(self, vals):
-        if 'DE' in self.company_id.account_fiscal_country_id.mapped('code') and ('code' in vals or 'name' in vals):
-            hashed_aml_domain = [
-                ('account_id', 'in', self.ids),
-                ('move_id.inalterable_hash', '!=', False),
-            ]
-            if self.env['account.move.line'].search_count(hashed_aml_domain, limit=1):
-                raise UserError(_("You can not change the code/name of an account if it contains hashed entries."))
+        if 'code' in vals and 'DE' in self.company_id.account_fiscal_country_id.mapped('code'):
+            if self.env['account.move.line'].search_count([('account_id', 'in', self.ids)], limit=1):
+                raise UserError(_("You can not change the code of an account."))
         super().write(vals)

--- a/addons/l10n_de/models/datev.py
+++ b/addons/l10n_de/models/datev.py
@@ -4,7 +4,7 @@ from odoo import fields, models
 class AccountTax(models.Model):
     _inherit = "account.tax"
 
-    l10n_de_datev_code = fields.Char(size=4, help="4 digits code use by Datev")
+    l10n_de_datev_code = fields.Char(size=4, help="4 digits code use by Datev", tracking=True)
 
 
 class ProductTemplate(models.Model):

--- a/addons/l10n_de/models/ir_attachment.py
+++ b/addons/l10n_de/models/ir_attachment.py
@@ -1,0 +1,46 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models, _
+from odoo.exceptions import UserError
+from odoo.tools.mimetypes import guess_mimetype
+from odoo.tools.misc import format_date
+
+
+class IrAttachment(models.Model):
+    _inherit = 'ir.attachment'
+
+    @api.ondelete(at_uninstall=True)
+    def _except_audit_trail(self):
+        for attachment in self:
+            if attachment.res_model == 'account.move' and attachment.res_id and guess_mimetype(attachment.raw) in (
+                'application/pdf',
+                'application/xml',
+            ):
+                move = self.env['account.move'].browse(attachment.res_id)
+                if move.posted_before and move.country_code == 'DE':
+                    raise UserError(_("You cannot remove parts of the audit trail."))
+
+    def write(self, vals):
+        if vals.keys() & {'res_id', 'res_model', 'raw', 'datas', 'store_fname', 'db_datas'}:
+            self._except_audit_trail()
+        return super().write(vals)
+
+    def unlink(self):
+        invoice_pdf_attachments = self.filtered(lambda attachment:
+            attachment.res_model == 'account.move'
+            and attachment.res_id
+            and attachment.res_field in ('invoice_pdf_report_file', 'ubl_cii_xml_id')
+        )
+        if invoice_pdf_attachments:
+            # only detach the document from the field, but keep it in the database for the audit trail
+            # it shouldn't be an issue as there aren't any security group on the fields as it is the public report
+            invoice_pdf_attachments.res_field = False
+            today = format_date(self.env, fields.Date.context_today(self))
+            for attachment in invoice_pdf_attachments:
+                attachment.name = _(
+                    '%(attachment_name)s (detached by %(user)s on %(date)s)',
+                    attachment_name=attachment.name,
+                    user=self.env.user.name,
+                    date=today,
+                )
+        return super(IrAttachment, self - invoice_pdf_attachments).unlink()

--- a/addons/l10n_de/models/res_company.py
+++ b/addons/l10n_de/models/res_company.py
@@ -15,7 +15,7 @@ class ResCompany(models.Model):
         help="Tax number. Scheme: ??FF0BBBUUUUP, e.g.: 2893081508152 https://de.wikipedia.org/wiki/Steuernummer",
         tracking=True,
     )
-    l10n_de_widnr = fields.Char(string="W-IdNr.", help="Business identification number.")
+    l10n_de_widnr = fields.Char(string="W-IdNr.", help="Business identification number.", tracking=True)
 
     @api.depends('country_code')
     @api.constrains('state_id', 'l10n_de_stnr')

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -3573,10 +3573,10 @@ class MailThread(models.AbstractModel):
         # prepare notification mail values
         base_mail_values = {
             'mail_message_id': message.id,
-            'mail_server_id': message.mail_server_id.id, # 2 query, check acces + read, may be useless, Falsy, when will it be used?
             'references': references,
-            'subject': mail_subject,
         }
+        if mail_subject != message.subject:
+            base_mail_values['subject'] = mail_subject
         if additional_values:
             base_mail_values.update(additional_values)
 

--- a/addons/mail/models/res_partner.py
+++ b/addons/mail/models/res_partner.py
@@ -15,6 +15,7 @@ class Partner(models.Model):
     _mail_flat_thread = False
 
     # override to add and order tracking
+    name = fields.Char(tracking=1)
     email = fields.Char(tracking=1)
     phone = fields.Char(tracking=2)
     parent_id = fields.Many2one(tracking=3)

--- a/addons/test_mass_mailing/tests/test_performance.py
+++ b/addons/test_mass_mailing/tests/test_performance.py
@@ -47,7 +47,7 @@ class TestMassMailPerformance(TestMassMailPerformanceBase):
         })
 
         # runbot needs +51 compared to local
-        with self.assertQueryCount(__system__=1622, marketing=1623):  # 1522, 1523
+        with self.assertQueryCount(__system__=1623, marketing=1624):  # 1522, 1523
             mailing.action_send_mail()
 
         self.assertEqual(mailing.sent, 50)
@@ -90,7 +90,7 @@ class TestMassMailBlPerformance(TestMassMailPerformanceBase):
         })
 
         # runbot needs +51 compared to local
-        with self.assertQueryCount(__system__=1694, marketing=1695):  # 1594, 1595
+        with self.assertQueryCount(__system__=1695, marketing=1696):  # 1594, 1595
             mailing.action_send_mail()
 
         self.assertEqual(mailing.sent, 50)


### PR DESCRIPTION
Multiple fixes related to Audit Trail:
* track more fields:
  * <account.move.line>.balance
  * <account.move.line>.tax_tag_ids
  * <account.tax>.l10n_de_datev_code
  * <res.company>.l10n_de_widnr
* Track newly created lines once the move has been posted
* Prevent deleting tracking messages/values linked to the audit trail

[task-4018800](https://www.odoo.com/odoo/project.task/4018800?cids=1)
