### PR TITLE
[FIX] mail: missing notif in systray / incorrect inbox notif

### DIFF
--- a/addons/im_livechat/models/mail_message.py
+++ b/addons/im_livechat/models/mail_message.py
@@ -21,7 +21,7 @@ class MailMessage(models.Model):
         for message in self:
             message.parent_body = message.parent_id.body if message.parent_id else False
 
-    def _message_format(self, format_reply=True, msg_vals=None, for_current_user=False):
+    def _message_format(self, *args, **kwargs):
         """Override to remove email_from and to return the livechat username if applicable.
         A third param is added to the author_id tuple in this case to be able to differentiate it
         from the normal name in client code.
@@ -31,7 +31,7 @@ class MailMessage(models.Model):
         This allows the frontend display to include the additional features
         (e.g: Show additional buttons with the available answers for this step). """
 
-        vals_list = super()._message_format(format_reply=format_reply, msg_vals=msg_vals, for_current_user=for_current_user)
+        vals_list = super()._message_format(*args, **kwargs)
         for vals in vals_list:
             message_sudo = self.browse(vals['id']).sudo().with_prefetch(self.ids)
             discuss_channel = self.env['discuss.channel'].browse(message_sudo.res_id) if message_sudo.model == 'discuss.channel' else self.env['discuss.channel']

--- a/addons/mail/controllers/mailbox.py
+++ b/addons/mail/controllers/mailbox.py
@@ -7,10 +7,13 @@ from odoo.http import request
 class MailboxController(http.Controller):
     @http.route("/mail/inbox/messages", methods=["POST"], type="json", auth="user")
     def discuss_inbox_messages(self, search_term=None, before=None, after=None, limit=30, around=None):
-        partner_id = request.env.user.partner_id.id
         domain = [("needaction", "=", True)]
         res = request.env["mail.message"]._message_fetch(domain, search_term=search_term, before=before, after=after, around=around, limit=limit)
