### PR TITLE
[FIX] purchase: Auto complete with all branches POs

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -322,6 +322,7 @@ class AccountMove(models.Model):
         string='Commercial Entity',
         compute='_compute_commercial_partner_id', store=True, readonly=True,
         ondelete='restrict',
+        check_company=True,
     )
     partner_shipping_id = fields.Many2one(
         comodel_name='res.partner',

--- a/addons/purchase/models/account_invoice.py
+++ b/addons/purchase/models/account_invoice.py
@@ -83,6 +83,10 @@ class AccountMove(models.Model):
             elif len(refs) > 1:
                 self.payment_reference = refs[-1]
 
+        # Copy company_id (only changes if the id is of a child company (branch))
+        if self.company_id != self.purchase_id.company_id:
+            self.company_id = self.purchase_id.company_id
+
         self.purchase_id = False
 
     @api.onchange('partner_id', 'company_id')

--- a/addons/purchase/views/account_move_views.xml
+++ b/addons/purchase/views/account_move_views.xml
@@ -15,7 +15,7 @@
                         invisible="state != 'draft' or move_type != 'in_invoice'"
                         readonly="state != 'draft'"
                         class="oe_edit_only"
-                        domain="partner_id and [('company_id', '=', company_id), ('partner_id.commercial_partner_id', '=', commercial_partner_id)] or [('company_id', '=', company_id)]"
+                        domain="partner_id and [('partner_id.commercial_partner_id', '=', commercial_partner_id)] or []"
                         placeholder="Select a purchase order or an old bill"
                         context="{'show_total_amount': True}"
                         options="{'no_create': True, 'no_open': True}"/>


### PR DESCRIPTION
In auto-complete field of a vendor bill, the domain before the current commit would only get purchase orders from the current company. The domain was amended to get POs from current company and all its descendant branches.

The POs of children companies should be visible on vendor bills of current company. If the user selects a PO that belongs to a child company, the company_id field should be = the child company.

task-3987695


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
