### PR TITLE
[FIX] [google_]calendar: X-named RRULE params

### DIFF
--- a/addons/calendar/models/calendar_recurrence.py
+++ b/addons/calendar/models/calendar_recurrence.py
@@ -3,6 +3,7 @@
 
 from datetime import datetime, time
 import pytz
+import re
 
 from dateutil import rrule
 from dateutil.relativedelta import relativedelta
@@ -360,6 +361,14 @@ class RecurrenceRule(models.Model):
         # LUL TODO clean this mess
         data = {}
         day_list = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun']
+
+        # Skip X-named RRULE extensions
+        # TODO Remove patch when dateutils contains the fix
+        # HACK https://github.com/dateutil/dateutil/pull/1374
+        # Optional parameters starts with X- and they can be placed anywhere in the RRULE string.
+        # RRULE:FREQ=MONTHLY;INTERVAL=3;X-RELATIVE=1
+        # RRULE;X-EVOLUTION-ENDDATE=20200120:FREQ=WEEKLY;COUNT=3;BYDAY=MO
+        rule_str = re.sub(r';?X-[-\w]+=[^;:]*', '', rule_str).replace(":;", ":")
 
         if 'Z' in rule_str and date_start and not date_start.tzinfo:
             date_start = pytz.utc.localize(date_start)

--- a/addons/calendar/tests/test_event_recurrence.py
+++ b/addons/calendar/tests/test_event_recurrence.py
@@ -469,6 +469,11 @@ class TestUpdateRecurrentEvents(TestRecurrentEvents):
         self.assertFalse(self.recurrence.tue)
         self.assertTrue(self.recurrence.wed)
 
+    def test_rrule_x_params(self):
+        self.recurrence.rrule = 'RRULE;X-EVOLUTION-ENDDATE=20191112;X-OTHER-PARAM=0:X-AMAZING=1;FREQ=WEEKLY;COUNT=3;X-MAIL-special=1;BYDAY=WE;X-RELATIVE=True'
+        self.assertFalse(self.recurrence.tue)
+        self.assertTrue(self.recurrence.wed)
+
     def test_shift_all_base_inactive(self):
         self.recurrence.base_event_id.active = False
         event = self.events[1]

--- a/addons/google_calendar/tests/test_sync_google2odoo.py
+++ b/addons/google_calendar/tests/test_sync_google2odoo.py
@@ -621,7 +621,7 @@ class TestSyncGoogle2Odoo(TestSyncGoogle):
         self.env['calendar.recurrence']._sync_google2odoo(GoogleEvent([values]))
         events = recurrence.calendar_event_ids.sorted('start')
         self.assertEqual(len(events), 2)
-        self.assertEqual(recurrence.rrule, 'FREQ=WEEKLY;COUNT=2;BYDAY=WE')
+        self.assertEqual(recurrence.rrule, 'RRULE:FREQ=WEEKLY;COUNT=2;BYDAY=WE')
         self.assertEqual(events[0].start_date, date(2020, 1, 8))
         self.assertEqual(events[1].start_date, date(2020, 1, 15))
         self.assertEqual(events[0].google_id, '%s_20200108' % google_id)
@@ -664,7 +664,7 @@ class TestSyncGoogle2Odoo(TestSyncGoogle):
         self.env['calendar.recurrence']._sync_google2odoo(GoogleEvent([values]))
         events = recurrence.calendar_event_ids.sorted('start')
         self.assertEqual(len(events), 2)
-        self.assertEqual(recurrence.rrule, 'FREQ=WEEKLY;COUNT=2;BYDAY=MO')
+        self.assertEqual(recurrence.rrule, 'RRULE:FREQ=WEEKLY;COUNT=2;BYDAY=MO')
         self.assertEqual(events.mapped('name'), ['coucou again', 'coucou again'])
         self.assertEqual(events[0].start_date, date(2020, 1, 6))
         self.assertEqual(events[1].start_date, date(2020, 1, 13))
@@ -717,7 +717,7 @@ class TestSyncGoogle2Odoo(TestSyncGoogle):
         self.env['calendar.recurrence']._sync_google2odoo(GoogleEvent([values]))
         events = recurrence.calendar_event_ids.sorted('start')
         self.assertEqual(len(events), 3)
-        self.assertEqual(recurrence.rrule, 'FREQ=WEEKLY;COUNT=3;BYDAY=MO')
+        self.assertEqual(recurrence.rrule, 'RRULE:FREQ=WEEKLY;COUNT=3;BYDAY=MO')
         self.assertEqual(events.mapped('name'), ['coucou again', 'coucou again', 'coucou again'])
         self.assertEqual(events[0].start, datetime(2021, 2, 15, 8, 0, 0))
         self.assertEqual(events[1].start, datetime(2021, 2, 22, 16, 0, 0))
