### PR TITLE
[IMP] sale, website_sale: improve product configurator modal

### DIFF
--- a/addons/sale/static/src/js/badge_extra_price/badge_extra_price.xml
+++ b/addons/sale/static/src/js/badge_extra_price/badge_extra_price.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
     <t t-name="sale.BadgeExtraPrice">
-        <span class="badge ms-1 ps-1 text-bg-info rounded-pill">
+        <span class="badge rounded-pill border ps-1 text-bg-light">
             <span t-out="this.props.price > 0 ? '+' : '-'" class="me-1"/>
             <i t-out="getFormattedPrice()"/>
         </span>

--- a/addons/sale/static/src/js/product/product.scss
+++ b/addons/sale/static/src/js/product/product.scss
@@ -9,12 +9,16 @@
 }
 
 .o_sale_product_configurator_img {
-    width: 120px;
+    width: 40px;
     max-height: 240px;
+
+    @include media-breakpoint-up(md) {
+        width: 120px;
+    }
 }
 
 .o_sale_product_configurator_qty {
-    width: 160px;
+    width: 64px;
 
     input {
         max-width: 4rem;
@@ -29,8 +33,16 @@
             -moz-appearance: textfield;
         }
     }
+
+    @include media-breakpoint-up(md) {
+        width: 160px;
+    }
 }
 
 .o_sale_product_configurator_price {
-    width: 160px;
+    width: 100px;
+
+    @include media-breakpoint-up(md) {
+        width: 160px;
+    }
 }

--- a/addons/sale/static/src/js/product/product.xml
+++ b/addons/sale/static/src/js/product/product.xml
@@ -15,7 +15,7 @@
         </td>
         <td class="p-3" t-att-colspan="this.props.optional ? 2:false">
             <div class="mb-4 text-break" name="o_sale_product_configurator_name">
-                <h5 t-out="this.props.display_name"/>
+                <span class="h5" t-out="this.props.display_name"/>
                 <div
                     t-if="this.props.description_sale"
                     t-out="this.props.description_sale"
@@ -32,21 +32,23 @@
             <t t-if="!this.props.optional">
                 <div
                     name="sale_product_configurator_quantity_buttons"
-                    class="input-group justify-content-end">
+                    class="input-group justify-content-center">
                     <button
                         class="btn btn-secondary d-none d-md-inline-block"
+                        name="sale_product_configurator_quantity_button_minus"
                         aria-label="Remove one"
                         t-on-click="decreaseQuantity">
                         <i class="fa fa-minus"/>
                     </button>
                     <input
-                        class="form-control quantity border-bottom border-top text-center"
+                        class="form-control quantity text-center"
                         name="product_quantity"
                         type="number"
                         t-att-value="this.props.quantity"
                         t-on-change="setQuantity"/>
                     <button
                         class="btn btn-secondary d-none d-md-inline-block"
+                        name="sale_product_configurator_quantity_button_plus"
                         aria-label="Add one"
                         t-on-click="increaseQuantity">
                         <i class="fa fa-plus"/>
@@ -74,14 +76,17 @@
                     class="btn btn-secondary"
                     t-att-class="{'disabled': !this.env.isPossibleCombination(this.props)}"
                     t-on-click="() => this.env.addProduct(this.props.product_tmpl_id)">
-                    <i class="fa fa-plus"/> Add
+                    <i class="fa fa-plus d-none d-md-inline" role="img"/> Add
                 </button>
             </t>
         </td>
     </t>
 
     <t t-name="sale.product_price">
-        <h5 class="text-nowrap" t-out="getFormattedPrice()"/>
+        <span
+            name="sale_product_configurator_formatted_price"
+            class="h5 text-nowrap"
+            t-out="getFormattedPrice()"/>
         <span t-if="this.props.price_info" t-out="this.props.price_info" class="text-muted"/>
     </t>
 </templates>

