### PR TITLE
[FIX] sale_mrp: avoid bom type change during a sale process

### DIFF
--- a/addons/sale_mrp/models/mrp_bom.py
+++ b/addons/sale_mrp/models/mrp_bom.py
@@ -12,6 +12,11 @@ class MrpBom(models.Model):
         self.filtered(lambda bom: bom.active)._ensure_bom_is_free()
         return super().toggle_active()
 
+    def write(self, vals):
+        if 'phantom' in self.mapped('type') and vals.get('type', 'phantom') != 'phantom':
+            self._ensure_bom_is_free()
+        return super().write(vals)
+
     def unlink(self):
         self._ensure_bom_is_free()
         return super().unlink()

--- a/addons/sale_mrp/tests/test_sale_mrp_flow.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_flow.py
@@ -2778,6 +2778,8 @@ class TestSaleMrpFlow(TestSaleMrpFlowCommon):
 
         so.action_confirm()
         with self.assertRaises(UserError):
+            self.bom_kit_1.write({'type': 'normal'})
+        with self.assertRaises(UserError):
             self.bom_kit_1.toggle_active()
         with self.assertRaises(UserError):
             self.bom_kit_1.unlink()
@@ -2787,6 +2789,8 @@ class TestSaleMrpFlow(TestSaleMrpFlowCommon):
         so.picking_ids.button_validate()
 
         self.assertEqual(so.picking_ids.state, 'done')
+        with self.assertRaises(UserError):
+            self.bom_kit_1.write({'type': 'normal'})
         with self.assertRaises(UserError):
             self.bom_kit_1.toggle_active()
         with self.assertRaises(UserError):
@@ -2798,4 +2802,6 @@ class TestSaleMrpFlow(TestSaleMrpFlowCommon):
         self.assertEqual(invoice.state, 'posted')
         self.bom_kit_1.toggle_active()
         self.bom_kit_1.toggle_active()
+        self.bom_kit_1.write({'type': 'normal'})
+        self.bom_kit_1.write({'type': 'phantom'})
         self.bom_kit_1.unlink()


### PR DESCRIPTION
Changing a BoM from 'phantom' (kit) to 'normal' (manufacture) during leads to an error if the kit is in the middle of a sale process.

## How to reproduce:
2. Create a product category PC: AVCO Automated
3. Create 3 storable products P_kit, P_01, P_02 in category PC
4. Create a BoM:
   - Product: P_kit
   - Type: kit
   - Components:
     - 1 x P_01
     - 1 x P_02
5. Create and confirm a SO with 1 x P_kit
6. Force the delivery
7. Change BoM type to 'Manufacture this product'
8. Create and confirm the SO's invoice

Error: a traceback appears "ValueError: Expected singleton: uom.uom..."

Related PR: https://github.com/odoo/odoo/pull/119944

OPW-3843356

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
