### PR TITLE
[FIX] pos_viva_wallet: prevent an error when system try to retrieve session_id

### DIFF
--- a/addons/pos_viva_wallet/i18n/pos_viva_wallet.pot
+++ b/addons/pos_viva_wallet/i18n/pos_viva_wallet.pot
@@ -179,6 +179,13 @@ msgid "Viva Wallet Webhook Verification Key"
 msgstr ""
 
 #. module: pos_viva_wallet
+#. odoo-python
+#: code:addons/pos_viva_wallet/models/pos_payment_method.py:0
+#, python-format
+msgid "Your transaction with Viva Wallet failed. Please try again later."
+msgstr ""
+
+#. module: pos_viva_wallet
 #: model:ir.model.fields,help:pos_viva_wallet.field_pos_payment_method__viva_wallet_terminal_id
 msgid "[Terminal ID of the Viva Wallet terminal], for example: 16002169"
 msgstr ""

--- a/addons/pos_viva_wallet/models/pos_payment_method.py
+++ b/addons/pos_viva_wallet/models/pos_payment_method.py
@@ -110,7 +110,14 @@ class PosPaymentMethod(models.Model):
         # Send a request to confirm the status of the sesions_id
         # Need wait to the status of sesions_id is updated setted in session headers; code 202
 
-        session_id, pos_session_id = data_webhook.get('MerchantTrns', '').split("/") # Split to retrieve pos_sessions_id
+        MerchantTrns = data_webhook.get('MerchantTrns')
+        if not MerchantTrns:
+            self._send_notification(
+                {'error': _(
+                    "Your transaction with Viva Wallet failed. Please try again later."
+                    )}
+                )
+        session_id, pos_session_id = MerchantTrns.split("/")  # Split to retrieve pos_sessions_id
         endpoint = f"sessions/{session_id}"
         data = self._call_viva_wallet(endpoint, 'get')
 


### PR DESCRIPTION
An error occurs when the system tries to retrieve 'session_id' at [1] from 'MerchantTrns' but it is not available. Because of failed transactions (Ref: https://developer.viva.com/webhooks-for-payments/transaction-failed/#response-example)

link [1]: https://github.com/odoo/odoo/blob/319cf81da8f16df21900f26bd6d8b4fc686e72eb/addons/pos_viva_wallet/models/pos_payment_method.py#L113

To resolve this issue, add a condition to check if 'MerchantTrns' is not available in 'data_webhook' then raise an error as send notification.

Sentry - 5466498742

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
