### PR TITLE
[FIX] im_livechat: standardize author name in livechat transcript

### DIFF
--- a/addons/im_livechat/data/mail_data.xml
+++ b/addons/im_livechat/data/mail_data.xml
@@ -37,7 +37,7 @@
             </div>
             <table cellspacing="0" cellpadding="0" style="width:100%; border-collapse: collapse;">
                 <t t-foreach="channel.message_ids.sorted(key=lambda m: m.date)" t-as="message" >
-                    <t t-set="author_name" t-value="message.author_id.name if message.author_id else 'You'" />
+                    <t t-set="author_name"><t t-if="message.author_id" t-esc="message.author_id.user_livechat_username or message.author_id.name"></t><t t-else="">You</t></t>
                     <tr>
                         <td valign="top" align="center" rowspan="2" t-att-style="'width: 70px;' + top + bottom + left">
                             <t t-if="message.author_avatar">

--- a/addons/im_livechat/i18n/im_livechat.pot
+++ b/addons/im_livechat/i18n/im_livechat.pot
@@ -1729,6 +1729,11 @@ msgid "Yesterday"
 msgstr ""
 
 #. module: im_livechat
+#: model_terms:ir.ui.view,arch_db:im_livechat.livechat_email_template
+msgid "You"
+msgstr ""
+
+#. module: im_livechat
 #: model_terms:ir.actions.act_window,help:im_livechat.im_livechat_channel_action
 msgid ""
 "You can create channels for each website on which you want\n"


### PR DESCRIPTION
Following odoo/odoo@82ae5b0769c2, we should reuse the same author name as in the transcript introduction.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
