### PR TITLE
[FIX] point_of_sale: remove taxes on combo parent product

### DIFF
--- a/addons/point_of_sale/models/product.py
+++ b/addons/point_of_sale/models/product.py
@@ -37,6 +37,11 @@ class ProductTemplate(models.Model):
         if not self.sale_ok:
             self.available_in_pos = False
 
+    @api.onchange('detailed_type')
+    def _onchange_detailed_type(self):
+        if self.detailed_type == 'combo':
+            self.taxes_id = None
+
     @api.constrains('available_in_pos')
     def _check_combo_inclusions(self):
         for product in self:
@@ -74,8 +79,14 @@ class ProductTemplate(models.Model):
             raise UserError(_("Combo products cannot contains variants or attributes"))
         return super()._onchange_type()
 
+
 class ProductProduct(models.Model):
     _inherit = 'product.product'
+
+    @api.onchange('detailed_type')
+    def _onchange_detailed_type(self):
+        if self.detailed_type == 'combo':
+            self.taxes_id = None
 
     @api.ondelete(at_uninstall=False)
     def _unlink_except_active_pos_session(self):

--- a/addons/point_of_sale/tests/test_point_of_sale_flow.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_flow.py
@@ -2231,3 +2231,28 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
         order_payment.with_context(payment_context).check()
         self.pos_config.current_session_id.action_pos_session_closing_control()
         self.assertEqual(order.picking_ids.move_line_ids_without_package.lot_id.name, '1001')
+
+    def test_product_combo_creation(self):
+        """We check that combo products are created without taxes."""
+        # Test product combo creation
+        product_form = Form(self.env['product.product'])
+        product_form.name = "Test Combo Product"
+        product_form.detailed_type = "product"
+        product_form.lst_price = 100
+        product_form.taxes_id = self.tax_sale_a
+        product_form.detailed_type = "combo"
+        product = product_form.save()
+
+        self.assertFalse(product.taxes_id)
+
+        # Test product write
+        product_form = Form(product)
+        product_form.detailed_type = "product"
+        product_form.taxes_id = self.tax_sale_a
+        product = product_form.save()
+        self.assertTrue(product.taxes_id)
+
+        product_form = Form(product)
+        product_form.detailed_type = "combo"
+        product = product_form.save()
+        self.assertFalse(product.taxes_id)


### PR DESCRIPTION
Currently, if you create a combo product, or modify an existing product into a combo product, the previous tax field is saved.

Steps to reproduce:
-------------------
* Create a new storable product with a tax set
* Modify the product type to `Consumable`
* Save
> Observation: Next to the price we see "(=... tax incl)

Why the fix:
------------
Combo products are not meant to have taxes set. It is confirmed by the fact that the field becomes invisible when we have combo products. Taxes are computed once the product is added to the cart depending on the taxes of the products chosen.

opw-4004978