### PR TITLE
[FIX] account_edi_ubl_cii: prevent crash on invoice with l10n_sg edi

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
@@ -252,7 +252,7 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
         for val in line_item_vals['classified_tax_category_vals']:
             # [UBL-CR-601] TaxExemptionReason must not appear in InvoiceLine Item ClassifiedTaxCategory
             # [BR-E-10] TaxExemptionReason must only appear in TaxTotal TaxSubtotal TaxCategory
-            val.pop('tax_exemption_reason')
+            val.pop('tax_exemption_reason', None)
 
         return line_item_vals
 


### PR DESCRIPTION

Problem: When the customer invoice journal uses the l10n_sg electronic invoicing and the user creates an invoice, a traceback error will occur. The traceback error details a key error since 'tax_exemption_reason' is not a key in the dict from _get_invoice_line_item_vals.

Purpose: Only if the key 'tax_exemption_reason' exists in the dict, then it should get popped.

Steps to Reproduce on Runbot:
1. Install l10n_sg
2. Switch to SG Company
3. Go to the “Customer Invoices” Journal and check the “SG BIS Billing 3.0” option for the “Electronic Invoicing” field
4. Create an invoice with a product
5. Confirming the invoice will throw the error.

opw-3984143

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
