### PR TITLE
[FIX] l10n_fr_account: Fixed module name in i18n files

### DIFF
--- a/addons/l10n_fr_account/i18n/fr.po
+++ b/addons/l10n_fr_account/i18n/fr.po
@@ -1,6 +1,6 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * l10n_fr
+# 	* l10n_fr_account
 #
 # Translators:
 # Cyrille de Lambert <cdelambert@teclib.com>, 2015
@@ -8,10 +8,10 @@
 # Nicolas JEUDY <nicolas@sudokeys.com>, 2015
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo 9.0\n"
+"Project-Id-Version: Odoo Server saas~17.2+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-04 09:09+0000\n"
-"PO-Revision-Date: 2015-11-11 21:04+0000\n"
+"POT-Creation-Date: 2024-07-04 09:43+0000\n"
+"PO-Revision-Date: 2024-07-04 09:43+0000\n"
 "Last-Translator: Maxime Chambreuil <maxime.chambreuil@gmail.com>\n"
 "Language-Team: French (http://www.transifex.com/odoo/odoo-9/language/fr/)\n"
 "Language: fr\n"
@@ -20,909 +20,1066 @@ msgstr ""
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_08_base
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "# 10"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "# 11"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "# 12"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "# 13"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "# 14"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "# 15"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "# 16"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "# 17"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_08_base
 msgid "08 - Standard rate 20% (base)"
 msgstr "08 - Taux normal 20 % (base)"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_08_taxe
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_08_taxe
 msgid "08 - Standard rate 20% (tax)"
 msgstr "08 - Taux normal 20 % (taxe)"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_09_base
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_09_base
 msgid "09 - Reduced rate 5.5% (base)"
 msgstr "09 - Taux réduit 5,5 % (base)"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_09_taxe
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_09_taxe
 msgid "09 - Reduced rate 5.5% (tax)"
 msgstr "09 - Taux réduit 5,5 % (taxe)"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_10_base
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_10_base
 msgid "10 - Standard rate 8.5% (base)"
 msgstr "10 - Taux normal 8,5 % (base)"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_10_taxe
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_10_taxe
 msgid "10 - Standard rate 8.5% (tax)"
 msgstr "10 - Taux normal 8,5 % (taxe)"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_11_base
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_11_base
 msgid "11 - Reduced rate 2.1% (base)"
 msgstr "11 - Taux réduit 2,1 % (base)"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_11_taxe
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_11_taxe
 msgid "11 - Reduced rate 2.1% (tax)"
 msgstr "11 - Taux réduit 2,1 % (taxe)"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_13_base
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_13_base
 msgid "13 - Former rates (base)"
 msgstr "13 - Anciens taux (base)"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_13_taxe
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_13_taxe
 msgid "13 - Former rates (tax)"
 msgstr "13 - Anciens taux (taxe)"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_14_base
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_14_base
 msgid "14 - Transactions taxable at a particular rate (base)"
 msgstr "14 - Opérations imposables à un taux particulier (base)"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_14_taxe
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_14_taxe
 msgid "14 - Transactions taxable at a particular rate (tax)"
 msgstr "14 - Opérations imposables à un taux particulier (taxe)"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_15
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_15
 msgid "15 - Previously deducted VAT to be repaid"
 msgstr "15 - TVA antérieurement déduite à reverser"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_16
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_16
 msgid "16 - Total gross VAT due"
 msgstr "16 - Total de la TVA brute due"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_17
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_17
 msgid "17 - Of which VAT on intra-Community acquisitions"
 msgstr "17 - Dont TVA sur acquisitions intracommunautaires"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_18
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_18
 msgid "18 - Of which VAT on transactions to Monaco"
 msgstr "18 - Dont TVA sur opérations à destination de Monaco"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_19
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_19
 msgid "19 - Assets constituting fixed assets"
 msgstr "19 - Biens constituant l'actif immobilisé"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_20
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_20
 msgid "20 - Other goods and services"
 msgstr "20 - Autres bien et services"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_21
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_21
 msgid "21 - Other deductible VAT"
 msgstr "21 - Autre TVA à déduire"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_22
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_22
 msgid "22 - Carry-over of credit from line 27 of the previous return"
-msgstr "22 - Report du crédit apparaissant ligne 27 de la précédente déclaration"
+msgstr ""
+"22 - Report du crédit apparaissant ligne 27 de la précédente déclaration"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_22A
-msgid "22A - Enter the single tax rate applicable for the period if different from 100%"
-msgstr "22A - Indiquer le coefficient de taxation unique applicable pour la période s'il est différent de 100 %"
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_22A
+msgid ""
+"22A - Enter the single tax rate applicable for the period if different from "
+"100%"
+msgstr ""
+"22A - Indiquer le coefficient de taxation unique applicable pour la période "
+"s'il est différent de 100 %"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_23
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_23
 msgid "23 - Total deductible VAT"
 msgstr "23 - Total TVA déductible"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_24
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_24
 msgid "24 - Of which deductible VAT on imports"
 msgstr "24 - Dont TVA déductible sur importations"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_25
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_25
 msgid "25 - VAT credit"
 msgstr "25 - Crédit de TVA"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_26
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_26
 msgid "26 - Repayment of credit requested on form n°3519 attached"
 msgstr "26 - Remboursement de crédit demandé sur formulaire n°3519 joint"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_27
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_27
 msgid "27 - Credit to be carried forward"
 msgstr "27 - Crédit à reporter"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_28
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_28
 msgid "28 - Net VAT due"
 msgstr "28 - TVA nette due"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_29
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_29
 msgid "29 - Similar taxes calculated on schedule n°3310-A-SD"
 msgstr "29 - Taxes assimilées calculées sur annexe n°3310-A-SD"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_2C
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_2C
 msgid "2C - Amounts to be charged, including advance holiday pay"
 msgstr "2C - Sommes à imputer, y compris acompte congés"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_2E
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_2E
 msgid "2E - Of which deductible VAT on petroleum products"
 msgstr "2E - Dont TVA déductible sur les produits pétroliers"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_32
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_32
 msgid "32 - Total payable"
 msgstr "32 - Total à payer"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_5B
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_5B
 msgid "5B - Amounts to be added, including advance holiday pay"
 msgstr "5B - Sommes à ajouter, y compris acompte congés"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_9B_base
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_9B_base
 msgid "9B - Reduced rate 10% (base)"
 msgstr "9B - Taux réduit 10 % (base)"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_9B_taxe
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_9B_taxe
 msgid "9B - Reduced rate 10% (tax)"
 msgstr "9B - Taux réduit 10 % (taxe)"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_montant_op_realisees
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_montant_op_realisees
 msgid "A. Amount of operations carried out"
 msgstr "A. Montant des opérations réalisées"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_A1
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_A1
 msgid "A1 - Sales, provision of services"
 msgstr "A1 - Ventes, prestations de services"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_A2
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_A2
 msgid "A2 - Other taxable transactions"
 msgstr "A2 - Autres opérations imposables"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_A3
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_A3
 msgid "A3 - Intra-Community purchases of services"
 msgstr "A3 - Achats de prestations de services intracommunautaires"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_A4
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_A4
 msgid "A4 - Imports (other than petroleum products)"
 msgstr "A4 - Importations (autres que les produits pétroliers)"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_A5
-msgid "A5 - Removal from suspensive tax regime (other than petroleum products)"
-msgstr "A5 - Sorties de régime fiscal suspensif (autres que les produits pétroliers)"
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_A5
+msgid ""
+"A5 - Removal from suspensive tax regime (other than petroleum products)"
+msgstr ""
+"A5 - Sorties de régime fiscal suspensif (autres que les produits pétroliers)"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_AA
-msgid "AA - VAT credit transferred to the head company on the recapitulative return 3310-CA3G"
-msgstr "AA - Crédit de TVA transféré à la société tête de groupe sur la déclaration récapitulative 3310-CA3G"
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_AA
+msgid ""
+"AA - VAT credit transferred to the head company on the recapitulative return"
+" 3310-CA3G"
+msgstr ""
+"AA - Crédit de TVA transféré à la société tête de groupe sur la déclaration "
+"récapitulative 3310-CA3G"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_AB
-msgid "AB - Total to be paid by the head company on the recapitulative declaration 3310-CA3G"
-msgstr "AB - Total à payer acquitté par la société tête de groupe sur la déclaration récapitulative 3310-CA3G"
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_AB
+msgid ""
+"AB - Total to be paid by the head company on the recapitulative declaration "
+"3310-CA3G"
+msgstr ""
+"AB - Total à payer acquitté par la société tête de groupe sur la déclaration"
+" récapitulative 3310-CA3G"
 
