### PR TITLE
[IMP] im_livechat: navigating livechat sessions

### DIFF
--- a/addons/im_livechat/static/src/core/common/channel_member_list_patch.xml
+++ b/addons/im_livechat/static/src/core/common/channel_member_list_patch.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="im_livechat.ChannelMemberList" t-inherit="discuss.ChannelMemberList" t-inherit-mode="extension">
+        <xpath expr="//button[@name='inviteButton']" position="attributes">
+            <attribute name="t-if">props.thread.channel_type != "livechat" or props.thread.livechat_active</attribute>
+        </xpath>
+    </t>
+</templates>

--- a/addons/im_livechat/static/src/core/common/thread_actions_patch.js
+++ b/addons/im_livechat/static/src/core/common/thread_actions_patch.js
@@ -1,0 +1,38 @@
+import { threadActionsRegistry } from "@mail/core/common/thread_actions";
+import { patch } from "@web/core/utils/patch";
+
+patch(threadActionsRegistry.get("invite-people"), {
+    condition(component) {
+        if (component.thread?.channel_type === "livechat") {
+            return super.condition(component) && component.thread.livechat_active;
+        }
+        return super.condition(component);
+    },
+});
+
+patch(threadActionsRegistry.get("notification-settings"), {
+    condition(component) {
+        if (component.thread?.channel_type === "livechat") {
+            return super.condition(component) && component.thread.livechat_active;
+        }
+        return super.condition(component);
+    },
+});
+
+patch(threadActionsRegistry.get("camera-call"), {
+    condition(component) {
+        if (component.thread?.channel_type === "livechat") {
+            return super.condition(component) && component.thread.livechat_active;
+        }
+        return super.condition(component);
+    },
+});
+
+patch(threadActionsRegistry.get("call"), {
+    condition(component) {
+        if (component.thread?.channel_type === "livechat") {
+            return super.condition(component) && component.thread.livechat_active;
+        }
+        return super.condition(component);
+    },
+});

--- a/addons/im_livechat/static/src/views/discuss_template.xml
+++ b/addons/im_livechat/static/src/views/discuss_template.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+    <t t-name="im_livechat.LivechatDiscuss">
+        <t t-if="thread">
+            <Discuss hasSidebar="false" thread="thread"/>
+        </t>
+        <t t-else="">
+            <div class="d-flex h-100 flex-column justify-content-center align-items-center">
+                <span class="fs-1">No conversation found</span>
+                <button type="button" class="btn btn-primary" t-on-click="redirectToSessions">
+                    Go to Sessions
+                </button>
+            </div>
+        </t>
+    </t>
+</templates>

--- a/addons/im_livechat/static/src/views/livechat_form_renderer.js
+++ b/addons/im_livechat/static/src/views/livechat_form_renderer.js
@@ -1,0 +1,44 @@
+import { Discuss } from "@mail/core/public_web/discuss";
+
+import { onWillStart, onWillUpdateProps, useState } from "@odoo/owl";
+
+import { useService } from "@web/core/utils/hooks";
+import { FormRenderer } from "@web/views/form/form_renderer";
+
+export class LivechatSessionFormRenderer extends FormRenderer {
+    static template = "im_livechat.LivechatDiscuss";
+    static components = {
+        ...FormRenderer.components,
+        Discuss,
+    };
+
+    setup() {
+        super.setup();
+        this.store = useState(useService("mail.store"));
+        onWillStart(async () => {
+            await this.getChannel(this.props);
+        });
+        onWillUpdateProps(async (nextProps) => {
+            await this.getChannel(nextProps);
+        });
+    }
+
+    /**
+     * Restore the discuss thread according to record id in the props if
+     * necessary.
+     *
+     * @param {Props} props
+     */
+    async getChannel(props) {
+        this.thread = await this.store.Thread.getOrFetch({
+            model: "discuss.channel",
+            id: props.record.resId,
+        });
+    }
+
+    redirectToSessions() {
+        this.env.services.action.doAction("im_livechat.discuss_channel_action", {
+            clearBreadcrumbs: true,
+        });
+    }
+}

