### PR TITLE
[FIX] pos_adyen,pos_viva_wallet: this.pos is undefined

### DIFF
--- a/addons/pos_adyen/static/src/app/pos_store.js
+++ b/addons/pos_adyen/static/src/app/pos_store.js
@@ -7,9 +7,9 @@ patch(PosStore.prototype, {
     async setup() {
         await super.setup(...arguments);
         this.onNotified("ADYEN_LATEST_RESPONSE", () => {
-            this.pos
-                .getPendingPaymentLine("adyen")
-                .payment_method.payment_terminal.handleAdyenStatusResponse();
+            this.getPendingPaymentLine(
+                "adyen"
+            ).payment_method.payment_terminal.handleAdyenStatusResponse();
         });
     },
 });

--- a/addons/pos_viva_wallet/static/src/overrides/pos_store.js
+++ b/addons/pos_viva_wallet/static/src/overrides/pos_store.js
@@ -7,9 +7,9 @@ patch(PosStore.prototype, {
     async setup() {
         await super.setup(...arguments);
         this.onNotified("VIVA_WALLET_LATEST_RESPONSE", () => {
-            this.pos
-                .getPendingPaymentLine("viva_wallet")
-                .payment_method.payment_terminal.handleVivaWalletStatusResponse();
+            this.getPendingPaymentLine(
+                "viva_wallet"
+            ).payment_method.payment_terminal.handleVivaWalletStatusResponse();
         });
     },
 });


### PR DESCRIPTION
Setting a adyen/viva-wallet terminal PoS setup and using it would cause the JS traceback:
`TypeError: Cannot read properties of undefined (reading 'getPendingPaymentLine')`

This error happen starting 17.2 due to the change of patched class PosBus (17.1) -> PosStore (17.2)
see: https://github.com/odoo/odoo/pull/136621

opw-3977273