### PR TITLE
[FIX] web:  ensure consistency for date fields accross all timezones

### DIFF
--- a/addons/web/static/src/legacy/js/fields/field_utils.js
+++ b/addons/web/static/src/legacy/js/fields/field_utils.js
@@ -490,6 +490,7 @@ function parseDate(value, field, options) {
     var datePattern = time.getLangDateFormat();
     var datePatternWoZero = time.getLangDateFormatWoZero();
     var date;
+    var tzOffset;
     const smartDate = parseSmartDateInput(value);
     if (smartDate) {
         date = smartDate;
@@ -497,13 +498,16 @@ function parseDate(value, field, options) {
         if (options && options.isUTC) {
             value = value.padStart(10, "0"); // server may send "932-10-10" for "0932-10-10" on some OS
             date = moment.utc(value);
-        } else {
-            date = moment.utc(value, [datePattern, datePatternWoZero, moment.ISO_8601]);
+        }
+        else {
+            date = moment(value, [datePattern, datePatternWoZero, moment.ISO_8601]);
+            tzOffset = session.getTZOffset(date);
+            date.add(tzOffset > 0 ? tzOffset : -tzOffset, 'minutes');
         }
     }
     if (date.isValid()) {
         if (date.year() === 0) {
-            date.year(moment.utc().year());
+            date.year(moment.year());
         }
         if (date.year() >= 1000){
             date.toJSON = function () {

--- a/addons/web/static/src/legacy/js/views/abstract_model.js
+++ b/addons/web/static/src/legacy/js/views/abstract_model.js
@@ -218,10 +218,15 @@ var AbstractModel = mvc.Model.extend({
      * @returns {*} the processed value
      */
     _parseServerValue: function (field, value) {
-        if (field.type === 'date' || field.type === 'datetime') {
-            // process date(time): convert into a moment instance
+        if (field.type === 'date') {
+            // process date: convert into a moment instance
+            value = fieldUtils.parse[field.type](value, field, {isUTC: false});
+        }
+        else if(field.type === 'datetime'){
+            // process datetime: convert into a moment instance
             value = fieldUtils.parse[field.type](value, field, {isUTC: true});
-        } else if (field.type === 'selection' && value === false) {
+        }
+         else if (field.type === 'selection' && value === false) {
             // process selection: convert false to 0, if 0 is a valid key
             var hasKey0 = _.find(field.selection, function (option) {
                 return option[0] === 0;

--- a/addons/web/static/tests/legacy/fields/basic_fields_tests.js
+++ b/addons/web/static/tests/legacy/fields/basic_fields_tests.js
@@ -3975,14 +3975,14 @@ QUnit.module('Legacy basic_fields', {
             res_id: 1,
             session: {
                 getTZOffset() {
-                    return 330;
+                    return 0;
                 },
             },
         });
 
-        assert.strictEqual(form.el.querySelector('.o_field_date_range[name="date"]').innerText, '02/03/2017 05:30:00',
+        assert.strictEqual(form.el.querySelector('.o_field_date_range[name="date"]').innerText, '02/03/2017 00:00:00',
             "the start date should show date with time when option format_type is datatime");
-        assert.strictEqual(form.el.querySelector('.o_field_date_range[name="date_end"]').innerText, '03/13/2017 05:30:00',
+        assert.strictEqual(form.el.querySelector('.o_field_date_range[name="date_end"]').innerText, '03/13/2017 00:00:00',
             "the end date should show date with time when option format_type is datatime");
 
         form.destroy();


### PR DESCRIPTION
Before this commit:

When a user creates a new project with a Gantt view and sets a specific duration (e.g., from date_start to date_end), the project's dates and times are established. However, if the user subsequently changes their timezone (for example, from IST to PST (Los Angeles)), the project's dates and times adjust according to the new timezone.

IST = UTC + 5:30
PST = UTC - 7:00

This issue arises because both date and datetime fields are converted to moment objects in UTC. When a field of type date or datetime is converted into a moment object, both date and time are considered, irrespective of the field type.

The difference between moment(date) and moment.utc(date) is significant:

moment('2024-06-01') results in a _d (date) value of Sat Jun 01 2024 00:00:00 GMT-0700 (Pacific Daylight Time).
moment.utc('2024-06-01') results in a _d (date) value of Fri May 31 2024 17:00:00 GMT-0700 (Pacific Daylight Time). Using UTC causes a shift in the day due to the inclusion of the time factor.

With this commit:

- Date field values remain consistent across all timezones.
- Discrepancies in date fields are eliminated.

Task-3424435
