### PR TITLE
[IMP] core: complement like operator

### DIFF
--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -803,26 +803,26 @@ class TestExpression(SavepointCaseWithUserDemo):
         Model = self.env['res.partner.category']
         record = Model.create({'name': 'XY', 'color': 42})
 
-        self.assertIn(record, Model.search([('name', 'like', 'X')]))
-        self.assertIn(record, Model.search([('name', 'ilike', 'X')]))
-        self.assertIn(record, Model.search([('name', 'not like', 'Z')]))
-        self.assertIn(record, Model.search([('name', 'not ilike', 'Z')]))
+        self.assertIn(record, self._search(Model, [('name', 'like', 'X')]))
+        self.assertIn(record, self._search(Model, [('name', 'ilike', 'X')]))
+        self.assertIn(record, self._search(Model, [('name', 'not like', 'Z')]))
+        self.assertIn(record, self._search(Model, [('name', 'not ilike', 'Z')]))
 
-        self.assertNotIn(record, Model.search([('name', 'like', 'Z')]))
-        self.assertNotIn(record, Model.search([('name', 'ilike', 'Z')]))
-        self.assertNotIn(record, Model.search([('name', 'not like', 'X')]))
-        self.assertNotIn(record, Model.search([('name', 'not ilike', 'X')]))
+        self.assertNotIn(record, self._search(Model, [('name', 'like', 'Z')]))
+        self.assertNotIn(record, self._search(Model, [('name', 'ilike', 'Z')]))
+        self.assertNotIn(record, self._search(Model, [('name', 'not like', 'X')]))
+        self.assertNotIn(record, self._search(Model, [('name', 'not ilike', 'X')]))
 
         # like, ilike, not like, not ilike convert their lhs to str
-        self.assertIn(record, Model.search([('color', 'like', '4')]))
-        self.assertIn(record, Model.search([('color', 'ilike', '4')]))
-        self.assertIn(record, Model.search([('color', 'not like', '3')]))
-        self.assertIn(record, Model.search([('color', 'not ilike', '3')]))
+        self.assertIn(record, self._search(Model, [('color', 'like', '4')]))
+        self.assertIn(record, self._search(Model, [('color', 'ilike', '4')]))
+        self.assertIn(record, self._search(Model, [('color', 'not like', '3')]))
+        self.assertIn(record, self._search(Model, [('color', 'not ilike', '3')]))
 
-        self.assertNotIn(record, Model.search([('color', 'like', '3')]))
-        self.assertNotIn(record, Model.search([('color', 'ilike', '3')]))
-        self.assertNotIn(record, Model.search([('color', 'not like', '4')]))
-        self.assertNotIn(record, Model.search([('color', 'not ilike', '4')]))
+        self.assertNotIn(record, self._search(Model, [('color', 'like', '3')]))
+        self.assertNotIn(record, self._search(Model, [('color', 'ilike', '3')]))
+        self.assertNotIn(record, self._search(Model, [('color', 'not like', '4')]))
+        self.assertNotIn(record, self._search(Model, [('color', 'not ilike', '4')]))
 
         # =like and =ilike don't work on non-character fields
         with mute_logger('odoo.sql_db'), self.assertRaises(psycopg2.Error):

--- a/odoo/addons/base/tests/test_search.py
+++ b/odoo/addons/base/tests/test_search.py
@@ -292,7 +292,7 @@ class test_search(TransactionCase):
         """, """
             SELECT "res_country"."id"
             FROM "res_country"
