### PR TITLE
[FIX] spreadsheet: show all errors instead of traceback if invalid field

### DIFF
--- a/addons/spreadsheet/models/spreadsheet_mixin.py
+++ b/addons/spreadsheet/models/spreadsheet_mixin.py
@@ -47,6 +47,7 @@ class SpreadsheetMixin(models.AbstractModel):
                     for fname in field_chain.split("."):  # field chain 'product_id.channel_ids'
                         if fname not in self.env[field_model]._fields:
                             errors.append(f"- field '{fname}' used in spreadsheet '{display_name}' does not exist on model '{field_model}'")
+                            continue
                         field = self.env[field_model]._fields[fname]
                         if field.relational:
                             field_model = field.comodel_name


### PR DESCRIPTION
__Current behavior before commit:__
If there is some invalid fields inside a spreadsheet, an error message will be added to the `errors` list but it will never be shown to the user.
Instead a Python `KeyError` traceback will appear because it still tries to access the field in the current iteration.

__Description of the fix:__
Add `continue` after having added the error message so that it can continue the normal execution of the function and display a nice error to the user.

task-4035272
