### PR TITLE
[IMP] account: Purchase UOM on Vendor Bills

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -811,6 +811,9 @@ class AccountMoveLine(models.Model):
     def _compute_product_uom_id(self):
         for line in self:
             line.product_uom_id = line.product_id.uom_id
+            # vendor bills should have the product purchase UOM
+            if line.move_type == 'in_invoice' and line.product_id.uom_po_id:
+                line.product_uom_id = line.product_id.uom_po_id
 
     @api.depends('display_type')
     def _compute_quantity(self):


### PR DESCRIPTION
Before this commit, selecting a product on a vendor bill line would set the product sale uom as the line uom by default. This behavior was changed to set the product purchase uom as the line uom by default.

The default uom behavior on Vendor Bills lines should be aligned with the default uom behavior on Purchase orders.

task-4012191

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
