### PR TITLE
[IMP] l10n_in_edi_ewaybill: enhancement in hsn invalid error

### DIFF
--- a/addons/l10n_in_edi_ewaybill/i18n/l10n_in_edi_ewaybill.pot
+++ b/addons/l10n_in_edi_ewaybill/i18n/l10n_in_edi_ewaybill.pot
@@ -847,8 +847,8 @@ msgstr ""
 
 #. module: l10n_in_edi_ewaybill
 #. odoo-python
-#: code:addons/l10n_in_edi_ewaybill/models/account_edi_format.py:0
-msgid "HSN code is not set in product %s"
+#: code:addons/l10n_in_edi_ewaybill/models/account_move.py:0
+msgid "HSN/SAC code is missing/invalid on Invoice Line"
 msgstr ""
 
 #. module: l10n_in_edi_ewaybill
@@ -1027,12 +1027,6 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_in_edi_ewaybill/models/error_codes.py:0
 msgid "Invalid HSN Code"
-msgstr ""
-
-#. module: l10n_in_edi_ewaybill
-#. odoo-python
-#: code:addons/l10n_in_edi_ewaybill/models/account_edi_format.py:0
-msgid "Invalid HSN Code (%s) in product %s"
 msgstr ""
 
 #. module: l10n_in_edi_ewaybill
@@ -1459,6 +1453,12 @@ msgstr ""
 #. module: l10n_in_edi_ewaybill
 #: model:ir.model,name:l10n_in_edi_ewaybill.model_account_move
 msgid "Journal Entry"
+msgstr ""
+
+#. module: l10n_in_edi_ewaybill
+#. odoo-python
+#: code:addons/l10n_in_edi_ewaybill/models/account_move.py:0
+msgid "Journal Items(s)"
 msgstr ""
 
 #. module: l10n_in_edi_ewaybill
@@ -2271,6 +2271,12 @@ msgstr ""
 #. module: l10n_in_edi_ewaybill
 #: model_terms:ir.ui.view,arch_db:l10n_in_edi_ewaybill.res_config_settings_view_form_inherit_l10n_in_edi_ewaybill
 msgid "Verify Username and Password"
+msgstr ""
+
+#. module: l10n_in_edi_ewaybill
+#. odoo-python
+#: code:addons/l10n_in_edi_ewaybill/models/account_move.py:0
+msgid "View Lines with Empty/Invalid HSN/SAC"
 msgstr ""
 
 #. module: l10n_in_edi_ewaybill

--- a/addons/l10n_in_edi_ewaybill/models/account_edi_format.py
+++ b/addons/l10n_in_edi_ewaybill/models/account_edi_format.py
@@ -110,15 +110,6 @@ class AccountEdiFormat(models.Model):
         if not re.match("^.{1,16}$", is_purchase and move.ref or move.name):
             error_message.append(_("%s number should be set and not more than 16 characters",
                 (is_purchase and "Bill Reference" or "Invoice")))
-        for line in goods_lines:
-            if line.display_type == 'product':
-                hsn_code = self._l10n_in_edi_extract_digits(line.l10n_in_hsn_code)
-                if not hsn_code:
-                    error_message.append(_("HSN code is not set in product line %s", line.name))
-                elif not re.match(r'^\d{4}$|^\d{6}$|^\d{8}$', hsn_code):
-                    error_message.append(_(
-                        "Invalid HSN Code (%s) in product line %s", hsn_code, line.name
-                    ))
         if error_message:
             error_message.insert(0, _("Impossible to send the Ewaybill."))
         return error_message

--- a/addons/l10n_in_edi_ewaybill/tests/test_edi_ewaybill_json.py
+++ b/addons/l10n_in_edi_ewaybill/tests/test_edi_ewaybill_json.py
@@ -1,10 +1,25 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from odoo.addons.l10n_in_edi.tests.test_edi_json import TestEdiJson
+from odoo.exceptions import RedirectWarning
 from odoo.tests import tagged
 
 
 @tagged("post_install_l10n", "post_install", "-at_install")
 class TestEdiEwaybillJson(TestEdiJson):
