### PR TITLE
[IMP] l10n_pl: use delivery date instead of accounting date

### DIFF
--- a/addons/l10n_pl/models/__init__.py
+++ b/addons/l10n_pl/models/__init__.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from . import product
 from . import account_move
+from . import account_move_line
 from . import res_partner
 from . import res_company
 from . import res_config_settings

--- a/addons/l10n_pl/models/account_move_line.py
+++ b/addons/l10n_pl/models/account_move_line.py
@@ -1,0 +1,17 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import models, fields, api
+
+
+class AccountMoveLine(models.Model):
+    _inherit = "account.move.line"
+
+    @api.depends('move_id.delivery_date')
+    def _compute_currency_rate(self):
+        super()._compute_currency_rate()
+
+    def _get_rate_date(self):
+        # EXTENDS 'account'
+        self.ensure_one()
+        if self.move_id.country_code == 'PL':
+            return self.move_id.delivery_date or self.move_id.date or fields.Date.context_today(self)
+        return super()._get_rate_date()

--- a/addons/l10n_pl/tests/__init__.py
+++ b/addons/l10n_pl/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_move

--- a/addons/l10n_pl/tests/test_move.py
+++ b/addons/l10n_pl/tests/test_move.py
@@ -1,0 +1,37 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.tests import tagged
+from odoo import Command
+
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class TestAccountPL(AccountTestInvoicingCommon):
+
+    @classmethod
+    def setUpClass(cls, chart_template_ref='pl'):
+        super().setUpClass(chart_template_ref=chart_template_ref)
+
+        cls.currency_usd = cls.env.ref('base.USD')
+        cls.invoice_a = cls.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'invoice_date': '2024-07-10',
+            'currency_id': cls.currency_usd.id,
+            'invoice_line_ids': [Command.create({
+                'quantity': 1.0,
+                'price_unit': 1000.0,
+            })],
+        })
+
+    def test_pl_out_invoice_onchange_accounting_date(self):
+        self.invoice_a.delivery_date = '2024-03-31'
+        self.assertEqual(self.invoice_a.invoice_line_ids[0].currency_rate, 1.0)
+
+        self.env['res.currency.rate'].create({
+                'name': '2024-04-28',
+                'rate': 4.2799058421,
+                'currency_id': self.currency_usd.id,
+        })
+
+        self.invoice_a.delivery_date = '2024-05-31'
+        self.assertEqual(self.invoice_a.invoice_line_ids[0].currency_rate, 4.2799058421)


### PR DESCRIPTION
[IMP] l10n_pl: use delivery date instead of accounting date

before, the currency conversion rate is dependent on accounting date. but It seems that in Eastern European country needs to use the delivery date as currency rate date in the first place.

Solution: the currency rate now is dependent on delivery date in first place

task-id#4023144

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr