### PR TITLE
[FIX] web_editor: line breaks at edges of block anchor nested within li

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/shiftEnter.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/shiftEnter.js
@@ -9,6 +9,7 @@ import {
     getState,
     leftPos,
     splitTextNode,
+    isBlock,
 } from '../utils/utils.js';
 
 Text.prototype.oShiftEnter = function (offset) {
@@ -60,9 +61,16 @@ HTMLAnchorElement.prototype.oShiftEnter = function () {
     }
     if (brs.includes(firstChild)) {
         brs.forEach(br => anchor.before(br));
-        setSelection(...rightPos(brs[brs.length - 1]));
     } else if (brs.includes(lastChild)) {
+        const brToRemove = isBlock(anchor) && brs.pop();
         brs.forEach(br => anchor.after(br));
-        setSelection(...rightPos(brs[0]));
+        if (brToRemove) {
+            // When the anchor tag is block, keeping the two `br` tags
+            // would have resulted into two new lines instead of one.
+            brToRemove.remove();
+            setSelection(...leftPos(brs[0]));
+        } else {
+            setSelection(...rightPos(brs[0]));
+        }
     }
 }

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/editor.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/editor.test.js
@@ -3885,6 +3885,11 @@ X[]
                         contentAfter: '<div><a>ab</a><br><br>[]</div>',
                     });
                     await testEditor(BasicEditor, {
+                        contentBefore: '<div><a style="display: block;">ab[]</a></div>',
+                        stepFunction: pressEnter,
+                        contentAfter: '<div><a style="display: block;">ab</a>[]<br></div>'
+                    })
+                    await testEditor(BasicEditor, {
                         contentBefore: '<div><a>ab[]</a>cd</div>',
                         stepFunction: pressEnter,
                         contentAfter: '<div><a>ab</a><br>[]cd</div>',

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -2433,10 +2433,16 @@ const Wysiwyg = Widget.extend({
         }
     },
     _onSelectionChange() {
-        if (this.odooEditor.autohideToolbar && this.linkPopover) {
+        if (this.linkPopover && this.isSelectionInEditable()) {
             const selectionInLink = getInSelection(this.odooEditor.document, 'a') === this.linkPopover.target;
             const isVisible = this.linkPopover.el.offsetParent;
-            if (isVisible && !selectionInLink) {
+            if (
+                isVisible &&
+                (
+                    (this.options.autohideToolbar && !this.odooEditor.document.getSelection().isCollapsed) ||
+                    !selectionInLink
+                )
+            ) {
                 this.linkPopover.hide();
             }
         }


### PR DESCRIPTION
Description of the issue this PR addresses:

I. Commit [1] handled cases of pressing enter at the edge of an anchor, which is a
child of an unbreakable element. The commit inserted the `br`'s after anchors;
however, it missed the situation where the anchor tags are block elements nested
inside an unbreakable element inside a `li`. In this specific case, inserting
two `br` tags after a anchor block resulted in the creation of two new lines.
This PR handles that case by only inserting one `br` tag after the anchor,
rather than both.

II. Previously when changing selection between links in website, when clicking on a
link the previous link used to get selected. This commit makes sure that when
changing selection in between links it selects the correct link.

III. This PR ensures that the link popover closes when the cursor moves outside
the link.

[1]: https://github.com/odoo/odoo/commit/df6f8dd0c54c40ea7edbd3821ae068d79b1b7af7

task-3631910

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
