### PR TITLE
[FIX] point_of_sale: add partner address to partner list and enable search from address

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -198,7 +198,7 @@ class PosSession(models.Model):
                 'fields': [
                     'id',
                     'name', 'street', 'city', 'state_id', 'country_id', 'vat', 'lang', 'phone', 'zip', 'mobile', 'email',
-                    'barcode', 'write_date', 'property_account_position_id', 'property_product_pricelist', 'parent_name'
+                    'barcode', 'write_date', 'property_account_position_id', 'property_product_pricelist', 'parent_name', 'contact_address'
                 ]
             },
             'res.company': {

--- a/addons/point_of_sale/static/src/app/models/res_partner.js
+++ b/addons/point_of_sale/static/src/app/models/res_partner.js
@@ -6,7 +6,7 @@ export class ResPartner extends Base {
     static pythonModel = "res.partner";
 
     get searchString() {
-        const fields = ['name', 'barcode', 'phone', 'mobile', 'email', 'vat', 'parent_name'];
+        const fields = ['name', 'barcode', 'phone', 'mobile', 'email', 'vat', 'parent_name', 'contact_address'];
         return fields.map((field) => {
             if ((field === 'phone' || field === 'mobile') && this[field]) {
                 return this[field].split(" ").join("");

--- a/addons/point_of_sale/static/src/app/screens/partner_list/partner_line/partner_line.xml
+++ b/addons/point_of_sale/static/src/app/screens/partner_list/partner_line/partner_line.xml
@@ -13,7 +13,7 @@
                 </button>
             </td>
             <td>
-                <div class="partner-line-adress" t-if="props.partner.address" t-esc="props.partner.address" />
+                <div class="partner-line-adress" t-if="props.partner.contact_address" t-esc="props.partner.contact_address" />
             </td>
             <td class="partner-line-email ">
                 <div class="mb-2" t-if="props.partner.phone">

--- a/addons/point_of_sale/static/tests/tours/ProductScreen.tour.js
+++ b/addons/point_of_sale/static/tests/tours/ProductScreen.tour.js
@@ -2,6 +2,7 @@
 
 import * as PaymentScreen from "@point_of_sale/../tests/tours/helpers/PaymentScreenTourMethods";
 import * as Dialog from "@point_of_sale/../tests/tours/helpers/DialogTourMethods";
+import * as PartnerList from "@point_of_sale/../tests/tours/helpers/PartnerListTourMethods";
 import * as ProductScreen from "@point_of_sale/../tests/tours/helpers/ProductScreenTourMethods";
 import * as Chrome from "@point_of_sale/../tests/tours/helpers/ChromeTourMethods";
 import * as ReceiptScreen from "@point_of_sale/../tests/tours/helpers/ReceiptScreenTourMethods";
@@ -267,5 +268,22 @@ registry.category("web_tour.tours").add("FiscalPositionPriceIncluded", {
             ProductScreen.totalAmountIs("100.00"),
 
             Chrome.endTour(),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("PosCustomerAllFieldsDisplayed", {
+    test: true,
+    url: "/pos/ui",
+    steps: () =>
+        [
+            Dialog.confirm("Open session"),
+            ProductScreen.clickPartnerButton(),
+            PartnerList.checkContactValues(
+                "John Doe",
+                "1 street of astreet",
+                "1234567890",
+                "0987654321",
+                "john@doe.com",
+            ),
         ].flat(),
 });

--- a/addons/point_of_sale/static/tests/tours/ProductScreen.tour.js
+++ b/addons/point_of_sale/static/tests/tours/ProductScreen.tour.js
@@ -4,11 +4,12 @@ import * as PaymentScreen from "@point_of_sale/../tests/tours/helpers/PaymentScr
 import * as Dialog from "@point_of_sale/../tests/tours/helpers/DialogTourMethods";
 import * as PartnerList from "@point_of_sale/../tests/tours/helpers/PartnerListTourMethods";
 import * as ProductScreen from "@point_of_sale/../tests/tours/helpers/ProductScreenTourMethods";
+import * as ProductScreenPartnerList from "@point_of_sale/../tests/tours/helpers/ProductScreenPartnerListTourMethods";
 import * as Chrome from "@point_of_sale/../tests/tours/helpers/ChromeTourMethods";
 import * as ReceiptScreen from "@point_of_sale/../tests/tours/helpers/ReceiptScreenTourMethods";
 import { registry } from "@web/core/registry";
 import * as Order from "@point_of_sale/../tests/tours/helpers/generic_components/OrderWidgetMethods";
-import { inLeftSide, scan_barcode } from "@point_of_sale/../tests/tours/helpers/utils";
+import { inLeftSide, scan_barcode, selectButton } from "@point_of_sale/../tests/tours/helpers/utils";
 import * as ProductConfiguratorPopup from "@point_of_sale/../tests/tours/helpers/ProductConfiguratorTourMethods";
 
 registry.category("web_tour.tours").add("ProductScreenTour", {
@@ -285,5 +286,18 @@ registry.category("web_tour.tours").add("PosCustomerAllFieldsDisplayed", {
                 "0987654321",
                 "john@doe.com",
             ),
+            selectButton("Ok"),
+            ProductScreen.goBackToMainScreen(),
+
+            // Check searches
+            ProductScreenPartnerList.searchCustomerValueAndClear("John Doe"),
+            ProductScreenPartnerList.searchCustomerValueAndClear("1 street of astreet"),
+            ProductScreenPartnerList.searchCustomerValueAndClear("99999"),
+            ProductScreenPartnerList.searchCustomerValueAndClear("Acity"),
+            ProductScreenPartnerList.searchCustomerValueAndClear("United States"),
+            ProductScreenPartnerList.searchCustomerValueAndClear("1234567890"),
+            ProductScreenPartnerList.searchCustomerValueAndClear("0987654321"),
+            ProductScreen.clickPartnerButton(),
+            PartnerList.searchCustomerValue("john@doe.com"),
         ].flat(),
 });

--- a/addons/point_of_sale/static/tests/tours/helpers/PartnerListTourMethods.js
+++ b/addons/point_of_sale/static/tests/tours/helpers/PartnerListTourMethods.js
@@ -71,3 +71,22 @@ export function checkContactValues(name, address = "", phone = "", mobile = "", 
 
     return steps;
 }
+
+export function searchCustomerValue(val) {
+    return [
+        {
+            content: `Click search field`,
+            trigger: `.fa-search.undefined`,
+        },
+        {
+            content: `Search customer with "${val}"`,
+            trigger: `.input-group input`,
+            run: `text ${val}`,
+        },
+        {
+            content: `Check "${val}" is shown`,
+            trigger: `.partner-list tr:nth-child(1):contains("${val}")`,
+            run: () => {},
+        },
+    ];
+}

--- a/addons/point_of_sale/static/tests/tours/helpers/PartnerListTourMethods.js
+++ b/addons/point_of_sale/static/tests/tours/helpers/PartnerListTourMethods.js
@@ -30,3 +30,44 @@ export function clickPartnerDetailsButton(name) {
         },
     ];
 }
+
+export function checkContactValues(name, address = "", phone = "", mobile = "", email = "") {
+    const steps = [
+        {
+            content: `Check partner "${name}" from partner list screen`,
+            trigger: `.partner-list td:contains("${name}")`,
+            run: () => {},
+        },
+        {
+            content: `Check address "${address}" for partner "${name}"`,
+            trigger: `.partner-list tr:contains("${name}") .partner-line-adress:contains("${address}")`,
+            run: () => {},
+        },
+    ];
+
+    if(phone) {
+        steps.push({
+            content: `Check phone number "${phone}" for partner "${name}"`,
+            trigger: `.partner-list tr:contains("${name}") .partner-line-email:contains("${phone}")`,
+            run: () => {},
+        });
+    }
+
+    if(mobile) {
+        steps.push({
+            content: `Check mobile number "${mobile}" for partner "${name}"`,
+            trigger: `.partner-list tr:contains("${name}") .partner-line-email:contains("${mobile}")`,
+            run: () => {},
+        });
+    }
+
+    if(email) {
+        steps.push({
+            content: `Check email address "${email}" for partner "${name}"`,
+            trigger: `.partner-list tr:contains("${name}") .partner-line-email .email-field:contains("${email}")`,
+            run: () => {},
+        });
+    }
+
+    return steps;
+}

--- a/addons/point_of_sale/static/tests/tours/helpers/ProductScreenPartnerListTourMethods.js
+++ b/addons/point_of_sale/static/tests/tours/helpers/ProductScreenPartnerListTourMethods.js
@@ -1,0 +1,14 @@
+/** @odoo-module */
+
+import * as PartnerList from "@point_of_sale/../tests/tours/helpers/PartnerListTourMethods";
+import * as ProductScreen from "@point_of_sale/../tests/tours/helpers/ProductScreenTourMethods";
+import { selectButton } from "@point_of_sale/../tests/tours/helpers/utils";
+
+export function searchCustomerValueAndClear(val) {
+    return [
+        ProductScreen.clickPartnerButton(),
+        PartnerList.searchCustomerValue(val),
+        selectButton("Ok"),
+        ProductScreen.goBackToMainScreen(),
+    ].flat();
+}

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1324,6 +1324,7 @@ class TestUi(TestPointOfSaleHttpCommon):
     def test_customer_all_fields_displayed(self):
         """
         Verify that all the field of a partner can be displayed in the partner list.
+        Also verify that all these fields can be searched.
         """
         self.env["res.partner"].create({
             "name": "John Doe",

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1321,6 +1321,25 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'FiscalPositionTwoTaxIncluded', login="accountman")
 
+    def test_customer_all_fields_displayed(self):
+        """
+        Verify that all the field of a partner can be displayed in the partner list.
+        """
+        self.env["res.partner"].create({
+            "name": "John Doe",
+            "street": "1 street of astreet",
+            "city": "Acity",
+            "state_id": self.env.ref("base.state_us_30").id,  # Ohio
+            "country_id": self.env.ref("base.us").id,
+            "zip": "99999",
+            "phone": "1234567890",
+            "mobile": "0987654321",
+            "email": "john@doe.com"
+        })
+
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'PosCustomerAllFieldsDisplayed', login="pos_user")
+
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):
     browser_size = '375x667'


### PR DESCRIPTION
Problem:
Partner address is never display in the partner list and the search doesn't work with the address

Steps to reproduce:
- Install "point_of_sale" app
- Start a shop session
- Click on "Customer"
- The address is not displayed for any partner

Cause:
The address field of a partner got lost during refactoring in v17.1

opw-4032931


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
