### PR TITLE
[FIX] pos_loyalty: install issue when gift card email template not set

### DIFF
--- a/addons/pos_loyalty/data/gift_card_data.xml
+++ b/addons/pos_loyalty/data/gift_card_data.xml
@@ -9,7 +9,8 @@
         <field name="taxes_id" eval="False"/>
     </record>
     <!-- Gift Cards -->
-    <record id="loyalty.gift_card_program" model="loyalty.program">
-        <field name="pos_report_print_id" ref="loyalty.report_gift_card"/>
-    </record>
+    <function name="write" model="loyalty.program">
+        <value model="loyalty.program" eval="obj().search([('id', '=', ref('loyalty.gift_card_program'))]).filtered(lambda l: l.mail_template_id).id"/>
+        <value eval="{'pos_report_print_id': ref('loyalty.report_gift_card', False)}"/>
+    </function>
 </odoo>


### PR DESCRIPTION
When the user removes the Email Template from the 'Gift Cards' program and tries to install the pos_loyalty module, they will encounter a ParseError with the message: `You must set 'Email template' before setting 'Print Report'.` As a result, the installation process will be aborted.

Steps to produce:
- Install the 'Sales' and 'Coupons & Loyalty' modules.
- Sales > Products > Gift cards & eWallet.
- Open the 'Gift Cards' program and remove the Email template from the field.
- Apps > 'Point of Sale - Coupons & Loyalty' > Activate.
- ParseError and stops the installation process.

When the write function is called during installation, it should check whether the 'Gift Card' program has an Email Template configured or not.

Sentry-4356842814

Ref - https://github.com/odoo/odoo/pull/130498
