### PR TITLE
[DRAFT][FIX] Replenishment buttons missing when screen width is too small

### DIFF
--- a/addons/stock/static/src/views/stock_orderpoint_list_buttons.xml
+++ b/addons/stock/static/src/views/stock_orderpoint_list_buttons.xml
@@ -3,6 +3,7 @@
 
     <t t-name="stock.StockOrderpoint.Buttons" t-inherit="web.ListView.Buttons">
         <xpath expr="//div[hasclass('o_list_buttons')]" position="inside">
+            <button style="display: none"/>
             <button t-if="nbSelected" type="button" t-on-click="() => this.onClickOrder(false)"
                     class="o_button_order btn btn-primary me-1">
                 Order


### PR DESCRIPTION
Steps to reproduce:
- Inventory > Replenishment
- Select at least one line
- Resize window over/under 1200px

What happens:
Replenishment buttons are only available when the screen is wider than 1200px

What should happen:
An arow button next to new should appear with a dropdown menu containing the replenihment actions.

Why is this an issue:
Some actions are unavailable depending on the display/device being used, this is particularly problematic on mobile as the screen is never wide enough to accomodate the extended display.

Why this happens:
Apparently the arrow button does not appear because of the t-if condition on the replenishment buttons (These actions are only available when a replenishment line is selected), this seems to happen no matter what the condition is and is fixed as soon as t-if is removed. I have no idea why to be honest.

What was done:
Adding an invisible dummy button without a conditional forces the arrow button to display (It has to be a button apparently). Unfortunately since a conditional cannot be used the arrow button is there even when the corresponding dropdown menu is empty.

opw-3983355

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
