### PR TITLE
[FIX] spreadsheet: more robust filter selection

### DIFF
--- a/addons/spreadsheet/static/src/pivot/plugins/pivot_ui_plugin.js
+++ b/addons/spreadsheet/static/src/pivot/plugins/pivot_ui_plugin.js
@@ -14,26 +14,47 @@ const { DateTime } = luxon;
  * Convert pivot period to the related filter value
  *
  * @param {import("@spreadsheet/global_filters/plugins/global_filters_core_plugin").RangeType} timeRange
- * @param {string} value
+ * @param {string|number} value
  * @returns {object}
  */
 function pivotPeriodToFilterValue(timeRange, value) {
     // reuse the same logic as in `parseAccountingDate`?
-    const yearOffset = (value.split("/").pop() | 0) - DateTime.now().year;
+    if (typeof value === "number") {
+        value = value.toString(10);
+    }
+    if (
+        value === "false" || // the value "false" is the default value when there is no data for a group header
+        typeof value !== "string"
+    ) {
+        // anything else then a string at this point is incorrect, so no filtering
+        return undefined;
+    }
+
+    const yearValue = value.split("/").at(-1);
+    if (!yearValue) {
+        return undefined;
+    }
+    const yearOffset = yearValue - DateTime.now().year;
     switch (timeRange) {
         case "year":
             return {
                 yearOffset,
             };
         case "month": {
-            const month = value.split("/")[0] | 0;
+            const month = value.includes("/") ? Number.parseInt(value.split("/")[0]) : -1;
+            if (!(month in monthsOptions)) {
+                return { yearOffset, period: undefined };
+            }
             return {
                 yearOffset,
                 period: monthsOptions[month - 1].id,
             };
         }
         case "quarter": {
-            const quarter = value.split("/")[0] | 0;
+            const quarter = value.includes("/") ? Number.parseInt(value.split("/")[0]) : -1;
+            if (!(quarter in FILTER_DATE_OPTION.quarter)) {
+                return { yearOffset, period: undefined };
+            }
             return {
                 yearOffset,
                 period: FILTER_DATE_OPTION.quarter[quarter - 1],


### PR DESCRIPTION
Before this commit, the getFiltersMatchingPivot was prone to errors when the input that is supposed to be generated automatically has been wrongly formed by the user.

After this commit, the function is more robust and has sensible defaults.

OWP: 3952358





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
