### PR TITLE
[FIX] mail: tests - fix non deterministic message test

### DIFF
--- a/addons/mail/static/tests/discuss_app/discuss_tests.js
+++ b/addons/mail/static/tests/discuss_app/discuss_tests.js
@@ -1829,8 +1829,9 @@ QUnit.test("Message shows up even if channel data is incomplete", async () => {
         ],
         channel_type: "chat",
     });
+    const subscribeProm = waitUntilSubscribe();
     env.services["bus_service"].forceUpdateChannels();
-    await waitUntilSubscribe();
+    await subscribeProm;
     await pyEnv.withUser(correspondentUserId, () =>
         env.services.rpc("/discuss/channel/notify_typing", {
             is_typing: true,


### PR DESCRIPTION
The `Message shows up even if channel data is incomplete` test
sometimes fails. This test ensures that a message received on a
partially known channel still appears.

To achieve this, the test needs to manually refresh the bus
subscription and wait for this subscription to complete before sending
a notification on the bus.

Sometimes, the notification occurs before `waitUntilSubscribe` is
called. Consequently, the `waitForSubscribe` function hangs because
the expected subscription for the test has already been completed.

This PR resolves this issue.

runbot-59270