### PR TITLE
[FIX] l10n_fr_account: Fixed module name in i18n files

### DIFF
--- a/addons/l10n_fr_account/i18n/fr.po
+++ b/addons/l10n_fr_account/i18n/fr.po
@@ -1,6 +1,6 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * l10n_fr
+# 	* l10n_fr_account
 #
 # Translators:
 # Cyrille de Lambert <cdelambert@teclib.com>, 2015
@@ -262,15 +262,16 @@ msgstr "A4 - Importations (autres que les produits pétroliers)"
 
 #. module: l10n_fr_account
 #: model:account.report.line,name:l10n_fr_account.tax_report_A5
-msgid "A5 - Removal from suspensive tax regime (other than petroleum products)"
+msgid ""
+"A5 - Removal from suspensive tax regime (other than petroleum products)"
 msgstr ""
 "A5 - Sorties de régime fiscal suspensif (autres que les produits pétroliers)"
 
 #. module: l10n_fr_account
 #: model:account.report.line,name:l10n_fr_account.tax_report_AA
 msgid ""
-"AA - VAT credit transferred to the head company on the recapitulative return "
-"3310-CA3G"
+"AA - VAT credit transferred to the head company on the recapitulative return"
+" 3310-CA3G"
 msgstr ""
 "AA - Crédit de TVA transféré à la société tête de groupe sur la déclaration "
 "récapitulative 3310-CA3G"
@@ -281,8 +282,8 @@ msgid ""
 "AB - Total to be paid by the head company on the recapitulative declaration "
 "3310-CA3G"
 msgstr ""
-"AB - Total à payer acquitté par la société tête de groupe sur la déclaration "
-"récapitulative 3310-CA3G"
+"AB - Total à payer acquitté par la société tête de groupe sur la déclaration"
+" récapitulative 3310-CA3G"
 
 #. module: l10n_fr_account
 #: model:ir.model,name:l10n_fr_account.model_account_chart_template
@@ -315,8 +316,8 @@ msgstr ""
 #. module: l10n_fr_account
 #: model:account.report.line,name:l10n_fr_account.tax_report_B4
 msgid ""
-"B4 - Purchases of goods or services from a taxable person not established in "
-"France"
+"B4 - Purchases of goods or services from a taxable person not established in"
+" France"
 msgstr ""
 "B4 - Achats de bien ou de prestations de services réalisés auprès d'un "
 "assujetti non établi en France"
@@ -329,7 +330,7 @@ msgstr "B5 - Régularisations"
 #. module: l10n_fr_account
 #: model:account.report.column,name:l10n_fr_account.tax_report_balance
 msgid "Balance"
-msgstr "Balance"
+msgstr ""
 
 #. module: l10n_fr_account
 #: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
@@ -410,7 +411,8 @@ msgstr "TVA Déductible"
 #. module: l10n_fr_account
 #: model:account.report.line,name:l10n_fr_account.tax_report_determination
 msgid "Determining the amount to be paid and/or VAT and/or TIC credits"
-msgstr "Détermination du montant à payer et/ou des crédits de TVA et/ou de TIC"
+msgstr ""
+"Détermination du montant à payer et/ou des crédits de TVA et/ou de TIC"
 
 #. module: l10n_fr_account
 #: model:ir.model.fields,field_description:l10n_fr_account.field_l10n_fr_fec_export_wizard__display_name
@@ -442,7 +444,8 @@ msgstr "E4 - Importations (autres que les produits pétroliers)"
 
 #. module: l10n_fr_account
 #: model:account.report.line,name:l10n_fr_account.tax_report_E5
-msgid "E5 - Removal from suspensive tax regime (other than petroleum products)"
+msgid ""
+"E5 - Removal from suspensive tax regime (other than petroleum products)"
 msgstr ""
 "E5 - Sorties de régime fiscal suspensif (autres que les produits pétroliers)"
 
@@ -519,7 +522,8 @@ msgstr "F4 - Mises à la consommation de produits pétroliers"
 #: model:account.report.line,name:l10n_fr_account.tax_report_F5
 msgid "F5 - Imports of petroleum products under a suspensive tax regime"
 msgstr ""
-"F5 - Importations de produits pétroliers placées sous régime fiscal suspensif"
+"F5 - Importations de produits pétroliers placées sous régime fiscal "
+"suspensif"
 
 #. module: l10n_fr_account
 #: model:account.report.line,name:l10n_fr_account.tax_report_F6
@@ -529,7 +533,8 @@ msgstr "F6 - Achats en franchise"
 #. module: l10n_fr_account
 #: model:account.report.line,name:l10n_fr_account.tax_report_F7
 msgid ""
-"F7 - Sales of goods or services by a taxable person not established in France"
+"F7 - Sales of goods or services by a taxable person not established in "
+"France"
 msgstr ""
 "F7 - Ventes de biens ou prestations de services réalisées par un assujetti "
 "non établi en France"
@@ -542,7 +547,8 @@ msgstr "F8 - Régularisations"
 #. module: l10n_fr_account
 #: model:account.report.line,name:l10n_fr_account.tax_report_F9
 msgid "F9 - Internal transactions between members of a single taxable person"
