### PR TITLE
[IMP] website_blog: turn blog post content into sections

### DIFF
--- a/addons/website_blog/__manifest__.py
+++ b/addons/website_blog/__manifest__.py
@@ -21,6 +21,7 @@
         'views/website_blog_templates.xml',
         'views/snippets/snippets.xml',
         'views/snippets/s_blog_posts.xml',
+        'views/snippets/s_text_block.xml',
         'views/snippets/s_dynamic_snippet_blog_posts_preview_data.xml',
         'views/website_pages_views.xml',
         'views/blog_post_add.xml',

--- a/addons/website_blog/data/website_blog_demo.xml
+++ b/addons/website_blog/data/website_blog_demo.xml
@@ -45,6 +45,7 @@
             <field name="tag_ids" eval="[(6, 0, [ref('blog_tag_1'), ref('blog_tag_2')])]"/>
             <field name="cover_properties">{"background-image": "url('/website_blog/static/src/img/cover_1.jpg')", "resize_class": "o_record_has_cover o_half_screen_height", "opacity": "0"}</field>
             <field name="content"><![CDATA[
+<section class="s_text_block pt16 pb16" data-snippet="s_text_block"><div class="s_allow_columns o_container_small">
 <p class="lead">Sierra Tarahumara, popularly known as Copper Canyon is situated in Mexico. The area is a favorite destination among those seeking an adventurous vacation.</p>
 <p>Copper Canyon is one of the six gorges in the area. Although the name suggests that the gorge might have some relevance to copper mining, this is not the case. The name is derived from the copper and green lichen covering the canyon. Copper Canyon has two climatic zones. The region features an alpine climate at the top and a subtropical climate at the lower levels. Winters are cold with frequent snowstorms at the higher altitudes. Summers are dry and hot. The capital city, Chihuahua, is a high altitude desert where weather ranges from cold winters to hot summers. The region is unique because of the various ecosystems that exist within it.</p>
 
@@ -67,6 +68,7 @@
 
 <p>A traveler may choose to explore the area by hiking around the canyon or venturing into it. Detailed planning is required for those who wish to venture into the depths of the canyon. There are a number of travel companies that specialize in organizing tours to the region. Visitors can fly to Copper Canyon using a tourist visa, which is valid for 180 days. Travelers can also drive from anywhere in the United States and acquire a visa at the Mexican customs station at the border.</p>
 <p>A holiday to the Copper Canyon promises to be an exciting mix of relaxation, culture, history, wildlife and hiking.</p>
+</div></section>
 ]]>
             </field>
         </record>
@@ -82,7 +84,7 @@
             <field name="visits">246</field>
             <field name="cover_properties">{"background-image": "url('/website_blog/static/src/img/cover_2.jpg')", "resize_class": "o_record_has_cover o_half_screen_height", "opacity": "0.4"}</field>
             <field name="content"><![CDATA[
-<section class="container">
+<section class="s_text_block pt16 pb16" data-snippet="s_text_block"><div class="s_allow_columns o_container_small">
     <div class="row">
         <div class="col">
             <p class="lead">Maui helicopter tours are a great way to see the island from a different perspective and have a fun adventure. If you have never been on a helicopter before, this is a great place to do it.</p>
@@ -95,7 +97,6 @@
             </figure>
         </div>
     </div>
-</section>
 
 <h2 class="mt-5">East Maui</h2>
 <figure class="mt-2 mb-4">
@@ -116,6 +117,7 @@
 People who live on the island have never even seen this remarkable scenery unless they have taken Maui helicopter tours to view it. When the weather has been rainy and there is a lot of rainfall for he season you will see many astounding waterfalls.</p>
 <p>The cliffs in this region are among the highest in the world and to see water cascading from the high peaks is simply breathtaking. The short jaunt from Maui with Maui helicopter tours is well worth seeing the beauty of this natural environment.</p>
 <p>Maui helicopter tours are a great way to tour those places that can not be reached on foot or by car. The tours last approximately one hour and range from approximately one hundred eight five dollars to two hundred forty dollars person. For many, this is a once in a lifetime opportunity to see natural scenery that will not be available again. Taking cameras and videos to capture the moments will also allow you to relive the tour again and again as you reminisce throughout the years.</p>
+</div></section>
 ]]>
             </field>
         </record>
@@ -131,6 +133,7 @@ People who live on the island have never even seen this remarkable scenery unles
             <field name="published_date" eval="(datetime.now()-relativedelta(days=1)).strftime('%Y-%m-%d %H:%M:%S')"/>
             <field name="cover_properties">{"background-image": "url('/website_blog/static/src/img/cover_3.jpg')", "resize_class": "o_record_has_cover o_half_screen_height", "opacity": "0.4"}</field>
             <field name="content"><![CDATA[
+<section class="s_text_block pt16 pb16" data-snippet="s_text_block"><div class="s_allow_columns o_container_small">
 <p class="lead">So you’re going abroad, you’ve chosen your destination and now you have to choose a hotel.</p>
 <p>Ten years ago, you’d have probably visited your local travel agent and trusted the face-to-face advice you were given by the so called ‘experts’. The 21st Century way to select and book your hotel is of course on the Internet, by using travel websites.</p>
 
@@ -169,6 +172,7 @@ People who live on the island have never even seen this remarkable scenery unles
 </ol>
 
 <p>Finally and most importantly, the quality hotel directory inspection team should have visited the hotel in question on a regular basis, met the staff, slept in a bedroom and tried the food. They should experience the hotel as only a hotel guest can and it is only then that they are really in a strong position to write about the hotel.</p>
+</div></section>
 ]]>
             </field>
         </record>
