### PR TITLE
[FIX] mrp: prevent scheduler from using draft MO

### DIFF
--- a/addons/mrp/models/stock_rule.py
+++ b/addons/mrp/models/stock_rule.py
@@ -56,7 +56,7 @@ class StockRule(models.Model):
                 domain = (
                     ('bom_id', '=', bom.id),
                     ('product_id', '=', procurement.product_id.id),
-                    ('state', 'in', ['draft', 'confirmed']),
+                    ('state', '=', 'confirmed'),
                     ('is_planned', '=', False),
                     ('picking_type_id', '=', rule.picking_type_id.id),
                     ('company_id', '=', procurement.company_id.id),
@@ -67,9 +67,7 @@ class StockRule(models.Model):
                         fields.Date.to_date(procurement.values['date_planned']) - relativedelta(days=int(bom.produce_delay)),
                         datetime.max.time()
                     )
-                    domain += ('|',
-                               '&', ('state', '=', 'draft'), ('date_deadline', '<=', procurement_date),
-                               '&', ('state', '=', 'confirmed'), ('date_start', '<=', procurement_date))
+                    domain += (('date_start', '<=', procurement_date),)
                 if group:
                     domain += (('procurement_group_id', '=', group.id),)
                 mo = self.env['mrp.production'].sudo().search(domain, limit=1)


### PR DESCRIPTION
The quantities produced by Draft Manufacturing Orders are not accounted for in the forecast quantity. 
Hence, when running the scheduler, if X quantities need to be produced, we can't select a draft MO to fulfill this need. 
Else, the next scheduler run will continue to try to fulfill the demand and keep increasing the quantity of this draft MO.

# How to reproduce:

https://github.com/odoo/odoo/assets/29302288/4ea7c2df-7f0d-4117-aa39-efc1bff63dbd

- Unarchive "Replenish on Order" route
- Create new product P with route "Replenish on Order" & "Manufacture" selected
- Create Reordering rules auto, min 0, max 0, route Manufacture
- Create Sale Order for 100 units of P
=> New draft MO created for 100 units of P
- Run Scheduler multiple times
=> For each run of the scheduler, the draft MO quantity is incremented by 100 units

OPW-3763875
