### PR TITLE
[IMP] web: replace attribute in form dialog footer

### DIFF
--- a/addons/hr_holidays/static/src/views/view_dialog/form_view_dialog.xml
+++ b/addons/hr_holidays/static/src/views/view_dialog/form_view_dialog.xml
@@ -16,11 +16,11 @@
                     t-on-click="deleteRecord"
                     data-hotkey="x">delete</button>
         </xpath>
-        <xpath expr="//div[contains(@class, 'o_cp_buttons')]" position="inside">
-            <div class="flex-grow-1 d-flex flex-row-reverse gap-1">
-                <button class="btn btn-secondary" t-if="canRefuse" t-on-click="() => this.onClick('action_refuse')" data-hotkey="z">Refuse</button>
-                <button class="btn btn-secondary" t-if="canApprove" t-on-click="() => this.onClick('action_approve')" data-hotkey="g">Approve</button>
+        <xpath expr="//div" position="inside">
+            <div class="ms-auto d-flex gap-1">
                 <button class="btn btn-secondary" t-if="canValidate" t-on-click="() => this.onClick('action_validate')" data-hotkey="v">Validate</button>
+                <button class="btn btn-secondary" t-if="canApprove" t-on-click="() => this.onClick('action_approve')" data-hotkey="g">Approve</button>
+                <button class="btn btn-secondary" t-if="canRefuse" t-on-click="() => this.onClick('action_refuse')" data-hotkey="z">Refuse</button>
             </div>
         </xpath>
     </t>

--- a/addons/web/static/src/views/fields/relational_utils.xml
+++ b/addons/web/static/src/views/fields/relational_utils.xml
@@ -6,29 +6,14 @@
         <FormRenderer record="record" archInfo="archInfo"/>
         <t t-set-slot="footer">
             <t t-if="footerArchInfo">
-                <FormRenderer record="record" archInfo="footerArchInfo"/>
+                <FormRenderer record="record" archInfo="footerArchInfo">
+                    <t t-set-slot="default_buttons">
+                        <t t-call="web.X2ManyFieldDialogDefaultButtons"/>
+                    </t>
+                </FormRenderer>
             </t>
             <t t-else="">
-                <t t-if="record.isInEdition">
-                    <t t-if="canCreate">
-                        <button class="btn btn-primary o_form_button_save" t-on-click="save" data-hotkey="c">Save &amp; Close</button>
-                        <button class="btn btn-primary o_form_button_save_new" t-on-click="saveAndNew" data-hotkey="n">Save &amp; New</button>
-                    </t>
-                    <t t-else="">
-                        <button class="btn btn-primary o_form_button_save" t-on-click="save" data-hotkey="c">Save</button>
-                    </t>
-                    <button class="btn btn-secondary o_form_button_cancel" t-on-click="discard" data-hotkey="j">Discard</button>
-
-                    <t t-if="props.delete">
-                        <button class="btn btn-secondary o_btn_remove" t-on-click="remove" data-hotkey="k">
-                            <t t-if="props.deleteButtonLabel" t-out="props.deleteButtonLabel"/>
-                            <t t-else="">Remove</t>
-                        </button>
-                    </t>
-                </t>
-                <t t-else="">
-                    <button class="btn btn-primary o_form_button_cancel" t-on-click="() => this.props.close()" data-hotkey="j">Close</button>
-                </t>
+                <t t-call="web.X2ManyFieldDialogDefaultButtons"/>
             </t>
         </t>
     </Dialog>
@@ -71,6 +56,29 @@
              t-attf-src="/web/image/{{option.resModel}}/{{option.value}}/avatar_128" />
         <t t-esc="option.label" />
     </span>
