### PR TITLE
[FIX] point_of_sale: generate new name in stock picking during uninstalling PoS

### DIFF
--- a/addons/point_of_sale/__init__.py
+++ b/addons/point_of_sale/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo import _
 from . import models
 from . import controllers
 from . import report
@@ -10,3 +11,6 @@ from . import wizard
 def uninstall_hook(env):
     #The search domain is based on how the sequence is defined in the _get_sequence_values method in /addons/point_of_sale/models/stock_warehouse.py
     env['ir.sequence'].search([('name', 'ilike', '%Picking POS%'), ('prefix', 'ilike', '%/POS/%')]).unlink()
+    pickings = env['stock.picking'].search([('pos_session_id', '!=', False)])
+    for picking in pickings:
+        picking.name = picking.name + _('(Deleted POS Session)')

--- a/addons/point_of_sale/i18n/point_of_sale.pot
+++ b/addons/point_of_sale/i18n/point_of_sale.pot
@@ -99,6 +99,13 @@ msgstr ""
 
 #. module: point_of_sale
 #. odoo-python
+#: code:addons/point_of_sale/__init__.py:0
+#, python-format
+msgid "(Deleted POS Session)"
+msgstr ""
+
+#. module: point_of_sale
+#. odoo-python
 #: code:addons/point_of_sale/models/pos_order.py:0
 #, python-format
 msgid "(RESCUE FOR %(session)s)"


### PR DESCRIPTION
After uninstalling the PoS module, if you try to reinstall it and open a new 
session, you encounter a traceback error when attempting to load demo data. 
This error occurs because Odoo is trying to create a sequence that already 
exists.

Steps to reproduce:
- Install ``Point_of_sale`` module(without demo data)
- Click on ``New Session`` > Open Session
- Click on ``demo data`` and make payment for any order
- Uninstall PoS
- Install PoS
- Click on ``New Session`` > Open Session
- Click on ``demo data``

Traceback:
```
ParseError
while parsing /home/odoo/src/odoo/saas-17.2/addons/point_of_sale/data/point_of_sale_onboarding_main_config.xml:103, somewhere inside
<function model="pos.session" name="action_pos_session_closing_control" eval="[[ref('pos_closed_session_1')]]"/>
```

Sentry-4726157101

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
