### PR TITLE
[PERF] hr_timesheet: speed up portal access to timesheets

### DIFF
--- a/addons/hr_timesheet/report/timesheets_analysis_report.py
+++ b/addons/hr_timesheet/report/timesheets_analysis_report.py
@@ -25,6 +25,16 @@ class TimesheetsAnalysisReport(models.Model):
     unit_amount = fields.Float("Time Spent", readonly=True)
     partner_id = fields.Many2one('res.partner', string="Partner", readonly=True)
     milestone_id = fields.Many2one('project.milestone', related='task_id.milestone_id')
+    message_partner_ids = fields.Many2many('res.partner', compute='_compute_message_partner_ids',
+                                           search='_search_message_partner_ids', readonly=True)
+
+    @api.depends('project_id.message_partner_ids', 'task_id.message_partner_ids')
+    def _compute_message_partner_ids(self):
+        for line in self:
+            line.message_partner_ids = line.task_id.message_partner_ids | line.project_id.message_partner_ids
+
+    def _search_message_partner_ids(self, operator, value):
+        return self.env['account.analytic.line']._search_message_partner_ids(operator, value)
 
     @property
     def _table_query(self):

--- a/addons/hr_timesheet/security/hr_timesheet_security.xml
+++ b/addons/hr_timesheet/security/hr_timesheet_security.xml
@@ -36,9 +36,7 @@
             <field name="active">0</field>
             <field name="domain_force">[
                 ('project_id', '!=', False),
-                '|',
-                    ('project_id.message_partner_ids', 'child_of', [user.partner_id.commercial_partner_id.id]),
-                    ('task_id.message_partner_ids', 'child_of', [user.partner_id.commercial_partner_id.id]),
+                ('message_partner_ids', 'child_of', [user.partner_id.commercial_partner_id.id]),
                 ('project_id.privacy_visibility', '=', 'portal'),
                 ('project_id.collaborator_ids.partner_id', 'in', [user.partner_id.id]),
             ]</field>
@@ -55,10 +53,9 @@
             <field name="domain_force">[
                 ('user_id', '=', user.id),
                 ('project_id', '!=', False),
-                '|', '|',
+                '|',
                     ('project_id.privacy_visibility', '!=', 'followers'),
-                    ('project_id.message_partner_ids', 'in', [user.partner_id.id]),
-                    ('task_id.message_partner_ids', 'in', [user.partner_id.id])
+                    ('message_partner_ids', 'in', [user.partner_id.id])
             ]</field>
             <field name="groups" eval="[(4, ref('group_hr_timesheet_user'))]"/>
         </record>
@@ -97,10 +94,9 @@
             <field name="model_id" ref="model_timesheets_analysis_report"/>
             <field name="domain_force">[
                 ('user_id', '=', user.id),
-                '|', '|',
+                '|',
                     ('project_id.privacy_visibility', '!=', 'followers'),
-                    ('project_id.message_partner_ids', 'in', [user.partner_id.id]),
-                    ('task_id.message_partner_ids', 'in', [user.partner_id.id])
+                    ('message_partner_ids', 'in', [user.partner_id.id])
             ]</field>
             <field name="groups" eval="[(4, ref('group_hr_timesheet_user'))]"/>
         </record>


### PR DESCRIPTION
## Description
On large database with a heavy activity of services (timesheets), the portal routes `/my` and `/my/timesheets` can be quite slow. `/my` is problematic, as it's the landing page after portal login, therefor it's a route that is hit frequently.

## Analysis
For both routes, the issue comes from domains of the form:
```py
['|', ('project_id.message_partner_ids', 'in', [user.partner_id.id]),
      ('task_id.message_partner_ids', 'in', [user.partner_id.id]),
 ('project_id.privacy_visibility', '=', 'portal')]
```
or worse (in `_timesheet_get_portal_domain`)
```py
['|',
    '&',
        '|',
            ('task_id.project_id.message_partner_ids', 'child_of', [self.env.user.partner_id.commercial_partner_id.id]),
            ('task_id.message_partner_ids', 'child_of', [self.env.user.partner_id.commercial_partner_id.id]),
        ('task_id.project_id.privacy_visibility', '=', 'portal'),
    '&',
        ('task_id', '=', False),
        '&',
            ('project_id.message_partner_ids', 'child_of', [self.env.user.partner_id.commercial_partner_id.id]),
            ('project_id.privacy_visibility', '=', 'portal')]
```
with generates queries with a lot of sub-queries
(AAL -> project/task -> mail_follower -> res_partner). This can lead Postgres to generate bad plans due to overestimations (lack of correlation between `res_id` of `mail.follower` and the `id` of it's respective comodel),
specially if the mentioned domain is extended into other modules, like what is done for `_timesheet_get_portal_domain` in `sale_timesheet` by adding the domain `[('timesheet_invoice_type', 'in', ['billable_time', 'non_billable', 'billable_fixed'])]`. This can lead to a non-selective `Index.Scan` (or worse a `Seq.Scan`) that is filtering on that extended condition plus additional filtering on the `Subplans`. Since `account.analytic.line` is a large table, this is a heavy operation IO wise.

## Solution
We introduce a searchable field (non-stored) `message_partner_ids` on `account.analytic.line` in `hr_timesheet`.
The goal of this search field is to *resolve* the subqueries for the followers into a list of ids.
The list of `ids` should always be relatively small, as one partner is rarely follower of too many projects/tasks. With a list of `ids` Postgres can do better estimations, leading to better plans, making use of the indexes on `task_id` and `project_id` directly.
Now domains of the form
```py
['|', ('project_id.message_partner_ids', 'in', [user.partner_id.id]),
      ('task_id.message_partner_ids', 'in', [user.partner_id.id])]
```
can be simplified to
```py
[('message_partner_ids', 'in', [user.partner_id.id])]
```
which is equivalent to
```py
['|', ('project_id', 'in', list_of_followed_project_ids),
      ('task_id', 'in', list_of_followed_task_ids)]
```
This change is equivalent, there is no semantic changes. For portal related domains, to simplify the domains and make use of the new searchable field,
we introduce a slight spec change:
- Current Spec: If a timesheet is associated to a task, the *task's* project should have a `portal` visibility.
- New Spec: If a timesheet is associated to a task, the *project* linked to the timesheet should have a `portal` visibility.

This change shouldn't alter the behaviour too much, as `_compute_project_id` of the timesheet in most cases keeps the `project_id` in sync to be the project of the `task_id`. This spec change allows us to simplify the domain, avoiding expensive lookup into the `project_task` table to fetch it's project, to see if it's portal, we can directly join the `project_project` table for the check of `portal` state.

⚠️ This new searchable field should be used in lookups with very little partners in the RHS (preferably only 1), in other cases the list of `ids` inlined into the query might be gigantic, leading to other performance issues, in that case the prior search via the subqueries is *the least evil of the two*.

## Benchmark
On large DB, with over 4M timesheets, 1.8M tasks, 12k projects. For a user that is follower to roughly 1.5k associated projects/tasks. The counter for the TS visible in the portal view upon hitting `/my`:

|               | Before | After  | Speed up |
|---------------|--------|--------|----------|
| Timings (hot) | 2.2s   | ~100ms | 22x      |

For the function `portal_my_timesheets` upon hitting `/my/timesheets`

|               | Before | After | Speed up |
|---------------|--------|-------|----------|
| Timings (hot) | 6.6s   | 880ms | 7.5x     |

## Reference
task-3977971

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
