### PR TITLE
[FIX] stock_dropshipping: do email confirmations

### DIFF
--- a/addons/stock_dropshipping/__manifest__.py
+++ b/addons/stock_dropshipping/__manifest__.py
@@ -23,6 +23,9 @@ internal transfer document is needed.
     'depends': ['sale_purchase_stock'],
     'data': [
         'data/stock_data.xml',
+        'report/report_dropship.xml',
+        'report/stock_report_views.xml',
+        'data/mail_template_data.xml',
         'views/sale_order_views.xml',
         'views/purchase_order_views.xml'
     ],

--- a/addons/stock_dropshipping/data/mail_template_data.xml
+++ b/addons/stock_dropshipping/data/mail_template_data.xml
@@ -1,0 +1,30 @@
+<?xml version='1.0' encoding='utf-8'?>
+<odoo><data noupdate="1">
+    <record id="mail_template_data_dropship_confirmation" model="mail.template">
+        <field name="name">Dropship: Send by Email</field>
+        <field name="model_id" ref="model_stock_picking"/>
+        <field name="subject">{{ object.company_id.name }} Shipment (Ref {{ object.name or 'n/a' }})</field>
+        <field name="partner_to">{{ object.sale_id.partner_id.email and object.sale_id.partner_id.id or object.sale_id.partner_id.parent_id.id }}</field>
+        <field name="description">Sent to the customers when orders are shipped, if the setting is enabled</field>
+        <field name="body_html" type="html">
+<div style="margin: 0px; padding: 0px;">
+    <p style="margin: 0px; padding: 0px; font-size: 13px;">
+        Hello <t t-out="object.sale_id.partner_id.name or ''">Brandon Freeman</t>,<br/><br/>
+        We are glad to inform you that your order has been shipped.
+        <br/><br/>
+        Please find your order attached for more details.<br/><br/>
+        Thank you,
+        <t t-if="user.signature">
+            <br />
+            <t t-out="user.signature or ''">--<br/>Mitchell Admin</t>
+        </t>
+    </p>
+</div>
+        </field>
+        <field name="report_template" ref="stock_dropshipping.action_report_dropship"/>
+        <field name="report_name">{{ (object.sale_id.name or '').replace('/','_') }}</field>
+        <field name="lang">{{ object.sale_id.partner_id.lang }}</field>
+        <field name="auto_delete" eval="True"/>
+    </record>
+</data>
+</odoo>

