### PR TITLE
[ADD] spreadsheet: introduce UPDATE_ODOO_LIST command

### DIFF
--- a/addons/spreadsheet/static/src/list/index.js
+++ b/addons/spreadsheet/static/src/list/index.js
@@ -24,10 +24,12 @@ coreTypes.add("RENAME_ODOO_LIST");
 coreTypes.add("REMOVE_ODOO_LIST");
 coreTypes.add("RE_INSERT_ODOO_LIST");
 coreTypes.add("UPDATE_ODOO_LIST_DOMAIN");
+coreTypes.add("UPDATE_ODOO_LIST");
 coreTypes.add("ADD_LIST_DOMAIN");
 coreTypes.add("DUPLICATE_ODOO_LIST");
 
 invalidateEvaluationCommands.add("UPDATE_ODOO_LIST_DOMAIN");
+invalidateEvaluationCommands.add("UPDATE_ODOO_LIST");
 invalidateEvaluationCommands.add("INSERT_ODOO_LIST");
 invalidateEvaluationCommands.add("REMOVE_ODOO_LIST");
 
@@ -51,6 +53,7 @@ cellMenuRegistry.add(
 inverseCommandRegistry
     .add("INSERT_ODOO_LIST", identity)
     .add("UPDATE_ODOO_LIST_DOMAIN", identity)
+    .add("UPDATE_ODOO_LIST", identity)
     .add("RE_INSERT_ODOO_LIST", identity)
     .add("RENAME_ODOO_LIST", identity)
     .add("REMOVE_ODOO_LIST", identity);

--- a/addons/spreadsheet/static/src/list/plugins/list_core_plugin.js
+++ b/addons/spreadsheet/static/src/list/plugins/list_core_plugin.js
@@ -87,6 +87,7 @@ export class ListCorePlugin extends OdooCorePlugin {
                     return CommandResult.EmptyName;
                 }
                 break;
+            case "UPDATE_ODOO_LIST":
             case "UPDATE_ODOO_LIST_DOMAIN":
                 if (!(cmd.listId in this.lists)) {
                     return CommandResult.ListIdNotFound;
@@ -147,6 +148,10 @@ export class ListCorePlugin extends OdooCorePlugin {
                     "domain",
                     cmd.domain
                 );
+                break;
+            }
+            case "UPDATE_ODOO_LIST": {
+                this.history.update("lists", cmd.listId, "definition", cmd.list);
                 break;
             }
             case "ADD_GLOBAL_FILTER":

--- a/addons/spreadsheet/static/src/list/plugins/list_ui_plugin.js
+++ b/addons/spreadsheet/static/src/list/plugins/list_ui_plugin.js
@@ -89,6 +89,7 @@ export class ListUIPlugin extends OdooUIPlugin {
             case "CLEAR_GLOBAL_FILTER_VALUE":
                 this._addDomains();
                 break;
+            case "UPDATE_ODOO_LIST":
             case "UPDATE_ODOO_LIST_DOMAIN": {
                 const listDefinition = this.getters.getListModelDefinition(cmd.listId);
                 const dataSourceId = this._getListDataSourceId(cmd.listId);
@@ -123,11 +124,13 @@ export class ListUIPlugin extends OdooUIPlugin {
                     this._addDomains();
                 }
 
-                const domainEditionCommands = cmd.commands.filter(
+                const updateCommands = cmd.commands.filter(
                     (cmd) =>
-                        cmd.type === "UPDATE_ODOO_LIST_DOMAIN" || cmd.type === "INSERT_ODOO_LIST"
+                        cmd.type === "UPDATE_ODOO_LIST_DOMAIN" ||
+                        cmd.type === "UPDATE_ODOO_LIST" ||
+                        cmd.type === "INSERT_ODOO_LIST"
                 );
-                for (const cmd of domainEditionCommands) {
+                for (const cmd of updateCommands) {
                     if (!this.getters.isExistingList(cmd.listId)) {
                         continue;
                     }


### PR DESCRIPTION
### [ADD] spreadsheet: introduce UPDATE_ODOO_LIST command

This commit introduces the `UPDATE_ODOO_LIST` command which updates the list definition of an odoo list. This command takes `listId` and `list` as arguments andupdates the list with `listId` as id with the new definition provided in the `list` argument.

Task: [3636092](https://www.odoo.com/odoo/project/2328/tasks/3636092)




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
