### PR TITLE
[DRAFT][FIX] Undesirable default description text in resume print

### DIFF
--- a/addons/hr_skills/views/hr_employee_cv_templates.xml
+++ b/addons/hr_skills/views/hr_employee_cv_templates.xml
@@ -84,7 +84,7 @@
                             </div>
                         </div>
                         <div class="o_main_panel_resume_description ps-5 w-auto">
-                            <p t-field="resume_line.description">Odoo India pvt. Ltd</p>
+                            <p t-field="resume_line.description"></p>
                         </div>
                     </t>
                 </div>


### PR DESCRIPTION
Steps to reproduce:
- Employees > Any employee
- Make any resume item with empty description field
- Gear in top-left > Print > Print Resume

What happens:
Resume items with no description default to placeholder "Odoo India pvt. Ltd".

Why is this an issue:
This put wrong information in resumes and cannot be corrected from the client side (The default is pulled directly from the template, which is not meant to be accessed casually).

What was done:
Removed description from template.

opw-4033434

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
