### PR TITLE
[FIX] hr_attendance: Make RPC user_attendance_data lighter

### DIFF
--- a/addons/hr_attendance/controllers/main.py
+++ b/addons/hr_attendance/controllers/main.py
@@ -15,19 +15,29 @@ class HrAttendance(http.Controller):
         return company
 
     @staticmethod
-    def _get_employee_info_response(employee):
+    def _get_user_attendance_data(employee):
         response = {}
         if employee:
             response = {
                 'id': employee.id,
-                'employee_name': employee.name,
-                'employee_avatar': employee.image_256,
                 'hours_today': float_round(employee.hours_today, precision_digits=2),
-                'total_overtime': float_round(employee.total_overtime, precision_digits=2),
+                'hours_previously_today': float_round(employee.hours_previously_today, precision_digits=2),
                 'last_attendance_worked_hours': float_round(employee.last_attendance_worked_hours, precision_digits=2),
                 'last_check_in': employee.last_check_in,
                 'attendance_state': employee.attendance_state,
-                'hours_previously_today': float_round(employee.hours_previously_today, precision_digits=2),
+                'display_systray': employee.company_id.attendance_from_systray,
+            }
+        return response
+
+    @staticmethod
+    def _get_employee_info_response(employee):
+        response = {}
+        if employee:
+            response = {
+                **HrAttendance._get_user_attendance_data(employee),
+                'employee_name': employee.name,
+                'employee_avatar': employee.image_256,
+                'total_overtime': float_round(employee.total_overtime, precision_digits=2),
                 'kiosk_delay': employee.company_id.attendance_kiosk_delay * 1000,
                 'attendance': {'check_in': employee.last_attendance_id.check_in,
                                'check_out': employee.last_attendance_id.check_out},
@@ -35,7 +45,6 @@ class HrAttendance(http.Controller):
                     ('employee_id', '=', employee.id), ('date', '=', datetime.date.today()),
                     ('adjustment', '=', False)]).duration or 0,
                 'use_pin': employee.company_id.attendance_kiosk_use_pin,
-                'display_systray': employee.company_id.attendance_from_systray,
                 'display_overtime': employee.company_id.hr_attendance_display_overtime
             }
         return response
@@ -158,4 +167,4 @@ class HrAttendance(http.Controller):
     @http.route('/hr_attendance/attendance_user_data', type="json", auth="user")
     def user_attendance_data(self):
         employee = request.env.user.employee_id
-        return self._get_employee_info_response(employee)
+        return self._get_user_attendance_data(employee)


### PR DESCRIPTION
Unecessary info is fetched with the route hr_attendance/attendance_user_data such as employee avatar and other kiosk related data which is not necessary for the systray.

task-4036988