### PR TITLE
[IMP] hw_drivers: add support for IoT box commands via websocket

### DIFF
--- a/addons/hw_drivers/__init__.py
+++ b/addons/hw_drivers/__init__.py
@@ -11,3 +11,4 @@ from . import http
 from . import interface
 from . import main
 from . import websocket_client
+from . import websocket_handlers

--- a/addons/hw_drivers/tools/helpers.py
+++ b/addons/hw_drivers/tools/helpers.py
@@ -472,6 +472,14 @@ def read_file_first_line(filename):
         with path.open('r') as f:
             return f.readline().strip('\n')
 
+
+def restart_odoo_or_reboot(action, delay=3):
+    _logger.info("restart_odoo_or_reboot called with %s as action", action)
+    if action == "restart_odoo":
+        odoo_restart(delay)
+    else:
+        subprocess.call(["sudo", "reboot"])
+
 def unlink_file(filename):
     with writable():
         path = path_file(filename)

--- a/addons/hw_drivers/websocket_handlers.py
+++ b/addons/hw_drivers/websocket_handlers.py
@@ -1,0 +1,44 @@
+import logging
+import pprint
+import time
+
+from odoo.addons.hw_drivers.tools import helpers
+from odoo.addons.hw_drivers import main
+
+
+_logger = logging.getLogger(__name__)
+
+
+def iot_device_action(message):
+    payload = message['message']['payload']
+    iot_mac = helpers.get_mac_address()
+    if iot_mac in payload['iotDevice']['iotIdentifiers']:
+        for device in payload['iotDevice']['identifiers']:
+            device_identifier = device['identifier']
+            if device_identifier in main.iot_devices:
+                start_operation_time = time.perf_counter()
+                _logger.debug("device '%s' action started with: %s", device_identifier, pprint.pformat(payload))
+                main.iot_devices[device_identifier].action(payload)
+                _logger.info("device '%s' action finished - %.*f", device_identifier, 3, time.perf_counter() - start_operation_time)
+    else:
+        # likely intended as IoT share the same channel
+        _logger.debug("message ignored due to different iot mac: %s", iot_mac)
+
+
+def iot_box_action(message):
+    payload = message['message']['payload']
+    iot_mac = helpers.get_mac_address()
+    if iot_mac in payload['iotIdentifiers'] and payload['action'] in ['reboot_box', 'restart_odoo']:
+        _logger.debug("IoT box action '%s' started", payload['action'])
+        helpers.restart_odoo_or_reboot(payload['action'])
+
+
+def print_confirmation(message):
+    _logger.debug("Print confirmation received: %s", message)
+
+
+websocket_handlers = {
+    "iot_device_action": iot_device_action,
+    "iot_box_action": iot_box_action,
+    "print_confirmation": print_confirmation
+}

--- a/addons/hw_posbox_homepage/controllers/main.py
+++ b/addons/hw_posbox_homepage/controllers/main.py
@@ -416,10 +416,7 @@ class IoTboxHomepage(Home):
     def iot_restart_odoo_or_reboot(self, action):
         """ Reboots the IoT Box / restarts Odoo on it depending on chosen 'action' argument"""
         try:
-            if action == 'restart_odoo':
-                helpers.odoo_restart(3)
-            else:
-                subprocess.call(['sudo', 'reboot'])
+            helpers.restart_odoo_or_reboot(action)
             return 'success'
         except Exception as e:
             _logger.error('An error encountered : %s ', e)


### PR DESCRIPTION
Add 'iot_command' message type and implement restarting Odoo and rebooting the IoT box. The existing 'iot_action' message type requires targeting a specific device, so was not suitable for these generic commands.

https://www.odoo.com/odoo/project/1428/tasks/3619591

Description of the issue/feature this PR addresses:
Extend Websocket functionality to allow restarting/rebooting the IoT box, and convert the existing longpolling mechanism to use the Websocket.

Current behavior before PR:
Rebooting IoT box and restarting Odoo service use longpolling.

Desired behavior after PR is merged:
Rebooting IoT box and restarting Odoo service are achieved via the websocket connection.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
