### PR TITLE
[ADD] website_hr_recruitment_livechat: Chatbot for the /jobs webpage

### DIFF
--- a/addons/website_hr_recruitment_livechat/__init__.py
+++ b/addons/website_hr_recruitment_livechat/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/addons/website_hr_recruitment_livechat/__manifest__.py
+++ b/addons/website_hr_recruitment_livechat/__manifest__.py
@@ -1,0 +1,21 @@
+{
+    'name': 'HR Recruitment Live Chat',
+    'category': 'Hidden',
+    'summary': 'Chatbot for the HR Recruitment',
+    'version': '1.0',
+    'description': """
+A chatbot to help the user be guided through recruitment process on the website and land on the right jobs position.
+    """,
+    'depends': ['website_hr_recruitment', 'im_livechat'],
+    'installable': True,
+    'auto_install': True,
+    'data': [
+        'security/ir.model.access.csv',
+        'security/website_hr_recruitment_livechat.xml',
+        'data/website_hr_recruitment_livechat_chatbot_demo_data.xml',
+    ],
+    'demo': [
+        'data/website_hr_recruitment_livechat_chatbot_demo.xml',
+    ],
+    'license': 'LGPL-3',
+}

--- a/addons/website_hr_recruitment_livechat/data/website_hr_recruitment_livechat_chatbot_demo.xml
+++ b/addons/website_hr_recruitment_livechat/data/website_hr_recruitment_livechat_chatbot_demo.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo><data noupdate="1">
+
+    <!-- Add a Channel Rule to demonstrate our bot on the '/jobs' page -->
+    
+    <record id="website_hr_recruitment_livechat_channel_rule_chatbot" model="im_livechat.channel.rule">
+        <field name="regex_url">/jobs</field>
+        <field name="sequence">5</field>
+        <field name="action">auto_popup</field>
+        <field name="auto_popup_timer">2</field>
+        <field name="is_script_flexible">True</field>
+        <field name="chatbot_script_id" ref="website_hr_recruitment_livechat.chatbot_script_recruitment_bot"/>
+        <field name="channel_id" ref="im_livechat.im_livechat_channel_data"/>
+    </record>
+
+</data></odoo>

