### PR TITLE
[IMP] website_editor: autosave custom snippet when drag and drap

### DIFF
--- a/addons/test_website/static/tests/tours/custom_snippets.js
+++ b/addons/test_website/static/tests/tours/custom_snippets.js
@@ -10,7 +10,8 @@ var tour = require('web_tour.tour');
  * -> drag a banner into page content
  * -> customize banner (set text)
  * -> save banner as custom snippet
- * -> confirm save
+ * -> rename custom snippet
+ * -> check if auto save works and rename snippet
  * -> ensure custom snippet is available
  * -> drag custom snippet
  * -> ensure block appears as banner
@@ -67,11 +68,11 @@ tour.register('test_custom_snippet', {
     {
         content: "set name",
         trigger: ".oe_snippet[name='Custom Banner'] input",
-        run: "text Bruce Banner",
+        run: "text_blur Bruce Banner",
     },
     {
-        content: "confirm rename",
-        trigger: ".oe_snippet[name='Custom Banner'] we-button.o_we_confirm_btn",
+        content: "check if the snippet is auto-saved when the focus is removed from the input field",
+        trigger: ".oe_snippet[name='Bruce Banner']"
     },
     {
         content: "drop custom snippet",

--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -3432,13 +3432,11 @@ var SnippetsMenu = Widget.extend({
     _onRenameBtnClick: function (ev) {
         const $snippet = $(ev.target).closest('.oe_snippet');
         const snippetName = $snippet.attr('name');
-        const confirmText = _t('Confirm');
         const cancelText = _t('Cancel');
         const $input = $(`
             <we-input class="o_we_user_value_widget w-100 mx-1">
                 <div>
                     <input type="text" autocomplete="chrome-off" value="${snippetName}" class="text-left"/>
-                    <we-button class="o_we_confirm_btn o_we_text_success fa fa-check" title="${confirmText}"/>
                     <we-button class="o_we_cancel_btn o_we_text_danger fa fa-times" title="${cancelText}"/>
                 </div>
             </we-input>
@@ -3449,9 +3447,9 @@ var SnippetsMenu = Widget.extend({
         $textInput.focus();
         $textInput.select();
         $snippet.find('.oe_snippet_thumbnail').addClass('o_we_already_dragging'); // prevent drag
-        $input.find('.o_we_confirm_btn').click(async () => {
-            const name = $textInput.val();
-            if (name !== snippetName) {
+        $input[0].addEventListener("focusout", async () => {
+            const name = $textInput[0].value.trim();
+            if (name && name !== snippetName) {
                 this._execWithLoadingEffect(async () => {
                     await this._rpc({
                         model: 'ir.ui.view',
@@ -3464,9 +3462,10 @@ var SnippetsMenu = Widget.extend({
                     });
                 }, true);
             }
-            await this._loadSnippetsTemplates(name !== snippetName);
+            await this._loadSnippetsTemplates(name && name !== snippetName);
         });
-        $input.find('.o_we_cancel_btn').click(async () => {
+        $input[0].querySelector(".o_we_cancel_btn").addEventListener("mousedown", async () => {
+            $textInput[0].value = snippetName;
             await this._loadSnippetsTemplates(false);
         });
     },


### PR DESCRIPTION
Specification:
When a user is renaming a custom snippet and tried to drag and drop another snippet, all unsaved changes to the name gets lost.

This PR introduces a feature to autosave the name of the custom snippet. It allows both custom and other snippets to be dragged and dropped, with automatic saving of changes. Additionally, it prevents saving null names to custom snippets.

task-3581814