### PR TITLE
[FIX] stock: always use computed company_id

### DIFF
--- a/addons/stock/models/stock_lot.py
+++ b/addons/stock/models/stock_lot.py
@@ -26,6 +26,13 @@ class StockLot(models.Model):
     _check_company_auto = True
     _order = 'name, id'
 
+    @api.model
+    def default_get(self, fields_list):
+        context = dict(self.env.context)
+        # We always want the company_id to be computed, regardless of where it's been created.
+        context.pop('default_company_id', False)
+        return super(StockLot, self.with_context(context)).default_get(fields_list)
+
     def _read_group_location_id(self, locations, domain, order):
         partner_locations = locations.search([('usage', 'in', ('customer', 'supplier'))])
         return partner_locations + locations.warehouse_id.search([]).lot_stock_id

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -907,8 +907,7 @@ Please change the quantity done or the rounding precision of your unit of measur
                 return text[len(prefix):]
             return text
         for key in context:
-            # Default company_id is set for the parent move, but we need to let the lot compute its own company.
-            if key.startswith('default_') and key != 'default_company_id':
+            if key.startswith('default_'):
                 default_vals[remove_prefix(key, 'default_')] = context[key]
 
         if default_vals['tracking'] == 'lot' and mode == 'generate':


### PR DESCRIPTION
Now that lots can be set without company, we want them to have by default the company of their related product.

The issue is that if there is a `default_company_id` set in the context at any point, it will prevent the computation of the right `company_id`, causing the wrong company (or a company where there shouldn't be one) to be set on the lot.

To prevent this, we simply pop the `default_company_id` from the context if present when checking the default values, forcing the use of the compute instead.

Also restores the `default_company_id` in
`action_generate_lot_line_vals`, as this removes the default from move lines, and is no longer necessary for lots.

Description of the issue/feature this PR addresses:

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
