### PR TITLE
[REF] web_tour: prepare to remove in_modal in step tour structure

### DIFF
--- a/addons/auth_totp/static/tests/totp_flow.js
+++ b/addons/auth_totp/static/tests/totp_flow.js
@@ -81,7 +81,8 @@ registry.category("web_tour.tours").add('totp_tour_setup', {
     run: "click",
 },
 {
-    trigger: "div:contains(enter your password)",
+    trigger: ".modal div:contains(enter your password)",
+    in_modal: false,
 },
 {
     content: "Check that we have to enter enhanced security mode and input password",
@@ -93,10 +94,12 @@ registry.category("web_tour.tours").add('totp_tour_setup', {
     run: "click",
 }, {
     content: "Check the wizard has opened",
-    trigger: 'li:contains("When requested to do so")',
+    trigger: '.modal li:contains("When requested to do so")',
+    in_modal: false,
 }, {
     content: "Get secret from collapsed div",
-    trigger: 'a:contains("Cannot scan it?")',
+    trigger: `.modal a:contains("Cannot scan it?")`,
+    in_modal: false,
     async run(helpers) {
         const secret = this.anchor
             .closest("div")
@@ -109,10 +112,18 @@ registry.category("web_tour.tours").add('totp_tour_setup', {
             secret: secret.textContent
         });
         helpers.edit(token, '[name=code] input');
-        helpers.click('button.btn-primary:contains(Activate)');
         document.querySelector("body").classList.add("got-token");
     }
-}, {
+}, 
+{
+    trigger: ".modal button.btn-primary:contains(Activate)",
+    in_modal: false,
+    run: "click",
+},
+{
+    trigger: "body:not(:has(.modal))",
+},
+{
     content: 'wait for rpc',
     trigger: 'body.got-token',
 },
@@ -241,7 +252,8 @@ registry.category("web_tour.tours").add('totp_login_device', {
     run: "click",
 },
 {
-    trigger: "div:contains(enter your password)",
+    trigger: ".modal div:contains(enter your password)",
+    in_modal: false,
 },
 {
     content: "Check that we have to enter enhanced security mode and input password",
@@ -330,17 +342,25 @@ registry.category("web_tour.tours").add('totp_admin_disables', {
     run: "click",
 },
 {
-    trigger: "div:contains(enter your password)",
+    trigger: ".modal div:contains(enter your password)",
+    in_modal: false,
 },
 { // enhanced security yo
     content: "Check that we have to enter enhanced security mode & input password",
-    trigger: '[name=password] input',
+    trigger: '.modal [name=password] input',
+    in_modal: false,
     run: "edit admin",
 }, {
     content: "Confirm",
-    trigger: "button:contains(Confirm Password)",
+    trigger: ".modal button:contains(Confirm Password)",
+    in_modal: false,
     run: "click",
-}, {
+}, 
+{
+    content: "Wait the modal is closed",
+    trigger: "body:not(:has(.modal))",
+},
+{
     content: "open the user's form",
     trigger: "td.o_data_cell:contains(demo)",
     run: "click",

--- a/addons/auth_totp_portal/static/tests/totp_portal.js
+++ b/addons/auth_totp_portal/static/tests/totp_portal.js
@@ -12,7 +12,8 @@ registry.category("web_tour.tours").add('totportal_tour_setup', {
     run: "click",
 }, {
     content: "Check that we have to enter enhanced security mode",
-    trigger: 'div:contains("enter your password")',
+    trigger: ".modal div:contains(enter your password)",
+    in_modal: false,
 }, {
     content: "Input password",
     trigger: '[name=password]',
@@ -88,7 +89,8 @@ registry.category("web_tour.tours").add('totportal_login_enabled', {
     run: "click",
 }, {
     content: "Check that we have to enter enhanced security mode",
-    trigger: 'div:contains("enter your password")',
+    trigger: ".modal div:contains(enter your password)",
+    in_modal: false,
 }, {
     content: "Input password",
     trigger: '[name=password]',

--- a/addons/hr_skills/static/tests/tours/skills_tour.js
+++ b/addons/hr_skills/static/tests/tours/skills_tour.js
@@ -50,8 +50,8 @@ registry.category("web_tour.tours").add('hr_skills_tour', {
     },
     {
         content: "Save it",
-        trigger: ".o_form_button_save",
-        in_modal: true,
+        trigger: ".modal .o_form_button_save",
+        in_modal: false,
         run: "click",
     },
     {
@@ -71,8 +71,8 @@ registry.category("web_tour.tours").add('hr_skills_tour', {
     },
     {
         content: "Save experience change",
-        trigger: ".o_form_button_save",
-        in_modal: true,
+        trigger: ".modal .o_form_button_save",
+        in_modal: false,
         run: "click",
     },
     {
@@ -107,8 +107,8 @@ registry.category("web_tour.tours").add('hr_skills_tour', {
     },
     {
         content: "Save new skill",
-        trigger: ".o_form_button_save",
-        in_modal: true,
+        trigger: ".modal .o_form_button_save",
+        in_modal: false,
         run: "click",
     },
     {
@@ -142,8 +142,8 @@ registry.category("web_tour.tours").add('hr_skills_tour', {
     },
     {
         content: "Save new skill",
-        trigger: ".o_form_button_save",
-        in_modal: true,
+        trigger: ".modal .o_form_button_save",
+        in_modal: false,
         run: "click",
     },
     {

--- a/addons/mass_mailing/static/tests/tours/mailing_campaign.js
+++ b/addons/mass_mailing/static/tests/tours/mailing_campaign.js
@@ -1,5 +1,4 @@
 /** @odoo-module **/
-    
 import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
 
@@ -30,12 +29,8 @@ registry.category('web_tour.tours').add('mailing_campaign', {
         },
         {
             content: 'Pick the basic theme',
-            trigger: 'iframe',
-            run(actions) {
-                // For some reason the selectors inside the iframe cannot be triggered.
-                const link = this.anchor.contentDocument.querySelector("#basic");
-                actions.click(link);
-            }
+            trigger: ":iframe #basic",
+            run: "click",
         },
         {
             content: 'Fill in Subject',
@@ -54,14 +49,17 @@ registry.category('web_tour.tours').add('mailing_campaign', {
         },
         {
             content: 'Save form',
-            trigger: '.o_form_button_save',
+            trigger: ".modal .o_form_button_save:contains(Save & Close)",
+            in_modal: false,
             run: "click",
+        },
+        {
+            trigger: "body:not(:has(.modal))",
         },
         {
             content: 'Check that newly created record is on the list',
             trigger: '[name="mailing_mail_ids"] td[name="subject"]:contains("TestFromTour")',
-            run: () => null,
         },
         ...stepUtils.saveForm(),
-    ]
+    ],
 });

--- a/addons/point_of_sale/static/tests/tours/utils/combo_popup_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/combo_popup_util.js
@@ -8,32 +8,32 @@ const confirmationButtonTrigger = `footer button.confirm`;
 export function select(productName) {
     return {
         content: `Select combo item ${productName}`,
-        trigger: productTrigger(productName),
-        in_modal: true,
+        trigger: `.modal ${productTrigger(productName)}`,
+        in_modal: false,
         run: "click",
     };
 }
 export function isSelected(productName) {
     return {
         content: `Check that ${productName} is selected`,
-        trigger: isComboSelectedTrigger(productName),
-        in_modal: true,
+        trigger: `.modal ${isComboSelectedTrigger(productName)}`,
+        in_modal: false,
         run: "click",
     };
 }
 export function isNotSelected(productName) {
     return {
         content: `Check that ${productName} is not selected`,
-        trigger: negate(isComboSelectedTrigger(productName), ".modal-body"),
-        in_modal: true,
+        trigger: `.modal ${negate(isComboSelectedTrigger(productName), ".modal-body")}`,
+        in_modal: false,
         run: "click",
     };
 }
 export function isConfirmationButtonDisabled() {
     return {
         content: "try to click `confirm` without having made all the selections",
-        trigger: `${confirmationButtonTrigger}[disabled]`,
+        trigger: `.modal ${confirmationButtonTrigger}[disabled]`,
+        in_modal: false,
         allowDisabled: true,
-        in_modal: true,
     };
 }

--- a/addons/point_of_sale/static/tests/tours/utils/dialog_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/dialog_util.js
@@ -1,22 +1,22 @@
 import { negate } from "@point_of_sale/../tests/tours/utils/common";
 
 export function confirm(confirmationText, button = ".btn-primary") {
-    let trigger = `.modal-footer ${button}`;
+    let trigger = `.modal .modal-footer ${button}`;
     if (confirmationText) {
         trigger += `:contains("${confirmationText}")`;
     }
     return {
         content: "confirm dialog",
-        in_modal: true,
         trigger,
+        in_modal: false,
         run: "click",
     };
 }
 export function cancel() {
     return {
         content: "cancel dialog",
-        trigger: `.modal-header button[aria-label="Close"]`,
-        in_modal: true,
+        trigger: `.modal .modal-header button[aria-label="Close"]`,
+        in_modal: false,
         run: "click",
     };
 }
@@ -29,14 +29,14 @@ export function discard() {
     };
 }
 export function is({ title } = {}) {
-    let trigger = ".modal-content";
+    let trigger = ".modal .modal-content";
     if (title) {
         trigger += ` .modal-header:contains("${title}")`;
     }
     return {
         content: "dialog is open",
+        in_modal: false,
         trigger,
-        in_modal: true,
     };
 }
 export function isNot() {

--- a/addons/point_of_sale/static/tests/tours/utils/number_popup_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/number_popup_util.js
@@ -3,15 +3,14 @@ import * as Numpad from "@point_of_sale/../tests/tours/utils/numpad_util";
 export function enterValue(keys) {
     return Numpad.enterValue(keys).map((step) => ({
         ...step,
-        in_modal: true,
     }));
 }
 export function isShown(val = "") {
     return [
         {
             content: `input shown is '${val}'`,
-            trigger: `.value:contains("${val}")`,
-            in_modal: true,
+            trigger: `.modal .value:contains("${val}")`,
+            in_modal: false,
         },
     ];
 }

--- a/addons/point_of_sale/static/tests/tours/utils/partner_list_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/partner_list_util.js
@@ -1,8 +1,8 @@
 export function clickPartner(name = "") {
     return {
         content: `click partner '${name}' from partner list screen`,
-        trigger: `.partner-list b:contains(${name})`,
-        in_modal: true,
+        trigger: `.modal .partner-list b:contains(${name})`,
+        in_modal: false,
         run: "click",
     };
 }

--- a/addons/point_of_sale/static/tests/tours/utils/payment_screen_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/payment_screen_util.js
@@ -352,8 +352,8 @@ export function clickPartnerButton() {
         },
         {
             content: "partner screen is shown",
-            trigger: PartnerList.clickPartner().trigger,
-            in_modal: true,
+            trigger: `.modal ${PartnerList.clickPartner().trigger}`,
+            in_modal: false,
         },
     ];
 }

--- a/addons/point_of_sale/static/tests/tours/utils/product_configurator_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/product_configurator_util.js
@@ -2,8 +2,8 @@ export function pickRadio(name) {
     return [
         {
             content: `picking radio attribute with name ${name}`,
-            trigger: `.attribute-name-cell:contains('${name}') input`,
-            in_modal: true,
+            trigger: `.modal .attribute-name-cell:contains('${name}') input`,
+            in_modal: false,
             run: "click",
         },
     ];
@@ -12,9 +12,9 @@ export function pickSelect(name) {
     return [
         {
             content: `picking select attribute with name ${name}`,
-            trigger: `.configurator_select:has(option:contains('${name}'))`,
+            trigger: `.modal .configurator_select:has(option:contains('${name}'))`,
+            in_modal: false,
             run: `select ${name}`,
-            in_modal: true,
         },
     ];
 }
@@ -22,8 +22,8 @@ export function pickColor(name) {
     return [
         {
             content: `picking color attribute with name ${name}`,
-            trigger: `.configurator_color[data-color='${name}']`,
-            in_modal: true,
+            trigger: `.modal .configurator_color[data-color='${name}']`,
+            in_modal: false,
             run: "click",
         },
     ];
@@ -32,9 +32,9 @@ export function fillCustomAttribute(value) {
     return [
         {
             content: `filling custom attribute with value ${value}`,
-            trigger: `.custom_value`,
+            trigger: `.modal .custom_value`,
+            in_modal: false,
             run: `edit ${value}`,
-            in_modal: true,
         },
     ];
 }

--- a/addons/point_of_sale/static/tests/tours/utils/product_screen_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/product_screen_util.js
@@ -145,8 +145,8 @@ export function clickPartnerButton() {
         },
         {
             content: "partner screen is shown",
-            trigger: PartnerList.clickPartner().trigger,
-            in_modal: true,
+            trigger: `${PartnerList.clickPartner().trigger}`,
+            in_modal: false,
         },
     ];
 }
@@ -309,8 +309,8 @@ export function clickFiscalPosition(name, checkIsNeeded = false) {
 export function closeWithCashAmount(val) {
     return [
         {
-            trigger: ".close-pos-popup .cash-input input",
-            in_modal: true,
+            trigger: ".modal .close-pos-popup .cash-input input",
+            in_modal: false,
             run: `edit ${val}`,
         },
     ];

--- a/addons/point_of_sale/static/tests/tours/utils/text_input_popup_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/text_input_popup_util.js
@@ -1,8 +1,8 @@
 export function inputText(val) {
     return {
         content: `input text '${val}'`,
-        trigger: `textarea`,
-        in_modal: true,
+        trigger: `.modal:not(.o_inactive_modal) textarea`,
+        in_modal: false,
         run: `edit ${val}`,
     };
 }

--- a/addons/pos_sale/static/tests/tours/utils/pos_sale_utils.js
+++ b/addons/pos_sale/static/tests/tours/utils/pos_sale_utils.js
@@ -9,8 +9,8 @@ function selectNthOrder(n) {
         ProductScreen.clickControlButton("Quotation/Order"),
         {
             content: `select nth order`,
-            trigger: `table.o_list_table tbody tr.o_data_row:nth-child(${n}) td`,
-            in_modal: true,
+            trigger: `.modal:not(.o_inactive_modal) table.o_list_table tbody tr.o_data_row:nth-child(${n}) td`,
+            in_modal: false,
             run: "click",
         },
     ];
@@ -21,9 +21,12 @@ export function settleNthOrder(n) {
         ...selectNthOrder(n),
         {
             content: `Choose to settle the order`,
-            trigger: `.selection-item:contains('Settle the order')`,
-            in_modal: true,
+            trigger: `.modal:not(.o_inactive_modal) .selection-item:contains('Settle the order')`,
+            in_modal: false,
             run: "click",
+        },
+        {
+            trigger: "body:not(:has(.modal))",
         },
     ];
 }

--- a/addons/project/static/tests/tours/project_task_history.js
+++ b/addons/project/static/tests/tours/project_task_history.js
@@ -84,7 +84,8 @@ registry.category("web_tour.tours").add("project_task_history_tour", {
         run: "click",
     }, {
         content: "Verify that 4 revisions are displayed (default empty description after the creation of the task + 3 edits)",
-        trigger: ".html-history-dialog .revision-list .btn",
+        trigger: ".modal .html-history-dialog .revision-list .btn",
+        in_modal: false,
         run: function () {
             const items = document.querySelectorAll(".revision-list .btn");
             if (items.length !== 4) {
@@ -93,45 +94,49 @@ registry.category("web_tour.tours").add("project_task_history_tour", {
         },
     }, {
         content: "Verify that the active revision (revision 4) is related to the third edit",
-        trigger: `.history-container .tab-pane:contains("${baseDescriptionContent} 2")`,
+        trigger: `.modal .history-container .tab-pane:contains("${baseDescriptionContent} 2")`,
+        in_modal: false,
         run: "click",
     }, {
         content: "Go to the third revision related to the second edit",
-        trigger: '.html-history-dialog .revision-list .btn:nth-child(2)',
+        trigger: ".modal .html-history-dialog .revision-list .btn:nth-child(2)",
+        in_modal: false,
         run: "click",
     }, {
         content: "Verify that the active revision is the one clicked in the previous step",
-        trigger: `.history-container .tab-pane:contains("${baseDescriptionContent} 1")`,
+        trigger: `.modal .history-container .tab-pane:contains("${baseDescriptionContent} 1")`,
+        in_modal: false,
         run: "click",
     }, {
         content: "Go to comparison tab",
-        trigger: ".history-container .nav-item:contains(Comparison) a",
+        trigger: ".modal .history-container .nav-item:contains(Comparison) a",
+        in_modal: false,
         run: "click",
     }, {
         content: "Verify comparaison text",
-        trigger: ".history-container .tab-pane",
+        trigger: ".modal .history-container .tab-pane",
+        in_modal: false,
         run: function () {
             const comparaisonHtml = document.querySelector(".history-container .tab-pane").innerHTML;
             const correctHtml = `<p><removed>${baseDescriptionContent} 3</removed><added>${baseDescriptionContent} 1</added></p>`;
             if (comparaisonHtml !== correctHtml) {
                 throw new Error(`Expect comparison to be ${correctHtml}, got ${comparaisonHtml}`);
             }
-        }
+        },
     }, {
         content: "Click on Restore History btn to get back to the selected revision in the previous step",
-        trigger: '.modal-footer .btn-primary:contains("Restore")',
+        trigger: ".modal button.btn-primary:contains(/^Restore history$/)",
+        in_modal: false,
         run: "click",
     }, {
         content: "Verify the confirmation dialog is opened",
-        trigger: '.modal-footer .btn-primary:contains("Restore")',
-        run: "click",
-    }, {
-        content: "Restore",
-        trigger: 'button.btn-primary',
+        in_modal: false,
+        trigger: ".modal button.btn-primary:contains(/^Restore$/)",
         run: "click",
     }, {
         content: "Verify that the description contains the right text after the restore",
-        trigger: `${descriptionField}`,
+        trigger: descriptionField,
+        in_modal: false,
         run: function () {
             const p = this.anchor?.innerText;
             const expected = `${baseDescriptionContent} 1`;

--- a/addons/project/static/tests/tours/project_update_tour_tests.js
+++ b/addons/project/static/tests/tours/project_update_tour_tests.js
@@ -130,7 +130,11 @@ registry.category("web_tour.tours").add('project_update_tour', {
 }, {
     trigger: ".modal-footer .o_form_button_save",
     run: "click",
-}, {
+}, 
+{
+    trigger: "body:not(:has(.modal))",
+},
+{
     trigger: ".o_add_milestone a",
     run: "click",
 }, {
@@ -142,7 +146,11 @@ registry.category("web_tour.tours").add('project_update_tour', {
 }, {
     trigger: ".modal-footer .o_form_button_save",
     run: "click",
-}, {
+}, 
+{
+    trigger: "body:not(:has(.modal))",
+},
+{
     trigger: ".o_rightpanel_milestone:eq(1) .o_milestone_detail",
     run: "click",
 }, {

--- a/addons/purchase_product_matrix/static/tests/tours/purchase_product_matrix_tour.js
+++ b/addons/purchase_product_matrix/static/tests/tours/purchase_product_matrix_tour.js
@@ -39,7 +39,8 @@ registry.category("web_tour.tours").add('purchase_matrix_tour', {
         [...document.querySelectorAll(".o_matrix_input")].forEach((el) => el.value = 1);
     }
 }, {
-    trigger: 'button:contains("Confirm")',
+    trigger: ".modal button:contains(Confirm)",
+    in_modal: false,
     run: 'click'
 }, {
     trigger: '.o_form_button_save',
@@ -64,7 +65,8 @@ registry.category("web_tour.tours").add('purchase_matrix_tour', {
             .forEach((el) => (el.value = 4));
     } // set the qty to 4 for half of the matrix products.
 }, {
-    trigger: 'button:contains("Confirm")',
+    trigger: ".modal button:contains(Confirm)",
+    in_modal: false,
     run: 'click' // apply the matrix
 }, 
 {
@@ -96,7 +98,8 @@ registry.category("web_tour.tours").add('purchase_matrix_tour', {
             .forEach((el) => (el.value = 8.2));
     }
 }, {
-    trigger: 'button:contains("Confirm")',
+    trigger: ".modal button:contains(Confirm)",
+    in_modal: false,
     run: 'click' // apply the matrix
 },
 {

--- a/addons/sale_project/static/tests/tours/task_create_sol_tour.js
+++ b/addons/sale_project/static/tests/tours/task_create_sol_tour.js
@@ -43,9 +43,9 @@ registry.category("web_tour.tours").add("task_create_sol_tour", {
         content: "Select the product in the autocomplete dropdown",
         run: "click",
     }, {
-        trigger: ".o_form_button_save",
+        trigger: ".modal .o_form_button_save",
         content: "Save Sales Order Item",
-        in_modal: true,
+        in_modal: false,
         run: "click",
     }, {
         trigger: ".o_form_button_save",

--- a/addons/sale_timesheet/static/tests/tours/project_create_sol_tour.js
+++ b/addons/sale_timesheet/static/tests/tours/project_create_sol_tour.js
@@ -39,7 +39,8 @@ patch(registry.category("web_tour.tours").get("project_create_sol_tour"), {
             content: "Select the customer in the autocomplete dropdown",
             run: "click",
         }, {
-            trigger: ".o_form_button_save",
+            trigger: ".modal:not(.o_inactive_modal) button:contains(save & close)",
+            in_modal: false,
             content: "Save project",
             run: "click",
         });

--- a/addons/stock/static/tests/tours/stock_picking_tour.js
+++ b/addons/stock/static/tests/tours/stock_picking_tour.js
@@ -27,20 +27,27 @@ registry.category("web_tour.tours").add('test_detailed_op_no_save_1', { test: tr
         run: "click",
     },
     {
-        trigger: '.o_field_x2many_list_row_add > a',
+        trigger: ".modal .o_field_x2many_list_row_add > a",
+        in_modal: false,
         run: "click",
     },
     {
-        trigger: ".o_field_widget[name=lot_name] input",
+        trigger: ".modal .o_field_widget[name=lot_name] input",
+        in_modal: false,
         run: "edit lot1",
     },
     {
-        trigger: ".o_field_widget[name=quantity] input",
+        trigger: ".modal .o_field_widget[name=quantity] input",
+        in_modal: false,
         run: "edit 4",
     },
     {
-        trigger: ".o_form_button_save",
+        trigger: ".modal button:contains(save)",
+        in_modal: false,
         run: "click",
+    },
+    {
+        trigger: "body:not(:has(.modal))",
     },
     {
         trigger: ".o_optional_columns_dropdown_toggle",
@@ -98,19 +105,23 @@ registry.category("web_tour.tours").add('test_generate_serial_1', { test: true, 
         run: "click",
     },
     {
-        trigger: "h4:contains('Generate Serial numbers')",
+        trigger: ".modal h4:contains('Generate Serial numbers')",
+        in_modal: false,
         run: "click",
     },
     {
-        trigger: "div[name=next_serial] input",
+        trigger: ".modal div[name=next_serial] input",
+        in_modal: false,
         run: "edit serial_n_1",
     },
     {
-        trigger: "div[name=next_serial_count] input",
+        trigger: ".modal div[name=next_serial_count] input",
+        in_modal: false,
         run: "edit 5 && click body",
     },
     {
-        trigger: ".btn-primary:contains('Generate')",
+        trigger: ".modal .btn-primary:contains('Generate')",
+        in_modal: false,
         run: "click",
     },
     {
@@ -123,8 +134,12 @@ registry.category("web_tour.tours").add('test_generate_serial_1', { test: true, 
         },
     },
     {
-        trigger: ".o_form_button_save",
+        trigger: ".modal button:contains(save)",
+        in_modal: false,
         run: "click",
+    },
+    {
+        trigger: "body:not(:has(.modal))",
     },
     {
         trigger: ".o_optional_columns_dropdown_toggle",
@@ -186,36 +201,44 @@ registry.category("web_tour.tours").add('test_generate_serial_2', { test: true, 
         run: "click",
     },
     {
-        trigger: "h4:contains('Stock move')",
+        trigger: ".modal h4:contains('Stock move')",
+        in_modal: false,
         run: "click",
     },
     // We generate lots for a first batch of 50 products
     {
-        trigger: '.o_widget_generate_serials > button',
+        trigger: ".modal .o_widget_generate_serials > button",
+        in_modal: false,
         run: "click",
     },
     {
-        trigger: "h4:contains('Generate Lot numbers')",
+        trigger: ".modal h4:contains('Generate Lot numbers')",
+        in_modal: false,
         run: "click",
     },
     {
-        trigger: "div[name=next_serial] input",
+        trigger: ".modal div[name=next_serial] input",
+        in_modal: false,
         run: "edit lot_n_1_1",
     },
     {
-        trigger: "div[name=next_serial_count] input",
-        run: "edit 7.5 && click body",
+        trigger: ".modal div[name=next_serial_count] input",
+        in_modal: false,
+        run: "edit 7.5",
     },
     {
-        trigger: "div[name=total_received] input",
-        run: "edit 50 && click body",
+        trigger: ".modal div[name=total_received] input",
+        in_modal: false,
+        run: "edit 50",
     },
     {
-        trigger: ".btn-primary:contains('Generate')",
+        trigger: ".modal .modal-footer button.btn-primary:contains(Generate)",
+        in_modal: false,
         run: "click",
     },
     {
-        trigger: "span[data-tooltip=Quantity]:contains('50')",
+        trigger: ".modal span[data-tooltip=Quantity]:contains(50)",
+        in_modal: false,
         run: () => {
             const nbLines = document.querySelectorAll(".o_field_cell[name=lot_name]").length;
             if (nbLines !== 7){
@@ -225,35 +248,42 @@ registry.category("web_tour.tours").add('test_generate_serial_2', { test: true, 
     },
     // We generate lots for the last 50 products
     {
-        trigger: '.o_widget_generate_serials > button',
+        trigger: ".modal .o_widget_generate_serials > button",
+        in_modal: false,
         run: "click",
     },
     {
-        trigger: "h4:contains('Generate Lot numbers')",
-        run: "click",
+        trigger: ".modal h4:contains('Generate Lot numbers')",
+        in_modal: false,
     },
     {
-        trigger: "div[name=next_serial] input",
+        trigger: ".modal div[name=next_serial] input",
+        in_modal: false,
         run: "edit lot_n_2_1",
     },
     {
-        trigger: "div[name=next_serial_count] input",
-        run: "edit 13 && click body",
+        trigger: ".modal div[name=next_serial_count] input",
+        in_modal: false,
+        run: "edit 13",
     },
     {
-        trigger: "div[name=total_received] input",
-        run: "edit 50 && click body",
+        trigger: ".modal div[name=total_received] input",
+        in_modal: false,
+        run: "edit 50",
     },
     {
-        trigger: "div[name=keep_lines] input",
+        trigger: ".modal div[name=keep_lines] input",
+        in_modal: false,
+        run: "check",
+    },
+    {
+        trigger: ".modal .modal-footer button.btn-primary:contains(Generate)",
+        in_modal: false,
         run: "click",
     },
     {
-        trigger: ".btn-primary:contains('Generate')",
-        run: "click",
-    },
-    {
-        trigger: "span[data-tooltip=Quantity]:contains('100')",
+        trigger: ".modal span[data-tooltip=Quantity]:contains(100)",
+        in_modal: false,
         run: () => {
             const nbLines = document.querySelectorAll(".o_field_cell[name=lot_name]").length;
             if (nbLines !== 11){
@@ -262,8 +292,12 @@ registry.category("web_tour.tours").add('test_generate_serial_2', { test: true, 
         },
     },
     {
-        trigger: ".o_form_button_save",
+        trigger: ".modal .o_form_button_save",
+        in_modal: false,
         run: "click",
+    },
+    {
+        trigger: "body:not(:has(.modal))",
     },
     {
         trigger: ".o_optional_columns_dropdown_toggle",
@@ -383,19 +417,25 @@ registry.category("web_tour.tours").add('test_add_new_line', {
             run: "click",
         },
         {
-            trigger: '.o_field_x2many_list_row_add > a',
+            trigger: ".modal .o_field_x2many_list_row_add > a",
+            in_modal: false,
             run: "click",
         },
         {
-            trigger: ".o_field_widget[name=lot_name] input",
+            trigger: ".modal .o_field_widget[name=lot_name] input",
+            in_modal: false,
             run: 'edit two',
         },
         {
-            trigger: ".o_form_view.modal-content .o_form_button_save",
+            trigger: ".modal .o_form_view.modal-content .o_form_button_save",
+            in_modal: false,
             run: "click",
         },
         {
-            trigger: ".o_form_view:not(.modal-content) .o_form_button_save",
+            trigger: "body:not(:has(.modal))",
+        },
+        {
+            trigger: ".o_form_view .o_form_button_save",
             run: "click",
         },
         {

--- a/addons/survey/static/tests/tours/survey_form.js
+++ b/addons/survey/static/tests/tours/survey_form.js
@@ -26,52 +26,59 @@ registry.category("web_tour.tours").add('survey_tour_test_survey_form_triggers',
         run: "click",
     }, {
         content: "Set the first question's title",
-        trigger: ".modal-content .o_field_widget[name=title] input",
+        trigger: ".modal .modal-content .o_field_widget[name=title] input",
         run: "edit Question 1",
     },
     ...addTwoAnswers(),
     ...saveAndNew(),
     {
         content: "Set the second question's title",
-        trigger: ".o_field_widget[name=title] input",
+        trigger: ".modal .o_field_widget[name=title] input",
+        in_modal: false,
         run: "edit Question 2",
-        in_modal: true,
     },
     ...addTwoAnswers(),
     ...changeTab("options"),
     {
         content: "Set a trigger for the first question",
-        trigger: ".o_field_widget[name=triggering_answer_ids] input",
+        trigger: ".modal .o_field_widget[name=triggering_answer_ids] input",
+        in_modal: false,
         run: "click",
-        in_modal: true,
     }, {
         content: "Set the first question's first answer as trigger",
-        trigger: 'ul.ui-autocomplete a:contains("Question 1 : Answer A")',
+        trigger: ".modal ul.ui-autocomplete a:contains(Question 1 : Answer A)",
+        in_modal: false,
         run: 'click',
-        in_modal: true,
     },
     ...changeTab("answers"),
     ...saveAndNew(),
     {
         content: "Set the third question's title",
-        trigger: ".o_field_widget[name=title] input",
+        trigger: ".modal .o_field_widget[name=title] input",
+        in_modal: false,
         run: "edit Question 3",
-        in_modal: true,
     },
     ...addTwoAnswers(),
     ...changeTab("options"),
     {
         content: "Set a trigger for the second question",
-        trigger: ".o_field_widget[name=triggering_answer_ids] input",
+        trigger: ".modal .o_field_widget[name=triggering_answer_ids] input",
+        in_modal: false,
         run: "click",
-        in_modal: true,
     }, {
         content: "Set the second question's second answer as trigger",
-        trigger: 'ul.ui-autocomplete a:contains("Question 2 : Answer B")',
+        trigger: ".modal ul.ui-autocomplete a:contains(Question 2 : Answer B)",
+        in_modal: false,
         run: 'click',
-        in_modal: true,
     },
-    ...stepUtils.saveForm(),
+    {
+        trigger: ".modal button:contains(save & close)",
+        in_modal: false,
+        run: "click",
+    },
+    {
+        trigger: "body:not(:has(.modal))",
+    },
     {
         content: "Check that Question 2 has 'normal' trigger icon",
         trigger: "tr:contains('Question 2') button i.fa-code-fork",
@@ -91,31 +98,38 @@ registry.category("web_tour.tours").add('survey_tour_test_survey_form_triggers',
         run: "click",
     }, {
         content: "Check that an alert is shown",
-        trigger: ".o_form_sheet_bg div:first-child.alert-warning:contains('positioned before some or all of its triggers')",
-        in_modal: true,
-        run: "click",
+        trigger: ".modal .o_form_sheet_bg div:first-child.alert-warning:contains('positioned before some or all of its triggers')",
+        in_modal: false,
     },
     ...changeTab("options"),
     {
         content: "Remove invalid trigger",
-        trigger: ".o_field_widget[name=triggering_answer_ids] span:contains('Question 2') a.o_delete",
+        trigger: ".modal .o_field_widget[name=triggering_answer_ids] span:contains('Question 2') a.o_delete",
+        in_modal: false,
         run: "click",
-        in_modal: true,
     }, {
         content: "Check that the alert is gone",
-        trigger: `.o_form_sheet_bg div:first-child:not(.alert-warning).o_form_sheet`,
-        in_modal: true,
+        trigger: `.modal .o_form_sheet_bg div:first-child:not(.alert-warning).o_form_sheet`,
+        in_modal: false,
     }, {
         content: "Choose a new valid trigger",
-        trigger: ".o_field_widget[name=triggering_answer_ids] input",
+        trigger: ".modal .o_field_widget[name=triggering_answer_ids] input",
+        in_modal: false,
         run: "click",
-        in_modal: true,
     }, {
         content: "Set the first question's second answer as trigger, then",
         trigger: 'ul.ui-autocomplete a:contains("Question 1 : Answer B")',
         run: 'click',
     },
-    ...stepUtils.saveForm(),
+    {
+        content: "Save the question (1)",
+        trigger: ".modal button:contains(save)",
+        in_modal: false,
+        run: "click",
+    },
+    {
+        trigger: "body:not(:has(.modal))",
+    },
     {
         content: "Check that Question 3 has its 'normal' trigger icon back",
         trigger: "tr:contains('Question 3') button i.fa-code-fork",
@@ -131,15 +145,22 @@ registry.category("web_tour.tours").add('survey_tour_test_survey_form_triggers',
     ...changeTab("options"),
     {
         content: "Add a second trigger to confirm we can now use Question 2 again",
-        trigger: ".modal-content .o_field_widget[name=triggering_answer_ids] input",
+        trigger: ".modal .modal-content .o_field_widget[name=triggering_answer_ids] input",
         run: "click",
-        in_modal: true,
     }, {
         content: "Add the second question's second answer as trigger, then",
         trigger: '.modal-content ul.ui-autocomplete a:contains("Question 2 : Answer B")',
         run: "click",
     },
-    ...stepUtils.saveForm(),
+    {
+        content: "Save the question (2)",
+        trigger: ".modal button:contains(save)",
+        in_modal: false,
+        run: "click",
+    },
+    {
+        trigger: "body:not(:has(.modal))",
+    },
     // Move question 1 below question 3,
     {
         content: "Move Question 1 back below Question 3",
@@ -154,22 +175,29 @@ registry.category("web_tour.tours").add('survey_tour_test_survey_form_triggers',
         run: "click",
     }, {
         content: "Check that an alert is shown also when only one trigger is misplaced",
-        trigger: ".o_form_sheet_bg div:first-child.alert-warning:contains('positioned before some or all of its triggers')",
-        in_modal: true,
-        run: "click",
+        trigger: ".modal .o_form_sheet_bg div:first-child.alert-warning:contains('positioned before some or all of its triggers')",
+        in_modal: false,
     },
     ...changeTab("options"),
     {
         content: "Remove temporarily used trigger",
-        trigger: ".o_field_widget[name=triggering_answer_ids] span:contains('Question 1') a.o_delete",
+        trigger: ".modal .o_field_widget[name=triggering_answer_ids] span:contains('Question 1') a.o_delete",
+        in_modal: false,
         run: "click",
-        in_modal: true,
     }, {
         content: "Check that the alert is gone in this case too",
-        trigger: `.o_form_sheet_bg div:first-child:not(.alert-warning).o_form_sheet`,
-        in_modal: true,
+        trigger: `.modal .o_form_sheet_bg div:first-child:not(.alert-warning).o_form_sheet`,
+        in_modal: false,
     },
-    ...stepUtils.saveForm(),
+    {
+        content: "Save the question (3)",
+        trigger: ".modal button:contains(save)",
+        in_modal: false,
+        run: "click",
+    },
+    {
+        trigger: "body:not(:has(.modal))",
+    },
     {
         content: "Check that Question 3 has its 'normal' trigger icon back",
         trigger: "tr:contains('Question 3') button i.fa-code-fork",
@@ -188,7 +216,15 @@ registry.category("web_tour.tours").add('survey_tour_test_survey_form_triggers',
         trigger: "div[name=suggested_answer_ids] tr:contains('Answer B') button[name=delete]",
         run: "click",
     },
-    ...stepUtils.saveForm(),
+    {
+        content: "Save the question (4)",
+        trigger: ".modal button:contains(save)",
+        in_modal: false,
+        run: "click",
+    },
+    {
+        trigger: "body:not(:has(.modal))",
+    },
     {
         content: "Check that Question 3 no longer has a trigger icon",
         trigger: "div[name=question_and_page_ids] tr:contains('Question 3') div.o_widget_survey_question_trigger:not(:has(button))",
@@ -218,23 +254,29 @@ function addTwoAnswers() {
     return [
         {
             content: "Add the first answer",
-            trigger: "div[name=suggested_answer_ids] .o_field_x2many_list_row_add a",
-            in_modal: true,
+            trigger:
+                ".modal div[name=suggested_answer_ids] .o_field_x2many_list_row_add a",
+            in_modal: false,
             run: "click",
-        }, {
-            trigger: 'tr.o_selected_row div[name=value] input',
+        },
+        {
+            trigger: ".modal tr.o_selected_row div[name=value] input",
+            in_modal: false,
             run: "edit Answer A",
-            in_modal: true,
-        }, {
+        },
+        {
             content: "Add the second answer",
-            trigger: "div[name=suggested_answer_ids] .o_field_x2many_list_row_add a",
-            in_modal: true,
+            trigger:
+                ".modal div[name=suggested_answer_ids] .o_field_x2many_list_row_add a",
+            in_modal: false,
             run: "click",
-        }, {
-            trigger: 'tr:nth-child(2).o_selected_row div[name=value] input',
+        },
+        {
+            trigger:
+                ".modal tr:nth-child(2).o_selected_row div[name=value] input",
+            in_modal: false,
             run: "edit Answer B",
-            in_modal: true,
-        }
+        },
     ];
 }
 
@@ -242,31 +284,31 @@ function saveAndNew() {
     return [
         {
             content: "Click Save & New",
-            trigger: "button.o_form_button_save_new",
-            in_modal: true,
+            trigger: ".modal button.o_form_button_save_new",
+            in_modal: false,
             run: "click",
-        }, {
+        },
+        {
             content: "Wait for the dialog to render new question form",
-            // suggested_answer_ids required even though in_modal is specified...
-            trigger: "div[name=suggested_answer_ids] .o_list_table tbody tr:first-child:not(.o_data_row)", // empty answers list
-            in_modal: true,
-        }
+            in_modal: false,
+            trigger:
+                ".modal div[name=suggested_answer_ids] .o_list_table tbody tr:first-child:not(.o_data_row)", // empty answers list
+        },
     ];
 }
 
-
 function changeTab(tabName) {
-    // Currently, .modal-content is required even though "in_modal"
     return [
         {
             content: `Go to ${tabName} tab`,
-            trigger: `.modal-content a[name=${tabName}].nav-link`,
-            in_modal: true,
+            trigger: `.modal .modal-content a[name=${tabName}].nav-link`,
+            in_modal: false,
             run: "click",
-        }, {
+        },
+        {
             content: `Wait for tab ${tabName} tab`,
-            trigger: `.modal-content a[name=${tabName}].nav-link.active`,
-            in_modal: true,
-        }
+            trigger: `.modal .modal-content a[name=${tabName}].nav-link.active`,
+            in_modal: false,
+        },
     ];
 }

--- a/addons/test_base_automation/static/tests/tour/base_automation_tour.js
+++ b/addons/test_base_automation/static/tests/tour/base_automation_tour.js
@@ -80,40 +80,46 @@ registry.category("web_tour.tours").add("test_base_automation", {
         },
         {
             content: "Set new action to update the record",
-            trigger: ".modal-content .o_form_renderer [name='state'] span[value*='object_write']",
+            in_modal: false,
+            trigger:
+                ".modal .modal-content .o_form_renderer [name='state'] span[value*='object_write']",
             run: "click",
         },
         {
             content: "Focus on the 'update_path' field",
-            trigger: ".modal-content .o_form_renderer [name='update_path'] .o_model_field_selector",
+            in_modal: false,
+            trigger:
+                ".modal .modal-content .o_form_renderer [name='update_path'] .o_model_field_selector",
             run: "click",
         },
         {
             content: "Input field name",
-            trigger:
-                ".o_model_field_selector_popover .o_model_field_selector_popover_search  input",
-            run: "edit Job Position",
+            trigger: ".o_model_field_selector_popover .o_model_field_selector_popover_search input",
             in_modal: false,
+            run: "edit Job Position",
         },
         {
             content: "Select field",
-            in_modal: false,
             trigger:
                 '.o_model_field_selector_popover .o_model_field_selector_popover_page li[data-name="function"] button',
+            in_modal: false,
             run: "click",
         },
         {
             content: "Open update select",
-            trigger: '.modal-content .o_form_renderer div[name="value"] textarea',
+            trigger:
+                '.modal .modal-content .o_form_renderer div[name="value"] textarea',
+            in_modal: false,
             run: "edit Test",
         },
         {
             content: "Open update select",
-            trigger: ".modal-content .o_form_button_save",
+            trigger: ".modal .modal-content .o_form_button_save",
+            in_modal: false,
             run: "click",
         },
         {
-            trigger: "body:not(:has(.modal-content))",
+            trigger: "body:not(:has(.modal))",
         },
         ...stepUtils.saveForm(),
     ],
@@ -186,20 +192,24 @@ registry.category("web_tour.tours").add("test_base_automation_on_tag_added", {
             run: "click",
         },
         {
-            trigger: " .modal-content .o_form_renderer [name='state'] span[value*='object_write']",
+            in_modal: false,
+            trigger:
+                ".modal .modal-content .o_form_renderer [name='state'] span[value*='object_write']",
             run: "click",
         },
         {
             content: "Focus on the 'update_path' field",
-            trigger: ".modal-content .o_form_renderer [name='update_path'] .o_model_field_selector",
+            in_modal: false,
+            trigger:
+                ".modal .modal-content .o_form_renderer [name='update_path'] .o_model_field_selector",
             run: "click",
         },
         {
             content: "Input field name",
+            in_modal: false,
             trigger:
                 ".o_model_field_selector_popover .o_model_field_selector_popover_search  input",
             run: "edit Name",
-            in_modal: false,
         },
         {
             content: "Select field",
@@ -209,42 +219,54 @@ registry.category("web_tour.tours").add("test_base_automation_on_tag_added", {
             run: "click",
         },
         {
-            trigger: '.modal-content .o_form_renderer div[name="value"] textarea',
+            in_modal: false,
+            trigger:
+                '.modal .modal-content .o_form_renderer div[name="value"] textarea',
             run: "edit Test",
         },
         {
-            trigger: ".modal-content .o_form_button_save",
+            in_modal: false,
+            trigger: ".modal .modal-content .o_form_button_save",
             run: "click",
+        },
+        {
+            trigger: "body:not(:has(.modal))",
         },
         {
             trigger: '.o_form_renderer div[name="action_server_ids"] button',
             run: "click",
         },
         {
-            trigger: " .modal-content .o_form_renderer [name='state'] span[value*='object_write']",
+            in_modal: false,
+            trigger:
+                ".modal .modal-content .o_form_renderer [name='state'] span[value*='object_write']",
             run: "click",
         },
         {
+            in_modal: false,
             content: "Focus on the 'update_path' field",
-            trigger: ".modal-content .o_form_renderer [name='update_path'] .o_model_field_selector",
+            trigger:
+                ".modal .modal-content .o_form_renderer [name='update_path'] .o_model_field_selector",
             run: "click",
         },
         {
+            in_modal: false,
             content: "Input field name",
             trigger:
                 ".o_model_field_selector_popover .o_model_field_selector_popover_search  input",
             run: "edit Priority",
-            in_modal: false,
         },
         {
-            content: "Select field",
             in_modal: false,
+            content: "Select field",
             trigger:
                 '.o_model_field_selector_popover .o_model_field_selector_popover_page li[data-name="priority"] button',
             run: "click",
         },
         {
-            trigger: '.modal-content .o_form_renderer div[name="selection_value"] input',
+            in_modal: false,
+            trigger:
+                '.modal .modal-content .o_form_renderer div[name="selection_value"] input',
             run: "edit High",
         },
         {
@@ -252,7 +274,8 @@ registry.category("web_tour.tours").add("test_base_automation_on_tag_added", {
             run: "click",
         },
         {
-            trigger: ".modal-content .o_form_button_save",
+            in_modal: false,
+            trigger: ".modal .modal-content .o_form_button_save",
             run: "click",
         },
         {

--- a/addons/test_sale_product_configurators/static/tests/tours/event_sale_with_product_configurator_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/event_sale_with_product_configurator_ui.js
@@ -4,154 +4,221 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
 import configuratorTourUtils from "@sale/js/tours/product_configurator_tour_utils";
 
-registry.category("web_tour.tours").add('event_sale_with_product_configurator_tour', {
-    url: '/web',
+registry.category("web_tour.tours").add("event_sale_with_product_configurator_tour", {
+    url: "/web",
     test: true,
-    steps: () => [stepUtils.showAppsMenuItem(), {
-    trigger: '.o_app[data-menu-xmlid="sale.sale_menu_root"]',
-    run: "click",
-}, 
-{
-    trigger: ".o_sale_order",
-},
-{
-    trigger: '.o_list_button_add',
-    run: "click",
-}, {
-    trigger: '.o_required_modifier[name=partner_id] input',
-    run: "edit Tajine Saucisse",
-}, {
-    isActive: ["auto"],
-    trigger: '.ui-menu-item > a:contains("Tajine Saucisse")',
-    run: "click",
-}, {
-    trigger: 'a:contains("Add a product")',
-    run: "click",
-}, {
-    trigger: 'div[name="product_template_id"] input',
-    run: "edit event (",
-}, {
-    trigger: 'ul.ui-autocomplete a:contains("Registration Event (TEST variants)")',
-    run: "click",
-}, {
-    trigger: 'tr:has(div[name="o_sale_product_configurator_name"]:contains("Memorabilia")) button:has(i.fa-plus)',
-    run: "click",
-}, {
-    trigger: 'button:contains(Confirm)',
-    run: "click",
-}, 
-{
-    trigger: ".modal .o_input_dropdown input",
-    run: "edit Test",
-}, {
-    trigger: '.modal div[name="event_id"] input',
-    run: "click",
-}, {
-    trigger: "ul.ui-autocomplete a:contains(TestEvent)",
-    run: "click",
-}, {
-    trigger: '.modal div[name="event_ticket_id"] input',
-    run: 'click',
-}, {
-    trigger: "ul.ui-autocomplete a:contains(Kid + meal)",
-    run: "click",
-}, {
-    trigger: ".modal .o_event_sale_js_event_configurator_ok",
-    run: "click",
-}, 
-{
-    trigger: 'td[name="price_subtotal"]:contains("16.50")', // wait for the optional product line
-},
-{
-    trigger: 'a:contains("Add a product")',
-    run: "click",
-}, 
-{
-    trigger: ".o_data_row:nth-child(3)", // wait for the new row to be created
-},
-{
-    trigger: 'div[name="product_template_id"] input',
-    run: "edit event (",
-}, {
-    trigger: 'ul.ui-autocomplete a:contains("Registration Event (TEST variants)")',
-    run: "click",
-}, {
-    trigger: 'tr:has(div[name="o_sale_product_configurator_name"]:contains("Registration Event (TEST variants)")) label:contains("Adult")',
-    run: "click",
-}, {
-    trigger: 'tr:has(div[name="o_sale_product_configurator_name"]:contains("Registration Event (TEST variants)")) .o_sale_product_configurator_qty input',
-    run: "edit 5 && click body",
-},
-    configuratorTourUtils.assertPriceTotal("150.00"),
-{
-    trigger: 'button:contains(Confirm)',
-    run: "click",
-}, 
-{
-    trigger: ".modal .o_input_dropdown input",
-    run: "edit Test",
-}, {
-    trigger: '.modal div[name="event_id"] input',
-    run: "click",
-}, {
-    trigger: 'ul.ui-autocomplete a:contains("TestEvent")',
-    run: "click",
-}, {
-    trigger: '.modal div[name="event_ticket_id"] input',
-    run: 'click',
-}, {
-    trigger: 'ul.ui-autocomplete a:contains("Adult")',
-    run: "click",
-}, {
-    trigger: ".modal .o_event_sale_js_event_configurator_ok",
-    run: "click",
-}, 
-{
-    trigger: 'td[name="price_subtotal"]:contains("150.00")', // wait for the adult tickets line
-},
-{
-    trigger: 'a:contains("Add a product")',
-    run: "click",
-}, 
-{
-    trigger: ".o_data_row:nth-child(4)", // wait for the new row to be created
-},
-{
-    trigger: 'div[name="product_template_id"] input',
-    run: "edit event (",
-}, {
-    trigger: 'ul.ui-autocomplete a:contains("Registration Event (TEST variants)")',
-    run: "click",
-}, {
-    trigger: 'tr:has(div[name="o_sale_product_configurator_name"]:contains("Registration Event (TEST variants)")) label:contains("VIP")',
-    run: "click",
-},
-    configuratorTourUtils.assertPriceTotal(60.00),
-{
-    trigger: 'button:contains(Confirm)',
-    run: "click",
-}, 
-{
-    trigger: ".modal .o_input_dropdown input",
-    run: "edit Test",
-}, {
-    trigger: 'div[name="event_id"] input',
-    run: "click",
-}, {
-    trigger: 'ul.ui-autocomplete a:contains("TestEvent")',
-    run: "click",
-}, {
-    trigger: '.modal div[name="event_ticket_id"] input',
-    run: 'click',
-}, {
-    trigger: 'ul.ui-autocomplete a:contains("VIP")',
-    run: "click",
-}, {
-    trigger: ".modal .o_event_sale_js_event_configurator_ok",
-    run: "click",
-},
-{
-    trigger: '.o_field_cell.o_data_cell.o_list_number:contains("60.00")',
-},
-...stepUtils.saveForm(),
-]});
+    steps: () => [
+        stepUtils.showAppsMenuItem(),
+        {
+            trigger: '.o_app[data-menu-xmlid="sale.sale_menu_root"]',
+            run: "click",
+        },
+        {
+            trigger: ".o_sale_order",
+        },
+        {
+            trigger: ".o_list_button_add",
+            run: "click",
+        },
+        {
+            trigger: ".o_required_modifier[name=partner_id] input",
+            run: "edit Tajine Saucisse",
+        },
+        {
+            isActive: ["auto"],
+            trigger: '.ui-menu-item > a:contains("Tajine Saucisse")',
+            run: "click",
+        },
+        {
+            trigger: 'a:contains("Add a product")',
+            run: "click",
+        },
+        {
+            trigger: 'div[name="product_template_id"] input',
+            run: "edit event (",
+        },
+        {
+            trigger: 'ul.ui-autocomplete a:contains("Registration Event (TEST variants)")',
+            run: "click",
+        },
+        {
+            trigger:
+                'tr:has(div[name="o_sale_product_configurator_name"]:contains("Memorabilia")) button:has(i.fa-plus)',
+            run: "click",
+        },
+        {
+            trigger: ".modal button:contains(Confirm)",
+            in_modal: false,
+            run: "click",
+        },
+        {
+            trigger: ".modal .o_input_dropdown input",
+            in_modal: false,
+            run: "edit Test",
+        },
+        {
+            trigger: '.modal div[name="event_id"] input',
+            in_modal: false,
+            run: "click",
+        },
+        {
+            trigger: '.modal ul.ui-autocomplete a:contains("TestEvent")',
+            in_modal: false,
+            run: "click",
+        },
+        {
+            trigger: '.modal div[name="event_ticket_id"] input',
+            in_modal: false,
+            run: "click",
+        },
+        {
+            trigger: '.modal ul.ui-autocomplete a:contains("Kid + meal")',
+            in_modal: false,
+            run: "click",
+        },
+        {
+            trigger: ".modal .o_event_sale_js_event_configurator_ok",
+            in_modal: false,
+            run: "click",
+        },
+        {
+            content: "Wait the modal is closed",
+            trigger: "body:not(:has(.modal))",
+        },
+        {
+            trigger: 'td[name="price_subtotal"]:contains("16.50")', // wait for the optional product line
+        },
+        {
+            trigger: 'a:contains("Add a product")',
+            run: "click",
+        },
+        {
+            trigger: ".o_data_row:nth-child(3)", // wait for the new row to be created
+        },
+        {
+            trigger: 'div[name="product_template_id"] input',
+            run: "edit event (",
+        },
+        {
+            trigger: 'ul.ui-autocomplete a:contains("Registration Event (TEST variants)")',
+            run: "click",
+        },
+        {
+            trigger:
+                'tr:has(div[name="o_sale_product_configurator_name"]:contains("Registration Event (TEST variants)")) label:contains("Adult")',
+            run: "click",
+        },
+        {
+            trigger:
+                'tr:has(div[name="o_sale_product_configurator_name"]:contains("Registration Event (TEST variants)")) .o_sale_product_configurator_qty input',
+            run: "edit 5 && click body",
+        },
+        configuratorTourUtils.assertPriceTotal("150.00"),
+        {
+            trigger: ".modal button:contains(Confirm)",
+            in_modal: false,
+            run: "click",
+        },
+        {
+            trigger: ".modal .o_input_dropdown input",
+            in_modal: false,
+            run: "edit Test",
+        },
+        {
+            trigger: '.modal div[name="event_id"] input',
+            in_modal: false,
+            run: "click",
+        },
+        {
+            trigger: '.modal ul.ui-autocomplete a:contains("TestEvent")',
+            in_modal: false,
+            run: "click",
+        },
+        {
+            trigger: '.modal div[name="event_ticket_id"] input',
+            in_modal: false,
+            run: "click",
+        },
+        {
+            trigger: '.modal ul.ui-autocomplete a:contains("Adult")',
+            in_modal: false,
+            run: "click",
+        },
+        {
+            trigger: ".modal .o_event_sale_js_event_configurator_ok",
+            in_modal: false,
+            run: "click",
+        },
+        {
+            content: "Wait the modal is closed",
+            trigger: "body:not(:has(.modal))",
+        },
+        {
+            trigger: 'td[name="price_subtotal"]:contains("150.00")', // wait for the adult tickets line
+        },
+        {
+            trigger: 'a:contains("Add a product")',
+            run: "click",
+        },
+        {
+            trigger: ".o_data_row:nth-child(4)", // wait for the new row to be created
+        },
+        {
+            trigger: 'div[name="product_template_id"] input',
+            run: "edit event (",
+        },
+        {
+            trigger: 'ul.ui-autocomplete a:contains("Registration Event (TEST variants)")',
+            run: "click",
+        },
+        {
+            trigger:
+                'tr:has(div[name="o_sale_product_configurator_name"]:contains("Registration Event (TEST variants)")) label:contains("VIP")',
+            run: "click",
+        },
+        configuratorTourUtils.assertPriceTotal(60.0),
+        {
+            trigger: ".modal button:contains(Confirm)",
+            in_modal: false,
+            run: "click",
+        },
+        {
+            trigger: ".modal .o_input_dropdown input",
+            in_modal: false,
+            run: "edit Test",
+        },
+        {
+            trigger: '.modal div[name="event_id"] input',
+            in_modal: false,
+            run: "click",
+        },
+        {
+            trigger: '.modal ul.ui-autocomplete a:contains("TestEvent")',
+            in_modal: false,
+            run: "click",
+        },
+        {
+            trigger: '.modal div[name="event_ticket_id"] input',
+            in_modal: false,
+            run: "click",
+        },
+        {
+            trigger: '.modal ul.ui-autocomplete a:contains("VIP")',
+            in_modal: false,
+            run: "click",
+        },
+        {
+            trigger: ".modal .o_event_sale_js_event_configurator_ok",
+            in_modal: false,
+            run: "click",
+        },
+        {
+            content: "Wait the modal is closed",
+            trigger: "body:not(:has(.modal))",
+        },
+        {
+            trigger: '.o_field_cell.o_data_cell.o_list_number:contains("60.00")',
+        },
+        ...stepUtils.saveForm(),
+    ],
+});

--- a/addons/test_sale_product_configurators/static/tests/tours/product_attribute_with_multi_type.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_attribute_with_multi_type.js
@@ -44,7 +44,8 @@ registry.category("web_tour.tours").add("product_attribute_multi_type", {
         run: "click",
     }, {
         content: "Click on Confirm",
-        trigger: 'button:contains(Confirm)',
+        trigger: ".modal button:contains(Confirm)",
+        in_modal: false,
         run: "click",
     }, ...stepUtils.saveForm()
 ]});

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_advanced_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_advanced_ui.js
@@ -63,7 +63,8 @@ registry.category("web_tour.tours").add('sale_product_configurator_advanced_tour
         }
     }
 }, {
-    trigger: 'button:contains(Confirm)',
+    trigger: '.modal button:contains(Confirm)',
+    in_modal: false,
     run: "click",
 }, {
     trigger: 'td.o_data_cell:contains("Customizable Desk (TEST) (Custom, White, PAV9, PAV5, PAV1)"):not(:contains("PA9: Single PAV"))',

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_custom_value_update_tour.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_custom_value_update_tour.js
@@ -37,7 +37,8 @@ registry.category("web_tour.tours").add('sale_product_configurator_custom_value_
 ...configuratorTourUtils.selectAndSetCustomAttribute("Customizable Desk (TEST)", "Legs", "Custom", "123"),
 configuratorTourUtils.assertProductNameContains("Customizable Desk (TEST) (Custom, White)"),
 {
-    trigger: 'button:contains(Confirm)',
+    trigger: ".modal button:contains(Confirm)",
+    in_modal: false,
     run: "click",
 }, {
     trigger: 'td.o_data_cell:contains("Legs: Custom: 123")',
@@ -59,7 +60,8 @@ configuratorTourUtils.assertProductNameContains("Customizable Desk (TEST) (Custo
 },
 configuratorTourUtils.setCustomAttribute("Customizable Desk (TEST)", "Legs", "123456"),
 {
-    trigger: 'button:contains(Confirm)',
+    trigger: ".modal button:contains(Confirm)",
+    in_modal: false,
     run: "click",
 }, {
     trigger: 'td.o_data_cell:contains("Legs: Custom: 123456")',

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_edition_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_edition_ui.js
@@ -40,7 +40,8 @@ registry.category("web_tour.tours").add('sale_product_configurator_edition_tour'
 }, {
     trigger: 'tr:has(div[name="o_sale_product_configurator_name"]:contains("Customizable Desk (TEST) (Aluminium, White)"))',
 }, {
-    trigger: 'button:contains(Confirm)',
+    trigger: ".modal button:contains(Confirm)",
+    in_modal: false,
     run: "click",
 }, 
 {
@@ -74,7 +75,8 @@ registry.category("web_tour.tours").add('sale_product_configurator_edition_tour'
     // used to sync with server
     trigger: 'div[name="o_sale_product_configurator_name"]:contains("Customizable Desk (TEST) (Custom, Black)")',
 }, {
-    trigger: 'button:contains(Confirm)',
+    trigger: ".modal button:contains(Confirm)",
+    in_modal: false,
     run: "click",
 }, 
 {
@@ -99,7 +101,8 @@ registry.category("web_tour.tours").add('sale_product_configurator_edition_tour'
 },
     configuratorTourUtils.setCustomAttribute("Customizable Desk", "Legs", "another nice custom value"),
 {
-    trigger: 'button:contains(Confirm)',
+    trigger: ".modal button:contains(Confirm)",
+    in_modal: false,
     run: "click",
 }, 
 {
@@ -123,7 +126,8 @@ registry.category("web_tour.tours").add('sale_product_configurator_edition_tour'
     // Mr Tajine Saucisse uses the pricelist that has a rule when 2 or more products. Price is 600
     configuratorTourUtils.assertPriceTotal("1,200.00"),
 {
-    trigger: 'button:contains(Confirm)',
+    trigger: ".modal button:contains(Confirm)",
+    in_modal: false,
     run: "click",
 }, {
     // check quantity

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_optional_products_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_optional_products_ui.js
@@ -51,7 +51,8 @@ registry.category("web_tour.tours").add('sale_product_configurator_optional_prod
     trigger: 'tr:has(div[name="o_sale_product_configurator_name"]:contains("Conference Chair")) button:has(i.fa-plus)',
     run: "click",
 }, {
-    trigger: 'button:contains(Confirm)',
+    trigger: ".modal button:contains(Confirm)",
+    in_modal: false,
     run: "click",
 }, 
 {

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_pricelist_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_pricelist_ui.js
@@ -74,7 +74,8 @@ stepUtils.showAppsMenuItem(),
     configuratorTourUtils.assertPriceTotal("1,257.00"),
 {
     content: "add to SO",
-    trigger: 'button:contains(Confirm)',
+    trigger: ".modal button:contains(Confirm)",
+    in_modal: false,
     run: "click",
 }, {
     content: "verify SO final price excluded",

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_single_custom_attribute_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_single_custom_attribute_ui.js
@@ -30,7 +30,8 @@ registry.category("web_tour.tours").add('sale_product_configurator_single_custom
 },
     configuratorTourUtils.setCustomAttribute("Customizable Desk (TEST)", "product attribute", "great single custom value"),
 {
-    trigger: 'button:contains(Confirm)',
+    trigger: ".modal button:contains(Confirm)",
+    in_modal: false,
     run: "click",
 },
 {

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_ui.js
@@ -66,7 +66,8 @@ registry.category("web_tour.tours").add('sale_product_configurator_tour', {
     configuratorTourUtils.addOptionalProduct("Conference Chair"),
     configuratorTourUtils.addOptionalProduct("Chair floor protection"),
 {
-    trigger: 'button:contains(Confirm)',
+    trigger: ".modal button:contains(Confirm)",
+    in_modal: false,
     id: 'quotation_product_selected',
     run: "click",
 },

--- a/addons/test_sale_product_configurators/static/tests/tours/product_matrix_tour.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_matrix_tour.js
@@ -48,13 +48,15 @@ registry.category("web_tour.tours").add('sale_matrix_tour', {
     trigger: 'ul.ui-autocomplete a:contains("Matrix")',
     run: "click",
 }, {
-    trigger: '.o_matrix_input_table',
+    trigger: ".modal .o_matrix_input_table",
+    in_modal: false,
     run: function () {
         // fill the whole matrix with 1's
         [...document.querySelectorAll(".o_matrix_input")].forEach((el) => (el.value = 1));
     }
 }, {
-    trigger: 'button:contains("Confirm")',
+    trigger: ".modal button:contains(Confirm)",
+    in_modal: false,
     run: "click",
 }, 
 {
@@ -75,7 +77,8 @@ registry.category("web_tour.tours").add('sale_matrix_tour', {
     trigger: '[name=product_template_id] button.fa-pencil',  // edit the matrix
     run: "click",
 }, {
-    trigger: '.o_matrix_input_table',
+    trigger: ".modal .o_matrix_input_table",
+    in_modal: false,
     run: function () {
         // whitespace normalization: removes newlines around text from markup
         // content, then collapse & convert internal whitespace to regular
@@ -92,7 +95,8 @@ registry.category("web_tour.tours").add('sale_matrix_tour', {
         [...document.querySelectorAll(".o_matrix_input")].forEach((el) => (el.value = 3));
     }
 }, {
-    trigger: 'button:contains("Confirm")',  // apply the matrix
+    trigger: ".modal button:contains(Confirm)", // apply the matrix
+    in_modal: false,
     run: "click",
 }, 
 {
@@ -113,13 +117,15 @@ registry.category("web_tour.tours").add('sale_matrix_tour', {
     trigger: '[name=product_template_id] button.fa-pencil',  // edit the matrix
     run: "click",
 }, {
-    trigger: '.o_matrix_input_table',
+    trigger: ".modal .o_matrix_input_table",
+    in_modal: false,
     run: function () {
         // reset all qties to 1
         [...document.querySelectorAll(".o_matrix_input")].forEach((el) => (el.value = 1));
     }
 }, {
-    trigger: 'button:contains("Confirm")',  // apply the matrix
+    trigger: ".modal button:contains(Confirm)", // apply the matrix
+    in_modal: false,
     run: "click",
 }, 
 {
@@ -145,7 +151,8 @@ registry.category("web_tour.tours").add('sale_matrix_tour', {
     trigger: '[name=product_template_id] button.fa-pencil',  // edit the matrix
     run: "click",
 }, {
-    trigger: '.o_matrix_input_table',
+    trigger: ".modal .o_matrix_input_table",
+    in_modal: false,
     run: function () {
         // update some of the matrix values.
         [...document.querySelectorAll(".o_matrix_input")]
@@ -153,7 +160,8 @@ registry.category("web_tour.tours").add('sale_matrix_tour', {
             .forEach((el) => (el.value = 4));
     } // set the qty to 4 for half of the matrix products.
 }, {
-    trigger: 'button:contains("Confirm")',  // apply the matrix
+    trigger: ".modal button:contains(Confirm)", // apply the matrix
+    in_modal: false,
     run: "click",
 }, 
 {
@@ -185,7 +193,8 @@ registry.category("web_tour.tours").add('sale_matrix_tour', {
             .forEach((el) => (el.value = 8.2));
     }
 }, {
-    trigger: 'button:contains("Confirm")',  // apply the matrix
+    trigger: ".modal button:contains(Confirm)", // apply the matrix
+    in_modal: false,
     run: "click",
         },
         {

--- a/addons/website/static/tests/tours/edit_megamenu.js
+++ b/addons/website/static/tests/tours/edit_megamenu.js
@@ -45,7 +45,8 @@ wTourUtils.registerWebsitePreviewTour('edit_megamenu', {
     },
     {
         content: "Confirm the mega menu label",
-        trigger: '.modal-footer .btn-primary',
+        trigger: ".modal .modal-footer button:contains(ok)",
+        in_modal: false,
         run: "click",
     },
     {
@@ -53,8 +54,12 @@ wTourUtils.registerWebsitePreviewTour('edit_megamenu', {
     },
     {
         content: "Save the website menu with a new mega menu",
-        trigger: '.modal-footer .btn-primary',
+        trigger: ".modal .modal-footer button:contains(save)",
+        in_modal: false,
         run: "click",
+    },
+    {
+        trigger: "body:not(:has(.modal))",
     },
     {
         trigger: '#oe_snippets.o_loaded',
@@ -149,7 +154,8 @@ wTourUtils.registerWebsitePreviewTour('edit_megamenu_big_icons_subtitles', {
     },
     {
         content: "Confirm the mega menu label",
-        trigger: '.modal-footer .btn-primary',
+        trigger: ".modal .modal-footer .btn-primary:contains(ok)",
+        in_modal: false,
         run: "click",
     },
     {

--- a/addons/website/static/tests/tours/edit_menus.js
+++ b/addons/website/static/tests/tours/edit_menus.js
@@ -25,17 +25,20 @@ wTourUtils.registerWebsitePreviewTour('edit_menus', {
     },
     {
         content: "Trigger the link dialog (click 'Add Mega Menu Item')",
-        trigger: '.modal-body a:eq(1)',
+        trigger: '.modal:not(.o_inactive_modal) .modal-body a:eq(1)',
+        in_modal: false,
         run: "click",
     },
     {
         content: "Write a label for the new menu item",
-        trigger: '.modal-dialog .o_website_dialog input',
+        trigger: '.modal:not(.o_inactive_modal) .modal-dialog .o_website_dialog input',
+        in_modal: false,
         run: "edit Megaaaaa!",
     },
     {
         content: "Confirm the mega menu label",
-        trigger: '.modal-footer .btn-primary',
+        trigger: ".modal:not(.o_inactive_modal) .modal-footer .btn-primary:contains(ok)",
+        in_modal: false,
         run: "click",
     },
     {
@@ -75,34 +78,41 @@ wTourUtils.registerWebsitePreviewTour('edit_menus', {
         run: "click",
     },
     {
-        trigger: ".modal-dialog .o_website_dialog input:eq(0)",
+        trigger: ".modal:not(.o_inactive_modal) .modal-dialog .o_website_dialog input:eq(0)",
+        in_modal: false,
     },
     {
         content: "Confirm the new menu entry without a label",
-        trigger: '.modal-footer .btn-primary',
+        trigger: ".modal:not(.o_inactive_modal) .modal-footer .btn-primary:contains(ok)",
+        in_modal: false,
         run: "click",
     },
     {
         content: "It didn't save without a label. Fill label input.",
-        trigger: '.modal-dialog .o_website_dialog input:eq(0)',
+            trigger: ".modal:not(.o_inactive_modal) .modal-dialog .o_website_dialog input:eq(0)",
+        in_modal: false,
         run: "edit Random!",
     },
     {
         content: "Confirm the new menu entry without a url",
-        trigger: '.modal-footer .btn-primary',
+        trigger: ".modal:not(.o_inactive_modal) .modal-footer .btn-primary:contains(ok)",
+        in_modal: false,
         run: "click",
     },
     {
-        trigger: ".modal-dialog .o_website_dialog input.is-invalid",
+        trigger: ".modal:not(.o_inactive_modal) .modal-dialog .o_website_dialog input.is-invalid",
+        in_modal: false,
     },
     {
         content: "It didn't save without a url. Fill url input.",
-        trigger: '.modal-dialog .o_website_dialog input:eq(1)',
+        trigger: '.modal:not(.o_inactive_modal) .modal-dialog .o_website_dialog input:eq(1)',
+        in_modal: false,
         run: "edit #",
     },
     {
         content: "Confirm the new menu entry",
-        trigger: '.modal-footer .btn-primary',
+        trigger: ".modal:not(.o_inactive_modal) .modal-footer .btn-primary:contains(ok)",
+        in_modal: false,
         run: "click",
     },
     {
@@ -110,8 +120,12 @@ wTourUtils.registerWebsitePreviewTour('edit_menus', {
     },
     {
         content: "Save the website menu with the new entry",
-        trigger: '.modal-footer .btn-primary',
+        trigger: '.modal:not(.o_inactive_modal) .modal-footer .btn-primary',
+        in_modal: false,
         run: "click",
+    },
+    {
+        trigger: "body:not(:has(.modal))",
     },
     {
         trigger: "#oe_snippets.o_loaded",
@@ -175,12 +189,14 @@ wTourUtils.registerWebsitePreviewTour('edit_menus', {
     },
     {
         content: "Change the label",
-        trigger: '.modal-dialog .o_website_dialog input:eq(0)',
+        trigger: ".modal:not(.o_inactive_modal) .modal-dialog .o_website_dialog input:eq(0)",
+        in_modal: false,
         run: "edit Modnar !!",
     },
     {
         content: "Confirm the new menu label",
-        trigger: '.modal-footer .btn-primary',
+        trigger: ".modal:not(.o_inactive_modal) .modal-footer button:contains(ok)",
+        in_modal: false,
         run: "click",
     },
     {
@@ -188,7 +204,8 @@ wTourUtils.registerWebsitePreviewTour('edit_menus', {
     },
     {
         content: "Save the website menu with the new menu label",
-        trigger: '.modal-footer .btn-primary',
+        trigger: ".modal:not(.o_inactive_modal) .modal-footer button:contains(save)",
+        in_modal: false,
         run: "click",
     },
     // Drag a block to be able to scroll later.

--- a/addons/website/static/tests/tours/link_tools.js
+++ b/addons/website/static/tests/tours/link_tools.js
@@ -209,10 +209,16 @@ wTourUtils.registerWebsitePreviewTour('link_tools', {
     },
     {
         content: "Enter mega menu name",
-        trigger: ".modal-body input",
+        trigger: ".modal .modal-body input",
+        in_modal: false,
         run: "edit Mega",
     },
-    wTourUtils.clickOnElement("OK button", ".btn-primary"),
+    {
+        content: "Clicking on the OK button",
+        trigger: ".modal button:contains(ok)",
+        in_modal: false,
+        run: "click",
+    },
     {
         content: "Drag Mega at the top",
         trigger: '.oe_menu_editor li:contains("Mega") .fa-bars',
@@ -229,7 +235,12 @@ wTourUtils.registerWebsitePreviewTour('link_tools', {
         content: "Wait for drop",
         trigger: '.oe_menu_editor:first-child:contains("Mega")',
     },
-    wTourUtils.clickOnElement("Save button", ".btn-primary:contains('Save')"),
+    {
+        content: "Clicking on the OK button",
+        trigger: ".modal button:contains(Save)",
+        in_modal: false,
+        run: "click",
+    },
     wTourUtils.clickOnElement("mega menu", ":iframe header .o_mega_menu_toggle"),
     wTourUtils.changeOption("MegaMenuLayout", "we-toggler"),
     wTourUtils.changeOption("MegaMenuLayout", '[data-select-label="Cards"]'),

--- a/addons/website/static/tests/tours/rte.js
+++ b/addons/website/static/tests/tours/rte.js
@@ -65,7 +65,8 @@ wTourUtils.registerWebsitePreviewTour('rte_translator', {
     run: "click",
 }, {
     content: "insert file name",
-    trigger: '.modal-dialog input[type="text"]',
+    trigger: '.modal .modal-dialog .modal-body input[type="text"]',
+    in_modal: false,
     run: "edit rte_translator.xml",
 },
 {
@@ -73,7 +74,8 @@ wTourUtils.registerWebsitePreviewTour('rte_translator', {
 },
 {
     content: "create file",
-    trigger: '.modal-dialog button.btn-primary:contains(create)',
+    trigger: ".modal button.btn-primary:contains(create)",
+    in_modal: false,
     run: "click",
 }, {
     content: "click on the 'page manager' button",
@@ -97,7 +99,8 @@ wTourUtils.registerWebsitePreviewTour('rte_translator', {
     run: "click",
 }, {
     content: "insert page name",
-    trigger: '.modal-dialog input[type="text"]',
+    trigger: '.modal .modal-dialog .modal-body input[type="text"]',
+    in_modal: false,
     run: "edit rte_translator",
 },
 {
@@ -105,8 +108,12 @@ wTourUtils.registerWebsitePreviewTour('rte_translator', {
 },
 {
     content: "create page",
-    trigger: '.modal-dialog button.btn-primary',
+    trigger: ".modal button.btn-primary:contains(create)",
+    in_modal: false,
     run: "click",
+},
+{
+    trigger: "body:not(:has(.modal))",
 },
 ...wTourUtils.dragNDrop({
     id: "s_cover",

--- a/addons/website_event/static/tests/tours/tickets_questions.js
+++ b/addons/website_event/static/tests/tours/tickets_questions.js
@@ -55,7 +55,8 @@ registry.category("web_tour.tours").add('test_tickets_questions', {
     trigger: 'div.o_wevent_registration_question_global select[name*="0-simple_choice"]',
     run: "selectByLabel A friend",
 }, {
-    trigger: 'button[type=submit]',
+    trigger: ".modal#modal_attendees_registration:not(.o_inactive_modal) button[type=submit].btn-primary",
+    in_modal: false,
     run: 'click'
 }, {
     // The tour stops too early and the registration fails if we don't wait the confirmation.

--- a/addons/website_event_sale/static/tests/tours/website_event_sale.js
+++ b/addons/website_event_sale/static/tests/tours/website_event_sale.js
@@ -1,17 +1,17 @@
 /** @odoo-module **/
 
 import { registry } from "@web/core/registry";
-import wsTourUtils from '@website_sale/js/tours/tour_utils';
+import wsTourUtils from "@website_sale/js/tours/tour_utils";
 
-registry.category("web_tour.tours").add('event_buy_tickets', {
+registry.category("web_tour.tours").add("event_buy_tickets", {
     test: true,
-    url: '/event',
+    url: "/event",
     steps: () => [
         {
             content: "Go to the `Events` page",
             trigger: 'a[href*="/event"]:contains("Conference for Architects TEST"):first',
             run: "click",
-        }, 
+        },
         {
             content: "Open the register modal",
             trigger: 'button:contains("Register")',
@@ -22,53 +22,98 @@ registry.category("web_tour.tours").add('event_buy_tickets', {
         },
         {
             content: "Select 1 unit of `Standard` ticket type",
-            trigger: 'select:eq(0)',
+            trigger: ".modal select:eq(0)",
+            in_modal: false,
             run: "select 1",
         },
         {
-            trigger: "select:eq(0):has(option:contains(1):selected)",
+            trigger: ".modal select:eq(0):has(option:contains(1):selected)",
+            in_modal: false,
         },
         {
             content: "Select 2 units of `VIP` ticket type",
-            trigger: 'select:eq(1)',
+            trigger: ".modal select:eq(1)",
+            in_modal: false,
             run: "select 2",
         },
         {
-            trigger: "select:eq(1):has(option:contains(2):selected)",
+            trigger: ".modal select:eq(1):has(option:contains(2):selected)",
+            in_modal: false,
         },
         {
             content: "Click on `Order Now` button",
-            trigger: '.btn-primary:contains("Register")',
+            trigger: '.modal .btn-primary:contains("Register")',
+            in_modal: false,
             run: "click",
         },
         {
             content: "Fill attendees details",
             trigger: 'form[id="attendee_registration"] .btn[type=submit]',
-            run: function () {
-                document.querySelector("input[name*='1-email']").value = "att1@example.com";
-                document.querySelector("input[name*='1-phone']").value = "111 111";
-                document.querySelector("input[name*='2-name']").value = "Att2";
-                document.querySelector("input[name*='2-phone']").value = "222 222";
-                document.querySelector("input[name*='2-email']").value = "att2@example.com";
-                document.querySelector("input[name*='1-name']").value = "Att1";
-                document.querySelector("input[name*='3-name']").value = "Att3";
-                document.querySelector("input[name*='3-phone']").value = "333 333";
-                document.querySelector("input[name*='3-email']").value = "att3@example.com";
-            },
+        },
+        {
+            in_modal: false,
+            trigger: ".modal#modal_attendees_registration input[name*='1-email']",
+            run: "edit att1@example.com",
+        },
+        {
+            in_modal: false,
+            trigger: ".modal#modal_attendees_registration input[name*='1-phone']",
+            run: "edit 111 111",
+        },
+        {
+            in_modal: false,
+            trigger: ".modal#modal_attendees_registration input[name*='2-name']",
+            run: "edit Att2",
+        },
+        {
+            in_modal: false,
+            trigger: ".modal#modal_attendees_registration input[name*='2-phone']",
+            run: "edit 222 222",
+        },
+        {
+            in_modal: false,
+            trigger: ".modal#modal_attendees_registration input[name*='2-email']",
+            run: "edit att2@example.com",
+        },
+        {
+            in_modal: false,
+            trigger: ".modal#modal_attendees_registration input[name*='1-name']",
+            run: "edit Att1",
+        },
+        {
+            in_modal: false,
+            trigger: ".modal#modal_attendees_registration input[name*='3-name']",
+            run: "edit Att3",
+        },
+        {
+            in_modal: false,
+            trigger: ".modal#modal_attendees_registration input[name*='3-phone']",
+            run: "edit 333 333",
+        },
+        {
+            in_modal: false,
+            trigger: ".modal#modal_attendees_registration input[name*='3-email']",
+            run: "edit att3@example.com",
+        },
+        {
+            in_modal: false,
+            trigger:
+                ".modal#modal_attendees_registration input[name*='1-name'], .modal#modal_attendees_registration input[name*='2-name'], .modal#modal_attendees_registration input[name*='3-name']",
         },
         {
             trigger: "input[name*='1-name'], input[name*='2-name'], input[name*='3-name']",
         },
         {
+            in_modal: false,
             content: "Validate attendees details",
-            trigger: 'button[type=submit]',
+            trigger: ".modal#modal_attendees_registration button[type=submit]",
             run: "click",
         },
-        wsTourUtils.goToCart({quantity: 3}),
+        wsTourUtils.goToCart({ quantity: 3 }),
         wsTourUtils.goToCheckout(),
         ...wsTourUtils.assertCartAmounts({
-            untaxed: '4,000.00',
+            untaxed: "4,000.00",
         }),
         ...wsTourUtils.payWithTransfer(),
-    ]
+    ],
 });

--- a/addons/website_event_sale/static/tests/tours/website_event_sale_pricelists.js
+++ b/addons/website_event_sale/static/tests/tours/website_event_sale_pricelists.js
@@ -1,12 +1,12 @@
 /** @odoo-module **/
 
-    import { registry } from "@web/core/registry";
-    import { getPriceListChecksSteps } from "@website_event_sale/../tests/tours/helpers/WebsiteEventSaleTourMethods";
+import { registry } from "@web/core/registry";
+import { getPriceListChecksSteps } from "@website_event_sale/../tests/tours/helpers/WebsiteEventSaleTourMethods";
 
-    registry.category("web_tour.tours").add('event_sale_pricelists_different_currencies', {
-        test: true,
-        url: '/event',
-        steps: () => [
+registry.category("web_tour.tours").add("event_sale_pricelists_different_currencies", {
+    test: true,
+    url: "/event",
+    steps: () => [
         // Register for tickets
         {
             content: "Open the Pycon event",
@@ -20,25 +20,50 @@
         },
         {
             content: "Click on Register button inside modal",
-            trigger: 'div.modal-footer button:contains("Register")',
-            run: 'click'
+            trigger: '.modal .modal-footer button:contains("Register")',
+            run: "click",
+            in_modal: false,
         },
         {
-            content: "Fill attendees details",
-            trigger: 'form[id="attendee_registration"]',
-            run: function () {
-                document.querySelector("input[name*='1-name']").value = "Great Name";
-                document.querySelector("input[name*='1-phone']").value = "111 111";
-                document.querySelector("input[name*='1-email']").value = "great@name.com";
-            },
+            in_modal: false,
+            trigger:
+                '.modal#modal_attendees_registration:not(.o_inactive_modal) form[id="attendee_registration"]',
+        },
+        {
+            in_modal: false,
+            trigger:
+                ".modal#modal_attendees_registration:not(.o_inactive_modal) input[name*='1-name']",
+            run: "edit Great Name",
+        },
+        {
+            in_modal: false,
+            trigger:
+                ".modal#modal_attendees_registration:not(.o_inactive_modal) input[name*='1-phone']",
+            run: "edit 111 111",
+        },
+        {
+            in_modal: false,
+            trigger:
+                ".modal#modal_attendees_registration:not(.o_inactive_modal) input[name*='1-email']",
+            run: "edit great@name.com",
+        },
+        {
+            in_modal: false,
+            trigger:
+                ".modal#modal_attendees_registration input[name*='1-name'], .modal#modal_attendees_registration input[name*='2-name']",
         },
         {
             trigger: "input[name*='1-name'], input[name*='2-name']",
         },
         {
+            in_modal: false,
             content: "Validate attendees details",
-            trigger: 'button[type=submit]',
+            trigger:
+                ".modal#modal_attendees_registration:not(.o_inactive_modal) button[type=submit]",
             run: "click",
+        },
+        {
+            trigger: "body:not(:has(.modal#modal_attendees_registration))",
         },
         ...getPriceListChecksSteps({
             pricelistName: "EUR With Discount Included",
@@ -62,4 +87,5 @@
             price: "900.00",
             priceBeforeDiscount: "1,000.00",
         }),
-    ]});
+    ],
+});

--- a/addons/website_sale/static/tests/tours/website_sale_shop_mail.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_mail.js
@@ -40,22 +40,28 @@ registry.category("web_tour.tours").add('shop_mail', {
     },
     {
         content: "Open recipients dropdown",
-        trigger: '.o_field_many2many_tags_email[name=partner_ids] input',
+        trigger: ".modal .o_field_many2many_tags_email[name=partner_ids] input",
+        in_modal: false,
         run: 'click',
     },
     {
         content: "Select azure interior",
-        trigger: '.ui-menu-item a:contains(Interior24)',
+        trigger: ".modal .ui-menu-item a:contains(Interior24)",
         in_modal: false,
         run: "click",
     },
     {
-        trigger: '.o_badge_text:contains("Azure")',
+        trigger: '.modal .o_badge_text:contains("Azure")',
+        in_modal: false,
     },
     {
         content: "click Send email",
-        trigger: '.btn[name="action_send_mail"]',
+        trigger: '.modal .btn[name="action_send_mail"]',
+        in_modal: false,
         run: "click",
+    },
+    {
+        trigger: "body:not(:has(.modal))",
     },
     {
         content: "wait mail to be sent, and go see it",

--- a/addons/website_slides/static/tests/tours/slide_course_publisher_standard.js
+++ b/addons/website_slides/static/tests/tours/slide_course_publisher_standard.js
@@ -32,7 +32,6 @@ wTourUtils.registerWebsitePreviewTour('course_publisher_standard', {
 }, {
     content: 'eLearning: select Gardening tag',
     trigger: '.ui-autocomplete a:contains("Gardening")',
-    in_modal: false,
     run: "click",
 }, {
     content: 'eLearning: set description',
@@ -44,8 +43,12 @@ wTourUtils.registerWebsitePreviewTour('course_publisher_standard', {
     run: "click",
 }, {
     content: 'eLearning: seems cool, create it',
-    trigger: 'button:contains("Save")',
+    trigger: '.modal button:contains("Save")',
+    in_modal: false,
     run: "click",
+},
+{
+    trigger: "body:not(:has(.modal))",
 },
 ...wTourUtils.clickOnEditAndWaitEditMode(),
 {

--- a/addons/website_slides/static/tests/tours/slides_course_publisher.js
+++ b/addons/website_slides/static/tests/tours/slides_course_publisher.js
@@ -24,23 +24,23 @@ wTourUtils.registerWebsitePreviewTour('course_publisher', {
     run: "click",
 }, {
     content: 'eLearning: set name',
-    trigger: 'div[name="name"] input',
+    trigger: "modal:not(.o_inactive_modal) div[name=name] input",
+    in_modal: false,
     run: "edit How to Déboulonnate",
-    in_modal: true,
 }, {
     content: 'eLearning: click on tags',
-    trigger: '.o_field_many2many_tags input',
+    trigger: ".modal .o_field_many2many_tags input",
+    in_modal: false,
     run: "edit Gard",
-    in_modal: true,
 }, {
     content: 'eLearning: select gardener tag',
-    trigger: '.ui-autocomplete a:contains("Gardener")',
-    in_modal: true,
+    trigger: ".modal .ui-autocomplete a:contains(Gardener)",
+    in_modal: false,
     run: "click",
 }, {
     content: 'eLearning: set description',
-    trigger: '.o_field_html[name="description"]',
-    in_modal: true,
+    trigger: '.modal .o_field_html[name="description"]',
+    in_modal: false,
     run: "editor Déboulonnate is very common at Fleurus",
 }, {
     content: 'eLearning: we want reviews',
@@ -48,7 +48,8 @@ wTourUtils.registerWebsitePreviewTour('course_publisher', {
     run: "click",
 }, {
     content: 'eLearning: seems cool, create it',
-    trigger: 'button:contains("Save")',
+    trigger: ".modal button:contains(Save)",
+    in_modal: false,
     run: "click",
 },
 ...wTourUtils.clickOnEditAndWaitEditMode(),

--- a/odoo/addons/test_apikeys/static/tests/apikey_flow.js
+++ b/odoo/addons/test_apikeys/static/tests/apikey_flow.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { queryAll } from "@odoo/hoot-dom";
+import { queryAll, queryText } from "@odoo/hoot-dom";
 import { rpc } from "@web/core/network/rpc";
 import { registry } from "@web/core/registry";
 
@@ -25,39 +25,50 @@ registry.category("web_tour.tours").add('apikeys_tour_setup', {
     run: "click",
 }, {
     content: "Check that we have to enter enhanced security mode",
-    trigger: 'div:contains("enter your password")',
+    trigger: ".modal div:contains(enter your password)",
+    in_modal: false,
 }, {
     content: "Input password",
-    trigger: '[name=password] input',
-    run: "edit demo", // FIXME: better way to do this?
+    trigger: '.modal [name=password] input',
+    in_modal: false,
+    run: "edit demo",
 }, {
     content: "Confirm",
-    trigger: "button:contains(Confirm Password)",
+    trigger: ".modal button:contains(Confirm Password)",
+    in_modal: false,
     run: "click",
 }, {
     content: "Check that we're now on the key description dialog",
-    trigger: 'p:contains("Enter a description of and purpose for the key.")',
+    trigger: '.modal p:contains("Enter a description of and purpose for the key.")',
+    in_modal: false,
 }, {
     content: "Enter description",
-    trigger: '[name=name] input',
+    trigger: '.modal [name=name] input',
+    in_modal: false,
     run: "edit my key",
 }, {
     content: "Confirm key creation",
-    trigger: 'button:contains("Generate key")',
+    trigger: '.modal button:contains("Generate key")',
+    in_modal: false,
     run: "click",
 }, {
     content: "Check that we're on the last step & grab key",
-    trigger: 'p:contains("Here is your new API key")',
+    trigger: '.modal p:contains("Here is your new API key")',
+    in_modal: false,
     run: async () => {
-        const key = $('code [name=key] span').text();
+        const key = queryText("code [name=key] span");
         await rpc('/web/dataset/call_kw', {
             model: 'ir.logging', method: 'send_key',
             args: [key],
             kwargs: {},
         });
-        $('button:contains("Done")').click();
     }
-}, {
+}, 
+{
+    trigger: "button:contains(Done)",
+    run: "click",
+},
+{
     content: "check that our key is present (FIXME: requires HR to be installed)",
     trigger: '[name=api_key_ids] td:contains("my key")',
 }]});
@@ -83,13 +94,19 @@ registry.category("web_tour.tours").add('apikeys_tour_teardown', {
     run: 'click',
 }, {
     content: "Input password for security mode again",
-    trigger: '[name=password] input',
-    run: "edit demo", // FIXME: better way to do this?
+    trigger: ".modal [name=password] input",
+    in_modal: false,
+    run: "edit demo",
 }, {
     content: "And confirm",
-    trigger: 'button:contains(Confirm Password)',
+    trigger: ".modal button:contains(Confirm Password)",
+    in_modal: false,
     run: "click",
-}, {
+},
+{
+    trigger: "body:not(:has(.modal))",
+},
+{
     content: 'Re-open preferences again',
     trigger: '.o_user_menu .dropdown-toggle',
     run: "click",
@@ -105,7 +122,7 @@ registry.category("web_tour.tours").add('apikeys_tour_teardown', {
     trigger: '.o_notebook',
     run: function() {
         if (queryAll("[name=api_key_ids]:visible", { root: this.anchor }).length) {
-            throw new Error("Expected API keys to be hidden (because empty), but it's not");
+            console.error("Expected API keys to be hidden (because empty), but it's not");
         };
     }
 }]});

--- a/odoo/addons/test_new_api/static/tests/tours/x2many.js
+++ b/odoo/addons/test_new_api/static/tests/tours/x2many.js
@@ -38,15 +38,18 @@
     },
     {
         content: "insert a name into the modal form",
-        trigger: '.modal .o_field_widget[name=name] input',
+        trigger: ".modal .o_field_widget[name=name] input",
+        in_modal: false,
         run: `edit user_test_${(inc = new Date().getTime())}`,
     }, {
         content: "insert an email into the modal form",
-        trigger: '.o_field_widget[name=login] input',
+        trigger: ".modal .o_field_widget[name=login] input",
+        in_modal: false,
         run: `edit user_test_${inc}@test`,
     }, {
         content: "save the modal content and create the new moderator",
-        trigger: '.o_form_button_save',
+        trigger: ".modal .o_form_button_save",
+        in_modal: false,
         run: "click",
     }, {
         content: "check if the modal is saved",


### PR DESCRIPTION
In order to simplify the structure of a tour step, it was decided to remove the "in_modal" key. The purpose of this key is to search for the trigger in a modal element. But actually you just need to add ".modal" to the selector.
This functionality therefore really has little added value. That's why we're removing it.
In this commit, we prepare the ground to be able to remove this functionality by adding .modal to the selectors and forcing the fact of not looking in a modal (in_modal: false) otherwise that would be duplicative.

task~3974087

https://github.com/odoo/enterprise/pull/65949