-#. module: l10n_fr
-#: model:ir.model.fields,field_description:l10n_fr.field_res_company__ape
-msgid "APE"
-msgstr "APE"
-
-#. module: l10n_fr
-#: model:ir.model,name:l10n_fr.model_account_chart_template
+#. module: l10n_fr_account
+#: model:ir.model,name:l10n_fr_account.model_account_chart_template
 msgid "Account Chart Template"
 msgstr "Modèle de plan comptable"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_decompte_tva
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_decompte_tva
 msgid "B. Settlement of VAT to be paid"
 msgstr "B. Décompte de la TVA à payer"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_B1
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_B1
 msgid "B1 - Releases for consumption of petroleum products"
 msgstr "B1 - Mises à la consommation de produits pétroliers"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_B2
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_B2
 msgid "B2 - Intra-Community acquisitions"
 msgstr "B2 - Acquisitions intracommunautaires"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_B3
-msgid "B3 - Taxable supplies of electricity, natural gas, heat or cooling in France"
-msgstr "B3 - Livraisons d'électricité, de gaz naturel, de chaleur ou de froid imposables en France"
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_B3
+msgid ""
+"B3 - Taxable supplies of electricity, natural gas, heat or cooling in France"
+msgstr ""
+"B3 - Livraisons d'électricité, de gaz naturel, de chaleur ou de froid "
+"imposables en France"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_B4
-msgid "B4 - Purchases of goods or services from a taxable person not established in France"
-msgstr "B4 - Achats de bien ou de prestations de services réalisés auprès d'un assujetti non établi en France"
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_B4
+msgid ""
+"B4 - Purchases of goods or services from a taxable person not established in"
+" France"
+msgstr ""
+"B4 - Achats de bien ou de prestations de services réalisés auprès d'un "
+"assujetti non établi en France"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_B5
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_B5
 msgid "B5 - Regularisations"
 msgstr "B5 - Régularisations"
 
-#. module: l10n_fr
-#: model:account.report.column,name:l10n_fr.tax_report_balance
+#. module: l10n_fr_account
+#: model:account.report.column,name:l10n_fr_account.tax_report_balance
 msgid "Balance"
-msgstr "Balance"
+msgstr ""
 
-#. module: l10n_fr
-#: model:ir.model,name:l10n_fr.model_res_company
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "Cancel"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "Column"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "Comment"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "CompAuxLib"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "CompAuxNum"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model:ir.model,name:l10n_fr_account.model_res_company
 msgid "Companies"
 msgstr "Sociétés"
 
-#. module: l10n_fr
-#: model:ir.model.fields,field_description:l10n_fr.field_res_company_registry
-msgid "Company ID"
-msgstr "SIREN"
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "CompteLib"
+msgstr ""
 
-#. module: l10n_fr
-#: model:ir.model,name:l10n_fr.model_res_partner
-msgid "Contact"
-msgstr "Contact"
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "CompteNum"
+msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_credit
+#. module: l10n_fr_account
+#: model:ir.model.fields,field_description:l10n_fr_account.field_l10n_fr_fec_export_wizard__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model:ir.model.fields,field_description:l10n_fr_account.field_l10n_fr_fec_export_wizard__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_credit
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
 msgid "Credit"
 msgstr "Crédit"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_credit_impute
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_credit_impute
 msgid "Credit charged"
 msgstr "Crédit imputé"
 
-#. module: l10n_fr
-#: model:res.country.group,name:l10n_fr.dom-tom
-msgid "DOM-TOM"
-msgstr "DOM-TOM"
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "DateLet"
+msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_tva_deductible
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "Debit"
+msgstr "Débit"
+
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_tva_deductible
 msgid "Deductible VAT"
 msgstr "TVA Déductible"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_determination
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_determination
 msgid "Determining the amount to be paid and/or VAT and/or TIC credits"
-msgstr "Détermination du montant à payer et/ou des crédits de TVA et/ou de TIC"
+msgstr ""
+"Détermination du montant à payer et/ou des crédits de TVA et/ou de TIC"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_E1
+#. module: l10n_fr_account
+#: model:ir.model.fields,field_description:l10n_fr_account.field_l10n_fr_fec_export_wizard__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_E1
 msgid "E1 - Exports outside the EU"
 msgstr "E1 - Exportations hors UE"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_E2
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_E2
 msgid "E2 - Other non-taxable transactions"
 msgstr "E2 - Autres opérations non imposables"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_E3
-msgid "E3 - Distance selling taxable in another Member State to non-taxable persons"
-msgstr "E3 - Ventes à distance taxables dans un autre État membre au profit des personnes non assujetties"
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_E3
+msgid ""
+"E3 - Distance selling taxable in another Member State to non-taxable persons"
+msgstr ""
+"E3 - Ventes à distance taxables dans un autre État membre au profit des "
+"personnes non assujetties"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_E4
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_E4
 msgid "E4 - Imports (other than petroleum products)"
 msgstr "E4 - Importations (autres que les produits pétroliers)"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_E5
-msgid "E5 - Removal from suspensive tax regime (other than petroleum products)"
-msgstr "E5 - Sorties de régime fiscal suspensif (autres que les produits pétroliers)"
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_E5
+msgid ""
+"E5 - Removal from suspensive tax regime (other than petroleum products)"
+msgstr ""
+"E5 - Sorties de régime fiscal suspensif (autres que les produits pétroliers)"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_E6
-msgid "E6 - Imports under suspensive tax arrangements (other than petroleum products)"
-msgstr "E6 - Importations placées sous régime fiscal suspensif (autres que les produits pétroliers)"
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_E6
+msgid ""
+"E6 - Imports under suspensive tax arrangements (other than petroleum "
+"products)"
+msgstr ""
+"E6 - Importations placées sous régime fiscal suspensif (autres que les "
+"produits pétroliers)"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_F1
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "EcritureDate"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "EcritureLet"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "EcritureLib"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "EcritureNum"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model:ir.model.fields,field_description:l10n_fr_account.field_l10n_fr_fec_export_wizard__date_to
+msgid "End Date"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model:ir.model.fields,field_description:l10n_fr_account.field_l10n_fr_fec_export_wizard__excluded_journal_ids
+msgid "Excluded Journals"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model:ir.model.fields,field_description:l10n_fr_account.field_l10n_fr_fec_export_wizard__export_type
+msgid "Export Type"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_F1
 msgid "F1 - Intra-Community acquisitions"
 msgstr "F1 - Acquisitions intracommunautaires"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_F2
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_F2
 msgid "F2 - Intra-Community supplies to a taxable person"
-msgstr "F2 - Livraisons intracommunautaires à destination d'une personne assujettie"
+msgstr ""
+"F2 - Livraisons intracommunautaires à destination d'une personne assujettie"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_F3
-msgid "F3 - Non-taxable supplies of electricity, natural gas, heat or cooling in France"
-msgstr "F3 - Livraisons d’électricité, de gaz naturel, de chaleur ou de froid non imposables en France"
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_F3
+msgid ""
+"F3 - Non-taxable supplies of electricity, natural gas, heat or cooling in "
+"France"
+msgstr ""
+"F3 - Livraisons d’électricité, de gaz naturel, de chaleur ou de froid non "
+"imposables en France"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_F4
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_F4
 msgid "F4 - Releases for consumption of petroleum products"
 msgstr "F4 - Mises à la consommation de produits pétroliers"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_F5
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_F5
 msgid "F5 - Imports of petroleum products under a suspensive tax regime"
