### PR TITLE
[IMP] point_of_sale: remove useless line in session report

### DIFF
--- a/addons/point_of_sale/views/report_saledetails.xml
+++ b/addons/point_of_sale/views/report_saledetails.xml
@@ -310,7 +310,6 @@
                     <h5>Discounts:</h5>
                     <div class="row">
                         <div class="col-12">
-                            <strong>Number of discounts</strong>:
                             <strong>Number of discounts</strong>: <span t-out="discount_number">5</span>
                         </div>
                     </div>


### PR DESCRIPTION
Before this commit, the session report was displaying a useless line "Number of discount". It was useless as it was a duplicate. This commit removes it.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
