### PR TITLE
[FIX] mail: tests - fix non-deterministic cross-tab test

### DIFF
--- a/addons/mail/static/tests/discuss/core/web/crosstab_tests.js
+++ b/addons/mail/static/tests/discuss/core/web/crosstab_tests.js
@@ -5,17 +5,17 @@ import { startServer } from "@bus/../tests/helpers/mock_python_environment";
 import { start } from "@mail/../tests/helpers/test_utils";
 
 import { patchWithCleanup } from "@web/../tests/helpers/utils";
-import { click, contains, insertText } from "@web/../tests/utils";
+import { assertSteps, click, contains, insertText, step } from "@web/../tests/utils";
 
 QUnit.module("crosstab");
 
-QUnit.test("Channel subscription is renewed when channel is manually added", async (assert) => {
+QUnit.test("Channel subscription is renewed when channel is manually added", async () => {
     const pyEnv = await startServer();
     pyEnv["discuss.channel"].create({ name: "General", channel_member_ids: [] });
     const { env, openDiscuss } = await start();
     patchWithCleanup(env.services["bus_service"], {
         forceUpdateChannels() {
-            assert.step("update-channels");
+            step("update-channels");
         },
     });
     openDiscuss();
@@ -23,6 +23,5 @@ QUnit.test("Channel subscription is renewed when channel is manually added", asy
     await insertText(".o-discuss-ChannelSelector input", "General");
     await click(":nth-child(1 of .o-discuss-ChannelSelector-suggestion)");
     await contains(".o-mail-DiscussSidebarChannel", { count: 1 });
-    await new Promise((resolve) => setTimeout(resolve)); // update of channels is debounced
-    assert.verifySteps(["update-channels"]);
+    await assertSteps(["update-channels"]);
 });


### PR DESCRIPTION
Before this PR, the `Channel subscription is renewed when channel is manually added` test was sometimes failing.

This test ensures the bus subscription is renewed when the user joins a channel. To do this, the test relies on the `assert.step` API: the channel is added, we wait for a tick, and then we assert that the step was correctly registered. However, a tick is sometimes not enough.

This PR replaces the usage of QUnit's tep API with the web one that waits for the step to be triggered, which is far more robust.

fixes runbot-61018