### PR TITLE
[IMP] mail: clean up the mute and settings

### DIFF
--- a/addons/mail/controllers/discuss/__init__.py
+++ b/addons/mail/controllers/discuss/__init__.py
@@ -5,4 +5,5 @@ from . import channel
 from . import gif
 from . import public_page
 from . import rtc
+from . import settings
 from . import voice

--- a/addons/mail/controllers/discuss/settings.py
+++ b/addons/mail/controllers/discuss/settings.py
@@ -1,0 +1,49 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from datetime import datetime
+from dateutil.relativedelta import relativedelta
+
+from odoo import fields
+from odoo.http import request, route, Controller
+
+
+class DiscussSettingsController(Controller):
+    @route("/discuss/settings/mute", methods=["POST"], type="json", auth="user")
+    def discuss_mute(self, minutes, channel_id=None):
+        """Mute notifications for the given number of minutes.
+        :param minutes: (integer) number of minutes to mute notifications, -1 means mute until the user unmutes
+        :param channel_id: (integer) id of the discuss.channel record, if not set, mute for res.users.settings
+        """
+        if not channel_id:
+            record = request.env['res.users.settings']._find_or_create_for_user(request.env.user)
+        else:
+            channel = request.env["discuss.channel"].browse(channel_id)
+            if not channel:
+                raise request.not_found()
+            record = channel._find_or_create_member_for_self()
+        if not record:
+            raise request.not_found()
+        if minutes == -1:
+            record.mute_until_dt = datetime.max
+        elif minutes:
+            record.mute_until_dt = fields.Datetime.now() + relativedelta(minutes=minutes)
+        else:
+            record.mute_until_dt = False
+        record._notify_mute()
+
+    @route("/discuss/settings/custom_notifications", methods=["POST"], type="json", auth="user")
+    def discuss_custom_notifications(self, custom_notifications, channel_id=None):
+        """Set custom notifications for the given channel or general user settings.
+        :param custom_notifications: (false|all|mentions|no_notif) custom notifications to set
+        :param channel_id: (integer) id of the discuss.channel record, if not set, set for res.users.settings
+        """
+        if not channel_id:
+            record = request.env['res.users.settings']._find_or_create_for_user(request.env.user)
+        else:
+            channel = request.env["discuss.channel"].browse(channel_id)
+            if not channel:
+                raise request.not_found()
+            record = channel._find_or_create_member_for_self()
+        if not record:
+            raise request.not_found()
+        record.set_custom_notifications(custom_notifications)

--- a/addons/mail/data/ir_cron_data.xml
+++ b/addons/mail/data/ir_cron_data.xml
@@ -72,7 +72,7 @@
             <field name="interval_number">1</field>
             <field name="interval_type">days</field>
             <field name="model_id" ref="model_discuss_channel_member"/>
-            <field name="code">model._unmute()</field>
+            <field name="code">model._cleanup_expired_mutes()</field>
             <field name="state">code</field>
         </record>
 

--- a/addons/mail/static/src/core/common/settings_model.js
+++ b/addons/mail/static/src/core/common/settings_model.js
@@ -3,6 +3,7 @@ import { sprintf } from "@web/core/utils/strings";
 import { browser } from "@web/core/browser/browser";
 import { Record } from "./record";
 import { debounce } from "@web/core/utils/timing";
