### PR TITLE
[FIX] l10n_ar: only select "AFIP Responsibility" fiscal position if set

### DIFF
--- a/addons/l10n_ar/models/account_fiscal_position.py
+++ b/addons/l10n_ar/models/account_fiscal_position.py
@@ -19,6 +19,8 @@ class AccountFiscalPosition(models.Model):
 
     def _prepare_fpos_base_domain(self, vat_required):
         domain = super()._prepare_fpos_base_domain(vat_required)
-        if self._context.get('l10n_ar_afip_responsibility_type_id'):
-            domain += [('l10n_ar_afip_responsibility_type_ids', '=', self._context.get('l10n_ar_afip_responsibility_type_id'))]
+        if 'l10n_ar_afip_responsibility_type_id' in self._context:
+            domain += ['|',
+                ('l10n_ar_afip_responsibility_type_ids', '=', False),
+                ('l10n_ar_afip_responsibility_type_ids', '=', self._context.get('l10n_ar_afip_responsibility_type_id'))]
         return domain


### PR DESCRIPTION
**Steps to reproduce:**
- Install l10n_ar and website_sale
- Switch to an Argentinian company
- Create a product with a customer tax (e.g. IVA 21%)

With a public user or a user without "AFIP Responsibility":
- Go to eShop and add the created product to the cart
- Go to the cart

**Issue:**
No tax is applied.

**Cause:**
There are some fiscal positions from Argentinian localization that map IVA 21% to IVA Exento (i.e. 0%).
These fiscal positions are linked to specific "AFIP Responsibility" types and should only be applied for users having these "AFIP Responsibility" types configured on their contact form.
However, when this field is not set, it is ignored in the domain computing the fiscal position and one of these Argentinian fiscal positions satisfies the resulting domain.

**Solution:**
Filter on "AFIP Responsibility" in the domain computing the fiscal position if "l10n_ar_afip_responsibility_type_id" key is present in the context, no matter what its value.

opw-3943108




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
