### PR TITLE
[IMP] point_of_sale: improve product info/attribute pop up UI

### DIFF
--- a/addons/point_of_sale/static/src/app/components/product_info_banner/product_info_banner.xml
+++ b/addons/point_of_sale/static/src/app/components/product_info_banner/product_info_banner.xml
@@ -7,14 +7,14 @@
                 <span class="h4" t-esc="props.product.name"/>
                 <span t-if="this.props.product.type !== 'service'" class="h4">
                     <span>On hand: </span>
-                    <span t-if="this.fetchStock.status === 'success' || this.props.info"><t t-esc="this.state.available_quantity"/></span>
+                    <span t-if="this.fetchStock.status === 'success' || this.props.info"><t t-esc="this.state.available_quantity"/> Units</span>
                     <span t-elif="this.fetchStock.status === 'error'">N/A</span>
                     <i t-else="" class="fa fa-fw fa-spin fa-circle-o-notch" aria-hidden="true" />
                 </span>
             </div>
             <div t-att-class="{ 'align-items-end': !this.ui.isSmall }" class="d-flex flex-column">
                 <span class="h4"><t t-esc="this.env.utils.formatCurrency(state.price_with_tax)"/></span>
-                <span class="h4">VAT: <t t-esc="state.tax_name || 0" /> | VAT: <t t-esc="this.env.utils.formatCurrency(state.tax_amount)" /></span>
+                <span class="h4">VAT: <t t-esc="state.tax_name || 0" /> (= <t t-esc="this.env.utils.formatCurrency(state.tax_amount)" />)</span>
             </div>
         </div>
     </t>

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_info_popup/product_info_popup.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_info_popup/product_info_popup.xml
@@ -3,33 +3,6 @@
     <t t-name="point_of_sale.ProductInfoPopup">
         <Dialog title="'Product information'">
             <ProductInfoBanner product="props.product" info="props.info"/>
-            <div class="section-financials mt-3 mb-4 pb-4 border-bottom text-start">
-                <h3 class="section-title">Financials</h3>
-                <div class="section-financials-body d-flex flex-column flex-sm-row">
-                    <table class="table table-borderless mb-0">
-                        <tr>
-                            <td>Price excl. Tax:</td>
-                            <td><t t-esc="env.utils.formatCurrency(props.info.productInfo.all_prices.price_without_tax)"/></td>
-                        </tr>
-                        <tr t-if="_hasMarginsCostsAccessRights()">
-                            <td>Cost:</td>
-                            <td><t t-esc="props.info.costCurrency"/></td>
-                        </tr>
-                        <tr t-if="_hasMarginsCostsAccessRights()">
-                            <td>Margin:</td>
-                            <td><t t-esc="props.info.marginCurrency"/> (<t t-esc="props.info.marginPercent"/>%) </td>
-                        </tr>
-                    </table>
-                    <table class="table table-borderless">
-                        <t t-foreach="props.info.productInfo.pricelists" t-as="pricelist" t-key="pricelist.name">
-                            <tr>
-                                <td t-esc="pricelist.name"/>
-                                <td t-esc="env.utils.formatCurrency(pricelist.price)"/>
-                            </tr>
-                        </t>
-                    </table>
-                </div>
-            </div>
             <div class="section-inventory mt-3 mb-4 pb-4 border-bottom text-start" t-if="!isVariant and props.info.productInfo.warehouses.length > 0">
                 <h3 class="section-title">
                     Inventory
@@ -73,44 +46,52 @@
                     </t>
                 </div>
             </div>
-            <div class="extra mt-3 mb-4 pb-4 border-bottom text-start" t-if="props.info.productInfo.variants.length > 0">
-                <div class="section-variants">
-                    <h3 class="section-title">Attributes</h3>
-                    <div class="section-variants-body">
-                        <t t-foreach="props.info.productInfo.variants" t-as="variant" t-key="variant.name">
-                            <div class="d-flex flex-column align-items-start gap-2 mb-2">
-                                <div>
-                                    <span t-esc="variant.name" class="table-name"/>:
-                                </div>
-                                <div class="d-flex flex-wrap gap-1">
-                                    <t t-foreach="variant.values" t-as="attribute_value" t-key="attribute_value.name">
-                                        <span class="searchable btn btn-secondary" t-on-click="() => this.searchProduct(attribute_value.search)">
-                                            <t t-esc="attribute_value.name"/>
-                                        </span>
-                                    </t>
-                                </div>
-                            </div>
-                        </t>
+            <div class="financials-order d-grid gap-2 mt-3" style="grid-template-columns: repeat(2, 1fr);">
+                <div class="section-financials text-start">
+                    <h3 class="section-title">Financials</h3>
+                    <div class="section-financials-body d-flex flex-column">
+                        <table class="table table-borderless mb-0">
+                            <tr>
+                                <td>Price excl. Tax:</td>
+                                <td><t t-esc="env.utils.formatCurrency(props.info.productInfo.all_prices.price_without_tax)"/></td>
+                            </tr>
+                            <tr t-if="_hasMarginsCostsAccessRights()">
+                                <td>Cost:</td>
+                                <td><t t-esc="props.info.costCurrency"/></td>
+                            </tr>
+                            <tr t-if="_hasMarginsCostsAccessRights()">
+                                <td>Margin:</td>
+                                <td><t t-esc="props.info.marginCurrency"/> (<t t-esc="props.info.marginPercent"/>%) </td>
+                            </tr>
+                        </table>
+                        <table class="table table-borderless">
+                            <t t-foreach="props.info.productInfo.pricelists" t-as="pricelist" t-key="pricelist.name">
+                                <tr>
+                                    <td t-esc="pricelist.name"/>
+                                    <td t-esc="env.utils.formatCurrency(pricelist.price)"/>
+                                </tr>
+                            </t>
+                        </table>
                     </div>
                 </div>
