### PR TITLE
[FIX] google_calendar: recurrence splitting

### DIFF
--- a/addons/google_calendar/models/google_sync.py
+++ b/addons/google_calendar/models/google_sync.py
@@ -10,7 +10,6 @@ from dateutil.parser import parse
 
 from odoo import api, fields, models, registry, _
 from odoo.tools import ormcache_context, email_normalize
-from odoo.exceptions import UserError
 from odoo.osv import expression
 
 from odoo.addons.google_calendar.utils.google_event import GoogleEvent
@@ -172,11 +171,16 @@ class GoogleSync(models.AbstractModel):
 
         cancelled_odoo._cancel()
         synced_records = new_odoo + cancelled_odoo
-        for gevent in existing - cancelled:
+        pending = existing - cancelled
+        pending_odoo = self.browse(pending.odoo_ids(self.env)).exists()
+        for gevent in pending:
+            odoo_record = self.browse(gevent.odoo_id(self.env))
+            if odoo_record not in pending_odoo:
+                # The record must have been deleted in the mean time; nothing left to sync
+                continue
             # Last updated wins.
             # This could be dangerous if google server time and odoo server time are different
             updated = parse(gevent.updated)
-            odoo_record = self.browse(gevent.odoo_id(self.env))
             # Use the record's write_date to apply Google updates only if they are newer than Odoo's write_date.
             odoo_record_write_date = write_dates.get(odoo_record.id, odoo_record.write_date)
             # Migration from 13.4 does not fill write_date. Therefore, we force the update from Google.

--- a/addons/google_calendar/models/google_sync.py
+++ b/addons/google_calendar/models/google_sync.py
@@ -156,7 +156,7 @@ class GoogleSync(models.AbstractModel):
         ]
         new_odoo = self.with_context(dont_notify=True)._create_from_google(new, odoo_values)
         cancelled = existing.cancelled()
-        cancelled_odoo = self.browse(cancelled.odoo_ids(self.env))
+        cancelled_odoo = self.browse(cancelled.odoo_ids(self.env)).exists()
 
         # Check if it is a recurring event that has been rescheduled.
         # We have to check if an event already exists in Odoo.

--- a/addons/google_calendar/tests/test_sync_google2odoo.py
+++ b/addons/google_calendar/tests/test_sync_google2odoo.py
@@ -981,6 +981,200 @@ class TestSyncGoogle2Odoo(TestSyncGoogle):
         self.assertGoogleAPINotCalled()
 
     @patch_api
