### PR TITLE
[FIX] stock: move/move_line bad uom conversion

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -2015,14 +2015,14 @@ Please change the quantity done or the rounding precision of your unit of measur
             taken_qty = min(qty, ml_qty)
             # Convert taken qty into move line uom
             if ml.product_uom_id != self.product_uom:
-                taken_qty = self.product_uom._compute_quantity(ml_qty, ml.product_uom_id, round=False)
+                taken_qty = self.product_uom._compute_quantity(taken_qty, ml.product_uom_id, round=False)
 
             # Assign qty_done and explicitly round to make sure there is no inconsistency between
             # ml.qty_done and qty.
             taken_qty = float_round(taken_qty, precision_rounding=ml.product_uom_id.rounding)
             res.append((1, ml.id, {'quantity': taken_qty}))
             if ml.product_uom_id != self.product_uom:
-                taken_qty = ml.product_uom_id._compute_quantity(ml_qty, self.product_uom, round=False)
+                taken_qty = ml.product_uom_id._compute_quantity(taken_qty, self.product_uom, round=False)
             qty -= taken_qty
 
         if float_compare(qty, 0.0, precision_rounding=self.product_uom.rounding) > 0:


### PR DESCRIPTION
When the stock_move_line and stock_move have the same UoM everything works as expected.

However, in the process of setting the done quantity from the move, to the move line, there are 2 places the wrong value is used in the compute, leading to misaligned data.

This can, in a worst case, make a move with a quantity as done, and no supporting move lines.  And no backorder created.

Description of the issue/feature this PR addresses:

This was raised in Odoo Ticket https://www.odoo.com/my/tasks/4033989

Current behavior before PR:

Creates mismatched moves

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