--- a/addons/website_hr_recruitment_livechat/data/website_hr_recruitment_livechat_chatbot_demo_data.xml
+++ b/addons/website_hr_recruitment_livechat/data/website_hr_recruitment_livechat_chatbot_demo_data.xml
@@ -1,0 +1,406 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<odoo><data noupdate="1">
+
+    <!--
+        This provides a working chatbot for people to work with.
+        It's placed into 'data' to give them a starting point.
+        From that record, they can duplicate / adapt / delete / ...
+    -->
+
+    <record id="chatbot_script_recruitment_bot" model="chatbot.script">
+        <field name="title">Jobs bot</field>
+        <field name="image_1920" type="base64" file="mail/static/src/img/odoobot.png"/>
+    </record>
+
+    <record id="chatbot_script_recruitment_step_help" model="chatbot.script.step">
+        <field name="message">Hello, can I help you find the perfect job?</field>
+        <field name="sequence">1</field>
+        <field name="step_type">question_selection</field>
+        <field name="chatbot_script_id" ref="chatbot_script_recruitment_bot"/>
+    </record>
+
+    <record id="chatbot_script_recruitment_step_help_answer_yes" model="chatbot.script.answer">
+        <field name="name">Yes</field>
+        <field name="sequence">1</field>
+        <field name="script_step_id" ref="chatbot_script_recruitment_step_help"/>
+    </record>
+
+    <!-- This record will be overwritten later in the file, to include a triggerring answer 
+    that is not defined yet (circular referencing) -->
+    <record id="chatbot_script_recruitment_step_department" model="chatbot.script.step">
+        <field name="message">What kind of job are you looking for?</field>
+        <field name="sequence">2</field>
+        <field name="step_type">question_selection</field>
+        <field name="chatbot_script_id" ref="chatbot_script_recruitment_bot"/>
+        <field name="triggering_answer_ids" eval="[
+            (4, ref('chatbot_script_recruitment_step_help_answer_yes')),
+        ]"/>    
+    </record>
+
+    <record id="chatbot_script_recruitment_step_department_answer_sales" model="chatbot.script.answer">
+        <field name="name">Sales</field>
+        <field name="sequence">1</field>
+        <field name="script_step_id" ref="chatbot_script_recruitment_step_department"/>
+    </record>
+
+    <record id="chatbot_script_recruitment_step_sales_job" model="chatbot.script.step">
+        <field name="message">What are you looking for in the Sales Department ?</field>
+        <field name="sequence">3</field>
+        <field name="step_type">question_selection</field>
+        <field name="chatbot_script_id" ref="chatbot_script_recruitment_bot"/>
+        <field name="triggering_answer_ids" eval="[(4, ref('chatbot_script_recruitment_step_department_answer_sales'))]"/>
+    </record>
+
+    <record id="chatbot_script_recruitment_step_sales_job_answer_consultant" model="chatbot.script.answer">
+        <field name="name">Boost sales through client strategies</field>
+        <field name="sequence">1</field>
+        <field name="redirect_link">/jobs/consultant-3</field>
+        <field name="script_step_id" ref="chatbot_script_recruitment_step_sales_job"/>
+    </record>
+
+    <record id="chatbot_script_recruitment_step_sales_consultant" model="chatbot.script.step">
+        <field name="message">We have a consultant position in stock, it should fit your needs!</field>
+        <field name="sequence">4</field>
+        <field name="step_type">text</field>
+        <field name="chatbot_script_id" ref="chatbot_script_recruitment_bot"/>
+        <field name="triggering_answer_ids" eval="[(4, ref('chatbot_script_recruitment_step_sales_job_answer_consultant'))]"/>
+    </record>
+
+    <record id="chatbot_script_recruitment_step_sales_job_answer_account" model="chatbot.script.answer">
+        <field name="name">Maintain and grow client relationships</field>
+        <field name="sequence">2</field>
+        <field name="script_step_id" ref="chatbot_script_recruitment_step_sales_job"/>
+    </record>
+
+    <record id="chatbot_script_recruitment_step_account_no_available" model="chatbot.script.step">
+        <field name="message">Hu-ho, it looks like we don't have such position in stock 🙁</field>
+        <field name="sequence">4</field>
+        <field name="step_type">text</field>
+        <field name="chatbot_script_id" ref="chatbot_script_recruitment_bot"/>
+        <field name="triggering_answer_ids" eval="[
+            (4, ref('chatbot_script_recruitment_step_sales_job_answer_account'))]"/>
+    </record>
+
+    <record id="chatbot_script_recruitment_step_account_other_proposition" model="chatbot.script.step">
+        <field name="message">But if you want, we do have a consultant position available!</field>
+        <field name="sequence">5</field>
+        <field name="step_type">text</field>
+        <field name="chatbot_script_id" ref="chatbot_script_recruitment_bot"/>
+        <field name="triggering_answer_ids" eval="[
+            (4, ref('chatbot_script_recruitment_step_sales_job_answer_account'))]"/>
+    </record>
+
+    <record id="chatbot_script_recruitment_step_account_what_next" model="chatbot.script.step">
+        <field name="message">What do you wanna do next?</field>
+        <field name="sequence">6</field>
+        <field name="step_type">question_selection</field>
+        <field name="chatbot_script_id" ref="chatbot_script_recruitment_bot"/>
+        <field name="triggering_answer_ids" eval="[
+            (4, ref('chatbot_script_recruitment_step_sales_job_answer_account'))]"/>
+    </record>
+
+    <record id="chatbot_script_recruitment_step_account_what_next_answer_consultant" model="chatbot.script.answer">
+        <field name="name">Inspect the consultant job offer</field>
+        <field name="sequence">1</field>
+        <field name="redirect_link">/jobs/consultant-3</field>
+        <field name="script_step_id" ref="chatbot_script_recruitment_step_account_what_next"/>
+    </record>
+
+    <record id="chatbot_script_recruitment_step_account_what_next_answer_keep_looking" model="chatbot.script.answer">
+        <field name="name">Keep looking for other jobs</field>
+        <field name="sequence">2</field>
+        <field name="script_step_id" ref="chatbot_script_recruitment_step_account_what_next"/>
+    </record>
+
+    <record id="chatbot_script_recruitment_step_account_what_next_answer_autonomous" model="chatbot.script.answer">
+        <field name="name">Discover the jobs by my own</field>
+        <field name="sequence">3</field>
+        <field name="script_step_id" ref="chatbot_script_recruitment_step_account_what_next"/>
+    </record>
+
+    <record id="chatbot_script_recruitment_step_department_answer_services" model="chatbot.script.answer">
+        <field name="name">Services</field>
+        <field name="sequence">2</field>
+        <field name="script_step_id" ref="chatbot_script_recruitment_step_department"/>
+    </record>
+
+    <record id="chatbot_script_recruitment_step_services_job" model="chatbot.script.step">
+        <field name="message">What are you looking for in the Services Department ?</field>
+        <field name="sequence">3</field>
+        <field name="step_type">question_selection</field>
+        <field name="chatbot_script_id" ref="chatbot_script_recruitment_bot"/>
+        <field name="triggering_answer_ids" eval="[(4, ref('chatbot_script_recruitment_step_department_answer_services'))]"/>
+    </record>
+
+    <record id="chatbot_script_recruitment_step_services_job_answer_media" model="chatbot.script.answer">
+        <field name="name">Manage social media</field>
+        <field name="sequence">1</field>
+        <field name="redirect_link">/jobs/marketing-and-community-manager-6</field>
+        <field name="script_step_id" ref="chatbot_script_recruitment_step_services_job"/>
+    </record>
+
+    <record id="chatbot_script_recruitment_step_services_media" model="chatbot.script.step">
+        <field name="message">We have a community manager position in stock, it should fit your needs!</field>
+        <field name="sequence">4</field>
+        <field name="step_type">text</field>
+        <field name="chatbot_script_id" ref="chatbot_script_recruitment_bot"/>
+        <field name="triggering_answer_ids" eval="[(4, ref('chatbot_script_recruitment_step_services_job_answer_media'))]"/>
+    </record>
+
+    <record id="chatbot_script_recruitment_step_services_job_answer_product" model="chatbot.script.answer">
+        <field name="name">Master the product</field>
+        <field name="sequence">2</field>
+        <field name="script_step_id" ref="chatbot_script_recruitment_step_services_job"/>
+    </record>
+
+    <record id="chatbot_script_recruitment_step_product_no_available" model="chatbot.script.step">
+        <field name="message">Hu-ho, it looks like we don't have such position in stock 🙁</field>
+        <field name="sequence">4</field>
+        <field name="step_type">text</field>
+        <field name="chatbot_script_id" ref="chatbot_script_recruitment_bot"/>
+        <field name="triggering_answer_ids" eval="[
+            (4, ref('chatbot_script_recruitment_step_services_job_answer_product'))]"/>
+    </record>
+
+    <record id="chatbot_script_recruitment_step_product_other_proposition" model="chatbot.script.step">
+        <field name="message">But if you want, we do have a community manager position available!</field>
+        <field name="sequence">5</field>
+        <field name="step_type">text</field>
+        <field name="chatbot_script_id" ref="chatbot_script_recruitment_bot"/>
+        <field name="triggering_answer_ids" eval="[
+            (4, ref('chatbot_script_recruitment_step_services_job_answer_product'))]"/>
+    </record>
+
+    <record id="chatbot_script_recruitment_step_product_what_next" model="chatbot.script.step">
+        <field name="message">What do you wanna do next?</field>
+        <field name="sequence">6</field>
+        <field name="step_type">question_selection</field>
+        <field name="chatbot_script_id" ref="chatbot_script_recruitment_bot"/>
+        <field name="triggering_answer_ids" eval="[
+            (4, ref('chatbot_script_recruitment_step_services_job_answer_product'))]"/>
+    </record>
+
+    <record id="chatbot_script_recruitment_step_product_what_next_answer_community" model="chatbot.script.answer">
+        <field name="name">Inspect the community manager job offer</field>
+        <field name="sequence">1</field>
+        <field name="redirect_link">/jobs/marketing-and-community-manager-6</field>
+        <field name="script_step_id" ref="chatbot_script_recruitment_step_product_what_next"/>
+    </record>
+
+    <record id="chatbot_script_recruitment_step_product_what_next_answer_keep_looking" model="chatbot.script.answer">
+        <field name="name">Keep looking for other jobs</field>
+        <field name="sequence">2</field>
+        <field name="script_step_id" ref="chatbot_script_recruitment_step_product_what_next"/>
+    </record>
+
+    <record id="chatbot_script_recruitment_step_product_what_next_answer_autonomous" model="chatbot.script.answer">
+        <field name="name">Discover the jobs by my own</field>
+        <field name="sequence">3</field>
+        <field name="script_step_id" ref="chatbot_script_recruitment_step_product_what_next"/>
+    </record>
+
+    <record id="chatbot_script_recruitment_step_department_answer_rd" model="chatbot.script.answer">
+        <field name="name">Research and Development</field> <!--&amp;-->
+        <field name="sequence">3</field>
+        <field name="script_step_id" ref="chatbot_script_recruitment_step_department"/>
+    </record>
+
+    <record id="chatbot_script_recruitment_step_rd_job" model="chatbot.script.step">
+        <field name="message">What are you looking for in the R&amp;D Department ?</field>
+        <field name="sequence">3</field>
+        <field name="step_type">question_selection</field>
+        <field name="chatbot_script_id" ref="chatbot_script_recruitment_bot"/>
+        <field name="triggering_answer_ids" eval="[(4, ref('chatbot_script_recruitment_step_department_answer_rd'))]"/>
+    </record>
+
+    <record id="chatbot_script_recruitment_step_rd_job_answer_dev" model="chatbot.script.answer">
+        <field name="name">Develop and optimize innovative software</field>
+        <field name="sequence">1</field>
+        <field name="redirect_link">/jobs/experienced-developer-4</field>
+        <field name="script_step_id" ref="chatbot_script_recruitment_step_rd_job"/>
+    </record>
+
+    <record id="chatbot_script_recruitment_step_rd_dev" model="chatbot.script.step">
+        <field name="message">We have a developer position in stock, it should fit your needs!</field>
+        <field name="sequence">4</field>
+        <field name="step_type">text</field>
+        <field name="chatbot_script_id" ref="chatbot_script_recruitment_bot"/>
+        <field name="triggering_answer_ids" eval="[(4, ref('chatbot_script_recruitment_step_rd_job_answer_dev'))]"/>
+    </record>
+
+    <record id="chatbot_script_recruitment_step_rd_job_answer_datascientist" model="chatbot.script.answer">
+        <field name="name">Analyze data to drive innovation</field>
+        <field name="sequence">2</field>
+        <field name="script_step_id" ref="chatbot_script_recruitment_step_rd_job"/>
+    </record>
+
+    <record id="chatbot_script_recruitment_step_datascientist_no_available" model="chatbot.script.step">
+        <field name="message">Hu-ho, it looks like we don't have such position in stock 🙁</field>
+        <field name="sequence">4</field>
+        <field name="step_type">text</field>
+        <field name="chatbot_script_id" ref="chatbot_script_recruitment_bot"/>
+        <field name="triggering_answer_ids" eval="[
+            (4, ref('chatbot_script_recruitment_step_rd_job_answer_datascientist'))]"/>
+    </record>
+
+    <record id="chatbot_script_recruitment_step_datascientist_other_proposition" model="chatbot.script.step">
+        <field name="message">But if you want, we do have an experienced developer position available!</field>
+        <field name="sequence">5</field>
+        <field name="step_type">text</field>
+        <field name="chatbot_script_id" ref="chatbot_script_recruitment_bot"/>
+        <field name="triggering_answer_ids" eval="[
+            (4, ref('chatbot_script_recruitment_step_rd_job_answer_datascientist'))]"/>
+    </record>
+
+    <record id="chatbot_script_recruitment_step_datascientist_what_next" model="chatbot.script.step">
+        <field name="message">What do you wanna do next?</field>
+        <field name="sequence">6</field>
+        <field name="step_type">question_selection</field>
+        <field name="chatbot_script_id" ref="chatbot_script_recruitment_bot"/>
+        <field name="triggering_answer_ids" eval="[
+            (4, ref('chatbot_script_recruitment_step_rd_job_answer_datascientist'))]"/>
+    </record>
+
+    <record id="chatbot_script_recruitment_step_datascientist_what_next_answer_developer" model="chatbot.script.answer">
+        <field name="name">Inspect the experienced developer job offer</field>
+        <field name="sequence">1</field>
+        <field name="redirect_link">/jobs/experienced-developer-4</field>
+        <field name="script_step_id" ref="chatbot_script_recruitment_step_datascientist_what_next"/>
+    </record>
+
+    <record id="chatbot_script_recruitment_step_datascientist_what_next_answer_keep_looking" model="chatbot.script.answer">
+        <field name="name">Keep looking for other jobs</field>
+        <field name="sequence">2</field>
+        <field name="script_step_id" ref="chatbot_script_recruitment_step_datascientist_what_next"/>
+    </record>
+
+    <record id="chatbot_script_recruitment_step_datascientist_what_next_answer_autonomous" model="chatbot.script.answer">
+        <field name="name">Discover the jobs by my own</field>
+        <field name="sequence">3</field>
+        <field name="script_step_id" ref="chatbot_script_recruitment_step_datascientist_what_next"/>
+    </record>
+
+    <record id="chatbot_script_recruitment_step_help_answer_no" model="chatbot.script.answer">
+        <field name="name">No</field>
+        <field name="sequence">2</field>
+        <field name="script_step_id" ref="chatbot_script_recruitment_step_help"/>
+    </record>
+
+    <record id="chatbot_script_recruitment_step_help_exit" model="chatbot.script.step">
+        <field name="message">If there is anything we can help with, let us know</field>
+        <field name="sequence">2</field>
+        <field name="step_type">text</field>
+        <field name="chatbot_script_id" ref="chatbot_script_recruitment_bot"/>
+        <field name="triggering_answer_ids" eval="[(4, ref('chatbot_script_recruitment_step_help_answer_no'))]"/>
+    </record>
+    
+    <!-- This is overwritting another record earlier in the file, to include a triggerring answer 
+    that was not defined yet (circular referencing) -->
+    <record id="chatbot_script_recruitment_step_department" model="chatbot.script.step">
+        <field name="message">What kind of job are you looking for?</field>
+        <field name="sequence">2</field>
+        <field name="step_type">question_selection</field>
+        <field name="chatbot_script_id" ref="chatbot_script_recruitment_bot"/>
+        <field name="triggering_answer_ids" eval="[
+            (4, ref('chatbot_script_recruitment_step_help_answer_yes')),
+            (4, ref('chatbot_script_recruitment_step_account_what_next_answer_keep_looking')),
+            (4, ref('chatbot_script_recruitment_step_product_what_next_answer_keep_looking')),
+            (4, ref('chatbot_script_recruitment_step_datascientist_what_next_answer_keep_looking')),
+        ]"/>    
+    </record>
+
+    <record id="chatbot_script_recruitment_step_job_redirect" model="chatbot.script.step">
+        <field name="message">And tadaaaa here you go! 🌟</field>
+        <field name="sequence">5</field>
+        <field name="step_type">text</field>
+        <field name="chatbot_script_id" ref="chatbot_script_recruitment_bot"/>
+        <field name="triggering_answer_ids" eval="[
+            (4, ref('chatbot_script_recruitment_step_account_what_next_answer_consultant')),
+            (4, ref('chatbot_script_recruitment_step_product_what_next_answer_community')),
+            (4, ref('chatbot_script_recruitment_step_datascientist_what_next_answer_developer')),
+        ]"/>
+    </record>
+
+    <record id="chatbot_script_recruitment_step_chat" model="chatbot.script.step">
+        <field name="message">Do you wanna chat with one of our HR about this job?</field>
+        <field name="sequence">6</field>
+        <field name="step_type">question_selection</field>
+        <field name="chatbot_script_id" ref="chatbot_script_recruitment_bot"/>
+        <field name="triggering_answer_ids" eval="[
+            (4, ref('chatbot_script_recruitment_step_services_job_answer_media')),
+            (4, ref('chatbot_script_recruitment_step_sales_job_answer_consultant')),
+            (4, ref('chatbot_script_recruitment_step_rd_job_answer_dev')),
+            (4, ref('chatbot_script_recruitment_step_account_what_next_answer_consultant')),
+            (4, ref('chatbot_script_recruitment_step_product_what_next_answer_community')),
+            (4, ref('chatbot_script_recruitment_step_datascientist_what_next_answer_developer')),
+        ]"/>
+    </record>
+
+    <record id="chatbot_script_recruitment_step_chat_answer_yes" model="chatbot.script.answer">
+        <field name="name">Yes please!</field>
+        <field name="sequence">1</field>
+        <field name="script_step_id" ref="chatbot_script_recruitment_step_chat"/>
+    </record>
+
+    <record id="chatbot_script_recruitment_step_chat_check" model="chatbot.script.step">
+        <field name="message">Hmmm, let me check if I can find someone that could help you with that...</field>
+        <field name="sequence">7</field>
+        <field name="step_type">text</field>
+        <field name="chatbot_script_id" ref="chatbot_script_recruitment_bot"/>
+        <field name="triggering_answer_ids" eval="[(4, ref('chatbot_script_recruitment_step_chat_answer_yes'))]"/>
+    </record>
+
+    <record id="chatbot_script_recruitment_step_chat_forward_operator" model="chatbot.script.step">
+        <field name="sequence">8</field>
+        <field name="step_type">forward_operator</field>
+        <field name="chatbot_script_id" ref="chatbot_script_recruitment_bot"/>
+        <field name="triggering_answer_ids" eval="[(4, ref('chatbot_script_recruitment_step_chat_answer_yes'))]"/>
+    </record>
+
+    <record id="chatbot_script_recruitment_step_chat_noone_available" model="chatbot.script.step">
+        <field name="message">Hu-ho, it looks like none of our operators are available 🙁</field>
+        <field name="sequence">9</field>
+        <field name="step_type">text</field>
+        <field name="chatbot_script_id" ref="chatbot_script_recruitment_bot"/>
+        <field name="triggering_answer_ids" eval="[(4, ref('chatbot_script_recruitment_step_chat_answer_yes'))]"/>
+    </record>
+
+    <record id="chatbot_script_recruitment_step_chat_email" model="chatbot.script.step">
+        <field name="message">Would you mind leaving your email address so that we can reach you back?</field>
+        <field name="sequence">10</field>
+        <field name="step_type">question_email</field>
+        <field name="chatbot_script_id" ref="chatbot_script_recruitment_bot"/>
+        <field name="triggering_answer_ids" eval="[(4, ref('chatbot_script_recruitment_step_chat_answer_yes'))]"/>
+    </record>
+
+    <record id="chatbot_script_recruitment_step_chat_base_exit" model="chatbot.script.step">
+        <field name="message">If you need anything else, feel free to get back in touch</field>
+        <field name="sequence">11</field>
+        <field name="step_type">text</field>
+        <field name="chatbot_script_id" ref="chatbot_script_recruitment_bot"/>
+        <field name="triggering_answer_ids" eval="[
+            (4, ref('chatbot_script_recruitment_step_chat_answer_yes')),
+        ]"/>
+    </record>
+
+    <record id="chatbot_script_recruitment_step_chat_answer_no" model="chatbot.script.answer">
+        <field name="name">No I'll discover by myself!</field>
+        <field name="sequence">2</field>
+        <field name="script_step_id" ref="chatbot_script_recruitment_step_chat"/>
+    </record>        
+    
+    <record id="chatbot_script_recruitment_step_chat_short_exit" model="chatbot.script.step">
+        <field name="message">Please do! If there is anything else we can help with, let us know</field>
+        <field name="sequence">7</field>
+        <field name="step_type">text</field>
+        <field name="chatbot_script_id" ref="chatbot_script_recruitment_bot"/>
+        <field name="triggering_answer_ids" eval="[
+            (4, ref('chatbot_script_recruitment_step_chat_answer_no')),
+            (4, ref('chatbot_script_recruitment_step_account_what_next_answer_autonomous')),
+            (4, ref('chatbot_script_recruitment_step_product_what_next_answer_autonomous')),
+            (4, ref('chatbot_script_recruitment_step_datascientist_what_next_answer_autonomous')),
+        ]"/>
+    </record>
+
+</data></odoo>