+</t>
+
+<t t-name="web.X2ManyFieldDialogDefaultButtons">
+    <t t-if="record.isInEdition">
+        <t t-if="canCreate">
+            <button class="btn btn-primary o_form_button_save" t-on-click="save" data-hotkey="c">Save &amp; Close</button>
+            <button class="btn btn-primary o_form_button_save_new" t-on-click="saveAndNew" data-hotkey="n">Save &amp; New</button>
+        </t>
+        <t t-else="">
+            <button class="btn btn-primary o_form_button_save" t-on-click="save" data-hotkey="c">Save</button>
+        </t>
+        <button class="btn btn-secondary o_form_button_cancel" t-on-click="discard" data-hotkey="j">Discard</button>
+
+        <t t-if="props.delete">
+            <button class="btn btn-secondary o_btn_remove" t-on-click="remove" data-hotkey="k">
+                <t t-if="props.deleteButtonLabel" t-out="props.deleteButtonLabel"/>
+                <t t-else="">Remove</t>
+            </button>
+        </t>
+    </t>
+    <t t-else="">
+        <button class="btn btn-primary o_form_button_cancel" t-on-click="() => this.props.close()" data-hotkey="j">Close</button>
+    </t>
 </t>
 
 </templates>

--- a/addons/web/static/src/views/form/form_compiler.js
+++ b/addons/web/static/src/views/form/form_compiler.js
@@ -16,6 +16,7 @@ import {
     makeSeparator,
 } from "@web/views/view_compiler";
 import { ViewCompiler } from "../view_compiler";
+import { exprToBoolean } from "@web/core/utils/strings";
 
 const compilersRegistry = registry.category("form_compilers");
 
