### PR TITLE
[FIX] website_event: fix submenu without page

### DIFF
--- a/addons/website_event/controllers/main.py
+++ b/addons/website_event/controllers/main.py
@@ -150,13 +150,11 @@ class WebsiteEventController(http.Controller):
             page = 'website_event.%s' % page
 
         view = request.env["website.event.menu"].sudo().search([
-            ("event_id", "=", event.id), ("view_id.key", "ilike", page)]).view_id
-        if not view:
-            return request.not_found()
+            ("event_id", "=", event.id), ("view_id.key", "ilike", page)], limit=1).view_id
 
         try:
             # Every event page view should have its own SEO.
-            page = view.key
+            page = view.key if view else page
             values['seo_object'] = request.website.get_template(page)
             values['main_object'] = event
         except ValueError:

--- a/addons/website_event/tests/test_event_menus.py
+++ b/addons/website_event/tests/test_event_menus.py
@@ -5,10 +5,10 @@ from datetime import datetime, timedelta
 
 from odoo import fields
 from odoo.addons.website_event.tests.common import OnlineEventCase
-from odoo.tests.common import users
+from odoo.tests.common import HttpCase, users
 
 
-class TestEventMenus(OnlineEventCase):
+class TestEventMenus(OnlineEventCase, HttpCase):
 
     @users('user_eventmanager')
     def test_menu_management(self):
@@ -67,6 +67,48 @@ class TestEventMenus(OnlineEventCase):
         # re-created from backend
         event.introduction_menu = True
         self._assert_website_menus(event, ['Introduction', 'Location', 'Register'], menus_out=['Community'])
+
+    def test_submenu_url(self):
+        """ Test that the different URL of a submenu page of an event are accessible """
+        old_event_1, old_event_2, event_1, event_2, event_3 = self.env["event.event"].create(
+            [
+                {
+                    "community_menu": False,
+                    "date_begin": fields.Datetime.to_string(
+                        datetime.today() + timedelta(days=1)
+                    ),
+                    "date_end": fields.Datetime.to_string(
+                        datetime.today() + timedelta(days=15)
+                    ),
+                    "is_published": True,
+                    "name": "Test Event",
+                    "website_menu": True,
+                }
+                for _ in range(5)
+            ]
+        )
+
+        # Use previous URL for submenu page
+        old_event_1.introduction_menu_ids.menu_id.url = f"/event/test-event-{old_event_1.id}/page/introduction-test-event"
+        old_event_2.introduction_menu_ids.menu_id.url = f"/event/test-event-{old_event_2.id}/page/introduction-test-event"
+        old_event_menus = (old_event_1 + old_event_2).introduction_menu_ids
+        self.assertEqual(len(old_event_menus.view_id), 2, "Each menu should have a view")
+
+        # Menu with unique page
+        new_event_menus = (event_1 + event_2).introduction_menu_ids
+        self.assertEqual(len(new_event_menus.view_id), 2, "Each menu should have a view")
+
+        # Menu without views
+        menu_without_view = event_3._create_menu(1, 'custom', f"/event/test-event-{event_3.id}/page/introduction-test-event", 'website_event.template_intro', 'introduction')
+        self.assertEqual(
+            len(self.env['website.event.menu'].search([('menu_id', 'in', menu_without_view.ids)]).view_id), 0,
+            "The menu should not have a view assigned because an URL has been given manually"
+        )
+
+        all_menus = old_event_menus.menu_id + new_event_menus.menu_id + menu_without_view
+        for menu in all_menus:
+            res = self.url_open(menu.url)
+            self.assertEqual(res.status_code, 200)
 
     def test_submenu_url_uniqueness(self):
         """Ensure that the last part of the menus URL (used to retrieve the right view)


### PR DESCRIPTION
This commit odoo/odoo@af46b928a18da8e6276c107c5ed07cfd9e87d1bf introduced a fix to ensure submenu pages uniqueness.

An issue arises when manual submenu are created and don't have a view_id set. To avoid this issue, we now fallback on the initial page receives if no view is found.