### PR TITLE
[IMP] hr_holidays: take consecutive leaves into account

### DIFF
--- a/addons/hr_holidays/static/src/persona_model_patch.js
+++ b/addons/hr_holidays/static/src/persona_model_patch.js
@@ -12,6 +12,6 @@ patch(Persona.prototype, {
         }
         const date = deserializeDateTime(this.out_of_office_date_end);
         const fdate = date.toLocaleString(DateTime.DATE_MED);
-        return _t("Out of office until %s", fdate);
+        return _t("Back on %s", fdate);
     },
 });

--- a/addons/hr_holidays/static/tests/thread_patch.test.js
+++ b/addons/hr_holidays/static/tests/thread_patch.test.js
@@ -22,5 +22,5 @@ test("out of office message on direct chat with out of office partner", async ()
     });
     await start();
     await openDiscuss(channelId);
-    await contains(".alert", { text: "Out of office until Jan 1, 2023" });
+    await contains(".alert", { text: "Back on Jan 1, 2023" });
 });

--- a/addons/hr_holidays/tests/test_res_partner.py
+++ b/addons/hr_holidays/tests/test_res_partner.py
@@ -4,6 +4,8 @@
 
 from dateutil.relativedelta import relativedelta
 
+from freezegun import freeze_time
+
 from odoo import Command, fields
 from odoo.tests.common import tagged, TransactionCase
 from odoo.addons.mail.tools.discuss import Store
@@ -13,6 +15,7 @@ from odoo.addons.mail.tools.discuss import Store
 class TestPartner(TransactionCase):
 
     @classmethod
+    @freeze_time('2024-06-04')
     def setUpClass(cls):
         super().setUpClass()
         # use a single value for today throughout the tests to avoid weird scenarios around midnight
@@ -42,17 +45,18 @@ class TestPartner(TransactionCase):
             'responsible_ids': cls.users.ids
         })
         cls.leaves = cls.env['hr.leave'].create([{
-            'request_date_from': cls.today + relativedelta(days=-2),
+            'request_date_from': cls.today + relativedelta(days=-1),
             'request_date_to': cls.today + relativedelta(days=2),
             'employee_id': cls.employees[0].id,
             'holiday_status_id': cls.leave_type.id,
         }, {
             'request_date_from': cls.today + relativedelta(days=-2),
-            'request_date_to': cls.today + relativedelta(days=3),
+            'request_date_to': cls.today + relativedelta(days=1),
             'employee_id': cls.employees[1].id,
             'holiday_status_id': cls.leave_type.id,
         }])
 
+    @freeze_time('2024-06-04')
     def test_res_partner_to_store(self):
         self.leaves.write({'state': 'validate'})
         self.assertEqual(

--- a/addons/hr_holidays/views/hr_views.xml
+++ b/addons/hr_holidays/views/hr_views.xml
@@ -141,12 +141,12 @@
                         context="{'search_default_employee_ids': id}"
                         invisible="not is_absent">
                         <div invisible="hr_icon_display != 'presence_holiday_present'"
-                              role="img" class="fa fa-fw fa-plane o_button_icon text-success" aria-label="Off Till" title="Off Till"/>
+                              role="img" class="fa fa-fw fa-plane o_button_icon text-success" aria-label="Back On" title="Back On"/>
                         <div invisible="hr_icon_display != 'presence_holiday_absent'" role="img"
-                             class="fa fa-fw fa-plane o_button_icon text-warning" aria-label="Off Till" title="Off Till"/>
+                             class="fa fa-fw fa-plane o_button_icon text-warning" aria-label="Back On" title="Back On"/>
                     <div class="o_field_widget o_stat_info">
                         <span class="o_stat_text">
-                            Off Till
+                            Back On
                         </span>
                         <span class="o_stat_value">
                             <field name="leave_date_to"/>
@@ -206,12 +206,12 @@
                         class="oe_stat_button"
                         invisible="not is_absent">
                         <div role="img" invisible="hr_icon_display != 'presence_holiday_present'"
-                             class="fa fa-fw fa-plane o_button_icon text-success" aria-label="Off Till" title="Off Till"/>
+                             class="fa fa-fw fa-plane o_button_icon text-success" aria-label="Back On" title="Back On"/>
                         <div invisible="hr_icon_display != 'presence_holiday_absent'" role="img"
-                             class="fa fa-fw fa-plane o_button_icon text-warning" aria-label="Off Till" title="Off Till"/>
+                             class="fa fa-fw fa-plane o_button_icon text-warning" aria-label="Back On" title="Back On"/>
                     <div class="o_field_widget o_stat_info">
                         <span class="o_stat_text">
-                            Off Till
+                            Back On
                         </span>
                         <span class="o_stat_value">
                             <field name="leave_date_to"/>
@@ -252,14 +252,14 @@
                         class="oe_stat_button"
                         invisible="context.get('from_my_profile', False) or not is_absent">
                         <div invisible="hr_icon_display != 'presence_holiday_present'"
-                             role="img" class="fa fa-fw fa-plane o_button_icon text-success" aria-label="Off Till"
-                             title="Off Till"/>
+                             role="img" class="fa fa-fw fa-plane o_button_icon text-success" aria-label="Back On"
+                             title="Back On"/>
                         <div invisible="hr_icon_display != 'presence_holiday_absent'"
-                             role="img" class="fa fa-fw fa-plane o_button_icon text-warning" aria-label="Off Till"
-                             title="Off Till"/>
+                             role="img" class="fa fa-fw fa-plane o_button_icon text-warning" aria-label="Back On"
+                             title="Back On"/>
                     <div class="o_field_widget o_stat_info">
                         <span class="o_stat_text">
-                            Off Till
+                            Back On
                         </span>
                         <span class="o_stat_value">
                             <field name="leave_date_to"/>


### PR DESCRIPTION
This commit changes the computation logic of `leave_date_to` field in `hr.employee` so that it reflects the first day that employee comes back in the office.

task: 3994866

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
