### PR TITLE
[FIX] sale: update amount_total on rounding_method change

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -453,7 +453,7 @@ class SaleOrder(models.Model):
                 )
             order.team_id = cached_teams[key]
 
-    @api.depends('order_line.price_subtotal', 'order_line.price_tax', 'order_line.price_total')
+    @api.depends('order_line.price_subtotal', 'order_line.price_tax', 'order_line.price_total', 'company_id.tax_calculation_rounding_method')
     def _compute_amounts(self):
         """Compute the total amounts of the SO."""
         for order in self:


### PR DESCRIPTION
Steps to reproduce:
- Install "Sales" and "Accounting"
- Make a sale order with two order lines: - Product with price of 10.5 and tax of 7% - Product with price of 10.99 and tax of 7%
- Total will now depends on rounding_method used (22.99 as total or 23.00)

Issues:
If you change the settings the total will be updated on the sale order since it's computed by JS code however on the list view the field `amount_total` will show the previous value. This is because the compute is not triggered after changing the rounding method as it's missing in it's dependencies.

opw-4035724