### PR TITLE
[FIX] stock: fix put in pack several move lines with different picking

### DIFF
--- a/addons/stock/i18n/stock.pot
+++ b/addons/stock/i18n/stock.pot
@@ -10124,6 +10124,16 @@ msgstr ""
 
 #. module: stock
 #. odoo-python
+#: code:addons/stock/models/stock_move_line.py:0
+#, python-format
+msgid ""
+"You cannot directly pack quantities from different transfers into the same "
+"package through this view. Try adding them to a batch picking and pack it "
+"there."
+msgstr ""
+
+#. module: stock
+#. odoo-python
 #: code:addons/stock/models/stock_quant.py:0
 #, python-format
 msgid "You cannot modify inventory loss quantity"

--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -921,9 +921,9 @@ class StockMoveLine(models.Model):
         }
 
     def action_put_in_pack(self):
-        for picking in self.picking_id:
-            picking.with_context(move_lines_to_pack_ids=self.ids).action_put_in_pack()
-        return True
+        if len(self.picking_id) > 1:
+            raise UserError(_("You cannot directly pack quantities from different transfers into the same package through this view. Try adding them to a batch picking and pack it there."))
+        return self.picking_id.with_context(move_lines_to_pack_ids=self.ids).action_put_in_pack()
 
     def _get_revert_inventory_move_values(self):
         self.ensure_one()

--- a/addons/stock/tests/test_move_lines.py
+++ b/addons/stock/tests/test_move_lines.py
@@ -3,6 +3,7 @@
 
 from odoo.addons.stock.tests.common import TestStockCommon
 from odoo.tests import Form
+from odoo.exceptions import UserError
 
 
 class StockMoveLine(TestStockCommon):
@@ -133,3 +134,27 @@ class StockMoveLine(TestStockCommon):
             delta=1e-6,
             msg="Small line quantity should get detected",
         )
+
+    def test_put_in_pack_with_several_move_lines(self):
+        """
+        Testing putting several move lines with different pickings into a pack should trigger a ValueError.
+        """
+        picking1 = self.env['stock.picking'].create({
+            'name': 'Picking 1',
+            'location_id': self.env.ref('stock.stock_location_stock').id,
+            'location_dest_id': self.env.ref('stock.stock_location_customers').id,
+            'picking_type_id': self.env.ref('stock.picking_type_out').id,
+        })
+        picking2 = picking1.copy({'name': 'picking 2'})
+        move_line1 = self.env['stock.move.line'].create({
+            'picking_id': picking1.id,
+            'product_id': self.productA.id,
+            'quantity': 1,
+        })
+        move_line2 = self.env['stock.move.line'].create({
+            'picking_id': picking2.id,
+            'product_id': self.productA.id,
+            'quantity': 1,
+        })
+        with self.assertRaises(UserError):
+            (move_line1 | move_line2).action_put_in_pack()


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a storable product “P1”
- Create a delivery for P1
- Click on “Detailed operation” smart button
- select the move line
- click on “put in pack”

Problem:
Nothing happens because the `put_in_pack` function of the 'stock.move.line' model always returns true after calling the same function of the 'stock.picking' model instead of returning the result.

Note that this function cannot handle multiple move lines with different pickings.

opw-4029393
