### PR TITLE
[FIX] l10n_sa_pos: increase QR code size on receipts

### DIFF
--- a/addons/l10n_sa_pos/static/src/overrides/models/models.js
+++ b/addons/l10n_sa_pos/static/src/overrides/models/models.js
@@ -19,7 +19,7 @@ patch(Order.prototype, {
                     this.get_total_tax()
                 );
                 const qr_code_svg = new XMLSerializer().serializeToString(
-                    codeWriter.write(qr_values, 150, 150)
+                    codeWriter.write(qr_values, 200, 200)
                 );
                 result.qr_code = "data:image/svg+xml;base64," + window.btoa(qr_code_svg);
             }


### PR DESCRIPTION
Prior to this commit, the QR code size on some receipts was too small to be scanned effectively.

opw-4008280

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
