### PR TITLE
[IMP] mrp,purchase,stock,sale: use never attributes

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -65,6 +65,18 @@ class MrpProduction(models.Model):
         compute='_compute_product_id', store=True, copy=True, precompute=True,
         readonly=False, required=True, check_company=True)
     product_variant_attributes = fields.Many2many('product.template.attribute.value', related='product_id.product_template_attribute_value_ids')
+    valid_product_template_attribute_line_ids = fields.Many2many(related='product_tmpl_id.valid_product_template_attribute_line_ids')
+    never_product_template_attribute_value_ids = fields.Many2many(
+        'product.template.attribute.value',
+        'template_attribute_value_mrp_production_rel',
+        'production_id', 'template_attribute_value_id',
+        domain="""[
+            '&',
+                ('attribute_line_id', 'in', valid_product_template_attribute_line_ids),
+                ('attribute_id.create_variant', '=', 'no_variant')]""",
+        string="Never attribute values",
+    )
+
     workcenter_id = fields.Many2one('mrp.workcenter', store=False)  # Only used for search in view_mrp_production_filter
     product_tracking = fields.Selection(related='product_id.tracking')
     product_tmpl_id = fields.Many2one('product.template', 'Product Template', related='product_id.product_tmpl_id')
@@ -368,7 +380,7 @@ class MrpProduction(models.Model):
             ):
                 production.product_id = bom.product_id or bom.product_tmpl_id.product_variant_id
 
-    @api.depends('product_id')
+    @api.depends('product_id', 'never_product_template_attribute_value_ids')
     def _compute_bom_id(self):
         mo_by_company_id = defaultdict(lambda: self.env['mrp.production'])
         for mo in self:
@@ -546,7 +558,8 @@ class MrpProduction(models.Model):
                 # keep manual entries
                 workorders_values = []
                 product_qty = production.product_uom_id._compute_quantity(production.product_qty, production.bom_id.product_uom_id)
-                exploded_boms, dummy = production.bom_id.explode(production.product_id, product_qty / production.bom_id.product_qty, picking_type=production.bom_id.picking_type_id)
+                exploded_boms, _dummy = production.bom_id.explode(production.product_id, product_qty / production.bom_id.product_qty, picking_type=production.bom_id.picking_type_id,
+                    never_attribute_values=production.never_product_template_attribute_value_ids)
 
                 for bom, bom_data in exploded_boms:
                     # If the operations of the parent BoM and phantom BoM are the same, don't recreate work orders.
@@ -698,7 +711,7 @@ class MrpProduction(models.Model):
                 date_finished = date_finished + relativedelta(minutes=workorder_expected_duration or 60)
             production.date_finished = date_finished
 
-    @api.depends('company_id', 'bom_id', 'product_id', 'product_qty', 'product_uom_id', 'location_src_id')
+    @api.depends('company_id', 'bom_id', 'product_id', 'product_qty', 'product_uom_id', 'location_src_id', 'never_product_template_attribute_value_ids')
     def _compute_move_raw_ids(self):
         for production in self:
             if production.state != 'draft' or self.env.context.get('skip_compute_move_raw_ids'):
@@ -706,7 +719,7 @@ class MrpProduction(models.Model):
             list_move_raw = [Command.link(move.id) for move in production.move_raw_ids.filtered(lambda m: not m.bom_line_id)]
             if not production.bom_id and not production._origin.product_id:
                 production.move_raw_ids = list_move_raw
