### PR TITLE
[PERF] web: improve perf of `search_panel_select_multi_range`

### DIFF
--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -788,7 +788,7 @@ class Base(models.AbstractModel):
 
         if field.type == 'many2many':
             comodel_records = Comodel.search_read(comodel_domain, field_names, limit=limit)
-            if expand and limit and len(comodel_records) == limit:
+            if limit and len(comodel_records) == limit:
                 return {'error_msg': str(SEARCH_PANEL_ERROR_MESSAGE)}
 
             group_domain = kwargs.get('group_domain')
@@ -831,9 +831,6 @@ class Base(models.AbstractModel):
                     if enable_counters:
                         values['__count'] = count
                     field_range.append(values)
-
-            if not expand and limit and len(field_range) == limit:
-                return {'error_msg': str(SEARCH_PANEL_ERROR_MESSAGE)}
 
             return { 'values': field_range, }
 


### PR DESCRIPTION
Issue -->

Using a `search_domain` that contains a field with complex search methods can cause a drop in the performance of a `searchpanel` section with max limit related records, with `enable_counters` enabled. This fix targets cases when the related field type is `many2many`.

Proposed Solution -->

Remove the check on `expand` and return the search panel error message if the number of related records to be displayed hits the limit, if the limit is set. This makes the error independent of `expand` and just dependent on `limit`.

Drawbacks -->

1) This performance improvement only applies if the number of related records equals the limit.
2) This fix assumes the possibility that the length of processed records which is stored in `field_range` is equal to the number of related records (`comodel_records`)

Benchmark -->

Example: Using domain `['qty_available', '>', 0]` in the `product.view.search.catalog` searchpanel. This results in computations done to search for products that match the domain parameters. In this view, `expand` is unset, and `enable_counters` is set in the searchpanel field arguments. 
In this view, products are grouped by `product_template_attribute_value_ids` in the searchpanel. In the current version, when there are `limit` (or 200 if `limit` is unset) number of comodel records, the error "Too many items to display" is returned **after** the computation loop here --> https://github.com/odoo/odoo/blob/15bfff301c4734efd66c45d83fe7fc8e3d2dc83d/addons/web/models/models.py#L835-L836

In method `search_panel_select_multi_range` --> 
| Before PR | After |
|--------|--------|
| ~100s | ~1s |

Before -->
![image](https://github.com/odoo/odoo/assets/93154859/a5979b71-26d9-4356-acd8-d4372040059a)

After -->
![image](https://github.com/odoo/odoo/assets/93154859/f5ab16a3-787b-47e0-80e8-d5f16b81fd77)

This change essentially skips the loop if the comodel recordset size hits the max limit set in the searchpanel. 

opw-3988303

