### PR TITLE
[IMP] l10n_in_pos: Set Place of Supply on Miscellaneous Journals

### DIFF
--- a/addons/l10n_in_pos/models/__init__.py
+++ b/addons/l10n_in_pos/models/__init__.py
@@ -4,3 +4,4 @@
 from . import pos_order
 from . import pos_session
 from . import pos_config
+from . import account_move

--- a/addons/l10n_in_pos/models/account_move.py
+++ b/addons/l10n_in_pos/models/account_move.py
@@ -1,0 +1,15 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import fields, models
+
+
+class AccountMove(models.Model):
+    _inherit = 'account.move'
+
+    l10n_in_pos_session_ids = fields.One2many("pos.session", "move_id", "POS Sessions")
+
+    def _compute_l10n_in_state_id(self):
+        res = super()._compute_l10n_in_state_id()
+        to_compute = self.filtered(lambda m: m.country_code == 'IN' and not m.l10n_in_state_id and m.journal_id.type == 'general' and m.l10n_in_pos_session_ids)
+        for move in to_compute:
+            move.l10n_in_state_id = move.company_id.state_id
+        return res


### PR DESCRIPTION
In This PR:

- Set Place of Supply on 'general' journals with POS sessions if the country is India and Place of Supply is not set.
- Adjusted state ID computation for account moves with POS sessions.

Task Id: 3935317
