### PR TITLE
[IMP] *: add view info in session info

### DIFF
--- a/addons/board/static/src/board_view.js
+++ b/addons/board/static/src/board_view.js
@@ -1,6 +1,5 @@
 /** @odoo-module **/
 
-import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { BoardController } from "./board_controller";
 import { visitXML } from "@web/core/utils/xml";
@@ -60,7 +59,6 @@ export class BoardArchParser {
 
 export const boardView = {
     type: "form",
-    display_name: _t("Board"),
     Controller: BoardController,
 
     props: (genericProps, view) => {

--- a/addons/hr_timesheet/static/tests/timesheet_graph_tests.js
+++ b/addons/hr_timesheet/static/tests/timesheet_graph_tests.js
@@ -84,7 +84,7 @@ QUnit.module('hr_timesheet', function (hooks) {
             views: {
                 // unit_amount is used as group_by and measure
                 "account.analytic.line,false,graph": `
-                    <graph>
+                    <graph js_class="hr_timesheet_graphview">
                         <field name="unit_amount"/>
                         <field name="unit_amount" type="measure"/>
                     </graph>
@@ -108,7 +108,7 @@ QUnit.module('hr_timesheet', function (hooks) {
         const graph = await makeView({
             serverData,
             resModel: "account.analytic.line",
-            type: "hr_timesheet_graphview",
+            type: "graph",
         });
 
         const renderedData = getGraphRenderer(graph).chart.data.datasets[0].data;
@@ -125,7 +125,7 @@ QUnit.module('hr_timesheet', function (hooks) {
         const graph = await makeView({
             serverData,
             resModel: "account.analytic.line",
-            type: "hr_timesheet_graphview",
+            type: "graph",
         });
 
         const renderedData = getGraphRenderer(graph).chart.data.datasets[0].data;

--- a/addons/mail/models/ir_ui_view.py
+++ b/addons/mail/models/ir_ui_view.py
@@ -9,3 +9,6 @@ class View(models.Model):
 
     def _is_qweb_based_view(self, view_type):
         return view_type == "activity" or super()._is_qweb_based_view(view_type)
+
+    def _get_view_info(self):
+        return {'activity': {'icon': 'fa fa-clock-o'}} | super()._get_view_info()

--- a/addons/mail/static/src/views/web/activity/activity_view.js
+++ b/addons/mail/static/src/views/web/activity/activity_view.js
@@ -7,9 +7,6 @@ import { registry } from "@web/core/registry";
 
 export const activityView = {
     type: "activity",
-    display_name: "Activity",
-    icon: "fa fa-clock-o",
-    multiRecord: true,
     searchMenuTypes: ["filter", "favorite"],
     Controller: ActivityController,
     Renderer: ActivityRenderer,

--- a/addons/project/static/tests/legacy/burndown_chart_tests.js
+++ b/addons/project/static/tests/legacy/burndown_chart_tests.js
@@ -61,7 +61,7 @@ QUnit.module("Project", {}, () => {
                 },
                 views: {
                     "burndown_chart,false,graph": `
-                        <graph type="line">
+                        <graph type="line" js_class="burndown_chart">
                             <field name="date" string="Date" interval="month"/>
                             <field name="stage_id"/>
                             <field name="is_closed"/>
@@ -76,7 +76,7 @@ QUnit.module("Project", {}, () => {
             makeViewParams = {
                 serverData,
                 resModel: "burndown_chart",
-                type: "burndown_chart",
+                type: "graph",
             };
             setupControlPanelServiceRegistry();
             const notificationMock = () => {

--- a/addons/web/controllers/webclient.py
+++ b/addons/web/controllers/webclient.py
@@ -99,15 +99,15 @@ class WebClient(http.Controller):
 
     @http.route('/web/tests/next', type='http', auth='user', readonly=True)
     def unit_tests_suite(self, mod=None, **kwargs):
-        return request.render('web.unit_tests_suite')
+        return request.render('web.unit_tests_suite', {'session_info': {'view_info': request.env['ir.ui.view'].get_view_info()}})
 
     @http.route('/web/tests', type='http', auth='user', readonly=True)
     def test_suite(self, mod=None, **kwargs):
-        return request.render('web.qunit_suite')
+        return request.render('web.qunit_suite', {'session_info': {'view_info': request.env['ir.ui.view'].get_view_info()}})
 
     @http.route('/web/tests/mobile', type='http', auth="none")
     def test_mobile_suite(self, mod=None, **kwargs):
-        return request.render('web.qunit_mobile_suite')
+        return request.render('web.qunit_mobile_suite', {'session_info': {'view_info': request.env['ir.ui.view'].get_view_info()}})
 
     @http.route('/web/bundle/<string:bundle_name>', auth='public', methods=['GET'], readonly=True)
     def bundle(self, bundle_name, **bundle_params):

--- a/addons/web/models/__init__.py
+++ b/addons/web/models/__init__.py
@@ -5,6 +5,7 @@ from . import ir_qweb_fields
 from . import ir_http
 from . import ir_model
 from . import ir_ui_menu
+from . import ir_ui_view
 from . import models
 from . import base_document_layout
 from . import res_config_settings

--- a/addons/web/models/ir_http.py
+++ b/addons/web/models/ir_http.py
@@ -120,6 +120,7 @@ class Http(models.AbstractModel):
                 'lang': request.session.context['lang'],
             },
             'test_mode': bool(config['test_enable'] or config['test_file']),
+            'view_info': self.env['ir.ui.view'].get_view_info(),
         }
         if request.session.debug:
             session_info['bundle_params']['debug'] = request.session.debug

--- a/addons/web/models/ir_ui_view.py
+++ b/addons/web/models/ir_ui_view.py
@@ -1,0 +1,32 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models, _
+
+
+class View(models.Model):
+    _inherit = 'ir.ui.view'
+
+    def get_view_info(self):
+        _view_info = self._get_view_info()
+        return {
+            'list' if type_ == 'tree' else type_: {
+                'display_name': _("List") if type_ == 'tree' else display_name,
+                'icon': _view_info[type_]['icon'],
+                'multi_record': _view_info[type_].get('multi_record', True),
+            }
+            for (type_, display_name)
+            in self.fields_get(['type'], ['selection'])['type']['selection']
+            if type_ != 'qweb'
+        }
+
+    def _get_view_info(self):
+        return {
+            'tree': {'icon': 'oi oi-view-list'},
+            'form': {'icon': 'fa fa-address-card', 'multi_record': False},
+            'graph': {'icon': 'fa fa-area-chart'},
+            'pivot': {'icon': 'oi oi-view-pivot'},
+            'kanban': {'icon': 'oi oi-view-kanban'},
+            'calendar': {'icon': 'fa fa-calendar'},
+            'gantt': {'icon': 'fa fa-tasks'},
+            'search': {'icon': 'oi oi-search'},
+        }

--- a/addons/web/static/src/@types/registries/views_registry.d.ts
+++ b/addons/web/static/src/@types/registries/views_registry.d.ts
@@ -1,5 +1,5 @@
 declare module "registries" {
-    import { FieldDefinition, FieldDefinitionMap } from "fields";
+    import { FieldDefinitionMap } from "fields";
     import { Component } from "@odoo/owl";
     import { Model } from "@web/model/model";
     import { SearchModel } from "@web/search/search_model";
@@ -27,11 +27,7 @@ declare module "registries" {
         buttonTemplate?: string;
         Controller: typeof Component;
         Compiler?: typeof ViewCompiler;
-        display_name: string;
-        icon: string;
-        isMobileFriendly?: boolean;
         Model: typeof Model;
-        multiRecord: boolean;
         props(genericProps: ViewInfo, viewDescr: ViewsRegistryItemShape, config: object): object;
         Renderer: typeof Component;
         searchMenuTypes?: ("filter" | "groupBy" | "comparison" | "favorite")[];

--- a/addons/web/static/src/views/calendar/calendar_view.js
+++ b/addons/web/static/src/views/calendar/calendar_view.js
@@ -7,9 +7,6 @@ import { CalendarController } from "./calendar_controller";
 export const calendarView = {
     type: "calendar",
 
-    display_name: "Calendar",
-    icon: "fa fa-calendar",
-    multiRecord: true,
     searchMenuTypes: ["filter", "favorite"],
 
     ArchParser: CalendarArchParser,

--- a/addons/web/static/src/views/form/form_view.js
+++ b/addons/web/static/src/views/form/form_view.js
@@ -7,8 +7,6 @@ import { FormCompiler } from "./form_compiler";
 
 export const formView = {
     type: "form",
-    display_name: "Form",
-    multiRecord: false,
     searchMenuTypes: [],
     Controller: FormController,
     Renderer: FormRenderer,

--- a/addons/web/static/src/views/graph/graph_view.js
+++ b/addons/web/static/src/views/graph/graph_view.js
@@ -10,9 +10,6 @@ const viewRegistry = registry.category("views");
 
 export const graphView = {
     type: "graph",
-    display_name: _t("Graph"),
-    icon: "fa fa-area-chart",
-    multiRecord: true,
     Controller: GraphController,
     Renderer: GraphRenderer,
     Model: GraphModel,

--- a/addons/web/static/src/views/kanban/kanban_view.js
+++ b/addons/web/static/src/views/kanban/kanban_view.js
@@ -8,10 +8,6 @@ import { KanbanRenderer } from "./kanban_renderer";
 export const kanbanView = {
     type: "kanban",
 
-    display_name: "Kanban",
-    icon: "oi oi-view-kanban",
-    multiRecord: true,
-
     ArchParser: KanbanArchParser,
     Controller: KanbanController,
     Model: RelationalModel,

--- a/addons/web/static/src/views/list/list_view.js
+++ b/addons/web/static/src/views/list/list_view.js
@@ -6,9 +6,6 @@ import { ListRenderer } from "./list_renderer";
 
 export const listView = {
     type: "list",
-    display_name: "List",
-    icon: "oi oi-view-list",
-    multiRecord: true,
     Controller: ListController,
     Renderer: ListRenderer,
     ArchParser: ListArchParser,

--- a/addons/web/static/src/views/pivot/pivot_view.js
+++ b/addons/web/static/src/views/pivot/pivot_view.js
@@ -10,9 +10,6 @@ const viewRegistry = registry.category("views");
 
 export const pivotView = {
     type: "pivot",
-    display_name: _t("Pivot"),
-    icon: "oi oi-view-pivot",
-    multiRecord: true,
     Controller: PivotController,
     Renderer: PivotRenderer,
     Model: PivotModel,

--- a/addons/web/static/src/views/view.js
+++ b/addons/web/static/src/views/view.js
@@ -221,9 +221,7 @@ export class View extends Component {
     }
 
     async loadView(props) {
-        // determine view type
-        let descr = viewRegistry.get(props.type);
-        const type = descr.type;
+        const type = props.type;
 
         // determine views for which descriptions should be obtained
         let { viewId, searchViewId } = props;
@@ -320,6 +318,7 @@ export class View extends Component {
             ...(props.className || "").split(" "),
         ]);
 
+        let descr = viewRegistry.get(type);
         // determine ViewClass to instantiate (if not already done)
         if (subType) {
             if (viewRegistry.contains(subType)) {

--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -29,6 +29,7 @@ import {
 import { downloadReport, getReportUrl } from "./reports/utils";
 import { omit, pick, shallowEqual } from "@web/core/utils/objects";
 import { zip } from "@web/core/utils/arrays";
+import { session } from "@web/session";
 
 class BlankComponent extends Component {
     static props = ["onMounted", "withControlPanel", "*"];
@@ -48,7 +49,6 @@ class BlankComponent extends Component {
 
 const actionHandlersRegistry = registry.category("action_handlers");
 const actionRegistry = registry.category("actions");
-const viewRegistry = registry.category("views");
 
 /** @typedef {number|false} ActionId */
 /** @typedef {Object} ActionDescription */
@@ -618,7 +618,7 @@ export function makeActionManager(env, router = _router) {
             .map((v) => {
                 const viewSwitcherEntry = {
                     icon: v.icon,
-                    name: v.display_name.toString(),
+                    name: v.display_name,
                     type: v.type,
                     multiRecord: v.multiRecord,
                 };
@@ -1103,8 +1103,9 @@ export function makeActionManager(env, router = _router) {
     async function _executeActWindowAction(action, options) {
         const views = [];
         for (const [, type] of action.views) {
-            if (type !== "search" && viewRegistry.contains(type)) {
-                views.push(viewRegistry.get(type));
+            if (type !== "search" && session.view_info[type]) {
+                const { icon, display_name, multi_record: multiRecord } = session.view_info[type];
+                views.push({ icon, display_name, multiRecord, type });
             }
         }
         if (!views.length) {

--- a/addons/web/static/tests/_framework/mock_server_state.hoot.js
+++ b/addons/web/static/tests/_framework/mock_server_state.hoot.js
@@ -2,6 +2,9 @@
 
 import { after, before, beforeEach, createJobScopedGetter } from "@odoo/hoot";
 
+const { view_info } = odoo.__session_info__ || {};
+delete odoo.__session_info__;
+
 const { Settings } = luxon;
 
 /**
@@ -65,6 +68,7 @@ const SERVER_STATE_VALUES = {
     timezone: "taht",
     userContext: {},
     userId: 7,
+    view_info,
 };
 
 const getServerStateValues = createJobScopedGetter(

--- a/addons/web/static/tests/_framework/mock_session.hoot.js
+++ b/addons/web/static/tests/_framework/mock_session.hoot.js
@@ -19,6 +19,7 @@ const makeSession = ({
     timezone,
     userContext,
     userId,
+    view_info,
 }) => ({
     active_ids_limit: 20000,
     bundle_params: {
@@ -61,6 +62,7 @@ const makeSession = ({
     user_id: [userId],
     username: "admin",
     ["web.base.url"]: "http://localhost:8069",
+    view_info,
 });
 
 //-----------------------------------------------------------------------------

--- a/addons/web/static/tests/mock_server/mock_server_state.test.js
+++ b/addons/web/static/tests/mock_server/mock_server_state.test.js
@@ -8,7 +8,10 @@ describe.current.tags("headless");
 
 test("default state", () => {
     expect(odoo.debug).toBe("");
-    expect(serverState).toEqual({
+    const s = { ...serverState };
+    expect("view_info" in s).toBe(true);
+    delete s.view_info;
+    expect(s).toEqual({
         companies: [{ id: 1, name: "Hermit" }],
         currencies: [
             { id: 1, name: "USD", position: "before", symbol: "$" },

--- a/addons/web/static/tests/search/search_bar_menu/favorite_menu.test.js
+++ b/addons/web/static/tests/search/search_bar_menu/favorite_menu.test.js
@@ -13,7 +13,9 @@ import {
     mountWithCleanup,
     mountWithSearch,
     onRpc,
+    patchWithCleanup,
     saveFavorite,
+    serverState,
     toggleMenuItem,
     toggleSaveFavorite,
     toggleSearchBarMenu,
@@ -92,9 +94,11 @@ test("delete an active favorite", async () => {
         }
     }
 
+    patchWithCleanup(serverState.view_info, {
+        toy: { multi_record: true, display_name: "Toy", icon: "fab fa-android" },
+    });
     viewsRegistry.add("toy", {
         type: "toy",
-        display_name: "Toy",
         Controller: ToyController,
     });
     after(() => viewsRegistry.remove("toy"));

--- a/addons/web/static/tests/views/view.test.js
+++ b/addons/web/static/tests/views/view.test.js
@@ -925,22 +925,6 @@ test("real life banner", async () => {
 // js_class
 ////////////////////////////////////////////////////////////////////////////
 
-test("rendering with given jsClass", async function () {
-    expect.assertions(4);
-    onRpc("get_views", ({ kwargs }) => {
-        expect(kwargs.views).toEqual([[false, "toy"]]);
-        expect(pick(kwargs.options, "action_id", "load_filters", "toolbar")).toEqual({
-            action_id: false,
-            load_filters: false,
-            toolbar: false,
-        });
-    });
-
-    await mountWithCleanup(View, { props: { resModel: "animal", type: "toy_imp" } });
-    expect(".o_toy_view.toy_imp").toHaveCount(1);
-    expect(".o_toy_view.toy_imp").toHaveText("Arch content (id=false)");
-});
-
 test("rendering with loaded arch attribute 'js_class'", async function () {
     expect.assertions(4);
     onRpc("get_views", ({ kwargs }) => {
@@ -971,62 +955,6 @@ test("rendering with given arch attribute 'js_class'", async function () {
     });
     expect(".o_toy_view.toy_imp").toHaveCount(1);
     expect(".o_toy_view.toy_imp").toHaveText("Specific arch content for specific class");
-});
-
-test("rendering with loaded arch attribute 'js_class' and given jsClass", async function () {
-    expect.assertions(3);
-    viewRegistry.add("toy_2", {
-        type: "toy",
-        Controller: class extends Component {
-            static props = ["*"];
-            static template = xml`<div class="o_toy_view_2"/>`;
-            static type = "toy";
-        },
-    });
-    onRpc("get_views", ({ kwargs }) => {
-        expect(kwargs.views).toEqual([[2, "toy"]]);
-        expect(pick(kwargs.options, "action_id", "load_filters", "toolbar")).toEqual({
-            action_id: false,
-            load_filters: false,
-            toolbar: false,
-        });
-    });
-    await mountWithCleanup(View, {
-        props: {
-            resModel: "animal",
-            type: "toy_2",
-            viewId: 2,
-        },
-    });
-    expect(".o_toy_view.toy_imp").toHaveCount(1);
-});
-
-test("rendering with given arch attribute 'js_class' and given jsClass", async function () {
-    expect.assertions(1);
-    viewRegistry.add(
-        "toy_2",
-        {
-            type: "toy",
-            Controller: class extends Component {
-                static props = ["*"];
-                static template = xml`<div class="o_toy_view_2"/>`;
-                static type = "toy";
-            },
-        },
-        { force: true }
-    );
-    onRpc("get_views", () => {
-        throw new Error("no get_views expected");
-    });
-    await mountWithCleanup(View, {
-        props: {
-            resModel: "animal",
-            type: "toy_2",
-            arch: `<toy js_class="toy_imp"/>`,
-            fields: {},
-        },
-    });
-    expect(".o_toy_view.toy_imp").toHaveCount(1);
 });
 
 ////////////////////////////////////////////////////////////////////////////

--- a/addons/web/static/tests/webclient/actions/concurrency.test.js
+++ b/addons/web/static/tests/webclient/actions/concurrency.test.js
@@ -12,6 +12,8 @@ import {
     models,
     mountWithCleanup,
     onRpc,
+    patchWithCleanup,
+    serverState,
     stepAllNetworkCalls,
     switchView,
     toggleMenuItem,
@@ -674,6 +676,9 @@ test("dialog will only open once for two rapid actions with the target new", asy
 });
 
 test.tags("desktop")("local state, global state, and race conditions", async () => {
+    patchWithCleanup(serverState.view_info, {
+        toy: { multi_record: true, display_name: "Toy", icon: "fab fa-android" },
+    });
     Partner._views = {
         "toy,false": `<toy/>`,
         "list,false": `<list><field name="display_name"/></list>`,
@@ -704,9 +709,6 @@ test.tags("desktop")("local state, global state, and race conditions", async () 
 
     registry.category("views").add("toy", {
         type: "toy",
-        display_name: "Toy",
-        icon: "fab fa-android",
-        multiRecord: true,
         Controller: ToyController,
     });
 

--- a/addons/web/views/webclient_templates.xml
+++ b/addons/web/views/webclient_templates.xml
@@ -219,6 +219,10 @@
             <t t-set="head">
                 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no"/>
 
+                <script type="text/javascript">
+                    odoo.__session_info__ = <t t-out="json.dumps(session_info)"/>;
+                </script>
+
                 <t t-call-assets="web.assets_unit_tests_setup" />
                 <t t-call-assets="web.assets_unit_tests" />
             </t>
@@ -230,6 +234,10 @@
             <t t-set="html_data" t-value="{'style': 'height: 100%;'}"/>
             <t t-set="title">Web Tests</t>
             <t t-set="head">
+                <script type="text/javascript">
+                    odoo.__session_info__ = <t t-out="json.dumps(session_info)"/>;
+                </script>
+
                 <t t-call="web.test_helpers"/>
 
                 <t t-call-assets="web.qunit_suite_tests" t-js="false"/>
@@ -246,6 +254,9 @@
             <t t-set="title">Web Mobile Tests</t>
             <t t-set="head">
                 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no"/>
+                <script type="text/javascript">
+                    odoo.__session_info__ = <t t-out="json.dumps(session_info)"/>;
+                </script>
 
                 <t t-call="web.test_helpers"/>
 

--- a/addons/web_hierarchy/models/ir_ui_view.py
+++ b/addons/web_hierarchy/models/ir_ui_view.py
@@ -52,3 +52,6 @@ class View(models.Model):
                 valid_attributes=format_list(self.env, HIERARCHY_VALID_ATTRIBUTES),
             )
             self._raise_view_error(msg, node)
+
+    def _get_view_info(self):
+        return {'hierarchy': {'icon': 'fa fa-share-alt o_hierarchy_icon'}} | super()._get_view_info()

--- a/addons/web_hierarchy/static/src/hierarchy_view.js
+++ b/addons/web_hierarchy/static/src/hierarchy_view.js
@@ -1,6 +1,3 @@
-/** @odoo-module */
-
-import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { HierarchyArchParser } from "./hierarchy_arch_parser";
 import { HierarchyController } from "./hierarchy_controller";
@@ -9,10 +6,6 @@ import { HierarchyRenderer } from "./hierarchy_renderer";
 
 export const hierarchyView = {
     type: "hierarchy",
-    display_name: _t("Hierarchy"),
-    icon: "fa fa-share-alt o_hierarchy_icon",
-    isMobileFriendly: false,
-    multiRecord: true,
     ArchParser: HierarchyArchParser,
     Controller: HierarchyController,
     Model: HierarchyModel,


### PR DESCRIPTION
We have noted that some view information like "icon" that was sometimes modified in some js classes were in fact not variable for a given (server side) type of view. Here we set a key "view_info" in `__session_info__` with the view information and make the action service use it.
This will allow us to easily lazy load views.

In preparation of Task `3546321`