### PR TITLE
[IMP] l10n_br: add a Brazil accounting menu

### DIFF
--- a/addons/l10n_br/__manifest__.py
+++ b/addons/l10n_br/__manifest__.py
@@ -66,6 +66,7 @@ Same as the l10n_br_avatax module with the extension to the sales order module.
         'data/l10n_latam.document.type.csv',
         'views/account_view.xml',
         'views/account_fiscal_position_views.xml',
+        'views/ir_ui_menu_brazil.xml',
         'views/res_company_views.xml',
         'views/account_journal_views.xml',
         'views/res_bank_views.xml',

--- a/addons/l10n_br/views/ir_ui_menu_brazil.xml
+++ b/addons/l10n_br/views/ir_ui_menu_brazil.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <menuitem
+        id="brazilian_accounting_menu"
+        name="Brazil"
+        parent="account.menu_finance_configuration"
+        sequence="25"/>
+</odoo>


### PR DESCRIPTION
To be used by other modules (e.g. l10n_br_avatax). The menu doesn't show if it has no children, so it's safe to add here.

task-3803424
task-3987919