### PR TITLE
[FIX] base: fallback on 1.0 for currency rate computation

### DIFF
--- a/odoo/addons/base/models/res_currency.py
+++ b/odoo/addons/base/models/res_currency.py
@@ -148,7 +148,7 @@ class Currency(models.Model):
         # the subquery selects the last rate before 'date' for the given currency/company
         currency_rates = (self + to_currency)._get_rates(self.env.company, date)
         for currency in self:
-            currency.rate = currency_rates.get(currency.id) / currency_rates.get(to_currency.id)
+            currency.rate = (currency_rates.get(currency.id) or 1.0) / currency_rates.get(to_currency.id)
             currency.inverse_rate = 1 / currency.rate
             if currency != company.currency_id:
                 currency.rate_string = '1 %s = %.6f %s' % (to_currency.name, currency.rate, currency.name)


### PR DESCRIPTION
Steps:
- Add "rate" field via Studio in the currency form
- Try to create a currency

Actual result:
- Traceback due to rate computation
```python
currency.rate = (currency_rates.get(currency.id) ) / currency_rates.get(to_currency.id)
TypeError: unsupported operand type(s) for /: 'NoneType' and 'float'
```

Expected result:
- Default rate value is 1.0 (cf 16.0)

opw-4039324

Caused-By: https://github.com/odoo/odoo/commit/9353a6f9ba81926c7002b3ca5b53ac66fed9aebd

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
