### PR TITLE
[IMP] base_import_module: add translations in data module

### DIFF
--- a/addons/account/models/ir_module.py
+++ b/addons/account/models/ir_module.py
@@ -72,8 +72,8 @@ class IrModule(models.Model):
             self.env.registry._auto_install_template = try_loading
         return res
 
-    def _load_module_terms(self, modules, langs, overwrite=False):
-        super()._load_module_terms(modules, langs, overwrite)
+    def _load_module_terms(self, modules, langs, **kwargs):
+        super()._load_module_terms(modules, langs, **kwargs)
         if 'account' in modules:
             def load_account_translations(env):
                 env['account.chart.template']._load_translations(langs=langs)

--- a/addons/base_import_module/models/ir_module.py
+++ b/addons/base_import_module/models/ir_module.py
@@ -7,7 +7,6 @@ import lxml
 import os
 import requests
 import sys
-import tempfile
 import zipfile
 from collections import defaultdict
 from io import BytesIO
@@ -194,6 +193,14 @@ class IrModule(models.Model):
             'res_id': asset.id,
         } for asset in created_assets])
 
+        self.env['ir.module.module']._load_module_terms(
+            [module],
+            [lang[0] for lang in self.env['res.lang'].get_installed()],
+            overwrite=True,
+            env=self.env,
+            imported_module=True,
+        )
+
         mod._update_from_terp(terp)
         _logger.info("Successfully imported module '%s'", module)
         return True
@@ -241,7 +248,8 @@ class IrModule(models.Model):
                     mod_name = filename.split('/')[0]
                     is_data_file = filename in module_data_files[mod_name]
                     is_static = filename.startswith('%s/static' % mod_name)
-                    if is_data_file or is_static:
+                    is_translation = filename.startswith('%s/i18n' % mod_name) and filename.endswith('.po')
+                    if is_data_file or is_static or is_translation:
                         z.extract(file, module_dir)
 
                 dirs = [d for d in os.listdir(module_dir) if os.path.isdir(opj(module_dir, d))]

--- a/addons/website/models/ir_module_module.py
+++ b/addons/website/models/ir_module_module.py
@@ -482,9 +482,9 @@ class IrModuleModule(models.Model):
             self.pool.website_views_to_adapt.clear()
 
     @api.model
-    def _load_module_terms(self, modules, langs, overwrite=False):
+    def _load_module_terms(self, modules, langs, overwrite=False, **kwargs):
         """ Add missing website specific translation """
-        res = super()._load_module_terms(modules, langs, overwrite=overwrite)
+        res = super()._load_module_terms(modules, langs, overwrite=overwrite, **kwargs)
 
         if not langs or langs == ['en_US'] or not modules:
             return res

--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -863,7 +863,7 @@ class Module(models.Model):
             for mod in update_mods
         }
         mod_names = topological_sort(mod_dict)
-        self.env['ir.module.module']._load_module_terms(mod_names, filter_lang, overwrite)
+        self.env['ir.module.module']._load_module_terms(mod_names, filter_lang, overwrite=overwrite)
 
     def _check(self):
         for module in self:
@@ -946,17 +946,17 @@ class Module(models.Model):
         return super(Module, self).search_panel_select_range(field_name, **kwargs)
 
     @api.model
-    def _load_module_terms(self, modules, langs, overwrite=False):
+    def _load_module_terms(self, modules, langs, overwrite=False, env=None, imported_module=False):
         """ Load PO files of the given modules for the given languages. """
         # load i18n files
         translation_importer = TranslationImporter(self.env.cr, verbose=False)
 
         for module_name in modules:
-            modpath = get_module_path(module_name)
+            modpath = get_module_path(module_name, downloaded=imported_module)
             if not modpath:
                 continue
             for lang in langs:
-                po_paths = get_po_paths(module_name, lang)
+                po_paths = get_po_paths(module_name, lang, env=env)
                 for po_path in po_paths:
                     _logger.info('module %s: loading translation file %s for language %s', module_name, po_path, lang)
                     translation_importer.load_file(po_path, lang)

--- a/odoo/addons/base/tests/test_translate.py
+++ b/odoo/addons/base/tests/test_translate.py
@@ -340,7 +340,7 @@ class TestLanguageInstall(TransactionCase):
         # running the wizard calls _load_module_terms() to load PO files
         loaded = []
 
-        def _load_module_terms(self, modules, langs, overwrite=False):
+        def _load_module_terms(self, modules, langs, overwrite=False, **kwargs):
             loaded.append((modules, langs, overwrite))
 
         with patch('odoo.addons.base.models.ir_module.Module._load_module_terms', _load_module_terms):

--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -5,6 +5,8 @@
 # AltGr + V for the opening curly quotes “
 # AltGr + B for the closing curly quotes ”
 
+from __future__ import annotations
+
 import codecs
 import fnmatch
 import functools
@@ -1376,7 +1378,7 @@ class TranslationImporter:
                      the language must be present and activated in the database
         :param xmlids: if given, only translations for records with xmlid in xmlids will be loaded
         """
-        with suppress(FileNotFoundError), file_open(filepath, mode='rb') as fileobj:
+        with suppress(FileNotFoundError), file_open(filepath, mode='rb', env=self.env) as fileobj:
             _logger.info('loading base translation file %s for language %s', filepath, lang)
             fileformat = os.path.splitext(filepath)[-1][1:].lower()
             self.load(fileobj, fileformat, lang, xmlids=xmlids)
@@ -1615,8 +1617,7 @@ def load_language(cr, lang):
     installer.lang_install()
 
 
-
-def get_po_paths(module_name: str, lang: str):
+def get_po_paths(module_name: str, lang: str, env: odoo.api.Environment | None = None):
     lang_base = lang.split('_')[0]
     # Load the base as a fallback in case a translation is missing:
     po_names = [lang_base, lang]
@@ -1631,7 +1632,7 @@ def get_po_paths(module_name: str, lang: str):
     ]
     for path in po_paths:
         with suppress(FileNotFoundError):
-            yield file_path(path)
+            yield file_path(path, env=env)
 
 
 class CodeTranslations:


### PR DESCRIPTION
Before this commit, translations in data modules were not taken into account as there were not extracted nor loaded. This commit adds the possibility to add a i18n folder that contains the translations for the imported module

task-3734243
