### PR TITLE
[FIX] project, web: tag names overflow from search bar

### DIFF
--- a/addons/project/static/tests/legacy/burndown_chart_tests.js
+++ b/addons/project/static/tests/legacy/burndown_chart_tests.js
@@ -220,7 +220,7 @@ QUnit.module("Project", {}, () => {
 
         function checkGroupByOrder(assert) {
             const dateSearchFacetXpath = `//div[contains(@class, 'o_searchview_facet')]
-                                            [.//small[@class='o_facet_value']
+                                            [.//small[contains(@class, 'o_facet_value')]
                                             [contains(., 'Date: Month')]]`;
             const dateSearchFacetElement = getFirstElementForXpath(target, dateSearchFacetXpath);
             const dateSearchFacetParts = dateSearchFacetElement.querySelectorAll('.o_facet_value');
@@ -241,7 +241,7 @@ QUnit.module("Project", {}, () => {
 
         function checkGroupByIsClosed(assert) {
             const dateSearchFacetXpath = `//div[contains(@class, 'o_searchview_facet')]
-                                            [.//small[@class='o_facet_value']
+                                            [.//small[contains(@class, 'o_facet_value')]
                                             [contains(., 'Date: Month')]]`;
             const dateSearchFacetElement = getFirstElementForXpath(target, dateSearchFacetXpath);
             const dateSearchFacetParts = dateSearchFacetElement.querySelectorAll('.o_facet_value');

--- a/addons/web/static/src/search/search_bar/search_bar.scss
+++ b/addons/web/static/src/search/search_bar/search_bar.scss
@@ -16,4 +16,12 @@
         // It was causing issues with the hotkey overlay
         z-index: 0;
     }
+
+    .o_facet_value {
+        max-width: $o-search-bar-facet-value-width;
+
+        @include media-breakpoint-down(md) {
+            max-width: $o-search-bar-facet-value-width / 2;
+        }
+    }
 }

--- a/addons/web/static/src/search/search_bar/search_bar.variables.scss
+++ b/addons/web/static/src/search/search_bar/search_bar.variables.scss
@@ -1,0 +1,1 @@
+$o-search-bar-facet-value-width: 16rem;

--- a/addons/web/static/src/search/search_bar/search_bar.xml
+++ b/addons/web/static/src/search/search_bar/search_bar.xml
@@ -3,7 +3,7 @@
 
     <t t-name="web.SearchBar.Facets">
         <t t-foreach="env.searchModel.facets" t-as="facet" t-key="facet_index">
-            <div class="o_searchview_facet position-relative d-inline-flex align-items-stretch rounded-2 bg-200 text-nowrap opacity-trigger-hover"
+            <div class="o_searchview_facet position-relative d-inline-flex align-items-stretch rounded-2 bg-200 text-nowrap opacity-trigger-hover mw-100"
                 t-att-class="{o_facet_with_domain: facet.domain }"
                 role="listitem"
                 aria-label="search"
@@ -42,10 +42,10 @@
                     </span>
                 </div>
 
-                <div class="o_facet_values position-relative d-flex flex-wrap align-items-center ps-2 rounded-end-2 text-wrap">
+                <div class="o_facet_values position-relative d-flex flex-wrap align-items-center ps-2 rounded-end-2 text-wrap overflow-hidden">
                     <t t-foreach="facet.values" t-as="facetValue" t-key="facetValue_index">
                         <em t-if="!facetValue_first" class="o_facet_values_sep small fw-bold mx-1 opacity-50" t-esc="facet.separator"/>
-                        <small class="o_facet_value" t-esc="facetValue"/>
+                        <small class="o_facet_value text-truncate" t-esc="facetValue" t-att-title="facetValue"/>
                     </t>
                     <button class="o_facet_remove oi oi-close btn btn-link py-0 px-2 text-danger d-print-none"
                         role="button"
@@ -115,7 +115,7 @@
                         role="img"
                     />
                 </button>
-                <div class="o_searchview_input_container d-flex flex-grow-1 flex-wrap gap-1">
+                <div class="o_searchview_input_container d-flex flex-grow-1 flex-wrap gap-1 mw-100">
                     <t t-call="web.SearchBar.Facets"/>
                     <t t-call="web.SearchBar.Input"/>
                     <t t-if="items.length">


### PR DESCRIPTION
Before this PR:

- Long search content overflows the container.
- Search input and searched content are misaligned when the
content isn't long.

Steps to Reproduce:

- Type a very long string in the search bar.
- Press enter and observe that the content overflows the container.

After this PR:

- Max-width is set on input_container to keep searched content 
within the container.
- Long searched content will be ellipsis, with full text viewable on hover.
- Max-width on searched content ensures alignment with search input.
- `$search-align-width-large and $search-align-width-small` keeps the (Search...) aligned when input is long.

task-4011097