### PR TITLE
[FIX] purchase: not modify date planned of PO lines

### DIFF
--- a/addons/purchase/tests/test_purchase.py
+++ b/addons/purchase/tests/test_purchase.py
@@ -42,9 +42,43 @@ class TestPurchase(AccountTestInvoicingCommon):
         self.assertAlmostEqual(po.order_line[0].date_planned, po.date_planned, delta=timedelta(seconds=10))
 
         # Set an even earlier date planned on the other PO line and check that the PO expected date matches it.
-        new_date_planned = orig_date_planned - timedelta(hours=72)
-        po.order_line[1].date_planned = new_date_planned
+        # Also check that the other PO line's date planned is not modified.
+        new_date_planned_2 = orig_date_planned - timedelta(hours=72)
+        po_form = Form(po)
+        with po_form.order_line.edit(1) as po_line:
+            po_line.date_planned = new_date_planned_2
+        po = po_form.save()
         self.assertAlmostEqual(po.order_line[1].date_planned, po.date_planned, delta=timedelta(seconds=10))
+        self.assertAlmostEqual(po.order_line[0].date_planned, new_date_planned, delta=timedelta(seconds=10))
+
+    def test_date_planned_2(self):
+        """
+        Check that the date_planned of the onchange is correctly applied:
+        Create a PO, change its date_planned to tommorow and check that the date_planned of the lines are updated.
+        Create a new line (this will update the date_planned of the PO but should not alter the other lines).
+        """
+
+        po = self.env['purchase.order'].create({
+            'partner_id': self.partner_a.id,
+            'order_line': [Command.create({
+                'name': self.product_a.name,
+                'product_id': self.product_a.id,
+                'product_uom_qty': 10,
+                'product_uom': self.product_a.uom_id.id,
+                'price_unit': 1,
+            })],
+        })
+        with Form(po) as po_form:
+            po_form.date_planned = fields.Datetime.now() + timedelta(days=1)
+        self.assertEqual(po.order_line.date_planned, po.date_planned)
+
+        with Form(po) as po_form:
+            with po_form.order_line.new() as new_line:
+                new_line.product_id = self.product_b
+                new_line.product_qty = 10
+                new_line.price_unit = 200
+        self.assertEqual(po.order_line[1].date_planned, po.date_planned)
+        self.assertNotEqual(po.order_line[0].date_planned, po.date_planned)
 
     def test_purchase_order_sequence(self):
         PurchaseOrder = self.env['purchase.order'].with_context(tracking_disable=True)


### PR DESCRIPTION
### Steps to reproduce

#### Use case 1:

1. Create a PO with 2 lines having different "expected arrival".
2. Change the "expected arrival" of one of the lines so that the earliest date of all the lines is modified.
3. This will change the "expected arrival" of the PO (intended) but also the "expected arrival" of all PO lines.
#### > the date is changed on all the lines

#### Use case 2:
1. Create a PO with 1 line and change its date planned to tomorrow
2. Save the PO
3. Add a new line on the SO and set a product
#### > the date is changed on all the lines

#### Use case 3:
1. Create a PO with 1 line and change its date planned to tomorrow
2. Save the PO
3. Add a new line for a product with at least 2 product variant and complete his grid for quantities
#### > the date is changed on all the lines

### Cause of the issue:

The `date_planned` fields of the `purchase.order` and `purchase.order.line` are both computed and stored.  When the `date_planned` of a line (new or already existing) is changed, it triggers the compute method of the `date_planned` of the purchase order and changes it: https://github.com/odoo/odoo/blob/5d8c8f3d01c3c633bcacbdb9e42419e11eb802d9/addons/purchase/models/purchase_order.py#L184-L190 
This will in turn trigger the `onchange_date_planned` of the purchase order since we are in the Form view of that model and will update the "planned_date" of every other existing line accordingly:
https://github.com/odoo/odoo/blob/5d8c8f3d01c3c633bcacbdb9e42419e11eb802d9/addons/purchase/models/purchase_order.py#L229-L232

### Fix

We add back the override of the onchange that was present in previous versions and removed in the onchange refactoring made in commit https://github.com/odoo/odoo/commit/109935dbc10256bebb1f5ee0d76a23df7ea91e9f. The purpose of this override being to remove any update of the 'date_planned' of the POL's from the onchange call if this one was triggered by a change of an POL.

#### Note: 
The third use case was fixed by commit 387e9a4 by adding the `_must_delete_date_planned` method but this fix becomes ineffective without the onchange override.

opw-4000019
opw-4012390
opw-4028100
---