### PR TITLE
[FIX] account_peppol: adapt for manual verification

### DIFF
--- a/addons/account_peppol/models/account_edi_proxy_user.py
+++ b/addons/account_peppol/models/account_edi_proxy_user.py
@@ -216,7 +216,7 @@ class AccountEdiProxyClientUser(models.Model):
                 )
 
     def _cron_peppol_get_participant_status(self):
-        edi_users = self.search([('company_id.account_peppol_proxy_state', '=', 'pending')])
+        edi_users = self.search([('company_id.account_peppol_proxy_state', 'in', ['pending', 'not_verified', 'sent_verification'])])
         edi_users._peppol_get_participant_status()
 
     def _peppol_get_participant_status(self):
@@ -228,5 +228,12 @@ class AccountEdiProxyClientUser(models.Model):
                 _logger.error('Error while updating Peppol participant status: %s', e)
                 continue
 
-            if proxy_user['peppol_state'] in {'active', 'rejected', 'canceled'}:
-                edi_user.company_id.account_peppol_proxy_state = proxy_user['peppol_state']
+            state_map = {
+                'active': 'active',
+                'verified': 'pending',
+                'rejected': 'rejected',
+                'canceled': 'canceled',
+            }
+
+            if proxy_user['peppol_state'] in state_map:
+                edi_user.company_id.account_peppol_proxy_state = state_map[proxy_user['peppol_state']]


### PR DESCRIPTION
For some phone numbers, our SMS provider fails to send messages. In this case, manual verification can become necessary. This verification would be performed by support staff, and a change on the IAP side would allow for it (see https://github.com/odoo/iap-apps/pull/836).

Considering this change, the client-side needs to be updated such that the participant state of unverified users is also checked and updated, by calling the participant status endpoint on the IAP.

This is performed by updating the _cron_peppol_get_participant_status cron to include EDI users that are not yet verified.

When the user has been verified on the IAP side, the state 'verified' will be returned when making a call to the participant status endpoint, for which the most accurate mapping to a client state is 'pending'.

Note that when managing users from versions 17.0 to 17.2 (inclusive) the support staff responsible for verifying the user should also take the steps to ensure that they are registered on the SMP too (since users of these versions will otherwise remain in the 'pending' state indefinitely until they are manually registered on the SMP).