### PR TITLE
[IMP] hr_skills,hr_timesheet,hr_work_entry: simplify kanban archs

### DIFF
--- a/addons/hr_skills/static/tests/many2one_avatar_employee.test.js
+++ b/addons/hr_skills/static/tests/many2one_avatar_employee.test.js
@@ -32,10 +32,8 @@ test("many2one_avatar_employee widget in kanban view with skills on avatar card"
         resModel: "m2o.avatar.employee",
         arch: `<kanban>
             <templates>
-                <t t-name="kanban-box">
-                    <div>
-                        <field name="employee_id" widget="many2one_avatar_employee"/>
-                    </div>
+                <t t-name="kanban-card">
+                    <field name="employee_id" widget="many2one_avatar_employee"/>
                 </t>
             </templates>
         </kanban>`,

--- a/addons/hr_timesheet/views/hr_timesheet_views.xml
+++ b/addons/hr_timesheet/views/hr_timesheet_views.xml
@@ -287,46 +287,26 @@
             <field name="model">account.analytic.line</field>
             <field name="arch" type="xml">
                 <kanban class="o_kanban_mobile" sample="1">
-                    <field name="date"/>
-                    <field name="employee_id"/>
-                    <field name="user_id"/>
-                    <field name="company_id"/>
-                    <field name="name"/>
-                    <field name="project_id"/>
-                    <field name="task_id" context="{'default_project_id': project_id}" domain="[('project_id', '=', project_id)]"/>
-                    <field name="unit_amount" widget="timesheet_uom"/>
                     <templates>
-                        <t t-name="kanban-box">
-                            <div class="oe_kanban_global_click o_kanban_record_has_image_fill px-0 pb-0">
-                                <div class="oe_kanban_details d-flex flex-column">
-                                    <div class="o_kanban_record_top px-2 h-50">
-                                        <img t-att-src="kanban_image('hr.employee', 'avatar_128', record.employee_id.raw_value)" t-att-title="record.employee_id.value" t-att-alt="record.employee_id.value" class="o_image_40_cover float-start"/>
-                                        <div class="o_kanban_record_headings ps-2 pe-2">
-                                            <div class="text-truncate">
-                                                <strong class="o_kanban_record_title">
-                                                    <span t-esc="record.project_id.value" t-att-title="record.project_id.value"/>
-                                                </strong>
-                                            </div>
-                                            <div class="text-truncate">
-                                                <i><span t-esc="record.task_id.value" t-att-title="record.task_id.value"/></i>
-                                            </div>
-                                            <div class="text-truncate">
-                                                <span t-esc="record.name.value" t-att-title="record.name.value"/>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <div class="o_kanban_record_bottom d-block mx-2">
-                                        <hr class="mt4 mb4"/>
-                                        <span>
-                                            <i class="fa fa-calendar me-1" role="img" aria-label="Date" title="Date"></i>
-                                            <t t-esc="record.date.value"/>
-                                        </span>
-                                        <span class="float-end" name="duration">
-                                            <strong>Duration: </strong><field name="unit_amount" widget="timesheet_uom" decoration-danger="unit_amount &gt; 24" decoration-muted="unit_amount == 0"/>
-                                        </span>
-                                    </div>
+                        <t t-name="kanban-card">
+                            <div class="d-flex flex-row">
+                                <span t-att-title="record.employee_id.value">
+                                    <field name="employee_id" widget="image" options="{'preview_image': 'avatar_128'}" class="o_image_40_cover me-2 float-start"/>
+                                </span>
+                                <div class="d-flex flex-column text-truncate lh-sm col-10">
+                                    <span class="text-truncate" t-att-title="record.project_id.value"><field name="project_id" class="p-0 fw-bold fs-5"/></span>
+                                    <span class="text-truncate" t-att-title="record.task_id.value"><field name="task_id" class="fst-italic"/></span>
+                                    <span class="text-truncate" t-att-title="record.name.value"><field name="name"/></span>
                                 </div>
                             </div>
+                            <hr class="mt4 mb4"/>
+                            <footer class="mt-0 pt-0 fs-6">
+                                <i class="fa fa-calendar me-1" role="img" aria-label="Date" title="Date"></i>
+                                <field name="date"/>
+                                <div class="d-flex ms-auto">
+                                    <strong>Duration:</strong><field name="unit_amount" widget="timesheet_uom" decoration-danger="unit_amount &gt; 24" decoration-muted="unit_amount == 0" class="ms-1"/>
+                                </div>
+                            </footer>
                         </t>
                     </templates>
                 </kanban>
@@ -340,10 +320,7 @@
             <field name="mode">primary</field>
             <field name="priority">10</field>
             <field name="arch" type="xml">
-                <xpath expr="//img[hasclass('o_image_40_cover')]" position="replace"/>
-                <xpath expr="//div[hasclass('o_kanban_record_headings')]" position="attributes">
-                    <attribute name="class">o_kanban_record_headings pe-2</attribute>
-                </xpath>
+                <xpath expr="//div/span" position="replace" class="ps-0"/>
             </field>
         </record>
         <!--

--- a/addons/hr_timesheet/views/project_task_sharing_views.xml
+++ b/addons/hr_timesheet/views/project_task_sharing_views.xml
@@ -54,33 +54,12 @@
                             <field name="unit_amount" string="Time Spent" widget="timesheet_uom" decoration-danger="unit_amount &gt; 24"/>
                         </tree>
                         <kanban class="o_kanban_mobile">
-                            <field name="date"/>
-                            <field name="employee_id"/>
-                            <field name="name"/>
-                            <field name="unit_amount" decoration-danger="unit_amount &gt; 24"/>
-                            <field name="project_id"/>
                             <templates>
-                                <t t-name="kanban-box">
-                                    <div t-attf-class="oe_kanban_card oe_kanban_global_click">
-                                        <div class="row">
-                                            <div class="col-6">
-                                                <strong><span><t t-esc="record.employee_id.value"/></span></strong>
-                                            </div>
-                                            <div class="col-6 float-end text-end">
-                                                <strong><t t-esc="record.date.value"/></strong>
-                                            </div>
-                                        </div>
-                                        <div class="row">
-                                            <div class="col-6 text-muted">
-                                                <span><t t-esc="record.name.value"/></span>
-                                            </div>
-                                            <div class="col-6">
-                                                <span class="float-end text-end">
-                                                    <field name="unit_amount" widget="float_time"/>
-                                                </span>
-                                            </div>
-                                        </div>
-                                    </div>
+                                <t t-name="kanban-card" class="row g-0">
+                                    <field name="employee_id" class="col-6 fw-bold"/>
+                                    <field name="date" class="col-6 text-end fw-bold" />
+                                    <field name="name" class="col-6 text-muted"/>
+                                    <field name="unit_amount" widget="float_time" class="col-6 text-end"/>
                                 </t>
                             </templates>
                         </kanban>

--- a/addons/hr_timesheet/views/project_task_views.xml
+++ b/addons/hr_timesheet/views/project_task_views.xml
@@ -54,35 +54,18 @@
                             <field name="company_id" column_invisible="True"/>
                         </tree>
                         <kanban class="o_kanban_mobile">
-                            <field name="readonly_timesheet"/>
-                            <field name="date"/>
-                            <field name="user_id"/>
-                            <field name="name"/>
-                            <field name="unit_amount" decoration-danger="unit_amount &gt; 24"/>
-                            <field name="project_id"/>
-                            <field name="task_id"/>
                             <templates>
-                                <t t-name="kanban-box">
-                                    <div t-attf-class="oe_kanban_card oe_kanban_global_click">
-                                        <div class="row">
-                                            <div class="col-6 d-flex">
-                                                <field name="employee_id" class="me-1" widget="many2one_avatar_employee" context="{'active_test': True}" readonly="readonly_timesheet"/>
-                                                <strong><span class="ps-1"><t t-esc="record.employee_id.value"/></span></strong>
-                                            </div>
-                                            <div class="col-6 float-end text-end">
-                                                <strong><t t-esc="record.date.value"/></strong>
-                                            </div>
+                                <t t-name="kanban-card">
+                                    <div class="row">
+                                        <div class="col-6 d-flex">
+                                            <field name="employee_id" class="me-1" widget="many2one_avatar_employee" context="{'active_test': True}" readonly="readonly_timesheet"/>
+                                            <field name="employee_id" class="ps-1 fw-bold"/>
                                         </div>
-                                        <div class="row">
-                                            <div class="col-6 text-muted">
-                                                <span><t t-esc="record.name.value"/></span>
-                                            </div>
-                                            <div class="col-6">
-                                                <span class="float-end text-end">
-                                                    <field name="unit_amount" widget="float_time"/>
-                                                </span>
-                                            </div>
-                                        </div>
+                                        <field name="date" class="col-6 text-end fw-bold"/>
+                                    </div>
+                                    <div class="row">
+                                        <field name="name" class="col-6 text-muted"/>
+                                        <field name="unit_amount" widget="float_time" class="col-6 text-end"/>
                                     </div>
                                 </t>
                             </templates>

--- a/addons/hr_work_entry/views/hr_work_entry_views.xml
+++ b/addons/hr_work_entry/views/hr_work_entry_views.xml
@@ -210,23 +210,14 @@
         <field name="name">hr.work.entry.type.kanban.view</field>
         <field name="model">hr.work.entry.type</field>
         <field name="arch" type="xml">
-            <kanban>
-                <field name="color"/>
+            <kanban highlight_color="color">
                 <templates>
                     <t t-name="kanban-menu" t-if="!selection_mode">
-                        <ul class="oe_kanban_colorpicker" data-field="color"/>
+                        <field name="color" widget="kanban_color_picker"/>
                     </t>
-                    <t t-name="kanban-box">
-                        <div t-attf-class="#{!selection_mode ? kanban_color(record.color.raw_value) : ''} oe_kanban_global_click">
-                            <div class="oe_kanban_content">
-                                <div>
-                                    <strong class="o_kanban_record_title"><span><field name="name"/></span></strong>
-                                </div>
-                                <div>
-                                    <span class="text-muted o_kanban_record_subtitle"><field name="code"/></span>
-                                </div>
-                            </div>
-                        </div>
+                    <t t-name="kanban-card" t-attf-class="#{!selection_mode ? record.color.raw_value : ''}">
+                        <field class="fw-bold fs-5" name="name"/>
+                        <field class="text-muted" name="code"/>
                     </t>
                 </templates>
             </kanban>


### PR DESCRIPTION
In this commit we have simplified the kanban arch for the hr_skills,hr_timesheet and hr_work_entry module.the goal is to simplify them, make them easier to read and use bootstrap utility classnames.

- Previously, we used kanban-box, but now we are using kanban-card instead.
- Deprecated oe_kanban_global_click and oe_kanban_global_click_edit.
- More use of <field/> tags
- Removed the oe_kanban_colorpicker class and replaced it with the kanban_color_picker widget.
- Changed type='edit' to type='open' to open records. since version 16, records always open in edit mode by default.
- kanban_image from rendering context, is deprecated so we use <field name="..." widget="image"/> instead
- kanban_color, kanban_getcolor and kanban_getcolorname are deprecated use new attribute highlight_color="color_field_name" on root node
- oe_kanban_colorpicker is deprecated, use kanban_color_picker widget instead

Related Enterprise PR : https://github.com/odoo/enterprise/pull/66288

Task-3992107

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
