### PR TITLE
[IMP] core: Query typing and return empty subselect

### DIFF
--- a/odoo/tools/__init__.py
+++ b/odoo/tools/__init__.py
@@ -24,7 +24,7 @@ from .i18n import *
 from .image import *
 from .mail import *
 from .misc import *
-from .query import Query, _generate_table_alias
+from .query import Query
 from .sql import *
 from .template_inheritance import *
 from .translate import *

--- a/odoo/tools/sql.py
+++ b/odoo/tools/sql.py
@@ -133,7 +133,7 @@ class SQL:
         return bool(self.__code)
 
     def __eq__(self, other):
-        return self.code == other.code and self.params == other.params
+        return isinstance(other, SQL) and self.code == other.code and self.params == other.params
 
     def __iter__(self):
         """ Yields ``self.code`` and ``self.params``. This was introduced for


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- Add typing annotations
- Return an empty select expression
- Stop exposing private method

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
