### PR TITLE
[FIX] point_of_sale: discount product search breaks when using name

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/models/pos_store.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_store.js
@@ -258,7 +258,7 @@ patch(PosStore.prototype, {
                 .filter((product) => domain.contains(product))
                 .forEach((product) => reward.all_discount_product_ids.add(product.id));
         } catch (error) {
-            if (!(error instanceof InvalidDomainError)) {
+            if (!(error instanceof InvalidDomainError || error instanceof TypeError)) {
                 throw error;
             }
             const index = this.rewards.indexOf(reward);


### PR DESCRIPTION
Using the name field in the domain for a discount product would cause the search to break because name was not being loaded into the Javascript through this function _loader_params_product_product.

Changed the types of errors that are thrown instead being shown a notification popup in order to avoid the clunky Javascript error in the case of a typeerror from not having the field loaded.

opw-4027900

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
