### PR TITLE
[FIX] mail: make most discuss <img/> non-draggable

### DIFF
--- a/addons/im_livechat/static/src/embed/common/feedback_panel/feedback_panel.xml
+++ b/addons/im_livechat/static/src/embed/common/feedback_panel/feedback_panel.xml
@@ -8,9 +8,9 @@
             <t t-if="state.step === STEP.RATING">
                 <p class="text-center fs-6 mb-4">Did we correctly answer your question?</p>
                 <div class="d-flex justify-content-center">
-                    <img role="button" class="mx-3 opacity-50 opacity-100-hover" t-att-class="{ 'opacity-100': state.rating === RATING.GOOD }" t-att-src="url(`/rating/static/src/img/rating_${RATING.GOOD}.png`)" t-att-alt="RATING.GOOD" t-on-click="() => this.select(RATING.GOOD)"/>
-                    <img role="button" class="mx-3 opacity-50 opacity-100-hover" t-att-class="{ 'opacity-100': state.rating === RATING.OK }" t-att-src="url(`/rating/static/src/img/rating_${RATING.OK}.png`)" t-att-alt="RATING.OK"  t-on-click="() => this.select(RATING.OK)"/>
-                    <img role="button" class="mx-3 opacity-50 opacity-100-hover" t-att-class="{ 'opacity-100': state.rating === RATING.BAD }" t-att-src="url(`/rating/static/src/img/rating_${RATING.BAD}.png`)" t-att-alt="RATING.BAD" t-on-click="() => this.select(RATING.BAD)"/>
+                    <img role="button" class="mx-3 opacity-50 opacity-100-hover" draggable="false" t-att-class="{ 'opacity-100': state.rating === RATING.GOOD }" t-att-src="url(`/rating/static/src/img/rating_${RATING.GOOD}.png`)" t-att-alt="RATING.GOOD" t-on-click="() => this.select(RATING.GOOD)"/>
+                    <img role="button" class="mx-3 opacity-50 opacity-100-hover" draggable="false" t-att-class="{ 'opacity-100': state.rating === RATING.OK }" t-att-src="url(`/rating/static/src/img/rating_${RATING.OK}.png`)" t-att-alt="RATING.OK"  t-on-click="() => this.select(RATING.OK)"/>
+                    <img role="button" class="mx-3 opacity-50 opacity-100-hover" draggable="false" t-att-class="{ 'opacity-100': state.rating === RATING.BAD }" t-att-src="url(`/rating/static/src/img/rating_${RATING.BAD}.png`)" t-att-alt="RATING.BAD" t-on-click="() => this.select(RATING.BAD)"/>
                 </div>
             </t>
             <t t-else="">

--- a/addons/im_livechat/static/src/embed/common/message_patch.xml
+++ b/addons/im_livechat/static/src/embed/common/message_patch.xml
@@ -3,7 +3,7 @@
     <t t-inherit="mail.Message" t-inherit-mode="extension">
         <xpath expr="//*[@t-ref='messageContent']" position="replace">
             <div t-if="props.isTypingMessage">
-                <img height="30" t-att-src="url('/im_livechat/static/src/img/chatbot_is_typing.gif')"/>
+                <img height="30" t-att-src="url('/im_livechat/static/src/img/chatbot_is_typing.gif')" draggable="false"/>
             </div>
             <t t-else="">$0</t>
         </xpath>

--- a/addons/mail/static/src/core/common/chat_hub.xml
+++ b/addons/mail/static/src/core/common/chat_hub.xml
@@ -59,7 +59,7 @@
             <ul class="m-0 p-0 overflow-auto" role="menu" t-ref="more-menu">
                 <t t-foreach="chatHub.actuallyHidden" t-as="cw" t-key="cw.localId">
                     <li class="o-mail-ChatHub-hiddenItem gap-2 px-2 py-1" role="menuitem" t-att-name="cw.displayName" t-on-click="() => cw.open()">
-                        <img class="o-mail-ChatHub-hiddenAvatar rounded-circle" t-att-src="cw.thread?.avatarUrl" alt="Thread image"/>
+                        <img class="o-mail-ChatHub-hiddenAvatar rounded-circle" draggable="false" t-att-src="cw.thread?.avatarUrl" alt="Thread image"/>
                         <p class="text-truncate fw-bold mb-0" t-esc="cw.displayName"/>
                         <div t-if="cw.thread?.importantCounter > 0" class="o-mail-ChatHub-hiddenCounter badge rounded-pill fw-bold o-discuss-badge" style="padding: 3px 6px">
                             <t t-out="cw.thread?.importantCounter"/>

