### PR TITLE
[FIX] l10n_ar_withholding: module reinstall

### DIFF
--- a/addons/l10n_ar_withholding/__init__.py
+++ b/addons/l10n_ar_withholding/__init__.py
@@ -27,6 +27,7 @@ def _l10n_ar_withholding_post_init(env):
             _logger.info("Company %s already has the Argentinean localization installed, updating...", company.name)
             company_chart_template = env['account.chart.template'].with_company(company)
             company_chart_template._deref_account_tags(template_code, data['account.tax'])
+            company_chart_template._pre_reload_data(company, {}, data)
             company_chart_template._load_data(data)
             company.l10n_ar_tax_base_account_id = env.ref('account.%i_base_tax_account' % company.id)
 


### PR DESCRIPTION
Uninstall l10n_ar_withholding
Install again l10n_ar_withholding

Issue:
 Reinstall will fail with error
 odoo.exceptions.ValidationError: Invoice and credit note distribution should each contain exactly one line for the base.

This occurs because the system attempt to create a tax repartition line in
existing tax instead of updating the data

opw-3946193