### PR TITLE
[FIX] l10n_it_edi_doi: fix a country code check on SOs

### DIFF
--- a/addons/l10n_it_edi_doi/models/sale_order.py
+++ b/addons/l10n_it_edi_doi/models/sale_order.py
@@ -48,7 +48,7 @@ class SaleOrder(models.Model):
     def _compute_l10n_it_edi_doi_use(self):
         for order in self:
             order.l10n_it_edi_doi_use = order.l10n_it_edi_doi_id \
-                or "IT" in order.country_code
+                or order.country_code == "IT"
 
     @api.depends('company_id', 'partner_id.commercial_partner_id', 'l10n_it_edi_doi_date', 'currency_id')
     def _compute_l10n_it_edi_doi_id(self):


### PR DESCRIPTION
Currently a country code check on SOs may fail in case there is no country code.

After this commit the check will return `False` in case there is no country code.

(no task)

see e.g.: https://runbot.odoo.com/runbot/build/64900406