@@ -50,6 +51,7 @@ export class FormCompiler extends ViewCompiler {
         this.compilers.push(
             ...compilersRegistry.getAll(),
             { selector: "div[name='button_box']", fn: this.compileButtonBox },
+            { selector: "footer", fn: this.compileFooter },
             { selector: "form", fn: this.compileForm, doNotCopyAttributes: true },
             { selector: "group", fn: this.compileGroup },
             { selector: "header", fn: this.compileHeader },
@@ -245,6 +247,32 @@ export class FormCompiler extends ViewCompiler {
             append(form, compiledList);
         }
         return form;
+    }
+
+    /**
+     * @param {Element} el
+     * @param {Record<string, any>} params
+     * @returns {Element}
+     */
+    compileFooter(el, params) {
+        const footer = createElement("t");
+        const replace = el.getAttribute("replace");
+        if (replace && !exprToBoolean(replace)) {
+            footer.append(
+                createElement("t", {
+                    "t-call": "web.DefaultButtonsSlot",
+                    "t-call-context": "{ props: __comp__.props }",
+                })
+            );
+        }
+        copyAttributes(el, footer);
+        for (const child of el.childNodes) {
+            const compiled = this.compileNode(child, params);
+            if (compiled) {
+                footer.append(compiled);
+            }
+        }
+        return footer;
     }
 
     /**

--- a/addons/web/static/src/views/form/form_controller.js
+++ b/addons/web/static/src/views/form/form_controller.js
@@ -191,8 +191,6 @@ export class FormController extends Component {
         };
         this.model = useState(useModel(this.props.Model, this.modelParams, { beforeFirstLoad }));
 
-        this.cpButtonsRef = useRef("cpButtons");
-
         onMounted(() => {
             effect(
                 (model) => {

--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -860,7 +860,7 @@
         }
     }
 
-    // Boolean 
+    // Boolean
     .o_field_boolean + .o_form_label {
         margin-right: $o-form-spacing-unit * 3;
     }
@@ -945,13 +945,6 @@
         }
     }
     @include media-breakpoint-down(md) {
-        .o_cp_buttons {
-            width: 100%;
-            > button {
-                width: 100%;
-            }
-        }
-
         .o_form_label:not(.o_invisible_modifier) {
             padding-bottom: 4px;
         }

--- a/addons/web/static/src/views/form/form_controller.xml
+++ b/addons/web/static/src/views/form/form_controller.xml
@@ -14,7 +14,11 @@
                     <t t-set-slot="layout-buttons">
                         <t t-if="env.inDialog">
                             <t t-if="footerArchInfo">
-                                <t t-component="props.Renderer" record="model.root" Compiler="props.Compiler" archInfo="footerArchInfo"/>
+                                <t t-component="props.Renderer" record="model.root" Compiler="props.Compiler" archInfo="footerArchInfo">
+                                    <t t-set-slot="default_buttons">
+                                        <t t-call="{{ props.buttonTemplate }}"/>
+                                    </t>
+                                </t>
                             </t>
                             <t t-else="">
                                 <t t-call="{{ props.buttonTemplate }}"/>
@@ -49,23 +53,25 @@
     </t>
 
     <t t-name="web.FormView.Buttons">
-        <div class="o_cp_buttons d-flex align-items-baseline w-100" role="toolbar" aria-label="Main actions" t-ref="cpButtons">
-            <div t-if="model.root.isInEdition" class="o_form_buttons_edit d-flex gap-1">
-                <button type="button" class="btn btn-primary o_form_button_save" data-hotkey="s" t-on-click.stop="() => this.saveButtonClicked({closable: true})">
-                    Save
-                </button>
-                <button type="button" class="btn btn-secondary o_form_button_cancel" data-hotkey="j" t-on-click.stop="discard">
-                    Discard
-                </button>
-                <button t-if="props.removeRecord" class="btn btn-secondary o_form_button_remove" t-on-click="props.removeRecord" data-hotkey="x">
-                    Remove
-                </button>
-            </div>
-            <div t-elif="canCreate" class="o_form_buttons_view">
-                <button type="button" class="btn btn-secondary o_form_button_create" data-hotkey="c" t-on-click.stop="create">
-                    New
-                </button>
-            </div>
+        <div t-if="model.root.isInEdition" class="o_form_buttons_edit d-flex gap-1">
+            <button type="button" class="btn btn-primary o_form_button_save" data-hotkey="s" t-on-click.stop="() => this.saveButtonClicked({closable: true})">
+                Save
+            </button>
+            <button type="button" class="btn btn-secondary o_form_button_cancel" data-hotkey="j" t-on-click.stop="discard">
+                Discard
+            </button>
+            <button t-if="props.removeRecord" class="btn btn-secondary o_form_button_remove" t-on-click="props.removeRecord" data-hotkey="x">
+                Remove
+            </button>
         </div>
+        <div t-elif="canCreate" class="o_form_buttons_view">
+            <button type="button" class="btn btn-secondary o_form_button_create" data-hotkey="c" t-on-click.stop="create">
+                New
+            </button>
+        </div>
+    </t>
+
+    <t t-name="web.DefaultButtonsSlot">
+        <t t-slot="default_buttons"></t>
     </t>
 </templates>

--- a/addons/web/static/src/views/form/form_renderer.js
+++ b/addons/web/static/src/views/form/form_renderer.js
@@ -52,6 +52,7 @@ export class FormRenderer extends Component {
         activeNotebookPages: { type: Object, optional: true },
         saveRecord: { type: Function, optional: true },
         setFieldAsDirty: { type: Function, optional: true },
+        slots: { type: Object, optional: true },
     };
     static defaultProps = {
         activeNotebookPages: {},

--- a/addons/web/static/src/webclient/settings_form_view/settings_form_view.xml
+++ b/addons/web/static/src/webclient/settings_form_view/settings_form_view.xml
@@ -37,10 +37,10 @@
     </t>
 
     <t t-name="web.SettingsFormView.Buttons" t-inherit="web.FormView.Buttons" t-inherit-mode="primary">
-        <xpath expr="//div[hasclass('o_cp_buttons')]" position="attributes">
+        <xpath expr="//div" position="attributes">
             <attribute name="class" add="order-first w-auto" separator=" "/>
         </xpath>
-        <xpath expr="//div[hasclass('o_cp_buttons')]" position="after">
+        <xpath expr="//div" position="after">
             <span t-if="model.root.dirty" class="text-muted ms-2 o_dirty_warning">Unsaved changes</span>
         </xpath>
     </t>

--- a/addons/web/static/tests/views/fields/one2many_field.test.js
+++ b/addons/web/static/tests/views/fields/one2many_field.test.js
@@ -12020,8 +12020,48 @@ test.tags("desktop")("one2many, form view dialog with custom footer", async () =
 
     // open it again
     await contains(".o_data_row td[name=name]").click();
+    expect(".modal-footer button").toHaveCount(0);
     expect(".modal-footer .my_span").toHaveCount(1);
 });
+
+test.tags("desktop")(
+    "one2many, form view dialog with added custom footer (replace='0')",
+    async () => {
+        Partner._records[0].p = [1];
+
+        await mountView({
+            type: "form",
+            resModel: "partner",
+            arch: `
+            <form>
+                <field name="p">
+                    <tree>
+                        <field name="name"/>
+                    </tree>
+                    <form>
+                        <field name="name"/>
+                        <footer replace="0">
+                            <button class="btn btn-primary my_button">Hello</button>
+                        </footer>
+                    </form>
+                </field>
+            </form>`,
+            resId: 1,
+        });
+
+        await contains(".o_data_row td[name=name]").click();
+        expect(".modal-footer .my_button").toHaveCount(1);
+        expect(".modal-footer button").toHaveCount(3);
+
+        await contains(".modal-header .btn-close").click();
+        expect(".modal").toHaveCount(0);
+
+        // open it again
+        await contains(".o_data_row td[name=name]").click();
+        expect(".modal-footer .my_button").toHaveCount(1);
+        expect(".modal-footer button").toHaveCount(3);
+    }
+);
 
 test('Add a line, click on "Save & New" with an invalid form', async () => {
     mockService("notification", {

--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -4454,6 +4454,44 @@ test.tags("desktop")(`buttons with attr "special" in dialog close the dialog`, a
     expect(`.o_form_status_indicator_buttons.invisible`).toHaveCount(1);
 });
 
+test.tags("desktop")(`Add custom buttons to default buttons (replace="0")`, async () => {
+    Product._views = {
+        form: `
+            <form>
+                <sheet>
+                    <field name="name" />
+                </sheet>
+                <footer replace="0">
+                    <button class="btn btn-primary">Custom 1</button>
+                    <button class="btn btn-secondary">Custom 2</button>
+                </footer>
+            </form>
+        `,
+    };
+    await mountView({
+        resModel: "partner",
+        type: "form",
+        arch: `
+            <form>
+                <sheet>
+                    <group>
+                        <field name="product_id"/>
+                    </group>
+                </sheet>
+            </form>
+        `,
+        resId: 2,
+    });
+    await contains(`[name="product_id"] input`).edit("ABC", { confirm: false });
+    await runAllTimers(); // skip debounce
+    await contains(`.o_m2o_dropdown_option_create_edit`).click();
+
+    expect(".o_dialog .o_form_button_save").toHaveCount(1);
+    expect(".o_dialog .o_form_button_cancel").toHaveCount(1);
+    expect(".o_dialog button:contains(Custom 1)").toHaveCount(1);
+    expect(".o_dialog button:contains(Custom 2)").toHaveCount(1);
+});
+
 test(`missing widgets do not crash`, async () => {
     Partner._fields.foo = fields.Generic({ type: "new field type without widget" });
 

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -7661,7 +7661,7 @@ test.tags("desktop")("kanban with sample data: do an on_create action", async ()
     await createKanbanRecord();
     expect(".modal").toHaveCount(1);
 
-    await contains(".modal .o_cp_buttons .o_form_button_save").click();
+    await contains(".modal .o_form_button_save").click();
     expect(queryFirst(".o_content")).not.toHaveClass("o_view_sample_data");
     expect(".o_kanban_record:not(.o_kanban_ghost)").toHaveCount(1);
     expect(".o_view_nocontent").toHaveCount(0);


### PR DESCRIPTION
This commit adds the optional replace attribute to the form dialog footer which allows to avoid replacing the default footer buttons template with the custom one when it is set to false. The custom footer will be added after the default buttons in this case. It also includes some arch and styling cleanup in form view's default buttons.

task-4010906