### PR TITLE
[FIX] sale_stock: open action "Forecasted Report"

### DIFF
--- a/addons/stock/report/report_stock_quantity.xml
+++ b/addons/stock/report/report_stock_quantity.xml
@@ -5,7 +5,7 @@
         <field name="name">stock_report_view_graph</field>
         <field name="model">report.stock.quantity</field>
         <field name="arch" type="xml">
-            <graph string="report_stock_quantity_graph" type="line" sample="1" disable_linking="1">
+            <graph js_class="stock_forecasted_graph" string="report_stock_quantity_graph" type="line" sample="1" disable_linking="1">
                     <field name="date" interval="day"/>
                     <field name="product_id"/>
                     <field name="product_qty" type="measure"/>

--- a/addons/stock/static/src/stock_forecasted/stock_forecasted.xml
+++ b/addons/stock/static/src/stock_forecasted/stock_forecasted.xml
@@ -14,7 +14,7 @@
         <div class="o-content pt-3 container-fluid overflow-auto o_stock_forecasted_page">
             <ForecastedHeader docs="docs" openView.bind="openView"/>
             <t t-if="context.warehouse_id">
-                <View type="'stock_forecasted_graph'"
+                <View type="'graph'"
                 viewId="stock_report_view_graph"
                 resModel="'report.stock.quantity'"
                 domain="graphDomain"


### PR DESCRIPTION
Since https://github.com/odoo/odoo/commit/47f7de04b12b38df9495685a714cb11d24d7fa27, the prop 'type' of the View component can no longer be a js_class.
Here we adapt the stock code to that change.