### PR TITLE
[FIX] web: router url with child elements

### DIFF
--- a/addons/web/static/src/core/browser/router.js
+++ b/addons/web/static/src/core/browser/router.js
@@ -286,7 +286,7 @@ browser.addEventListener("click", (ev) => {
         let url;
         try {
             // ev.target.href is the full url including current path
-            url = new URL(ev.target.href);
+            url = new URL(ev.target.closest("a").href);
         } catch {
             return;
         }

--- a/addons/web/static/tests/core/router.test.js
+++ b/addons/web/static/tests/core/router.test.js
@@ -1720,6 +1720,43 @@ describe("internal links", () => {
         expect(defaultPrevented).toBe(true);
     });
 
+    test("click on internal link with children does a loadState instead of a full reload", async () => {
+        redirect("/odoo");
+        createRouter({ onPushState: () => expect.step("pushState") });
+        const fixture = getFixture();
+        const link = document.createElement("a");
+        const span = document.createElement("span");
+        link.appendChild(span);
+        link.href = "/odoo/some-action/2";
+        fixture.appendChild(link);
+
+        expect(router.current).toEqual({});
+
+        let defaultPrevented;
+        browser.addEventListener("click", (ev) => {
+            expect.step("click");
+            defaultPrevented = ev.defaultPrevented;
+            ev.preventDefault();
+        });
+        click("span");
+        await tick();
+        expect.verifySteps(["click"]);
+        expect(router.current).toEqual({
+            action: "some-action",
+            actionStack: [
+                {
+                    action: "some-action",
+                },
+                {
+                    action: "some-action",
+                    resId: 2,
+                },
+            ],
+            resId: 2,
+        });
+        expect(defaultPrevented).toBe(true);
+    });
+
     test("click on internal link with different protocol does a loadState", async () => {
         redirect("/odoo");
         createRouter({ onPushState: () => expect.step("pushState") });


### PR DESCRIPTION
Before this PR, a click on an internal link would not trigger the loadState if the click was not directly on the `a` element.
This is because the children of `a` don't have a `href` element.

This PR fixes the issue by using the closest `a` as a reference for the `href`.
