### PR TITLE
[FIX] hr_timesheet: create task/project cell value if column exist

### DIFF
--- a/addons/hr_timesheet/report/report_timesheet_templates.xml
+++ b/addons/hr_timesheet/report/report_timesheet_templates.xml
@@ -39,8 +39,8 @@
                                 <t t-if="show_task and line.task_id" t-set="timesheet_record_info" t-value="'%s / %s' % (timesheet_record_info, line.task_id.sudo().name)"/>
                             </t>
                             <t t-elif="show_task" t-set="timesheet_record_info" t-value="line.task_id.sudo().name"/>
-                            <td t-if="timesheet_record_info" class="align-middle">
-                                <span t-out="timesheet_record_info">Research and Development/New Portal System</span>
+                            <td t-if="show_task or show_project" class="align-middle">
+                                <span t-if="timesheet_record_info" t-out="timesheet_record_info">Research and Development/New Portal System</span>
                             </td>
                             <td class="align-middle">
                                 <span t-field="line.name" t-options="{'widget': 'text'}">Call client and discuss project</span>


### PR DESCRIPTION
Steps to reproduce:
-------------------

- Install `Task Logs` module
- Go to `Timesheets`
- Create a timesheet line in the project `Research & Development` and give a description (but set no task)
- Go to `Project` and open `Research & Development` project settings
- Click on `Actions` button and select `Timesheets` to download report
- Open the downloaded report

Issue:
------

The `Task` column contains the `Description` of the timesheet, and the `Hours` value is in the `Description` column.

Cause:
------

If the timesheet line has no task and generating report only for one project, the cell value will not be created for the timesheet line.

Solution:
---------

If the column `Task` (or `Project`) exist, create the cell anyway.

opw-3984479