### PR TITLE
[FIX] web: Dialog's footer responsive buttons justification

### DIFF
--- a/addons/web/static/src/core/dialog/dialog.scss
+++ b/addons/web/static/src/core/dialog/dialog.scss
@@ -5,11 +5,11 @@
         display: flex;
         flex-wrap: wrap;
         flex: 1 1 auto;
-        justify-content: flex-start;
+        justify-content: space-around;
         gap: map-get($spacers, 1);
 
-        @include media-breakpoint-down(md) {
-            justify-content: space-around;
+        @include media-breakpoint-up(md) {
+            justify-content: flex-start;
         }
     }
 

--- a/addons/web/static/src/core/dialog/dialog.xml
+++ b/addons/web/static/src/core/dialog/dialog.xml
@@ -20,7 +20,7 @@
                         </header>
                         <!-- FIXME: WOWL there is a bug on t-portal on owl, in which t-portal don't work on multinode.
                         To avoid this we place the footer before the body -->
-                        <footer t-if="props.footer" class="modal-footer justify-content-around justify-content-sm-start flex-wrap gap-1" style="order:2">
+                        <footer t-if="props.footer" class="modal-footer justify-content-around justify-content-md-start flex-wrap gap-1" style="order:2">
                             <t t-slot="footer" close="data.close">
                                 <button class="btn btn-primary o-default-button" t-on-click="data.close">
                                     <t>Ok</t>

--- a/addons/web/static/src/legacy/xml/base.xml
+++ b/addons/web/static/src/legacy/xml/base.xml
@@ -261,7 +261,7 @@
                         <main class="modal-body">
                             <t t-slot="default"/>
                         </main>
-                        <footer t-if="props.renderFooter" class="modal-footer justify-content-around justify-content-sm-start flex-wrap gap-1" t-ref="modal-footer">
+                        <footer t-if="props.renderFooter" class="modal-footer justify-content-around justify-content-md-start flex-wrap gap-1" t-ref="modal-footer">
                             <t t-slot="buttons" close="_close" >
                                 <button class="btn btn-primary" t-on-click.prevent="_close">
                                     <t>Ok</t>

--- a/addons/web/static/src/legacy/xml/dialog.xml
+++ b/addons/web/static/src/legacy/xml/dialog.xml
@@ -18,7 +18,7 @@
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" tabindex="-1"></button>
                 </header>
                 <main class="modal-body"/>
-                <footer t-if="renderFooter" class="modal-footer justify-content-around justify-content-sm-start flex-wrap gap-1"/>
+                <footer t-if="renderFooter" class="modal-footer justify-content-around justify-content-md-start flex-wrap gap-1"/>
             </div>
         </div>
     </div>


### PR DESCRIPTION
This commit normalize the breakpoint used to set the justification of the dialog footer's buttons. The issue is that the breakpoint used in the utility classes didn't match the css used for nested footer's children, resulting into discrepancy in in-between viewport sizes.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
