### PR TITLE
[IMP] website_event,*: event website facelift

### DIFF
--- a/addons/test_event_full/static/src/js/tours/wevent_register_tour.js
+++ b/addons/test_event_full/static/src/js/tours/wevent_register_tour.js
@@ -141,8 +141,12 @@ var initTourSteps = function (eventName) {
 };
 
 var browseTalksSteps = [{
-    content: 'Browse Talks',
-    trigger: 'a:contains("Talks")',
+    content: 'Browse Talks Menu',
+    trigger: 'a[href*="#"]:contains("Talks")',
+    run: "click",
+}, {
+    content: 'Browse Talks Submenu',
+    trigger: 'a.dropdown-item span:contains("Talks")',
     run: "click",
 }, {
     content: 'Check we are on the talk list page',
@@ -164,9 +168,9 @@ registry.category("web_tour.tours").add('wevent_register', {
         initTourSteps('Online Reveal'),
         browseTalksSteps,
         discoverTalkSteps('What This Event Is All About', true, true),
-        browseTalksSteps,
+        browseBackSteps,
         discoverTalkSteps('Live Testimonial', false, false, false),
-        browseTalksSteps,
+        browseBackSteps,
         discoverTalkSteps('Our Last Day Together!', true, false, true),
         browseBackSteps,
         registerSteps,

--- a/addons/test_event_full/tests/test_event_event.py
+++ b/addons/test_event_full/tests/test_event_event.py
@@ -42,7 +42,6 @@ class TestEventEvent(TestEventFullCommon):
         self.assertEqual(len(event.event_mail_ids), 3)
         self.assertEqual(len(event.event_ticket_ids), 2)
         self.assertTrue(event.introduction_menu)
-        self.assertTrue(event.location_menu)
         self.assertEqual(event.message_partner_ids, self.env.user.partner_id)
         self.assertEqual(event.note, '<p>Template note</p>')
         self.assertTrue(event.register_menu)

--- a/addons/website_event/controllers/main.py
+++ b/addons/website_event/controllers/main.py
@@ -181,8 +181,6 @@ class WebsiteEventController(http.Controller):
             values['main_object'] = event
         except ValueError:
             # page not found
-            values['path'] = re.sub(r"^website_event\.", '', page)
-            values['from_template'] = 'website_event.default_page'  # .strip('website_event.')
             page = 'website.page_404'
 
         return request.render(page, values)

--- a/addons/website_event/models/event_event.py
+++ b/addons/website_event/models/event_event.py
@@ -76,6 +76,9 @@ class EventEvent(models.Model):
     community_menu_ids = fields.One2many(
         "website.event.menu", "event_id", string="Event Community Menus",
         domain=[("menu_type", "=", "community")])
+    other_menu_ids = fields.One2many(
+        "website.event.menu", "event_id", string="Other Menus",
+        domain=[("menu_type", "=", "other")])
     # live information
     is_ongoing = fields.Boolean(
         'Is Ongoing', compute='_compute_time_data', search='_search_is_ongoing',
@@ -246,13 +249,8 @@ class EventEvent(models.Model):
             default_menu_values = {'event_id': new_event.id}
             new_event.menu_id = old_event.menu_id.copy({'name': new_event.name, 'website_id': new_event.website_id.id})
             new_event.introduction_menu_ids = old_event.introduction_menu_ids.copy(default_menu_values)
-            custom_page_menus = old_event.community_menu_ids.filtered(lambda menu: menu.view_id)
-            if custom_page_menus:
-                # workaround for stable, 'regular' community menus are not supposed to be duplicated
-                # remove this if in master, see 'website.menu#save' method override
-                custom_page_menus.copy(default_menu_values)
-
-            (new_event.introduction_menu_ids + new_event.community_menu_ids + new_event.register_menu_ids).menu_id.parent_id = new_event.menu_id
+            new_event.other_menu_ids = old_event.other_menu_ids.copy(default_menu_values)
+            (new_event.introduction_menu_ids + new_event.other_menu_ids + new_event.community_menu_ids + new_event.register_menu_ids).menu_id.parent_id = new_event.menu_id
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/website_event/models/website_event_menu.py
+++ b/addons/website_event/models/website_event_menu.py
@@ -19,6 +19,7 @@ class WebsiteEventMenu(models.Model):
         [('community', 'Community Menu'),
          ('introduction', 'Home'),
          ('register', 'Practical'),
+         ('other', 'Other'),
         ], string="Menu Type", required=True)
 
     def copy(self, default=None):

--- a/addons/website_event/models/website_event_menu.py
+++ b/addons/website_event/models/website_event_menu.py
@@ -17,9 +17,8 @@ class WebsiteEventMenu(models.Model):
     view_id = fields.Many2one('ir.ui.view', string='View', ondelete='cascade', help='Used when not being an url based menu')
     menu_type = fields.Selection(
         [('community', 'Community Menu'),
-         ('introduction', 'Introduction'),
-         ('location', 'Location'),
-         ('register', 'Info'),
+         ('introduction', 'Home'),
+         ('register', 'Practical'),
         ], string="Menu Type", required=True)
 
     def copy(self, default=None):

--- a/addons/website_event/models/website_menu.py
+++ b/addons/website_event/models/website_menu.py
@@ -16,10 +16,6 @@ class WebsiteMenu(models.Model):
         for event_menu in website_event_menus:
             to_update = event_updates.setdefault(event_menu.event_id, list())
             for menu_type, fname in event_menu.event_id._get_menu_type_field_matching().items():
-                # workaround for stable, remove this if in master, see 'save' method override
-                if menu_type == 'community' and event_menu.view_id:
-                    continue
-
                 if event_menu.menu_type == menu_type:
                     to_update.append(fname)
 
@@ -113,7 +109,7 @@ class WebsiteMenu(models.Model):
                     event_menu_values.append({
                         'menu_id': menu_record.id,
                         'event_id': parent_event_menu.event_id.id,
-                        'menu_type': 'community',  # dummy value for required field, adapt in master
+                        'menu_type': 'other',
                     })
 
                 # if the current user can create website.menu, then he should be able to

--- a/addons/website_event/static/src/scss/event_templates_page.scss
+++ b/addons/website_event/static/src/scss/event_templates_page.scss
@@ -21,6 +21,10 @@
                     color: rgba($body-color, .7);
                     cursor: default;
                 }
+                &.active:hover {
+                    color: rgba($body-color, .9);
+                    cursor: pointer;
+                }
             }
         }
     }