--- a/addons/mail/static/src/core/common/chat_window.xml
+++ b/addons/mail/static/src/core/common/chat_window.xml
@@ -93,7 +93,7 @@
 
 <t t-name="mail.ChatWindow.headerContent">
     <div t-if="thread" class="o-mail-ChatWindow-threadAvatar my-0" t-attf-class="{{ threadActions.actions.length > 4 ? 'ms-1' : 'ms-3' }} me-1">
-        <img class="rounded" t-att-src="thread.avatarUrl" alt="Thread Image"/>
+        <img class="rounded" draggable="false" t-att-src="thread.avatarUrl" alt="Thread Image"/>
     </div>
     <ThreadIcon t-if="thread and thread.channel_type === 'chat' and thread.correspondent" thread="thread"/>
     <div t-if="!state.editingName" class="text-truncate fw-bold border border-transparent me-1 my-0" t-att-title="props.chatWindow.displayName" t-esc="props.chatWindow.displayName" t-att-class="thread ? 'ms-1' : 'ms-3'"/>

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -15,7 +15,7 @@
                     'o-hasSelfAvatar': !env.inChatWindow and thread,
                 }" t-attf-class="{{ props.className }}">
             <div class="o-mail-Composer-sidebarMain flex-shrink-0" t-if="!compact and props.sidebar">
-                <img class="o-mail-Composer-avatar o_avatar rounded" t-att-src="store.self.avatarUrl" alt="Avatar of user"/>
+                <img class="o-mail-Composer-avatar o_avatar rounded" draggable="false" t-att-src="store.self.avatarUrl" alt="Avatar of user"/>
             </div>
             <div class="o-mail-Composer-coreHeader text-truncate small p-2" t-if="props.composer.thread and props.messageToReplyTo?.thread?.eq(props.composer.thread)">
                 <span class="cursor-pointer" t-on-click="() => env.messageHighlight?.highlightMessage(props.messageToReplyTo.message, props.composer.thread)">

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -17,7 +17,7 @@
                 <div class="o-mail-Message-core position-relative d-flex flex-shrink-0">
                     <div class="o-mail-Message-sidebar d-flex flex-shrink-0" t-att-class="{ 'justify-content-end': isAlignedRight, 'align-items-start justify-content-start': !isAlignedRight  }">
                         <div t-if="!props.squashed" class="o-mail-Message-avatarContainer position-relative bg-view" t-att-class="getAvatarContainerAttClass()">
-                            <img class="o-mail-Message-avatar w-100 h-100 rounded" t-att-src="authorAvatarUrl" t-att-class="authorAvatarAttClass"/>
+                            <img class="o-mail-Message-avatar w-100 h-100 rounded" draggable="false" t-att-src="authorAvatarUrl" t-att-class="authorAvatarAttClass"/>
                         </div>
                         <t t-elif="message.isPending" t-call="mail.Message.pendingStatus"/>
                         <t t-elif="!message.is_transient">

--- a/addons/mail/static/src/core/common/message_in_reply.xml
+++ b/addons/mail/static/src/core/common/message_in_reply.xml
@@ -8,7 +8,7 @@
             <small class="position-relative d-block text-small mb-1" t-attf-class="{{ env.inChatWindow and props.alignedRight ? 'justify-content-end pe-5': 'ps-5' }}">
                 <span class="o-mail-MessageInReply-corner position-absolute bottom-0 top-50 pe-4 border-top text-300" t-attf-class="{{ env.inChatWindow and props.alignedRight ? 'o-isRightAlign border-end' : 'o-isLeftAlign border-start' }}" t-att-class="{ 'ms-n2': store.discuss.isActive }"/>
                 <span t-if="!props.message.parentMessage.isEmpty" class="d-inline-flex align-items-center text-muted opacity-75" t-att-class="{ 'cursor-pointer opacity-100-hover': props.onClick }" t-on-click="() => this.props.onClick?.()">
