### PR TITLE
[FIX] stock: Prevent draft move in done picking

### DIFF
--- a/addons/stock/i18n/stock.pot
+++ b/addons/stock/i18n/stock.pot
@@ -8658,6 +8658,12 @@ msgid ""
 msgstr ""
 
 #. module: stock
+#: code:addons/stock/models/stock_move.py:0
+#, python-format
+msgid "Only 'Done' stock moves can be added to a 'Done' transfer.'"
+msgstr ""
+
+#. module: stock
 #: code:addons/stock/models/stock_location.py:0
 #, python-format
 msgid "You cannot archive the location %s as it is used by your warehouse %s"

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -586,6 +586,10 @@ class StockMove(models.Model):
                 picking = self.env['stock.picking'].browse(vals['picking_id'])
                 if picking.group_id:
                     vals['group_id'] = picking.group_id.id
+            if vals.get('picking_id') and vals.get('state'):
+                picking = self.env['stock.picking'].browse(vals['picking_id'])
+                if picking.state == 'done' and vals['state'] != 'done':
+                    raise UserError(_('Only \'Done\' stock moves can be added to a \'Done\' transfer.'))
         res = super().create(vals_list)
         res._update_orderpoints()
         return res


### PR DESCRIPTION
## How to Reproduce:

https://github.com/odoo/odoo/assets/29302288/25298f18-7597-4883-b8b0-31a9e69ae40e

- Create products P1 & P2, storable
- Create receipt picking for 1 unit of P1 -> Confirm
- Open receipt in 2 browser tabs.
- In Tab 1, add a new operation line for 1 unit of P2. !Do Not Save!
- In Tab 2, validate the receipt.
- In Tab 1, save. => Picking went from Ready -> Done -> Ready. Move P1 state = 'done' while move P2 state ='assigned'

OPW-3919976
