### PR TITLE
[FIX] spreadsheet: ensure correct padding for sign-in button

### DIFF
--- a/addons/spreadsheet/views/public_readonly_spreadsheet_templates.xml
+++ b/addons/spreadsheet/views/public_readonly_spreadsheet_templates.xml
@@ -19,7 +19,7 @@
                         <a class="btn btn-secondary btn-block o_download_btn" t-att-href="props['downloadExcelUrl']" title="Download"><i class="fa fa-download"/></a>
                     </div>
                 </div>
-                <div class="d-table my-auto">
+                <div class="nav d-table my-auto">
                     <t t-call="portal.user_dropdown">
                         <t t-set="_user_name" t-value="True"/>
                         <t t-set="_item_class" t-valuef="nav-item d-table-cell text-center"/>


### PR DESCRIPTION
# Description

Since upgrading Bootstrap a few months ago, the `nav-link-padding-x` and `nav-link-padding-y` classes now rely on CSS variables defined within the `nav` class. To ensure these variables are correctly applied, we need to wrap the `nav-item` in a nav class.

This change fixes the missing padding issue for the sign-in button.

Task: [4032574](https://www.odoo.com/odoo/project/2328/tasks/4032574?cids=2)




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
