### PR TITLE
[IMP] *: remove problematic occurrences of gettext concatenation

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -986,7 +986,7 @@ class AccountMoveLine(models.Model):
                     'move_id': line.move_id.id,
                     'display_type': line.display_type,
                 }): {
-                    'name': tax['name'] + (' ' + _('(Discount)') if line.display_type == 'epd' else ''),
+                    'name': _('%(tax_name)s (Discount)', tax_name=tax['name']) if line.display_type == 'epd' else tax['name'],
                     'balance': sign * tax['amount'] / rate,
                     'amount_currency': sign * tax['amount'],
                     'tax_base_amount': sign * tax['base'] / rate * (-1 if line.tax_tag_invert else 1),

--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -1132,9 +1132,9 @@ class AccountPayment(models.Model):
             })
             paired_payment.move_id._post(soft=False)
             payment.paired_internal_transfer_payment_id = paired_payment
-            body = _("This payment has been created from:") + payment._get_html_link()
+            body = _("This payment has been created from: %(link)s", link=payment._get_html_link())
             paired_payment.message_post(body=body)
-            body = _("A second payment has been created:") + paired_payment._get_html_link()
+            body = _("A second payment has been created: %(link)s", link=paired_payment._get_html_link())
             payment.message_post(body=body)
 
             lines = (payment.move_id.line_ids + paired_payment.move_id.line_ids).filtered(

--- a/addons/account/wizard/account_automatic_entry_wizard.py
+++ b/addons/account/wizard/account_automatic_entry_wizard.py
@@ -493,14 +493,18 @@ class AutomaticEntryWizard(models.TransientModel):
     def _format_new_transfer_move_log(self, acc_transfer_per_move):
         transfer_format = Markup("<li>%s, <strong>%%(account_source_name)s</strong></li>") % \
             _("{amount} ({debit_credit}) from {link}")
-        rslt = Markup(_("This entry transfers the following amounts to %(destination)s") + "<ul>%(transfer_logs)s</ul>") % {
-            'destination': Markup("<strong>%s</strong>") % self.destination_account_id.display_name,
-            'transfer_logs': Markup().join([
-                self._format_strings(transfer_format % {'account_source_name': account.display_name}, move, balance)
-                for move, balances_per_account in acc_transfer_per_move.items()
-                for account, balance in balances_per_account.items()
-                if account != self.destination_account_id  # Otherwise, logging it here is confusing for the user
-            ])
+        rslt = _(
+            "This entry transfers the following amounts to %(destination)s",
+            destination=Markup("<strong>%s</strong>") % self.destination_account_id.display_name,
+        ) + Markup("<ul>%(transfer_logs)s</ul>") % {
+            "transfer_logs": Markup().join(
+                [
+                    self._format_strings(transfer_format % {"account_source_name": account.display_name}, move, balance)
+                    for move, balances_per_account in acc_transfer_per_move.items()
+                    for account, balance in balances_per_account.items()
+                    if account != self.destination_account_id  # Otherwise, logging it here is confusing for the user
+                ],
+            ),
         }
         return rslt
 

--- a/addons/account_check_printing/models/account_journal.py
+++ b/addons/account_check_printing/models/account_journal.py
@@ -77,7 +77,7 @@ class AccountJournal(models.Model):
         """ Create a check sequence for the journal """
         for journal in self:
             journal.check_sequence_id = self.env['ir.sequence'].sudo().create({
-                'name': journal.name + _(": Check Number Sequence"),
+                'name': _("%(journal)s: Check Number Sequence", journal=journal.name),
                 'implementation': 'no_gap',
                 'padding': 5,
                 'number_increment': 1,

--- a/addons/account_edi/models/account_move.py
+++ b/addons/account_edi/models/account_move.py
@@ -76,14 +76,15 @@ class AccountMove(models.Model):
                 move.edi_blocking_level = error_doc.blocking_level
             else:
                 error_levels = set([doc.blocking_level for doc in move.edi_document_ids])
+                count = str(move.edi_error_count)
                 if 'error' in error_levels:
-                    move.edi_error_message = str(move.edi_error_count) + _(" Electronic invoicing error(s)")
+                    move.edi_error_message = _("%(count)s Electronic invoicing error(s)", count=count)
                     move.edi_blocking_level = 'error'
                 elif 'warning' in error_levels:
-                    move.edi_error_message = str(move.edi_error_count) + _(" Electronic invoicing warning(s)")
+                    move.edi_error_message = _("%(count)s Electronic invoicing warning(s)", count=count)
                     move.edi_blocking_level = 'warning'
                 else:
-                    move.edi_error_message = str(move.edi_error_count) + _(" Electronic invoicing info(s)")
+                    move.edi_error_message = _("%(count)s Electronic invoicing info(s)", count=count)
                     move.edi_blocking_level = 'info'
 
     @api.depends(

--- a/addons/barcodes/static/src/barcode_handlers.js
+++ b/addons/barcodes/static/src/barcode_handlers.js
@@ -79,7 +79,7 @@ export const barcodeGenericHandlers = {
                 if (fn) {
                     fn();
                 } else {
-                    notification.add(_t("Barcode: ") + `'${barcode}'`, {
+                    notification.add(_t("Barcode: %(barcode)s", { barcode }), {
                         title: _t("Unknown barcode command"),
                         type: "danger"
                     });

--- a/addons/barcodes_gs1_nomenclature/models/barcode_nomenclature.py
+++ b/addons/barcodes_gs1_nomenclature/models/barcode_nomenclature.py
@@ -26,7 +26,7 @@ class BarcodeNomenclature(models.Model):
                 try:
                     re.compile("(?:%s)?" % nom.gs1_separator_fnc1)
                 except re.error as error:
-                    raise ValidationError(_("The FNC1 Separator Alternative is not a valid Regex: ") + str(error))
+                    raise ValidationError(_("The FNC1 Separator Alternative is not a valid Regex: %(error)s", error))
 
     @api.model
     def gs1_date_to_date(self, gs1_date):

--- a/addons/barcodes_gs1_nomenclature/models/barcode_rule.py
+++ b/addons/barcodes_gs1_nomenclature/models/barcode_rule.py
@@ -57,7 +57,7 @@ class BarcodeRule(models.Model):
             try:
                 re.compile(rule.pattern)
             except re.error as error:
-                raise ValidationError(_("The rule pattern \"%s\" is not a valid Regex: ", rule.name) + str(error))
+                raise ValidationError(_("The rule pattern '%(rule)s' is not a valid Regex: %(error)s", rule=rule.name, error=error))
             groups = re.findall(r'\([^)]*\)', rule.pattern)
             if len(groups) != 2:
                 raise ValidationError(_(

--- a/addons/base_geolocalize/models/base_geocoder.py
+++ b/addons/base_geolocalize/models/base_geocoder.py
@@ -156,4 +156,4 @@ class GeoCoder(models.AbstractModel):
         return self._geo_query_address_default(street=street, zip=zip, city=city, state=state, country=country)
 
     def _raise_query_error(self, error):
-        raise UserError(_('Error with geolocation server:') + ' %s' % error)
+        raise UserError(_('Error with geolocation server: %s', error))

--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -414,21 +414,23 @@ class Meeting(models.Model):
         for meeting in self:
             if not meeting.allday and meeting.start and meeting.stop and meeting.stop < meeting.start:
                 raise ValidationError(
-                    _('The ending date and time cannot be earlier than the starting date and time.') + '\n' +
-                    _("Meeting '%(name)s' starts '%(start_datetime)s' and ends '%(end_datetime)s'",
-                      name=meeting.name,
-                      start_datetime=meeting.start,
-                      end_datetime=meeting.stop
-                    )
+                    _(
+                        "The ending date and time cannot be earlier than the starting date and time.\n"
+                        "Meeting “%(name)s” starts at %(start_time)s and ends at %(end_time)s",
+                        name=meeting.name,
+                        start_time=meeting.start,
+                        end_time=meeting.stop,
+                    ),
                 )
             if meeting.allday and meeting.start_date and meeting.stop_date and meeting.stop_date < meeting.start_date:
                 raise ValidationError(
-                    _('The ending date cannot be earlier than the starting date.') + '\n' +
-                    _("Meeting '%(name)s' starts '%(start_datetime)s' and ends '%(end_datetime)s'",
-                      name=meeting.name,
-                      start_datetime=meeting.start,
-                      end_datetime=meeting.stop
-                    )
+                    _(
+                        "The ending date cannot be earlier than the starting date.\n"
+                        "Meeting “%(name)s” starts on %(start_date)s and ends on %(end_date)s",
+                        name=meeting.name,
+                        start_date=meeting.start_date,
+                        end_date=meeting.stop_date,
+                    ),
                 )
 
     @api.depends('recurrence_id', 'recurrency')

--- a/addons/delivery/models/sale_order.py
+++ b/addons/delivery/models/sale_order.py
@@ -223,7 +223,7 @@ class SaleOrder(models.Model):
             'is_delivery': True,
         }
         if carrier.free_over and self.currency_id.is_zero(price_unit) :
-            values['name'] += '\n' + _('Free Shipping')
+            values['name'] = _('%s\nFree Shipping', values['name'])
         if self.order_line:
             values['sequence'] = self.order_line[-1].sequence + 1
         del context

--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -343,14 +343,14 @@ class HolidaysType(models.Model):
             return super()._compute_display_name()
         for record in self:
             name = record.name
-            if record.requires_allocation == "yes" and not self._context.get('from_manager_leave_form'):
-                name = "{name} ({count})".format(
-                    name=name,
-                    count=_('%(remaining)g remaining out of %(maximum)g',
-                        remaining=float_round(record.virtual_remaining_leaves, precision_digits=2) or 0.0,
-                        maximum=float_round(record.max_leaves, precision_digits=2) or 0.0,
-                    ) + (_(' hours') if record.request_unit == 'hour' else _(' days')),
-            )
+            if record.requires_allocation == "yes" and not self._context.get("from_manager_leave_form"):
+                remaining_time = float_round(record.virtual_remaining_leaves, precision_digits=2) or 0.0
+                maximum = float_round(record.max_leaves, precision_digits=2) or 0.0
+
+                if record.request_unit == "hour":
+                    name = _("%(name)s (%(time)g remaining out of %(maximum)g hours)", name=record.name, time=remaining_time, maximum=maximum)
+                else:
+                    name = _("%(name)s (%(time)g remaining out of %(maximum)g days)", name=record.name, time=remaining_time, maximum=maximum)
             record.display_name = name
 
     @api.model

--- a/addons/hr_work_entry_contract/models/hr_contract.py
+++ b/addons/hr_work_entry_contract/models/hr_contract.py
@@ -11,7 +11,7 @@ from dateutil.relativedelta import relativedelta
 from odoo import api, fields, models, _
 from odoo.addons.resource.models.utils import string_to_datetime, Intervals
 from odoo.osv import expression
-from odoo.tools import ormcache
+from odoo.tools import ormcache, format_list
 from odoo.exceptions import UserError
 
 
@@ -335,8 +335,9 @@ class HrContract(models.Model):
         canceled_contracts = self.filtered(lambda c: c.state == 'cancel')
         if canceled_contracts:
             raise UserError(
-                _("Sorry, generating work entries from cancelled contracts is not allowed.") + '\n%s' % (
-                    ', '.join(canceled_contracts.mapped('name'))))
+                _("Sorry, generating work entries from cancelled contracts is not allowed.")
+                + "\n%s" % (format_list(self.env, canceled_contracts.mapped("name"))),
+            )
         vals_list = []
         self.write({'last_generation_date': fields.Date.today()})
 

--- a/addons/l10n_ar/models/l10n_latam_document_type.py
+++ b/addons/l10n_ar/models/l10n_latam_document_type.py
@@ -44,15 +44,19 @@ class L10nLatamDocumentType(models.Model):
         if not document_number:
             return False
 
-        msg = "'%s' " + _("is not a valid value for") + " '%s'.<br/>%s"
-
         if not self.code:
             return document_number
 
         # Import Dispatch Number Validator
         if self.code in ['66', '67']:
             if len(document_number) != 16:
-                raise UserError(msg % (document_number, self.name, _('The number of import Dispatch must be 16 characters')))
+                raise UserError(
+                    _(
+                        "%(value)s is not a valid value for %(field)s.\nThe number of import Dispatch must be 16 characters.",
+                        value=document_number,
+                        field=self.name,
+                    ),
+                )
             return document_number
 
         # Invoice Number Validator (For Eg: 123-123)
@@ -68,9 +72,12 @@ class L10nLatamDocumentType(models.Model):
                 failed = True
             document_number = '{:>05s}-{:>08s}'.format(pos, number)
         if failed:
-            raise UserError(msg % (document_number, self.name, _(
-                'The document number must be entered with a dash (-) and a maximum of 5 characters for the first part'
-                'and 8 for the second. The following are examples of valid numbers:\n* 1-1\n* 0001-00000001'
-                '\n* 00001-00000001')))
+            raise UserError(
+                _(
+                    "%(value)s is not a valid value for %(field)s.\nThe document number must be entered with a dash (-) and a maximum of 5 characters for the first part and 8 for the second. The following are examples of valid numbers:\n* 1-1\n* 0001-00000001\n* 00001-00000001",
+                    value=document_number,
+                    field=self.name,
+                ),
+            )
 
         return document_number

--- a/addons/l10n_it_stock_ddt/models/stock_picking.py
+++ b/addons/l10n_it_stock_ddt/models/stock_picking.py
@@ -62,10 +62,10 @@ class StockPickingType(models.Model):
     def _get_dtt_ir_seq_vals(self, warehouse_id, sequence_code):
         if warehouse_id:
             wh = self.env['stock.warehouse'].browse(warehouse_id)
-            ir_seq_name = wh.name + ' ' + _('Sequence') + ' ' + sequence_code
+            ir_seq_name = _('%(warehouse)s Sequence %(code)s', warehouse=wh.name, code=sequence_code)
             ir_seq_prefix = wh.code + '/' + sequence_code + '/DDT'
         else:
-            ir_seq_name = _('Sequence') + ' ' + sequence_code
+            ir_seq_name = _('Sequence %(code)s', code=sequence_code)
             ir_seq_prefix = sequence_code + '/DDT'
         return ir_seq_name, ir_seq_prefix
 

--- a/addons/l10n_sa_edi/models/account_edi_format.py
+++ b/addons/l10n_sa_edi/models/account_edi_format.py
@@ -232,7 +232,7 @@ class AccountEdiFormat(models.Model):
             PCSID_data = invoice.journal_id._l10n_sa_api_get_pcsid()
         except UserError as e:
             return ({
-                'error': _("Could not generate PCSID values: \n") + e.args[0],
+                'error': _("Could not generate PCSID values:\n%(error)s", error=e.args[0]),
                 'blocking_level': 'error',
                 'response': unsigned_xml
             }, unsigned_xml)
@@ -243,7 +243,7 @@ class AccountEdiFormat(models.Model):
             signed_xml = self._l10n_sa_get_signed_xml(invoice, unsigned_xml, x509_cert)
         except UserError as e:
             return ({
-                'error': _("Could not generate signed XML values: \n") + e.args[0],
+                'error': _("Could not generate signed XML values:\n%(error)s", error=e.args[0]),
                 'blocking_level': 'error',
                 'response': unsigned_xml
             }, unsigned_xml)

--- a/addons/l10n_sa_edi/models/account_journal.py
+++ b/addons/l10n_sa_edi/models/account_journal.py
@@ -180,10 +180,16 @@ class AccountJournal(models.Model):
         """
         self.ensure_one()
         if any(not self.company_id[f] for f in self._l10n_sa_csr_required_fields()):
-            raise UserError(_("Please, make sure all the following fields have been correctly set on the Company: \n")
-                            + "\n".join(
-                " - %s" % self.company_id._fields[f].string for f in self._l10n_sa_csr_required_fields() if
-                not self.company_id[f]))
+            raise UserError(
+                _(
+                    "Please, make sure all the following fields have been correctly set on the Company:%(fields)s",
+                    fields="".join(
+                        "\n - %s" % self.company_id._fields[f].string
+                        for f in self._l10n_sa_csr_required_fields()
+                        if not self.company_id[f]
+                    ),
+                ),
+            )
         self._l10n_sa_reset_certificates()
         self.l10n_sa_csr = self._l10n_sa_get_csr_str()
 
@@ -564,7 +570,7 @@ class AccountJournal(models.Model):
         except (ValueError, HTTPError) as ex:
             # In the case of an explicit error from ZATCA, i.e we got a response but the code of the response is not 2xx
             return {
-                'error': _("Server returned an unexpected error: ") + (request_response.text or str(ex)),
+                'error': _("Server returned an unexpected error: %(error)s", error=(request_response.text or str(ex))),
                 'blocking_level': 'error'
             }
         except RequestException as ex:

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -9,7 +9,7 @@ from collections import defaultdict
 from odoo import _, api, fields, models, modules, tools
 from odoo.exceptions import AccessError
 from odoo.osv import expression
-from odoo.tools import clean_context, groupby, SQL
+from odoo.tools import clean_context, format_list, groupby, SQL
 from odoo.tools.misc import OrderedSet
 from odoo.addons.mail.tools.discuss import Store
 
@@ -411,8 +411,14 @@ class Message(models.Model):
                                     message.id = ANY (%%s)''' % (self._table), ('comment', self.ids,))
             if self._cr.fetchall():
                 raise AccessError(
-                    _('The requested operation cannot be completed due to security restrictions. Please contact your system administrator.\n\n(Document type: %(type)s, Operation: %(operation)s)', type=self._description, operation=operation)
-                    + ' - ({} {}, {} {})'.format(_('Records:'), self.ids[:6], _('User:'), self._uid)
+                    _(
+                        "The requested operation cannot be completed due to security restrictions. Please contact your system administrator.\n\n(Document type: %(type)s, Operation: %(operation)s)\n\n"
+                        "Records: %(records)s, User: %(user)s",
+                        type=self._description,
+                        operation=operation,
+                        records=format_list(self.env, list(map(str, self.ids[:6]))),
+                        user=self._uid,
+                    ),
                 )
 
         # Read mail_message.ids to have their values
@@ -581,8 +587,14 @@ class Message(models.Model):
         if not self.browse(messages_to_check).exists():
             return
         raise AccessError(
-            _('The requested operation cannot be completed due to security restrictions. Please contact your system administrator.\n\n(Document type: %(type)s, Operation: %(operation)s)', type=self._description, operation=operation)
-            + ' - ({} {}, {} {})'.format(_('Records:'), list(messages_to_check)[:6], _('User:'), self._uid)
+            _(
+                "The requested operation cannot be completed due to security restrictions. Please contact your system administrator.\n\n(Document type: %(type)s, Operation: %(operation)s)\n\n"
+                "Records: %(records)s, User: %(user)s",
+                type=self._description,
+                operation=operation,
+                records=format_list(self.env, list(map(str, list(messages_to_check)[:6]))),
+                user=self._uid,
+            ),
         )
 
     def _validate_access_for_current_persona(self, operation):

--- a/addons/mail/models/mail_notification.py
+++ b/addons/mail/models/mail_notification.py
@@ -110,7 +110,9 @@ class MailNotification(models.Model):
         if self.failure_type != 'unknown':
             return dict(self._fields['failure_type'].selection).get(self.failure_type, _('No Error'))
         else:
-            return _("Unknown error") + ": %s" % (self.failure_reason or '')
+            if self.failure_reason:
+                return _("Unknown error: %(error)s", error=self.failure_reason)
+            return _("Unknown error")
 
     # ------------------------------------------------------------
     # DISCUSS

--- a/addons/mass_mailing/wizard/mailing_contact_import.py
+++ b/addons/mass_mailing/wizard/mailing_contact_import.py
@@ -89,16 +89,20 @@ class MailingContactImport(models.TransientModel):
             for email, values in unique_contacts.items()
         ])
 
-        ignored = len(contacts) - len(unique_contacts)
+        if ignored := len(contacts) - len(unique_contacts):
+            message = _(
+                "Contacts successfully imported. Number of contacts imported: %(imported_count)s. Number of duplicates ignored: %(duplicate_count)s",
+                imported_count=len(unique_contacts),
+                duplicate_count=ignored,
+            )
+        else:
+            message = _("Contacts successfully imported. Number of contacts imported: %(imported_count)s", imported_count=len(unique_contacts))
 
         return {
             'type': 'ir.actions.client',
             'tag': 'display_notification',
             'params': {
-                'message': (
-                    _('%i Contacts have been imported.', len(unique_contacts))
-                    + (_(' %i duplicates have been ignored.', ignored) if ignored else '')
-                ),
+                'message': message,
                 'type': 'success',
                 'sticky': False,
                 'next': {

--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -2691,7 +2691,10 @@ class MrpProduction(models.Model):
                 if move.has_tracking in ('serial', 'lot') and (not move.picked or any(not line.lot_id for line in move.move_line_ids if line.quantity and line.picked)):
                     missing_lot_id_products += "\n  - %s" % move.product_id.display_name
         if missing_lot_id_products:
-            error_msg = _("You need to supply Lot/Serial Number for products and 'consume' them:") + missing_lot_id_products
+            error_msg = _(
+                "You need to supply Lot/Serial Number for products and 'consume' them: %(missing_products)s",
+                missing_products=missing_lot_id_products,
+            )
             raise UserError(error_msg)
 
     def _get_autoprint_done_report_actions(self):

--- a/addons/mrp/models/mrp_unbuild.py
+++ b/addons/mrp/models/mrp_unbuild.py
@@ -315,7 +315,7 @@ class MrpUnbuild(models.Model):
             return self.action_unbuild()
         else:
             return {
-                'name': self.product_id.display_name + _(': Insufficient Quantity To Unbuild'),
+                'name': _('%(product)s: Insufficient Quantity To Unbuild', product=self.product_id.display_name),
                 'view_mode': 'form',
                 'res_model': 'stock.warn.insufficient.qty.unbuild',
                 'view_id': self.env.ref('mrp.stock_warn_insufficient_qty_unbuild_form_view').id,

--- a/addons/mrp/models/stock_warehouse.py
+++ b/addons/mrp/models/stock_warehouse.py
@@ -187,9 +187,9 @@ class StockWarehouse(models.Model):
     def _get_sequence_values(self, name=False, code=False):
         values = super(StockWarehouse, self)._get_sequence_values(name=name, code=code)
         values.update({
-            'pbm_type_id': {'name': self.name + ' ' + _('Sequence picking before manufacturing'), 'prefix': self.code + '/PC/', 'padding': 5, 'company_id': self.company_id.id},
-            'sam_type_id': {'name': self.name + ' ' + _('Sequence stock after manufacturing'), 'prefix': self.code + '/SFP/', 'padding': 5, 'company_id': self.company_id.id},
-            'manu_type_id': {'name': self.name + ' ' + _('Sequence production'), 'prefix': self.code + '/MO/', 'padding': 5, 'company_id': self.company_id.id},
+            'pbm_type_id': {'name': _('%(name)s Sequence picking before manufacturing', name=self.name), 'prefix': self.code + '/PC/', 'padding': 5, 'company_id': self.company_id.id},
+            'sam_type_id': {'name': _('%(name)s Sequence stock after manufacturing', name=self.name), 'prefix': self.code + '/SFP/', 'padding': 5, 'company_id': self.company_id.id},
+            'manu_type_id': {'name': _('%(name)s Sequence production', name=self.name), 'prefix': self.code + '/MO/', 'padding': 5, 'company_id': self.company_id.id},
         })
         return values
 

--- a/addons/mrp/wizard/mrp_consumption_warning.py
+++ b/addons/mrp/wizard/mrp_consumption_warning.py
@@ -65,9 +65,12 @@ class MrpConsumptionWarning(models.TransientModel):
                         'picked': True,
                     })
         if problem_tracked_products:
+            products_list = "".join(f"\n- {product_name}" for product_name in problem_tracked_products.mapped("name"))
             raise UserError(
-                _("Values cannot be set and validated because a Lot/Serial Number needs to be specified for a tracked product that is having its consumed amount increased:\n- ") +
-                "\n- ".join(problem_tracked_products.mapped('name'))
+                _(
+                    "Values cannot be set and validated because a Lot/Serial Number needs to be specified for a tracked product that is having its consumed amount increased:%(products)s",
+                    products=products_list,
+                ),
             )
         if missing_move_vals:
             self.env['stock.move'].create(missing_move_vals)

--- a/addons/mrp_subcontracting/models/stock_warehouse.py
+++ b/addons/mrp_subcontracting/models/stock_warehouse.py
@@ -158,13 +158,13 @@ class StockWarehouse(models.Model):
         count = self.env['ir.sequence'].search_count([('prefix', '=like', self.code + '/SBC%/%')])
         values.update({
             'subcontracting_type_id': {
-                'name': self.name + ' ' + _('Sequence subcontracting'),
+                'name': _('%(name)s Sequence subcontracting', name=self.name),
                 'prefix': self.code + (('/SBC' + str(count) + '/') if count else '/SBC/'),
                 'padding': 5,
                 'company_id': self.company_id.id
             },
             'subcontracting_resupply_type_id': {
-                'name': self.name + ' ' + _('Sequence Resupply Subcontractor'),
+                'name': _('%(name)s Sequence Resupply Subcontractor', name=self.name),
                 'prefix': self.code + (('/RES' + str(count) + '/') if count else '/RES/'),
                 'padding': 5,
                 'company_id': self.company_id.id

--- a/addons/phone_validation/models/phone_blacklist.py
+++ b/addons/phone_validation/models/phone_blacklist.py
@@ -37,7 +37,7 @@ class PhoneBlackList(models.Model):
             try:
                 sanitized_value = self.env.user._phone_format(number=value['number'], raise_exception=True)
             except UserError as err:
-                raise UserError(str(err) + _(" Please correct the number and try again.")) from err
+                raise UserError(_("%(error)s Please correct the number and try again.", error=err)) from err
             if sanitized_value in done:
                 continue
             done.add(sanitized_value)
@@ -66,7 +66,7 @@ class PhoneBlackList(models.Model):
             try:
                 sanitized = self.env.user._phone_format(number=values['number'], raise_exception=True)
             except UserError as err:
-                raise UserError(str(err) + _(" Please correct the number and try again.")) from err
+                raise UserError(_("%(error)s Please correct the number and try again.", error=str(err))) from err
             values['number'] = sanitized
         return super(PhoneBlackList, self).write(values)
 

--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -493,7 +493,7 @@ class PosOrder(models.Model):
 
     def _compute_order_name(self):
         if self.refunded_order_id.exists():
-            return self.refunded_order_id.name + _(' REFUND')
+            return _('%(refunded_order)s REFUND', refunded_order=self.refunded_order_id.name)
         else:
             return self.session_id.config_id.sequence_id._next()
 
@@ -1024,7 +1024,7 @@ class PosOrder(models.Model):
     def _prepare_refund_values(self, current_session):
         self.ensure_one()
         return {
-            'name': self.name + _(' REFUND'),
+            'name': _('%(name)s REFUND', name=self.name),
             'session_id': current_session.id,
             'date_order': fields.Datetime.now(),
             'pos_reference': self.pos_reference,
@@ -1274,7 +1274,7 @@ class PosOrderLine(models.Model):
         """
         self.ensure_one()
         return {
-            'name': self.name + _(' REFUND'),
+            'name': _('%(name)s REFUND', name=self.name),
             'qty': -(self.qty - self.refunded_qty),
             'order_id': refund_order.id,
             'price_subtotal': -self.price_subtotal,

--- a/addons/point_of_sale/models/report_sale_details.py
+++ b/addons/point_of_sale/models/report_sale_details.py
@@ -204,7 +204,7 @@ class ReportSaleDetails(models.AbstractModel):
                         payment['cash_moves'] = cash_in_out_list
                         payment['count'] = True
             if not is_cash_method:
-                cash_name = _('Cash') + ' ' + str(session.name)
+                cash_name = _('Cash %(session_name)s', session_name=session.name)
                 previous_session = self.env['pos.session'].search([('id', '<', session.id), ('state', '=', 'closed'), ('config_id', '=', session.config_id.id)], limit=1)
                 final_count = previous_session.cash_register_balance_end_real + session.cash_real_transaction
                 cash_difference = session.cash_register_balance_end_real - final_count

--- a/addons/point_of_sale/models/stock_warehouse.py
+++ b/addons/point_of_sale/models/stock_warehouse.py
@@ -12,7 +12,7 @@ class Warehouse(models.Model):
         sequence_values = super(Warehouse, self)._get_sequence_values(name=name, code=code)
         sequence_values.update({
             'pos_type_id': {
-                'name': self.name + ' ' + _('Picking POS'),
+                'name': _('%(name)s Picking POS', name=self.name),
                 'prefix': self.code + '/POS/',
                 'padding': 5,
                 'company_id': self.company_id.id,

--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -502,7 +502,7 @@ class Project(models.Model):
                 # This does not benefit from multi create, this is to allow the default description from being built.
                 # This does seem ok since last_update_status should only be updated on one record at once.
                 self.env['project.update'].with_context(default_project_id=project.id).create({
-                    'name': _('Status Update - ') + fields.Date.today().strftime(get_lang(self.env).date_format),
+                    'name': _('Status Update - %(date)s', date=fields.Date.today().strftime(get_lang(self.env).date_format)),
                     'status': vals.get('last_update_status'),
                 })
             vals.pop('last_update_status')

--- a/addons/repair/models/repair.py
+++ b/addons/repair/models/repair.py
@@ -365,11 +365,21 @@ class Repair(models.Model):
         if any(repair.sale_order_id for repair in self):
             concerned_ro = self.filtered('sale_order_id')
             ref_str = "\n".join(ro.name for ro in concerned_ro)
-            raise UserError(_("You cannot create a quotation for a repair order that is already linked to an existing sale order.\nConcerned repair order(s) :\n") + ref_str)
+            raise UserError(
+                _(
+                    "You cannot create a quotation for a repair order that is already linked to an existing sale order.\nConcerned repair order(s):\n%(ref_str)s",
+                    ref_str=ref_str,
+                ),
+            )
         if any(not repair.partner_id for repair in self):
             concerned_ro = self.filtered(lambda ro: not ro.partner_id)
             ref_str = "\n".join(ro.name for ro in concerned_ro)
-            raise UserError(_("You need to define a customer for a repair order in order to create an associated quotation.\nConcerned repair order(s) :\n") + ref_str)
+            raise UserError(
+                _(
+                    "You need to define a customer for a repair order in order to create an associated quotation.\nConcerned repair order(s):\n%(ref_str)s",
+                    ref_str=ref_str,
+                ),
+            )
         sale_order_values_list = []
         for repair in self:
             sale_order_values_list.append({
@@ -545,7 +555,7 @@ class Repair(models.Model):
                 return self._action_repair_confirm()
 
         return {
-            'name': self.product_id.display_name + _(': Insufficient Quantity To Repair'),
+            'name': _('%(product)s: Insufficient Quantity To Repair', product=self.product_id.display_name),
             'view_mode': 'form',
             'res_model': 'stock.warn.insufficient.qty.repair',
             'view_id': self.env.ref('repair.stock_warn_insufficient_qty_repair_form_view').id,

--- a/addons/repair/models/stock_warehouse.py
+++ b/addons/repair/models/stock_warehouse.py
@@ -13,7 +13,7 @@ class StockWarehouse(models.Model):
         values = super(StockWarehouse, self)._get_sequence_values(name=name, code=code)
         values.update({
             'repair_type_id': {
-                'name': self.name + ' ' + _('Sequence repair'),
+                'name': _('%(name)s Sequence repair', name=self.name),
                 'prefix': self.code + '/RO/',
                 'padding': 5,
                 'company_id': self.company_id.id

--- a/addons/spreadsheet/models/spreadsheet_mixin.py
+++ b/addons/spreadsheet/models/spreadsheet_mixin.py
@@ -61,7 +61,12 @@ class SpreadsheetMixin(models.AbstractModel):
                     errors.append(f"- menu with xml id '{xml_id}' used in spreadsheet '{display_name}' does not have an action")
 
             if errors:
-                raise ValidationError(_("Uh-oh! Looks like the spreadsheet file contains invalid data.") + "\n\n" + "\n".join(errors))
+                raise ValidationError(
+                    _(
+                        "Uh-oh! Looks like the spreadsheet file contains invalid data.\n\n%(errors)s",
+                        errors="\n".join(errors),
+                    ),
+                )
 
     @api.depends("spreadsheet_binary_data")
     def _compute_spreadsheet_data(self):

--- a/addons/stock/models/stock_lot.py
+++ b/addons/stock/models/stock_lot.py
@@ -112,7 +112,12 @@ class StockLot(models.Model):
             if (company and (cross_lots.get((product, name), 0) + count) > 1) or count > 1:
                 error_message_lines.add(_(" - Product: %(product)s, Lot/Serial Number: %(lot)s", product=product.display_name, lot=name))
         if error_message_lines:
-            raise ValidationError(_("The combination of lot/serial number and product must be unique within a company including when no company is defined.\nThe following combinations contain duplicates:\n") + '\n'.join(error_message_lines))
+            raise ValidationError(
+                _(
+                    "The combination of lot/serial number and product must be unique within a company including when no company is defined.\nThe following combinations contain duplicates:\n%(error_lines)s",
+                    error_lines="\n".join(error_message_lines),
+                ),
+            )
 
     def _check_create(self):
         active_picking_id = self.env.context.get('active_picking_id', False)

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1254,7 +1254,7 @@ Please change the quantity done or the rounding precision of your unit of measur
             for quant in quants:
                 sn_to_location += _("\n(%(serial_number)s) exists in location %(location)s", serial_number=quant.lot_id.display_name, location=quant.location_id.display_name)
             return {
-                'warning': {'title': _('Warning'), 'message': _('Unavailable Serial numbers. Please correct the serial numbers encoded:') + sn_to_location}
+                'warning': {'title': _('Warning'), 'message': _('Unavailable Serial numbers. Please correct the serial numbers encoded: %(serial_numbers_to_locations)s', serial_numbers_to_locations=sn_to_location)}
             }
 
     @api.onchange('product_uom')

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -158,13 +158,13 @@ class PickingType(models.Model):
                 if vals.get('warehouse_id'):
                     wh = self.env['stock.warehouse'].browse(vals['warehouse_id'])
                     vals['sequence_id'] = self.env['ir.sequence'].sudo().create({
-                        'name': wh.name + ' ' + _('Sequence') + ' ' + vals['sequence_code'],
+                        'name': _('%(warehouse)s Sequence %(code)s', warehouse=wh.name, code=vals['sequence_code']),
                         'prefix': wh.code + '/' + vals['sequence_code'] + '/', 'padding': 5,
                         'company_id': wh.company_id.id,
                     }).id
                 else:
                     vals['sequence_id'] = self.env['ir.sequence'].sudo().create({
-                        'name': _('Sequence') + ' ' + vals['sequence_code'],
+                        'name': _('Sequence %(code)s', code=vals['sequence_code']),
                         'prefix': vals['sequence_code'], 'padding': 5,
                         'company_id': vals.get('company_id') or self.env.company.id,
                     }).id
@@ -189,13 +189,13 @@ class PickingType(models.Model):
             for picking_type in self:
                 if picking_type.warehouse_id:
                     picking_type.sequence_id.sudo().write({
-                        'name': picking_type.warehouse_id.name + ' ' + _('Sequence') + ' ' + vals['sequence_code'],
+                        'name': _('%(warehouse)s Sequence %(code)s', warehouse=picking_type.warehouse_id.name, code=vals['sequence_code']),
                         'prefix': picking_type.warehouse_id.code + '/' + vals['sequence_code'] + '/', 'padding': 5,
                         'company_id': picking_type.warehouse_id.company_id.id,
                     })
                 else:
                     picking_type.sequence_id.sudo().write({
-                        'name': _('Sequence') + ' ' + vals['sequence_code'],
+                        'name': _('Sequence %(code)s', code=vals['sequence_code']),
                         'prefix': vals['sequence_code'], 'padding': 5,
                         'company_id': picking_type.env.company.id,
                     })

--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -170,13 +170,14 @@ class StockRule(models.Model):
                 suffix += _("<br>If the products are not available in <b>%s</b>, a rule will be triggered to bring products in this location.", source)
             message_dict = {
                 'pull': _(
-                    'When products are needed in <b>%(destination)s</b>, <br/> <b>%(operation)s</b> are created from <b>%(source_location)s</b> to fulfill the need.',
+                    'When products are needed in <b>%(destination)s</b>, <br> <b>%(operation)s</b> are created from <b>%(source_location)s</b> to fulfill the need.',
                     destination=destination,
                     operation=operation,
                     source_location=source,
-                ) + suffix,
+                    suffix=suffix,
+                ),
                 'push': _(
-                    'When products arrive in <b>%(source_location)s</b>, <br/> <b>%(operation)s</b> are created to send them to <b>%(destination)s</b>.',
+                    'When products arrive in <b>%(source_location)s</b>, <br> <b>%(operation)s</b> are created to send them to <b>%(destination)s</b>.',
                     source_location=source,
                     operation=operation,
                     destination=destination,

--- a/addons/stock/models/stock_scrap.py
+++ b/addons/stock/models/stock_scrap.py
@@ -210,7 +210,7 @@ class StockScrap(models.Model):
                 'default_product_uom_name': self.product_id.uom_name
             })
             return {
-                'name': self.product_id.display_name + _(': Insufficient Quantity To Scrap'),
+                'name': _('%(product)s: Insufficient Quantity To Scrap', product=self.product_id.display_name),
                 'view_mode': 'form',
                 'res_model': 'stock.warn.insufficient.qty.scrap',
                 'view_id': self.env.ref('stock.stock_warn_insufficient_qty_scrap_form_view').id,

--- a/addons/stock/models/stock_warehouse.py
+++ b/addons/stock/models/stock_warehouse.py
@@ -1092,17 +1092,17 @@ class Warehouse(models.Model):
         code = code if code else self.code
         return {
             'in_type_id': {
-                'name': name + ' ' + _('Sequence in'),
+                'name': _('%(name)s Sequence in', name=name),
                 'prefix': code + '/IN/', 'padding': 5,
                 'company_id': self.company_id.id,
             },
             'out_type_id': {
-                'name': name + ' ' + _('Sequence out'),
+                'name': _('%(name)s Sequence out', name=name),
                 'prefix': code + '/OUT/', 'padding': 5,
                 'company_id': self.company_id.id,
             },
             'pack_type_id': {
-                'name': name + ' ' + _('Sequence packing'),
+                'name': _('%(name)s Sequence packing', name=name),
                 'prefix': code + '/PACK/', 'padding': 5,
                 'company_id': self.company_id.id,
             },
@@ -1112,22 +1112,22 @@ class Warehouse(models.Model):
                 'company_id': self.company_id.id,
             },
             'qc_type_id': {
-                'name': name + ' ' + _('Sequence quality control'),
+                'name': _('%(name)s Sequence quality control', name=name),
                 'prefix': code + '/QC/', 'padding': 5,
                 'company_id': self.company_id.id,
             },
             'store_type_id': {
-                'name': name + ' ' + _('Sequence storage'),
+                'name': _('%(name)s Sequence storage', name=name),
                 'prefix': code + '/STOR/', 'padding': 5,
                 'company_id': self.company_id.id,
             },
             'int_type_id': {
-                'name': name + ' ' + _('Sequence internal'),
+                'name': _('%(name)s Sequence internal', name=name),
                 'prefix': code + '/INT/', 'padding': 5,
                 'company_id': self.company_id.id,
             },
             'xdock_type_id': {
-                'name': name + ' ' + _('Sequence cross dock'),
+                'name': _('%(name)s Sequence cross dock', name=name),
                 'prefix': code + '/XD/', 'padding': 5,
                 'company_id': self.company_id.id,
             },

--- a/addons/stock_delivery/models/sale_order.py
+++ b/addons/stock_delivery/models/sale_order.py
@@ -27,9 +27,10 @@ class SaleOrder(models.Model):
         if carrier.invoice_policy == 'real':
             sol.update({
                 'price_unit': 0,
-                'name': sol['name']+ _(
-                    ' (Estimated Cost: %s )',
-                    self._format_currency_amount(price_unit)
+                'name': _(
+                    "%(name)s (Estimated Cost: %(cost)s)",
+                    name=sol["name"],
+                    cost=self._format_currency_amount(price_unit),
                 ),
             })
         del context

--- a/addons/stock_landed_costs/models/stock_landed_cost.py
+++ b/addons/stock_landed_costs/models/stock_landed_cost.py
@@ -430,12 +430,13 @@ class AdjustmentLines(models.Model):
 
         # Create account move lines for quants already out of stock
         if qty_out > 0:
+            name_text = _("%(product)s: %(quantity)s already out", product=self.name, quantity=qty_out)
             debit_line = dict(base_line,
-                              name=(self.name + ": " + str(qty_out) + _(' already out')),
+                              name=name_text,
                               quantity=0,
                               account_id=already_out_account_id)
             credit_line = dict(base_line,
-                               name=(self.name + ": " + str(qty_out) + _(' already out')),
+                               name=name_text,
                                quantity=0,
                                account_id=debit_account_id)
             diff = diff * qty_out / self.quantity
@@ -452,11 +453,11 @@ class AdjustmentLines(models.Model):
             if self.env.company.anglo_saxon_accounting:
                 expense_account_id = self.product_id.product_tmpl_id.get_product_accounts()['expense'].id
                 debit_line = dict(base_line,
-                                  name=(self.name + ": " + str(qty_out) + _(' already out')),
+                                  name=name_text,
                                   quantity=0,
                                   account_id=expense_account_id)
                 credit_line = dict(base_line,
-                                   name=(self.name + ": " + str(qty_out) + _(' already out')),
+                                   name=name_text,
                                    quantity=0,
                                    account_id=already_out_account_id)
 

--- a/addons/web/static/src/core/barcode/barcode_video_scanner.js
+++ b/addons/web/static/src/core/barcode/barcode_video_scanner.js
@@ -70,8 +70,9 @@ export class BarcodeVideoScanner extends Component {
                     NotFoundError: _t("No device can be found."),
                     NotAllowedError: _t("Odoo needs your authorization first."),
                 };
-                const errorMessage =
-                    _t("Could not start scanning. ") + (errors[err.name] || err.message);
+                const errorMessage = _t("Could not start scanning. %(message)s", {
+                    message: errors[err.name] || err.message,
+                });
                 this.props.onError(new Error(errorMessage));
                 return;
             }

--- a/addons/web/static/src/views/debug_items.js
+++ b/addons/web/static/src/views/debug_items.js
@@ -58,7 +58,7 @@ export function editView({ accessRights, component, env }) {
         return;
     }
     const displayName = type[0].toUpperCase() + type.slice(1);
-    const description = _t("Edit View: ") + displayName;
+    const description = _t("Edit View: %(displayName)s", { displayName });
     return {
         type: "item",
         description,

--- a/addons/web/static/src/views/fields/gauge/gauge_field.js
+++ b/addons/web/static/src/views/fields/gauge/gauge_field.js
@@ -80,9 +80,9 @@ export class GaugeField extends Component {
                         callbacks: {
                             label: function (tooltipItem) {
                                 if (tooltipItem.dataIndex === 0) {
-                                    return _t("Value: ") + gaugeValue;
+                                    return _t("Value: %(value)s", { value: gaugeValue });
                                 }
-                                return _t("Max: ") + maxLabel;
+                                return _t("Max: %(max)s", { max: maxLabel });
                             },
                         },
                     },

--- a/addons/web/static/src/views/kanban/kanban_record.js
+++ b/addons/web/static/src/views/kanban/kanban_record.js
@@ -350,9 +350,12 @@ export class KanbanRecord extends Component {
                 break;
             }
             default: {
-                return this.notification.add(_t("Kanban: no action for type: ") + type, {
-                    type: "danger",
-                });
+                return this.notification.add(
+                    _t("Kanban: no action for type: %(type)s", { type }),
+                    {
+                        type: "danger",
+                    }
+                );
             }
         }
     }

--- a/addons/web/static/src/webclient/actions/reports/utils.js
+++ b/addons/web/static/src/webclient/actions/reports/utils.js
@@ -34,17 +34,18 @@ export function getReportUrl(action, type, userContext) {
 function getWKHTMLTOPDF_MESSAGES(status) {
     const link = '<br><br><a href="http://wkhtmltopdf.org/" target="_blank">wkhtmltopdf.org</a>'; // FIXME missing markup
     const _status = {
-        broken:
-            _t(
-                "Your installation of Wkhtmltopdf seems to be broken. The report will be shown in html."
-            ) + link,
-        install:
-            _t("Unable to find Wkhtmltopdf on this system. The report will be shown in html.") +
-            link,
-        upgrade:
-            _t(
-                "You should upgrade your version of Wkhtmltopdf to at least 0.12.0 in order to get a correct display of headers and footers as well as support for table-breaking between pages."
-            ) + link,
+        broken: _t(
+            "Your installation of Wkhtmltopdf seems to be broken. The report will be shown in html.%(link)s",
+            { link }
+        ),
+        install: _t(
+            "Unable to find Wkhtmltopdf on this system. The report will be shown in html.%(link)s",
+            { link }
+        ),
+        upgrade: _t(
+            "You should upgrade your version of Wkhtmltopdf to at least 0.12.0 in order to get a correct display of headers and footers as well as support for table-breaking between pages.%(link)s",
+            { link }
+        ),
         workers: _t(
             "You need to start Odoo with at least two workers to print a pdf version of the reports."
         ),

--- a/addons/website/static/src/components/resource_editor/utils.js
+++ b/addons/website/static/src/components/resource_editor/utils.js
@@ -27,7 +27,7 @@ export function checkSCSS(scss) {
                     isValid: false,
                     error: {
                         line,
-                        message: _t("Unexpected ") + scss[i],
+                        message: _t("Unexpected %(char)s", {char: scss[i]}),
                     },
                 };
             }
@@ -40,7 +40,7 @@ export function checkSCSS(scss) {
             isValid: false,
             error: {
                 line,
-                message: _t("Expected ") + MAPPING[stack.pop()],
+                message: _t("Expected %(char)s", {char: MAPPING[stack.pop()]}),
             },
         };
     }

--- a/addons/website/static/src/js/editor/snippets.editor.js
+++ b/addons/website/static/src/js/editor/snippets.editor.js
@@ -320,7 +320,7 @@ export class WebsiteSnippetsMenu extends weSnippetEditor.SnippetsMenu {
             return {
                 isValid: isValid,
                 message: !isValid &&
-                    _t("Invalid API Key. The following error was returned by Google:") + " " + (await response.text()),
+                    _t("Invalid API Key. The following error was returned by Google: %(error)s", {error: await response.text()}),
             };
         } catch {
             return {

--- a/addons/website_blog/models/website_blog.py
+++ b/addons/website_blog/models/website_blog.py
@@ -8,6 +8,7 @@ from odoo import api, models, fields, _
 from odoo.addons.website.tools import text_from_html
 from odoo.tools.json import scriptsafe as json_scriptsafe
 from odoo.tools.translate import html_translate
+from odoo.tools import html_escape
 
 
 class Blog(models.Model):
@@ -163,9 +164,10 @@ class BlogPost(models.Model):
             blog_post.website_url = "/blog/%s/%s" % (self.env['ir.http']._slug(blog_post.blog_id), self.env['ir.http']._slug(blog_post))
 
     def _default_content(self):
-        return '''
-            <p class="o_default_snippet_text">''' + _("Start writing here...") + '''</p>
-        '''
+        text = html_escape(_("Start writing here..."))
+        return """
+            <p class="o_default_snippet_text">%(text)s</p>
+        """ % {"text": text}
     name = fields.Char('Title', required=True, translate=True, default='')
     subtitle = fields.Char('Sub Title', translate=True)
     author_id = fields.Many2one('res.partner', 'Author', default=lambda self: self.env.user.partner_id, index='btree_not_null')

--- a/addons/website_links/static/src/js/website_links_charts.js
+++ b/addons/website_links/static/src/js/website_links_charts.js
@@ -45,7 +45,7 @@ var BarChart = publicWidget.Widget.extend({
             data.push(pt[1]);
         });
 
-        this.$('.title').html(nbClicks + _t(' clicks'));
+        this.$('.title').text(_t('%(clicks)s clicks', {clicks: nbClicks}));
 
         var config = {
             type: 'line',
@@ -95,7 +95,7 @@ var PieChart = publicWidget.Widget.extend({
         }
 
         // Set title
-        this.$('.title').html(this.data.length + _t(' countries'));
+        this.$('.title').text(_t('%(count)s countries', {count: this.data.length}));
 
         var config = {
             type: 'pie',

--- a/addons/website_sale_loyalty/wizard/coupon_share.py
+++ b/addons/website_sale_loyalty/wizard/coupon_share.py
@@ -84,7 +84,7 @@ class CouponShare(models.TransientModel):
             raise UserError(_("Provide either a coupon or a program."))
 
         return {
-            'name': _('Share') + f' {self.env["loyalty.program"]._program_items_name().get((program or coupon).program_type, "")}',
+            'name': _('Share %s', self.env["loyalty.program"]._program_items_name().get((program or coupon).program_type, "")),
             'type': 'ir.actions.act_window',
             'view_mode': 'form',
             'res_model': 'coupon.share',

--- a/odoo/addons/base/models/ir_mail_server.py
+++ b/odoo/addons/base/models/ir_mail_server.py
@@ -442,10 +442,11 @@ class IrMailServer(models.Model):
                     raise UserError(_('Could not load your certificate / private key. \n%s', str(e)))
 
         if not smtp_server:
-            raise UserError(
-                (_("Missing SMTP Server") + "\n" +
-                 _("Please define at least one SMTP server, "
-                   "or provide the SMTP parameters explicitly.")))
+            raise UserError(_(
+                "Missing SMTP Server\n"
+                "Please define at least one SMTP server, "
+                "or provide the SMTP parameters explicitly.",
+            ))
 
         if smtp_encryption == 'ssl':
             if 'SMTP_SSL' not in smtplib.__all__:

--- a/odoo/addons/base/models/ir_rule.py
+++ b/odoo/addons/base/models/ir_rule.py
@@ -238,12 +238,12 @@ class IrRule(models.Model):
         if company_related:
             suggested_companies = records_sudo._get_redirect_suggested_company()
             if suggested_companies and len(suggested_companies) != 1:
-                resolution_info += "\n\n" + _('Note: this might be a multi-company issue. Switching company may help - in Odoo, not in real life!')
+                resolution_info += _('\n\nNote: this might be a multi-company issue. Switching company may help - in Odoo, not in real life!')
             elif suggested_companies and suggested_companies in self.env.user.company_ids:
                 context = {'suggested_company': {'id': suggested_companies.id, 'display_name': suggested_companies.display_name}}
-                resolution_info += "\n\n" + _('This seems to be a multi-company issue, you might be able to access the record by switching to the company: %s.', suggested_companies.display_name)
+                resolution_info += _('\n\nThis seems to be a multi-company issue, you might be able to access the record by switching to the company: %s.', suggested_companies.display_name)
             elif suggested_companies:
-                resolution_info += "\n\n" + _('This seems to be a multi-company issue, but you do not have access to the proper company to access the record anyhow.')
+                resolution_info += _('\n\nThis seems to be a multi-company issue, but you do not have access to the proper company to access the record anyhow.')
 
         if not self.env.user.has_group('base.group_no_one') or not self.env.user._is_internal():
             msg = f"{operation_error}\n{failing_model}\n\n{resolution_info}"

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -1328,7 +1328,7 @@ class BaseModel(metaclass=MetaModel):
                 except Exception as e:
                     _logger.debug("Error while loading record", exc_info=True)
                     info = rec_data['info']
-                    message = (_(u'Unknown error during import:') + u' %s: %s' % (type(e), e))
+                    message = _('Unknown error during import: %(error_type)s: %(error_message)s', error_type=type(e), error_message=e)
                     moreinfo = _('Resolve other errors first')
                     messages.append(dict(info, type='error', message=message, moreinfo=moreinfo))
                     # Failed for some reason, perhaps due to invalid data supplied,
@@ -4322,10 +4322,13 @@ class BaseModel(metaclass=MetaModel):
             return
         _logger.info('Failed operation on deleted record(s): %s, uid: %s, model: %s', operation, self._uid, self._name)
         raise MissingError(
-            _('One of the documents you are trying to access has been deleted, please try again after refreshing.')
-            + '\n\n({} {}, {} {}, {} {}, {} {})'.format(
-                _('Document type:'), self._name, _('Operation:'), operation,
-                _('Records:'), invalid.ids[:6], _('User:'), self._uid,
+            _(
+                'One of the documents you are trying to access has been deleted, please try again after refreshing.\n\n'
+                'Document type: %(document_type)s, Operation: %(operation)s, Records: %(records)s, User: %(user)s',
+                document_type=self._name,
+                operation=operation,
+                records=invalid.ids[:6],
+                user=self._uid,
             )
         )
 

--- a/odoo/tools/template_inheritance.py
+++ b/odoo/tools/template_inheritance.py
@@ -211,7 +211,7 @@ def apply_inheritance_specs(source, specs_tree, inherit_branding=False, pre_loca
                     node.text = spec.text
 
                 else:
-                    raise ValueError(_("Invalid mode attribute:") + " '%s'" % mode)
+                    raise ValueError(_("Invalid mode attribute: “%s”", mode))
             elif pos == 'attributes':
                 for child in spec.getiterator('attribute'):
                     # The element should only have attributes:


### PR DESCRIPTION
There are many places in the code where translated strings are concatenated to other strings, translated or untranslated.
While it is sometimes the right thing to do, there are also a lot of problematic cases:
- When concatenating untranslated strings, it obviously means they won't be translated, even though they sometimes should be
- Even if they don't need to be, the order of words can vary greatly between languages, and including it makes reordering easier.
- The same issue can arise when concatenating multiple translated strings, especially if they are part of one sentence.

This commit fixes the problematic occurrences of concatenation.
It also adds some named placeholders and uses of the `format_list` helper.

Enterprise: https://github.com/odoo/enterprise/pull/65834

Task-3997249