-msgstr "F5 - Importations de produits pétroliers placées sous régime fiscal suspensif"
+msgstr ""
+"F5 - Importations de produits pétroliers placées sous régime fiscal "
+"suspensif"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_F6
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_F6
 msgid "F6 - Franchise purchases"
 msgstr "F6 - Achats en franchise"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_F7
-msgid "F7 - Sales of goods or services by a taxable person not established in France"
-msgstr "F7 - Ventes de biens ou prestations de services réalisées par un assujetti non établi en France"
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_F7
+msgid ""
+"F7 - Sales of goods or services by a taxable person not established in "
+"France"
+msgstr ""
+"F7 - Ventes de biens ou prestations de services réalisées par un assujetti "
+"non établi en France"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_F8
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_F8
 msgid "F8 - Accruals"
 msgstr "F8 - Régularisations"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_F9
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_F9
 msgid "F9 - Internal transactions between members of a single taxable person"
-msgstr "F9 - Opérations internes réalisées entre membres d'un assujetti unique"
+msgstr ""
+"F9 - Opérations internes réalisées entre membres d'un assujetti unique"
 
-#. module: l10n_fr
-#: model:account.account,name:l10n_fr.1_pcg_6233
-#: model:account.account,name:l10n_fr.2_pcg_6233
-#: model:account.account.template,name:l10n_fr.pcg_6233
-msgid "Fairs and exhibitions"
-msgstr "Foires et expositions"
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "FEC File Generation"
+msgstr ""
 
-#. module: l10n_fr
-#: model:account.account,name:l10n_fr.1_pcg_6415
-#: model:account.account,name:l10n_fr.2_pcg_6415
-#: model:account.account.template,name:l10n_fr.pcg_6415
-msgid "Family income supplement"
-msgstr "Supplément familial"
+#. module: l10n_fr_account
+#: model:ir.model,name:l10n_fr_account.model_l10n_fr_fec_export_wizard
+msgid "Fichier Echange Informatise"
+msgstr ""
 
-#. module: l10n_fr
-#: model:account.account,name:l10n_fr.1_pcg_6226
-#: model:account.account,name:l10n_fr.2_pcg_6226
-#: model:account.account.template,name:l10n_fr.pcg_6226
-msgid "Fees"
-msgstr "Honoraires"
+#. module: l10n_fr_account
+#: model:ir.model.fields,field_description:l10n_fr_account.field_l10n_fr_fec_export_wizard__filename
+msgid "Filename"
+msgstr ""
 
-#. module: l10n_fr
-#: model:account.group,name:l10n_fr.1_pcg_66
-#: model:account.group,name:l10n_fr.2_pcg_66
-#: model:account.group.template,name:l10n_fr.pcg_66
-msgid "Financial charges"
-msgstr "Charges financières"
-
-#. module: l10n_fr
-#: model:account.group,name:l10n_fr.1_pcg_76
-#: model:account.group,name:l10n_fr.2_pcg_76
-#: model:account.group.template,name:l10n_fr.pcg_76
-msgid "Financial income"
-msgstr "Produits financiers"
-
-#. module: l10n_fr
-#: model:account.group,name:l10n_fr.1_pcg_511
-#: model:account.group,name:l10n_fr.2_pcg_511
-#: model:account.group.template,name:l10n_fr.pcg_511
-msgid "Financial instruments for collection"
-msgstr "Valeurs à l'encaissement"
-
-#. module: l10n_fr
-#: model:account.group,name:l10n_fr.1_pcg_355
-#: model:account.group,name:l10n_fr.2_pcg_355
-#: model:account.group.template,name:l10n_fr.pcg_355
-msgid "Finished products"
-msgstr "Produits finis"
-
-#. module: l10n_fr
-#: model:account.account,name:l10n_fr.1_pcg_3551
-#: model:account.account,name:l10n_fr.1_pcg_7011
-#: model:account.account,name:l10n_fr.2_pcg_3551
-#: model:account.account,name:l10n_fr.2_pcg_7011
-#: model:account.account.template,name:l10n_fr.pcg_3551
-#: model:account.account.template,name:l10n_fr.pcg_7011
-msgid "Finished products (or group) A"
-msgstr "Ventes de produits finis (ou groupe) A"
-
-#. module: l10n_fr
-#: model:account.account,name:l10n_fr.1_pcg_3552
-#: model:account.account,name:l10n_fr.1_pcg_7012
-#: model:account.account,name:l10n_fr.2_pcg_3552
-#: model:account.account,name:l10n_fr.2_pcg_7012
-#: model:account.account.template,name:l10n_fr.pcg_3552
-#: model:account.account.template,name:l10n_fr.pcg_7012
-msgid "Finished products (or group) B"
-msgstr "Ventes de produits finis (ou groupe) B"
-
-#. module: l10n_fr
-#: model:account.group,name:l10n_fr.1_pcg_404
-#: model:account.group,name:l10n_fr.2_pcg_404
-#: model:account.group.template,name:l10n_fr.pcg_404
-msgid "Fixed asset suppliers"
-msgstr "Fournisseurs d'immobilisations"
-
-#. module: l10n_fr
-#: model:account.account,name:l10n_fr.1_pcg_405
-#: model:account.account,name:l10n_fr.2_pcg_405
-#: model:account.account.template,name:l10n_fr.pcg_405
-msgid "Fixed asset suppliers - Bills payable"
-msgstr "Fournisseurs d'immobilisations - Effets à payer"
-
-#. module: l10n_fr
-#: model:account.account,name:l10n_fr.1_pcg_4047
-#: model:account.account,name:l10n_fr.2_pcg_4047
-#: model:account.account.template,name:l10n_fr.pcg_4047
-msgid "Fixed asset suppliers - Contract performance holdbacks"
-msgstr "Fournisseurs d'immobilisations - Retenues de garantie"
-
-#. module: l10n_fr
-#: model:account.account,name:l10n_fr.1_pcg_22
-#: model:account.account,name:l10n_fr.2_pcg_22
-#: model:account.account.template,name:l10n_fr.pcg_22
-msgid "Fixed assets in concession"
-msgstr "Immobilisations mises en concession"
-
-#. module: l10n_fr
-#: model:account.group,name:l10n_fr.1_pcg_23
-#: model:account.group,name:l10n_fr.2_pcg_23
-#: model:account.group.template,name:l10n_fr.pcg_23
-msgid "Fixed assets in progress"
-msgstr "Immobilisations en cours"
-
-#. module: l10n_fr
-#: model:account.account,name:l10n_fr.1_pcg_2313
-#: model:account.account,name:l10n_fr.2_pcg_2313
-#: model:account.account.template,name:l10n_fr.pcg_2313
-msgid "Fixed assets in progress - Constructions"
-msgstr "Immobilisations corporelles en cours - Constructions"
-
-#. module: l10n_fr
-#: model:account.account,name:l10n_fr.1_pcg_2312
-#: model:account.account,name:l10n_fr.2_pcg_2312
-#: model:account.account.template,name:l10n_fr.pcg_2312
-msgid "Fixed assets in progress - Land"
-msgstr "Immobilisations corporelles en cours - Terrains"
-
-#. module: l10n_fr
-#: model:account.account,name:l10n_fr.1_pcg_2315
-#: model:account.account,name:l10n_fr.2_pcg_2315
-#: model:account.account.template,name:l10n_fr.pcg_2315
-msgid ""
-"Fixed assets in progress - Technical installations, plant and machinery, "
-"equipment and fixtures"
-msgstr "Immobilisations corporelles en cours - Installations techniques matériel et outillage industriels"
-
-#. module: l10n_fr
-#: model:ir.ui.menu,name:l10n_fr.account_reports_fr_statements_menu
+#. module: l10n_fr_account
+#: model:ir.ui.menu,name:l10n_fr_account.account_reports_fr_statements_menu
 msgid "France"
