### PR TITLE
[FIX] Website_sale : Fix add to cart notifications

### DIFF
--- a/addons/website_sale/static/src/js/notification/cart_notification/cart_notification.js
+++ b/addons/website_sale/static/src/js/notification/cart_notification/cart_notification.js
@@ -9,9 +9,10 @@ export class CartNotification extends Component {
     static template = "website_sale.cartNotification";
     static props = {
         message: [String, { toString: Function }],
-        warning: [String, { toString: Function }],
+        warning: {type : [String, { toString: Function }],optional: true},
         lines: {
             type: Array,
+            optional: true,
             element: {
                 type: Object,
                 shape: {
@@ -27,6 +28,8 @@ export class CartNotification extends Component {
         currency_id: Number,
         className: String,
         close: Function,
+        refresh: Function,
+        freeze: Function,
     }
 
     /**


### PR DESCRIPTION
-fix and issue when adding a product to the cart (in debug mode only)
 an error pops up because freeze and refresh functions are missing
 from the props and the warning prop is not set as optional.

opw-4016928


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
