### PR TITLE
[FIX] point_of_sale: offline fetch stocks

### DIFF
--- a/addons/point_of_sale/static/src/app/components/product_info_banner/product_info_banner.js
+++ b/addons/point_of_sale/static/src/app/components/product_info_banner/product_info_banner.js
@@ -29,6 +29,9 @@ export class ProductInfoBanner extends Component {
                     let result = {};
                     if (!this.props.info) {
                         await this.fetchStock.call(this.props.product);
+                        if (this.fetchStock.status === "error") {
+                            throw this.fetchStock.result;
+                        }
                         result = this.fetchStock.result;
                     } else {
                         result = this.props.info;


### PR DESCRIPTION
When the POS is offline, the fetch stocks is not working properly. This commit fixes the issue by adding a condition to check if the method called to fetch the stocks returns an error or a succes so that no code trying to access the result is executed.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
