### PR TITLE
[IMP] mail: computed fields are self-observed

### DIFF
--- a/addons/mail/static/src/model/make_store.js
+++ b/addons/mail/static/src/model/make_store.js
@@ -63,7 +63,9 @@ export function makeStore(env, { localRegistry } = {}) {
                                 return res;
                             }
                             if (Model._.fieldsCompute.get(name) && !Model._.fieldsEager.get(name)) {
-                                record._.fieldsComputeInNeed.set(name, true);
+                                if (!record._.fieldsComputeSelfObserve.get(name)) {
+                                    record._.fieldsComputeInNeed.set(name, true);
+                                }
                                 if (record._.fieldsComputeOnNeed.get(name)) {
                                     record._.compute(record, name);
                                 }

--- a/addons/mail/static/src/model/record_internal.js
+++ b/addons/mail/static/src/model/record_internal.js
@@ -57,6 +57,8 @@ export class RecordInternal {
     fieldsSortProxy2 = new Map();
     /** @type {Map<string, this>} */
     fieldsComputeProxy2 = new Map();
+    /** @type {Map<string, boolean>} */
+    fieldsComputeSelfObserve = new Map();
     uses = new RecordUses();
     updatingAttrs = new Map();
     proxyUsed = new Map();
@@ -196,11 +198,13 @@ export class RecordInternal {
         const store = record._rawStore;
         this.fieldsComputing.set(fieldName, true);
         this.fieldsComputeOnNeed.delete(fieldName);
+        const proxy2 = this.fieldsComputeProxy2.get(fieldName);
         store._.updateFields(record, {
-            [fieldName]: Model._.fieldsCompute
-                .get(fieldName)
-                .call(this.fieldsComputeProxy2.get(fieldName)),
+            [fieldName]: Model._.fieldsCompute.get(fieldName).call(proxy2),
         });
+        this.fieldsComputeSelfObserve.set(fieldName, true);
+        void proxy2[fieldName];
+        this.fieldsComputeSelfObserve.delete(fieldName);
         this.fieldsComputing.delete(fieldName);
     }
     /**


### PR DESCRIPTION
Before this commit, a computed field was not observing its value unless explicitly defined in the computed method.

For example:

```js
class Message extends Record {
	body = Record.attr(0, {
	    compute() {
	        if (this.markdown) {
	            return this.markdown;
	        }
	        return this.body;
	    },
	});
	markdown;
}

const msg = Message.insert({ body: false, markdown: "marked" });
msg.body;            // "marked"
msg.body = "bodied";
msg.body;            // "bodied" instead of expected "marked"
```

In example above, we'd expect that explicitly writing "bodied" on the field keeps value "marked": a compute method is a declarative definition, so we expect it to have precedence over any explicit write. If we'd like the resulting value to be the explicit write, then we'd expect the compute method to explicitly define the precedence in its implementation:

```js
class Message extends Record {
	body = Record.attr(0, {
	    compute() {
	        if (this.body) {
	            return this.body;
	        }
	        return this.markdown;
	    },
	});
	markdown;
}
```

This commit now ensures compute methods are properly requested when the field is explicitly written. This ensures compute methods are applied after the explicit write on field.
