### PR TITLE
[FIX] stock: report availability from sublocations

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -470,9 +470,13 @@ Please change the quantity done or the rounding precision of your unit of measur
             if not warehouse:  # No prediction possible if no warehouse.
                 continue
             moves = self.browse(moves_ids)
-            forecast_info = moves._get_forecast_availability_outgoing(warehouse)
+            moves_per_location = defaultdict(lambda: self.env['stock.move'])
             for move in moves:
-                move.forecast_availability, move.forecast_expected_date = forecast_info[move]
+                moves_per_location[move.location_id] |= move
+            for location, mvs in moves_per_location.items():
+                forecast_info = mvs._get_forecast_availability_outgoing(warehouse, location)
+                for move in mvs:
+                    move.forecast_availability, move.forecast_expected_date = forecast_info[move]
 
     def _set_date_deadline(self, new_deadline):
         # Handle the propagation of `date_deadline` fields (up and down stream - only update by up/downstream documents)
@@ -2241,15 +2245,16 @@ Please change the quantity done or the rounding precision of your unit of measur
         self.filtered(lambda m: m.id in unseen).move_orig_ids._rollup_move_origs(seen)
         return seen
 
-    def _get_forecast_availability_outgoing(self, warehouse):
+    def _get_forecast_availability_outgoing(self, warehouse, location_id=False):
         """ Get forcasted information (sum_qty_expected, max_date_expected) of self for the warehouse's locations.
         :param warehouse: warehouse to search under
+        :param  location_id: location source of outgoing moves
         :return: a defaultdict of outgoing moves from warehouse for product_id in self, values are tuple (sum_qty_expected, max_date_expected)
         :rtype: defaultdict
         """
-        wh_location_query = self.env['stock.location']._search([('id', 'child_of', warehouse.view_location_id.id)])
+        wh_location_query = self.env['stock.location']._search([('id', 'child_of', location_id.id if location_id else warehouse.view_location_id.id)])
 
-        forecast_lines = self.env['stock.forecasted_product_product']._get_report_lines(False, self.product_id.ids, wh_location_query, warehouse.lot_stock_id, read=False)
+        forecast_lines = self.env['stock.forecasted_product_product']._get_report_lines(False, self.product_id.ids, wh_location_query, location_id or warehouse.lot_stock_id, read=False)
         result = defaultdict(lambda: (0.0, False))
         for line in forecast_lines:
             move_out = line.get('move_out')


### PR DESCRIPTION
### Steps to reproduce:

- Enable multisteps route in the settings
- Create a storable product P and put 10 units in WH/Stock/Shelf
- Create and confirm an SO for 1 unit of P
- Go to the associated delivery and change the Source Location to WH/Stock/Shelf
- Back to the SO, click on the chart icon > view forecast
- Unreserve the 1 unit currently used by your picking

### Issue:

While you have 10 units in WH/Stock/Shelf perfectly suitable to fulfill the demand of the picking, instead of displaying a line allowing you to reserve the 1 unit, you have a line telling you that the qty is "not available" -1 unit associated with the SO.

If you go back to the SO: the chart icon is displayed red and the details displayed in the availability widget shows a: "No future availability".

### Cause of the issue:

The chart icon is red because the JS detects a forecasted issue: https://github.com/odoo/odoo/blob/758ced91f8cb220a003a49b01e047b507f8509d7/addons/sale_stock/static/src/widgets/qty_at_date_widget.xml#L8 This issue comes from the fact that the demand is not expected to be fulfilled since the `free_qty_today` of the SOL is smaller than its `qty_to_deliver`:
https://github.com/odoo/odoo/blob/758ced91f8cb220a003a49b01e047b507f8509d7/addons/sale_stock/static/src/widgets/qty_at_date_widget.js#L45 https://github.com/odoo/odoo/blob/758ced91f8cb220a003a49b01e047b507f8509d7/addons/sale_stock/static/src/widgets/qty_at_date_widget.js#L54-L55 The reason for this forecasted issue is that the `free_qty_today` is computed to be -1 rather than 1 here:
https://github.com/odoo/odoo/blob/758ced91f8cb220a003a49b01e047b507f8509d7/addons/sale_stock/models/sale_order_line.py#L80-L82 since the `move.forecast_availability` is itself -1 rather than 1. Note that if the source of the move was still WH/Stock rather than WH/Stock/Shelf both of these value would be set to +1 and the issue would not appear. However, the `forecast_availability` of moves is not correctly computed if the location_id of the move is a strict sublocation of the warehouse. To be more precise, the forecasted availability is set to a negative quantity here:
https://github.com/odoo/odoo/blob/758ced91f8cb220a003a49b01e047b507f8509d7/addons/stock/models/stock_move.py#L470-L472 since the report line computed in the `_get_forecast_availability_outgoing` specifies that 'replenishment_filled' is False and should not be: https://github.com/odoo/odoo/blob/758ced91f8cb220a003a49b01e047b507f8509d7/addons/stock/models/stock_move.py#L2228 We are finally at the core of the problem, the replenishement is not filled because in the `_get_report_lines`, the `currents` dict used to compute both the reserved and the on hand quantity only updates the quantity of the warehouse if the location belongs to the warehouse: https://github.com/odoo/odoo/blob/758ced91f8cb220a003a49b01e047b507f8509d7/addons/stock/report/stock_forecasted.py#L327-L330 As such, 0 units are considered to be available in these locations and nothing can be taken from stock for these moves:
https://github.com/odoo/odoo/blob/758ced91f8cb220a003a49b01e047b507f8509d7/addons/stock/report/stock_forecasted.py#L236-L242 which of course result in the impossibility to fulfill the replenishment

opw-3979953
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
