### PR TITLE
[FIX] web: list: show horizontal scrollbar

### DIFF
--- a/addons/web/static/src/views/list/list_controller.js
+++ b/addons/web/static/src/views/list/list_controller.js
@@ -18,7 +18,7 @@ import { ViewButton } from "@web/views/view_button/view_button";
 import { useViewButtons } from "@web/views/view_button/view_button_hook";
 import { ExportDataDialog } from "@web/views/view_dialogs/export_data_dialog";
 
-import { Component, onWillStart, useSubEnv, useEffect, useRef } from "@odoo/owl";
+import { Component, onMounted, onWillStart, useSubEnv, useEffect, useRef } from "@odoo/owl";
 
 export class ListViewHeaderButton extends ViewButton {
     async onClick() {
@@ -85,6 +85,15 @@ export class ListController extends Component {
             this.isExportEnable = await this.userService.hasGroup("base.group_allow_export");
         });
 
+        onMounted(() => {
+            const { rendererScrollPositions } = this.props.state || {};
+            if (rendererScrollPositions) {
+                const renderer = this.rootRef.el.querySelector(".o_list_renderer");
+                renderer.scrollLeft = rendererScrollPositions.left;
+                renderer.scrollTop = rendererScrollPositions.top;
+            }
+        });
+
         this.archiveEnabled =
             "active" in fields
                 ? !fields.active.readonly
@@ -118,8 +127,10 @@ export class ListController extends Component {
                 }
             },
             getLocalState: () => {
+                const renderer = this.rootRef.el.querySelector(".o_list_renderer");
                 return {
                     rootState: this.model.root.exportState(),
+                    rendererScrollPositions: { left: renderer.scrollLeft, top: renderer.scrollTop },
                 };
             },
             getOrderBy: () => {

--- a/addons/web/static/src/views/list/list_renderer.scss
+++ b/addons/web/static/src/views/list/list_renderer.scss
@@ -6,6 +6,10 @@
     --ListRenderer-thead-bg-color: #{$gray-200};
     --ListRenderer-thead-border-end-color: #{$border-color};
 
+    @include media-breakpoint-up(md) {
+        height: 100%;
+    }
+
     .o_list_view &  {
         --ListRenderer-table-padding-h: #{$o-horizontal-padding};
     }

--- a/addons/web/static/tests/webclient/actions/misc_tests.js
+++ b/addons/web/static/tests/webclient/actions/misc_tests.js
@@ -482,7 +482,8 @@ QUnit.module("ActionManager", (hooks) => {
         );
     });
 
-    QUnit.test("stores and restores scroll position", async function (assert) {
+    QUnit.test("stores and restores scroll position (in kanban)", async function (assert) {
+        serverData.actions[3].views = [[false, "kanban"]];
         assert.expect(3);
         for (let i = 0; i < 60; i++) {
             serverData.models.partner.records.push({ id: 100 + i, foo: `Record ${i}` });
@@ -503,6 +504,31 @@ QUnit.module("ActionManager", (hooks) => {
         // go back using the breadcrumbs
         await click(target.querySelector(".o_control_panel .breadcrumb a"));
         assert.strictEqual(target.querySelector(".o_content").scrollTop, 100);
+    });
+
+    QUnit.test("stores and restores scroll position (in list)", async function (assert) {
+        for (let i = 0; i < 60; i++) {
+            serverData.models.partner.records.push({ id: 100 + i, foo: `Record ${i}` });
+        }
+        const container = document.createElement("div");
+        container.classList.add("o_web_client");
+        container.style.height = "250px";
+        target.appendChild(container);
+        const webClient = await createWebClient({ target: container, serverData });
+        // execute a first action
+        await doAction(webClient, 3);
+        assert.strictEqual(target.querySelector(".o_content").scrollTop, 0);
+        assert.strictEqual(target.querySelector(".o_list_renderer").scrollTop, 0);
+        // simulate a scroll
+        target.querySelector(".o_list_renderer").scrollTop = 100;
+        await nextTick();
+        // execute a second action (in which we don't scroll)
+        await doAction(webClient, 4);
+        assert.strictEqual(target.querySelector(".o_content").scrollTop, 0);
+        // go back using the breadcrumbs
+        await click(target.querySelector(".o_control_panel .breadcrumb a"));
+        assert.strictEqual(target.querySelector(".o_content").scrollTop, 0);
+        assert.strictEqual(target.querySelector(".o_list_renderer").scrollTop, 100);
     });
 
     QUnit.test(


### PR DESCRIPTION
Have a list view with both vertical and horizontal scrollbars. Before this commit, the horizontal scrollbar was only visible on the very bottom (the user had to scroll vertically to the bottom to see it). With this commit, it is always visible.

opw~3897327

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
