### PR TITLE
[IMP] mail: revamp mail composer

### DIFF
--- a/addons/mail/static/src/chatter/web/chatter.xml
+++ b/addons/mail/static/src/chatter/web/chatter.xml
@@ -75,17 +75,24 @@
             </div>
             <t t-if="state.composerType">
                 <t t-if="state.composerType === 'message'">
-                    <div class="d-flex flex-shrink-0 pt-3 text-truncate small mb-2 ms-5">
-                        <span class="fw-bold">To:</span> <span t-if="toRecipientsText" t-out="toRecipientsText" class="ps-1"/>
-                        <SuggestedRecipientsList t-elif="state.thread.suggestedRecipients.length > 0" className="'ps-2'" thread="state.thread" onSuggestedRecipientAdded.bind="onSuggestedRecipientAdded"/>
-                        <span t-else="" class="ps-1">No recipient</span>
-                        <button t-if="state.thread.recipients.length > 0" class="o-mail-Chatter-recipientListButton btn btn-link badge rounded-pill border-0 p-1 ms-1" title="Show all recipients" t-on-click="onClickRecipientList">
-                            <i class="fa fa-caret-down"/>
-                        </button>
+                    <div class="d-flex flex-shrink-0 pt-3 text-truncate small mb-2 ms-5 gap-1">
+                        <span class="fw-bold">To: </span>
+                        <BaseRecipientsList
+                            t-if="state.thread.recipients.length > 0"
+                            thread="state.thread"/>
+                        <SuggestedRecipientsList
+                            t-elif="state.thread.suggestedRecipients.length > 0"
+                            thread="state.thread"
+                            onSuggestedRecipientAdded.bind="onSuggestedRecipientAdded"/>
+                        <span t-else="" class="fst-italic">No recipient</span>
                     </div>
                 </t>
                 <t t-set="type" t-value="state.composerType === 'message' ? 'message' : 'note'"/>
-                <SuggestedRecipientsList t-if="state.composerType !== 'note' and toRecipientsText" styleString="'margin-left:48px;'" thread="state.thread" onSuggestedRecipientAdded.bind="onSuggestedRecipientAdded"/>
+                <SuggestedRecipientsList
+                    t-if="state.composerType !== 'note' and state.thread.recipients.length > 0"
+                    styleString="'margin-left:48px;'"
+                    thread="state.thread"
+                    onSuggestedRecipientAdded.bind="onSuggestedRecipientAdded"/>
                 <Composer composer="state.thread.composer" autofocus="true" className="state.composerType === 'message' ? '' : 'pt-4'" mode="'extended'" onPostCallback.bind="onPostCallback" dropzoneRef="rootRef" type="state.composerType" t-key="props.threadId"/>
             </t>
         </div>

--- a/addons/mail/static/src/chatter/web/mail_composer_form.js
+++ b/addons/mail/static/src/chatter/web/mail_composer_form.js
@@ -1,6 +1,6 @@
 import { formView } from "@web/views/form/form_view";
 import { registry } from "@web/core/registry";
-import { toRaw } from "@odoo/owl";
+import { toRaw, useEffect, useRef } from "@odoo/owl";
 
 export class MailComposerFormController extends formView.Controller {
     setup() {
@@ -9,7 +9,29 @@ export class MailComposerFormController extends formView.Controller {
     }
 }
 
+export class MailComposerFormRenderer extends formView.Renderer {
+    setup() {
+        super.setup();
+        // Autofocus the visible editor in edition mode.
+        this.root = useRef("compiled_view_root");
+        useEffect((isInEdition, root) => {
+            if (root && root.el && isInEdition) {
+                const element = root.el.querySelector(".note-editable[contenteditable]");
+                if (element) {
+                    element.focus();
+                    document.dispatchEvent(new Event("selectionchange", {}));
+                }
+            }
+        }, () => [
+            this.props.record.isInEdition,
+            this.root,
+            this.props.record.resId
+        ]);
+    }
+}
+
 registry.category("views").add("mail_composer_form", {
     ...formView,
     Controller: MailComposerFormController,
+    Renderer: MailComposerFormRenderer,
 });

--- a/addons/mail/static/src/chatter/web_portal/chatter.scss
+++ b/addons/mail/static/src/chatter/web_portal/chatter.scss
@@ -22,10 +22,6 @@
     padding-right: var(--Chatter-default-padding-x);
 }
 
-.o-mail-Chatter-recipientListButton:hover {
-    background-color: rgba(0, 0, 0, 0.1);
-}
-
 .o-mail-Followers-button:focus {
     background-color: $gray-200;
 }

