### PR TITLE
[FIX] pos_mrp: kit cogs

### DIFF
--- a/addons/pos_mrp/models/pos_order.py
+++ b/addons/pos_mrp/models/pos_order.py
@@ -22,10 +22,11 @@ class PosOrder(models.Model):
         bom = product.env['mrp.bom']._bom_find(product, company_id=self.mapped('picking_ids.move_line_ids').company_id.id, bom_type='phantom')[product]
         if not bom:
             return super()._get_pos_anglo_saxon_price_unit(product, partner_id, quantity)
-        dummy, components = bom.explode(product, quantity)
+        _dummy, components = bom.explode(product, quantity)
         total_price_unit = 0
         for comp in components:
             price_unit = super()._get_pos_anglo_saxon_price_unit(comp[0].product_id, partner_id, comp[1]['qty'])
             price_unit = comp[0].product_id.uom_id._compute_price(price_unit, comp[0].product_uom_id)
-            total_price_unit += price_unit
+            qty_per_kit = comp[1]['qty'] / bom.product_qty / quantity
+            total_price_unit += price_unit * qty_per_kit
         return total_price_unit

--- a/addons/pos_mrp/tests/test_pos_mrp_flow.py
+++ b/addons/pos_mrp/tests/test_pos_mrp_flow.py
@@ -284,11 +284,11 @@ class TestPosMrp(TestPointOfSaleCommon):
         bom_product_form = Form(self.env['mrp.bom'])
         bom_product_form.product_id = self.kit
         bom_product_form.product_tmpl_id = self.kit.product_tmpl_id
-        bom_product_form.product_qty = 1.0
+        bom_product_form.product_qty = 2.0
         bom_product_form.type = 'phantom'
         with bom_product_form.bom_line_ids.new() as bom_line:
             bom_line.product_id = self.component_a
-            bom_line.product_qty = 1.0
+            bom_line.product_qty = 6.0
             bom_line.product_uom_id = self.env.ref('uom.product_uom_unit')
         self.bom_a = bom_product_form.save()
 
@@ -310,7 +310,7 @@ class TestPosMrp(TestPointOfSaleCommon):
                         'product_id': self.kit.id,
                         'price_subtotal': 2,
                         'price_subtotal_incl': 2,
-                        'qty': 1,
+                        'qty': 2,
                         'tax_ids': []}],
                         ],
                 'name': 'Order 00042-003-0014',
@@ -329,6 +329,6 @@ class TestPosMrp(TestPointOfSaleCommon):
         order = self.env['pos.order'].browse(order[0]['id'])
         accounts = self.kit.product_tmpl_id.get_product_accounts()
         expense_line = order.account_move.line_ids.filtered(lambda l: l.account_id.id == accounts['expense'].id)
-        self.assertEqual(expense_line.filtered(lambda l: l.product_id == self.kit).debit, 1000.0)
+        self.assertEqual(expense_line.filtered(lambda l: l.product_id == self.kit).debit, 6000.0)
         interim_line = order.account_move.line_ids.filtered(lambda l: l.account_id.id == accounts['stock_output'].id)
-        self.assertEqual(interim_line.filtered(lambda l: l.product_id == self.kit).credit, 1000.0)
+        self.assertEqual(interim_line.filtered(lambda l: l.product_id == self.kit).credit, 6000.0)


### PR DESCRIPTION
Steps to reproduce:
- Create a kit BOM composed of 40kg of storable product X.
- Set cost of X as 10$
- Sell 3 kits in POS
- Select customer and create an invoice
- in accounting check the the invoice lines
- Odoo is calculating the COGS as 3kg instead of 120kg. (30$ instead of 120$)

Bug:
kit quantities not taken into consideration

opw-3962665
