### PR TITLE
[FIX] web_editor: prevent text overflow in banner

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/utils.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/utils.test.js
@@ -1850,7 +1850,7 @@ describe('Utils', () => {
                 contentBefore: unformat(`
                     <div class="o_editor_banner o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" data-oe-protected="true" contenteditable="false">
                         <i class="fs-4 fa fa-info-circle mb-3" aria-label="Banner Info"></i>
-                        <div class="w-100 ms-3" data-oe-protected="false" contenteditable="true">
+                        <div class="w-100 px-3" data-oe-protected="false" contenteditable="true">
                             <p>abc</p>
                             <p>def</p>
                         </div>
@@ -1870,7 +1870,7 @@ describe('Utils', () => {
                 contentAfter: unformat(`
                     <div class="o_editor_banner o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" data-oe-protected="true" contenteditable="false">
                         <i class="fs-4 fa fa-info-circle mb-3" aria-label="Banner Info"></i>
-                        <div class="w-100 ms-3" data-oe-protected="false" contenteditable="true">
+                        <div class="w-100 px-3" data-oe-protected="false" contenteditable="true">
                             <p>abc</p>
                             <p>def</p>
                         </div>

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -2353,7 +2353,7 @@ export class Wysiwyg extends Component {
                 const bannerElement = parseHTML(this.odooEditor.document, `
                     <div class="o_editor_banner o_not_editable lh-1 d-flex align-items-center alert alert-${alertClass} pb-0 pt-3" role="status" data-oe-protected="true">
                         <i class="fs-4 fa ${iconClass} mb-3" aria-label="${_t(title)}"></i>
-                        <div class="w-100 ms-3" data-oe-protected="false">
+                        <div class="w-100 px-3" data-oe-protected="false">
                             <p><br></p>
                         </div>
                     </div>

--- a/addons/web_editor/static/tests/banner_tests.js
+++ b/addons/web_editor/static/tests/banner_tests.js
@@ -75,7 +75,7 @@ QUnit.module(
                 editable.innerHTML,
                 `<p>Test</p><div class="o_editor_banner o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" data-oe-protected="true" contenteditable="false">
                         <i class="fs-4 fa fa-info-circle mb-3" aria-label="Banner Info"></i>
-                        <div class="w-100 ms-3" data-oe-protected="false" contenteditable="true">
+                        <div class="w-100 px-3" data-oe-protected="false" contenteditable="true">
                             <p placeholder=\"Type &quot;/&quot; for commands\" class=\"oe-hint oe-command-temporary-hint\"><br></p>
                         </div>
                     </div><p><br></p>`,
@@ -94,7 +94,7 @@ QUnit.module(
                 editable.innerHTML,
                 `<p>Test</p><div class="o_editor_banner o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" data-oe-protected="true" contenteditable="false">
                         <i class="fs-4 fa fa-info-circle mb-3" aria-label="Banner Info"></i>
-                        <div class="w-100 ms-3" data-oe-protected="false" contenteditable="true">
+                        <div class="w-100 px-3" data-oe-protected="false" contenteditable="true">
                             <p placeholder=\"Type &quot;/&quot; for commands\" class=\"oe-hint oe-command-temporary-hint\"><br></p>
                         </div>
                     </div><p><br></p>`,
@@ -122,7 +122,7 @@ QUnit.module(
                 editable.innerHTML,
                 `<p>Test</p><div class="o_editor_banner o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" data-oe-protected="true" contenteditable="false">
                         <i class="fs-4 fa fa-info-circle mb-3" aria-label="Banner Info"></i>
-                        <div class="w-100 ms-3" data-oe-protected="false" contenteditable="true">
+                        <div class="w-100 px-3" data-oe-protected="false" contenteditable="true">
                             <p placeholder=\"Type &quot;/&quot; for commands\" class=\"oe-hint oe-command-temporary-hint\"><br></p></div>
                     </div><p><br></p>`,
             );


### PR DESCRIPTION
**Current behavior before PR:**

Long texts overflowed beyond the banner's boundaries.

**Desired behavior after PR is merged:**

Ensure that text remains within the banner's limits to improve readability and visual consistency.

task-4037185

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
