### PR TITLE
[FIX] core: groupby relational property with invalid model

### DIFF
--- a/odoo/addons/test_new_api/tests/test_properties.py
+++ b/odoo/addons/test_new_api/tests/test_properties.py
@@ -2612,18 +2612,14 @@ class PropertiesGroupByCase(TestPropertiesMixin):
             )  # bypass the ORM to set an invalid model name
             definition = self._get_sql_definition(self.discussion_1)
             self.assertEqual(definition[0]['comodel'], invalid_model_name)
-            with self.assertQueryCount(3):
+            error_message = f"You cannot use 'Partners' because the linked {invalid_model_name!r} model doesn't exist or is invalid"
+            with self.assertRaisesRegex(UserError, error_message):
                 result = Model.read_group(
                     domain=[('discussion', '!=', self.wrong_discussion_id)],
                     fields=[],
                     groupby=['attributes.mypartners'],
                     lazy=False,
                 )
-
-            self.assertEqual(len(result), 1)
-            self.assertFalse(result[0]['attributes.mypartners'])
-            self.assertEqual(result[0]['__count'], 4)
-            self._check_domains_count(result)
 
     @mute_logger('odoo.fields')
     def test_properties_field_read_group_many2one(self):
@@ -2632,6 +2628,7 @@ class PropertiesGroupByCase(TestPropertiesMixin):
         # group by many2one property
         self.message_1.attributes = [{
             'name': 'mypartner',
+            'string': 'My Partner',
             'type': 'many2one',
             'value': self.partner_2.id,
             'comodel': 'test_new_api.partner',
@@ -2715,17 +2712,14 @@ class PropertiesGroupByCase(TestPropertiesMixin):
             )  # bypass the ORM to set an invalid model name
             definition = self._get_sql_definition(self.discussion_1)
             self.assertEqual(definition[0]['comodel'], invalid_model_name)
-            with self.assertQueryCount(3):
+            error_message = f"You cannot use 'My Partner' because the linked {invalid_model_name!r} model doesn't exist or is invalid"
+            with self.assertRaisesRegex(UserError, error_message):
                 result = Model.read_group(
                     domain=[('discussion', '!=', self.wrong_discussion_id)],
                     fields=[],
                     groupby=['attributes.mypartner'],
                     lazy=False,
                 )
-
-            self.assertEqual(len(result), 1)
-            self.assertEqual(result[0]['__count'], 4)
-            self._check_domains_count(result)
 
     @mute_logger('odoo.fields')
     def test_properties_field_read_group_selection(self):

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -2878,15 +2878,16 @@ class BaseModel(metaclass=MetaModel):
             else:
                 comodel = self.env.get(definition.get('comodel'))
                 if comodel is None or comodel._transient or comodel._abstract:
-                    # all value are false, because the model does not exist anymore
-                    # (or is a transient model e.g.)
-                    condition = SQL("FALSE")
-                else:
-                    # check the existences of the many2many
-                    condition = SQL(
-                        "%s::int IN (SELECT id FROM %s)",
-                        SQL.identifier(property_alias), SQL.identifier(comodel._table),
-                    )
+                    raise UserError(_(
+                                            "You cannot use %(property_name)r because the linked %(model_name)r model doesn't exist or is invalid",
+                        property_name=definition.get('string', property_name), model_name=definition.get('comodel'),
+                    ))
+
+                # check the existences of the many2many
+                condition = SQL(
+                    "%s::int IN (SELECT id FROM %s)",
+                    SQL.identifier(property_alias), SQL.identifier(comodel._table),
+                )
 
             query.add_join(
                 "LEFT JOIN",
@@ -2914,9 +2915,10 @@ class BaseModel(metaclass=MetaModel):
         elif property_type == 'many2one':
             comodel = self.env.get(definition.get('comodel'))
             if comodel is None or comodel._transient or comodel._abstract:
-                # all value are false, because the model does not exist anymore
-                # (or is a transient model e.g.)
-                return SQL('FALSE')
+                raise UserError(_(
+                    "You cannot use %(property_name)r because the linked %(model_name)r model doesn't exist or is invalid",
+                    property_name=definition.get('string', property_name), model_name=definition.get('comodel'),
+                ))
 
             return SQL(
                 """ CASE


### PR DESCRIPTION
In PostgreSQL 16, we can no longer order by the constant FALSE anymore ("ERROR: non-integer constant in ORDER BY"). But the ORM can generate this `ORDER BY FALSE` (and `GROUP BY FALSE`) clause if we group by a property field linked to an invalid (transient/abstract) or non-existent model. Instead of making no sense query, raise a UserError to indicate the problem.
