### PR TITLE
[IMP] hr_expense: Made currency mass editable on expense list view

### DIFF
--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -84,7 +84,9 @@
                            readonly="not is_editable or not is_multiple_currency or product_has_cost"
                            options="{'currency_field': 'currency_id'}" optional="hide" decoration-bf="1"
                            groups="base.group_multi_currency"/>
-                    <field name="currency_id" optional="hide" readonly="True" groups="base.group_multi_currency"/>
+                    <field name="currency_id" optional="hide"
+                           readonly="not is_editable or product_has_cost"
+                           groups="base.group_multi_currency"/>
                     <field name="state" optional="show" readonly="True" decoration-info="state in ['draft', 'reported']"
                            decoration-success="state in ['approved', 'done']"
                            decoration-warning="state == 'submitted'" decoration-danger="state == 'refused'" widget="badge"/>


### PR DESCRIPTION
This commit allows for currency editing on the expense list view.

This is needed because sometimes the OCR does not recognize the currency. In that case, mass edit of the currency from the list view would make it easier to set proper currencies on expenses.

task-4020134

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
