### PR TITLE
[IMP] core: remove _search() parameter access_rights_uid

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -4,13 +4,12 @@
 import logging
 import pytz
 import threading
-from ast import literal_eval
 from collections import OrderedDict, defaultdict
-from datetime import date, datetime, timedelta
+from datetime import datetime, timedelta
 from markupsafe import Markup
 from psycopg2 import sql
 
-from odoo import api, fields, models, tools, SUPERUSER_ID
+from odoo import api, fields, models, tools
 from odoo.addons.iap.tools import iap_tools
 from odoo.addons.mail.tools import mail_validation
 from odoo.addons.phone_validation.tools import phone_validation
@@ -956,7 +955,7 @@ class Lead(models.Model):
             search_domain = ['|', ('id', 'in', stages.ids), ('team_id', '=', False)]
 
         # perform search
-        stage_ids = stages._search(search_domain, order=stages._order, access_rights_uid=SUPERUSER_ID)
+        stage_ids = stages.sudo()._search(search_domain, order=stages._order)
         return stages.browse(stage_ids)
 
     def _stage_find(self, team_id=False, domain=None, order='sequence, id', limit=1):

--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -373,7 +373,7 @@ class HrEmployeePrivate(models.Model):
         return res
 
     @api.model
-    def _search(self, domain, offset=0, limit=None, order=None, access_rights_uid=None):
+    def _search(self, domain, offset=0, limit=None, order=None):
         """
             We override the _search because it is the method that checks the access rights
             This is correct to override the _search. That way we enforce the fact that calling
@@ -383,9 +383,9 @@ class HrEmployeePrivate(models.Model):
             employees exactly match the ids of the related hr.employee.
         """
         if self.check_access_rights('read', raise_exception=False):
-            return super()._search(domain, offset, limit, order, access_rights_uid)
+            return super()._search(domain, offset, limit, order)
         try:
-            ids = self.env['hr.employee.public']._search(domain, offset, limit, order, access_rights_uid)
+            ids = self.env['hr.employee.public']._search(domain, offset, limit, order)
         except ValueError:
             raise AccessError(_('You do not have access to this document.'))
         # the result is expected from this table, so we should link tables

--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -341,7 +341,7 @@ class HolidaysType(models.Model):
             record.display_name = name
 
     @api.model
-    def _search(self, domain, offset=0, limit=None, order=None, access_rights_uid=None):
+    def _search(self, domain, offset=0, limit=None, order=None):
         """ Override _search to order the results, according to some employee.
         The order is the following
 
@@ -356,11 +356,11 @@ class HolidaysType(models.Model):
         employee = self.env['hr.employee']._get_contextual_employee()
         if order == self._order and employee:
             # retrieve all leaves, sort them, then apply offset and limit
-            leaves = self.browse(super()._search(domain, access_rights_uid=access_rights_uid))
+            leaves = self.browse(super()._search(domain))
             leaves = leaves.sorted(key=self._model_sorting_key, reverse=True)
             leaves = leaves[offset:(offset + limit) if limit else None]
             return leaves._as_query()
-        return super()._search(domain, offset, limit, order, access_rights_uid)
+        return super()._search(domain, offset, limit, order)
 
     def copy_data(self, default=None):
         vals_list = super().copy_data(default=default)

--- a/addons/hr_recruitment/models/hr_applicant.py
+++ b/addons/hr_recruitment/models/hr_applicant.py
@@ -1,12 +1,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import re
 
-import re
-
 from markupsafe import Markup
 from dateutil.relativedelta import relativedelta
 
-from odoo import api, fields, models, tools, SUPERUSER_ID
+from odoo import api, fields, models, tools
 from odoo.exceptions import AccessError, UserError
 from odoo.osv import expression
 from odoo.tools.translate import _
@@ -298,7 +296,7 @@ class Applicant(models.Model):
         if stages:
             search_domain = ['|', ('id', 'in', stages.ids)] + search_domain
 
-        stage_ids = stages._search(search_domain, order=stages._order, access_rights_uid=SUPERUSER_ID)
+        stage_ids = stages.sudo()._search(search_domain, order=stages._order)
         return stages.browse(stage_ids)
 
     @api.depends('job_id', 'department_id')

--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -340,7 +340,7 @@ class MailActivity(models.Model):
         return super(MailActivity, self).unlink()
 
     @api.model
-    def _search(self, domain, offset=0, limit=None, order=None, access_rights_uid=None):
+    def _search(self, domain, offset=0, limit=None, order=None):
         """ Override that adds specific access rights of mail.activity, to remove
         ids uid could not see according to our custom rules. Please refer to
         _filter_access_rules_remaining for more details about those rules.
