### PR TITLE
[FIX] mrp: 'quantity received' field in generate lot number dialog

### DIFF
--- a/addons/mrp/views/stock_move_views.xml
+++ b/addons/mrp/views/stock_move_views.xml
@@ -14,6 +14,9 @@
             <field name="mode">primary</field>
             <field name="inherit_id" ref="stock.view_stock_move_operations" />
             <field name="arch" type="xml">
+                <xpath expr="//field[@name='show_lots_m2o']" position="after">
+                    <field name="quantity" invisible="1"/>
+                </xpath>
                 <xpath expr="//label[@for='product_uom_qty']" position="attributes">
 		            <attribute name="string">Total To Consume</attribute>
                 </xpath>


### PR DESCRIPTION
Issue:
============================
There is an 'undefined' value for the 'Quantity Received' field in the generate 
lot number dialog. When attempting to generate a lot number for a component 
from the shop floor, the 'Quantity Received' field displays as 'undefined', 
leading to an error.

Steps to Reproduce:
============================
1. Install the 'mrp_workorder' module.
2. Create a Bill of Materials (BoM) in the Manufacturing module with 
   manual consumption components tracked by lot.
3. Create a Manufacturing Order (MO) for the product.
4. Open the 'detailed operation' wizard for a component with lot tracking in the
   shop floor module.
5. Click on 'Generate Serials/Lots'.
6. Verify that the Quantity Received field displays the 'undefined' value.

Resolution:
============================
Currently, the "quantity received" field displays 'undefined', causing an error 
when generating a lot number for a component. This issue occurred due to not 
getting a quantity field in the shop floor module. Added the "quantity" field to
the relevant view to ensure that the "quantity received" field gets an actual 
quantity field value, preventing the error.

Expected Result:
=============================
This fix resolves the error and allows for efficient lot number generation of 
products in the shop floor module.
