### PR TITLE
[IMP] rating: make last rating value aggregate to an average

### DIFF
--- a/addons/rating/models/rating_mixin.py
+++ b/addons/rating/models/rating_mixin.py
@@ -13,7 +13,7 @@ class RatingMixin(models.AbstractModel):
     _description = "Rating Mixin"
     _inherit = 'mail.thread'
 
-    rating_last_value = fields.Float('Rating Last Value', groups='base.group_user', compute='_compute_rating_last_value', compute_sudo=True, store=True)
+    rating_last_value = fields.Float('Rating Last Value', groups='base.group_user', compute='_compute_rating_last_value', compute_sudo=True, store=True, aggregator="avg")
     rating_last_feedback = fields.Text('Rating Last Feedback', groups='base.group_user', related='rating_ids.feedback')
     rating_last_image = fields.Binary('Rating Last Image', groups='base.group_user', related='rating_ids.rating_image')
     rating_count = fields.Integer('Rating count', compute="_compute_rating_stats", compute_sudo=True)


### PR DESCRIPTION
This commit sets the aggregate method of the field rating_last_value to average, as it doesn't make sense to sum ratings, and it avoids the field being automatically added to cohort views.

Task-3383332