### PR TITLE
[IMP] account: disable CUD for analytic items related to a journal item

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4605,7 +4605,7 @@ class AccountMove(models.Model):
             if move.inalterable_hash:
                 raise UserError(_('You cannot modify a sent entry of this journal because it is in strict mode.'))
             # We remove all the analytics entries for this journal
-            move.mapped('line_ids.analytic_line_ids').unlink()
+            move.mapped('line_ids.analytic_line_ids').with_context(force_analytic_line_delete=True).unlink()
 
         self.mapped('line_ids').remove_move_reconcile()
         self.state = 'draft'

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1236,7 +1236,7 @@ class AccountMoveLine(models.Model):
         lines_to_modify = self.env['account.move.line'].browse([
             line.id for line in self if line.parent_state == "posted"
         ])
-        lines_to_modify.analytic_line_ids.unlink()
+        lines_to_modify.analytic_line_ids.with_context(force_analytic_line_delete=True).unlink()
 
         context = dict(self.env.context)
         context.pop('default_account_id', None)


### PR DESCRIPTION
The analytic items related to a journal item are generated from the
journal item's analytic distribution.

But it is possible for a user, by accessing the analytic
items view, to create/updtate/delete analytic items related to a journal
item.
The analytic distribution is then unsynced with the analytic items.

With this commit, it is no longer possible, so the analytic items of a
journal item will always reflect its analytic distribution.

task-3977961
