### PR TITLE
[FIX] auth_password_policy: Fixing translation mapping

### DIFF
--- a/addons/auth_password_policy/models/res_users.py
+++ b/addons/auth_password_policy/models/res_users.py
@@ -27,7 +27,7 @@ class ResUsers(models.Model):
             if not password:
                 continue
             if len(password) < minlength:
-                failures.append(_("Your password must contain at least %(minimal_length)d characters and only has %(current_count)d.", minlength, len(password)))
+                failures.append(_("Your password must contain at least %(minimal_length)d characters and only has %(current_count)d.", minimal_length=minlength, current_count=len(password)))
 
         if failures:
             raise UserError(u'\n\n '.join(failures))


### PR DESCRIPTION
The bug was introduced in https://github.com/odoo/odoo/pull/160182

Before this commit, when we try to change password, we have the following traceback

 File "/data/build/odoo/addons/auth_password_policy/models/res_users.py", line 17, in _set_password
    self._check_password_policy(self.mapped('password'))
  File "/data/build/odoo/addons/auth_password_policy/models/res_users.py", line 30, in _check_password_policy
    failures.append(_("Your password must contain at least %(minimal_length)d characters and only has %(current_count)d.", minlength, len(password)))
  File "/data/build/odoo/odoo/tools/translate.py", line 518, in __call__
    translation = source % (args or kwargs)
TypeError: format requires a mapping

This commit fixed the translation mapping.

task-4035890

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
