### PR TITLE
[IMP] point_of_sale: remove park order

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.js
@@ -115,27 +115,6 @@ export class ControlButtons extends Component {
             },
         });
     }
-    onClickSave() {
-        const orderline = this.pos.get_order().get_selected_orderline();
-        if (!orderline) {
-            this.notification.add(_t("You cannot save an empty order"));
-            return;
-        }
-        this._selectEmptyOrder();
-        this.pos.addPendingOrder([this.pos.get_order().id]);
-        this.pos.syncAllOrders();
-        this.notification.add(_t("Order saved for later"));
-    }
-    _selectEmptyOrder() {
-        const orders = this.pos.get_open_orders();
-        const emptyOrders = orders.filter((order) => order.is_empty());
-        if (emptyOrders.length > 0) {
-            this.pos.syncAllOrders();
-            this.pos.set_order(emptyOrders[0]);
-        } else {
-            this.pos.add_new_order();
-        }
-    }
     get internalNoteLabel() {
         return _t("Internal Note");
     }

--- a/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
@@ -36,10 +36,6 @@
                     <i class="fa fa-undo me-1" role="img" aria-label="Refund" title="Refund" />
                     Refund
                 </button>
-                <button class="btn btn-light rounded-0 fw-bolder" t-on-click="onClickSave">
-                    <i class="fa fa-upload" role="img" aria-label="Save" title="Save" />
-                    Park Order
-                </button>
             </t>
         </div>
     </t>

--- a/addons/pos_sale/static/tests/tours/pos_sale_tour.js
+++ b/addons/pos_sale/static/tests/tours/pos_sale_tour.js
@@ -163,16 +163,3 @@ registry.category("web_tour.tours").add("PosSettleAndInvoiceOrder", {
             PaymentScreen.clickValidate(),
         ].flat(),
 });
-
-registry.category("web_tour.tours").add("PosQuotationSaving", {
-    test: true,
-    url: "/pos/ui",
-    steps: () =>
-        [
-            Dialog.confirm("Open session"),
-            PosSale.settleNthOrder(1),
-            ProductScreen.selectedOrderlineHas("Product", "4.00", "40.00"),
-            ProductScreen.clickControlButton("More..."),
-            ProductScreen.clickControlButton("Park Order"),
-        ].flat(),
-});

--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -510,35 +510,3 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
         self.env['pos.order'].sync_from_ui([pos_order])
         self.assertEqual(sale_order.order_line[0].untaxed_amount_invoiced, 10, "Untaxed invoiced amount should be 10")
         self.assertEqual(sale_order.order_line[1].untaxed_amount_invoiced, 0, "Untaxed invoiced amount should be 0")
-
-    def test_quotation_saving(self):
-        """ Verify that a saved quotation doesn't change the state of the quotation """
-        trusted_pos_config = self.env['pos.config'].create({
-            'name': 'Trusted Shop',
-            'module_pos_restaurant': False,
-        })
-
-        product = self.env['product.product'].create({
-            'name': 'Product',
-            'available_in_pos': True,
-            'type': 'consu',
-            'lst_price': 10.0,
-            'taxes_id': False,
-        })
-
-        sale_order = self.env['sale.order'].create({
-            'partner_id': self.env['res.partner'].create({'name': 'Test Partner'}).id,
-            'order_line': [(0, 0, {
-                'product_id': product.id,
-                'name': product.name,
-                'product_uom_qty': 4,
-                'price_unit': product.lst_price,
-            })],
-        })
-        self.assertEqual(sale_order.state, 'draft')
-
-        self.main_pos_config.trusted_config_ids = trusted_pos_config.ids
-        self.main_pos_config.open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PosQuotationSaving', login="accountman")
-
-        self.assertEqual(sale_order.state, 'draft')


### PR DESCRIPTION
One of the control buttons in pos is the "Park Order" button. In this commit we remove this button, as it does not actually serve a purpose. The need that this button would have served can be much better addressed by simply creating a new order from the "Orders" page.

Task: 4035626




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
