### PR TITLE
[FIX] l10n_it_edi_withholding: VAT field currency

### DIFF
--- a/addons/l10n_it_edi_withholding/models/account_move.py
+++ b/addons/l10n_it_edi_withholding/models/account_move.py
@@ -11,10 +11,10 @@ _logger = logging.getLogger(__name__)
 class AccountMove(models.Model):
     _inherit = 'account.move'
 
-    l10n_it_amount_vat_signed = fields.Monetary(string='VAT', compute='_compute_amount_extended')
-    l10n_it_amount_pension_fund_signed = fields.Monetary(string='Pension Fund', compute='_compute_amount_extended')
-    l10n_it_amount_withholding_signed = fields.Monetary(string='Withholding', compute='_compute_amount_extended')
-    l10n_it_amount_before_withholding_signed = fields.Monetary(string='Total Before Withholding', compute='_compute_amount_extended')
+    l10n_it_amount_vat_signed = fields.Monetary(string='VAT', compute='_compute_amount_extended', currency_field='company_currency_id')
+    l10n_it_amount_pension_fund_signed = fields.Monetary(string='Pension Fund', compute='_compute_amount_extended', currency_field='company_currency_id')
+    l10n_it_amount_withholding_signed = fields.Monetary(string='Withholding', compute='_compute_amount_extended', currency_field='company_currency_id')
+    l10n_it_amount_before_withholding_signed = fields.Monetary(string='Total Before Withholding', compute='_compute_amount_extended', currency_field='company_currency_id')
 
     @api.depends('amount_total_signed')
     def _compute_amount_extended(self):


### PR DESCRIPTION
With an IT company setup
Create a BILL in foreign currency with tax
Go to List view
Activate field VAT (l10n_it_edi_amount_vat_signed)

Issue: VAT amount is in company currency (symbol in foreign),
it should be in foreign currency

opw-4034566