-        return {**res, "messages": res["messages"]._message_format_personalize(partner_id)}
+        messages = res.pop("messages")
+        return {
+            **res,
+            "messages": messages._message_format(for_current_user=True, add_followers=True),
+        }
 
     @http.route("/mail/history/messages", methods=["POST"], type="json", auth="user")
     def discuss_history_messages(self, search_term=None, before=None, after=None, limit=30, around=None):

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -952,7 +952,6 @@ class Message(models.Model):
                     'parentMessage': {...}, # formatted message that this message is a reply to. Only present if format_reply is True
                 }
         """
-        self.check_access_rule("read")
         vals_list = self._read_format(self._get_message_format_fields())
         com_id = self.env["ir.model.data"]._xmlid_to_res_id("mail.mt_comment")
         note_id = self.env["ir.model.data"]._xmlid_to_res_id("mail.mt_note")

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -10,7 +10,7 @@ from collections import defaultdict
 from odoo import _, api, Command, fields, models, modules, tools
 from odoo.exceptions import AccessError
 from odoo.osv import expression
-from odoo.tools import clean_context, groupby as tools_groupby, SQL
+from odoo.tools import clean_context, groupby, SQL
 
 _logger = logging.getLogger(__name__)
 _image_dataurl = re.compile(r'(data:image/[a-z]+?);base64,([a-z0-9+/\n]{3,}=*)\n*([\'"])(?: data-filename="([^"]*)")?', re.I)
@@ -897,15 +897,33 @@ class Message(models.Model):
                 record_by_message[message] = self.env[message.model].browse(message.res_id).with_prefetch(record_ids_by_model_name[message.model])
         return record_by_message
 
-    def _message_format(self, format_reply=True, msg_vals=None, for_current_user=False):
-        """ Get the message values in the format for web client. Since message
-        values can be broadcasted, computed fields MUST NOT BE READ and
-        broadcasted.
+    def _message_format(
+        self,
+        format_reply=True,
+        msg_vals=None,
+        for_current_user=False,
+        add_followers=False,
+        followers=None,
+    ):
+        """Get the message values in the format for web client.
+
+        :param format_reply: if True, also get data about the parent message if it exists.
+            Only makes sense for discuss channel.
 
         :param msg_vals: dictionary of values used to create the message. If
           given it may be used to access values related to ``message`` without
           accessing it directly. It lessens query count in some optimized use
           cases by avoiding access message content in db;
+
+        :param for_current_user: if True, get extra fields only relevant to the current user.
+            When this param is set, the result should not be broadcasted to other users!
+
+        :param add_followers: if True, also add followers of the current user for each thread of
+            each message. Only applicable if ``for_current_user`` is also True.
+
+        :param followers: if given, use this pre-computed list of followers instead of fetching
+            them. It lessen query count in some optimized use cases.
+            Only applicable if ``add_followers`` is True.
 
         :returns list(dict).
              Example :
@@ -967,6 +985,33 @@ class Message(models.Model):
             for scheduler in schedulers:
                 scheduled_dt_by_msg_id[scheduler.mail_message_id.id] = scheduler.scheduled_datetime
         record_by_message = self._record_by_message()
+        if add_followers:
+            if followers is None:
+                domain = expression.OR(
+                    [
+                        ("res_model", "=", model),
+                        ("res_id", "in", list({message.res_id for message in messages})),
+                    ]
+                    for model, messages in groupby(
+                        (
+                            message
+                            for message in self
+                            if message.res_id
+                            and message.model not in {None, False, "", "discuss.channel"}
+                        ),
+                        key=lambda message: message.model,
+                    )
+                )
+                domain = expression.AND([domain, [("partner_id", "=", self.env.user.partner_id.id)]])
+                # sudo: mail.followers - reading followers of current partner
+                followers = self.env["mail.followers"].sudo().search(domain)
+            follower_by_record_and_partner = {
+                (
+                    self.env[follower.res_model].browse(follower.res_id),
+                    follower.partner_id,
+                ): follower
+                for follower in followers
+            }
         for vals in vals_list:
             message_sudo = self.browse(vals['id']).sudo().with_prefetch(self.ids)
             author = False
@@ -1013,7 +1058,7 @@ class Message(models.Model):
                 "recipients": [{"id": p.id, "name": p.name, "type": "partner"} for p in message_sudo.partner_ids],
                 "scheduledDatetime": scheduled_dt_by_msg_id.get(message_sudo.id, False),
             })
-            if message_sudo.model and message_sudo.res_id:
+            if record:
                 thread = {"model": message_sudo.model, "id": message_sudo.res_id}
                 if message_sudo.model != "discuss.channel":
                     thread["name"] = record_name
@@ -1029,6 +1074,17 @@ class Message(models.Model):
                 vals["needaction"] = not self.env.user._is_public() and self.env.user.partner_id in notifications_partners
                 vals["starred"] = message_sudo.starred
                 vals["trackingValues"] = displayed_tracking_ids._tracking_value_format()
+                if record and add_followers:
+                    if follower := follower_by_record_and_partner.get(
+                        (record, self.env.user.partner_id)
+                    ):
+                        vals["thread"]["selfFollower"] = {
+                            "id": follower.id,
+                            "is_active": True,
+                            "partner": {"id": follower.partner_id.id, "type": "partner"},
+                        }
+                    else:
+                        vals["thread"]["selfFollower"] = False
         return vals_list
 
     def _message_format_extras(self, format_reply):
@@ -1062,77 +1118,6 @@ class Message(models.Model):
         if after:
             res["messages"] = res["messages"].sorted('id', reverse=True)
         return res
-
-    @api.model
-    def _message_format_personalized_prepare(self, messages_formatted, partner_ids=None):
-        """ Prepare message to be personalized by partner.
-
-        This method add partner information in batch to the messages so that the
-        messages could be personalized for each partner by using
-        _message_format_personalize with no or a limited number of queries.
-
-        For example, it gathers all followers of the record related to the messages
-        in one go (or limit it to the partner given in parameter), so that the method
-        _message_format_personalize could then personalize each message for each partner.
-
-        Note that followers for message related to discuss.channel are not fetched.
-
-        :param list messages_formatted: list of message formatted using the method
-            message_format
-        :param list partner_ids: (optional) limit value computation to the partners
-            of the given list; if not set, all partners are considered (all partners
-            following each record will be included in follower_id_by_partner_id).
-
-        :return: list of messages_formatted with added value:
-            'follower_id_by_partner_id': dict partner_id -> follower_id of the record
-        """
-        domain = expression.OR([
-            [('res_model', '=', model), ('res_id', 'in', list({value['res_id'] for value in values}))]
-            for model, values in tools_groupby(
-                (vals for vals in messages_formatted
-                 if vals.get("res_id") and vals.get("model") not in {None, False, '', 'discuss.channel'}),
-                key=lambda r: r["model"]
-            )
-        ])
-        if partner_ids:
-            domain = expression.AND([domain, [('partner_id', 'in', partner_ids)]])
-        records_followed = self.env['mail.followers'].sudo().search(domain)
-        followers_by_record_ref = (
-            {(res_model, res_id): {value['partner_id'][0]: value['id'] for value in values}
-             for (res_model, res_id), values in tools_groupby(
-                records_followed.read(['res_id', 'res_model', 'partner_id']),
-                key=lambda r: (r["res_model"], r['res_id'])
-            )})
-        for vals in messages_formatted:
-            vals['follower_id_by_partner_id'] = followers_by_record_ref.get((vals['model'], vals['res_id']), dict())
-        return messages_formatted
-
-    def _message_format_personalize(self, partner_id, messages_formatted=None, format_reply=True, msg_vals=None):
-        """ Personalize the messages for the partner.
-
-        :param integer partner_id: id of the partner to personalize the messages for
-        :param list messages_formatted: (optional) list of message formatted using
-            the method _message_format_personalized_prepare.
-            If not provided message_format is called on self with the 2 next parameters
-            to format the messages and then the messages are personalized.
-        :param bool format_reply: (optional) see method message_format
-        :param dict msg_vals: (optional) see method message_format
-        :return: list of messages_formatted personalized for the partner
-        """
-        if not messages_formatted:
-            messages_formatted = self._message_format(format_reply=format_reply, msg_vals=msg_vals, for_current_user=True)
-            self._message_format_personalized_prepare(messages_formatted, [partner_id])
-        for vals in messages_formatted:
-            # set value for user being a follower, fallback to False if not prepared
-            follower_id_by_pid = vals.pop('follower_id_by_partner_id', {})
-            follower_id = follower_id_by_pid.get(partner_id, False)
-            if follower_id:
-                vals['thread']['selfFollower'] = {
-                    'id': follower_id,
-                    'is_active': True,
-                    'partner': {'id': partner_id, 'type': "partner"},
-                }
-        return messages_formatted
 
     def _get_message_format_fields(self):
         return [

--- a/addons/mail/static/tests/legacy/helpers/mock_server/controllers/discuss.js
+++ b/addons/mail/static/tests/legacy/helpers/mock_server/controllers/discuss.js
@@ -74,8 +74,7 @@ patch(MockServer.prototype, {
             return this._mockRouteMailMessageHistory(search_term, after, before, limit);
         }
         if (route === "/mail/inbox/messages") {
-            const { search_term, after, around, before, limit } = args;
-            return this._mockRouteMailMessageInbox(search_term, after, before, around, limit);
+            return { count: 0, messages: [] };
         }
         if (route === "/mail/link_preview") {
             return this._mockRouteMailLinkPreview(args.message_id);
@@ -363,35 +362,6 @@ patch(MockServer.prototype, {
             ...res,
             messages: this._mockMailMessageMessageFormat(
                 messagesWithNotification.map((message) => message.id)
-            ),
-        };
-    },
-    /**
-     * Simulates the `/mail/inbox/messages` route.
-     *
-     * @private
-     * @returns {Object}
-     */
-    _mockRouteMailMessageInbox(
-        search_term = false,
-        after = false,
-        before = false,
-        around = false,
-        limit = 30
-    ) {
-        const domain = [["needaction", "=", true]];
-        const res = this._mockMailMessage_MessageFetch(
-            domain,
-            search_term,
-            before,
-            after,
-            around,
-            limit
-        );
-        return {
-            ...res,
-            messages: this._mockMailMessageFormatPersonalize(
-                res.messages.map((message) => message.id)
             ),
         };
     },

--- a/addons/mail/static/tests/legacy/helpers/mock_server/models/mail_message.js
+++ b/addons/mail/static/tests/legacy/helpers/mock_server/models/mail_message.js
@@ -337,34 +337,6 @@ patch(MockServer.prototype, {
         });
     },
     /**
-     * Simulate `_message_format_personalize` on `mail.message` for the current partner.
-     *
-     * @private
-     * @returns {integer[]} ids
-     * @returns {Object[]}
-     */
-    _mockMailMessageFormatPersonalize(ids) {
-        const messages = this._mockMailMessageMessageFormat(ids);
-        messages.forEach((message) => {
-            if (message.model && message.res_id) {
-                const follower = this.getRecords("mail.followers", [
-                    ["res_model", "=", message.model],
-                    ["res_id", "=", message.res_id],
-                    ["partner_id", "=", this.pyEnv.currentPartnerId],
-                ]);
-                if (follower.length !== 0) {
-                    const follower_id = follower[0].id;
-                    message.thread.selfFollower = {
-                        id: follower_id,
-                        is_active: true,
-                        partner: { id: this.pyEnv.currentPartnerId, type: "partner" },
-                    };
-                }
-            }
-        });
-        return messages;
-    },
-    /**
      * Simulates `_message_notification_format` on `mail.message`.
      *
      * @private

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -459,8 +459,9 @@ async function discuss_inbox_messages(request) {
     const res = MailMessage._message_fetch(domain, search_term, before, after, around, limit);
     return {
         ...res,
-        messages: MailMessage._message_format_personalize(
-            res.messages.map((message) => message.id)
+        messages: MailMessage._message_format(
+            res.messages.map((message) => message.id),
+            makeKwArgs({ for_current_user: true, add_followers: true })
         ),
     };
 }

--- a/addons/mail/static/tests/mock_server/mock_models/mail_thread.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_thread.js
@@ -448,7 +448,10 @@ export class MailThread extends models.ServerModel {
                         notifications.push([
                             partner,
                             "mail.message/inbox",
-                            MailMessage._message_format_personalize([message_id])[0],
+                            MailMessage._message_format(
+                                [message_id],
+                                makeKwArgs({ for_current_user: true, add_followers: true })
+                            )[0],
                         ]);
                     }
                 }

--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -921,12 +921,18 @@ class MailCase(MockEmail):
             self.assertEqual(self._new_notifs, done_notifs, 'Mail: invalid notification creation (%s) / expected (%s)' % (len(self._new_notifs), len(done_notifs)))
 
     @contextmanager
-    def assertBus(self, channels, message_items=None):
-        """ Check content of bus notifications. """
+    def assertBus(self, channels=None, message_items=None, get_params=None):
+        """Check content of bus notifications.
+        Params might not be determined in advance (newly created id, create_date, ...), in this case
+        the `get_params` function can be given to return the expected values, called after the
+        execution of the tested code.
+        """
         try:
             with self.mock_bus():
                 yield
         finally:
+            if get_params:
+                channels, message_items = get_params()
             found_bus_notifs = self.assertBusNotifications(channels, message_items=message_items)
             self.assertEqual(
                 self._new_bus_notifs,

--- a/addons/rating/models/mail_message.py
+++ b/addons/rating/models/mail_message.py
@@ -26,8 +26,8 @@ class MailMessage(models.Model):
         ])
         return [('id', 'in', ratings.mapped('message_id').ids)]
 
-    def _message_format(self, format_reply=True, msg_vals=None, for_current_user=False):
-        message_values = super()._message_format(format_reply=format_reply, msg_vals=msg_vals, for_current_user=for_current_user)
+    def _message_format(self, *args, **kwargs):
+        message_values = super()._message_format(*args, **kwargs)
         rating_mixin_messages = self.filtered(lambda message:
             message.model
             and message.res_id

--- a/addons/sms/models/mail_message.py
+++ b/addons/sms/models/mail_message.py
@@ -33,17 +33,16 @@ class MailMessage(models.Model):
             return ['&', ('notification_ids.notification_status', '=', 'exception'), ('notification_ids.notification_type', '=', 'sms')]
         raise NotImplementedError()
 
-    def _message_format(self, format_reply=True, msg_vals=None, for_current_user=False):
+    def _message_format(self, *args, **kwargs):
         """ Override in order to retrieves data about SMS (recipient name and
             SMS status)
 
         TDE FIXME: clean the overall message_format thingy
         """
-        message_values = super()._message_format(format_reply=format_reply, msg_vals=msg_vals, for_current_user=for_current_user)
-        all_sms_notifications = self.env['mail.notification'].sudo().search([
-            ('mail_message_id', 'in', [r['id'] for r in message_values]),
-            ('notification_type', '=', 'sms')
-        ])
+        message_values = super()._message_format(*args, **kwargs)
+        all_sms_notifications = self.notification_ids.filtered(
+            lambda notification: notification.notification_type == "sms"
+        )
         msgid_to_notif = defaultdict(lambda: self.env['mail.notification'].sudo())
         for notif in all_sms_notifications:
             msgid_to_notif[notif.mail_message_id.id] += notif

--- a/addons/test_mail/tests/test_mail_followers.py
+++ b/addons/test_mail/tests/test_mail_followers.py
@@ -859,12 +859,15 @@ class UnfollowFromInboxTest(MailCommon):
         cls.user_employee.write({'notification_type': 'inbox'})
 
     def _fetch_inbox_message(self, message_id, user=None):
-        """ Fetch the given message similarly to the controller. """
-        MailMessage = self.env['mail.message'].with_user(user) if user else self.env['mail.message']
-        partner_id = self.env.user.partner_id.id
-        return list(filter(
-            lambda m: m['id'] == message_id,
-            MailMessage._message_fetch(domain=[('needaction', '=', True)])["messages"]._message_format_personalize(partner_id)))
+        """Fetch the given message similarly to the controller."""
+        MailMessage = self.env["mail.message"].with_user(user) if user else self.env["mail.message"]
+        messages = MailMessage._message_fetch(domain=[("needaction", "=", True)])["messages"]
+        return list(
+            filter(
+                lambda m: m["id"] == message_id,
+                messages._message_format(for_current_user=True, add_followers=True),
+            )
+        )
 
     @users('employee')
     @mute_logger('odoo.models')

--- a/addons/test_mail/tests/test_mail_thread_internals.py
+++ b/addons/test_mail/tests/test_mail_thread_internals.py
@@ -442,17 +442,12 @@ class TestDiscuss(MailCommon, TestRecipients):
     @users("employee")
     def test_unlink_notification_message(self):
         channel = self.env['discuss.channel'].create({'name': 'testChannel'})
-        notification_msg = channel.with_user(self.user_admin).message_notify(
+        channel.with_user(self.user_admin).message_notify(
             body='test',
             partner_ids=[self.partner_2.id],
         )
-
-        with self.assertRaises(exceptions.AccessError):
-            notification_msg.with_env(self.env)._message_format(for_current_user=True)
-
         channel_message = self.env['mail.message'].sudo().search([('model', '=', 'discuss.channel'), ('res_id', 'in', channel.ids)])
         self.assertEqual(len(channel_message), 1, "Test message should have been posted")
-
         channel.sudo().unlink()
         remaining_message = channel_message.exists()
         self.assertEqual(len(remaining_message), 0, "Test message should have been deleted")

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -1328,7 +1328,6 @@ class TestMailFormattersPerformance(BaseMailPerformance):
             res = messages._message_format(for_current_user=True)
             self.assertEqual(len(res), 6)
 
-    @mute_logger("odoo.models.unlink")
     @warmup
     def test_message_format_multi_followers_inbox(self):
         """Test query count as well as bus notifcations from sending a message to multiple followers
