### PR TITLE
[FIX] sale: link between refunds and their original invoice

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1437,6 +1437,10 @@ class SaleOrder(models.Model):
                 render_values={'self': move, 'origin': move.line_ids.sale_line_ids.order_id},
                 subtype_xmlid='mail.mt_note',
             )
+        if moves.mapped('move_type') == ['out_refund']:
+            original_invoices = self.invoice_ids - moves
+            if len(original_invoices) == 1 and original_invoices.move_type == 'out_invoice':
+                moves.reversed_entry_id = original_invoices.id
         return moves
 
     # MAIL #


### PR DESCRIPTION
For the Kenya localization we need to do invoice on delivery and we see that while doing that and you create a refund from the sale order that the link with the original invoice is not set.

A lot of EDIs, not only Kenya and even for accounting audits, require you however to have a value set for the original invoice of the refund.

So, here, we added a logic that if there is only one original invoice and then we do a return that when it creates a refund it automatically links it to the original invoice.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
