### PR TITLE
[FIX] account: no label on journal item when no label on product

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -515,9 +515,11 @@ class AccountMoveLine(models.Model):
 
             values = []
             if line.journal_id.type == 'sale':
+                values.append(product.display_name)
                 if product.description_sale:
                     values.append(product.description_sale)
             elif line.journal_id.type == 'purchase':
+                values.append(product.display_name)
                 if product.description_purchase:
                     values.append(product.description_purchase)
             line.name = '\n'.join(values)

--- a/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.js
+++ b/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.js
@@ -142,7 +142,14 @@ export class ProductLabelSectionAndNoteField extends Many2OneField {
     }
 
     get label() {
-        return this.props.record.data.name;
+        let label = this.props.record.data.name;
+        if (label.includes(this.productName)) {
+            label = label.replace(this.productName, "");
+            if (label.includes("\n")) {
+                label = label.replace("\n", "");
+            }
+        }
+        return label;
     }
 
     get Many2XAutocompleteProps() {
@@ -187,7 +194,7 @@ export class ProductLabelSectionAndNoteField extends Many2OneField {
     }
 
     updateLabel(value) {
-        this.props.record.update({ name: value });
+        this.props.record.update({ name: this.productName ? `${this.productName}\n${value}` : value });
     }
 }
 

