### PR TITLE
[IMP] core: remove 'inselect' operator

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -310,7 +310,7 @@ class HolidaysRequest(models.Model):
         if not is_officer:
             domain = expression.AND([domain, [('user_id', '=', self.env.user.id)]])
         query = self.sudo()._search(domain)
-        return [('id', 'inselect', query.select())]
+        return [('id', 'in', query)]
 
     @api.depends('holiday_status_id')
     def _compute_state(self):

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -144,8 +144,8 @@ class MailThread(models.AbstractModel):
             ('res_model', '=', self._name),
             ('partner_id', operator, operand),
         ])
-        # use inselect to avoid reading thousands of potentially followed objects
-        return [('id', neg + 'inselect', followers.subselect('res_id'))]
+        # use `in` query to avoid reading thousands of potentially followed objects
+        return [('id', neg + 'in', followers.subselect('res_id'))]
 
     @api.depends('message_follower_ids')
     def _compute_message_is_follower(self):
@@ -183,10 +183,10 @@ class MailThread(models.AbstractModel):
 
     def _search_has_message(self, operator, value):
         if (operator == '=' and value is True) or (operator == '!=' and value is False):
-            operator_new = 'inselect'
+            operator_new = 'in'
         else:
-            operator_new = 'not inselect'
-        return [('id', operator_new, ("SELECT res_id FROM mail_message WHERE model=%s", [self._name]))]
+            operator_new = 'not in'
+        return [('id', operator_new, SQL("(SELECT res_id FROM mail_message WHERE model = %s)", self._name))]
 
     def _compute_message_needaction(self):
         res = dict.fromkeys(self.ids, 0)

--- a/addons/mrp/models/product.py
+++ b/addons/mrp/models/product.py
@@ -51,7 +51,7 @@ class ProductTemplate(models.Model):
         neg = ''
         if (operator == '=' and not value) or (operator == '!=' and value):
             neg = 'not '
-        return [('id', neg + 'inselect', bom_tmpl_query.subselect('product_tmpl_id'))]
+        return [('id', neg + 'in', bom_tmpl_query.subselect('product_tmpl_id'))]
 
     def _compute_show_qty_status_button(self):
         super()._compute_show_qty_status_button()
@@ -158,8 +158,8 @@ class ProductProduct(models.Model):
         if (operator == '=' and not value) or (operator == '!=' and value):
             neg = 'not '
             op = '&'
-        return [op, ('product_tmpl_id', neg + 'inselect', bom_tmpl_query.subselect('product_tmpl_id')),
-                ('id', neg + 'inselect', bom_product_query.subselect('product_id'))]
+        return [op, ('product_tmpl_id', neg + 'in', bom_tmpl_query.subselect('product_tmpl_id')),
+                ('id', neg + 'in', bom_product_query.subselect('product_id'))]
 
     def _compute_show_qty_status_button(self):
         super()._compute_show_qty_status_button()

--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -313,19 +313,19 @@ class Project(models.Model):
         if operator not in ['=', '!=']:
             raise ValueError(_('Invalid operator: %s', operator))
 
-        query = """
+        sql = SQL("""(
             SELECT P.id
               FROM project_project P
          LEFT JOIN project_milestone M ON P.id = M.project_id
              WHERE M.is_reached IS false
                AND P.allow_milestones IS true
                AND M.deadline <= CAST(now() AS date)
-        """
+        )""")
         if (operator == '=' and value is True) or (operator == '!=' and value is False):
-            operator_new = 'inselect'
+            operator_new = 'in'
         else:
-            operator_new = 'not inselect'
-        return [('id', operator_new, (query, ()))]
+            operator_new = 'not in'
+        return [('id', operator_new, sql)]
 
     @api.depends('collaborator_ids', 'privacy_visibility')
     def _compute_collaborator_count(self):

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -11,7 +11,7 @@ from odoo.addons.rating.models import rating_data
 from odoo.addons.web_editor.tools import handle_history_divergence
 from odoo.exceptions import UserError, ValidationError, AccessError
 from odoo.osv import expression
-from odoo.tools import format_list
+from odoo.tools import format_list, SQL
 from odoo.addons.resource.models.utils import filter_domain_leaf
 
 
