### PR TITLE
[IMP] stock: show final destination

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -78,10 +78,10 @@ class StockMove(models.Model):
         help='The operations brings product to this location', readonly=False,
         index=True, store=True, compute='_compute_location_dest_id', precompute=True)
     location_final_id = fields.Many2one(
-        'stock.location', 'Destination Location',
+        'stock.location', 'Final Location',
         readonly=False, store=True,
         help="The operation brings the products to the intermediate location."
-        "But this operation is part of a chain of operations targeting the destination location.",
+        "But this operation is part of a chain of operations targeting the final location.",
         auto_join=True, index=True, check_company=True)
     location_usage = fields.Selection(string="Source Location Type", related='location_id.usage')
     location_dest_usage = fields.Selection(string="Destination Location Type", related='location_dest_id.usage')

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -285,6 +285,7 @@
                                     <field name="is_storable" column_invisible="True"/>
                                     <field name="has_tracking" column_invisible="True"/>
                                     <field name="product_id" context="{'default_is_storable': True}" required="1" readonly="(state != 'draft' and not additional) or move_lines_count &gt; 0" force_save="1"/>
+                                    <field name="location_final_id" optional="hide" groups="stock.group_stock_multi_locations"/>
                                     <field name="description_picking" string="Description" optional="hide"/>
                                     <field name="date" optional="hide"/>
                                     <field name="date_deadline" optional="hide"/>


### PR DESCRIPTION
This commit give the ability to display the final destination of a stock move in the picking view directly.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