+import { rpc } from "@web/core/network/rpc";
 
 export class Settings extends Record {
     id;
@@ -68,15 +69,15 @@ export class Settings extends Record {
     get NOTIFICATIONS() {
         return [
             {
-                id: "all",
+                label: "all",
                 name: _t("All Messages"),
             },
             {
-                id: "mentions",
+                label: "mentions",
                 name: _t("Mentions Only"),
             },
             {
-                id: "no_notif",
+                label: "no_notif",
                 name: _t("Nothing"),
             },
         ];
@@ -85,32 +86,32 @@ export class Settings extends Record {
     get MUTES() {
         return [
             {
-                id: "15_mins",
+                label: "15_mins",
                 value: 15,
                 name: _t("For 15 minutes"),
             },
             {
-                id: "1_hour",
+                label: "1_hour",
                 value: 60,
                 name: _t("For 1 hour"),
             },
             {
-                id: "3_hours",
+                label: "3_hours",
                 value: 180,
                 name: _t("For 3 hours"),
             },
             {
-                id: "8_hours",
+                label: "8_hours",
                 value: 480,
                 name: _t("For 8 hours"),
             },
             {
-                id: "24_hours",
+                label: "24_hours",
                 value: 1440,
                 name: _t("For 24 hours"),
             },
             {
-                id: "forever",
+                label: "forever",
                 value: -1,
                 name: _t("Until I turn it back on"),
             },
@@ -127,27 +128,25 @@ export class Settings extends Record {
     }
 
     /**
-     * @param {string} notif
+     * @param {string} custom_notifications
+     * @param {import("models").Thread} thread
      */
-    setChannelNotifications(notif) {
-        this.store.env.services.orm.call(
-            "res.users.settings",
-            "set_res_users_settings",
-            [[this.id]],
-            {
-                new_settings: {
-                    channel_notifications: notif === "mentions" ? false : notif,
-                },
-            }
-        );
+    async setCustomNotifications(custom_notifications, thread = undefined) {
+        return rpc("/discuss/settings/custom_notifications", {
+            custom_notifications:
+                !thread && custom_notifications === "mentions" ? false : custom_notifications,
+            channel_id: thread?.id,
+        });
     }
 
     /**
      * @param {integer|false} minutes
+     * @param {import("models").Thread} thread
      */
-    setMuteDuration(minutes) {
-        this.store.env.services.orm.call("res.users.settings", "mute", [[this.id]], {
-            minutes: minutes,
+    async setMuteDuration(minutes, thread = undefined) {
+        return rpc("/discuss/settings/mute", {
+            minutes,
+            channel_id: thread?.id,
         });
     }
 

--- a/addons/mail/static/src/discuss/core/common/discuss_notification_settings.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_notification_settings.js
@@ -15,7 +15,7 @@ export class DiscussNotificationSettings extends Component {
     onChangeDisplayMuteDetails() {
         // set the default mute duration to forever when opens the mute details
         if (!this.store.settings.mute_until_dt) {
-            const FOREVER = this.store.settings.MUTES.find((m) => m.id === "forever").value;
+            const FOREVER = this.store.settings.MUTES.find((m) => m.label === "forever").value;
             this.store.settings.setMuteDuration(FOREVER);
             this.state.selectedDuration = FOREVER;
         } else {
@@ -29,9 +29,5 @@ export class DiscussNotificationSettings extends Component {
         }
         this.store.settings.setMuteDuration(parseInt(ev.target.value));
         this.state.selectedDuration = parseInt(ev.target.value);
-    }
-
-    onChangeCustomNotifications(value) {
-        this.store.settings.setChannelNotifications(value);
     }
 }

--- a/addons/mail/static/src/discuss/core/common/discuss_notification_settings.xml
+++ b/addons/mail/static/src/discuss/core/common/discuss_notification_settings.xml
@@ -20,8 +20,8 @@
                 <div class="flex-grow-1"/>
                 <select class="form-select w-auto d-flex" t-on-change="onChangeMuteDuration">
                     <option value="default">Select duration</option>
-                    <t t-foreach="store.settings.MUTES" t-as="item" t-key="item.id">
-                        <option t-att-value="item.value" t-esc="item.name" t-att-selected="item.value === state.selectedDuration"/>
+                    <t t-foreach="store.settings.MUTES" t-as="mute" t-key="mute.label">
+                        <option t-att-value="mute.value" t-esc="mute.name" t-att-selected="mute.value === state.selectedDuration"/>
                     </t>
                 </select>
             </label>
@@ -29,11 +29,11 @@
             <div class="d-flex flex-column my-1">
                 <h5>Channel notification settings</h5>
                 <span class="mb-1">This setting will be applied to all channels using the default category.</span>
-                <t t-foreach="store.settings.NOTIFICATIONS" t-as="item" t-key="item.id">
-                    <button class="btn d-flex my-1" t-att-class="{'bg-300' : item.id === store.settings.channel_notifications}" t-on-click="()=> this.onChangeCustomNotifications(item.id)">
-                        <input class="form-check-input" type="radio" t-att-checked="item.id === store.settings.channel_notifications"/>
+                <t t-foreach="store.settings.NOTIFICATIONS" t-as="notif" t-key="notif.label">
+                    <button class="btn d-flex my-1" t-att-class="{'bg-300' : notif.label === store.settings.channel_notifications}" t-on-click="()=> this.store.settings.setCustomNotifications(notif.label)">
+                        <input class="form-check-input" type="radio" t-att-checked="notif.label === store.settings.channel_notifications"/>
                         <div class="d-flex flex-column text-start flex-grow-1 mx-3">
-                            <span t-esc="item.name"/>
+                            <span t-esc="notif.name"/>
                         </div>
                     </button>
                 </t>

--- a/addons/mail/static/src/discuss/core/common/notification_settings.js
+++ b/addons/mail/static/src/discuss/core/common/notification_settings.js
@@ -12,13 +12,8 @@ export class NotificationSettings extends Component {
         this.store = useState(useService("mail.store"));
     }
 
-    selectUnmute() {
-        this.props.thread.mute();
-        this.props.close();
-    }
-
     setMute(minutes) {
-        this.props.thread.mute({ minutes });
+        this.store.settings.setMuteDuration(minutes, this.props.thread);
         this.props.close();
     }
 }

--- a/addons/mail/static/src/discuss/core/common/notification_settings.xml
+++ b/addons/mail/static/src/discuss/core/common/notification_settings.xml
@@ -4,7 +4,7 @@
     <t t-name="discuss.NotificationSettings">
         <div class="o-discuss-NotificationSettings">
             <t t-if="props.thread.mute_until_dt">
-                <button class="btn w-100 d-flex p-1 opacity-75 opacity-100-hover" t-on-click="selectUnmute">
+                <button class="btn w-100 d-flex p-1 opacity-75 opacity-100-hover" t-on-click="()=>this.setMute(false)">
                     <div class="d-flex flex-column flex-grow-1 px-2 py-1 w-100 rounded">
                         <span class="fs-6 fw-bold text-wrap text-start text-break">Unmute Channel</span>
                         <span class="fw-normal o-smaller" t-out="store.settings.getMuteUntilText(props.thread.mute_until_dt)"/>
@@ -21,8 +21,8 @@
                         </div>
                     </button>
                     <t t-set-slot="content">
-                        <t t-foreach="store.settings.MUTES" t-as="item" t-key="item.id">
-                            <DropdownItem class="'o-mail-NotificationSettings-muteDuration btn rounded-0 d-flex align-items-center px-2 py-2 m-0 opacity-75 opacity-100-hover'" onSelected="()=>this.setMute(item.value)"><button class="btn p-0 mx-2 text-wrap text-start text-break" t-out="item.name"/></DropdownItem>
+                        <t t-foreach="store.settings.MUTES" t-as="mute" t-key="mute.label">
+                            <DropdownItem class="'o-mail-NotificationSettings-muteDuration btn rounded-0 d-flex align-items-center px-2 py-2 m-0 opacity-75 opacity-100-hover'" onSelected="()=>this.setMute(mute.value)"><button class="btn p-0 mx-2 text-wrap text-start text-break" t-out="mute.name"/></DropdownItem>
                         </t>
                     </t>
                 </Dropdown>
@@ -31,29 +31,29 @@
                         <span class="fs-6 fw-bold text-wrap text-start text-break">Mute Channel</span>
                     </div>
                     <hr class="solid mx-2 my-0"/>
-                    <t t-foreach="store.settings.MUTES" t-as="item" t-key="item.id">
-                        <button class="o-mail-NotificationSettings-muteDuration btn rounded d-flex align-items-center fs-6 fw-normal px-3 py-2 m-0 opacity-75 opacity-100-hover" t-att-title="item.name" t-on-click="() => this.setMute(item.value)" t-out="item.name"/>
+                    <t t-foreach="store.settings.MUTES" t-as="mute" t-key="mute.label">
+                        <button class="o-mail-NotificationSettings-muteDuration btn rounded d-flex align-items-center fs-6 fw-normal px-3 py-2 m-0 opacity-75 opacity-100-hover" t-att-title="mute.name" t-on-click="() => this.setMute(mute.value)" t-out="mute.name"/>
                     </t>
                 </div>
             </div>
             <t t-if="props.thread.channel_type === 'channel'">
                 <hr class="solid mx-2 my-0"/>
-                <button class="btn d-flex w-100 px-1 py-0 opacity-75 opacity-100-hover" t-on-click="() => props.thread.updateCustomNotifications(false)">
+                <button class="btn d-flex w-100 px-1 py-0 opacity-75 opacity-100-hover" t-on-click="() => store.settings.setCustomNotifications(false, props.thread)">
                     <div class="d-flex flex-grow-1 align-items-center p-2 rounded">
                         <div class="d-flex flex-column align-items-start">
                             <span class="fs-6 fw-normal text-wrap text-start text-break">Use Default</span>
-                            <span class="fw-bolder o-smaller"><t t-out="store.settings.NOTIFICATIONS.find((n) => n.id === store.settings.channel_notifications).name"/></span>
+                            <span class="fw-bolder o-smaller"><t t-out="store.settings.NOTIFICATIONS.find((n) => n.label === store.settings.channel_notifications).name"/></span>
                         </div>
                         <div class="o-discuss-NotificationSettings-separator flex-grow-1"/>
                         <input class="form-check-input" type="radio" t-att-checked="!props.thread.custom_notifications"/>
                     </div>
                 </button>
-                <t t-foreach="store.settings.NOTIFICATIONS" t-as="item" t-key="item.id">
-                    <button class="btn w-100 d-flex px-1 py-0 opacity-75 opacity-100-hover" t-on-click="() => props.thread.updateCustomNotifications(item.id)">
+                <t t-foreach="store.settings.NOTIFICATIONS" t-as="notif" t-key="notif.label">
+                    <button class="btn w-100 d-flex px-1 py-0 opacity-75 opacity-100-hover" t-on-click="() => store.settings.setCustomNotifications(notif.label, props.thread)">
                         <div class="d-flex flex-grow-1 align-items-center p-2 rounded">
-                            <span class="fs-6 fw-normal text-wrap text-start text-break" t-esc="item.name"/>
+                            <span class="fs-6 fw-normal text-wrap text-start text-break" t-esc="notif.name"/>
                             <div class="o-discuss-NotificationSettings-separator flex-grow-1"/>
-                            <input class="form-check-input ms-2" type="radio" t-att-checked="props.thread.custom_notifications === item.id"/>
+                            <input class="form-check-input ms-2" type="radio" t-att-checked="props.thread.custom_notifications === notif.label"/>
                         </div>
                     </button>
                 </t>

--- a/addons/mail/static/src/discuss/core/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/thread_model_patch.js
@@ -59,9 +59,6 @@ const threadPatch = {
             this.isLoadingAttachments = false;
         }
     },
-    async mute({ minutes = false } = {}) {
-        await rpc("/discuss/channel/mute", { channel_id: this.id, minutes });
-    },
     /** @param {string} body */
     async post(body) {
         if (this.model === "discuss.channel" && body.startsWith("/")) {
@@ -76,14 +73,6 @@ const threadPatch = {
             }
         }
         return super.post(...arguments);
-    },
-    async updateCustomNotifications(custom_notifications) {
-        // Update the UI instantly to provide a better UX (no need to wait for the RPC to finish).
-        this.custom_notifications = custom_notifications;
-        await rpc("/discuss/channel/update_custom_notifications", {
-            channel_id: this.id,
-            custom_notifications,
-        });
     },
 };
 patch(Thread.prototype, threadPatch);


### PR DESCRIPTION
There are many repeated codes in js and py to achieve the same functions (changing notif and mute for channel and res_users_settings, the only difference is that one provides channel_id and the other provides res_users_settings_id).

This commit cleans up these repeated codes.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
