### PR TITLE
[IMP] point_of_sale: mobile: move dialog buttons to the left

### DIFF
--- a/addons/point_of_sale/static/src/app/navbar/cash_move_popup/cash_move_popup.xml
+++ b/addons/point_of_sale/static/src/app/navbar/cash_move_popup/cash_move_popup.xml
@@ -24,14 +24,16 @@
                 <label for="reason">Reason</label>
             </div>
             <t t-set-slot="footer">
-                <button class="button confirm btn btn-lg btn-primary"
-                    t-on-click="confirm"
-                    t-att-disabled="!env.utils.isValidFloat(state.amount)">
-                    Confirm <span t-esc="format(state.amount)"/>
-                </button>
-                <button class="button cancel btn btn-lg btn-secondary" t-on-click="props.close">
-                    Discard
-                </button>
+                <div class="d-flex w-100 justify-content-start gap-2">
+                    <button class="button confirm btn btn-lg btn-primary"
+                        t-on-click="confirm"
+                        t-att-disabled="!env.utils.isValidFloat(state.amount)">
+                        Confirm <span t-esc="format(state.amount)"/>
+                    </button>
+                    <button class="button cancel btn btn-lg btn-secondary" t-on-click="props.close">
+                        Discard
+                    </button>
+                </div>
             </t>
         </Dialog>
     </t>

--- a/addons/point_of_sale/static/src/app/navbar/closing_popup/closing_popup.xml
+++ b/addons/point_of_sale/static/src/app/navbar/closing_popup/closing_popup.xml
@@ -99,7 +99,7 @@
                     <button class="button btn btn-lg btn-secondary" t-att-disabled="!canCancel()" t-on-click="cancel">Discard</button>
                 </div>
                 <!-- Download Sale Details -->
-                <div class="modal-footer-right d-flex gap-2 ms-auto">
+                <div class="modal-footer-right d-flex gap-2 ms-sm-auto">
                     <button class="button icon btn btn-lg btn-secondary"
                         t-on-click="downloadSalesReport"
                         title="Download a report with all the sales of the current PoS Session">

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_info_popup/product_info_popup.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_info_popup/product_info_popup.xml
@@ -127,8 +127,10 @@
                 </div>
             </div>
             <t t-set-slot="footer">
-                <button class="btn btn-primary" t-on-click="props.close">Ok</button>
-                <button class="btn btn-secondary" t-on-click="editProduct">Edit</button>
+                <div class="d-flex w-100 justify-content-start gap-2">
+                    <button class="btn btn-primary" t-on-click="props.close">Ok</button>
+                    <button class="btn btn-secondary" t-on-click="editProduct">Edit</button>
+                </div>
             </t>
         </Dialog>
     </t>

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.xml
@@ -28,7 +28,7 @@
                                     </div>
                                 </div>
                                 <div t-att-class="{'mt-1': this.ui.isSmall}" class="gap-1 d-flex sending-receipt-management justify-content-center">
-                                    <button t-att-class="{'opacity-50': state.mode !== 'email', 'py-3': this.ui.isSmall, 'px-5': !this.ui.isSmall}" t-on-click="() => this.changeMode('email')" class="btn btn-primary d-flex align-items-center justify-content-center" >
+                                    <button t-att-class="{'opacity-50': state.mode !== 'email', 'py-3': this.ui.isSmall, 'px-5': !this.ui.isSmall}" t-on-click="() => this.changeMode('email')" class="btn btn-primary flex-grow-1 d-flex align-items-center justify-content-center" >
                                         <i t-attf-class="fa {{sendReceipt.status === 'loading' and sendReceipt.lastArgs?.[0]?.name === 'Email' ?  'fa-fw fa-spin fa-circle-o-notch' : 'fa-envelope'}}" aria-hidden="true" />
                                     </button>
                                 </div>
@@ -58,7 +58,7 @@
                         </div>
                     </div>
                 </div>
-                <div  id="action_btn_mobile" t-if="ui.isSmall" class="switchpane d-flex h-12">
+                <div  id="action_btn_mobile" t-if="ui.isSmall" class="switchpane d-flex h-12 gap-1">
                     <div class="btn-switchpane validation-button btn btn-primary flex-fill d-flex justify-content-center align-items-center rounded-0 fw-bolder fs-1" t-att-class="{ highlight: !locked }" t-if="!splittedOrder" t-on-click="orderDone" name="done">
                                 New Order
                     </div>

