### PR TITLE
[FIX] mail: font-awesome loaded before bootstrap

### DIFF
--- a/addons/mail/__manifest__.py
+++ b/addons/mail/__manifest__.py
@@ -202,7 +202,6 @@ For more specific needs, you may also assign custom-defined actions
         'mail.assets_public': [
             'web/static/lib/jquery/jquery.js',
             'web/static/lib/odoo_ui_icons/style.css',
-            'web/static/src/libs/fontawesome/css/font-awesome.css',
             ('include', 'web._assets_helpers'),
             ('include', 'web._assets_backend_helpers'),
             'web/static/src/scss/pre_variables.scss',
@@ -211,6 +210,7 @@ For more specific needs, you may also assign custom-defined actions
             'web/static/lib/bootstrap/scss/_maps.scss',
             ('include', 'web._assets_bootstrap_backend'),
             'web/static/src/scss/bootstrap_overridden.scss',
+            'web/static/src/libs/fontawesome/css/font-awesome.css',
             'web/static/src/webclient/webclient.scss',
             'web/static/src/scss/mimetypes.scss',
             ('include', 'web._assets_core'),


### PR DESCRIPTION
The Font Awesome library was loaded before the Bootstrap override, which 
caused the 'fa-ellipsis-h' icons to not display correctly. Placing the Font 
Awesome library after the Bootstrap override will resolve the issue.

Before:
![image](https://github.com/odoo/odoo/assets/120459796/a682313d-ba10-47b2-aa1e-68d1d27fcf69)


After:
![image](https://github.com/odoo/odoo/assets/120459796/38368198-20d7-4985-b46a-5d4bae93cd8f)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
