### PR TITLE
[FIX] account_tax_python: Custom formula field under computation selection field

### DIFF
--- a/addons/account_tax_python/views/account_tax_views.xml
+++ b/addons/account_tax_python/views/account_tax_views.xml
@@ -5,12 +5,8 @@
             <field name="model">account.tax</field>
             <field name="inherit_id" ref="account.view_tax_form" />
             <field name="arch" type="xml">
-                 <xpath expr="//field[@name='children_tax_ids']" position="before">
-                    <group invisible="amount_type != 'code'">
-                        <group>
-                            <field name="formula" required="amount_type == 'code'" />
-                        </group>
-                    </group>
+                 <xpath expr="//field[@name='amount_type']" position="after">
+                    <field name="formula" invisible="amount_type != 'code'" required="amount_type == 'code'" />
                 </xpath>
             </field>
         </record>


### PR DESCRIPTION
When selecting Custom Formula as the tax computation method, the formula field was viewed at the bottom of the page. To improve the usability, make it under the tax computation selection field.

task-3997626

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