+    def test_recurrence_reduced(self):
+        # This test is a bit special because it's testing 2 sync processes. The
+        # bug it's protecting against is cross-contamination when event dicts
+        # are mutated in different ways during the call to
+        # `_sync_google_calendar()`. If you want to do a new test, this one is
+        # probably not the best example.
+        google_id = "oj44nep1ldf8a3ll02uip0c9aa"
+        with self.mock_datetime_and_now("2024-06-07"):
+            # We start with an event with 2 repetitions
+            values = [
+                # Recurrence from day 7 changes
+                {
+                    "id": google_id,
+                    "summary": "coucou",
+                    "recurrence": [
+                        "RRULE:FREQ=WEEKLY;WKST=MO;UNTIL=20240620T215959Z;BYDAY=FR"
+                    ],
+                    "start": {"dateTime": "2024-06-07T08:00:00+00:00"},
+                    "end": {"dateTime": "2024-06-07T10:00:00+00:00"},
+                    "reminders": {"useDefault": True},
+                    "updated": self.now,
+                    "attendees": [
+                        {
+                            "email": self.organizer_user.partner_id.email,
+                            "responseStatus": "accepted",
+                        },
+                        {
+                            "email": self.attendee_user.partner_id.email,
+                            "responseStatus": "accepted",
+                        },
+                    ],
+                },
+                # Event details for day 7
+                {
+                    "id": "%s_20240607T080000Z" % google_id,
+                    "summary": "coucou",
+                    "start": {"dateTime": "2024-06-07T08:00:00+00:00"},
+                    "end": {"dateTime": "2024-06-07T10:00:00+00:00"},
+                    "reminders": {"useDefault": True},
+                    "updated": self.now,
+                    "recurringEventId": google_id,
+                    "attendees": [
+                        {
+                            "email": self.organizer_user.partner_id.email,
+                            "responseStatus": "accepted",
+                        },
+                        {
+                            "email": self.attendee_user.partner_id.email,
+                            "responseStatus": "accepted",
+                        },
+                    ],
+                },
+                # Event details for day 14
+                {
+                    "id": "%s_20240614T080000Z" % google_id,
+                    "summary": "coucou",
+                    "start": {"dateTime": "2024-06-14T08:00:00+00:00"},
+                    "end": {"dateTime": "2024-06-14T10:00:00+00:00"},
+                    "reminders": {"useDefault": True},
+                    "updated": self.now,
+                    "recurringEventId": google_id,
+                    "attendees": [
+                        {
+                            "email": self.organizer_user.partner_id.email,
+                            "responseStatus": "accepted",
+                        },
+                        {
+                            "email": self.attendee_user.partner_id.email,
+                            "responseStatus": "accepted",
+                        },
+                    ],
+                },
+            ]
+            with patch.object(
+                GoogleCalendarService,
+                "get_events",
+                return_value=(
+                    GoogleEvent(values),
+                    None,
+                    [{"method": "popup", "minutes": 30}],
+                ),
+            ):
+                self.attendee_user.sudo()._sync_google_calendar(self.google_service)
+            events = self.env["calendar.event"].search(
+                [("google_id", "like", google_id)]
+            )
+            self.assertEqual(len(events.exists()), 2)
+
+        with self.mock_datetime_and_now("2024-06-10"):
+            # From Google Calendar, they alter events from day 14 onwards and move
+            # them 1h later. However, they regret and move them back 1h again.
+            values = [
+                # Recurrence from day 7 changes
+                {
+                    "id": google_id,
+                    "summary": "coucou",
+                    "recurrence": [
+                        "RRULE:FREQ=WEEKLY;WKST=MO;UNTIL=20240613T215959Z;BYDAY=FR"
+                    ],
+                    "start": {"dateTime": "2024-06-07T08:00:00+00:00"},
+                    "end": {"dateTime": "2024-06-07T10:00:00+00:00"},
+                    "reminders": {"useDefault": True},
+                    "updated": self.now,
+                    "attendees": [
+                        {
+                            "email": self.organizer_user.partner_id.email,
+                            "responseStatus": "accepted",
+                        },
+                        {
+                            "email": self.attendee_user.partner_id.email,
+                            "responseStatus": "accepted",
+                        },
+                    ],
+                },
+                # Event details for day 7
+                {
+                    "id": "%s_20240607T080000Z" % google_id,
+                    "summary": "coucou",
+                    "start": {"dateTime": "2024-06-07T08:00:00+00:00"},
+                    "end": {"dateTime": "2024-06-07T10:00:00+00:00"},
+                    "reminders": {"useDefault": True},
+                    "updated": self.now,
+                    "recurringEventId": google_id,
+                    "attendees": [
+                        {
+                            "email": self.organizer_user.partner_id.email,
+                            "responseStatus": "accepted",
+                        },
+                        {
+                            "email": self.attendee_user.partner_id.email,
+                            "responseStatus": "accepted",
+                        },
+                    ],
+                },
+                # Event details for day 14
+                {
+                    "id": "%s_20240614T080000Z" % google_id,
+                    "summary": "coucou",
+                    "start": {"dateTime": "2024-06-14T08:00:00+00:00"},
+                    "end": {"dateTime": "2024-06-14T10:00:00+00:00"},
+                    "reminders": {"useDefault": True},
+                    "updated": self.now,
+                    "recurringEventId": "%s_R20240614T080000" % google_id,
+                    "attendees": [
+                        {
+                            "email": self.organizer_user.partner_id.email,
+                            "responseStatus": "accepted",
+                        },
+                        {
+                            "email": self.attendee_user.partner_id.email,
+                            "responseStatus": "accepted",
+                        },
+                    ],
+                },
+                # New recurrence that starts on day 14
+                {
+                    "id": "%s_R20240614T080000" % google_id,
+                    "summary": "coucou",
+                    "start": {"dateTime": "2024-06-14T08:00:00+00:00"},
+                    "end": {"dateTime": "2024-06-14T10:00:00+00:00"},
+                    "recurrence": [
+                        "RRULE:FREQ=WEEKLY;WKST=MO;UNTIL=20240620T215959Z;BYDAY=FR"
+                    ],
+                    "reminders": {"useDefault": True},
+                    "updated": self.now,
+                    "attendees": [
+                        {
+                            "email": self.organizer_user.partner_id.email,
+                            "responseStatus": "accepted",
+                        },
+                        {
+                            "email": self.attendee_user.partner_id.email,
+                            "responseStatus": "accepted",
+                        },
+                    ],
+                },
+            ]
+            # Then, Odoo syncs
+            with patch.object(
+                GoogleCalendarService,
+                "get_events",
+                return_value=(
+                    GoogleEvent(values),
+                    None,
+                    [{"method": "popup", "minutes": 30}],
+                ),
+            ):
+                self.attendee_user.sudo()._sync_google_calendar(self.google_service)
+            events = self.env["calendar.event"].search(
+                [("google_id", "like", google_id)]
+            )
+            self.assertEqual(len(events.exists()), 2)
+
+    @patch_api
     def test_new_google_notifications(self):
         """ Event from Google should not create notifications and trigger. It ruins the perfs on large databases """
         cron_id = self.env.ref('calendar.ir_cron_scheduler_alarm').id

