### PR TITLE
[FIX] hr_attendance: fix traceback in attendance kanban view

### DIFF
--- a/addons/hr_attendance/views/hr_employee_view.xml
+++ b/addons/hr_attendance/views/hr_employee_view.xml
@@ -109,7 +109,7 @@
         <field name="model">hr.employee</field>
         <field name="priority">99</field>
         <field name="arch" type="xml">
-            <kanban create="false" action="action_employee_kiosk_confirm" type="object">
+            <kanban create="false">
                 <field name="attendance_state"/>
                 <field name="hours_today"/>
                 <field name="total_overtime"/>


### PR DESCRIPTION
Version 17.0
steps to produce:

- open 'hr_employees_view_kanban' in debug mode by searching in 'open view'
- open hr attendance kanban view
- click on kanban record
- The method 'action_employee_kiosk_confirm' does not exist on the model 'hr.employee'

issue:
faced with a traceback

cause:
'action_employee_kiosk_confirm' action was removed from hr.employee.public

solution:
remove 'action_employee_kiosk_confirm' action from 'hr_employees_view_kanban' view.

task-4022620
