### PR TITLE
[FIX] {test_}mail: allow filtering on falsy activity_user_id

### DIFF
--- a/addons/mail/models/mail_activity_mixin.py
+++ b/addons/mail/models/mail_activity_mixin.py
@@ -211,6 +211,8 @@ class MailActivityMixin(models.AbstractModel):
 
     @api.model
     def _search_activity_user_id(self, operator, operand):
+        if isinstance(operand, bool) and ((operator == '=' and not operand) or (operator == '!=' and operand)):
+            return [('activity_ids', '=', False)]
         return [('activity_ids', 'any', [('active', 'in', [True, False]), ('user_id', operator, operand)])]
 
     @api.model

--- a/addons/test_mail/tests/test_mail_activity.py
+++ b/addons/test_mail/tests/test_mail_activity.py
@@ -578,6 +578,22 @@ class TestActivityMixin(TestActivityCommon):
             self.assertEqual(activity_2.state, 'overdue')
             self.assertEqual(activity_3.state, 'today')
 
+    @users('employee')
+    def test_mail_activity_mixin_search_activity_user_id_false(self):
+        """Test the search method on the "activity_user_id" when searching for non-set user"""
+        MailTestActivity = self.env['mail.test.activity']
+        test_records = self.test_record | self.test_record_2
+        self.assertFalse(test_records.activity_ids)
+        self.assertEqual(MailTestActivity.search([('activity_user_id', '=', False)]), test_records)
+
+        self.env['mail.activity'].create({
+            'summary': 'Test',
+            'activity_type_id': self.env.ref('test_mail.mail_act_test_todo').id,
+            'res_model_id': self.env.ref('test_mail.model_mail_test_activity').id,
+            'res_id': self.test_record.id,
+        })
+        self.assertEqual(MailTestActivity.search([('activity_user_id', '!=', True)]), self.test_record_2)
+
     @mute_logger('odoo.addons.mail.models.mail_mail', 'odoo.tests')
     def test_mail_activity_mixin_search_state_basic(self):
         """Test the search method on the "activity_state".


### PR DESCRIPTION
Introduced in 5f4add917a55f62c024a7a79c9240dc628a9f14f, we allowed filtering on 'done' activities. This induced a change in the search method of activity_user_id field, now readonly, to allow searching on done activities.

As user_id is required on mail.activity, we can do as we do for the activity_date_dateline search method (date_dateline being required too on mail.activity): when using 'is not set' as a custom domain (~ '= False'), return records having no activities, and therefore no activity_user_id.

A small test is added in test_mail

Task-4027928

