### PR TITLE
[FIX] web_editor: horizontal scroll of grid mode

### DIFF
--- a/addons/web_editor/static/src/scss/web_editor.frontend.scss
+++ b/addons/web_editor/static/src/scss/web_editor.frontend.scss
@@ -63,6 +63,10 @@
     column-gap: 0px !important;
 }
 
+.o_grid_item > .row {
+    margin-inline: 10px;
+}
+
 .o_grid_item_image {
     img, .media_iframe_video {
         width: 100% !important;


### PR DESCRIPTION
This commit changes the margin-right property of .row elements that are
child of a .o_grid_item parent element. It changes it to compensate the
exact size of the y grid item padding.

Steps to reproduce :
 - Enter edit mode
 - Drag & Drop a company team snippet
 - Check grid mode & content width : full
 - Save it
 => A horizontal scroll bar appears because the sub rows of the snippet
 are too wide (caused by their margin)

opw-3981579

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
