### PR TITLE
[FIX] l10n_gcc_invoice: traceback fixed on creating product

### DIFF
--- a/addons/l10n_gcc_invoice/models/product.py
+++ b/addons/l10n_gcc_invoice/models/product.py
@@ -20,4 +20,5 @@ class ProductProduct(models.Model):
 
         super()._compute_display_name()
         for product in self:
-            product.display_name = re.sub(r'(\d)(\s)([\u0600-\u06FF])', repl, product.display_name)
+            if product.display_name:
+                product.display_name = re.sub(r'(\d)(\s)([\u0600-\u06FF])', repl, product.display_name)


### PR DESCRIPTION
before this commit, a traceback was showing on creating product variant

steps to reproduce:
* click create button in product, traceback will be showing

after this commit, without any traceback product is created

traceback is introduced in: https://github.com/odoo/odoo/commit/758ced91f8cb220a003a49b01e047b507f8509d7

traceback details:

![2024-07-08_14-02](https://github.com/odoo/odoo/assets/99093808/fc3c5132-3e22-478f-8b93-2daf60877bc0)

super()._compute_display_name()
File "/data/build/enterprise/sale_renting/models/product_product.py", line 14, in _compute_display_name
super()._compute_display_name()
File "/data/build/odoo/addons/l10n_gcc_invoice/models/product.py", line 23, in _compute_display_name
product.display_name = re.sub(r'(\d)(\s)([\u0600-\u06FF])', repl, product.display_name)
File "/usr/lib/python3.10/re.py", line 209, in sub
return _compile(pattern, flags).sub(repl, string, count)
TypeError: expected string or bytes-like object

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
