### PR TITLE
[FIX] web: no multiple registering of template extensions

### DIFF
--- a/addons/web/static/src/core/templates.js
+++ b/addons/web/static/src/core/templates.js
@@ -19,6 +19,16 @@ function getClone(template) {
     return c;
 }
 
+const registered = new Set();
+function isRegistered(...args) {
+    const key = JSON.stringify([...args]);
+    if (registered.has(key)) {
+        return true;
+    }
+    registered.add(key);
+    return false;
+}
+
 let blockType = null;
 let blockId = 0;
 
@@ -26,6 +36,9 @@ const templates = {};
 const parsedTemplates = {};
 const info = {};
 export function registerTemplate(name, url, templateString) {
+    if (isRegistered(...arguments)) {
+        return;
+    }
     if (blockType !== "templates") {
         blockType = "templates";
         blockId++;
@@ -40,6 +53,9 @@ export function registerTemplate(name, url, templateString) {
 const templateExtensions = {};
 const parsedTemplateExtensions = {};
 export function registerTemplateExtension(inheritFrom, url, templateString) {
+    if (isRegistered(...arguments)) {
+        return;
+    }
     if (blockType !== "extensions") {
         blockType = "extensions";
         blockId++;


### PR DESCRIPTION
Before that commit, it was possible to register several times the same template extension. This can lead to crash in some occasions. For example consider the template
```xml
<t t-name="A">
    <div attr="a" />
</t>
```
and its extension
```xml
<t t-name="B" t-inherit="A" t-inherit-mode="extension">
    <xpath expr=".//div[@attr='a']" position="attributes">
        <attribute name="attr">b</attribute>
    </xpath>
</t>
```
In that case, when building the template A with B registered twice, the first application of B to A will succeed while the second application will cause a crash (no target found for the xpath).

Here we prevent multiple registering of the same template extensions. Note that this is similar to what happens when the same js module is received several times: odoo.define has no effect after the first registering.
