### PR TITLE
[IMP] pos_self_order: open menu page directly in qr menu mode

### DIFF
--- a/addons/pos_self_order/controllers/self_entry.py
+++ b/addons/pos_self_order/controllers/self_entry.py
@@ -7,7 +7,7 @@ from odoo.http import request
 
 class PosSelfKiosk(http.Controller):
     @http.route(["/pos-self/<config_id>", "/pos-self/<config_id>/<path:subpath>"], auth="public", website=True, sitemap=True)
-    def start_self_ordering(self, config_id=None, access_token=None, table_identifier=None):
+    def start_self_ordering(self, config_id=None, access_token=None, table_identifier=None, subpath=None):
         pos_config, _, config_access_token = self._verify_entry_access(config_id, access_token, table_identifier)
         return request.render(
                 'pos_self_order.index',

--- a/addons/pos_self_order/models/pos_config.py
+++ b/addons/pos_self_order/models/pos_config.py
@@ -205,7 +205,7 @@ class PosConfig(models.Model):
         table_route = ""
 
         if self.self_ordering_mode == 'consultation':
-            return base_route
+            return f"{base_route}/products"
 
         if self.self_ordering_mode == 'mobile':
             table = self.env["restaurant.table"].search(

--- a/addons/pos_self_order/static/tests/tours/self_order_common_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_common_tour.js
@@ -17,7 +17,6 @@ registry.category("web_tour.tours").add("self_order_is_open_consultation", {
     test: true,
     steps: () => [
         LandingPage.isOpened(),
-        Utils.clickBtn("Order Now"),
         ProductPage.clickProduct("Coca-Cola"),
         Utils.checkIsNoBtn("Order"),
     ],


### PR DESCRIPTION
Before this commit:
====================
The order button is visible on the home page in self order QR menu mode. Upon clicking the order button, the product screen is displayed, similar to other self order modes. In QR menu mode, only the digital menu should be visible, and orders should not be accepted, making the order button redundant.

After this commit:
================
When the self order mode is set to QR, the system will open the menu page (product page) directly, bypassing the home page and the order button.

task- 4031859

