### PR TITLE
[FIX] STOCK: incorrect style in informations section in deliveryslip report

### DIFF
--- a/addons/delivery/views/report_deliveryslip.xml
+++ b/addons/delivery/views/report_deliveryslip.xml
@@ -1,19 +1,19 @@
 <odoo>
     <template id="report_delivery_document2" inherit_id="stock.report_delivery_document">
         <xpath expr="//div[@name='div_sched_date']" position="after">
-            <div t-if="o.picking_type_id.code == 'outgoing' and o.carrier_id" class="col-auto">
+            <div t-if="o.picking_type_id.code == 'outgoing' and o.carrier_id" class="col-auto col-3 mw-100 mb-2">
                 <strong>Carrier:</strong>
-                <p t-field="o.carrier_id"/>
+                <p t-field="o.carrier_id" class="m-0"/>
             </div>
-            <div t-if="o.shipping_weight" class="col-auto">
+            <div t-if="o.shipping_weight" class="col-auto col-3 mw-100 mb-2">
                 <strong>Total Weight:</strong>
                 <br/>
                 <span t-field="o.shipping_weight"/>
                 <span t-field="o.weight_uom_name"/>
             </div>
-            <div t-if="o.carrier_tracking_ref" class="col-auto" style="max-width:30%;">
+            <div t-if="o.carrier_tracking_ref" class="col-auto col-3 mw-100 mb-2">
                 <strong>Tracking Number:</strong>
-                <p t-field="o.carrier_tracking_ref"/>
+                <p t-field="o.carrier_tracking_ref" class="m-0"/>
             </div>
             <t t-set="has_hs_code" t-value="o.move_ids.filtered(lambda l: l.product_id.hs_code)"/>
         </xpath>

--- a/addons/sale_stock/report/stock_report_deliveryslip.xml
+++ b/addons/sale_stock/report/stock_report_deliveryslip.xml
@@ -2,9 +2,9 @@
 <odoo>
     <template id="report_delivery_document_inherit_sale_stock" inherit_id="stock.report_delivery_document">
         <xpath expr="//div[@name='div_sched_date']" position="after">
-            <div class="col-auto justify-content-end" t-if="o.sudo().sale_id.client_order_ref">
+            <div t-if="o.sudo().sale_id.client_order_ref" class="col-auto col-3 mw-100 mb-2">
                 <strong>Customer Reference:</strong>
-                <p t-field="o.sudo().sale_id.client_order_ref"/>
+                <p t-field="o.sudo().sale_id.client_order_ref" class="m-0"/>
             </div>
         </xpath>
     </template>

--- a/addons/stock/report/report_deliveryslip.xml
+++ b/addons/stock/report/report_deliveryslip.xml
@@ -45,19 +45,19 @@
                     <h2>
                         <span t-field="o.name"/>
                     </h2>
-                    <div class="row mt32 mb32">
-                        <div t-if="o.origin" class="col-auto" name="div_origin">
+                    <div class="row mt-4 mb-4">
+                        <div t-if="o.origin" class="col-auto col-3 mw-100 mb-2" name="div_origin">
                             <strong>Order:</strong>
-                            <p t-field="o.origin"/>
+                            <p t-field="o.origin" class="m-0"/>
                         </div>
-                        <div t-if="o.state" class="col-auto" name="div_sched_date">
+                        <div t-if="o.state" class="col-auto col-3 mw-100 mb-2"  name="div_sched_date">
                             <strong>Shipping Date:</strong>
                             <t t-if="o.state == 'done'">
-                                <p t-field="o.date_done"/>
+                                <p t-field="o.date_done" class="m-0"/>
                             </t>
                             <t t-if="o.state != 'done'">
-                                <p t-field="o.scheduled_date"/>
-                           </t>
+                                <p t-field="o.scheduled_date" class="m-0"/>
+                            </t>
                         </div>
                     </div>
                     <table class="table table-sm" t-if="o.state!='done'" name="stock_move_table">


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

This PR fixes the incorrect styling applied by the css when reporting the client_order_ref field.

Current behavior before PR:

![Selección_990](https://github.com/odoo/odoo/assets/6359121/da0333a6-196d-4d3a-bb3f-509f269d27b3)

Desired behavior after PR is merged:

![Selección_989](https://github.com/odoo/odoo/assets/6359121/304bbf9d-4471-42bf-a92b-d9c28c93cae7)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