-                    <img class="o-mail-MessageInReply-avatar me-2 rounded" t-att-src="authorAvatarUrl" t-att-title="props.message.parentMessage.author?.name ?? props.message.parentMessage.email_from" alt="Avatar"/>
+                    <img class="o-mail-MessageInReply-avatar me-2 rounded" draggable="false" t-att-src="authorAvatarUrl" t-att-title="props.message.parentMessage.author?.name ?? props.message.parentMessage.email_from" alt="Avatar"/>
                     <span class="o-mail-MessageInReply-content overflow-hidden">
                         <b>@<t t-out="props.message.parentMessage.author?.name ?? props.message.parentMessage.email_from"/></b>:
                         <br t-if="env.inChatWindow and !props.alignedRight"/>

--- a/addons/mail/static/src/core/common/message_reaction_menu.xml
+++ b/addons/mail/static/src/core/common/message_reaction_menu.xml
@@ -14,7 +14,7 @@
                 </div>
                 <div class="d-flex overflow-auto flex-column flex-grow-1 bg-view p-2 h-100">
                     <div t-foreach="state.reaction.personas" t-as="persona" t-key="persona.id" class="o-mail-MessageReactionMenu-persona d-flex p-1 align-items-center" t-att-class="{ 'o-isDeviceSmall': ui.isSmall }">
-                        <img class="rounded o_object_fit_cover o-mail-MessageReactionMenu-avatar" t-att-src="persona.avatarUrl"/>
+                        <img class="rounded o_object_fit_cover o-mail-MessageReactionMenu-avatar" draggable="false" t-att-src="persona.avatarUrl"/>
                         <span class="d-flex flex-grow-1 align-items-center">
                             <span class="mx-2 text-truncate fs-6" t-esc="persona.name"/>
                             <div class="flex-grow-1"/>

--- a/addons/mail/static/src/core/common/thread.xml
+++ b/addons/mail/static/src/core/common/thread.xml
@@ -74,7 +74,7 @@
                         You can mark any message as 'starred', and it shows up in this mailbox.
                     </t>
                     <t t-if="props.thread.id === 'history'">
-                        <img src="/web/static/img/neutral_face.svg" alt="History"/>
+                        <img src="/web/static/img/neutral_face.svg" draggable="false" alt="History"/>
                         <h4 class="mb-3 fw-bolder">
                             No history messages
                         </h4>

--- a/addons/mail/static/src/core/public_web/discuss.xml
+++ b/addons/mail/static/src/core/public_web/discuss.xml
@@ -8,7 +8,7 @@
             <div class="o-mail-Discuss-header px-3 bg-view d-flex flex-shrink-0 align-items-center border-bottom z-1" t-att-class="{ 'flex-grow-1': !ui.isSmall and !store.inPublicPage }" t-ref="header">
                 <t t-if="thread">
                     <div t-if="['channel', 'group', 'chat'].includes(thread.channel_type)" class="o-mail-Discuss-threadAvatar position-relative align-self-center align-items-center mt-2 mb-2 me-2">
-                        <img class="rounded" t-att-src="thread.avatarUrl" alt="Thread Image"/>
+                        <img class="rounded" draggable="false" t-att-src="thread.avatarUrl" alt="Thread Image"/>
                         <FileUploader t-if="thread.is_editable" acceptedFileExtensions="'.bmp, .jpg, .jpeg, .png, .svg'" showUploadingText="false" multiUpload="false" onUploaded.bind="(data) => this.onFileUploaded(data)">
                             <t t-set-slot="toggler">
                                 <a href="#" class="position-absolute z-1 h-100 w-100 rounded start-0 bottom-0" title="Upload Avatar">
@@ -47,7 +47,7 @@
                             </button>
                         </t>
                         <div t-if="store.inPublicPage and !ui.isSmall" class="d-flex align-items-center">
-                            <img class="o-mail-Discuss-selfAvatar mx-1 rounded-circle o_object_fit_cover flex-shrink-0" alt="Avatar" t-att-src="store.self.avatarUrl"/>
+                            <img class="o-mail-Discuss-selfAvatar mx-1 rounded-circle o_object_fit_cover flex-shrink-0" draggable="false" alt="Avatar" t-att-src="store.self.avatarUrl"/>
                             <div class="lead fw-bold flex-shrink-1 text-dark">
                                 <t t-if="store.self.type === 'partner'" t-esc="store.self.name"/>
                                 <t t-else="">

