### PR TITLE
[FIX] website_sale: multi-company issue on cart creation

### DIFF
--- a/addons/website_sale/i18n/website_sale.pot
+++ b/addons/website_sale/i18n/website_sale.pot
@@ -910,13 +910,6 @@ msgid "Can Publish"
 msgstr ""
 
 #. module: website_sale
-#. odoo-python
-#: code:addons/website_sale/controllers/main.py:0
-#, python-format
-msgid "You can't use a video as the product's main image."
-msgstr ""
-
-#. module: website_sale
 #: model_terms:ir.ui.view,arch_db:website_sale.snippet_options
 msgid "Cards"
 msgstr ""
@@ -4331,6 +4324,13 @@ msgid ""
 msgstr ""
 
 #. module: website_sale
+#. odoo-python
+#: code:addons/website_sale/controllers/main.py:0
+#, python-format
+msgid "You can't use a video as the product's main image."
+msgstr ""
+
+#. module: website_sale
 #: model_terms:ir.actions.act_window,help:website_sale.sale_report_action_carts
 #: model_terms:ir.actions.act_window,help:website_sale.sale_report_action_dashboard
 msgid "You don't have any order from the website"
@@ -4372,6 +4372,15 @@ msgstr ""
 #: code:addons/website_sale/static/src/js/website_sale_form_editor.js:0
 #, python-format
 msgid "Your Name"
+msgstr ""
+
+#. module: website_sale
+#. odoo-python
+#: code:addons/website_sale/models/website.py:0
+#, python-format
+msgid ""
+"Your account is not allowed to pay in company %s. Please log out and create "
+"a new account for this website, or contact the website administrator."
 msgstr ""
 
 #. module: website_sale

--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import _, _lt, SUPERUSER_ID, api, fields, models, tools
+from odoo import SUPERUSER_ID, _, _lt, api, fields, models, tools
+from odoo.exceptions import UserError
 from odoo.http import request
 from odoo.osv import expression
 
@@ -360,6 +361,16 @@ class Website(models.Model):
         pricelist_id = False
 
         partner_sudo = self.env.user.partner_id
+
+        if partner_sudo.company_id and not partner_sudo.filtered_domain(
+            self.env['res.partner']._check_company_domain(self.company_id)
+        ):
+            raise UserError(_(
+                "Your account is not allowed to pay in company %s."
+                " Please log out and create a new account for this website, or contact the website"
+                " administrator.",
+                self.company_id.name,
+            ))
 
         # cart creation was requested
         if not sale_order_sudo:


### PR DESCRIPTION
A recent fix forbade the usage of partners from other companies on a SO (see 7be39d0b2157ec53e84c730a210868e4a4a1f8d9, and the comment on the original PR).

On the ecommerce, in some advanced multi-company & multi-website configuration, this led some customers to be unable to create a cart (add products to it), because their partner was restricted to another company.

It was previously possible, but led to other issues later on, e.g. during the post-processing of payment transactions linked to the cart.

Therefore, we consider it's still better to show a warning early on, but we prefer to replace the standard multi-company warning by a dedicated error message recommending the customer to have another account, or to contact the website administrator.

To solve the issue for a given customer, either he should have a separate account for the given company, or no company (ID) should be set on its partner record, so that it's shared between companies.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
