### PR TITLE
[FIX] web: don't stack dataset when using comparison in graph view

### DIFF
--- a/addons/web/static/src/views/graph/graph_model.js
+++ b/addons/web/static/src/views/graph/graph_model.js
@@ -165,7 +165,11 @@ export class GraphModel extends Model {
         metaData.groupBy = groupBy.length ? groupBy : this.initialGroupBy;
         if (metaData.mode !== "pie") {
             metaData.order = "graph_order" in context ? context.graph_order : metaData.order;
-            metaData.stacked = "graph_stacked" in context ? context.graph_stacked : metaData.stacked;
+            if (comparison) {
+                metaData.stacked = false;
+            } else if ("graph_stacked" in context) {
+                metaData.stacked = context.graph_stacked;
+            }
             if (metaData.mode === "line") {
                 metaData.cumulated = "graph_cumulated" in context ? context.graph_cumulated : metaData.cumulated;
             }

--- a/addons/web/static/tests/views/graph_view_tests.js
+++ b/addons/web/static/tests/views/graph_view_tests.js
@@ -1369,6 +1369,56 @@ QUnit.module("Views", (hooks) => {
     });
 
     QUnit.test(
+        "line chart rendering (one groupBy, several domains with date identification) without stacked attribute",
+        async function (assert) {
+            serverData.models.foo.records = [
+                { date: "2021-01-04", revenue: 12 },
+                { date: "2021-01-12", revenue: 5 },
+                { date: "2021-01-19", revenue: 15 },
+                { date: "2021-01-26", revenue: 2 },
+                { date: "2021-02-04", revenue: 14 },
+                { date: "2021-02-17", revenue: false },
+                { date: false, revenue: 0 },
+            ];
+            await makeView({
+                serverData,
+                type: "graph",
+                resModel: "foo",
+                arch: `
+                    <graph type="line">
+                        <field name="revenue" type="measure"/>
+                        <field name="date" interval="week"/>
+                    </graph>
+                `,
+                comparison: {
+                    domains: [
+                        {
+                            arrayRepr: [
+                                ["date", ">=", "2021-02-01"],
+                                ["date", "<=", "2021-02-28"],
+                            ],
+                            description: "February 2021",
+                        },
+                        {
+                            arrayRepr: [
+                                ["date", ">=", "2021-01-01"],
+                                ["date", "<=", "2021-01-31"],
+                            ],
+                            description: "January 2021",
+                        },
+                    ],
+                    fieldName: "date",
+                },
+            });
+            assert.doesNotHaveClass(
+                target.querySelector(".o_graph_button[data-tooltip=Stacked]"),
+                "active",
+                "The stacked mode should be disabled"
+            );
+        }
+    );
+
+    QUnit.test(
         "line chart rendering (one groupBy, several domains with date identification)",
         async function (assert) {
             assert.expect(19);


### PR DESCRIPTION
Steps to reproduce
==================

- Install sale_management
- Create a new Quotation
  * select a partner
  * quotation date: exactly one year ago
  * add a line with a product
  * save but don't confirm
- Go to Sales > Reporting
- Remove any filter
- Filter by order date: the current month
- Add a comparison: "Order date: Previous Year"

=> The dataset are stacked

Let's say with have the following values:

July 2024: 10k
July 2023: 5k

The July 2023 point will be displayed with an Y coordinate being the sum of both: 15k.

It doesn't make sense as we wan't to be able to compare both values visually

Solution
========

Always disable the stacked mode when using a comparison

opw-3960098