### PR TITLE
[FIX] stock: fix putting partial picking with multiple dest locations

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -1462,7 +1462,10 @@ class Picking(models.Model):
                 'views': [(view_id, 'form')],
                 'type': 'ir.actions.act_window',
                 'res_id': wiz.id,
-                'target': 'new'
+                'target': 'new',
+                'context': {
+                    'move_lines_to_pack_ids': move_line_ids.ids,
+                }
             }
         else:
             return {}

--- a/addons/stock/wizard/stock_package_destination.py
+++ b/addons/stock/wizard/stock_package_destination.py
@@ -15,8 +15,12 @@ class ChooseDestinationLocation(models.TransientModel):
 
     @api.depends('picking_id')
     def _compute_move_line_ids(self):
+        # specific move lines selected from move line view
+        move_lines_to_pack_ids = self.env.context.get('move_lines_to_pack_ids')
         for destination in self:
             destination.move_line_ids = destination.picking_id.move_line_ids.filtered(lambda l: l.quantity > 0 and not l.result_package_id)
+            if move_lines_to_pack_ids:
+                destination.move_line_ids = destination.move_line_ids.filtered(lambda l: l.id in move_lines_to_pack_ids)
 
     @api.depends('move_line_ids')
     def _filter_location(self):


### PR DESCRIPTION
Steps to reproduce:
- Create a serial tracked storable product.
- Create a receipt picking for this product with quantity > 2.
- Confirm the picking and assign serial numbers.
- Click on "Detailed Operations" smart button.
- Change the destination location of one or more move line.
- Select some move lines with different destination location.
- Click on "Put in Pack" button.

Expected behavior:
`stock.package.destination` wizard opens with only the selected move lines.

Current behavior:
The wizard opens with all the move lines in the picking.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
