### PR TITLE
[FIX] l10n_nz: include BOX 6 once in "Sales and Income" section

### DIFF
--- a/addons/l10n_nz/data/account_tax_report_data.xml
+++ b/addons/l10n_nz/data/account_tax_report_data.xml
@@ -15,7 +15,7 @@
         <field name="line_ids">
             <record id="tax_report_sale_and_income" model="account.report.line">
                 <field name="name">Sales and Income</field>
-                <field name="aggregation_formula">NZBOX5.balance + NZBOX6.balance + NZBOX9.balance</field>
+                <field name="aggregation_formula">NZBOX5.balance + NZBOX9.balance</field>
                 <field name="sequence">100</field>
                 <field name="children_ids">
                     <record id="tax_report_box5" model="account.report.line">


### PR DESCRIPTION
**Steps to reproduce:**
- Install Accounting and l10n_nz
- Switch to a New Zeland company (e.g. NZ Company)
- Create an invoice with a 0% tax
- Go to "Accounting / Reporting / Statement Reports / Tax Report"
- Select "Tax Report (NZ)" and the period of the invoice

**Issue:**
The amount of the invoice with the 0% tax is included twice in `Total Sales and Income` section.

Cause:
The formula for `Total Sales and Income` is `BOX5 + BOX6 + BOX9`.
However, the value of BOX6 is already included in BOX5 as seen in its description `[BOX 6] Zero-rated supplies in Box 5`.

opw-3883198




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
