### PR TITLE
[FIX] account: prevent a error when create an accrued expense entry

### DIFF
--- a/addons/account/wizard/accrued_orders.py
+++ b/addons/account/wizard/accrued_orders.py
@@ -215,7 +215,7 @@ class AccruedExpenseRevenue(models.TransientModel):
             analytic_distribution = {}
             total = sum(order.amount_total for order in orders)
             for line in orders.order_line:
-                ratio = line.price_total / total
+                ratio = line.price_total / (total or 1)
                 if not is_purchase and line.order_id.analytic_account_id:
                     account_id = str(line.order_id.analytic_account_id.id)
                     analytic_distribution.update({account_id: analytic_distribution.get(account_id, 0) +100.0*ratio})

--- a/addons/purchase/tests/test_accrued_purchase_orders.py
+++ b/addons/purchase/tests/test_accrued_purchase_orders.py
@@ -121,3 +121,18 @@ class TestAccruedPurchaseOrders(AccountTestInvoicingCommon):
             {'account_id': self.alt_exp_account.id, 'debit': 2000.0, 'credit': 0.0, 'analytic_distribution': {str(self.analytic_account_b.id): 100.0}},
             {'account_id': self.account_revenue.id, 'debit': 0.0, 'credit': 12000.0, 'analytic_distribution': {str(self.analytic_account_a.id): 66.67, str(self.analytic_account_b.id): 33.33}},
         ])
+
+    def test_accrued_order_with_zero_order_amount(self):
+        # purchase order with zero total amount
+        self.purchase_order.amount_total = 0.0
+        self.assertFalse(self.purchase_order.amount_total)
+        self.wizard.write({'amount': 1})
+
+        self.assertRecordValues(self.env['account.move'].search(self.wizard.create_entries()['domain']).line_ids, [
+            # reverse move lines
+            {'account_id': self.account_expense.id, 'debit': 0.0, 'credit': 1.0, 'amount_currency': -1.0},
+            {'account_id': self.account_revenue.id, 'debit': 1.0, 'credit': 0.0, 'amount_currency': 1.0},
+            # move lines
+            {'account_id': self.account_expense.id, 'debit': 1.0, 'credit': 0.0, 'amount_currency': 1.0},
+            {'account_id': self.account_revenue.id, 'debit': 0.0, 'credit': 1.0, 'amount_currency': -1.0},
+        ])


### PR DESCRIPTION
Currently, an error occurs when creating an accrued expense entry with 0.0 amount total.

Step to produce:

- Install the 'account_accountant' and 'purchase' module. (with demo data)
-  Create a purchase order, set a 'Vendor' and product whose price is 0.0.
- Open an 'Accrued Expense Entry' through the action button.
- Add an amount and try to 'CREATE ENTRY'.

Traceback On Sentry:

```
ZeroDivisionError: float division by zero
  File "odoo/http.py", line 2248, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1823, in _serve_db
    return self._transactioning(_serve_ir_http, readonly=ro)
  File "odoo/http.py", line 1843, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1821, in _serve_ir_http
    return self._serve_ir_http(rule, args)
  File "odoo/http.py", line 1828, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2053, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 220, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 756, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 38, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 34, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 458, in call_kw
    result = getattr(recs, name)(*args, **kwargs)
  File "addons/web/models/models.py", line 1018, in onchange
    snapshot1 = RecordSnapshot(record, fields_spec)
  File "addons/web/models/models.py", line 1105, in __init__
    self.fetch(name)
  File "addons/web/models/models.py", line 1120, in fetch
    self[field_name] = self.record[field_name]
  File "odoo/models.py", line 6608, in __getitem__
    return self._fields[key].__get__(self, self.env.registry[self._name])
  File "odoo/fields.py", line 1261, in __get__
    self.compute_value(recs)
  File "odoo/fields.py", line 1443, in compute_value
    records._compute_field_value(self)
  File "odoo/models.py", line 4934, in _compute_field_value
    fields.determine(field.compute, self)
  File "odoo/fields.py", line 100, in determine
    return needle(*args)
  File "addons/account/wizard/accrued_orders.py", line 61, in _compute_display_amount
    preview_data = json.loads(self.preview_data)
  File "odoo/fields.py", line 1261, in __get__
    self.compute_value(recs)
  File "odoo/fields.py", line 1443, in compute_value
    records._compute_field_value(self)
  File "odoo/models.py", line 4934, in _compute_field_value
    fields.determine(field.compute, self)
  File "odoo/fields.py", line 100, in determine
    return needle(*args)
  File "addons/account/wizard/accrued_orders.py", line 85, in _compute_preview_data
    record._compute_move_vals()[0],
  File "addons/account/wizard/accrued_orders.py", line 207, in _compute_move_vals
    ratio = line.price_total / total
```

An error occurs when the system tries to divide a float number by 0.0 due to the total amount of purchase is 0.0 at [1]

Link [1]: https://github.com/odoo/odoo/blob/ace8768a36badd28c4be6b56acf526f8ea53c8f5/addons/account/wizard/accrued_orders.py#L218

To handle this issue, we have to divide the price total by 1 if total amount of purchase is 0.0.

sentry - 5560340833

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
