### PR TITLE
[FIX] packaging: fix oversight of a checksum flag

### DIFF
--- a/setup/package.dfwine
+++ b/setup/package.dfwine
@@ -77,8 +77,7 @@ ADD --chown=odoo:odoo \
 # Pre install requirements
 ADD --chown=odoo:odoo requirements.txt ${DRIVE_C_DIR}
 ADD --chown=odoo:odoo requirements-local-proxy.txt ${DRIVE_C_DIR}
-ADD --checksum=sha256:b97e3cc7cb844e6e5d0e7967586ef5cc55ccc9886db99a4bb534ddba749a9c33 \
-    --chown=odoo:odoo https://nightly.odoo.com/wheels/netifaces-0.11.0-cp312-cp312-win_amd64.whl ${DRIVE_C_DIR}
+ADD --chown=odoo:odoo https://nightly.odoo.com/wheels/netifaces-0.11.0-cp312-cp312-win_amd64.whl ${DRIVE_C_DIR}
 RUN wine ${ODOO_BUILD_DIR}/WinPy64/python-3.12.3.amd64/python.exe -m pip install --upgrade pip \
     && wine ${ODOO_BUILD_DIR}/WinPy64/python-3.12.3.amd64/python.exe -m pip install "c:\netifaces-0.11.0-cp312-cp312-win_amd64.whl" \
     && cat ${DRIVE_C_DIR}/requirements*.txt | while read PACKAGE ; do \


### PR DESCRIPTION
Another checksum flag was added in 4a578a58 but this flag is not supported by older versions of Docker.

