### PR TITLE
[IMP] l10n_in(_withholding): display alert message on absence of PAN

### DIFF
--- a/addons/l10n_in/models/account_invoice.py
+++ b/addons/l10n_in/models/account_invoice.py
@@ -29,7 +29,7 @@ class AccountMove(models.Model):
     l10n_in_shipping_port_code_id = fields.Many2one('l10n_in.port.code', 'Port code')
     l10n_in_reseller_partner_id = fields.Many2one('res.partner', 'Reseller', domain=[('vat', '!=', False)], help="Only Registered Reseller")
     l10n_in_journal_type = fields.Selection(string="Journal Type", related='journal_id.type')
-    l10n_in_hsn_code_warning = fields.Json(compute="_compute_hsn_code_warning")
+    l10n_in_warning = fields.Json(compute="_compute_l10n_in_warning")
 
     @api.depends('partner_id', 'partner_id.l10n_in_gst_treatment', 'state')
     def _compute_l10n_in_gst_treatment(self):
@@ -80,7 +80,7 @@ class AccountMove(models.Model):
         return super()._onchange_name_warning()
 
     @api.depends('invoice_line_ids.l10n_in_hsn_code', 'company_id.l10n_in_hsn_code_digit')
-    def _compute_hsn_code_warning(self):
+    def _compute_l10n_in_warning(self):
 
         def build_warning(record, action_name, message, views, domain=False):
             return {
@@ -106,7 +106,7 @@ class AccountMove(models.Model):
                 msg = _("Ensure that the HSN/SAC Code consists either %s in invoice lines",
                     digit_suffixes.get(move.company_id.l10n_in_hsn_code_digit, _("Invalid HSN/SAC Code digit"))
                 )
-                move.l10n_in_hsn_code_warning = {
+                move.l10n_in_warning = {
                     'invalid_hsn_code_length': build_warning(
                         message=msg,
                         action_name=_("Journal Items(s)"),
@@ -116,8 +116,8 @@ class AccountMove(models.Model):
                     )
                 } if lines else {}
             else:
-                move.l10n_in_hsn_code_warning = {}
-        (self - indian_invoice).l10n_in_hsn_code_warning = {}
+                move.l10n_in_warning = {}
+        (self - indian_invoice).l10n_in_warning = {}
 
     def _get_name_invoice_report(self):
         self.ensure_one()

--- a/addons/l10n_in/views/account_invoice_views.xml
+++ b/addons/l10n_in/views/account_invoice_views.xml
@@ -6,9 +6,9 @@
         <field name="inherit_id" ref="account.view_move_form"/>
         <field name="arch" type="xml">
             <xpath expr="//sheet" position="before">
-                <div class="alert alert-warning mt-1 mb-1" role="alert" invisible="not l10n_in_hsn_code_warning">
+                <div class="alert alert-warning mt-1 mb-1" role="alert" invisible="not l10n_in_warning">
                     <div>
-                        <field name="l10n_in_hsn_code_warning" widget="actionable_errors"/>
+                        <field name="l10n_in_warning" widget="actionable_errors"/>
                     </div>
                 </div>
             </xpath>

--- a/addons/l10n_in_withholding/__manifest__.py
+++ b/addons/l10n_in_withholding/__manifest__.py
@@ -14,6 +14,7 @@
         'views/l10n_in_section_alert_views.xml',
         'views/account_account_views.xml',
         'views/account_move_views.xml',
+        'views/account_move_line_views.xml',
         'views/account_payment_views.xml',
         'views/account_tax_views.xml',
         'views/res_config_settings_views.xml',

--- a/addons/l10n_in_withholding/models/l10n_in_section_alert.py
+++ b/addons/l10n_in_withholding/models/l10n_in_section_alert.py
@@ -22,6 +22,7 @@ class L10nInSectionAlert(models.Model):
             ('monthly', 'Monthly'),
             ('fiscal_yearly', 'Financial Yearly'),
         ], string="Aggregate Period", default='fiscal_yearly')
+    l10n_in_section_tax_ids = fields.One2many("account.tax", "l10n_in_section_id", string="Taxes")
 
     _sql_constraints = [
         ('per_transaction_limit', 'CHECK(per_transaction_limit >= 0)', 'Per transaction limit must be positive'),

--- a/addons/l10n_in_withholding/views/account_move_line_views.xml
+++ b/addons/l10n_in_withholding/views/account_move_line_views.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_move_line_tree_l10n_in" model="ir.ui.view">
+        <field name="name">account.move.line.tree.l10n.in</field>
+        <field name="model">account.move.line</field>
+        <field name="inherit_id" ref="l10n_in.view_move_line_tree_hsn_l10n_in"/>
+        <field name="mode">primary</field>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='l10n_in_hsn_code']" position="after">
+                <field name="tax_ids" widget="many2many_tags" domain="[('type_tax_use', '=', 'sale')]"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/addons/l10n_in_withholding/views/account_move_views.xml
+++ b/addons/l10n_in_withholding/views/account_move_views.xml
@@ -7,6 +7,8 @@
             <xpath expr="//header" position="inside">
                 <button name="%(l10n_in_withholding_entry_form_action)d" string="TDS Entry" type="action" class="btn btn-secondary float-end"
                         invisible="country_code != 'IN' or move_type not in ('out_invoice', 'in_invoice', 'out_refund', 'in_refund') or state != 'posted'"/>
+                <button name="action_l10n_in_apply_higher_tax" string="Apply Higher TCS" type="object" class="btn btn-secondary float-end"
+                        invisible="not l10n_in_display_higher_tcs_button"/>
             </xpath>
             <xpath expr="//div[@name='button_box']" position="inside">
                 <button name="action_l10n_in_withholding_entries"

--- a/addons/l10n_in_withholding/wizard/l10n_in_withhold_wizard.xml
+++ b/addons/l10n_in_withholding/wizard/l10n_in_withhold_wizard.xml
@@ -13,11 +13,10 @@
         <field name="model">l10n_in.withhold.wizard</field>
         <field name="arch" type="xml">
             <form>
-                <div name="warning_message"
-                     class="alert alert-warning text-center fw-bold"
-                     role="alert"
-                     invisible="not warning_message">
-                    <field name="warning_message"/>
+                <div class="alert alert-warning mt-1 mb-1" role="alert" invisible="not l10n_in_withholding_warning">
+                    <div>
+                        <field name="l10n_in_withholding_warning" widget="actionable_errors"/>
+                    </div>
                 </div>
                 <sheet>
                     <group>


### PR DESCRIPTION
Under Section 206AA/206AB of the Income Tax Act, 1961, if the PAN of a Vendor/Customer is unavailable, TDS/TCS should be at a higher rate.

With this PR, whenever a user applies a TDS/TCS tax and the PAN is absent/invalid of a partner, they will get an alert message to apply TDS/TCS at a higher rate.
Also `Apply Higher Tax` button will be added on the invoice so user can apply higher tax on all invalid lines at one click.

**task**-4037680
related enterprise PR: https://github.com/odoo/enterprise/pull/66135
