### PR TITLE
[FIX] website_slides: nav-links disappear on white

### DIFF
--- a/addons/website_slides/static/src/scss/website_slides.scss
+++ b/addons/website_slides/static/src/scss/website_slides.scss
@@ -421,7 +421,7 @@ $line-height-truncate: 1.25em;
 
         .o_wslides_lesson_nav {
             .navbar {
-                @if ( not has-enough-contrast($body-bg, $dark) ) {
+                @if ( lightness($body-bg) < 50% ) {
                     .nav-link, .navbar-brand{
                         color: $navbar-dark-color;
                     }


### PR DESCRIPTION
Current behaviour:
---
In a course, if you modify some colors via the editor, 
the nav-links (Article, Documents, etc.) can disappear

Steps to reproduce:
---
1. Select a course
2. In Options > Display, select Documentation
3. Click on Go to website
4. Go to Edit > Theme
5. Click on the palette
6. Select the first theme (black-white-gray)
7. In Light & Dark, set the third color as white
8. The nav-links have disappeared

Cause of the issue:
---
Caused by: https://github.com/odoo/odoo/commit/6019e26804637907d49bd367eff2bad3aa9275bf

Fix:
---
Inspired by: https://github.com/odoo/odoo/commit/d34e14a684fb6bffdd6ccc8fb4d2041c949db3f4

opw-3941599

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
