### PR TITLE
[FIX] website_event_sale: free tickets in SO if mix with paid ticket

### DIFF
--- a/addons/event_sale/tests/test_event_sale.py
+++ b/addons/event_sale/tests/test_event_sale.py
@@ -519,7 +519,17 @@ class TestEventSale(TestEventSaleCommon):
         registration = self.event_0.registration_ids
         self.assertEqual(registration.sale_status, 'to_pay')
         registration.sale_order_line_id.price_total = 0.0
-        self.assertEqual(registration.sale_status, 'free', "Price of $0.00 should be free")
+        self.assertEqual(registration.sale_status, 'to_pay', "Free SO line on SO with non zero amount should be paid")
+        registration.sale_order_id.amount_total = 0.0
+        self.assertEqual(registration.sale_status, 'free', "Free SO line on SO with zero amount should be free")
+        # Remove the SO and so_line relations to test the "free ticket without SO" case
+        sale_order = registration.sale_order_id
+        so_line = registration.sale_order_line_id
+        registration.sale_order_id = False
+        registration.sale_order_line_id = False
+        self.assertEqual(registration.sale_status, 'free', "Price of $0.00 without so_line should be free")
+        registration.sale_order_id = sale_order
+        registration.sale_order_line_id = so_line
         registration.sale_order_line_id.price_total = 0.01
         self.assertEqual(registration.sale_status, 'to_pay', "Price of $0.01 should be paid")
         registration.sale_order_id.action_confirm()

--- a/addons/website_event_sale/controllers/main.py
+++ b/addons/website_event_sale/controllers/main.py
@@ -29,8 +29,8 @@ class WebsiteEventSaleController(WebsiteEventController):
             for event_ticket in request.env['event.event.ticket'].sudo().browse(event_ticket_ids)
         }
 
-        if all(event_ticket.price == 0 for event_ticket in event_ticket_by_id.values()):
-            # all chosen tickets are free, skip SO and payment process
+        if all(event_ticket.price == 0 for event_ticket in event_ticket_by_id.values()) and not request.website.sale_get_order().id:
+            # all chosen tickets are free AND no existing SO -> skip SO and payment process
             return super()._create_attendees_from_registration_post(event, registration_data)
 
         order_sudo = request.website.sale_get_order(force_create=True)
@@ -38,15 +38,14 @@ class WebsiteEventSaleController(WebsiteEventController):
             request.website.sale_reset()
             order_sudo = request.website.sale_get_order(force_create=True)
 
-        paid_tickets_data = defaultdict(int)
+        tickets_data = defaultdict(int)
         for data in registration_data:
             event_ticket_id = data.get('event_ticket_id')
-            event_ticket = event_ticket_by_id.get(event_ticket_id)
-            if event_ticket and event_ticket.price != 0:
-                paid_tickets_data[event_ticket_id] += 1
+            if event_ticket_id:
+                tickets_data[event_ticket_id] += 1
 
         cart_data = {}
-        for ticket_id, count in paid_tickets_data.items():
+        for ticket_id, count in tickets_data.items():
             ticket_sudo = event_ticket_by_id.get(ticket_id)
             cart_values = order_sudo._cart_update(
                 product_id=ticket_sudo.product_id.id,
@@ -58,7 +57,7 @@ class WebsiteEventSaleController(WebsiteEventController):
         for data in registration_data:
             event_ticket_id = data.get('event_ticket_id')
             event_ticket = event_ticket_by_id.get(event_ticket_id)
-            if event_ticket and event_ticket.price != 0:
+            if event_ticket:
                 data['sale_order_id'] = order_sudo.id
                 data['sale_order_line_id'] = cart_data[event_ticket_id]
 
@@ -72,8 +71,8 @@ class WebsiteEventSaleController(WebsiteEventController):
 
         registrations = self._process_attendees_form(event, post)
         order_sudo = request.website.sale_get_order()
-        if not any(line.event_ticket_id for line in order_sudo.order_line):
-            # order does not contain any tickets, meaning we are confirming a free event
+        if not order_sudo.id:
+            # order does not contain any lines related to the event, meaning we are confirming only free tickets of this event
             return res
 
         # we have at least one registration linked to a ticket -> sale mode activate


### PR DESCRIPTION
ENT branch : https://github.com/odoo/enterprise/pull/66648

In case of a mix of free/paid tickets, we wants to consider free tickets in the SO if their is also paid ticket from the same event. Otherwise we just want to trigger the event confirmation page without triggering the SO. (event if it contains tickets for other events)

[task-4019577](https://www.odoo.com/odoo/my-tasks/4019577?cids=1)