### PR TITLE
[IMP] core: complement correcly relationship traversal

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -6281,10 +6281,16 @@ class BaseModel(metaclass=MetaModel):
                 # determine the field with the final type for values
                 field = None
                 if key:
-                    model = self.browse()
-                    for fname in key.split('.'):
-                        field = model._fields[fname]
-                        model = model[fname]
+                    if '.' in key:
+                        fname, rest = key.split('.', 1)
+                        field = self._fields[fname]
+                        if field.relational:
+                            # for relational fields, evaluate as 'any'
+                            # so that negations are applied on the result of 'any' instead
+                            # of on the mapped value
+                            key, comparator, value = fname, 'any', [(rest, comparator, value)]
+                    else:
+                        field = self._fields[key]
 
                 if comparator in ('like', 'ilike', '=like', '=ilike', 'not ilike', 'not like'):
                     if comparator.endswith('ilike'):

--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -331,7 +331,9 @@ def distribute_not(domain):
         if is_leaf(token):
             if negate:
                 left, operator, right = token
-                if operator in TERM_OPERATORS_NEGATION:
+                if operator in TERM_OPERATORS_NEGATION and (isinstance(left, int) or "." not in left):
+                    # rewrite using the negated operator, except for relationship traversal
+                    # because not ('a.b', '=', x) should become ('a', 'not any', ('b', '=', x))
                     if token in (TRUE_LEAF, FALSE_LEAF):
                         result.append(FALSE_LEAF if token == TRUE_LEAF else TRUE_LEAF)
                     else:


### PR DESCRIPTION
When distributing the '!' operator, we should handle relationship traversal with care and avoid some optimizations.
The following domains are equivalent (if 'a' is a relation):

    ['!', ('a.b', '=', x)]
    ['!', ('a', 'any', [('b', '=', x)])]
    [('a', 'not any', [('b', '=', x)])]


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
