### PR TITLE
[FIX] website_payment: cache currency for donation snippet

### DIFF
--- a/addons/website_payment/static/src/snippets/s_donation/000.js
+++ b/addons/website_payment/static/src/snippets/s_donation/000.js
@@ -4,6 +4,7 @@ import { _t } from "@web/core/l10n/translation";
 import publicWidget from '@web/legacy/js/public/public_widget';
 
 const CUSTOM_BUTTON_EXTRA_WIDTH = 10;
+let cachedCurrency;
 
 publicWidget.registry.DonationSnippet = publicWidget.Widget.extend({
     selector: '.s_donation',
@@ -88,7 +89,11 @@ publicWidget.registry.DonationSnippet = publicWidget.Widget.extend({
      * @private
      */
     _displayCurrencies() {
-        return this.rpc('/website/get_current_currency').then((result) => {
+        return this._getCachedCurrency().then((result) => {
+            // No need to recreate the elements if the currency is already set.
+            if (this.currency === result) {
+                return;
+            }
             this.currency = result;
             this.$('.s_donation_currency').remove();
             const $prefilledButtons = this.$('.s_donation_btn, .s_range_bubble');
@@ -104,6 +109,17 @@ publicWidget.registry.DonationSnippet = publicWidget.Widget.extend({
                 }
             });
         });
+    },
+    /**
+     * @private
+     */
+    _getCachedCurrency() {
+        return cachedCurrency
+            ? Promise.resolve(cachedCurrency)
+            : this.rpc("/website/get_current_currency").then((result) => {
+                cachedCurrency = result;
+                return result;
+            });
     },
 
     //--------------------------------------------------------------------------


### PR DESCRIPTION
Since 17.0 and [renderToElement], the snippet is rerendered (and thus starts anew) on every key input in the descriptions options. The donation's publicWidget fetches the currency to display every time on start, meaning that it does a query on every key press. This also triggers jumps on the screen.
To avoid both issues, this commit caches the currency for the duration of the publicWidget life.

[renderToElement]: f956e83c744bd9c970d3f16ce1cb3cff8bba2f6b

task-4032975