### PR TITLE
[FIX] purchase_stock, mrp: hide the "order once" button after clicking

### DIFF
--- a/addons/mrp/models/stock_orderpoint.py
+++ b/addons/mrp/models/stock_orderpoint.py
@@ -35,6 +35,7 @@ class StockWarehouseOrderpoint(models.Model):
                         'url': f'#action={action.id}&id={production.id}&model=mrp.production'
                     }],
                     'sticky': False,
+                    'next': {'type': 'ir.actions.act_window_close'},
                 }
             }
         return super()._get_replenishment_order_notification()

--- a/addons/purchase_stock/models/stock.py
+++ b/addons/purchase_stock/models/stock.py
@@ -167,6 +167,7 @@ class Orderpoint(models.Model):
                         'url': f'#action={action.id}&id={order.id}&model=purchase.order',
                     }],
                     'sticky': False,
+                    'next': {'type': 'ir.actions.act_window_close'},
                 }
             }
         return super()._get_replenishment_order_notification()

--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -483,6 +483,7 @@ class StockWarehouseOrderpoint(models.Model):
                 'params': {
                     'title': _('The inter-warehouse transfers have been generated'),
                     'sticky': False,
+                    'next': {'type': 'ir.actions.act_window_close'},
                 }
             }
         return False


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a storable product “P1”:
    - Create a reorder rule:
        - Min qty: 5
        - Route: Buy
    - Click the “To order” button

Problem:
The button does not become invisible; the page must be refreshed to see the update. This can lead to user error if the user clicks the “order once” button a second time.


opw-3994600
