### PR TITLE
[FIX] pos_loyalty: fix runbot error 69954

### DIFF
--- a/addons/pos_loyalty/static/tests/tours/PosLoyaltyTour.js
+++ b/addons/pos_loyalty/static/tests/tours/PosLoyaltyTour.js
@@ -450,9 +450,9 @@ registry.category("web_tour.tours").add("PosLoyaltyPointsGlobalDiscountProgramNo
     steps: () =>
         [
             Dialog.confirm("Open session"),
+            ProductScreen.addOrderline("product_a", "1"),
             ProductScreen.clickPartnerButton(),
             ProductScreen.clickCustomer("AAAA"),
-            ProductScreen.addOrderline("product_a", "1"),
             PosLoyalty.hasRewardLine("10% on your order", "-10.00"),
             PosLoyalty.orderTotalIs("90"),
             PosLoyalty.pointsAwardedAre("90"),


### PR DESCRIPTION
The step to check the reward line added was sometimes happening before it had time to render. Changed the order of the step to allow the reward line to be rendered before checking it.

runbot error: 69954
