### PR TITLE
[IMP] hr,hr_attendance,hr_presence: simplify kanban archs

### DIFF
--- a/addons/hr/static/tests/m2x_avatar_employee_tests.js
+++ b/addons/hr/static/tests/m2x_avatar_employee_tests.js
@@ -155,10 +155,8 @@ QUnit.module("M2XAvatarEmployee", ({ beforeEach }) => {
         const views = {
             "m2x.avatar.employee,false,kanban": `<kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="employee_id" widget="many2one_avatar_employee"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="employee_id" widget="many2one_avatar_employee"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -230,10 +228,8 @@ QUnit.module("M2XAvatarEmployee", ({ beforeEach }) => {
             const views = {
                 "m2x.avatar.employee,false,kanban": `<kanban>
                     <templates>
-                        <t t-name="kanban-box">
-                            <div>
-                                <field name="employee_id" widget="many2one_avatar_employee"/>
-                            </div>
+                        <t t-name="kanban-card">
+                            <field name="employee_id" widget="many2one_avatar_employee"/>
                         </t>
                     </templates>
                 </kanban>`,
@@ -271,10 +267,8 @@ QUnit.module("M2XAvatarEmployee", ({ beforeEach }) => {
         const views = {
             "m2x.avatar.employee,false,kanban": `<kanban>
                     <templates>
-                        <t t-name="kanban-box">
-                            <div>
-                                <field name="employee_id" widget="many2one_avatar_employee" options="{'relation': 'hr.employee.public'}"/>
-                            </div>
+                        <t t-name="kanban-card">
+                            <field name="employee_id" widget="many2one_avatar_employee" options="{'relation': 'hr.employee.public'}"/>
                         </t>
                     </templates>
                 </kanban>`,
@@ -625,16 +619,10 @@ QUnit.module("M2XAvatarEmployee", ({ beforeEach }) => {
         const views = {
             "m2x.avatar.employee,false,kanban": `<kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <div class="oe_kanban_footer">
-                                <div class="o_kanban_record_bottom">
-                                    <div class="oe_kanban_bottom_right">
-                                        <field name="employee_ids" widget="many2many_avatar_employee"/>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                    <t t-name="kanban-card">
+                        <footer>
+                            <field name="employee_ids" widget="many2many_avatar_employee"/>
+                        </footer>
                     </t>
                 </templates>
             </kanban>`,

--- a/addons/hr/static/tests/tours/hr_employee_flow.js
+++ b/addons/hr/static/tests/tours/hr_employee_flow.js
@@ -15,7 +15,7 @@ registry.category("web_tour.tours").add('hr_employee_tour', {
     },
     {
         content: "Open an Employee Profile",
-        trigger: ".o_kanban_record_title:contains('Johnny H.')",
+        trigger: ".o_kanban_record:contains('Johnny H.')",
         run: 'click',
     },
     {

--- a/addons/hr/static/tests/web/m2x_avatar_user_tests.js
+++ b/addons/hr/static/tests/web/m2x_avatar_user_tests.js
@@ -95,10 +95,8 @@ QUnit.module("M2XAvatarUser", ({ beforeEach }) => {
             "m2x.avatar.user,false,kanban": `
                     <kanban>
                         <templates>
-                            <t t-name="kanban-box">
-                                <div>
-                                    <field name="user_id" widget="many2one_avatar_user"/>
-                                </div>
+                            <t t-name="kanban-card">
+                                <field name="user_id" widget="many2one_avatar_user"/>
                             </t>
                         </templates>
                     </kanban>`,

--- a/addons/hr/views/hr_employee_public_views.xml
+++ b/addons/hr/views/hr_employee_public_views.xml
@@ -124,61 +124,40 @@
             <field name="priority">10</field>
             <field name="arch" type="xml">
                 <kanban class="o_hr_employee_kanban" sample="1">
-                    <field name="id"/>
-                    <field name="hr_presence_state"/>
-                    <field name="user_id"/>
-                    <field name="user_partner_id"/>
-                    <field name="last_activity"/>
-                    <field name="hr_icon_display"/>
                     <field name="show_hr_icon_display"/>
                     <field name="image_128" />
                     <templates>
-                        <t t-name="kanban-box">
-                        <div class="oe_kanban_global_click o_kanban_record_has_image_fill o_hr_kanban_record">
-                            <t t-if="!record.image_1024.raw_value">
-                                <field name="avatar_128" class="o_kanban_image_fill_left d-block"
-                                    widget="background_image" options="{'zoom': true, 'zoom_delay': 1000}"/>
-                            </t>
-                            <t t-else="">
-                                <field name="image_1024" class="o_kanban_image_fill_left d-block" preview_image="image_128"
-                                    widget="background_image" options="{'zoom': true, 'zoom_delay': 1000}"/>
-                            </t>
-                            <div class="oe_kanban_details">
-                                <div class="o_kanban_record_top">
-                                    <div class="o_kanban_record_headings">
-                                        <strong class="o_kanban_record_title">
-                                            <field name="name" placeholder="Employee's Name"/>
-                                            <div class="float-end">
-                                                <t t-if="record.show_hr_icon_display.raw_value">
-                                                    <field name="hr_icon_display" class="o_employee_availability align-items-center" widget="hr_presence_status" />
-                                                </t>
-                                            </div>
-                                        </strong>
-                                        <span t-if="record.job_title.raw_value" class="o_kanban_record_subtitle"><field name="job_title"/></span>
+                        <t t-name="kanban-card" class="flex-row">
+                            <aside class="o_kanban_aside_full">
+                                <t t-if="!record.image_1024.raw_value">
+                                    <field name="avatar_128" class="d-block position-relative"
+                                        widget="background_image" options="{'zoom': true, 'zoom_delay': 1000}"/>
+                                </t>
+                                <t t-else="">
+                                    <field name="image_1024" class="d-block position-relative" preview_image="image_128"
+                                        widget="background_image" options="{'zoom': true, 'zoom_delay': 1000}"/>
+                                </t>
+                            </aside>
+                            <main class="ms-2">
+                                <div>
+                                    <field class="fw-bolder" name="name" placeholder="Employee's Name"/>
+                                    <div t-if="record.show_hr_icon_display.raw_value" class="float-end">
+                                        <field name="hr_icon_display" class="o_employee_availability align-items-center" widget="hr_presence_status" />
                                     </div>
                                 </div>
-                                <ul>
-                                    <li t-if="record.work_email.raw_value">
-                                        <i class="fa fa-fw me-2 fa-envelope text-primary" title="Email"/>
-                                        <field name="work_email"/>
-                                    </li>
-                                    <li t-if="record.work_phone.raw_value" class="o_force_ltr">
-                                        <i class="fa fa-fw me-2 fa-phone text-primary" title="Phone"/>
-                                        <field name="work_phone"/>
-                                    </li>
-                                </ul>
-                                <div class="oe_kanban_content position-absolute start-0 bottom-0 end-0 me-2">
-                                    <div class="o_kanban_record_bottom mt-3">
-                                        <div class="oe_kanban_bottom_left"/>
-                                        <div class="oe_kanban_bottom_right">
-                                            <div class="hr_avatar mb-1 ms-2 me-n1">
-                                                <field name="user_id" widget="many2one_avatar_user" readonly="1"/>
-                                            </div>
-                                        </div>
-                                    </div>
+                                <field t-if="record.job_title.raw_value" name="job_title"/>
+                                <div t-if="record.work_email.raw_value" class="o_text_overflow">
+                                    <i class="fa fa-fw me-2 fa-envelope text-primary" title="Email"/>
+                                    <field name="work_email"/>
                                 </div>
-                            </div>
-                        </div>
+                                <div t-if="record.work_phone.raw_value">
+                                    <i class="fa fa-fw me-2 fa-phone text-primary" title="Phone"/>
+                                    <field name="work_phone"/>
+                                </div>
+                                <footer class="fs-6 position-absolute bottom-0 end-0">
+                                    <field name="user_id" widget="many2one_avatar_user" readonly="1" class="mb-2 ms-auto me-2"/>
+                                </footer>
+                            </main>
                         </t>
                     </templates>
                 </kanban>

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -270,79 +270,52 @@
             <field name="priority">10</field>
             <field name="arch" type="xml">
                 <kanban class="o_hr_employee_kanban" sample="1">
-                    <field name="id"/>
-                    <field name="hr_presence_state"/>
-                    <field name="user_id"/>
-                    <field name="user_partner_id"/>
-                    <field name="hr_icon_display"/>
                     <field name="show_hr_icon_display"/>
                     <field name="image_128" />
                     <field name="company_id"/>
                     <templates>
-                        <t t-name="kanban-box">
-                        <div class="oe_kanban_global_click o_kanban_record_has_image_fill o_hr_kanban_record">
-                            <t t-if="record.image_1024.raw_value">
-                                <field name="image_1024" class="o_kanban_image_fill_left d-block" preview_image="image_128"
-                                    widget="background_image" options="{'zoom': true, 'zoom_delay': 1000}"/>
-                            </t>
-                            <t t-elif="record.image_128.raw_value">
-                                <field name="avatar_128" class="o_kanban_image_fill_left d-block"
-                                    widget="background_image" options="{'zoom': true, 'zoom_delay': 1000}"/>
-                            </t>
-                            <div t-else="" class="o_kanban_image_fill_left d-flex align-items-center justify-content-center bg-100 bg-gradient">
-                                <svg class="w-75 h-75 opacity-50" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-                                    <g fill="currentColor">
-                                        <path d="M 10 11 C 4.08 11 2 14 2 16 L 2 19 L 18 19 L 18 16 C 18 14 15.92 11 10 11 Z"/>
-                                        <circle cx="10" cy="5.5" r="4.5"/>
-                                    </g>
-                                </svg>
-                            </div>
-
-                            <div class="oe_kanban_details">
-                                <div class="o_kanban_record_top">
-                                    <div class="o_kanban_record_headings">
-                                        <strong class="o_kanban_record_title">
-                                            <field name="name" placeholder="Employee's Name"/>
-                                            <div class="float-end">
-                                                <div t-if="record.show_hr_icon_display.raw_value">
-                                                    <field name="hr_icon_display" class="o_employee_availability" widget="hr_presence_status" />
-                                                </div>
-                                            </div>
-                                        </strong>
-                                        <span t-if="record.job_title.raw_value" class="o_kanban_record_subtitle">
-                                            <field name="job_title"/>
-                                        </span>
+                        <t t-name="kanban-card" class="flex-row">
+                            <aside class="o_kanban_aside_full">
+                                <t t-if="record.image_1024.raw_value">
+                                    <field name="image_1024" widget="background_image" options="{'zoom': true, 'zoom_delay': 1000, 'preview_image':'image_128'}" class="d-block position-relative"/>
+                                </t>
+                                <t t-elif="record.image_128.raw_value">
+                                    <field name="avatar_128" widget="background_image" options="{'zoom': true, 'zoom_delay': 1000}" class="d-block position-relative"/>
+                                </t>
+                                <div t-else="" class="d-flex align-items-center justify-content-center bg-100 bg-gradient">
+                                    <svg class="w-75 h-75 opacity-50" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+                                        <g fill="currentColor">
+                                            <path d="M 10 11 C 4.08 11 2 14 2 16 L 2 19 L 18 19 L 18 16 C 18 14 15.92 11 10 11 Z"/>
+                                            <circle cx="10" cy="5.5" r="4.5"/>
+                                        </g>
+                                    </svg>
+                                </div>
+                            </aside>
+                            <main class="ms-2">
+                                <div>
+                                    <field class="fw-bold fs-5" name="name" placeholder="Employee's Name"/>
+                                    <div t-if="record.show_hr_icon_display.raw_value" class="float-end">
+                                        <field name="hr_icon_display" class="o_employee_availability" widget="hr_presence_status" />
                                     </div>
                                 </div>
-                                <ul>
-                                    <li t-if="record.work_email.raw_value" class="o_text_overflow">
-                                        <i class="fa fa-fw me-2 fa-envelope text-primary" title="Email"/>
-                                        <field name="work_email" />
-                                    </li>
-                                    <li t-if="record.work_phone.raw_value" class="o_force_ltr">
-                                        <i class="fa fa-fw me-2 fa-phone text-primary" title="Phone"/>
-                                        <field name="work_phone" />
-                                    </li>
-                                        <field name="employee_properties" widget="properties"/>
-                                    <li class="hr_tags">
-                                        <field name="category_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="hide"/>
-                                    </li>
-                                </ul>
-                            </div>
-                            <div class="oe_kanban_content o_hr_employee_kanban_bottom position-absolute bottom-0 start-0 end-0">
-                                <div class="o_kanban_record_bottom mt-3">
-                                    <div class="oe_kanban_bottom_left"/>
-                                    <div class="oe_kanban_bottom_right">
-                                        <div class="hr_avatar mb-1 ms-2 me-n1">
-                                            <field name="user_id" widget="many2one_avatar_user" readonly="1"/>
-                                        </div>
-                                        <div class="hr_activity_container mb-1 ms-2 me-n1">
-                                            <field name="activity_ids" widget="kanban_activity"/>
-                                        </div>
-                                    </div>
+                                <field t-if="record.job_title.raw_value" name="job_title"/>
+                                <div t-if="record.work_email.raw_value" class="o_text_overflow">
+                                    <i class="fa fa-fw me-2 fa-envelope text-primary" title="Email"/>
+                                    <field name="work_email" />
                                 </div>
-                            </div>
-                        </div>
+                                <div t-if="record.work_phone.raw_value">
+                                    <i class="fa fa-fw me-2 fa-phone text-primary" title="Phone"/>
+                                    <field name="work_phone" />
+                                </div>
+                                <field name="employee_properties" widget="properties"/>
+                                <field class="hr_tags" name="category_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="hide"/>
+                                <footer class="fs-6 position-absolute bottom-0 end-0">
+                                    <div class="d-flex ms-auto">
+                                        <field name="user_id" widget="many2one_avatar_user" readonly="1" class="mb-1 ms-2"/>
+                                        <field name="activity_ids" widget="kanban_activity" class="m-1 ms-2"/>
+                                    </div>
+                                </footer>
+                            </main>
                         </t>
                     </templates>
                 </kanban>

--- a/addons/hr/views/hr_job_views.xml
+++ b/addons/hr/views/hr_job_views.xml
@@ -60,18 +60,10 @@
             <field name="arch" type="xml">
                 <kanban class="o_kanban_mobile" sample="1">
                     <templates>
-                        <t t-name="kanban-box">
-                            <div class="oe_kanban_global_click">
-                                <div>
-                                    <strong><field name="name"/></strong>
-                                </div>
-                                <div>
-                                    <span><field name="department_id"/>&amp;nbsp;</span>
-                                </div>
-                                <div t-if="!selection_mode">
-                                    <span>Vacancies: <field name="expected_employees"/></span>
-                                </div>
-                            </div>
+                        <t t-name="kanban-card">
+                            <field class="fw-bold" name="name"/>
+                            <field name="department_id"/>
+                            <span t-if="!selection_mode">Vacancies: <field name="expected_employees"/></span>
                         </t>
                     </templates>
                 </kanban>

--- a/addons/hr_attendance/views/hr_attendance_view.xml
+++ b/addons/hr_attendance/views/hr_attendance_view.xml
@@ -36,21 +36,15 @@
         <field name="model">hr.attendance</field>
         <field name="arch" type="xml">
             <kanban class="o_kanban_mobile" sample="1">
-                <field name="employee_id"/>
                 <field name="check_in"/>
                 <field name="check_out"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div t-attf-class="oe_kanban_global_click">
-                            <div class="o_kanban_record_title">
-                                <field name="employee_id" widget="many2one_avatar_user" options="{'display_avatar_name': True}" class="fs-5 fw-bold"/>
-                            </div>
-                            <hr class="mt4 mb8"/>
-                            <div class="o_kanban_record_subtitle">
-                                <i class="fa fa-calendar" aria-label="Period" role="img" title="Period"></i>
-                                <t t-esc="record.check_in.value"/>
-                                - <t t-esc="record.check_out.value"/>
-                            </div>
+                    <t t-name="kanban-card">
+                        <field name="employee_id" widget="many2one_avatar_user" options="{'display_avatar_name': True}" class="fs-5 fw-bold mb-2"/>
+                        <hr class="mt4 mb8"/>
+                        <div>
+                            <i class="fa fa-calendar me-1" aria-label="Period" role="img" title="Period"></i>
+                            <field name="check_in" /> - <field name="check_out" />
                         </div>
                     </t>
                 </templates>

--- a/addons/hr_attendance/views/hr_employee_view.xml
+++ b/addons/hr_attendance/views/hr_employee_view.xml
@@ -111,35 +111,26 @@
         <field name="arch" type="xml">
             <kanban create="false">
                 <field name="attendance_state"/>
-                <field name="hours_today"/>
-                <field name="total_overtime"/>
-                <field name="id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                    <div class="oe_kanban_global_click">
-                        <div class="o_kanban_image">
-                            <img t-att-src="kanban_image('hr.employee.public', 'avatar_128', record.id.raw_value)" alt="Employee"/>
-                        </div>
-                        <div class="oe_kanban_details">
-                            <div id="textbox">
+                    <t t-name="kanban-card" class="flex-row">
+                        <aside>
+                            <field name="avatar_128" widget="image" alt="Employee" class="mb-0"/>
+                        </aside>
+                        <main class="w-100 ms-2">
+                            <div>
                                 <div class="float-end" t-if="record.attendance_state.raw_value == 'checked_in'">
-                                    <span id="oe_hr_attendance_status" class="fa fa-circle text-success me-1" role="img" aria-label="Available" title="Available"></span>
+                                    <span class="fa fa-circle text-success me-1" role="img" aria-label="Available" title="Available"></span>
                                 </div>
                                 <div class="float-end" t-if="record.attendance_state.raw_value == 'checked_out'">
-                                    <span id="oe_hr_attendance_status" class="fa fa-circle text-warning me-1"
+                                    <span class="fa fa-circle text-warning me-1"
                                           role="img" aria-label="Not available" title="Not available">
                                     </span>
                                 </div>
-                                <strong>
-                                    <field name="name"/>
-                                </strong>
+                                <field class="fw-bolder" name="name"/>
                             </div>
-                            <ul>
-                                <li t-if="record.job_id.raw_value"><field name="job_id"/></li>
-                                <li t-if="record.work_location_id.raw_value"><field name="work_location_id"/></li>
-                            </ul>
-                        </div>
-                    </div>
+                            <field t-if="record.job_id.raw_value" name="job_id"/>
+                            <field t-if="record.work_location_id.raw_value" name="work_location_id"/>
+                        </main>
                     </t>
                 </templates>
             </kanban>

--- a/addons/hr_presence/views/hr_employee_views.xml
+++ b/addons/hr_presence/views/hr_employee_views.xml
@@ -36,15 +36,15 @@
             <xpath expr="//kanban" position="attributes">
                 <attribute name="create">0</attribute>
             </xpath>
-            <xpath expr="//div[hasclass('oe_kanban_details')]" position="inside">
-                <div class="oe_kanban_content d-flex flex-column gap-1">
-                    <div class="oe_kanban_row d-flex gap-1">
+            <xpath expr="//main" position="inside">
+                <div class="d-flex flex-column gap-1">
+                    <div class="d-flex gap-1">
                         <field name="hr_presence_state" invisible="1"/>
-                        <button name="action_set_present" type="object" class="btn btn-success btn-sm fa fa-check" title="Set as present" invisible="hr_presence_state == 'present'"> </button>
-                        <button name="action_set_absent" type="object" class="btn btn-warning btn-sm fa fa-times" title="Set as absent" invisible="hr_presence_state != 'present'"> </button>
+                        <button name="action_set_present" type="object" class="btn btn-success btn-sm fa fa-check" title="Set as present" invisible="hr_presence_state == 'present'"></button>
+                        <button name="action_set_absent" type="object" class="btn btn-warning btn-sm fa fa-times" title="Set as absent" invisible="hr_presence_state != 'present'"></button>
                         <button name="action_open_leave_request" type="object" class="btn btn-secondary btn-sm">Time Off</button>
                     </div>
-                    <div class="oe_kanban_row d-flex gap-1">
+                    <div class="d-flex gap-1">
                         <button name="action_send_sms" type="object" class="btn btn-secondary btn-sm">SMS</button>
                         <button name="action_send_mail" type="object" class="btn btn-secondary btn-sm">Log</button>
                     </div>


### PR DESCRIPTION
In this commit we have simplified the kanban arch for the hr,hr_presence and hr_attendance module.the goal is to simplify them, make them easier to read and use bootstrap utility classnames.

- Previously, we used `kanban-box`, but now we are using `kanban-card` instead.
- Deprecated `oe_kanban_global_click` and `oe_kanban_global_click_edit`.
- More use of `<field/>` tags
- Removed the `oe_kanban_colorpicker` class and replaced it with the `kanban_color_picker` widget.
- Changed `type='edit'` to `type='open'` to open records. since version 16, records always open in edit mode by default.
- `kanban_image` from rendering context, is deprecated so we use `<field name="..." widget="image"/>` instead
- `kanban_color`, `kanban_getcolor` and `kanban_getcolorname` are deprecated use new attribute `highlight_color="color_field_name"` on root node
- `oe_kanban_colorpicker` is deprecated, use `kanban_color_picker` widget instead

Task-3992107

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