-            if any(move.bom_line_id.bom_id != production.bom_id or move.bom_line_id._skip_bom_line(production.product_id)\
+            if any(move.bom_line_id.bom_id != production.bom_id or move.bom_line_id._skip_bom_line(production.product_id, production.never_product_template_attribute_value_ids)
                 for move in production.move_raw_ids if move.bom_line_id):
                 production.move_raw_ids = [Command.clear()]
             if production.bom_id and production.product_id and production.product_qty > 0:
@@ -797,7 +810,7 @@ class MrpProduction(models.Model):
                 return {'warning': {'title': _('Warning'), 'message': message}}
         return True
 
-    @api.onchange('product_id', 'move_raw_ids')
+    @api.onchange('product_id', 'move_raw_ids', 'never_product_template_attribute_value_ids')
     def _onchange_product_id(self):
         for move in self.move_raw_ids:
             if self.product_id == move.product_id:
@@ -1142,7 +1155,7 @@ class MrpProduction(models.Model):
             if not production.bom_id:
                 continue
             factor = production.product_uom_id._compute_quantity(production.product_qty, production.bom_id.product_uom_id) / production.bom_id.product_qty
-            boms, lines = production.bom_id.explode(production.product_id, factor, picking_type=production.bom_id.picking_type_id)
+            _boms, lines = production.bom_id.explode(production.product_id, factor, picking_type=production.bom_id.picking_type_id, never_attribute_values=production.never_product_template_attribute_value_ids)
             for bom_line, line_data in lines:
                 if bom_line.child_bom_id and bom_line.child_bom_id.type == 'phantom' or\
                         bom_line.product_id.type != 'consu':
@@ -1253,7 +1266,7 @@ class MrpProduction(models.Model):
             moves_in_first_operation = self.move_raw_ids.filtered(lambda move: move.operation_id == first_operation)
         moves_in_first_operation = moves_in_first_operation.filtered(
             lambda move: move.bom_line_id and
-            not move.bom_line_id._skip_bom_line(self.product_id)
+            not move.bom_line_id._skip_bom_line(self.product_id, self.never_product_template_attribute_value_ids)
         )
 
         if all(move.state == 'assigned' for move in moves_in_first_operation):

--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -224,14 +224,13 @@ class StockMove(models.Model):
         for bom in self.bom_line_id.bom_id:
             if bom.type != 'phantom':
                 continue
-            line_ids = bom.bom_line_ids.ids
+            line_ids = self.bom_line_id.filtered(lambda line: line.bom_id == bom).mapped('id')
             total = len(line_ids)
-            name = bom.display_name
             for i, line_id in enumerate(line_ids):
-                bom_line_description[line_id] = '%s - %d/%d' % (name, i+1, total)
+                bom_line_description[line_id] = '%s - %d/%d' % (bom.display_name, i + 1, total)
 
         for move in self:
-            move.description_bom_line = bom_line_description.get(move.bom_line_id.id)
+            move.description_bom_line = bom_line_description.get(move.bom_line_id.id, move.description_bom_line)
 
     @api.depends('raw_material_production_id.priority')
     def _compute_priority(self):

--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -472,7 +472,7 @@ class StockMove(models.Model):
                 factor = move.product_uom._compute_quantity(move.quantity, bom.product_uom_id) / bom.product_qty
             else:
                 factor = move.product_uom._compute_quantity(move.product_uom_qty, bom.product_uom_id) / bom.product_qty
-            boms, lines = bom.sudo().explode(move.product_id, factor, picking_type=bom.picking_type_id)
+            _dummy, lines = bom.sudo().explode(move.product_id, factor, picking_type=bom.picking_type_id, never_attribute_values=move.never_product_template_attribute_value_ids)
             for bom_line, line_data in lines:
                 if float_is_zero(move.product_uom_qty, precision_rounding=move.product_uom.rounding) or self.env.context.get('is_scrap'):
                     phantom_moves_vals_list += move._generate_move_phantom(bom_line, 0, line_data['qty'])

--- a/addons/mrp/models/stock_rule.py
+++ b/addons/mrp/models/stock_rule.py
@@ -161,6 +161,7 @@ class StockRule(models.Model):
             'origin': origin,
             'product_id': product_id.id,
             'product_description_variants': values.get('product_description_variants'),
+            'never_product_template_attribute_value_ids': values.get('never_product_template_attribute_value_ids'),
             'product_qty': product_uom._compute_quantity(product_qty, bom.product_uom_id) if bom else product_qty,
             'product_uom_id': bom.product_uom_id.id if bom else product_uom.id,
             'location_src_id': self.picking_type_id.default_location_src_id.id,
@@ -264,7 +265,7 @@ class ProcurementGroup(models.Model):
             if bom_kit:
                 order_qty = procurement.product_uom._compute_quantity(procurement.product_qty, bom_kit.product_uom_id, round=False)
                 qty_to_produce = (order_qty / bom_kit.product_qty)
-                boms, bom_sub_lines = bom_kit.explode(procurement.product_id, qty_to_produce)
+                _dummy, bom_sub_lines = bom_kit.explode(procurement.product_id, qty_to_produce, never_attribute_values=procurement.values.get("never_product_template_attribute_value_ids"))
                 for bom_line, bom_line_data in bom_sub_lines:
                     bom_line_uom = bom_line.product_uom_id
                     quant_uom = bom_line.product_id.uom_id

--- a/addons/mrp/tests/test_bom.py
+++ b/addons/mrp/tests/test_bom.py
@@ -2335,6 +2335,75 @@ class TestBoM(TestMrpCommon):
         self.assertEqual(bom.days_to_prepare_mo, 0.0)
         self.assertEqual((notification['type'], notification['tag']), ('ir.actions.client', 'display_notification'))
 
+    def test_bom_never_attribute(self):
+        # We create 4 bom lines, one without any attribute values, two with one value and one with two values
+        # Create a MO with, modify its never_product_template_attribute_value_ids and check if the moves created are correct
+
+        product_attribute_radio = self.env['product.attribute'].create({
+            'name': 'PA',
+            'display_type': 'radio',
+            'create_variant': 'no_variant',
+        })
+        product = self.env['product.product'].create({
+            'name': 'test1',
+        })
+        self.env['product.attribute.value'].create([{
+            'name': 'radio_PAV' + str(i),
+            'attribute_id': product_attribute_radio.id
+        } for i in range(3)])
+
+        tmpl_attr_line_radio = self.env['product.template.attribute.line'].create({
+            'attribute_id': product_attribute_radio.id,
+            'product_tmpl_id': self.product_1.product_tmpl_id.id,
+            'value_ids': [(6, 0, product_attribute_radio.value_ids.ids)],
+        })
+
+        self.env['mrp.bom'].create({
+            'product_tmpl_id': self.product_1.product_tmpl_id.id,
+            'product_uom_id': self.product_1.product_tmpl_id.uom_id.id,
+            'product_qty': 1.0,
+            'type': 'normal',
+            'bom_line_ids': [
+                Command.create({
+                    'product_id': self.product_2.id,
+                    'product_qty': 1,
+                }),
+                Command.create({
+                    'product_id': self.product_3.id,
+                    'product_qty': 2,
+                    'bom_product_template_attribute_value_ids': [Command.link(tmpl_attr_line_radio.product_template_value_ids[0].id)]
+                }),
+                Command.create({
+                    'product_id': product.id,
+                    'product_qty': 1,
+                    'bom_product_template_attribute_value_ids': [Command.link(tmpl_attr_line_radio.product_template_value_ids[1].id)]
+                }),
+                Command.create({
+                    'product_id': self.product_8.id,
+                    'product_qty': 10,
+                    'bom_product_template_attribute_value_ids': [Command.link(tmpl_attr_line_radio.product_template_value_ids[1].id), Command.link(tmpl_attr_line_radio.product_template_value_ids[2].id)]
+                }),
+            ]
+        })
+
+        mo_form = Form(self.env['mrp.production'])
+        mo_form.product_id = self.product_1
+        mo_order = mo_form.save()
+
+        # no never values, so only the first bom line should be used
+        self.assertEqual(len(mo_order.move_raw_ids), 1, "Only one move with no never_product_template_attribute_value_ids should be created")
+        self.assertEqual(mo_order.move_raw_ids.product_id, self.product_2)
+
+        # one never values, the two first bom line should match
+        mo_order.never_product_template_attribute_value_ids = tmpl_attr_line_radio.product_template_value_ids[0]
+        self.assertEqual(len(mo_order.move_raw_ids), 2)
+        self.assertEqual(mo_order.move_raw_ids.product_id, self.product_2 + self.product_3)
+
+        # two never values, the first and fourth bom line should match
+        mo_order.never_product_template_attribute_value_ids = tmpl_attr_line_radio.product_template_value_ids[1] + tmpl_attr_line_radio.product_template_value_ids[2]
+        self.assertEqual(len(mo_order.move_raw_ids), 3)
+        self.assertEqual(mo_order.move_raw_ids.product_id, self.product_2 + product + self.product_8)
+
 
 @tagged('-at_install', 'post_install')
 class TestTourBoM(HttpCase):

--- a/addons/point_of_sale/models/stock_picking.py
+++ b/addons/point_of_sale/models/stock_picking.py
@@ -84,6 +84,7 @@ class StockPicking(models.Model):
             'location_id': self.location_id.id,
             'location_dest_id': self.location_dest_id.id,
             'company_id': self.company_id.id,
+            'never_product_template_attribute_value_ids': first_line.attribute_value_ids.filtered(lambda a: a.attribute_id.create_variant == 'no_variant'),
         }
 
     def _create_move_from_pos_order_lines(self, lines):

