### PR TITLE
[FIX] account_payment_term: prevent error when days on next month is empty

### DIFF
--- a/addons/account_payment_term/models/account_payment_term.py
+++ b/addons/account_payment_term/models/account_payment_term.py
@@ -23,7 +23,7 @@ class AccountPaymentTermLine(models.Model):
     @api.constrains('days_next_month')
     def _check_valid_char_value(self):
         for record in self:
-            if record.days_next_month.isnumeric():
+            if record.days_next_month and record.days_next_month.isnumeric():
                 if not (0 <= int(record.days_next_month) <= 31):
                     raise ValidationError(_('The days added must be between 0 and 31.'))
             else:


### PR DESCRIPTION
This error occurs in ``Payment Terms`` when the ``Days end of month`` field is selected in the payment terms line, but the ``days`` field is left empty.

Steps to reproduce:
- Install ``account`` module
- Go to ``Payment Terms``
- Create a new one and select ``Days end of month on the`` payment terms line and empty the days

Traceback: 
`` AttributeError: 'bool' object has no attribute 'isnumeric'``

At [1] ``days_next_month`` in the record is getting as ``false``.

This commit will fix the above error by checking that ``days_next_month`` is present in the record otherwise it will raise an error.

[1]- https://github.com/odoo/odoo/blob/a800b5dc2a7444c1f4944dd99509d36096bc797f/addons/account_payment_term/models/account_payment_term.py#L26

Sentry-5583615279

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
