### PR TITLE
[FIX] hw_drivers: Changed log encoding from ascii to utf-8

### DIFF
--- a/addons/hw_drivers/server_logger.py
+++ b/addons/hw_drivers/server_logger.py
@@ -65,7 +65,7 @@ class AsyncHTTPHandler(logging.Handler):
 
     def _flush_logs(self, odoo_session):
         def convert_to_byte(s):
-            return bytes(s, encoding="ascii") + b'<log/>\n'
+            return bytes(s, encoding="utf-8") + b'<log/>\n'
 
         def convert_server_line(log_level, line_formatted):
             return convert_to_byte(f"{log_level},{line_formatted}")


### PR DESCRIPTION
Before this commit, trying to log non-ascii characters from the IoT box would raise an error.
The case primarily happens when a user has devices in their system that are named with special characters (e.g Chinese characters for printer names, accented French names, etc).

After this commit, a device name containing non-ascii characters will be logged properly without triggering any tracebacks.

REASON: It's the option that incurs the least amount of changes in the codebase. Furthermore, alternative options would lead to lots of bespoke code to cover all cases.
The proposed change is also the one that offers the greatest flexibility: clients can freely use their native language to name their devices.

OPW-4001252