### PR TITLE
[FIX] mail: avoid calling pyToJsLocale with undefined

### DIFF
--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -384,7 +384,8 @@ export class Thread extends Record {
         }
         if (this.type === "group" && !this.name) {
             const listFormatter = new Intl.ListFormat(
-                pyToJsLocale(this._store.env.services["user"].lang),
+                this._store.env.services["user"].lang &&
+                    pyToJsLocale(this._store.env.services["user"].lang),
                 { type: "conjunction", style: "long" }
             );
             return listFormatter.format(

--- a/addons/mail/static/src/core/web/chatter.js
+++ b/addons/mail/static/src/core/web/chatter.js
@@ -244,7 +244,8 @@ export class Chatter extends Component {
                 )}">${escape(text)}</span>`;
             });
         const formatter = new Intl.ListFormat(
-            pyToJsLocale(this.store.env.services["user"].lang),
+            this.store.env.services["user"].lang &&
+                pyToJsLocale(this.store.env.services["user"].lang),
             { type: "unit" }
         );
         if (this.state.thread && this.state.thread.recipients.length > 5) {


### PR DESCRIPTION
Calling pyToJsLocale with undefined returns an empty string.
Intl.ListFormat expects a valid BCP 47 tag or undefined.
When the user's language is not defined, passing it to pyToJsLocale will return an empty string, which can't be used as the argument of Intl.ListFormat.

This commit ensures that the value passed to Intl.ListFormat when there is no language is undefined instead of an empty string.

Follow-up of https://github.com/odoo/odoo/pull/171837