--- a/addons/mail/static/src/core/web/activity.xml
+++ b/addons/mail/static/src/core/web/activity.xml
@@ -5,7 +5,7 @@
     <div class="o-mail-Activity d-flex py-1 mb-2">
         <div class="o-mail-Activity-sidebar flex-shrink-0 position-relative">
             <a role="button" t-on-click="onClickAvatar">
-                <img class="w-100 h-100 rounded" t-att-src="props.activity.persona.avatarUrl" />
+                <img draggable="false" class="w-100 h-100 rounded" t-att-src="props.activity.persona.avatarUrl" />
             </a>
             <div
                 class="o-mail-Activity-iconContainer position-absolute top-100 start-100 translate-middle d-flex align-items-center justify-content-center mt-n1 ms-n1 rounded-circle w-50 h-50"

--- a/addons/mail/static/src/core/web/activity_list_popover_item.xml
+++ b/addons/mail/static/src/core/web/activity_list_popover_item.xml
@@ -27,7 +27,7 @@
                 </t>
             </div>
             <div class="d-flex align-items-center flex-wrap mx-3">
-                <img t-if="props.activity.user_id[0]" class="me-2 rounded" t-att-src="activityAssigneeAvatar" style="max-width: 1.5rem; max-height: 1.5rem;"/>
+                <img t-if="props.activity.user_id[0]" draggable="false" class="me-2 rounded" t-att-src="activityAssigneeAvatar" style="max-width: 1.5rem; max-height: 1.5rem;"/>
                 <div class="mt-1">
                     <t t-if="props.activity.user_id[0]">
                         <small class="text-truncate" t-esc="props.activity.user_id[1]"/>

--- a/addons/mail/static/src/core/web/activity_menu.xml
+++ b/addons/mail/static/src/core/web/activity_menu.xml
@@ -16,7 +16,7 @@
                     <t t-foreach="store.activityGroups" t-as="group" t-key="group_index" name="activityGroupLoop">
                         <div class="o-mail-ActivityGroup list-group-item list-group-item-action d-flex p-2 cursor-pointer"
                              t-att-data-model_name="group.model" t-on-click="() => this.openActivityGroup(group)">
-                            <img alt="Activity" t-att-src="group.icon"/>
+                            <img draggable="false" alt="Activity" t-att-src="group.icon"/>
                             <div class="flex-grow-1 overflow-hidden">
                                 <div class="d-flex px-2" name="activityTitle" t-out="group.name"/>
                                 <div t-if="group.type === 'activity'" class="d-flex">

--- a/addons/mail/static/src/core/web/command_palette.xml
+++ b/addons/mail/static/src/core/web/command_palette.xml
@@ -3,7 +3,7 @@
 
     <t t-name="mail.DiscussCommand">
         <div class="o_command_default d-flex align-items-center px-4 py-2">
-            <img class="rounded me-2" t-if="props.imgUrl" t-att-src="props.imgUrl"  style="width: 25px; height: 25px"/>
+            <img draggable="false" class="rounded me-2" t-if="props.imgUrl" t-att-src="props.imgUrl"  style="width: 25px; height: 25px"/>
             <ImStatus t-if="props.persona" className="'me-1'" persona="props.persona"/>
             <span class="pe-1 text-ellipsis fw-bold">
                 <t t-slot="name" />

--- a/addons/mail/static/src/core/web/follower_list.xml
+++ b/addons/mail/static/src/core/web/follower_list.xml
@@ -30,7 +30,7 @@
 <t t-name="mail.Follower">
     <div class="dropdown-item o-mail-Follower d-flex justify-content-between p-0">
         <a class="o-mail-Follower-details d-flex align-items-center flex-grow-1 px-3 o-min-width-0" t-att-class="{ 'o-inactive fst-italic opacity-25': !follower.is_active }" href="#" role="menuitem" t-on-click.prevent="(ev) => this.onClickDetails(ev, follower)">
-            <img class="o-mail-Follower-avatar me-2 rounded" t-att-src="follower.partner.avatarUrl" alt=""/>
+            <img draggable="false" class="o-mail-Follower-avatar me-2 rounded" t-att-src="follower.partner.avatarUrl" alt=""/>
             <span class="flex-shrink text-truncate" t-esc="follower.partner.name"/>
         </a>
         <t t-if="follower.isEditable">

