### PR TITLE
[FIX] hr: fix traceback when the user clicks on the chat button

### DIFF
--- a/addons/hr/static/src/components/employee_chat/employee_chat.xml
+++ b/addons/hr/static/src/components/employee_chat/employee_chat.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="hr.OpenChat">
-        <a t-if="props.record.data.user_id"
+        <a t-if="props.record.data.user_id and props.record.resId"
             title="Chat"
             icon="fa-comments"
             t-on-click.prevent="() => openChat(props.record.resId)"


### PR DESCRIPTION
Currently, a traceback is occurring when the user clicks on the chat button while creating a new employee record.

To reproduce this issue:

1) Install `employee`
2) Create a new `employee` record
3) Give the value for the related user in the `HR Setting` page 
4) A chat button appears at the left side of the `employee name` 
5) Click on the chat button, and a traceback occurs

Error:- 
```
TypeError: '<' not supported between instances of 'int' and 'NoneType'
  File "odoo/http.py", line 2248, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1823, in _serve_db
    return self._transactioning(_serve_ir_http, readonly=ro)
  File "odoo/http.py", line 1843, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1821, in _serve_ir_http
    return self._serve_ir_http(rule, args)
  File "odoo/http.py", line 1828, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2053, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 220, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 756, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 38, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 34, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 458, in call_kw
    result = getattr(recs, name)(*args, **kwargs)
  File "addons/mail/models/discuss/discuss_channel.py", line 973, in channel_get
    """, (tuple(partners_to), tuple(partners_to), sorted(list(partners_to)),))
```

When the related user value is given, the `chat` button is visible to the user before saving the record. 
But here in the `openChat` method, we used `props.record.resId`.
which is created after the employee record is created.

https://github.com/odoo/odoo/blob/a6c14effd3e38cf38966ae89675e8e54b54cf825/addons/hr/static/src/components/employee_chat/employee_chat.xml#L4-L11

It leads to the above traceback as `channel_get` calls with `partners_to` as `None` from the below line

https://github.com/odoo/odoo/blob/a6c14effd3e38cf38966ae89675e8e54b54cf825/addons/mail/static/src/core/common/thread_service.js#L555-L557

This commit will resolve this issue by making it visible to the user after the employee record is created.

Note:- An alternative solution can be at this line
https://github.com/odoo/odoo/blob/9f84ff581686f8e2198a0a88d19f7a52e27ccb53/addons/hr/static/src/thread_service_patch.js#L9
```
if (!person) {
            this.notificationService.add(
                _t("To open chat, please first save the record.."),
                { type: "info" }
            );
            return;
        }
```

sentry- 5501637214