### PR TITLE
[FIX] stock{,_account}: avoid quant duplication

### DIFF
--- a/addons/stock/views/product_views.xml
+++ b/addons/stock/views/product_views.xml
@@ -513,7 +513,7 @@
             <field name="model">product.product</field>
             <field name="priority" eval="100"/>
             <field name="arch" type="xml">
-                <tree sample="1" js_class="stock_report_list_view">
+                <tree sample="1" js_class="stock_report_list_view" duplicate="0">
                     <field name="id" column_invisible="True"/>
                     <field name="display_name" string="Product"/>
                     <field name="categ_id" optional="hide"/>

--- a/addons/stock/views/stock_move_line_views.xml
+++ b/addons/stock/views/stock_move_line_views.xml
@@ -4,7 +4,7 @@
         <field name="name">stock.move.line.tree</field>
         <field name="model">stock.move.line</field>
         <field name="arch" type="xml">
-            <tree string="Move Lines" create="0" default_order="id desc" action="action_open_reference" type="object">
+            <tree string="Move Lines" create="0" default_order="id desc" action="action_open_reference" type="object" duplicate="0">
                 <field name="location_usage" column_invisible="True"/>
                 <field name="location_dest_usage" column_invisible="True"/>
                 <field name="date"/>

--- a/addons/stock/views/stock_move_views.xml
+++ b/addons/stock/views/stock_move_views.xml
@@ -30,7 +30,7 @@
             <field name="model">stock.move</field>
             <field eval="8" name="priority"/>
             <field name="arch" type="xml">
-                <tree string="Moves" create="0" default_order="date desc">
+                <tree string="Moves" create="0" default_order="date desc" duplicate ="0">
                     <field name="date" groups="base.group_no_one" decoration-danger="(state not in ('cancel','done')) and date > current_date"/>
                     <field name="reference"/>
                     <field name="picking_type_id" column_invisible="True"/>

--- a/addons/stock/views/stock_quant_views.xml
+++ b/addons/stock/views/stock_quant_views.xml
@@ -112,7 +112,7 @@
         <field name="arch" type="xml">
             <tree editable="bottom"
                   create="1" edit="1" js_class="inventory_report_list"
-                  sample="1">
+                  sample="1" duplicate="0">
                 <header>
                     <button name="action_inventory_at_date" string="Inventory at Date" type="object"
                             invisible="((context.get('inventory_mode') and not context.get('inventory_report_mode')) or context.get('no_at_date'))"

--- a/addons/stock_account/views/stock_valuation_layer_views.xml
+++ b/addons/stock_account/views/stock_valuation_layer_views.xml
@@ -43,7 +43,8 @@
         <field name="arch" type="xml">
             <tree default_order="id desc" create="0"
                   import="0" js_class="inventory_report_list"
-                  action="action_open_reference" type="object">
+                  action="action_open_reference" type="object"
+                  duplicate="0">
                 <header>
                     <button name="action_valuation_at_date" string="Valuation at Date" type="object"
                             invisible="((context.get('inventory_mode') and not context.get('inventory_report_mode')) or context.get('no_at_date'))"


### PR DESCRIPTION
### Steps to reproduce:

- Enable Multi-step routes
- Create a storable product P
- Change the on hand quantity to 10
- Create and confirm a delivery order for 4 units of the product
- Go back to the product form, click the "On hand" smart button
- Select the quant line > Actions > duplicate

### Issues:

The reserved quantity was copied but this reserved quantity does not match any move reservation. In addition, since you can not have a quant for a product twice in the same location (unless the product is tracked and the lot_ids are different), the two lines will be merged. However, since you can not modify the reserved quantity directly, you will not be able to update it back and you will not be able to correct the forecast by deleting your duplicated line since it does not exist anymore.

#### Note:

The stock.quant duplication was introduced in 17.0 because of commit 3192051 which enabled the copy action in the list view. Prior to that it was in my knowledge not possible to copy quants from the UI.

### Fix:

We introduce a root attribute `duplicate="0"` on the tree view. We also add the other root attributes `duplicate="0"` added by the commit 9f2949d in saas-17.3 to prior versions where they are also needed.

opw-4035690
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