-            WHERE "res_country"."code" IS NULL
+            WHERE FALSE
             ORDER BY "res_country"."name"->>%s
         """]):
             Model.search([('code', 'ilike', '')])

--- a/odoo/addons/test_new_api/tests/test_domain.py
+++ b/odoo/addons/test_new_api/tests/test_domain.py
@@ -55,12 +55,12 @@ class TestDomain(common.TransactionCase):
         self.assertListEqual(EmptyChar.search([('name', '=', '')]).mapped('name'), [''])
         self.assertListEqual(EmptyChar.search([('name', '!=', '')]).mapped('name'), ['name'])
         self.assertListEqual(EmptyChar.search([('name', 'ilike', '')]).mapped('name'), ['name', '', False])
-        self.assertListEqual(EmptyChar.search([('name', 'not ilike', '')]).mapped('name'), [False])
+        self.assertListEqual(EmptyChar.search([('name', 'not ilike', '')]).mapped('name'), [])
 
         self.assertListEqual(EmptyChar.search([('name', '=', False)]).mapped('name'), [False])
         self.assertListEqual(EmptyChar.search([('name', '!=', False)]).mapped('name'), ['name', ''])
         self.assertListEqual(EmptyChar.search([('name', 'ilike', False)]).mapped('name'), ['name', '', False])
-        self.assertListEqual(EmptyChar.search([('name', 'not ilike', False)]).mapped('name'), [False])
+        self.assertListEqual(EmptyChar.search([('name', 'not ilike', False)]).mapped('name'), [])
 
         values = ['name', '', False]
         for length in range(len(values) + 1):
@@ -90,12 +90,12 @@ class TestDomain(common.TransactionCase):
         self.assertListEqual(records_fr.search([('name', '=', '')]).mapped('name'), [''])
         self.assertListEqual(records_fr.search([('name', '!=', '')]).mapped('name'), ['name'])
         self.assertListEqual(records_fr.search([('name', 'ilike', '')]).mapped('name'), ['name', '', False])
-        self.assertListEqual(records_fr.search([('name', 'not ilike', '')]).mapped('name'), [False])
+        self.assertListEqual(records_fr.search([('name', 'not ilike', '')]).mapped('name'), [])
 
         self.assertListEqual(records_fr.search([('name', '=', False)]).mapped('name'), [False])
         self.assertListEqual(records_fr.search([('name', '!=', False)]).mapped('name'), ['name', ''])
         self.assertListEqual(records_fr.search([('name', 'ilike', False)]).mapped('name'), ['name', '', False])
-        self.assertListEqual(records_fr.search([('name', 'not ilike', False)]).mapped('name'), [False])
+        self.assertListEqual(records_fr.search([('name', 'not ilike', False)]).mapped('name'), [])
 
         values = ['name', '', False]
         for length in range(len(values) + 1):

--- a/odoo/addons/test_new_api/tests/test_indexed_translation.py
+++ b/odoo/addons/test_new_api/tests/test_indexed_translation.py
@@ -62,7 +62,7 @@ class TestIndexedTranslation(odoo.tests.TransactionCase):
         """, """
             SELECT "test_new_api_indexed_translation"."id"
             FROM "test_new_api_indexed_translation"
-            WHERE "test_new_api_indexed_translation"."name" IS NULL
+            WHERE FALSE
             ORDER BY "test_new_api_indexed_translation"."id"
         """]):
             record_en.search([('name', 'ilike', 'foo')])

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -3070,7 +3070,7 @@ class BaseModel(metaclass=MetaModel):
             sql_value = self.env.registry.unaccent(sql_value)
 
         if need_wildcard and not value:
-            return SQL("%s IS NULL", sql_field) if operator in expression.NEGATIVE_TERM_OPERATORS else SQL("TRUE")
+            return SQL("FALSE") if operator in expression.NEGATIVE_TERM_OPERATORS else SQL("TRUE")
 
         sql = SQL("(%s %s %s)", sql_left, sql_operator, sql_value)
         if value and operator in expression.NEGATIVE_TERM_OPERATORS:
@@ -6250,11 +6250,12 @@ class BaseModel(metaclass=MetaModel):
                 if comparator in ('like', 'ilike', '=like', '=ilike', 'not ilike', 'not like'):
                     if comparator.endswith('ilike'):
                         # ilike uses unaccent and lower-case comparison
+                        # we may get something which is not a string
                         def unaccent(x):
-                            return self.pool.unaccent_python(x.lower()) if x else ''
+                            return self.pool.unaccent_python(str(x).lower()) if x else ''
                     else:
                         def unaccent(x):
-                            return x or ''
+                            return str(x) if x else ''
                     value_esc = unaccent(value).replace('_', '?').replace('%', '*').replace('[', '?')
                     if not comparator.startswith('='):
                         value_esc = f'*{value_esc}*'

--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -1394,7 +1394,7 @@ class expression(object):
                     need_wildcard = operator in WILDCARD_OPERATORS
 
                     if need_wildcard and not right:
-                        push_result(SQL("%s IS NULL", sql_field) if operator in NEGATIVE_TERM_OPERATORS else SQL("TRUE"))
+                        push_result(SQL("FALSE") if operator in NEGATIVE_TERM_OPERATORS else SQL("TRUE"))
                         continue
 
                     if not need_wildcard:


### PR DESCRIPTION
Current behavior before PR:
ilike "" results in TRUE, but not ilike "" result in NOT NULL.

Desired behavior after PR is merged:
ilike "" results in TRUE, so not ilike "" should be FALSE.


task-4016779

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
