### PR TITLE
[FIX] web: reorder all when not already sorted client-side

### DIFF
--- a/addons/web/static/src/views/relational_model.js
+++ b/addons/web/static/src/views/relational_model.js
@@ -1762,18 +1762,15 @@ class DynamicList extends DataPoint {
         const lastIndex = Math.max(fromIndex, toIndex) + 1;
         let reorderAll = records.some((record) => record.data[handleField] === undefined);
         if (!reorderAll) {
-            let lastSequence = (asc ? -1 : 1) * Infinity;
-            for (let index = 0; index < records.length; index++) {
-                const sequence = getSequence(records[index]);
-                if (
-                    ((index < firstIndex || index >= lastIndex) &&
-                        ((asc && lastSequence >= sequence) ||
-                            (!asc && lastSequence <= sequence))) ||
-                    (index >= firstIndex && index < lastIndex && lastSequence === sequence)
-                ) {
+            // if the list is not already ordered by sequence (strict), reorder all
+            const sequences = records.map(getSequence);
+            for (let i = 0; i < sequences.length - 1; i++) {
+                const seq1 = sequences[i];
+                const seq2 = sequences[i + 1];
+                if ((asc && seq1 >= seq2) || (!asc && seq1 <= seq2)) {
                     reorderAll = true;
+                    break;
                 }
-                lastSequence = sequence;
             }
         }
 


### PR DESCRIPTION
Problem
---
Sometimes resequencing items with the handle causes the order to get scrambled.

Steps
---
* create new odoo database with only stock installed (This may be
  unnecessary but the bug is a bit finicky to reproduce without a
  way to inspect sequence numbers directly)
* go to stock product attributes list view (view from the ticket)
* create a new attribute. its sequence is set to 0, it appears at the
  bottom of the list
* move it up a few (n) items. The items will get the sequences [0..n]
* **do the above exactly once, do not move to the top of the list**
* refresh
* =>the last items move to the top, crisscrossing with items which
  had the same sequence (ie the first n+1 ones)

Cause
---
in `_resequence` there is an optimization which attempts to figure out whether we need to reorder all the items or only the subset between the one we moved, and where we moved it to.  

This optimization makes the implicit assumption that the items are sorted by sequence in the view, however sometimes this doesn't hold because when the `sequence` field has no specified default, it may have NULL values in the db, which get converted to 0 js-side but will still be placed at the end by the query.

---
Check that the items in the view are actually sorted by sequence (with no duplicates), to decide if need to reorder all.
Replace the previous check which was something like:
* check if items are sorted before and after the interval that would be reordered
* check if there are sequential duplicates inside the interval.

---
opw-3937263
