### PR TITLE
[FIX] point_of_sale: split internal note when adding product

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/customer_note_button/customer_note_button.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/customer_note_button/customer_note_button.js
@@ -48,7 +48,26 @@ export class OrderlineNoteButton extends Component {
             startingValue: this.props.getter(selectedOrderline),
         });
 
-        this.props.setter(selectedOrderline, payload);
+        var quantity_with_note = 0;
+        const changes = this.pos.getOrderChanges();
+        for (const key in changes.orderlines) {
+            if (changes.orderlines[key].uuid == selectedOrderline.uuid) {
+                quantity_with_note = changes.orderlines[key].quantity;
+                break;
+            }
+        }
+        const saved_quantity = selectedOrderline.qty - quantity_with_note;
+        if (saved_quantity > 0 && quantity_with_note > 0) {
+            await this.pos.addLineToCurrentOrder({
+                product_id: selectedOrderline.product_id,
+                qty: quantity_with_note,
+                note: payload,
+            });
+            selectedOrderline.qty = saved_quantity;
+        } else {
+            this.props.setter(selectedOrderline, payload);
+        }
+
         return { confirmed: typeof payload === "string", inputNote: payload, oldNote };
     }
 }


### PR DESCRIPTION
If you already ordered product A and add another product A with an
internal note. The internal note would end up on both product A. The
correct behavior would be to have the internal note on only one of them.

Steps to reproduce:
-------------------
* Setup a PoS restaurant and a preparation display
* Open PoS session
* Add 1 product A to the order and send it to preparation
* Add 1 product A, and add an internal note on it
* Send it to preparation
> Observation: On the preparation display both product will have the
internal note

Why the fix:
------------
To fix the issue, when adding an internal note we only add it on the
product that hasn't been sent in preparation and split the order line in
2 if necessary. We also take the order line uuid in account when
processing the orders in the preparation display to differentiate the
line correctly.

The behavior should be the following:
- If you add a note on a line that has no quantity sent in preparation
  the note will be on all the quantity
- If you add a note on a line that has all quantity sent in preparation
  the note will be on all the quantity
- If you add a note on a line that has a part of the quantity sent in
  preparation the note will be on the quantity not sent, and the line
  will be split in 2. One line with already sent, and one with the rest.

opw-4000386