--- a/addons/purchase/models/purchase_order_line.py
+++ b/addons/purchase/models/purchase_order_line.py
@@ -86,6 +86,8 @@ class PurchaseOrderLine(models.Model):
             "CHECK(display_type IS NULL OR (product_id IS NULL AND price_unit = 0 AND product_uom_qty = 0 AND product_uom IS NULL AND date_planned is NULL))",
             "Forbidden values on non-accountable purchase order line"),
     ]
+    product_template_attribute_value_ids = fields.Many2many(related='product_id.product_template_attribute_value_ids', readonly=True)
+    product_no_variant_attribute_value_ids = fields.Many2many('product.template.attribute.value', string='Product attribute values that do not create variants', ondelete='restrict')
 
     @api.depends('product_qty', 'price_unit', 'taxes_id', 'discount')
     def _compute_amount(self):

--- a/addons/purchase_stock/models/purchase_order_line.py
+++ b/addons/purchase_stock/models/purchase_order_line.py
@@ -327,6 +327,7 @@ class PurchaseOrderLine(models.Model):
         res['orderpoint_id'] = values.get('orderpoint_id', False) and values.get('orderpoint_id').id
         res['propagate_cancel'] = values.get('propagate_cancel')
         res['product_description_variants'] = values.get('product_description_variants')