-msgstr "France"
+msgstr ""
 
-#. module: l10n_fr
-#: model:res.country.group,name:l10n_fr.fr_and_mc
-msgid "France and Monaco"
-msgstr "France et Monaco"
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "Generate"
+msgstr "Générer"
 
-#. module: l10n_fr
-#: model_terms:account.fiscal.position,note:l10n_fr.1_fiscal_position_template_intraeub2b
-#: model_terms:account.fiscal.position,note:l10n_fr.2_fiscal_position_template_intraeub2b
-msgid "French VAT exemption according to articles 262 ter I (for products) and/or 283-2 (for services) of \"CGI\""
-msgstr "Exonération de la TVA française selon les articles 262 ter I (pour les produits) et/ou 283-2 (pour les services) du \"CGI\""
-
-#. module: l10n_fr
-#: model_terms:account.fiscal.position,note:l10n_fr.1_fiscal_position_template_import_export
-#: model_terms:account.fiscal.position,note:l10n_fr.2_fiscal_position_template_import_export
-msgid "French VAT exemption according to articles 291, 294 and 262 I of \"CGI\""
-msgstr "Exonération de la TVA française selon les articles 291, 294 et 262 I du \"CGI\""
-
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_tva_brute
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_tva_brute
 msgid "Gross VAT"
 msgstr "TVA Brute"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_I1_base
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_I1_base
 msgid "I1 - Standard rate 20% (base)"
 msgstr "I1 - Taux normal 20% (base)"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_I1_taxe
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_I1_taxe
 msgid "I1 - Standard rate 20% (tax)"
 msgstr "I1 - Taux normal 20% (taxe)"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_I2_base
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_I2_base
 msgid "I2 - Reduced rate 10% (base)"
 msgstr "I2 - Taux réduit 10% (base)"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_I2_taxe
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_I2_taxe
 msgid "I2 - Reduced rate 10% (tax)"
 msgstr "I2 - Taux réduit 10% (taxe)"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_I3_base
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_I3_base
 msgid "I3 - Reduced rate 8.5% (base)"
 msgstr "I3 - Taux réduit 8.5% (base)"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_I3_taxe
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_I3_taxe
 msgid "I3 - Reduced rate 8.5% (tax)"
 msgstr "I3 - Taux réduit 8.5% (taxe)"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_I4_base
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_I4_base
 msgid "I4 - Reduced rate 5.5% (base)"
 msgstr "I4 - Taux réduit 5.5% (base)"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_I4_taxe
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_I4_taxe
 msgid "I4 - Reduced rate 5.5% (tax)"
 msgstr "I4 - Taux réduit 5.5% (taxe)"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_I5_base
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_I5_base
 msgid "I5 - Reduced rate 2.1% (base)"
 msgstr "I5 - Taux réduit 2.1% (base)"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_I5_taxe
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_I5_taxe
 msgid "I5 - Reduced rate 2.1% (tax)"
 msgstr "I5 - Taux réduit 2.1% (taxe)"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_I6_base
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_I6_base
 msgid "I6 - Reduced rate 1.05% (base)"
 msgstr "I6 - Taux réduit 1.05% (base)"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_I6_taxe
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_I6_taxe
 msgid "I6 - Reduced rate 1.05% (tax)"
 msgstr "I6 - Taux réduit 1.05% (taxe)"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_tva_brute_import
+#. module: l10n_fr_account
+#: model:ir.model.fields,field_description:l10n_fr_account.field_l10n_fr_fec_export_wizard__id
+msgid "ID"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "Idevise"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_tva_brute_import
 msgid "Imports"
 msgstr "Importations"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_tva_brute_petrolier
+#. module: l10n_fr_account
+#: model:ir.model,name:l10n_fr_account.model_account_move
+msgid "Journal Entry"
+msgstr "Pièce comptable"
+
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "JournalCode"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "JournalLib"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model:ir.model.fields,field_description:l10n_fr_account.field_res_company__l10n_fr_rounding_difference_loss_account_id
+msgid "L10N Fr Rounding Difference Loss Account"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model:ir.model.fields,field_description:l10n_fr_account.field_res_company__l10n_fr_rounding_difference_profit_account_id
+msgid "L10N Fr Rounding Difference Profit Account"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model:ir.model.fields,field_description:l10n_fr_account.field_l10n_fr_fec_export_wizard__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model:ir.model.fields,field_description:l10n_fr_account.field_l10n_fr_fec_export_wizard__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "Montantdevise"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model:ir.model.fields.selection,name:l10n_fr_account.selection__l10n_fr_fec_export_wizard__export_type__nonofficial
+msgid "Non-official FEC report (posted and unposted entries)"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model:ir.model.fields.selection,name:l10n_fr_account.selection__l10n_fr_fec_export_wizard__export_type__official
+msgid "Official FEC report (posted entries only)"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_tva_brute_petrolier
 msgid "Oil products"
 msgstr "Produits pétroliers"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_tva_brute_metropo
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_tva_brute_metropo
 msgid "Operations carried out in mainland France"
 msgstr "Opérations réalisées en France métropolitaine"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_tva_brute_dom
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_tva_brute_dom
 msgid "Operations carried out in the DOM"
 msgstr "Opérations réalisées dans les DOM"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_reliquat
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "Options"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_reliquat
 msgid "Outstanding credit"
 msgstr "Reliquat de crédit à rembourser"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_P1_base
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_P1_base
 msgid "P1 - Standard rate 20% (base)"
 msgstr "P1 - Taux normal 20% (base)"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_P1_taxe
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_P1_taxe
 msgid "P1 - Standard rate 20% (tax)"
 msgstr "P1 - Taux normal 20% (taxe)"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_P2_base
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_P2_base
 msgid "P2 - Reduced rate 13% (base)"
 msgstr "P2 - Taux réduit 13% (base)"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_P2_taxe
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_P2_taxe
 msgid "P2 - Reduced rate 13% (tax)"
 msgstr "P2 - Taux réduit 13% (taxe)"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_credit_constate
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "PieceDate"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "PieceRef"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_credit_constate
 msgid "Recognised credit"
 msgstr "Crédit constaté"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_regularisation
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_regularisation
 msgid "Regularisation of domestic consumption taxes (TIC)"
 msgstr "Régularisation des taxes intérieures de consommation (TIC)"
 
-#. module: l10n_fr
-#: model:ir.model.fields,field_description:l10n_fr.field_res_company__siret
-#: model:ir.model.fields,field_description:l10n_fr.field_res_partner__siret
-#: model:ir.model.fields,field_description:l10n_fr.field_res_users__siret
-msgid "SIRET"
-msgstr "SIRET"
-
-#. module: l10n_fr
-#: model:account.account.tag,name:l10n_fr.account_fr_tag_salaires
+#. module: l10n_fr_account
+#: model:account.account.tag,name:l10n_fr_account.account_fr_tag_salaires
 msgid "Salaries"
 msgstr "Salaires"
 
-#. module: l10n_fr
-#. odoo-python
-#: code:addons/l10n_fr/models/res_company.py:0
-msgid "Securisation of %s - %s"
-msgstr "Sécurisation de %s - %s"
-
-#. module: l10n_fr
-#: model:ir.model.fields,field_description:l10n_fr.field_res_company__l10n_fr_closing_sequence_id
-msgid "Sequence to use to build sale closings"
-msgstr "Séquence à utiliser pour construire des clôtures de vente"
-
-#. module: l10n_fr
-#: model:account.account.tag,name:l10n_fr.account_fr_tag_charges_sociales
+#. module: l10n_fr_account
+#: model:account.account.tag,name:l10n_fr_account.account_fr_tag_charges_sociales
 msgid "Social charges"
 msgstr "Charges sociales"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_T1_base
+#. module: l10n_fr_account
+#: model:ir.model.fields,field_description:l10n_fr_account.field_l10n_fr_fec_export_wizard__date_from
+msgid "Start Date"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_T1_base
 msgid ""
 "T1 - Transactions carried out in the French overseas departments and taxable"
 " at 1.75% (base)"
