### PR TITLE
[FIX] pos_viva_wallet: prevent traceback when paying using viva wallet

### DIFF
--- a/addons/pos_viva_wallet/models/pos_payment_method.py
+++ b/addons/pos_viva_wallet/models/pos_payment_method.py
@@ -55,8 +55,6 @@ class PosPaymentMethod(models.Model):
 
     def _bearer_token(self, session):
         self.ensure_one()
-        if not self.env.user.has_group('point_of_sale.group_pos_user'):
-            raise AccessError(_("Do not have access to fetch token from Viva Wallet"))
 
         data = {'grant_type': 'client_credentials'}
         auth = requests.auth.HTTPBasicAuth(self.viva_wallet_client_id, self.viva_wallet_client_secret)


### PR DESCRIPTION
When customer pay using viva wallet, a traceback will appear.

First, the method was called from the public controller at line [1].
From the public controller, the method from model was called at [2],
where access right was checked by the code.
But since the method was called from the controller,
we do not have any users in the environment,
so the below error will occur.

Traceback:
```
ValueError: not enough values to unpack (expected 1, got 0)
  File "odoo/models.py", line 5851, in ensure_one
    _id, = self._ids
ValueError: Expected singleton: res.users()
  File "odoo/http.py", line 2248, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1823, in _serve_db
    return self._transactioning(_serve_ir_http, readonly=ro)
  File "odoo/http.py", line 1843, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1821, in _serve_ir_http
    return self._serve_ir_http(rule, args)
  File "odoo/http.py", line 1828, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1966, in dispatch
    return self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 220, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 756, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/pos_viva_wallet/controllers/main.py", line 24, in notification
    payment_method_sudo._retrieve_session_id(data_webhook)
  File "addons/pos_viva_wallet/models/pos_payment_method.py", line 115, in _retrieve_session_id
    data = self._call_viva_wallet(endpoint, 'get')
  File "addons/pos_viva_wallet/models/pos_payment_method.py", line 99, in _call_viva_wallet
    session.headers.update(self._bearer_token(session))
  File "addons/pos_viva_wallet/models/pos_payment_method.py", line 58, in _bearer_token
    if not self.env.user.has_group('point_of_sale.group_pos_user'):
  File "odoo/addons/base/models/res_users.py", line 1120, in has_group
    self.ensure_one()
  File "odoo/models.py", line 5854, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
```

[1] https://github.com/odoo/odoo/blob/5d065006005a18836b83e7309193864ac6e303f7/addons/pos_viva_wallet/controllers/main.py#L24

[2]- https://github.com/odoo/odoo/blob/5d065006005a18836b83e7309193864ac6e303f7/addons/pos_viva_wallet/models/pos_payment_method.py#L58-L59

sentry-5563172568

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
