### PR TITLE
[FIX] event: mail templates not received

### DIFF
--- a/addons/event/models/event_mail.py
+++ b/addons/event/models/event_mail.py
@@ -303,7 +303,8 @@ class EventMailRegistration(models.Model):
             }
             if not reg_mail.scheduler_id.template_ref.email_from:
                 email_values['email_from'] = author.email_formatted
-            reg_mail.scheduler_id.template_ref.send_mail(reg_mail.registration_id.id, email_values=email_values)
+            template = reg_mail.scheduler_id.template_ref.with_context(tpl_partners_only=True)
+            template.send_mail(reg_mail.registration_id.id, email_values=email_values)
         todo.write({'mail_sent': True})
 
     @api.depends('registration_id', 'scheduler_id.interval_unit', 'scheduler_id.interval_type')

--- a/addons/event/tests/test_event_mail_schedule.py
+++ b/addons/event/tests/test_event_mail_schedule.py
@@ -123,7 +123,7 @@ class TestMailSchedule(TestEventCommon, MockEmail):
         # check emails effectively sent
         self.assertEqual(len(self._new_mails), 2, 'event: should have 2 scheduled emails (1 / registration)')
         self.assertMailMailWEmails(
-            [formataddr((reg1.name, reg1.email)), formataddr((reg2.name, reg2.email))],
+            [reg1.email, reg2.email],
             'outgoing',
             content=None,
             fields_values={'subject': 'Your registration at %s' % test_event.name,
@@ -161,7 +161,7 @@ class TestMailSchedule(TestEventCommon, MockEmail):
         # check emails effectively sent
         self.assertEqual(len(self._new_mails), 2, 'event: should have 2 scheduled emails (1 / registration)')
         self.assertMailMailWEmails(
-            [formataddr((reg1.name, reg1.email)), formataddr((reg2.name, reg2.email))],
+            [reg1.email, reg2.email],
             'outgoing',
             content=None,
             fields_values={'subject': 'Your registration at %s' % test_event.name,
@@ -251,7 +251,7 @@ class TestMailSchedule(TestEventCommon, MockEmail):
             self.assertEqual(mail.email_from, self.user_eventmanager.company_id.email_formatted)
             self.assertEqual(mail.subject, 'Your registration at %s' % test_event.name)
             self.assertEqual(mail.state, 'outgoing')
-            self.assertEqual(mail.email_to, formataddr((reg3.name, reg3.email)))
+            self.assertEqual(mail.recipient_ids[0].email, reg3.email)
 
         # POST SCHEDULERS (MOVE FORWARD IN TIME)
         # --------------------------------------------------


### PR DESCRIPTION
Current behaviour:
---
When creating an attendee on an event that has a communication 
"trigger after each registration", the email is not received by the attendee

Steps to reproduce:
---
1. Select an event
2. Set a template to trigger after each registration
3. Go to Attendees
4. Create a new attendee, with only an email
5. A template is generated and sent
6. = The attendee will not receive the email
7. In the debug menu > manage messages
8. Last message > Recipients > No recipients

Fix:
---
Using the tpl_partners_only context, to force create a partner thus setting the recipient_ids field

opw-3947879

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
