### PR TITLE
[IMP] loyalty: merge e-wallet and loyalty cards

### DIFF
--- a/addons/loyalty/models/loyalty_card.py
+++ b/addons/loyalty/models/loyalty_card.py
@@ -40,6 +40,7 @@ class LoyaltyCard(models.Model):
     expiration_date = fields.Date()
 
     use_count = fields.Integer(compute='_compute_use_count')
+    active = fields.Boolean(default=True)
 
     _sql_constraints = [
         ('card_code_unique', 'UNIQUE(code)', 'A coupon/loyalty card must have a unique code.')

--- a/addons/loyalty/wizard/__init__.py
+++ b/addons/loyalty/wizard/__init__.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import base_partner_merge
 from . import loyalty_generate_wizard

--- a/addons/loyalty/wizard/base_partner_merge.py
+++ b/addons/loyalty/wizard/base_partner_merge.py
@@ -1,0 +1,45 @@
+from odoo import models
+
+
+class MergePartnerAutomatic(models.TransientModel):
+    _inherit = 'base.partner.merge.automatic.wizard'
+
+    def _update_foreign_keys(self, src_partners, dst_partner):
+        """ Override of base to merge corresponding nominative loyalty cards."""
+        self._merge_loyalty_cards(src_partners, dst_partner)
+        super()._update_foreign_keys(src_partners, dst_partner)
+
+    def _merge_loyalty_cards(self, src_partners, dst_partner):
+        """ Merge nominative loyalty cards.
+
+        :param src_partners: recordset of source res.partner records to merge
+        :param dst_partner: destination res.partner record
+        """
+        LoyaltyCard = self.env['loyalty.card'].sudo()
+        cards_per_program = dict(
+            LoyaltyCard._read_group(
+                domain=[
+                    ('partner_id', 'in', src_partners.ids),
+                    '|',
+                        ('program_id.applies_on', '=', 'both'),
+                        '&',
+                            ('program_id.program_type', 'in', ('ewallet', 'loyalty')),
+                            ('program_id.applies_on', '=', 'future'),
+                ],
+                groupby=['program_id'],
+                aggregates=['id:recordset'],
+            )
+        )
+        for program, cards in cards_per_program.items():
+            total_points = sum(card.points for card in cards)
+            dst_card = LoyaltyCard.search([
+                ('partner_id', '=', dst_partner.id),
+                ('program_id', '=', program.id),
+            ], limit=1)
+            if dst_card:
+                final_card = dst_card
+                total_points += dst_card.points
+            else:
+                final_card = cards[0]
+            final_card.sudo().write({'partner_id': dst_partner.id, 'points': total_points})
+            (cards - final_card).sudo().write({'points': 0, 'active': False})


### PR DESCRIPTION
Before this commit:
When contacts were merged, their loyalty points were not merged but simply added as separate loyalty cards. For example, if Contact A had 100 points and Contact B had 200 points, merging them resulted in Contact A having two separate loyalty cards with 100 points and 200 points respectively. And the second card could not be used.

After this commit:
When contacts are merged, the related loyalty cards of nominative programs (eWallet and Loyalty) also have their points merged into the destination contact's loyalty card. The points in the source contacts' loyalty cards are set to zero, and these cards are archived. This ensures that all points are consolidated into a single loyalty card for the merged contact.

Example:
- Contact A: 100 points
- Contact B: 200 points

After merging (Contact B into A):
- Contact A: 300 points (single loyalty card)
- Contact B: points set to zero and archived.

task-3993220
