### PR TITLE
[FIX] mail: keep uppercase when creating channel

### DIFF
--- a/addons/mail/static/src/discuss/core/web/channel_selector.js
+++ b/addons/mail/static/src/discuss/core/web/channel_selector.js
@@ -99,7 +99,7 @@ export class ChannelSelector extends Component {
                 choices.push({
                     channelId: "__create__",
                     classList: "o-discuss-ChannelSelector-suggestion",
-                    label: cleanedTerm,
+                    label: this.state.value,
                 });
                 this.state.navigableListProps.options = choices;
                 return;


### PR DESCRIPTION
Before this commit, when creating a channel from the discuss sidebar, the name of the channel would be transformed to lower case.

This happens because the same cleaned term used for searching gets used to define the name of the new channel.

This commit fixes the issue by using the unaltered search term.

Before:
![image](https://github.com/odoo/odoo/assets/32620115/c0fb9a31-d8ae-4607-9c14-cd26cda34a0c)

After:
![image](https://github.com/odoo/odoo/assets/32620115/58d1480d-3818-4aab-baac-b8617958cf13)
