### PR TITLE
[FIX] loyalty: error when adding expiration date to loyalty card

### DIFF
--- a/addons/loyalty/i18n/loyalty.pot
+++ b/addons/loyalty/i18n/loyalty.pot
@@ -877,6 +877,13 @@ msgstr ""
 
 #. module: loyalty
 #. odoo-python
+#: code:addons/loyalty/models/loyalty_card.py:0
+#, python-format
+msgid "Expiration date cannot be set on a loyalty card."
+msgstr ""
+
+#. module: loyalty
+#. odoo-python
 #: code:addons/loyalty/models/loyalty_program.py:0
 #: code:addons/loyalty/models/loyalty_program.py:0
 #, python-format

--- a/addons/loyalty/models/loyalty_card.py
+++ b/addons/loyalty/models/loyalty_card.py
@@ -54,6 +54,12 @@ class LoyaltyCard(models.Model):
         for card in self:
             card.points_display = card._format_points(card.points)
 
+    @api.onchange('expiration_date')
+    def _restrict_expiration_on_loyalty(self):
+        for card in self:
+            if card.program_type == 'loyalty':
+                raise ValidationError(_("Expiration date cannot be set on a loyalty card."))
+
     def _format_points(self, points):
         self.ensure_one()
         if self.point_name == self.program_id.currency_id.symbol:


### PR DESCRIPTION
Expiration dates on loyalty cards are available to be used, but do notdo anything. Added a validation error when expiration dates are added to loyalty cards to warn about this.

opw-3997339
