### PR TITLE
[IMP] mail: prevent the switching of sort order

### DIFF
--- a/addons/mail/static/src/views/web/activity/activity_renderer.js
+++ b/addons/mail/static/src/views/web/activity/activity_renderer.js
@@ -48,17 +48,6 @@ export class ActivityRenderer extends Component {
         this.setupStorageActiveColumns();
     }
 
-    /**
-     * Gets all activity resIds in the view.
-     *
-     * @returns filtered resIds first then the rest.
-     */
-    get activityResIds() {
-        return [...this.props.activityResIds].sort((a) =>
-            this.activeFilter.resIds.has(a) ? -1 : 0
-        );
-    }
-
     getGroupInfo(activityType) {
         const types = {
             done: {

--- a/addons/mail/static/src/views/web/activity/activity_renderer.xml
+++ b/addons/mail/static/src/views/web/activity/activity_renderer.xml
@@ -56,7 +56,7 @@
 
 <t t-name="mail.ActivityViewBody">
     <tbody>
-        <t t-foreach="activityResIds" t-as="resId" t-key="resId">
+        <t t-foreach="props.activityResIds" t-as="resId" t-key="resId">
             <t t-call="mail.ActivityViewRow"/>
         </t>
     </tbody>

--- a/addons/test_mail/static/tests/activity.test.js
+++ b/addons/test_mail/static/tests/activity.test.js
@@ -1013,7 +1013,7 @@ test("Activity view: apply progressbar filter", async () => {
     });
     await contains(".o_activity_view tbody .o_activity_filter_planned", { count: 5 });
     const tr = document.querySelectorAll(".o_activity_view tbody tr")[1];
-    expect(tr.querySelectorAll("td")[1]).toHaveClass("o_activity_empty_cell");
+    expect(tr.querySelectorAll("td")[2]).toHaveClass("o_activity_empty_cell");
 });
 
 test("Activity view: hide/show columns", async () => {


### PR DESCRIPTION
Specification:
In the activity view, clicking on the progress bar should not change the sort order from ascending to descending.

Observed behavior:
The sort order switches from ascending to descending.

Task-4036923