--- a/addons/account/tests/test_account_move_in_invoice.py
+++ b/addons/account/tests/test_account_move_in_invoice.py
@@ -22,7 +22,7 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
         cls.invoice = cls.init_invoice('in_invoice', products=cls.product_a+cls.product_b)
 
         cls.product_line_vals_1 = {
-            'name': '',
+            'name': 'product_a',
             'product_id': cls.product_a.id,
             'account_id': cls.product_a.property_account_expense_id.id,
             'partner_id': cls.partner_a.id,
@@ -41,7 +41,7 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
             'date_maturity': False,
         }
         cls.product_line_vals_2 = {
-            'name': '',
+            'name': 'product_b',
             'product_id': cls.product_b.id,
             'account_id': cls.product_b.property_account_expense_id.id,
             'partner_id': cls.partner_a.id,
@@ -180,7 +180,7 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
         self.assertInvoiceValues(self.invoice, [
             {
                 **self.product_line_vals_1,
-                'name': '',
+                'name': 'product_b',
                 'product_id': self.product_b.id,
                 'product_uom_id': self.product_b.uom_id.id,
                 'account_id': self.product_b.property_account_expense_id.id,

--- a/addons/account/tests/test_account_move_in_refund.py
+++ b/addons/account/tests/test_account_move_in_refund.py
@@ -39,7 +39,7 @@ class TestAccountMoveInRefundOnchanges(AccountTestInvoicingCommon):
             'date_maturity': False,
         }
         cls.product_line_vals_2 = {
-            'name': '',
+            'name': 'product_b',
             'product_id': cls.product_b.id,
             'account_id': cls.product_b.property_account_expense_id.id,
             'partner_id': cls.partner_a.id,
@@ -150,7 +150,7 @@ class TestAccountMoveInRefundOnchanges(AccountTestInvoicingCommon):
         self.assertInvoiceValues(self.invoice, [
             {
                 **self.product_line_vals_1,
-                'name': '',
+                'name': 'product_b',
                 'product_id': self.product_b.id,
                 'product_uom_id': self.product_b.uom_id.id,
                 'account_id': self.product_b.property_account_expense_id.id,

--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -25,7 +25,7 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
         cls.invoice = cls.init_invoice('out_invoice', products=cls.product_a+cls.product_b)
 
         cls.product_line_vals_1 = {
-            'name': '',
+            'name': 'product_a',
             'product_id': cls.product_a.id,
             'account_id': cls.product_a.property_account_income_id.id,
             'partner_id': cls.partner_a.id,
@@ -44,7 +44,7 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
             'date_maturity': False,
         }
         cls.product_line_vals_2 = {
-            'name': '',
+            'name': 'product_b',
             'product_id': cls.product_b.id,
             'account_id': cls.product_b.property_account_income_id.id,
             'partner_id': cls.partner_a.id,
@@ -166,7 +166,7 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
         self.assertInvoiceValues(self.invoice, [
             {
                 **self.product_line_vals_1,
-                'name': '',
+                'name': 'product_b',
                 'product_id': self.product_b.id,
                 'product_uom_id': self.product_b.uom_id.id,
                 'account_id': self.product_b.property_account_income_id.id,

--- a/addons/account/tests/test_account_move_out_refund.py
+++ b/addons/account/tests/test_account_move_out_refund.py
@@ -18,7 +18,7 @@ class TestAccountMoveOutRefundOnchanges(AccountTestInvoicingCommon):
         cls.invoice = cls.init_invoice('out_refund', products=cls.product_a+cls.product_b)
 
         cls.product_line_vals_1 = {
-            'name': '',
+            'name': 'product_a',
             'product_id': cls.product_a.id,
             'account_id': cls.product_a.property_account_income_id.id,
             'partner_id': cls.partner_a.id,
@@ -37,7 +37,7 @@ class TestAccountMoveOutRefundOnchanges(AccountTestInvoicingCommon):
             'date_maturity': False,
         }
         cls.product_line_vals_2 = {
-            'name': '',
+            'name': 'product_b',
             'product_id': cls.product_b.id,
             'account_id': cls.product_b.property_account_income_id.id,
             'partner_id': cls.partner_a.id,
@@ -144,7 +144,7 @@ class TestAccountMoveOutRefundOnchanges(AccountTestInvoicingCommon):
         self.assertInvoiceValues(self.invoice, [
             {
                 **self.product_line_vals_1,
-                'name': '',
+                'name': 'product_b',
                 'product_id': self.product_b.id,
                 'product_uom_id': self.product_b.uom_id.id,
                 'account_id': self.product_b.property_account_income_id.id,

--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -131,9 +131,7 @@
                                     <tr t-att-class="'bg-200 fw-bold o_line_section' if line.display_type == 'line_section' else 'fst-italic o_line_note' if line.display_type == 'line_note' else ''">
                                         <t t-if="line.display_type == 'product'" name="account_invoice_line_accountable">
                                             <td name="account_invoice_line_name">
-                                                <span t-if="line.product_id.name and line.product_id.default_code">[<t t-out="line.product_id.default_code"/>] </span>
-                                                <span t-if="line.product_id.name" t-field="line.product_id.name" t-options="{'widget': 'text'}"/>
-                                                <span t-if="line.name" t-field="line.name" t-options="{'widget': 'text'}"/>
+                                                <span t-if="line.name" t-field="line.name" t-options="{'widget': 'text'}">Bacon Burger</span>
                                             </td>
                                             <td name="td_quantity" class="text-end">
                                                 <span t-field="line.quantity">3.00</span>

--- a/addons/purchase/tests/test_purchase_invoice.py
+++ b/addons/purchase/tests/test_purchase_invoice.py
@@ -814,7 +814,7 @@ class TestInvoicePurchaseMatch(TestPurchaseToInvoiceCommon):
         invoice_lines = invoice.line_ids.filtered(lambda l: l.price_unit)
         self.assertEqual(len(invoice_lines), 2)
         for line in invoice_lines:
-            if (line.product_id.name != self.product_order.name):
+            if (line.product_id == self.product_order):
                 self.assertTrue(line.purchase_line_id in po.order_line)
             else:
                 self.assertFalse(line.purchase_line_id in po.order_line)


### PR DESCRIPTION
Description of the issue this commit addresses:

Following the change of behavior in the invoice lines removing the product name
from the label of the line, the journal items do not receive the proper label
anymore. When a product has no label, the journal item linked to that line has
no label at all.

---

Desired behavior after this commit is merged:

The desired behavior is actually for the label to contain the product name so
this is kind of a reverse but it has not to be displayed in the invoice lines
so the product name is in the journal item name but is parsed out of the label
that is displayed on the invoice lines.

---

task-feedback

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
