### PR TITLE
[FIX] l10n_at: specific tax scopes and ec sales tax report tags

### DIFF
--- a/addons/l10n_at/__manifest__.py
+++ b/addons/l10n_at/__manifest__.py
@@ -10,7 +10,7 @@
 
 {
     "name": "Austria - Accounting",
-    "version": "3.1",
+    "version": "3.1.1",
     "author": "WT-IO-IT GmbH, Wolfgang Taferner",
     "website": "https://www.wt-io-it.at",
     'category': 'Accounting/Localizations/Account Charts',

--- a/addons/l10n_at/data/account_tax_template.xml
+++ b/addons/l10n_at/data/account_tax_template.xml
@@ -227,6 +227,7 @@
             <field name="chart_template_id" ref="l10n_at_chart_template"/>
             <field name="sequence">300</field>
             <field name="type_tax_use">sale</field>
+            <field name="tax_scope">consu</field>
             <field eval="0" name="amount"/>
             <field name="amount_type">percent</field>
             <field name="price_include" eval="0"/>
@@ -334,7 +335,11 @@
             <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0,{
                   'repartition_type': 'base',
-                  'plus_report_expression_ids': [ref('tax_report_line_l10n_at_tva_line_4_8_tag'), ref('tax_report_line_l10n_at_tva_line_4_1_tag')],
+                  'plus_report_expression_ids': [
+                        ref('tax_report_line_l10n_at_tva_line_4_8_tag'),
+                        ref('tax_report_line_l10n_at_tva_line_4_1_tag'),
+                        ref('tax_report_line_l10n_at_tva_line_3_zm_igl_tag')
+                  ],
                 }),
                 (0,0,{
                   'repartition_type': 'tax',
@@ -344,7 +349,11 @@
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0,{
                   'repartition_type': 'base',
-                  'minus_report_expression_ids': [ref('tax_report_line_l10n_at_tva_line_4_8_tag'), ref('tax_report_line_l10n_at_tva_line_4_1_tag')],
+                  'minus_report_expression_ids': [
+                        ref('tax_report_line_l10n_at_tva_line_4_8_tag'),
+                        ref('tax_report_line_l10n_at_tva_line_4_1_tag'),
+                        ref('tax_report_line_l10n_at_tva_line_3_zm_igl_tag')
+                  ],
                 }),
                 (0,0,{
                   'repartition_type': 'tax',
@@ -367,7 +376,11 @@
             <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0,{
                   'repartition_type': 'base',
-                  'plus_report_expression_ids': [ref('tax_report_line_l10n_at_tva_line_4_9_tag'), ref('tax_report_line_l10n_at_tva_line_4_1_tag')],
+                  'plus_report_expression_ids': [
+                        ref('tax_report_line_l10n_at_tva_line_4_9_tag'),
+                        ref('tax_report_line_l10n_at_tva_line_4_1_tag'),
+                        ref('tax_report_line_l10n_at_tva_line_3_zm_igl_tag')
+                  ],
                 }),
                 (0,0,{
                   'repartition_type': 'tax',
@@ -377,7 +390,11 @@
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0,{
                   'repartition_type': 'base',
-                  'minus_report_expression_ids': [ref('tax_report_line_l10n_at_tva_line_4_9_tag'), ref('tax_report_line_l10n_at_tva_line_4_1_tag')],
+                  'minus_report_expression_ids': [
+                        ref('tax_report_line_l10n_at_tva_line_4_9_tag'),
+                        ref('tax_report_line_l10n_at_tva_line_4_1_tag'),
+                        ref('tax_report_line_l10n_at_tva_line_3_zm_igl_tag')
+                  ],
                 }),
                 (0,0,{
                   'repartition_type': 'tax',
@@ -490,6 +507,7 @@
             <field name="chart_template_id" ref="l10n_at_chart_template"/>
             <field name="sequence">50</field>
             <field name="type_tax_use">sale</field>
+            <field name="tax_scope">consu</field>
             <field eval="20" name="amount"/>
             <field name="amount_type">percent</field>
             <field name="price_include" eval="0"/>
@@ -523,6 +541,7 @@
             <field name="chart_template_id" ref="l10n_at_chart_template"/>
             <field name="sequence">100</field>
             <field name="type_tax_use">sale</field>
+            <field name="tax_scope">service</field>
             <field eval="20" name="amount"/>
             <field name="amount_type">percent</field>
             <field name="price_include" eval="0"/>
@@ -556,6 +575,7 @@
             <field name="chart_template_id" ref="l10n_at_chart_template"/>
             <field name="sequence">100</field>
             <field name="type_tax_use">sale</field>
+            <field name="tax_scope">consu</field>
             <field eval="10" name="amount"/>
             <field name="amount_type">percent</field>
             <field name="price_include" eval="0"/>
@@ -924,6 +944,7 @@
             <field name="chart_template_id" ref="l10n_at_chart_template"/>
             <field name="sequence">200</field>
             <field name="type_tax_use">sale</field>
+            <field name="tax_scope">service</field>
             <field eval="0" name="amount"/>
             <field name="amount_type">percent</field>
             <field name="price_include" eval="0"/>
@@ -931,6 +952,7 @@
             <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0,{
                   'repartition_type': 'base',
+                  'plus_report_expression_ids': [ref('tax_report_line_l10n_at_tva_line_3_zm_dl_tag')],
                 }),
                 (0,0,{
                   'repartition_type': 'tax',
@@ -940,6 +962,7 @@
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0,{
                   'repartition_type': 'base',
+                  'minus_report_expression_ids': [ref('tax_report_line_l10n_at_tva_line_3_zm_dl_tag')],
                 }),
                 (0,0,{
                   'repartition_type': 'tax',
@@ -953,6 +976,7 @@
             <field name="chart_template_id" ref="l10n_at_chart_template"/>
             <field name="sequence">300</field>
             <field name="type_tax_use">sale</field>
+            <field name="tax_scope">service</field>
             <field eval="0" name="amount"/>
             <field name="amount_type">percent</field>
             <field name="price_include" eval="0"/>


### PR DESCRIPTION
Improving tax scopes and EC sales tax report tags for `l10n_at`

Old PR: odoo/odoo#171606
Info: @wt-io-it

Ticket link: https://www.odoo.com/odoo/project.task/3916300
opw-3916300

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
