### PR TITLE
[IMP] mail: move thread open function to the correct bundle

### DIFF
--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -945,10 +945,11 @@ export class Thread extends Record {
         this.setAsDiscussThread();
     }
 
-    openChatWindow({ fromMessagingMenu } = {}) {
-        const cw = this.store.ChatWindow.insert(
-            assignDefined({ thread: this }, { fromMessagingMenu })
-        );
+    openChatWindow(chatWindowData = {}) {
+        const cw = this.store.ChatWindow.insert({
+            thread: this,
+            ...chatWindowData,
+        });
         this.store.chatHub.opened.delete(cw);
         this.store.chatHub.opened.unshift(cw);
         cw.focus();

--- a/addons/mail/static/src/core/web/thread_model_patch.js
+++ b/addons/mail/static/src/core/web/thread_model_patch.js
@@ -62,7 +62,7 @@ patch(Thread.prototype, {
             });
             return;
         }
-        super.open();
+        super.open(options);
     },
     async unpin() {
         const chatWindow = this.store.ChatWindow.get({ thread: this });

--- a/addons/mail/static/src/discuss/core/public_web/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/public_web/thread_model_patch.js
@@ -10,6 +10,18 @@ patch(Thread.prototype, {
         super.delete(...arguments);
     },
 
+    open() {
+        if (
+            this.store.discuss.isActive &&
+            !this.store.env.services.ui.isSmall &&
+            this.model === "discuss.channel"
+        ) {
+            this.setAsDiscussThread();
+            return;
+        }
+        super.open(...arguments);
+    },
+
     onPinStateUpdated() {
         super.onPinStateUpdated();
         if (this.is_pinned) {


### PR DESCRIPTION
The mail module is split into several sub-folders to determine when the files should be loaded (e.g., web, public, public_web...).

Currently, several code snippets are misplaced, which increases the load on public pages or live chat.

Moreover, this can lead to dependency hell, especially when moving a feature to another bundle.

This PR fixes the `thread.open` method and its overrides.

Part of task-3972988