### PR TITLE
[IMP] mail: remove unnecessary temporary_id

### DIFF
--- a/addons/mail/controllers/thread.py
+++ b/addons/mail/controllers/thread.py
@@ -111,8 +111,6 @@ class ThreadController(http.Controller):
         message_data = thread.message_post(
             **{key: value for key, value in post_data.items() if key in self._get_allowed_message_post_params()}
         )._message_format(for_current_user=True)[0]
-        if "temporary_id" in request.context:
-            message_data["temporary_id"] = request.context["temporary_id"]
         return message_data
 
     @http.route("/mail/message/update_content", methods=["POST"], type="json", auth="public")

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -154,8 +154,6 @@ export class Message extends Record {
     translationErrors;
     /** @type {string} */
     message_type;
-    /** @type {string} */
-    temporary_id = null;
     /** @type {string|undefined} */
     notificationType;
     /** @type {luxon.DateTime} */

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -1063,7 +1063,6 @@ export class Thread extends Record {
                     body: prettyContent,
                     isPending: true,
                     thread: this,
-                    temporary_id: tmpId,
                 },
                 { html: true }
             );
@@ -1077,9 +1076,6 @@ export class Thread extends Record {
         const data = await this.store.doMessagePost(params, tmpMsg);
         if (!data) {
             return;
-        }
-        if (data.id in this.store.Message.records) {
-            data.temporary_id = null;
         }
         const message = this.store.Message.insert(data, { html: true });
         this.addOrReplaceMessage(message, tmpMsg);

--- a/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
@@ -165,7 +165,7 @@ export class DiscussCoreCommon {
             return;
         }
         const temporaryId = messageData.temporary_id;
-        messageData.temporary_id = null;
+        delete messageData.temporary_id;
         const message = this.store.Message.insert(messageData, { html: true });
         if (message.notIn(channel.messages)) {
             if (!channel.loadNewer) {

--- a/addons/mail/static/tests/legacy/helpers/mock_server/models/mail_thread.js
+++ b/addons/mail/static/tests/legacy/helpers/mock_server/models/mail_thread.js
@@ -243,9 +243,7 @@ patch(MockServer.prototype, {
             });
         }
         this._mockMailThread_NotifyThread(model, ids, messageId, context?.temporary_id);
-        return Object.assign(this._mockMailMessageMessageFormat([messageId])[0], {
-            temporary_id: context?.temporary_id,
-        });
+        return Object.assign(this._mockMailMessageMessageFormat([messageId])[0]);
     },
     /**
      * Simulates `message_subscribe` on `mail.thread`.

--- a/addons/mail/static/tests/mock_server/mock_models/mail_thread.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_thread.js
@@ -154,10 +154,7 @@ export class MailThread extends models.ServerModel {
             });
         }
         MailThread._notify_thread.call(this, ids, messageId, kwargs.context?.temporary_id);
-        return {
-            ...MailMessage._message_format([messageId], true)[0],
-            temporary_id: kwargs.context?.temporary_id,
-        };
+        return { ...MailMessage._message_format([messageId], true)[0] };
     }
 
     /**


### PR DESCRIPTION
In the flow of message post, the temporary message is locally known so it doesn't need to be received from the server, neither does it need to be stored on a message field.

The temporary_id is now only used when receiving the bus notification before the return of the RPC, and its handling is local to the handler by finding the corresponding message id.

Part of task-3605717