### PR TITLE
[FIX] hw_driver: enable print compatibility windows iot and saas-17.2

### DIFF
--- a/addons/hw_drivers/websocket_client.py
+++ b/addons/hw_drivers/websocket_client.py
@@ -47,7 +47,7 @@ def on_message(ws, messages):
     """
     messages = json.loads(messages)
     for document in messages:
-        if (document['message']['type'] == 'print'):
+        if (document['message']['type'] in ['print', 'iot_action']):
             payload = document['message']['payload']
             iot_mac = helpers.get_mac_address()
             if iot_mac in payload['iotDevice']['iotIdentifiers']:


### PR DESCRIPTION
Currently, a client that has a database in version saas-17.2 and above and the uses the windows virtual IoT is not able to print.

Steps to reproduce:
-------------------
* Install **IoT** and **Sales** App for example
* Connect a windows IoT to the db
* Connect a report to a printer (**PDF Quote** for example)
* Select any quotation
* Print **PDF Quote** and select the printer
> Observation: Error warning message appears: Check if the printer is still connected

Why the fix:
------------
The windows IoT only has installs for the major versions. When using a database on saas-17.2, the latest installer for the iot is 17.0.

In 17.0, when we want to print a report we send a `'print'` request: https://github.com/odoo/enterprise/blob/9efb3ed6b6649c2302849a1493869d0718be85d8/iot/models/ir_actions_report.py#L40

In saas-17.2 we sent a `'iot_action'` request:
https://github.com/odoo/enterprise/blob/30230dbf37d9949567d93fbdea056ac2b1fe92c8/iot/models/ir_actions_report.py#L40

Since the windows IoT uses the code from 17.0, it expects a `'print'` request but receives a `'iot_action'` request:
https://github.com/odoo/odoo/blob/3d9006647e1687a2e25cb52fa1fa0e163f99c016/addons/hw_drivers/websocket_client.py#L45

This fix makes the v17 IoT compatible with saas-17.2.

We look at 3 use cases:
* DB: saas-17.2 + physical IoT: This pr will not affect this case as the physical IoT will use the code of saas-17.2.
* DB: saas-17.2 + Windows IoT: The IoT will be able to handle the `'iot_action'` request.
* DB: 17.0 + physical IoT: `'print'` request is still being handled. The new action seems ok as no `'iot_action'` request exists in 17.0

opw-3987995