@@ -184,6 +188,7 @@ People who live on the island have never even seen this remarkable scenery unles
             <field name="published_date" eval="(datetime.now()-relativedelta(days=6)).strftime('%Y-%m-%d %H:%M:%S')"/>
             <field name="cover_properties">{"background-image": "url('/website_blog/static/src/img/cover_4.jpg')", "resize_class": "o_record_has_cover o_half_screen_height", "text_align_class": "text-center", "opacity": "0.2"}</field>
             <field name="content"><![CDATA[
+<section class="s_text_block pt16 pb16" data-snippet="s_text_block"><div class="s_allow_columns o_container_small">
 <p class="lead">It is safe to say that at some point on our lives, each and every one of us has that moment when we are suddenly stunned when we come face to face with the enormity of the universe that we see in the night sky.</p>
 
 <p>For many of us who are city dwellers, we don’t really notice that sky up there on a routine basis. The lights of the city do a good job of disguising the amazing display that is above all of our heads all of the time.</p>
@@ -211,6 +216,7 @@ People who live on the island have never even seen this remarkable scenery unles
 <p>Before you go to that big expense, it might be a better next step from the naked eye to invest in a good set of binoculars. There are even binoculars that are suited for star gazing that will do just as good a job at giving you that extra vision you want to see just a little better the wonders of the universe. A well designed set of binoculars also gives you much more mobility and ability to keep your “enhanced vision” at your fingertips when that amazing view just presents itself to you.</p>
 
 <p>None of this precludes you from moving forward with your plans to put together an awesome telescope system. Just be sure you get quality advice and training on how to configure your telescope to meet your needs. Using these guidelines, you will enjoy hours of enjoyment stargazing at the phenomenal sights in the night sky that are beyond the naked eye.</p>
+</div></section>
 ]]>
             </field>
         </record>
@@ -225,6 +231,7 @@ People who live on the island have never even seen this remarkable scenery unles
             <field name="published_date" eval="(datetime.now()-relativedelta(days=4)).strftime('%Y-%m-%d %H:%M:%S')"/>
             <field name="cover_properties">{"background-image": "url('/website_blog/static/src/img/cover_5.jpg')", "resize_class": "o_record_has_cover o_half_screen_height", "text_align_class": "text-center", "opacity": "0.2"}</field>
             <field name="content"><![CDATA[
+<section class="s_text_block pt16 pb16" data-snippet="s_text_block"><div class="s_allow_columns o_container_small">
 <p class="lead">From the tiniest baby to the most advanced astrophysicist, there is something for anyone who wants to enjoy astronomy. In fact, it is a science that is so accessible that virtually anybody can do it virtually anywhere they are. All they have to know how to do is to look up.</p>
 <p>It really is amazing when you think about it that just by looking up on any given night, you could see virtually hundreds of thousands of stars, star systems, planets, moons, asteroids, comets and maybe a even an occasional space shuttle might wander by. It is even more breathtaking when you realize that the sky you are looking up at is for all intents and purposes the exact same sky that our ancestors hundreds and thousands of years ago enjoyed when they just looked up.</p>
 
@@ -255,6 +262,7 @@ People who live on the island have never even seen this remarkable scenery unles
 <p> Not only knowing the weather will make sure your star gazing is rewarding but if you learn when the big meteor showers and other big astronomy events will happen will make the excitement of astronomy come alive for you.</p>
 
 <p>And when all is said and done,<b> get equipped</b>. Your quest for newer and better telescopes will be a lifelong one. Let yourself get addicted to astronomy and the experience will enrich every aspect of life. It will be an addiction you never want to break.</p>
+</div></section>
 ]]>
             </field>
         </record>
