### PR TITLE
[FIX] point_of_sale: clear search on new order

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
@@ -104,6 +104,7 @@ export class ReceiptScreen extends Component {
     orderDone() {
         this.pos.removeOrder(this.currentOrder);
         this._addNewOrder();
+        this.pos.resetProductScreenSearch();
         const { name, props } = this.nextScreen;
         this.pos.showScreen(name, props);
     }

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -244,8 +244,7 @@ export class PosStore extends Reactive {
         window.addEventListener("beforeunload", () =>
             this.db.save("TO_REFUND_LINES", this.toRefundLines)
         );
-        const { start_category, iface_start_categ_id } = this.config;
-        this.selectedCategoryId = (start_category && iface_start_categ_id?.[0]) || 0;
+        this.resetProductScreenSearch();
         this.hasBigScrollBars = this.config.iface_big_scrollbars;
         // Push orders in background, do not await
         this.push_orders();
@@ -2050,6 +2049,12 @@ export class PosStore extends Reactive {
 
     redirectToBackend() {
         window.location = "/web#action=point_of_sale.action_client_pos_menu";
+    }
+
+    resetProductScreenSearch() {
+        this.searchProductWord = "";
+        const { start_category, iface_start_categ_id } = this.config;
+        this.selectedCategoryId = (start_category && iface_start_categ_id?.[0]) || 0;
     }
 }
 


### PR DESCRIPTION
Before this commit, after searching for an article via the search button, selecting it, and completing payment, the search term persisted in the search field when starting a new order. This behavior could lead to confusion or slower workflows for cashiers.

opw-4015200

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
