### PR TITLE
[FIX] loyalty: gift card report shows expiration text incorrectly

### DIFF
--- a/addons/loyalty/report/loyalty_report_templates.xml
+++ b/addons/loyalty/report/loyalty_report_templates.xml
@@ -95,7 +95,7 @@
                         <span t-field="o.code"/>
                     </p>
                 </div>
-                <div style="padding:0; margin:0px; padding-top:10px; padding-bottom:10px; text-align:center;">
+                <div t-if="o.expiration_date" style="padding:0; margin:0px; padding-top:10px; padding-bottom:10px; text-align:center;">
                     <h3 style="margin:0px; line-height:17px; font-family:arial, 'helvetica neue', helvetica, sans-serif; font-size:14px; font-style:normal; font-weight:normal; color:#A9A9A9; text-align:center">
                         Card expires <span t-field="o.expiration_date"/>
                     </h3>


### PR DESCRIPTION
When printing the gift card report the text saying "Card expires" would show despite there being no expiration date.

Added a t-if to check if the field is populated before displaying that text.

Backport of https://github.com/odoo/odoo/commit/ec4d3f0a3233b64931b39a0cd9f27d536888010c

opw-4016994