### PR TITLE
[FIX] point_of_sale: correctly compute price with included tax after fp

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1129,7 +1129,7 @@ export class PosStore extends Reactive {
             const mapped_included_taxes = [];
             let new_included_taxes = [];
             taxes.forEach((tax) => {
-                const line_taxes = this.get_taxes_after_fp([tax.id], order.fiscal_position);
+                const line_taxes = this.get_taxes_after_fp([tax], order.fiscal_position);
                 if (line_taxes.length && line_taxes[0].price_include) {
                     new_included_taxes = new_included_taxes.concat(line_taxes);
                 }

--- a/addons/point_of_sale/static/tests/tours/ProductScreen.tour.js
+++ b/addons/point_of_sale/static/tests/tours/ProductScreen.tour.js
@@ -253,3 +253,19 @@ registry.category("web_tour.tours").add("CheckProductInformation", {
             },
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("FiscalPositionPriceIncluded", {
+    test: true,
+    url: "/pos/ui",
+    steps: () =>
+        [
+            Dialog.confirm("Open session"),
+            ProductScreen.clickShowProductsMobile(),
+            ProductScreen.clickDisplayedProduct("Test Product"),
+            ProductScreen.totalAmountIs("100.00"),
+            ProductScreen.changeFiscalPosition("No Change"),
+            ProductScreen.totalAmountIs("100.00"),
+
+            Chrome.endTour(),
+        ].flat(),
+});


### PR DESCRIPTION
Before this commit, when a fiscal position was mapped to a tax that is included in the price, the computation did not work correctly. This commit ensures that prices are accurately recalculated when taxes included in the price are affected by fiscal position mappings.

opw-3995279

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