--- a/addons/google_calendar/tests/test_sync_google2odoo.py
+++ b/addons/google_calendar/tests/test_sync_google2odoo.py
@@ -2054,6 +2054,101 @@ class TestSyncGoogle2Odoo(TestSyncGoogle):
         self.assertEqual(events[0].attendee_ids[0].state, 'accepted', 'after google sync, organizer should have accepted status still')
         self.assertGoogleAPINotCalled()
 
+    @patch.object(GoogleCalendarService, "get_events")
+    def test_recurring_event_moved_to_future(self, mock_get_events):
+        # There's a daily recurring event from 2024-07-01 to 2024-07-02
+        recurrence_id = "abcd1"
+        recurrence = self.generate_recurring_event(
+            mock_dt="2024-07-01",
+            google_id=recurrence_id,
+            rrule="FREQ=DAILY;INTERVAL=1;COUNT=2",
+            start=datetime(2024, 7, 1, 9),
+            stop=datetime(2024, 7, 1, 10),
+            partner_ids=[
+                Command.set(
+                    [
+                        self.organizer_user.partner_id.id,
+                        self.attendee_user.partner_id.id,
+                    ]
+                )
+            ],
+        )
+        self.assertRecordValues(
+            recurrence.calendar_event_ids.sorted("start"),
+            [
+                {
+                    "start": datetime(2024, 7, 1, 9),
+                    "stop": datetime(2024, 7, 1, 10),
+                    "google_id": f"{recurrence_id}_20240701T090000Z",
+                },
+                {
+                    "start": datetime(2024, 7, 2, 9),
+                    "stop": datetime(2024, 7, 2, 10),
+                    "google_id": f"{recurrence_id}_20240702T090000Z",
+                },
+            ],
+        )
+        # User moves batch to next week
+        common = {
+            "attendees": [
+                {
+                    "email": self.attendee_user.partner_id.email,
+                    "responseStatus": "needsAction",
+                },
+                {
+                    "email": self.organizer_user.partner_id.email,
+                    "responseStatus": "needsAction",
+                },
+            ],
+            "organizer": {"email": self.organizer_user.partner_id.email},
+            "reminders": {"useDefault": True},
+            "summary": "coucou",
+            "updated": "2024-07-02T08:00:00Z",
+        }
+        google_events = [
+            # Recurrence event
+            dict(
+                common,
+                id=recurrence_id,
+                start={"dateTime": "2024-07-08T09:00:00+00:00"},
+                end={"dateTime": "2024-07-08T10:00:00+00:00"},
+                recurrence=["RRULE:FREQ=DAILY;INTERVAL=1;COUNT=2"],
+            ),
+            # Cancelled instances
+            {"id": f"{recurrence_id}_20240701T090000Z", "status": "cancelled"},
+            {"id": f"{recurrence_id}_20240702T090000Z", "status": "cancelled"},
+            # New base event
+            dict(
+                common,
+                id=f"{recurrence_id}_20240708T090000Z",
+                start={"dateTime": "2024-07-08T09:00:00+00:00"},
+                end={"dateTime": "2024-07-08T10:00:00+00:00"},
+                recurringEventId=recurrence_id,
+            ),
+        ]
+        mock_get_events.return_value = (
+            GoogleEvent(google_events),
+            None,
+            [{"method": "popup", "minutes": 30}],
+        )
+        with self.mock_datetime_and_now("2024-04-03"):
+            self.organizer_user.sudo()._sync_google_calendar(self.google_service)
+            self.assertRecordValues(
+                recurrence.calendar_event_ids.sorted("start"),
+                [
+                    {
+                        "start": datetime(2024, 7, 8, 9),
+                        "stop": datetime(2024, 7, 8, 10),
+                        "google_id": f"{recurrence_id}_20240708T090000Z",
+                    },
+                    {
+                        "start": datetime(2024, 7, 9, 9),
+                        "stop": datetime(2024, 7, 9, 10),
+                        "google_id": f"{recurrence_id}_20240709T090000Z",
+                    },
+                ],
+            )
+
     @patch.object(GoogleCalendarService, 'get_events')
     def test_accepting_recurrent_event_with_this_event_option_synced_by_attendee(self, mock_get_events):
         """


### PR DESCRIPTION
Imagine a scenario where Odoo and Google calendars are synced. Then, this happens:
1. User goes to Google and changes one event from a recurrence series.
2. When saving, user chooses to modify "this event and all upcoming".
3. Odoo syncs from Google automatically via cron.

<details>

```
2024-07-04 10:02:21,094 25 INFO odoo odoo.addons.google_calendar.models.res_users: Calendar Synchro - Starting synchronization for res.users(15,)                                                             
2024-07-04 10:02:21,568 25 INFO odoo odoo.addons.google_calendar.models.calendar_recurrence_rule: Recurrence #4838 | current rule: FREQ=WEEKLY;WKST=MO;UNTIL=20240620T215959Z;BYDAY=FR | new rule: FREQ=WEEKLY;WKST=MO;UNTIL=20240613T215959Z;BYDAY=FR | remaining: 1 | removed: 1                                                                                                                                          
2024-07-04 10:02:21,583 25 INFO odoo odoo.models.unlink: User #15 deleted calendar.event records with IDs: [1999701]                                                                                          
2024-07-04 10:02:21,586 25 INFO odoo odoo.models.unlink: User #15 deleted mail.followers records with IDs: [3665655, 3665656, 3665657, 3665658, 3665659, 3665660, 3665661, 3665662, 3665768]                  
2024-07-04 10:02:21,919 25 ERROR odoo odoo.addons.google_calendar.models.res_users: [res.users(15,)] Calendar Synchro - Exception : Record does not exist or has been deleted.                                
(Record: calendar.event(1999701,), User: 15) !                                                                                                                                                                
Traceback (most recent call last):                                                                                                                                                                            
  File "/opt/odoo/custom/src/odoo/odoo/﻿[﻿api.py﻿](https://api.py/)﻿", line 997, in get                                                                                                                                              
    cache_value = field_cache[record._ids[0]]                                                                                                                                                                 
KeyError: 1999701                                                                                                                                                                                             
                                                                                                                                                                                                              
During handling of the above exception, another exception occurred:                                                                                                                                           
                                                                                                                                                                                                              
Traceback (most recent call last):                                                                                                                                                                            
  File "/opt/odoo/custom/src/odoo/odoo/﻿[﻿fields.py﻿](https://fields.py/)﻿", line 1161, in __get__                                                                                                                                      
    value = env.cache.get(record, self)                                                                                                                                                                       
  File "/opt/odoo/custom/src/odoo/odoo/﻿[﻿api.py﻿](https://api.py/)﻿", line 1004, in get                                                                                                                                             
    raise CacheMiss(record, field)                                                                                                                                                                            
odoo.exceptions.CacheMiss: 'calendar.event(1999701,).write_date'                                                                                                                                              
                                                                                                                                                                                                              
During handling of the above exception, another exception occurred:                                                                                                                                           
                                                                                                                                                                                                              
Traceback (most recent call last):                                                                                                                                                                            
  File "/opt/odoo/auto/addons/google_calendar/models/﻿[﻿res_users.py﻿](https://res_users.py/)﻿", line 100, in _sync_all_google_calendar                                                                                                    
    user.with_user(user).sudo()._sync_google_calendar(google)                                                                                                                                                 
  File "/opt/odoo/auto/addons/google_calendar/models/﻿[﻿res_users.py﻿](https://res_users.py/)﻿", line 79, in _sync_google_calendar                                                                                                         
    synced_events = self.env['calendar.event'].with_context(write_dates=events_write_dates)._sync_google2odoo(events - recurrences, default_reminders=default_reminders)                                      
  File "/opt/odoo/auto/addons/google_calendar/models/﻿[﻿google_sync.py﻿](https://google_sync.py/)﻿", line 181, in _sync_google2odoo                                                                                                          
    odoo_record_write_date = write_dates.get(﻿[﻿odoo_record.id﻿](https://odoo_record.id/)﻿, odoo_record.write_date)                                                                                                                          
  File "/opt/odoo/custom/src/odoo/odoo/﻿[﻿fields.py﻿](https://fields.py/)﻿", line 1191, in __get__                                                                                                                                      
    raise MissingError("\n".join([                                                                                                                                                                            
odoo.exceptions.MissingError: Record does not exist or has been deleted.                                                                                                                                      
(Record: calendar.event(1999701,), User: 15)
```

</details>

In such case, due to the way this was handled, Odoo would die with `MissingError`.

Here I contribute a test for such scenario and the fix.

@moduon MT-6287





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