@@ -638,14 +638,14 @@ class Task(models.Model):
         if operator != 'ilike' and not isinstance(value, str):
             raise ValidationError(_('Not Implemented.'))
 
-        query = """
+        sql = SQL("""(
             SELECT task_user.task_id
               FROM project_task_user_rel task_user
         INNER JOIN res_users users ON task_user.user_id = users.id
         INNER JOIN res_partner partners ON partners.id = users.partner_id
              WHERE partners.name ILIKE %s
-        """
-        return [('id', 'inselect', (query, [f'%{value}%']))]
+        )""", f"%{value}%")
+        return [('id', 'in', sql)]
 
     def _compute_display_parent_task_button(self):
         accessible_parent_tasks = self.parent_id.with_user(self.env.user)._filter_access_rules('read')

--- a/addons/sale_project/models/project_task.py
+++ b/addons/sale_project/models/project_task.py
@@ -3,6 +3,7 @@
 from odoo import api, fields, models, _
 from odoo.exceptions import ValidationError, AccessError
 from odoo.osv import expression
+from odoo.tools import SQL
 
 
 class ProjectTask(models.Model):
@@ -161,16 +162,16 @@ class ProjectTask(models.Model):
 
     @api.model
     def _search_task_to_invoice(self, operator, value):
-        query = """
+        sql = SQL("""(
             SELECT so.id
             FROM sale_order so
             WHERE so.invoice_status != 'invoiced'
                 AND so.invoice_status != 'no'
-        """
-        operator_new = 'inselect'
+        )""")
+        operator_new = 'in'
         if (bool(operator == '=') ^ bool(value)):
-            operator_new = 'not inselect'
-        return [('sale_order_id', operator_new, (query, ()))]
+            operator_new = 'not in'
+        return [('sale_order_id', operator_new, sql)]
 
     @api.onchange('sale_line_id')
     def _onchange_partner_id(self):

--- a/addons/website/tests/test_website_visitor.py
+++ b/addons/website/tests/test_website_visitor.py
@@ -143,7 +143,7 @@ class WebsiteVisitorTestsCommon(MockVisitor, HttpCaseWithUserDemo):
 
         self.env['ir.config_parameter'].sudo().set_param('website.visitor.live.days', 7)
 
-        # ensure we keep a single query by correct usage of "not inselect"
+        # ensure we keep a single query by correct usage of "not in"
         # (+1 query to fetch the 'ir.config_parameter')
         with self.assertQueryCount(2):
             WebsiteVisitor.search(WebsiteVisitor._inactive_visitors_domain())

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -2976,7 +2976,7 @@ class BaseModel(metaclass=MetaModel):
         SQL query.
         """
         # sanity checks - should never fail
-        assert operator in (expression.TERM_OPERATORS + ('inselect', 'not inselect')), \
+        assert operator in expression.TERM_OPERATORS, \
             f"Invalid operator {operator!r} in domain term {(fname, operator, value)!r}"
         assert fname in self._fields, \
             f"Invalid field {fname!r} in domain term {(fname, operator, value)!r}"
@@ -2992,18 +2992,6 @@ class BaseModel(metaclass=MetaModel):
                 return self._condition_to_sql(alias, fname, '=', value, query)
 
         sql_field = self._field_to_sql(alias, fname, query)
-
-        if operator == 'inselect':
-            if not isinstance(value, SQL):
-                subquery, subparams = value
-                value = SQL(subquery, *subparams)
-            return SQL("(%s IN (%s))", sql_field, value)
-
-        if operator == 'not inselect':
-            if not isinstance(value, SQL):
-                subquery, subparams = value
-                value = SQL(subquery, *subparams)
-            return SQL("(%s NOT IN (%s))", sql_field, value)
 
         field = self._fields[fname]
         sql_operator = expression.SQL_OPERATORS[operator]


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
We can use 'in' SQL instead of inselect which is an internal operator.

Current behavior before PR:
Using internal operator `inselect` in _search functions

Desired behavior after PR is merged:
Use `in` with a SQL or Query object.


task-4022654

https://github.com/odoo/enterprise/pull/65796
https://github.com/odoo/documentation/pull/10026

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
