### PR TITLE
[FIX] account: fix lock date in _unlink_or_reverse for multi company

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3768,8 +3768,8 @@ class AccountMove(models.Model):
             return
         to_reverse = self.env['account.move']
         to_unlink = self.env['account.move']
-        lock_date = self.company_id._get_user_fiscal_lock_date()
         for move in self:
+            lock_date = move.company_id._get_user_fiscal_lock_date()
             if move.inalterable_hash or move.date <= lock_date:
                 to_reverse += move
             else:


### PR DESCRIPTION
Currently all moves are assumed to belong to the same company for the lock date computation.

This commit fixes that issue.

(no task)
