### PR TITLE
[IMP] mail: move mail boxes to the correct bundle

### DIFF
--- a/addons/mail/models/res_users.py
+++ b/addons/mail/models/res_users.py
@@ -311,21 +311,19 @@ class Users(models.Model):
         bus_last_id = self.env["bus.bus"].sudo()._bus_last_id()
         store.add(
             {
-                "discuss": {
-                    "inbox": {
-                        "counter": self.partner_id._get_needaction_count(),
-                        "counter_bus_id": bus_last_id,
-                        "id": "inbox",
-                        "model": "mail.box",
-                    },
-                    "starred": {
-                        "counter": self.env["mail.message"].search_count(
-                            [("starred_partner_ids", "in", self.partner_id.ids)]
-                        ),
-                        "counter_bus_id": bus_last_id,
-                        "id": "starred",
-                        "model": "mail.box",
-                    },
+                "inbox": {
+                    "counter": self.partner_id._get_needaction_count(),
+                    "counter_bus_id": bus_last_id,
+                    "id": "inbox",
+                    "model": "mail.box",
+                },
+                "starred": {
+                    "counter": self.env["mail.message"].search_count(
+                        [("starred_partner_ids", "in", self.partner_id.ids)]
+                    ),
+                    "counter_bus_id": bus_last_id,
+                    "id": "starred",
+                    "model": "mail.box",
                 },
             }
         )

--- a/addons/mail/static/src/core/common/discuss_app_model.js
+++ b/addons/mail/static/src/core/common/discuss_app_model.js
@@ -53,10 +53,6 @@ export class DiscussApp extends Record {
     thread = Record.one("Thread");
     channels = Record.one("DiscussAppCategory");
     chats = Record.one("DiscussAppCategory");
-    // mailboxes in sidebar
-    inbox = Record.one("Thread");
-    starred = Record.one("Thread");
-    history = Record.one("Thread");
     hasRestoredThread = false;
 }
 

--- a/addons/mail/static/src/core/common/mail_core_common_service.js
+++ b/addons/mail/static/src/core/common/mail_core_common_service.js
@@ -32,24 +32,9 @@ export class MailCoreCommon {
                 message.delete();
             }
         });
-        this.busService.subscribe("mail.message/toggle_star", (payload, { id: notifId }) => {
-            const { message_ids: messageIds, starred } = payload;
-            for (const messageId of messageIds) {
-                const message = this.store.Message.insert({ id: messageId, starred });
-                const starredBox = this.store.discuss.starred;
-                if (starred) {
-                    if (notifId > starredBox.counter_bus_id) {
-                        starredBox.counter++;
-                    }
-                    starredBox.messages.add(message);
-                } else {
-                    if (notifId > starredBox.counter_bus_id) {
-                        starredBox.counter--;
-                    }
-                    starredBox.messages.delete(message);
-                }
-            }
-        });
+        this.busService.subscribe("mail.message/toggle_star", (payload, metadata) =>
+            this._handleNotificationToggleStar(payload, metadata)
+        );
         this.busService.subscribe("res.users.settings", (payload) => {
             if (payload) {
                 this.store.settings.update(payload);
@@ -67,6 +52,11 @@ export class MailCoreCommon {
                 }
             }
         });
+    }
+
+    _handleNotificationToggleStar(payload, metadata) {
+        const { message_ids: messageIds, starred } = payload;
+        this.store.Message.insert(messageIds.map((id) => ({ id, starred })));
     }
 }
 

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -293,25 +293,7 @@ export class Store extends BaseStore {
     }
 
     /** Provides an override point for when the store service has started. */