--- a/addons/point_of_sale/static/src/app/store/combo_configurator_popup/combo_configurator_popup.xml
+++ b/addons/point_of_sale/static/src/app/store/combo_configurator_popup/combo_configurator_popup.xml
@@ -27,15 +27,17 @@
                 </div>
             </div>
             <t t-set-slot="footer">
-                <button class="confirm btn btn-lg btn-primary"
-                    t-att-disabled="!areAllCombosSelected()" t-on-click="confirm">
-                    Add to order
-                </button>
-                <div class="ms-auto">
-                    <!-- TODO: Restore the feature the shows the price of the selection. -->
-                    <t t-if="!areAllCombosSelected">
-                        Complete the selection to proceed
-                    </t>
+                <div class="d-flex w-100 justify-content-start gap-2">
+                    <button class="confirm btn btn-lg btn-primary"
+                        t-att-disabled="!areAllCombosSelected()" t-on-click="confirm">
+                        Add to order
+                    </button>
+                    <div class="ms-auto">
+                        <!-- TODO: Restore the feature the shows the price of the selection. -->
+                        <t t-if="!areAllCombosSelected">
+                            Complete the selection to proceed
+                        </t>
+                    </div>
                 </div>
             </t>
         </Dialog>

--- a/addons/point_of_sale/static/src/app/store/product_configurator_popup/product_configurator_popup.xml
+++ b/addons/point_of_sale/static/src/app/store/product_configurator_popup/product_configurator_popup.xml
@@ -131,7 +131,9 @@
                 <MultiProductAttribute t-elif="attribute.display_type === 'multi'" attributeLine="attributeLine"/>
             </div>
             <t t-set-slot="footer">
-                <button class="btn btn-primary o-default-button" t-on-click="confirm">Ok</button>
+                <div class="d-flex w-100 justify-content-start gap-2">
+                    <button class="btn btn-primary o-default-button" t-on-click="confirm">Ok</button>
+                </div>
             </t>
         </Dialog>
     </t>

--- a/addons/point_of_sale/static/src/app/utils/input_popups/text_input_popup.xml
+++ b/addons/point_of_sale/static/src/app/utils/input_popups/text_input_popup.xml
@@ -10,8 +10,10 @@
             </t>
             <textarea t-att-rows="props.rows" class="form-control form-control-lg mx-auto" type="text" t-model="state.inputValue" t-ref="input" t-att-placeholder="props.placeholder" t-on-keydown="onKeydown" />
             <t t-set-slot="footer">
-                <button class="btn btn-primary o-default-button" t-on-click="confirm">Apply</button>
-                <button class="btn btn-secondary o-default-button" t-on-click="close">Discard</button>
+                <div class="d-flex w-100 justify-content-start gap-2">
+                    <button class="btn btn-primary o-default-button" t-on-click="confirm">Apply</button>
+                    <button class="btn btn-secondary o-default-button" t-on-click="close">Discard</button>
+                </div>
             </t>
         </Dialog>
     </t>

--- a/addons/pos_restaurant/static/src/app/bill_screen/bill_screen.xml
+++ b/addons/pos_restaurant/static/src/app/bill_screen/bill_screen.xml
@@ -6,9 +6,11 @@
                 <OrderReceipt data="{...pos.orderExportForPrinting(pos.get_order()), isBill: true}" formatCurrency="env.utils.formatCurrency" />
             </div>
             <t t-set-slot="footer">
-                <div class="button print btn btn-lg btn-primary" t-on-click="print">
-                    <i t-attf-class="fa {{printer.state.isPrinting ? 'fa-fw fa-spin fa-circle-o-notch' : 'fa-print'}} me-1" />
-                    Print
+                <div class="d-flex w-100 justify-content-start gap-2">
+                    <div class="button print btn btn-lg btn-primary" t-on-click="print">
+                        <i t-attf-class="fa {{printer.state.isPrinting ? 'fa-fw fa-spin fa-circle-o-notch' : 'fa-print'}} me-1" />
+                        Print
+                    </div>
                 </div>
             </t>
         </Dialog>


### PR DESCRIPTION
Additionally:
- We remove excessive spaces in the customer list.
- Put a gap between "New Order" and "Resume Order" buttons in the receipt screen.

Task id : 3964834
