### PR TITLE
[IMP] project_timesheet_holidays: add hook to decide when to unlink analytic lines linked to the time off

### DIFF
--- a/addons/project_timesheet_holidays/models/hr_holidays.py
+++ b/addons/project_timesheet_holidays/models/hr_holidays.py
@@ -89,7 +89,7 @@ class Holidays(models.Model):
 
         # Unlink previous timesheets to avoid doublon (shouldn't happen on the interface but meh)
         old_timesheets = self.env["account.analytic.line"].sudo().search([('project_id', '!=', False), ('holiday_id', 'in', leave_ids)])
-        if old_timesheets:
+        if old_timesheets and not self.env.context.get('skip_unlink_timesheets')::
             old_timesheets.holiday_id = False
             old_timesheets.unlink()
 


### PR DESCRIPTION
Not sure if those kind of PRs can be attended but I am just trying it out.

I have an automated process that massively creates & approve leaves for public holidays. The code in here is deleting the analytic lines just after they are created and consequently no time sheet lines are created. That process is out of Odoo standard but I think it is a good idea to have such a hook. Thanks.


