### PR TITLE
[IMP] spreadsheet: accept date values for quarter granularity

### DIFF
--- a/addons/spreadsheet/static/src/pivot/pivot_time_adapters.js
+++ b/addons/spreadsheet/static/src/pivot/pivot_time_adapters.js
@@ -1,12 +1,14 @@
 /** @odoo-module */
 // @ts-check
 
-import { registries } from "@odoo/o-spreadsheet";
+import { registries, helpers, constants } from "@odoo/o-spreadsheet";
 import { deserializeDate } from "@web/core/l10n/dates";
 import { _t } from "@web/core/l10n/translation";
 import { user } from "@web/core/user";
 
 const { pivotTimeAdapterRegistry } = registries;
+const { formatValue, toNumber, toString } = helpers;
+const { DEFAULT_LOCALE } = constants;
 
 const { DateTime } = luxon;
 
@@ -58,7 +60,23 @@ const odooDayAdapter = {
     },
 };
 
+/**
+ * Normalized value: "2/2023" for week 2 of 2023
+ */
 const odooWeekAdapter = {
+    normalizeFunctionValue(value) {
+        const [week, year] = toString(value).split("/");
+        return `${Number(week)}/${Number(year)}`;
+    },
+    toValueAndFormat(normalizedValue, locale) {
+        const [week, year] = normalizedValue.split("/");
+        return {
+            value: _t("W%(week)s %(year)s", { week, year }),
+        };
+    },
+    toFunctionValue(normalizedValue) {
+        return `"${normalizedValue}"`;
+    },
     normalizeServerValue(groupBy, field, readGroupResult) {
         const weekValue = readGroupResult[groupBy];
         const { week, year } = parseServerWeekHeader(weekValue);
@@ -74,7 +92,24 @@ const odooWeekAdapter = {
     },
 };
 
+/**
+ * normalized month value is a string formatted as "MM/yyyy" (luxon format)
+ * e.g. "01/2020" for January 2020
+ */
 const odooMonthAdapter = {
+    normalizeFunctionValue(value) {
+        const date = toNumber(value, DEFAULT_LOCALE);
+        return formatValue(date, { locale: DEFAULT_LOCALE, format: "mm/yyyy" });
+    },
+    toValueAndFormat(normalizedValue) {
+        return {
+            value: toNumber(normalizedValue, DEFAULT_LOCALE),
+            format: "mmmm yyyy",
+        };
+    },
+    toFunctionValue(normalizedValue) {
+        return `"${normalizedValue}"`;
+    },
     normalizeServerValue(groupBy, field, readGroupResult) {
         const firstOfTheMonth = getGroupStartingDay(field, groupBy, readGroupResult);
         const date = deserializeDate(firstOfTheMonth);
@@ -87,7 +122,24 @@ const odooMonthAdapter = {
     },
 };
 
+/**
+ * normalized quarter value is "quarter/year"
+ * e.g. "1/2020" for Q1 2020
+ */
 const odooQuarterAdapter = {
+    normalizeFunctionValue(value) {
+        const [quarter, year] = toString(value).split("/");
+        return `${quarter}/${year}`;
+    },
+    toValueAndFormat(normalizedValue) {
+        const [quarter, year] = normalizedValue.split("/");
+        return {
+            value: _t("Q%(quarter)s %(year)s", { quarter, year }),
+        };
+    },
+    toFunctionValue(normalizedValue) {
+        return `"${normalizedValue}"`;
+    },
     normalizeServerValue(groupBy, field, readGroupResult) {
         const firstOfTheQuarter = getGroupStartingDay(field, groupBy, readGroupResult);
         const date = deserializeDate(firstOfTheQuarter);
@@ -164,10 +216,11 @@ function extendSpreadsheetAdapter(granularity, adapter) {
     );
 }
 
+pivotTimeAdapterRegistry.add("week", falseHandlerDecorator(odooWeekAdapter));
+pivotTimeAdapterRegistry.add("month", falseHandlerDecorator(odooMonthAdapter));
+pivotTimeAdapterRegistry.add("quarter", falseHandlerDecorator(odooQuarterAdapter));
+
 extendSpreadsheetAdapter("day", odooDayAdapter);
-extendSpreadsheetAdapter("week", odooWeekAdapter);
-extendSpreadsheetAdapter("month", odooMonthAdapter);
-extendSpreadsheetAdapter("quarter", odooQuarterAdapter);
 extendSpreadsheetAdapter("year", odooYearAdapter);
 
 /**

--- a/addons/spreadsheet/static/tests/pivots/model/pivot_plugin.test.js
+++ b/addons/spreadsheet/static/tests/pivots/model/pivot_plugin.test.js
@@ -822,6 +822,25 @@ test("PIVOT.HEADER grouped by date field without value", async function () {
     }
 });
 
+test("PIVOT functions can accept spreadsheet dates", async function () {
+    const { model } = await createSpreadsheetWithPivot({
+        arch: /* xml */ `
+            <pivot>
+                <field name="date" interval="quarter" type="col"/>
+                <field name="probability" type="measure"/>
+            </pivot>`,
+    });
+    setCellContent(model, "A1", '=PIVOT.HEADER(1, "date:quarter",DATE(2016, 4, 1))');
+    expect(getCellValue(model, "A1")).toBe("Q2 2016");
+
+    setCellContent(model, "A1", '=PIVOT.VALUE(1, "probability", "date:quarter",DATE(2016, 4, 1))');
+    expect(getCellValue(model, "A1")).toBe(10);
+
+    // not the first day of the quarter
+    setCellContent(model, "A1", '=PIVOT.VALUE(1, "probability", "date:quarter",DATE(2016, 4, 2))');
+    expect(getCellValue(model, "A1")).toBe(10);
+});
+
 test("PIVOT formulas are correctly formatted at evaluation", async function () {
     const { model } = await createSpreadsheetWithPivot({
         arch: /* xml */ `

--- a/addons/spreadsheet/static/tests/pivots/pivot_helpers.test.js
+++ b/addons/spreadsheet/static/tests/pivots/pivot_helpers.test.js
@@ -8,6 +8,7 @@ const {
     getNumberOfPivotFunctions,
     pivotTimeAdapter,
     toNormalizedPivotValue,
+    toNumber,
 } = helpers;
 const { DEFAULT_LOCALE } = constants;
 
@@ -125,6 +126,21 @@ describe("toNormalizedPivotValue", () => {
             expect(() => toNormalizedPivotValue(dimension, "true")).toThrow();
             expect(() => toNormalizedPivotValue(dimension, true)).toThrow();
             expect(() => toNormalizedPivotValue(dimension, "won")).toThrow();
+
+            dimension.granularity = "quarter";
+            // special quarter syntax:
+            expect(toNormalizedPivotValue(dimension, "1/2020")).toBe("1/2020");
+            expect(toNormalizedPivotValue(dimension, "2/2020")).toBe("2/2020");
+            expect(toNormalizedPivotValue(dimension, "3/2020")).toBe("3/2020");
+            expect(toNormalizedPivotValue(dimension, "4/2020")).toBe("4/2020");
+
+            // falls back on regular date parsing:
+            expect(toNormalizedPivotValue(dimension, "5/2020")).toBe("2/2020");
+            expect(toNormalizedPivotValue(dimension, "01/01/2020")).toBe("1/2020");
+            expect(toNormalizedPivotValue(dimension, toNumber("01/01/2020", DEFAULT_LOCALE))).toBe(
+                "1/2020"
+            );
+            expect(() => toNormalizedPivotValue(dimension, "hello")).toThrow();
 
             dimension.granularity = "year";
             expect(toNormalizedPivotValue(dimension, "2020")).toBe(2020);


### PR DESCRIPTION
When building a pivot function with a dynamic quart part (let's say based on
the value of TODAY()), you have to carefully build the quarter argument to
match the expected format.

The only expected values are of the form: "1/2020", "2/2020", "3/2020", "4/2020"

So from TODAY() (let's say A1 contains =TODAY()), you have to build an
intermediary value like =QUARTER(A1)&"/"&YEAR(A1) and use it in your pivot
quarter formulas.

Now you can just use TODAY() or any other date value in the formula.
The quarter is inferred automatically.

Task: 4019715


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
