### PR TITLE
[FIX] l10n_nl: Add the condition for tag

### DIFF
--- a/addons/l10n_nl/migrations/3.3/post-migrate_update_taxes.py
+++ b/addons/l10n_nl/migrations/3.3/post-migrate_update_taxes.py
@@ -23,6 +23,9 @@ def migrate(cr, version):
     services_taxes = env['account.tax'].browse(_get_tax_ids_for_xml_id(cr, 'btw_X0_diensten'))
 
     old_tax_tags = env['account.account.tag']._get_tax_tags('3bl (omzet)', 'nl')
+    if not old_tax_tags:
+        return
+
     goods_tax_tags = env['account.account.tag']._get_tax_tags('3bg (omzet)', 'nl')
     services_tax_tags = env['account.account.tag']._get_tax_tags('3bs (omzet)', 'nl')
 


### PR DESCRIPTION
While upgrading to version 16.0, an error occurs due to [this](https://github.com/odoo/odoo/blob/65378432c6ab2ae1cb130c527b90b6be2940e3bb/addons/l10n_nl/migrations/3.3/post-migrate_update_taxes.py#L51) file. The tag '3bl (omzet)' is not present in version 16.0, so it return ```False``` value and this ```False``` value being updated in this [query](https://github.com/odoo/odoo/blob/65378432c6ab2ae1cb130c527b90b6be2940e3bb/addons/l10n_nl/migrations/3.3/post-migrate_update_taxes.py#L51) and ```account_account_tag_id``` is an integer type and  ```old_tax_tags``` a boolean value

```
2024-07-01 15:37:54,561 28 ERROR db_1780619 odoo.sql_db: bad query:
                UPDATE account_account_tag_account_tax_repartition_line_rel
                SET account_account_tag_id = 150
                WHERE account_tax_repartition_line_id = ANY(ARRAY[1831,1832])
                AND account_account_tag_id = false

ERROR: operator does not exist: integer = boolean
LINE 5:                 AND account_account_tag_id = false
                                                   ^
HINT:  No operator matches the given name and argument types. You might need to
add explicit type casts.
```
upg-1780619
opw-4027545

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
