### PR TITLE
[IMP] project: removed state in task activity view

### DIFF
--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -896,8 +896,6 @@
                                 </div>
                             </div>
                             <div class="d-flex justify-content-end gap-2 flex-grow-1">
-                                <field name="state" widget="project_task_state_selection" class="align-self-center"
-                                       options="{'is_toggle_mode': false}"/>
                                 <field name="user_ids" widget="many2many_avatar_user" class="o_many2many_avatar_user_no_wrap"/>
                             </div>
                         </div>


### PR DESCRIPTION
Prior to this commit, the state of the task was displayed in the Activity view of project task.
This feature was not informing due to the lack of context such as the stage of the task.
Additionally, this state was not aligned when the task was unassigned.

After this commit, this state selection is removed from the Activity view of the project task.

Task: 4029663

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
