### PR TITLE
[FIX] l10n_cl: use email and website test domains

### DIFF
--- a/addons/l10n_cl/demo/partner_demo.xml
+++ b/addons/l10n_cl/demo/partner_demo.xml
@@ -2,15 +2,15 @@
 <odoo>
 
     <record id="res_partner_bmya" model="res.partner">
-        <field name="name">Blanco Martin &amp; Asociados EIRL</field>
-        <field name="email">info@bmya.cl</field>
+        <field name="name">Blanco Martin &amp; Asociados SpA</field>
+        <field name="email">info@bmyademo.cl</field>
         <field name="is_company">1</field>
         <field name="city">Las Condes</field>
         <field name="country_id" ref="base.cl"/>
         <field name="street">Apoquindo 6410</field>
         <field name="street2">Oficina 212, Santiago (RM)</field>
         <field name="phone">+56 2 28400990</field>
-        <field name="website">http://www.bmya.cl</field>
+        <field name="website">http://www.bmyademo.cl</field>
         <field name='l10n_latam_identification_type_id' ref="it_RUT"/>
         <field name='l10n_cl_sii_taxpayer_type'>1</field>
         <field name='vat'>76201224-3</field>
@@ -27,14 +27,14 @@
 
     <record id="res_partner_teksa" model="res.partner">
         <field name="name">Teksa SpA</field>
-        <field name="email">teksa@teksa.cl</field>
+        <field name="email">teksa@teksademo.cl</field>
         <field name="is_company">1</field>
         <field name="city">Pudahuel</field>
         <field name="country_id" ref="base.cl"/>
         <field name="street">Puerto Madero 9710</field>
         <field name="street2">Of A15, Santiago (RM)</field>
         <field name="phone">+562 2840 5918</field>
-        <field name="website">http://www.teksa.cl</field>
+        <field name="website">http://www.teksademo.cl</field>
         <field name='l10n_latam_identification_type_id' ref="it_RUT"/>
         <field name='l10n_cl_sii_taxpayer_type'>1</field>
         <field name='vat'>76882486-K</field>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Some email domains in demo data and test data match real emails. So we changed them for demo domains to prevent reception of test emails in real accounts


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
