### PR TITLE
[FIX] mail: Banner should not hide the chatter actions

### DIFF
--- a/addons/mail/static/src/core_ui/thread.js
+++ b/addons/mail/static/src/core_ui/thread.js
@@ -162,6 +162,7 @@ export class Thread extends Component {
     updateShowJumpPresent() {
         this.state.showJumpPresent =
             this.props.thread.loadNewer || !this.presentThresholdState.isVisible;
+        this.env.bus.trigger("toggle_position_jumpPresent", { addTop: this.state.showJumpPresent });
     }
 
     onClickLoadOlder() {

--- a/addons/mail/static/src/core_ui/thread.scss
+++ b/addons/mail/static/src/core_ui/thread.scss
@@ -20,6 +20,7 @@
 .o-mail-Thread-jumpPresent {
     background-color: mix(map-get($theme-colors, 'info'), $o-webclient-background-color, 5%);
     z-index: $o-mail-NavigableList-zIndex - 1;
+    top: 3rem;
 }
 
 .o-mail-NotificationMessage p {

--- a/addons/mail/static/src/core_ui/thread.xml
+++ b/addons/mail/static/src/core_ui/thread.xml
@@ -90,7 +90,7 @@
 </t>
 
 <t t-name="mail.Thread.jumpPresent" owl="1">
-    <span t-if="state.showJumpPresent" class="o-mail-Thread-jumpPresent position-sticky btn btn-link alert alert-info d-flex cursor-pointer align-items-center py-2 m-0" t-att-class="{ 'px-4': !env.inChatWindow, 'px-2': env.inChatWindow, 'top-0': props.order !== 'asc', 'bottom-0': props.order === 'asc' }" role="button" t-on-click="() => this.jumpToPresent()">
+    <span t-if="state.showJumpPresent" class="o-mail-Thread-jumpPresent position-sticky btn btn-link alert alert-info d-flex cursor-pointer align-items-center py-2 m-0" t-att-class="{ 'px-4': !env.inChatWindow, 'px-2': env.inChatWindow, 'bottom-0': props.order === 'asc' }" role="button" t-on-click="() => this.jumpToPresent()">
         <span class="small">You're viewing older messages</span>
         <span class="flex-grow-1"/>
         <span class="fw-bolder small pe-2">Jump to Present</span>

--- a/addons/mail/static/src/web/chatter.js
+++ b/addons/mail/static/src/web/chatter.js
@@ -95,6 +95,7 @@ export class Chatter extends Component {
         this.orm = useService("orm");
         this.rpc = useService("rpc");
         this.state = useState({
+            isBannerVisible: false,
             composerType: false,
             isAttachmentBoxOpened: this.props.isAttachmentBoxVisibleInitially,
             jumpThreadPresent: 0,
@@ -111,6 +112,12 @@ export class Chatter extends Component {
         this.scrollPosition = useScrollPosition("root", undefined, "top");
         this.rootRef = useRef("root");
         this.onScrollDebounced = useThrottleForAnimation(this.onScroll);
+        this.env.bus.addEventListener("toggle_position_jumpPresent", ({ detail: { addTop } }) => {
+            this.state.isBannerVisible = addTop;
+            if (addTop) {
+                document.body.click(); // hack to close dropdown
+            }
+        });
         useChildSubEnv({
             inChatter: true,
             reloadParentView: () => this.reloadParentView(),

--- a/addons/mail/static/src/web/chatter.scss
+++ b/addons/mail/static/src/web/chatter.scss
@@ -19,6 +19,14 @@
     }
 }
 
+.o-jump-Present-composer-message {
+    margin-top: 1.5rem;
+}
+
+.o-jump-Present-composer-log {
+    margin-top: 20px;
+}
+
 .o-mail-Followers-button:focus {
     background-color: $gray-200;
 }

--- a/addons/mail/static/src/web/chatter.xml
+++ b/addons/mail/static/src/web/chatter.xml
@@ -32,7 +32,7 @@
                         </t>
                     </FileUploader>
                     <t t-else="" t-call="mail.Chatter.attachFiles"/>
-                    <Dropdown t-if="props.hasFollowers" position="'bottom-end'" disabled="isDisabled" class="'o-mail-Followers d-flex me-1'" menuClass="'o-mail-Followers-dropdown flex-column'" menuDisplay="'d-flex'" title="followerButtonLabel" togglerClass="'o-mail-Followers-button btn btn-link text-action px-1 ' + (props.compactHeight ? '' : 'my-2')">
+                    <Dropdown t-if="props.hasFollowers" position="'bottom-end'" disabled="isDisabled or state.isBannerVisible" class="'o-mail-Followers d-flex me-1'" menuClass="'o-mail-Followers-dropdown flex-column'" menuDisplay="'d-flex'" title="followerButtonLabel" togglerClass="'o-mail-Followers-button btn btn-link text-action px-1 ' + (props.compactHeight ? '' : 'my-2')">
                         <t t-set-slot="toggler">
                             <i class="fa fa-user-o" role="img"/>
                             <span class="o-mail-Followers-counter ps-1" t-esc="state.thread.followers.size"/>
@@ -93,10 +93,11 @@
             </div>
             <t t-if="state.composerType">
                 <t t-if="state.composerType === 'message'">
-                    <div class="flex-shrink-0 px-3 pt-3 text-truncate small" style="margin-left:48px" t-out="toFollowersText"/>
+                    <div class="flex-shrink-0 px-3 pt-3 text-truncate small" style="margin-left:48px" t-out="toFollowersText"  t-att-class="{ 'o-jump-Present-composer-message': state.isBannerVisible }"/>
                 </t>
                 <t t-set="type" t-value="state.composerType === 'message' ? 'message' : 'note'"/>
                 <SuggestedRecipientsList t-if="props.hasFollowers and state.composerType !== 'note'" className="'px-3'" styleString="'margin-left:48px;'" thread="state.thread"/>
+                <div t-if="state.composerType != 'message' &amp;&amp; state.isBannerVisible" class="o-jump-Present-composer-log"></div>
                 <Composer composer="state.thread.composer" autofocus="true" className="state.composerType === 'message' ? '' : 'pt-4'" mode="'extended'" onPostCallback.bind="onPostCallback" dropzoneRef="rootRef" type="state.composerType" t-key="props.threadId"/>
             </t>
         </div>


### PR DESCRIPTION
**Current behavior before PR:**

When scrolling down on the chatter, the 'Jump to present' banner hides the chatter actions.

**Desired behavior after PR is merged:**

the issues was resolved by fixing the potions of banner, now scrolling down on the chatter,the 'Jump to present' banner it displayed below chatter actions.

task-3930968

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