-msgstr "T1 - Opérations réalisées dans les DOM et imposables au taux de 1,75 % (base)"
+msgstr ""
+"T1 - Opérations réalisées dans les DOM et imposables au taux de 1,75 % "
+"(base)"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_T1_taxe
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_T1_taxe
 msgid ""
 "T1 - Transactions carried out in the French overseas departments and taxable"
 " at 1.75% (tax)"
-msgstr "T1 - Opérations réalisées dans les DOM et imposables au taux de 1,75 % (taxe)"
+msgstr ""
+"T1 - Opérations réalisées dans les DOM et imposables au taux de 1,75 % "
+"(taxe)"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_T2_taxe
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_T2_taxe
 msgid ""
 "T2 - Transactions carried out in the French overseas departments and taxable"
 " at 1,05% (tax)"
-msgstr "T2 - Opérations réalisées dans les DOM et imposables au taux de 1,05 % (taxe)"
+msgstr ""
+"T2 - Opérations réalisées dans les DOM et imposables au taux de 1,05 % "
+"(taxe)"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_T2_base
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_T2_base
 msgid ""
 "T2 - Transactions carried out in the French overseas departments and taxable"
 " at 1.05% (base)"
-msgstr "T2 - Opérations réalisées dans les DOM et imposables au taux de 1,05 % (base)"
+msgstr ""
+"T2 - Opérations réalisées dans les DOM et imposables au taux de 1,05 % "
+"(base)"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_T3_base
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_T3_base
 msgid ""
 "T3 - Transactions carried out in Corsica and taxable at the rate of 10% "
 "(base)"
-msgstr "T3 - Opérations réalisées en Corse et imposables au taux de 10 % (base)"
+msgstr ""
+"T3 - Opérations réalisées en Corse et imposables au taux de 10 % (base)"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_T3_taxe
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_T3_taxe
 msgid ""
 "T3 - Transactions carried out in Corsica and taxable at the rate of 10% "
 "(tax)"
-msgstr "T3 - Opérations réalisées en Corse et imposables au taux de 10 % (taxe)"
+msgstr ""
+"T3 - Opérations réalisées en Corse et imposables au taux de 10 % (taxe)"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_T4_base
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_T4_base
 msgid ""
 "T4 - Transactions carried out in Corsica and taxable at the rate of 2,1% "
 "(base)"
-msgstr "T4 - Opérations réalisées en Corse et imposables au taux de 2,1 % (base)"
+msgstr ""
+"T4 - Opérations réalisées en Corse et imposables au taux de 2,1 % (base)"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_T4_taxe
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_T4_taxe
 msgid ""
 "T4 - Transactions carried out in Corsica and taxable at the rate of 2,1% "
 "(tax)"
-msgstr "T4 - Opérations réalisées en Corse et imposables au taux de 2,1 % (taxe)"
+msgstr ""
+"T4 - Opérations réalisées en Corse et imposables au taux de 2,1 % (taxe)"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_T5_base
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_T5_base
 msgid ""
 "T5 - Transactions carried out in Corsica and taxable at the rate of 0,9% "
 "(base)"
-msgstr "T5 - Opérations réalisées en Corse et imposables au taux de 0,9 % (base)"
+msgstr ""
+"T5 - Opérations réalisées en Corse et imposables au taux de 0,9 % (base)"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_T5_taxe
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_T5_taxe
 msgid ""
 "T5 - Transactions carried out in Corsica and taxable at the rate of 0,9% "
 "(tax)"
-msgstr "T5 - Opérations réalisées en Corse et imposables au taux de 0,9 % (taxe)"
+msgstr ""
+"T5 - Opérations réalisées en Corse et imposables au taux de 0,9 % (taxe)"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_T6_base
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_T6_base
 msgid ""
 "T6 - Transactions carried out in mainland France at the rate of 2,1% (base)"
-msgstr "T6 - Opérations réalisées en France continentale au taux de 2,1 % (base)"
+msgstr ""
+"T6 - Opérations réalisées en France continentale au taux de 2,1 % (base)"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_T6_taxe
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_T6_taxe
 msgid ""
 "T6 - Transactions carried out in mainland France at the rate of 2,1% (tax)"
-msgstr "T6 - Opérations réalisées en France continentale au taux de 2,1 % (taxe)"
+msgstr ""
+"T6 - Opérations réalisées en France continentale au taux de 2,1 % (taxe)"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_T7_base
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_T7_base
 msgid "T7 - Withholding of VAT on copyright (base)"
 msgstr "T7 - Retenue de TVA sur droits d’auteur (base)"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_T7_taxe
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_T7_taxe
 msgid "T7 - Withholding of VAT on copyright (tax)"
 msgstr "T7 - Retenue de TVA sur droits d’auteur (taxe)"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_TD
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_TD
 msgid "TD - VAT Due"
 msgstr "TD - TVA Due"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_TICC
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_TICC
 msgid "TICC"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_TICFE
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_TICFE
 msgid "TICFE"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_TICGN
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_TICGN
 msgid "TICGN"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report,name:l10n_fr.tax_report
+#. module: l10n_fr_account
+#: model:account.report,name:l10n_fr_account.tax_report
 msgid "Tax Report"
 msgstr "Rapport de taxes"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_tic_tax
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_tic_tax
 msgid "Tax due"
 msgstr "Taxe due"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_taxes_a_payer
-msgid "Tax to be paid"
-msgstr "Taxe à Payer"
-
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_op_imposables_ht
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_op_imposables_ht
 msgid "Taxable transactions (excl. VAT)"
 msgstr "Opérations imposables (H.T.)"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_TIC_total
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "Technical Info"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "Technical Name"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model:ir.model.fields,field_description:l10n_fr_account.field_l10n_fr_fec_export_wizard__test_file
+msgid "Test File"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid ""
+"The encoding of this text file is UTF-8. The structure of file is CSV "
+"separated by pipe '|'."
+msgstr ""
+
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_TIC_total
 msgid "Total"
 msgstr ""
 
-
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_tva_brute_autre
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_tva_brute_autre
 msgid "Transactions taxable at another rate (metropolitan France or DOM)"
 msgstr "Opérations imposables à un autre taux (France métropolitaine ou DOM)"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_op_non_imposables
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_op_non_imposables
 msgid "Untaxed operations"
 msgstr "Opérations Non Taxées"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_X1
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "ValidDate"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "We use partner.id"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid ""
+"When you download a FEC file, the lock date is set to the end date.\n"
+"                If you want to test the FEC file generation, please tick the test file checkbox."
+msgstr ""
+
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_X1
 msgid "X1"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_X2
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_X2
 msgid "X2"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_X3
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_X3
 msgid "X3"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_X4
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_X4
 msgid "X4"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_X5
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_X5
 msgid "X5 - TIC credit offset against VAT (carried forward from line X4)"
 msgstr "X5 - Crédit de TIC imputé sur la TVA (report de la ligne X4)"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_Y1
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_Y1
 msgid "Y1"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_Y2
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_Y2
 msgid "Y2"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_Y3
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_Y3
 msgid "Y3"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_Y4
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_Y4
 msgid "Y4"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_Y5
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_Y5
 msgid "Y5 - Refund of TIC balance requested (carried forward from line Y4)"
 msgstr "Y5 - Remboursement de reliquat de TIC demandé (report de la ligne Y4)"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_Y6
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_Y6
 msgid ""
 "Y6 - TIC credit transferred to the head company on the 3310-CA3G "
 "recapitulative return (carried forward from line Y4)"
-msgstr "Y6 - Crédit de TIC transféré à la société tête de groupe sur la déclaration récapitulative 3310-CA3G (report de la ligne Y4)"
+msgstr ""
+"Y6 - Crédit de TIC transféré à la société tête de groupe sur la déclaration "
+"récapitulative 3310-CA3G (report de la ligne Y4)"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_Z1
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid ""
+"You are in test mode. The FEC file generation will not set the lock date."
+msgstr ""
+
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_Z1
 msgid "Z1"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_Z2
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_Z2
 msgid "Z2"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_Z3
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_Z3
 msgid "Z3"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_Z4
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_Z4
 msgid "Z4"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_Z5
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_Z5
 msgid "Z5 - Total domestic consumption tax due (carried forward from line Z4)"
