### PR TITLE
[IMP] payment_razorpay, _*: quick onboarding with payment razorpay

### DIFF
--- a/addons/payment_razorpay/__manifest__.py
+++ b/addons/payment_razorpay/__manifest__.py
@@ -12,7 +12,8 @@
         'views/payment_provider_views.xml',
         'views/payment_razorpay_templates.xml',
 
-        'data/payment_provider_data.xml',  # Depends on views/payment_razorpay_templates.xml
+        'data/payment_provider_data.xml',  # Depends on views/payment_razorpay_templates.xml,
+        'data/ir_cron_data.xml'
     ],
     'assets': {
         'web.assets_frontend': [

--- a/addons/payment_razorpay/const.py
+++ b/addons/payment_razorpay/const.py
@@ -145,4 +145,9 @@ HANDLED_WEBHOOK_EVENTS = [
     'payment.failed',
     'refund.failed',
     'refund.processed',
+    'account.app.authorization_revoked',
 ]
+
+# TODO: change IAP url to the correct one (right now it's a test url)
+OAUTH_URL = "https://razorpay.api.odoo.com"
+OAUTH_TEST_URL = "https://razorpay.test.odoo.com"

--- a/addons/payment_razorpay/controllers/__init__.py
+++ b/addons/payment_razorpay/controllers/__init__.py
@@ -1,3 +1,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import main
+from . import razorpay_auth

--- a/addons/payment_razorpay/controllers/razorpay_auth.py
+++ b/addons/payment_razorpay/controllers/razorpay_auth.py
@@ -1,0 +1,100 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import logging
+
+from odoo import _, exceptions, fields, http
+from odoo.addons.iap.tools import iap_tools
+from odoo.http import request
+from datetime import timedelta
+
+from werkzeug.exceptions import Forbidden
+from werkzeug.urls import url_join
+from werkzeug.utils import redirect
+
+
+_logger = logging.getLogger(__name__)
+
+
+class RazorpayController(http.Controller):
+    def _get_razorpay_payment_provider(self, state):
+        """ To search the razorpay provider
+        :return: The razorpay provider
+        :rtype: recordset of `payment.provider`
+        """
+        return request.env['payment.provider'].sudo().search([('code', '=', 'razorpay'), ('razorpay_authorization_state', '=', state)], limit=1)
+
+    @http.route('/payment/razorpay/oauth/callback', type='http', auth='user')
+    def razorpay_callback(self, **data):
+        """ Razorpay OAuth2 Callback Endpoint.
+        This HTTP route handles the callback from Razorpay during the OAuth2 authorization process.
+        It expects parameters such as 'code' and 'state'. If the 'code' is present, it redirects the
+        user to the authorization URL. If 'code' is not present, it redirects the user to their
+        base URL.
+        :param dict data: The callback data containing 'code' and 'state'.
+        :return: A redirection to the appropriate URL.
+        :rtype: werkzeug.wrappers.response.Response
+        """
+        state = data.get('state')
+        if not state:
+            _logger.error('Razorpay: oauth callback without state.')
+            raise Forbidden()
+        razorpay_provider = self._get_razorpay_payment_provider(state)
+        if not razorpay_provider:
+            _logger.warning('Razorpay: not find any razorpay payment provider with state %s', state)
+            raise Forbidden()
+        code = data.get('code')
+        is_successful = False
+
+        if code:
+            dbuuid = request.env['ir.config_parameter'].sudo().get_param('database.uuid')
+            request_url = url_join(razorpay_provider._get_razorpay_oauth_url(), '/api/razorpay/1/get_access_token')
+            try:
+                params = {
+                    'dbuuid': dbuuid,
+                    'code': data.get('code'),
+                }
+                response = iap_tools.iap_jsonrpc(request_url, params=params, timeout=60)
+                if 'access_token' in response:
+                    is_successful = True
+                    razorpay_provider.sudo().write({**self._get_razorpay_provider_vals(response), 'razorpay_key_secret': dbuuid})
+            except exceptions.AccessError:
+                raise exceptions.UserError(
+                    _('Something went wrong during your token generation.')
+                )
+            try:
+                razorpay_provider.sudo().action_razorpay_create_and_update_webhook()
+            except exceptions.UserError as e:
+                _logger.warning("Error on creating webhook %s", str(e))
+        return self._get_payment_provider_web_url(razorpay_provider, is_successful)
+
+    def _get_payment_provider_web_url(self, razorpay_provider, is_successful=True):
+        """ Get the redirect URL for the payment provider based on the success status.
+        :param razorpay_provider: The payment provider recordset.
+        :type razorpay_provider: recordset of `payment.provider`
+        :param is_successful: A flag indicating whether the operation is successful or not.
+        :type is_successful: bool
+        :return: The redirect URL for the payment provider.
+        :rtype: str
+        """
+        view_ref = is_successful and 'payment.action_payment_provider' or 'payment_razorpay.action_payment_provider_onboarding_using_key'
+        redirect_url = f'/web#model={razorpay_provider._name}&id={razorpay_provider.id}&action={request.env.ref(view_ref).id}&view_type=form'
+
+        return redirect(redirect_url)
+
+    def _get_razorpay_provider_vals(self, data):
+        """ Create a vals
+        :return: The razorpay provider
+        :rtype: recordset of `payment.provider
+        """
+        expires_in = fields.Datetime.now() + timedelta(seconds=int(data.get('expires_in')))
+        return {
+            'razorpay_access_token': data.get('access_token'),
+            'razorpay_public_token': data.get('public_token'),
+            'razorpay_access_token_expiration': expires_in,
+            'razorpay_refresh_token': data.get('refresh_token'),
+            'razorpay_account_id': data.get('razorpay_account_id'),
+            # Remove old connect method data
+            'razorpay_key_id': False,
+            'razorpay_key_secret': False,
+            'razorpay_webhook_secret': False,
+        }

--- a/addons/payment_razorpay/data/ir_cron_data.xml
+++ b/addons/payment_razorpay/data/ir_cron_data.xml
@@ -1,0 +1,10 @@
+<odoo noupdate="1">
+    <record id="ir_cron_razorpay" model="ir.cron">
+        <field name="name">Razorpay Refresh token</field>
+        <field name="model_id" ref="model_payment_provider"/>
+        <field name="state">code</field>
+        <field name="code">model.cron_razorpay_refresh_token()</field>
+        <field name="interval_number">1</field>
+        <field name="interval_type">days</field>
+    </record>
+</odoo>

--- a/addons/payment_razorpay/data/neutralize.sql
+++ b/addons/payment_razorpay/data/neutralize.sql
@@ -2,4 +2,11 @@
 UPDATE payment_provider
    SET razorpay_key_id = NULL,
        razorpay_key_secret = NULL,
-       razorpay_webhook_secret = NULL;
+       razorpay_webhook_secret = NULL,
+       razorpay_authorization_state = NULL,
+       razorpay_public_token = NULL,
+       razorpay_refresh_token = NULL,
+       razorpay_access_token = NULL,
+       razorpay_access_token_expiration = NULL,
+       razorpay_account_id = NULL,
+       razorpay_webhook_id = NULL;

--- a/addons/payment_razorpay/models/payment_provider.py
+++ b/addons/payment_razorpay/models/payment_provider.py
@@ -5,11 +5,17 @@ import hmac
 import logging
 import pprint
 
-import requests
-from werkzeug.urls import url_join
+import secrets
+import string
 
-from odoo import _, fields, models
-from odoo.exceptions import ValidationError
+import requests
+from werkzeug.urls import url_join, url_encode
+
+from odoo import _, api, exceptions, fields, models
+from odoo.exceptions import ValidationError, UserError
+
+from odoo.addons.iap.tools import iap_tools
+from datetime import timedelta
 
 from odoo.addons.payment_razorpay import const
 
@@ -26,18 +32,31 @@ class PaymentProvider(models.Model):
     razorpay_key_id = fields.Char(
         string="Razorpay Key Id",
         help="The key solely used to identify the account with Razorpay.",
-        required_if_provider='razorpay',
+        copy=False
     )
     razorpay_key_secret = fields.Char(
         string="Razorpay Key Secret",
-        required_if_provider='razorpay',
         groups='base.group_system',
+        copy=False
     )
     razorpay_webhook_secret = fields.Char(
         string="Razorpay Webhook Secret",
-        required_if_provider='razorpay',
         groups='base.group_system',
+        copy=False
     )
+
+    # Use for OAuth
+    razorpay_authorization_state = fields.Char(string='Authorization State', groups='base.group_system', copy=False)
+    razorpay_public_token = fields.Char(string='Public Token', groups='base.group_system', copy=False)
+    razorpay_refresh_token = fields.Char(string='Refresh Token', groups='base.group_system', copy=False)
+    razorpay_access_token = fields.Char(string='Access Token', groups='base.group_system', copy=False)
+    razorpay_access_token_expiration = fields.Datetime(string='Access Token Expiration', groups='base.group_system', copy=False)
+    razorpay_account_id = fields.Char(string="Customer Account ID", copy=False)
+    razorpay_webhook_id = fields.Char(string="Webhook ID", copy=False)
+
+    _sql_constraints = [
+        ('unique_razorpay_authorization_state', 'UNIQUE(razorpay_authorization_state)', 'Authorization State must be unique!'),
+    ]
 
     #=== COMPUTE METHODS ===#
 
@@ -76,12 +95,18 @@ class PaymentProvider(models.Model):
         self.ensure_one()
 
         url = url_join('https://api.razorpay.com/v1/', endpoint)
-        auth = (self.razorpay_key_id, self.razorpay_key_secret)
+        headers = {}
+        auth = None
+        # razorpay_access_token = self._get_razorpay_access_token()
+        if self.razorpay_access_token:
+            headers = {'Authorization': f'Bearer {self.razorpay_access_token}'}
+        else:
+            auth = (self.razorpay_key_id, self.razorpay_key_secret)
         try:
             if method == 'GET':
-                response = requests.get(url, params=payload, auth=auth, timeout=10)
+                response = requests.get(url, params=payload, headers=headers, auth=auth, timeout=10)
             else:
-                response = requests.post(url, json=payload, auth=auth, timeout=10)
+                response = requests.post(url, json=payload, headers=headers, auth=auth, timeout=10)
             try:
                 response.raise_for_status()
             except requests.exceptions.HTTPError:
@@ -129,3 +154,262 @@ class PaymentProvider(models.Model):
             return res
 
         return 1.0
+
+    # === BASE METHODS ===#
+
+    @api.onchange('state')
+    def _onchange_state(self):
+        for provider in self.filtered(lambda p: p.code == 'razorpay'):
+            change_from_test = provider._origin.state == 'test' and (provider.state == 'disabled' or provider.state == 'enabled')
+            if self.razorpay_public_token and (provider.state == 'test' or change_from_test):
+                self.write({
+                    'razorpay_access_token': False,
+                    'razorpay_refresh_token': False,
+                    'razorpay_access_token_expiration': False,
+                    'razorpay_public_token': False,
+                    'razorpay_key_id': False,
+                    'razorpay_key_secret': False,
+                    'razorpay_webhook_secret': False,
+                })
+
+    def _get_razorpay_oauth_url(self):
+        """ Get the OAuth URL for Razorpay.
+        :return: The OAuth URL.
+        :rtype: str
+        """
+        self.ensure_one()
+        OAUTH_URL = const.OAUTH_TEST_URL if self.state == 'test' else const.OAUTH_URL
+        return self.env['ir.config_parameter'].sudo().get_param('payment_razorpay.oauth_url', OAUTH_URL)
+
+    # === ONBOARDING APIS ===#
+
+    def action_razorpay_connect_account(self):
+        """ Create a Razorpay Connect account and redirect the user to the next onboarding step.
+            If the provider is already enabled, close the current window. Otherwise, generate a Razorpay
+            Connect onboarding link and redirect the user to it. If provided, the menu id is included in
+            the URL the user is redirected to when coming back on Odoo after the onboarding. If the link
+            generation failed, redirect the user to the provider form.
+        :return: URL (The next step action)
+        :rtype: str
+        """
+        self.ensure_one()
+        return {
+            'type': 'ir.actions.act_url',
+            'url': self._get_razorpay_authorize_url(),
+            'target': 'self',
+        }
+
+    def _razorpay_generate_state(self):
+        """ Generates a random string of 80 characters using the secrets module and the characters from ASCII letters and digits.
+            This function might be useful for generating a secure state parameter,
+            perhaps for use in authentication or authorization processes.
+        return: str
+        """
+        return ''.join(secrets.choice(string.ascii_letters + string.digits) for _ in range(80))
+
+    def _get_razorpay_authorize_url(self):
+        """ Generate the authorization URL for Razorpay integration.
+            This function initiates the process of getting authorization for our application with Razorpay.
+            The response will include state and code parameters. The generated URL includes necessary
+            information such as state, scope, redirect_uri, request_url, and uuid.
+            Note: This function relies on Razorpay's authorization flow.
+            Note: Make sure to handle the response containing state and code appropriately.
+        :return: The URL for authorization
+        :rtype: dict
+        """
+        self.razorpay_authorization_state = self._razorpay_generate_state()
+        IrConfigParameter_sudo = self.env['ir.config_parameter'].sudo()
+        dbuuid = IrConfigParameter_sudo.get_param('database.uuid')
+        oauth_url = self._get_razorpay_oauth_url()
+        base_url = self.get_base_url()
+        return url_join(oauth_url, 'api/razorpay/1/authorize?%s' % url_encode({
+            'dbuuid': dbuuid,
+            'state': self.razorpay_authorization_state,
+            'redirect_url': base_url + '/payment/razorpay/oauth/callback',
+        }))
+
+    def cron_razorpay_refresh_token(self):
+        """
+            This cron job is designed to automatically refresh Razorpay access tokens for instances where the token is about to expire within the next day.
+            It searches for records with the code 'razorpay', matching the provided refresh token, and with an access token expiration within the specified timeframe.
+        """
+        razorpay_need_refresh = self.search([
+            ('code', '=', 'razorpay'),
+            ('razorpay_refresh_token', '=', self.razorpay_refresh_token),
+            ('razorpay_access_token_expiration', '<=', fields.Datetime.now() + timedelta(days=1))])
+        for razorpay in razorpay_need_refresh:
+            try:
+                razorpay._razorpay_refresh_token()
+                self.env.cr.commit()
+            except exceptions.UserError as e:
+                _logger.warning("Razorpay refresh token cron error %s", str(e))
+
+    def _razorpay_refresh_token(self):
+        """ Action to retrieve the refresh token URL for Razorpay.
+            This action is used to trigger the process of refreshing the Razorpay access token. It returns
+            an 'ir.actions.act_url' with the generated refresh token URL.
+            Note: Make sure to handle the response containing the updated access token appropriately.
+        :return: The action URL for refreshing the access token
+        :rtype: dict
+        """
+        self.ensure_one()
+        dbuuid = self.env['ir.config_parameter'].sudo().get_param('database.uuid')
+        request_url = url_join(self._get_razorpay_oauth_url(), '/api/razorpay/1/get_refresh_token')
+        params = {
+            'dbuuid': dbuuid,
+            'refresh_token': self.razorpay_refresh_token,
+        }
+        try:
+            response = iap_tools.iap_jsonrpc(request_url, params=params, timeout=60)
+        except exceptions.AccessError:
+            raise exceptions.UserError(
+                _('Something went wrong during refreshing the token.')
+            )
+        if response.get('error'):
+            error = response['error']
+            raise exceptions.UserError(
+                _('Error :during refreshing token. %s', str(error))
+            )
+        if not response.get('access_token'):
+            _logger.warning("Razorpay refresh token not found in responce %s", response)
+            raise exceptions.UserError(
+                _('New Token not exist in responce.')
+            )
+        expires_in = fields.Datetime.now() + timedelta(seconds=int(response.get('expires_in')))
+        vals = {
+            'razorpay_access_token': response.get('access_token'),
+            'razorpay_public_token': response.get('public_token'),
+            'razorpay_access_token_expiration': expires_in,
+            'razorpay_refresh_token': response.get('refresh_token'),
+        }
+        self.write(vals)
+
+    def action_razorpay_revoked_token(self):
+        """ Action to revoke the Razorpay access token.
+            This action is used to trigger the process of revoking the Razorpay access token. It returns
+            an 'ir.actions.act_url' with the generated URL for revoking the access token.
+            Note: After revocation, the access token will no longer be valid.
+        :return: The action URL for revoking the access token
+        :rtype: str
+        """
+        self.ensure_one()
+        dbuuid = self.env['ir.config_parameter'].sudo().get_param('database.uuid')
+        request_url = url_join(self._get_razorpay_oauth_url(), '/api/razorpay/1/revoked')
+        params = {
+            'dbuuid': dbuuid,
+            'token_type_hint': "access_token",
+            'access_token': self.razorpay_access_token,
+        }
+        is_successful = False
+        try:
+            self.razorpay_delete_webhook()
+        except UserError as e:
+            _logger.warning("Error on Delete webhook %s", str(e))
+        try:
+            response = iap_tools.iap_jsonrpc(request_url, params=params, timeout=60)
+        except exceptions.AccessError:
+            raise exceptions.UserError(
+                _('Something went wrong during revoking the token.')
+            )
+        if response.get('message') or response.get('error').get('code') == 'http_error':
+            is_successful = True
+            self.write({
+                'razorpay_access_token': False,
+                'razorpay_refresh_token': False,
+                'razorpay_access_token_expiration': False,
+                'razorpay_public_token': False,
+                'razorpay_key_id': False,
+                'razorpay_key_secret': False,
+                'razorpay_webhook_secret': False,
+                'state': 'disabled'
+            })
+        return {
+            'type': 'ir.actions.client',
+            'tag': 'display_notification',
+            'params': {
+                'type': is_successful and 'info' or 'warning',
+                'sticky': False,
+                'message': _("Disconnected %s", is_successful and _("successfully") or _("Not successfully")),
+                'next': {'type': 'ir.actions.client', 'tag': 'reload'}
+            }
+        }
+
+    def action_razorpay_create_and_update_webhook(self):
+        """ This method is responsible for creating or updating the Razorpay webhook associated with the current Odoo instance.
+            The webhook is crucial for updating payment states within Odoo when changes occur in Razorpay.
+            If the base URL is modified, it is necessary to update the webhook to ensure seamless communication.
+            The function constructs the necessary parameters and makes a request to create or update the webhook using the Razorpay API.
+        """
+        self.ensure_one()
+        dbuuid = self.env['ir.config_parameter'].sudo().get_param('database.uuid')
+        request_url = url_join(self._get_razorpay_oauth_url(), '/api/razorpay/1/create_webhook')
+        params = {
+            'dbuuid': dbuuid,
+            'account_id': self.razorpay_account_id,
+            'access_token': self.razorpay_access_token,
+            'webhook_url': self.get_base_url() + '/payment/razorpay/webhook',
+            'webhook_id': self.razorpay_webhook_id,
+        }
+        try:
+            response = iap_tools.iap_jsonrpc(request_url, params=params, timeout=60)
+        except exceptions.AccessError as e:
+            raise UserError(_("Unable to connect with Razorpay. Razorpay gave us the following information: %s", str(e)))
+        if response.get('id'):
+            self.write({
+                'razorpay_webhook_secret': dbuuid,
+                'razorpay_webhook_id': response['id'],
+            })
+        else:
+            error = response.get('error', {})
+            if self.razorpay_webhook_id and error.get('code') == 'http_error':
+                self.razorpay_webhook_id = False
+                return {
+                    'type': 'ir.actions.client',
+                    'tag': 'display_notification',
+                    'params': {
+                        'type': 'warning',
+                        'message': _("Can't update webhook because it's already deleted in Razorpay"),
+                        'next': {'type': 'ir.actions.client', 'tag': 'reload'}
+                    }
+                }
+            elif error.get('code') == 'http_error':
+                _logger.exception("Error on connect with Razorpay %s", error.get('message', str(error)))
+                raise UserError(_('Unable/Unauthorized to connect Razorpay.'))
+            elif error:
+                raise UserError(error.get('description', str(error)))
+            _logger.exception("Unknown Error during creating the webhook. %s", str(response))
+            raise UserError(_("Unknown Error"))
+        return {
+            'type': 'ir.actions.client',
+            'tag': 'display_notification',
+            'params': {
+                'type': 'info',
+                'message': _("Webhook successfully updated"),
+                'next': {'type': 'ir.actions.client', 'tag': 'reload'}
+            }
+        }
+
+    def razorpay_delete_webhook(self):
+        """ This method is designed to delete the Razorpay webhook associated with the current Odoo instance.
+            The function constructs the necessary parameters and makes a request to the Razorpay API to delete the webhook.
+        """
+        self.ensure_one()
+        dbuuid = self.env['ir.config_parameter'].sudo().get_param('database.uuid')
+        request_url = url_join(self._get_razorpay_oauth_url(), '/api/razorpay/1/delete_webhook')
+        params = {
+            'dbuuid': dbuuid,
+            'account_id': self.razorpay_account_id,
+            'webhook_id': self.razorpay_webhook_id,
+            'access_token': self.razorpay_access_token,
+        }
+        try:
+            response = iap_tools.iap_jsonrpc(request_url, params=params, timeout=60)
+        except exceptions.AccessError as e:
+            raise UserError(_("Unable to connect with Razorpay. Razorpay gave us the following information: %s", str(e)))
+        if isinstance(response, dict) and response.get('error'):
+            error = response['error']
+            raise UserError(error.get('description', '') or error.get('message', str(error)))
+        self.write({
+            'razorpay_webhook_secret': False,
+            'razorpay_webhook_id': False,
+        })

--- a/addons/payment_razorpay/models/payment_transaction.py
+++ b/addons/payment_razorpay/models/payment_transaction.py
@@ -39,8 +39,10 @@ class PaymentTransaction(models.Model):
 
         customer_id = self._razorpay_create_customer()['id']
         order_id = self._razorpay_create_order(customer_id)['id']
+        # razorpay_public_token = self._get_razorpay_public_token()
         return {
             'razorpay_key_id': self.provider_id.razorpay_key_id,
+            'razorpay_public_token': self.provider_id.razorpay_public_token,
             'razorpay_customer_id': customer_id,
             'is_tokenize_request': self.tokenize,
             'razorpay_order_id': order_id,

--- a/addons/payment_razorpay/static/src/js/payment_form.js
+++ b/addons/payment_razorpay/static/src/js/payment_form.js
@@ -59,7 +59,7 @@ paymentForm.include({
      */
     _prepareRazorpayOptions(processingValues) {
         return Object.assign({}, processingValues, {
-            'key': processingValues['razorpay_key_id'],
+            'key': processingValues['razorpay_public_token'] || processingValues['razorpay_key_id'],
             'customer_id': processingValues['razorpay_customer_id'],
             'order_id': processingValues['razorpay_order_id'],
             'description': processingValues['reference'],

--- a/addons/payment_razorpay/views/payment_provider_views.xml
+++ b/addons/payment_razorpay/views/payment_provider_views.xml
@@ -11,16 +11,59 @@
                        invisible="code != 'razorpay'">
                     <field name="razorpay_key_id"
                            string="Key Id"
-                           required="code == 'razorpay' and state != 'disabled'"/>
+                           groups="base.group_no_one"/>
                     <field name="razorpay_key_secret"
                            string="Key Secret"
-                           required="code == 'razorpay' and state != 'disabled'"
+                           groups="base.group_no_one"
                            password="True"/>
-                    <field name="razorpay_webhook_secret"
-                           string="Webhook Secret"
-                           required="code == 'razorpay' and state != 'disabled'"
-                           password="True"/>
+                    <label for="razorpay_webhook_secret"/>
+                    <div class="o_row">
+                        <field name="razorpay_webhook_secret"
+                            string="Webhook Secret"
+                            groups="base.group_no_one"
+                            password="True"/>
+                        <button string="Create Webhook"
+                                name="action_razorpay_create_and_update_webhook"
+                                type="object"
+                                help="If you change the your base url, you will need to update the webhook. else payment state will not be updated in odoo."
+                                class="btn-primary"
+                                groups="base.group_no_one"
+                                invisible="not razorpay_access_token or razorpay_webhook_id"/>
+                        <button string="Update Webhook"
+                                name="action_razorpay_create_and_update_webhook"
+                                type="object"
+                                help="If you change the your base url, you will need to update the webhook. else payment state will not be updated in odoo."
+                                class="btn-primary"
+                                groups="base.group_no_one"
+                                invisible="not razorpay_access_token or not razorpay_webhook_id"/>
+                    </div>
                 </group>
+            </group>
+            <group name="provider_credentials" position="after">
+                <field name="razorpay_public_token" invisible="1"/>
+                <field name="razorpay_refresh_token" invisible="1"/>
+                <field name="razorpay_account_id" invisible="1"/>
+                <field name="razorpay_access_token" invisible="1"/>
+                <field name="razorpay_access_token_expiration" invisible="1"/>
+                <field name="razorpay_key_id" invisible="1"/>
+                <field name="razorpay_webhook_secret" invisible="1"/>
+                <field name="razorpay_webhook_id" invisible="1"/>
+                <div class="alert alert-warning" role="alert" invisible="not razorpay_key_id">
+                    You are using Old method key and secret suggested to change to Oauth By click on Connect.
+                </div>
+                <div invisible="code != 'razorpay'">
+                    <button string="Connect"
+                            name="action_razorpay_connect_account"
+                            type="object"
+                            class="btn-primary"
+                            invisible="razorpay_public_token"/>
+                    <button string="Disconnect"
+                            name="action_razorpay_revoked_token"
+                            type="object"
+                            class="btn-secondary"
+                            confirm="Are you sure you want to disconnect?"
+                            invisible="not razorpay_access_token"/>
+                </div>
             </group>
             <field name="allow_tokenization" position="after">
                 <div invisible="code != 'razorpay' or not allow_tokenization" colspan="2">
@@ -28,6 +71,13 @@
                 </div>
             </field>
         </field>
+    </record>
+
+    <record id="action_payment_provider_onboarding_using_key" model="ir.actions.act_window">
+        <field name="name">Payment Providers</field>
+        <field name="res_model">payment.provider</field>
+        <field name="view_mode">form</field>
+        <!-- <field name="view_id" ref="payment_provider_form_razorpay_oauth_fail"/> -->
     </record>
 
 </odoo>

--- a/addons/website_payment/models/__init__.py
+++ b/addons/website_payment/models/__init__.py
@@ -5,3 +5,4 @@ from . import account_payment
 from . import payment_provider
 from . import payment_transaction
 from . import res_config_settings
+from . import res_currency

--- a/addons/website_payment/models/res_config_settings.py
+++ b/addons/website_payment/models/res_config_settings.py
@@ -18,6 +18,8 @@ class ResConfigSettings(models.TransientModel):
         compute='_compute_providers_state')
     is_stripe_supported_country = fields.Boolean(
         related='company_id.country_id.is_stripe_supported_country')
+    is_razorpay_supported_currency = fields.Boolean(
+        related='company_id.currency_id.is_razorpay_supported_currency')
 
     def _get_activated_providers(self):
         self.ensure_one()
@@ -52,6 +54,17 @@ class ResConfigSettings(models.TransientModel):
         menu = self.env.ref('website.menu_website_website_settings', raise_if_not_found=False)
         menu_id = menu and menu.id
         return self.env.company._run_payment_onboarding_step(menu_id=menu_id)
+
+    def action_activate_razorpay(self):
+        self.ensure_one()
+        razorpay = self.env['payment.provider'].search([
+            *self.env['payment.provider']._check_company_domain(self.env.company),
+            ('code', '=', 'razorpay')
+        ], limit=1)
+
+        if not self.is_razorpay_supported_currency:
+            return False
+        return razorpay.action_razorpay_connect_account()
 
     def action_configure_first_provider(self):
         self.ensure_one()

--- a/addons/website_payment/models/res_currency.py
+++ b/addons/website_payment/models/res_currency.py
@@ -1,0 +1,13 @@
+from odoo import api, fields, models
+from odoo.addons.payment_razorpay.const import SUPPORTED_CURRENCIES as RAZORPAY_SUPPORTED_CURRENCIES
+
+
+class ResCurrency(models.Model):
+    _inherit = 'res.currency'
+
+    is_razorpay_supported_currency = fields.Boolean(compute='_compute_is_razorpay_supported_currency')
+
+    @api.depends('name')
+    def _compute_is_razorpay_supported_currency(self):
+        for currency in self:
+            currency.is_razorpay_supported_currency = currency.name in RAZORPAY_SUPPORTED_CURRENCIES

--- a/addons/website_payment/views/res_config_settings_views.xml
+++ b/addons/website_payment/views/res_config_settings_views.xml
@@ -18,6 +18,7 @@
                             <div class="row" invisible="providers_state == 'other_than_paypal'">
                                 <field name="providers_state" invisible="1"/>
                                 <field name="is_stripe_supported_country" invisible="1"/>
+                                <field name="is_razorpay_supported_currency" invisible="1"/>
                                 <div class="oe_inline"
                                      invisible="not is_stripe_supported_country">
                                     <button string="Activate Stripe" name="action_activate_stripe" type="object" class="btn-primary"/>
@@ -26,6 +27,19 @@
                                      title="Stripe Connect is not available in your country, please use another payment provider."
                                      invisible="is_stripe_supported_country">
                                     <button string="Activate Stripe" class="btn-primary" disabled=""/>
+                                </div>
+                                <div class="oe_inline"
+                                     invisible="not is_razorpay_supported_currency">
+                                    <button string="Connect Razorpay"
+                                            name="action_activate_razorpay"
+                                            type="object"
+                                            class="btn-primary"/>
+                                </div>
+                                <div class="oe_inline"
+                                     title="Razorpay is not available in your country, please use another payment provider."
+                                     invisible="is_razorpay_supported_currency">
+                                    <button string="Connect Razorpay"
+                                            class="btn-primary"/>
                                 </div>
                                 <button type="action"
                                         name="%(payment.action_payment_provider)d"


### PR DESCRIPTION
_* = website_payment

This commit Razorpay payment onboarding form to take advantage of the Razorpay Connect Onboarding Flow. It integrates the Razorpay Onboarding using the IAP proxy.

Purpose
=======
Help users easily onboard with Razorpay by using the Razorpay Connect API.

Specification
=============
1.  Connect and authorized the razorpay account. To connect to a sub-merchant's Razorpay account, the application redirects the user to a Razorpay-hosted webpage. The user can approve or deny the authorisation request on this page.

2.  Get an access token. After you obtain an access token, you can use it to access the sub-merchant data on Razorpay APIs. The access is controlled based on the scope requested for and granted by the user during the authorization process.

3.  Get a refresh token. You can use refresh tokens to generate a new access token. If your access token expires, you will receive a 4XX response from the API. You can make a request using your refresh token to generate a new access token.

4.  Revoke token. The API supports token revocation to enhance security and manage access. If needed, tokens can be revoked through this mechanism.

5.  Create & update webhook. This method is responsible for creating or updating the Razorpay webhook associated with the current Odoo instance. The webhook is crucial for updating payment states within Odoo when changes occur in Razorpay.

6.  Revoke the application from Razorpay. User can initiate the revocation of their application from the Razorpay side facilitating a seamless process for application revocation.

task-3537535