--- a/addons/mail/static/src/core/web/base_recipients_list.js
+++ b/addons/mail/static/src/core/web/base_recipients_list.js
@@ -1,0 +1,48 @@
+import { _t } from "@web/core/l10n/translation";
+import { escape } from "@web/core/utils/strings";
+import { formatList } from "@web/core/l10n/utils";
+import { markup, Component } from "@odoo/owl";
+import { usePopover } from "@web/core/popover/popover_hook";
+
+import { RecipientList } from "@mail/core/web/recipient_list";
+import { SuggestedRecipientsList } from "@mail/core/web/suggested_recipient_list";
+import { Thread } from "@mail/core/common/thread_model";
+
+
+export class BaseRecipientsList extends Component {
+    static template = "mail.BaseRecipientsList";
+    static components = { SuggestedRecipientsList };
+    static props = { thread: { type: Thread } };
+
+    setup() {
+        this.recipientsPopover = usePopover(RecipientList);
+    }
+
+    /** @returns {Markup} */
+    getRecipientListToHTML() {
+        const recipients = this.props.thread.recipients.slice(0, 5).map((
+            { partner }) => {
+                const text = partner.email ? partner.emailWithoutDomain : partner.name;
+                return `<span class="text-muted" title="${escape(
+                    partner.email || _t("no email address")
+                )}">${escape(text)}</span>`;
+            });
+        if (this.props.thread.recipients.length > 5) {
+            recipients.push(escape(
+                _t("%(recipientCount)s more", {
+                    recipientCount: this.props.thread.recipients.length - 5}))
+            );
+        }
+        return markup(formatList(recipients));
+    }
+
+    /** @param {Event} ev */
+    onClickRecipientList(ev) {
+        if (this.recipientsPopover.isOpen) {
+            return this.recipientsPopover.close();
+        }
+        this.recipientsPopover.open(ev.target, {
+            thread: this.props.thread
+        });
+    }
+};

--- a/addons/mail/static/src/core/web/base_recipients_list.scss
+++ b/addons/mail/static/src/core/web/base_recipients_list.scss
@@ -1,0 +1,3 @@
+.o-mail-BaseRecipientsList-caret:hover {
+    background-color: rgba(0, 0, 0, 0.1);
+}

--- a/addons/mail/static/src/core/web/base_recipients_list.xml
+++ b/addons/mail/static/src/core/web/base_recipients_list.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates>
+    <t t-name="mail.BaseRecipientsList">
+        <t t-if="props.thread.recipients.length > 0">
+            <t t-out="getRecipientListToHTML()"/>
+            <button class="o-mail-BaseRecipientsList-caret btn btn-link badge rounded-pill border-0 p-1" title="Show all recipients" t-on-click="onClickRecipientList">
+                <i class="fa fa-caret-down"/>
+            </button>
+        </t>
+    </t>
+</templates>

--- a/addons/mail/static/src/core/web/mail_composer_attachment_list.js
+++ b/addons/mail/static/src/core/web/mail_composer_attachment_list.js
@@ -1,0 +1,16 @@
+import { registry } from "@web/core/registry";
+import {
+    many2ManyBinaryField,
+    Many2ManyBinaryField
+} from "@web/views/fields/many2many_binary/many2many_binary_field";
+
+export class MailComposerAttachmentList extends Many2ManyBinaryField {
+    static template = "mail.MailComposerAttachmentList";
+}
+
+export const mailComposerAttachmentList = {
+    ...many2ManyBinaryField,
+    component: MailComposerAttachmentList,
+};
+
+registry.category("fields").add("mail_composer_attachment_list", mailComposerAttachmentList);

--- a/addons/mail/static/src/core/web/mail_composer_attachment_list.scss
+++ b/addons/mail/static/src/core/web/mail_composer_attachment_list.scss
@@ -1,0 +1,6 @@
+.o_field_mail_composer_attachment_list {
+    --fieldWidget-display: block;
+    li {
+        max-width: 325px;
+    }
+}

--- a/addons/mail/static/src/core/web/mail_composer_attachment_list.xml
+++ b/addons/mail/static/src/core/web/mail_composer_attachment_list.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates>
+    <t t-name="mail.MailComposerAttachmentList">
+        <ul class="list-unstyled m-0">
+            <li t-foreach="files" t-as="file" t-key="file_index" class="d-flex align-items-center bg-200 p-1 ps-3 my-2">
+                <a t-att-href="getUrl(file.id)" t-out="file.name" class="flex-grow-1 text-truncate"/>
+                <button class="btn flex-shrink-0" t-on-click.stop="() => this.onFileRemove(file.id)">
+                    <i class="fa fa-fw fa-times"/>
+                </button>
+            </li>
+        </ul>
+    </t>
+</templates>

