### PR TITLE
[FIX] repair: create w/ correct default_get syntax

### DIFF
--- a/addons/repair/models/repair.py
+++ b/addons/repair/models/repair.py
@@ -289,7 +289,9 @@ class Repair(models.Model):
     def create(self, vals_list):
         # We generate a standard reference
         for vals in vals_list:
-            picking_type = self.env['stock.picking.type'].browse(vals.get('picking_type_id', self.default_get('picking_type_id')))
+            picking_type = self.env['stock.picking.type'].browse(
+                vals.get('picking_type_id', self.default_get(['picking_type_id'])['picking_type_id'])
+            )
             if 'picking_type_id' not in vals:
                 vals['picking_type_id'] = picking_type.id
             if not vals.get('name', False) or vals['name'] == 'New':

--- a/addons/repair/tests/test_repair.py
+++ b/addons/repair/tests/test_repair.py
@@ -696,7 +696,6 @@ class TestRepair(common.TransactionCase):
         repair_order = self.env['repair.order'].create({
             'product_id': self.product_product_3.id,
             'product_uom': self.product_product_3.uom_id.id,
-            'picking_type_id': self.stock_warehouse.repair_type_id.id,
             'partner_id': self.res_partner_12.id,
             'move_ids': [
                 Command.create({


### PR DESCRIPTION
**Current behavior:**
When importing a repair order record, if a picking_type_id is not supplied by the data source, the import will fail.

**Expected behavior:**
Fields with default values shouldn't be required during record creation.

**Steps to reproduce:**
1. Create a .CSV with one column (e.g., `scheduled date`) and load it in the import record view in the Repair app

2. Map the CSV column to the repair model's date field

3. Click the test button to see the error (bad query)

**Cause of the issue:**
If a `picking_type_id` is not supplied, we try to get the default field value via `default_get()`. However, it is called incorrectly (string argument vs. container), so the string is iterated over and each letter is treated as a field name (none of which, of course, exist in the model).

Later in the create sequence, we assume there is a `picking_type_id` value obtained from the `default_get()` call but it is not there. This (eventually) causes the invalid query.

**Fix:**
Correct the call to `default_get()`.

opw-3813273