### PR TITLE
[FIX] web: prevent website configurator flickering

### DIFF
--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -930,7 +930,7 @@ export function makeActionManager(env, router = _router) {
                         pushState(nextStack);
                     },
                 });
-                env.bus.trigger("ACTION_MANAGER:BEFORE-UI-UPDATE", _getActionMode(action));
+                // env.bus.trigger("ACTION_MANAGER:BEFORE-UI-UPDATE", _getActionMode(action));
                 if (action.target !== "new") {
                     this.__beforeLeave__ = new CallbackRecorder();
                     this.__getGlobalState__ = new CallbackRecorder();
@@ -1441,6 +1441,7 @@ export function makeActionManager(env, router = _router) {
         let action = await keepLast.add(actionProm);
         action = _preprocessAction(action, options.additionalContext);
         options.clearBreadcrumbs = action.target === "main" || options.clearBreadcrumbs;
+        env.bus.trigger("ACTION_MANAGER:BEFORE-UI-UPDATE", _getActionMode(action));
         switch (action.type) {
             case "ir.actions.act_url":
                 return _executeActURLAction(action, options);

--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -930,6 +930,7 @@ export function makeActionManager(env, router = _router) {
                         pushState(nextStack);
                     },
                 });
+                env.bus.trigger("ACTION_MANAGER:BEFORE-UI-UPDATE", _getActionMode(action));
                 if (action.target !== "new") {
                     this.__beforeLeave__ = new CallbackRecorder();
                     this.__getGlobalState__ = new CallbackRecorder();

--- a/addons/web/static/src/webclient/webclient.js
+++ b/addons/web/static/src/webclient/webclient.js
@@ -37,7 +37,7 @@ export class WebClient extends Component {
         }
         this.localization = localization;
         this.state = useState({
-            fullscreen: false,
+            fullscreen: true,
         });
         useBus(routerBus, "ROUTE_CHANGE", async () => {
             document.body.style.pointerEvents = "none";
@@ -146,6 +146,9 @@ export class WebClient extends Component {
         const root = this.menuService.getMenu("root");
         const firstApp = root.children[0];
         if (firstApp) {
+            if (!firstApp.actionID) {
+                this.state.fullscreen = false;
+            }
             return this.menuService.selectMenu(firstApp);
         }
     }

--- a/addons/web/static/src/webclient/webclient.js
+++ b/addons/web/static/src/webclient/webclient.js
@@ -47,6 +47,11 @@ export class WebClient extends Component {
                 document.body.style.pointerEvents = "auto";
             }
         });
+        useBus(this.env.bus, "ACTION_MANAGER:BEFORE-UI-UPDATE", ({ detail: mode }) => {
+            if (mode !== "new") {
+                this.state.fullscreen = mode === "fullscreen";
+            }
+        });
         useBus(this.env.bus, "ACTION_MANAGER:UI-UPDATED", ({ detail: mode }) => {
             if (mode !== "new") {
                 this.state.fullscreen = mode === "fullscreen";
@@ -77,9 +82,7 @@ export class WebClient extends Component {
 
             if (matchingMenus.length > 0) {
                 // Use sessionStorage context to determine the correct menu
-                menuId = matchingMenus.find(m => 
-                    m.appID === storedMenuId
-                )?.appID;
+                menuId = matchingMenus.find((m) => m.appID === storedMenuId)?.appID;
                 if (!menuId) {
                     menuId = matchingMenus[0]?.appID;
                 }


### PR DESCRIPTION
Before this PR:
Users were facing an issue of flickering when trying to configure a newly created website. The reason behind this was that the target was decided after the web client was mounted. When the action target is evaluated (i.e., new, current, or fullscreen), the navbar was hidden based on the target.

In this commit, the state of the web client is now set based on the current action, specifically setting the fullscreen state for the website configurator to address the flickering issue.

task-3050040