### PR TITLE
[16.0][FIX] base: Correct date format in cookies for wkhtmltopdf compatibility

### DIFF
--- a/doc/cla/corporate/adhoc.md
+++ b/doc/cla/corporate/adhoc.md
@@ -29,3 +29,4 @@ Rocio Marina Vega rov@adhoc.com.ar https://github.com/rov-adhoc
 Camila Vives cav@adhoc.com.ar https://github.com/cav-adhoc
 Celina Devigili ced@adhoc.com.ar https://github.com/ced-adhoc
 Matías Velazquez mav@adhoc.com.ar https://github.com/mav-adhoc
+Franco Leyes lef@adhoc.com.ar https://github.com/lef-adhoc

--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -439,7 +439,7 @@ class IrActionsReport(models.Model):
         if request and request.db:
             expiration = datetime.now() + timedelta(hours=1)
             # Use format_datetime to force locale
-            expiration = format_datetime(self.env, expiration, "UTC", "E, d-M-Y H:m:s z", "en_US")
+            expiration = format_datetime(self.env, expiration, "UTC", "EEE, dd MMM yyyy HH:mm:ss 'GMT'", "en_US")
             base_url = self._get_report_url()
             domain = urlparse(base_url).hostname
             cookie = f'session_id={request.session.sid}; HttpOnly; expires={expiration}; domain={domain}; path=/;'


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
When generating PDF reports using wkhtmltopdf, the CSS formatting is not applied correctly. This issue is caused by the date format in cookies, which does not comply with the RFC 6265 standard.

**Current behavior before PR:**
PDF reports generated with wkhtmltopdf lack proper CSS formatting when working with multiple databases. The issue stems from incorrectly formatted cookie expiration dates.

**Desired behavior after PR is merged:**
PDF reports will have correct CSS formatting regardless of the number of databases. The cookies' expiration dates will be formatted in compliance with RFC 6265.

**Details of the fix:**
The fix involves updating the date format in cookies to "EEE, dd MMM yyyy HH:mm:ss 'GMT'", ensuring compatibility with the RFC 6265 standard. This change will prevent the cookies from being considered expired prematurely, allowing the correct application of CSS in generated PDFs.

**Related issues:**
[Issue #171463](https://github.com/odoo/odoo/issues/171463)

**More info here:**
Expiration format: https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie
How to render: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toUTCString

This is the pr of my CLA #171858 