### PR TITLE
[FIX] web: kanban: record displayed twice after being d&d

### DIFF
--- a/addons/web/static/src/model/relational_model/dynamic_group_list.js
+++ b/addons/web/static/src/model/relational_model/dynamic_group_list.js
@@ -105,6 +105,11 @@ export class DynamicGroupList extends DynamicList {
         // step 1: move record to correct position
         const refIndex = targetGroup.list.records.findIndex((r) => r.id === refId);
         const oldIndex = sourceGroup.list.records.findIndex((r) => r.id === dataRecordId);
+
+        const sourceList = sourceGroup.list;
+        // if the source contains more records than what's loaded, reload it after moving the record
+        const mustReloadSourceList = sourceList.count > sourceList.offset + sourceList.limit;
+
         sourceGroup._removeRecords([record.id]);
         targetGroup._addRecord(record, refIndex + 1);
         // step 2: update record value
@@ -127,14 +132,18 @@ export class DynamicGroupList extends DynamicList {
             revert();
             throw e;
         }
-        if (!targetGroup.isFolded) {
-            await targetGroup.list._resequence(
-                targetGroup.list.records,
-                this.resModel,
-                dataRecordId,
-                refId
-            );
+
+        const proms = [];
+        if (mustReloadSourceList) {
+            const { offset, limit, orderBy, domain } = sourceGroup.list;
+            proms.push(sourceGroup.list._load(offset, limit, orderBy, domain));
         }
+        if (!targetGroup.isFolded) {
+            const targetList = targetGroup.list;
+            const records = targetList.records;
+            proms.push(targetList._resequence(records, this.resModel, dataRecordId, refId));
+        }
+        return Promise.all(proms);
     }
 
     async resequence(movedGroupId, targetGroupId) {

--- a/addons/web/static/src/model/relational_model/dynamic_list.js
+++ b/addons/web/static/src/model/relational_model/dynamic_list.js
@@ -250,7 +250,8 @@ export class DynamicList extends DataPoint {
             );
             this.model.notification.add(msg, { title: _t("Warning") });
         }
-        await this._removeRecords(records.map((r) => r.id));
+        this._removeRecords(records.map((r) => r.id));
+        await this._load(this.offset, this.limit, this.orderBy, this.domain);
         return unlinked;
     }
 

