### PR TITLE
[16.0][IMP] web: Add context to fetchUnusualDays()

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -1649,7 +1649,9 @@ class HolidaysRequest(models.Model):
 
     @api.model
     def get_unusual_days(self, date_from, date_to=None):
-        return self.env.user.employee_id.sudo(False)._get_unusual_days(date_from, date_to)
+        employee_id = self.env.context.get('employee_id', False)
+        employee = self.env['hr.employee'].browse(employee_id) if employee_id else self.env.user.employee_id
+        return employee.sudo(False)._get_unusual_days(date_from, date_to)
 
     def _get_start_or_end_from_attendance(self, hour, date, employee):
         hour = float_to_time(float(hour))

--- a/addons/web/static/src/views/calendar/calendar_model.js
+++ b/addons/web/static/src/views/calendar/calendar_model.js
@@ -442,7 +442,11 @@ export class CalendarModel extends Model {
         return this.orm.call(this.meta.resModel, "get_unusual_days", [
             serializeDateTime(data.range.start),
             serializeDateTime(data.range.end),
-        ]);
+        ],{
+            context: {
+                'employee_id': this.employeeId,
+            }
+        });
     }
     /**
      * @protected


### PR DESCRIPTION
Add context to fetchUnusualDays()

When you click on the Time-off smart-button on an employee's tab, you define a context that must be maintained

Similar to 15.0: https://github.com/odoo/odoo/blob/15.0/addons/web/static/src/legacy/js/views/calendar/calendar_controller.js#L160

Related to https://github.com/OCA/hr-holidays/pull/132

@Tecnativa TT49839

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
