### PR TITLE
[16.0][FIX] web: Discarding in an x2many form removes the unsaved changes.

### DIFF
--- a/addons/web/static/src/views/basic_relational_model.js
+++ b/addons/web/static/src/views/basic_relational_model.js
@@ -812,13 +812,13 @@ export class Record extends DataPoint {
         this.model.notify();
     }
 
-    async discard() {
+    async discard(options) {
         if (this._closeUrgentSaveNotification) {
             this._closeUrgentSaveNotification();
         }
         await this._savePromise;
         this._closeInvalidFieldsNotification();
-        this.model.__bm__.discardChanges(this.__bm_handle__);
+        this.model.__bm__.discardChanges(this.__bm_handle__, options);
         this._invalidFields = new Set();
         this.__syncData();
         this.model.notify();

--- a/addons/web/static/src/views/fields/relational_utils.js
+++ b/addons/web/static/src/views/fields/relational_utils.js
@@ -520,7 +520,7 @@ export class X2ManyFieldDialog extends Component {
 
     discard() {
         if (this.record.isInEdition) {
-            this.record.discard();
+            this.record.discard({rollback: true});
         }
         this.props.close();
     }


### PR DESCRIPTION
At least in version 16.0, when a change is made to a record in an x2many field, saving it without saving the parent form and then accessing the record again and pressing discard will delete the changes previously made to the record.

On next gif the problem is shown:
![problem_discard](https://github.com/odoo/odoo/assets/35952655/20e0e020-fee9-4586-8765-2d8777597dc9)

As you can see, discarding has reverted to the state saved in the database and not to the last saved state of the record.

With these changes, the issue does not occur, and discarding returns the record to the state it was last saved in.

On next gif the problem is solved:
![solve_discard](https://github.com/odoo/odoo/assets/35952655/bd7f46de-1696-4e76-9d0f-7cf711fa0aed)

cc @Tecnativa
ping @yajo @rafaelbn @chienandalu @pedrobaeza 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
