### PR TITLE
[REF] mail: rename thread to store

### DIFF
--- a/addons/mail/controllers/thread.py
+++ b/addons/mail/controllers/thread.py
@@ -14,7 +14,9 @@ class ThreadController(http.Controller):
     @http.route("/mail/thread/data", methods=["POST"], type="json", auth="user")
     def mail_thread_data(self, thread_model, thread_id, request_list):
         thread = request.env[thread_model].with_context(active_test=False).search([("id", "=", thread_id)])
-        return Store(thread, request_list=request_list).get_result()
+        store = Store()
+        thread._thread_to_store(store, request_list=request_list)
+        return store.get_result()
 
     @http.route("/mail/thread/messages", methods=["POST"], type="json", auth="user")
     def mail_thread_messages(self, thread_model, thread_id, search_term=None, before=None, after=None, around=None, limit=30):

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -4542,7 +4542,7 @@ class MailThread(models.AbstractModel):
         self.ensure_one()
         return self.env['ir.attachment'].search([('res_id', '=', self.id), ('res_model', '=', self._name)], order='id desc')
 
-    def _to_store(self, store: Store, request_list):
+    def _thread_to_store(self, store: Store, /, *, request_list):
         res = {'hasWriteAccess': False, 'hasReadAccess': True, "id": self.id, "model": self._name}
         if not self:
             res['hasReadAccess'] = False

--- a/addons/mail/models/mail_thread_main_attachment.py
+++ b/addons/mail/models/mail_thread_main_attachment.py
@@ -49,8 +49,8 @@ class MailMainAttachmentMixin(models.AbstractModel):
                     key=lambda r: (r.mimetype.endswith('pdf'), r.mimetype.startswith('image'))
                 ).id
 
