### PR TITLE
[FIX] web: reslove ribbon overlaps while open dropdown menu

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_controller.scss
+++ b/addons/web/static/src/views/kanban/kanban_controller.scss
@@ -45,7 +45,6 @@
     --Ribbon-gap-right: 0;
     --Ribbon-wrapper-width: 6.5rem;
     --Ribbon-height:  calc(var(--Ribbon-font-size) * 2);
-    --Ribbon-z-index: 0;
 
     // ----------------------------------------------------------------------------
 

--- a/addons/web/static/src/views/widgets/ribbon/ribbon.scss
+++ b/addons/web/static/src/views/widgets/ribbon/ribbon.scss
@@ -12,9 +12,8 @@
         --Ribbon-height-default: calc(var(--Ribbon-font-size, var(--Ribbon-font-size-default)) * 2.5);
         --Ribbon-shadow-distance: .25rem;
         --Ribbon-shadow-blur: .5rem;
-        --Ribbon-z-index: 1;
 
-        z-index: var( --Ribbon-z-index);
+        z-index: var(--Ribbon-z-index);
         position: absolute;
         width: 141.421%; //Square root of 2 to get the diagonal of the parent
         height: var(--Ribbon-height, var(--Ribbon-height-default));
@@ -66,4 +65,8 @@
             margin-right: 100px;
         }
     }
+}
+
+.o_form_sheet .ribbon {
+   --Ribbon-z-index: 1;
 }


### PR DESCRIPTION
Specification:
The ribbon overlaps with the dropdown menu.

![image](https://github.com/odoo/odoo/assets/120459800/0aa2c2e0-2d62-4413-94d8-134828511c0e)


Expected behavior:
The ribbon should not overlap with the dropdown menu.

Task-3940927
