### PR TITLE
[FIX] web: hide label in percentpie widget

### DIFF
--- a/addons/web/static/src/views/fields/percent_pie/percent_pie_field.scss
+++ b/addons/web/static/src/views/fields/percent_pie/percent_pie_field.scss
@@ -8,3 +8,11 @@
         margin-right: var(--PercentPieField-gap, #{map-get($spacers, 2) });
     }
 }
+
+.o_field_percent_pie .o_pie_text {
+    display: none;
+}
+
+.oe_stat_button .o_field_percent_pie .o_pie_text {
+    display: block;
+}

--- a/addons/web/static/tests/views/fields/percent_pie_field_tests.js
+++ b/addons/web/static/tests/views/fields/percent_pie_field_tests.js
@@ -155,4 +155,52 @@ QUnit.module("Fields", (hooks) => {
             "pie should have a background computed for its value of 33.3333%"
         );
     });
+
+    QUnit.test(
+        "hide the string when the PercentPieField widget is used in the view",
+        async function (assert) {
+            await makeView({
+                serverData,
+                type: "form",
+                resModel: "partner",
+                arch: `
+                    <form>
+                        <sheet>
+                            <group>
+                                <field name="int_field" widget="percentpie"/>
+                            </group>
+                        </sheet>
+                    </form>`,
+                resId: 2,
+            });
+            assert.containsOnce(target, ".o_field_percent_pie.o_field_widget .o_pie");
+            assert.isNotVisible(
+                target.querySelector(".o_field_percent_pie.o_field_widget .o_pie_info .o_pie_text")
+            );
+        }
+    );
+
+    QUnit.test(
+        "show the string when the PercentPieField widget is used in a button with the class oe_stat_button",
+        async function (assert) {
+            await makeView({
+                serverData,
+                type: "form",
+                resModel: "partner",
+                arch: `
+                    <form>
+                        <div name="button_box" class="oe_button_box">
+                            <button type="object" class="oe_stat_button">
+                                <field name="int_field" widget="percentpie"/>
+                            </button>
+                        </div>
+                    </form>`,
+                resId: 2,
+            });
+            assert.containsOnce(target, ".o_field_percent_pie.o_field_widget .o_pie");
+            assert.isVisible(
+                target.querySelector(".o_field_percent_pie.o_field_widget .o_pie_info .o_pie_text")
+            );
+        }
+    );
 });


### PR DESCRIPTION
Specification:
when creating a widget percentpie with Studio, the field's name has been added after percent pie, which is not user-friendly.


![image](https://github.com/odoo/odoo/assets/120459800/be0d6197-a386-4016-a6d4-015a6c1bf20d)


Expected behavior:
The duplicate label should not be visible.

Task-3942207
