### PR TITLE
[MOV] barcodes: moving manual barcode dialog to barcodes module

### DIFF
--- a/addons/barcodes/static/src/components/manual_barcode.js
+++ b/addons/barcodes/static/src/components/manual_barcode.js
@@ -1,0 +1,40 @@
+import { BarcodeDialog } from '@web/core/barcode/barcode_dialog';
+import { Component, onMounted, useRef, useState } from "@odoo/owl";
+
+export class BarcodeInput extends Component {
+    static template = "stock_barcode.BarcodeInput";
+    static props = {
+        onSubmit: Function,
+    };
+
+    setup() {
+        this.state = useState({
+            barcode: false,
+        });
+        this.barcodeManual = useRef('manualBarcode');
+        // Autofocus processing was blocked because a document already has a focused element.
+        onMounted(() => {
+            this.barcodeManual.el.focus();
+        });
+    }
+
+    /**
+     * Called when press Enter after filling barcode input manually.
+     *
+     * @private
+     * @param {KeyboardEvent} ev
+     */
+    _onKeydown(ev) {
+        if (ev.key === "Enter" && this.state.barcode) {
+            this.props.onSubmit(this.state.barcode);
+        }
+    }
+}
+
+export class ManualBarcodeScanner extends BarcodeDialog {
+    static template = "stock_barcode.ManualBarcodeScanner";
+    static components = {
+        ...BarcodeDialog.components,
+        BarcodeInput,
+    };
+}

--- a/addons/barcodes/static/src/components/manual_barcode.js
+++ b/addons/barcodes/static/src/components/manual_barcode.js
@@ -1,17 +1,22 @@
-import { BarcodeDialog } from '@web/core/barcode/barcode_dialog';
+import { BarcodeDialog } from "@web/core/barcode/barcode_dialog";
 import { Component, onMounted, useRef, useState } from "@odoo/owl";
+import { getActiveHotkey } from "@web/core/hotkeys/hotkey_service";
+import { _t } from "@web/core/l10n/translation";
 
 export class BarcodeInput extends Component {
-    static template = "stock_barcode.BarcodeInput";
+    static template = "barcodes.BarcodeInput";
     static props = {
         onSubmit: Function,
+        placeholder: { type: String, optional: true },
     };
-
+    static defaultProps = {
+        placeholder: _t("Enter a barcode..."),
+    };
     setup() {
         this.state = useState({
             barcode: false,
         });
-        this.barcodeManual = useRef('manualBarcode');
+        this.barcodeManual = useRef("manualBarcode");
         // Autofocus processing was blocked because a document already has a focused element.
         onMounted(() => {
             this.barcodeManual.el.focus();
@@ -25,16 +30,18 @@ export class BarcodeInput extends Component {
      * @param {KeyboardEvent} ev
      */
     _onKeydown(ev) {
-        if (ev.key === "Enter" && this.state.barcode) {
+        const hotkey = getActiveHotkey(ev);
+        if (hotkey === "enter" && this.state.barcode) {
             this.props.onSubmit(this.state.barcode);
         }
     }
 }
 
 export class ManualBarcodeScanner extends BarcodeDialog {
-    static template = "stock_barcode.ManualBarcodeScanner";
+    static template = "barcodes.ManualBarcodeScanner";
     static components = {
         ...BarcodeDialog.components,
         BarcodeInput,
     };
+    static props = [...BarcodeDialog.props, "placeholder?"];
 }

--- a/addons/barcodes/static/src/components/manual_barcode.xml
+++ b/addons/barcodes/static/src/components/manual_barcode.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="stock_barcode.BarcodeInput">
+        <div class="input-group">
+            <input id="manual_barcode" t-model="state.barcode" type="text" name="barcode"
+                    class="form-control" t-ref="manualBarcode"
+                    placeholder="Enter a barcode..." t-on-keydown="_onKeydown"/>
+            <button class="input-group-text" t-att-disabled="!state.barcode"
+                    t-on-click.prevent="(ev) => this.props.onSubmit(state.barcode)">
+                Apply
+            </button>
+        </div>
+    </t>
+
+    <t t-name="stock_barcode.ManualBarcodeScanner" t-inherit="web.BarcodeDialog" t-inherit-mode="primary">
+        <Dialog position="attributes">
+            <attribute name="footer">true</attribute>
+        </Dialog>
+        <Dialog position="inside">
+            <t t-set-slot="footer">
+                <BarcodeInput onSubmit="props.onResult"/>
+            </t>
+        </Dialog>
+    </t>
+</templates>

--- a/addons/barcodes/static/src/components/manual_barcode.xml
+++ b/addons/barcodes/static/src/components/manual_barcode.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
-    <t t-name="stock_barcode.BarcodeInput">
+    <t t-name="barcodes.BarcodeInput">
         <div class="input-group">
             <input id="manual_barcode" t-model="state.barcode" type="text" name="barcode"
                     class="form-control" t-ref="manualBarcode"
-                    placeholder="Enter a barcode..." t-on-keydown="_onKeydown"/>
+                    t-att-placeholder="props.placeholder" t-on-keydown="_onKeydown"/>
             <button class="input-group-text" t-att-disabled="!state.barcode"
                     t-on-click.prevent="(ev) => this.props.onSubmit(state.barcode)">
                 Apply
@@ -12,13 +12,13 @@
         </div>
     </t>
 
-    <t t-name="stock_barcode.ManualBarcodeScanner" t-inherit="web.BarcodeDialog" t-inherit-mode="primary">
+    <t t-name="barcodes.ManualBarcodeScanner" t-inherit="web.BarcodeDialog" t-inherit-mode="primary">
         <Dialog position="attributes">
             <attribute name="footer">true</attribute>
         </Dialog>
         <Dialog position="inside">
             <t t-set-slot="footer">
-                <BarcodeInput onSubmit="props.onResult"/>
+                <BarcodeInput onSubmit="props.onResult" placeholder="props.placeholder"/>
             </t>
         </Dialog>
     </t>

--- a/addons/l10n_in/models/account_invoice.py
+++ b/addons/l10n_in/models/account_invoice.py
@@ -193,3 +193,7 @@ class AccountMove(models.Model):
                 'taxes_data': line.tax_ids,
             })
         return self.env['account.tax']._l10n_in_get_hsn_summary_table(base_lines, display_uom)
+
+    def _l10n_in_get_bill_from_irn(self, irn):
+        # TO OVERRIDE
+        return False

--- a/addons/web/static/src/core/barcode/barcode_video_scanner.js
+++ b/addons/web/static/src/core/barcode/barcode_video_scanner.js
@@ -24,6 +24,7 @@ export class BarcodeVideoScanner extends Component {
         onReady: { type: Function, optional: true },
         onResult: Function,
         onError: Function,
+        placeholder: { type: String, optional: true },
         delayBetweenScan: { type: Number, optional: true },
     };
     static defaultProps = {


### PR DESCRIPTION

Moving the `manual_bacode` files to barcodes module from `stock_barcode` module. The `ManualBarcodeScanner` component can be needed multiple times for the common manual entries and scanning purpose.

Also providing support for dynamic placeholder in `BarcodeInput` component, by passing placeholder
as props. 

ENT-PR :- https://github.com/odoo/enterprise/pull/66059

task-4022648