--- a/addons/website_hr_recruitment_livechat/models/__init__.py
+++ b/addons/website_hr_recruitment_livechat/models/__init__.py
@@ -1,0 +1,2 @@
+from . import chatbot_script_step
+from . import im_livechat_channel

--- a/addons/website_hr_recruitment_livechat/models/chatbot_script_step.py
+++ b/addons/website_hr_recruitment_livechat/models/chatbot_script_step.py
@@ -1,0 +1,66 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+from odoo.osv import expression
+
+
+class ChatbotScriptStep(models.Model):
+    _inherit = 'chatbot.script.step'
+
+    def _fetch_next_step(self, selected_answer_ids):
+        """ Fetch the next step depending on the user's last selected answer.
+            If a step contains multiple triggering answers from the same step or from different steps
+            the condition between them must be a 'OR'.
+            A step can trigger steps that have a lower sequence than itself (allowing to do go back
+            in the dialogue and to do loops)
+
+            e.g:
+
+            STEP 1 : A B
+            STEP 2 : C D
+            STEP 3 : E
+            STEP 4 ONLY IF A C
+
+            Scenario 1 (B C E):
+
+            B in (A) -> NOK
+            C in (C) -> OK
+
+            -> OK
+
+            Scenario 2 (B D E):
+
+            B in (A) -> NOK
+            D in (C) -> NOK
+
+            -> NOK
+        """
+        self.ensure_one()
+
+        if self.env['im_livechat.channel.rule'].search([('chatbot_script_id', '=', self.chatbot_script_id.id)], limit=1).is_script_flexible:
+            last_answer = selected_answer_ids[0] if selected_answer_ids else None
+
+            domain = [('chatbot_script_id', '=', self.chatbot_script_id.id)]
+            if selected_answer_ids:
+                domain = expression.AND([domain, [
+                    '|',
+                    ('triggering_answer_ids', '=', False),
+                    ('triggering_answer_ids', 'in', [last_answer.id])]])
+
+            if last_answer and not last_answer in self.triggering_answer_ids:
+                steps = self.env['chatbot.script.step'].search(domain)
+                for step in steps:
+                    if last_answer in step.triggering_answer_ids:
+                        return step
+
+            domain = expression.AND([domain, [('sequence', '>', self.sequence)]])
+            steps = self.env['chatbot.script.step'].search(domain)
+            for step in steps:
+                if (last_answer and last_answer in step.triggering_answer_ids) \
+                        or not step.triggering_answer_ids:
+                    return step
+
+            return self.env['chatbot.script.step']
+
+        else:
+            return super()._fetch_next_step(selected_answer_ids)

