### PR TITLE
[PERF] point_of_sale: backport search_fetch optimization

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -1599,20 +1599,30 @@ class PosSession(models.Model):
 
     def _get_attributes_by_ptal_id(self):
         product_attributes = self.env['product.attribute'].search([('create_variant', '=', 'no_variant')])
-        product_attributes_by_id = {product_attribute.id: product_attribute for product_attribute in product_attributes}
-        domain = [('attribute_id', 'in', product_attributes.mapped('id'))]
-        product_template_attribute_values = self.env['product.template.attribute.value'].search(domain)
-        key = lambda ptav: (ptav.attribute_line_id.id, ptav.attribute_id.id)
+        product_template_attribute_values = self.env['product.template.attribute.value'].search([
+            ('attribute_id', 'in', product_attributes.ids),
+        ])
+        product_template_attribute_values._read(['attribute_id', 'attribute_line_id', 'product_attribute_value_id', 'price_extra', 'ptav_active'])
+        product_template_attribute_values.product_attribute_value_id._read(['name', 'is_custom', 'html_color'])
+
+        def key1(ptav):
+            return ptav.attribute_line_id.id, ptav.attribute_id.id
+
+        def key2(ptav):
+            return ptav.attribute_line_id.id, ptav.attribute_id
         res = {}
-        for key, group in groupby(sorted(product_template_attribute_values, key=key), key=key):
-            attribute_line_id, attribute_id = key
-            values = [{**ptav.product_attribute_value_id.read(['name', 'is_custom', 'html_color'])[0],
+        for key, group in groupby(sorted(product_template_attribute_values, key=key1), key=key2):
+            attribute_line_id, attribute = key
+            values = [{'id': ptav.product_attribute_value_id.id,
+                       'name': ptav.product_attribute_value_id.name,
+                       'is_custom': ptav.is_custom,
+                       'html_color': ptav.html_color,
                        'price_extra': ptav.price_extra} for ptav in list(group) if ptav.ptav_active]
             res[attribute_line_id] = {
                 'id': attribute_line_id,
-                'name': product_attributes_by_id[attribute_id].name,
-                'display_type': product_attributes_by_id[attribute_id].display_type,
-                'values': values
+                'name': attribute.name,
+                'display_type': attribute.display_type,
+                'values': values,
             }
 
         return res


### PR DESCRIPTION
Backport search_feat optimization of 6ef37728474 to speedup opening a point_of_sale session. As search_fetch is not available in 16.0, it's replaced by a call to `_read`. Also, because `read` does not check the field_cache in 16.0,
as opposed to the new `fetch`, the field values are retrieved through dot-notation instead.

#### speedup

In a v16 customer database with `limited_product_loading` set to 1000, 
the time to load the data when opening a PoS session: 
- 16s -> 6.5s.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
