### PR TITLE
[IMP] base: res_partner making field `function` (Job Position) translatable

### DIFF
--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -243,7 +243,7 @@ class Partner(models.Model):
                                     column2='category_id', string='Tags', default=_default_category)
     active = fields.Boolean(default=True)
     employee = fields.Boolean(help="Check this box if this contact is an Employee.")
-    function = fields.Char(string='Job Position')
+    function = fields.Char(string='Job Position', translate=True)
     type = fields.Selection(
         [('contact', 'Contact'),
          ('invoice', 'Invoice Address'),


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Making `Job Position` field translatable to be able to translate in website on appointments.

Current behavior before PR: This field had only one language and it wasn't a perfect solution for `multi-language` websites, where you could book an appointment and client/user sees only one language.

Desired behavior after PR is merged: This field would be translatable on `website` and on `res.partner`. If client wants to book an apointment, they could understand what is written in different languages.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
