### PR TITLE
[IMP] web: add icon html to toast notification

### DIFF
--- a/addons/web/static/src/webclient/actions/client_actions.js
+++ b/addons/web/static/src/webclient/actions/client_actions.js
@@ -17,7 +17,9 @@ export function displayNotificationAction(env, action) {
     const links = (params.links || []).map((link) => {
         return `<a href="${escape(link.url)}" target="_blank">${escape(link.label)}</a>`;
     });
-    const message = markup(sprintf(escape(params.message), ...links));
+    const messageContent = sprintf(escape(params.message), ...links);
+    // conditionally prepend an icon to the message
+    const message = params.icon ? markup(`<span class="${escape(params.icon)}"></span> ${messageContent}`) : markup(messageContent);
     env.services.notification.add(message, options);
     return params.next;
 }

--- a/addons/web/static/tests/webclient/actions/client_action.test.js
+++ b/addons/web/static/tests/webclient/actions/client_action.test.js
@@ -355,6 +355,27 @@ test("test next action on display_notification client action", async () => {
     expect.verifySteps(["onClose"]);
 });
 
+test("test next icon on display_notification client action", async () => {
+    await mountWithCleanup(WebClient);
+    await getService("action").doAction({
+        type: "ir.actions.client",
+        tag: "display_notification",
+        params: {
+            title: "title",
+            message: "message",
+            icon: "fa fa-fw fa-check",
+            sticky: true,
+            next: {
+                type: "ir.actions.act_window_close",
+            },
+        },
+    });
+    await animationFrame(); // wait for the notification to be displayed
+    expect(".o_notification_manager .o_notification .o_notification_content span").toHaveClass(
+        "fa fa-fw fa-check"
+    );
+});
+
 test("test reload client action", async () => {
     redirect("/odoo?test=42");
     browser.location.search = "?test=42";


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

Before this commit, the toast notification was only able to display text string as message whenever the call was made via the function `display_notification`. This prevented the flexibility to display an icon along with the message when the notification was coded in the backend side.

### Desired behavior after PR is merged:
This commit adds the possibility to display an optional icon along with the message when the display_notification is called.

related task id: 3916119

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
