### PR TITLE
[FIX] mail: unable to unpin livechats

### DIFF
--- a/addons/mail/static/src/discuss/core/web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/web/discuss_sidebar_categories.xml
@@ -66,13 +66,13 @@
             <div class="flex-grow-1"/>
             <div class="o-mail-DiscussSidebarChannel-commands d-none ms-1 me-2">
                 <div class="btn-group btn-group-sm">
-                    <button t-if="thread.channel_type === 'channel'" class="btn btn-secondary" t-on-click="() => this.openSettings(thread)" title="Channel settings">
+                    <button t-if="thread.channel_type === 'channel'" class="btn btn-secondary" t-on-click.stop="() => this.openSettings(thread)" title="Channel settings">
                         <i t-attf-class="fa fa-cog" role="img"/>
                     </button>
-                    <button t-if="thread.canLeave" class="btn btn-secondary" t-on-click="() => this.leaveChannel(thread)" title="Leave this channel">
+                    <button t-if="thread.canLeave" class="btn btn-secondary" t-on-click.stop="() => this.leaveChannel(thread)" title="Leave this channel">
                         <i t-attf-class="fa fa-times" role="img"/>
                     </button>
-                    <button t-if="thread.canUnpin" class="btn btn-secondary" t-on-click="() => thread.unpin()" title="Unpin Conversation">
+                    <button t-if="thread.canUnpin" class="btn btn-secondary" t-on-click.stop="() => thread.unpin()" title="Unpin Conversation">
                         <i t-attf-class="fa fa-times" role="img"/>
                     </button>
                 </div>


### PR DESCRIPTION
Before this commit, when opening a livechat session from the livechat app it would not be possible to unpin it from discuss.

This happens because the click event on the unpin button would propagate to a parent element and trigger the opening of the thread.

This commit fixes the issue by stopping the propagation of the click event from the unpin button to parent elements.

The propagation stop was removed in https://github.com/odoo-dev/odoo/commit/652d55b08b87ac02140c7fc84ca129dceb3a69f9

task-4011692
