### PR TITLE
[IMP] web: add possibility to skip multiple days

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_controller.js
+++ b/addons/web/static/src/views/calendar/calendar_controller.js
@@ -367,14 +367,18 @@ export class CalendarController extends Component {
 
     onWillStartModel() {}
 
-    async setDate(move) {
+    async setDate(move, numberDaysToMove = false) {
         let date = null;
         switch (move) {
             case "next":
-                date = this.model.date.plus({ [`${this.model.scale}s`]: 1 });
+                date = this.model.date.plus({
+                    [`${this.model.scale}s`]: numberDaysToMove ? numberDaysToMove : 1,
+                });
                 break;
             case "previous":
-                date = this.model.date.minus({ [`${this.model.scale}s`]: 1 });
+                date = this.model.date.minus({
+                    [`${this.model.scale}s`]: numberDaysToMove ? numberDaysToMove : 1,
+                });
                 break;
             case "today":
                 date = luxon.DateTime.local().startOf("day");


### PR DESCRIPTION
This commit adds a parameter to the setDate method in order for the calendar to follow the logic in Knowledge when some days are hidden.

Originally, when clicking on next/previous the calendar would switch to the next date, regardless of whether or not days were hidden. In Knowledge, we added the possibility for the users to only display certain days. These behaviors conflicted when the scale was set to "day" as hidden days weren't taken into account.

With this new parameter, we now have the possibility to move more than 1 day at a time if needed. The computations are done on the Knowledge side so as to limit the modifications done to the Calendar Controller.

task-3902124

ENT PR: odoo/enterprise#64006﻿﻿

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
