### PR TITLE
[FIX][draft] sale_project: fix the name overwrite when creating an sol

### DIFF
--- a/addons/sale_project/models/project.py
+++ b/addons/sale_project/models/project.py
@@ -139,6 +139,7 @@ class Project(models.Model):
                 'show_sale': True,
                 'link_to_project': self.id,
                 'form_view_ref': 'sale_project.sale_order_line_view_form_editable', # Necessary for some logic in the form view
+                'action_view_sols': True,
                 'default_partner_id': self.partner_id.id,
                 'default_company_id': self.company_id.id,
                 'default_order_id': self.sale_order_id.id,

--- a/addons/sale_project/models/sale_order_line.py
+++ b/addons/sale_project/models/sale_order_line.py
@@ -77,7 +77,7 @@ class SaleOrderLine(models.Model):
         # To get the right product when creating a SOL on the fly, we need to get
         # the name that was entered in the field from the `default_get` method.
         # The easiest way of doing that is to store it in the context.
-        if self.env.context.get('form_view_ref') == 'sale_project.sale_order_line_view_form_editable':
+        if self.env.context.get('form_view_ref') == 'sale_project.sale_order_line_view_form_editable' and not self.env.context.get('action_view_sols'):
             self = self.with_context(sol_product_name=name)
         return super().name_create(name)
 
@@ -87,7 +87,7 @@ class SaleOrderLine(models.Model):
         # called with whatever was typed in the field. However, we don't want
         # that value to overwrite the computed SOL name if we find a product.
         defaults = super()._add_missing_default_values(values)
-        if self.env.context.get('form_view_ref') == 'sale_project.sale_order_line_view_form_editable':
+        if self.env.context.get('form_view_ref') == 'sale_project.sale_order_line_view_form_editable' and not self.env.context.get('action_view_sols'):
             if "name" in defaults and "product_id" in defaults:
                 del defaults["name"]
         return defaults


### PR DESCRIPTION
This commit's purpose is to keep the user input when he creates an sol from the formview sol.

Step to reproduce :

- open project update
- cilck on 'sols' stat button
- click on 'new' to create a new sol
- give a name 'youpi' to the sol
- save the sol

The name of the sol will be overwritten with a default one. Expected behavior:
The name of the sol should be the one the user has set.

Source of the problem:
The name of sol is used for some computation in some use case when the form view of sol from the sale_project module is used. But this form view is also used in the use case where the name override is not needed.

Solution: add a context key to differentiate the 2 use cases.

task - 4031977
version : 17.0 - master

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
