### PR TITLE
[FIX] mail: missing spacing on recipients list

### DIFF
--- a/addons/mail/static/src/chatter/web_portal/chatter.js
+++ b/addons/mail/static/src/chatter/web_portal/chatter.js
@@ -235,7 +235,7 @@ export class Chatter extends Component {
             .slice(0, 5)
             .map(({ partner }) => {
                 const text = partner.email ? partner.emailWithoutDomain : partner.name;
-                return `<span class="text-muted ps-1" title="${escape(
+                return `<span class="text-muted" title="${escape(
                     partner.email || _t("no email address")
                 )}">${escape(text)}</span>`;
             });

--- a/addons/mail/static/src/chatter/web_portal/chatter.xml
+++ b/addons/mail/static/src/chatter/web_portal/chatter.xml
@@ -73,7 +73,7 @@
             <t t-if="state.composerType">
                 <t t-if="state.composerType === 'message'">
                     <div class="d-flex flex-shrink-0 pt-3 text-truncate small mb-2 ms-5">
-                        <span class="fw-bold">To:</span> <t t-if="toRecipientsText" t-out="toRecipientsText"/>
+                        <span class="fw-bold">To:</span> <span t-if="toRecipientsText" t-out="toRecipientsText" class="ps-1"/>
                         <SuggestedRecipientsList t-elif="state.thread.suggestedRecipients.length > 0" className="'ps-2'" thread="state.thread" onSuggestedRecipientAdded.bind="onSuggestedRecipientAdded"/>
                         <span t-else="" class="ps-1">No recipient</span>
                         <button t-if="state.thread.recipients.length > 0" class="o-mail-Chatter-recipientListButton btn btn-link badge rounded-pill border-0 p-1 ms-1" title="Show all recipients" t-on-click="onClickRecipientList">


### PR DESCRIPTION
Before this commit the recipients list displayed when sending a message on the chatter missed spacing between the recipients and conjunctions.

This happens because the container has display flex which removes whitespace from child elements.

This commit fixes the issue by wrapping the list in a div tag so to preserve the whitespace.

task-4032550

Before:
![image](https://github.com/odoo/odoo/assets/32620115/81b878f3-17a6-44a4-b392-333c11452ea6)

After:
![image](https://github.com/odoo/odoo/assets/32620115/c9cb7e10-bdfa-4714-a73a-acb2af376c98)