+        res['product_no_variant_attribute_value_ids'] = values.get('never_product_template_attribute_value_ids')
         return res
 
     def _create_stock_moves(self, picking):

--- a/addons/sale_stock/models/sale_order_line.py
+++ b/addons/sale_stock/models/sale_order_line.py
@@ -270,6 +270,7 @@ class SaleOrderLine(models.Model):
             'company_id': self.order_id.company_id,
             'product_packaging_id': self.product_packaging_id,
             'sequence': self.sequence,
+            'never_product_template_attribute_value_ids': self.product_no_variant_attribute_value_ids,
         })
         return values
 

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -46,6 +46,12 @@ class StockMove(models.Model):
         'product.product', 'Product',
         check_company=True,
         domain="[('type', '=', 'consu')]", index=True, required=True)
+    never_product_template_attribute_value_ids = fields.Many2many(
+        'product.template.attribute.value',
+        'template_attribute_value_stock_move_rel',
+        'move_id', 'template_attribute_value_id',
+        string="Never attribute Values"
+    )
     description_picking = fields.Text('Description of Picking')
     product_qty = fields.Float(
         'Real Quantity', compute='_compute_product_qty', inverse='_set_product_qty',
@@ -1070,7 +1076,7 @@ Please change the quantity done or the rounding precision of your unit of measur
             'product_id', 'price_unit', 'procure_method', 'location_id', 'location_dest_id', 'location_final_id',
             'product_uom', 'restrict_partner_id', 'scrapped', 'origin_returned_move_id',
             'package_level_id', 'propagate_cancel', 'description_picking',
-            'product_packaging_id',
+            'product_packaging_id', 'never_product_template_attribute_value_ids',
         ]
         if self.env['ir.config_parameter'].sudo().get_param('stock.merge_only_same_date'):
             fields.append('date')
@@ -1543,6 +1549,7 @@ Please change the quantity done or the rounding precision of your unit of measur
             warehouse = self.rule_id.propagate_warehouse_id
         return {
             'product_description_variants': self.description_picking and self.description_picking.replace(product_id._get_description(self.picking_type_id), ''),
+            'never_product_template_attribute_value_ids': self.never_product_template_attribute_value_ids,
             'date_planned': dates_info.get('date_planned'),
             'date_order': dates_info.get('date_order'),
             'date_deadline': self.date_deadline,

--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -378,6 +378,7 @@ class StockRule(models.Model):
             'picking_type_id': self.picking_type_id.id,
             'group_id': group_id,
             'route_ids': [(4, route.id) for route in values.get('route_ids', [])],
+            'never_product_template_attribute_value_ids': values.get('never_product_template_attribute_value_ids'),
             'warehouse_id': self.warehouse_id.id,
             'date': date_scheduled,
             'date_deadline': False if self.group_propagation_option == 'fixed' else date_deadline,


### PR DESCRIPTION
Problem
--------------
As for now, it was not possible to differentiate products variants
with different attributes that did not create a variant.

Let's take a pizza as an example. The product template is a pizza,
with an attribute "type" with "margherita, veggie, bbq"
which create variants.

We also have another attribute "supplements" with values
"extra cheese" and "extra peperoni" that do not create variants.

Untill for now, it was not possible to differentiate stock moves with the same
pizza variant but with different values for the 'no_variants' attributes
(i.e. no difference between two pizza of same type with different supplements).

The same applies to purchases, but also to manufacturing orders.

Solution
------------
This pr adds the field never_product_template_attribute_value_ids to mrp_production, stock_move and purchase_order_lines.
BoM lines can now be applied on never attributes => the line applied on a never attribute can be added in MO, kits, etc. 

To do
-------
This commit addresses the technical part and thus the never attribute values
are not displayed on the different views.
Another commit/PR will take care of making it accessible for the user

task-id: 4017183
enterprise: https://github.com/odoo/enterprise/pull/65955

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
