### PR TITLE
[FIX] mail: do not fetch mention suggestions if no need

### DIFF
--- a/addons/mail/static/tests/suggestion/suggestion.test.js
+++ b/addons/mail/static/tests/suggestion/suggestion.test.js
@@ -91,6 +91,25 @@ test('display partner mention suggestions on typing "@" in chatter', async () =>
     await contains(".o-mail-Composer-suggestion strong", { text: "Mitchell Admin" });
 });
 
+test("Do not fetch if search more specific and fetch had no result", async () => {
+    await startServer();
+    onRpc("res.partner", "get_mention_suggestions", () => {
+        step("get_mention_suggestions");
+    });
+    await start();
+    await openFormView("res.partner", serverState.partnerId);
+    await click("button", { text: "Send message" });
+    insertText(".o-mail-Composer-input", "@");
+    await contains(".o-mail-Composer-suggestion", { count: 3 }); // Mitchell Admin, Hermit, Public user
+    await contains(".o-mail-Composer-suggestion", { text: "Mitchell Admin" });
+    await assertSteps(["get_mention_suggestions"]);
+    insertText(".o-mail-Composer-input", "x");
+    await contains(".o-mail-Composer-suggestion", { count: 0 });
+    await assertSteps(["get_mention_suggestions"]);
+    insertText(".o-mail-Composer-input", "x");
+    await assertSteps([]);
+});
+
 test("show other channel member in @ mention", async () => {
     const pyEnv = await startServer();
     const partnerId = pyEnv["res.partner"].create({


### PR DESCRIPTION
Before this commit, when typing an `@mention` in composer and there was no suggestion results, typing more characters was triggering more silent fetches.

Steps to reproduce:

- Open `#general` in Discuss app
- Type `@marc` => should RPC `get_mention_from_channel` up to "marc"
- Type `andsomemorechars` => It continues to fetch `get_mention_from_channel` for each added chars

When a silent fetch has no result, making the search more specific would necessarily keep result to 0. There's no reason to fetch again, especially when the RPC is costly on big DBs.

This commit fixes the issue by tracking last search fetch that lead to no result, and when it detects a pending attempt to fetch is a finer search than the previous no result, it doesn't attempt any fetch.

<img width="1282" alt="before" src="https://github.com/odoo/odoo/assets/6569390/3b934f9a-18f8-45d1-ae72-e7b98821b459">
<img width="1280" alt="after" src="https://github.com/odoo/odoo/assets/6569390/fa90700a-89f0-42e1-b43f-6714170ce653">