-            </div>
-            <div class="section-order mt-3 mb-4 pb-4 border-bottom text-start">
-                <h3 class="section-title">Order</h3>
-                <div class="section-order-body">
-                    <table class="table table-borderless w-100 w-sm-50 mb-0">
-                        <tr>
-                            <td>Total Price excl. Tax:</td>
-                            <td t-esc="props.info.orderPriceWithoutTaxCurrency" class="table-value"/>
-                        </tr>
-                        <tr t-if="_hasMarginsCostsAccessRights()">
-                            <td>Total Cost:</td>
-                            <td t-esc="props.info.orderCostCurrency" class="table-value"/>
-                        </tr>
-                        <tr t-if="_hasMarginsCostsAccessRights()">
-                            <td>Total Margin:</td>
-                            <td class="table-value"><t t-esc="props.info.orderMarginCurrency"/> (<t t-esc="props.info.orderMarginPercent"/>%)</td>
-                        </tr>
-                    </table>
+                <div class="section-order text-start">
+                    <h3 class="section-title">Order</h3>
+                    <div class="section-order-body">
+                        <table class="table table-borderless w-100 mb-0">
+                            <tr>
+                                <td>Total Price excl. Tax:</td>
+                                <td t-esc="props.info.orderPriceWithoutTaxCurrency" class="table-value"/>
+                            </tr>
+                            <tr t-if="_hasMarginsCostsAccessRights()">
+                                <td>Total Cost:</td>
+                                <td t-esc="props.info.orderCostCurrency" class="table-value"/>
+                            </tr>
+                            <tr t-if="_hasMarginsCostsAccessRights()">
+                                <td>Total Margin:</td>
+                                <td class="table-value"><t t-esc="props.info.orderMarginCurrency"/> (<t t-esc="props.info.orderMarginPercent"/>%)</td>
+                            </tr>
+                        </table>
+                    </div>
                 </div>
             </div>
             <t t-set-slot="footer">

--- a/addons/point_of_sale/static/src/app/store/product_configurator_popup/product_configurator_popup.xml
+++ b/addons/point_of_sale/static/src/app/store/product_configurator_popup/product_configurator_popup.xml
@@ -121,7 +121,6 @@
 
     <t t-name="point_of_sale.ProductConfiguratorPopup">
         <Dialog title="'Attribute selection'">
-            <ProductInfoBanner product="this.state.product" />
             <div t-ref="input-area">
                 <div t-foreach="this.props.product.attribute_line_ids" t-as="attributeLine" t-key="attributeLine.id" class="attribute mb-3">
                     <div class="attribute_name mb-2 fw-bolder" t-esc="attributeLine.attribute_id.name"/>

--- a/addons/pos_sale/static/src/overrides/components/product_info_popup/product_info_popup.xml
+++ b/addons/pos_sale/static/src/overrides/components/product_info_popup/product_info_popup.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="pos_sale.ProductInfoPopup" t-inherit="point_of_sale.ProductInfoPopup" t-inherit-mode="extension">
-        <xpath expr="//div[hasclass('extra')]" position="after">
+        <xpath expr="//div[hasclass('financials-order')]" position="before">
             <div class="section-optional-product mt-3 mb-4 pb-4 border-bottom text-start" t-if="props.info.productInfo.optional_products.length > 0">
                 <h3 class="section-title">Optional Products:</h3>
                 <div class="section-optional-product-body" t-foreach="props.info.productInfo.optional_products" t-as="optional" t-key="optional.name">

--- a/addons/pos_self_order/static/src/overrides/components/product_info_banner/product_info_banner.xml
+++ b/addons/pos_self_order/static/src/overrides/components/product_info_banner/product_info_banner.xml
@@ -2,9 +2,9 @@
 <templates id="template" xml:space="preserve">
     <t t-name="pos_self_order.ProductInfoBanner" t-inherit="point_of_sale.ProductInfoBanner" t-inherit-mode="extension">
         <xpath expr="//div[hasclass('section-product-info-title')]" position="after">
-            <div class="section-self-order-availability mt-3 mb-4 pb-4 border-bottom text-start">
-                <h3 class="section-title">Self-ordering availability:</h3>
-                <div class="section-self-order-availability-body">
+            <div class="section-self-order-availability mt-3 mb-4 pb-4 border-bottom text-start d-flex align-items-center">
+                <h3 class="section-title">Self-ordering:</h3>
+                <div class="section-self-order-availability-body d-flex ms-auto">
                     <div class="form-check form-switch">
                         <input class="form-check-input" type="checkbox" t-att-checked="props.product.self_order_available" t-on-click="() => this.switchSelfAvailability()" />
                     </div>


### PR DESCRIPTION
### UI Improvements:
- For the `Attribute selection` popup:
	- remove the **product info _(price / units / VAT)_** section
	- remove the **self-ordering availability** section

- For the `Product information` popup:
	- add **Units** to the right of the **on hand** quantity
	- reformat the **VAT**
	- reformat the **self-ordering availability** section
	- place the **Order** section next to the **Financial** section

task-4012437