### PR TITLE
[FIX] stock: hide placeholder on report when no name on delivery address

### DIFF
--- a/addons/stock/report/report_deliveryslip.xml
+++ b/addons/stock/report/report_deliveryslip.xml
@@ -202,7 +202,7 @@
                         <div class="offset-8">
                             <img t-att-src="image_data_uri(o.signature)" style="max-height: 4cm; max-width: 8cm;"/>
                         </div>
-                        <div t-if="o.partner_id" class="offset-8 text-center">
+                        <div t-if="o.partner_id.name" class="offset-8 text-center">
                             <p t-field="o.partner_id.name">John Doe</p>
                         </div>
                     </div>


### PR DESCRIPTION
Problem: Placeholders were added in 17.0 to be used when switching to Studio mode. However, this placeholder will appear on the printed report if the `res.partner` has no name. Creating a `Delivery Address` for a `res.partner` does not require a name due to its type.

Purpose: Hide this placeholder in cases were `Delivery Address` record does not have a `name` set.

Steps to Reproduce:
1) Enable `Signatures` for deliveries
2) Create a new `Delivery Address` with no `name` for an existing `res.partner` record
3) Create a SO -> confirm -> sign delivery
4) Print `Delivery Slip`

opw-3988100