### PR TITLE
[FIX] account: send and print with audit trail

### DIFF
--- a/addons/account/wizard/account_move_send.py
+++ b/addons/account/wizard/account_move_send.py
@@ -475,6 +475,7 @@ class AccountMoveSend(models.TransientModel):
             )
 
         # Prevent duplicated attachments linked to the invoice.
+        new_message.attachment_ids.invalidate_recordset(['res_id', 'res_model'], flush=False)
         self.env.cr.execute("UPDATE ir_attachment SET res_id = NULL WHERE id IN %s", [tuple(new_message.attachment_ids.ids)])
         new_message.attachment_ids.write({
             'res_model': new_message._name,


### PR DESCRIPTION
We were removing the `res_id` in SQL to avoid raising when the audit trail is activated (because we cannot modify an attachment anymore) But it still failed when the value was still in cache.

[opw-4040187](https://www.odoo.com/odoo/project/49/tasks/4040187)