--- a/addons/mail/static/src/core/web/mail_composer_attachment_selector.js
+++ b/addons/mail/static/src/core/web/mail_composer_attachment_selector.js
@@ -1,0 +1,44 @@
+import { _t } from "@web/core/l10n/translation";
+import { registry } from "@web/core/registry";
+import { standardFieldProps } from "@web/views/fields/standard_field_props";
+import { useService } from "@web/core/utils/hooks";
+import { useX2ManyCrud } from "@web/views/fields/relational_utils";
+
+import { Component } from "@odoo/owl";
+import { FileInput } from "@web/core/file_input/file_input";
+
+
+export class MailComposerAttachmentSelector extends Component {
+    static template = "mail.MailComposerAttachmentSelector";
+    static components = { FileInput };
+    static props = { ...standardFieldProps };
+
+    setup() {
+        this.notification = useService("notification");
+        this.operations = useX2ManyCrud(() => {
+            return this.props.record.data["attachment_ids"];
+        }, true);
+    }
+
+    /** @param {Array[Object]} files */
+    async onFileUploaded(files) {
+        for (const file of files) {
+            if (file.error) {
+                return this.notification.add(file.error, {
+                    title: _t("Uploading error"),
+                    type: "danger",
+                });
+            }
+            await this.operations.saveRecord([file.id]);
+        }
+    }
+}
+
+export const mailComposerAttachmentSelector = {
+    component: MailComposerAttachmentSelector,
+    fieldDependencies: [
+        { name: "can_edit_body", type: "boolean" },
+    ]
+};
+
+registry.category("fields").add("mail_composer_attachment_selector", mailComposerAttachmentSelector);

--- a/addons/mail/static/src/core/web/mail_composer_attachment_selector.xml
+++ b/addons/mail/static/src/core/web/mail_composer_attachment_selector.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates>
+    <t t-name="mail.MailComposerAttachmentSelector">
+        <FileInput
+            t-if="props.record.data.can_edit_body"
+            multiUpload="true"
+            onUpload.bind="onFileUploaded"
+            resModel="props.record.resModel"
+            resId="props.record.resId or 0">
+            <button class="btn btn-light" data-hotkey="a">
+                <i class="fa fa-fw fa-paperclip"/>
+            </button>
+        </FileInput>
+    </t>
+</templates>

--- a/addons/mail/static/src/core/web/mail_composer_chatgpt.js
+++ b/addons/mail/static/src/core/web/mail_composer_chatgpt.js
@@ -1,0 +1,51 @@
+import { _t } from "@web/core/l10n/translation";
+import { registry } from "@web/core/registry";
+import { standardFieldProps } from "@web/views/fields/standard_field_props";
+
+import { ChatGPTPromptDialog } from "@html_editor/main/chatgpt/chatgpt_prompt_dialog";
+import { Component, markup } from "@odoo/owl";
+
+
+export class MailComposerChatGPT extends Component {
+    static template = "mail.MailComposerChatGPT";
+    static props = { ...standardFieldProps };
+
+    setup() {
+        this.btnLabel = _t("AI"); // workaround to translate short string
+    }
+
+    async onOpenChatGPTPromptDialogBtnClick() {
+        this.env.services.dialog.add(ChatGPTPromptDialog, {
+            /** @param {DocumentFragment} content */
+            insert: content => {
+                const root = document.createElement("div");
+                root.appendChild(content);
+                const { body } = this.props.record.data;
+                this.props.record.update({
+                    body: body + markup(root.innerHTML)
+                });
+            },
+            /**
+             * @param {HTMLElement} fragment
+             * @returns {string}
+             */
+            sanitize: (fragment) => {
+                return DOMPurify.sanitize(fragment, {
+                    IN_PLACE: true,
+                    ADD_TAGS: ["#document-fragment"],
+                    ADD_ATTR: ["contenteditable"],
+                });
+            },
+        });
+    }
+}
+
+export const mailComposerChatGPT = {
+    component: MailComposerChatGPT,
+    fieldDependencies: [
+        { name: "can_edit_body", type: "boolean" },
+        { name: "body", type: "text" },
+    ]
+};
+
+registry.category("fields").add("mail_composer_chatgpt", mailComposerChatGPT);

--- a/addons/mail/static/src/core/web/mail_composer_chatgpt.xml
+++ b/addons/mail/static/src/core/web/mail_composer_chatgpt.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates>
+    <t t-name="mail.MailComposerChatGPT">
+        <button class="btn btn-light" data-hotkey="c"
+            t-if="props.record.data.can_edit_body"
+            t-on-click="onOpenChatGPTPromptDialogBtnClick"
+            t-out="btnLabel"/>
+    </t>
+</templates>

