### PR TITLE
[FIX] website: prevent duplicate menu creation on page creation

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -1148,16 +1148,21 @@ class Website(models.Model):
             page = self.env['website.page'].create(default_page_values)
             result['page_id'] = page.id
         if add_menu:
-            default_menu_values = {
-                'name': name,
-                'url': page_url,
-                'parent_id': website.menu_id.id,
-                'page_id': page.id,
-                'website_id': website.id,
-            }
-            if menu_values:
-                default_menu_values.update(menu_values)
-            menu = self.env['website.menu'].create(default_menu_values)
+            menu = self.env['website.menu'].search([
+                ('url', '=', page_url),
+                ('website_id', '=', website.id),
+            ], limit=1)
+            if not menu:
+                default_menu_values = {
+                    'name': name,
+                    'url': page_url,
+                    'parent_id': website.menu_id.id,
+                    'page_id': page.id,
+                    'website_id': website.id,
+                }
+                if menu_values:
+                    default_menu_values.update(menu_values)
+                menu = self.env['website.menu'].create(default_menu_values)
             result['menu_id'] = menu.id
         return result
 


### PR DESCRIPTION
   
    When creating a new page, if you chose to add it to the menu, it will be
    done even if another menu pointing to that URL already exists.
    
    Steps to reproduce :
    - Go to website
    - Go to 'Site' -> 'Menu Editor'
    - Click on 'Add Menu Item' button
    - Enter 'Hello Page' in the Menu Label input and '/hello-page' in the
      URL input
    - Save (both dialogs)
    - Click on 'New' at the top right
    - Select blank template
    - Enter 'Hello Page' in Page Title input (*let* the 'Add to menu' input
      checked)
    - Click on 'Create'
      => You have two website.menu pointing to the same URL in your global
      website menu
    
    task-3634878