--- a/addons/website_event/static/tests/tours/website_event_pages_seo.js
+++ b/addons/website_event/static/tests/tours/website_event_pages_seo.js
@@ -2,7 +2,7 @@ import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("website_event_pages_seo", {
     // The tour must start on an event's custom page (not register page)
-    // url: `/event/openwood-collection-online-reveal-8/page/introduction-openwood-collection-online-reveal`,
+    // url: `/event/openwood-collection-online-reveal-8/page/home-openwood-collection-online-reveal`,
     steps: () => [
         {
             trigger: ":iframe #o_wevent_event_submenu", // Ensure we landed on the event page

--- a/addons/website_event/tests/common.py
+++ b/addons/website_event/tests/common.py
@@ -32,7 +32,7 @@ class OnlineEventCase(EventCase):
         })
 
     def _get_menus(self):
-        return {'Introduction', 'Community', 'Info', 'Location'}
+        return {'Home', 'Practical', 'Rooms'}
 
     def _assert_website_menus(self, event, menus_in=None, menus_out=None):
         self.assertTrue(event.menu_id)
@@ -41,20 +41,17 @@ class OnlineEventCase(EventCase):
             menus_in = list(self._get_menus())
 
         menus = self.env['website.menu'].search([('parent_id', '=', event.menu_id.id)])
+        menus |= menus.child_id  # add child menus to simplify checks, containing notably talks submenus
         self.assertTrue(len(menus) >= len(menus_in))
         self.assertTrue(all(menu_name in menus.mapped('name') for menu_name in menus_in))
         if menus_out:
             self.assertTrue(all(menu_name not in menus.mapped('name') for menu_name in menus_out))
 
-        for page_specific in ['Introduction', 'Location']:
-            view = self.env['ir.ui.view'].search(
-                [('name', '=', f'{page_specific} {event.name}')]
-            )
-            if page_specific in menus_in:
-                self.assertTrue(bool(view))
-            else:
-                self.assertFalse(bool(view))
-
+        home_view = self.env['ir.ui.view'].search([('name', '=', f'Home {event.name}')])
+        if 'Home' in menus_in:
+            self.assertTrue(bool(home_view))
+        else:
+            self.assertFalse(bool(home_view))
 
 class TestEventOnlineCommon(OnlineEventCase):
 

--- a/addons/website_event/tests/test_event_menus.py
+++ b/addons/website_event/tests/test_event_menus.py
@@ -12,7 +12,7 @@ class TestEventMenus(OnlineEventCase, HttpCase):
 
     @users('admin')
     def test_menu_copy(self):
-        """ Test that the content of the introduction and location menu are
+        """ Test that the content of the introduction(Home) menu is
         correctly copied when duplicating an event """
 
         event = self.env['event.event'].create({
@@ -23,33 +23,22 @@ class TestEventMenus(OnlineEventCase, HttpCase):
         })
         self.assertTrue(event.website_menu)
         self.assertTrue(event.introduction_menu)
-        self.assertTrue(event.location_menu)
-        self.env['ir.ui.view'].create([{
+        self.env['ir.ui.view'].create({
             'arch_db': '<xpath expr="//div[@id=\'oe_structure_website_event_intro_2\']" position="replace"><p>This is an intro</p></xpath>',
             'inherit_id': event.introduction_menu_ids.view_id.id,
             'key': 'website_event.intro-test-child',
-        }, {
-            'arch_db': '<xpath expr="//div[@id=\'oe_structure_website_event_location_2\']" position="replace"><p>This is a location</p></xpath>',
-            'inherit_id': event.location_menu_ids.view_id.id,
-            'key': 'website_event.location-test-child',
-        }])
+        })
         event_copy = event.copy()
         self.assertTrue(event_copy.website_menu)
         self.assertTrue(event_copy.introduction_menu)
-        self.assertTrue(event.location_menu)
 
         # The menu used should be different
         self.assertNotEqual(event.introduction_menu_ids, event_copy.introduction_menu_ids)
-        self.assertNotEqual(event.location_menu_ids, event_copy.location_menu_ids)
 
         # The child in the view should be different
         self.assertNotEqual(
             event.introduction_menu_ids.view_id.inherit_children_ids,
             event_copy.introduction_menu_ids.view_id.inherit_children_ids,
-        )
-        self.assertNotEqual(
-            event.location_menu_ids.view_id.inherit_children_ids,
-            event_copy.location_menu_ids.view_id.inherit_children_ids,
         )
 
         # The content of the views should be the same
@@ -58,19 +47,10 @@ class TestEventMenus(OnlineEventCase, HttpCase):
             event_copy.introduction_menu_ids.view_id.arch_db,
         )
         self.assertEqual(
-            event.location_menu_ids.view_id.arch_db,
-            event_copy.location_menu_ids.view_id.arch_db,
-        )
-        self.assertEqual(
             event.introduction_menu_ids.view_id.inherit_children_ids[0].arch_db,
             event_copy.introduction_menu_ids.view_id.inherit_children_ids[0].arch_db,
         )
-        self.assertEqual(
-            event.location_menu_ids.view_id.inherit_children_ids[0].arch_db,
-            event_copy.location_menu_ids.view_id.inherit_children_ids[0].arch_db,
-        )
         self.assertIn("This is an intro", event_copy.introduction_menu_ids.view_id.inherit_children_ids[0].arch_db)
-        self.assertIn("This is a location", event_copy.location_menu_ids.view_id.inherit_children_ids[0].arch_db)
 
     @users('admin')
     def test_menu_deletion(self):
@@ -126,13 +106,12 @@ class TestEventMenus(OnlineEventCase, HttpCase):
         })
         self.assertTrue(event.website_menu)
         self.assertTrue(event.introduction_menu)
-        self.assertTrue(event.location_menu)
         self.assertTrue(event.register_menu)
         self.assertFalse(event.community_menu)
-        self._assert_website_menus(event, ['Introduction', 'Location', 'Info'], menus_out=['Community'])
+        self._assert_website_menus(event, ['Home', 'Practical'], menus_out=['Rooms'])
 
         event.community_menu = True
-        self._assert_website_menus(event, ['Introduction', 'Location', 'Info', 'Community'])
+        self._assert_website_menus(event, ['Home', 'Rooms', 'Practical'])
 
         # test create without any requested menus
         event = self.env['event.event'].create({
@@ -143,14 +122,13 @@ class TestEventMenus(OnlineEventCase, HttpCase):
         })
         self.assertFalse(event.website_menu)
         self.assertFalse(event.introduction_menu)
-        self.assertFalse(event.location_menu)
         self.assertFalse(event.register_menu)
         self.assertFalse(event.community_menu)
         self.assertFalse(event.menu_id)
 
         # test update of website_menu triggering 3 sub menus
         event.write({'website_menu': True})
-        self._assert_website_menus(event, ['Introduction', 'Location', 'Info'], menus_out=['Community'])
+        self._assert_website_menus(event, ['Home', 'Practical'], menus_out=['Rooms'])
 
     @users('user_event_web_manager')
     def test_menu_management_frontend(self):
@@ -161,17 +139,17 @@ class TestEventMenus(OnlineEventCase, HttpCase):
             'website_menu': True,
             'community_menu': False,
         })
-        self._assert_website_menus(event, ['Introduction', 'Location', 'Info'], menus_out=['Community'])
+        self._assert_website_menus(event, ['Home', 'Practical'], menus_out=['Rooms'])
 
         # simulate menu removal from frontend: aka unlinking a menu
-        event.menu_id.child_id.filtered(lambda menu: menu.name == 'Introduction').unlink()
+        event.menu_id.child_id.filtered(lambda menu: menu.name == 'Home').unlink()
 
         self.assertTrue(event.website_menu)
-        self._assert_website_menus(event, ['Location', 'Info'], menus_out=['Introduction', 'Community'])
+        self._assert_website_menus(event, ['Practical'], menus_out=['Home', 'Rooms'])
 
         # re-created from backend
         event.introduction_menu = True
-        self._assert_website_menus(event, ['Introduction', 'Location', 'Info'], menus_out=['Community'])
+        self._assert_website_menus(event, ['Home', 'Practical'], menus_out=['Rooms'])
 
     def test_submenu_url(self):
         """ Test that the different URL of a submenu page of an event are accessible """
@@ -194,8 +172,8 @@ class TestEventMenus(OnlineEventCase, HttpCase):
         )
 
         # Use previous URL for submenu page
-        old_event_1.introduction_menu_ids.menu_id.url = f"/event/test-event-{old_event_1.id}/page/introduction-test-event"
-        old_event_2.introduction_menu_ids.menu_id.url = f"/event/test-event-{old_event_2.id}/page/introduction-test-event"
+        old_event_1.introduction_menu_ids.menu_id.url = f"/event/test-event-{old_event_1.id}/page/home-test-event"
+        old_event_2.introduction_menu_ids.menu_id.url = f"/event/test-event-{old_event_2.id}/page/home-test-event"
         old_event_menus = (old_event_1 + old_event_2).introduction_menu_ids
         self.assertEqual(len(old_event_menus.view_id), 2, "Each menu should have a view")
 
@@ -204,7 +182,7 @@ class TestEventMenus(OnlineEventCase, HttpCase):
         self.assertEqual(len(new_event_menus.view_id), 2, "Each menu should have a view")
 
         # Menu without views
-        menu_without_view = event_3._create_menu(1, 'custom', f"/event/test-event-{event_3.id}/page/introduction-test-event", 'website_event.template_intro', 'introduction')
+        menu_without_view = event_3._create_menu(1, 'custom', f"/event/test-event-{event_3.id}/page/home-test-event", 'website_event.template_intro', 'introduction')
         self.assertEqual(
             len(self.env['website.event.menu'].search([('menu_id', 'in', menu_without_view.ids)]).view_id), 0,
             "The menu should not have a view assigned because an URL has been given manually"
@@ -236,13 +214,14 @@ class TestEventMenus(OnlineEventCase, HttpCase):
         )
 
         # Skip the register and community menus since they already have a unique URL
-        event_1_menus = event_1.menu_id.child_id.filtered(
-            lambda menu: menu.name in ["Introduction", "Location"]
+        event_1_home_menu = event_1.menu_id.child_id.filtered(
+            lambda menu: menu.name == "Home"
         )
-        event_2_menus = event_2.menu_id.child_id.filtered(
-            lambda menu: menu.name in ["Introduction", "Location"]
+        event_2_home_menu = event_2.menu_id.child_id.filtered(
+            lambda menu: menu.name == "Home"
         )
-        for event_1_menu, event_2_menu in zip(event_1_menus, event_2_menus):
+
+        for event_1_menu, event_2_menu in zip(event_1_home_menu, event_2_home_menu):
             end_url_1 = event_1_menu.url.split("/")[-1]
             end_url_2 = event_2_menu.url.split("/")[-1]
             self.assertNotEqual(end_url_1, end_url_2)

--- a/addons/website_event/views/event_event_views.xml
+++ b/addons/website_event/views/event_event_views.xml
@@ -41,7 +41,6 @@
                     <field name="website_menu"/>
                     <!-- hidden sub-menus, they are triggered all at once based on "website_menu" -->
                     <field name="introduction_menu" invisible="1"/>
-                    <field name="location_menu" invisible="1"/>
                     <field name="register_menu" invisible="1"/>
                     <label for="community_menu" string="Community" invisible="1"/>
                     <field name="community_menu" invisible="1"/>

--- a/addons/website_event/views/event_templates_page_misc.xml
+++ b/addons/website_event/views/event_templates_page_misc.xml
@@ -1,13 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
-<!-- Multipage event - Default template when creating a new page -->
-<template id="default_page">
-    <t t-call="website.layout">
-        <div class="oe_structure oe_empty"/>
-    </t>
-</template>
-
 <!-- Multipage event - Default template for the Introduction page -->
 <template id="template_intro">
     <t t-call="website_event.layout">
@@ -20,51 +13,6 @@
             </section>
         </div>
         <div class="oe_structure oe_empty" id="oe_structure_website_event_intro_2"/>
-    </t>
-</template>
-
-<!-- Multipage event - Default template for the Location page -->
-<template id="template_location">
-    <t t-call="website_event.layout">
-        <div class="oe_structure" id="oe_structure_website_event_location_1"/>
-        <section>
-            <div class="container">
-                <div class="row">
-                    <div class="col-12">
-                        <h3 class="mt-3 mb-4">Event Location</h3>
-                        <h4 class="mb-3" t-field="event.address_id" t-options='{
-                            "widget": "contact",
-                            "fields": ["name"],
-                        }'/>
-                        <div class="mb-3" t-field="event.address_id" t-options='{
-                            "widget": "contact",
-                            "fields": ["address"],
-                            "no_marker": True
-                        }'/>
-                        <div class="mb-3" t-field="event.address_id" t-options='{
-                            "widget": "contact",
-                            "fields": ["phone", "mobile", "email"],
-                            "no_marker": True
-                        }'/>
-                    </div>
-                </div>
-            </div>
-        </section>
-        <div class="oe_structure" id="oe_structure_website_event_location_2"/>
-    </t>
-</template>
-
-<template id="404" name="Event 404">
-    <t t-call="website.layout">
-        <div id="wrap">
-            <div class="oe_structure oe_empty">
-                <div class="container">
-                    <h1 class="mt-4">Event not found!</h1>
-                    <p>Sorry, the requested event is not available anymore.</p>
-                    <p><a t-attf-href="/event">Return to the event list.</a></p>
-                </div>
-            </div>
-        </div>
     </t>
 </template>
 

--- a/addons/website_event_booth/models/event_event.py
+++ b/addons/website_event_booth/models/event_event.py
@@ -55,5 +55,5 @@ class EventEvent(models.Model):
     def _get_website_menu_entries(self):
         self.ensure_one()
         return super()._get_website_menu_entries() + [
-            (_('Get A Booth'), '/event/%s/booth' % self.env['ir.http']._slug(self), False, 90, 'booth')
+            (_('Become exhibitor'), '/event/%s/booth' % self.env['ir.http']._slug(self), False, 90, 'booth', False)
         ]

--- a/addons/website_event_booth/views/event_booth_registration_templates.xml
+++ b/addons/website_event_booth/views/event_booth_registration_templates.xml
@@ -8,7 +8,7 @@
                     <a class="d-inline d-md-none btn btn-light me-2" t-attf-href="/event/#{slug(event)}/booth?#{keep_query('booth_category_id', 'booth_ids')}" title="Go back">
                         <i class="oi oi-chevron-left" role="img"/>
                     </a>
-                    <h4 class="my-0">Get A Booth</h4>
+                    <h3 class="my-0">Get A Booth</h3>
                 </div>
                 <t t-call="website_event_booth.event_booth_order_progress">
                     <t t-set="step" t-value="'STEP_DETAILS_FORM'"/>

--- a/addons/website_event_booth/views/event_booth_templates.xml
+++ b/addons/website_event_booth/views/event_booth_templates.xml
@@ -45,7 +45,7 @@
         <t t-call="website_event_booth.event_booth_layout">
             <t t-if="event_booths and not event.is_finished">
                 <div class="d-flex flex-wrap align-items-center justify-content-between my-3">
-                    <h4 class="my-0">Get A Booth</h4>
+                    <h3 class="my-0">Get A Booth</h3>
                     <t t-call="website_event_booth.event_booth_order_progress">
                         <t t-set="step" t-value="'STEP_BOOTH_SELECTION'"/>
                     </t>

--- a/addons/website_event_booth_exhibitor/static/tests/tours/website_event_booth_exhibitor.js
+++ b/addons/website_event_booth_exhibitor/static/tests/tours/website_event_booth_exhibitor.js
@@ -10,7 +10,7 @@
         run: "click",
     }, {
         content: 'Browse Booths',
-        trigger: 'a:contains("Get A Booth")',
+        trigger: 'a:contains("Become exhibitor")',
         run: "click",
     }, {
         content: 'Wait for the first item to be properly selected before proceeding',

--- a/addons/website_event_booth_sale/static/tests/tours/helpers/WebsiteEventBoothSaleTourMethods.js
+++ b/addons/website_event_booth_sale/static/tests/tours/helpers/WebsiteEventBoothSaleTourMethods.js
@@ -13,8 +13,8 @@
                 run: "click",
             },
             {
-                content: 'Go to "Get A Booth" page',
-                trigger: 'li.nav-item a:has(span:contains("Get A Booth"))',
+                content: 'Go to "Booth" page',
+                trigger: 'a:contains("Become exhibitor")',
                 run: "click",
             },
             {

--- a/addons/website_event_booth_sale/static/tests/tours/website_event_booth.js
+++ b/addons/website_event_booth_sale/static/tests/tours/website_event_booth.js
@@ -10,8 +10,8 @@ registry.category("web_tour.tours").add('website_event_booth_tour', {
     trigger: 'h5.card-title span:contains("Test Event Booths")',
     run: "click",
 }, {
-    content: 'Go to "Get A Booth" page',
-    trigger: 'li.nav-item a:has(span:contains("Get A Booth"))',
+    content: 'Go to "Booth" page',
+    trigger: 'a:contains("Become exhibitor")',
     run: "click",
 }, {
     content: 'Select the first two booths',

--- a/addons/website_event_booth_sale/static/tests/tours/website_event_booth_sale_pricelists.js
+++ b/addons/website_event_booth_sale/static/tests/tours/website_event_booth_sale_pricelists.js
@@ -12,8 +12,8 @@ registry.category("web_tour.tours").add('event_booth_sale_pricelists_different_c
         run: "click",
     },
     {
-        content: 'Go to "Get A Booth" page',
-        trigger: 'li.nav-item a:has(span:contains("Get A Booth"))',
+        content: 'Go to "Become exhibitor" page',
+        trigger: 'a:contains("Become exhibitor")',
         run: "click",
     },
     {

--- a/addons/website_event_exhibitor/models/event_event.py
+++ b/addons/website_event_exhibitor/models/event_event.py
@@ -63,5 +63,5 @@ class EventEvent(models.Model):
     def _get_website_menu_entries(self):
         self.ensure_one()
         return super(EventEvent, self)._get_website_menu_entries() + [
-            (_('Exhibitors'), '/event/%s/exhibitors' % self.env['ir.http']._slug(self), False, 60, 'exhibitor')
+            (_('Exhibitors list'), '/event/%s/exhibitors' % self.env['ir.http']._slug(self), False, 60, 'exhibitor', False)
         ]

--- a/addons/website_event_track/models/event_event.py
+++ b/addons/website_event_track/models/event_event.py
@@ -89,7 +89,8 @@ class EventEvent(models.Model):
     def _get_website_menu_entries(self):
         self.ensure_one()
         return super()._get_website_menu_entries() + [
-            (_('Talks'), '/event/%s/track' % self.env['ir.http']._slug(self), False, 10, 'track'),
-            (_('Agenda'), '/event/%s/agenda' % self.env['ir.http']._slug(self), False, 70, 'track'),
-            (_('Talk Proposals'), '/event/%s/track_proposal' % self.env['ir.http']._slug(self), False, 15, 'track_proposal')
+            (_('Talks'), '#', False, 10, 'track', False),
+            (_('Talks'), '/event/%s/track' % self.env['ir.http']._slug(self), False, 10, 'track', 'track'),
+            (_('Agenda'), '/event/%s/agenda' % self.env['ir.http']._slug(self), False, 15, 'track', 'track'),
+            (_('Propose a talk'), '/event/%s/track_proposal' % self.env['ir.http']._slug(self), False, 20, 'track_proposal', 'track')
         ]

--- a/addons/website_event_track/tests/test_event_menus.py
+++ b/addons/website_event_track/tests/test_event_menus.py
@@ -11,7 +11,7 @@ from odoo.tests.common import users
 class TestEventWebsiteTrack(OnlineEventCase):
 
     def _get_menus(self):
-        return super(TestEventWebsiteTrack, self)._get_menus() | set(['Talks', 'Agenda', 'Talk Proposals'])
+        return super(TestEventWebsiteTrack, self)._get_menus() | set(['Talks', 'Agenda', 'Propose a talk'])
 
     @users('user_eventmanager')
     def test_create_menu(self):
@@ -35,7 +35,7 @@ class TestEventWebsiteTrack(OnlineEventCase):
             'website_track': False,
             'website_track_proposal': False,
         })
-        self._assert_website_menus(event, ['Introduction', 'Location', 'Info', 'Community'], menus_out=['Talks', 'Agenda', 'Talk Proposals'])
+        self._assert_website_menus(event, ['Home', 'Rooms', 'Practical'], menus_out=['Talks', 'Agenda', 'Propose a talk'])
 
     @users('user_event_web_manager')
     def test_menu_management_frontend(self):
@@ -53,28 +53,29 @@ class TestEventWebsiteTrack(OnlineEventCase):
         self.assertTrue(event.website_track_proposal)
         self._assert_website_menus(event, self._get_menus())
 
-        introduction_menu = event.menu_id.child_id.filtered(lambda menu: menu.name == 'Introduction')
-        introduction_menu.unlink()
-        self._assert_website_menus(event, ['Location', 'Info', 'Community', 'Talks', 'Agenda', 'Talk Proposals'], menus_out=["Introduction"])
+        menus = event.menu_id.child_id
+        home_menu = menus.filtered(lambda menu: menu.name == 'Home')
+        home_menu.unlink()
+        self._assert_website_menus(event, ['Talks', 'Agenda', 'Propose a talk', 'Rooms', 'Practical'], menus_out=['Home'])
 
-        menus = event.menu_id.child_id.filtered(lambda menu: menu.name in ['Agenda', 'Talk Proposals'])
-        menus.unlink()
+        sub_menus = menus.child_id.filtered(lambda menu: menu.name in ['Agenda', 'Propose a talk'])
+        sub_menus.unlink()
         self.assertTrue(event.website_track)
         self.assertFalse(event.website_track_proposal)
 
-        menus = event.menu_id.child_id.filtered(lambda menu: menu.name in ['Talks'])
-        menus.unlink()
+        talks_menu = menus.child_id.filtered(lambda menu: menu.name == 'Talks')
+        talks_menu.unlink()
         self.assertFalse(event.website_track)
         self.assertFalse(event.website_track_proposal)
 
-        self._assert_website_menus(event, ['Location', 'Info', 'Community'], menus_out=["Introduction", "Talks", "Agenda", "Talk Proposals"])
-
-        event.write({'website_track_proposal': True})
-        self.assertFalse(event.website_track)
-        self.assertTrue(event.website_track_proposal)
-        self._assert_website_menus(event, ['Location', 'Info', 'Community', 'Talk Proposals'], menus_out=["Introduction", "Talks", "Agenda"])
+        self._assert_website_menus(event, ['Practical', 'Rooms'], menus_out=['Home', 'Talks', 'Agenda', 'Propose a talk'])
 
         event.write({'website_track': True})
         self.assertTrue(event.website_track)
         self.assertTrue(event.website_track_proposal)
-        self._assert_website_menus(event, ['Location', 'Info', 'Community', 'Talks', 'Agenda', 'Talk Proposals'], menus_out=["Introduction"])
+        self._assert_website_menus(event, ['Practical', 'Rooms', 'Talks', 'Agenda', 'Propose a talk'], menus_out=['Home'])
+
+        event.write({'website_track_proposal': False})
+        self.assertTrue(event.website_track)
+        self.assertFalse(event.website_track_proposal)
+        self._assert_website_menus(event, ['Practical', 'Rooms', 'Talks', 'Agenda'], menus_out=['Home', 'Propose a talk'])


### PR DESCRIPTION
*=test_event_full,website,website_event_booth,website_event_exhibitor,website_event_booth_sale,website_event_booth_exhibitor,website_event_track

Before this PR:
- User can't edit 'Social' Block under Event Registration through website editor
- Ungroup event talks menus

After this PR:
- Removed Location page as it's covered in '/register' page
- User can edit Social Share Block using website editor
- Changed 'Introduction' page to 'Home' page
- Changed 'Info' page to 'Practical' page
- Regrouped event talks menus inside parent menu 'Talks' for ease of use
- Clean up event sub-menus creation code

Note- Some test cases were changed accordingly to work with this PR's flow!

Task-3661323
