### PR TITLE
[FIX] mail: do not populate whatsapp channel

### DIFF
--- a/addons/mail/populate/discuss/discuss_channel_member.py
+++ b/addons/mail/populate/discuss/discuss_channel_member.py
@@ -17,6 +17,7 @@ class ChannelMember(models.Model):
         res = super()._populate(size)
         random = populate.Random("discuss.channel.member")
         channels = self.env["discuss.channel"].browse(self.env.registry.populated_models["discuss.channel"])
+        channels = channels.filtered(lambda channel: channel.channel_type in ['channel', 'group', 'chat'])
         users = self.env["res.users"].browse(self.env.registry.populated_models["res.users"])
         users = users.filtered(lambda user: user.active)
         admin = self.env.ref("base.user_admin")

--- a/addons/mail/populate/discuss/mail_message.py
+++ b/addons/mail/populate/discuss/mail_message.py
@@ -20,6 +20,7 @@ class Message(models.Model):
         admin = self.env.ref("base.user_admin").partner_id
         random = populate.Random("mail.message in discuss")
         channels = self.env["discuss.channel"].browse(self.env.registry.populated_models["discuss.channel"])
+        channels = channels.filtered(lambda channel: channel.channel_type in ['channel', 'group', 'chat'])
         messages = []
         big_done = 0
         for channel in channels.filtered(lambda channel: channel.channel_member_ids):


### PR DESCRIPTION
**Current behavior before PR:**

When data is populated in the Discuss module, the messages are also being sent
to WhatsApp channels, and members are added to these channels.

**Desired behavior after PR is merged:**

After merging this PR, populating data in the Discuss module will no longer
result in messages being sent to any WhatsApp channels, and members will no
longer be added to these channels.

Task: 3984360



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
