### PR TITLE
[FIX] addons/microsoft_outlook: remove too restrictive constraint

### DIFF
--- a/addons/microsoft_outlook/models/ir_mail_server.py
+++ b/addons/microsoft_outlook/models/ir_mail_server.py
@@ -33,7 +33,7 @@ class IrMailServer(models.Model):
             'To extend its use, you should set a "mail.default.from" system parameter.')
         super(IrMailServer, self - outlook_servers)._compute_smtp_authentication_info()
 
-    @api.constrains('smtp_authentication', 'smtp_pass', 'smtp_encryption', 'from_filter', 'smtp_user')
+    @api.constrains('smtp_authentication', 'smtp_pass', 'smtp_encryption', 'smtp_user')
     def _check_use_microsoft_outlook_service(self):
         outlook_servers = self.filtered(lambda server: server.smtp_authentication == 'outlook')
         for server in outlook_servers:
@@ -46,11 +46,6 @@ class IrMailServer(models.Model):
                 raise UserError(_(
                     'Incorrect Connection Security for Outlook mail server %r. '
                     'Please set it to "TLS (STARTTLS)".', server.name))
-
-            if server.from_filter != server.smtp_user:
-                raise UserError(_(
-                    'This server %r can only be used for your personal email address. '
-                    'Please fill the "from_filter" field with %r.', server.name, server.smtp_user))
 
             if not server.smtp_user:
                 raise UserError(_(


### PR DESCRIPTION
When configuring an outgoing SMTP server for outlook, there is a check that the username in the filter must match exactly the account to connect. This is not needed. It is perfectly acceptable, and in some cases needed, to connect with an ENTRA-ID user to send mail for a shared maibox.

Example: connect with administrator@example.com to send mail for info@example.com.

Description of the issue/feature this PR addresses:

Impossible to send mail through Outlook for shared mail boxes/

Current behavior before PR:

Trying to configure outgoing mail server for shared mail box results in UserError exception.

Desired behavior after PR is merged:

A single ENTRA-ID can be used for one or multiple mail addresses, differing from the mail address of the connection account.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
