### PR TITLE
[FIX] hr_expense: outgoing payment account selection

### DIFF
--- a/addons/hr_expense/models/hr_expense_sheet.py
+++ b/addons/hr_expense/models/hr_expense_sheet.py
@@ -750,7 +750,7 @@ class HrExpenseSheet(models.Model):
         if self.payment_mode == 'company_account':
             journal = self.payment_method_line_id.journal_id
             account_dest = (
-                journal.outbound_payment_method_line_ids[:1].payment_account_id
+                self.payment_method_line_id.payment_account_id
                 or journal.company_id.account_journal_payment_credit_account_id
             )
         else:


### PR DESCRIPTION
Open Bank Journal settings
In 'Outgoing Payments' tab add a payment method entry:
- Type: Manual
- Name: [TEST]
- Outstanding Payment Account: [ACCOUNT]

Create an expense paid by company
Create the report, select as payment method [TEST]
Approve the expense and post journal entry
Check the created payment

Issue: Payment line is not using [ACCOUNT], but the account of the first
outgoing payment line found in the Bank Journal

opw-4015780