### PR TITLE
[FIX] account: batch delete of `account.move`

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2553,17 +2553,16 @@ class AccountMove(models.Model):
         If a user is a Billing Administrator/Accountant or if fidu mode is activated, we show a warning,
         but they can delete the moves even if it creates a sequence gap.
         """
-        for record in self:
-            if not (
-                record.user_has_groups('account.group_account_manager')
-                or record.company_id.quick_edit_mode
-                or record._context.get('force_delete')
-                or record.check_move_sequence_chain()
-            ):
-                raise UserError(_(
-                    "You cannot delete this entry, as it has already consumed a sequence number and is not the last one in the chain. "
-                    "You should probably revert it instead."
-                ))
+        if not (
+            self.user_has_groups('account.group_account_manager')
+            or any(self.company_id.mapped('quick_edit_mode'))
+            or self._context.get('force_delete')
+            or self.check_move_sequence_chain()
+        ):
+            raise UserError(_(
+                "You cannot delete this entry, as it has already consumed a sequence number and is not the last one in the chain. "
+                "You should probably revert it instead."
+            ))
 
     def unlink(self):
         self = self.with_context(skip_invoice_sync=True, dynamic_unlink=True)  # no need to sync to delete everything


### PR DESCRIPTION
A previous fix was iterating on all the records in `self` in order to remove an issue when multiple companies are involved in the deletion. However the way it is fixed was triggering multiple calls to `check_move_sequence_chain` even though that method is optimized to only check once every move, hence worse perforance.
Also, the moves need to be deleted in order if we wanted to do it that way.

Fixup of f3863949b95613c4b1d7292f7fc2da2696af467a

