### PR TITLE
[FIX] account: Fix the payment reference if empty

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4273,6 +4273,8 @@ class AccountMove(models.Model):
             lock_dates = move._get_violated_lock_dates(move.date, affects_tax_report)
             if lock_dates:
                 move.date = move._get_accounting_date(move.invoice_date or move.date, affects_tax_report)
+            if not move.payment_reference and move.move_type in ('in_invoice', 'in_refund', 'in_receipt'):
+                move.payment_reference = move.ref
 
         # Create the analytic lines in batch is faster as it leads to less cache invalidation.
         to_post.line_ids._create_analytic_lines()

--- a/addons/hr_expense/tests/test_expenses.py
+++ b/addons/hr_expense/tests/test_expenses.py
@@ -166,7 +166,7 @@ class TestExpenses(TestExpenseCommon):
             {'balance':   208.70, 'account_id': tax_account_id,             'name': '15%',                                'date': date(2021, 10, 31),           'invoice_date': date(2021, 10, 10)},
             {'balance':    18.46, 'account_id': tax_account_id,             'name': '15%',                                'date': date(2021, 10, 31),           'invoice_date': date(2021, 10, 10)},
             {'balance':    18.46, 'account_id': tax_account_id,             'name': '15% (Copy)',                         'date': date(2021, 10, 31),           'invoice_date': date(2021, 10, 10)},
-            {'balance': -1760.00, 'account_id': default_account_payable_id, 'name': False,                                'date': date(2021, 10, 31),           'invoice_date': date(2021, 10, 10)},
+            {'balance': -1760.00, 'account_id': default_account_payable_id, 'name': 'Expense for John Smith',             'date': date(2021, 10, 31),           'invoice_date': date(2021, 10, 10)},
 
             # company_account expense 2 move
             {'balance':  123.08, 'account_id': product_b_account_id,        'name': 'expense_employee: PB 160 + 2*15% 2', 'date': date(2021, 10, 12),           'invoice_date': False},


### PR DESCRIPTION
[FIX] account: Fix the payment reference if empty

We have a placeholder on the payment reference "Use Bill Reference" which should use the bill ref if the payment reference if empty We added the placeholder and forgot to add the logic of it

Solution: when posting, fill the payment ref with the bill ref if empty

Benefit: This will help odoo when recomputing the label of the journal items when posting the bills as it's currently having it empty as we missed to have that functionality in-place when we added the placeholder

task-id#4004739

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr