### PR TITLE
[DRAFT][FIX] Contract job info not passed down to employee

### DIFF
--- a/addons/hr_contract/models/hr_contract.py
+++ b/addons/hr_contract/models/hr_contract.py
@@ -158,6 +158,13 @@ class Contract(models.Model):
                     contract=contract.name, start=contract.date_start, end=contract.date_end,
                 ))
 
+    @api.onchange('state')
+    def _onchange_state(self):
+        for contract in self.filtered(lambda contract: contract.state == 'open'):
+            employee = contract.employee_id
+            employee.job_id = employee.job_id or contract.job_id
+            employee.department_id = employee.department_id or contract.department_id
+
     @api.model
     def update_state(self):
         from_cron = 'from_cron' in self.env.context

--- a/addons/hr_contract/tests/test_contract.py
+++ b/addons/hr_contract/tests/test_contract.py
@@ -7,7 +7,7 @@ from freezegun import freeze_time
 
 from odoo.exceptions import ValidationError
 from odoo.addons.hr_contract.tests.common import TestContractCommon
-from odoo.tests import tagged
+from odoo.tests import tagged, Form
 
 @tagged('test_contracts')
 class TestHrContracts(TestContractCommon):
@@ -184,3 +184,33 @@ class TestHrContracts(TestContractCommon):
 
             mail_activity = self.env['mail.activity'].search([('res_id', '=', contract_1.id), ('res_model', '=', 'hr.contract')])
             self.assertTrue(len(mail_activity) == 2, "There should be reminder activity as employee contract and work permit going to end soon")
+
+    def test_running_contract_updates_employee_job_info(self):
+        employee = self.env['hr.employee'].create({
+            'name': 'John Doe'
+        })
+        job = self.env['hr.job'].create({
+            'name': 'Software dev'
+        })
+        department = self.env['hr.department'].create({
+            'name': 'R&D'
+        })
+
+        contract_form = Form(self.env['hr.contract'].create({
+            'name': 'Contract',
+            'employee_id': employee.id,
+            'job_id': job.id,
+            'department_id': department.id,
+            'wage': 1,
+        }))
+
+        contract_form.save()
+        self.assertFalse(employee.job_id)
+        self.assertFalse(employee.job_title)
+        self.assertFalse(employee.department_id)
+
+        contract_form.state = 'open'
+        contract_form.save()
+        self.assertEqual(contract_form.job_id, employee.job_id)
+        self.assertEqual(contract_form.job_id.name, employee.job_title)
+        self.assertEqual(contract_form.department_id, employee.department_id)


### PR DESCRIPTION
Necessary modules:
employee, hr_contract

Steps to reproduce:
- Create an employee, leave job position / department empty
- Add a contract (top-right of form)
- Set job position / department
- Set the contract to 'Running'

What happens:
The employee's job position / department fields stay empty

Why is this an issue:
The contract autofills with employee information so the same is expected of the opposite interaction.

What was done:
We should be fine to assume an employee's job is determined by their active contract but to err of caution this autofill has been set NOT to overwrite the employee's current job if it is already filld in.

opw-4037757

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