--- a/addons/im_livechat/static/src/views/livechat_form_view.js
+++ b/addons/im_livechat/static/src/views/livechat_form_view.js
@@ -1,0 +1,11 @@
+import { registry } from "@web/core/registry";
+import { formView } from "@web/views/form/form_view";
+import { LivechatSessionFormRenderer } from "./livechat_form_renderer";
+
+export const LivechatSesionFormView = {
+    ...formView,
+    Renderer: LivechatSessionFormRenderer,
+    display: { controlPanel: false },
+};
+
+registry.category("views").add("livechat_session_form", LivechatSesionFormView);

--- a/addons/im_livechat/static/src/views/livechat_view_controller_mixin.js
+++ b/addons/im_livechat/static/src/views/livechat_view_controller_mixin.js
@@ -1,5 +1,4 @@
 import { useService } from "@web/core/utils/hooks";
-import { _t } from "@web/core/l10n/translation";
 
 export const LivechatViewControllerMixin = (ViewController) =>
     class extends ViewController {
@@ -10,18 +9,14 @@ export const LivechatViewControllerMixin = (ViewController) =>
         }
 
         async openRecord(record) {
-            if (!this.ui.isSmall) {
-                return this.actionService.doAction("mail.action_discuss", {
-                    name: _t("Discuss"),
-                    additionalContext: { active_id: record.resId },
+            if (this.ui.isSmall) {
+                const thread = await this.store.Thread.getOrFetch({
+                    model: "discuss.channel",
+                    id: record.resId,
                 });
-            }
-            const thread = await this.store.Thread.getOrFetch({
-                model: "discuss.channel",
-                id: record.resId,
-            });
-            if (thread) {
-                return thread.open({ focus: true });
+                if (thread) {
+                    return thread.open();
+                }
             }
             return super.openRecord(record);
         }

--- a/addons/im_livechat/static/tests/channel_invite.test.js
+++ b/addons/im_livechat/static/tests/channel_invite.test.js
@@ -43,6 +43,7 @@ test("Can invite a partner to a livechat channel", async () => {
         ],
         channel_type: "livechat",
         livechat_operator_id: serverState.partnerId,
+        livechat_active: true,
     });
     await start();
     await openDiscuss(channelId);
@@ -85,6 +86,7 @@ test("Available operators come first", async () => {
             Command.create({ guest_id: guestId }),
         ],
         channel_type: "livechat",
+        livechat_active: true,
     });
     await start();
     await openDiscuss(channelId);
@@ -119,6 +121,7 @@ test("Partners invited most frequently by the current user come first", async ()
             Command.create({ guest_id: guestId_1, last_interest_dt: "2021-01-03 12:00:00" }),
         ],
         livechat_operator_id: serverState.partnerId,
+        livechat_active: true,
     });
     const guestId_2 = pyEnv["mail.guest"].create({ name: "Visitor #2" });
     pyEnv["discuss.channel"].create({
@@ -172,6 +175,7 @@ test("shows operators are in call", async () => {
             Command.create({ partner_id: serverState.partnerId }),
             Command.create({ guest_id: guestId }),
         ],
+        livechat_active: true,
     });
     await start();
     await openDiscuss(channelId);

--- a/addons/im_livechat/static/tests/discuss_patch.test.js
+++ b/addons/im_livechat/static/tests/discuss_patch.test.js
@@ -76,6 +76,7 @@ test("invite button should be present on livechat", async () => {
         ],
         channel_type: "livechat",
         livechat_operator_id: serverState.partnerId,
+        livechat_active: true,
     });
     await start();
     await openDiscuss(channelId);

--- a/addons/im_livechat/static/tests/thread_model_patch.test.js
+++ b/addons/im_livechat/static/tests/thread_model_patch.test.js
@@ -32,6 +32,7 @@ test("Thread name unchanged when inviting new users", async () => {
         ],
         channel_type: "livechat",
         livechat_operator_id: serverState.partnerId,
+        livechat_active: true,
     });
     await start();
     await openDiscuss(channelId);