+
+    def test_edi_empty_hsn(self):
+        invoice = self.init_invoice("out_invoice", products=self.product_a)
+        invoice.write({
+            "l10n_in_type_id": self.env.ref("l10n_in_edi_ewaybill.type_tax_invoice_sub_type_supply"),
+            "l10n_in_distance": 20,
+            "l10n_in_mode": "1",
+            "l10n_in_vehicle_no": "GJ11AA1234",
+            "l10n_in_vehicle_type": "R",
+        })
+        invoice.invoice_line_ids.l10n_in_hsn_code = False
+        invoice.action_post()
+        with self.assertRaises(RedirectWarning):
+            invoice.l10n_in_edi_ewaybill_send()
 
     def test_edi_json(self):
         (self.invoice + self.invoice_full_discount + self.invoice_zero_qty).write({

--- a/addons/l10n_in_ewaybill_stock/__manifest__.py
+++ b/addons/l10n_in_ewaybill_stock/__manifest__.py
@@ -20,6 +20,7 @@ This module enables users to create E-waybill from Inventory App without generat
         "data/ewaybill_type_data.xml",
         "views/l10n_in_ewaybill_views.xml",
         "views/stock_picking_views.xml",
+        "views/product_views.xml",
         "report/ewaybill_report_views.xml",
         "report/ewaybill_report.xml",
         "wizard/l10n_in_ewaybill_cancel_views.xml",

--- a/addons/l10n_in_ewaybill_stock/models/stock_picking.py
+++ b/addons/l10n_in_ewaybill_stock/models/stock_picking.py
@@ -1,7 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import _, fields, models
-from odoo.exceptions import UserError
+from odoo import fields, models
 
 
 class StockPicking(models.Model):
@@ -14,16 +13,6 @@ class StockPicking(models.Model):
 
     def action_l10n_in_ewaybill_create(self):
         self.ensure_one()
-        if (
-            product_with_no_hsn := self.move_ids.mapped('product_id').filtered(
-                lambda product: not product.l10n_in_hsn_code
-            )
-        ):
-            raise UserError(_("Please set HSN code in below products: \n%s", '\n'.join(
-                [product.name for product in product_with_no_hsn]
-            )))
-        if self.l10n_in_ewaybill_id:
-            raise UserError(_("Ewaybill already created for this picking."))
         action = self._get_l10n_in_ewaybill_form_action()
         ewaybill = self.env['l10n.in.ewaybill'].create({
             'picking_id': self.id,

--- a/addons/l10n_in_ewaybill_stock/tests/test_ewaybill_stock.py
+++ b/addons/l10n_in_ewaybill_stock/tests/test_ewaybill_stock.py
@@ -4,6 +4,7 @@ from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo import _
 from odoo.fields import Command
 from odoo.tests import tagged
+from odoo.exceptions import RedirectWarning
 
 
 @tagged('post_install', '-at_install', 'post_install_l10n')
@@ -198,3 +199,11 @@ class TestStockEwaybill(AccountTestInvoicingCommon):
         }
         ewaybill._l10n_in_ewaybill_stock_handle_zero_distance_alert_if_present(response)
         self.assertEqual(ewaybill.distance, expected_distance)
+
+    def test_ewaybill_stock_test_4(self):
+        """Test with missing hsn code"""
+        delivery_picking = self._create_stock_picking()
+        delivery_picking.move_ids.product_id.l10n_in_hsn_code = False
+        delivery_picking.action_l10n_in_ewaybill_create()
+        with self.assertRaises(RedirectWarning):
+            delivery_picking.l10n_in_ewaybill_id.generate_ewaybill()

--- a/addons/l10n_in_ewaybill_stock/views/product_views.xml
+++ b/addons/l10n_in_ewaybill_stock/views/product_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_product_tree_hsn_l10n_in" model="ir.ui.view">
+        <field name="name">product.product.tree.l10n_in</field>
+        <field name="model">product.product</field>
+        <field name="arch" type="xml">
+            <tree sample="1" string="Products" editable="top" create="0" delete="0">
+                <field name="name" string="Product" readonly="1"/>
+                <field name="l10n_in_hsn_code"/>
+            </tree>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Before this PR:
- If the HSN code was missing or invalid in multiple lines, an alert message was displayed multiple times with the product label. 
  Additionally, the HSN warning wasn't displayed for service-type products in invoices.
- In the inventory module, HSN validation occurred twice when creating an
  E-waybill.

After this PR:
- The alert message is displayed only once. A single button allows the user to list view of invoice lines with invalid or empty 
   HSN codes and an HSN warning will be displayed for all types of products in invoices.
- HSN validation will occur only once during the final generation of the E-waybill in inventory, with the error message showing 
  only once for all invalid or empty HSN products. A single button redirects to the list view of all those products.

**task**-3660731