--- a/addons/sale/static/src/js/product_configurator_dialog/product_configurator_dialog.xml
+++ b/addons/sale/static/src/js/product_configurator_dialog/product_configurator_dialog.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
     <t t-name="sale.ProductConfiguratorDialog">
-        <Dialog size="size" title="title" contentClass="this.state.optionalProducts.length ? 'h-75' : ''">
+        <Dialog size="size" title="title" contentClass="'o_sale_product_configurator_dialog'">
             <ProductList t-if="this.state.products.length" products="this.state.products"/>
             <ProductList
                 t-if="this.state.optionalProducts.length"

--- a/addons/sale/static/src/js/product_list/product_list.xml
+++ b/addons/sale/static/src/js/product_list/product_list.xml
@@ -1,12 +1,18 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
     <t t-name="sale.ProductList">
-        <h4 class="mt-4 mb-3" t-if="this.props.areProductsOptional" t-out="optionalProductsTitle"/>
-        <table class="o_sale_product_configurator_table table table-sm position-relative mb-0" t-att-class="{'o_sale_product_configurator_table_optional': this.props.areProductsOptional}">
+        <span
+            name="sale_product_configurator_list_title"
+            class="d-inline-block mt-4 mb-3 h4"
+            t-if="this.props.areProductsOptional"
+            t-out="optionalProductsTitle"/>
+        <table
+            class="o_sale_product_configurator_table table table-sm position-relative mb-0"
+            t-att-class="{'o_sale_product_configurator_table_optional': this.props.areProductsOptional}">
             <thead t-if="!this.props.areProductsOptional">
                 <tr>
                     <th class="px-0 border-bottom-0" colspan="2">Product</th>
-                    <th class="px-0 text-end border-bottom-0">Quantity</th>
+                    <th class="px-0 text-center border-bottom-0">Quantity</th>
                     <th class="px-0 text-end border-bottom-0">Price</th>
                 </tr>
             </thead>
@@ -16,7 +22,9 @@
                 </tr>
                 <tr t-if="!this.props.areProductsOptional">
                     <td colspan="4" class="border-bottom-0 text-end">
-                        <h4>Total: <span t-out="getFormattedTotal()"/></h4>
+                        <span name="sale_product_configurator_list_total" class="h4">
+                            Total: <span t-out="getFormattedTotal()"/>
+                        </span>
                     </td>
                 </tr>
             </tbody>

