### PR TITLE
[FIX] web_editor : set a nested invisible element to show on click

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -2736,7 +2736,7 @@ class SnippetsMenu extends Component {
                 return false;
             });
             // Insert an invisible snippet in its "parentEl" element.
-            const createInvisibleElement = async (invisibleSnippetEl, isRootParent, isDescendant) => {
+            const createInvisibleElement = async (invisibleSnippetEl, isRootParent, isDescendant, parents) => {
                 const editor = await this._createSnippetEditor($(invisibleSnippetEl), true);
                 return {
                     editor,
@@ -2747,6 +2747,7 @@ class SnippetsMenu extends Component {
                     invisibleSnippetEl,
                     isVisible: editor.isTargetVisible(),
                     children: [],
+                    parents: isDescendant ? parents : null,
                 };
             };
             // Insert all the invisible snippets contained in "snippetEls" as
@@ -2758,15 +2759,15 @@ class SnippetsMenu extends Component {
             //     └ descendantInvisibleSnippet
             //          └ descendantOfDescendantInvisibleSnippet
             //               └ etc...
-            const createInvisibleElements = (snippetEls, isDescendant) => {
+            const createInvisibleElements = (snippetEls, isDescendant, parents) => {
                 return Promise.all((snippetEls).map(async (snippetEl) => {
                     const descendantSnippetEls = descendantPerSnippet.get(snippetEl);
                     // An element is considered as "RootParent" if it has one or
                     // more invisible descendants but is not a descendant.
                     const invisibleElement = await createInvisibleElement(snippetEl,
-                        !isDescendant && !!descendantSnippetEls, isDescendant);
+                        !isDescendant && !!descendantSnippetEls, isDescendant, parents);
                     if (descendantSnippetEls) {
-                        invisibleElement.children = await createInvisibleElements(descendantSnippetEls, true);
+                        invisibleElement.children = await createInvisibleElements(descendantSnippetEls, true, invisibleElement);
                     }
                     return invisibleElement;
                 }));
@@ -4231,15 +4232,30 @@ class SnippetsMenu extends Component {
      * @param {Event} ev
      */
     async onInvisibleEntryClick(invisibleEntry) {
-        const $snippet = $(invisibleEntry.snippetEl);
-        const isVisible = await this._execWithLoadingEffect(async () => {
-            const editor = await this._createSnippetEditor($snippet, true);
-            const show = editor.toggleTargetVisibility();
-            this._disableUndroppableSnippets();
-            return show;
-        }, true);
-        invisibleEntry.isVisible = isVisible;
-        return this._activateSnippet(isVisible ? $snippet : false);
+        const toggleVisibility = async (snippetEl) => {
+            const isVisible = await this._execWithLoadingEffect(async () => {
+                const editor = await this._createSnippetEditor($(snippetEl));
+                const show = editor.toggleTargetVisibility();
+                this._disableUndroppableSnippets();
+                return show;
+            }, true);
+            invisibleEntry.isVisible = isVisible;
+            this._activateSnippet(isVisible ? $(snippetEl) : false);
+        };
+
+        // Toggle all its descendants to invisible (Hide)
+        if (invisibleEntry.isVisible) {
+            invisibleEntry.children.forEach((child) => {
+                if (child.isVisible) {
+                    this.onInvisibleEntryClick(child);
+                }
+            });
+        } else if (invisibleEntry.parents && !invisibleEntry.parents.isVisible) {
+            // Toggle all its parents to visible (show)
+            this.onInvisibleEntryClick(invisibleEntry.parents);
+        }
+
+        await toggleVisibility(invisibleEntry.snippetEl);
     }
     /**
      * @private

--- a/addons/website/static/tests/tours/snippet_visibility_option.js
+++ b/addons/website/static/tests/tours/snippet_visibility_option.js
@@ -1,0 +1,113 @@
+import wTourUtils from "@website/js/tours/tour_utils";
+
+wTourUtils.registerWebsitePreviewTour("snippet_visibility_option", {
+    test: true,
+    url: "/",
+    edition: true,
+}, () => [
+    ...wTourUtils.dragNDrop({
+        id: "s_popup",
+        name: "Popup",
+    }),
+    {
+        content: "Click on the column within the popup snippet.",
+        trigger: ":iframe #wrap .s_popup .o_cc1",
+        run: "click"
+    },
+    {
+        content: "Click the 'No Desktop' visibility option.",
+        trigger: ".snippet-option-DeviceVisibility we-button[data-toggle-device-visibility='no_desktop']",
+        run: "click"
+    },
+    {
+        content: "Click on the banner within the popup snippet.",
+        trigger: ":iframe #wrap .s_popup .s_banner",
+        run: "click"
+    },
+    {
+        content: "Click the 'No Desktop' visibility option.",
+        trigger: "we-button[data-toggle-device-visibility='no_desktop']",
+        run: "click"
+    },
+    {
+        content: "Click on the popup snippet to hide",
+        trigger: ".o_we_invisible_root_parent",
+        run: "click"
+    },
+    {
+        content: "Click on the popup snippet in the list of invisible elements.",
+        trigger: ".o_we_invisible_root_parent",
+        run: "click"
+    },
+    {
+        content: "Verify that both the banner and column are marked as invisible.",
+        trigger: ".o_we_invisible_root_parent",
+        run: () => {
+            const isBlockInvisible = document.querySelector("li .o_we_invisible_entry i").classList.contains("fa-eye-slash");
+            const isColumnInvisible = document.querySelector("li li .o_we_invisible_entry i").classList.contains("fa-eye-slash");
+            if (!isBlockInvisible || !isColumnInvisible) {
+                console.error("Visibility issue detected with the elements.");
+            }
+        }
+    },
+    ...wTourUtils.clickOnSave(),
+    ...wTourUtils.clickOnEditAndWaitEditMode(),
+    {
+        content: "Click on the banner snippet in the list of invisible elements.",
+        trigger: "li > .o_we_invisible_entry",
+        run: "click"
+    },
+    {
+        content: "Verify that the popup is visible and the column is still invisible.",
+        trigger: "li > .o_we_invisible_entry",
+        run: () => {
+            const isPopupVisible = document.querySelector(".o_we_invisible_root_parent i").classList.contains("fa-eye");
+            const isColumnInvisible = document.querySelector("li li .o_we_invisible_entry i").classList.contains("fa-eye-slash");
+            if (!isPopupVisible || !isColumnInvisible) {
+                console.error("Visibility issue detected with the elements.");
+            }
+        }
+    },
+    ...wTourUtils.clickOnSave(),
+    ...wTourUtils.clickOnEditAndWaitEditMode(),
+    {
+        content: "Click on the column snippet in the list of invisible elements.",
+        trigger: "li li .o_we_invisible_entry",
+        run: "click"
+    },
+    {
+        content: "Verify that both the popup and the banner are now visible.",
+        trigger: ".o_we_invisible_root_parent",
+        run: () => {
+            const isPopupVisible = document.querySelector(".o_we_invisible_root_parent i").classList.contains("fa-eye");
+            const isBlockVisible = document.querySelector("li .o_we_invisible_entry i").classList.contains("fa-eye");
+            if (!isPopupVisible || !isBlockVisible) {
+                console.error("Visibility issue detected with the elements.");
+            }
+        }
+    },
+    {
+        content: "Click on the popup snippet to hide its descendant elements.",
+        trigger: ".o_we_invisible_root_parent",
+        run: () => {
+            setTimeout(() => {
+                document.querySelector(".o_we_invisible_root_parent").click();
+            }, 1000);
+        }
+    },
+    {
+        content: "Make sure the parent snippet is invisible.",
+        trigger: ".o_we_invisible_root_parent i.fa-eye-slash",
+    },
+    {
+        content: "Verify that both the banner and column snippets are marked as invisible.",
+        trigger: ".o_we_invisible_root_parent",
+        run: () => {
+            const isBlockInvisible = document.querySelector("li .o_we_invisible_entry i").classList.contains("fa-eye-slash");
+            const isColumnInvisible = document.querySelector("li li .o_we_invisible_entry i").classList.contains("fa-eye-slash");
+            if (!isColumnInvisible || !isBlockInvisible) {
+                console.error("Visibility issue detected with the elements.");
+            }
+        }
+    },
+]);

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -693,3 +693,6 @@ class TestUi(odoo.tests.HttpCase):
 
     def test_media_iframe_video(self):
         self.start_tour("/", "website_media_iframe_video", login="admin")
+
+    def test_snippet_visibility_option(self):
+        self.start_tour("/", "snippet_visibility_option", login="admin")


### PR DESCRIPTION
Steps to reproduce:
1.Drag & drop a popup
2.Click on its inner block
3.Set the visibility hidden on desktop
4.Save & enter edit mode (not really needed)
5. Click "Block" to show, popup remains hidden

Issue:
Nested elements do not toggle visibility correctly. Clicking "Block" fails to show the popup. Clicking the popup first, then the block, will make it visible.

Key changes:
Previously, only parent-child paths were stored, limiting navigation from parent to child. Now, paths from parent to children are connected and stored.

Solution:
Ensure clicking a child element makes itself and its parents visible. Conversely, clicking on a parent element should hide itself and all its children.

This PR aims to resolve the visibility toggle bug by creating proper parent-to-child connectivity. Clicking on an invisible element now toggles all its parents visible. Similarly, clicking on a visible element toggles all its descendants invisible.

task-3806730