@@ -349,11 +349,11 @@ class MailActivity(models.Model):
 
         # Rules do not apply to administrator
         if self.env.is_superuser():
-            return super()._search(domain, offset, limit, order, access_rights_uid)
+            return super()._search(domain, offset, limit, order)
 
         # retrieve activities and their corresponding res_model, res_id
         # Don't use the ORM to avoid cache pollution
-        query = super()._search(domain, offset, limit, order, access_rights_uid)
+        query = super()._search(domain, offset, limit, order)
         fnames_to_read = ['id', 'res_model', 'res_id', 'user_id']
         rows = self.env.execute_query(query.select(
             *[self._field_to_sql(self._table, fname) for fname in fnames_to_read],
@@ -368,7 +368,7 @@ class MailActivity(models.Model):
 
         allowed_ids = defaultdict(set)
         for res_model, res_ids in model_ids.items():
-            records = self.env[res_model].with_user(access_rights_uid or self._uid).browse(res_ids)
+            records = self.env[res_model].browse(res_ids)
             # fall back on related document access right checks. Use the same as defined for mail.thread
             # if available; otherwise fall back on read
             operation = getattr(records, '_mail_post_access', 'read')

--- a/addons/mail/models/mail_blacklist.py
+++ b/addons/mail/models/mail_blacklist.py
@@ -54,7 +54,7 @@ class MailBlackList(models.Model):
             values['email'] = tools.email_normalize(values['email'])
         return super(MailBlackList, self).write(values)
 
-    def _search(self, domain, offset=0, limit=None, order=None, access_rights_uid=None):
+    def _search(self, domain, offset=0, limit=None, order=None):
         """ Override _search in order to grep search on email field and make it
         lower-case and sanitized """
         def normalize(arg):
@@ -65,7 +65,7 @@ class MailBlackList(models.Model):
             return arg
 
         domain = [normalize(item) for item in domain]
-        return super()._search(domain, offset, limit, order, access_rights_uid)
+        return super()._search(domain, offset, limit, order)
 
     def _add(self, email, message=None):
         normalized = tools.email_normalize(email)

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -263,7 +263,7 @@ class Message(models.Model):
         self._cr.execute("""CREATE INDEX IF NOT EXISTS mail_message_model_res_id_id_idx ON mail_message (model, res_id, id)""")
 
     @api.model
-    def _search(self, domain, offset=0, limit=None, order=None, access_rights_uid=None):
+    def _search(self, domain, offset=0, limit=None, order=None):
         """ Override that adds specific access rights of mail.message, to remove
         ids uid could not see according to our custom rules. Please refer to
         check_access_rule for more details about those rules.
@@ -280,14 +280,14 @@ class Message(models.Model):
         """
         # Rules do not apply to administrator
         if self.env.is_superuser():
-            return super()._search(domain, offset, limit, order, access_rights_uid)
+            return super()._search(domain, offset, limit, order)
 
         # Non-employee see only messages with a subtype and not internal
         if not self.env.user._is_internal():
             domain = self._get_search_domain_share() + domain
 
         # make the search query with the default rules
-        query = super()._search(domain, offset, limit, order, access_rights_uid)
+        query = super()._search(domain, offset, limit, order)
 
         # retrieve matching records and determine which ones are truly accessible
         self.flush_model(['model', 'res_id', 'author_id', 'message_type', 'partner_ids'])

--- a/addons/maintenance/models/maintenance.py
+++ b/addons/maintenance/models/maintenance.py
@@ -3,7 +3,7 @@
 import ast
 from dateutil.relativedelta import relativedelta
 from odoo.exceptions import ValidationError
-from odoo import api, fields, models, SUPERUSER_ID, _
+from odoo import api, fields, models, _
 from odoo.exceptions import UserError
 from odoo.osv import expression
 
@@ -190,7 +190,9 @@ class MaintenanceEquipment(models.Model):
         """ Read group customization in order to display all the categories in
             the kanban view, even if they are empty.
         """
-        category_ids = categories._search([], order=categories._order, access_rights_uid=SUPERUSER_ID)
+        # bypass ir.model.access checks, but search with ir.rules
+        search_domain = self.env['ir.rule']._compute_domain(categories._name)
+        category_ids = categories.sudo()._search(search_domain, order=categories._order)
         return categories.browse(category_ids)
 
 
@@ -383,7 +385,7 @@ class MaintenanceRequest(models.Model):
         """ Read group customization in order to display all the stages in the
             kanban view, even if they are empty
         """
-        stage_ids = stages._search([], order=stages._order, access_rights_uid=SUPERUSER_ID)
+        stage_ids = stages.sudo()._search([], order=stages._order)
         return stages.browse(stage_ids)
 
 

--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -6,7 +6,7 @@ from dateutil.relativedelta import relativedelta
 from collections import defaultdict
 import json
 
-from odoo import api, fields, models, _, SUPERUSER_ID
+from odoo import api, fields, models, _
 from odoo.exceptions import UserError, ValidationError
 from odoo.tools import float_compare, float_round, format_datetime
 
@@ -19,7 +19,9 @@ class MrpWorkorder(models.Model):
     def _read_group_workcenter_id(self, workcenters, domain):
         workcenter_ids = self.env.context.get('default_workcenter_id')
         if not workcenter_ids:
-            workcenter_ids = workcenters._search([], order=workcenters._order, access_rights_uid=SUPERUSER_ID)
+            # bypass ir.model.access checks, but search with ir.rules
+            search_domain = self.env['ir.rule']._compute_domain(workcenters._name)
+            workcenter_ids = workcenters.sudo()._search(search_domain, order=workcenters._order)
         return workcenters.browse(workcenter_ids)
 
     name = fields.Char(

--- a/addons/phone_validation/models/phone_blacklist.py
+++ b/addons/phone_validation/models/phone_blacklist.py
@@ -70,7 +70,7 @@ class PhoneBlackList(models.Model):
             values['number'] = sanitized
         return super(PhoneBlackList, self).write(values)
 
-    def _search(self, domain, offset=0, limit=None, order=None, access_rights_uid=None):
+    def _search(self, domain, offset=0, limit=None, order=None):
         """ Override _search in order to grep search on sanitized number field """
         def sanitize_number(arg):
             if isinstance(arg, (list, tuple)) and arg[0] == 'number':
@@ -83,7 +83,7 @@ class PhoneBlackList(models.Model):
             return arg
 
         domain = [sanitize_number(item) for item in domain]
-        return super()._search(domain, offset, limit, order, access_rights_uid)
+        return super()._search(domain, offset, limit, order)
 
     def add(self, number, message=None):
         sanitized = self.env.user._phone_format(number=number)

--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -2,7 +2,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import re
-from collections import defaultdict
 from operator import itemgetter
 
 from odoo import api, fields, models, tools, _
@@ -462,12 +461,12 @@ class ProductProduct(models.Model):
         return new_products
 
     @api.model
-    def _search(self, domain, offset=0, limit=None, order=None, access_rights_uid=None):
+    def _search(self, domain, offset=0, limit=None, order=None):
         # TDE FIXME: strange
         if self._context.get('search_default_categ_id'):
             domain = domain.copy()
             domain.append((('categ_id', 'child_of', self._context['search_default_categ_id'])))
-        return super()._search(domain, offset, limit, order, access_rights_uid)
+        return super()._search(domain, offset, limit, order)
 
     @api.depends('name', 'default_code', 'product_tmpl_id')
     @api.depends_context('display_default_code', 'seller_id', 'company_id', 'partner_id')

--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -4,7 +4,7 @@ import itertools
 import logging
 from collections import defaultdict
 
-from odoo import api, fields, models, tools, _, SUPERUSER_ID
+from odoo import api, fields, models, tools, _
 from odoo.exceptions import UserError, ValidationError
 from odoo.osv import expression
 
@@ -35,7 +35,7 @@ class ProductTemplate(models.Model):
     def _read_group_categ_id(self, categories, domain):
         category_ids = self.env.context.get('default_categ_id')
         if not category_ids and self.env.context.get('group_expand'):
-            category_ids = categories._search([], order=categories._order, access_rights_uid=SUPERUSER_ID)
+            category_ids = categories.sudo()._search([], order=categories._order)
         return categories.browse(category_ids)
 
     name = fields.Char('Name', index='trigram', required=True, translate=True)

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -6,7 +6,7 @@ from pytz import UTC
 from collections import defaultdict
 from datetime import timedelta, datetime, time
 
-from odoo import api, Command, fields, models, tools, SUPERUSER_ID, _, _lt
+from odoo import api, Command, fields, models, tools, SUPERUSER_ID, _
 from odoo.addons.rating.models import rating_data
 from odoo.addons.web_editor.tools import handle_history_divergence
 from odoo.exceptions import UserError, ValidationError, AccessError
@@ -135,7 +135,7 @@ class Task(models.Model):
         if 'default_project_id' in self.env.context and not self._context.get('subtask_action'):
             search_domain = ['|', ('project_ids', '=', self.env.context['default_project_id'])] + search_domain
 
-        stage_ids = stages._search(search_domain, order=stages._order, access_rights_uid=SUPERUSER_ID)
+        stage_ids = stages.sudo()._search(search_domain, order=stages._order)
         return stages.browse(stage_ids)
 
     @api.model

--- a/addons/utm/models/utm_campaign.py
+++ b/addons/utm/models/utm_campaign.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models, api, SUPERUSER_ID
+from odoo import fields, models, api
 
 
 class UtmCampaign(models.Model):
@@ -56,5 +56,5 @@ class UtmCampaign(models.Model):
         """Read group customization in order to display all the stages in the
         Kanban view, even if they are empty.
         """
-        stage_ids = stages._search([], order=stages._order, access_rights_uid=SUPERUSER_ID)
+        stage_ids = stages.sudo()._search([], order=stages._order)
         return stages.browse(stage_ids)

--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -4,8 +4,6 @@ import base64
 import binascii
 import contextlib
 import hashlib
-import io
-import itertools
 import logging
 import mimetypes
 import os
@@ -15,7 +13,6 @@ import uuid
 import werkzeug
 
 from collections import defaultdict
-from PIL import Image
 
 from odoo import api, fields, models, SUPERUSER_ID, tools, _
 from odoo.exceptions import AccessError, ValidationError, UserError
@@ -516,7 +513,7 @@ class IrAttachment(models.Model):
         return ret_attachments
 
     @api.model
-    def _search(self, domain, offset=0, limit=None, order=None, access_rights_uid=None):
+    def _search(self, domain, offset=0, limit=None, order=None):
         # add res_field=False in domain if not present; the arg[0] trick below
         # works for domain items and '&'/'|'/'!' operators too
         disable_binary_fields_attachments = False
@@ -526,14 +523,14 @@ class IrAttachment(models.Model):
 
         if self.env.is_superuser():
             # rules do not apply for the superuser
-            return super()._search(domain, offset, limit, order, access_rights_uid)
+            return super()._search(domain, offset, limit, order)
 
         # For attachments, the permissions of the document they are attached to
         # apply, so we must remove attachments for which the user cannot access
         # the linked document. For the sake of performance, fetch the fields to
         # determine those permissions within the same SQL query.
         fnames_to_read = ['id', 'res_model', 'res_id', 'res_field', 'public', 'create_uid']
-        query = super()._search(domain, offset, limit, order, access_rights_uid)
+        query = super()._search(domain, offset, limit, order)
         rows = self.env.execute_query(query.select(
             *[self._field_to_sql(self._table, fname) for fname in fnames_to_read],
         ))
@@ -577,7 +574,7 @@ class IrAttachment(models.Model):
         if len(all_ids) == limit and len(result) < self._context.get('need', limit):
             need = self._context.get('need', limit) - len(result)
             more_ids = self.with_context(need=need)._search(
-                domain, offset + len(all_ids), limit, order, access_rights_uid,
+                domain, offset + len(all_ids), limit, order,
             )
             result.extend(list(more_ids)[:limit - len(result)])
 

--- a/odoo/addons/base/models/res_bank.py
+++ b/odoo/addons/base/models/res_bank.py
@@ -119,7 +119,7 @@ class ResPartnerBank(models.Model):
             acc.display_name = f'{acc.acc_number} - {acc.bank_id.name}' if acc.bank_id else acc.acc_number
 
     @api.model
-    def _search(self, domain, offset=0, limit=None, order=None, access_rights_uid=None):
+    def _search(self, domain, offset=0, limit=None, order=None):
         def sanitize(arg):
             if isinstance(arg, (tuple, list)) and arg[0] == 'acc_number':
                 value = arg[2]
@@ -131,4 +131,4 @@ class ResPartnerBank(models.Model):
             return arg
 
         domain = [sanitize(item) for item in domain]
-        return super()._search(domain, offset, limit, order, access_rights_uid)
+        return super()._search(domain, offset, limit, order)

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -236,14 +236,14 @@ class Groups(models.Model):
             return expression.OR(where_domains)
 
     @api.model
-    def _search(self, domain, offset=0, limit=None, order=None, access_rights_uid=None):
+    def _search(self, domain, offset=0, limit=None, order=None):
         # add explicit ordering if search is sorted on full_name
         if order and order.startswith('full_name'):
             groups = super().search(domain)
             groups = groups.sorted('full_name', reverse=order.endswith('DESC'))
             groups = groups[offset:offset+limit] if limit else groups[offset:]
             return groups._as_query(order)
-        return super()._search(domain, offset, limit, order, access_rights_uid)
+        return super()._search(domain, offset, limit, order)
 
     def copy_data(self, default=None):
         default = dict(default or {})
@@ -653,12 +653,12 @@ class Users(models.Model):
         return super()._read_group_groupby(groupby_spec, query)
 
     @api.model
-    def _search(self, domain, offset=0, limit=None, order=None, access_rights_uid=None):
+    def _search(self, domain, offset=0, limit=None, order=None):
         if not self.env.su and domain:
             domain_fields = {term[0] for term in domain if isinstance(term, (tuple, list))}
             if domain_fields.intersection(USER_PRIVATE_FIELDS):
                 raise AccessError(_('Invalid search criterion'))
-        return super()._search(domain, offset, limit, order, access_rights_uid)
+        return super()._search(domain, offset, limit, order)
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/odoo/addons/test_converter/models.py
+++ b/odoo/addons/test_converter/models.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import models, fields, api, SUPERUSER_ID
+from odoo import models, fields, api
 
 class test_model(models.Model):
     _name = 'test_converter.test_model'
@@ -30,7 +30,7 @@ class test_model(models.Model):
 
     @api.model
     def _gbf_m2o(self, subs, domain):
-        sub_ids = subs._search([], order=subs._order, access_rights_uid=SUPERUSER_ID)
+        sub_ids = subs.sudo()._search([], order=subs._order)
         return subs.browse(sub_ids)
 
 

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -5472,17 +5472,12 @@ class BaseModel(metaclass=MetaModel):
             self.env[model_name].flush_model(field_names)
 
     @api.model
-    def _search(self, domain, offset=0, limit=None, order=None, access_rights_uid=None) -> Query:
+    def _search(self, domain, offset=0, limit=None, order=None) -> Query:
         """
-        Private implementation of search() method, allowing specifying the uid to use for the access right check.
-        This is useful for example when filling in the selection list for a drop-down and avoiding access rights errors,
-        by specifying ``access_rights_uid=1`` to bypass access rights check, but not ir.rules!
-        This is ok at the security level because this method is private and not callable through XML-RPC.
+        Private implementation of search() method.
 
         No default order is applied when the method is invoked without parameter ``order``.
 
-        :param access_rights_uid: optional user ID to use when checking access rights
-                                  (not for ir.rules, this is only for ir.model.access)
         :return: a :class:`Query` object that represents the matching records
 
         This method may be overridden to modify the domain being searched, or to
@@ -5491,8 +5486,7 @@ class BaseModel(metaclass=MetaModel):
         default the returned query object is not actually executed, and it can
         be injected as a value in a domain in order to generate sub-queries.
         """
-        model = self.with_user(access_rights_uid) if access_rights_uid else self
-        model.check_access_rights('read')
+        self.check_access_rights('read')
 
         if expression.is_false(self, domain):
             # optimization: no need to query, as no record satisfies the domain


### PR DESCRIPTION
The existing parameter `access_rights_uid` was used to optionally check access rights with a different user.  In practice, the only sensible value for that parameter was `SUPERUSER_ID`, and if the current user had no access to the model, the search was done with global ir.rules only.  As this feature is not much used and a bit too tricky, we remove it altogether.  The use-cases of that feature now use `sudo()` instead.

task-id 4040382