### PR TITLE
[FIX] web: Discarding in an x2many form removes the unsaved changes.

### DIFF
--- a/addons/web/static/src/views/basic_relational_model.js
+++ b/addons/web/static/src/views/basic_relational_model.js
@@ -812,13 +812,13 @@ export class Record extends DataPoint {
         this.model.notify();
     }
 
-    async discard() {
+    async discard(options) {
         if (this._closeUrgentSaveNotification) {
             this._closeUrgentSaveNotification();
         }
         await this._savePromise;
         this._closeInvalidFieldsNotification();
-        this.model.__bm__.discardChanges(this.__bm_handle__);
+        this.model.__bm__.discardChanges(this.__bm_handle__, options);
         this._invalidFields = new Set();
         this.__syncData();
         this.model.notify();

--- a/addons/web/static/src/views/fields/relational_utils.js
+++ b/addons/web/static/src/views/fields/relational_utils.js
@@ -520,7 +520,7 @@ export class X2ManyFieldDialog extends Component {
 
     discard() {
         if (this.record.isInEdition) {
-            this.record.discard();
+            this.record.discard({ rollback: true });
         }
         this.props.close();
     }

--- a/addons/web/static/tests/views/fields/one2many_field_tests.js
+++ b/addons/web/static/tests/views/fields/one2many_field_tests.js
@@ -4932,6 +4932,56 @@ QUnit.module("Fields", (hooks) => {
         await clickSave(target);
     });
 
+    QUnit.test("one2many, edit record in dialog, save, re-edit, discard", async function (assert) {
+        assert.expect(6);
+        serverData.models.partner.records[0].p = [2];
+
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            serverData,
+            arch: `
+                <form>
+                    <field name="p">
+                        <form>
+                            <field name="int_field"/>
+                        </form>
+                        <tree>
+                            <field name="int_field"/>
+                        </tree>
+                    </field>
+                </form>`,
+            resId: 1,
+        });
+
+        assert.strictEqual(target.querySelector(".o_data_cell[name=int_field]").innerText, "9");
+
+        await click(target.querySelector(".o_data_row .o_data_cell"));
+        assert.strictEqual(
+            target.querySelector(".modal .o_field_widget[name=int_field] input").value,
+            "9"
+        );
+
+        await editInput(target, ".modal .o_field_widget[name=int_field] input", "123");
+        await clickSave(target.querySelector(".modal"));
+        assert.strictEqual(target.querySelector(".o_data_cell[name=int_field]").innerText, "123");
+
+        await click(target.querySelector(".o_data_row .o_data_cell"));
+        assert.strictEqual(
+            target.querySelector(".modal .o_field_widget[name=int_field] input").value,
+            "123"
+        );
+
+        await clickDiscard(target.querySelector(".modal"));
+        assert.strictEqual(target.querySelector(".o_data_cell[name=int_field]").innerText, "123");
+
+        await click(target.querySelector(".o_data_row .o_data_cell"));
+        assert.strictEqual(
+            target.querySelector(".modal .o_field_widget[name=int_field] input").value,
+            "123"
+        );
+    });
+
     QUnit.test(
         "one2many list with inline form view with context with parent key",
         async function (assert) {


### PR DESCRIPTION
In version 16.0, when a change is made to a record in an x2many field, saving it without saving the parent form and then accessing the record again and pressing discard will delete the changes previously made to the record.

With these changes, the issue does not occur, and discarding returns the record to the state it was last saved in.

Closing #171703

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
