### PR TITLE
[IMP] hr_contract: update employee info

### DIFF
--- a/addons/hr_contract/models/hr_contract.py
+++ b/addons/hr_contract/models/hr_contract.py
@@ -257,9 +257,19 @@ class Contract(models.Model):
         else:
             self.write(vals)
 
+    def _get_employee_vals_to_update(self):
+        self.ensure_one()
+        vals = {'contract_id': self.id}
+        if self.job_id and self.job_id != self.employee_id.job_id:
+            vals['job_id'] = self.job_id.id
+        if self.department_id:
+            vals['department_id'] = self.department_id.id
+        return vals
+
     def _assign_open_contract(self):
         for contract in self:
-            contract.employee_id.sudo().write({'contract_id': contract.id})
+            vals = contract._get_employee_vals_to_update()
+            contract.employee_id.sudo().write(vals)
 
     @api.depends('wage')
     def _compute_contract_wage(self):


### PR DESCRIPTION
Prior, employee information - job_title, job_id and department_id were updated as soon as employee signed a new offer. This is flawed behavior, as even though employee signed offer, the new contract might have not started yet. In this task we correct this.

After this, above mentioned employee information will be updated once the new contract is running.

task-3035630