--- a/addons/im_livechat/static/tests/tours/im_livechat_history_back_and_forth.js
+++ b/addons/im_livechat/static/tests/tours/im_livechat_history_back_and_forth.js
@@ -35,7 +35,7 @@ registry.category("web_tour.tours").add("im_livechat_history_back_and_forth_tour
             run: "click",
         },
         {
-            trigger: ".o-mail-DiscussSidebar-item:contains(Visitor).o-active",
+            trigger: ".o-mail-Discuss-threadName[title='Visitor']",
             run() {
                 history.back();
             },
@@ -47,11 +47,7 @@ registry.category("web_tour.tours").add("im_livechat_history_back_and_forth_tour
             },
         },
         {
-            trigger: ".o-mail-DiscussSidebar-item:contains(Visitor).o-active",
-            run: "click",
-        },
-        {
-            trigger: ".o-mail-DiscussSidebar-item:contains(Visitor).o-active",
+            trigger: ".o-mail-Discuss-threadName[title='Visitor']",
             run() {
                 history.back();
             },

--- a/addons/im_livechat/static/tests/tours/im_livechat_session_history_open.js
+++ b/addons/im_livechat/static/tests/tours/im_livechat_session_history_open.js
@@ -1,0 +1,44 @@
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("im_livechat_session_history_open", {
+    steps: () => [
+        {
+            trigger: "body",
+            run: "press ctrl+k",
+        },
+        {
+            trigger: ".o_command_palette_search input",
+            run: "fill /",
+        },
+        {
+            trigger: ".o_command_palette_search input",
+            run: "fill Sessions",
+        },
+        {
+            trigger: ".o_command:contains(Live Chat / Sessions)",
+            run: "click",
+        },
+        {
+            trigger: ".o_switch_view[data-tooltip='List']",
+            run: "click",
+        },
+        {
+            trigger: ".d-block:contains('Participants')",
+            run: "click",
+        },
+        {
+            trigger: ".o_data_cell:contains('test 1')",
+            run: "click",
+        },
+        {
+            trigger: ".o-mail-Message-content:contains('Test Channel 1 Msg')",
+        },
+        {
+            trigger: ".oi-chevron-right",
+            run: "click",
+        },
+        {
+            trigger: ".o-mail-Message-content:contains('Test Channel 2 Msg')",
+        },
+    ],
+});

--- a/addons/im_livechat/tests/__init__.py
+++ b/addons/im_livechat/tests/__init__.py
@@ -17,3 +17,4 @@ from . import test_upload_attachment
 from . import test_res_users
 from . import test_session_history
 from . import test_user_livechat_username
+from . import test_session_history_open

--- a/addons/im_livechat/tests/test_session_history_open.py
+++ b/addons/im_livechat/tests/test_session_history_open.py
@@ -1,0 +1,31 @@
+from odoo import Command
+from odoo.tests import new_test_user
+from odoo.addons.im_livechat.tests.common import TestImLivechatCommon
+from odoo.tests.common import users, tagged
+
+
+@tagged("-at_install", "post_install")
+class TestImLivechatSessionHistoryOpen(TestImLivechatCommon):
+    @users('admin')
+    def test_session_history_open(self):
+        operator = new_test_user(self.env, login="operator", groups="base.group_user,im_livechat.im_livechat_group_manager")
+        [user_1, user_2] = self.env["res.partner"].create([{"name": "test 1"}, {"name": "test 2"}])
+        [channel1, channel2] = self.env["discuss.channel"].create(
+            [{
+                "name": "test 1",
+                "channel_type": "livechat",
+                "livechat_channel_id": 1,
+                "livechat_operator_id": operator.partner_id.id,
+                "channel_member_ids": [Command.create({"partner_id": user_1.id})],
+            },
+            {
+                "name": "test 2",
+                "channel_type": "livechat",
+                "livechat_channel_id": 1,
+                "livechat_operator_id": operator.partner_id.id,
+                "channel_member_ids": [Command.create({"partner_id": user_2.id})],
+            }]
+        )
+        channel1.message_post(body="Test Channel 1 Msg", message_type="comment", subtype_xmlid="mail.mt_comment")
+        channel2.message_post(body="Test Channel 2 Msg", message_type="comment", subtype_xmlid="mail.mt_comment")
+        self.start_tour("/web", "im_livechat_session_history_open", login="operator", step_delay=25)

--- a/addons/im_livechat/views/discuss_channel_views.xml
+++ b/addons/im_livechat/views/discuss_channel_views.xml
@@ -71,7 +71,7 @@
             <field name="name">discuss.channel.form</field>
             <field name="model">discuss.channel</field>
             <field name="arch" type="xml">
-                <form string="Session Form" create="false" edit="false">
+                <form string="Session Form" create="false" edit="false" js_class="livechat_session_form">
                     <sheet>
                         <div style="width:50%" class="float-end">
                             <field name="rating_last_image" widget="image" class="float-end bg-view" readonly="1" nolabel="1"/>

--- a/addons/mail/static/src/core/public_web/discuss.js
+++ b/addons/mail/static/src/core/public_web/discuss.js
@@ -8,16 +8,7 @@ import { ThreadIcon } from "@mail/core/common/thread_icon";
 import { DiscussSidebar } from "@mail/core/public_web/discuss_sidebar";
 import { useMessageEdition, useMessageHighlight } from "@mail/utils/common/hooks";
 
-import {
-    Component,
-    onMounted,
-    onWillUnmount,
-    useRef,
-    useState,
-    useExternalListener,
-    useEffect,
-    useSubEnv,
-} from "@odoo/owl";
+import { Component, useRef, useState, useExternalListener, useEffect, useSubEnv } from "@odoo/owl";
 import { getActiveHotkey } from "@web/core/hotkeys/hotkey_service";
 
 import { _t } from "@web/core/l10n/translation";
@@ -39,6 +30,7 @@ export class Discuss extends Component {
     };
     static props = {
         hasSidebar: { type: Boolean, optional: true },
+        thread: { optional: true },
     };
     static defaultProps = { hasSidebar: true };
     static template = "mail.Discuss";
@@ -94,8 +86,6 @@ export class Discuss extends Component {
                 () => [this.thread, this.ui.isSmall]
             );
         }
