### PR TITLE
[IMP] spreadsheet: improve & fix tests helpers

### DIFF
--- a/addons/spreadsheet/static/tests/helpers/model.js
+++ b/addons/spreadsheet/static/tests/helpers/model.js
@@ -1,12 +1,12 @@
 import { Model } from "@odoo/o-spreadsheet";
 import { OdooDataProvider } from "@spreadsheet/data_sources/odoo_data_provider";
 import { animationFrame } from "@odoo/hoot-mock";
-import { defineActions, defineMenus, makeMockEnv, onRpc } from "@web/../tests/web_test_helpers";
-import { addRecordsFromServerData } from "./data";
+import { defineActions, defineParams, makeMockEnv, onRpc } from "@web/../tests/web_test_helpers";
+import { addRecordsFromServerData, addViewsFromServerData } from "./data";
 import { getMockEnv } from "@web/../tests/_framework/env_test_helpers";
 
 /**
- * @typedef {import("@spreadsheet/../tests/legacy/utils/data").ServerData} ServerData
+ * @typedef {import("@spreadsheet/../tests/helpers/data").ServerData} ServerData
  * @typedef {import("@spreadsheet/helpers/model").OdooSpreadsheetModel} OdooSpreadsheetModel
  * @typedef {import("@web/../tests/_framework/mock_server/mock_server").MockServerEnvironment} MockServerEnvironment
  */
