### PR TITLE
[FIX] base, account, l10n_th: Refactor test_reports for better modularity

### DIFF
--- a/addons/account/tests/__init__.py
+++ b/addons/account/tests/__init__.py
@@ -43,3 +43,4 @@ from . import test_early_payment_discount
 from . import test_ir_actions_report
 from . import test_download_xsds
 from . import test_mail_tracking_value
+from . import test_reports

--- a/addons/account/tests/test_reports.py
+++ b/addons/account/tests/test_reports.py
@@ -1,0 +1,6 @@
+from odoo.addons.base.tests.test_reports import SPECIFIC_MODEL_DOMAINS
+
+
+SPECIFIC_MODEL_DOMAINS.update({
+    'account.report_original_vendor_bill': [('move_type', 'in', ('in_invoice', 'in_receipt'))],
+})

--- a/addons/l10n_th/tests/__init__.py
+++ b/addons/l10n_th/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_reports

--- a/addons/l10n_th/tests/test_reports.py
+++ b/addons/l10n_th/tests/test_reports.py
@@ -1,0 +1,6 @@
+from odoo.addons.base.tests.test_reports import SPECIFIC_MODEL_DOMAINS
+
+
+SPECIFIC_MODEL_DOMAINS.update({
+    'l10n_th.report_commercial_invoice': [('move_type', 'in', ('out_invoice', 'out_refund', 'out_receipt', 'in_invoice', 'in_refund', 'in_receipt'))],
+})

--- a/odoo/addons/base/tests/test_reports.py
+++ b/odoo/addons/base/tests/test_reports.py
@@ -8,17 +8,12 @@ import odoo.tests
 
 _logger = logging.getLogger(__name__)
 
+SPECIFIC_MODEL_DOMAINS = {}
+
 
 @odoo.tests.tagged('post_install', '-at_install', 'post_install_l10n')
 class TestReports(odoo.tests.TransactionCase):
     def test_reports(self):
-        invoice_domain = [('move_type', 'in', ('out_invoice', 'out_refund', 'out_receipt', 'in_invoice', 'in_refund', 'in_receipt'))]
-        specific_model_domains = {
-            'account.report_original_vendor_bill': [('move_type', 'in', ('in_invoice', 'in_receipt'))],
-            'account.report_invoice_with_payments': invoice_domain,
-            'account.report_invoice': invoice_domain,
-            'l10n_th.report_commercial_invoice': invoice_domain,
-        }
         Report = self.env['ir.actions.report']
         for report in Report.search([('report_type', 'like', 'qweb')]):
             report_model = 'report.%s' % report.report_name
@@ -27,7 +22,7 @@ class TestReports(odoo.tests.TransactionCase):
             except KeyError:
                 # Only test the generic reports here
                 _logger.info("testing report %s", report.report_name)
-                report_model_domain = specific_model_domains.get(report.report_name, [])
+                report_model_domain = SPECIFIC_MODEL_DOMAINS.get(report.report_name, [])
                 report_records = self.env[report.model].search(report_model_domain, limit=10)
                 if not report_records:
                     _logger.info("no record found skipping report %s", report.report_name)


### PR DESCRIPTION
Refactor report tests to introduce `SPECIFIC_MODEL_DOMAINS`, a new variable that can be updated in other modules to simplify the addition of new domain-specific reports.

This change enhances test flexibility and maintainability by eliminating the need for direct modifications to the test code or monkey patching (for non-standard modules), which were previously necessary when adding new domain-specific reports.

Additionally, the 'account.report_invoice_with_payments' and 'account.report_invoice' reports are no longer tested by test_reports. The models 'report.account.report_invoice_with_payments' and 'report.account.report_invoice' exist, and KeyError exceptions are not triggered, so these reports do not need to be included in the `SPECIFIC_MODEL_DOMAINS` variable.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