--- a/addons/website_hr_recruitment_livechat/models/im_livechat_channel.py
+++ b/addons/website_hr_recruitment_livechat/models/im_livechat_channel.py
@@ -1,0 +1,9 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models, fields
+
+
+class ImLivechatChannelRule(models.Model):
+    _inherit = 'im_livechat.channel.rule'
+
+    is_script_flexible = fields.Boolean(default=False)

--- a/addons/website_hr_recruitment_livechat/security/ir.model.access.csv
+++ b/addons/website_hr_recruitment_livechat/security/ir.model.access.csv
@@ -1,0 +1,5 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_im_livechat_channel_public_public,im_livechat.channel.public,im_livechat.model_im_livechat_channel,base.group_public,1,0,0,0
+access_im_livechat_channel_public_portal,im_livechat.channel.public,im_livechat.model_im_livechat_channel,base.group_portal,1,0,0,0
+access_im_livechat_channel_public_employee,im_livechat.channel.public,im_livechat.model_im_livechat_channel,base.group_user,1,0,0,0
+access_website_track_livechat_users,website.track.livechat.users,website.model_website_track,im_livechat.im_livechat_group_user,1,0,0,0

--- a/addons/website_hr_recruitment_livechat/security/website_hr_recruitment_livechat.xml
+++ b/addons/website_hr_recruitment_livechat/security/website_hr_recruitment_livechat.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+
+    <record id="im_livechat_channel_rule_public" model="ir.rule">
+        <field name="name">website_hr_recruitment_livechat.channel.public</field>
+        <field name="model_id" ref="im_livechat.model_im_livechat_channel"/>
+        <field name="domain_force">[('website_published', '=', True)]</field>
+        <field name="groups" eval="[(4, ref('base.group_public')), (4, ref('base.group_portal'))]"/>
+        <field name="perm_read" eval="1"/>
+        <field name="perm_create" eval="0"/>
+        <field name="perm_write" eval="0"/>
+        <field name="perm_unlink" eval="0"/>
+    </record>
+
+</odoo>


### PR DESCRIPTION
The chatbot guides the user through recruitment process on the website and helps it to land on the right jobs position.

The chatbot opens automatically on the /jobs page of the website.

It is only in the scope of demo, the possible options are hardcoded

task-3977869