### PR TITLE
[FIX] mail: fix popup button in image preview

### DIFF
--- a/addons/mail/static/src/core/common/attachment_view.scss
+++ b/addons/mail/static/src/core/common/attachment_view.scss
@@ -51,6 +51,7 @@
         opacity: 0.3;
         margin-top: -15px;
         transition: all 0.3s;
+        z-index: $zindex-dropdown; // due to the absolute position in o-mail-Attachment-imgContainer
         &:hover {
             opacity: 0.7;
         }


### PR DESCRIPTION
Steps to reproduce:
1. In a move, click the attachment icon in the chatter
2. Add an image (not a PDF)
3. Depending on the size of the image, the popup button may not be visible or is visible but not clickable
4. Optional: compare it with the desired behavior by uploading a PDF

Cause of the issue:
The image attachment class has position: absolute, which creates a new stacking context where the z-index is not auto.

Fix:
By adding z-index: $zindex-dropdown to o_attachment_control, we ensure that the button is visible and clickable, without unintended layout changes that could result from changing the position of o-mail-Attachment-imgContainer.

task-4017146


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
