### PR TITLE
[FIX] hr_holidays: prevent referenced accrual plan unlink

### DIFF
--- a/addons/hr_holidays/i18n/hr_holidays.pot
+++ b/addons/hr_holidays/i18n/hr_holidays.pot
@@ -3008,6 +3008,14 @@ msgid "Sick Time Off"
 msgstr ""
 
 #. module: hr_holidays
+#: code:addons/hr_holidays/models/hr_leave_accrual_plan.py:0
+#, python-format
+msgid ""
+"Some of the accrual plans you're trying to delete are linked to an existing "
+"allocation. Delete or cancel them first."
+msgstr ""
+
+#. module: hr_holidays
 #: model:ir.model.fields,help:hr_holidays.field_hr_leave_accrual_plan__time_off_type_id
 msgid ""
 "Specify if this accrual plan can only be used with this Time Off Type.\n"

--- a/addons/hr_holidays/models/hr_leave_accrual_plan.py
+++ b/addons/hr_holidays/models/hr_leave_accrual_plan.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models, _
+from odoo.exceptions import ValidationError
 
 
 class AccrualPlan(models.Model):
@@ -61,3 +62,15 @@ class AccrualPlan(models.Model):
         default = dict(default or {},
                        name=_("%s (copy)", self.name))
         return super().copy(default=default)
+
+    @api.ondelete(at_uninstall=False)
+    def _prevent_used_plan_unlink(self):
+        domain = [
+            ('allocation_type', '=', 'accrual'),
+            ('accrual_plan_id', 'in', self.ids),
+            ('state', 'not in', ('cancel', 'refuse')),
+        ]
+        if self.env['hr.leave.allocation'].search_count(domain):
+            raise ValidationError(_(
+                "Some of the accrual plans you're trying to delete are linked to an existing allocation. Delete or cancel those first."
+            ))

--- a/addons/hr_holidays/models/hr_leave_accrual_plan.py
+++ b/addons/hr_holidays/models/hr_leave_accrual_plan.py
@@ -72,5 +72,5 @@ class AccrualPlan(models.Model):
         ]
         if self.env['hr.leave.allocation'].search_count(domain):
             raise ValidationError(_(
-                "Some of the accrual plans you're trying to delete are linked to an existing allocation. Delete or cancel those first."
+                "Some of the accrual plans you're trying to delete are linked to an existing allocation. Delete or cancel them first."
             ))


### PR DESCRIPTION
Before this commit, it was possible to delete an accrual plan while
it was referenced by an allocation.
This commit introduces an error message if the user tries to delete
an accrual plan in those conditions.

task-4023187

Also updates the `hr_holidays.pot` file