### PR TITLE
[FIX] account: new bank account not stored to bank statement line

### DIFF
--- a/addons/account/models/account_bank_statement_line.py
+++ b/addons/account/models/account_bank_statement_line.py
@@ -463,7 +463,7 @@ class AccountBankStatementLine(models.Model):
                 'partner_id': self.partner_id.id,
                 'journal_id': None,
             })
-        return bank_account.filtered(lambda x: x.company_id in (False, self.company_id))
+        return bank_account.filtered(lambda x: not x.company_id or x.company_id == self.company_id)
 
     def _get_default_amls_matching_domain(self):
         self.ensure_one()

--- a/doc/cla/corporate/Implex.md
+++ b/doc/cla/corporate/Implex.md
@@ -1,0 +1,15 @@
+Slovenia, 2024-07-01
+
+Implex System Engineering d.o.o. agrees to the terms of the Odoo Corporate Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Jan Zorko jan.zorko@implex.si https://github.com/JZorko
+
+List of contributors:
+
+Jan Zorko jan.zorko@implex.si https://github.com/JZorko


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
When reconciling a bank statement line (Transaction) with a previously unseen bank account number the newly created `res.partners.bank` record does not get set as the transactions `partner_bank_id`.

For subsequent transactions for the same partner `partner_bank_id` does get set, immediately on create, but it just ignores the bank account number field and takes the first available bank account from the partner, which is also not ideal, but is I guess correct most of the time, as bank accounts rarely change.

I noticed this when I tried to group transactions by 'Recipient Bank' and saw that there are transactions with the bank account number that either does not belong to the group or ones that should be in a group but are not. See first screenshot.

**Current behavior before PR:**
Importing or manually creating a bank statement line with a new bank account number and then validating (matching) it does not set `partner_bank_id` to the newly created bank account.
This is because `bank_account.company_id` for the newly created `bank_account` is not `False`, but rather an empty recordset, which does not equal `False` and thus always gets filtered out by the current check:
```py
return bank_account.filtered(lambda x: x.company_id in (False, self.company_id))
```

**Desired behavior after PR is merged:**
Return the newly created bank account so it gets set to the related account move.
The fix is to explicitly check for the case where `company_id` is not set. See second screenshot.

**Steps to reproduce (on enterprise runbot):**
- Go to the Bank journal, view Transactions.
- Make sure you enable the 'Bank Account Number' and 'Journal Entry' columns.
- Create a New transaction:
    - Set the 'Label', 'Partner', 'Amount' and 'Bank Account Number'.
- Save the new transaction.
- Make note of the related 'Journal Entry' or come back here later.
- Match it with any other move, so it goes through `_action_validate` which calls `_find_or_create_bank_account`.
- Open the Journal Entry related to the Transaction.
- Use the debug mode to 'View Raw Record Data'.
- Verify if `partner_bank_id` is set or not.

**Screenshots:**
Odd grouping behaviour (manually edited view to add 'Recipient Bank' column for demonstration):
![Groupby](https://github.com/odoo/odoo/assets/34187274/cb520a2d-8325-4e79-aac5-18c78ab834e3)

How the old and new return statements evaluate:
![Debugger](https://github.com/odoo/odoo/assets/34187274/2f409d9b-adc7-45d7-a3d1-81cb37de8820)



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr