### PR TITLE
[FIX] hr_timesheet: set the account_id on the right dynamic field

### DIFF
--- a/addons/hr_timesheet/tests/test_timesheet.py
+++ b/addons/hr_timesheet/tests/test_timesheet.py
@@ -131,7 +131,12 @@ class TestTimesheet(TestCommonTimesheet):
             'name': 'my first timesheet',
             'unit_amount': 4,
         })
-        self.assertEqual(timesheet1.account_id, self.project_customer.analytic_account_id, 'Analytic account should be the same as the project')
+        project_account = self.project_customer.analytic_account_id
+        self.assertEqual(
+            timesheet1[project_account.plan_id._column_name()],
+            project_account,
+            'Analytic account should be the same as the project'
+        )
         self.assertEqual(timesheet1.employee_id, self.empl_employee, 'Employee should be the one of the current user')
         self.assertEqual(timesheet1.partner_id, self.task1.partner_id, 'Customer of task should be the same of the one set on new timesheet')
         self.assertEqual(timesheet1.product_uom_id, timesheet_uom, "The UoM of the timesheet should be the one set on the company of the analytic account.")


### PR DESCRIPTION
Problem
---
When creating timesheets, we always set the account_id on the `account_id` field, regardless of the account's plan. However, `account.analytic.line` is meant to have one dynamically generated field per plan (of the form `x_plan{plan_id}_id`, and we should set the `account_id` on the corresponding dynamic field. (cf: dc696c8ed4850)

Steps
---
* install project, timesheets, analytic, account_accountant
* in the setting enable *Timesheets* and *Analytic Accounting*
* create a new project with a new task in it
* set the project's analytic accounts' plan to something other than *Project* (e.g. *Departments* from demo data) (in the *Settings* notebook page)
* record a timesheet for the task
* |=> in the `analytic.account.line` views, the timesheet's account's still appears on the project field. This also prevents us from grouping by plan.

opw-4029417
