### PR TITLE
[FIX] web, discuss: prevent incoherent state with debounce

### DIFF
--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -964,7 +964,7 @@ export class Rtc {
                 );
             },
             3000,
-            true
+            { leading: true, trailing: true }
         );
         this.state.channel.rtcInvitingSession = undefined;
         await this.loadSfuClient();

--- a/addons/web/static/src/core/utils/timing.js
+++ b/addons/web/static/src/core/utils/timing.js
@@ -27,44 +27,58 @@ export function batched(callback, synchronize = () => Promise.resolve()) {
  * which will postpone its execution until after 'delay' milliseconds
  * have elapsed since the last time it was invoked. The debounced function
  * will return a Promise that will be resolved when the function (func)
- * has been fully executed. If `immediate` is passed, trigger the function
- * on the leading edge, instead of the trailing.
+ * has been fully executed.
+ *
+ * If both `options.trailing` and `options.leading` are true, the function
+ * will only be invoked at the trailing edge if the debounced function was
+ * called at least once more during the wait time.
  *
  * @template {Function} T the return type of the original function
  * @param {T} func the function to debounce
  * @param {number | "animationFrame"} delay how long should elapse before the function
  *      is called. If 'animationFrame' is given instead of a number, 'requestAnimationFrame'
  *      will be used instead of 'setTimeout'.
- * @param {boolean} [immediate=false] whether the function should be called on
- *      the leading edge instead of the trailing edge.
+ * @param {boolean} [options] if true, equivalent to exclusive leading. If false, equivalent to exclusive trailing.
+ * @param {object} [options]
+ * @param {boolean} [options.leading=false] whether the function should be invoked at the leading edge of the timeout
+ * @param {boolean} [options.trailing=true] whether the function should be invoked at the trailing edge of the timeout
  * @returns {T & { cancel: () => void }} the debounced function
  */
-export function debounce(func, delay, immediate = false) {
+export function debounce(func, delay, options) {
     let handle;
     const funcName = func.name ? func.name + " (debounce)" : "debounce";
     const useAnimationFrame = delay === "animationFrame";
     const setFnName = useAnimationFrame ? "requestAnimationFrame" : "setTimeout";
     const clearFnName = useAnimationFrame ? "cancelAnimationFrame" : "clearTimeout";
     let lastArgs;
+    let leading = false;
+    let trailing = true;
+    if (typeof options === "boolean") {
+        leading = options;
+        trailing = !options;
+    } else if (options) {
+        leading = options.leading ?? leading;
+        trailing = options.trailing ?? trailing;
+    }
+
     return Object.assign(
         {
             /** @type {any} */
             [funcName](...args) {
-                lastArgs = args;
                 return new Promise((resolve) => {
-                    const callNow = immediate && !handle;
+                    if (leading && !handle) {
+                        Promise.resolve(func.apply(this, args)).then(resolve);
+                    } else {
+                        lastArgs = args;
+                    }
                     browser[clearFnName](handle);
                     handle = browser[setFnName](() => {
                         handle = null;
-                        if (!immediate) {
-                            lastArgs = undefined;
-                            Promise.resolve(func.apply(this, args)).then(resolve);
+                        if (trailing && lastArgs) {
+                            Promise.resolve(func.apply(this, lastArgs)).then(resolve);
+                            lastArgs = null;
                         }
                     }, delay);
-                    if (callNow) {
-                        lastArgs = undefined;
-                        Promise.resolve(func.apply(this, args)).then(resolve);
-                    }
                 });
             },
         }[funcName],


### PR DESCRIPTION
Before this commit and since the refactor (odoo/odoo#110188), `updateAndBroadcastDebounce` would send outdated data if used within the debounce delay as it was immediate, which meant that state updates done within the debounce timing would be ignored.

Note that the members of the call would still have live and correct information as they obtain it from the dataChannel. The inconsistent information is only visible to members outside the call.

This commit fixes this issue by adding updating the API of debounce so that it allows more flexibility by allowing to have a combination of leading and trailing calls.

Behavior/API inspired from lodash:
https://lodash.com/docs/4.17.15#debounce