-msgstr "Z5 - Total des taxes intérieures de consommation dues (report de la ligne Z4)"
+msgstr ""
+"Z5 - Total des taxes intérieures de consommation dues (report de la ligne "
+"Z4)"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_15_2
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_15_2
 msgid "of which VAT on imported products excluding petroleum products"
 msgstr "dont TVA sur les produits importés hors produits pétroliers"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_15_1
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_15_1
 msgid "of which VAT on petroleum products"
 msgstr "dont TVA sur les produits pétroliers"

--- a/addons/l10n_fr_account/i18n/l10n_fr.pot
+++ b/addons/l10n_fr_account/i18n/l10n_fr.pot
@@ -1,13 +1,13 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# 	* l10n_fr
+# 	* l10n_fr_account
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 16.1alpha1+e\n"
+"Project-Id-Version: Odoo Server saas~17.2+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-04 09:09+0000\n"
-"PO-Revision-Date: 2023-01-04 09:09+0000\n"
+"POT-Creation-Date: 2024-07-04 09:42+0000\n"
+"PO-Revision-Date: 2024-07-04 09:42+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -15,852 +15,1020 @@ msgstr ""
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_08_base
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "# 10"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "# 11"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "# 12"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "# 13"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "# 14"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "# 15"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "# 16"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "# 17"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_08_base
 msgid "08 - Standard rate 20% (base)"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_08_taxe
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_08_taxe
 msgid "08 - Standard rate 20% (tax)"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_09_base
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_09_base
 msgid "09 - Reduced rate 5.5% (base)"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_09_taxe
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_09_taxe
 msgid "09 - Reduced rate 5.5% (tax)"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_10_base
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_10_base
 msgid "10 - Standard rate 8.5% (base)"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_10_taxe
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_10_taxe
 msgid "10 - Standard rate 8.5% (tax)"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_11_base
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_11_base
 msgid "11 - Reduced rate 2.1% (base)"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_11_taxe
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_11_taxe
 msgid "11 - Reduced rate 2.1% (tax)"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_13_base
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_13_base
 msgid "13 - Former rates (base)"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_13_taxe
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_13_taxe
 msgid "13 - Former rates (tax)"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_14_base
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_14_base
 msgid "14 - Transactions taxable at a particular rate (base)"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_14_taxe
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_14_taxe
 msgid "14 - Transactions taxable at a particular rate (tax)"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_15
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_15
 msgid "15 - Previously deducted VAT to be repaid"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_16
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_16
 msgid "16 - Total gross VAT due"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_17
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_17
 msgid "17 - Of which VAT on intra-Community acquisitions"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_18
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_18
 msgid "18 - Of which VAT on transactions to Monaco"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_19
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_19
 msgid "19 - Assets constituting fixed assets"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_20
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_20
 msgid "20 - Other goods and services"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_21
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_21
 msgid "21 - Other deductible VAT"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_22
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_22
 msgid "22 - Carry-over of credit from line 27 of the previous return"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_22A
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_22A
 msgid ""
 "22A - Enter the single tax rate applicable for the period if different from "
 "100%"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_23
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_23
 msgid "23 - Total deductible VAT"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_24
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_24
 msgid "24 - Of which deductible VAT on imports"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_25
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_25
 msgid "25 - VAT credit"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_26
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_26
 msgid "26 - Repayment of credit requested on form n°3519 attached"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_27
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_27
 msgid "27 - Credit to be carried forward"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_28
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_28
 msgid "28 - Net VAT due"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_29
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_29
 msgid "29 - Similar taxes calculated on schedule n°3310-A-SD"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_2C
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_2C
 msgid "2C - Amounts to be charged, including advance holiday pay"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_2E
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_2E
 msgid "2E - Of which deductible VAT on petroleum products"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_32
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_32
 msgid "32 - Total payable"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_5B
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_5B
 msgid "5B - Amounts to be added, including advance holiday pay"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_9B_base
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_9B_base
 msgid "9B - Reduced rate 10% (base)"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_9B_taxe
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_9B_taxe
 msgid "9B - Reduced rate 10% (tax)"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_montant_op_realisees
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_montant_op_realisees
 msgid "A. Amount of operations carried out"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_A1
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_A1
 msgid "A1 - Sales, provision of services"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_A2
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_A2
 msgid "A2 - Other taxable transactions"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_A3
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_A3
 msgid "A3 - Intra-Community purchases of services"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_A4
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_A4
 msgid "A4 - Imports (other than petroleum products)"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_A5
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_A5
 msgid ""
 "A5 - Removal from suspensive tax regime (other than petroleum products)"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_AA
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_AA
 msgid ""
 "AA - VAT credit transferred to the head company on the recapitulative return"
 " 3310-CA3G"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_AB
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_AB
 msgid ""
 "AB - Total to be paid by the head company on the recapitulative declaration "
 "3310-CA3G"
 msgstr ""
 
-#. module: l10n_fr
-#: model:ir.model.fields,field_description:l10n_fr.field_res_company__ape
-msgid "APE"
-msgstr ""
-
-#. module: l10n_fr
-#: model:ir.model,name:l10n_fr.model_account_chart_template
+#. module: l10n_fr_account
+#: model:ir.model,name:l10n_fr_account.model_account_chart_template
 msgid "Account Chart Template"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_decompte_tva
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_decompte_tva
 msgid "B. Settlement of VAT to be paid"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_B1
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_B1
 msgid "B1 - Releases for consumption of petroleum products"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_B2
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_B2
 msgid "B2 - Intra-Community acquisitions"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_B3
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_B3
 msgid ""
 "B3 - Taxable supplies of electricity, natural gas, heat or cooling in France"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_B4
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_B4
 msgid ""
 "B4 - Purchases of goods or services from a taxable person not established in"
 " France"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_B5
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_B5
 msgid "B5 - Regularisations"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.column,name:l10n_fr.tax_report_balance
+#. module: l10n_fr_account
+#: model:account.report.column,name:l10n_fr_account.tax_report_balance
 msgid "Balance"
 msgstr ""
 
-#. module: l10n_fr
-#: model:ir.model,name:l10n_fr.model_res_company
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "Cancel"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "Column"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "Comment"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "CompAuxLib"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "CompAuxNum"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model:ir.model,name:l10n_fr_account.model_res_company
 msgid "Companies"
 msgstr ""
 