-    onStarted() {
-        this.discuss.inbox = {
-            id: "inbox",
-            model: "mail.box",
-            name: _t("Inbox"),
-        };
-        this.discuss.starred = {
-            id: "starred",
-            model: "mail.box",
-            name: _t("Starred"),
-            counter: 0,
-        };
-        this.discuss.history = {
-            id: "history",
-            model: "mail.box",
-            name: _t("History"),
-            counter: 0,
-        };
-    }
+    onStarted() {}
 
     /**
      * Search and fetch for a partner with a given user or partner id.
@@ -604,13 +586,6 @@ export class Store extends BaseStore {
             partners.push(...Persona);
         }
         return partners;
-    }
-
-    async unstarAll() {
-        // apply the change immediately for faster feedback
-        this.discuss.starred.counter = 0;
-        this.discuss.starred.messages = [];
-        await this.env.services.orm.call("mail.message", "unstar_all");
     }
 }
 Store.register();

--- a/addons/mail/static/src/core/common/thread.xml
+++ b/addons/mail/static/src/core/common/thread.xml
@@ -51,50 +51,13 @@
         </t>
         <t t-else="">
             <div class="o-mail-Thread-empty d-flex flex-column align-items-center justify-content-center text-muted fst-italic h-100" t-att-class="{'p-4': props.showEmptyMessage}">
-                <t t-if="props.thread.isLoaded">
-                    <t t-if="props.thread.isEmpty and props.thread.model === 'mail.box'">
-                    <t t-if="props.thread.id === 'inbox' and state.mountedAndLoaded">
-                        <div t-if="store.self.notification_preference !== 'inbox'" class="align-items-center text-center">
-                            <h4 class="mb-3 fw-bolder">
-                                Your inbox is empty
-                            </h4>
-                            <t t-call="mail.Thread.inboxHint"/>
-                        </div>
-                        <div t-else="" class="align-items-center text-center">
-                            <h4 class="mb-3 fw-bolder">
-                                Congratulations, your inbox is empty
-                            </h4>
-                            New messages appear here.
-                        </div>
-                    </t>
-                    <t t-if="props.thread.id === 'starred'">
-                        <h4 class="mb-3 fw-bolder">
-                            No starred messages
-                        </h4>
-                        You can mark any message as 'starred', and it shows up in this mailbox.
-                    </t>
-                    <t t-if="props.thread.id === 'history'">
-                        <img src="/web/static/img/neutral_face.svg" alt="History"/>
-                        <h4 class="mb-3 fw-bolder">
-                            No history messages
-                        </h4>
-                        Messages marked as read will appear in the history.
-                    </t>
-                    </t>
-                    <t t-elif="props.showEmptyMessage">
-                        There are no messages in this conversation.
-                    </t>
+                <t t-if="props.thread.isLoaded and props.showEmptyMessage">
+                    <span t-ref="empty-message">There are no messages in this conversation.</span>
                 </t>
             </div>
         </t>
     </div>
     <t t-if="!env.inChatter" t-call="mail.Thread.jumpPresent"/>
-</t>
-
-<t t-name="mail.Thread.inboxHint">
-    <t t-esc="preferenceButtonText.before"/>
-    <button class="btn btn-link m-0 p-0 align-baseline o-hover-text-underline" t-on-click="onClickPreferences" t-esc="preferenceButtonText.inside"/>
-    <t t-esc="preferenceButtonText.after"/>
 </t>
 
 <t t-name="mail.Thread.jumpPresent">

--- a/addons/mail/static/src/core/public_web/discuss.js
+++ b/addons/mail/static/src/core/public_web/discuss.js
@@ -17,7 +17,6 @@ import {
     useChildSubEnv,
     useRef,
     useState,
-    useEffect,
     useExternalListener,
 } from "@odoo/owl";
 import { getActiveHotkey } from "@web/core/hotkeys/hotkey_service";
@@ -50,7 +49,6 @@ export class Discuss extends Component {
         this.orm = useService("orm");
         this.effect = useService("effect");
         this.ui = useState(useService("ui"));
-        this.prevInboxCounter = this.store.discuss.inbox.counter;
         useChildSubEnv({
             inDiscussApp: true,
             messageHighlight: this.messageHighlight,
@@ -68,23 +66,6 @@ export class Discuss extends Component {
                 }
             },
             { capture: true }
-        );
-        useEffect(
-            () => {
-                if (
-                    this.thread?.id === "inbox" &&
-                    this.prevInboxCounter !== this.store.discuss.inbox.counter &&
-                    this.store.discuss.inbox.counter === 0
-                ) {
-                    this.effect.add({
-                        message: _t("Congratulations, your inbox is empty!"),
-                        type: "rainbow_man",
-                        fadeout: "fast",
-                    });
-                }
-                this.prevInboxCounter = this.store.discuss.inbox.counter;
-            },
-            () => [this.store.discuss.inbox.counter]
         );
         onMounted(() => (this.store.discuss.isActive = true));
         onWillUnmount(() => (this.store.discuss.isActive = false));

--- a/addons/mail/static/src/core/public_web/discuss.xml
+++ b/addons/mail/static/src/core/public_web/discuss.xml
@@ -3,7 +3,6 @@
 
 <t t-name="mail.Discuss">
     <div class="o-mail-Discuss d-flex h-100 flex-grow-1" t-att-class="{ 'flex-column align-items-center bg-view': ui.isSmall }" t-ref="root">
-        <div t-if="ui.isSmall and store.discuss.activeTab === 'main'" class="w-100 border-bottom" t-call="mail.Discuss.mobileTopbar" t-ref="mobileTopbar"/>
         <div t-if="store.inPublicPage or !(ui.isSmall and store.discuss.activeTab !== 'main')" class="o-mail-Discuss-content d-flex flex-column h-100 w-100 overflow-auto" t-ref="content">
             <div class="o-mail-Discuss-header px-3 bg-view d-flex flex-shrink-0 align-items-center border-bottom z-1" t-att-class="{ 'flex-grow-1': !ui.isSmall and !store.inPublicPage }" t-ref="header">
                 <t t-if="thread">
@@ -79,20 +78,6 @@
                 </div>
             </div>
         </div>
-    </div>
-</t>
-
-<t t-name="mail.Discuss.mobileTopbar">
-    <div class="btn-group d-flex w-100 p-1">
-        <t t-call="mail.MobileMailbox" >
-            <t t-set="mailbox" t-value="store.discuss.inbox"/>
-        </t>
-        <t t-call="mail.MobileMailbox">
-            <t t-set="mailbox" t-value="store.discuss.starred"/>
-        </t>
-        <t t-call="mail.MobileMailbox">
-            <t t-set="mailbox" t-value="store.discuss.history"/>
-        </t>
     </div>
 </t>
 

--- a/addons/mail/static/src/core/web/@types/models.d.ts
+++ b/addons/mail/static/src/core/web/@types/models.d.ts
@@ -2,6 +2,11 @@ declare module "models" {
     import { Activity as ActivityClass } from "@mail/core/web/activity_model";
 
     export interface Activity extends ActivityClass {}
+    export interface Discuss  {
+        inbox: Thread,
+        stared: Thread,
+        history: Thread,
+    }
     export interface Store {
         activityCounter: number,
         activity_counter_bus_id: number,

--- a/addons/mail/static/src/core/web/discuss_patch.js
+++ b/addons/mail/static/src/core/web/discuss_patch.js
@@ -1,10 +1,11 @@
-import { onRendered } from "@odoo/owl";
+import { onRendered, useEffect } from "@odoo/owl";
 
 import { Discuss } from "@mail/core/public_web/discuss";
 import { DiscussSidebar } from "@mail/core/web/discuss_sidebar";
 import { MessagingMenu } from "@mail/core/web/messaging_menu";
 
 import { ControlPanel } from "@web/search/control_panel/control_panel";
+import { _t } from "@web/core/l10n/translation";
 import { patch } from "@web/core/utils/patch";
 
 Object.assign(Discuss.components, { ControlPanel, DiscussSidebar, MessagingMenu });
@@ -12,10 +13,28 @@ Object.assign(Discuss.components, { ControlPanel, DiscussSidebar, MessagingMenu 
 patch(Discuss.prototype, {
     setup() {
         super.setup();
+        this.prevInboxCounter = this.store.inbox.counter;
         onRendered(() => {
             if (this.thread?.displayName) {
                 this.env.config?.setDisplayName(this.thread.displayName);
             }
         });
+        useEffect(
+            () => {
+                if (
+                    this.thread?.id === "inbox" &&
+                    this.prevInboxCounter !== this.store.inbox.counter &&
+                    this.store.inbox.counter === 0
+                ) {
+                    this.effect.add({
+                        message: _t("Congratulations, your inbox is empty!"),
+                        type: "rainbow_man",
+                        fadeout: "fast",
+                    });
+                }
+                this.prevInboxCounter = this.store.inbox.counter;
+            },
+            () => [this.store.inbox.counter]
+        );
     },
 });

--- a/addons/mail/static/src/core/web/discuss_patch.xml
+++ b/addons/mail/static/src/core/web/discuss_patch.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-inherit="mail.Discuss" t-inherit-mode="extension">
+        <xpath expr="//*[@t-ref='content']" position="before">
+            <div t-if="ui.isSmall and store.discuss.activeTab === 'main'" class="w-100 border-bottom" t-call="mail.Discuss.mobileTopbar" t-ref="mobileTopbar"/>
+        </xpath>
         <xpath expr="//*[@t-ref='core']" position="before">
             <t t-if="ui.isSmall" t-call="mail.Discuss.loading"/>
             <DiscussSidebar t-else=""/>
@@ -37,6 +40,20 @@
     <t t-name="mail.Discuss.loading">
         <div t-if="store.channels.status === 'fetching'" class="d-flex flex-grow-1 align-items-center justify-content-center h-100 w-100 o-pointer-events-none">
             <h4 class="text-muted opacity-50 o-visible-short-delay"><b><i class="o-mail-Discuss-mobileLoading fa fa-circle-o-notch fa-spin"/></b></h4>
+        </div>
+    </t>
+
+    <t t-name="mail.Discuss.mobileTopbar">
+        <div class="btn-group d-flex w-100 p-1">
+            <t t-call="mail.MobileMailbox" >
+                <t t-set="mailbox" t-value="store.inbox"/>
+            </t>
+            <t t-call="mail.MobileMailbox">
+                <t t-set="mailbox" t-value="store.starred"/>
+            </t>
+            <t t-call="mail.MobileMailbox">
+                <t t-set="mailbox" t-value="store.history"/>
+            </t>
         </div>
     </t>
 </templates>

--- a/addons/mail/static/src/core/web/discuss_sidebar_mailboxes.xml
+++ b/addons/mail/static/src/core/web/discuss_sidebar_mailboxes.xml
@@ -4,13 +4,13 @@
     <t t-name="mail.DiscussSidebarMailboxes">
         <div class="d-flex flex-column flex-grow-0">
             <t t-call="mail.Mailbox">
-                <t t-set="mailbox" t-value="store.discuss.inbox"/>
+                <t t-set="mailbox" t-value="store.inbox"/>
             </t>
             <t t-call="mail.Mailbox">
-                <t t-set="mailbox" t-value="store.discuss.starred"/>
+                <t t-set="mailbox" t-value="store.starred"/>
             </t>
             <t t-call="mail.Mailbox">
-                <t t-set="mailbox" t-value="store.discuss.history"/>
+                <t t-set="mailbox" t-value="store.history"/>
             </t>
         </div>
     </t>

--- a/addons/mail/static/src/core/web/mail_core_common_service_patch.js
+++ b/addons/mail/static/src/core/web/mail_core_common_service_patch.js
@@ -1,0 +1,25 @@
+import { patch } from "@web/core/utils/patch";
+import { MailCoreCommon } from "@mail/core/common/mail_core_common_service";
+
+patch(MailCoreCommon.prototype, {
+    _handleNotificationToggleStar(payload, metadata) {
+        super._handleNotificationToggleStar(payload, metadata);
+        const { id: notifId } = metadata;
+        const { message_ids: messageIds, starred } = payload;
+        for (const id of messageIds) {
+            const message = this.store.Message.get({ id });
+            const starredBox = this.store.starred;
+            if (starred) {
+                if (notifId > starredBox.counter_bus_id) {
+                    starredBox.counter++;
+                }
+                starredBox.messages.add(message);
+            } else {
+                if (notifId > starredBox.counter_bus_id) {
+                    starredBox.counter--;
+                }
+                starredBox.messages.delete(message);
+            }
+        }
+    },
+});

--- a/addons/mail/static/src/core/web/mail_core_web_service.js
+++ b/addons/mail/static/src/core/web/mail_core_web_service.js
@@ -23,17 +23,17 @@ export class MailCoreWeb {
             }
         });
         this.env.bus.addEventListener("mail.message/delete", ({ detail: { message, notifId } }) => {
-            if (message.needaction && notifId > this.store.discuss.inbox.counter_bus_id) {
-                this.store.discuss.inbox.counter--;
+            if (message.needaction && notifId > this.store.inbox.counter_bus_id) {
+                this.store.inbox.counter--;
             }
-            if (message.starred && notifId > this.store.discuss.starred.counter_bus_id) {
-                this.store.discuss.starred.counter--;
+            if (message.starred && notifId > this.store.starred.counter_bus_id) {
+                this.store.starred.counter--;
             }
         });
         this.busService.subscribe("mail.message/inbox", (payload, { id: notifId }) => {
             const { Message: messages = [] } = this.store.insert(payload, { html: true });
             const [message] = messages;
-            const inbox = this.store.discuss.inbox;
+            const inbox = this.store.inbox;
             if (notifId > inbox.counter_bus_id) {
                 inbox.counter++;
             }
@@ -44,7 +44,7 @@ export class MailCoreWeb {
         });
         this.busService.subscribe("mail.message/mark_as_read", (payload, { id: notifId }) => {
             const { message_ids: messageIds, needaction_inbox_counter } = payload;
-            const inbox = this.store.discuss.inbox;
+            const inbox = this.store.inbox;
             for (const messageId of messageIds) {
                 // We need to ignore all not yet known messages because we don't want them
                 // to be shown partially as they would be linked directly to cache.
@@ -67,7 +67,7 @@ export class MailCoreWeb {
                 // move messages from Inbox to history
                 message.needaction = false;
                 inbox.messages.delete({ id: messageId });
-                const history = this.store.discuss.history;
+                const history = this.store.history;
                 history.messages.add(message);
             }
             if (notifId > inbox.counter_bus_id) {

--- a/addons/mail/static/src/core/web/messaging_menu.js
+++ b/addons/mail/static/src/core/web/messaging_menu.js
@@ -39,11 +39,11 @@ export class MessagingMenu extends Component {
     beforeOpen() {
         this.store.isReady.then(() => {
             if (
-                !this.store.discuss.inbox.isLoaded &&
-                this.store.discuss.inbox.status !== "loading" &&
-                this.store.discuss.inbox.counter !== this.store.discuss.inbox.messages.length
+                !this.store.inbox.isLoaded &&
+                this.store.inbox.status !== "loading" &&
+                this.store.inbox.counter !== this.store.inbox.messages.length
             ) {
-                this.store.discuss.inbox.fetchNewMessages();
+                this.store.inbox.fetchNewMessages();
             }
         });
     }
@@ -215,7 +215,7 @@ export class MessagingMenu extends Component {
             this.env.inDiscussApp &&
             (!this.store.discuss.thread || this.store.discuss.thread.model !== "mail.box")
         ) {
-            this.store.discuss.inbox.setAsDiscussThread();
+            this.store.inbox.setAsDiscussThread();
         }
         if (this.store.discuss.activeTab !== "main") {
             this.store.discuss.thread = undefined;
@@ -224,7 +224,7 @@ export class MessagingMenu extends Component {
 
     get counter() {
         let value =
-            this.store.discuss.inbox.counter +
+            this.store.inbox.counter +
             this.store.failures.reduce((acc, f) => acc + parseInt(f.notifications.length), 0);
         if (this.canPromptToInstall) {
             value++;

--- a/addons/mail/static/src/core/web/store_service_patch.js
+++ b/addons/mail/static/src/core/web/store_service_patch.js
@@ -100,9 +100,27 @@ const StorePatch = {
                 return b.localId > a.localId ? 1 : -1;
             },
         });
+        this.inbox = Record.one("Thread");
+        this.starred = Record.one("Thread");
+        this.history = Record.one("Thread");
     },
     onStarted() {
         super.onStarted(...arguments);
+        this.inbox = {
+            id: "inbox",
+            model: "mail.box",
+            name: _t("Inbox"),
+        };
+        this.starred = {
+            id: "starred",
+            model: "mail.box",
+            name: _t("Starred"),
+        };
+        this.history = {
+            id: "history",
+            model: "mail.box",
+            name: _t("History"),
+        };
         try {
             // useful for synchronizing activity data between multiple tabs
             this.activityBroadcastChannel = new browser.BroadcastChannel("mail.activity.channel");
@@ -175,6 +193,12 @@ const StorePatch = {
                 break;
             }
         }
+    },
+    async unstarAll() {
+        // apply the change immediately for faster feedback
+        this.store.starred.counter = 0;
+        this.store.starred.messages = [];
+        await this.env.services.orm.call("mail.message", "unstar_all");
     },
 };
 patch(Store.prototype, StorePatch);

--- a/addons/mail/static/src/core/web/thread_patch.xml
+++ b/addons/mail/static/src/core/web/thread_patch.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-inherit="mail.Thread" t-inherit-mode="extension">
+        <xpath expr="//*[@t-ref='empty-message']" position="replace">
+            <t t-if="props.thread.isEmpty and props.thread.model === 'mail.box'">
+                <t t-if="props.thread.id === 'inbox' and state.mountedAndLoaded">
+                    <div t-if="store.self.notification_preference !== 'inbox'" class="align-items-center text-center">
+                        <h4 class="mb-3 fw-bolder">Your inbox is empty</h4>
+                        <t t-esc="preferenceButtonText.before"/>
+                        <button class="btn btn-link m-0 p-0 align-baseline o-hover-text-underline" t-on-click="onClickPreferences" t-esc="preferenceButtonText.inside"/>
+                        <t t-esc="preferenceButtonText.after"/>
+                    </div>
+                    <div t-else="" class="align-items-center text-center">
+                        <h4 class="mb-3 fw-bolder">Congratulations, your inbox is empty</h4>
+                        New messages appear here.
+                    </div>
+                </t>
+                <t t-if="props.thread.id === 'starred'">
+                    <h4 class="mb-3 fw-bolder">No starred messages</h4>
+                    You can mark any message as 'starred', and it shows up in this mailbox.
+                </t>
+                <t t-if="props.thread.id === 'history'">
+                    <img src="/web/static/img/neutral_face.svg" alt="History"/>
+                    <h4 class="mb-3 fw-bolder">No history messages</h4>
+                    Messages marked as read will appear in the history.
+                </t>
+            </t>
+            <t t-else="">$0</t>
+        </xpath>
+    </t>
+</templates>

--- a/addons/mail/static/src/discuss/core/web/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/web/thread_model_patch.js
@@ -51,7 +51,7 @@ patch(Thread.prototype, {
                 const newThread =
                     this.store.discuss.channels.threads.find(
                         (thread) => thread.displayToSelf || thread.isLocallyPinned
-                    ) || this.store.discuss.inbox;
+                    ) || this.store.inbox;
                 newThread.setAsDiscussThread();
             } else {
                 this.store.discuss.thread = undefined;

--- a/addons/mail/static/src/discuss/web/discuss_core_common_service_patch.js
+++ b/addons/mail/static/src/discuss/web/discuss_core_common_service_patch.js
@@ -1,0 +1,34 @@
+import { DiscussCoreCommon } from "@mail/discuss/core/common/discuss_core_common_service";
+import { patch } from "@web/core/utils/patch";
+
+patch(DiscussCoreCommon.prototype, {
+    _handleNotificationChannelDelete(thread, metadata) {
+        const { notifId } = metadata;
+        const filteredStarredMessages = [];
+        let starredCounter = 0;
+        for (const msg of this.store.starred.messages) {
+            if (!msg.thread?.eq(thread)) {
+                filteredStarredMessages.push(msg);
+            } else {
+                starredCounter++;
+            }
+        }
+        this.store.starred.messages = filteredStarredMessages;
+        if (notifId > this.store.starred.counter_bus_id) {
+            this.store.starred.counter -= starredCounter;
+        }
+        this.store.inbox.messages = this.store.inbox.messages.filter(
+            (msg) => !msg.thread?.eq(thread)
+        );
+        if (notifId > this.store.inbox.counter_bus_id) {
+            this.store.inbox.counter -= thread.message_needaction_counter;
+        }
+        this.store.history.messages = this.store.history.messages.filter(
+            (msg) => !msg.thread?.eq(thread)
+        );
+        if (thread.eq(this.store.discuss.thread)) {
+            this.store.inbox.setAsDiscussThread();
+        }
+        super._handleNotificationChannelDelete(thread, metadata);
+    },
+});

--- a/addons/mail/static/tests/discuss_app/sidebar.test.js
+++ b/addons/mail/static/tests/discuss_app/sidebar.test.js
@@ -184,17 +184,17 @@ test("default thread rendering", async () => {
     await contains(".o-mail-DiscussSidebarChannel", { text: "General" });
     await contains("button.o-active", { text: "Inbox" });
     await contains(".o-mail-Thread", {
-        text: "Your inbox is empty Change your preferences to receive new notifications in your inbox.",
+        text: "Your inbox is emptyChange your preferences to receive new notifications in your inbox.",
     });
     await click("button", { text: "Starred" });
     await contains("button.o-active", { text: "Starred" });
     await contains(".o-mail-Thread", {
-        text: "No starred messages  You can mark any message as 'starred', and it shows up in this mailbox.",
+        text: "No starred messages You can mark any message as 'starred', and it shows up in this mailbox.",
     });
     await click("button", { text: "History" });
     await contains("button.o-active", { text: "History" });
     await contains(".o-mail-Thread", {
-        text: "No history messages  Messages marked as read will appear in the history.",
+        text: "No history messages Messages marked as read will appear in the history.",
     });
     await click(".o-mail-DiscussSidebarChannel", { text: "General" });
     await contains(".o-mail-DiscussSidebarChannel.o-active", { text: "General" });

--- a/addons/mail/static/tests/mock_server/mock_models/res_users.js
+++ b/addons/mail/static/tests/mock_server/mock_models/res_users.js
@@ -126,20 +126,18 @@ export class ResUsers extends webModels.ResUsers {
         ]);
         const bus_last_id = this.env["bus.bus"].lastBusNotificationId;
         store.add({
-            discuss: {
-                inbox: {
-                    counter: ResPartner._get_needaction_count(user.partner_id),
-                    counter_bus_id: bus_last_id,
-                    id: "inbox",
-                    model: "mail.box",
-                },
-                starred: {
-                    counter: MailMessage._filter([["starred_partner_ids", "in", user.partner_id]])
-                        .length,
-                    counter_bus_id: bus_last_id,
-                    id: "starred",
-                    model: "mail.box",
-                },
+            inbox: {
+                counter: ResPartner._get_needaction_count(user.partner_id),
+                counter_bus_id: bus_last_id,
+                id: "inbox",
+                model: "mail.box",
+            },
+            starred: {
+                counter: MailMessage._filter([["starred_partner_ids", "in", user.partner_id]])
+                    .length,
+                counter_bus_id: bus_last_id,
+                id: "starred",
+                model: "mail.box",
             },
             initChannelsUnreadCounter: members.filter((member) => member.message_unread_counter)
                 .length,

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -752,7 +752,7 @@ class TestChannelInternals(MailCommon, HttpCase):
             - OR we have access to the channel
         """
         self.authenticate(self.user_employee.login, self.user_employee.login)
-        self.assertEqual(self.make_jsonrpc_request("/mail/action", {"init_messaging": {}})["Store"]['discuss']['starred']['counter'], 0)
+        self.assertEqual(self.make_jsonrpc_request("/mail/action", {"init_messaging": {}})["Store"]['starred']['counter'], 0)
         test_group = self.env['discuss.channel'].create({
             'name': 'Private Channel',
             'channel_type': 'group',
@@ -761,14 +761,14 @@ class TestChannelInternals(MailCommon, HttpCase):
 
         test_group_own_message = test_group.with_user(self.user_employee.id).message_post(body='TestingMessage')
         test_group_own_message.write({'starred_partner_ids': [(6, 0, self.partner_employee.ids)]})
-        self.assertEqual(self.make_jsonrpc_request("/mail/action", {"init_messaging": {}})["Store"]['discuss']['starred']['counter'], 1)
+        self.assertEqual(self.make_jsonrpc_request("/mail/action", {"init_messaging": {}})["Store"]['starred']['counter'], 1)
 
         test_group_message = test_group.message_post(body='TestingMessage')
         test_group_message.write({'starred_partner_ids': [(6, 0, self.partner_employee.ids)]})
-        self.assertEqual(self.make_jsonrpc_request("/mail/action", {"init_messaging": {}})["Store"]['discuss']['starred']['counter'], 2)
+        self.assertEqual(self.make_jsonrpc_request("/mail/action", {"init_messaging": {}})["Store"]['starred']['counter'], 2)
 
         test_group.write({'channel_partner_ids': False})
-        self.assertEqual(self.make_jsonrpc_request("/mail/action", {"init_messaging": {}})["Store"]['discuss']['starred']['counter'], 1)
+        self.assertEqual(self.make_jsonrpc_request("/mail/action", {"init_messaging": {}})["Store"]['starred']['counter'], 1)
 
     def test_multi_company_chat(self):
         self.assertEqual(self.env.user.company_id, self.company_admin)

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -250,20 +250,18 @@ class TestDiscussFullPerformance(HttpCase):
                 self._expected_result_for_rtc_session(self.channel_channel_group_1, self.users[2]),
             ],
             "Store": {
-                "discuss": {
-                    "inbox": {
-                        "counter": 1,
-                        "counter_bus_id": bus_last_id,
-                        "id": "inbox",
-                        "model": "mail.box",
-                    },
-                    "starred":
-                    {
-                        "counter": 1,
-                        "counter_bus_id": bus_last_id,
-                        "id": "starred",
-                        "model": "mail.box",
-                    },
+                "inbox": {
+                    "counter": 1,
+                    "counter_bus_id": bus_last_id,
+                    "id": "inbox",
+                    "model": "mail.box",
+                },
+                "starred":
+                {
+                    "counter": 1,
+                    "counter_bus_id": bus_last_id,
+                    "id": "starred",
+                    "model": "mail.box",
                 },
                 "initChannelsUnreadCounter": 1,
                 "odoobotOnboarding": False,


### PR DESCRIPTION
The mail module is split into several sub-folders to determine when the files should be loaded (e.g., web, public, public_web...).

Currently, several code snippets are misplaced, which increases the load on public pages or live chat.

Moreover, this can lead to dependency hell, especially when moving a feature to another bundle.

This PR moves the `starred`, `inbox` and `history` fields, which are only used in web, to the web bundle.

Part of task-3972988
