### PR TITLE
[FIX] stock: 'Pick From' could create sml with picking_id to False

### DIFF
--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -274,6 +274,7 @@
                                 add-label="Add a Product">
                                 <tree decoration-muted="scrapped == True or state == 'cancel' or (state == 'done' and is_locked == True)" string="Stock Moves" editable="1">
                                     <field name="company_id" column_invisible="True"/>
+                                    <field name="picking_id" column_invisible="True"/>
                                     <field name="name" column_invisible="True"/>
                                     <field name="state" readonly="0" column_invisible="True"/>
                                     <field name="picking_type_id" column_invisible="True"/>


### PR DESCRIPTION
When opening a new (virtual) 'stock.move' to create a 'stock.move.line' and directly validating the picking afterward, the created 'stock.move.line' was not directly associated to the picking_id. This happens because the virtual record does not have the picking_id because this field is not present on the tree view.

One impact of this issue has is that the stock.move.line created doesn't show on the Delivery Slip report.

## HOW TO REPRODUCE

https://github.com/odoo/odoo/assets/29302288/5c17e601-4d67-4515-8d5a-286460b9a9cd

- On TODO picking, do the following steps WITHOUT CLICKING ON SAVE
- Operations -> Add a line: (demand 0, quantity 0)
- Click on 'Open Move' button (fa-list icon)
- Popup 'Open: Stock move': Add a line
- Popup 'Add line: <product>': click on 'New'
- Popup 'Create Move Line': click on 'Save & Close'
- Popup 'Open: Stock move': set Quantity = 1, click on 'Save & Close'
- Validate picking -> Create backorder => Check picking move_line_ids = EMPTY

## Solution
Add picking_id field on view_picking_form -> move_ids_without_package tree view (Operations list).

OPW-3974109
