### PR TITLE
[FIX] website_event: allow proper event indexing

### DIFF
--- a/addons/website_event/views/event_templates_page_registration.xml
+++ b/addons/website_event/views/event_templates_page_registration.xml
@@ -5,6 +5,8 @@
 <template id="event_details" name="Event Header">
     <t t-call="website_event.layout">
         <div name="event" itemscope="itemscope" itemtype="http://schema.org/Event">
+            <meta itemprop="startDate" t-attf-content="{{event.date_begin}}Z"/>
+            <meta itemprop="endDate" t-attf-content="{{event.date_end}}Z"/>
             <t t-call="website.record_cover">
                 <t t-set="_record" t-value="event"/>
                 <t t-set="use_filters" t-value="True"/>


### PR DESCRIPTION
Issue
-----
Events displayed on website are not correctly indexed by Google. This results in events not being displayed in the "Rich Results" format and simply as links in Google searches.

Cause
-----
The start date is a required field for proper indexation and is missing from the registration page of the event.

Fix
-----
Add information in Microdata format.

opw-3993758