### PR TITLE
[FIX] website_event_sale: free tickets in SO if mix with paid ticket

### DIFF
--- a/addons/website_event_sale/controllers/main.py
+++ b/addons/website_event_sale/controllers/main.py
@@ -19,10 +19,6 @@ class WebsiteEventSaleController(WebsiteEventController):
         return res
 
     def _create_attendees_from_registration_post(self, event, registration_data):
-        # we have at least one registration linked to a ticket -> sale mode activate
-        if not any(info.get('event_ticket_id') for info in registration_data):
-            return super()._create_attendees_from_registration_post(event, registration_data)
-
         event_ticket_ids = [registration['event_ticket_id'] for registration in registration_data if registration.get('event_ticket_id')]
         event_ticket_by_id = {
             event_ticket.id: event_ticket
@@ -38,15 +34,14 @@ class WebsiteEventSaleController(WebsiteEventController):
             request.website.sale_reset()
             order_sudo = request.website.sale_get_order(force_create=True)
 
-        paid_tickets_data = defaultdict(int)
+        tickets_data = defaultdict(int)
         for data in registration_data:
             event_ticket_id = data.get('event_ticket_id')
-            event_ticket = event_ticket_by_id.get(event_ticket_id)
-            if event_ticket and event_ticket.price != 0:
-                paid_tickets_data[event_ticket_id] += 1
+            if event_ticket_id:
+                tickets_data[event_ticket_id] += 1
 
         cart_data = {}
-        for ticket_id, count in paid_tickets_data.items():
+        for ticket_id, count in tickets_data.items():
             ticket_sudo = event_ticket_by_id.get(ticket_id)
             cart_values = order_sudo._cart_update(
                 product_id=ticket_sudo.product_id.id,
@@ -72,8 +67,8 @@ class WebsiteEventSaleController(WebsiteEventController):
 
         registrations = self._process_attendees_form(event, post)
         order_sudo = request.website.sale_get_order()
-        if not any(line.event_ticket_id for line in order_sudo.order_line):
-            # order does not contain any tickets, meaning we are confirming a free event
+        if not any(line.event_id == event for line in order_sudo.order_line):
+            # order does not contain any lines related to the event, meaning we are confirming only free tickets of this event
             return res
 
         # we have at least one registration linked to a ticket -> sale mode activate

--- a/addons/website_event_sale/tests/test_website_event_sale.py
+++ b/addons/website_event_sale/tests/test_website_event_sale.py
@@ -5,16 +5,16 @@ from odoo.addons.website_event_sale.tests.common import TestWebsiteEventSaleComm
 
 class TestWebsiteEventSale(HttpCaseWithUserPortal, TestWebsiteEventSaleCommon):
 
-    def test_website_event_sale(self):
+    def test_website_event_sale_free_tickets(self):
         """ Test saleorder is created for tickets having price only """
         self.authenticate('portal', 'portal')
         free_ticket = self.env['event.event.ticket'].create({
             'event_id': self.event.id,
             'name': 'Free',
-            'product_id': self.product_event.id,
             'price': 0,
         })
         event_questions = self.event.question_ids
+        event_registration_count = len(self.event.registration_ids)
         name_question = event_questions.filtered(lambda q: q.question_type == 'name')
         email_question = event_questions.filtered(lambda q: q.question_type == 'email')
         phone_question = event_questions.filtered(lambda q: q.question_type == 'phone')
@@ -29,8 +29,22 @@ class TestWebsiteEventSale(HttpCaseWithUserPortal, TestWebsiteEventSaleCommon):
             ('partner_id', '=', self.partner_portal.id),
             ('order_line.event_ticket_id', '=', free_ticket.id)
         ]), "Sale order should not be created for the free tickets")
-        self.assertEqual(len(self.event.registration_ids), 1)
+        self.assertEqual(len(self.event.registration_ids), event_registration_count + 1)
 
+    def test_website_event_sale_free_paid_mix(self):
+        """ Test saleorder is created for tickets having price only """
+        self.authenticate('portal', 'portal')
+        free_ticket = self.env['event.event.ticket'].create({
+            'event_id': self.event.id,
+            'name': 'Free',
+            # 'product_id': self.product_event.id,
+            'price': 0,
+        })
+        event_questions = self.event.question_ids
+        event_registration_count = len(self.event.registration_ids)
+        name_question = event_questions.filtered(lambda q: q.question_type == 'name')
+        email_question = event_questions.filtered(lambda q: q.question_type == 'email')
+        phone_question = event_questions.filtered(lambda q: q.question_type == 'phone')
         self.url_open(f'/event/{self.event.id}/registration/confirm', data={
             f'1-name-{name_question.id}': 'Bob',
             f'1-email-{email_question.id}': 'bob@test.lan',
@@ -43,12 +57,9 @@ class TestWebsiteEventSale(HttpCaseWithUserPortal, TestWebsiteEventSaleCommon):
             'csrf_token': http.Request.csrf_token(self),
         })
 
-        self.assertEqual(len(self.event.registration_ids), 3)
-        self.assertFalse(self.env['sale.order'].search([
-            ('partner_id', '=', self.partner_portal.id),
-            ('order_line.event_ticket_id', '=', free_ticket.id)
-        ]), "Sale order should not be created for the free tickets")
+        self.assertEqual(len(self.event.registration_ids), event_registration_count + 2)
         self.assertTrue(self.env['sale.order'].search([
             ('partner_id', '=', self.partner_portal.id),
-            ('order_line.event_ticket_id', '=', self.ticket.id)
-        ]), "Sale order should be created for the paid tickets")
+            ('order_line.event_ticket_id', '=', self.ticket.id),
+            ('order_line.event_ticket_id', '=', free_ticket.id)
+        ]), "Sale order should be created for the free/paid tickets mix")


### PR DESCRIPTION
In case of a mix of free/paid tickets, we wants to consider free tickets in the SO if their is also paid ticket from the same event. Otherwise we just want to trigger the event confirmation page without triggering the SO. (event if it contains tickets for other events)

[task-4019577](https://www.odoo.com/odoo/project/965/tasks/4019577?cids=1)