### PR TITLE
[FIX] stock: show only the product variants on hand quantity

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -916,7 +916,10 @@ class ProductTemplate(models.Model):
 
     # Be aware that the exact same function exists in product.product
     def action_open_quants(self):
-        return self.product_variant_ids.filtered(lambda p: p.active or p.qty_available != 0).action_open_quants()
+        if (self.env.context.get('default_product_id')):
+            return self.env['product.product'].browse(self.env.context['default_product_id']).action_open_quants()
+        else:
+            return self.product_variant_ids.filtered(lambda p: p.active or p.qty_available != 0).action_open_quants()
 
     def action_update_quantity_on_hand(self):
         advanced_option_groups = [


### PR DESCRIPTION
Problem: When you click on the On Hand smart button from a product variant, it will show the on hand quantity for all of the product's variants.

Purpose: Clicking on the On Hand smart button from a product variant should show only the on hand quantity for that specific product variant.

Steps to Reproduce on Runbot:

1. Create a storable product with an attribute that has two values to create two product variants
2. Purchase stock for both product variants
3. Receive the purchased products
4. Enable Storage Locations in Settings > Inventory
5. Navigate to one of the product variants and click on the On Hand smart button
6. Observe that it shows the on hand quantity for both product variants

opw-3988374

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