-#. module: l10n_fr
-#: model:ir.model.fields,field_description:l10n_fr.field_res_company_registry
-msgid "Company ID"
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "CompteLib"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.account,name:l10n_fr.1_pcg_6161
-#: model:account.account,name:l10n_fr.2_pcg_6161
-#: model:account.account.template,name:l10n_fr.pcg_6161
-msgid "Comprehensive risk"
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "CompteNum"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.account,name:l10n_fr.1_pcg_6162
-#: model:account.account,name:l10n_fr.2_pcg_6162
-#: model:account.account.template,name:l10n_fr.pcg_6162
-msgid "Compulsory construction loss insurance"
+#. module: l10n_fr_account
+#: model:ir.model.fields,field_description:l10n_fr_account.field_l10n_fr_fec_export_wizard__create_uid
+msgid "Created by"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.account,name:l10n_fr.1_pcg_6511
-#: model:account.account,name:l10n_fr.2_pcg_6511
-#: model:account.account.template,name:l10n_fr.pcg_6511
-msgid "Concessions, patents, licences, trade marks, processes, software"
+#. module: l10n_fr_account
+#: model:ir.model.fields,field_description:l10n_fr_account.field_l10n_fr_fec_export_wizard__create_date
+msgid "Created on"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.group,name:l10n_fr.1_pcg_213
-#: model:account.group,name:l10n_fr.2_pcg_213
-#: model:account.group.template,name:l10n_fr.pcg_213
-msgid "Constructions"
-msgstr ""
-
-#. module: l10n_fr
-#: model:account.group,name:l10n_fr.1_pcg_321
-#: model:account.group,name:l10n_fr.1_pcg_6021
-#: model:account.group,name:l10n_fr.2_pcg_321
-#: model:account.group,name:l10n_fr.2_pcg_6021
-#: model:account.group.template,name:l10n_fr.pcg_321
-#: model:account.group.template,name:l10n_fr.pcg_6021
-msgid "Consumable materials"
-msgstr ""
-
-#. module: l10n_fr
-#: model:account.group,name:l10n_fr.1_pcg_322
-#: model:account.group,name:l10n_fr.1_pcg_6022
-#: model:account.group,name:l10n_fr.2_pcg_322
-#: model:account.group,name:l10n_fr.2_pcg_6022
-#: model:account.group.template,name:l10n_fr.pcg_322
-#: model:account.group.template,name:l10n_fr.pcg_6022
-msgid "Consumable supplies"
-msgstr ""
-
-#. module: l10n_fr
-#: model:ir.model,name:l10n_fr.model_res_partner
-msgid "Contact"
-msgstr ""
-
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_credit
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_credit
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
 msgid "Credit"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_credit_impute
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_credit_impute
 msgid "Credit charged"
 msgstr ""
 
-
-#. module: l10n_fr
-#: model:res.country.group,name:l10n_fr.dom-tom
-msgid "DOM-TOM"
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "DateLet"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_tva_deductible
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "Debit"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_tva_deductible
 msgid "Deductible VAT"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_determination
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_determination
 msgid "Determining the amount to be paid and/or VAT and/or TIC credits"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_E1
+#. module: l10n_fr_account
+#: model:ir.model.fields,field_description:l10n_fr_account.field_l10n_fr_fec_export_wizard__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_E1
 msgid "E1 - Exports outside the EU"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_E2
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_E2
 msgid "E2 - Other non-taxable transactions"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_E3
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_E3
 msgid ""
 "E3 - Distance selling taxable in another Member State to non-taxable persons"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_E4
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_E4
 msgid "E4 - Imports (other than petroleum products)"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_E5
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_E5
 msgid ""
 "E5 - Removal from suspensive tax regime (other than petroleum products)"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_E6
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_E6
 msgid ""
 "E6 - Imports under suspensive tax arrangements (other than petroleum "
 "products)"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_F1
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "EcritureDate"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "EcritureLet"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "EcritureLib"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "EcritureNum"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model:ir.model.fields,field_description:l10n_fr_account.field_l10n_fr_fec_export_wizard__date_to
+msgid "End Date"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model:ir.model.fields,field_description:l10n_fr_account.field_l10n_fr_fec_export_wizard__excluded_journal_ids
+msgid "Excluded Journals"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model:ir.model.fields,field_description:l10n_fr_account.field_l10n_fr_fec_export_wizard__export_type
+msgid "Export Type"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_F1
 msgid "F1 - Intra-Community acquisitions"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_F2
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_F2
 msgid "F2 - Intra-Community supplies to a taxable person"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_F3
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_F3
 msgid ""
 "F3 - Non-taxable supplies of electricity, natural gas, heat or cooling in "
 "France"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_F4
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_F4
 msgid "F4 - Releases for consumption of petroleum products"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_F5
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_F5
 msgid "F5 - Imports of petroleum products under a suspensive tax regime"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_F6
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_F6
 msgid "F6 - Franchise purchases"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_F7
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_F7
 msgid ""
 "F7 - Sales of goods or services by a taxable person not established in "
 "France"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_F8
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_F8
 msgid "F8 - Accruals"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_F9
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_F9
 msgid "F9 - Internal transactions between members of a single taxable person"
 msgstr ""
 
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "FEC File Generation"
+msgstr ""
 
-#. module: l10n_fr
-#: model:ir.ui.menu,name:l10n_fr.account_reports_fr_statements_menu
+#. module: l10n_fr_account
+#: model:ir.model,name:l10n_fr_account.model_l10n_fr_fec_export_wizard
+msgid "Fichier Echange Informatise"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model:ir.model.fields,field_description:l10n_fr_account.field_l10n_fr_fec_export_wizard__filename
+msgid "Filename"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model:ir.ui.menu,name:l10n_fr_account.account_reports_fr_statements_menu
 msgid "France"
 msgstr ""
 
-#. module: l10n_fr
-#: model:res.country.group,name:l10n_fr.fr_and_mc
-msgid "France and Monaco"
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "Generate"
 msgstr ""
 
-#. module: l10n_fr
-#: model_terms:account.fiscal.position,note:l10n_fr.1_fiscal_position_template_intraeub2b
-#: model_terms:account.fiscal.position,note:l10n_fr.2_fiscal_position_template_intraeub2b
-msgid ""
-"French VAT exemption according to articles 262 ter I (for products) and/or "
-"283-2 (for services) of \"CGI\""
-msgstr ""
-
-#. module: l10n_fr
-#: model_terms:account.fiscal.position,note:l10n_fr.1_fiscal_position_template_import_export
-#: model_terms:account.fiscal.position,note:l10n_fr.2_fiscal_position_template_import_export
-msgid "French VAT exemption according to articles 291, 294 and 262 I of \"CGI\""
-msgstr ""
-
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_tva_brute
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_tva_brute
 msgid "Gross VAT"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_I1_base
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_I1_base
 msgid "I1 - Standard rate 20% (base)"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_I1_taxe
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_I1_taxe
 msgid "I1 - Standard rate 20% (tax)"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_I2_base
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_I2_base
 msgid "I2 - Reduced rate 10% (base)"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_I2_taxe
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_I2_taxe
 msgid "I2 - Reduced rate 10% (tax)"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_I3_base
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_I3_base
 msgid "I3 - Reduced rate 8.5% (base)"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_I3_taxe
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_I3_taxe
 msgid "I3 - Reduced rate 8.5% (tax)"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_I4_base
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_I4_base
 msgid "I4 - Reduced rate 5.5% (base)"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_I4_taxe
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_I4_taxe
 msgid "I4 - Reduced rate 5.5% (tax)"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_I5_base
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_I5_base
 msgid "I5 - Reduced rate 2.1% (base)"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_I5_taxe
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_I5_taxe
 msgid "I5 - Reduced rate 2.1% (tax)"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_I6_base
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_I6_base
 msgid "I6 - Reduced rate 1.05% (base)"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_I6_taxe
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_I6_taxe
 msgid "I6 - Reduced rate 1.05% (tax)"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_tva_brute_import
+#. module: l10n_fr_account
+#: model:ir.model.fields,field_description:l10n_fr_account.field_l10n_fr_fec_export_wizard__id
+msgid "ID"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "Idevise"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_tva_brute_import
 msgid "Imports"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_tva_brute_petrolier
