### PR TITLE
[FIX] base_automation: fetch ID and improve button functionality

### DIFF
--- a/addons/base_automation/static/src/base_automation_error_dialog.xml
+++ b/addons/base_automation/static/src/base_automation_error_dialog.xml
@@ -5,8 +5,8 @@
         <xpath expr="//div[@role='alert']" position="inside">
             <p>
                 The error occurred during the execution of the automation rule
-                "<t t-esc="actionName"/>"
-                (ID: <t t-esc="actionId"/>).
+                "<t t-esc="automationName"/>"
+                (ID: <t t-esc="automationId"/>).
                 <br/>
             </p>
             <p t-if="isUserAdmin">
@@ -22,10 +22,10 @@
         </xpath>
         <xpath expr="//div[@role='alert']//button" position="after">
             <t t-if="isUserAdmin">
-                <button class="btn btn-secondary mt4 o_disable_action_button me-3" t-on-click.prevent="disableAction">
+                <button class="btn btn-secondary mt4 o_disable_action_button me-3" t-on-click.prevent="disableAutomation">
                     <i class="fa fa-ban mr8"/>Disable Automation Rule
                 </button>
-                <button class="btn btn-secondary mt4 o_edit_action_button" t-on-click.prevent="editAction">
+                <button class="btn btn-secondary mt4 o_edit_action_button" t-on-click.prevent="editAutomation">
                     <i class="fa fa-edit mr8"/>Edit Automation Rule
                 </button>
             </t>

--- a/addons/base_automation/static/tests/base_automation_error_dialog.js
+++ b/addons/base_automation/static/tests/base_automation_error_dialog.js
@@ -119,4 +119,36 @@ QUnit.module("base_automation", {}, function () {
         assert.containsNone(target, ".modal .o_disable_action_button");
         assert.containsNone(target, ".modal .o_edit_action_button");
     });
+
+    QUnit.test("display automation rule id and name in Error dialog", async function (assert) {
+        assert.expect(1);
+
+        const errorContext = {
+            exception_class: "base_automation",
+            base_automation: {
+                id: 1,
+                name: "Test base automation error dialog",
+            },
+        };
+
+        const error = makeServerError({
+            subType: "Odoo Client Error",
+            message: "Message",
+            context: errorContext,
+        });
+
+
+        const env = await makeTestEnv();
+        await mount(MainComponentsContainer, target, { env });
+
+        const errorEvent = new PromiseRejectionEvent("error", {
+            reason: error,
+            promise: null,
+            cancelable: true,
+            bubbles: true,
+        });
+        await unhandledRejectionCb(errorEvent);
+        await nextTick();
+        assert.strictEqual(target.querySelector(".modal-body p:nth-child(5)").textContent, " The error occurred during the execution of the automation rule \"Test base automation error dialog\" (ID: 1). ");
+    });
 });


### PR DESCRIPTION
Specification:
The automation name and ID are not visible. Additionally, the 'Disable Automation Rule' and 'Edit Automation Rule' buttons are not working in the error dialog.

Expected behavior:
The automation rule ID and name are visible, and both buttons work as expected.

Task-3959044