### PR TITLE
[FIX] web_editor,website : remove URL when video is inserted in options

### DIFF
--- a/addons/web_editor/static/src/components/media_dialog/media_dialog.js
+++ b/addons/web_editor/static/src/components/media_dialog/media_dialog.js
@@ -184,6 +184,16 @@ export class MediaDialog extends Component {
                         if (this.props.media.dataset.shapeColors) {
                             element.dataset.shapeColors = this.props.media.dataset.shapeColors;
                         }
+                    } else if ([TABS.VIDEOS.id, TABS.DOCUMENTS.id].includes(this.state.activeTab)) {
+                        const parentEl = this.props.media.parentElement;
+                        if (
+                            parentEl.tagName === "A" &&
+                            parentEl.children.length === 1 &&
+                            this.props.media.tagName === "IMG"
+                        ) {
+                            // If an image is wrapped in an <a> tag, we remove the link when replacing it with a video or document
+                            parentEl.replaceWith(parentEl.firstElementChild);
+                        }
                     }
                 }
                 for (const otherTab of Object.keys(TABS).filter(key => key !== this.state.activeTab)) {

--- a/addons/website/static/tests/tours/media_iframe_video.js
+++ b/addons/website/static/tests/tours/media_iframe_video.js
@@ -1,0 +1,61 @@
+/** @odoo-module */
+import wTourUtils from "website.tour_utils";
+
+wTourUtils.registerWebsitePreviewTour(
+    "website_media_iframe_video",
+    {
+        test: true,
+        url: "/",
+        edition: true,
+    },
+    [
+        wTourUtils.dragNDrop({
+            id: "s_text_image",
+            name: "Text - Image",
+        }),
+        {
+            content: "Select the image",
+            trigger: "iframe #wrap .s_text_image img",
+        },
+        {
+            content: "Open image link options",
+            trigger: "[data-name='media_link_opt']",
+        },
+        {
+            content: "Enter the url",
+            trigger: "input[placeholder='www.example.com']",
+            run: "text odoo.com",
+        },
+        {
+            content: "Click on replace media",
+            trigger: "[data-replace-media='true']",
+        },
+        {
+            content: "Click on video button",
+            trigger: "a:contains('Videos')",
+        },
+        {
+            content: "Enter video link",
+            trigger: "#o_video_text",
+            run: "text https://youtu.be/nbso3NVz3p8",
+        },
+        {
+            content: "Check video is preview",
+            trigger: ".o_video_dialog_iframe",
+            run: () => {}, // This is a check.
+        },
+        {
+            content: "Click on 'add' button",
+            trigger: ".modal-footer button:contains('Add')",
+        },
+        {
+            content: "Ensure that the parent of media_iframe_video is not an 'a' tag.",
+            trigger: "iframe .media_iframe_video",
+            run: function () {
+                if (this.$anchor[0].parentElement.tagName === "A") {
+                    console.error("Iframe video has link!!!");
+                }
+            },
+        },
+    ]
+);

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -563,3 +563,6 @@ class TestUi(odoo.tests.HttpCase):
 
     def test_snippet_carousel(self):
         self.start_tour('/', 'snippet_carousel', login='admin')
+
+    def test_media_iframe_video(self):
+        self.start_tour("/", "website_media_iframe_video", login="admin")


### PR DESCRIPTION
Steps to reproduce: 
1.Add an any image block ( here Text - Image )
2.Add the URL on the image
3.Now edit the image and add the video to it; you will notice that the URL remains as it is in the toolbar
4.Click on Save

Issue:
For versions 15.0-16.0, the link and URL both remain. 
For version 17.0-Master, the video element gets removed unexpectedly.

Expected Behavior:
When a video is inserted, the URL should be automatically removed to avoid element removal or loss of responsiveness.

Issue:
The issue of element getting removed or loss of responsiveness is because we did not remove the url link when we inserted the video.

Solution:
This PR resolves the issue by removing the URL link when a video is inserted in place of an image, ensuring the video element is retained and options are hidden appropriately.

task-4023555