### PR TITLE
[FIX] purchase_requisition: correct compute of PO agreements ordered qty

### DIFF
--- a/addons/purchase_requisition/models/purchase_requisition.py
+++ b/addons/purchase_requisition/models/purchase_requisition.py
@@ -4,6 +4,7 @@ from datetime import datetime, time
 
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
+from collections import defaultdict
 
 
 PURCHASE_REQUISITION_STATES = [
@@ -229,7 +230,7 @@ class PurchaseRequisitionLine(models.Model):
 
     @api.depends('requisition_id.purchase_ids.state')
     def _compute_ordered_qty(self):
-        line_found = set()
+        line_found = defaultdict(set)
         for line in self:
             total = 0.0
             for po in line.requisition_id.purchase_ids.filtered(lambda purchase_order: purchase_order.state in ['purchase', 'done']):
@@ -238,9 +239,9 @@ class PurchaseRequisitionLine(models.Model):
                         total += po_line.product_uom._compute_quantity(po_line.product_qty, line.product_uom_id)
                     else:
                         total += po_line.product_qty
-            if line.product_id not in line_found :
+            if line.product_id not in line_found[line.requisition_id]:
                 line.qty_ordered = total
-                line_found.add(line.product_id)
+                line_found[line.requisition_id].add(line.product_id)
             else:
                 line.qty_ordered = 0
 


### PR DESCRIPTION
**Steps to reproduce the bug:**
- Create a storable product P1.
- Create two purchase agreement with the same product and qty=10

- Create and confirm a PO with only the second PO

- Try to export both purchase agreements, selecting the one without a
PO first and then the other. For the fields to export, choose: Products
to purchase/ordered quantities.

**Problem**:
Sure, here is the corrected version in English:

Both lines will show 0 units. When the `_compute_ordered_qty` is called
with the first PO requisition line, no purchase order is linked, and
therefore the total quantity remains at 0. However, the product is added
as a founded line.
So, on the second requisition line, even though the total quantity (10)
is correctly calculated because a PO is linked, the condition that
checks if the product has already been found will be true, and therefore
the quantity will be set to 0.

https://github.com/odoo/odoo/blob/e7850da5848993e036ab70b731f37005ccd64604/addons/purchase_requisition/models/purchase_requisition.py#L240-L244

opw-[4005265](https://www.odoo.com/web#id=4005265&view_type=form&model=project.task)


