### PR TITLE
[FIX] website_sale: improve the ui behavior

### DIFF
--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -419,7 +419,14 @@ a.no-decoration {
     .carousel-outer {
         height: 400px;
         max-height: 90vh;
-
+        display: flex;
+        align-items: center;
+        @include media-breakpoint-down(md) {
+            height: 300px;
+        }
+        @include media-breakpoint-down(sm) {
+            height: 200px;
+        }
         .carousel-inner {
             img {
                 object-fit: contain;
@@ -435,8 +442,8 @@ a.no-decoration {
     }
 
     .carousel-control-prev, .carousel-control-next {
-        height: 70%;
-        top: 15%;
+        top: auto;
+        bottom: auto;
         opacity: 0.5;
         cursor: pointer;
         transition: opacity 0.8s;


### PR DESCRIPTION
To reproduce the bug:
1. Add a video to a product media.
2. In the eCommerce app, go to the product page and switch to the added video.
3. Decrease the browser page width and try to click the play/pause button.

The play/pause button is located under the arrow HTML element, making it unclickable. This is because the page is not responsive, and the size of the container element is fixed at 400px.

To fix this, I propose making the element responsive and decreasing the height of the arrow elements.

opw-3986105