### PR TITLE
[IMP] hr_holidays: simplify kanban archs

### DIFF
--- a/addons/hr_holidays/static/src/scss/accrual_plan_level.scss
+++ b/addons/hr_holidays/static/src/scss/accrual_plan_level.scss
@@ -32,12 +32,8 @@ $o-hr-holidays-border-color: map-get($grays, '300');
 
         .o_kanban_renderer.o_kanban_ungrouped .o_kanban_record {
             counter-increment: o-hr-holidays-accrual-plan-level-counter;
-            display: flex;
             flex: 0 0 100%;
-            border: 0px;
             padding: 0px 0px 0px 100px;
-            margin: 0px 0px 0px 0px;
-            background-color: transparent;
 
             // Timeline Border
             &:before {
@@ -55,8 +51,8 @@ $o-hr-holidays-border-color: map-get($grays, '300');
 
             // Whole record
             .o_hr_holidays_body {
-                margin-left: 8px;
-                padding-top: 20px;
+                margin-left: 16px;
+                padding-top: 28px;
 
                 // Left side 'Level'
                 .o_hr_holidays_timeline {

--- a/addons/hr_holidays/views/hr_leave_accrual_views.xml
+++ b/addons/hr_holidays/views/hr_leave_accrual_views.xml
@@ -144,29 +144,14 @@
                             >
                             <kanban default_order="sequence">
                                 <field name="sequence"/>
-                                <field name="start_count"/>
-                                <field name="start_type"/>
-                                <field name="added_value"/>
-                                <field name="added_value_type"/>
-                                <field name="frequency"/>
-                                <field name="week_day"/>
-                                <field name="first_day"/>
-                                <field name="second_day"/>
-                                <field name="first_month_day"/>
-                                <field name="first_month"/>
-                                <field name="second_month_day"/>
-                                <field name="second_month"/>
-                                <field name="yearly_day"/>
-                                <field name="yearly_month"/>
-                                <field name="maximum_leave"/>
                                 <field name="action_with_unused_accruals"/>
                                 <field name="cap_accrued_time"/>
                                 <templates>
-                                    <div t-name="kanban-box" class="border-0 bg-transparent">
-                                        <div class="o_hr_holidays_body oe_kanban_global_click">
+                                    <div t-name="kanban-card" class="bg-transparent border-0">
+                                        <div class="o_hr_holidays_body">
                                             <div class="o_hr_holidays_timeline text-center">
                                                 <t t-if="record.start_count.raw_value > 0">
-                                                    after <t t-esc="record.start_count.value"/> <t t-esc="record.start_type.value"/>
+                                                    after <field name="start_count"/> <field name="start_type"/>
                                                 </t>
                                                 <t t-else="">
                                                     initially
@@ -212,9 +197,9 @@
                                                     <div class="pe-0 me-0" style="width: 6rem;">
                                                         Cap:
                                                     </div>
-                                                    <div class="col-3 m-0 ps-1">
-                                                        <t t-if="record.cap_accrued_time.raw_value &amp;&amp; record.maximum_leave.raw_value > 0">
-                                                            <field name="maximum_leave" widget="FloatWithoutTrailingZeros"/> <field name="added_value_type"/>
+                                                    <div class="col-3 m-0 ps-1 d-flex">
+                                                        <t t-if="record.cap_accrued_time.raw_value and record.maximum_leave.raw_value > 0">
+                                                            <field name="maximum_leave" widget="FloatWithoutTrailingZeros"/> <field class="ms-1" name="added_value_type"/>
                                                         </t>
                                                         <t t-else="">
                                                             Unlimited
@@ -227,7 +212,7 @@
                                                     </div>
                                                     <div class="col-3 m-0 ps-1">
                                                         <t t-if="record.action_with_unused_accruals.raw_value === 'all'">all</t>
-                                                        <t t-elif="record.action_with_unused_accruals.raw_value == 'maximum'">up to <field name="postpone_max_days" /> <t t-esc="record.added_value_type.raw_value" /></t>
+                                                        <t t-elif="record.action_with_unused_accruals.raw_value == 'maximum'">up to <field name="postpone_max_days" /> <field name="added_value_type" /></t>
                                                         <t t-else="">no</t>
                                                     </div>
                                                 </div>

--- a/addons/hr_holidays/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays/views/hr_leave_allocation_views.xml
@@ -360,51 +360,42 @@
         <field name="model">hr.leave.allocation</field>
         <field name="arch" type="xml">
             <kanban class="o_kanban_mobile" create="0" sample="1">
-                <field name="employee_id"/>
-                <field name="date_from"/>
-                <field name="date_to"/>
-                <field name="name"/>
-                <field name="number_of_days"/>
                 <field name="can_approve"/>
-                <field name="state"/>
-                <field name="holiday_status_id"/>
                 <templates>
                     <t t-name="kanban-menu" groups="base.group_user">
                         <a t-if="widget.editable" role="menuitem" type="edit" class="dropdown-item">Edit Allocation</a>
                         <a t-if="widget.deletable" role="menuitem" type="delete" class="dropdown-item">Delete</a>
                     </t>
-                    <t t-name="kanban-box">
-                        <div class="oe_kanban_global_click container">
-                            <div class="row g-0">
-                                <div class="col-3">
-                                    <img t-att-src="kanban_image('hr.employee', 'avatar_128', record.employee_id.raw_value)"
-                                        t-att-title="record.employee_id.value"
-                                        t-att-alt="record.employee_id.value"
-                                        class="o_image_64_cover float-start mr4"/>
-                                </div>
-                                <div class="col-9">
-                                    <span class="badge rounded-pill float-end mt4 mr16"><t t-esc="record.number_of_days.value"/> days</span>
-                                    <strong class="o_kanban_record_title"><t t-esc="record.employee_id.value"/></strong>
-                                    <div class="text-muted o_kanban_record_subtitle">
-                                        <t t-esc="record.holiday_status_id.value"/>
-                                    </div>
-                                    <div t-if="['validate', 'refuse'].includes(record.state.raw_value)">
-                                        <span t-if="record.state.raw_value === 'validate'" class="fa fa-check text-muted" aria-label="validated"/>
-                                        <span t-else="" class="fa fa-ban text-muted" aria-label="refused"/>
-                                        <t t-set="classname" t-value="{'validate': 'text-bg-success', 'refuse': 'text-bg-danger'}[record.state.raw_value] || 'text-bg-light'"/>
-                                        <span t-attf-class="badge rounded-pill {{ classname }}"><t t-esc="record.state.value"/></span>
-                                    </div>
-                                    <div t-if="record.can_approve.raw_value">
-                                        <button t-if="record.state.raw_value === 'confirm'" name="action_validate" type="object" class="btn btn-link btn-sm ps-0">
-                                            <i class="fa fa-check"/> Validate
-                                        </button>
-                                        <button t-if="record.state.raw_value === 'confirm'" name="action_refuse" type="object" class="btn btn-link btn-sm ps-0">
-                                            <i class="fa fa-times"/> Refuse
-                                        </button>
-                                    </div>
-                                </div>
+                    <t t-name="kanban-card" class="flex-row">
+                        <aside>
+                            <field name="employee_id"
+                                widget="image"
+                                options="{'preview_image': 'avatar_128'}"
+                                t-att-title="record.employee_id.value"
+                                t-att-alt="record.employee_id.value"
+                                class="o_image_64_cover float-start mr4"/>
+                        </aside>
+                        <main class="w-100 ps-3">
+                            <div class="flex-row mb-1">
+                                <field class="fw-bold fs-5" name="employee_id"/>
+                                <span class="badge rounded-pill float-end mt4 mr16"><field name="number_of_days"/> days</span>
                             </div>
-                        </div>
+                            <field class="text-muted" name="holiday_status_id"/>
+                            <div t-if="['validate', 'refuse'].includes(record.state.raw_value)">
+                                <span t-if="record.state.raw_value === 'validate'" class="fa fa-check text-muted" aria-label="validated"/>
+                                <span t-else="" class="fa fa-ban text-muted" aria-label="refused"/>
+                                <t t-set="classname" t-value="{'validate': 'text-bg-success', 'refuse': 'text-bg-danger'}[record.state.raw_value] || 'text-bg-light'"/>
+                                <span t-attf-class="badge rounded-pill {{ classname }}"><field name="state"/></span>
+                            </div>
+                            <div t-if="record.can_approve.raw_value and record.state.raw_value === 'confirm'">
+                                <button name="action_validate" type="object" class="btn btn-link btn-sm ps-0">
+                                    <i class="fa fa-check"/> Validate
+                                </button>
+                                <button name="action_refuse" type="object" class="btn btn-link btn-sm ps-0">
+                                    <i class="fa fa-times"/> Refuse
+                                </button>
+                            </div>
+                        </main>
                     </t>
                 </templates>
             </kanban>

--- a/addons/hr_holidays/views/hr_leave_type_views.xml
+++ b/addons/hr_holidays/views/hr_leave_type_views.xml
@@ -109,15 +109,11 @@
         <field name="arch" type="xml">
             <kanban class="o_kanban_mobile">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div t-attf-class="oe_kanban_global_click">
-                            <div>
-                                <strong><field name="name"/></strong>
-                            </div>
-                            <div>
-                                <span>Max Time Off: <field name="max_leaves"/></span>
-                                <span class="float-end">Time Off Taken: <field name="leaves_taken"/></span>
-                            </div>
+                    <t t-name="kanban-card">
+                        <field class="fw-bold" name="name"/>
+                        <div>
+                            Max Time Off: <field name="max_leaves"/>
+                            <span class="float-end">Time Off Taken: <field name="leaves_taken"/></span>
                         </div>
                     </t>
                 </templates>

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -109,70 +109,54 @@
         <field name="model">hr.leave</field>
         <field name="arch" type="xml">
             <kanban class="o_kanban_mobile" create="0" sample="1">
-                <field name="employee_id"/>
-                <field name="date_from"/>
-                <field name="date_to"/>
-                <field name="name"/>
-                <field name="number_of_days"/>
-                <field name="can_approve"/>
-                <field name="holiday_status_id"/>
-                <field name="state"/>
                 <field name="supported_attachment_ids_count"/>
                 <templates>
                     <t t-name="kanban-menu" groups="base.group_user">
                         <a t-if="widget.editable" role="menuitem" type="edit" class="dropdown-item">Edit Time Off</a>
                         <a t-if="widget.deletable" role="menuitem" type="delete" class="dropdown-item">Delete</a>
                     </t>
-                    <t t-name="kanban-box">
-                        <div class="d-flex flex-column justify-content-between oe_kanban_global_click container">
-                            <div class="row g-0">
-                                <div class="o_leave_kanban_info col-12">
-                                    <span class="badge rounded-pill float-end mt4 mr16"><t t-esc="record.number_of_days.value"/> days</span>
-                                    <strong class="o_kanban_record_title"><t t-out="record.employee_id.value"/></strong>
-                                    <div class="text-muted o_kanban_record_subtitle">
-                                        <t t-esc="record.holiday_status_id.value"/>
-                                    </div>
-                                    <div>
-                                        <span class="text-muted">from </span>
-                                        <field name="date_from" readonly="state in ['cancel', 'refuse', 'validate', 'validate1']"/>
-                                        <span class="text-muted"> to </span>
-                                        <field name="date_to" readonly="state in ['cancel', 'refuse', 'validate', 'validate1']"/>
-                                    </div>
-                                    <div class="o_leave_kanban_name p-2">
-                                        <field name="name" nolabel="1"/>
-                                    </div>
-                                </div>
+                    <t t-name="kanban-card" class="row g-0">
+                        <div class="ms-3 col">
+                            <span class="badge rounded-pill float-end"><field name="number_of_days"/> days</span>
+                            <field class="fw-bold fs-5" name="employee_id"/>
+                            <field class="text-muted d-block" name="holiday_status_id"/>
+                            <div class="mb-1">
+                                <span class="text-muted">from </span>
+                                <field name="date_from" readonly="state in ['cancel', 'refuse', 'validate', 'validate1']"/>
+                                <span class="text-muted"> to </span>
+                                <field name="date_to" readonly="state in ['cancel', 'refuse', 'validate', 'validate1']"/>
                             </div>
-                            <div class="d-flex justify-content-end">
-                                <div class="me-2 d-flex align-items-center" t-if="!['draft'].includes(record.state.raw_value)">
-                                    <span t-if="record.state.raw_value === 'validate'" class="fa fa-check text-muted me-1" aria-label="validated"/>
-                                    <span t-if="record.state.raw_value === 'refuse'" class="fa fa-ban text-muted me-1" aria-label="refused"/>
-                                    <span t-if="['confirm', 'validate1'].includes(record.state.raw_value)" class="me-1" aria-label="to refuse"/>
-                                    <t t-set="classname"
-                                        t-value="{'validate': 'text-bg-success', 'refuse': 'text-bg-danger', 'cancel': 'text-bg-danger', 'confirm': 'text-bg-warning', 'validate1': 'text-bg-warning'}[record.state.raw_value] || 'text-bg-light'"/>
-                                    <span t-attf-class="badge rounded-pill {{ classname }}">
-                                        <t t-out="record.state.value"/>
-                                    </span>
-                                </div>
-                                <div class="me-2 align-items-center" t-if="['confirm', 'validate1'].includes(record.state.raw_value)">
-                                    <button t-if="record.state.raw_value === 'confirm'" name="action_approve" type="object" class="btn btn-link btn-sm ps-0"
-                                        groups="hr_holidays.group_hr_holidays_user">
-                                        <i class="fa fa-thumbs-up"/> Approve
-                                    </button>
-                                    <button t-if="record.state.raw_value === 'validate1'" name="action_validate" type="object" class="btn btn-link btn-sm ps-0"
-                                        groups="hr_holidays.group_hr_holidays_manager">
-                                        <i class="fa fa-check"/> Validate
-                                    </button>
-                                    <button t-if="['confirm', 'validate1'].includes(record.state.raw_value)" name="action_refuse" type="object" class="btn btn-link btn-sm ps-0"
-                                        groups="hr_holidays.group_hr_holidays_user">
-                                        <i class="fa fa-times"/> Refuse
-                                    </button>
-                                </div>
-                                <div class="text-end">
-                                    <button t-if="record.supported_attachment_ids_count.raw_value > 0" name="action_documents" type="object" class="btn btn-link btn-sm ps-0">
-                                        <i class="fa fa-paperclip"> <field name="supported_attachment_ids_count" nolabel="1"/></i>
-                                    </button>
-                                </div>
+                            <field class="p-2" name="name" nolabel="1"/>
+                        </div>
+                        <div class="d-flex">
+                            <div class="me-2 ms-auto" t-if="!['draft'].includes(record.state.raw_value)">
+                                <span t-if="record.state.raw_value === 'validate'" class="fa fa-check text-muted me-1" aria-label="validated"/>
+                                <span t-if="record.state.raw_value === 'refuse'" class="fa fa-ban text-muted me-1" aria-label="refused"/>
+                                <span t-if="['confirm', 'validate1'].includes(record.state.raw_value)" class="me-1" aria-label="to refuse"/>
+                                <t t-set="classname"
+                                    t-value="{'validate': 'text-bg-success', 'refuse': 'text-bg-danger', 'cancel': 'text-bg-danger', 'confirm': 'text-bg-warning', 'validate1': 'text-bg-warning'}[record.state.raw_value] || 'text-bg-light'"/>
+                                <span t-attf-class="badge rounded-pill {{ classname }}">
+                                    <field name="state"/>
+                                </span>
+                            </div>
+                            <div t-if="['confirm', 'validate1'].includes(record.state.raw_value)">
+                                <button t-if="record.state.raw_value === 'confirm'" name="action_approve" type="object" class="btn btn-link btn-sm ps-0"
+                                    groups="hr_holidays.group_hr_holidays_user">
+                                    <i class="fa fa-thumbs-up"/> Approve
+                                </button>
+                                <button t-if="record.state.raw_value === 'validate1'" name="action_validate" type="object" class="btn btn-link btn-sm ps-0"
+                                    groups="hr_holidays.group_hr_holidays_manager">
+                                    <i class="fa fa-check"/> Validate
+                                </button>
+                                <button t-if="['confirm', 'validate1'].includes(record.state.raw_value)" name="action_refuse" type="object" class="btn btn-link btn-sm ps-0"
+                                    groups="hr_holidays.group_hr_holidays_user">
+                                    <i class="fa fa-times"/> Refuse
+                                </button>
+                            </div>
+                            <div class="text-end">
+                                <button t-if="record.supported_attachment_ids_count.raw_value > 0" name="action_documents" type="object" class="btn btn-link btn-sm ps-0">
+                                    <i class="fa fa-paperclip"> <field name="supported_attachment_ids_count" nolabel="1"/></i>
+                                </button>
                             </div>
                         </div>
                     </t>
@@ -187,18 +171,13 @@
         <field name="mode">primary</field>
         <field name="model">hr.leave</field>
         <field name="arch" type="xml">
-            <xpath expr="//div[hasclass('o_leave_kanban_info')]" position='before'>
-                <div class="col-3">
-                    <img t-att-src="kanban_image('hr.employee', 'avatar_128', record.employee_id.raw_value)"
-                        t-att-title="record.employee_id.value"
-                        t-att-alt="record.employee_id.value"
-                        class="o_image_64_cover float-start mr4"/>
-                </div>
+            <xpath expr="//field[@name='number_of_days']/../.." position='before'>
+                <field name="employee_id" widget="image" options="{'preview_image': 'avatar_128'}"
+                    t-att-title="record.employee_id.value"
+                    t-att-alt="record.employee_id.value"
+                    class="o_image_64_cover float-start me-2 col-3"/>
             </xpath>
-            <xpath expr="//div[hasclass('o_leave_kanban_info')]" position="attributes">
-                <attribute name="class">o_leave_kanban_info col-9</attribute>
-            </xpath>
-            <xpath expr="//div[hasclass('o_leave_kanban_name')]" position="replace"/>
+            <xpath expr="//field[@name='name']" position="replace"/>
         </field>
     </record>
 
@@ -651,9 +630,9 @@
         <field name="mode">primary</field>
         <field name="model">hr.leave</field>
         <field name="arch" type="xml">
-            <strong class="o_kanban_record_title" position='attributes'>
+            <field name="employee_id" position='attributes'>
                 <attribute name="invisible">1</attribute>
-            </strong>
+            </field>
         </field>
     </record>
 


### PR DESCRIPTION
In this commit we have simplified the kanban arch for the hr_holidays module. The goal is to simplify them, make them easier to read, and use bootstrap utility classnames.
- Previously, we used `kanban-box`, but now we are using `kanban-card` instead.
- Deprecated `oe_kanban_global_click` and `oe_kanban_global_click_edit`.
- More use of `<field/>` tags
- Removed the `oe_kanban_colorpicker` class and replaced it with the `kanban_color_picker` widget.
- Changed type='edit' to type='open' to open records. since version 16, records always open in edit mode by default.
- `kanban_image` from rendering context, is deprecated so we use `<field name=... widget=image/>` instead

Task-3992107

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
