### PR TITLE
[FIX] web: grouped editable list: dont discard on add new line

### DIFF
--- a/addons/web/static/src/model/relational_model/group.js
+++ b/addons/web/static/src/model/relational_model/group.js
@@ -65,7 +65,7 @@ export class Group extends DataPoint {
     }
 
     async addNewRecord(_unused, atFirstPosition = false) {
-        const canProceed = await this.model.root.leaveEditMode({ discard: true });
+        const canProceed = await this.model.root.leaveEditMode();
         if (canProceed) {
             const record = await this.list.addNewRecord(atFirstPosition);
             if (record) {

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -2621,6 +2621,33 @@ test(`editable list: add a line and discard`, async () => {
     expect(`.o_pager_value`).toHaveText("1-1", { message: "pager should be correct" });
 });
 
+test(`grouped editable list: edit a record and click on "Add a line"`, async () => {
+    await mountView({
+        resModel: "foo",
+        type: "list",
+        arch: `<tree editable="bottom"><field name="foo" required="1"/><field name="bar"/></tree>`,
+        groupBy: ["foo"],
+    });
+
+    expect(".o_group_header").toHaveCount(3);
+    expect(".o_data_row").toHaveCount(0);
+
+    await contains(".o_group_header").click();
+    expect(".o_data_row").toHaveCount(2);
+
+    // edit an existing row and click on "Add a line" => edited record should not be discarded
+    await contains(".o_data_row .o_data_cell").click();
+    await contains(".o_data_row .o_data_cell .o_field_widget[name=foo] input").edit("coucou");
+    await contains(".o_group_field_row_add a").click();
+    expect(".o_data_row .o_data_cell:first").toHaveText("coucou");
+    expect(".o_data_row").toHaveCount(3);
+
+    // edit the new line, and click again on "Add a line" => created record should not be discarded
+    await contains(".o_data_row .o_data_cell .o_field_widget[name=foo] input").edit("new line");
+    await contains(".o_group_field_row_add a").click();
+    expect(".o_data_row").toHaveCount(4);
+});
+
 test(`field changes are triggered correctly`, async () => {
     Foo._onChanges = {
         foo() {


### PR DESCRIPTION
Before this commit, in a grouped editable list view, clicking on "Add a line" in the bottom of a group while editing a record discarded the edited record. If it was a new record, it vanished.

This commit fixes the issue: if the record can be saved, we save it. If it can't be saved, the user is blocked on that edited row, and must fix the record or discard it manually.

Task 4019619

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
