### PR TITLE
[IMP] account: Field payment_tolerance_type editability styling

### DIFF
--- a/addons/account/__manifest__.py
+++ b/addons/account/__manifest__.py
@@ -96,6 +96,7 @@ You could use this simplified accounting in case you work with an (external) acc
             'account/static/src/scss/account_journal_dashboard.scss',
             'account/static/src/scss/account_searchpanel.scss',
             'account/static/src/scss/account_payment_term.scss',
+            'account/static/src/scss/account_reconcile_model.scss',
             'account/static/src/components/**/*',
             'account/static/src/services/*.js',
             'account/static/src/views/*.js',

--- a/addons/account/static/src/scss/account_reconcile_model.scss
+++ b/addons/account/static/src/scss/account_reconcile_model.scss
@@ -1,0 +1,3 @@
+.o_show_selection_caret {
+    background: transparent $o-caret-down no-repeat right center;
+}

--- a/addons/account/views/account_reconcile_model_views.xml
+++ b/addons/account/views/account_reconcile_model_views.xml
@@ -116,7 +116,7 @@
                                             <field name="allow_payment_tolerance"/>
                                             <span invisible="not allow_payment_tolerance" class="d-flex gap-2 w-100">
                                                 <field name="payment_tolerance_param"/>
-                                                <field name="payment_tolerance_type"/>
+                                                <field name="payment_tolerance_type" class="o_field_highlight o_show_selection_caret"/>
                                             </span>
                                         </div>
                                         <field name="match_same_currency" invisible="rule_type != 'invoice_matching'"/>


### PR DESCRIPTION
In the model account_reconcile_model form view, this commit made the field payment_tolerance_type editability visible.

Before this commit, it was not evident that the field is editable because the editability styling would only be applied after hover or click.

task-4037701

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
