### PR TITLE
[FIX] hr_timesheet: hide analytic acct. warning if timesheet opt. disabled

### DIFF
--- a/addons/hr_timesheet/views/project_task_views.xml
+++ b/addons/hr_timesheet/views/project_task_views.xml
@@ -28,7 +28,7 @@
                     </div>
                 </xpath>
                 <xpath expr="//t[@name='warning_section']" position="inside">
-                    <div class="alert alert-warning text-center mb-2" role="alert" invisible="analytic_account_active or not project_id" groups="hr_timesheet.group_hr_timesheet_user">
+                    <div class="alert alert-warning text-center mb-2" role="alert" invisible="analytic_account_active or not allow_timesheets" groups="hr_timesheet.group_hr_timesheet_user">
                         You cannot log timesheets on this project since it is linked to an inactive analytic account.<br/> Please change this account, or reactivate the current one to timesheet on the project.
                     </div>
                 </xpath>


### PR DESCRIPTION
Following odoo/odoo@79e3e783dc05, the warning for inactive analytic account was moved from the `Timesheet` page to the form top but miss the same invisible attrs as the page.

This commit hide the warning as well when the `Timesheet` option is disable (when there is no project, that option is also considered disabled).

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
