### PR TITLE
[FIX] website: fix horizontal position of mega menu in dropdown menu

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -856,6 +856,9 @@ $-transition-duration: 200ms;
             max-width: none;
             flex: auto;
         }
+        > .o_mega_menu_container_size {
+            transform: unset;
+        }
     }
 }
 


### PR DESCRIPTION
__Current behavior before commit:__
When a mega menu has the class `o_mega_menu_container_size`, it is
translated by 50% to the left because of this line [1]. However it
shouldn't be if it is displayed inside a dropdown menu.

__Description of the fix:__
Unset `transform` of `.o_mega_menu_container_size` when it is inside
an `.o_extra_menu_items` element.

__Steps to reproduce the issue on runbot:__
1. Add a mega menu to the website
2. In the Editor, set Mega Menu > Size to `Narrow` and save
3. Resize the window just enough that a dropdown menu appear
4. Open the dropdown menu
-> The mega menu is offset to the left

opw-4021738

[1]: https://github.com/odoo/odoo/blob/9835632/addons/website/static/src/scss/website.scss#L1294