### PR TITLE
[IMP] mail: move chat windows field from discuss to store 

### DIFF
--- a/addons/im_livechat/static/src/embed/common/livechat_service.js
+++ b/addons/im_livechat/static/src/embed/common/livechat_service.js
@@ -119,7 +119,7 @@ export class LivechatService {
         const temporaryThread = this.thread;
         await this._createThread({ persist: true });
         if (temporaryThread) {
-            const chatWindow = this.store.discuss.chatWindows.find(
+            const chatWindow = this.store.chatWindows.find(
                 (c) => c.thread?.id === temporaryThread.id
             );
             temporaryThread.delete();

--- a/addons/mail/static/src/core/common/chat_window_model.js
+++ b/addons/mail/static/src/core/common/chat_window_model.js
@@ -23,7 +23,7 @@ export class ChatWindow extends Record {
      * @returns {import("models").ChatWindow}
      */
     static _insert(data = {}) {
-        const chatWindow = this.store.discuss.chatWindows.find((c) => c.thread?.eq(data.thread));
+        const chatWindow = this.store.chatWindows.find((c) => c.thread?.eq(data.thread));
         if (!chatWindow) {
             /** @type {import("models").ChatWindow} */
             const chatWindow = this.preinsert(data);
@@ -32,23 +32,23 @@ export class ChatWindow extends Record {
             const visible = this.store.visibleChatWindows;
             const maxVisible = this.store.maxVisibleChatWindows;
             if (!data.replaceNewMessageChatWindow) {
-                if (maxVisible <= this.store.discuss.chatWindows.length) {
+                if (maxVisible <= this.store.chatWindows.length) {
                     const swaped = visible[visible.length - 1];
                     index = visible.length - 1;
                     swaped.hide();
                 } else {
-                    index = this.store.discuss.chatWindows.length;
+                    index = this.store.chatWindows.length;
                 }
             } else {
-                const newMessageChatWindowIndex = this.store.discuss.chatWindows.findIndex(
+                const newMessageChatWindowIndex = this.store.chatWindows.findIndex(
                     (cw) => !cw.thread
                 );
                 index =
                     newMessageChatWindowIndex !== -1
                         ? newMessageChatWindowIndex
-                        : this.store.discuss.chatWindows.length;
+                        : this.store.chatWindows.length;
             }
-            this.store.discuss.chatWindows.splice(
+            this.store.chatWindows.splice(
                 index,
                 data.replaceNewMessageChatWindow ? 1 : 0,
                 chatWindow
@@ -78,24 +78,21 @@ export class ChatWindow extends Record {
 
     async close(options = {}) {
         const { escape = false } = options;
-        if (
-            !this.hidden &&
-            this.store.maxVisibleChatWindows < this.store.discuss.chatWindows.length
-        ) {
+        if (!this.hidden && this.store.maxVisibleChatWindows < this.store.chatWindows.length) {
             const swaped = this.store.hiddenChatWindows[0];
             swaped.hidden = false;
             swaped.folded = false;
         }
-        const index = this.store.discuss.chatWindows.findIndex((c) => c.eq(this));
+        const index = this.store.chatWindows.findIndex((c) => c.eq(this));
         if (index > -1) {
-            this.store.discuss.chatWindows.splice(index, 1);
+            this.store.chatWindows.splice(index, 1);
         }
         const thread = this.thread;
         if (thread) {
             thread.state = "closed";
         }
-        if (escape && this.store.discuss.chatWindows.length > 0) {
-            this.store.discuss.chatWindows.at(index - 1).focus();
+        if (escape && this.store.chatWindows.length > 0) {
+            this.store.chatWindows.at(index - 1).focus();
         }
         await this._onClose(options);
         this.delete();

--- a/addons/mail/static/src/core/common/discuss_app_model.js
+++ b/addons/mail/static/src/core/common/discuss_app_model.js
@@ -42,7 +42,6 @@ export class DiscussApp extends Record {
 
     /** @type {'main'|'channel'|'chat'|'livechat'} */
     activeTab = "main";
-    chatWindows = Record.many("ChatWindow");
     isActive = false;
     allCategories = Record.many("DiscussAppCategory", {
         inverse: "app",

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -82,6 +82,7 @@ export class Store extends BaseStore {
      * @type {string[]}
      */
     channel_types_with_seen_infos = [];
+    chatWindows = Record.many("ChatWindow");
     /** This is the current logged partner / guest */
     self = Record.one("Persona");
     /**
@@ -221,11 +222,11 @@ export class Store extends BaseStore {
     }
 
     get visibleChatWindows() {
-        return this.discuss.chatWindows.filter((chatWindow) => !chatWindow.hidden);
+        return this.chatWindows.filter((chatWindow) => !chatWindow.hidden);
     }
 
     get hiddenChatWindows() {
-        return this.discuss.chatWindows.filter((chatWindow) => chatWindow.hidden);
+        return this.chatWindows.filter((chatWindow) => chatWindow.hidden);
     }
 
     get maxVisibleChatWindows() {
@@ -244,7 +245,7 @@ export class Store extends BaseStore {
     }
 
     closeNewMessage() {
-        const newMessageChatWindow = this.discuss.chatWindows.find(({ thread }) => !thread);
+        const newMessageChatWindow = this.chatWindows.find(({ thread }) => !thread);
         newMessageChatWindow?.close();
     }
 
@@ -656,7 +657,7 @@ export class Store extends BaseStore {
     }
 
     openNewMessage({ openMessagingMenuOnClose } = {}) {
-        if (this.discuss.chatWindows.some(({ thread }) => !thread)) {
+        if (this.chatWindows.some(({ thread }) => !thread)) {
             // New message chat window is already opened.
             return;
         }

--- a/addons/mail/static/src/core/web/messaging_menu.js
+++ b/addons/mail/static/src/core/web/messaging_menu.js
@@ -172,7 +172,7 @@ export class MessagingMenu extends Component {
             });
             // Close the related chat window as having both the form view
             // and the chat window does not look good.
-            this.store.discuss.chatWindows.find(({ thr }) => thr?.eq(thread))?.close();
+            this.store.chatWindows.find(({ thr }) => thr?.eq(thread))?.close();
         } else {
             thread.open(undefined, { openMessagingMenuOnClose: true });
         }

--- a/addons/mail/static/src/core/web/thread_model_patch.js
+++ b/addons/mail/static/src/core/web/thread_model_patch.js
@@ -21,7 +21,7 @@ patch(Thread.prototype, {
         return this.recipientsCount === this.recipients.length;
     },
     closeChatWindow() {
-        const chatWindow = this.store.discuss.chatWindows.find((c) => c.thread?.eq(this));
+        const chatWindow = this.store.chatWindows.find((c) => c.thread?.eq(this));
         chatWindow?.close({ notifyState: false });
     },
     async leave() {
@@ -65,7 +65,7 @@ patch(Thread.prototype, {
         super.open(replaceNewMessageChatWindow);
     },
     async unpin() {
-        const chatWindow = this.store.discuss.chatWindows.find((c) => c.thread?.eq(this));
+        const chatWindow = this.store.chatWindows.find((c) => c.thread?.eq(this));
         await chatWindow?.close();
         super.unpin(...arguments);
     },

--- a/addons/mail/static/src/discuss/core/web/discuss_core_web_service.js
+++ b/addons/mail/static/src/discuss/core/web/discuss_core_web_service.js
@@ -67,7 +67,7 @@ export class DiscussCoreWeb {
                 if (data.fold_state !== thread.state) {
                     thread.state = data.fold_state;
                     if (thread.state === "closed") {
-                        const chatWindow = this.store.discuss.chatWindows.find((chatWindow) =>
+                        const chatWindow = this.store.chatWindows.find((chatWindow) =>
                             chatWindow.thread?.eq(thread)
                         );
                         chatWindow?.close({ notifyState: false });


### PR DESCRIPTION
The `chatWindows` field is stored in the discuss model. However, chat
windows can exist without the discuss app. Currently, this is not an
issue since the discuss model is loaded even when not needed (e.g.,
live chat). However, bundles are being refactored to ease the
development of environment-specific features. As a result, this field
should be moved to the store, which is always available regardless of
the environment.

Part of task-3972988