-    def _to_store(self, store: Store, request_list):
-        super()._to_store(store, request_list)
+    def _thread_to_store(self, store: Store, request_list, **kwargs):
+        super()._thread_to_store(store, request_list=request_list, **kwargs)
         if 'attachments' in request_list:
             store.add(
                 "Thread",

--- a/addons/mail/static/tests/chatter/web/follower.test.js
+++ b/addons/mail/static/tests/chatter/web/follower.test.js
@@ -28,9 +28,9 @@ test("base rendering not editable", async () => {
         res_model: "res.partner",
     });
     patchWithCleanup(MailThread.prototype, {
-        _to_store(ids, store) {
+        _thread_to_store(ids, store) {
             // mimic user without write access
-            super._to_store(...arguments);
+            super._thread_to_store(...arguments);
             store.add("Thread", { hasWriteAccess: false, id: ids[0], model: this._name });
         },
     });

--- a/addons/mail/static/tests/chatter/web/follower_list_menu.test.js
+++ b/addons/mail/static/tests/chatter/web/follower_list_menu.test.js
@@ -30,9 +30,9 @@ test("base rendering editable", async () => {
     const pyEnv = await startServer();
     const partnerId = pyEnv["res.partner"].create({});
     patchWithCleanup(MailThread.prototype, {
-        _to_store(ids, store) {
+        _thread_to_store(ids, store) {
             // mimic user with write access
-            super._to_store(...arguments);
+            super._thread_to_store(...arguments);
             store.add("Thread", { hasWriteAccess: true, id: ids[0], model: this._name });
         },
     });
@@ -61,9 +61,9 @@ test('click on "add followers" button', async () => {
         res_model: "res.partner",
     });
     patchWithCleanup(MailThread.prototype, {
-        _to_store(ids, store) {
+        _thread_to_store(ids, store) {
             // mimic user with write access
-            super._to_store(...arguments);
+            super._thread_to_store(...arguments);
             store.add("Thread", { hasWriteAccess: true, id: ids[0], model: this._name });
         },
     });
@@ -119,9 +119,9 @@ test("click on remove follower", async () => {
         res_model: "res.partner",
     });
     patchWithCleanup(MailThread.prototype, {
-        _to_store(ids, store) {
+        _thread_to_store(ids, store) {
             // mimic user with write access
-            super._to_store(...arguments);
+            super._thread_to_store(...arguments);
             store.add("Thread", { hasWriteAccess: true, id: ids[0], model: this._name });
         },
     });
@@ -160,9 +160,9 @@ test('Hide "Add follower" and subtypes edition/removal buttons except own user o
         },
     ]);
     patchWithCleanup(MailThread.prototype, {
-        _to_store(ids, store) {
+        _thread_to_store(ids, store) {
             // mimic user without write access
-            super._to_store(...arguments);
+            super._thread_to_store(...arguments);
             store.add("Thread", { hasWriteAccess: false, id: ids[0], model: this._name });
         },
     });
@@ -298,9 +298,9 @@ test('Show "Add follower" and subtypes edition/removal buttons on all followers 
         },
     ]);
     patchWithCleanup(MailThread.prototype, {
-        _to_store(ids, store) {
+        _thread_to_store(ids, store) {
             // mimic user with write access
-            super._to_store(...arguments);
+            super._thread_to_store(...arguments);
             store.add("Thread", { hasWriteAccess: true, id: ids[0], model: this._name });
         },
     });
@@ -320,9 +320,9 @@ test('Show "No Followers" dropdown-item if there are no followers and user does 
     const pyEnv = await startServer();
     const partnerId = pyEnv["res.partner"].create({});
     patchWithCleanup(MailThread.prototype, {
-        _to_store(ids, store) {
+        _thread_to_store(ids, store) {
             // mimic user without write access
-            super._to_store(...arguments);
+            super._thread_to_store(...arguments);
             store.add("Thread", { hasWriteAccess: false, id: ids[0], model: this._name });
         },
     });

--- a/addons/mail/static/tests/chatter/web/follower_subtype.test.js
+++ b/addons/mail/static/tests/chatter/web/follower_subtype.test.js
@@ -28,9 +28,9 @@ test("simplest layout of a followed subtype", async () => {
         subtype_ids: [subtypeId],
     });
     patchWithCleanup(MailThread.prototype, {
-        _to_store(ids, store) {
+        _thread_to_store(ids, store) {
             // mimic user with write access
-            super._to_store(...arguments);
+            super._thread_to_store(...arguments);
             store.add("Thread", { hasWriteAccess: true, id: ids[0], model: this._name });
         },
     });
@@ -60,9 +60,9 @@ test("simplest layout of a not followed subtype", async () => {
         res_id: serverState.partnerId,
     });
     patchWithCleanup(MailThread.prototype, {
-        _to_store(ids, store) {
+        _thread_to_store(ids, store) {
             // mimic user with write access
-            super._to_store(...arguments);
+            super._thread_to_store(...arguments);
             store.add("Thread", { hasWriteAccess: true, id: ids[0], model: this._name });
         },
     });
@@ -88,9 +88,9 @@ test("toggle follower subtype checkbox", async () => {
         res_id: serverState.partnerId,
     });
     patchWithCleanup(MailThread.prototype, {
-        _to_store(ids, store) {
+        _thread_to_store(ids, store) {
             // mimic user with write access
-            super._to_store(...arguments);
+            super._thread_to_store(...arguments);
             store.add("Thread", { hasWriteAccess: true, id: ids[0], model: this._name });
         },
     });

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -746,7 +746,7 @@ export async function mail_thread_data(request) {
     const { request_list, thread_model, thread_id } = await parseRequestParams(request);
     const records = this.env[thread_model].search([["id", "=", thread_id]]);
     const store = new mailDataHelpers.Store();
-    MailThread._to_store.call(this.env[thread_model], [...records], store, request_list);
+    MailThread._thread_to_store.call(this.env[thread_model], [...records], store, request_list);
     return store.get_result();
 }
 

--- a/addons/mail/static/tests/mock_server/mock_models/mail_thread.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_thread.js
@@ -592,7 +592,7 @@ export class MailThread extends models.ServerModel {
         return false;
     }
 
-    _to_store(ids, store, request_list) {
+    _thread_to_store(ids, store, request_list) {
         const kwargs = getKwArgs(arguments, "ids", "store", "request_list");
         const id = kwargs.ids[0];
         store = kwargs.store;


### PR DESCRIPTION
There is a conflict between the _to_store of the thread and the _to_store of the record, which will be highlighted when converting partner format to store.

Thread is a specific use case which is therefore renamed to avoid issue.

Part of task-3605717

https://github.com/odoo/enterprise/pull/66157