### PR TITLE
[FIX] account: evaluate placeholder of email_to in send & print

### DIFF
--- a/addons/account/wizard/account_move_send.py
+++ b/addons/account/wizard/account_move_send.py
@@ -122,10 +122,12 @@ class AccountMoveSend(models.TransientModel):
     def _get_default_mail_partner_ids(self, move, mail_template, mail_lang):
         partners = self.env['res.partner'].with_company(move.company_id)
         if mail_template.email_to:
-            for mail_data in tools.email_split(mail_template.email_to):
+            email_to = self._get_mail_default_field_value_from_template(mail_template, mail_lang, move, 'email_to')
+            for mail_data in tools.email_split(email_to):
                 partners |= partners.find_or_create(mail_data)
         if mail_template.email_cc:
-            for mail_data in tools.email_split(mail_template.email_cc):
+            email_cc = self._get_mail_default_field_value_from_template(mail_template, mail_lang, move, 'email_cc')
+            for mail_data in tools.email_split(email_cc):
                 partners |= partners.find_or_create(mail_data)
         if mail_template.partner_to:
             partner_to = self._get_mail_default_field_value_from_template(mail_template, mail_lang, move, 'partner_to')


### PR DESCRIPTION
**Steps to reproduce:**
- Install Invoicing
- Go to "Settings / Technical / Email / Email Templates"
- Open "Invoicing: Sending"
- In "Email Configuration" tab, remove value of "To (Partners)" [partner_to] and add a placeholder for "To (Emails)" [email_to] For example: {{ object.partner_id.email }})
- Create an invoice and open "Send & Print" wizard

**Issue:**
Recipients field is empty. It should contain customer's email.
Same issue with "Cc" [email_cc] field of email template.

**Cause:**
When generating the recipients of "Send & Print" wizard, the placeholder defined in email_to field of the email template is not evaluated.

opw-3999260




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
