### PR TITLE
[FIX] base: stdnum library timeout

### DIFF
--- a/addons/partner_autocomplete/models/res_partner.py
+++ b/addons/partner_autocomplete/models/res_partner.py
@@ -135,7 +135,7 @@ class ResPartner(models.Model):
         else:
             vies_result = None
             try:
-                vies_result = check_vies(vat)
+                vies_result = check_vies(vat, timeout=timeout)
             except Exception:
                 _logger.exception("Failed VIES VAT check.")
             if vies_result:


### PR DESCRIPTION
stdnum library incorrectly sets zeep Transport timeout, resulting in some requests hanging for 15 minutes. With this monkeypatch the timeout will be set correctly.
Zeep github issue: mvantellingen/python-zeep#140

opw-3980718

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
