### PR TITLE
[FIX] stock: rename incoterm fields

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -677,7 +677,7 @@ msgstr ""
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
-msgid "<span class=\"o_form_label\">Default Incoterm</span>"
+msgid "<span class=\"o_form_label\">Default Incoterms</span>"
 msgstr ""
 
 #. module: account
@@ -1036,7 +1036,7 @@ msgstr ""
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
-msgid "<strong>Incoterm: </strong>"
+msgid "<strong>Incoterms: </strong>"
 msgstr ""
 
 #. module: account
@@ -3171,7 +3171,7 @@ msgstr ""
 #. module: account
 #: model:ir.model.fields,help:account.field_account_incoterms__active
 msgid ""
-"By unchecking the active field, you may hide an INCOTERM you will not use."
+"By unchecking the active field, you may hide INCOTERMS you will not use."
 msgstr ""
 
 #. module: account
@@ -4224,7 +4224,7 @@ msgstr ""
 
 #. module: account
 #: model_terms:ir.actions.act_window,help:account.action_incoterms_tree
-msgid "Create a new incoterm"
+msgid "Create new incoterms"
 msgstr ""
 
 #. module: account
@@ -5011,7 +5011,7 @@ msgstr ""
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
-msgid "Default Incoterm of your company"
+msgid "Default Incoterms of your company"
 msgstr ""
 
 #. module: account
@@ -5060,7 +5060,7 @@ msgstr ""
 #. module: account
 #: model:ir.model.fields,field_description:account.field_res_company__incoterm_id
 #: model:ir.model.fields,field_description:account.field_res_config_settings__incoterm_id
-msgid "Default incoterm"
+msgid "Default incoterms"
 msgstr ""
 
 #. module: account
@@ -7229,12 +7229,12 @@ msgstr ""
 #: model:ir.model.fields,field_description:account.field_account_bank_statement_line__invoice_incoterm_id
 #: model:ir.model.fields,field_description:account.field_account_move__invoice_incoterm_id
 #: model:ir.model.fields,field_description:account.field_account_payment__invoice_incoterm_id
-msgid "Incoterm"
+msgid "Incoterms"
 msgstr ""
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_incoterms__code
-msgid "Incoterm Standard Code"
+msgid "Incoterms Standard Code"
 msgstr ""
 
 #. module: account

