### PR TITLE
[FIX] pos_loyalty: prevent partial rewards to align with sale behavior

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/models/loyalty.js
+++ b/addons/pos_loyalty/static/src/overrides/models/loyalty.js
@@ -1303,9 +1303,11 @@ patch(Order.prototype, {
         }
         let maxDiscount = reward.discount_max_amount || Infinity;
         if (reward.discount_mode === "per_point") {
+            // Rewards cannot be partially offered to customers
+            const points = Math.floor(this._getRealCouponPoints(coupon_id) / reward.required_points) * reward.required_points;
             maxDiscount = Math.min(
                 maxDiscount,
-                reward.discount * this._getRealCouponPoints(coupon_id)
+                reward.discount * points
             );
         } else if (reward.discount_mode === "per_order") {
             maxDiscount = Math.min(maxDiscount, reward.discount);

--- a/addons/pos_loyalty/static/tests/tours/PosLoyaltyTour.js
+++ b/addons/pos_loyalty/static/tests/tours/PosLoyaltyTour.js
@@ -236,7 +236,7 @@ registry.category("web_tour.tours").add("PosLoyaltyTour6", {
             ProductScreen.clickDisplayedProduct("Test Product A"),
             PosLoyalty.clickRewardButton(),
             SelectionPopup.clickItem("$ 1 per point on your order"),
-            ProductScreen.totalAmountIs("138.50"),
+            ProductScreen.totalAmountIs("165.00"),
         ].flat(),
 });
 

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -1058,7 +1058,7 @@ class TestUi(TestPointOfSaleHttpCommon):
             })],
             'reward_ids': [(0, 0, {
                 'reward_type': 'discount',
-                'required_points': 1,
+                'required_points': 100,
                 'discount': 1,
                 'discount_mode': 'per_point',
             })],


### PR DESCRIPTION
Before this commit, the POS loyalty program allowed the partial rewards which was inconsistent with the sale module's behavior.

This change aligns the POS module with the sale module's behavior as updated in the following commit: https://github.com/odoo/odoo/commit/5188566444df102561b9d3e58f6671f60c61ffc3

opw-4000589

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