@@ -59,16 +59,22 @@ export async function createModelWithDataSource(params = {}) {
  */
 export async function makeSpreadsheetMockEnv(params = {}) {
     if (params.mockRPC) {
+        // Note: calling onRpc with only a callback only works for routes such as orm routes that have a default listener
+        // For arbitrary rpc request (eg. /web/domain/validate) we need to call onRpc("/my/route", callback)
         onRpc((args) => params.mockRPC(args.route, args)); // separate route from args for legacy (& forward ports) compatibility
     }
     if (params.serverData?.menus) {
-        defineMenus(Object.values(params.serverData.menus));
+        const menus = Object.values(params.serverData.menus);
+        defineParams({ menus }, "replace");
     }
     if (params.serverData?.actions) {
         defineActions(Object.values(params.serverData.actions));
     }
     if (params.serverData?.models) {
         addRecordsFromServerData(params.serverData);
+    }
+    if (params.serverData?.views) {
+        addViewsFromServerData(params.serverData);
     }
     const env = getMockEnv() || (await makeMockEnv());
     return env;

--- a/addons/spreadsheet/static/tests/links/menu_data_utils.js
+++ b/addons/spreadsheet/static/tests/links/menu_data_utils.js
@@ -4,23 +4,34 @@ import { serverState } from "@web/../tests/web_test_helpers";
 export function getMenuServerData() {
     const serverData = {};
     serverData.menus = {
-        root: { id: "root", children: [1], name: "root", appID: "root" },
-        1: {
-            id: 1,
-            children: [11, 12],
-            name: "App_1",
-            appID: 1,
-            xmlid: "app_1",
+        root: {
+            id: "root",
+            name: "root",
+            appID: "root",
+            children: [
+                {
+                    id: 1,
+                    name: "App_1",
+                    appID: 1,
+                    xmlid: "app_1",
+                    children: [
+                        {
+                            id: 11,
+                            name: "menu with xmlid",
+                            appID: 1,
+                            xmlid: "test_menu",
+                            actionID: "spreadsheet.action1",
+                        },
+                        {
+                            id: 12,
+                            name: "menu without xmlid",
+                            actionID: "spreadsheet.action1",
+                            appID: 1,
+                        },
+                    ],
+                },
+            ],
         },
-        11: {
-            id: 11,
-            children: [],
-            name: "menu with xmlid",
-            appID: 1,
-            xmlid: "test_menu",
-            actionID: "action1",
-        },
-        12: { id: 12, children: [], name: "menu without xmlid", actionID: "action1", appID: 1 },
     };
     serverData.actions = {
         action1: {

--- a/addons/spreadsheet/static/tests/links/open_links.test.js
+++ b/addons/spreadsheet/static/tests/links/open_links.test.js
@@ -59,7 +59,7 @@ test("click a menu link", async () => {
     const cell = getEvaluatedCell(model, "A1");
     expect(urlRepresentation(cell.link, model.getters)).toBe("menu with xmlid");
     openLink(cell.link, env);
-    expect.verifySteps(["action1"]);
+    expect.verifySteps(["spreadsheet.action1"]);
 });
 
 test("click a menu link [2]", async () => {

--- a/addons/spreadsheet/static/tests/lists/list_plugin.test.js
+++ b/addons/spreadsheet/static/tests/lists/list_plugin.test.js
@@ -54,10 +54,10 @@ test("List export", async () => {
 
 test("Return display name of selection field", async () => {
     const { model } = await createSpreadsheetWithList({
-        model: "documents.document",
-        columns: ["handler"],
+        model: "res.currency",
+        columns: ["position"],
     });
-    expect(getCellValue(model, "A2")).toBe("Spreadsheet");
+    expect(getCellValue(model, "A2")).toBe("A");
 });
 
 test("Return display_name of many2one field", async () => {

--- a/addons/spreadsheet_account/static/tests/accounting_test_data.js
+++ b/addons/spreadsheet_account/static/tests/accounting_test_data.js
@@ -1,5 +1,9 @@
-import { getBasicData } from "@spreadsheet/../tests/helpers/data";
-import { defineModels, fields, models } from "@web/../tests/web_test_helpers";
+import {
+    SpreadsheetModels,
+    defineSpreadsheetModels,
+    getBasicData,
+} from "@spreadsheet/../tests/helpers/data";
+import { fields, models } from "@web/../tests/web_test_helpers";
 
 export class AccountMoveLine extends models.Model {
     _name = "account.move.line";
@@ -59,5 +63,7 @@ export function getAccountingData() {
 }
 
 export function defineSpreadsheetAccountModels() {
-    defineModels([AccountMoveLine, AccountAccount]);
+    const SpreadsheetAccountModels = [AccountMoveLine, AccountAccount];
+    Object.assign(SpreadsheetModels, SpreadsheetAccountModels);
+    defineSpreadsheetModels();
 }

--- a/addons/spreadsheet_account/static/tests/model/account_groups.test.js
+++ b/addons/spreadsheet_account/static/tests/model/account_groups.test.js
@@ -1,16 +1,14 @@
-import { defineSpreadsheetModels } from "@spreadsheet/../tests/helpers/data";
 import { describe, expect, test } from "@odoo/hoot";
 import { setCellContent } from "@spreadsheet/../tests/helpers/commands";
-import { createModelWithDataSource } from "@spreadsheet/../tests/helpers/model";
 import { getCellValue } from "@spreadsheet/../tests/helpers/getters";
-import {
-    getAccountingData,
-    defineSpreadsheetAccountModels,
-} from "@spreadsheet_account/../tests/accounting_test_data";
+import { createModelWithDataSource } from "@spreadsheet/../tests/helpers/model";
 import { waitForDataLoaded } from "@spreadsheet/helpers/model";
+import {
+    defineSpreadsheetAccountModels,
+    getAccountingData,
+} from "@spreadsheet_account/../tests/accounting_test_data";
 
 describe.current.tags("headless");
-defineSpreadsheetModels();
 defineSpreadsheetAccountModels();
 
 const serverData = getAccountingData();

--- a/addons/spreadsheet_account/static/tests/model/accounting.test.js
+++ b/addons/spreadsheet_account/static/tests/model/accounting.test.js
@@ -1,22 +1,20 @@
-import { defineSpreadsheetModels } from "@spreadsheet/../tests/helpers/data";
 import { describe, expect, test } from "@odoo/hoot";
-import { makeServerError } from "@web/../tests/web_test_helpers";
 import { setCellContent } from "@spreadsheet/../tests/helpers/commands";
-import { createModelWithDataSource } from "@spreadsheet/../tests/helpers/model";
-import { parseAccountingDate } from "@spreadsheet_account/accounting_functions";
 import { getCellValue, getEvaluatedCell } from "@spreadsheet/../tests/helpers/getters";
+import { createModelWithDataSource } from "@spreadsheet/../tests/helpers/model";
+import { camelToSnakeObject } from "@spreadsheet/helpers/helpers";
 import {
     defineSpreadsheetAccountModels,
     getAccountingData,
 } from "@spreadsheet_account/../tests/accounting_test_data";
-import { camelToSnakeObject } from "@spreadsheet/helpers/helpers";
+import { parseAccountingDate } from "@spreadsheet_account/accounting_functions";
+import { makeServerError } from "@web/../tests/web_test_helpers";
 import { sprintf } from "@web/core/utils/strings";
 
 import * as spreadsheet from "@odoo/o-spreadsheet";
 import { waitForDataLoaded } from "@spreadsheet/helpers/model";
 
 describe.current.tags("headless");
-defineSpreadsheetModels();
 defineSpreadsheetAccountModels();
 
 const { DEFAULT_LOCALE: locale } = spreadsheet.constants;

--- a/addons/spreadsheet_account/static/tests/ui/accounting_drilldown.test.js
+++ b/addons/spreadsheet_account/static/tests/ui/accounting_drilldown.test.js
@@ -1,18 +1,16 @@
-import { mockService } from "@web/../tests/web_test_helpers";
-import { defineSpreadsheetModels } from "@spreadsheet/../tests/helpers/data";
 import { describe, expect, test } from "@odoo/hoot";
-import { selectCell, setCellContent } from "@spreadsheet/../tests/helpers/commands";
 import * as spreadsheet from "@odoo/o-spreadsheet";
+import { selectCell, setCellContent } from "@spreadsheet/../tests/helpers/commands";
+import { createModelWithDataSource } from "@spreadsheet/../tests/helpers/model";
+import { doMenuAction } from "@spreadsheet/../tests/helpers/ui";
+import { waitForDataLoaded } from "@spreadsheet/helpers/model";
 import {
     defineSpreadsheetAccountModels,
     getAccountingData,
 } from "@spreadsheet_account/../tests/accounting_test_data";
-import { createModelWithDataSource } from "@spreadsheet/../tests/helpers/model";
-import { waitForDataLoaded } from "@spreadsheet/helpers/model";
-import { doMenuAction } from "@spreadsheet/../tests/helpers/ui";
+import { mockService } from "@web/../tests/web_test_helpers";
 
 describe.current.tags("headless");
-defineSpreadsheetModels();
 defineSpreadsheetAccountModels();
 
 const { cellMenuRegistry } = spreadsheet.registries;

--- a/addons/spreadsheet_dashboard/static/tests/clickable_cells/clickable_cells.test.js
+++ b/addons/spreadsheet_dashboard/static/tests/clickable_cells/clickable_cells.test.js
@@ -1,7 +1,5 @@
 import { describe, expect, getFixture, test } from "@odoo/hoot";
 import { animationFrame } from "@odoo/hoot-mock";
-
-import { defineSpreadsheetModels } from "@spreadsheet/../tests/helpers/data";
 import { createSpreadsheetDashboard } from "@spreadsheet_dashboard/../tests/helpers/dashboard_action";
 import {
     SpreadsheetDashboard,
@@ -9,7 +7,6 @@ import {
 } from "@spreadsheet_dashboard/../tests/helpers/data";
 
 describe.current.tags("desktop");
-defineSpreadsheetModels();
 defineSpreadsheetDashboardModels();
 
 async function createDashboardActionWithData(data) {

--- a/addons/spreadsheet_dashboard/static/tests/dashboard/dashboard_action.test.js
+++ b/addons/spreadsheet_dashboard/static/tests/dashboard/dashboard_action.test.js
@@ -1,7 +1,7 @@
 import { describe, expect, getFixture, onError as onErrorHoot, test } from "@odoo/hoot";
 import { press } from "@odoo/hoot-dom";
 import { animationFrame } from "@odoo/hoot-mock";
-import { defineSpreadsheetModels, getBasicData } from "@spreadsheet/../tests/helpers/data";
+import { getBasicData } from "@spreadsheet/../tests/helpers/data";
 import { createSpreadsheetDashboard } from "@spreadsheet_dashboard/../tests/helpers/dashboard_action";
 import {
     defineSpreadsheetDashboardModels,
@@ -13,7 +13,6 @@ import { RPCError } from "@web/core/network/rpc";
 import { Deferred } from "@web/core/utils/concurrency";
 
 describe.current.tags("desktop");
-defineSpreadsheetModels();
 defineSpreadsheetDashboardModels();
 
 function getServerData(spreadsheetData) {

--- a/addons/spreadsheet_dashboard/static/tests/dashboard/dashboard_loader.test.js
+++ b/addons/spreadsheet_dashboard/static/tests/dashboard/dashboard_loader.test.js
@@ -1,6 +1,5 @@
 import { expect, test } from "@odoo/hoot";
 import { animationFrame } from "@odoo/hoot-mock";
-import { defineSpreadsheetModels } from "@spreadsheet/../tests/helpers/data";
 import { getCellValue } from "@spreadsheet/../tests/helpers/getters";
 import { makeSpreadsheetMockEnv } from "@spreadsheet/../tests/helpers/model";
 import { waitForDataLoaded } from "@spreadsheet/helpers/model";
@@ -15,7 +14,6 @@ import {
 import { patchWithCleanup } from "@web/../tests/web_test_helpers";
 import { RPCError } from "@web/core/network/rpc";
 
-defineSpreadsheetModels();
 defineSpreadsheetDashboardModels();
 
 /**

--- a/addons/spreadsheet_dashboard/static/tests/helpers/data.js
+++ b/addons/spreadsheet_dashboard/static/tests/helpers/data.js
@@ -1,6 +1,6 @@
-import { defineModels, fields, models } from "@web/../tests/web_test_helpers";
+import { SpreadsheetModels, defineSpreadsheetModels } from "@spreadsheet/../tests/helpers/data";
+import { fields, models } from "@web/../tests/web_test_helpers";
 import { RPCError } from "@web/core/network/rpc";
-import { SpreadsheetModels } from "@spreadsheet/../tests/helpers/data";
 
 export function getDashboardServerData() {
     return {
@@ -75,7 +75,7 @@ export class SpreadsheetDashboardGroup extends models.Model {
 }
 
 export function defineSpreadsheetDashboardModels() {
-    defineModels([SpreadsheetDashboard, SpreadsheetDashboardGroup]);
-    SpreadsheetModels["SpreadsheetDashboard"] = SpreadsheetDashboardGroup;
-    SpreadsheetModels["SpreadsheetDashboardGroup"] = SpreadsheetDashboard;
+    const SpreadsheetDashboardModels = [SpreadsheetDashboard, SpreadsheetDashboardGroup];
+    Object.assign(SpreadsheetModels, SpreadsheetDashboardModels);
+    defineSpreadsheetModels();
 }

--- a/addons/spreadsheet_dashboard/static/tests/mobile/mobile_dashboard_action.test.js
+++ b/addons/spreadsheet_dashboard/static/tests/mobile/mobile_dashboard_action.test.js
@@ -1,7 +1,6 @@
 import { describe, expect, getFixture, test } from "@odoo/hoot";
 import { dblclick } from "@odoo/hoot-dom";
 import { animationFrame } from "@odoo/hoot-mock";
-import { defineSpreadsheetModels } from "@spreadsheet/../tests/helpers/data";
 import { createSpreadsheetDashboard } from "@spreadsheet_dashboard/../tests/helpers/dashboard_action";
 import {
     defineSpreadsheetDashboardModels,
@@ -10,7 +9,6 @@ import {
 import { contains } from "@web/../tests/web_test_helpers";
 
 describe.current.tags("mobile");
-defineSpreadsheetModels();
 defineSpreadsheetDashboardModels();
 
 test("is empty with no figures", async () => {


### PR DESCRIPTION
Some fixes & improvement in the tests helpers done in the process
of converting the documents_spreadhseet tests to Hoot:

- the menu server data is now correctly adapted for Hoot (the object
is now a tree of menu rather than a flat list)
- added the possibility to add views when creating the mock server
- moved the models related to documents into the enterprise module

Task: [4011327](https://www.odoo.com/odoo/2328/tasks/4011327?cids=1)



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
