### PR TITLE
[FIX] web: prevent crash when starting AnimationEffect in some cases

### DIFF
--- a/addons/web/static/src/legacy/js/libs/jquery.js
+++ b/addons/web/static/src/legacy/js/libs/jquery.js
@@ -206,9 +206,13 @@ $.fn.extend({
      * @returns {jQuery}
      */
     getScrollingTarget(contextItem = window.document) {
-        const $scrollingElement = contextItem instanceof Element
+        // Cannot use `instanceof` because of cross-frame issues.
+        const isElement = obj => obj && obj.nodeType === Node.ELEMENT_NODE;
+        const isJQuery = obj => obj && ('jquery' in obj);
+
+        const $scrollingElement = isElement(contextItem)
             ? $(contextItem)
-            : contextItem instanceof jQuery
+            : isJQuery(contextItem)
             ? contextItem
             : $().getScrollingElement(contextItem);
         const document = $scrollingElement[0].ownerDocument;


### PR DESCRIPTION
Bug introduced with [1] on Chrome only. Using `instanceof` seems to be an issue in this case because of cross-frames code.

Steps to reproduce:
- Drag & drop a "Popup" snippet into a page
- Drag & drop a "Parallax" snippet into the popup => Traceback (on Chrome, not Firefox)

[1]: https://github.com/odoo/odoo/commit/f801f272582455461d561e6289e59a5306dc1a9c

task-4018819