--- a/addons/sale/static/src/js/product_template_attribute_line/product_template_attribute_line.scss
+++ b/addons/sale/static/src/js/product_template_attribute_line/product_template_attribute_line.scss
@@ -1,3 +1,15 @@
+.o_sale_product_configurator_table {
+    div[name="ptal"] > div {
+        @include media-breakpoint-up(lg) {
+            align-items: center;
+        }
+
+        &:has(.form-check) {
+            align-items: flex-start;
+        }
+    }
+}
+
 .o_sale_product_configurator_ptav_color {
     border: 5px solid $border-color;
     transition: $input-transition;

--- a/addons/sale/static/src/js/product_template_attribute_line/product_template_attribute_line.xml
+++ b/addons/sale/static/src/js/product_template_attribute_line/product_template_attribute_line.xml
@@ -16,7 +16,7 @@
                 <t t-if="showValuesChoice" t-call="{{getPTAVTemplate()}}"/>
             </div>
             <input
-                class="o_input w-75 mb-4 ms-lg-auto"
+                class="o_input w-lg-75 mb-4 ms-lg-auto"
                 type="text"
                 placeholder="Enter a customized value"
                 t-if="hasPTAVCustom &amp;&amp; isSelectedPTAVCustom()"
@@ -27,7 +27,7 @@
     </t>
     <!-- Attributes value templates -->
     <t t-name="sale.ptav_select">
-        <select class="o_input w-50 flex-grow-1"
+        <select class="o_input w-lg-50 flex-grow-1"
             t-on-change="updateSelectedPTAV"
             t-att-name="'ptal-' + this.props.id">
             <option
@@ -46,10 +46,10 @@
                 class="mb-2">
                 <div class="form-check">
                     <label
-                        class="form-check-label d-inline-flex align-items-center"
+                        class="form-check-label d-inline-flex align-items-center flex-wrap"
                         t-att-class="{ 'css_not_available': ptav.excluded }"
                         t-attf-for="ptav-{{ptav.id}}-input">
-                        <span t-out="ptav.name"/>
+                        <span class="me-1" t-out="ptav.name"/>
                         <BadgeExtraPrice
                             t-if="ptav.price_extra"
                             price="ptav.price_extra"

--- a/addons/sale/static/src/js/tours/product_configurator_tour_utils.js
+++ b/addons/sale/static/src/js/tours/product_configurator_tour_utils.js
@@ -6,7 +6,7 @@ function productSelector(productName) {
     return `
         table.o_sale_product_configurator_table
         tr:has(td>div[name="o_sale_product_configurator_name"]
-        h5:contains("${productName}"))
+        span:contains("${productName}"))
     `;
 }
 
@@ -14,7 +14,7 @@ function optionalProductSelector(productName) {
     return `
         table.o_sale_product_configurator_table_optional
         tr:has(td>div[name="o_sale_product_configurator_name"]
-        h5:contains("${productName}"))
+        span:contains("${productName}"))
     `;
 }
 
@@ -153,7 +153,7 @@ function assertProductPrice(productName, price) {
         trigger: `
             ${productSelector(productName)}
             td.o_sale_product_configurator_price
-            h5:contains("${price}")
+            span:contains("${price}")
         `,
     };
 }