+#. module: l10n_fr_account
+#: model:ir.model,name:l10n_fr_account.model_account_move
+msgid "Journal Entry"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "JournalCode"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "JournalLib"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model:ir.model.fields,field_description:l10n_fr_account.field_res_company__l10n_fr_rounding_difference_loss_account_id
+msgid "L10N Fr Rounding Difference Loss Account"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model:ir.model.fields,field_description:l10n_fr_account.field_res_company__l10n_fr_rounding_difference_profit_account_id
+msgid "L10N Fr Rounding Difference Profit Account"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model:ir.model.fields,field_description:l10n_fr_account.field_l10n_fr_fec_export_wizard__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model:ir.model.fields,field_description:l10n_fr_account.field_l10n_fr_fec_export_wizard__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "Montantdevise"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model:ir.model.fields.selection,name:l10n_fr_account.selection__l10n_fr_fec_export_wizard__export_type__nonofficial
+msgid "Non-official FEC report (posted and unposted entries)"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model:ir.model.fields.selection,name:l10n_fr_account.selection__l10n_fr_fec_export_wizard__export_type__official
+msgid "Official FEC report (posted entries only)"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_tva_brute_petrolier
 msgid "Oil products"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_tva_brute_metropo
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_tva_brute_metropo
 msgid "Operations carried out in mainland France"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_tva_brute_dom
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_tva_brute_dom
 msgid "Operations carried out in the DOM"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_reliquat
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "Options"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_reliquat
 msgid "Outstanding credit"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_P1_base
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_P1_base
 msgid "P1 - Standard rate 20% (base)"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_P1_taxe
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_P1_taxe
 msgid "P1 - Standard rate 20% (tax)"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_P2_base
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_P2_base
 msgid "P2 - Reduced rate 13% (base)"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_P2_taxe
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_P2_taxe
 msgid "P2 - Reduced rate 13% (tax)"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_credit_constate
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "PieceDate"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "PieceRef"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_credit_constate
 msgid "Recognised credit"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_regularisation
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_regularisation
 msgid "Regularisation of domestic consumption taxes (TIC)"
 msgstr ""
 
-#. module: l10n_fr
-#: model:ir.model.fields,field_description:l10n_fr.field_res_company__siret
-#: model:ir.model.fields,field_description:l10n_fr.field_res_partner__siret
-#: model:ir.model.fields,field_description:l10n_fr.field_res_users__siret
-msgid "SIRET"
-msgstr ""
-
-#. module: l10n_fr
-#: model:account.account.tag,name:l10n_fr.account_fr_tag_salaires
+#. module: l10n_fr_account
+#: model:account.account.tag,name:l10n_fr_account.account_fr_tag_salaires
 msgid "Salaries"
 msgstr ""
 
-#. module: l10n_fr
-#. odoo-python
-#: code:addons/l10n_fr/models/res_company.py:0
-msgid "Securisation of %s - %s"
-msgstr ""
-
-#. module: l10n_fr
-#: model:ir.model.fields,field_description:l10n_fr.field_res_company__l10n_fr_closing_sequence_id
-msgid "Sequence to use to build sale closings"
-msgstr ""
-
-#. module: l10n_fr
-#: model:account.account.tag,name:l10n_fr.account_fr_tag_charges_sociales
+#. module: l10n_fr_account
+#: model:account.account.tag,name:l10n_fr_account.account_fr_tag_charges_sociales
 msgid "Social charges"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_T1_base
+#. module: l10n_fr_account
+#: model:ir.model.fields,field_description:l10n_fr_account.field_l10n_fr_fec_export_wizard__date_from
+msgid "Start Date"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_T1_base
 msgid ""
 "T1 - Transactions carried out in the French overseas departments and taxable"
 " at 1.75% (base)"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_T1_taxe
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_T1_taxe
 msgid ""
 "T1 - Transactions carried out in the French overseas departments and taxable"
 " at 1.75% (tax)"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_T2_taxe
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_T2_taxe
 msgid ""
 "T2 - Transactions carried out in the French overseas departments and taxable"
 " at 1,05% (tax)"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_T2_base
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_T2_base
 msgid ""
 "T2 - Transactions carried out in the French overseas departments and taxable"
 " at 1.05% (base)"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_T3_base
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_T3_base
 msgid ""
 "T3 - Transactions carried out in Corsica and taxable at the rate of 10% "
 "(base)"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_T3_taxe
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_T3_taxe
 msgid ""
 "T3 - Transactions carried out in Corsica and taxable at the rate of 10% "
 "(tax)"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_T4_base
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_T4_base
 msgid ""
 "T4 - Transactions carried out in Corsica and taxable at the rate of 2,1% "
 "(base)"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_T4_taxe
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_T4_taxe
 msgid ""
 "T4 - Transactions carried out in Corsica and taxable at the rate of 2,1% "
 "(tax)"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_T5_base
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_T5_base
 msgid ""
 "T5 - Transactions carried out in Corsica and taxable at the rate of 0,9% "
 "(base)"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_T5_taxe
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_T5_taxe
 msgid ""
 "T5 - Transactions carried out in Corsica and taxable at the rate of 0,9% "
 "(tax)"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_T6_base
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_T6_base
 msgid ""
 "T6 - Transactions carried out in mainland France at the rate of 2,1% (base)"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_T6_taxe
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_T6_taxe
 msgid ""
 "T6 - Transactions carried out in mainland France at the rate of 2,1% (tax)"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_T7_base
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_T7_base
 msgid "T7 - Withholding of VAT on copyright (base)"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_T7_taxe
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_T7_taxe
 msgid "T7 - Withholding of VAT on copyright (tax)"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_TD
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_TD
 msgid "TD - VAT Due"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_TICC
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_TICC
 msgid "TICC"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_TICFE
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_TICFE
 msgid "TICFE"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_TICGN
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_TICGN
 msgid "TICGN"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report,name:l10n_fr.tax_report
+#. module: l10n_fr_account
+#: model:account.report,name:l10n_fr_account.tax_report
 msgid "Tax Report"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_tic_tax
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_tic_tax
 msgid "Tax due"
 msgstr ""
 
-
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_taxes_a_payer
-msgid "Tax to be paid"
-msgstr ""
-
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_op_imposables_ht
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_op_imposables_ht
 msgid "Taxable transactions (excl. VAT)"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_TIC_total
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "Technical Info"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "Technical Name"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model:ir.model.fields,field_description:l10n_fr_account.field_l10n_fr_fec_export_wizard__test_file
+msgid "Test File"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid ""
+"The encoding of this text file is UTF-8. The structure of file is CSV "
+"separated by pipe '|'."
+msgstr ""
+
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_TIC_total
 msgid "Total"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_tva_brute_autre
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_tva_brute_autre
 msgid "Transactions taxable at another rate (metropolitan France or DOM)"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_op_non_imposables
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_op_non_imposables
 msgid "Untaxed operations"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_X1
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "ValidDate"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid "We use partner.id"
+msgstr ""
+
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid ""
+"When you download a FEC file, the lock date is set to the end date.\n"
+"                If you want to test the FEC file generation, please tick the test file checkbox."
+msgstr ""
+
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_X1
 msgid "X1"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_X2
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_X2
 msgid "X2"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_X3
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_X3
 msgid "X3"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_X4
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_X4
 msgid "X4"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_X5
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_X5
 msgid "X5 - TIC credit offset against VAT (carried forward from line X4)"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_Y1
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_Y1
 msgid "Y1"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_Y2
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_Y2
 msgid "Y2"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_Y3
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_Y3
 msgid "Y3"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_Y4
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_Y4
 msgid "Y4"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_Y5
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_Y5
 msgid "Y5 - Refund of TIC balance requested (carried forward from line Y4)"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_Y6
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_Y6
 msgid ""
 "Y6 - TIC credit transferred to the head company on the 3310-CA3G "
 "recapitulative return (carried forward from line Y4)"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_Z1
+#. module: l10n_fr_account
+#: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
+msgid ""
+"You are in test mode. The FEC file generation will not set the lock date."
+msgstr ""
+
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_Z1
 msgid "Z1"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_Z2
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_Z2
 msgid "Z2"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_Z3
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_Z3
 msgid "Z3"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_Z4
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_Z4
 msgid "Z4"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_Z5
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_Z5
 msgid "Z5 - Total domestic consumption tax due (carried forward from line Z4)"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_15_2
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_15_2
 msgid "of which VAT on imported products excluding petroleum products"
 msgstr ""
 
-#. module: l10n_fr
-#: model:account.report.line,name:l10n_fr.tax_report_15_1
+#. module: l10n_fr_account
+#: model:account.report.line,name:l10n_fr_account.tax_report_15_1
 msgid "of which VAT on petroleum products"
 msgstr ""


### PR DESCRIPTION
The French accounting localization module name was changed from l10n_fr to l10n_fr_account without fixing the module references in the translation files. This commit fixes the module references in the i18n files.

The French tax report was not showing the French translation.

task-3986901

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
