### PR TITLE
[FIX] stock: create 'stock.lot' records if 'use_existing_lots' is True

### DIFF
--- a/addons/product_expiry/tests/test_generate_serial_numbers.py
+++ b/addons/product_expiry/tests/test_generate_serial_numbers.py
@@ -10,6 +10,12 @@ from odoo.tools.misc import get_lang
 
 class TestStockLot(StockGenerateCommon):
 
+    def _import_lots(self, lots, move):
+        location_id = move.location_id
+        move_lines_vals = move.split_lots(lots)
+        move_lines_commands = move._generate_serial_move_line_commands(move_lines_vals, location_dest_id=location_id)
+        move.update({'move_line_ids': move_lines_commands})
+
     def test_set_multiple_lot_name_with_expiration_date_01(self):
         """ In a move line's `lot_name` field, pastes a list of lots and expiration dates.
         Checks the values are correctly interpreted and the expiration dates are correctly created

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -816,9 +816,36 @@ Please change the quantity done or the rounding precision of your unit of measur
             location_id = self.location_dest_id
         lot_names = self.env['stock.lot'].generate_lot_names(next_serial, next_serial_count or self.next_serial_count)
         field_data = [{'lot_name': lot_name['lot_name'], 'quantity': 1} for lot_name in lot_names]
+        if self.picking_type_id.use_existing_lots:
+            self._create_lot_ids_from_move_line_vals(field_data, self.product_id.id, self.company_id.id)
         move_lines_commands = self._generate_serial_move_line_commands(field_data)
         self.move_line_ids = move_lines_commands
         return True
+
+    def _create_lot_ids_from_move_line_vals(self, vals_list, product_id, company_id):
+        """ This method will search or create the lot_id from the lot_name and set it in the vals_list
+        """
+        lot_names = {vals['lot_name'] for vals in vals_list if vals.get('lot_name')}
+        lot_ids = self.env['stock.lot'].search([
+            ('product_id', '=', product_id),
+            ('company_id', '=', company_id),
+            ('name', 'in', list(lot_names)),
+        ])
+
+        lot_names -= set(lot_ids.mapped('name'))  # lot_names not found to create
+        lots_to_create_vals = [
+            {'product_id': product_id, 'name': lot_name, 'company_id': company_id}
+            for lot_name in lot_names
+        ]
+        lot_ids |= self.env['stock.lot'].create(lots_to_create_vals)
+
+        lot_id_by_name = {lot.name: lot.id for lot in lot_ids}
+        for vals in vals_list:
+            lot_name = vals.get('lot_name', None)
+            if not lot_name:
+                continue
+            vals['lot_id'] = lot_id_by_name[lot_name]
+            vals['lot_name'] = False
 
     @api.model
     def split_lots(self, lots):
@@ -856,19 +883,6 @@ Please change the quantity done or the rounding precision of your unit of measur
                     # don't try to guess and simply use the full string as the lot name.
                     move_line_vals['lot_name'] = lot_text
                     break
-            if self.picking_type_id.use_existing_lots:
-                lot_id = self.env['stock.lot'].search([
-                    ('product_id', '=', self.product_id.id),
-                    ('name', '=', lot_text),
-                    ('company_id', '=', self.company_id.id),
-                ])
-                if not lot_id:
-                    lot_id = self.env['stock.lot'].create({
-                        'product_id': self.product_id.id,
-                        'name': lot_text,
-                        'company_id': self.company_id.id,
-                    })
-                move_line_vals['lot_id'] = lot_id.id
             move_lines_vals.append(move_line_vals)
         return move_lines_vals
 
@@ -901,6 +915,10 @@ Please change the quantity done or the rounding precision of your unit of measur
                              'location_dest_id': loc_dest.id,
                              'product_uom_id': product.uom_id.id,
                             })
+        if default_vals.get('picking_type_id'):
+            picking_type = self.env['stock.picking.type'].browse(default_vals['picking_type_id'])
+            if picking_type.use_existing_lots:
+                self._create_lot_ids_from_move_line_vals(vals_list, default_vals['product_id'], default_vals['company_id'])
         # format many2one values for webclient, id + display_name
         for values in vals_list:
             for key, value in values.items():


### PR DESCRIPTION
In a receipt picking, you can automatically set the Serial/Lots with 3 actions: 'Generate Serial/Lots' / 'Import Serial/Lots' / 'Assign Serial Numbers'. However, if 'use_existing_lots' is True on the picking type, the resulting move lines will appear without lots on the frontend.

This is because these actions only set the lot_name, not the lot_id.

After this commit, these 3 actions will use lot_id instead of lot_name if 'use_existing_lots' is True. They will either assign an existing 'stock.lot' or create a new one in the correct company.

---

## BEFORE


https://github.com/odoo/odoo/assets/29302288/f571d68d-86cb-42bf-bf8b-5e918c2ca2c2


## AFTER


https://github.com/odoo/odoo/assets/29302288/325c7870-a24a-4094-b0c0-5ff8274712d8


---

OPW-3983532

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