--- a/addons/stock_dropshipping/i18n/stock_dropshipping.pot
+++ b/addons/stock_dropshipping/i18n/stock_dropshipping.pot
@@ -16,6 +16,99 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: stock_dropshipping
+#: model:ir.actions.report,print_report_name:stock_dropshipping.action_report_dropship
+msgid ""
+"'Dropship Order - %s - %s' % (object.sale_id.partner_id.name or '', "
+"object.sale_id.name)"
+msgstr ""
+
+#. module: stock_dropshipping
+#: model:mail.template,body_html:stock_dropshipping.mail_template_data_dropship_confirmation
+msgid ""
+"<div style=\"margin: 0px; padding: 0px;\">\n"
+"    <p style=\"margin: 0px; padding: 0px; font-size: 13px;\">\n"
+"        Hello <t t-out=\"object.sale_id.partner_id.name or ''\">Brandon Freeman</t>,<br><br>\n"
+"        We are glad to inform you that your order has been shipped.\n"
+"        <br><br>\n"
+"        Please find your order attached for more details.<br><br>\n"
+"        Thank you,\n"
+"        <t t-if=\"user.signature\">\n"
+"            <br>\n"
+"            <t t-out=\"user.signature or ''\">--<br>Mitchell Admin</t>\n"
+"        </t>\n"
+"    </p>\n"
+"</div>\n"
+"        "
+msgstr ""
+
+#. module: stock_dropshipping
+#: model_terms:ir.ui.view,arch_db:stock_dropshipping.report_dropship
+msgid ""
+"<i class=\"fa fa-exclamation-triangle\"/>\n"
+"                                All products could not be reserved. Click on the \"Check Availability\" button to try to reserve products."
+msgstr ""
+
+#. module: stock_dropshipping
+#: model_terms:ir.ui.view,arch_db:stock_dropshipping.report_dropship
+msgid "<span><strong>Customer Address:</strong></span>"
+msgstr ""
+
+#. module: stock_dropshipping
+#: model_terms:ir.ui.view,arch_db:stock_dropshipping.report_dropship
+msgid "<span><strong>Delivery Address:</strong></span>"
+msgstr ""
+
+#. module: stock_dropshipping
+#: model_terms:ir.ui.view,arch_db:stock_dropshipping.report_dropship
+msgid "<span><strong>Warehouse Address:</strong></span>"
+msgstr ""
+
+#. module: stock_dropshipping
+#: model_terms:ir.ui.view,arch_db:stock_dropshipping.report_dropship
+msgid "<strong>From</strong>"
+msgstr ""
+
+#. module: stock_dropshipping
+#: model_terms:ir.ui.view,arch_db:stock_dropshipping.report_dropship
+msgid "<strong>Lot/Serial Number</strong>"
+msgstr ""
+
+#. module: stock_dropshipping
+#: model_terms:ir.ui.view,arch_db:stock_dropshipping.report_dropship
+msgid "<strong>Order:</strong>"
+msgstr ""
+
+#. module: stock_dropshipping
+#: model_terms:ir.ui.view,arch_db:stock_dropshipping.report_dropship
+msgid "<strong>Product Barcode</strong>"
+msgstr ""
+
+#. module: stock_dropshipping
+#: model_terms:ir.ui.view,arch_db:stock_dropshipping.report_dropship
+msgid "<strong>Product</strong>"
+msgstr ""
+
+#. module: stock_dropshipping
+#: model_terms:ir.ui.view,arch_db:stock_dropshipping.report_dropship
+msgid "<strong>Quantity</strong>"
+msgstr ""
+
+#. module: stock_dropshipping
+#: model_terms:ir.ui.view,arch_db:stock_dropshipping.report_dropship
+msgid "<strong>Scheduled Date:</strong>"
+msgstr ""
+
+#. module: stock_dropshipping
+#: model_terms:ir.ui.view,arch_db:stock_dropshipping.report_dropship
+msgid "<strong>Status:</strong>"
+msgstr ""
+
+#. module: stock_dropshipping
+#: model_terms:ir.ui.view,arch_db:stock_dropshipping.report_dropship
+msgid "<strong>To</strong>"
+msgstr ""
+
+#. module: stock_dropshipping
 #: model:ir.model,name:stock_dropshipping.model_res_company
 msgid "Companies"
 msgstr ""
@@ -31,6 +124,16 @@ msgstr ""
 #: model:ir.model.fields,field_description:stock_dropshipping.field_purchase_order__dropship_picking_count
 #: model:ir.model.fields,field_description:stock_dropshipping.field_sale_order__dropship_picking_count
 msgid "Dropship Count"
+msgstr ""
+
+#. module: stock_dropshipping
+#: model:ir.actions.report,name:stock_dropshipping.action_report_dropship
+msgid "Dropship Slip"
+msgstr ""
+
+#. module: stock_dropshipping
+#: model:mail.template,name:stock_dropshipping.mail_template_data_dropship_confirmation
+msgid "Dropship: Send by Email"
 msgstr ""
 
 #. module: stock_dropshipping
@@ -74,6 +177,12 @@ msgid "Sales Order Line"
 msgstr ""
 
 #. module: stock_dropshipping
+#: model:mail.template,description:stock_dropshipping.mail_template_data_dropship_confirmation
+msgid ""
+"Sent to the customers when orders are shipped, if the setting is enabled"
+msgstr ""
+
+#. module: stock_dropshipping
 #: model:ir.model,name:stock_dropshipping.model_stock_rule
 msgid "Stock Rule"
 msgstr ""
@@ -81,4 +190,14 @@ msgstr ""
 #. module: stock_dropshipping
 #: model:ir.model,name:stock_dropshipping.model_stock_picking
 msgid "Transfer"
+msgstr ""
+
+#. module: stock_dropshipping
+#: model:mail.template,report_name:stock_dropshipping.mail_template_data_dropship_confirmation
+msgid "{{ (object.sale_id.name or '').replace('/','_') }}"
+msgstr ""
+
+#. module: stock_dropshipping
+#: model:mail.template,subject:stock_dropshipping.mail_template_data_dropship_confirmation
+msgid "{{ object.company_id.name }} Shipment (Ref {{ object.name or 'n/a' }})"
 msgstr ""

--- a/addons/stock_dropshipping/models/stock.py
+++ b/addons/stock_dropshipping/models/stock.py
@@ -39,6 +39,22 @@ class StockPicking(models.Model):
         self.ensure_one()
         return super()._is_to_external_location() or self.is_dropship
 
