### PR TITLE
[FIX] l10n_latam_invoice_document: document type changed on invoice that was posted

### DIFF
--- a/addons/l10n_latam_invoice_document/models/account_move.py
+++ b/addons/l10n_latam_invoice_document/models/account_move.py
@@ -196,7 +196,7 @@ class AccountMove(models.Model):
 
     @api.depends('l10n_latam_available_document_type_ids', 'debit_origin_id')
     def _compute_l10n_latam_document_type(self):
-        for rec in self.filtered(lambda x: x.state == 'draft'):
+        for rec in self.filtered(lambda x: x.state == 'draft' and not x.posted_before):
             document_types = rec.l10n_latam_available_document_type_ids._origin
             invoice_type = rec.move_type
             if invoice_type in ['out_refund', 'in_refund']:


### PR DESCRIPTION
### Version:
15, 16, 17, master

### Description of the issue/feature this PR addresses:

Argentinean localization: if a customer invoice with partner with "IVA Responsable Inscripto" AFIP Responsibility is confirmed, then reset to draft and changed the partner to one with  "Consumidor Final" AFIP Responsibility, then "Document Type" field is changed and this is not the desired behavior because that field is readonly when the invoice was posted. Compute method should not overried the document type if the invoice was posted before. If it does then an incosistency will occurr because the name, document type and sequence will not match. A new sequence non-real will be used. Also the user it is not aware is happening because the field is readonly.

[Video﻿](https://drive.google.com/file/d/1D4uqNnXMkguS813NiLl9td4_f_TJ35Xf/view)﻿ showing how to replicate the bug:

### Steps to reproduce:

1. Log in with admin on runbot odoo enterprise 16 instance and install l10n_ar_edi (Argentinean Electronic Invoicing) module.
2. Take position on company "Responsable Inscripto"
3. Go to "Accounting / Customers / Invoices" and create a new customer invoice with customer "ADHOC SA" (this partner has "IVA Responsable Inscripto" AFIP Responsibility), with a sale journal "Pre-printed Invoice" AFIP POS System (i.e Ventas Preimpreso), add an invoice line and confirm it. ![image](https://github.com/user-attachments/assets/5e770259-6195-45af-b2d2-6e7a701f9fb5)

4. Reset to draft the invoice mentioned in step 3 (now journal and document type are readonly fields), change customer to "Consumidor Final Anónimo" (this partner has "Consumidor Final" AFIP Responsibility) and save. Check that the document type has changed from "(1) FACTURAS A" to "(6) FACTURAS B" and this is not the desired behavior because is a readonly field now because the invoice was posted before. 
![image](https://github.com/user-attachments/assets/d9d4cced-59df-4f0b-8222-1a581702bd0b)

### Current behavior before PR:

When a customer invoice with customer with "IVA Responsable Inscripto" AFIP Responsibility is confirmed, then reset to draft and changed the customer to one with  "Consumidor Final" AFIP Responsibility, then "Document Type" field is changed and this is not the desired behavior because that field is readonly when the invoice was posted.

### Desired behavior after PR is merged:

When a customer invoice with customer with "IVA Responsable Inscripto" AFIP Responsibility is confirmed, then reset to draft and changed the customer to one with  "Consumidor Final" AFIP Responsibility, then "Document Type" field is not changed.

Ticket Adhoc side: 77058
Task latam: 1235


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
