### PR TITLE
[REM] stock: remove unnecessary context check in `_package_move_lines`

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -1733,8 +1733,6 @@ class Picking(models.Model):
         move_line_ids = quantity_move_line_ids.filtered(lambda ml: ml.picked)
         if not move_line_ids:
             move_line_ids = quantity_move_line_ids
-        if self.env.context.get('move_lines_to_pack_ids', False):
-            move_line_ids = move_line_ids.filtered(lambda ml: ml.id in self.env.context['move_lines_to_pack_ids'])
         if move_lines_to_pack:
             move_line_ids = move_line_ids & move_lines_to_pack
         return move_line_ids


### PR DESCRIPTION
This commit removes the check for `move_lines_to_pack` key in the context since it's no longer passed in the context. It's now passed as an argument for the function, hence, the context check is now obsolete.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
