### PR TITLE
[FIX] mail: message preview not closed

### DIFF
--- a/addons/im_livechat/static/tests/embed/chat_window.test.js
+++ b/addons/im_livechat/static/tests/embed/chat_window.test.js
@@ -42,7 +42,7 @@ test("do not save fold state of temporary live chats", async () => {
     await waitNotifications([env, "discuss.Thread/fold_state"]);
     await contains(".o-mail-Message", { text: "Hello", count: 0 });
     await assertSteps(["fold - folded"]);
-    await contains(".o-mail-ChatBubble");
+    await click(".o-mail-ChatBubble");
     await click("[title*='Close Chat Window']");
     await assertSteps(["fold - open"]); // clicking close shows the feedback panel
     await click("button", { text: "Close conversation" });

--- a/addons/im_livechat/static/tests/embed/feedback_panel.test.js
+++ b/addons/im_livechat/static/tests/embed/feedback_panel.test.js
@@ -96,7 +96,7 @@ test("Closing folded chat window should open it with feedback", async () => {
     await contains(".o-mail-Message-content", { text: "Hello World!" });
     await click("[title='Fold']");
     await waitNotifications([env, "discuss.Thread/fold_state"]);
-    await contains(".o-mail-ChatBubble");
+    await click(".o-mail-ChatBubble");
     await click("[title*='Close Chat Window']");
     await contains(".o-mail-ChatBubble", { count: 0 });
     await contains(".o-mail-ChatWindow p", { text: "Did we correctly answer your question?" });

--- a/addons/mail/static/src/core/common/chat_bubble.js
+++ b/addons/mail/static/src/core/common/chat_bubble.js
@@ -34,7 +34,7 @@ export class ChatBubble extends Component {
         });
         this.preview = useDropdownState();
         this.rootRef = useRef("root");
-        this.state = useState({ bouncing: false, showClose: true });
+        this.state = useState({ bouncing: false, showClose: false });
         useEffect(
             () => {
                 this.state.bouncing = this.thread.importantCounter ? true : this.state.bouncing;

--- a/addons/mail/static/tests/chat_bubble/chat_bubble.test.js
+++ b/addons/mail/static/tests/chat_bubble/chat_bubble.test.js
@@ -231,6 +231,7 @@ test("chat bubbles are synced between tabs", async () => {
     await contains(".o-mail-ChatWindow", { target: tab2 }); // open sync
     await click(".o-mail-ChatWindow-command[title='Fold']", { target: tab2 });
     await contains(".o-mail-ChatWindow", { target: tab1, count: 0 }); // fold sync
+    await hover(".o-mail-ChatBubble[name='Marc']", { target: tab1 });
     await click(".o-mail-ChatBubble[name='Marc'] .o-mail-ChatBubble-close", { target: tab1 });
     await contains(".o-mail-ChatBubble[name='Marc']", { target: tab2, count: 0 }); // close sync
 });


### PR DESCRIPTION
Before this commit:
When we hover over the chatBubble, the message preview is opened, 
but as we leave the message preview is not closed, it is closed when the we 
click outside the preview.

After this commit:
The cause of this bug is that the state variable showClose already contains 
the value true. Setting it to true again does not trigger a re-render of the 
chat bubble because there is no actual state change. In this commit, showClose 
is first set to false and then set to true, which forces the component to re-render, 
thereby resolving the issue
