### PR TITLE
[FIX] web: prevent website configurator flickering

### DIFF
--- a/addons/web/static/src/webclient/webclient.js
+++ b/addons/web/static/src/webclient/webclient.js
@@ -51,6 +51,12 @@ export class WebClient extends Component {
     }
 
     mounted() {
+        // Hack: added fullscreen mode to prevent flickering in the web client
+        // when navigating to the theme install kanban view.
+        const path = document.location.hash;
+        if(path.includes("theme_install_kanban_action")) {
+            this.el.classList.add("o_fullscreen");
+        }
         // the chat window and dialog services listen to 'web_client_ready' event in
         // order to initialize themselves:
         this.env.bus.trigger("WEB_CLIENT_READY");


### PR DESCRIPTION
Before this PR:
Users were facing an issue of flickering when trying to configure a newly created website. The reason behind this was that the target was decided after the web client was mounted. When the action target is evaluated (i.e., new, current, or fullscreen), the navbar was hidden based on the target.
    
In this PR, we have made the target of the web client fullscreen by default to avoid flickering. If we receive any action with a different target (i.e., new or current), the navbar will behave accordingly, as this was already covered in earlier PRs.

task-3050040