### PR TITLE
[IMP] sale: system parameter to track draft orders

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1446,7 +1446,8 @@ class SaleOrder(models.Model):
         if (len(self) == 1
             # The method _track_finalize is sometimes called too early or too late and it
             # might cause a desynchronization with the cache, thus this condition is needed.
-            and self.env.cache.contains(self, self._fields['state']) and self.state == 'draft'):
+            and self.env.cache.contains(self, self._fields['state']) and self.state == 'draft'
+            and not self.env['ir.config_parameter'].sudo().get_param('sale.track_draft_orders')):
             self.env.cr.precommit.data.pop(f'mail.tracking.{self._name}', {})
             self.env.flush_all()
             return


### PR DESCRIPTION
before this commit, there is no option to enable
tracking for draft sale orders. In some cases
end users need this functionality, right now we
have to customize and make this possible

after this commit, a new system parameter 
is introduced sale.track_draft_orders , 
by which end user can control the tracking.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
