### PR TITLE
[FIX] website: make the sidebar header content scrollable

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -1185,6 +1185,7 @@ header {
                     width: 100%;
                     align-items: start;
                     padding: $spacer;
+                    overflow: auto;
 
                     .navbar-brand {
                         max-width: 100%;


### PR DESCRIPTION
Before this commit, the sidebar header content was not scrollable, so overflowed content was hidden outside the screen. This commit makes the sidebar header content scrollable when it has overflowed content.

task-3366354
