### PR TITLE
[FIX] website_sale_product_configurator: show strikethrough price

### DIFF
--- a/addons/website_sale_product_configurator/views/website_sale_product_configurator_templates.xml
+++ b/addons/website_sale_product_configurator/views/website_sale_product_configurator_templates.xml
@@ -4,6 +4,25 @@
         <xpath expr="//th[hasclass('td-qty')]/span[hasclass('label')]" position="attributes">
             <attribute name='t-if'>not request.is_frontend or (request.is_frontend and is_view_active('website_sale.product_quantity'))</attribute>
         </xpath>
+        <xpath expr="//td[hasclass('td-price')]//span[hasclass('oe_price')]" position="before">
+            <div
+                t-if="combination_info.get('compare_list_price')
+                    and combination_info['compare_list_price'] &gt; combination_info['price']"
+                class="text-danger oe_striked_price"
+                t-out="combination_info['compare_list_price']"
+                groups="website_sale.group_product_price_comparison"
+                t-options='{
+                    "widget": "monetary",
+                    "display_currency": (pricelist or product).currency_id,
+                }'
+            />
+        </xpath>
+        <xpath
+            expr="//td[hasclass('td-price')]//div[contains(@t-attf-class,'oe_striked_price')]"
+            position="attributes"
+        >
+            <attribute name="t-if">not combination_info.get('compare_list_price')</attribute>
+        </xpath>
     </template>
     <template id="product_quantity_config_website" inherit_id="sale_product_configurator.product_quantity_config" priority="18">
         <xpath expr="//div[hasclass('css_quantity')]" position="attributes">
@@ -16,6 +35,25 @@
     <template id="optional_product_items_website" inherit_id="sale_product_configurator.optional_product_items">
         <xpath expr="//tr[hasclass('js_product')]" position="attributes">
             <attribute name="t-if">not combination_info.get('prevent_zero_price_sale', False)</attribute>
+        </xpath>
+        <xpath expr="//td[hasclass('td-price')]//div[hasclass('oe_price')]" position="before">
+            <div
+                t-if="combination_info.get('compare_list_price')
+                    and combination_info['compare_list_price'] &gt; combination_info['price']"
+                class="text-danger oe_striked_price"
+                t-out="combination_info['compare_list_price']"
+                groups="website_sale.group_product_price_comparison"
+                t-options='{
+                    "widget": "monetary",
+                    "display_currency": (pricelist or product).currency_id
+                }'
+            />
+        </xpath>
+        <xpath
+            expr="//td[hasclass('td-price')]//div[contains(@t-attf-class,'oe_striked_price')]"
+            position="attributes"
+        >
+            <attribute name="t-if">not combination_info.get('compare_list_price')</attribute>
         </xpath>
     </template>
 </odoo>


### PR DESCRIPTION
Steps:
- Turn on Comparison Price from settings and set a comparison price for a product with variants or/and optional products.
- Go to /shop -> product and click the Add to Cart button.
- OR make SO and add the same product to order line.
- In the Product Configurator, there is no strikethrough price.

Issue:
When the comparison price is activated the strikethrough price is not visible in the product configurator

Cause:
There was no `compare_price_list` in the template, hence the comparison price was never visible.

Fix:
- Added the `compare_price_list` to the template using XPath because `compare_price_list` is added to the `combination_info` dictionary in the website_sale module and made it conditionally hidden using `t-if` (not with `d-none` as we do for other cases) because the same product configurator template is being used in the backend (like while making a Sale or Rental order) where the `compare_list_price` is not present in `combination_info` which gives a key not found error.

opw-3992683
