### PR TITLE
[IMP] hr_holidays: cap yearly on accrual level

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 # Copyright (c) 2005-2006 Axelor SARL. (http://www.axelor.com)
@@ -12,7 +11,6 @@ from odoo.addons.hr_holidays.models.hr_leave import get_employee_from_context
 from odoo.exceptions import AccessError, UserError, ValidationError
 from odoo.tools.float_utils import float_round
 from odoo.tools.date_utils import get_timedelta
-from odoo.osv import expression
 
 
 MONTHS_TO_INTEGER = {"jan": 1, "feb": 2, "mar": 3, "apr": 4, "may": 5, "jun": 6, "jul": 7, "aug": 8, "sep": 9, "oct": 10, "nov": 11, "dec": 12}
@@ -101,6 +99,7 @@ class HolidaysAllocation(models.Model):
     lastcall = fields.Date("Date of the last accrual allocation", readonly=True)
     nextcall = fields.Date("Date of the next accrual allocation", readonly=True, default=False)
     already_accrued = fields.Boolean()
+    yearly_accrued_amount = fields.Float(export_string_translation=False)
     allocation_type = fields.Selection([
         ('regular', 'Regular Allocation'),
         ('accrual', 'Accrual Allocation')
@@ -195,7 +194,8 @@ class HolidaysAllocation(models.Model):
     @api.depends('number_of_days')
     def _compute_number_of_hours_display(self):
         for allocation in self:
-            allocation.number_of_hours_display = allocation.number_of_days * HOURS_PER_DAY
+            hours_per_day = allocation.employee_id.sudo().resource_id.calendar_id.hours_per_day or HOURS_PER_DAY
+            allocation.number_of_hours_display = allocation.number_of_days * hours_per_day
 
     @api.depends('number_of_hours_display', 'number_of_days_display')
     def _compute_duration_display(self):
@@ -299,9 +299,18 @@ class HolidaysAllocation(models.Model):
     def _add_days_to_allocation(self, current_level, current_level_maximum_leave, leaves_taken, period_start, period_end):
         days_to_add = self._process_accrual_plan_level(
             current_level, period_start, self.lastcall, period_end, self.nextcall)
-        self.number_of_days += days_to_add
+        if current_level.cap_accrued_time_yearly:
+            hours_per_day = self.employee_id.sudo().resource_id.calendar_id.hours_per_day or HOURS_PER_DAY
+            maximum_leave_yearly = current_level.maximum_leave_yearly\
+                if current_level.added_value_type != 'hour'\
+                else current_level.maximum_leave_yearly / hours_per_day
+            yearly_remaining_amount = maximum_leave_yearly - self.yearly_accrued_amount
+            days_to_add = min(days_to_add, yearly_remaining_amount)
         if current_level.cap_accrued_time:
-            self.number_of_days = min(self.number_of_days, current_level_maximum_leave + leaves_taken)
+            capped_total_balance = leaves_taken + current_level_maximum_leave
+            days_to_add = min(days_to_add, capped_total_balance - self.number_of_days)
+        self.number_of_days += days_to_add
+        self.yearly_accrued_amount += days_to_add
 
     def _get_current_accrual_plan_level_id(self, date, level_ids=False):
         """
@@ -444,6 +453,7 @@ class HolidaysAllocation(models.Model):
                     allocation._add_days_to_allocation(current_level, current_level_maximum_leave, leaves_taken, period_start, period_end)
                 # if it's the carry-over date, adjust days using current level's carry-over policy, then continue
                 if allocation.nextcall == carryover_date:
+                    allocation.yearly_accrued_amount = 0
                     if current_level.action_with_unused_accruals in ['lost', 'maximum']:
                         allocation_days = allocation.number_of_days + leaves_taken
                         allocation_max_days = current_level.postpone_max_days + leaves_taken

--- a/addons/hr_holidays/tests/test_allocations.py
+++ b/addons/hr_holidays/tests/test_allocations.py
@@ -181,7 +181,7 @@ class TestAllocations(TestHrHolidaysCommon):
             ('employee_id', '=', self.employee_emp.id),
         ])
 
-        self.assertAlmostEqual(employee_allocation.number_of_hours_display, 11.43, places=2)
+        self.assertAlmostEqual(employee_allocation.number_of_hours_display, 10, places=2)
         self.assertAlmostEqual(employee_emp_allocation.number_of_hours_display, 10.0, places=2)
 
     def change_allocation_type_hours(self):

--- a/addons/hr_holidays/views/hr_leave_accrual_views.xml
+++ b/addons/hr_holidays/views/hr_leave_accrual_views.xml
@@ -53,12 +53,15 @@
                         </div>
                     </group>
                     <group name="maximum_leave">
-                        <field name="cap_accrued_time" style="width: 9.35rem"/>
-                        <div style="width: 9.35rem"/>
-                        <div invisible="not cap_accrued_time">
-                            <field name="maximum_leave" style="width: 5rem" widget="FloatWithoutTrailingZeros"/>
-                            <field name="added_value_type" style="white-space: nowrap;width: 5rem"/>
-                        </div>
+                        <label for="cap_accrued_time"/>
+                        <span>
+                            <field name="cap_accrued_time" nolabel="1"/>
+                            <span class="position-absolute" invisible="not cap_accrued_time">
+                                <field name="maximum_leave" style="width: 5rem" widget="FloatWithoutTrailingZeros"
+                                    nolabel="1"/>
+                                <field name="added_value_type" readonly="1" style="white-space: nowrap;width: 5rem"/>
+                            </span>
+                        </span>
                     </group>
                     <group name="milestone">
                         <div class="o_td_label">
@@ -79,7 +82,19 @@
                                 <field name="added_value_type" nolabel="1" readonly="1" force_save="1" style="width: 5rem"/>
                             </div>
                         </div>
-                        <field name="postpone_max_days" class="w-25" invisible="action_with_unused_accruals != 'postponed'"/>
+                        <div invisible="action_with_unused_accruals == 'lost'">
+                            <label for="cap_accrued_time_yearly"/>
+                        </div>
+                        <div invisible="action_with_unused_accruals == 'lost'">
+                            <span>
+                                <field name="cap_accrued_time_yearly" nolabel="1"/>
+                                <span class="position-absolute" invisible="not cap_accrued_time_yearly">
+                                    <field name="maximum_leave_yearly" style="width: 5rem" widget="FloatWithoutTrailingZeros"
+                                        nolabel="1"/>
+                                    <field name="added_value_type" readonly="1" style="white-space: nowrap;width: 5rem"/>
+                                </span>
+                            </span>
+                        </div>
                     </group>
                 </sheet>
             </form>
@@ -172,7 +187,8 @@
                                             <div class="content container" style="width: 560px;">
                                                 <div class="row w-100">
                                                     <div class="pe-0 me-0" style="width: 6rem;">
-                                                        <field name="added_value" widget="FloatWithoutTrailingZeros"/> <field name="added_value_type"/>,
+                                                        <field name="added_value" invisible="1"/>
+                                                        <span t-out="record.added_value.raw_value"/> <field name="added_value_type"/>,
                                                     </div>
                                                     <div class="col-auto m-0 p-0">
                                                         <field name="frequency" class="ms-1"/>
@@ -223,7 +239,7 @@
                             </kanban>
                         </field>
                     </div>
-               </sheet>
+                </sheet>
             </form>
         </field>
     </record>


### PR DESCRIPTION
This commit introduces the possibility to cap on a level the total amount accrued over one year. If unchecked, the behaviour will be the same as previously. However, if checked, the amount defined as a yearly cap will prevent the accrual plan from granting more than that amount over the multiple accrual processes done after the carry-over date.

Also fixes the accrual plan view by avoiding useless 0 decimals on the accrued amount preview for levels.

task-4037699