### PR TITLE
[IMP] payment: Smarter retrieval of outstanding account when duplicating provider

### DIFF
--- a/addons/payment/tests/test_payments.py
+++ b/addons/payment/tests/test_payments.py
@@ -158,14 +158,20 @@ class TestPayments(PaymentCommon):
             # Test changing the journal.
             copy_journal = journal.copy()
             acquirer.journal_id = copy_journal
+            payment_method_line = get_payment_method_line(acquirer)
             self.assertRecordValues(acquirer, [{'journal_id': copy_journal.id}])
-            self.assertRecordValues(get_payment_method_line(acquirer), [{'journal_id': copy_journal.id}])
+            self.assertRecordValues(payment_method_line, [{'journal_id': copy_journal.id}])
 
             # Test duplication of the acquirer.
+            payment_method_line.payment_account_id = self.env.company.account_journal_payment_debit_account_id
             copy_acquirer = self.acquirer.copy()
             self.assertRecordValues(copy_acquirer, [{'journal_id': False}])
             copy_acquirer.state = 'test'
             self.assertRecordValues(copy_acquirer, [{'journal_id': journal.id}])
+            self.assertRecordValues(get_payment_method_line(copy_acquirer), [{
+                'journal_id': journal.id,
+                'payment_account_id': payment_method_line.payment_account_id.id,
+            }])
 
             # We are able to have both on the same journal...
             with self.assertRaises(ValidationError):


### PR DESCRIPTION
When you duplicate a payment provider, a new payment method line is generated. However, in some configurations, people specifies custom outstanding accounts on payment method lines. When duplicating the payment provider, the outstanding account is not copied and then, at the end of the payment flow, the payment raises an error because an outstanding account is missing and the journal items can't be generated.

task_id: 4019380

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