--- a/addons/mail/static/src/core/web/mail_composer_recipient_list.js
+++ b/addons/mail/static/src/core/web/mail_composer_recipient_list.js
@@ -1,0 +1,34 @@
+import { registry } from "@web/core/registry";
+import { standardWidgetProps } from "@web/views/widgets/standard_widget_props";
+import { useService } from "@web/core/utils/hooks";
+
+import { Component, useState, onWillStart } from "@odoo/owl";
+import { BaseRecipientsList } from "@mail/core/web/base_recipients_list";
+
+
+export class MailComposerRecipientList extends Component {
+    static template = "mail.MailComposerRecipientList";
+    static components = { BaseRecipientsList };
+    static props = { ...standardWidgetProps };
+
+    setup() {
+        const { Thread } = useService("mail.store");
+        this.state = useState({});
+        onWillStart(async () => {
+            try {
+                const resIds = JSON.parse(this.props.record.data.res_ids);
+                const thread = await Thread.getOrFetch({
+                    model: this.props.record.data.model,
+                    id: resIds[0],
+                });
+                this.state.thread = thread;
+            } catch {};
+        });
+    }
+}
+
+const mailComposerRecipientList = {
+    component: MailComposerRecipientList
+};
+
+registry.category("view_widgets").add("mail_composer_recipient_list", mailComposerRecipientList);

--- a/addons/mail/static/src/core/web/mail_composer_recipient_list.xml
+++ b/addons/mail/static/src/core/web/mail_composer_recipient_list.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates>
+    <t t-name="mail.MailComposerRecipientList">
+        <BaseRecipientsList t-if="state.thread" thread="state.thread"/>
+    </t>
+</templates>

--- a/addons/mail/static/src/core/web/mail_composer_template_selector.js
+++ b/addons/mail/static/src/core/web/mail_composer_template_selector.js
@@ -1,9 +1,11 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
+import { sprintf } from "@web/core/utils/strings";
 import { standardFieldProps } from "@web/views/fields/standard_field_props";
 import { useService } from "@web/core/utils/hooks";
 
 import { Component, useState, onWillStart } from "@odoo/owl";
+import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { SelectCreateDialog } from "@web/views/view_dialogs/select_create_dialog";
@@ -42,6 +44,48 @@ export class MailComposerTemplateSelector extends Component {
         });
     }
 
