### PR TITLE
[FIX] point_of_sale: search with system date format in paid orders

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -3,7 +3,7 @@
 import { Order } from "@point_of_sale/app/store/models";
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
-import { deserializeDateTime, formatDateTime } from "@web/core/l10n/dates";
+import { deserializeDateTime, formatDateTime, parseDateTime } from "@web/core/l10n/dates";
 import { parseFloat } from "@web/views/fields/parsers";
 import { _t } from "@web/core/l10n/translation";
 
@@ -691,6 +691,20 @@ export class TicketScreen extends Component {
                 repr: (order) => formatDateTime(order.date_order),
                 displayName: _t("Date"),
                 modelField: "date_order",
+                formatSearch: (searchTerm) => {
+                    const includesTime = searchTerm.includes(':');
+                    let parsedDateTime;
+                    try {
+                        parsedDateTime = parseDateTime(searchTerm);
+                    } catch {
+                        return searchTerm;
+                    }
+                    if (includesTime) {
+                        return parsedDateTime.toUTC().toFormat("yyyy-MM-dd HH:mm:ss");
+                    } else {
+                        return parsedDateTime.toFormat("yyyy-MM-dd");
+                    }
+                }
             },
             PARTNER: {
                 repr: (order) => order.get_partner_name(),
@@ -752,13 +766,16 @@ export class TicketScreen extends Component {
     }
     //#region SEARCH SYNCED ORDERS
     _computeSyncedOrdersDomain() {
-        const { fieldName, searchTerm } = this._state.ui.searchDetails;
+        let { fieldName, searchTerm } = this._state.ui.searchDetails;
         if (!searchTerm) {
             return [];
         }
-        const modelField = this._getSearchFields()[fieldName].modelField;
-        if (modelField) {
-            return [[modelField, "ilike", `%${searchTerm}%`]];
+        const searchField = this._getSearchFields()[fieldName];
+        if (searchField) {
+            if (searchField.formatSearch) {
+                searchTerm = searchField.formatSearch(searchTerm);
+            }
+            return [[searchField.modelField, "ilike", `%${searchTerm}%`]];
         } else {
             return [];
         }


### PR DESCRIPTION
Before this commit, searching for paid orders using the system's date format was not possible due to the lack of proper date parsing and formatting in the search fields.

opw-4008489

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
