### PR TITLE
[FIX] pos_sale: add domain to the SaleOrderFetcher even when a client is not set

### DIFF
--- a/addons/pos_sale/static/src/js/OrderManagementScreen/SaleOrderManagementControlPanel.js
+++ b/addons/pos_sale/static/src/js/OrderManagementScreen/SaleOrderManagementControlPanel.js
@@ -38,9 +38,9 @@ odoo.define('pos_sale.SaleOrderManagementControlPanel', function (require) {
             let currentClient = this.env.pos.get_client();
             if (currentClient) {
                 this.orderManagementContext.searchString = currentClient.name;
-                let domain = this._computeDomain();
-                SaleOrderFetcher.setSearchDomain(domain);
             }
+            let domain = this._computeDomain();
+            SaleOrderFetcher.setSearchDomain(domain);
         }
         onInputKeydown(event) {
             if (event.key === 'Enter') {

--- a/addons/pos_sale/static/tests/helpers/ProductScreenTourMethods.js
+++ b/addons/pos_sale/static/tests/helpers/ProductScreenTourMethods.js
@@ -67,6 +67,14 @@ odoo.define('pos_sale.tour.ProductScreenTourMethods', function (require) {
                 }
             ];
         }
+        checkOrdersListEmpty() {
+            return [
+                {
+                    content: 'Check that the orders list is empty',
+                    trigger: '.order-list:not(:has(.order-row))',
+                }
+            ]
+        }
     }
     return createTourMethods('ProductScreen', DoExt, CheckExt, Execute);
 });

--- a/addons/pos_sale/static/tests/tours/pos_sale_tours.js
+++ b/addons/pos_sale/static/tests/tours/pos_sale_tours.js
@@ -116,4 +116,17 @@ odoo.define('pos_sale.tour', function (require) {
 
     Tour.register('PosSettleOrderWithNote', { test: true, url: '/pos/ui' }, getSteps());
 
+    startSteps();
+
+    ProductScreen.do.clickQuotationButton();
+    ProductScreen.do.selectFirstOrder();
+    ProductScreen.do.clickPayButton();
+    PaymentScreen.do.clickPaymentMethod('Bank');
+    PaymentScreen.do.clickValidate();
+    ReceiptScreen.do.clickNextOrder();
+    ProductScreen.do.clickQuotationButton();
+    ProductScreen.check.checkOrdersListEmpty();
+
+    Tour.register('PosOrderDoesNotRemainInList', { test: true, url: '/pos/ui' }, getSteps());
+
 });

--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -415,3 +415,23 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
         self.env['pos.order'].create_from_ui([pos_order])
         self.assertEqual(sale_order.order_line[0].untaxed_amount_invoiced, 10, "Untaxed invoiced amount should be 10")
         self.assertEqual(sale_order.order_line[1].untaxed_amount_invoiced, 0, "Untaxed invoiced amount should be 0")
+
+    def test_order_does_not_remain_in_list(self):
+        """Verify that a paid order doesn't remain in the orders list"""
+
+        # Create a sale order
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.env['res.partner'].create({'name': 'Test Partner'}).id,
+            'order_line': [(0, 0, {
+                'product_id': self.whiteboard_pen.id,
+                'name': self.whiteboard_pen.name,
+                'product_uom_qty': 1,
+                'price_unit': 100,
+                'product_uom': self.whiteboard_pen.uom_id.id
+            })],
+        })
+
+        sale_order.action_confirm()
+
+        self.main_pos_config.open_session_cb()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PosOrderDoesNotRemainInList', login="accountman")


### PR DESCRIPTION
Fix for 15.0 only

Current behavior:
After settling the payment of an order, the order remains in the orders list

Steps to reproduce:
- Install "Point of Sale" and "Sales" apps
- Start a shop session, select an order and proceed to the payment
- Go back to the orders list and see the paid order still there

opw-4019204


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