+    def _send_confirmation_email(self):
+        dropship_pickings = self.filtered('is_dropship')
+        for picking in dropship_pickings:
+            dropship_template_id = self.env.ref(
+                'stock_dropshipping.mail_template_data_dropship_confirmation',
+                raise_if_not_found=False
+            )
+            if dropship_template_id:
+                picking.with_context(force_send=True).message_post_with_template(
+                    dropship_template_id.id,
+                    email_layout_xmlid='mail.mail_notification_light'
+                )
+
+        return super(StockPicking, self - dropship_pickings)._send_confirmation_email()
+
+
 class StockPickingType(models.Model):
     _inherit = 'stock.picking.type'
 

--- a/addons/stock_dropshipping/report/report_dropship.xml
+++ b/addons/stock_dropshipping/report/report_dropship.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <data>
+        <template id="report_dropship">
+            <t t-call="web.html_container">
+                <t t-foreach="docs" t-as="o">
+                    <t t-call="web.external_layout">
+                        <div class="page">
+                            <div class="row justify-content-end mb16">
+                                <div class="col-4" name="right-box">
+                                    <div t-field="o.name" t-options="{'widget': 'barcode', 'width': 600, 'height': 100, 'img_style': 'width:300px;height:50px;'}"/>
+                                </div>
+                            </div>
+                            <div class="row">
+                                <div class="col-6" name="div_outgoing_address">
+                                    <div t-if="o.should_print_delivery_address()">
+                                        <span><strong>Delivery Address:</strong></span>
+                                        <div t-field="o.sale_id.partner_id"
+                                            t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True, "phone_icons": True}'/>
+                                    </div>
+                                    <div t-elif="o.picking_type_id.warehouse_id.partner_id">
+                                        <span><strong>Warehouse Address:</strong></span>
+                                        <div t-field="o.picking_type_id.warehouse_id.partner_id"
+                                            t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True, "phone_icons": True}'/>
+                                    </div>
+                                </div>
+                                <div class="col-5 offset-1" name="div_incoming_address">
+                                    <t t-set="show_partner" t-value="False" />
+                                    <div t-if="o.is_dropship and o.sale_id.partner_id and o.sale_id.partner_id != o.sale_id.partner_id.commercial_partner_id">
+                                        <span><strong>Customer Address:</strong></span>
+                                        <t t-set="show_partner" t-value="True" />
+                                    </div>
+                                    <div t-if="show_partner" name="partner_header">
+                                        <div t-field="o.sale_id.partner_id.commercial_partner_id"
+                                             t-options='{"widget": "contact", "fields": ["address", "name", "phone", "vat"], "no_marker": True, "phone_icons": True}'/>
+                                    </div>
+                                </div>
+                            </div>
+                            <br/>
+                            <h1 t-field="o.name" class="mt0"/>
+                            <div class="row mt48 mb32">
+                                <div t-if="o.origin" class="col-auto" name="div_origin">
+                                    <strong>Order:</strong>
+                                    <p t-field="o.sale_id"/>
+                                </div>
+                                <div class="col-auto" name="div_state">
+                                    <strong>Status:</strong>
+                                    <p t-field="o.state"/>
+                                </div>
+                                <div class="col-auto" name="div_sched_date">
+                                    <strong>Scheduled Date:</strong>
+                                    <p t-field="o.scheduled_date"/>
+                                </div>
+                            </div>
+                            <table class="table table-sm" t-if="o.move_line_ids and o.move_ids_without_package">
+                                <t t-set="has_barcode" t-value="any(move_line.product_id and move_line.product_id.sudo().barcode or move_line.package_id for move_line in o.move_line_ids)"/>
+                                <t t-set="has_serial_number" t-value="any(move_line.lot_id or move_line.lot_name for move_line in o.move_line_ids)" groups="stock.group_production_lot"/>
+                                <thead>
+                                    <tr>
+                                        <th name="th_product">
+                                            <strong>Product</strong>
+                                        </th>
+                                        <th>
+                                            <strong>Quantity</strong>
+                                        </th>
+                                        <th name="th_from" t-if="o.picking_type_id.code != 'incoming'" align="left" groups="stock.group_stock_multi_locations">
+                                            <strong>From</strong>
+                                        </th>
+                                        <th name="th_to" t-if="o.picking_type_id.code != 'outgoing'" groups="stock.group_stock_multi_locations">
+                                            <strong>To</strong>
+                                        </th>
+                                        <th name="th_serial_number" class="text-center" t-if="has_serial_number">
+                                           <strong>Lot/Serial Number</strong>
+                                        </th>
+                                        <th name="th_barcode" class="text-center" t-if="has_barcode">
+                                            <strong>Product Barcode</strong>
+                                        </th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <!-- In case you come across duplicated lines, ask NIM or LAP -->
+                                    <t t-foreach="o.move_line_ids_without_package.sorted(lambda ml: (ml.location_id.complete_name, ml.location_dest_id.complete_name))" t-as="ml">
+                                        <tr>
+                                            <td>
+                                                <span t-field="ml.product_id.display_name"/><br/>
+                                                <span t-field="ml.product_id.description_picking"/>
+                                            </td>
+                                            <td>
+                                                <span t-if="o.state != 'done'" t-field="ml.reserved_uom_qty"/>
+                                                <span t-if="o.state == 'done'" t-field="ml.qty_done"/>
+                                                <span t-field="ml.product_uom_id" groups="uom.group_uom"/>
+                                            </td>
+                                            <td class=" text-center h6" t-if="has_serial_number">
+                                                <div t-if="has_serial_number and (ml.lot_id or ml.lot_name)" t-esc="ml.lot_id.name or ml.lot_name" t-options="{'widget': 'barcode', 'humanreadable': 1, 'width': 400, 'height': 100, 'img_style': 'width:auto;height:35px;'}"/>
+                                            </td>
+                                            <td class="text-center" t-if="has_barcode">
+                                                <t t-if="product_barcode != ml.product_id.barcode">
+                                                    <span t-if="ml.product_id and ml.product_id.barcode">
+                                                        <div t-field="ml.product_id.barcode" t-options="{'widget': 'barcode', 'symbology': 'auto', 'width': 400, 'height': 100, 'quiet': 0, 'img_style': 'height:35px;'}"/>
+                                                    </span>
+                                                    <t t-set="product_barcode" t-value="ml.product_id.barcode"/>
+                                                </t>
+                                            </td>
+                                        </tr>
+                                    </t>
+                                </tbody>
+                            </table>
+                            <t t-set="no_reserved_product" t-value="o.move_ids.filtered(lambda x: x.product_uom_qty != x.reserved_availability and x.move_line_ids and x.state!='done')"/>
+                            <p t-if="o.state in ['draft', 'waiting', 'confirmed'] or no_reserved_product"><i class="fa fa-exclamation-triangle" />
+                                All products could not be reserved. Click on the "Check Availability" button to try to reserve products.
+                            </p>
+                            <p t-field="o.note"/>
+                        </div>
+                    </t>
+                </t>
+            </t>
+        </template>
+    </data>
+</odoo>

