### PR TITLE
[FIX] web_editor : resolve traceback on popup snippet visibility toggle

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -733,7 +733,7 @@ var SnippetEditor = Widget.extend({
         var $element = this.$target.parent();
         while ($element.length) {
             var parentEditor = $element.data('snippet-editor');
-            if (parentEditor) {
+            if (parentEditor && parentEditor._customize$Elements) {
                 this._customize$Elements = this._customize$Elements
                     .concat(parentEditor._customize$Elements);
                 break;


### PR DESCRIPTION
Steps to reproduce traceback:
1.Drag and drop popup snippet (Top on all other snippet) 
2.Select the inside column and make it 'Hide on desktop' 
3.Drag any other snippet below popup and make it 'Hide on desktop' 
4.Save the changes.
5.Open editor and try to make popup visible.
You can see traceback of `cannnot read the properties of undefined data`.

Issue:
The error occurs because, in certain iterations, the widget returns an undefined value, which is stored in `this._customize$Elements`.

This PR will resolves the traceback by preventing undefined values from being inserted into `this._customize$Elements`.

task-4004873
