### PR TITLE
[IMP] core: Use get_domain_list in relations

### DIFF
--- a/addons/l10n_latam_check/tests/common.py
+++ b/addons/l10n_latam_check/tests/common.py
@@ -17,7 +17,11 @@ class L10nLatamCheckTest(AccountTestInvoicingCommon):
         cls.bank_journal = cls.company_data_3['default_journal_bank']
         # enable use electronic/deferred checks on bank journal
         cls.bank_journal.l10n_latam_manual_checks = True
-        third_party_checks_journals = cls.env['account.journal'].search([('outbound_payment_method_line_ids.code', '=', 'new_third_party_checks'), ('inbound_payment_method_line_ids.code', '=', 'out_third_party_checks'), ('inbound_payment_method_line_ids.code', '=', 'new_third_party_checks')])
+        third_party_checks_journals = cls.env['account.journal'].search([
+            ('inbound_payment_method_line_ids.code', '=', 'in_third_party_checks'),
+            ('inbound_payment_method_line_ids.code', '=', 'new_third_party_checks'),
+            ('outbound_payment_method_line_ids.code', '=', 'out_third_party_checks'),
+        ])
         cls.third_party_check_journal = third_party_checks_journals[0]
         cls.rejected_check_journal = third_party_checks_journals[1]
 

--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -1712,11 +1712,14 @@ class TestOne2many(TransactionCase):
             WHERE ("res_partner"."id" IN (
                 SELECT "res_partner"."parent_id"
                 FROM "res_partner"
-                WHERE ("res_partner"."id" IN (
-                    SELECT "res_partner_bank"."partner_id"
-                    FROM "res_partner_bank"
-                    WHERE ("res_partner_bank"."sanitized_acc_number"::text LIKE %s)
-                )) AND "res_partner"."parent_id" IS NOT NULL
+                WHERE (
+                    ("res_partner"."active" = TRUE)
+                    AND ("res_partner"."id" IN (
+                        SELECT "res_partner_bank"."partner_id"
+                        FROM "res_partner_bank"
+                        WHERE ("res_partner_bank"."sanitized_acc_number"::text LIKE %s)
+                    ))
+                ) AND "res_partner"."parent_id" IS NOT NULL
             ))
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):

--- a/odoo/addons/test_new_api/tests/test_search.py
+++ b/odoo/addons/test_new_api/tests/test_search.py
@@ -272,7 +272,10 @@ class TestSubqueries(TransactionCase):
                 AND "test_new_api_multi__tags"."test_new_api_multi_tag_id" IN (
                     SELECT "test_new_api_multi_tag"."id"
                     FROM "test_new_api_multi_tag"
-                    WHERE ("test_new_api_multi_tag"."name"::text LIKE %s)
+                    WHERE (
+                        ("test_new_api_multi_tag"."name"::text ILIKE %s)
+                        AND ("test_new_api_multi_tag"."name"::text LIKE %s)
+                    )
                 )
             ) AND EXISTS (
                 SELECT 1
@@ -281,7 +284,10 @@ class TestSubqueries(TransactionCase):
                 AND "test_new_api_multi__tags"."test_new_api_multi_tag_id" IN (
                     SELECT "test_new_api_multi_tag"."id"
                     FROM "test_new_api_multi_tag"
-                    WHERE ("test_new_api_multi_tag"."name"::text LIKE %s)
+                    WHERE (
+                        ("test_new_api_multi_tag"."name"::text ILIKE %s)
+                        AND ("test_new_api_multi_tag"."name"::text LIKE %s)
+                    )
                 )
             ))
             ORDER BY "test_new_api_multi"."id"
@@ -302,8 +308,12 @@ class TestSubqueries(TransactionCase):
                 AND "test_new_api_multi__tags"."test_new_api_multi_tag_id" IN (
                     SELECT "test_new_api_multi_tag"."id"
                     FROM "test_new_api_multi_tag"
-                    WHERE (("test_new_api_multi_tag"."name"::text LIKE %s)
-                        OR ("test_new_api_multi_tag"."name"::text LIKE %s)
+                    WHERE (
+                        ("test_new_api_multi_tag"."name"::text ILIKE %s)
+                        AND (
+                            ("test_new_api_multi_tag"."name"::text LIKE %s)
+                            OR ("test_new_api_multi_tag"."name"::text LIKE %s)
+                        )
                     )
                 )
             )
@@ -327,7 +337,10 @@ class TestSubqueries(TransactionCase):
                     AND "test_new_api_multi__tags"."test_new_api_multi_tag_id" IN (
                         SELECT "test_new_api_multi_tag"."id"
                         FROM "test_new_api_multi_tag"
-                        WHERE ("test_new_api_multi_tag"."name"::text LIKE %s)
+                        WHERE (
+                            ("test_new_api_multi_tag"."name"::text ILIKE %s)
+                            AND ("test_new_api_multi_tag"."name"::text LIKE %s)
+                        )
                     )
                 ) AND EXISTS (
                     SELECT 1
@@ -336,8 +349,12 @@ class TestSubqueries(TransactionCase):
                     AND "test_new_api_multi__tags"."test_new_api_multi_tag_id" IN (
                         SELECT "test_new_api_multi_tag"."id"
                         FROM "test_new_api_multi_tag"
-                        WHERE (("test_new_api_multi_tag"."name"::text LIKE %s)
-                            OR ("test_new_api_multi_tag"."name"::text LIKE %s)
+                        WHERE (
+                            ("test_new_api_multi_tag"."name"::text ILIKE %s)
+                            AND (
+                                ("test_new_api_multi_tag"."name"::text LIKE %s)
+                                OR ("test_new_api_multi_tag"."name"::text LIKE %s)
+                            )
                         )
                     )
                 )

--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -1132,7 +1132,9 @@ class expression(object):
 
             # Making search easier when there is a left operand as one2many or many2many
             elif operator in ('any', 'not any') and field.type in ('many2many', 'one2many'):
-                right_ids = comodel._search(right)
+                domain = field.get_domain_list(model)
+                domain = AND([domain, right])
+                right_ids = comodel._search(domain)
                 push((left, ANY_IN[operator], right_ids), model, alias)
 
             elif not field.store:


### PR DESCRIPTION
When searching for records using operator `'any'` with an x2many field, add the field's domain list to the search before running the query and transforming the condition into an `'in'`.

Current behavior before PR:
The domain on the field is not injected into the search when filtering.

Desired behavior after PR is merged:
Use the `domain` defined on x2many fields during search.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
