### PR TITLE
[FIX] mail: make chat bubble non-draggable

### DIFF
--- a/addons/mail/static/src/core/common/chat_bubble.xml
+++ b/addons/mail/static/src/core/common/chat_bubble.xml
@@ -16,7 +16,7 @@
             <button t-if="state.showClose and !env.embedLivechat" class="o-mail-ChatBubble-close position-absolute border-0 shadow rounded-pill fw-bold oi oi-close bg-view p-0" title="Close Chat Window" t-on-click.stop="() => this.props.chatWindow.close()"/>
             <ImStatus t-if="thread?.correspondent?.persona?.im_status and thread?.correspondent?.persona?.im_status != 'offline'" className="'o-mail-ChatBubble-status position-absolute o-mail-brighter'" persona="thread.correspondent.persona" thread="thread"/>
             <button class="o-mail-ChatHub-bubbleBtn btn ms-1 border-0">
-                <img class="o-mail-ChatBubble-avatar rounded-circle shadow" t-att-class="{ 'o-big': env.embedLivechat }" t-att-src="thread?.avatarUrl" alt="Thread image"/>
+                <img class="o-mail-ChatBubble-avatar rounded-circle shadow" t-att-class="{ 'o-big': env.embedLivechat }" t-att-src="thread?.avatarUrl" alt="Thread image" draggable="false"/>
             </button>
         </button>
     </t>

--- a/addons/mail/static/src/core/common/chat_hub.xml
+++ b/addons/mail/static/src/core/common/chat_hub.xml
@@ -59,7 +59,7 @@
             <ul class="m-0 p-0 overflow-auto" role="menu" t-ref="more-menu">
                 <t t-foreach="chatHub.actuallyHidden" t-as="cw" t-key="cw.localId">
                     <li class="o-mail-ChatHub-hiddenItem gap-2 px-2 py-1" role="menuitem" t-att-name="cw.displayName" t-on-click="() => cw.open()">
-                        <img class="o-mail-ChatHub-hiddenAvatar rounded-circle" t-att-src="cw.thread?.avatarUrl" alt="Thread image"/>
+                        <img class="o-mail-ChatHub-hiddenAvatar rounded-circle" t-att-src="cw.thread?.avatarUrl" alt="Thread image" draggable="false"/>
                         <p class="text-truncate fw-bold mb-0" t-esc="cw.displayName"/>
                         <div t-if="cw.thread?.importantCounter > 0" class="o-mail-ChatHub-hiddenCounter badge rounded-pill fw-bold o-discuss-badge" style="padding: 3px 6px">
                             <t t-out="cw.thread?.importantCounter"/>


### PR DESCRIPTION
Before this commit, chat bubbles could be dragged as images in a project task.

Steps to reproduce:

- open a chat window, e.g. #general from messaging menu in home menu
- fold / minimize the chat window
- open a project task
- drag and drop the folded chat window / bubble into the project task description text area => the image is added in the description

This happens because `<img/>` are draggable by default. This feature makes sense when the image represents a user-valuable asset, such as an image that has been posted in a conversation. However, when the image is simply used to identify a conversation, the draggable feature is generally non-desirable. In fact, this could be bothersome when dragging is a feature on those images, such as in chat bubbles when the button could be dragged to change position.

This commit fixes the issue by flagging chat bubble as non-draggable.