### PR TITLE
[FIX] im_livechat: fix failing support page test

### DIFF
--- a/addons/im_livechat/static/src/embed/external/boot.js
+++ b/addons/im_livechat/static/src/embed/external/boot.js
@@ -9,9 +9,12 @@ import { mount, whenReady } from "@odoo/owl";
 import { templates } from "@web/core/assets";
 import { _t } from "@web/core/l10n/translation";
 import { MainComponentsContainer } from "@web/core/main_components_container";
+import { Deferred } from "@web/core/utils/concurrency";
 import { registry } from "@web/core/registry";
 import { makeEnv, startServices } from "@web/env";
 import { session } from "@web/session";
+
+odoo.livechatReady = new Deferred();
 
 (async function boot() {
     session.origin = serverUrl;
@@ -28,4 +31,5 @@ import { session } from "@web/session";
         translateFn: _t,
         dev: env.debug,
     });
+    odoo.livechatReady.resolve();
 })();

--- a/addons/im_livechat/tests/test_im_livechat_support_page.py
+++ b/addons/im_livechat/tests/test_im_livechat_support_page.py
@@ -12,7 +12,7 @@ class TestImLivechatSupportPage(HttpCase):
         # Give some time to the assets to load to prevent fetch
         # interrupt errors then ensures all the assets are loaded.
         check_js_modules = """
-            setTimeout(() => {
+            odoo.livechatReady.then(() => {
                 const { missing, failed, unloaded } = odoo.loader.findErrors();
                 if ([missing, failed, unloaded].some(arr => arr.length)) {
                     console.error("Couldn't load all JS modules.", JSON.stringify({ missing, failed, unloaded }));
@@ -24,7 +24,6 @@ class TestImLivechatSupportPage(HttpCase):
                     error: () => {},
                     warn: () => {},
                 });
-            }, 1000);
-
+            })
         """
         self.browser_js("/im_livechat/support/1", code=check_js_modules)


### PR DESCRIPTION
Before this PR, the live chat support page test was sometimes failing. This test ensures all the Odoo modules are successfully loaded on the support page.

Until now, the test was waiting 1 second, which might be enough to load Odoo modules but not all the live chat assets. If the live chat assets are still loading when the browser instance is closed, the promise rejects and the test fails.

This test now ensures all the live chat assets are loaded beforehand. This change is beneficial because it also ensures that runtime assets such as translations, live chat CSS, or fonts are properly loaded as well.

This PR fixes this issue.

runbot-60514