### PR TITLE
[FIX] project_account: rename other costs section to avoid conflict

### DIFF
--- a/addons/project_account/models/project_project.py
+++ b/addons/project_account/models/project_project.py
@@ -95,20 +95,20 @@ class Project(models.Model):
         return {
             **super()._get_profitability_labels(),
             'other_purchase_costs': _lt('Vendor Bills'),
-            'other_revenues': _lt('Other Revenues'),
-            'other_costs': _lt('Other Costs'),
+            'other_revenues_aal': _lt('Other Revenues'),
+            'other_costs_aal': _lt('Other Costs'),
         }
 
     def _get_profitability_sequence_per_invoice_type(self):
         return {
             **super()._get_profitability_sequence_per_invoice_type(),
             'other_purchase_costs': 11,
-            'other_revenues': 14,
-            'other_costs': 15,
+            'other_revenues_aal': 14,
+            'other_costs_aal': 15,
         }
 
     def action_profitability_items(self, section_name, domain=None, res_id=False):
-        if section_name in ['other_revenues', 'other_costs']:
+        if section_name in ['other_revenues_aal', 'other_costs_aal']:
             action = self.env["ir.actions.actions"]._for_xml_id("analytic.account_analytic_line_action_entries")
             action['domain'] = domain
             action['context'] = {
@@ -173,12 +173,12 @@ class Project(models.Model):
         # we dont know what part of the numbers has already been billed or not, so we have no choice but to put everything under the billed/invoiced columns.
         # The to bill/to invoice ones will simply remain 0
         profitability_sequence_per_invoice_type = self._get_profitability_sequence_per_invoice_type()
-        revenues = {'id': 'other_revenues', 'sequence': profitability_sequence_per_invoice_type['other_revenues'], 'invoiced': total_revenues, 'to_invoice': 0.0}
-        costs = {'id': 'other_costs', 'sequence': profitability_sequence_per_invoice_type['other_costs'], 'billed': total_costs, 'to_bill': 0.0}
+        revenues = {'id': 'other_revenues_aal', 'sequence': profitability_sequence_per_invoice_type['other_revenues_aal'], 'invoiced': total_revenues, 'to_invoice': 0.0}
+        costs = {'id': 'other_costs_aal', 'sequence': profitability_sequence_per_invoice_type['other_costs_aal'], 'billed': total_costs, 'to_bill': 0.0}
 
         if with_action and self.user_has_groups('account.group_account_readonly'):
-            costs['action'] = self._get_action_for_profitability_section(cost_ids, 'other_costs')
-            revenues['action'] = self._get_action_for_profitability_section(revenue_ids, 'other_revenues')
+            costs['action'] = self._get_action_for_profitability_section(cost_ids, 'other_costs_aal')
+            revenues['action'] = self._get_action_for_profitability_section(revenue_ids, 'other_revenues_aal')
 
         return {
             'revenues': {'data': [revenues], 'total': {'invoiced': total_revenues, 'to_invoice': 0.0}},

--- a/addons/project_account/tests/test_project_profitability.py
+++ b/addons/project_account/tests/test_project_profitability.py
@@ -50,9 +50,9 @@ class TestProjectAccountProfitability(TestProjectProfitabilityCommon):
         self.assertDictEqual(
             project._get_profitability_items(False),
             {
-                'revenues': {'data': [{'id': 'other_revenues', 'sequence': self.project._get_profitability_sequence_per_invoice_type()['other_revenues'],
+                'revenues': {'data': [{'id': 'other_revenues_aal', 'sequence': self.project._get_profitability_sequence_per_invoice_type()['other_revenues_aal'],
                     'invoiced': 30.0, 'to_invoice': 0.0}], 'total': {'invoiced': 30.0, 'to_invoice': 0.0}},
-                'costs': {'data': [{'id': 'other_costs', 'sequence': self.project._get_profitability_sequence_per_invoice_type()['other_costs'],
+                'costs': {'data': [{'id': 'other_costs_aal', 'sequence': self.project._get_profitability_sequence_per_invoice_type()['other_costs_aal'],
                     'billed': -30.0, 'to_bill': 0.0}], 'total': {'billed': -30.0, 'to_bill': 0.0}}
             },
             'The profitability data of the project should return the total amount for the revenues and costs from tha AAL of the account of the project.'
@@ -78,9 +78,9 @@ class TestProjectAccountProfitability(TestProjectProfitabilityCommon):
         self.assertDictEqual(
             project._get_profitability_items(False),
             {
-                'revenues': {'data': [{'id': 'other_revenues', 'sequence': project._get_profitability_sequence_per_invoice_type()['other_revenues'],
+                'revenues': {'data': [{'id': 'other_revenues_aal', 'sequence': project._get_profitability_sequence_per_invoice_type()['other_revenues_aal'],
                     'invoiced': 180.0, 'to_invoice': 0.0}], 'total': {'invoiced': 180.0, 'to_invoice': 0.0}},
-                'costs': {'data': [{'id': 'other_costs', 'sequence': project._get_profitability_sequence_per_invoice_type()['other_costs'],
+                'costs': {'data': [{'id': 'other_costs_aal', 'sequence': project._get_profitability_sequence_per_invoice_type()['other_costs_aal'],
                     'billed': -180.0, 'to_bill': 0.0}], 'total': {'billed': -180.0, 'to_bill': 0.0}}
             },
             'The profitability data of the project should return the total amount for the revenues and costs from tha AAL of the account of the project.'

--- a/addons/project_purchase/tests/test_project_profitability.py
+++ b/addons/project_purchase/tests/test_project_profitability.py
@@ -56,8 +56,8 @@ class TestProjectPurchaseProfitability(TestProjectProfitabilityCommon, TestPurch
             self.project._get_profitability_items(False)['costs'],
             {
                 'data': [{
-                    'id': 'other_costs',
-                    'sequence': self.project._get_profitability_sequence_per_invoice_type()['other_costs'],
+                    'id': 'other_costs_aal',
+                    'sequence': self.project._get_profitability_sequence_per_invoice_type()['other_costs_aal'],
                     'to_bill': 0.0,
                     'billed': -150.0,
                 }, {
@@ -76,8 +76,8 @@ class TestProjectPurchaseProfitability(TestProjectProfitabilityCommon, TestPurch
             self.project._get_profitability_items(False)['costs'],
             {
                 'data': [{
-                    'id': 'other_costs',
-                    'sequence': self.project._get_profitability_sequence_per_invoice_type()['other_costs'],
+                    'id': 'other_costs_aal',
+                    'sequence': self.project._get_profitability_sequence_per_invoice_type()['other_costs_aal'],
                     'to_bill': 0.0,
                     'billed': -150.0,
                 }, {
@@ -117,8 +117,8 @@ class TestProjectPurchaseProfitability(TestProjectProfitabilityCommon, TestPurch
             self.project._get_profitability_items(False)['costs'],
             {
                 'data': [{
-                    'id': 'other_costs',
-                    'sequence': self.project._get_profitability_sequence_per_invoice_type()['other_costs'],
+                    'id': 'other_costs_aal',
+                    'sequence': self.project._get_profitability_sequence_per_invoice_type()['other_costs_aal'],
                     'to_bill': 0.0,
                     'billed': -150.0,
                 }, {
@@ -140,8 +140,8 @@ class TestProjectPurchaseProfitability(TestProjectProfitabilityCommon, TestPurch
             self.project._get_profitability_items(False)['costs'],
             {
                 'data': [{
-                    'id': 'other_costs',
-                    'sequence': self.project._get_profitability_sequence_per_invoice_type()['other_costs'],
+                    'id': 'other_costs_aal',
+                    'sequence': self.project._get_profitability_sequence_per_invoice_type()['other_costs_aal'],
                     'to_bill': 0.0,
                     'billed': -150.0,
                 }, {
@@ -178,8 +178,8 @@ class TestProjectPurchaseProfitability(TestProjectProfitabilityCommon, TestPurch
             self.project._get_profitability_items(False)['costs'],
             {
                 'data': [{
-                    'id': 'other_costs',
-                    'sequence': self.project._get_profitability_sequence_per_invoice_type()['other_costs'],
+                    'id': 'other_costs_aal',
+                    'sequence': self.project._get_profitability_sequence_per_invoice_type()['other_costs_aal'],
                     'to_bill': 0.0,
                     'billed': -150.0,
                 }, {
@@ -206,8 +206,8 @@ class TestProjectPurchaseProfitability(TestProjectProfitabilityCommon, TestPurch
             self.project._get_profitability_items(False)['costs'],
             {
                 'data': [{
-                    'id': 'other_costs',
-                    'sequence': self.project._get_profitability_sequence_per_invoice_type()['other_costs'],
+                    'id': 'other_costs_aal',
+                    'sequence': self.project._get_profitability_sequence_per_invoice_type()['other_costs_aal'],
                     'to_bill': 0.0,
                     'billed': -150.0,
                 }, {

--- a/addons/sale_project/tests/test_project_profitability.py
+++ b/addons/sale_project/tests/test_project_profitability.py
@@ -178,8 +178,8 @@ class TestSaleProjectProfitability(TestProjectProfitabilityCommon, TestSaleCommo
                 'revenues': {
                     'data': [
                         {
-                            'id': 'other_revenues',
-                            'sequence': sequence_per_invoice_type['other_revenues'],
+                            'id': 'other_revenues_aal',
+                            'sequence': sequence_per_invoice_type['other_revenues_aal'],
                             'invoiced': 100.0,
                             'to_invoice': 0.0,
                         },
@@ -197,7 +197,7 @@ class TestSaleProjectProfitability(TestProjectProfitabilityCommon, TestSaleCommo
                     },
                 },
                 'costs': {
-                    'data': [{'id': 'other_costs', 'sequence': sequence_per_invoice_type['other_costs'], 'billed': -100.0, 'to_bill': 0.0}],
+                    'data': [{'id': 'other_costs_aal', 'sequence': sequence_per_invoice_type['other_costs_aal'], 'billed': -100.0, 'to_bill': 0.0}],
                     'total': {'billed': -100.0, 'to_bill': 0.0},
                 },
             }
@@ -214,8 +214,8 @@ class TestSaleProjectProfitability(TestProjectProfitabilityCommon, TestSaleCommo
                 'revenues': {
                     'data': [
                         {
-                            'id': 'other_revenues',
-                            'sequence': sequence_per_invoice_type['other_revenues'],
+                            'id': 'other_revenues_aal',
+                            'sequence': sequence_per_invoice_type['other_revenues_aal'],
                             'invoiced': 100.0,
                             'to_invoice': 0.0,
                         },
@@ -233,7 +233,7 @@ class TestSaleProjectProfitability(TestProjectProfitabilityCommon, TestSaleCommo
                     },
                 },
                 'costs': {
-                    'data': [{'id': 'other_costs', 'sequence': sequence_per_invoice_type['other_costs'], 'billed': -100.0, 'to_bill': 0.0}],
+                    'data': [{'id': 'other_costs_aal', 'sequence': sequence_per_invoice_type['other_costs_aal'], 'billed': -100.0, 'to_bill': 0.0}],
                     'total': {'billed': -100.0, 'to_bill': 0.0},
                 },
             }
@@ -259,8 +259,8 @@ class TestSaleProjectProfitability(TestProjectProfitabilityCommon, TestSaleCommo
                 'revenues': {
                     'data': [
                         {
-                            'id': 'other_revenues',
-                            'sequence': sequence_per_invoice_type['other_revenues'],
+                            'id': 'other_revenues_aal',
+                            'sequence': sequence_per_invoice_type['other_revenues_aal'],
                             'invoiced': 100.0,
                             'to_invoice': 0.0,
                         },
@@ -279,7 +279,7 @@ class TestSaleProjectProfitability(TestProjectProfitabilityCommon, TestSaleCommo
                 },
                 'costs': {
                     'data': [
-                        {'id': 'other_costs', 'sequence': sequence_per_invoice_type['other_costs'], 'billed': -100.0,
+                        {'id': 'other_costs_aal', 'sequence': sequence_per_invoice_type['other_costs_aal'], 'billed': -100.0,
                          'to_bill': 0.0}],
                     'total': {'billed': -100.0, 'to_bill': 0.0},
                 },
@@ -311,8 +311,8 @@ class TestSaleProjectProfitability(TestProjectProfitabilityCommon, TestSaleCommo
                 'revenues': {
                     'data': [
                         {
-                            'id': 'other_revenues',
-                            'sequence': sequence_per_invoice_type['other_revenues'],
+                            'id': 'other_revenues_aal',
+                            'sequence': sequence_per_invoice_type['other_revenues_aal'],
                             'invoiced': 100.0,
                             'to_invoice': 0.0,
                         },
@@ -329,7 +329,7 @@ class TestSaleProjectProfitability(TestProjectProfitabilityCommon, TestSaleCommo
                     },
                 },
                 'costs': {
-                    'data': [{'id': 'other_costs', 'sequence': sequence_per_invoice_type['other_costs'], 'billed': -100.0, 'to_bill': 0.0}],
+                    'data': [{'id': 'other_costs_aal', 'sequence': sequence_per_invoice_type['other_costs_aal'], 'billed': -100.0, 'to_bill': 0.0}],
                     'total': {'billed': -100.0, 'to_bill': 0.0},
                 },
             }
@@ -357,8 +357,8 @@ class TestSaleProjectProfitability(TestProjectProfitabilityCommon, TestSaleCommo
                 'revenues': {
                     'data': [
                         {
-                            'id': 'other_revenues',
-                            'sequence': sequence_per_invoice_type['other_revenues'],
+                            'id': 'other_revenues_aal',
+                            'sequence': sequence_per_invoice_type['other_revenues_aal'],
                             'invoiced': 100.0,
                             'to_invoice': 0.0,
                         },
@@ -381,7 +381,7 @@ class TestSaleProjectProfitability(TestProjectProfitabilityCommon, TestSaleCommo
                     },
                 },
                 'costs': {
-                    'data': [{'id': 'other_costs', 'sequence': sequence_per_invoice_type['other_costs'], 'billed': -100.0, 'to_bill': 0.0}],
+                    'data': [{'id': 'other_costs_aal', 'sequence': sequence_per_invoice_type['other_costs_aal'], 'billed': -100.0, 'to_bill': 0.0}],
                     'total': {'billed': -100.0, 'to_bill': 0.0},
                 },
             },
@@ -415,8 +415,8 @@ class TestSaleProjectProfitability(TestProjectProfitabilityCommon, TestSaleCommo
                 'revenues': {
                     'data': [
                         {
-                            'id': 'other_revenues',
-                            'sequence': sequence_per_invoice_type['other_revenues'],
+                            'id': 'other_revenues_aal',
+                            'sequence': sequence_per_invoice_type['other_revenues_aal'],
                             'invoiced': 100.0,
                             'to_invoice': 0.0,
                         },
@@ -441,7 +441,7 @@ class TestSaleProjectProfitability(TestProjectProfitabilityCommon, TestSaleCommo
                     },
                 },
                 'costs': {
-                    'data': [{'id': 'other_costs', 'sequence': sequence_per_invoice_type['other_costs'], 'billed': -100.0, 'to_bill': 0.0}],
+                    'data': [{'id': 'other_costs_aal', 'sequence': sequence_per_invoice_type['other_costs_aal'], 'billed': -100.0, 'to_bill': 0.0}],
                     'total': {'billed': -100.0, 'to_bill': 0.0},
                 },
             },
@@ -461,8 +461,8 @@ class TestSaleProjectProfitability(TestProjectProfitabilityCommon, TestSaleCommo
                 'revenues': {
                     'data': [
                         {
-                            'id': 'other_revenues',
-                            'sequence': sequence_per_invoice_type['other_revenues'],
+                            'id': 'other_revenues_aal',
+                            'sequence': sequence_per_invoice_type['other_revenues_aal'],
                             'invoiced': 100.0,
                             'to_invoice': 0.0,
                         },
@@ -487,7 +487,7 @@ class TestSaleProjectProfitability(TestProjectProfitabilityCommon, TestSaleCommo
                     },
                 },
                 'costs': {
-                    'data': [{'id': 'other_costs', 'sequence': sequence_per_invoice_type['other_costs'], 'billed': -100.0, 'to_bill': 0.0}],
+                    'data': [{'id': 'other_costs_aal', 'sequence': sequence_per_invoice_type['other_costs_aal'], 'billed': -100.0, 'to_bill': 0.0}],
                     'total': {'billed': -100.0, 'to_bill': 0.0},
                 },
             },
@@ -506,8 +506,8 @@ class TestSaleProjectProfitability(TestProjectProfitabilityCommon, TestSaleCommo
                 'revenues': {
                     'data': [
                         {
-                            'id': 'other_revenues',
-                            'sequence': sequence_per_invoice_type['other_revenues'],
+                            'id': 'other_revenues_aal',
+                            'sequence': sequence_per_invoice_type['other_revenues_aal'],
                             'invoiced': 100.0,
                             'to_invoice': 0.0,
                         },
@@ -532,7 +532,7 @@ class TestSaleProjectProfitability(TestProjectProfitabilityCommon, TestSaleCommo
                     },
                 },
                 'costs': {
-                    'data': [{'id': 'other_costs', 'sequence': sequence_per_invoice_type['other_costs'], 'billed': -100.0, 'to_bill': 0.0}],
+                    'data': [{'id': 'other_costs_aal', 'sequence': sequence_per_invoice_type['other_costs_aal'], 'billed': -100.0, 'to_bill': 0.0}],
                     'total': {'billed': -100.0, 'to_bill': 0.0},
                 },
             },
@@ -550,8 +550,8 @@ class TestSaleProjectProfitability(TestProjectProfitabilityCommon, TestSaleCommo
                 'revenues': {
                     'data': [
                         {
-                            'id': 'other_revenues',
-                            'sequence': sequence_per_invoice_type['other_revenues'],
+                            'id': 'other_revenues_aal',
+                            'sequence': sequence_per_invoice_type['other_revenues_aal'],
                             'invoiced': 100.0,
                             'to_invoice': 0.0,
                         },
@@ -574,7 +574,7 @@ class TestSaleProjectProfitability(TestProjectProfitabilityCommon, TestSaleCommo
                     },
                 },
                 'costs': {
-                    'data': [{'id': 'other_costs', 'sequence': sequence_per_invoice_type['other_costs'], 'billed': -100.0, 'to_bill': 0.0}],
+                    'data': [{'id': 'other_costs_aal', 'sequence': sequence_per_invoice_type['other_costs_aal'], 'billed': -100.0, 'to_bill': 0.0}],
                     'total': {'billed': -100.0, 'to_bill': 0.0},
                 },
             },
@@ -624,11 +624,11 @@ class TestSaleProjectProfitability(TestProjectProfitabilityCommon, TestSaleCommo
                 # even if the sale order is canceled, if some expenses/revenues were added manually to the account, those lines must appear in the project profitabilty panel
                 'revenues': {
                     'data': [
-                        {'id': 'other_revenues', 'sequence': sequence_per_invoice_type['other_revenues'], 'invoiced': 100.0, 'to_invoice': 0.0}],
+                        {'id': 'other_revenues_aal', 'sequence': sequence_per_invoice_type['other_revenues_aal'], 'invoiced': 100.0, 'to_invoice': 0.0}],
                     'total': {'to_invoice': 0.0, 'invoiced': 100},
                 },
                 'costs': {
-                    'data': [{'id': 'other_costs', 'sequence': sequence_per_invoice_type['other_costs'], 'billed': -100.0, 'to_bill': 0.0}],
+                    'data': [{'id': 'other_costs_aal', 'sequence': sequence_per_invoice_type['other_costs_aal'], 'billed': -100.0, 'to_bill': 0.0}],
                     'total': {'billed': -100.0, 'to_bill': 0.0},
                 },
             },
@@ -647,8 +647,8 @@ class TestSaleProjectProfitability(TestProjectProfitabilityCommon, TestSaleCommo
                 'revenues': {
                     'data': [
                         {
-                            'id': 'other_revenues',
-                            'sequence': sequence_per_invoice_type['other_revenues'],
+                            'id': 'other_revenues_aal',
+                            'sequence': sequence_per_invoice_type['other_revenues_aal'],
                             'invoiced': 100.0,
                             'to_invoice': 0.0,
                         },
@@ -676,7 +676,7 @@ class TestSaleProjectProfitability(TestProjectProfitabilityCommon, TestSaleCommo
                     },
                 },
                 'costs': {
-                    'data': [{'id': 'other_costs', 'sequence': sequence_per_invoice_type['other_costs'], 'billed': -100.0, 'to_bill': 0.0}],
+                    'data': [{'id': 'other_costs_aal', 'sequence': sequence_per_invoice_type['other_costs_aal'], 'billed': -100.0, 'to_bill': 0.0}],
                     'total': {'billed': -100.0, 'to_bill': 0.0},
                 },
             },
@@ -937,8 +937,8 @@ class TestSaleProjectProfitability(TestProjectProfitabilityCommon, TestSaleCommo
             self.project_billable_no_company._get_profitability_items(False)['costs'],
             {
                 'data': [{
-                    'id': 'other_costs',
-                    'sequence': self.project_billable_no_company._get_profitability_sequence_per_invoice_type()['other_costs'],
+                    'id': 'other_costs_aal',
+                    'sequence': self.project_billable_no_company._get_profitability_sequence_per_invoice_type()['other_costs_aal'],
                     'to_bill': 0.0,
                     'billed': -150.0,
                 }, {
@@ -970,8 +970,8 @@ class TestSaleProjectProfitability(TestProjectProfitabilityCommon, TestSaleCommo
             self.project_billable_no_company._get_profitability_items(False)['costs'],
             {
                 'data': [{
-                    'id': 'other_costs',
-                    'sequence': self.project_billable_no_company._get_profitability_sequence_per_invoice_type()['other_costs'],
+                    'id': 'other_costs_aal',
+                    'sequence': self.project_billable_no_company._get_profitability_sequence_per_invoice_type()['other_costs_aal'],
                     'to_bill': 0.0,
                     'billed': -150.0,
                 }, {
@@ -990,8 +990,8 @@ class TestSaleProjectProfitability(TestProjectProfitabilityCommon, TestSaleCommo
             self.project_billable_no_company._get_profitability_items(False)['costs'],
             {
                 'data': [{
-                    'id': 'other_costs',
-                    'sequence': self.project_billable_no_company._get_profitability_sequence_per_invoice_type()['other_costs'],
+                    'id': 'other_costs_aal',
+                    'sequence': self.project_billable_no_company._get_profitability_sequence_per_invoice_type()['other_costs_aal'],
                     'to_bill': 0.0,
                     'billed': -150.0,
                 }, {
@@ -1009,8 +1009,8 @@ class TestSaleProjectProfitability(TestProjectProfitabilityCommon, TestSaleCommo
             self.project_billable_no_company._get_profitability_items(False)['costs'],
             {
                 'data': [{
-                    'id': 'other_costs',
-                    'sequence': self.project_billable_no_company._get_profitability_sequence_per_invoice_type()['other_costs'],
+                    'id': 'other_costs_aal',
+                    'sequence': self.project_billable_no_company._get_profitability_sequence_per_invoice_type()['other_costs_aal'],
                     'to_bill': 0.0,
                     'billed': -150.0,
                 }, {
@@ -1048,8 +1048,8 @@ class TestSaleProjectProfitability(TestProjectProfitabilityCommon, TestSaleCommo
             self.project_billable_no_company._get_profitability_items(False)['costs'],
             {
                 'data': [{
-                    'id': 'other_costs',
-                    'sequence': self.project_billable_no_company._get_profitability_sequence_per_invoice_type()['other_costs'],
+                    'id': 'other_costs_aal',
+                    'sequence': self.project_billable_no_company._get_profitability_sequence_per_invoice_type()['other_costs_aal'],
                     'to_bill': 0.0,
                     'billed': -150.0,
                 }, {
@@ -1071,8 +1071,8 @@ class TestSaleProjectProfitability(TestProjectProfitabilityCommon, TestSaleCommo
             self.project_billable_no_company._get_profitability_items(False)['costs'],
             {
                 'data': [{
-                    'id': 'other_costs',
-                    'sequence': self.project_billable_no_company._get_profitability_sequence_per_invoice_type()['other_costs'],
+                    'id': 'other_costs_aal',
+                    'sequence': self.project_billable_no_company._get_profitability_sequence_per_invoice_type()['other_costs_aal'],
                     'to_bill': 0.0,
                     'billed': -150.0,
                 }, {
@@ -1116,8 +1116,8 @@ class TestSaleProjectProfitability(TestProjectProfitabilityCommon, TestSaleCommo
             self.project_billable_no_company._get_profitability_items(False)['costs'],
             {
                 'data': [{
-                    'id': 'other_costs',
-                    'sequence': self.project_billable_no_company._get_profitability_sequence_per_invoice_type()['other_costs'],
+                    'id': 'other_costs_aal',
+                    'sequence': self.project_billable_no_company._get_profitability_sequence_per_invoice_type()['other_costs_aal'],
                     'to_bill': 0.0,
                     'billed': -150.0,
                 }, {
@@ -1139,9 +1139,9 @@ class TestSaleProjectProfitability(TestProjectProfitabilityCommon, TestSaleCommo
             self.project_billable_no_company._get_profitability_items(False)['costs'],
             {
                 'data': [{
-                    'id': 'other_costs',
+                    'id': 'other_costs_aal',
                     'sequence': self.project_billable_no_company._get_profitability_sequence_per_invoice_type()[
-                        'other_costs'],
+                        'other_costs_aal'],
                     'to_bill': 0.0,
                     'billed': -150.0,
                 }, {

--- a/addons/sale_timesheet/tests/test_project_profitability.py
+++ b/addons/sale_timesheet/tests/test_project_profitability.py
@@ -136,12 +136,12 @@ class TestSaleTimesheetProjectProfitability(TestCommonSaleTimesheet):
             self.project_task_rate._get_profitability_items(False),
             {
                 'revenues': {
-                    'data': [{'id': 'other_revenues', 'sequence': sequence_per_invoice_type['other_revenues'], 'invoiced': 100.0, 'to_invoice': 0.0}],
+                    'data': [{'id': 'other_revenues_aal', 'sequence': sequence_per_invoice_type['other_revenues_aal'], 'invoiced': 100.0, 'to_invoice': 0.0}],
                     'total': {'invoiced': 100.0, 'to_invoice': 0.0},
                 },
                 'costs': {
                     'data': [
-                        {'id': 'other_costs', 'sequence': sequence_per_invoice_type['other_costs'], 'billed': -100.0, 'to_bill': 0.0},
+                        {'id': 'other_costs_aal', 'sequence': sequence_per_invoice_type['other_costs_aal'], 'billed': -100.0, 'to_bill': 0.0},
                         {
                             'id': 'billable_manual',
                             'sequence': sequence_per_invoice_type['billable_manual'],
@@ -177,12 +177,12 @@ class TestSaleTimesheetProjectProfitability(TestCommonSaleTimesheet):
             self.project_task_rate._get_profitability_items(False),
             {
                 'revenues': {
-                    'data': [{'id': 'other_revenues', 'sequence': sequence_per_invoice_type['other_revenues'], 'invoiced': 100.0, 'to_invoice': 0.0}],
+                    'data': [{'id': 'other_revenues_aal', 'sequence': sequence_per_invoice_type['other_revenues_aal'], 'invoiced': 100.0, 'to_invoice': 0.0}],
                     'total': {'invoiced': 100.0, 'to_invoice': 0.0},
                 },
                 'costs': {
                     'data': [
-                        {'id': 'other_costs', 'sequence': sequence_per_invoice_type['other_costs'], 'billed': -100.0, 'to_bill': 0.0},
+                        {'id': 'other_costs_aal', 'sequence': sequence_per_invoice_type['other_costs_aal'], 'billed': -100.0, 'to_bill': 0.0},
                         {
                             'id': 'billable_manual',
                             'sequence': sequence_per_invoice_type['billable_manual'],
@@ -215,12 +215,12 @@ class TestSaleTimesheetProjectProfitability(TestCommonSaleTimesheet):
             self.project_task_rate._get_profitability_items(False),
             {
                 'revenues': {
-                    'data': [{'id': 'other_revenues', 'sequence': sequence_per_invoice_type['other_revenues'], 'invoiced': 100.0, 'to_invoice': 0.0}],
+                    'data': [{'id': 'other_revenues_aal', 'sequence': sequence_per_invoice_type['other_revenues_aal'], 'invoiced': 100.0, 'to_invoice': 0.0}],
                     'total': {'invoiced': 100.0, 'to_invoice': 0.0},
                 },
                 'costs': {
                     'data': [
-                        {'id': 'other_costs', 'sequence': sequence_per_invoice_type['other_costs'], 'billed': -100.0, 'to_bill': 0.0},
+                        {'id': 'other_costs_aal', 'sequence': sequence_per_invoice_type['other_costs_aal'], 'billed': -100.0, 'to_bill': 0.0},
                         {
                             'id': 'billable_manual',
                             'sequence': sequence_per_invoice_type['billable_manual'],
@@ -260,12 +260,12 @@ class TestSaleTimesheetProjectProfitability(TestCommonSaleTimesheet):
             self.project_task_rate._get_profitability_items(False),
             {
                 'revenues': {
-                    'data': [{'id': 'other_revenues', 'sequence': sequence_per_invoice_type['other_revenues'], 'invoiced': 100.0, 'to_invoice': 0.0}],
+                    'data': [{'id': 'other_revenues_aal', 'sequence': sequence_per_invoice_type['other_revenues_aal'], 'invoiced': 100.0, 'to_invoice': 0.0}],
                     'total': {'invoiced': 100.0, 'to_invoice': 0.0},
                 },
                 'costs': {
                     'data': [
-                        {'id': 'other_costs', 'sequence': sequence_per_invoice_type['other_costs'], 'billed': -100.0, 'to_bill': 0.0},
+                        {'id': 'other_costs_aal', 'sequence': sequence_per_invoice_type['other_costs_aal'], 'billed': -100.0, 'to_bill': 0.0},
                         {
                             'id': 'billable_manual',
                             'sequence': sequence_per_invoice_type['billable_manual'],
@@ -306,7 +306,7 @@ class TestSaleTimesheetProjectProfitability(TestCommonSaleTimesheet):
             {
                 'revenues': {
                     'data': [
-                        {'id': 'other_revenues', 'sequence': sequence_per_invoice_type['other_revenues'], 'invoiced': 100.0, 'to_invoice': 0.0},
+                        {'id': 'other_revenues_aal', 'sequence': sequence_per_invoice_type['other_revenues_aal'], 'invoiced': 100.0, 'to_invoice': 0.0},
                         {
                             'id': 'billable_time',
                             'sequence': sequence_per_invoice_type['billable_time'],
@@ -318,7 +318,7 @@ class TestSaleTimesheetProjectProfitability(TestCommonSaleTimesheet):
                 },
                 'costs': {
                     'data': [
-                        {'id': 'other_costs', 'sequence': sequence_per_invoice_type['other_costs'], 'billed': -100.0, 'to_bill': 0.0},
+                        {'id': 'other_costs_aal', 'sequence': sequence_per_invoice_type['other_costs_aal'], 'billed': -100.0, 'to_bill': 0.0},
                         {
                             'id': 'billable_time',
                             'sequence': sequence_per_invoice_type['billable_time'],
@@ -364,7 +364,7 @@ class TestSaleTimesheetProjectProfitability(TestCommonSaleTimesheet):
             {
                 'revenues': {
                     'data': [
-                        {'id': 'other_revenues', 'sequence': sequence_per_invoice_type['other_revenues'],
+                        {'id': 'other_revenues_aal', 'sequence': sequence_per_invoice_type['other_revenues_aal'],
                          'invoiced': 100.0, 'to_invoice': 0.0},
                         {
                             'id': 'billable_time',
@@ -377,7 +377,7 @@ class TestSaleTimesheetProjectProfitability(TestCommonSaleTimesheet):
                 },
                 'costs': {
                     'data': [
-                        {'id': 'other_costs', 'sequence': sequence_per_invoice_type['other_costs'], 'billed': -100.0,
+                        {'id': 'other_costs_aal', 'sequence': sequence_per_invoice_type['other_costs_aal'], 'billed': -100.0,
                          'to_bill': 0.0},
                         {
                             'id': 'billable_time',


### PR DESCRIPTION
This commit's purpose is to rename the other costs & other revenues section to avoid id conflict with other section of the project profitability panel.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
