### PR TITLE
[FIX] purchase: allow vendor to confirm that delivery will be on time

### DIFF
--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -846,6 +846,8 @@ class PurchaseOrder(models.Model):
         date_planned = date_planned or self.date_planned
         if not date_planned:
             return False
+        if isinstance(date_planned, str):
+            date_planned = fields.Datetime.from_string(date_planned)
         tz = self.get_order_timezone()
         return date_planned.astimezone(tz)
 

--- a/addons/purchase/tests/test_purchase.py
+++ b/addons/purchase/tests/test_purchase.py
@@ -116,6 +116,8 @@ class TestPurchase(AccountTestInvoicingCommon):
         po_tz = pytz.timezone(po.user_id.tz)
         localized_date_planned = po.date_planned.astimezone(po_tz)
         self.assertEqual(localized_date_planned, po.get_localized_date_planned())
+        # Ensure that the function get_localized_date_planned can accept a date in string format
+        self.assertEqual(localized_date_planned, po.get_localized_date_planned(po.date_planned.strftime('%Y-%m-%d %H:%M:%S')))
 
         # check vendor is a message recipient
         self.assertTrue(po.partner_id in po.message_partner_ids)


### PR DESCRIPTION
**Steps to reproduce the bug:**
- Go to contact and select azure interior:
    - Sales & purchase tab:
        - Enable “Receipt Reminder” 1 day

- Create a purchase order:
    - Select azure interior as vendor
    - add any storable product
    - Delivery date: Tomorrow

- Confirm the PO

- Go to the Scheduled Actions: Purchase reminder
- Run it Manually
- Come back to the Dashbord > Emails
- Select the email for Azure interior:
    - Try to click on “YES”

**Problem:**
A traceback is triggered: `AttributeError: type object 'datetime.datetime' has no attribute 'from_string'`

When the “YES” button is clicked, we retrieve the “confirmed_date” from the arguments as a string and then call the `confirm_reminder_mail` function https://github.com/odoo/odoo/blob/181c7d82e30d0848bbac7f7d0188e81aced0af07/addons/purchase/controllers/portal.py#L117

This date will be localized to the PO timezone using the `get_localized_date_planned` function: https://github.com/odoo/odoo/blob/a0be5ea52aeff3520f8f1a92206a5aad38fdaa82/addons/purchase/models/purchase.py#L823

We then get the timezone and use the `astimezone` function to transform this date, but since it is in string format, an error is triggered.

opw-4028362
