### PR TITLE
[FIX] website_slides: Error message Youtube preview with no API key

### DIFF
--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -821,6 +821,8 @@ class Slide(models.Model):
         The received duration is under a special format (e.g: PT1M21S15, meaning 1h 21m 15s). """
 
         key = self.env['website'].get_current_website().sudo().website_slide_google_app_key
+        if not key:
+            return {'error': _('Please enter a Google API key in your settings to have a preview. Settings > Website > Features > API Key')}
         fetch_res = self._fetch_data('https://www.googleapis.com/youtube/v3/videos', {'id': document_id, 'key': key, 'part': 'snippet,contentDetails', 'fields': 'items(id,snippet,contentDetails)'}, 'json')
         if fetch_res.get('error'):
             return {'error': self._extract_google_error_message(fetch_res.get('error'))}


### PR DESCRIPTION
Steps to reproduce:

Install website_slides
Have 2 websites
Create a course for the second website
Go on the course on the website
Add a video content and put any Youtube link

Current behavior before PR:

Error message no clear due to an empty API Key
"Could not fetch data from url. Document or access right not available: badRequest"

Desired behavior after PR is merged:

Having a clear message to make the user set up a key.

task-3861625
