### PR TITLE
[IMP] core: complement search on many2one like

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -6296,7 +6296,11 @@ class BaseModel(metaclass=MetaModel):
                         if isinstance(value, (list, tuple, set)) and value:
                             v = next(iter(value))
                         if isinstance(v, str):
-                            data = data.mapped('display_name')
+                            try:
+                                data = data.mapped('display_name')
+                            except AccessError:
+                                # failed to access the record, return empty string for comparison
+                                data = ['']
                         else:
                             data = data and data.ids or [False]
                     elif field and field.type in ('date', 'datetime'):

--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -1326,11 +1326,12 @@ class expression(object):
                         operator = dict_op[operator]
                     elif isinstance(right, list) and operator in ('!=', '='):  # for domain (FIELD,'=',['value1','value2'])
                         operator = dict_op[operator]
-                    res_ids = comodel._name_search(right, [], operator)
                     if operator in NEGATIVE_TERM_OPERATORS:
-                        for dom_leaf in ('|', (left, 'in', res_ids), (left, '=', False)):
+                        res_ids = comodel._name_search(right, [], TERM_OPERATORS_NEGATION[operator])
+                        for dom_leaf in ('|', (left, 'not in', res_ids), (left, '=', False)):
                             push(dom_leaf, model, alias)
                     else:
+                        res_ids = comodel._name_search(right, [], operator)
                         push((left, 'in', res_ids), model, alias)
 
                 else:


### PR DESCRIPTION
Searching [(m2o, 'not like', 'test')] should be executed as a NOT IN. It is equivalent to ['!', (m2o, 'like', 'test')] which is executed as [(m2o, 'not in', name_search_query)]. Using the 'in' operator and checking for False, misses inaccessible records, because they are not False and not returned by the search.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
