### PR TITLE
[FIX] project: set default value of analytic plan in the project config setting

### DIFF
--- a/addons/hr_timesheet/tests/test_timesheet.py
+++ b/addons/hr_timesheet/tests/test_timesheet.py
@@ -705,7 +705,7 @@ class TestTimesheet(TestCommonTimesheet):
         self.assertEqual(self.task1.progress, 100, 'The percentage of allocated hours should be 100%.')
 
     def test_analytic_plan_setting(self):
-        self.env['ir.config_parameter'].set_param('analytic.analytic_plan_projects', 1)
+        self.env['ir.config_parameter'].set_param('analytic.project_plan', 1)
         project_1 = self.env['project.project'].create({
             'name': "Project with plan setting 1",
             'allow_timesheets': True,
@@ -713,7 +713,7 @@ class TestTimesheet(TestCommonTimesheet):
         })
         self.assertEqual(project_1.analytic_account_id.plan_id.id, 1)
 
-        self.env['ir.config_parameter'].set_param('analytic.analytic_plan_projects', 2)
+        self.env['ir.config_parameter'].set_param('analytic.project_plan', 2)
         project_2 = self.env['project.project'].create({
             'name': "Project with plan setting 2",
             'allow_timesheets': True,

--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -900,7 +900,7 @@ class Project(models.Model):
     @api.model
     def _create_analytic_account_from_values(self, values):
         company = self.env['res.company'].browse(values.get('company_id', False))
-        project_plan_id = int(self.env['ir.config_parameter'].sudo().get_param('analytic.analytic_plan_projects'))
+        project_plan_id = int(self.env['ir.config_parameter'].sudo().get_param('analytic.project_plan'))
 
         if not project_plan_id:
             project_plan, _other_plans = self.env['account.analytic.plan']._get_all_plans()

--- a/addons/project/models/res_config_settings.py
+++ b/addons/project/models/res_config_settings.py
@@ -18,7 +18,7 @@ class ResConfigSettings(models.TransientModel):
     analytic_plan_id = fields.Many2one(
         comodel_name='account.analytic.plan',
         string="Analytic Plan",
-        config_parameter="analytic.analytic_plan_projects",
+        config_parameter="analytic.project_plan",
     )
 
     @api.model


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

- In v17.0, the default value of 'analytic plan' (analytic_plan_id) has not been set in setting.
- Analytic plan has config_parameter is set as "[analytic.analytic_plan_projects](https://github.com/odoo/odoo/blob/758ced91f8cb220a003a49b01e047b507f8509d7/addons/project/models/res_config_settings.py#L18-L22)" However, the default key was set different "[account.plan_projects](https://github.com/odoo/odoo/blob/758ced91f8cb220a003a49b01e047b507f8509d7/addons/analytic/data/analytic_data.xml#L13)" 
- And during the migration from v16.0 to v17.0, the default key generated in v16.0 is  [removed](https://github.com/odoo/upgrade/blob/20faf7ba48595c61fc028ba1b4cf278d2c44e3cc/migrations/analytic/saas~16.5.1.1/pre-migrate.py#L10-L18) in saas~16.5 and new key will be set which this only "account.plan_projects" .
- Because of the incorrect key value of 'analytic plan'(analytic_plan_id) is null.

**Steps to reproduce:**

- Install project module.
- Go to Setting > Projects > got to Analytics section in that Analytic Plan.
- Default analytic plan value is not there.

**Solution:**

- Set the correct key `analytic.project_plan` for the 'analytic_plan_id' field.


**Current behavior in 16.0 :**
![image](https://github.com/odoo/odoo/assets/139756070/675bfed9-8b41-4323-b227-4a79d9893cfb)

**Current behavior in 17.0 before pr:**
![image](https://github.com/odoo/odoo/assets/139756070/5ad89fb3-cdf8-4eb6-a904-fb6072c39c51)

**Desired behavior after PR is merged:**
![image](https://github.com/odoo/odoo/assets/139756070/98dd93e8-c6f9-4154-a1a7-d2851da0a33b)


task-3941668
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
