### PR TITLE
[PERF] stock_account: disable prefetching of AMLs for stock valuation

### DIFF
--- a/addons/stock_account/models/account_move.py
+++ b/addons/stock_account/models/account_move.py
@@ -203,7 +203,7 @@ class AccountMove(models.Model):
 
                 if product_interim_account.reconcile:
                     # Search for anglo-saxon lines linked to the product in the journal entry.
-                    product_account_moves = move.line_ids.filtered(
+                    product_account_moves = move.line_ids.with_context(prefetch_fields=False).filtered(
                         lambda line: line.product_id == prod and line.account_id == product_interim_account and not line.reconciled)
 
                     # Search for anglo-saxon lines linked to the product in the stock moves.


### PR DESCRIPTION
## Issue 
When reconciling moves in anglosaxon accounting, the prefetcher may be too aggressive and fetch too many fields, leading to a memory crash if too many records have to be loaded. 

## Solution
We disable the prefetcher when fetching lines linked to the product to avoid blocking situations (e.g. can't validate a transfer).

## References
opw-3997691



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
