### PR TITLE
[FIX] point_of_sale: prevent duplicate order numbers

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -95,6 +95,10 @@ class PosSession(models.Model):
 
     _sql_constraints = [('uniq_name', 'unique(name)', "The name of this POS Session must be unique!")]
 
+    def sync_sequence_number_from_ui(self, session_id, sequence_number):
+        session = self.browse(session_id)
+        session.sequence_number = sequence_number
+
     @api.model
     def _load_pos_data_relations(self, model, response):
         model_fields = self.env[model]._fields

--- a/addons/point_of_sale/static/tests/tours/sequence_number_tour.js
+++ b/addons/point_of_sale/static/tests/tours/sequence_number_tour.js
@@ -1,0 +1,71 @@
+import * as ProductScreen from "@point_of_sale/../tests/tours/utils/product_screen_util";
+import * as ReceiptScreen from "@point_of_sale/../tests/tours/utils/receipt_screen_util";
+import * as Dialog from "@point_of_sale/../tests/tours/utils/dialog_util";
+import * as PaymentScreen from "@point_of_sale/../tests/tours/utils/payment_screen_util";
+import * as TicketScreen from "@point_of_sale/../tests/tours/utils/ticket_screen_util";
+import * as Chrome from "@point_of_sale/../tests/tours/utils/chrome_util";
+import { openRegister } from "@point_of_sale/../tests/tours/utils/common";
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("SequenceNumberTour.1", {
+    test: true,
+    steps: () =>
+        [
+            Dialog.confirm("Open session"),
+
+            // Order 1 is at Product Screen
+            ProductScreen.clickDisplayedProduct("Desk Pad"),
+            Chrome.clickMenuOption("Orders"),
+            TicketScreen.checkStatus("-0001", "Ongoing"),
+
+            // Order 2 is at Payment Screen
+            TicketScreen.clickNewTicket(),
+            ProductScreen.clickDisplayedProduct("Monitor Stand"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.isShown(),
+            Chrome.clickMenuOption("Orders"),
+            TicketScreen.checkStatus("-0002", "Payment"),
+
+            // Order 3 is at Receipt Screen
+            TicketScreen.clickNewTicket(),
+            ProductScreen.clickDisplayedProduct("Whiteboard Pen"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank", true, { remaining: "0.0" }),
+            PaymentScreen.validateButtonIsHighlighted(true),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.isShown(),
+            Chrome.clickMenuOption("Orders"),
+            TicketScreen.checkStatus("-0003", "Receipt"),
+
+            // Order 4 is at Product Screen
+            TicketScreen.clickNewTicket(),
+            ProductScreen.clickDisplayedProduct("Desk Pad"),
+            Chrome.clickMenuOption("Orders"),
+            TicketScreen.checkStatus("-0004", "Ongoing"),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("SequenceNumberTour.2", {
+    test: true,
+    steps: () =>
+        [
+            Dialog.confirm("Open session"),
+
+            ProductScreen.clickDisplayedProduct("Whiteboard Pen"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank", true, { remaining: "0.0" }),
+            PaymentScreen.validateButtonIsHighlighted(true),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.isShown(),
+            Chrome.clickMenuOption("Orders"),
+            TicketScreen.checkStatus("-0001", "Receipt"),
+
+            Chrome.clickMenuOption("Backend"),
+
+            openRegister(),
+
+            ProductScreen.clickDisplayedProduct("Monitor Stand"),
+            Chrome.clickMenuOption("Orders"),
+            TicketScreen.checkStatus("-0002", "Ongoing"),
+        ].flat(),
+});

--- a/addons/point_of_sale/static/tests/tours/utils/common.js
+++ b/addons/point_of_sale/static/tests/tours/utils/common.js
@@ -57,3 +57,10 @@ export function selectButton(name) {
         run: "click",
     };
 }
+
+export function openRegister() {
+    return {
+        trigger: "button[name='open_ui']",
+        run: "click",
+    };
+}

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1481,6 +1481,13 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'CashRoundingPayment', login="accountman")
 
+    def test_sequence_number_1(self):
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'SequenceNumberTour.1', login="pos_user")
+
+    def test_sequence_number_2(self):
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'SequenceNumberTour.2', login="pos_user")
 
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):

--- a/addons/pos_self_order/controllers/orders.py
+++ b/addons/pos_self_order/controllers/orders.py
@@ -27,6 +27,7 @@ class PosSelfOrderController(http.Controller):
             del order['picking_type_id']
 
         order['name'] = order_reference
+        order['sequence_number'] = sequence_number
         order['pos_reference'] = order_reference
         order['sequence_number'] = sequence_number
         order['user_id'] = request.session.uid


### PR DESCRIPTION
### Steps to reproduce:
- Install **PoS** app
- Open a new pos session
- Place an order
- Go to backend
- Open the session again via (**continue selling**) button
- Place another order
- In the menu bar, go to **Orders** > **Sessions**
- Open the session where we placed the orders
- Click on the **Orders** smart button and show the order number column
- Notice how the two orders have the same order number!

### Investigation
- The order number (`tracking_number`) is computed by concatenating the (`session_id` % 10) to the order (`sequence_number` % 100)
- The issue occurs when the session is reloaded as the sequence_number resets back to its default value which is 1
- For example for a session with an id = 5,
	- the first order will have a sequence_number of 1 resulting in an order number of **501**.
	- the second order will have a `sequence_number` of 2 resulting in an order number of **502**. However when the session is reloaded, the `sequence_number` is 1 resulting in a wrong order number of a duplicate **501**.

Suggested ### Solution
- before creating a new order, get the `sequence_number` of the most recent order placed at associated session. This way, the sequence_number is not affected when the session is reloaded

task-4017135