### PR TITLE
[FIX] account: remove readonly constraint

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -858,7 +858,7 @@
                                      groups="account.group_account_readonly">
                                     <field name="journal_id"
                                            options="{'no_create': True}"
-                                           attrs="{'readonly': [('posted_before', '=', True)]}"/>
+                                           attrs="{'readonly': [('posted_before', '=', True), ('name', 'not in', (False, '', '/'))]}"/>
                                     <span class="oe_inline o_form_label mx-3 oe_read_only"
                                         groups="base.group_multi_currency"> in </span>
                                     <!-- Bigger margin on the left because in edit mode the external link button covers the text -->


### PR DESCRIPTION
This commit will remove the readonly constraint on the journal when an account move has been posted.

task: 4028973



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
