### PR TITLE
[FIX] sale_stock: compute sol reserved qty from pick move

### DIFF
--- a/addons/sale_stock/tests/test_sale_stock.py
+++ b/addons/sale_stock/tests/test_sale_stock.py
@@ -1780,3 +1780,44 @@ class TestSaleStock(TestSaleCommon, ValuationReconciliationTestCommon):
         picking.button_validate()
         self.assertEqual(sale_order.order_line.qty_delivered, -1.0)
         self.assertEqual(sale_order.order_line.qty_to_invoice, -1.0)
+
+    def test_sol_reserved_qty_wizard_3_steps_delivery(self):
+        """
+        Check that the reserved qty wizard related to a sol is computed from
+        the pick move in 2+ step deliveries.
+        """
+        admin = self.env.ref('base.user_admin')
+        warehouse = self.env.ref('stock.warehouse0').with_user(admin)
+        warehouse.delivery_steps = 'pick_pack_ship'
+        product = self.product_a
+        product.type = 'product'
+        self.env['stock.quant']._update_available_quantity(product, warehouse.lot_stock_id, 10.0)
+        sale_order = self.env['sale.order'].with_user(admin).create({
+            'company_id': warehouse.company_id.id,
+            'warehouse_id': warehouse.id,
+            'partner_id': self.partner_a.id,
+            'order_line': [
+                Command.create({
+                'product_id': product.id,
+                'product_uom_qty': 7.0,
+                }),
+            ],
+        })
+        sale_order.action_confirm()
+        self.assertEqual(len(sale_order.picking_ids), 3)
+        pick = sale_order.picking_ids.filtered(lambda p: p.location_id == warehouse.lot_stock_id)
+        ship = sale_order.picking_ids.filtered(lambda p: p.location_dest_id == self.env.ref('stock.stock_location_customers'))
+        pack = sale_order.picking_ids - pick - ship
+        self.assertEqual(pick.move_ids.quantity, 7.0)
+        self.assertEqual(sale_order.order_line.qty_available_today, 7.0)
+        self.assertEqual((pack | ship).move_ids.mapped('quantity'), [0.0, 0.0])
+        pick.button_validate()
+        self.assertEqual(pack.move_ids.quantity, 7.0)
+        self.assertEqual(sale_order.order_line.qty_available_today, 7.0)
+        pack.button_validate()
+        self.assertEqual(sum(ship.move_ids.mapped('quantity')), 7.0)
+        self.assertEqual(sale_order.order_line.qty_available_today, 7.0)
+        self.assertEqual(sale_order.order_line.qty_delivered, 0.0)
+        ship.button_validate()
+        self.assertEqual(sale_order.order_line.qty_available_today, 0.0)
+        self.assertEqual(sale_order.order_line.qty_delivered, 7.0)

--- a/addons/stock_dropshipping/tests/test_dropship.py
+++ b/addons/stock_dropshipping/tests/test_dropship.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo import Command
+
 from odoo.tests import common, Form
 from odoo.tools import mute_logger
 
@@ -207,3 +209,28 @@ class TestDropship(common.TransactionCase):
         self.assertEqual(sale_order.picking_ids.state, 'done')
         self.assertEqual(sale_order.picking_ids.move_line_ids.lot_id.name, '123')
         self.assertEqual(sale_order.picking_ids.move_line_ids.lot_id.last_delivery_partner_id, self.customer)
+
+    def test_sol_reserved_qty_wizard_dropship(self):
+        """
+        Check that the reserved qty wizard related to a sol is computed from
+        the PO if the product is dropshipped.
+        """
+        product = self.dropship_product
+        product.route_ids = self.dropshipping_route
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.customer.id,
+            'order_line': [Command.create({
+                'product_id': product.id,
+                'product_uom_qty': 3.0,
+            })]
+        })
+        sale_order.action_confirm()
+        self.assertEqual(sale_order.order_line.qty_available_today, 0.0)
+        purchase_order = self.env['purchase.order'].search([('partner_id', '=', self.supplier.id)])
+        purchase_order.button_confirm()
+        picking_dropship = sale_order.picking_ids.filtered(lambda p: p.picking_type_id)
+        self.assertTrue(picking_dropship)
+        self.assertEqual(sale_order.order_line.qty_available_today, 3.0)
+        self.assertRecordValues(sale_order.order_line, [{'qty_available_today': 3.0, 'qty_delivered': 0.0}])
+        picking_dropship.button_validate()
+        self.assertEqual(sale_order.order_line.qty_delivered, 3.0)


### PR DESCRIPTION
### Issue: 
The reserved quantity appearing on the SOL wizard is not well behaved with respect to 2+ steps deliveries.

### Steps to reproduce:

- Enable Multi-step routes in the settings
- Inventory > Configuration > Warehouse Management > Warehouses
- Enable delivery in 2 steps
- Create a storable product and put 1 unit in stock
- Create and confirm an SO for 1 unit
- Click on the chart icon next to the delivered qty

#### > the reserved qty is 0 + "No future availability" even though 1 unit is reserved from stock

### Cause of the issue:

The reserved qty displayed on the next to the delivered qty on the SOL is the `qty_available_today` computed field of the SOL model. This field is computed by summing the qties of the stock moves linked to the SOL: https://github.com/odoo/odoo/blob/817186b7b896c9a415bd947baf189bf7f1bde321/addons/sale_stock/models/sale_order_line.py#L69 https://github.com/odoo/odoo/blob/817186b7b896c9a415bd947baf189bf7f1bde321/addons/sale_stock/models/sale_order_line.py#L80-L81

However, when you are not delivering in 1 step, the only delivery move linkedto the SOL will be the move which destination is the customer location. To be more precise, confirming the SO in a delivery in two steps a stock move from the Output to the customer will be created and linked to the SOL. During the action confirm of this move a procurment will be run to generate a move from stock to the Output but the SOL will not be referenced anymore so that the SOL will not be linked to it.

### Note:

The behavior is different in saas-17.2 where each of the delivering move is linked to the SOL so that the fix needs to be adapted in that version

opw-3981935
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
