### PR TITLE
[FIX] point_of_sale: ensure exact matches for short internal references

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -357,7 +357,7 @@ export class ProductScreen extends Component {
     
         const exactMatches = products.filter((product) => product.exactMatch(searchWord));
 
-        if (exactMatches.length > 0 && searchWord.length > 5) {
+        if (exactMatches.length > 0 && searchWord.length > 2) {
             return exactMatches;
         }
 


### PR DESCRIPTION
Before this commit, searching for internal references or barcodes with less than 6 characters would result in a fuzzy search, even when an exact match was available. This behavior was based on the assumption that barcodes and internal references are at least 6 characters long.

opw-4029891

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
