### PR TITLE
[IMP] mail: move discuss app model to the correct bundle

### DIFF
--- a/addons/im_livechat/__manifest__.py
+++ b/addons/im_livechat/__manifest__.py
@@ -70,6 +70,7 @@ Help your customers with this chat, and analyse their feedback.
             'im_livechat/static/src/scss/im_livechat_history.scss',
             'im_livechat/static/src/scss/im_livechat_form.scss',
             'im_livechat/static/src/core/common/**/*',
+            'im_livechat/static/src/core/public_web/**/*',
             'im_livechat/static/src/core/web/**/*',
         ],
         'web.assets_unit_tests': [

--- a/addons/im_livechat/static/src/core/public_web/discuss_app_category_model_patch.js
+++ b/addons/im_livechat/static/src/core/public_web/discuss_app_category_model_patch.js
@@ -1,5 +1,5 @@
 import { patch } from "@web/core/utils/patch";
-import { DiscussAppCategory } from "@mail/core/common/discuss_app_category_model";
+import { DiscussAppCategory } from "@mail/core/public_web/discuss_app_category_model";
 import { Record } from "@mail/core/common/record";
 import { compareDatetime } from "@mail/utils/common/misc";
 

--- a/addons/im_livechat/static/src/core/public_web/discuss_app_model_patch.js
+++ b/addons/im_livechat/static/src/core/public_web/discuss_app_model_patch.js
@@ -1,4 +1,4 @@
-import { DiscussApp } from "@mail/core/common/discuss_app_model";
+import { DiscussApp } from "@mail/core/public_web/discuss_app_model";
 import { Record } from "@mail/core/common/record";
 
 import { _t } from "@web/core/l10n/translation";

--- a/addons/mail/static/src/core/common/@types/models.d.ts
+++ b/addons/mail/static/src/core/common/@types/models.d.ts
@@ -6,8 +6,6 @@ declare module "models" {
     import { ChatWindow as ChatWindowClass } from "@mail/core/common/chat_window_model";
     import { Composer as ComposerClass } from "@mail/core/common/composer_model";
     import { Country as CountryClass } from "@mail/core/common/country_model";
-    import { DiscussApp as DiscussAppClass } from "@mail/core/common/discuss_app_model";
-    import { DiscussAppCategory as DiscussAppCategoryClass } from "@mail/core/common/discuss_app_category_model";
     import { Failure as FailureClass } from "@mail/core/common/failure_model";
     import { Follower as FollowerClass } from "@mail/core/common/follower_model";
     import { LinkPreview as LinkPreviewClass } from "@mail/core/common/link_preview_model";
@@ -28,8 +26,6 @@ declare module "models" {
     export interface ChatWindow extends ChatWindowClass {}
     export interface Composer extends ComposerClass {}
     export interface Country extends CountryClass {}
-    export interface DiscussApp extends DiscussAppClass {}
-    export interface DiscussAppCategory extends DiscussAppCategoryClass {}
     export interface Failure extends FailureClass {}
     export interface Follower extends FollowerClass {}
     export interface LinkPreview extends LinkPreviewClass {}
@@ -51,8 +47,6 @@ declare module "models" {
         "ChatWindow": ChatWindow,
         "Composer": Composer,
         "Country": Country,
-        "DiscussApp": DiscussApp,
-        "DiscussAppCategory": DiscussAppCategory,
         "Failure": Failure,
         "Follower": Follower,
         "LinkPreview": LinkPreview,

--- a/addons/mail/static/src/core/common/chat_hub.js
+++ b/addons/mail/static/src/core/common/chat_hub.js
@@ -70,6 +70,10 @@ export class ChatHub extends Component {
         return counter;
     }
 
+    get isShown() {
+        return !this.ui.isSmall;
+    }
+
     expand() {
         this.chatHub.compact = false;
         Object.assign(this.compactPosition, { left: "auto", top: "auto" });

--- a/addons/mail/static/src/core/common/chat_hub.xml
+++ b/addons/mail/static/src/core/common/chat_hub.xml
@@ -2,13 +2,13 @@
 <templates xml:space="preserve">
 
 <t t-name="mail.ChatHub">
-    <div class="o-mail-ChatHub" t-if="(!store.discuss.isActive or ui.isSmall)">
+    <div class="o-mail-ChatHub" t-if="isShown or ui.isSmall">
         <t t-if="!store.chatHub.compact">
             <t t-foreach="chatHub.actuallyOpened" t-as="cw" t-key="cw.localId">
                 <ChatWindow chatWindow="cw" right="env.embedLivechat ? chatHub.WINDOW_GAP : (chatHub.BUBBLE_START + chatHub.BUBBLE + (chatHub.BUBBLE_OUTER*2) + (chatHub.actuallyOpened.length - cw_index - 1) * (chatHub.WINDOW + chatHub.WINDOW_INBETWEEN * 2))"/>
             </t>
         </t>
-        <div t-if="!store.discuss.isActive and !ui.isSmall" class="o-mail-ChatHub-bubbles position-fixed end-0 d-flex flex-column align-content-start justify-content-end align-items-center" t-att-class="{ 'bottom-0': !store.chatHub.compact or compactPosition.top === 'auto' }" t-ref="bubbles" t-att-style="store.chatHub.compact ? `top: ${ compactPosition.top }; left: ${ compactPosition.left };` : ''">
+        <div t-if="isShown" class="o-mail-ChatHub-bubbles position-fixed end-0 d-flex flex-column align-content-start justify-content-end align-items-center" t-att-class="{ 'bottom-0': !store.chatHub.compact or compactPosition.top === 'auto' }" t-ref="bubbles" t-att-style="store.chatHub.compact ? `top: ${ compactPosition.top }; left: ${ compactPosition.left };` : ''">
             <div class="d-flex flex-column align-content-start justify-content-end align-items-center">
                 <t t-if="store.chatHub.compact">
                     <t t-call="mail.ChatHub.compactButton"/>

--- a/addons/mail/static/src/core/public_web/@types/models.d.ts
+++ b/addons/mail/static/src/core/public_web/@types/models.d.ts
@@ -1,0 +1,24 @@
+declare module "models" {
+    import { DiscussApp as DiscussAppClass } from "@mail/core/public_web/discuss_app_model";
+    import { DiscussAppCategory as DiscussAppCategoryClass } from "@mail/core/public_web/discuss_app_category_model";
+
+    export interface DiscussApp extends DiscussAppClass { }
+    export interface DiscussAppCategory extends DiscussAppCategoryClass { }
+    export interface Store {
+        DiscussApp: DiscussApp,
+        DiscussAppCategory : DiscussAppCategory,
+        discuss: DiscussApp,
+        action_discuss_id: number,
+    }
+
+    export interface Thread {
+        discussAppCategory: DiscussAppCategory,
+        setAsDiscussThread: (pushState: boolean) => void,
+        unpin: () => Promise<void>,
+    }
+
+    export interface Models {
+        "DiscussApp": DiscussApp,
+        "DiscussAppCategory": DiscussAppCategory,
+    }
+}

--- a/addons/mail/static/src/core/public_web/discuss_app_category_model.js
+++ b/addons/mail/static/src/core/public_web/discuss_app_category_model.js
@@ -1,5 +1,5 @@
 import { compareDatetime } from "@mail/utils/common/misc";
-import { Record } from "./record";
+import { Record } from "@mail/core/common/record";
 import { browser } from "@web/core/browser/browser";
 
 export class DiscussAppCategory extends Record {

--- a/addons/mail/static/src/core/public_web/discuss_app_model.js
+++ b/addons/mail/static/src/core/public_web/discuss_app_model.js
@@ -1,5 +1,5 @@
+import { Record } from "@mail/core/common/record";
 import { _t } from "@web/core/l10n/translation";
-import { Record } from "./record";
 
 export class DiscussApp extends Record {
     static new(data) {

--- a/addons/mail/static/src/core/public_web/store_service_patch.js
+++ b/addons/mail/static/src/core/public_web/store_service_patch.js
@@ -1,0 +1,34 @@
+import { Store, storeService } from "@mail/core/common/store_service";
+import { Record } from "@mail/core/common/record";
+import { router } from "@web/core/browser/router";
+import { patch } from "@web/core/utils/patch";
+
+patch(Store.prototype, {
+    setup() {
+        super.setup(...arguments);
+        this.discuss = Record.one("DiscussApp");
+        this.action_discuss_id;
+    },
+    onStarted() {
+        super.onStarted(...arguments);
+        this.discuss = { activeTab: "main" };
+    },
+});
+
+patch(storeService, {
+    start(env, services) {
+        const store = super.start(...arguments);
+        const discussActionIds = ["mail.action_discuss", "discuss"];
+        if (store.action_discuss_id) {
+            discussActionIds.push(store.action_discuss_id);
+        }
+        store.discuss.isActive ||= discussActionIds.includes(router.current.action);
+        services.ui.bus.addEventListener("resize", () => {
+            store.discuss.activeTab = "main";
+            if (services.ui.isSmall && store.discuss.thread?.channel_type) {
+                store.discuss.activeTab = store.discuss.thread.channel_type;
+            }
+        });
+        return store;
+    },
+});

--- a/addons/mail/static/src/core/public_web/thread_model_patch.js
+++ b/addons/mail/static/src/core/public_web/thread_model_patch.js
@@ -1,0 +1,58 @@
+import { patch } from "@web/core/utils/patch";
+import { Thread } from "@mail/core/common/thread_model";
+import { Record } from "@mail/core/common/record";
+import { router } from "@web/core/browser/router";
+
+patch(Thread.prototype, {
+    setup() {
+        super.setup(...arguments);
+        this.discussAppCategory = Record.one("DiscussAppCategory", {
+            compute() {
+                return this._computeDiscussAppCategory();
+            },
+        });
+    },
+
+    _computeDiscussAppCategory() {
+        if (["group", "chat"].includes(this.channel_type)) {
+            return this.store.discuss.chats;
+        }
+        if (this.channel_type === "channel") {
+            return this.store.discuss.channels;
+        }
+    },
+
+    /** @param {boolean} pushState */
+    setAsDiscussThread(pushState) {
+        if (pushState === undefined) {
+            pushState = this.notEq(this.store.discuss.thread);
+        }
+        this.store.discuss.thread = this;
+        const activeId =
+            typeof this.id === "string" ? `mail.box_${this.id}` : `discuss.channel_${this.id}`;
+        this.store.discuss.activeTab =
+            !this.store.env.services.ui.isSmall || this.model === "mail.box"
+                ? "main"
+                : ["chat", "group"].includes(this.channel_type)
+                ? "chat"
+                : "channel";
+        if (pushState) {
+            router.pushState({ active_id: activeId });
+        }
+    },
+
+    async unpin() {
+        this.isLocallyPinned = false;
+        if (this.eq(this.store.discuss.thread)) {
+            router.replaceState({ active_id: undefined });
+        }
+        if (this.model === "discuss.channel" && this.is_pinned) {
+            return this.store.env.services.orm.silent.call(
+                "discuss.channel",
+                "channel_pin",
+                [this.id],
+                { pinned: false }
+            );
+        }
+    },
+});

--- a/addons/mail/static/src/core/web/@types/models.d.ts
+++ b/addons/mail/static/src/core/web/@types/models.d.ts
@@ -11,6 +11,7 @@ declare module "models" {
         activityCounter: number,
         activity_counter_bus_id: number,
         activityGroups: Object[],
+        getDiscussSidebarCategoryCounter: (categoryId: number) => number,
     }
     export interface Thread {
         recipients: Follower[],

--- a/addons/mail/static/src/core/web/chat_hub_patch.js
+++ b/addons/mail/static/src/core/web/chat_hub_patch.js
@@ -1,0 +1,8 @@
+import { patch } from "@web/core/utils/patch";
+import { ChatHub } from "@mail/core/common/chat_hub";
+
+patch(ChatHub.prototype, {
+    get isShown() {
+        return super.isShown && !this.store.discuss.isActive;
+    },
+});

--- a/addons/mail/static/src/core/web/store_service_patch.js
+++ b/addons/mail/static/src/core/web/store_service_patch.js
@@ -142,6 +142,15 @@ const StorePatch = {
             systray_get_activities: true,
         };
     },
+    getDiscussSidebarCategoryCounter(categoryId) {
+        return this.DiscussAppCategory.get({ id: categoryId }).threads.reduce((acc, channel) => {
+            if (categoryId === "channels") {
+                return channel.message_needaction_counter > 0 ? acc + 1 : acc;
+            } else {
+                return channel.selfMember?.message_unread_counter > 0 ? acc + 1 : acc;
+            }
+        }, 0);
+    },
     getNeedactionChannels() {
         return this.getRecentChannels().filter((channel) => channel.importantCounter > 0);
     },

--- a/addons/mail/static/src/core/web/thread_model_patch.js
+++ b/addons/mail/static/src/core/web/thread_model_patch.js
@@ -24,6 +24,12 @@ patch(Thread.prototype, {
         const chatWindow = this.store.ChatWindow.get({ thread: this });
         chatWindow?.close({ notifyState: false });
     },
+    computeIsDisplayed() {
+        if (this.store.discuss.isActive && !this.store.env.services.ui.isSmall) {
+            return this.eq(this.store.discuss.thread);
+        }
+        return super.computeIsDisplayed();
+    },
     async leave() {
         this.closeChatWindow();
         super.leave(...arguments);


### PR DESCRIPTION
The mail module is split into several sub-folders to determine when
the files should be loaded (e.g., web, public, public_web...).

Currently, several code snippets are misplaced, which increases the
load on public pages or live chat.

Moreover, this can lead to dependency hell, especially when moving a
feature to another bundle.

This PR moves the discuss app model, which is only used in the web
and public bundle, to the public_web bundle.

Part of task-3972988

enterprise: https://github.com/odoo/enterprise/pull/65892