### PR TITLE
[FIX] web: make error formatting more resilient cross browsers

### DIFF
--- a/addons/web/static/src/core/errors/error_utils.js
+++ b/addons/web/static/src/core/errors/error_utils.js
@@ -22,17 +22,15 @@ export function getErrorTechnicalName(error) {
 export function formatTraceback(error) {
     let traceback = error.stack;
     const errorName = getErrorTechnicalName(error);
-    if (!isBrowserChrome()) {
-        // transforms the stack into a chromium stack
-        // Chromium stack example:
-        // Error: Mock: Can't write value
-        //     _onOpenFormView@http://localhost:8069/web/content/425-baf33f1/web.assets.js:1064:30
-        //     ...
-        traceback = `${errorName}: ${error.message}\n${error.stack}`.replace(/\n/g, "\n    ");
-    } else if (error.stack) {
-        // Chromium stack starts with the error's name but the name is "Error" by default
-        // so we replace it to have the error type name
-        traceback = error.stack.replace(/^[^:]*/g, errorName);
+    // ensure the proper error name and error message are present in the traceback, no matter the error.stack brower's formatting.
+    // Stack example:
+    // Error: Mock: Can't write value
+    //     _onOpenFormView@http://localhost:8069/web/content/425-baf33f1/web.assets.js:1064:30
+    //     ...
+    const descriptionLine = `${errorName}: ${error.message}`;
+    if (error.stack.split("\n")[0].trim() !== descriptionLine) {
+        // avoid having the description line twice if already present
+        traceback = `${descriptionLine}\n${error.stack}`.replace(/\n/g, "\n    ");
     }
     return traceback;
 }

--- a/addons/web/static/tests/core/errors/error_service_tests.js
+++ b/addons/web/static/tests/core/errors/error_service_tests.js
@@ -54,7 +54,7 @@ QUnit.module("Error Service", {
 });
 
 QUnit.test("handle RPC_ERROR of type='server' and no associated dialog class", async (assert) => {
-    assert.expect(2);
+    assert.expect(4);
     const error = new RPCError();
     error.code = 701;
     error.message = "Some strange error occured";
@@ -62,7 +62,7 @@ QUnit.test("handle RPC_ERROR of type='server' and no associated dialog class", a
     error.subType = "strange_error";
     function addDialog(dialogClass, props) {
         assert.strictEqual(dialogClass, RPCErrorDialog);
-        assert.deepEqual(props, {
+        assert.deepEqual(_.omit(props, "traceback"), {
             name: "RPC_ERROR",
             type: "server",
             code: 701,
@@ -72,8 +72,9 @@ QUnit.test("handle RPC_ERROR of type='server' and no associated dialog class", a
             subType: "strange_error",
             message: "Some strange error occured",
             exceptionName: null,
-            traceback: error.stack,
         });
+        assert.ok(props.traceback.indexOf("RPC_ERROR")>= 0);
+        assert.ok(props.traceback.indexOf("Some strange error occured")>= 0);
     }
     serviceRegistry.add("dialog", makeFakeDialogService(addDialog), { force: true });
     await makeTestEnv();
@@ -84,7 +85,7 @@ QUnit.test("handle RPC_ERROR of type='server' and no associated dialog class", a
 QUnit.test(
     "handle custom RPC_ERROR of type='server' and associated custom dialog class",
     async (assert) => {
-        assert.expect(2);
+        assert.expect(4);
         class CustomDialog extends Component {}
         CustomDialog.template = tags.xml`<RPCErrorDialog title="'Strange Error'"/>`;
         CustomDialog.components = { RPCErrorDialog };
@@ -98,7 +99,7 @@ QUnit.test(
         error.data = errorData;
         function addDialog(dialogClass, props) {
             assert.strictEqual(dialogClass, CustomDialog);
-            assert.deepEqual(props, {
+            assert.deepEqual(_.omit(props, "traceback"), {
                 name: "RPC_ERROR",
                 type: "server",
                 code: 701,
@@ -106,8 +107,9 @@ QUnit.test(
                 subType: null,
                 message: "Some strange error occured",
                 exceptionName: null,
-                traceback: error.stack,
             });
+            assert.ok(props.traceback.indexOf("RPC_ERROR")>= 0);
+            assert.ok(props.traceback.indexOf("Some strange error occured")>= 0);
         }
         serviceRegistry.add("dialog", makeFakeDialogService(addDialog), { force: true });
         await makeTestEnv();
@@ -120,7 +122,7 @@ QUnit.test(
 QUnit.test(
     "handle normal RPC_ERROR of type='server' and associated custom dialog class",
     async (assert) => {
-        assert.expect(2);
+        assert.expect(4);
         class CustomDialog extends Component {}
         CustomDialog.template = tags.xml`<RPCErrorDialog title="'Strange Error'"/>`;
         CustomDialog.components = { RPCErrorDialog };
@@ -137,7 +139,7 @@ QUnit.test(
         error.data = errorData;
         function addDialog(dialogClass, props) {
             assert.strictEqual(dialogClass, NormalDialog);
-            assert.deepEqual(props, {
+            assert.deepEqual(_.omit(props, "traceback"), {
                 name: "RPC_ERROR",
                 type: "server",
                 code: 701,
@@ -145,8 +147,9 @@ QUnit.test(
                 subType: null,
                 message: "A normal error occured",
                 exceptionName: "normal_error",
-                traceback: error.stack,
             });
+            assert.ok(props.traceback.indexOf("RPC_ERROR")>= 0);
+            assert.ok(props.traceback.indexOf("A normal error occured")>= 0);
         }
         serviceRegistry.add("dialog", makeFakeDialogService(addDialog), { force: true });
         await makeTestEnv();
@@ -224,11 +227,12 @@ QUnit.test("handle uncaught promise errors", async (assert) => {
 
     function addDialog(dialogClass, props) {
         assert.strictEqual(dialogClass, ClientErrorDialog);
-        assert.deepEqual(props, {
+        assert.deepEqual(_.omit(props, "traceback"), {
             name: "UncaughtPromiseError > TestError",
             message: "Uncaught Promise > This is an error test",
-            traceback: error.stack,
         });
+        assert.ok(props.traceback.indexOf("TestError")>= 0);
+        assert.ok(props.traceback.indexOf("This is an error test")>= 0);
     }
     serviceRegistry.add("dialog", makeFakeDialogService(addDialog), { force: true });
     await makeTestEnv();


### PR DESCRIPTION
Before this commit, the error service attempted to adapt the
`error.stack` format to match the one used by Chrome.

But even then, the error_service_tests (that compare exactly the
traceback) didn't pass on Firefox.

Since version 125, even Chrome itself doesn't pass that test.

This commit adapts the stack formatting code to ensure the actual
error name is present and its message, but without trying to match a
(too) specific format.

Also in this commit, the related tests are adapted to be a little less
strict (and more resilient), but stil ensuring the actual error name and
message are present.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