--- a/addons/stock_dropshipping/report/stock_report_views.xml
+++ b/addons/stock_dropshipping/report/stock_report_views.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="action_report_dropship" model="ir.actions.report">
+            <field name="name">Dropship Slip</field>
+            <field name="model">stock.picking</field>
+            <field name="report_type">qweb-pdf</field>
+            <field name="report_name">stock_dropshipping.report_dropship</field>
+            <field name="report_file">stock_dropshipping.report_dropship</field>
+            <field name="print_report_name">'Dropship Order - %s - %s' % (object.sale_id.partner_id.name or '', object.sale_id.name)</field>
+            <field name="binding_model_id" ref="model_stock_picking"/>
+            <field name="binding_type">report</field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
**Current behavior:**
Email confirmation notifications are not currently supported for dropshipping.

**Expected behavior:**
As, functionally speaking, a dropshipment is the same thing as a delivery (from the client's perspective) the same kind of email notifications should be permitted when fulfilling order via dropshipment.

**Steps to reproduce:**
1. Enable email confirmations

2. Add the dropship route to some product and define a vendor

3. Create a sale order to some other partner for the product that has the dropship route

4. Confirm both the sale and purchase orders, then confirm the generated receipt

5. Observe that no chatter post has been made to alert the partner who is defined as the dropship recipient.

**Cause of the issue:**
There is no infrastructure for this type of notification for dropship pickings.

**Fix:**
Create a new mail template and accompanying action report based on the existing ones for delivery notifications.

Override the `_send_confirmation_email()` in the dropship module to generate and post the report if the setting is enabled.

opw-3854527