### PR TITLE
[FIX] point_of_sale: ensure loading of archived attribute values

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1400,7 +1400,7 @@ class PosOrderLine(models.Model):
         return {
             'id': orderline.id,
             'qty': orderline.qty,
-            'attribute_value_ids': orderline.attribute_value_ids.ids,
+            'attribute_value_ids': orderline.attribute_value_ids.filtered(lambda av: av.ptav_active).ids,
             'custom_attribute_value_ids': orderline.custom_attribute_value_ids.read(['id', 'name', 'custom_product_template_attribute_value_id', 'custom_value'], load=False),
             'price_unit': orderline.price_unit,
             'skip_change': orderline.skip_change,


### PR DESCRIPTION
Following the changes introduced in https://github.com/odoo/odoo/commit/5a452e9baecb32d3a7de7b975841a1a981b20dcc, archived product template attribute values were not being loaded, leading to errors when loading paid orders.

opw-4012873

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
