### PR TITLE
[IMP] base: test_13_m2o_order_loop_multi locale fix

### DIFF
--- a/odoo/addons/base/tests/test_search.py
+++ b/odoo/addons/base/tests/test_search.py
@@ -218,9 +218,16 @@ class test_search(TransactionCase):
         kw = dict(groups_id=[Command.set([self.ref('base.group_system'),
                                      self.ref('base.group_partner_manager')])])
 
-        u1 = Users.create(dict(name='Q', login='m', **kw)).id
+        # When creating with the superuser, the ordering by 'create_uid' will
+        # compare user logins with the superuser's login "__system__", which
+        # may give different results, because "_" may come before or after
+        # letters, depending on the database's locale.  In order to avoid this
+        # issue, use a user with a login that doesn't include "_".
+        u0 = Users.create(dict(name='A system', login='a', **kw)).id
+
+        u1 = Users.with_user(u0).create(dict(name='Q', login='m', **kw)).id
         u2 = Users.with_user(u1).create(dict(name='B', login='f', **kw)).id
-        u3 = Users.create(dict(name='C', login='c', **kw)).id
+        u3 = Users.with_user(u0).create(dict(name='C', login='c', **kw)).id
         u4 = Users.with_user(u2).create(dict(name='D', login='z', **kw)).id
 
         expected_ids = [u2, u4, u3, u1]


### PR DESCRIPTION
Depending on the locale, the user with login `"__system__"` can be considered as before or after others, because of the order of `"_"` with respect to letters.  To fix this, create all users with a user that only has letters in the login.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
