### PR TITLE
[FIX] base: re-allow fetching user-restricted images in reports

### DIFF
--- a/addons/web/tests/__init__.py
+++ b/addons/web/tests/__init__.py
@@ -21,3 +21,4 @@ from . import test_web_redirect
 from . import test_res_users
 from . import test_webmanifest
 from . import test_ir_qweb
+from . import test_reports

--- a/addons/web/tests/test_reports.py
+++ b/addons/web/tests/test_reports.py
@@ -1,0 +1,76 @@
+import odoo.tests
+
+from odoo.addons.website.tools import MockRequest
+
+
+class TestReports(odoo.tests.HttpCase):
+    def test_report_session_cookie(self):
+        """ Asserts wkhtmltopdf forwards the user session when requesting resources to Odoo, such as images,
+        and that the resource is correctly returned as expected.
+        """
+        partner_id = self.env.user.partner_id.id
+        img = b'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4//8/AAX+Av4N70a4AAAAAElFTkSuQmCC'
+        image = self.env['ir.attachment'].create({
+            'name': 'foo',
+            'res_model': 'res.partner',
+            'res_id': partner_id,
+            'datas': img,
+        })
+        report = self.env['ir.actions.report'].create({
+            'name': 'test report',
+            'report_name': 'base.test_report',
+            'model': 'res.partner',
+        })
+        self.env['ir.ui.view'].create({
+            'type': 'qweb',
+            'name': 'base.test_report',
+            'key': 'base.test_report',
+            'arch': f'''
+                <main>
+                    <div class="article" data-oe-model="res.partner" t-att-data-oe-id="docs.id">
+                        <img src="/web/image/{image.id}"/>
+                    </div>
+                </main>
+            '''
+        })
+
+        result = {}
+        origin_find_record = self.env.registry['ir.binary']._find_record
+
+        def _find_record(self, xmlid=None, res_model='ir.attachment', res_id=None, access_token=None, field=None):
+            if res_model == 'ir.attachment' and res_id == image.id:
+                result['uid'] = self.env.uid
+                record = origin_find_record(self, xmlid, res_model, res_id, access_token, field)
+                result.update({'record_id': record.id, 'data': record.datas})
+            else:
+                record = origin_find_record(self, xmlid, res_model, res_id, access_token, field)
+            return record
+
+        self.patch(self.env.registry['ir.binary'], '_find_record', _find_record)
+
+        # 1. Request the report as admin, who has access to the image
+        admin = self.env.ref('base.user_admin')
+        report = report.with_user(admin)
+        with MockRequest(report.env) as mock_request:
+            mock_request.session.sid = self.authenticate(admin.login, admin.login).sid
+            report.with_context(force_report_rendering=True)._render_qweb_pdf(report.id, [partner_id])
+
+        self.assertEqual(
+            result.get('uid'), admin.id, 'wkhtmltopdf is not fetching the image as the user printing the report'
+        )
+        self.assertEqual(result.get('record_id'), image.id, 'wkhtmltopdf did not fetch the expected record')
+        self.assertEqual(result.get('data'), img, 'wkhtmltopdf did not fetch the right image content')
+
+        # 2. Request the report as public, who has no acess to the image
+        self.logout()
+        result.clear()
+        public = self.env.ref('base.public_user')
+        report = report.with_user(public)
+        with MockRequest(self.env) as mock_request:
+            report.with_context(force_report_rendering=True)._render_qweb_pdf(report.id, [partner_id])
+
+        self.assertEqual(
+            result.get('uid'), public.id, 'wkhtmltopdf is not fetching the image as the user printing the report'
+        )
+        self.assertEqual(result.get('record_id'), None, 'wkhtmltopdf must not have been allowed to fetch the image')
+        self.assertEqual(result.get('data'), None, 'wkhtmltopdf must not have been allowed to fetch the image')

--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -1,13 +1,12 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from markupsafe import Markup
-from datetime import datetime, timedelta
 from urllib.parse import urlparse
 
 from odoo import api, fields, models, tools, SUPERUSER_ID, _
 from odoo.exceptions import UserError, AccessError
 from odoo.tools.safe_eval import safe_eval, time
-from odoo.tools.misc import find_in_path, format_datetime, ustr
+from odoo.tools.misc import find_in_path, ustr
 from odoo.tools import check_barcode_encoding, config, is_html_empty, parse_version, split_every
 from odoo.http import request
 from odoo.osv.expression import NEGATIVE_TERM_OPERATORS, FALSE_DOMAIN
@@ -451,12 +450,9 @@ class IrActionsReport(models.Model):
 
         # Passing the cookie to wkhtmltopdf in order to resolve internal links.
         if request and request.db:
-            expiration = datetime.now() + timedelta(hours=1)
-            # Use format_datetime to force locale
-            expiration = format_datetime(self.env, expiration, "UTC", "E, d-M-Y H:m:s z", "en_US")
             base_url = self._get_report_url()
             domain = urlparse(base_url).hostname
-            cookie = f'session_id={request.session.sid}; HttpOnly; expires={expiration}; domain={domain}; path=/;'
+            cookie = f'session_id={request.session.sid}; HttpOnly; domain={domain}; path=/;'
             cookie_jar_file_fd, cookie_jar_file_path = tempfile.mkstemp(suffix='.txt', prefix='report.cookie_jar.tmp.')
             temporary_files.append(cookie_jar_file_path)
             with closing(os.fdopen(cookie_jar_file_fd, 'wb')) as cookie_jar_file:


### PR DESCRIPTION
This is an oversight in bd7fe63ab4d7efd09304d9fd0546a16270c398eb

The expiration date should follow the format defined in RFC 6265, which is Day, DD-Mon-YYYY HH:MM:SS GMT

The expected format of the date for the expiration for `format_time`, using `babel`, is
`EEE, dd-MMM-yyyy HH:mm:ss z`
not
`E, d-M-Y H:m:s z`

During the development of the above revision,
during the functional testing,
the images in the reports were correctly working as expected. This is because the date parser was confused because of the wrong date format, and was ok for the date during which the tests were done (on April 23 2024).

Nevertheless, since a few days, beginning of July, the expiration date parser no longer accepts the confusing format date, and believe the expiration date is passed,
and hence wkhtmltopdf no longer forward the session id as expected, and hence the images with a restricted access right can no longer be downloaded, as the requests coming from wkhtmltopdf are no longer authenticated with the user printing the report.

However, there is actually no need to set an expiration date in the first place, as this expiration date is meant for the client-side only, and the cookie jar file is deleted right after the report is printed.

We therefore take the choice to simply remove the expiration date to solve the issue.

A unit test is added to cover the case, so this can no longer happens.

opw-3985316
opw-3985758
opw-3996620
opw-4023078
opw-4023430
opw-4023619
opw-4024377
opw-4024378
opw-4024528
opw-4027104
opw-4027115
opw-4027146
opw-4027207
opw-4027316
opw-4027338
opw-4027355
opw-4027391
opw-4027423
opw-4027622
opw-4027922
opw-4028933
opw-4029223
opw-4029395
opw-4029582
opw-4030219
opw-4032424
opw-4032956
opw-4033108
opw-4033142
opw-4033182
opw-4033766
opw-4033837
opw-4034508
opw-4035079
opw-4035246
