### PR TITLE
[FIX] account_edi: invisible condition

### DIFF
--- a/addons/account_edi/views/account_journal_views.xml
+++ b/addons/account_edi/views/account_journal_views.xml
@@ -7,7 +7,7 @@
             <field name="inherit_id" ref="account.view_account_journal_form" />
             <field name="arch" type="xml">
                 <xpath expr="//group[@name='group_edi_config']" position="attributes">
-                    <attribute name="invisible">0</attribute>
+                    <attribute name="invisible">not compatible_edi_ids</attribute>
                 </xpath>
                 <xpath expr="//group[@name='group_edi_config']" position="inside">
                     <field name="compatible_edi_ids" invisible="1" />


### PR DESCRIPTION
This commit will change the invisible condition on the group "group_edi_config" so that the group is not there if empty.

task: 4028343




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
