### PR TITLE
[FIX] website: allow restricted editor with modification rights to edit

### DIFF
--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -766,11 +766,10 @@ class Website(Home):
         res = {'can_edit_seo': True}
         record = request.env[res_model].browse(res_id)
         try:
-            record.check_access_rights('write')
-            record.check_access_rule('write')
+            request.website._check_user_can_modify(record)
         except AccessError:
-            record = record.sudo()
             res['can_edit_seo'] = False
+        record = record.sudo()
 
         res.update(record.read(fields)[0])
         res['has_social_default_image'] = request.website.has_social_default_image


### PR DESCRIPTION
For records such as blogs, no specific rights exists. Customizations could decide to give access to specific records based on their own rules. They are limited by the fact that the check for edition is not overridable.

This commit makes it possible to implement specific checks for restricted editors to edit records from the website builder.

Steps to reproduce:
- Install `website_blog`.
- Setup a restricted editor user.
- Override `website._check_user_can_modify` to allow access for a given user to a given blog post record.
- Edit that blog post with that user from the website builder.

=> Blog post could not be edited.
