### PR TITLE
[FIX] core: wrong invalid field name in read_group() error message

### DIFF
--- a/odoo/addons/test_read_group/tests/__init__.py
+++ b/odoo/addons/test_read_group/tests/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from . import test_empty
+from . import test_exceptions
 from . import test_group_expand
 from . import test_group_operator
 from . import test_fill_temporal

--- a/odoo/addons/test_read_group/tests/test_exceptions.py
+++ b/odoo/addons/test_read_group/tests/test_exceptions.py
@@ -1,0 +1,16 @@
+from odoo.tests import common
+
+
+class TestExceptions(common.TransactionCase):
+    """ Test what happens when grouping unknown fields or aggregates. """
+
+    def setUp(self):
+        super().setUp()
+        self.Model = self.env['test_read_group.aggregate']
+
+    def test_unkonwn_field(self):
+        with self.assertRaisesRegex(ValueError, "Invalid field 'unknown_field' on model"):
+            self.Model.read_group([], ['unknown_field'], ['partner_id'])
+
+        with self.assertRaisesRegex(ValueError, "Invalid field 'unknown_field' on model"):
+            self.Model.read_group([], ['partner_id'], ['unknown_field'])

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -2704,7 +2704,7 @@ class BaseModel(metaclass=MetaModel):
                 continue
 
             if name not in self._fields:
-                raise ValueError(f"Invalid field {field_name!r} on model {self._name!r}")
+                raise ValueError(f"Invalid field {name!r} on model {self._name!r}")
             field = self._fields[name]
             if field.base_field.store and field.base_field.column_type and field.group_operator and field_spec not in annoted_groupby:
                 annoted_aggregates[name] = f"{name}:{field.group_operator}"


### PR DESCRIPTION
When calling read_group() with an invalid field name, the error message was misleading, indicating the last aggregated field name instead of the field that was invalid (non-existant on the model)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
