### PR TITLE
[FIX] web: prevent Firefox crash with iframe observer in macro

### DIFF
--- a/addons/web/static/src/core/macro.js
+++ b/addons/web/static/src/core/macro.js
@@ -192,11 +192,9 @@ export class MacroEngine {
     observeIframe(iframeEl, observer) {
         const observeIframeContent = () => {
             if (iframeEl.contentDocument) {
-                iframeEl.contentDocument.addEventListener("readystatechange", () => {
-                    if (iframeEl.contentDocument.readyState === "complete") {
-                        this.delayedCheck();
-                        observer.observe(iframeEl.contentDocument, this.observerOptions);
-                    }
+                iframeEl.contentDocument.addEventListener("load", (event) => {
+                    this.delayedCheck();
+                    observer.observe(event.target, this.observerOptions);
                 });
                 if (!iframeEl.src || iframeEl.contentDocument.readyState === "complete") {
                     this.delayedCheck();


### PR DESCRIPTION
__Current behavior before commit:__
On Firefox `iframeEl.contentDocument` might be `null` inside the `readystatechange` event handler. This makes the page crash with the error `TypeError: iframeEl.contentDocument is null`.

__Description of the fix:__
Utilizing `event.target` instead of `iframeEl.contentDocument` to make sure the document is not `null`.
Since nothing is done in the event handler unless
`document.readyState === "complete"` we can just use the `load` event instead.

__Steps to reproduce the issue on runbot:__
On Firefox (127):
1. Install `mass_mailing`
2. Open the debug menu > Start Tour
3. Start the `mass_mailing_tour`
4. Go to Email Marketing > open a mailing with the `Sent` state
5. Click on any link/tab (e.g. a/B Tests) -> Crash

opw-4005833