+    /**
+     * @param {Object} template
+     * @param {integer} template.id
+     * @param {string} template.display_name
+     */
+    async onDeleteTemplate(template) {
+        this.env.services.dialog.add(ConfirmationDialog, {
+            body: sprintf(_t('Are you sure you want to delete "%(template_name)s"?'), {
+                template_name: template.display_name,
+            }),
+            confirmLabel: _t("Delete Template"),
+            confirm: async () => {
+                await this.orm.unlink("mail.template", [template.id]);
+                this.state.templates = this.state.templates.filter(current => {
+                    return current.id !== template.id;
+                });
+            },
+            cancel: () => {},
+        });
+    }
+
+    /**
+     * @param {Object} template
+     * @param {integer} template.id
+     * @param {string} template.display_name
+     */
+    async onOverwriteTemplate(template) {
+        this.env.services.dialog.add(ConfirmationDialog, {
+            body: sprintf(_t('Are your sure you want to update "%(template_name)s"?'), {
+                template_name: template.display_name,
+            }),
+            confirmLabel: _t("Update Template"),
+            confirm: async () => {
+                await this.orm.write("mail.template", [template.id], {
+                    subject: this.props.record.data.subject,
+                    body_html: this.props.record.data.body,
+                });
+            },
+            cancel: () => {},
+        });
+    }
+
     async onSaveTemplate() {
         await this.props.record.save();
         await this.action.doActionButton({
@@ -62,6 +106,38 @@ export class MailComposerTemplateSelector extends Component {
             onSelected: async templateIds => {
                 await this.props.record.update({
                     template_id: templateIds
+                });
+            },
+        });
+    }
+
+    onDeleteTemplateSearchMoreBtnClick() {
+        this.env.services.dialog.add(SelectCreateDialog, {
+            resModel: "mail.template",
+            title: _t("Delete Template"),
+            multiSelect: true,
+            noCreate: true,
+            domain: [["model", "=", this.props.record.data.render_model]],
+            onSelected: async templateIds => {
+                await this.orm.unlink("mail.template", templateIds);
+                this.state.templates = this.state.templates.filter(current => {
+                    return !templateIds.includes(current.id);
+                });
+            },
+        });
+    }
+
+    onOverwriteTemplateSearchMoreBtnClick() {
+        this.env.services.dialog.add(SelectCreateDialog, {
+            resModel: "mail.template",
+            title: _t("Overwrite Template"),
+            multiSelect: false,
+            noCreate: true,
+            domain: [["model", "=", this.props.record.data.render_model]],
+            onSelected: async templateIds => {
+                await this.orm.write("mail.template", templateIds, {
+                    subject: this.props.record.data.subject,
+                    body_html: this.props.record.data.body,
                 });
             },
         });

--- a/addons/mail/static/src/core/web/mail_composer_template_selector.js
+++ b/addons/mail/static/src/core/web/mail_composer_template_selector.js
@@ -1,0 +1,79 @@
+import { _t } from "@web/core/l10n/translation";
+import { registry } from "@web/core/registry";
+import { standardFieldProps } from "@web/views/fields/standard_field_props";
+import { useService } from "@web/core/utils/hooks";
+
+import { Component, useState, onWillStart } from "@odoo/owl";
+import { Dropdown } from "@web/core/dropdown/dropdown";
+import { DropdownItem } from "@web/core/dropdown/dropdown_item";
+import { SelectCreateDialog } from "@web/views/view_dialogs/select_create_dialog";
+
+
+export class MailComposerTemplateSelector extends Component {
+    static template = "mail.MailComposerTemplateSelector";
+    static components = { Dropdown, DropdownItem };
+    static props = { ...standardFieldProps };
+
+    setup() {
+        this.action = useService("action");
+        this.orm = useService("orm");
+        this.state = useState({});
+        this.limit = 7;
+
+        onWillStart(() => {
+            this.fetchTemplates();
+        });
+    }
+
+    async fetchTemplates() {
+        const domain = [["model", "=", this.props.record.data.render_model]];
+        const fields = ["display_name"];
+        this.state.templates = await this.orm.searchRead("mail.template", domain, fields, { limit: this.limit });
+    }
+
+    /**
+     * @param {Object} template
+     * @param {integer} template.id
+     * @param {string} template.display_name
+     */
+    async onLoadTemplate(template) {
+        await this.props.record.update({
+            template_id: [template.id]
+        });
+    }
+
+    async onSaveTemplate() {
+        await this.props.record.save();
+        await this.action.doActionButton({
+            type: "object",
+            name: "open_template_creation_wizard",
+            resId: this.props.record.resId,
+            resModel: this.props.record.resModel
+        });
+    }
+
+    onSelectTemplateSearchMoreBtnClick() {
+        this.env.services.dialog.add(SelectCreateDialog, {
+            resModel: "mail.template",
+            title: _t("Insert Templates"),
+            multiSelect: false,
+            noCreate: true,
+            domain: [["model", "=", this.props.record.data.render_model]],
+            onSelected: async templateIds => {
+                await this.props.record.update({
+                    template_id: templateIds
+                });
+            },
+        });
+    }
+}
+
+export const mailComposerTemplateSelector = {
+    component: MailComposerTemplateSelector,
+    fieldDependencies: [
+        { name: "can_edit_body", type: "boolean" },
+        { name: "render_model", type: "string" },
+    ],
+};
+
+registry.category("fields").add("mail_composer_template_selector", mailComposerTemplateSelector);

--- a/addons/mail/static/src/core/web/mail_composer_template_selector.xml
+++ b/addons/mail/static/src/core/web/mail_composer_template_selector.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates>
+    <t t-name="mail.MailComposerTemplateSelector">
+        <Dropdown t-if="props.record.data.can_edit_body" menuClass="'mail-composer-template-dropdown'">
+            <button class="btn btn-light mail-composer-template-dropdown-btn" data-hotkey="t">
+                <i class="fa fa-fw fa-ellipsis-v"/>
+            </button>
+            <t t-set-slot="content">
+                <div class="px-3 pb-1 text-muted">Insert Template</div>
+                <t t-foreach="state.templates" t-as="template" t-key="template_index">
+                    <DropdownItem onSelected="() => this.onLoadTemplate(template)">
+                        <t t-if="template.display_name" t-out="template.display_name"/>
+                        <span t-else="" class="fst-italic">Untitled</span>
+                    </DropdownItem>
+                </t>
+                <div t-if="state.templates.length === 0" class="fst-italic px-3">
+                    No saved templates
+                </div>
+                <DropdownItem t-if="state.templates.length >= this.limit" onSelected="() => this.onSelectTemplateSearchMoreBtnClick()">
+                    <a href="#">Search More...</a>
+                </DropdownItem>
+                <div class="dropdown-divider"/>
+                <DropdownItem onSelected="() => this.onSaveTemplate()">
+                    Save as Template
+                </DropdownItem>
+            </t>
+        </Dropdown>
+    </t>
+</templates>

--- a/addons/mail/static/src/core/web/mail_composer_template_selector.xml
+++ b/addons/mail/static/src/core/web/mail_composer_template_selector.xml
@@ -20,9 +20,47 @@
                     <a href="#">Search More...</a>
                 </DropdownItem>
                 <div class="dropdown-divider"/>
-                <DropdownItem onSelected="() => this.onSaveTemplate()">
-                    Save as Template
-                </DropdownItem>
+                <Dropdown>
+                    <div>Save as Template</div>
+                    <t t-set-slot="content">
+                        <div class="px-3 pb-1 text-muted">Overwrite Template</div>
+                        <t t-foreach="state.templates" t-as="template" t-key="template_index">
+                            <DropdownItem onSelected="() => this.onOverwriteTemplate(template)">
+                                <t t-if="template.display_name" t-out="template.display_name"/>
+                                <span t-else="" class="fst-italic">Untitled</span>
+                            </DropdownItem>
+                        </t>
+                        <div t-if="state.templates.length === 0" class="fst-italic px-3">
+                            No saved templates
+                        </div>
+                        <DropdownItem t-if="state.templates.length >= this.limit" onSelected="() => this.onOverwriteTemplateSearchMoreBtnClick()">
+                            <a href="#">Search More...</a>
+                        </DropdownItem>
+                        <div class="dropdown-divider"/>
+                        <DropdownItem onSelected="() => this.onSaveTemplate()">
+                            Save as Template
+                        </DropdownItem>
+                    </t>
+                </Dropdown>
+                <div class="dropdown-divider"/>
+                <Dropdown>
+                    <div>Delete Template</div>
+                    <t t-set-slot="content">
+                        <div class="px-3 pb-1 text-muted">Delete Template</div>
+                        <t t-foreach="state.templates" t-as="template" t-key="template_index">
+                            <DropdownItem onSelected="() => this.onDeleteTemplate(template)">
+                                <t t-if="template.display_name" t-out="template.display_name"/>
+                                <span t-else="" class="fst-italic">Untitled</span>
+                            </DropdownItem>
+                        </t>
+                        <div t-if="state.templates.length === 0" class="fst-italic px-3">
+                            No saved templates
+                        </div>
+                        <DropdownItem t-if="state.templates.length >= this.limit" onSelected="() => this.onDeleteTemplateSearchMoreBtnClick()">
+                            <a href="#">Search More...</a>
+                        </DropdownItem>
+                    </t>
+                </Dropdown>
             </t>
         </Dropdown>
     </t>

--- a/addons/mail/static/src/views/web/fields/html_composer_message_field/html_composer_message_field.scss
+++ b/addons/mail/static/src/views/web/fields/html_composer_message_field/html_composer_message_field.scss
@@ -1,0 +1,5 @@
+.o_field_html_composer_message {
+    .note-editable {
+        min-height: 180px !important;
+    }
+}

--- a/addons/mail/static/tests/tours/mail_composer_test_tour.js
+++ b/addons/mail/static/tests/tours/mail_composer_test_tour.js
@@ -60,7 +60,7 @@ registry.category("web_tour.tours").add("mail/static/tests/tours/mail_composer_t
         },
         {
             content: "Check the earlier provided attachment is listed",
-            trigger: '.o_attachment[title="text.txt"]',
+            trigger: ".o_field_mail_composer_attachment_list a:contains(text.txt)",
         },
         {
             content: "Check subject is autofilled",

--- a/addons/mail/static/tests/tours/mail_composer_test_tour.js
+++ b/addons/mail/static/tests/tours/mail_composer_test_tour.js
@@ -97,16 +97,13 @@ registry.category("web_tour.tours").add("mail/static/tests/tours/mail_composer_t
             },
         },
         {
-            content: "Open templates",
-            trigger: '.o_field_widget[name="template_id"] input',
-            run(helpers) {
-                this.anchor.value = "test";
-                this.anchor.dispatchEvent(new InputEvent("input", { bubbles: true }));
-            },
+            content: "Click on the mail template selector",
+            trigger: ".mail-composer-template-dropdown-btn",
+            run: "click"
         },
         {
             content: "Check a template is listed",
-            trigger: '.ui-autocomplete .ui-menu-item a:contains("Test template")',
+            trigger: '.mail-composer-template-dropdown.popover .o-dropdown-item:contains("Test template")',
         },
         {
             content: "Send message",

--- a/addons/mail/views/mail_template_views.xml
+++ b/addons/mail/views/mail_template_views.xml
@@ -85,7 +85,7 @@
                                         <field name="user_id" widget="many2one_avatar_user"
                                             readonly="not is_template_editor"
                                             invisible="not is_template_editor"
-                                            placeholder="If not set, shared with all users."
+                                            placeholder="Shared with all users."
                                             help="If set, will restrict the template to this specific user.
                                                   If not set, shared with all users."/>
                                         <field name="description"/>

--- a/addons/mail/wizard/mail_compose_message_views.xml
+++ b/addons/mail/wizard/mail_compose_message_views.xml
@@ -91,6 +91,7 @@
                                 invisible="not can_edit_body"
                                 class="float-end btn-secondary" data-hotkey="w" help="Save as a new template"/>
                         <field name="attachment_ids" widget="mail_composer_attachment_selector"/>
+                        <field name="body" widget="mail_composer_chatgpt"/>
                     </footer>
                 </form>
             </field>

--- a/addons/mail/wizard/mail_compose_message_views.xml
+++ b/addons/mail/wizard/mail_compose_message_views.xml
@@ -103,9 +103,7 @@
             <field name="arch" type="xml">
                 <form string="Templates">
                     <group>
-                        <field name="subject"
-                            options="{'dynamic_placeholder': true, 'dynamic_placeholder_model_reference_field': 'model'}"
-                            placeholder="e.g. &quot;Welcome to MyCompany&quot; or &quot;Nice to meet you, {{ object.name }}&quot;"/>
+                        <field name="template_name" placeholder="e.g: Send order confirmation"/>
                         <field name="model" invisible="1"/>
                     </group>
                     <footer>

--- a/addons/mail/wizard/mail_compose_message_views.xml
+++ b/addons/mail/wizard/mail_compose_message_views.xml
@@ -35,9 +35,9 @@
                         <!-- visible wizard -->
                         <field name="email_from"
                             invisible="composition_mode != 'mass_mail'"/>
-                        <label for="partner_ids" string="Recipients" invisible="composition_mode != 'comment' or subtype_is_log"/>
+                        <label for="partner_ids" string="To" invisible="composition_mode != 'comment' or subtype_is_log"/>
                         <div groups="base.group_user" invisible="composition_mode != 'comment' or subtype_is_log">
-                            <span name="document_followers_text" invisible="not model or composition_mode == 'mass_mail'">Followers of the document and</span>
+                            <widget invisible="not model or composition_mode == 'mass_mail'" name="mail_composer_recipient_list"/>
                             <field name="partner_ids" widget="many2many_tags_email" placeholder="Add contacts to notify..."
                                 options="{'no_quick_create': True}" context="{'show_email':True, 'form_view_ref': 'base.view_partner_simple_form'}"/>
                         </div>

--- a/addons/mail/wizard/mail_compose_message_views.xml
+++ b/addons/mail/wizard/mail_compose_message_views.xml
@@ -48,9 +48,7 @@
                         <field name="body" widget="html_composer_message" class="oe-bordered-editor"
                             placeholder="Write your message here..." readonly="not can_edit_body" force_save="1"
                             options="{'dynamic_placeholder': true, 'dynamic_placeholder_model_reference_field': 'render_model'}"/>
-                        <group>
-                            <field name="attachment_ids" widget="many2many_binary" string="Attach a file" nolabel="1"/>
-                        </group>
+                        <field name="attachment_ids" widget="mail_composer_attachment_list"/>
                         <group>
                             <field name="template_id" string="Load template" options="{'no_create': True}" class="w-50"
                                 context="{'default_model': model, 'default_body_html': body, 'default_subject': subject}"/>
@@ -62,9 +60,7 @@
                                 <field name="body" widget="html_composer_message" class="oe-bordered-editor"
                                     placeholder="Write your message here..." readonly="not can_edit_body" force_save="1"
                                     options="{'dynamic_placeholder': true, 'dynamic_placeholder_model_reference_field': 'render_model'}"/>
-                                <group>
-                                    <field name="attachment_ids" widget="many2many_binary" string="Attach a file" nolabel="1"/>
-                                </group>
+                                <field name="attachment_ids" widget="mail_composer_attachment_list"/>
                                 <group>
                                     <field name="template_id" string="Load template" options="{'no_create': True}" class="w-50"
                                         context="{'default_model': model, 'default_body_html': body, 'default_subject': subject}"/>
@@ -94,6 +90,7 @@
                                 name="open_template_creation_wizard" string="Save Template"
                                 invisible="not can_edit_body"
                                 class="float-end btn-secondary" data-hotkey="w" help="Save as a new template"/>
+                        <field name="attachment_ids" widget="mail_composer_attachment_selector"/>
                     </footer>
                 </form>
             </field>

--- a/addons/mail/wizard/mail_compose_message_views.xml
+++ b/addons/mail/wizard/mail_compose_message_views.xml
@@ -6,7 +6,7 @@
             <field name="model">mail.compose.message</field>
             <field name="groups_id" eval="[Command.link(ref('base.group_user'))]"/>
             <field name="arch" type="xml">
-                <form string="Compose Email" class="pt-0 pb-0 o_mail_composer_form" js_class="mail_composer_form">
+                <form string="Compose Email" class="pt-0 pb-0 o_mail_composer_form" disable_autofocus="1" js_class="mail_composer_form">
                     <group>
                         <!-- truly invisible fields for control and options -->
                         <field name="author_id" invisible="1"/>

--- a/addons/mail/wizard/mail_compose_message_views.xml
+++ b/addons/mail/wizard/mail_compose_message_views.xml
@@ -49,10 +49,6 @@
                             placeholder="Write your message here..." readonly="not can_edit_body" force_save="1"
                             options="{'dynamic_placeholder': true, 'dynamic_placeholder_model_reference_field': 'render_model'}"/>
                         <field name="attachment_ids" widget="mail_composer_attachment_list"/>
-                        <group>
-                            <field name="template_id" string="Load template" options="{'no_create': True}" class="w-50"
-                                context="{'default_model': model, 'default_body_html': body, 'default_subject': subject}"/>
-                        </group>
                     </div>
                     <notebook invisible="composition_mode != 'mass_mail'">
                         <page string="Content" name="page_content">
@@ -61,10 +57,6 @@
                                     placeholder="Write your message here..." readonly="not can_edit_body" force_save="1"
                                     options="{'dynamic_placeholder': true, 'dynamic_placeholder_model_reference_field': 'render_model'}"/>
                                 <field name="attachment_ids" widget="mail_composer_attachment_list"/>
-                                <group>
-                                    <field name="template_id" string="Load template" options="{'no_create': True}" class="w-50"
-                                        context="{'default_model': model, 'default_body_html': body, 'default_subject': subject}"/>
-                                </group>
                             </div>
                         </page>
                         <page string="Settings" name="page_settings">
@@ -86,11 +78,8 @@
                                 type="object" class="btn-primary" data-hotkey="q"
                                 invisible="not subtype_is_log"/>
                         <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="x" />
-                        <button icon="fa-cloud-upload" type="object"
-                                name="open_template_creation_wizard" string="Save Template"
-                                invisible="not can_edit_body"
-                                class="float-end btn-secondary" data-hotkey="w" help="Save as a new template"/>
                         <field name="attachment_ids" widget="mail_composer_attachment_selector"/>
+                        <field name="template_id" widget="mail_composer_template_selector"/>
                         <field name="body" widget="mail_composer_chatgpt"/>
                     </footer>
                 </form>

--- a/addons/test_mail/tests/test_mail_composer.py
+++ b/addons/test_mail/tests/test_mail_composer.py
@@ -1234,6 +1234,7 @@ class TestComposerInternals(TestMailComposer):
         self.env['mail.compose.message'].with_context(
             self._get_web_context(self.test_record, add_web=False)
         ).create({
+            'template_name': 'My Template',
             'subject': 'Template Subject',
             'body': '<p>Template Body</p>',
         }).create_mail_template()
@@ -1243,7 +1244,9 @@ class TestComposerInternals(TestMailComposer):
             ('model', '=', self.test_record._name),
             ('subject', '=', 'Template Subject')
         ], limit=1)
-        self.assertEqual(template.name, 'Template Subject')
+
+        self.assertEqual(template.name, 'My Template')
+        self.assertEqual(template.subject, 'Template Subject')
         self.assertEqual(template.body_html, '<p>Template Body</p>', 'email_template incorrect body_html')
 
     @users('erp_manager')


### PR DESCRIPTION
The pull request (PR) will introduce a significant update to the entire mail composer, enhancing its functionality by adding a new toolbar. This toolbar will provide users with four key features:

1. Attach a file: Users will be able to easily add attachments to their emails.
2. Use, create, overwrite, or delete a mail template: This feature will allow users to manage email templates, making it simpler to reuse standard email formats or create new ones.
3. Insert text generated by ChatGPT: Users can incorporate AI-generated text directly into their emails using ChatGPT.

The objective of this PR is to simplify the overall mail composer, making it more user-friendly. By highlighting the key features with the new toolbar, these functionalities will be more accessible and easier to use for all users.

task-3748652
