### PR TITLE
[DRAFT][FIX] mrp: raise validation error if component is also byproduct

### DIFF
--- a/addons/mrp/report/mrp_report_mo_overview.py
+++ b/addons/mrp/report/mrp_report_mo_overview.py
@@ -543,6 +543,7 @@ class ReportMoOverview(models.AbstractModel):
                 'currency_id': currency.id,
                 'currency': currency,
             }
+            forecast_line['already_used'] = True
             if doc_in._name == 'mrp.production':
                 replenishment['components'] = self._get_components_data(doc_in, replenish_data, level + 2, replenishment_index)
                 replenishment['operations'] = self._get_operations_data(doc_in, level + 2, replenishment_index)
@@ -558,7 +559,6 @@ class ReportMoOverview(models.AbstractModel):
             replenishment['summary']['mo_cost_decorator'] = self._get_comparison_decorator(replenishment['summary']['real_cost'], replenishment['summary']['mo_cost'], replenishment['summary']['currency'].rounding)
             replenishment['summary']['formatted_state'] = self._format_state(doc_in, replenishment['components']) if doc_in._name == 'mrp.production' else self._format_state(doc_in)
             replenishments.append(replenishment)
-            forecast_line['already_used'] = True
             total_ordered += replenishment['summary']['quantity']
 
         # Add "In transit" line if necessary


### PR DESCRIPTION
Steps to reproduce:
- Manufacturing > Products > Bills of Material > New
- Add any item as component then the same item as by-product
- Confirm
- Operations > Manufacturing Order > New
- Pick the product associated to your newly created BoM
- Confirm > Overview

What happens and why:
Odoo raises an RPC error due to an infinite recursion between _get_components_data and _get_replenishment_lines. Both calls are made before the manufacturing order line is flagged as processed so the functions are mutually dependent on the other finishing first.
The looping call is conditionally called when document_in and document_out are the same, which seems to be why the stock moves 'move_in' (component) and 'move_out' (by-product) need to be configured this way on the BoM.

Why is this an error:
This prevents the user from accessing the overview of a valid MO.

What this fix does:
Moves the flag to before the looping call can be made, so the recursive call does not propagate infinitely.

opw-4013371

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
