### PR TITLE
[FIX] account: include user company in currency mapping

### DIFF
--- a/addons/account/models/res_currency.py
+++ b/addons/account/models/res_currency.py
@@ -56,6 +56,8 @@ class ResCurrency(models.Model):
         if companies == user_company:
             currency_rates = {user_company.currency_id.id: 1.0}
         else:
+            if user_company not in companies:
+                companies |= user_company
             currency_rates = companies.mapped('currency_id')._get_rates(user_company, conversion_date)
 
         conversion_rates = []


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

When the current user is the system user, which happens during install and upgrades, the env company is possibly not included with the companies given to `_get_query_currency_table`, this can lead to a KeyError when [fetching the rate ](https://github.com/odoo/odoo/blob/2130b3bbe627d97b41bbb9a93ff407c2990560a3/addons/account/models/res_currency.py#L65)for said company.

Current behavior before PR:
Steps to reproduce:
- Create company 2 with a currency different than the original company
- Deactivate the original company
- Install module Purchase (or another module that uses `_get_query_currency_table`)
- failure

Same behavior on upgrade if purchase is already installed and the company linked to the system user is deactivated and has a different currency than the active companies.

Desired behavior after PR is merged:



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
