### PR TITLE
[FIX] mail: tests - fix modify own profile tour

### DIFF
--- a/addons/mail/static/tests/tours/user_modify_own_profile_tour.js
+++ b/addons/mail/static/tests/tours/user_modify_own_profile_tour.js
@@ -1,4 +1,5 @@
 import { registry } from "@web/core/registry";
+import { contains, insertText } from "@web/../tests/utils";
 
 /**
  * Verify that a user can modify their own profile information.
@@ -19,7 +20,10 @@ registry.category("web_tour.tours").add("mail/static/tests/tours/user_modify_own
         {
             content: "Update the email address",
             trigger: 'div[name="email"] input',
-            run: "edit updatedemail@example.com",
+            async run() {
+                await insertText("div[name='email'] input", "updatedemail@example.com");
+                await contains(".o_form_dirty", { count: 1 });
+            },
         },
         {
             trigger: "body.modal-open",
@@ -34,6 +38,9 @@ registry.category("web_tour.tours").add("mail/static/tests/tours/user_modify_own
             content: "Wait until the modal is closed",
             trigger: "body:not(.modal-open)",
             in_modal: false,
+            async run() {
+                await contains(".o_form_dirty", { count: 0 });
+            },
         },
     ],
 });


### PR DESCRIPTION
Before this PR, the 'user_modify_own_profile_tour' tour would sometimes fail with the error: "Form views in edition mode are automatically saved when the page is closed, which leads to stray network requests and inconsistencies."

The failure occurred because the test concluded with a form save without waiting for the subsequent page reload. This led to a race condition where the test ended with the form in a dirty state.

This PR ensures that the test waits until the form is properly saved and closed before concluding the tour.

fixes runbot-70155