--- a/addons/account/models/account_incoterms.py
+++ b/addons/account/models/account_incoterms.py
@@ -13,7 +13,7 @@ class AccountIncoterms(models.Model):
         help="Incoterms are series of sales terms. They are used to divide transaction costs and responsibilities between buyer and seller and reflect state-of-the-art transportation practices.")
     code = fields.Char(
         'Code', size=3, required=True,
-        help="Incoterm Standard Code")
+        help="Incoterms Standard Code")
     active = fields.Boolean(
         'Active', default=True,
-        help="By unchecking the active field, you may hide an INCOTERM you will not use.")
+        help="By unchecking the active field, you may hide INCOTERMS you will not use.")

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -513,7 +513,7 @@ class AccountMove(models.Model):
     )
     invoice_incoterm_id = fields.Many2one(
         comodel_name='account.incoterms',
-        string='Incoterm',
+        string='Incoterms',
         default=lambda self: self.env.company.incoterm_id,
         help='International Commercial Terms are a series of predefined commercial '
              'terms used in international transactions.',

--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -97,7 +97,7 @@ class ResCompany(models.Model):
     property_stock_account_output_categ_id = fields.Many2one('account.account', string="Output Account for Stock Valuation")
     property_stock_valuation_account_id = fields.Many2one('account.account', string="Account Template for Stock Valuation")
     bank_journal_ids = fields.One2many('account.journal', 'company_id', domain=[('type', '=', 'bank')], string='Bank Journals')
-    incoterm_id = fields.Many2one('account.incoterms', string='Default incoterm',
+    incoterm_id = fields.Many2one('account.incoterms', string='Default incoterms',
         help='International Commercial Terms are a series of predefined commercial terms used in international transactions.')
 
     qr_code = fields.Boolean(string='Display QR-code on invoices')

--- a/addons/account/models/res_config_settings.py
+++ b/addons/account/models/res_config_settings.py
@@ -131,7 +131,7 @@ class ResConfigSettings(models.TransientModel):
     qr_code = fields.Boolean(string='Display SEPA QR-code', related='company_id.qr_code', readonly=False)
     invoice_is_print = fields.Boolean(string='Print', related='company_id.invoice_is_print', readonly=False)
     invoice_is_email = fields.Boolean(string='Send Email', related='company_id.invoice_is_email', readonly=False)
-    incoterm_id = fields.Many2one('account.incoterms', string='Default incoterm', related='company_id.incoterm_id', help='International Commercial Terms are a series of predefined commercial terms used in international transactions.', readonly=False)
+    incoterm_id = fields.Many2one('account.incoterms', string='Default incoterms', related='company_id.incoterm_id', help='International Commercial Terms are a series of predefined commercial terms used in international transactions.', readonly=False)
     invoice_terms = fields.Html(related='company_id.invoice_terms', string="Terms & Conditions", readonly=False)
     invoice_terms_html = fields.Html(related='company_id.invoice_terms_html', string="Terms & Conditions as a Web page",
                                      readonly=False)

--- a/addons/account/views/account_incoterms_view.xml
+++ b/addons/account/views/account_incoterms_view.xml
@@ -50,7 +50,7 @@
             <field name="view_mode">tree,form</field>
             <field name="help" type="html">
               <p class="o_view_nocontent_smiling_face">
-                Create a new incoterm
+                Create new incoterms
               </p><p>
                 Incoterms are used to divide transaction costs and responsibilities between buyer and seller.
               </p>

--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -244,7 +244,7 @@
                         <span t-field="o.fiscal_position_id.note"/>
                     </p>
                     <p t-if="o.invoice_incoterm_id" name="incoterm">
-                        <strong>Incoterm: </strong><span t-field="o.invoice_incoterm_id.code"/> - <span t-field="o.invoice_incoterm_id.name"/>
+                        <strong>Incoterms: </strong><span t-field="o.invoice_incoterm_id.code"/> - <span t-field="o.invoice_incoterm_id.name"/>
                     </p>
                     <div id="qrcode" t-if="o.display_qr_code and o.amount_residual > 0">
                         <t t-set="qr_code_url" t-value="o._generate_qr_code(silent_errors=True)"/>

--- a/addons/account/views/res_config_settings_views.xml
+++ b/addons/account/views/res_config_settings_views.xml
@@ -298,9 +298,9 @@
                             <div class="col-12 col-lg-6 o_setting_box" id="default_incoterm">
                                 <div class="o_setting_left_pane"/>
                                 <div class="o_setting_right_pane">
-                                    <span class="o_form_label">Default Incoterm</span>
+                                    <span class="o_form_label">Default Incoterms</span>
                                     <div class="text-muted">
-                                        Default Incoterm of your company
+                                        Default Incoterms of your company
                                     </div>
                                     <div class="text-muted">
                                         <field name="incoterm_id"/>

--- a/addons/l10n_ar/i18n/l10n_ar.pot
+++ b/addons/l10n_ar/i18n/l10n_ar.pot
@@ -107,7 +107,7 @@ msgstr ""
 
 #. module: l10n_ar
 #: model_terms:ir.ui.view,arch_db:l10n_ar.report_invoice_document
-msgid "<br/><strong>Incoterm:</strong>"
+msgid "<br/><strong>Incoterms:</strong>"
 msgstr ""
 
 #. module: l10n_ar

--- a/addons/l10n_ar/views/report_invoice.xml
+++ b/addons/l10n_ar/views/report_invoice.xml
@@ -225,7 +225,7 @@
                     <!-- We do not have remitos implement yet. print here the remito number when we have it -->
 
                     <t t-if="o.invoice_incoterm_id">
-                        <br/><strong>Incoterm:</strong><span t-field="o.invoice_incoterm_id.name"/>
+                        <br/><strong>Incoterms:</strong><span t-field="o.invoice_incoterm_id.name"/>
                     </t>
 
                 </div>

--- a/addons/l10n_cl/i18n/l10n_cl.pot
+++ b/addons/l10n_cl/i18n/l10n_cl.pot
@@ -66,7 +66,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:l10n_cl.informations
 msgid ""
 "<br/>\n"
-"                    <strong>Incoterm:</strong>"
+"                    <strong>Incoterms:</strong>"
 msgstr ""
 
 #. module: l10n_cl

--- a/addons/l10n_cl/views/report_invoice.xml
+++ b/addons/l10n_cl/views/report_invoice.xml
@@ -110,7 +110,7 @@
 
                 <t t-if="o.invoice_incoterm_id">
                     <br/>
-                    <strong>Incoterm:</strong>
+                    <strong>Incoterms:</strong>
                     <span t-field="o.invoice_incoterm_id.name"/>
                 </t>
 

--- a/addons/l10n_din5008_purchase/i18n/l10n_din5008_purchase.pot
+++ b/addons/l10n_din5008_purchase/i18n/l10n_din5008_purchase.pot
@@ -33,7 +33,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_din5008_purchase/models/purchase.py:0
 #, python-format
-msgid "Incoterm"
+msgid "Incoterms"
 msgstr ""
 
 #. module: l10n_din5008_purchase

--- a/addons/l10n_din5008_purchase/models/purchase.py
+++ b/addons/l10n_din5008_purchase/models/purchase.py
@@ -28,7 +28,7 @@ class PurchaseOrder(models.Model):
             elif record.date_order:
                 data.append((_("Order Deadline"), format_date(self.env, record.date_order)))
             if record.incoterm_id:
-                data.append((_("Incoterm"), record.incoterm_id.code))
+                data.append((_("Incoterms"), record.incoterm_id.code))
 
 
 

--- a/addons/l10n_din5008_sale/i18n/l10n_din5008_sale.pot
+++ b/addons/l10n_din5008_sale/i18n/l10n_din5008_sale.pot
@@ -33,7 +33,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_din5008_sale/models/sale.py:0
 #, python-format
-msgid "Incoterm"
+msgid "Incoterms"
 msgstr ""
 
 #. module: l10n_din5008_sale

--- a/addons/l10n_din5008_sale/models/sale.py
+++ b/addons/l10n_din5008_sale/models/sale.py
@@ -29,7 +29,7 @@ class SaleOrder(models.Model):
             if record.user_id:
                 data.append((_("Salesperson"), record.user_id.name))
             if 'incoterm' in record._fields and record.incoterm:
-                data.append((_("Incoterm"), record.incoterm.code))
+                data.append((_("Incoterms"), record.incoterm.code))
 
     def _compute_l10n_din5008_document_title(self):
         for record in self:

--- a/addons/l10n_gcc_invoice/views/report_invoice.xml
+++ b/addons/l10n_gcc_invoice/views/report_invoice.xml
@@ -477,7 +477,7 @@
                 <p t-if="o.invoice_incoterm_id" name="incoterm">
                     <div class="row">
                         <div class="col-6 text-start">
-                            <strong>Incoterm:
+                            <strong>Incoterms:
                             </strong>
                             <span
                                     t-out="o.invoice_incoterm_id.code"/>

--- a/addons/product_expiry/i18n/product_expiry.pot
+++ b/addons/product_expiry/i18n/product_expiry.pot
@@ -372,7 +372,7 @@ msgstr ""
 #: code:addons/product_expiry/wizard/confirm_expiry.py:0
 #, python-format
 msgid ""
-"You are going to deliver some product expired lots.\n"
+"You are going to transfer some product expired lots.\n"
 "Do you confirm you want to proceed ?"
 msgstr ""
 
@@ -381,7 +381,7 @@ msgstr ""
 #: code:addons/product_expiry/wizard/confirm_expiry.py:0
 #, python-format
 msgid ""
-"You are going to deliver the product %(product_name)s, %(lot_name)s which is expired.\n"
+"You are going to transfer the product %(product_name)s, %(lot_name)s which is expired.\n"
 "Do you confirm you want to proceed ?"
 msgstr ""
 

--- a/addons/product_expiry/wizard/confirm_expiry.py
+++ b/addons/product_expiry/wizard/confirm_expiry.py
@@ -20,13 +20,13 @@ class ConfirmExpiry(models.TransientModel):
         if self.show_lots:
             # For multiple expired lots, they are listed in the wizard view.
             self.description = _(
-                "You are going to deliver some product expired lots."
+                "You are going to transfer some product expired lots."
                 "\nDo you confirm you want to proceed ?"
             )
         else:
             # For one expired lot, its name is written in the wizard message.
             self.description = _(
-                "You are going to deliver the product %(product_name)s, %(lot_name)s which is expired."
+                "You are going to transfer the product %(product_name)s, %(lot_name)s which is expired."
                 "\nDo you confirm you want to proceed ?",
                 product_name=self.lot_ids.product_id.display_name,
                 lot_name=self.lot_ids.name

--- a/addons/purchase/i18n/purchase.pot
+++ b/addons/purchase/i18n/purchase.pot
@@ -1287,7 +1287,7 @@ msgstr ""
 
 #. module: purchase
 #: model:ir.model.fields,field_description:purchase.field_purchase_order__incoterm_id
-msgid "Incoterm"
+msgid "Incoterms"
 msgstr ""
 
 #. module: purchase

--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -135,7 +135,7 @@ class PurchaseOrder(models.Model):
         compute_sudo=True,
         help="Technical field to filter the available taxes depending on the fiscal country and fiscal position.")
     payment_term_id = fields.Many2one('account.payment.term', 'Payment Terms', domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]")
-    incoterm_id = fields.Many2one('account.incoterms', 'Incoterm', states={'done': [('readonly', True)]}, help="International Commercial Terms are a series of predefined commercial terms used in international transactions.")
+    incoterm_id = fields.Many2one('account.incoterms', 'Incoterms', states={'done': [('readonly', True)]}, help="International Commercial Terms are a series of predefined commercial terms used in international transactions.")
 
     product_id = fields.Many2one('product.product', related='order_line.product_id', string='Product')
     user_id = fields.Many2one(

--- a/addons/purchase_stock/i18n/purchase_stock.pot
+++ b/addons/purchase_stock/i18n/purchase_stock.pot
@@ -69,7 +69,7 @@ msgstr ""
 #. module: purchase_stock
 #: model_terms:ir.ui.view,arch_db:purchase_stock.report_purchaseorder_document
 #: model_terms:ir.ui.view,arch_db:purchase_stock.report_purchasequotation_document
-msgid "<strong>Incoterm:</strong>"
+msgid "<strong>Incoterms:</strong>"
 msgstr ""
 
 #. module: purchase_stock
@@ -317,12 +317,12 @@ msgstr ""
 
 #. module: purchase_stock
 #: model:ir.model.fields,field_description:purchase_stock.field_purchase_order__incoterm_id
-msgid "Incoterm"
+msgid "Incoterms"
 msgstr ""
 
 #. module: purchase_stock
 #: model:ir.model.fields,field_description:purchase_stock.field_purchase_order__incoterm_location
-msgid "Incoterm Location"
+msgid "Incoterms Location"
 msgstr ""
 
 #. module: purchase_stock

--- a/addons/purchase_stock/models/purchase.py
+++ b/addons/purchase_stock/models/purchase.py
@@ -18,8 +18,8 @@ class PurchaseOrder(models.Model):
     def _default_picking_type(self):
         return self._get_picking_type(self.env.context.get('company_id') or self.env.company.id)
 
-    incoterm_id = fields.Many2one('account.incoterms', 'Incoterm', states={'done': [('readonly', True)]}, help="International Commercial Terms are a series of predefined commercial terms used in international transactions.")
-    incoterm_location = fields.Char(string='Incoterm Location', states={'done': [('readonly', True)]})
+    incoterm_id = fields.Many2one('account.incoterms', 'Incoterms', states={'done': [('readonly', True)]}, help="International Commercial Terms are a series of predefined commercial terms used in international transactions.")
+    incoterm_location = fields.Char(string='Incoterms Location', states={'done': [('readonly', True)]})
     incoming_picking_count = fields.Integer("Incoming Shipment count", compute='_compute_incoming_picking_count')
     picking_ids = fields.Many2many('stock.picking', compute='_compute_picking_ids', string='Receptions', copy=False, store=True)
     dest_address_id = fields.Many2one('res.partner', compute='_compute_dest_address_id', store=True, readonly=False)

--- a/addons/purchase_stock/report/purchase_report_templates.xml
+++ b/addons/purchase_stock/report/purchase_report_templates.xml
@@ -15,7 +15,7 @@
         </xpath>
         <xpath expr="//div[@t-elif='o.date_order']" position="after">
             <div t-if="o.incoterm_id" class="col-3 bm-2">
-                <strong>Incoterm:</strong>
+                <strong>Incoterms:</strong>
                 <p t-if="o.incoterm_location" t-out="'%s %s' % (o.incoterm_id.code, o.incoterm_location)" class="m-0"/>
                 <p t-else="" t-field="o.incoterm_id.code" class="m-0"/>
             </div>
@@ -37,7 +37,7 @@
         <xpath expr="//span[@t-field='o.name']/.." position="after">
             <div id="informations" class="row mt16 mb16">
                 <div t-if="o.incoterm_id" class="col-3 bm-2">
-                    <strong>Incoterm:</strong>
+                    <strong>Incoterms:</strong>
                     <p t-if="o.incoterm_location" t-out="'%s %s' % (o.incoterm_id.code, o.incoterm_location)" class="m-0"/>
                     <p t-else="" t-field="o.incoterm_id.code" class="m-0"/>
                 </div>

--- a/addons/sale_stock/i18n/sale_stock.pot
+++ b/addons/sale_stock/i18n/sale_stock.pot
@@ -70,13 +70,13 @@ msgstr ""
 
 #. module: sale_stock
 #: model_terms:ir.ui.view,arch_db:sale_stock.sale_order_portal_content_inherit_sale_stock
-msgid "<strong>Incoterm: </strong>"
+msgid "<strong>Incoterms: </strong>"
 msgstr ""
 
 #. module: sale_stock
 #: model_terms:ir.ui.view,arch_db:sale_stock.report_invoice_document_inherit_sale_stock
 #: model_terms:ir.ui.view,arch_db:sale_stock.report_saleorder_document_inherit_sale_stock
-msgid "<strong>Incoterm:</strong>"
+msgid "<strong>Incoterms:</strong>"
 msgstr ""
 
 #. module: sale_stock
@@ -300,12 +300,12 @@ msgstr ""
 
 #. module: sale_stock
 #: model:ir.model.fields,field_description:sale_stock.field_sale_order__incoterm
-msgid "Incoterm"
+msgid "Incoterms"
 msgstr ""
 
 #. module: sale_stock
 #: model:ir.model.fields,field_description:sale_stock.field_sale_order__incoterm_location
-msgid "Incoterm Location"
+msgid "Incoterms Location"
 msgstr ""
 
 #. module: sale_stock

--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -14,9 +14,9 @@ class SaleOrder(models.Model):
     _inherit = "sale.order"
 
     incoterm = fields.Many2one(
-        'account.incoterms', 'Incoterm',
+        'account.incoterms', 'Incoterms',
         help="International Commercial Terms are a series of predefined commercial terms used in international transactions.")
-    incoterm_location = fields.Char(string='Incoterm Location')
+    incoterm_location = fields.Char(string='Incoterms Location')
     picking_policy = fields.Selection([
         ('direct', 'As soon as possible'),
         ('one', 'When all products are ready')],

--- a/addons/sale_stock/report/sale_order_report_templates.xml
+++ b/addons/sale_stock/report/sale_order_report_templates.xml
@@ -3,7 +3,7 @@
     <template id="report_saleorder_document_inherit_sale_stock" inherit_id="sale.report_saleorder_document">
         <xpath expr="//div[@name='expiration_date']" position="after">
             <div class="col-auto col-3 mw-100 mb-2" t-if="doc.incoterm">
-                <strong>Incoterm:</strong>
+                <strong>Incoterms:</strong>
                 <p t-if="doc.incoterm_location" t-out="'%s %s' % (doc.incoterm.code, doc.incoterm_location)" class="m-0"/>
                 <p t-else="" t-field="doc.incoterm.code" class="m-0"/>
             </div>
@@ -13,7 +13,7 @@
     <template id="report_invoice_document_inherit_sale_stock" inherit_id="account.report_invoice_document">
         <xpath expr="//div[@name='reference']" position="after">
             <div class="col-auto col-3 mw-100 mb-2" t-if="o.invoice_incoterm_id" groups="sale_stock.group_display_incoterm" name="invoice_incoterm_id">
-                <strong>Incoterm:</strong>
+                <strong>Incoterms:</strong>
                 <p class="m-0" t-field="o.invoice_incoterm_id.code"/>
             </div>
         </xpath>

--- a/addons/sale_stock/views/sale_stock_portal_template.xml
+++ b/addons/sale_stock/views/sale_stock_portal_template.xml
@@ -7,7 +7,7 @@
         <xpath expr="//div[@id='so_date']" position="after">
             <div t-if="sale_order.incoterm" class="row">
                 <div class="mb-3 col-6 ms-auto">
-                    <strong>Incoterm: </strong> <span t-field="sale_order.incoterm"/>
+                    <strong>Incoterms: </strong> <span t-field="sale_order.incoterm"/>
                 </div>
             </div>
         </xpath>


### PR DESCRIPTION
## stock: rename incoterm fields

According to international standards, it should be incoterms.
Therefore, this commit renames all incoterm fields and string
references in the following modules:
* purchase
* purchase_stock
* sale_stock

## product_expiry: reword product_expiry warning

Reword deliver to transfer on .pot and .py string
within the referenced files.

task: 3983531

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
