### PR TITLE
[FIX] digest: avoid deletion of default digest

### DIFF
--- a/addons/digest/i18n/digest.pot
+++ b/addons/digest/i18n/digest.pot
@@ -522,6 +522,12 @@ msgid ""
 msgstr ""
 
 #. module: digest
+#: code:addons/digest/models/digest.py:0
+#, python-format
+msgid "You cannot delete the default digest, deactivate it instead."
+msgstr ""
+
+#. module: digest
 #: model_terms:ir.ui.view,arch_db:digest.portal_digest_unsubscribed
 msgid "You have been successfully unsubscribed from:<br/>"
 msgstr ""


### PR DESCRIPTION
**Issue**
-----
If the default digest email is deleted by the user, some modules will not be able to be installed (CRM, helpdesk...).

**Cause**
-----
Some modules rely on digest_digest_default existing at installation. https://github.com/odoo/odoo/blob/5970e583ccff0b1a0015af93e2b10491a5657452/addons/crm/data/digest_data.xml#L3-L8

**Fix**
-----
Prevent user deletion of the record.

opw-4032081