@@ -913,7 +913,7 @@ class TestSyncGoogle2Odoo(TestSyncGoogle):
             'summary': 'Pricing new update',
             'visibility': 'public',
             'recurrence': ['EXDATE;TZID=Europe/Rome:20200113',
-                           'RRULE:FREQ=WEEKLY;COUNT=3;BYDAY=MO'],
+                           'RRULE;X-EVOLUTION-ENDDATE=20200120:FREQ=WEEKLY;COUNT=3;BYDAY=MO;X-RELATIVE=1'],
             'reminders': {'useDefault': True},
             'start': {'date': '2020-01-6'},
             'end': {'date': '2020-01-7'},

--- a/addons/google_calendar/utils/google_event.py
+++ b/addons/google_calendar/utils/google_event.py
@@ -65,8 +65,7 @@ class GoogleEvent(abc.Set):
     @property
     def rrule(self):
         if self.recurrence and any('RRULE' in item for item in self.recurrence):
-            rrule = next(item for item in self.recurrence if 'RRULE' in item)
-            return rrule[6:]  # skip "RRULE:" in the rrule string
+            return next(item for item in self.recurrence if 'RRULE' in item)
 
     def odoo_id(self, env):
         self.odoo_ids(env)  # load ids


### PR DESCRIPTION
If you created an event using GNOME Evolution/Calendar, it could add an `X-EVOLUTION-ENDDATE` parameter to the event's `RRULE`.

When that happens, if the event is pushed to a Google Calendar and synced in Odoo, all participants' calendars stop syncing from there onwards.

<details>

```
2024-06-26 07:10:57,942 41 ERROR odoo odoo.addons.google_calendar.models.res_users: [res.users(15,)] Calendar Synchro - Exception : unsupported property: X-EVOLUTION-ENDDATE=20371102T114500Z !
Traceback (most recent call last):
  File "/opt/odoo/auto/addons/google_calendar/models/﻿﻿res_users.py﻿﻿", line 100, in _sync_all_google_calendar
    user.with_user(user).sudo()._sync_google_calendar(google)
  File "/opt/odoo/auto/addons/google_calendar/models/﻿﻿res_users.py﻿﻿", line 78, in _sync_google_calendar
    synced_recurrences = self.env['calendar.recurrence'].with_context(write_dates=recurrences_write_dates)._sync_google2odoo(recurrences)
  File "/opt/odoo/auto/addons/google_calendar/models/﻿﻿google_sync.py﻿﻿", line 185, in _sync_google2odoo
    odoo_record.with_context(dont_notify=True)._write_from_google(gevent, vals)
  File "/opt/odoo/auto/addons/google_calendar/models/﻿﻿calendar_recurrence_rule.py﻿﻿", line 88, in _write_from_google
    super()._write_from_google(gevent, vals)
  File "/opt/odoo/auto/addons/google_calendar/models/﻿﻿google_sync.py﻿﻿", line 304, in _write_from_google
    self.write(vals)
  File "/opt/odoo/auto/addons/google_calendar/models/﻿﻿google_sync.py﻿﻿", line 71, in write
    result = super().write(vals)
  File "/opt/odoo/custom/src/odoo/odoo/﻿﻿models.py﻿﻿", line 3808, in write
    fields[0].determine_inverse(real_recs)
  File "/opt/odoo/custom/src/odoo/odoo/﻿﻿fields.py﻿﻿", line 1401, in determine_inverse
    determine(self.inverse, records)
  File "/opt/odoo/custom/src/odoo/odoo/﻿﻿fields.py﻿﻿", line 98, in determine
    return needle(*args)
  File "/opt/odoo/auto/addons/calendar/models/﻿﻿calendar_recurrence.py﻿﻿", line 219, in _inverse_rrule
    values = self._rrule_parse(recurrence.rrule, recurrence.dtstart)
  File "/opt/odoo/auto/addons/calendar/models/﻿﻿calendar_recurrence.py﻿﻿", line 366, in _rrule_parse
    rule = rrule.rrulestr(rule_str, dtstart=date_start)
  File "/usr/local/lib/python3.10/site-packages/dateutil/﻿﻿rrule.py﻿﻿", line 1730, in __call__
    return self._parse_rfc(s, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/dateutil/﻿﻿rrule.py﻿﻿", line 1698, in _parse_rfc
    raise ValueError("unsupported property: "+name)
ValueError: unsupported property: X-EVOLUTION-ENDDATE=20371102T114500Z
```

</details>

In https://discourse.gnome.org/t/working-with-evolution-mail-and-web-calendar-using-rrule-fail-because-of-x-evolution-enddate-in-rrule/19710/3 it explains why this happens and how it's actually a supported feature of RFC 5545.

Dateutil doesn't support that feature. It just fails with `ValueError`. Progress is being tracked in https://github.com/dateutil/dateutil/pull/1374.

Regarding what matters to Odoo, we can just strip any X-named params from the RRULE prefix and live happy with the rest (or fail if there's really a wrongly-formatted RRULE param). This way we avoid dateutil to fail unnecessarily and unlock users Google calendars synchronizations.

@moduon MT-6287



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