@@ -269,6 +277,7 @@ People who live on the island have never even seen this remarkable scenery unles
             <field name="published_date" eval="(datetime.now()-relativedelta(days=3)).strftime('%Y-%m-%d %H:%M:%S')"/>
             <field name="cover_properties">{"background-image": "url('/website_blog/static/src/img/cover_6.jpg')", "resize_class": "o_record_has_cover o_half_screen_height", "text_align_class": "text-center", "opacity": "0.2"}</field>
             <field name="content"><![CDATA[
+<section class="s_text_block pt16 pb16" data-snippet="s_text_block"><div class="s_allow_columns o_container_small">
 <p class="lead">Buying the right telescope to take your love of astronomy to the next level is a big next step in the development of your passion for the stars.</p>
 <p>In many ways, it is a big step from someone who is just fooling around with astronomy to a serious student of the science. But you and I both know that there is still another big step after buying a telescope before you really know how to use it.</p>
 <p>So it is critically important that you get just the right telescope for where you are and what your star gazing preferences are. To start with, let’s discuss the three major kinds of telescopes and then lay down some “Telescope 101″ concepts to increase your chances that you will buy the right thing.</p>
@@ -297,6 +306,7 @@ People who live on the island have never even seen this remarkable scenery unles
 <p>The tripod or other accessory decisions will change significantly with a telescope that will live on your deck versus one that you plan to take to many remote locations.</p>
 <h4>Along those lines, how difficult is the set up and break down?</h4>
 <p>How complex is the telescope and will you have trouble with maintenance? Network to get the answers to these and other questions. If you do your homework like this, you will find just the right telescope for this next big step in the evolution of your passion for astronomy.</p>
+</div></section>
 ]]>
             </field>
         </record>
@@ -311,6 +321,7 @@ People who live on the island have never even seen this remarkable scenery unles
             <field name="published_date" eval="(datetime.now()-relativedelta(days=7)).strftime('%Y-%m-%d %H:%M:%S')"/>
             <field name="cover_properties">{"background-image": "url('/website_blog/static/src/img/cover_7.jpg')", "resize_class": "o_record_has_cover o_half_screen_height", "opacity": "0.4"}</field>
             <field name="content"><![CDATA[
+<section class="s_text_block pt16 pb16" data-snippet="s_text_block"><div class="s_allow_columns o_container_small">
 <p class="lead">For many of us, our very first experience of learning about the celestial bodies begins when we saw our first full moon in the sky. It is truly a magnificent view even to the naked eye.</p>
 <p>If the night is clear, you can see amazing detail of the lunar surface just star gazing on in your back yard.
 Naturally, as you grow in your love of astronomy, you will find many celestial bodies fascinating. But the moon may always be our first love because is the one far away space object that has the unique distinction of flying close to the earth and upon which man has walked.</p>
@@ -341,6 +352,7 @@ Naturally, as you grow in your love of astronomy, you will find many celestial b
 <p>To take it to a natural next level, you may want to take advantage of partnerships with other astronomers or by visiting one of the truly great telescopes that have been set up by professionals who have invested in better techniques for eliminating atmospheric interference to see the moon even better. The internet can give you access to the Hubble and many of the huge telescopes that are pointed at the moon all the time. Further, many astronomy clubs are working on ways to combine multiple telescopes, carefully synchronized with computers for the best view of the lunar landscape.</p>
 
 <p>Becoming part of the society of devoted amateur astronomers will give you access to these organized efforts to reach new levels in our ability to study the Earth’s moon. And it will give you peers and friends who share your passion for astronomy and who can share their experience and areas of expertise as you seek to find where you might look next in the huge night sky, at the moon and beyond it in your quest for knowledge about the seemingly endless universe above us. </p>
+</div></section>
 ]]>
             </field>
         </record>

--- a/addons/website_blog/models/website_blog.py
+++ b/addons/website_blog/models/website_blog.py
@@ -171,10 +171,12 @@ class BlogPost(models.Model):
             blog_post.website_url = "/blog/%s/%s" % (self.env['ir.http']._slug(blog_post.blog_id), self.env['ir.http']._slug(blog_post))
 
     def _default_content(self):
-        text = html_escape(_("Start writing here..."))
-        return """
-            <p>%(text)s</p>
-        """ % {"text": text}
+        website = self.env['website'].get_current_website()
+        # TODO Remove with_context when is_view_active does it.
+        is_regular_cover = website.with_context(website_id=website.id).is_view_active('website_blog.opt_blog_post_regular_cover')
+        return self.env['ir.ui.view'].with_context(inherit_branding=False)._render_template('website_blog.s_text_block', {
+            'is_regular_cover': is_regular_cover,
+        })
     name = fields.Char('Title', required=True, translate=True, default='')
     subtitle = fields.Char('Sub Title', translate=True)
     author_id = fields.Many2one('res.partner', 'Author', default=lambda self: self.env.user.partner_id, index='btree_not_null')

