### PR TITLE
[FIX] mrp: prevent traceback when produced quantity is zero

### DIFF
--- a/addons/mrp/models/mrp_unbuild.py
+++ b/addons/mrp/models/mrp_unbuild.py
@@ -236,7 +236,7 @@ class MrpUnbuild(models.Model):
         for unbuild in self:
             if unbuild.mo_id:
                 raw_moves = unbuild.mo_id.move_raw_ids.filtered(lambda move: move.state == 'done')
-                factor = unbuild.product_qty / unbuild.mo_id.product_uom_id._compute_quantity(unbuild.mo_id.qty_produced, unbuild.product_uom_id)
+                factor = unbuild.product_qty / unbuild.mo_id.product_uom_id._compute_quantity(unbuild.mo_id.qty_produced or 1.0, unbuild.product_uom_id)
                 for raw_move in raw_moves:
                     moves += unbuild._generate_move_from_existing_move(raw_move, factor, raw_move.location_dest_id, self.location_dest_id)
             else:


### PR DESCRIPTION
When the produced quantity is zero in manufacturing order,
and the customer clicks on the unbuild button,
a traceback will appear.

Steps to reproduce the error:
- Create Manufacturing order
- Confirm > Mark as Done
- Unlock > set produced quantity to 0
- Unbuild > Confirm

Traceback:
```
ZeroDivisionError: float division by zero
  File "odoo/http.py", line 2248, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1823, in _serve_db
    return self._transactioning(_serve_ir_http, readonly=ro)
  File "odoo/http.py", line 1843, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1821, in _serve_ir_http
    return self._serve_ir_http(rule, args)
  File "odoo/http.py", line 1828, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2053, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 220, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 756, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 42, in call_button
    action = self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 34, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 458, in call_kw
    result = getattr(recs, name)(*args, **kwargs)
  File "addons/mrp/wizard/stock_warn_insufficient_qty.py", line 19, in action_done
    return self.unbuild_id.action_unbuild()
  File "addons/mrp/models/mrp_unbuild.py", line 180, in action_unbuild
    consume_moves = self._generate_consume_moves()
  File "addons/mrp/models/mrp_unbuild.py", line 243, in _generate_consume_moves
    factor = unbuild.product_qty / unbuild.mo_id.product_uom_id._compute_quantity(unbuild.mo_id.qty_produced, unbuild.product_uom_id)
```

https://github.com/odoo/odoo/blob/d76a46c45b908292a5d14e19ef16fbeb0a4ab13f/addons/mrp/models/mrp_unbuild.py#L239 Here, when the produced quantity is zero,
It will lead to the above traceback.

sentry-5534150712

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