--- a/addons/web/static/src/model/relational_model/dynamic_record_list.js
+++ b/addons/web/static/src/model/relational_model/dynamic_record_list.js
@@ -149,22 +149,13 @@ export class DynamicRecordList extends DynamicList {
     }
 
     _removeRecords(recordIds) {
-        const _records = this.records.filter((r) => !recordIds.includes(r.id));
-        if (this.offset && !_records.length) {
+        const keptRecords = this.records.filter((r) => !recordIds.includes(r.id));
+        this.count -= this.records.length - keptRecords.length;
+        this.records = keptRecords;
+        if (this.offset && !this.records.length) {
             // we weren't on the first page, and we removed all records of the current page
             const offset = Math.max(this.offset - this.limit, 0);
-            return this._load(offset, this.limit, this.orderBy, this.domain);
-        }
-        const nbRemovedRecords = this.records.length - _records.length;
-        if (nbRemovedRecords > 0) {
-            if (this.count > this.offset + this.limit) {
-                // we removed some records, and there are other pages after the current one
-                return this._load(this.offset, this.limit, this.orderBy, this.domain);
-            } else {
-                // we are on the last page and there are still records remaining
-                this.count -= nbRemovedRecords;
-                this.records = _records;
-            }
+            this.model._updateConfig(this.config, { offset }, { reload: false });
         }
     }
 

--- a/addons/web/static/src/model/relational_model/group.js
+++ b/addons/web/static/src/model/relational_model/group.js
@@ -118,7 +118,7 @@ export class Group extends DataPoint {
 
     async _removeRecords(recordIds) {
         const idsToRemove = recordIds.filter((id) => this.list.records.some((r) => r.id === id));
-        await this.list._removeRecords(idsToRemove);
+        this.list._removeRecords(idsToRemove);
         this.count -= idsToRemove.length;
     }
 }

--- a/addons/web/static/tests/views/kanban/kanban_view_tests.js
+++ b/addons/web/static/tests/views/kanban/kanban_view_tests.js
@@ -4981,6 +4981,33 @@ QUnit.module("Views", (hooks) => {
         assert.deepEqual(allNames, ["hello", "", "xmo", ""]);
     });
 
+    QUnit.test("drag and drop a record with load more", async (assert) => {
+        await makeView({
+            type: "kanban",
+            resModel: "partner",
+            serverData,
+            arch: `
+                <kanban limit="1">
+                    <templates>
+                        <t t-name="kanban-box">
+                            <div><field name="id"/></div>
+                        </t>
+                    </templates>
+                </kanban>`,
+            groupBy: ["bar"],
+        });
+
+        assert.deepEqual(getCardTexts(target, 0), ["4"]);
+        assert.deepEqual(getCardTexts(target, 1), ["1"]);
+
+        await dragAndDrop(
+            getColumn(target, 1).querySelector(".o_kanban_record"),
+            ".o_kanban_group:nth-child(1)"
+        );
+        assert.deepEqual(getCardTexts(target, 0), ["4", "1"]);
+        assert.deepEqual(getCardTexts(target, 1), ["2"]);
+    });
+
     QUnit.test("can drag and drop a record from one column to the next", async (assert) => {
         await makeView({
             type: "kanban",

--- a/addons/web/static/tests/views/list_view_tests.js
+++ b/addons/web/static/tests/views/list_view_tests.js
@@ -6557,6 +6557,40 @@ QUnit.module("Views", (hooks) => {
         }
     );
 
+    QUnit.test("grouped list, reload aggregates when a record is deleted", async function (assert) {
+        serverData.models.foo.records = [
+            { id: 121, foo: "blip", int_field: 100 },
+            { id: 122, foo: "blip", int_field: 300 },
+            { id: 123, foo: "blip", int_field: 700 },
+        ];
+        await makeView({
+            type: "list",
+            resModel: "foo",
+            serverData,
+            arch: /*xml*/ `
+                <tree expand="1">
+                    <field name="foo"/>
+                    <field name="int_field"/>
+                </tree>`,
+            groupBy: ["foo"],
+            actionMenus: {},
+        });
+
+        assert.strictEqual(
+            target.querySelector(".o_group_header .o_list_number").textContent.trim(),
+            "1100"
+        );
+
+        await click(target.querySelector(".o_data_row input"));
+        await toggleActionMenu(target);
+        await toggleMenuItem(target, "Delete");
+        await click(target, ".modal .btn-primary");
+        assert.strictEqual(
+            target.querySelector(".o_group_header .o_list_number").textContent.trim(),
+            "1000"
+        );
+    });
+
     QUnit.test("pager (ungrouped and grouped mode), default limit", async function (assert) {
         assert.expect(4);
 


### PR DESCRIPTION
In a grouped kanban view, drag and drop a record from a group which contains a lot of records and has the "Load more" displayed in the bottom (i.e. which contains more records than the limit). Before this commit, the drag&dropped record was displayed twice: once where it was dropped (which is fine), and once from where it was dragged (which is wrong).

This happened because we didn't correctly synchronize the reload of the column (which must be done because there're more records than the limit, and we "removed" one record from the column) and the update on the moved record (s.t. it belongs to the correct column). As a consequence, we reloaded the column before updating the record, so it was still part of the original column.

This commit fixes the issue by splitting the logic of the _removeRecords function: before, it altered the records locally (to filter out removed records) and updated the count, and, if necessary, it reloaded the list. Now, _removeRecords is only responsible to update the list locally, which must be done directly as we want the user to get a direct feedback of the move. In the flows where a reload might be necessary, we do it afterwards. In the case of a moveRecord, we can then do it after the update on the record.

opw-3891269

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
