### PR TITLE
[FIX] pos_sale: fix down payment made in sales imported in PoS

### DIFF
--- a/addons/pos_sale/models/sale_order.py
+++ b/addons/pos_sale/models/sale_order.py
@@ -52,13 +52,13 @@ class SaleOrderLine(models.Model):
             sale_line.qty_invoiced += sum([self._convert_qty(sale_line, pos_line.qty, 'p2s') for pos_line in sale_line.pos_order_line_ids], 0)
 
     def _get_sale_order_fields(self):
-        return ["product_id", "display_name", "price_unit", "product_uom_qty", "tax_id", "qty_delivered", "qty_invoiced", "discount", "qty_to_invoice", "price_total"]
+        return ["product_id", "display_name", "price_unit", "product_uom_qty", "tax_id", "qty_delivered", "qty_invoiced", "discount", "qty_to_invoice", "price_total", "is_downpayment"]
 
     def read_converted(self):
         field_names = self._get_sale_order_fields()
         results = []
         for sale_line in self:
-            if sale_line.product_type:
+            if sale_line.product_type or (sale_line.is_downpayment and sale_line.price_unit != 0):
                 product_uom = sale_line.product_id.uom_id
                 sale_line_uom = sale_line.product_uom
                 item = sale_line.read(field_names, load=False)[0]

--- a/addons/pos_sale/static/src/app/order_management_screen/sale_order_management_screen/sale_order_management_screen.js
+++ b/addons/pos_sale/static/src/app/order_management_screen/sale_order_management_screen/sale_order_management_screen.js
@@ -157,7 +157,7 @@ export class SaleOrderManagementScreen extends Component {
             // settle the order
             const lines = sale_order.order_line;
             const product_to_add_in_pos = lines
-                .filter((line) => !this.pos.models["product.product"].get(line.product_id))
+                .filter((line) => !this.pos.models["product.product"].get(line.product_id) && line.product_id)
                 .map((line) => line.product_id);
             if (product_to_add_in_pos.length) {
                 const confirmed = await ask(this.dialog, {
@@ -200,7 +200,7 @@ export class SaleOrderManagementScreen extends Component {
 
             for (var i = 0; i < lines.length; i++) {
                 const line = lines[i];
-                const productProduct = this.pos.models["product.product"].get(line.product_id);
+                const productProduct = line.is_downpayment ? this.pos.config.down_payment_product_id : this.pos.models["product.product"].get(line.product_id);
 
                 if (!productProduct) {
                     continue;

--- a/addons/pos_sale/static/tests/tours/PosSaleTour.js
+++ b/addons/pos_sale/static/tests/tours/PosSaleTour.js
@@ -201,3 +201,16 @@ registry
             ProductScreen.controlButton("Save"),
         ].flat(),
     });
+
+registry
+    .category("web_tour.tours")
+    .add('PoSSaleOrderWithDownpayment', {
+        test: true,
+        steps: () => [
+            Dialog.confirm("Open session"),
+            ProductScreen.controlButton("Quotation/Order"),
+            ProductScreen.selectFirstOrder(),
+            ProductScreen.selectedOrderlineHas('Down Payment (POS)', '1.00', '20.00'),
+            ProductScreen.totalAmountIs(980.0)
+        ].flat(),
+    });


### PR DESCRIPTION
When a downpayment was made in the sales app, it was not imported correctly in PoS when importing the order.

Steps to reproduce:
-------------------
* Create a sale order
* Make a downpayment for the sale order (Create invoice -> downpayment)
* Pay the downpayment
* Open PoS and try to settle the order
> Observation: The downpayment doesn't appear in the PoS

Why the fix:
------------
Since this PR #148732 the downpayment product has been removed when doing a downpayment in PoS. It was causing the downpayment line to be filtered out when importing the order in PoS here https://github.com/odoo/odoo/blob/0592aa98bc582dab6ac739a82bf3f6d9ec372ec8/addons/pos_sale/models/sale_order.py#L61

opw-4021708
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
