### PR TITLE
[FIX] cloud_storage: avoid unset provider when another provider is uninstalled

### DIFF
--- a/addons/cloud_storage/models/res_config_settings.py
+++ b/addons/cloud_storage/models/res_config_settings.py
@@ -51,7 +51,7 @@ class CloudStorageSettings(models.TransientModel):
         """
         return {}
 
-    def _check_cloud_storage_uninstallable(self, provider_name):
+    def _check_cloud_storage_uninstallable(self):
         """
         Check if the cloud storages provider is used by any attachments
         :raise UserError: when the cloud storage provider cannot be uninstalled
@@ -62,9 +62,9 @@ class CloudStorageSettings(models.TransientModel):
         ICP = self.env['ir.config_parameter']
         cloud_storage_configuration_before = self._get_cloud_storage_configuration()
         cloud_storage_provider_before = ICP.get_param('cloud_storage_provider')
+        if cloud_storage_provider_before and self.cloud_storage_provider != cloud_storage_provider_before:
+            self._check_cloud_storage_uninstallable()
         super().set_values()
-        if cloud_storage_provider_before and ICP.get_param('cloud_storage_provider') != cloud_storage_provider_before:
-            self._check_cloud_storage_uninstallable(cloud_storage_provider_before)
         cloud_storage_configuration = self._get_cloud_storage_configuration()
         if not cloud_storage_configuration and self.cloud_storage_provider:
             raise UserError(_('Please configure the Cloud Storage before enabling it'))

--- a/addons/cloud_storage_azure/__init__.py
+++ b/addons/cloud_storage_azure/__init__.py
@@ -4,10 +4,11 @@ from . import models
 
 
 def uninstall_hook(env):
-    env['res.config.settings']._check_cloud_storage_uninstallable('azure')
-
-    env['ir.config_parameter'].set_param('cloud_storage_provider', False)
-    env['ir.config_parameter'].search([('key', 'in', [
+    ICP = env['ir.config_parameter']
+    if ICP.get_param('cloud_storage_provider') == 'azure':
+        env['res.config.settings']._check_cloud_storage_uninstallable()
+        ICP.set_param('cloud_storage_provider', False)
+    ICP.search([('key', 'in', [
         'cloud_storage_azure_container_name',
         'cloud_storage_azure_account_name',
         'cloud_storage_azure_tenant_id',

--- a/addons/cloud_storage_azure/models/res_config_settings.py
+++ b/addons/cloud_storage_azure/models/res_config_settings.py
@@ -81,9 +81,9 @@ class CloudStorageSettings(models.TransientModel):
         if download_response.status_code != 200:
             raise ValidationError(_('The connection string is not allowed to download blobs from the container.\n%s', str(download_response.text)))
 
-    def _check_cloud_storage_uninstallable(self, provider_name):
-        if provider_name != 'azure':
-            return super()._check_cloud_storage_uninstallable(provider_name)
+    def _check_cloud_storage_uninstallable(self):
+        if self.env['ir.config_parameter'].get_param('cloud_storage_provider') != 'azure':
+            return super()._check_cloud_storage_uninstallable()
         cr = self.env.cr
         cr.execute(
             """

--- a/addons/cloud_storage_google/__init__.py
+++ b/addons/cloud_storage_google/__init__.py
@@ -4,10 +4,11 @@ from . import models
 
 
 def uninstall_hook(env):
-    env['res.config.settings']._check_cloud_storage_uninstallable('google')
-
-    env['ir.config_parameter'].sudo().set_param('cloud_storage_provider', False)
-    env['ir.config_parameter'].sudo().search([('key', 'in', [
+    ICP = env['ir.config_parameter']
+    if ICP.get_param('cloud_storage_provider') == 'google':
+        env['res.config.settings']._check_cloud_storage_uninstallable()
+        ICP.set_param('cloud_storage_provider', False)
+    ICP.search([('key', 'in', [
         'cloud_storage_google_bucket_name',
         'cloud_storage_google_account_info',
     ])]).unlink()

--- a/addons/cloud_storage_google/models/res_config_settings.py
+++ b/addons/cloud_storage_google/models/res_config_settings.py
@@ -106,9 +106,9 @@ class CloudStorageSettings(models.TransientModel):
         }
         return configuration if all(configuration.values()) else {}
 
-    def _check_cloud_storage_uninstallable(self, provider_name):
-        if provider_name != 'google':
-            return super()._check_cloud_storage_uninstallable(provider_name)
+    def _check_cloud_storage_uninstallable(self):
+        if self.env['ir.config_parameter'].get_param('cloud_storage_provider') != 'google':
+            return super()._check_cloud_storage_uninstallable()
         cr = self.env.cr
         cr.execute(
             """


### PR DESCRIPTION
In the uninstall_hook, only unset cloud.storage.provider when the used one is the uninstalled one

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
