### PR TITLE
[FIX] website_event: fix ticket seats availability check on registration

### DIFF
--- a/addons/website_event/controllers/main.py
+++ b/addons/website_event/controllers/main.py
@@ -5,6 +5,7 @@ import re
 import werkzeug
 
 from ast import literal_eval
+from collections import Counter
 from werkzeug.datastructures import OrderedMultiDict
 from werkzeug.exceptions import NotFound
 
@@ -362,9 +363,9 @@ class WebsiteEventController(http.Controller):
             If we don't, the user is instead redirected to page to register with a
             formatted error message. """
         registrations_data = self._process_attendees_form(event, post)
-        event_ticket_ids = {registration['event_ticket_id'] for registration in registrations_data}
-        event_tickets = request.env['event.event.ticket'].browse(event_ticket_ids)
-        if any(event_ticket.seats_limited and event_ticket.seats_available < len(registrations_data) for event_ticket in event_tickets):
+        registration_tickets = Counter(registration['event_ticket_id'] for registration in registrations_data)
+        event_tickets = request.env['event.event.ticket'].browse(list(registration_tickets.keys()))
+        if any(event_ticket.seats_limited and event_ticket.seats_available < registration_tickets.get(event_ticket.id) for event_ticket in event_tickets):
             return request.redirect('/event/%s/register?registration_error_code=insufficient_seats' % event.id)
         attendees_sudo = self._create_attendees_from_registration_post(event, registrations_data)
 

--- a/addons/website_event/i18n/website_event.pot
+++ b/addons/website_event/i18n/website_event.pot
@@ -218,6 +218,12 @@ msgid "<span>Online Events</span>"
 msgstr ""
 
 #. module: website_event
+#: model_terms:ir.ui.view,arch_db:website_event.registration_template
+msgid ""
+"Registration failed! These tickets are not available anymore."
+msgstr ""
+
+#. module: website_event
 #: model_terms:ir.ui.view,arch_db:website_event.registration_attendee_details
 msgid "<strong> You ordered more tickets than available seats</strong>"
 msgstr ""

--- a/addons/website_event/views/event_templates_page_registration.xml
+++ b/addons/website_event/views/event_templates_page_registration.xml
@@ -138,6 +138,9 @@
             </t>
         </div>
         <button t-if="event.event_registrations_open" type="button" data-bs-toggle="modal" data-bs-target="#modal_ticket_registration" class="btn btn-primary w-100">Register</button>
+        <div t-if="registration_error_code == 'insufficient_seats'" class="alert alert-danger my-3" role="alert">
+            Registration failed! These tickets are not available anymore.
+        </div>
     </div>
     <div t-if="toast_message" class="o_wevent_register_toaster d-none" t-att-data-message="toast_message"/>
     <div t-if="not event.event_registrations_open" class="mb-3">


### PR DESCRIPTION
Previously, seats availability check was not working properly. The check was comparing the availability of each ticket with the global amount of tickets in the registration (all tickets combined).

This commit fixes the issue by comparing the availability of each ticket.

In addition to that, the commit also adds an error message on the event page so that the user can see the error message when the ticket is not available.

TASK-4029299