### PR TITLE
[IMP] account: Purchase UOM on Vendor Bills

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4053,9 +4053,10 @@ class AccountMoveLine(models.Model):
 
     def _get_computed_uom(self):
         self.ensure_one()
-        if self.product_id:
+        if self.move_id.is_purchase_document():
+            return self.product_id.uom_po_id
+        else:
             return self.product_id.uom_id
-        return False
 
     def _set_price_and_tax_after_fpos(self):
         self.ensure_one()

--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -74,6 +74,7 @@ class AccountTestInvoicingCommon(TransactionCase):
         cls.product_a = cls.env['product.product'].create({
             'name': 'product_a',
             'uom_id': cls.env.ref('uom.product_uom_unit').id,
+            'uom_po_id': cls.env.ref('uom.product_uom_unit').id,
             'lst_price': 1000.0,
             'standard_price': 800.0,
             'property_account_income_id': cls.company_data['default_account_revenue'].id,
@@ -84,6 +85,7 @@ class AccountTestInvoicingCommon(TransactionCase):
         cls.product_b = cls.env['product.product'].create({
             'name': 'product_b',
             'uom_id': cls.env.ref('uom.product_uom_dozen').id,
+            'uom_po_id': cls.env.ref('uom.product_uom_dozen').id,
             'lst_price': 200.0,
             'standard_price': 160.0,
             'property_account_income_id': cls.copy_account(cls.company_data['default_account_revenue']).id,

--- a/addons/account/tests/test_account_move_in_invoice.py
+++ b/addons/account/tests/test_account_move_in_invoice.py
@@ -2124,3 +2124,23 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
         self.assertTrue(follower_mail)
         self.assertNotIn('access_token=', follower_mail.body_html,
                       "The followers should not bet sent the access token by default")
+
+    def test_purchase_uom_on_vendor_bills(self):
+        uom_gram = self.env.ref('uom.product_uom_gram')
+        uom_kgm = self.env.ref('uom.product_uom_kgm')
+
+        # product with different sale and purchase UOM
+        product = self.env['product.product'].create({
+            'name': 'product',
+            'uom_id': uom_gram.id,
+            'uom_po_id': uom_kgm.id,
+            'standard_price': 110.0,
+        })
+        # customer invoice should have sale uom
+        invoice = self.init_invoice(move_type='out_invoice', products=[product])
+        invoice_uom = invoice.invoice_line_ids[0].product_uom_id
+        self.assertEqual(invoice_uom, uom_gram)
+        # vendor bill should have purchase uom
+        bill = self.init_invoice(move_type='in_invoice', products=[product])
+        bill_uom = bill.invoice_line_ids[0].product_uom_id
+        self.assertEqual(bill_uom, uom_kgm)


### PR DESCRIPTION
Before this commit, selecting a product on a vendor bill line would set the product sale uom as the line uom by default. This behavior was changed to set the product purchase uom as the line uom by default.

The default uom behavior on Vendor Bills lines should be aligned with the default uom behavior on Purchase orders.

task-4012191


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
