### PR TITLE
[FIX] sale_loyalty: make reward sale order lines readonly

### DIFF
--- a/addons/sale_loyalty/views/sale_order_views.xml
+++ b/addons/sale_loyalty/views/sale_order_views.xml
@@ -18,6 +18,18 @@
                         help="Update current promotional lines and select new rewards if applicable."
                         class="btn btn-secondary"/>
             </button>
+            <xpath expr="//tree//field[@name='product_uom_qty']" position="before">
+                <field name="is_reward_line" column_invisible="True"/>
+            </xpath>
+            <xpath expr="//tree//field[@name='product_uom_qty']" position="attributes">
+                <attribute name="readonly" add="is_reward_line" separator=" or "/>
+            </xpath>
+            <xpath expr="//tree//field[@name='price_unit']" position="attributes">
+                <attribute name="readonly" add="is_reward_line" separator=" or "/>
+            </xpath>
+            <xpath expr="//tree//field[@name='tax_id']" position="attributes">
+                <attribute name="readonly" add="is_reward_line" separator=" or "/>
+            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
Previously, users were able to edit reward sale order lines. However, these edits were undone on confirming the SO, which was confusing. This fix makes the quantity, unit price, and taxes of such lines readonly to make it clear that they're not meant to be edited.

opw-3971219