### PR TITLE
[FIX] web: fix closing dynamic placeholder

### DIFF
--- a/addons/web/static/src/views/fields/dynamic_placeholder_popover.js
+++ b/addons/web/static/src/views/fields/dynamic_placeholder_popover.js
@@ -24,7 +24,11 @@ export class DynamicPlaceholderPopover extends Component {
         return !["one2many", "boolean", "many2many"].includes(fieldDef.type) && fieldDef.searchable;
     }
     closeFieldSelector() {
-        this.state.isPathSelected = true;
+        if (this.state.path) {
+            this.state.isPathSelected = true;
+            return;
+        }
+        this.props.close();
     }
     setPath(path) {
         this.state.path = path;


### PR DESCRIPTION
Purpose
=======
Fix the dynamic placeholder popup which wasn't closing when clicking on escape or on the "x" button in the field selection view. Instead of closing, the default value selection was displayed.

Specification
=============
The dynamic placeholder files have been cleaned recently and a mistake was made as the isPathSelected value was being set to true on popup closing no matter if the path was selected or not.

Fixing the issue by checking if the path value is correctly set, if it is, displaying the default value view, else closing the popover.

related PR: odoo/odoo#117951

Task-4001976

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
