### PR TITLE
[REM] mail, im_livechat: remove _channel_fetch_message

### DIFF
--- a/addons/im_livechat/static/tests/mock_server/livechat_mock_server.js
+++ b/addons/im_livechat/static/tests/mock_server/livechat_mock_server.js
@@ -145,20 +145,6 @@ async function feedback(request) {
     return channel.rating_ids[0];
 }
 
-registerRoute("/im_livechat/chat_history", chat_history);
-/** @type {RouteCallback} */
-async function chat_history(request) {
-    /** @type {import("mock_models").DiscussChannel} */
-    const DiscussChannel = this.env["discuss.channel"];
-
-    const { channel_id, last_id, limit = 20 } = await parseRequestParams(request);
-    const [channel] = DiscussChannel.search_read([["id", "=", channel_id]]);
-    if (!channel) {
-        return [];
-    }
-    return DiscussChannel._channel_fetch_message(channel.id, last_id, limit);
-}
-
 registerRoute("/im_livechat/init", livechat_init);
 /** @type {RouteCallback} */
 async function livechat_init(request) {

--- a/addons/im_livechat/static/tests/mock_server/mock_models/discuss_channel.js
+++ b/addons/im_livechat/static/tests/mock_server/mock_models/discuss_channel.js
@@ -66,20 +66,7 @@ export class DiscussChannel extends mailModels.DiscussChannel {
     _get_visitor_leave_message() {
         return "Visitor left the conversation.";
     }
-    _channel_fetch_message(channelId, lastId, limit) {
-        /** @type {import("mock_models").MailMessage} */
-        const MailMessage = this.env["mail.message"];
 
-        const domain = [
-            ["model", "=", "discuss.channel"],
-            ["res_id", "=", channelId],
-        ];
-        if (lastId) {
-            domain.push(["id", "<", lastId]);
-        }
-        const messages = MailMessage._message_fetch(domain, limit);
-        return MailMessage._message_format(messages.map(({ id }) => id));
-    }
     /**
      * @override
      * @type {typeof mailModels.DiscussChannel["prototype"]["_types_allowing_seen_infos"]}

--- a/addons/im_livechat/tests/test_get_discuss_channel.py
+++ b/addons/im_livechat/tests/test_get_discuss_channel.py
@@ -274,24 +274,6 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
         channel_ids = [channel["id"] for channel in operator_channels]
         self.assertIn(channel_id, channel_ids, "channel should be fetched by operator on new page")
 
-    def test_operator_livechat_username(self):
-        """Ensures the operator livechat_username is returned by `_channel_fetch_message`, which is
-        the method called by the public route displaying chat history."""
-        operator = self.operators[0]
-        operator.write({
-            'email': 'michel@example.com',
-            'livechat_username': 'Michel at your service',
-        })
-        data = self.make_jsonrpc_request('/im_livechat/get_session', {'anonymous_name': 'whatever', 'channel_id': self.livechat_channel.id})
-        channel = self.env['discuss.channel'].browse(data["Thread"][0]['id'])
-        channel.with_user(operator).message_post(body='Hello', message_type='comment', subtype_xmlid='mail.mt_comment')
-        message_formats = channel.with_user(None).sudo()._channel_fetch_message()
-        self.assertEqual(len(message_formats), 1)
-        self.assertNotIn('name', message_formats[0]['author'])
-        self.assertEqual(message_formats[0]['author']['id'], operator.partner_id.id)
-        self.assertEqual(message_formats[0]['author']['user_livechat_username'], operator.livechat_username)
-        self.assertFalse(message_formats[0].get('email_from'), "should not send email_from to livechat user")
-
     def test_read_channel_unpined_for_operator_after_one_day(self):
         data = self.make_jsonrpc_request('/im_livechat/get_session', {'anonymous_name': 'visitor', 'channel_id': self.livechat_channel.id})
         member_of_operator = self.env['discuss.channel.member'].search([('channel_id', '=', data["Thread"][0]['id']), ('partner_id', 'in', self.operators.partner_id.ids)])

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -975,20 +975,6 @@ class Channel(models.Model):
             ]
             store.add("Thread", info)
 
-    def _channel_fetch_message(self, last_id=False, limit=20):
-        """ Return message values of the current channel.
-            :param last_id : last message id to start the research
-            :param limit : maximum number of messages to fetch
-            :returns list of messages values
-            :rtype : list(dict)
-        """
-        self.ensure_one()
-        domain = ["&", ("model", "=", "discuss.channel"), ("res_id", "in", self.ids)]
-        if last_id:
-            domain.append(("id", "<", last_id))
-        res = self.env['mail.message']._message_fetch(domain=domain, limit=limit)
-        return res["messages"]._message_format()
-
     def _channel_format(self, fields=None):
         if not fields:
             fields = {'id': True}


### PR DESCRIPTION
This method is no longer used since livechat refactoring.

Part of task-3605717