### PR TITLE
[PERF] project: split `_compute_task_count`

### DIFF
--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -3,15 +3,14 @@
 
 import ast
 import json
-from collections import defaultdict
 from datetime import timedelta
 
 from odoo import api, Command, fields, models, _, _lt
 from odoo.addons.rating.models import rating_data
 from odoo.exceptions import UserError
+from odoo.osv.expression import AND
 from odoo.tools import get_lang, SQL
 from .project_update import STATUS_COLOR
-from .project_task import CLOSED_STATES
 
 
 class Project(models.Model):
@@ -30,24 +29,27 @@ class Project(models.Model):
     _systray_view = 'activity'
     _track_duration_field = 'stage_id'
 
-    def _compute_task_count(self):
-        project_and_state_counts = self.env['project.task'].with_context(
+    def __compute_task_count(self, count_field='task_count', additional_domain=None):
+        count_fields = {fname for fname in self._fields if 'count' in fname}
+        if count_field not in count_fields:
+            raise ValueError(f"Parameter 'count_field' can only be one of {count_fields}, got {count_field} instead.")
+        domain = [('project_id', 'in', self.ids)]
+        if additional_domain:
+            domain = AND([domain, additional_domain])
+        tasks_count_by_project = dict(self.env['project.task'].with_context(
             active_test=any(project.active for project in self)
-        )._read_group(
-            [('project_id', 'in', self.ids)],
-            ['project_id', 'state'],
-            ['__count'],
-        )
-        task_counts_per_project_id = defaultdict(lambda: {
-            'open_task_count': 0,
-            'closed_task_count': 0,
-        })
-        for project, state, count in project_and_state_counts:
-            task_counts_per_project_id[project.id]['closed_task_count' if state in CLOSED_STATES else 'open_task_count'] += count
+        )._read_group(domain, ['project_id'], ['__count']))
         for project in self:
-            open_task_count, closed_task_count = task_counts_per_project_id[project.id].values()
-            project.open_task_count = open_task_count
-            project.task_count = open_task_count + closed_task_count
+            project.update({count_field: tasks_count_by_project.get(project, 0)})
+
+    def _compute_task_count(self):
+        self.__compute_task_count()
+
+    def _compute_open_task_count(self):
+        self.__compute_task_count(
+            count_field='open_task_count',
+            additional_domain=[('state', 'in', self.env['project.task'].OPEN_STATES)],
+        )
 
     def _default_stage_id(self):
         # Since project stages are order by sequence first, this should fetch the one with the lowest sequence number.
@@ -97,7 +99,7 @@ class Project(models.Model):
         'resource.calendar', string='Working Time', compute='_compute_resource_calendar_id', export_string_translation=False)
     type_ids = fields.Many2many('project.task.type', 'project_task_type_rel', 'project_id', 'type_id', string='Tasks Stages', export_string_translation=False)
     task_count = fields.Integer(compute='_compute_task_count', string="Task Count", export_string_translation=False)
-    open_task_count = fields.Integer(compute='_compute_task_count', string="Open Task Count", export_string_translation=False)
+    open_task_count = fields.Integer(compute='_compute_open_task_count', string="Open Task Count", export_string_translation=False)
     task_ids = fields.One2many('project.task', 'project_id', string='Tasks', export_string_translation=False,
                                domain=lambda self: [('is_closed', '=', False)])
     color = fields.Integer(string='Color Index', export_string_translation=False)

--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -388,7 +388,6 @@
                     <field name="display_name"/>
                     <field name="partner_id"/>
                     <field name="color"/>
-                    <field name="task_count"/>
                     <field name="open_task_count"/>
                     <field name="milestone_count_reached"/>
                     <field name="milestone_count"/>


### PR DESCRIPTION
## Description
On large database with many tasks, opening the default kanban view of a Projects can quite slow. It's often a pain point for large DBs that relies heavily on Projects for their day-to-day operations.

## Analysis
The majority of the bottleneck comes from the computation of the tasks' count. The views loads both `task_count` and `open_task_count`, which are compute non-stored fields, yet only the `open_task_count` is shown and actually needed. They both share the same compute `_compute_task_count`, which will compute the counts of tasks for the projects visible in the view, including tasks that are in a closed state. This is unnecessary, as the view now actually needs only the open tasks, whch is usually a significantly lower number of tasks for large long living databases.

## Solution
1) Decouple the compute for `task_count` and `open_task_count` into their own computes, this achieves two goals:
  - Computing the count for the open tasks is significantly faster, as we are filtering on the open tasks, which is a highly selective criteria (can also be supported by a good partial index of the form `(project_id) WHERE state = <list_of_open_states>`)
  - Computing the regular `task_count` doesn't filter based on state anymore, making it more straight forward.
2) Remove `task_count` from the view, as it is not necessary at all, and if not present, it's compute won't be recomputed.

The only downside of this approach is when a view necessitate both `open_task_count` **and** `task_count`, in that case both compute will be triggered individually, which is a bit slower than doing a combined `_read_group` and filtering on the `state` as it was done before.

## Benchmark
On a DB with over 1.8M `project.task`, with a default favourite filter (5 projects, 1 of which has 1M tasks, but only 44k are open) on hot loading

|         | Before | After | Speed up |
|---------|--------|-------|----------|
| Timings | 1.4s   | 575ms | 2.4x     |

Same benchmark, but without any favourite filter, hot load

|         | Before | After | Speed up |
|---------|--------|-------|----------|
| Timings | 2.3s   | 1.3s  | 1.75x    |

## Reference
task-3924914

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