@@ -164,7 +164,7 @@ function assertOptionalProductPrice(productName, price) {
         trigger: `
             ${optionalProductSelector(productName)}
             td.o_sale_product_configurator_qty
-            h5:contains("${price}")
+            span:contains("${price}")
         `,
     };
 }

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_edition_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_edition_ui.js
@@ -57,15 +57,15 @@ registry.category("web_tour.tours").add('sale_product_configurator_edition_tour'
     run: "click",
 }, {
     // check updated legs
-    trigger: 'table.o_sale_product_configurator_table tr:has(td>div[name="o_sale_product_configurator_name"] h5:contains("Customizable Desk")) td>div[name="ptal"]:has(div>label:contains("Legs")) label:has(span:contains("Aluminium")) ~ input:checked',
+    trigger: 'table.o_sale_product_configurator_table tr:has(td>div[name="o_sale_product_configurator_name"] span:contains("Customizable Desk")) td>div[name="ptal"]:has(div>label:contains("Legs")) label:has(span:contains("Aluminium")) ~ input:checked',
 }, {
     // check updated price
-    trigger: 'table.o_sale_product_configurator_table tr:has(td>div[name="o_sale_product_configurator_name"] h5:contains("Customizable Desk")) td[name="price"] h5:contains("800.40")',
+    trigger: 'table.o_sale_product_configurator_table tr:has(td>div[name="o_sale_product_configurator_name"] span:contains("Customizable Desk")) td[name="price"] span:contains("800.40")',
 }, {
-    trigger: 'table.o_sale_product_configurator_table tr:has(td>div[name="o_sale_product_configurator_name"] h5:contains("Customizable Desk")) td>div[name="ptal"]:has(div>label:contains("Legs")) label:has(span:contains("Custom")) ~ input',
+    trigger: 'table.o_sale_product_configurator_table tr:has(td>div[name="o_sale_product_configurator_name"] span:contains("Customizable Desk")) td>div[name="ptal"]:has(div>label:contains("Legs")) label:has(span:contains("Custom")) ~ input',
     run: "click",
 }, {
-    trigger: 'table.o_sale_product_configurator_table tr:has(td>div[name="o_sale_product_configurator_name"] h5:contains("Customizable Desk")) td>div[name="ptal"]:has(div>label:contains("Legs")) input[type="text"]',
+    trigger: 'table.o_sale_product_configurator_table tr:has(td>div[name="o_sale_product_configurator_name"] span:contains("Customizable Desk")) td>div[name="ptal"]:has(div>label:contains("Legs")) input[type="text"]',
     run: "edit nice custom value && click .modal-body",
 }, {
     trigger: 'tr:has(div[name="o_sale_product_configurator_name"]:contains("Customizable Desk")) label[style="background-color:#000000"] input',
@@ -115,7 +115,7 @@ registry.category("web_tour.tours").add('sale_product_configurator_edition_tour'
     trigger: '.fa-pencil',
     run: "click",
 }, {
-    trigger: 'table.o_sale_product_configurator_table tr:has(td>div[name="o_sale_product_configurator_name"] h5:contains("Customizable Desk")) td>div[name="ptal"]:has(div>label:contains("Legs")) label:has(span:contains("Steel")) ~ input',
+    trigger: 'table.o_sale_product_configurator_table tr:has(td>div[name="o_sale_product_configurator_name"] span:contains("Customizable Desk")) td>div[name="ptal"]:has(div>label:contains("Legs")) label:has(span:contains("Steel")) ~ input',
     run: "click",
 },
     configuratorTourUtils.assertProductNameContains("Customizable Desk (TEST) (Steel, Black)"),

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_pricelist_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_pricelist_ui.js
@@ -58,14 +58,14 @@ stepUtils.showAppsMenuItem(),
     run: "click",
 }, {
     content: "check price is correct (USD)",
-    trigger: 'main.modal-body>table:nth-child(1)>tbody>tr:nth-child(1)>td:nth-child(4) h5:contains("750.00")',
+    trigger: 'main.modal-body>table:nth-child(1)>tbody>tr:nth-child(1)>td:nth-child(4) span:contains("750.00")',
 }, {
     content: "add one more",
     trigger: 'main.modal-body>table:nth-child(1)>tbody>tr:nth-child(1)>td:nth-child(3)>div>button:has(i.fa-plus)',
     run: "click",
 }, {
     content: "check price for 2",
-    trigger: 'main.modal-body>table:nth-child(1)>tbody>tr:nth-child(1)>td:nth-child(4) h5:contains("600.00")',
+    trigger: 'main.modal-body>table:nth-child(1)>tbody>tr:nth-child(1)>td:nth-child(4) span:contains("600.00")',
 },
     configuratorTourUtils.addOptionalProduct("Conference Chair"),
     configuratorTourUtils.increaseProductQuantity("Conference Chair"),

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_single_custom_attribute_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_single_custom_attribute_ui.js
@@ -45,12 +45,12 @@ registry.category("web_tour.tours").add('sale_product_configurator_single_custom
     trigger: '.fa-pencil',
     run: "click",
 }, {
-    trigger: 'table.o_sale_product_configurator_table tr:has(td>div[name="o_sale_product_configurator_name"] h5:contains("Customizable Desk (TEST)")) td>div[name="ptal"]:has(div>label:contains("product attribute")) input[type="text"]',
+    trigger: 'table.o_sale_product_configurator_table tr:has(td>div[name="o_sale_product_configurator_name"] *:contains("Customizable Desk (TEST)")) td>div[name="ptal"]:has(div>label:contains("product attribute")) input[type="text"]',
     run: function () {
         // check custom value initialized
         if (
             queryOne(
-                'table.o_sale_product_configurator_table tr:has(td>div[name="o_sale_product_configurator_name"] h5:contains("Customizable Desk (TEST)")) td>div[name="ptal"]:has(div>label:contains("product attribute")) input[type="text"]'
+                'table.o_sale_product_configurator_table tr:has(td>div[name="o_sale_product_configurator_name"] *:contains("Customizable Desk (TEST)")) td>div[name="ptal"]:has(div>label:contains("product attribute")) input[type="text"]'
             ).value !== "great single custom value"
         ) {
             console.error("The value of custom product attribute should be 'great single custom value'.");

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_ui.js
@@ -37,13 +37,13 @@ registry.category("web_tour.tours").add('sale_product_configurator_tour', {
     trigger: 'ul.ui-autocomplete a:contains("Customizable Desk (TEST)")',
     run: "click",
 }, {
-    trigger: '.o_sale_product_configurator_table tr:has(td>div[name="o_sale_product_configurator_name"] h5:contains("Customizable Desk")) label:contains("Steel")',
+    trigger: '.o_sale_product_configurator_table tr:has(td>div[name="o_sale_product_configurator_name"] span:contains("Customizable Desk")) label:contains("Steel")',
     run: "click",
 }, {
-    trigger: '.o_sale_product_configurator_table tr:has(td>div[name="o_sale_product_configurator_name"] h5:contains("Customizable Desk")) label:contains("Aluminium")',
+    trigger: '.o_sale_product_configurator_table tr:has(td>div[name="o_sale_product_configurator_name"] span:contains("Customizable Desk")) label:contains("Aluminium")',
     run: "click",
 }, {
-    trigger: '.o_sale_product_configurator_table tr:has(td>div[name="o_sale_product_configurator_name"] h5:contains("Customizable Desk")) td[name="price"] h5:contains("800.40")',
+    trigger: '.o_sale_product_configurator_table tr:has(td>div[name="o_sale_product_configurator_name"] span:contains("Customizable Desk")) td[name="price"] span:contains("800.40")',
 }, {
     trigger: 'label[style="background-color:#000000"] input',
     run: "click",
@@ -60,7 +60,7 @@ registry.category("web_tour.tours").add('sale_product_configurator_tour', {
 {
     trigger: '.btn-primary:not(:disabled):contains("Confirm")',
 }, {
-    trigger: 'span:contains("Aluminium"):eq(1)',
+    trigger: '.o_sale_product_configurator_table_optional span:contains("Aluminium")',
     run: "click",
 },
     configuratorTourUtils.addOptionalProduct("Conference Chair"),

--- a/addons/website_sale/static/src/js/product/product.xml
+++ b/addons/website_sale/static/src/js/product/product.xml
@@ -3,12 +3,20 @@
     <t t-inherit="sale.Product" t-inherit-mode="extension">
         <div name="sale_product_configurator_quantity_buttons" position="attributes">
             <attribute name="t-if">this.props.can_be_sold</attribute>
+            <attribute name="class" add="css_quantity" separator=" "/>
         </div>
         <div name="sale_product_configurator_quantity_buttons" position="after">
             <t t-call="website_sale.not_for_sale"/>
         </div>
+        <button name="sale_product_configurator_quantity_button_minus" position="attributes">
+            <attribute name="class" remove="btn-secondary" add="btn-light" separator=" "/>
+        </button>
+        <button name="sale_product_configurator_quantity_button_plus" position="attributes">
+            <attribute name="class" remove="btn-secondary" add="btn-light" separator=" "/>
+        </button>
         <button name="sale_product_configurator_add_button" position="attributes">
             <attribute name="t-if">this.props.can_be_sold</attribute>
+            <attribute name="class" remove="btn-secondary" add="btn-light" separator=" "/>
         </button>
         <button name="sale_product_configurator_add_button" position="after">
             <t t-call="website_sale.not_for_sale"/>
@@ -19,6 +27,17 @@
         <t name="sale_product_configurator_optional_price" position="before">
             <t t-call="website_sale.strikethrough_product_price"/>
         </t>
+        <xpath
+            expr="//div[@name='o_sale_product_configurator_name']//span[hasclass('h5')]"
+            position="attributes">
+            <attribute name="class" remove="h5" add="h6" separator=" "/>
+        </xpath>
+    </t>
+
+    <t t-inherit="sale.product_price" t-inherit-mode="extension">
+        <span name="sale_product_configurator_formatted_price" position="attributes">
+            <attribute name="class" remove="h5" add="h6" separator=" "/>
+        </span>
     </t>
 
     <t t-name="website_sale.not_for_sale">

--- a/addons/website_sale/static/src/js/product_configurator_dialog/product_configurator_dialog.scss
+++ b/addons/website_sale/static/src/js/product_configurator_dialog/product_configurator_dialog.scss
@@ -1,0 +1,5 @@
+.o_sale_product_configurator_dialog {
+    // Ensure a minimal border regardless of the theme options
+    --modal-header-border-width: #{$border-width};
+    --modal-footer-border-width: #{$border-width};
+}

--- a/addons/website_sale/static/src/js/product_list/product_list.xml
+++ b/addons/website_sale/static/src/js/product_list/product_list.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+    <t t-inherit="sale.ProductList" t-inherit-mode="extension">
+        <span name="sale_product_configurator_list_title" position="attributes">
+            <attribute name="class" remove="h4" add="h5" separator=" "/>
+        </span>
+        <span name="sale_product_configurator_list_total" position="attributes">
+            <attribute name="class" remove="h4" add="h5" separator=" "/>
+        </span>
+    </t>
+</templates>

--- a/addons/website_sale/static/src/js/product_template_attribute_line/product_template_attribute_line.xml
+++ b/addons/website_sale/static/src/js/product_template_attribute_line/product_template_attribute_line.xml
@@ -6,11 +6,18 @@
                 this.env.isMainProductConfigurable
                     || this.env.mainProductTmplId !== this.props.productTmplId
             </attribute>
+            <attribute name="class" remove="o_input" separator=" "/>
         </div>
         <div name="ptal" position="after">
             <t t-elif="isSelectedPTAVCustom() || this.props.create_variant == 'no_variant'">
                 <div t-out="getReadOnlyPtal()" class="text-muted small"/>
             </t>
         </div>
+    </t>
+
+    <t t-inherit="sale.ptav_select" t-inherit-mode="extension">
+        <select position="attributes">
+            <attribute name="class" add="form-select" separator=" "/>
+        </select>
     </t>
 </templates>

--- a/addons/website_sale/static/src/js/tours/product_configurator_tour_utils.js
+++ b/addons/website_sale/static/src/js/tours/product_configurator_tour_utils.js
@@ -8,7 +8,7 @@ function assertProductStrikethroughPrice(productName, price) {
         trigger: `
             ${configuratorTourUtils.productSelector(productName)}
             td.o_sale_product_configurator_price
-            h5.oe_striked_price:contains("${price}")
+            .oe_striked_price:contains("${price}")
         `,
     };
 }
@@ -19,7 +19,7 @@ function assertOptionalProductStrikethroughPrice(productName, price) {
         trigger: `
             ${configuratorTourUtils.optionalProductSelector(productName)}
             td.o_sale_product_configurator_qty
-            h5.oe_striked_price:contains("${price}")
+            .oe_striked_price:contains("${price}")
         `,
     };
 }


### PR DESCRIPTION
---

Originally coded by [@]anso-odoo , see https://github.com/odoo-dev/odoo/pull/3246

---

`ProductConfiguratorDialog` component is now shared between front-end and back-end. This causes some visual discrepancies, as we obviously don't use the same design in both environments.

This commit adapts `ProductConfiguratorDialog` to make it more visually appealing and usable in the front-end by:

- Reducing font size of text (`font-size` in back-end being `14px` and `16px` in front-end).
- Improving the responsiveness of columns in the table, tweaking their and their content's sizes.
- Changing button colors with `btn-light` to be more consistent with the rest of the front-end.

task-3916399



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
