### PR TITLE
[FIX] web, website: move the check of 'True'/'False' CSS variables value

### DIFF
--- a/addons/web/static/src/scss/utils.scss
+++ b/addons/web/static/src/scss/utils.scss
@@ -221,20 +221,10 @@
     @return $-with-support-font;
 }
 
-// Function to remove all null values of a map. Also transforms `'True'` and
-// `'False'` values into boolean `true` and `false`. This is needed in website
-// because of some options that wrongly set some CSS variables to these values.
-// TODO in master, this should be moved in website, as the only use case is in
-// website user values files.
+// Function to remove all null values of a map.
 @function o-map-omit($map) {
     $-map: ();
     @each $key, $value in $map {
-        @if $value == 'True' {
-            $value: true;
-        }
-        @if $value == 'False' {
-            $value: false;
-        }
         @if $value != null {
             $-map: map-merge($-map, (
                 $key: $value,

--- a/addons/website/static/src/scss/primary_variables.scss
+++ b/addons/website/static/src/scss/primary_variables.scss
@@ -2204,9 +2204,18 @@ $o-theme-font-configs: (
 // and resetting to theme default": ideally, we should review that system to
 // actually removing the custos in those cases instead of setting a null value
 // but this cannot be migrated at the moment).
+// Also transforms `'True'` and `'False'` values into boolean `true`/`false`.
+// This is needed because of some options that wrongly set some CSS variables to
+// these values.
 @function o-map-force-nulls($map) {
     $-map: ();
     @each $key, $value in $map {
+        @if $value == 'True' {
+            $value: true;
+        }
+        @if $value == 'False' {
+            $value: false;
+        }
         $-map: map-merge($-map, (
             $key: if($value == 'NULL', null, $value),
         ));


### PR DESCRIPTION
In commit [1], the `o-map-omit` SCSS function has been modified in order to fix the values of CSS variables that would have been wrongly set to `'True'` or `'False'`, instead of boolean `true` and `false`. However, the issue only happened in "website", so the code should not have been added in this function which is located in the "web" module, because it is really website-specific.

This commit moves this fix in the website `o-map-force-nulls` function instead.

[1]: https://github.com/odoo/odoo/commit/e01b861b89546ab5d7b5ce8269b06e9b7a845835

Related to opw-3957157