--- a/addons/mail/static/src/core/web/notification_item.xml
+++ b/addons/mail/static/src/core/web/notification_item.xml
@@ -5,7 +5,7 @@
     <ActionSwiper onLeftSwipe="props.onSwipeLeft ? props.onSwipeLeft : undefined" onRightSwipe="props.onSwipeRight ? props.onSwipeRight : undefined">
         <button class="o-mail-NotificationItem list-group-item d-flex cursor-pointer align-items-center bg-view w-100 gap-2" t-att-class="{ 'o-important': props.muted === 0, 'text-muted': props.muted === 1, 'opacity-50': props.muted === 2, 'border-start-0 border-end-0': ui.isSmall, 'border-top-0': props.first, 'p-2 pe-3': !ui.isSmall }" t-on-click="onClick" t-ref="root">
             <div class="position-relative bg-inherit m-1 flex-shrink-0" style="width:40px;height:40px;">
-                <img class="o_avatar w-100 h-100 rounded" alt="Notification Item Image" t-att-src="props.iconSrc"/>
+                <img class="o_avatar w-100 h-100 rounded" draggable="false" alt="Notification Item Image" t-att-src="props.iconSrc"/>
                 <t t-slot="icon"/>
             </div>
             <div class="d-flex flex-column flex-grow-1 align-self-start overflow-auto">

--- a/addons/mail/static/src/discuss/call/common/call_invitation.xml
+++ b/addons/mail/static/src/discuss/call/common/call_invitation.xml
@@ -5,6 +5,7 @@
         <div class="o-discuss-CallInvitation d-flex flex-column m-2 p-5 border border-dark rounded-1 text-bg-900" t-attf-class="{{ className }}" t-ref="root">
             <div t-if="props.thread.rtcInvitingSession" class="o-discuss-CallInvitation-correspondent d-flex flex-column justify-content-around align-items-center text-nowrap">
                 <img class="mb-2 rounded-circle cursor-pointer"
+                    draggable="false"
                     t-att-src="props.thread.rtcInvitingSession.channelMember.persona.avatarUrl"
                     t-on-click="onClickAvatar"
                     alt="Avatar"/>

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.xml
@@ -11,7 +11,7 @@
                             <div class="o-discuss-ChannelInvitation-selectable o_object_fit_cover d-flex align-items-center px-3 py-1 btn" t-on-click="() => this.onClickSelectablePartner(selectablePartner)">
                                 <div class="d-flex align-items-center p-2">
                                     <div class="o-discuss-ChannelInvitation-avatar position-relative d-flex flex-shrink-0">
-                                        <img class="w-100 h-100 rounded o_object_fit_cover"
+                                        <img class="w-100 h-100 rounded o_object_fit_cover" draggable="false"
                                             t-att-src="selectablePartner.avatarUrl"/>
                                         <ImStatus persona="selectablePartner" className="'position-absolute top-100 start-100 translate-middle bg-view mt-n1 ms-n1'"/>
                                     </div>

--- a/addons/mail/static/src/discuss/core/common/channel_member_list.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_member_list.xml
@@ -29,7 +29,7 @@
     <t t-name="discuss.channel_member">
         <div class="o-discuss-ChannelMember d-flex align-items-center p-2 bg-view" t-att-class="{ 'cursor-pointer': canOpenChatWith(member) }" t-on-click.stop="(ev) => this.onClickAvatar(ev, member)">
             <div class="bg-inherit o-discuss-ChannelMember-avatar position-relative d-flex ms-4 flex-shrink-0">
-                <img class="w-100 h-100 rounded o_object_fit_cover"
+                <img class="w-100 h-100 rounded o_object_fit_cover" draggable="false"
                      t-att-src="member.persona.avatarUrl"/>
                 <ImStatus persona="member.persona" className="'position-absolute top-100 start-100 translate-middle mt-n1 ms-n1'"/>
             </div>

--- a/addons/mail/static/src/discuss/core/web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/web/discuss_sidebar_categories.xml
@@ -56,7 +56,7 @@
         >
             <button class="btn border-0 rounded-0 text-reset overflow-hidden d-flex align-items-center px-0 py-2">
                 <div class="bg-inherit position-relative d-flex ms-3 flex-shrink-0" style="width:26px;height:26px">
