### PR TITLE
[FIX] pos_sale: keep price from imported sale orders

### DIFF
--- a/addons/pos_sale/static/src/js/OrderManagementScreen/SaleOrderManagementScreen.js
+++ b/addons/pos_sale/static/src/js/OrderManagementScreen/SaleOrderManagementScreen.js
@@ -194,6 +194,7 @@ odoo.define('pos_sale.SaleOrderManagementScreen', function (require) {
                         description: line.product_id[1],
                         price: line.price_unit,
                         tax_ids: orderFiscalPos ? undefined : line.tax_id,
+                        price_automatically_set: true,
                         price_manually_set: false,
                         sale_order_origin_id: clickedOrder,
                         sale_order_line_id: line,

--- a/addons/pos_sale/static/tests/tours/pos_sale_tours.js
+++ b/addons/pos_sale/static/tests/tours/pos_sale_tours.js
@@ -149,4 +149,16 @@ odoo.define('pos_sale.tour', function (require) {
     ProductScreen.check.checkOrdersListEmpty();
 
     Tour.register('PosOrderDoesNotRemainInList', { test: true, url: '/pos/ui' }, getSteps());
+
+    startSteps();
+    
+    ProductScreen.do.confirmOpeningPopup();
+    ProductScreen.do.clickQuotationButton();
+    ProductScreen.do.selectFirstOrder();
+    ProductScreen.check.selectedOrderlineHas('product_a', '1', '100');
+    ProductScreen.do.clickPartnerButton();
+    ProductScreen.do.clickCustomer('partner_a');
+    ProductScreen.check.selectedOrderlineHas('product_a', '1', '100');
+
+    Tour.register('PosSettleCustomPrice', { test: true, url: '/pos/ui' }, getSteps());
 });

--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -463,3 +463,25 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
 
         self.main_pos_config.open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PosOrderDoesNotRemainInList', login="accountman")
+
+    def test_settle_order_change_customer(self):
+        """
+        When settling an order, the price set on the sol shouldn't reset to
+        the sale price of the product when changing customer.
+        """
+        self.product_a.lst_price = 150
+        self.product_a.taxes_id = None
+        self.product_a.available_in_pos = True
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.env['res.partner'].create({'name': 'Test Partner'}).id,
+            'order_line': [(0, 0, {
+                'product_id': self.product_a.id,
+                'name': self.product_a.name,
+                'product_uom_qty': 1,
+                'price_unit': 100,
+            })],
+        })
+        sale_order.action_confirm()
+
+        self.main_pos_config.open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PosSettleCustomPrice', login="accountman")


### PR DESCRIPTION
Currently when importing an order from sale to pos, if the price was set manually, changing the partner associated with the order will set back the price to the original product sale price.

Steps to reproduce:
-------------------
* Make a new quotation in **sales**
* Change the unit price of a product
* Confirm quotation
* Open the pos shop session
* Import the newly created quotation to be settled
* Change the partner
> Observation: The price set manually changes to the product sale price

Why the fix:
------------
When changing the partner of a sale order we compute all the line that have to recompute their prices:
https://github.com/odoo/odoo/blob/57f1b0bd502938a6d50244896e71df73705584b5/addons/point_of_sale/static/src/js/models.js#L2918-L2920

We see that when we settle an order, `price_manually_set` is set to false. In this example, if we set it to true it would solve the issue but we cannot use it, see with https://github.com/odoo/odoo/commit/70668ee3c3e2c1dd213903b44f4d36cc8ac9fa29 .

Instead what we can do is to use `price_automatically_set` and set it to true. This does not undo the previously mentionned commit and fixes this current issue. This variable was created in https://github.com/odoo/odoo/commit/067299539116b55a449f022706c395dda2177829

opw-4001497