@@ -1341,6 +1340,7 @@ class TestMailFormattersPerformance(BaseMailPerformance):
         follower_2 = record.message_follower_ids.filtered(
             lambda f: f.partner_id == self.user_test_inbox_2.partner_id
         )
+
         def get_bus_params():
             message = self.env["mail.message"].search([], order="id desc", limit=1)
             notif_1 = message.notification_ids.filtered(
@@ -1426,7 +1426,7 @@ class TestMailFormattersPerformance(BaseMailPerformance):
                                     },
                                 },
                             },
-                            "needaction": False,
+                            "needaction": True,
                             "starred": False,
                             "trackingValues": [],
                             "sms_ids": [],
@@ -1495,15 +1495,15 @@ class TestMailFormattersPerformance(BaseMailPerformance):
                                 "name": "Test",
                                 "module_icon": "/base/static/description/icon.png",
                                 "selfFollower": {
-                                    "id": follower_1.id,
+                                    "id": follower_2.id,
                                     "is_active": True,
                                     "partner": {
-                                        "id": self.user_test_inbox.partner_id.id,
+                                        "id": self.user_test_inbox_2.partner_id.id,
                                         "type": "partner",
                                     },
                                 },
                             },
-                            "needaction": False,
+                            "needaction": True,
                             "starred": False,
                             "trackingValues": [],
                             "sms_ids": [],
@@ -1515,7 +1515,7 @@ class TestMailFormattersPerformance(BaseMailPerformance):
         self._reset_bus()
         self.env.invalidate_all()
         with self.assertBus(get_params=get_bus_params):
-            with self.assertQueryCount(21):
+            with self.assertQueryCount(20):
                 record.message_post(
                     body=Markup("<p>Test Post Performances with multiple inbox ping!</p>"),
                     message_type="comment",


### PR DESCRIPTION
When handling notifications in Odoo and tagging the user on a SO / task / whatever, the messaging counter is increased by 1 and the notification appears in the inbox, but not in the systray.

This is because the needaction is wrongly set with the value of the current user, which is the user that is doing the action, not the user that should be notified. This happens since the introduction of `for_current_user` param and the removal of broadcasting too much stuff.

This commit fixes the issue by correctly setting user when it comes to the personalized notify.

Replaces https://github.com/odoo/odoo/pull/168855

Backport of https://github.com/odoo/odoo/pull/171863 and https://github.com/odoo/odoo/pull/171869 to fix the issue.
It's still unclear whether 17.3 will ever be put in production, but it's still sticky on runbot so we have to support it.
Stable policy is stretched a little bit here as nobody should be using the removed methods at this point.