### PR TITLE
[FIX] ensure 'sort' field in ir.filters holds JSON value

### DIFF
--- a/addons/website_blog/data/blog_snippet_template_data.xml
+++ b/addons/website_blog/data/blog_snippet_template_data.xml
@@ -7,7 +7,7 @@
             <field name="model_id">blog.post</field>
             <field name="user_id" eval="False" />
             <field name="domain">[('post_date', '&lt;=', context_today())]</field>
-            <field name="sort">['post_date desc']</field>
+            <field name="sort">["post_date desc"]</field>
             <field name="action_id" ref="website.action_website"/>
         </record>
         <record id="dynamic_snippet_most_viewed_blog_post_filter" model="ir.filters">
@@ -15,7 +15,7 @@
             <field name="model_id">blog.post</field>
             <field name="user_id" eval="False" />
             <field name="domain">[('post_date', '&lt;=', context_today()), ('visits', '!=', False)]</field>
-            <field name="sort">['visits desc']</field>
+            <field name="sort">["visits desc"]</field>
             <field name="action_id" ref="website.action_website"/>
         </record>
         <!-- Dynamic Filter -->

--- a/addons/website_sale/data/data.xml
+++ b/addons/website_sale/data/data.xml
@@ -65,7 +65,7 @@
             <field name="user_id" eval="False" />
             <field name="domain">[('website_published', '=', True)]</field>
             <field name="context">{'display_default_code': False, 'add2cart_rerender': False}</field>
-            <field name="sort">['create_date desc']</field>
+            <field name="sort">["create_date desc"]</field>
             <field name="action_id" ref="website.action_website"/>
         </record>
         <!-- Action Server for Dynamic Filter -->


### PR DESCRIPTION
Following the additions of dynamic filters to website_blog and website_sale in [1] & [2], the sort field was mistakenly set as a JS array instead of a stringified JSON array with double quotes. This caused update scripts to fail when reading the record.

This commit fixes this issue.

[1]: https://github.com/odoo/odoo/commit/3c0d98bcd8adf9325ee3497eb8d25ec7f904d6a5#diff-80650b3ebe3ff7900a5409e2047c91a71c7d86b11cb2dbc1f5c99b77f381ae95
[2]: https://github.com/odoo/odoo/commit/3355dc16235355fe51e894f14e275210464608c6#diff-2c13c95bb9b3423a9150ff5b7fb5a78ba1b7c1f405f0dd40ff951bdb62fe8f95

task-4032875

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
