### PR TITLE
[IMP] l10n_in: update expenses account of Indian payroll

### DIFF
--- a/addons/l10n_in/data/template/account.account-in.csv
+++ b/addons/l10n_in/data/template/account.account-in.csv
@@ -84,7 +84,7 @@
 "p300003","Bonus to Employee Expense","300003","expense","","False"
 "p300004","Supplementary Allowance Expense","300004","liability_current","","False"
 "p300005","Performance Bonus","300005","liability_current","","False"
-"p300006","Employee Reimbursement Expense","300006","liability_current","","False"
+"p300006","Employee Reimbursement Expense","300006","liability_payable","","True"
 "p300007","Provident fund - Employee Payable","300007","liability_current","","False"
 "p300008","Provident fund - Employer Payable","300008","liability_current","","False"
 "p300009","Advance to Employee","300009","liability_current","","False"


### PR DESCRIPTION
Given that the expenses account of Indian payroll is a debit account, its type is set as `liability_payable` and it is reconcilable 

task-3901055


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
