### PR TITLE
[IMP] mail: remove check_access_rule from _message_format

### DIFF
--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -946,7 +946,6 @@ class Message(models.Model):
                     'parentMessage': {...}, # formatted message that this message is a reply to. Only present if format_reply is True
                 }
         """
-        self.check_access_rule("read")
         vals_list = self._read_format(self._get_message_format_fields())
         com_id = self.env["ir.model.data"]._xmlid_to_res_id("mail.mt_comment")
         note_id = self.env["ir.model.data"]._xmlid_to_res_id("mail.mt_note")

--- a/addons/test_mail/tests/test_mail_thread_internals.py
+++ b/addons/test_mail/tests/test_mail_thread_internals.py
@@ -442,17 +442,12 @@ class TestDiscuss(MailCommon, TestRecipients):
     @users("employee")
     def test_unlink_notification_message(self):
         channel = self.env['discuss.channel'].create({'name': 'testChannel'})
-        notification_msg = channel.with_user(self.user_admin).message_notify(
+        channel.with_user(self.user_admin).message_notify(
             body='test',
             partner_ids=[self.partner_2.id],
         )
-
-        with self.assertRaises(exceptions.AccessError):
-            notification_msg.with_env(self.env)._message_format(for_current_user=True)
-
         channel_message = self.env['mail.message'].sudo().search([('model', '=', 'discuss.channel'), ('res_id', 'in', channel.ids)])
         self.assertEqual(len(channel_message), 1, "Test message should have been posted")
-
         channel.sudo().unlink()
         remaining_message = channel_message.exists()
         self.assertEqual(len(remaining_message), 0, "Test message should have been deleted")


### PR DESCRIPTION
It is completely useless, introduced when `_message_format` was still a public method.

This is adding extra queries when fixing inbox flow (`with_user` checking extra ACL for no reason) when doing
`self.env.user.partner_id.id` in `operation == 'read'`.

`_get_recipient_data` doing manual queries that therefore don't fill the cache correctly even though it returns both `pid` and `uid`.

Part of task-3605717

Prep for PR https://github.com/odoo/odoo/pull/171869
Prep for PR https://github.com/odoo/odoo/pull/171585