### PR TITLE
[FIX] account_peppol: skip move state update when processing

### DIFF
--- a/addons/account_peppol/models/account_edi_proxy_user.py
+++ b/addons/account_peppol/models/account_edi_proxy_user.py
@@ -202,6 +202,11 @@ class AccountEdiProxyClientUser(models.Model):
 
                 move = message_uuids[uuid]
                 if content.get('error'):
+                    # "Peppol request not ready" error:
+                    # thrown when the IAP is still processing the message
+                    if content['error'].get('code') == 702:
+                        continue
+
                     move.peppol_move_state = 'error'
                     move._message_log(body=_("Peppol error: %s", content['error']['message']))
                     continue


### PR DESCRIPTION
When the client side requests an update of message statuses for
sent invoices that are "Pending reception" (`peppol_move_state == "processing"`),
the IAP throws an error if message is still being processed on the server side.
We get a `702` "Peppol Request Not Ready" error code from the server in that case.

Currently, on the client side as long as we see an error, we update
`peppol_move_state` to `error`, which prevents further status updates
(we only check "processing" messages).

We should not update the move state to error and just keep it as processing,
so that we will retry fetching the state on the next scheduled action run.

no task, customer feedback



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