--- a/addons/website_blog/static/src/js/tours/website_blog.js
+++ b/addons/website_blog/static/src/js/tours/website_blog.js
@@ -72,7 +72,7 @@ registerWebsitePreviewTour("blog", {
     tooltipPosition: "top",
     run: "click",
 }, {
-    trigger: ":iframe #o_wblog_post_content p",
+    trigger: ":iframe #o_wblog_post_content .o_wblog_post_content_field",
     content: markup(_t("<b>Write your story here.</b> Use the top toolbar to style your text: add an image or table, set bold or italic, etc. Drag and drop building blocks for more graphical blogs.")),
     tooltipPosition: "top",
     run: "editor Blog content",

--- a/addons/website_blog/static/src/js/website_blog.js
+++ b/addons/website_blog/static/src/js/website_blog.js
@@ -5,7 +5,8 @@ import { share } from "./contentshare";
 
 publicWidget.registry.websiteBlog = publicWidget.Widget.extend({
     selector: '.website_blog',
-    events: {
+    disabledInEditableMode: false,
+    read_events: {
         'click #o_wblog_next_container': '_onNextBlogClick',
         'click #o_wblog_post_content_jump': '_onContentAnchorClick',
         'click .o_twitter, .o_facebook, .o_linkedin, .o_google, .o_twitter_complete, .o_facebook_complete, .o_linkedin_complete, .o_google_complete': '_onShareArticle',
@@ -14,11 +15,80 @@ publicWidget.registry.websiteBlog = publicWidget.Widget.extend({
     /**
      * @override
      */
-    start: function () {
-        document.querySelectorAll(".js_tweet, .js_comment").forEach((el) => {
-            share(el);
-        });
-        return this._super.apply(this, arguments);
+    start() {
+        if (!this.editableMode) {
+            document.querySelectorAll(".js_tweet, .js_comment").forEach((el) => {
+                share(el);
+            });
+        }
+
+        this.widthClasses = ['o_container_small', 'container', 'container-fluid'];
+
+        // The 'o_container_as_first' class is used to mark blocks that need
+        // to be kept aligned with the first text block on the blog content.
+        // (e.g. breadcrumbs, tags...)
+        this.containerSizeUpdatingEls = this.el.querySelectorAll('.o_container_as_first');
+        this._adjustWidth();
+        for (const el of this.containerSizeUpdatingEls) {
+            // Removing the class triggers the fade-in animation.
+            el.classList.remove('o_container_as_first');
+        }
+        // Keep width adjusted upon further updates.
+        // TODO Remove event listener once page's core.bus can be reached from editor.
+        // core.bus.on('blog_width_update', this, this._adjustWidth);
+        this.__boundAdjustWidth = this._adjustWidth.bind(this);
+        this.el.addEventListener('blog_width_update', this.__boundAdjustWidth);
+
+        return this._super(...arguments);
+    },
+    /**
+     * @override
+     */
+    destroy() {
+        this._super(...arguments);
+
+        // TODO Remove event listener once page's core.bus can be reached from editor.
+        this.el.removeEventListener('blog_width_update', this.__boundAdjustWidth);
+        // core.bus.off('blog_width_update', this, this._adjustWidth);
+
+        for (const el of this.containerSizeUpdatingEls) {
+            el.classList.remove(...this.widthClasses);
+            el.classList.add('o_container_as_first');
+        }
+    },
+
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
+    /**
+     * Adjusts the containers'width class based on the first (text) section of
+     * the blog post content.
+     * If there is a text section it uses the first text section, otherwise it
+     * uses the first section.
+     *
+     * @private
+     */
+    _adjustWidth() {
+        const blogPostContentEl = this.el.querySelector('.o_wblog_post_content_field');
+        if (!blogPostContentEl) {
+            return;
+        }
+
+        let targetClass = 'o_container_small';
+        for (const extraSelector of ['.s_text_block ', ':first-of-type', ':first-of-type ']) {
+            const selector = this.widthClasses.map(cls => `section${extraSelector}.${cls}`);
+            const source = blogPostContentEl.querySelector(selector);
+            if (source) {
+                targetClass = this.widthClasses.find(cls => source.classList.contains(cls));
+                break;
+            }
+        }
+
+        for (const containerEl of this.containerSizeUpdatingEls) {
+            containerEl.classList.remove(...this.widthClasses);
+            containerEl.classList.add(targetClass);
+        }
     },
 
     //--------------------------------------------------------------------------

--- a/addons/website_blog/static/src/scss/website_blog.scss
+++ b/addons/website_blog/static/src/scss/website_blog.scss
@@ -55,13 +55,8 @@ $o-wblog-loader-size: 50px;
         background-color: rgba(black, 0.005);
     }
 
-    .o_wblog_read_with_sidebar {
-        max-width: map-get($container-max-widths, md) + $o-wblog-sidebar-width;
-    }
-
     // This option class is assigned to the post's content using the "Customize"
-    // menu. The aim is to be able to write simple articles on the fly,
-    // achieving a good design without being forced to use snippets.
+    // menu. The aim is to be able to write simple articles on the fly.
     .o_wblog_read_text {
         @include font-size(18px);
         font-weight: 300;
@@ -102,12 +97,22 @@ $o-wblog-loader-size: 50px;
         a.oe_mail_expand {
             font-weight: bold;
         }
+        .breadcrumb, .o_wblog_post_tags {
+            animation: o-wblog-fade-In 0.3s cubic-bezier(.02, .01, .47, 1);
+        }
     }
 
     #o_wblog_post_comments {
+        animation: o-wblog-fade-In 0.3s cubic-bezier(.02, .01, .47, 1);
         .o_portal_chatter > hr {
             display: none;
         }
+    }
+
+    .o_container_as_first {
+        // Important needed to be applied within #o_wblog_post_content.
+        animation: none !important;
+        opacity: 0;
     }
 
     // Blog Post Page Cover

--- a/addons/website_blog/views/snippets/s_text_block.xml
+++ b/addons/website_blog/views/snippets/s_text_block.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<!--
+    Default text block for blogs: it was considered easier and more readable
+    to fully rewrite the snippet rather than parameterizing the base one or
+    primary inheriting that base one. All aspects are indeed changed and the
+    base structure is very simple (that's not a whole lot of duplication)
+-->
+<template id="s_text_block" name="Text">
+    <section class="s_text_block pt16 pb16" data-snippet="s_text_block">
+        <div t-attf-class="#{is_regular_cover and 'container' or 'o_container_small'} s_allow_columns">
+            <p>Start writing here...</p>
+        </div>
+    </section>
+</template>
+
+</odoo>

--- a/addons/website_blog/views/snippets/snippets.xml
+++ b/addons/website_blog/views/snippets/snippets.xml
@@ -43,11 +43,6 @@
                          data-customize-website-views="website_blog.opt_blog_cards_design"
                          data-no-preview="true"
                          data-reload="/"/>
-            <we-checkbox string="Increase Readability"
-                         class="o_we_sublevel_1"
-                         data-customize-website-views="website_blog.opt_blog_readable"
-                         data-no-preview="true"
-                         data-reload="/"/>
             <we-checkbox string="Sidebar"
                          data-name="blog_posts_sidebar_opt"
                          data-customize-website-views="website_blog.opt_blog_sidebar_show"
@@ -97,11 +92,6 @@
                 <we-button data-customize-website-views="website_blog.opt_blog_post_regular_cover">Title Above Cover</we-button>
                 <we-button data-customize-website-views="">Title Inside Cover</we-button>
             </we-select>
-            <we-checkbox string="Increase Readability"
-                         class="o_we_sublevel_1"
-                         data-customize-website-views="website_blog.opt_blog_post_readable"
-                         data-no-preview="true"
-                         data-reload="/"/>
             <we-checkbox string="Sidebar"
                          data-name="blog_post_sidebar_opt"
                          data-customize-website-views="website_blog.opt_blog_post_sidebar"
@@ -166,11 +156,6 @@
     </xpath>
     <xpath expr="//*[@data-js='anchor']" position="attributes">
         <attribute name="data-exclude" add=".o_wblog_post_content_field > :not(div, section)" separator=","/>
-    </xpath>
-
-    <!-- Hides ContainerWidth option for content in blog posts -->
-    <xpath expr="//div[@data-js='ContainerWidth']" position="attributes">
-        <attribute name="data-exclude" add="#o_wblog_post_content *" separator=","/>
     </xpath>
 </template>
 

--- a/addons/website_blog/views/website_blog_components.xml
+++ b/addons/website_blog/views/website_blog_components.xml
@@ -140,7 +140,7 @@
         <div t-if="blog_post.author_avatar"
              t-field="blog_post.author_avatar"
              style="line-height:1"
-             t-options='{"widget": "image", "class": "rounded-circle " + "o_wblog_author_avatar me-1" if hide_date else  "o_wblog_author_avatar_date me-2"}' />
+             t-options='{"widget": "image", "class": "rounded-circle " + "o_wblog_author_avatar me-1" if hide_date else  "o_wblog_author_avatar_date me-2",}' />
         <div t-att-class="not hide_date and 'small fw-bold'" style="line-height:1">
             <span t-if="editable" t-field="blog_post.author_id" t-options='{ "widget": "contact", "fields": ["name"]}'/>
             <span t-else="" t-esc="blog_post.author_name"/>
@@ -152,12 +152,14 @@
 <!-- ======   Template: Post Breadcrumbs   =====================================
 ============================================================================ -->
 <template id="post_breadcrumbs">
-    <nav aria-label="breadcrumb" t-attf-class="breadcrumb flex-nowrap py-0 px-0 css_editable_mode_hidden #{additionnal_classes or ''}">
-        <li t-if="len(blogs) &gt; 1" class="breadcrumb-item"><a href="/blog">All Blogs</a></li>
-        <li class="breadcrumb-item">
-            <a t-attf-href="#{blog_url(tag=None, date_begin=None, date_end=None)}" t-esc="blog.name"/>
-        </li>
-        <li class="breadcrumb-item text-truncate active"><span t-esc="blog_post.name"/></li>
+    <nav aria-label="breadcrumb" t-attf-class="breadcrumb o_no_link_popover #{additionnal_classes or ''}">
+        <ol class="breadcrumb bg-transparent mb-0 ps-0 py-0">
+            <li t-if="len(blogs) &gt; 1" class="breadcrumb-item"><a href="/blog">All Blogs</a></li>
+            <li class="breadcrumb-item">
+                <a t-attf-href="#{blog_url(tag=None, date_begin=None, date_end=None)}" t-out="blog.name"/>
+            </li>
+            <li class="breadcrumb-item text-truncate active"><span t-esc="blog_post.name"/></li>
+        </ol>
     </nav>
 </template>
 

--- a/addons/website_blog/views/website_blog_posts_loop.xml
+++ b/addons/website_blog/views/website_blog_posts_loop.xml
@@ -35,7 +35,7 @@ according to the enabled options.
             </div>
         </div>
 
-        <div t-attf-class="row #{posts and not opt_blog_readable and 'mx-n2'}">
+        <div class="row">
             <!-- Filters -->
             <div t-if="tag or date_begin or search" class="col-12 mb-3">
                 <div t-if="posts" class="h4 mb-3">
@@ -86,14 +86,8 @@ according to the enabled options.
             <!-- Define 'colWidth' qWeb variable, to be assigned later.
             Adjust accordingly if sidebar and/or readability modes are active. -->
             <t t-if="not opt_blog_list_view">
-                <t t-if="opt_blog_readable">
-                    <t t-if="opt_blog_sidebar_show" t-set="colWidth" t-value="'col-md-6'"/>
-                    <t t-else="" t-set="colWidth" t-value="'col-md-6 col-xl-4'"/>
-                </t>
-                <t t-else="">
-                    <t t-if="opt_blog_sidebar_show" t-set="colWidth" t-value="'px-2 col-md-6 col-xl-4'"/>
-                    <t t-else="" t-set="colWidth" t-value="'px-2 col-sm-6 col-lg-4 col-xl-3'"/>
-                </t>
+                <t t-if="opt_blog_sidebar_show" t-set="colWidth" t-valuef="col-md-6"/>
+                <t t-else="" t-set="colWidth" t-valuef="col-md-6 col-xl-4"/>
             </t>
             <!-- Loop through posts: exclude the first one if already displayed as top banner -->
             <t t-foreach="posts" t-as="blog_post">
@@ -152,7 +146,7 @@ according to the enabled options.
 <template id="post_heading">
     <a t-attf-href="/blog/#{slug(blog_post.blog_id)}/#{slug(blog_post)}"
        t-field="blog_post.name"
-       t-attf-class="d-block text-reset text-decoration-none o_blog_post_title my-0 #{'h3' if opt_blog_list_view else ('h5' if opt_blog_readable else 'h6')}">
+       t-attf-class="d-block text-reset text-decoration-none o_blog_post_title my-0 #{'h3' if opt_blog_list_view else 'h5'}">
        Untitled Post
    </a>
 
@@ -204,7 +198,7 @@ according to the enabled options.
     <t t-cache="blog_post,str(active_tag_ids)">
     <a t-attf-href="/blog/#{slug(blog_post.blog_id)}/#{slug(blog_post)}" class="text-reset text-decoration-none">
         <div t-if="opt_blog_list_view" t-field="blog_post.teaser" class="mt-2 o_wblog_read_text"/>
-        <div t-else="" t-field="blog_post.teaser" t-attf-class="mt-2 #{opt_blog_readable and 'o_wblog_normalize_font'}"/>
+        <div t-else="" t-field="blog_post.teaser" class="mt-2 o_wblog_normalize_font"/>
     </a>
 
     <!-- Tags -->

--- a/addons/website_blog/views/website_blog_templates.xml
+++ b/addons/website_blog/views/website_blog_templates.xml
@@ -31,7 +31,6 @@ list of filtered posts (by date or tag).
         <!-- Check for active options: the stored value may be used in sub-templates too  -->
         <t t-set="opt_blog_cards_design" t-value="is_view_active('website_blog.opt_blog_cards_design')"/>
         <t t-set="opt_blog_list_view" t-value="is_view_active('website_blog.opt_blog_list_view')"/>
-        <t t-set="opt_blog_readable" t-value="is_view_active('website_blog.opt_blog_readable')"/>
         <t t-set="opt_blog_sidebar_show" t-value="is_view_active('website_blog.opt_blog_sidebar_show')"/>
 
         <div id="o_wblog_blog_top">
@@ -163,11 +162,6 @@ list of filtered posts (by date or tag).
 -->
 <template id="opt_blog_list_view" name="List View" inherit_id="website_blog.blog_post_short" active="False"/>
 
-<!-- (Option) Blog: Increase readability
-    Increase font-size, adapt layout
--->
-<template id="opt_blog_readable" name="Increase Readability" inherit_id="website_blog.blog_post_short" active="True"/>
-
 
 <!-- ====== Blog Post Complete Layout ==========================================
 ============================================================================ -->
@@ -175,7 +169,6 @@ list of filtered posts (by date or tag).
     <t t-call="website_blog.index">
 
         <!-- Check for active options: the stored value may be used in sub-templates too  -->
-        <t t-set="opt_blog_post_readable" t-value="is_view_active('website_blog.opt_blog_post_readable')"/>
         <t t-set="opt_blog_post_sidebar" t-value="is_view_active('website_blog.opt_blog_post_sidebar')"/>
         <t t-set="opt_blog_post_regular_cover" t-value="is_view_active('website_blog.opt_blog_post_regular_cover')"/>
         <t t-set="opt_blog_post_breadcrumb" t-value="is_view_active('website_blog.opt_blog_post_breadcrumb')"/>
@@ -208,28 +201,28 @@ list of filtered posts (by date or tag).
             </div>
         </section>
 
-        <section id="o_wblog_post_main" t-attf-class="container pt-4 pb-5 #{'anim' in request.params and 'o_wblog_post_main_transition'}">
+        <div id="o_wblog_post_main" t-attf-class="pb-5 #{'anim' in request.params and 'o_wblog_post_main_transition'}">
             <!-- Sidebar-enabled Layout -->
-            <div t-if="opt_blog_post_sidebar" t-attf-class="mx-auto #{opt_blog_post_readable and 'o_wblog_read_with_sidebar'}">
-                <div t-attf-class="d-flex flex-column flex-lg-row #{opt_blog_post_readable and 'justify-content-between'}">
-                    <div id="o_wblog_post_content" t-attf-class="#{opt_blog_post_readable and 'o_container_small mx-0 w-100 flex-shrink-0' or 'w-lg-75'}">
+            <div t-if="opt_blog_post_sidebar" class="mx-auto container">
+                <div class="row justify-content-start mx-0">
+                    <div id="o_wblog_post_content" class="col-lg-9 col-12 px-0">
                         <t t-call="website_blog.blog_post_content"/>
                     </div>
-                    <div id="o_wblog_post_sidebar_col" t-attf-class="ps-lg-5 #{not opt_blog_post_readable and 'flex-grow-1 w-lg-25'}">
+                    <div id="o_wblog_post_sidebar_col" class="ps-lg-4 pt-lg-4 col-lg-3">
                         <t t-call="website_blog.blog_post_sidebar"/>
                     </div>
                 </div>
             </div>
 
             <!-- No-Sidebar Layout -->
-            <div t-if="not opt_blog_post_sidebar" t-attf-class="#{opt_blog_post_readable and 'o_container_small'}">
+            <t t-if="not opt_blog_post_sidebar">
                 <div class="d-flex flex-column flex-lg-row">
-                    <div id="o_wblog_post_content" t-attf-class=" #{opt_blog_post_readable and 'o_container_small w-100 flex-shrink-0'}">
+                    <div id="o_wblog_post_content" class="w-100 flex-shrink-0">
                         <t t-call="website_blog.blog_post_content"/>
                     </div>
                 </div>
-            </div>
-        </section>
+            </t>
+        </div>
         <section id="o_wblog_post_footer"/>
     </t>
 </template>
@@ -238,14 +231,13 @@ list of filtered posts (by date or tag).
 ============================================================================ -->
 <template id="blog_post_content" name="Blog post content">
     <t t-if="opt_blog_post_breadcrumb and not opt_blog_post_regular_cover" t-call="website_blog.post_breadcrumbs">
-        <t t-set="additionnal_classes" t-value="'mb-3 bg-transparent'"></t>
+        <t t-set="additionnal_classes" t-value="'mb-0 pb-0 bg-transparent o_container_as_first pt-4'"></t>
     </t>
     <t t-set="editor_message">WRITE HERE OR DRAG BUILDING BLOCKS</t>
     <div t-field="blog_post.content"
         t-att-data-editor-message="editor_message"
-        t-attf-class="o_wblog_post_content_field #{'js_tweet' if opt_blog_post_select_to_tweet else ''} #{'js_comment' if opt_blog_post_select_to_comment else ''} #{'o_wblog_read_text' if opt_blog_post_readable else ''}"/>
-
-    <div t-if="len(blogs) > 1 or len(blog_post.tag_ids) > 0" class="css_editable_mode_hidden text-muted">
+        t-attf-class="o_wblog_post_content_field o_wblog_read_text #{'js_tweet' if opt_blog_post_select_to_tweet else ''} #{'js_comment' if opt_blog_post_select_to_comment else ''}"/>
+    <div t-if="len(blogs) > 1 or len(blog_post.tag_ids) > 0" class="text-muted o_wblog_post_tags o_container_as_first o_no_link_popover o_not_editable">
         <div t-if="len(blogs) > 1">in <a t-attf-href="#{blog_url(blog=blog_post.blog_id)}"><b t-field="blog.name"/></a></div>
         <div t-if="len(blog_post.tag_ids) > 0">#
             <t t-foreach="blog_post.tag_ids" t-as="one_tag">
@@ -254,12 +246,6 @@ list of filtered posts (by date or tag).
         </div>
     </div>
 </template>
-
-
-<!-- (Option) Post: Increase readability
-    Increase font-size, adapt content width
--->
-<template id="opt_blog_post_readable" name="Increase Readability" inherit_id="website_blog.blog_post_complete" active="True"/>
 
 <!-- (Option) Post: Show Sidebar
     Show sidebar beside the post content
@@ -272,13 +258,11 @@ list of filtered posts (by date or tag).
 <template id="opt_blog_post_regular_cover" name="'Regular' Cover" inherit_id="website_blog.blog_post_complete" active="False">
     <xpath expr="//div[@id='title']" position="replace">
         <div class="container">
-            <t t-set="readableClass" t-if="opt_blog_post_readable and opt_blog_post_sidebar" t-value="'o_wblog_read_with_sidebar mx-auto'"/>
-            <t t-set="readableClass" t-elif="opt_blog_post_readable" t-value="'container'"/>
 
-            <div id="title" t-attf-class="blog_header o_wblog_regular_cover_container #{readableClass}">
+            <div id="title" class="blog_header o_wblog_regular_cover_container">
 
                 <t t-if="opt_blog_post_breadcrumb" t-call="website_blog.post_breadcrumbs">
-                    <t t-set="additionnal_classes" t-value="'mt-4 mb-3 bg-transparent'"></t>
+                    <t t-set="additionnal_classes" t-value="'mt-4 mb-3 bg-transparent container'"></t>
                 </t>
 
                 <div t-att-class="not opt_blog_post_breadcrumb and 'pt-4'">
@@ -330,21 +314,16 @@ list of filtered posts (by date or tag).
 <!-- (Option) Post: Comments
     Enable comments
 -->
-<template id="opt_blog_post_comment" name="Allow Comments" inherit_id="website_blog.blog_post_complete" active="False">
-    <xpath expr="//section[@id='o_wblog_post_main']" position="inside">
-        <t t-set="readableClass" t-if="opt_blog_post_readable and opt_blog_post_sidebar" t-value="'o_wblog_read_with_sidebar'"/>
-        <t t-set="readableClass" t-elif="opt_blog_post_readable" t-value="'o_container_small'"/>
-
-        <div class="container">
-            <div t-attf-class="mx-auto #{readableClass}">
-                <div id="o_wblog_post_comments" t-attf-class="pt-4 o_container_small">
-                    <div groups="base.group_public" class="small mb-4">
-                        <a t-attf-href="/web/login?redirect=/blog/{{slug(blog_post.blog_id)}}/{{slug(blog_post)}}#discussion" class="btn btn-sm btn-primary"><b>Sign in</b></a> to leave a comment
-                    </div>
-                    <t t-call="portal.message_thread">
-                        <t t-set="object" t-value="blog_post"/>
-                    </t>
+<template id="opt_blog_post_comment" name="Allow Comments" inherit_id="website_blog.blog_post_content" active="False">
+    <xpath expr="//div[hasclass('o_wblog_post_tags')]" position="after">
+        <div class="mx-auto o_container_as_first">
+            <div id="o_wblog_post_comments" class="pt-4">
+                <div groups="base.group_public" class="small mb-4">
+                    <a t-attf-href="/web/login?redirect=/blog/{{slug(blog_post.blog_id)}}/{{slug(blog_post)}}#discussion" class="btn btn-sm btn-primary"><b>Sign in</b></a> to leave a comment
                 </div>
+                <t t-call="portal.message_thread">
+                    <t t-set="object" t-value="blog_post"/>
+                </t>
             </div>
         </div>
     </xpath>
@@ -362,11 +341,8 @@ list of filtered posts (by date or tag).
     <xpath expr="//section[@id='o_wblog_post_footer']" position="inside">
         <div t-if="next_post" class="mt-5">
             <t t-if="opt_blog_post_regular_cover">
-                <t t-if="opt_blog_post_sidebar" t-set="readableClass" t-value="'o_wblog_read_with_sidebar'"/>
-                <t t-else="" t-set="readableClass" t-value="'o_container_small'"/>
-
-                <div class="container">
-                    <div t-attf-class="mb-4 mx-auto #{ readableClass if opt_blog_post_readable else ''}">
+                <div class="pb-5 container">
+                    <div class="mb-4 mx-auto">
                         <hr/>
                         <div class="d-flex text-end py-4">
                             <div class="flex-grow-1 pe-3">


### PR DESCRIPTION
Before this commit the blog post content was one single editable text. This made some edition behaviors different from the ones in general purpose web pages.

After this commit the initial blog post content is a block that contains a text snippet section. This makes the blog edition behave the same way as in any other page.
This commit also removes the "Increase Readability" customization option from both the blogs page and the blog posts page, keeping the display as if it were always enabled.

With the new layout and the suppression of the "Increase Readability" customization, the breadcrumbs and tags would remain aligned with sections set as `o_container_small`.

Therefore we make sure that the newly dropped blocks inside a blog post are indeed set as `o_container_small` by default for the full cover layout, and to `container` for the "Regular Cover" layout. But in case this is changed, the breadcrumbs and tags are realigned with the first text section (or the first section if there is no text section within the blog post content).
These positions are re-evaluated both on page load and dynamically while the blog post content is being edited.
We also align Comments with the content and make Regular Cover's Read Next span over the sidebar if it exists.

task-2449620

Related to https://github.com/odoo/upgrade/pull/6200
