### PR TITLE
[IMP] sale: Restrict confirmation of sale quotation without order lines

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -971,12 +971,15 @@ class SaleOrder(models.Model):
         :return: True
         :rtype: bool
         :raise: UserError if trying to confirm cancelled SO's
+        :raise: UserError if it contains no order lines
         """
         if not all(order._can_be_confirmed() for order in self):
             raise UserError(_(
                 "The following orders are not in a state requiring confirmation: %s",
                 ", ".join(self.mapped('display_name')),
             ))
+        if not self.order_line:
+            raise UserError(_("You need to add a line before confirm."))
 
         self.order_line._validate_analytic_distribution()
 

--- a/doc/cla/individual/fasilwdr.md
+++ b/doc/cla/individual/fasilwdr.md
@@ -1,0 +1,12 @@
+India, 2024-06-30
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Fasil Muhammed fasilwdr@hotmail.com https://github.com/fasilwdr
+


### PR DESCRIPTION
This update adds a restriction to prevent users from confirming a sale quotation if it contains no order lines. This ensures data integrity by avoiding empty sales orders in the system.

Description of the issue/feature this PR addresses:
This PR addresses the issue of allowing sale quotations to be confirmed without any order lines. Confirming such quotations can lead to the creation of empty sales orders

Current behavior before PR:
Currently, users can confirm sale quotations even if they have no order lines. This can result in empty sales orders being saved in the system

Desired behavior after PR is merged:
After merging this PR, the system will restrict the confirmation of sale quotations that contain no order lines. Users will receive an error message prompting them to add at least one order line before proceeding with the confirmation. This ensures that all confirmed sales orders contain necessary data, maintaining data integrity and completeness



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
