### PR TITLE
[FIX] pos_viva_wallet: prevent error when sending walled response bus notification

### DIFF
--- a/addons/pos_viva_wallet/models/pos_payment_method.py
+++ b/addons/pos_viva_wallet/models/pos_payment_method.py
@@ -130,7 +130,9 @@ class PosPaymentMethod(models.Model):
         # Send a notification to the point of sale channel to indicate that the transaction are finish
         pos_session_sudo = self.env["pos.session"].browse(int(data.get('pos_session_id', False)))
         if pos_session_sudo:
-            self.env['bus.bus']._sendone(pos_session_sudo._get_bus_channel_name(), 'VIVA_WALLET_LATEST_RESPONSE', pos_session_sudo.config_id.id)
+            pos_session_sudo.config_id._notify('VIVA_WALLET_LATEST_RESPONSE', {
+                'config_id': pos_session_sudo.config_id.id
+            })
 
     def viva_wallet_send_payment_request(self, data):
         if not self.env.user.has_group('point_of_sale.group_pos_user'):


### PR DESCRIPTION
With commit [1], we removed the method ``_get_bus_channel_name``, but at
line [2], it's still referenced, which causes an error.

AttributeError:
``'pos.session' object has no attribute '_get_bus_channel_name'``

This commit will fix the issue by using ``_notify`` for calling the notification
bus.

[1]-https://github.com/odoo/odoo/commit/3836aad466c6c111f0f0d33c357a1c7a5150f3fd
[2]-https://github.com/odoo/odoo/blob/5633d590decc6e8989c0f454a355e965f072f967/addons/pos_viva_wallet/models/pos_payment_method.py#L133

sentry-5562979975

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