-        onMounted(() => (this.store.discuss.isActive = true));
-        onWillUnmount(() => (this.store.discuss.isActive = false));
         useEffect(
             (memberListAction) => {
                 if (!memberListAction) {
@@ -116,7 +106,7 @@ export class Discuss extends Component {
     }
 
     get thread() {
-        return this.store.discuss.thread;
+        return this.props.thread || this.store.discuss.thread;
     }
 
     async onFileUploaded(file) {

--- a/addons/mail/static/src/core/public_web/discuss_client_action.js
+++ b/addons/mail/static/src/core/public_web/discuss_client_action.js
@@ -1,6 +1,6 @@
 import { Discuss } from "@mail/core/public_web/discuss";
 
-import { Component, onWillStart, onWillUpdateProps } from "@odoo/owl";
+import { Component, onMounted, onWillStart, onWillUnmount, onWillUpdateProps } from "@odoo/owl";
 
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
@@ -30,6 +30,8 @@ export class DiscussClientAction extends Component {
             // bracket to avoid blocking rendering with restore promise
             this.restoreDiscussThread(nextProps);
         });
+        onMounted(() => (this.store.discuss.isActive = true));
+        onWillUnmount(() => (this.store.discuss.isActive = false));
     }
 
     getActiveId(props) {

--- a/addons/mail/static/src/discuss/core/common/channel_member_list.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_member_list.xml
@@ -3,7 +3,7 @@
 
     <t t-name="discuss.ChannelMemberList">
         <ActionPanel title.translate="Members" minWidth="200" initialWidth="250" icon="'fa fa-users'">
-            <button t-on-click="() => props.openChannelInvitePanel({ keepPrevious: env.inChatWindow })" class="btn btn-sm btn-secondary mt-2 d-flex align-items-center justify-content-center gap-1 rounded"><i class="fa fa-user-plus opacity-75"/><span>Invite a User</span></button>
+            <button name="inviteButton" t-on-click="() => props.openChannelInvitePanel({ keepPrevious: env.inChatWindow })" class="btn btn-sm btn-secondary mt-2 d-flex align-items-center justify-content-center gap-1 rounded"><i class="fa fa-user-plus opacity-75"/><span>Invite a User</span></button>
             <t t-if="props.thread.onlineMembers.length > 0">
                 <t t-call="discuss.ChannelMemberList.section">
                     <t t-set="sectionName" t-value="onlineSectionText"/>


### PR DESCRIPTION
**Current behavior before PR:**

Since v17, we open all the livechat sessions in Discuss, which is better in terms of UX, but doesn't allow you to switch from one session to another, as we only open the selected one.

**Desired behavior after PR is merged:**

This commit improve this when in livechat a session is opened from the session history, it is now open with pager to navigate back and forth with the use of form renderer.

Task-3764236

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
