### PR TITLE
[FIX] purchase: Apply decimal precision on mobile PO lines

### DIFF
--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -346,7 +346,7 @@
                                                          <div class="col-12 text-muted">
                                                              <span>
                                                                  Unit Price:
-                                                                 <t t-esc="record.price_unit.value"/>
+                                                                 <field name="price_unit"/>
                                                              </span>
                                                          </div>
                                                      </div>


### PR DESCRIPTION
Steps to reproduce the issue:
- Debug mode > Settings > Technical > Decimal Precision > Product Price
- Set to another number
- Purchase > Any Purchase order
- Mobile view, puchased item has a decimal precision of 2

Why is this a bug:
Kanban view is the only one to disregard Product Price Precision setting

What this fix does:
Update the display with correct decimal precision

opw-3984082

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
