### PR TITLE
[FIX] bus: reduce concurrency when fetching notifications

### DIFF
--- a/addons/bus/websocket.py
+++ b/addons/bus/websocket.py
@@ -12,7 +12,7 @@ import selectors
 import threading
 import time
 from collections import defaultdict, deque
-from contextlib import closing, suppress
+from contextlib import contextmanager, suppress
 from enum import IntEnum
 from psycopg2.pool import PoolError
 from urllib.parse import urlparse
@@ -35,16 +35,24 @@ _logger = logging.getLogger(__name__)
 
 
 MAX_TRY_ON_POOL_ERROR = 10
-DELAY_ON_POOL_ERROR = 0.03
+DELAY_ON_POOL_ERROR = 0.2
+# Keep 10% of the cursors to handle connection requests, rest can be used to
+# fetch notifications/process incoming messages.
+WS_CURSORS_COUNT = int(int(config.get("db_maxconn_gevent") or config["db_maxconn"]) * 0.9)
+WS_CURSORS_SEM = threading.Semaphore(WS_CURSORS_COUNT)
 
 
+@contextmanager
 def acquire_cursor(db):
     """ Try to acquire a cursor up to `MAX_TRY_ON_POOL_ERROR` """
-    for tryno in range(1, MAX_TRY_ON_POOL_ERROR + 1):
-        with suppress(PoolError):
-            return odoo.registry(db).cursor()
-        time.sleep(random.uniform(DELAY_ON_POOL_ERROR, DELAY_ON_POOL_ERROR * tryno))
-    raise PoolError('Failed to acquire cursor after %s retries' % MAX_TRY_ON_POOL_ERROR)
+    with WS_CURSORS_SEM:
+        for tryno in range(1, MAX_TRY_ON_POOL_ERROR + 1):
+            with suppress(PoolError), odoo.registry(db).cursor() as cursor:
+                yield cursor
+                return
+            time.sleep(random.uniform(DELAY_ON_POOL_ERROR, DELAY_ON_POOL_ERROR * tryno))
+        raise PoolError('Failed to acquire cursor after %s retries' % MAX_TRY_ON_POOL_ERROR)
+
 
 
 # ------------------------------------------------------
@@ -272,12 +280,12 @@ class Websocket:
                 if not readables:
                     self._send_ping_frame()
                     continue
-                if self.__notif_sock_r in readables:
-                    self._dispatch_bus_notifications()
                 if self.__socket in readables:
                     message = self._process_next_message()
                     if message is not None:
                         yield message
+                if self.__notif_sock_r in readables:
+                    self._dispatch_bus_notifications()
             except Exception as exc:
                 self._handle_transport_error(exc)
 
@@ -602,7 +610,7 @@ class Websocket:
         """
         if not self.__event_callbacks[event_type]:
             return
-        with closing(acquire_cursor(self._db)) as cr:
+        with acquire_cursor(self._db) as cr:
             env = api.Environment(cr, self._session.uid, self._session.context)
             for callback in self.__event_callbacks[event_type]:
                 try:
@@ -751,7 +759,7 @@ class WebsocketRequest:
         ) as exc:
             raise InvalidDatabaseException() from exc
 
-        with closing(acquire_cursor(self.db)) as cr:
+        with acquire_cursor(self.db) as cr:
             self.env = api.Environment(cr, self.session.uid, self.session.context)
             threading.current_thread().uid = self.env.uid
             service_model.retrying(


### PR DESCRIPTION
When no cursor is available to fetch bus notifications, websockets retry up to 10 times to acquire one. However, the delay between each attempt is too short, resulting in minimal chance of recovery when the connection pool is full.

This PR focuses on several points to ease recovery:
- introduces a semaphore to reduce the likelihood of reaching this state and increases the delay between each retry to allow the system to cool down.
- keep 10% of the available cursors to handle incoming connection requests.
- process incoming messages first to ensure responses to control frames are sent first.