### PR TITLE
[FIX] account: Fixed highest_name computation in account_move

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -703,6 +703,8 @@ class AccountMove(models.Model):
                 self.env.add_to_compute(move.line_ids._fields['date'], move.line_ids)
                 # might be protected because `_get_accounting_date` requires the `name`
                 self.env.add_to_compute(self._fields['name'], move)
+            # Highest name should be changed as the sequence date (date field) changes
+            move._compute_highest_name()
 
     @api.depends('auto_post')
     def _compute_auto_post_until(self):


### PR DESCRIPTION
The highest_name field should change whenever the field date changes. However, this was not always the case because the api.depends decorating _compute_highest_name would only call the compute method if the date field changes through the UI. This commit calls '_compute_highest_name' inside the '_compute_date' method to solve this issue.

task-4001574

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
