### PR TITLE
[FIX] account_edi: Cancel errors clear on call of cancellation

### DIFF
--- a/addons/account_edi/models/account_move.py
+++ b/addons/account_edi/models/account_move.py
@@ -648,7 +648,7 @@ class AccountMove(models.Model):
             if is_move_marked:
                 move.message_post(body=_("A request for cancellation of the EDI has been called off."))
 
-        documents.write({'state': 'sent'})
+        documents.write({'state': 'sent', 'error': False, 'blocking_level': False})
 
     def _get_edi_document(self, edi_format):
         return self.edi_document_ids.filtered(lambda d: d.edi_format_id == edi_format)


### PR DESCRIPTION
Clear the EDI document errors and the blocking_level when the action to abandon cancel posted moves is called.

Fixed the following case:
1. Stamp a customer invoice (Could you test with a Mexican record)
2. Request EDI cancellation (In this case must be generated a cancel error from the PAC, maybe the customer does not accept the cancellation)
3. Ensure that in step 2, the EDI document has an error message
4. Call the action to abandon the EDI cancellation

Without this commit, the EDI document returns to `send`, but the record presents the error.





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
