### PR TITLE
[FIX] web_editor: prevent a submit button from being unlinked

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -43,7 +43,7 @@ import {
     firstLeaf,
     previousLeaf,
     nextLeaf,
-    isUnremovable,
+    isUnremovableForRange,
     fillEmpty,
     isEmptyBlock,
     getUrlsInfosInString,
@@ -2063,14 +2063,14 @@ export class OdooEditor extends EventTarget {
         }
         range = getDeepRange(this.editable, { sel });
         // Restore unremovables removed by extractContents.
-        [...contents.querySelectorAll('*')].filter(isUnremovable).forEach(n => {
+        [...contents.querySelectorAll('*')].filter(isUnremovableForRange).forEach(n => {
             closestBlock(range.endContainer).after(n);
             n.textContent = '';
         });
         // If the end container was fully selected, extractContents may have
         // emptied it without removing it. Ensure it's gone.
         const isRemovableInvisible = (node, noBlocks = true) =>
-            !isVisible(node, noBlocks) && !isUnremovable(node);
+            !isVisible(node, noBlocks) && !isUnremovableForRange(node);
         const endIsStart = end === start;
         while (end && isRemovableInvisible(end, false) && !end.contains(range.endContainer)) {
             const parent = end.parentNode;

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
@@ -1603,6 +1603,18 @@ export function isUnremovable(node) {
     );
 }
 
+export function isUnremovableForRange(node) {
+    return (
+        (node.nodeType !== Node.COMMENT_NODE && node.nodeType !== Node.ELEMENT_NODE && node.nodeType !== Node.TEXT_NODE) ||
+        node.oid === "root" ||
+        (node.nodeType === Node.ELEMENT_NODE &&
+            (node.classList.contains("o_editable") || node.getAttribute("t-set") || node.getAttribute("t-call"))) ||
+        (node.classList && (node.classList.contains("oe_unremovable") && !node.classList.contains("allowForRange"))) ||
+        (node.nodeName === "SPAN" && node.parentElement && node.parentElement.getAttribute("data-oe-type") === "monetary") ||
+        (node.ownerDocument && node.ownerDocument.defaultWindow && !ancestors(node).find(ancestor => ancestor.oid === "root")) // Node is in DOM but not in editable.
+    );
+}
+
 export function containsUnbreakable(node) {
     if (!node) {
         return false;

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_popover_widget.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_popover_widget.js
@@ -303,6 +303,10 @@ const LinkPopoverWidget = Widget.extend({
      */
     _onEditLinkClick(ev) {
         ev.preventDefault();
+        if (ev.currentTarget.classList.contains("o_disable_link")) {
+            ev.stopImmediatePropagation();
+            return;
+        }
         this.options.wysiwyg.toggleLinkTools({
             forceOpen: true,
             link: this.$target[0],
@@ -318,6 +322,10 @@ const LinkPopoverWidget = Widget.extend({
      */
     _onRemoveLinkClick(ev) {
         ev.preventDefault();
+        if (ev.currentTarget.classList.contains("o_disable_link")) {
+            ev.stopImmediatePropagation();
+            return;
+        }
         this.options.wysiwyg.removeLink();
         ev.stopImmediatePropagation();
         this.popover.hide();

--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -3846,7 +3846,23 @@ options.registry.sizing.include({
             $body.on('mouseup', documentMouseUp);
         });
         return defs;
-    }
+    },
+    /**
+     * Ensure Submit button and form fields are 
+     * not allowed to move outside of the form.
+     *
+     * @override
+     */
+    async updateUIVisibility() {
+        await this._super(...arguments);
+        // Hiding the move handle for submit button and form fields
+        // so we can't drag them outside of the form.
+        const moveHandleEl = this.$overlay[0].querySelector(".o_move_handle");
+        moveHandleEl.classList.toggle(
+            "d-none",
+            ["s_website_form_field", "s_website_form_submit"]
+            .some(cls => this.$target[0].classList.contains(cls)));
+    },
 });
 
 options.registry.SwitchableViews = options.Class.extend({

--- a/addons/website/static/src/js/widgets/link_popover_widget.js
+++ b/addons/website/static/src/js/widgets/link_popover_widget.js
@@ -21,6 +21,15 @@ weWidgets.LinkPopoverWidget.include({
                 timeoutID = setTimeout(() => this.$target.popover('show'), 1500);
             });
         }
+        // Disable "edit link" & remove link" buttons in link popover.
+        if (this.target.classList.contains("s_website_form_send")) {
+            this.el.querySelectorAll(".o_we_edit_link, .o_we_remove_link").forEach((anchor) => {
+                anchor.style.cursor = "default";
+                anchor.classList.add("text-muted", "o_disable_link");
+                anchor.classList.remove("text-dark");
+                anchor.setAttribute("title", _t("This button is dynamic and linked to the form, it cannot be updated."));
+            });
+        }
 
         return this._super(...arguments);
     },

--- a/addons/website/static/src/snippets/s_website_form/000.js
+++ b/addons/website/static/src/snippets/s_website_form/000.js
@@ -33,6 +33,9 @@ odoo.define('website.s_website_form', function (require) {
                     }
                 });
             }
+            // Make below changes in XML itself in master.
+            this.el.querySelector(".s_website_form_send").classList.add("oe_unremovable");
+            this.el.querySelector(".s_website_form_send").classList.add("allowForRange");
             return this._super(...arguments);
         },
     });

--- a/addons/website/static/tests/tours/website_form_editor.js
+++ b/addons/website/static/tests/tours/website_form_editor.js
@@ -416,9 +416,6 @@ odoo.define('website.tour.form_editor', function (require) {
             content: "Click submit button to show edit popover",
             trigger: 'iframe .s_website_form_send',
         }, {
-            content: "Click on Edit Link in Popover",
-            trigger: 'iframe .o_edit_menu_popover .o_we_edit_link',
-        }, {
             content: "Check that no URL field is suggested",
             trigger: '#toolbar:has(#url_row:hidden)',
             run: () => null,
@@ -436,6 +433,18 @@ odoo.define('website.tour.form_editor', function (require) {
         }, {
             content: "Check the resulting button",
             trigger: 'iframe .s_website_form_send.btn.btn-sm.btn-secondary.rounded-circle',
+            run: () => null,
+        },
+        // Checks "remove link" button of linkDialog is disabled for submit button.
+        {
+            content: "Click submit button to show edit popover",
+            trigger: "iframe .s_website_form_send",
+        }, {
+            content: "Click on Remove Link in Popover",
+            trigger: "iframe .o_edit_menu_popover .o_we_remove_link",
+        }, {
+            content: "Check the resulting button",
+            trigger: "iframe .s_website_form_send.btn.btn-sm.btn-secondary.rounded-circle",
             run: () => null,
         },
         // Add a default value to a auto-fillable field.

--- a/addons/website/views/snippets/s_website_form.xml
+++ b/addons/website/views/snippets/s_website_form.xml
@@ -217,7 +217,7 @@
         <div data-js="WebsiteFormFieldRequired" data-selector=".s_website_form .s_website_form_model_required"/>
 
         <!-- Remove the delete and duplicate option of the submit button -->
-        <div data-js="WebsiteFormSubmitRequired" data-selector=".s_website_form .s_website_form_submit"/>
+        <div data-js="WebsiteFormSubmitRequired" data-selector=".s_website_form .s_website_form_submit, .s_website_form .s_website_form_send"/>
     </xpath>
 </template>
 

--- a/addons/website_payment/__manifest__.py
+++ b/addons/website_payment/__manifest__.py
@@ -28,6 +28,8 @@ This is a bridge module that adds multi-website support for payment providers.
         'website.assets_wysiwyg': [
             'website_payment/static/src/snippets/s_donation/options.js',
             'website_payment/static/src/snippets/s_donation/options.xml',
+            "website_payment/static/src/js/link.js",
+            "website_payment/static/src/js/link_popover_widget.js",
         ],
         'web.assets_frontend': [
             'website_payment/static/src/js/website_payment_donation.js',

--- a/addons/website_payment/static/src/js/link.js
+++ b/addons/website_payment/static/src/js/link.js
@@ -1,0 +1,18 @@
+/** @odoo-module **/
+
+import Link from "wysiwyg.widgets.Link";
+
+Link.include({
+    /**
+     * @override
+     */
+    init() {
+        this._super(...arguments);
+        // 's_donation_donate_btn' prevents from changing link of 'Donate Now'
+        //  anchor of Donation snippet.
+        if (/(?:o_submit|s_donation_donate_btn)/.test(this.data.className)) {
+            this.isButton = true;
+        }
+    }
+});
+

--- a/addons/website_payment/static/src/js/link_popover_widget.js
+++ b/addons/website_payment/static/src/js/link_popover_widget.js
@@ -1,0 +1,23 @@
+/** @odoo-module **/
+
+import weWidgets from "wysiwyg.widgets";
+import {_t} from "web.core";
+
+weWidgets.LinkPopoverWidget.include({
+    /**
+     * @override
+     */
+    start() {
+        // Disable "edit link" & remove link" buttons in link popover.
+        if (this.target.classList.contains("s_donation_donate_btn")) {
+            this.el.querySelectorAll(".o_we_edit_link, .o_we_remove_link").forEach((anchor) => {
+                anchor.style.cursor = "default";
+                anchor.classList.add("text-muted", "o_disable_link");
+                anchor.classList.remove("text-dark");
+                anchor.setAttribute("title", _t("This button is dynamic and linked to the form, it cannot be updated."));
+            });
+        }
+
+        return this._super(...arguments);
+    },
+});

--- a/addons/website_payment/static/src/snippets/s_donation/000.js
+++ b/addons/website_payment/static/src/snippets/s_donation/000.js
@@ -34,6 +34,11 @@ publicWidget.registry.DonationSnippet = publicWidget.Widget.extend({
             const width = context.measureText(customButtonEl.placeholder).width;
             customButtonEl.style.maxWidth = `${Math.ceil(width) + CUSTOM_BUTTON_EXTRA_WIDTH}px`;
         }
+        // Make below changes in XML itself in master.
+        this.el.querySelector(".s_donation_form").setAttribute("contentEditable", "false");
+        this.el.querySelector(".s_donation_donate_btn").setAttribute("contentEditable", "true");
+        this.el.querySelector(".s_donation_donate_btn").classList.add("oe_unremovable");
+        this.el.querySelector(".s_donation_donate_btn").classList.add("allowForRange");
     },
     /**
      * @override

--- a/addons/website_payment/static/src/snippets/s_donation/options.js
+++ b/addons/website_payment/static/src/snippets/s_donation/options.js
@@ -313,6 +313,38 @@ options.registry.Donation = options.Class.extend({
     },
 });
 
+// Superclass for options that need to disable a button from the snippet overlay
+// TODO: In master Export this class from website.
+const DisableOverlayButtonOption = options.Class.extend({
+    // Disable a button of the snippet overlay
+    disableButton(buttonName, message) {
+        // TODO refactor in master
+        const className = "oe_snippet_" + buttonName;
+        this.$overlay.add(this.$overlay.data("$optionsSection")).on("click", "." + className, this.preventButton);
+        const $button = this.$overlay.add(this.$overlay.data("$optionsSection")).find("." + className);
+        $button.attr("title", message).tooltip({delay: 0});
+        // TODO In master: add `o_disabled` but keep actual class.
+        $button.removeClass(className); // Disable the functionnality
+    },
+
+    preventButton(event) {
+        // Snippet options bind their functions before the editor, so we
+        // can't cleanly unbind the editor onRemove function from here
+        event.preventDefault();
+        event.stopImmediatePropagation();
+    }
+});
+
+// Disable delete and duplicate button for "Donate Now" Button
+options.registry.DonateNowButtonRequired = DisableOverlayButtonOption.extend({
+    start() {
+        this.disableButton("remove", _t("You can't remove the Donate Now button of the form"));
+        this.disableButton("clone", _t("You can't duplicate the Donate Now button of the form."));
+        return this._super(...arguments);
+    }
+});
+
 export default {
     Donation: options.registry.Donation,
+    DonateNowButtonRequired: options.registry.DonateNowButtonRequired,
 };

--- a/addons/website_payment/views/snippets/s_donation.xml
+++ b/addons/website_payment/views/snippets/s_donation.xml
@@ -81,6 +81,7 @@
             <we-input string="Default Amount" data-step="1" data-attribute-default-value="25"
                 data-select-data-attribute="" data-attribute-name="defaultAmount"/>
         </div>
+        <div data-js="DonateNowButtonRequired" data-selector=".s_donation .s_donation_form .s_donation_donate_btn"/>
     </xpath>
 </template>
 


### PR DESCRIPTION
Specification:
To prevent a "submit" & "Donate Now" button from being
unlinked/removed/edited

Before this commit:
- It is possible to unlink "Submit" & "Donate Now" button from form,
Donation snippet, which kind of make them useless.
- Link of "Donate Now" anchor is Editable, which should not be the case
because we need it to redirect to specific URL to continue it's
functionality.
- It is possible to remove "Submit" & "Donate Now" Buttons without
removing entire snippet.

After this commit:
- It is not possible to unlink "Submit" & "Donate Now" Button from Form,
Donation snippet.
- Link of "Donate Now" anchor is not editable.
- It is not possible to remove "Submit" & "Donate Now" Buttons without
removing entire snippet.
- Introduced new 'isUnremovableForRange' method in utils.js to make
buttons removable if they are selected with rest of the content.


Task-3549514


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
