### PR TITLE
[FIX] core: support repeated calls to parse_config again

### DIFF
--- a/odoo/addons/base/tests/test_configmanager.py
+++ b/odoo/addons/base/tests/test_configmanager.py
@@ -381,3 +381,11 @@ class TestConfigManager(TransactionCase):
         self.assertEqual(len(capture.output), 1)
         full_output = "\n".join(capture.output)
         self.assertIn("longpolling-port is a deprecated alias", full_output)
+
+    def test_05_repeat_parse_config(self):
+        """Emulate multiple calls to parse_config()"""
+        config = configmanager()
+        config._parse_config()
+        config._warn_deprecated_options()
+        config._parse_config()
+        config._warn_deprecated_options()

--- a/odoo/tools/config.py
+++ b/odoo/tools/config.py
@@ -560,13 +560,12 @@ class configmanager(object):
         return opt
 
     def _warn_deprecated_options(self):
-        longpolling_port = self.options.pop('longpolling_port', 0)
-        if longpolling_port:
+        if self.options.get('longpolling_port', 0):
             warnings.warn(
                 "The longpolling-port is a deprecated alias to "
                 "the gevent-port option, please use the latter.",
                 DeprecationWarning)
-            self.options['gevent_port'] = longpolling_port
+            self.options['gevent_port'] = self.options.pop('longpolling_port')
 
         for old_option_name, new_option_name in [
             ('geoip_database', 'geoip_city_db'),


### PR DESCRIPTION
In rare circumstances, such as the test suite of click-odoo, `odoo.tools.config.parse_config()` is called multiple times.

Since 7a074c903f0531e7e258f1a71161ec1dd04aca85, this breaks with a `KeyError` on `longpolling_port`.

To reproduce with Odoo 17:

```python
import odoo
odoo.tools.config.parse_config()
odoo.tools.config.parse_config()
```