-                    <img class="w-100 h-100 rounded" t-att-src="thread.avatarUrl" alt="Thread Image"/>
+                    <img class="w-100 h-100 rounded" draggable="false" t-att-src="thread.avatarUrl" alt="Thread Image"/>
                     <ThreadIcon t-if="thread.channel_type === 'chat' or (thread.channel_type === 'channel' and !thread.authorizedGroupFullName)" thread="thread" size="'small'" className="'o-mail-DiscussSidebarChannel-threadIcon position-absolute bottom-0 end-0 p-1 me-n1 mb-n1 d-flex align-items-center justify-content-center rounded-circle bg-inherit'"/>
                 </div>
                 <span class="mx-2 text-truncate" t-att-class="thread.selfMember?.message_unread_counter > 0 and !thread.mute_until_dt ? 'o-item-unread fw-bolder' : 'text-muted'">

--- a/addons/mail/static/src/discuss/gif_picker/common/gif_picker.xml
+++ b/addons/mail/static/src/discuss/gif_picker/common/gif_picker.xml
@@ -26,6 +26,7 @@
                                 t-att-src="state.favorites.gifs[0].media_formats.tinygif.url"
                                 loading="lazy"
                                 alt="GIF Favorites"
+                                draggable="false"
                             />
                             <div class="position-absolute w-100 h-100 top-0 start-0 text-center o-text-white align-middle fs-2 o-bg-black bg-opacity-50">
                                 Favorites
@@ -45,7 +46,7 @@
                         <t t-foreach="state.categories" t-as="category" t-key="category.name">
                             <div class="col">
                                 <div class="position-relative ratio ratio-16x9 cursor-pointer rounded overflow-hidden" t-on-click="() => this.onClickCategory(category)" aria-label="list-item">
-                                    <img class="o-discuss-GifPickerCategory-img img-fluid" t-att-src="category.image" loading="lazy" alt="GIF Category"/>
+                                    <img class="o-discuss-GifPickerCategory-img img-fluid" draggable="false" t-att-src="category.image" loading="lazy" alt="GIF Category"/>
                                     <div class="position-absolute w-100 h-100 top-0 start-0 text-center o-text-white align-middle fs-2 o-bg-black bg-opacity-50">
                                         <t t-out="category.name"/>
                                     </div>
@@ -94,6 +95,7 @@
                 loading="lazy"
                 alt="GIF"
                 t-att-style="style"
+                draggable="false"
             />
         </div>
     </t>

--- a/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.xml
+++ b/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.xml
@@ -8,6 +8,7 @@
                         <img t-if="props.id"
                             t-attf-src="/web/image/res.users/{{props.id}}/avatar_128"
                             class="rounded"
+                            draggable="false"
                         />
                         <span t-if="user.im_status" name="icon" class="o_card_avatar_im_status position-absolute d-flex align-items-center justify-content-center">
                             <i t-if="user.im_status === 'online'" class="fa fa-fw fa-circle text-success" title="Online" role="img" aria-label="User is online"/>

--- a/addons/mail/static/src/views/web/fields/avatar/avatar.xml
+++ b/addons/mail/static/src/views/web/fields/avatar/avatar.xml
@@ -6,6 +6,7 @@
             <img t-attf-class="rounded {{props.noSpacing ? '' : 'me-2'}}"
                 t-attf-src="/web/image/{{props.resModel}}/{{props.resId}}/avatar_128"
                 t-on-click.stop.prevent="onClickAvatar"
+                draggable="false"
             />
             <span t-if="props.displayName" class="text-truncate w-0 flex-grow-1" t-esc="props.displayName"/>
         </div>


### PR DESCRIPTION
Before this commit, most `<img/>` in Discuss app
were draggable, which could lead to unintended behavior like adding the images as attachment to project task description.

Steps to reproduce:

- open a chat window, e.g. #general from messaging menu in home menu
- fold / minimize the chat window
- open a project task
- drag and drop the folded chat window / bubble into the project task description text area => the image is added in the description

This happens because `<img/>` are draggable by default. This feature makes sense when the image represents a user-valuable asset, such as an image that has been posted in a conversation. However, when the image is simply used to identify a conversation, the draggable feature is generally non-desirable. In fact, this could be bothersome when dragging is a feature on those images, such as chat bubbles when hidden the bubble can be dragged.

This commit fixes the issue by flagging most `<img/>` in discuss non-draggable. Some are kept draggable, such as user attachments and link previews as it can be handy to use built-in dragging feature in some cases.
