### PR TITLE
[IMP] mail: move seen indicator into the bubble

### DIFF
--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -247,6 +247,10 @@ export class Message extends Component {
         return this.env.inChatter ? 2 : 3;
     }
 
+    get showSeenIndicator() {
+        return this.props.message.isSelfAuthored && this.props.thread?.hasSeenFeature;
+    }
+
     get showSubtypeDescription() {
         return (
             this.message.subtype_description &&
@@ -433,9 +437,7 @@ export class Message extends Component {
                     res_id: id,
                 });
                 if (!this.env.isSmall) {
-                    this.props.thread.open(true, {
-                        autofocus: false
-                    });
+                    this.props.thread.open(true, { autofocus: false });
                 }
             }
             return;

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -24,12 +24,6 @@
                             <small t-if="isActive and props.showDates" class="o-mail-Message-date text-muted opacity-75 o-smaller mt-2">
                                 <t t-esc="message.dateSimple"/>
                             </small>
-                            <div t-else="">
-                                <MessageSeenIndicator
-                                    t-if="props.message.isSelfAuthored and props.thread?.hasSeenFeature"
-                                    message="props.message"
-                                    thread="props.thread"/>
-                            </div>
                         </t>
                     </div>
                     <div class="w-100 o-min-width-0" t-att-class="{ 'flex-grow-1': message.composer }" t-ref="messageContent">
@@ -43,11 +37,6 @@
                                 <t t-if="message.isPending" t-call="mail.Message.pendingStatus"/>
                                 <RelativeTime t-else="" datetime="message.datetime"/>
                             </small>
-                            <MessageSeenIndicator
-                                t-if="props.message.isSelfAuthored and !props.squashed and props.thread?.hasSeenFeature"
-                                className="'ms-1'"
-                                message="props.message"
-                                thread="props.thread"/>
                             <small t-if="!isOriginThread and !message.is_transient and message.thread" t-on-click.prevent="openRecord" class="ms-1 text-500">
                                 <t t-if="message.thread.model !== 'discuss.channel'">
                                     on <a t-att-href="message.resUrl"><t t-esc="message.thread.displayName"/></a>
@@ -110,6 +99,13 @@
                                                         <!-- <small t-if="message.editDate" class="o-mail-Message-edited fst-italic text-muted" t-att-class="{ 'ms-2': !message.isBodyEmpty }" t-att-title="message.editDatetimeHuge">(edited)</small> --> <!-- DISABLED because new messages sent by email are wrongly flagged as (edited) -->
                                                         <t t-if="showSubtypeDescription" t-out="props.messageSearch?.highlight(message.subtype_description) ?? message.subtype_description"/>
                                                     </t>
+                                                </div>
+                                                <div class="position-absolute bottom-0 end-0 smaller me-1">
+                                                    <MessageSeenIndicator
+                                                        t-if="showSeenIndicator"
+                                                        message="props.message"
+                                                        thread="props.thread"
+                                                    />
                                                 </div>
                                             </div>
                                         </t>

--- a/addons/mail/static/src/core/common/message_seen_indicator.scss
+++ b/addons/mail/static/src/core/common/message_seen_indicator.scss
@@ -3,7 +3,6 @@
     line-height: 1.5;
 
     &.o-second {
-        top: -1px;
-        left: -1px;
+        top: -3px;
     }
 }

--- a/addons/mail/static/src/core/common/message_seen_indicator.xml
+++ b/addons/mail/static/src/core/common/message_seen_indicator.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.MessageSeenIndicator">
-        <span class="o-mail-MessageSeenIndicator position-relative d-flex" t-att-class="{ 'opacity-50': !props.message.hasEveryoneSeen, 'o-all-seen text-primary': props.message.hasEveryoneSeen }" t-attf-class="{{ props.className }}">
+        <span class="o-mail-MessageSeenIndicator position-relative" t-att-class="{ 'opacity-50': !props.message.hasEveryoneSeen, 'o-all-seen text-primary': props.message.hasEveryoneSeen }">
             <t t-if="!props.message.isMessagePreviousToLastSelfMessageSeenByEveryone">
                 <i t-if="props.message.hasSomeoneFetched or props.message.hasSomeoneSeen" class="fa fa-check ps-1"/>
-                <i t-if="props.message.hasSomeoneSeen" class="o-second fa fa-check position-absolute"/>
+                <i t-if="props.message.hasSomeoneSeen" class="o-second start-0 fa fa-check position-absolute"/>
             </t>
         </span>
     </t>


### PR DESCRIPTION
Before this PR the position of the message seen indicator doesn't feel
consistent: if the message is squashed, its position is on the left. Otherwise,
it's on the right after the date of the message.

This PR removed those 2 positions and moved the message seen indicators on the
bottom right of the message bubble.

https://github.com/odoo/enterprise/pull/66025

![image](https://github.com/odoo/odoo/assets/1810149/8fb3a7c1-8933-419e-9b25-2e03dd232d6b)
![image](https://github.com/odoo/odoo/assets/1810149/ec80d780-d2a6-49b3-ae64-47f37cc29c32)
![image](https://github.com/odoo/odoo/assets/1810149/57a370bc-0ab6-4ec5-b14a-b01320715965)
![image](https://github.com/odoo/odoo/assets/1810149/5f625afc-198f-4497-b0d4-8403774f1284)

