### PR TITLE
[IMP] sale_timesheet: update label for reporting of timesheets

### DIFF
--- a/addons/sale_timesheet/views/project_task_views.xml
+++ b/addons/sale_timesheet/views/project_task_views.xml
@@ -108,8 +108,8 @@
             </xpath>
             <xpath expr="//page[@name='settings']//field[@name='allow_billable']" position="after">
                 <div invisible="not allow_billable or not allow_timesheets" class="text-muted">
-                    Timesheets without a sales order item are
-                    <field name="billing_type" nolabel="1"/>
+                    Timesheets without a sales order item are reported as
+                    <field name="billing_type" nolabel="1" class="w-auto"/>
                 </div>
             </xpath>
         </field>


### PR DESCRIPTION
Update label to clarify field purpose: Changed from 'are billed manually or 
non-billable' to 'are reported as billed manually or non-billable'. This 
indicates that the option affects only how timesheets with empty sale order 
items appear in reports, not how they're invoiced.


task-4005182





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
