### PR TITLE
[FIX] hr_holidays: hide archived leave in report

### DIFF
--- a/addons/hr_holidays/report/hr_leave_report.py
+++ b/addons/hr_holidays/report/hr_leave_report.py
@@ -85,7 +85,8 @@ class LeaveReport(models.Model):
                     request.employee_company_id as company_id
                 from hr_leave as request
                 inner join hr_employee as employee on (request.employee_id = employee.id)
-                where employee.active IS True
+                where employee.active IS True AND
+                request.active is True
                 ) leaves
             );
         """)


### PR DESCRIPTION
In 17.0, some reports would not exclude archived leaves. This is specific to that version, as the active field is replaced by a "cancel" state in further versions.