### PR TITLE
[IMP] web: KanbanQuickCreateController export

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_record_quick_create.js
+++ b/addons/web/static/src/views/kanban/kanban_record_quick_create.js
@@ -35,7 +35,7 @@ const ACTION_SELECTORS = [
     ".o-kanban-button-new",
 ];
 
-class KanbanQuickCreateController extends Component {
+export class KanbanQuickCreateController extends Component {
     static props = {
         Model: Function,
         Renderer: Function,


### PR DESCRIPTION
This commit exports the KanbanQuickCreateController so that it can be extended in other modules. This is necessary for the bank reconciliation (account_accountant) to work properly. More here odoo/enterprise@250325429dea72eb176ef7ca7b5fef2ef2d09f8a (odoo/enterprise#65891)

Task ID: 3916563

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