-msgstr "F9 - Opérations internes réalisées entre membres d'un assujetti unique"
+msgstr ""
+"F9 - Opérations internes réalisées entre membres d'un assujetti unique"
 
 #. module: l10n_fr_account
 #: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
@@ -562,7 +568,7 @@ msgstr ""
 #. module: l10n_fr_account
 #: model:ir.ui.menu,name:l10n_fr_account.account_reports_fr_statements_menu
 msgid "France"
-msgstr "France"
+msgstr ""
 
 #. module: l10n_fr_account
 #: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
@@ -652,7 +658,7 @@ msgstr "Importations"
 #. module: l10n_fr_account
 #: model:ir.model,name:l10n_fr_account.model_account_move
 msgid "Journal Entry"
-msgstr ""
+msgstr "Pièce comptable"
 
 #. module: l10n_fr_account
 #: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
@@ -782,34 +788,38 @@ msgstr ""
 #. module: l10n_fr_account
 #: model:account.report.line,name:l10n_fr_account.tax_report_T1_base
 msgid ""
-"T1 - Transactions carried out in the French overseas departments and taxable "
-"at 1.75% (base)"
+"T1 - Transactions carried out in the French overseas departments and taxable"
+" at 1.75% (base)"
 msgstr ""
-"T1 - Opérations réalisées dans les DOM et imposables au taux de 1,75 % (base)"
+"T1 - Opérations réalisées dans les DOM et imposables au taux de 1,75 % "
+"(base)"
 
 #. module: l10n_fr_account
 #: model:account.report.line,name:l10n_fr_account.tax_report_T1_taxe
 msgid ""
-"T1 - Transactions carried out in the French overseas departments and taxable "
-"at 1.75% (tax)"
+"T1 - Transactions carried out in the French overseas departments and taxable"
+" at 1.75% (tax)"
 msgstr ""
-"T1 - Opérations réalisées dans les DOM et imposables au taux de 1,75 % (taxe)"
+"T1 - Opérations réalisées dans les DOM et imposables au taux de 1,75 % "
+"(taxe)"
 
 #. module: l10n_fr_account
 #: model:account.report.line,name:l10n_fr_account.tax_report_T2_taxe
 msgid ""
-"T2 - Transactions carried out in the French overseas departments and taxable "
-"at 1,05% (tax)"
+"T2 - Transactions carried out in the French overseas departments and taxable"
+" at 1,05% (tax)"
 msgstr ""
-"T2 - Opérations réalisées dans les DOM et imposables au taux de 1,05 % (taxe)"
+"T2 - Opérations réalisées dans les DOM et imposables au taux de 1,05 % "
+"(taxe)"
 
 #. module: l10n_fr_account
 #: model:account.report.line,name:l10n_fr_account.tax_report_T2_base
 msgid ""
-"T2 - Transactions carried out in the French overseas departments and taxable "
-"at 1.05% (base)"
+"T2 - Transactions carried out in the French overseas departments and taxable"
+" at 1.05% (base)"
 msgstr ""
-"T2 - Opérations réalisées dans les DOM et imposables au taux de 1,05 % (base)"
+"T2 - Opérations réalisées dans les DOM et imposables au taux de 1,05 % "
+"(base)"
 
 #. module: l10n_fr_account
 #: model:account.report.line,name:l10n_fr_account.tax_report_T3_base
@@ -822,7 +832,8 @@ msgstr ""
 #. module: l10n_fr_account
 #: model:account.report.line,name:l10n_fr_account.tax_report_T3_taxe
 msgid ""
-"T3 - Transactions carried out in Corsica and taxable at the rate of 10% (tax)"
+"T3 - Transactions carried out in Corsica and taxable at the rate of 10% "
+"(tax)"
 msgstr ""
 "T3 - Opérations réalisées en Corse et imposables au taux de 10 % (taxe)"
 
@@ -968,8 +979,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:l10n_fr_account.fec_export_wizard_view
 msgid ""
 "When you download a FEC file, the lock date is set to the end date.\n"
-"                If you want to test the FEC file generation, please tick the "
-"test file checkbox."
+"                If you want to test the FEC file generation, please tick the test file checkbox."
 msgstr ""
 
 #. module: l10n_fr_account
@@ -1061,7 +1071,8 @@ msgstr ""
 #: model:account.report.line,name:l10n_fr_account.tax_report_Z5
 msgid "Z5 - Total domestic consumption tax due (carried forward from line Z4)"
 msgstr ""
-"Z5 - Total des taxes intérieures de consommation dues (report de la ligne Z4)"
+"Z5 - Total des taxes intérieures de consommation dues (report de la ligne "
+"Z4)"
 
 #. module: l10n_fr_account
 #: model:account.report.line,name:l10n_fr_account.tax_report_15_2


### PR DESCRIPTION
The French accounting localization module name was changed from l10n_fr to l10n_fr_account without fixing the module references in the translation files. This commit fixes the module references in the i18n files.

The French tax report was not showing the French translation.

task-3986901


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
