### PR TITLE
[FIX] sale_project, _*: link the project AA to the newly created record in project updates stat buttons

### DIFF
--- a/addons/project_hr_expense/models/__init__.py
+++ b/addons/project_hr_expense/models/__init__.py
@@ -1,3 +1,2 @@
-# -*- coding: utf-8 -*-
-
+from . import hr_expense
 from . import project_project

--- a/addons/project_hr_expense/models/hr_expense.py
+++ b/addons/project_hr_expense/models/hr_expense.py
@@ -1,0 +1,14 @@
+from odoo import models
+
+
+class HrExpense(models.Model):
+    _inherit = 'hr.expense'
+
+    def _compute_analytic_distribution(self):
+        project_id = self.env.context.get('project_id')
+        if not project_id:
+            super()._compute_analytic_distribution()
+        else:
+            analytic_account = self.env['project.project'].browse(project_id).analytic_account_id
+            for expense in self:
+                expense.analytic_distribution = expense.analytic_distribution or {analytic_account.id: 100}

--- a/addons/project_hr_expense/models/project_project.py
+++ b/addons/project_hr_expense/models/project_project.py
@@ -50,7 +50,7 @@ class Project(models.Model):
         action.update({
             'display_name': _('Expenses'),
             'views': [[False, 'tree'], [False, 'form'], [False, 'kanban'], [False, 'graph'], [False, 'pivot']],
-            'context': {'default_analytic_distribution': {self.analytic_account_id.id: 100}},
+            'context': {'project_id': self.id},
             'domain': domain or [('id', 'in', expense_ids)],
         })
         if len(expense_ids) == 1:

--- a/addons/project_mrp/models/__init__.py
+++ b/addons/project_mrp/models/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+from . import mrp_production
 from . import project_project

--- a/addons/project_mrp/models/mrp_production.py
+++ b/addons/project_mrp/models/mrp_production.py
@@ -1,0 +1,14 @@
+from odoo import models
+
+
+class MrpProduction(models.Model):
+    _inherit = 'mrp.production'
+
+    def _compute_analytic_distribution(self):
+        project_id = self.env.context.get('project_id')
+        if not project_id:
+            super()._compute_analytic_distribution()
+        else:
+            analytic_account = self.env['project.project'].browse(project_id).analytic_account_id
+            for production in self:
+                production.analytic_distribution = production.analytic_distribution or {analytic_account.id: 100}

--- a/addons/project_mrp/models/project_project.py
+++ b/addons/project_mrp/models/project_project.py
@@ -16,7 +16,7 @@ class Project(models.Model):
         self.ensure_one()
         action = self.env['ir.actions.actions']._for_xml_id('mrp.mrp_production_action')
         action['domain'] = [('id', 'in', self.analytic_account_id.production_ids.ids)]
-        action['context'] = {'default_analytic_account_id': self.analytic_account_id.id}
+        action['context'] = {'project_id': self.id}
         if self.production_count == 1:
             action['view_mode'] = 'form'
             action['res_id'] = self.analytic_account_id.production_ids.id

--- a/addons/sale_project/models/account_move.py
+++ b/addons/sale_project/models/account_move.py
@@ -11,3 +11,8 @@ class AccountMoveLine(models.Model):
         # analytic account from being overridden by analytic default rules and lack thereof
         project_amls = self.filtered(lambda aml: aml.analytic_distribution and any(aml.sale_line_ids.project_id))
         super(AccountMoveLine, self - project_amls)._compute_analytic_distribution()
+        project_id = self.env.context.get('project_id')
+        if project_id:
+            analytic_account = self.env['project.project'].browse(project_id).analytic_account_id
+            for line in self:
+                line.analytic_distribution = line.analytic_distribution or {analytic_account.id: 100}

--- a/addons/sale_project/models/project.py
+++ b/addons/sale_project/models/project.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import ast
 import json
 from collections import defaultdict
 from datetime import date
@@ -166,7 +167,12 @@ class Project(models.Model):
             "type": "ir.actions.act_window",
             "res_model": "sale.order",
             'name': _("%(name)s's Sales Orders", name=self.name),
-            "context": {"create": self.env.context.get('create_for_project_id', False), "show_sale": True},
+            "context": {
+                "create": self.env.context.get('create_for_project_id', False),
+                "show_sale": True,
+                "default_partner_id": self.partner_id.id,
+                "default_analytic_account_id": self.analytic_account_id.id,
+            },
         }
         if len(all_sale_orders) <= 1:
             action_window.update({
@@ -207,6 +213,11 @@ class Project(models.Model):
         if section_name in ['other_invoice_revenues', 'downpayments']:
             action = self.env["ir.actions.actions"]._for_xml_id("account.action_move_out_invoice_type")
             action['domain'] = domain if domain else []
+            action['context'] = {
+                **ast.literal_eval(action['context']),
+                'default_partner_id': self.partner_id.id,
+                'project_id': self.id,
+            }
             if res_id:
                 action['views'] = [(False, 'form')]
                 action['view_mode'] = 'form'
@@ -256,7 +267,9 @@ class Project(models.Model):
             'views': [[False, 'tree'], [False, 'form'], [False, 'kanban']],
             'domain': [('id', 'in', invoice_ids)],
             'context': {
-                'create': False,
+                'default_move_type': 'out_invoice',
+                'default_partner_id': self.partner_id.id,
+                'project_id': self.id,
             }
         }
         if len(invoice_ids) == 1:
@@ -683,6 +696,9 @@ class Project(models.Model):
                 'number': self_sudo.sale_order_count,
                 'action_type': 'object',
                 'action': 'action_view_sos',
+                'additional_context': json.dumps({
+                    'create_for_project_id': self.id,
+                }),
                 'show': self_sudo.display_sales_stat_buttons and self_sudo.sale_order_count > 0,
                 'sequence': 27,
             })
@@ -769,7 +785,8 @@ class Project(models.Model):
             'views': [[False, 'tree'], [False, 'form'], [False, 'kanban']],
             'domain': [('id', 'in', vendor_bill_ids)],
             'context': {
-                'create': False,
+                'default_move_type': 'in_invoice',
+                'project_id': self.id,
             }
         }
         if len(vendor_bill_ids) == 1:


### PR DESCRIPTION
After this commit, the following stat buttons from the project updates panel have been fixed:

- Vendor Bills: Add the possibility to create new vendor bills from the stat button and link the new vendor bill to the AA of the current project. Also fix the "Upload" button (no more error "The journal in which to upload the invoice is not specified").
- Invoices: Same as for Vendor Bills (link the AA to the newly created invoice).
- Manufacturing Orders: Same fix as above.
- Expenses (access via the "Expenses" link from the profitability table): Same fix as above.
- Sales Orders: Before this commit, we could only create new SOs from the project form view stat button, we can now do it from the stat button of the project updates panel. And again, same fix as above for the AA.

version-17.0
task-3973206

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
