### PR TITLE
[FIX] pos*: correctly set default values for a new partner

### DIFF
--- a/addons/l10n_ar_pos/static/src/overrides/components/partner_list/partner_list.js
+++ b/addons/l10n_ar_pos/static/src/overrides/components/partner_list/partner_list.js
@@ -4,16 +4,17 @@ import { PartnerList } from "@point_of_sale/app/screens/partner_list/partner_lis
 import { patch } from "@web/core/utils/patch";
 
 patch(PartnerList.prototype, {
-    createPartner() {
-        super.createPartner(...arguments);
-        if (this.props.partner && this.pos.isArgentineanCompany()) {
-            this.props.partner.l10n_latam_identification_type_id = this.pos.models[
+    newPartnerDefaults() {
+        const newPartner = super.newPartnerDefaults(...arguments);
+        if (this.pos.isArgentineanCompany()) {
+            newPartner.l10n_latam_identification_type_id = this.pos.models[
                 "l10n_latam.identification.type"
             ].get(this.pos["l10n_latam.identification.type"][0].id);
 
-            this.props.partner.l10n_ar_afip_responsibility_type_id = this.pos.models[
+            newPartner.l10n_ar_afip_responsibility_type_id = this.pos.models[
                 "l10n_ar.afip.responsibility.type"
             ].get(this.pos["l10n_ar.afip.responsibility.type"][0].id);
         }
+        return newPartner;
     },
 });

--- a/addons/l10n_pe_pos/static/src/overrides/components/partner_list/partner_list.js
+++ b/addons/l10n_pe_pos/static/src/overrides/components/partner_list/partner_list.js
@@ -4,18 +4,17 @@ import { PartnerList } from "@point_of_sale/app/screens/partner_list/partner_lis
 import { patch } from "@web/core/utils/patch";
 
 patch(PartnerList.prototype, {
-    createPartner() {
-        const res = super.createPartner(...arguments);
-        if (!this.pos.isPeruvianCompany()) {
-            return res;
+    newPartnerDefaults() {
+        const newPartner = super.newPartnerDefaults(...arguments);
+        if (this.pos.isPeruvianCompany()) {
+            newPartner.city_id = this.pos.models["res.city"].get(this.pos["res.city"][0].id);
+            newPartner.l10n_latam_identification_type_id = this.pos.models[
+                "l10n_latam.identification.type"
+            ].get(this.pos["l10n_latam.identification.type"][0].id);
+            newPartner.l10n_pe_district = this.pos.models[
+                "l10n_pe.res.city.district"
+            ].get(this.pos["l10n_pe.res.city.district"][0].id);
         }
-        this.props.partner.city_id = this.pos.models["res.city"].get(this.pos["res.city"][0].id);
-        this.props.partner.l10n_latam_identification_type_id = this.pos.models[
-            "l10n_latam.identification.type"
-        ].get(this.pos["l10n_latam.identification.type"][0].id);
-        this.props.partner.l10n_pe_district = this.pos.models[
-            "l10n_pe.res.city.district"
-        ].get(this.pos["l10n_pe.res.city.district"][0].id);
-        return res;
+        return newPartner;
     },
 });

--- a/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.js
+++ b/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.js
@@ -148,12 +148,15 @@ export class PartnerList extends Component {
     }
     createPartner() {
         // initialize the edit screen with default details about country, state, and lang
+        this.editPartner(this.newPartnerDefaults());
+    }
+    newPartnerDefaults() {
         const { country_id, state_id } = this.pos.company;
-        this.editPartner({
+        return {
             country_id,
             state_id,
             lang: user.lang,
-        });
+        };
     }
     async saveChanges(processedChanges) {
         let partner;


### PR DESCRIPTION
Before this commit, creating a new partner incorrectly wrote the default values into `this.props.partner`. This commit ensures that default values are correctly set for new partners.

Enterprise PR: https://github.com/odoo/enterprise/pull/66310

opw-4042039

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
