### PR TITLE
[IMP] point_of_sale: Enhance session closure with product-level journal entries

### DIFF
--- a/addons/l10n_in/views/account_invoice_views.xml
+++ b/addons/l10n_in/views/account_invoice_views.xml
@@ -46,6 +46,9 @@
             <xpath expr="//field[@name='invoice_line_ids']/tree//field[@name='product_id']" position="after">
                 <field name="l10n_in_hsn_code" optional="hide" column_invisible="parent.country_code != 'IN'"/>
             </xpath>
+            <xpath expr="//field[@name='line_ids']/tree//field[@name='name']" position="after">
+                <field name="l10n_in_hsn_code" optional="hide" column_invisible="parent.country_code != 'IN'"/>
+            </xpath>
         </field>
     </record>
 </odoo>

--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -192,6 +192,9 @@ class PosConfig(models.Model):
     show_category_images = fields.Boolean(string="Show Category Images", help="Show category images in the Point of Sale interface.", default=True)
     note_ids = fields.Many2many('pos.note', string='Note Models', help='The predefined notes of this point of sale.')
     module_pos_sms = fields.Boolean(string="SMS Enabled", help="Activate SMS feature for point_of_sale")
+    is_closing_entry_by_product = fields.Boolean(
+        string='Closing Entry by product',
+        help="Display the breakdown of sales lines by product in the automatically generated closing entry.")
 
     @api.model
     def _load_pos_data_domain(self, data):

--- a/addons/point_of_sale/models/res_config_settings.py
+++ b/addons/point_of_sale/models/res_config_settings.py
@@ -114,6 +114,7 @@ class ResConfigSettings(models.TransientModel):
     point_of_sale_ticket_portal_url_display_mode = fields.Selection(related='company_id.point_of_sale_ticket_portal_url_display_mode', readonly=False, required=True)
     pos_note_ids = fields.Many2many(related='pos_config_id.note_ids', readonly=False)
     pos_module_pos_sms = fields.Boolean(related="pos_config_id.module_pos_sms", readonly=False)
+    pos_is_closing_entry_by_product = fields.Boolean(related='pos_config_id.is_closing_entry_by_product', readonly=False)
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/point_of_sale/views/res_config_settings_views.xml
+++ b/addons/point_of_sale/views/res_config_settings_views.xml
@@ -211,6 +211,9 @@
                                     </div>
                                 </div>
                             </setting>
+                            <setting string="Closing Entry by product" id="pos_closeing_entry_by_product" help="Display the breakdown of sales lines by product in the automatically generated closing entry.">
+                                <field name="pos_is_closing_entry_by_product"/>
+                            </setting>
                         </block>
 
                         <block title="Pricing" id="pos_pricing_section">


### PR DESCRIPTION
Before this commit:
    - Closing a session created a single journal entry with the total sales.
After this commit:
    - Introduced a new configuration option, 'closing entry with product lines', in the point-of-sale module.
    - When enabled, the system generates a journal entry with one line per product upon session closure.
    
This change enhances the POS system's accuracy and granularity of financial reporting.
    
Task ID: 3359658
