### PR TITLE
[REF] mail, *: flatten store data sent on network (part 6 - guest, attachment, notification, link preview)

### DIFF
--- a/addons/cloud_storage/controllers/attachment.py
+++ b/addons/cloud_storage/controllers/attachment.py
@@ -21,12 +21,12 @@ class CloudAttachmentController(AttachmentController):
         if not is_cloud_storage:
             return response
 
-        attachmentData = response.json
-        if attachmentData.get('error'):
+        data = response.json
+        if data.get("error"):
             return response
 
         # append upload url to the response to allow the client to directly
         # upload files to the cloud storage
-        attachment = request.env['ir.attachment'].browse(attachmentData['id']).sudo()
-        attachmentData['upload_info'] = attachment._generate_cloud_storage_upload_info()
-        return request.make_json_response(attachmentData)
+        attachment = request.env["ir.attachment"].browse(data["data"]["Attachment"][0]["id"]).sudo()
+        data["upload_info"] = attachment._generate_cloud_storage_upload_info()
+        return request.make_json_response(data)

--- a/addons/mail/controllers/attachment.py
+++ b/addons/mail/controllers/attachment.py
@@ -12,6 +12,7 @@ from odoo.http import request, content_disposition
 
 from odoo.tools import consteq
 from ..models.discuss.mail_guest import add_guest_to_context
+from odoo.addons.mail.tools.discuss import Store
 
 logger = logging.getLogger(__name__)
 
@@ -74,12 +75,10 @@ class AttachmentController(http.Controller):
             # sudo: ir.attachment - posting a new attachment on an accessible thread
             attachment = request.env["ir.attachment"].sudo().create(vals)
             attachment._post_add_create(**kwargs)
-            attachmentData = attachment._attachment_format()[0]
-            if attachment.access_token:
-                attachmentData["accessToken"] = attachment.access_token
+            res = {"data": Store("Attachment", attachment._attachment_format(access_token=True)).get_result()}
         except AccessError:
-            attachmentData = {"error": _("You are not allowed to upload an attachment here.")}
-        return request.make_json_response(attachmentData)
+            res = {"error": _("You are not allowed to upload an attachment here.")}
+        return request.make_json_response(res)
 
     @http.route("/mail/attachment/delete", methods=["POST"], type="json", auth="public")
     @add_guest_to_context

--- a/addons/mail/controllers/attachment.py
+++ b/addons/mail/controllers/attachment.py
@@ -75,7 +75,7 @@ class AttachmentController(http.Controller):
             # sudo: ir.attachment - posting a new attachment on an accessible thread
             attachment = request.env["ir.attachment"].sudo().create(vals)
             attachment._post_add_create(**kwargs)
-            res = {"data": Store("Attachment", attachment._attachment_format(access_token=True)).get_result()}
+            res = {"data": Store(attachment, access_token=True).get_result()}
         except AccessError:
             res = {"error": _("You are not allowed to upload an attachment here.")}
         return request.make_json_response(res)

--- a/addons/mail/controllers/discuss/channel.py
+++ b/addons/mail/controllers/discuss/channel.py
@@ -173,7 +173,10 @@ class ChannelController(http.Controller):
         if before:
             domain.append(["id", "<", before])
         # sudo: ir.attachment - reading attachments of a channel that the current user can access
-        return request.env["ir.attachment"].sudo().search(domain, limit=limit, order="id DESC")._attachment_format()
+        attachments = (
+            request.env["ir.attachment"].sudo().search(domain, limit=limit, order="id DESC")
+        )
+        return Store("Attachment", attachments._attachment_format()).get_result()
 
     @http.route("/discuss/channel/fold", methods=["POST"], type="json", auth="public")
     @add_guest_to_context

--- a/addons/mail/controllers/discuss/channel.py
+++ b/addons/mail/controllers/discuss/channel.py
@@ -173,10 +173,9 @@ class ChannelController(http.Controller):
         if before:
             domain.append(["id", "<", before])
         # sudo: ir.attachment - reading attachments of a channel that the current user can access
-        attachments = (
+        return Store(
             request.env["ir.attachment"].sudo().search(domain, limit=limit, order="id DESC")
-        )
-        return Store("Attachment", attachments._attachment_format()).get_result()
+        ).get_result()
 
     @http.route("/discuss/channel/fold", methods=["POST"], type="json", auth="public")
     @add_guest_to_context

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -977,18 +977,6 @@ class Channel(models.Model):
             ]
             store.add("Thread", info)
 
-    def _channel_format(self, fields=None):
-        if not fields:
-            fields = {'id': True}
-        channels_formatted_data = {}
-        for channel in self:
-            data = {}
-            if 'id' in fields:
-                data['id'] = channel.id
-                data['model'] = "discuss.channel"
-            channels_formatted_data[channel] = data
-        return channels_formatted_data
-
     # User methods
     @api.model
     @api.returns('self', lambda channels: Store(channels).get_result())

--- a/addons/mail/models/discuss/discuss_channel_member.py
+++ b/addons/mail/models/discuss/discuss_channel_member.py
@@ -244,13 +244,8 @@ class ChannelMember(models.Model):
                     )
                     data["persona"] = {"id": member.partner_id.id, "type": "partner"}
                 if member.guest_id:
-                    # sudo: mail.guest - reading _guest_format related to a member is considered acceptable
-                    store.add(
-                        "Persona",
-                        member.guest_id.sudo()
-                        ._guest_format(fields=fields.get("persona", {}).get("guest"))
-                        .get(member.guest_id),
-                    )
+                    # sudo: mail.guest - reading guest related to a member is considered acceptable
+                    store.add(member.guest_id.sudo(), fields=fields.get("persona", {}).get("guest"))
                     data["persona"] = {"id": member.guest_id.id, "type": "guest"}
             if 'custom_notifications' in fields:
                 data['custom_notifications'] = member.custom_notifications

--- a/addons/mail/models/discuss/discuss_channel_member.py
+++ b/addons/mail/models/discuss/discuss_channel_member.py
@@ -233,7 +233,7 @@ class ChannelMember(models.Model):
             if 'id' in fields:
                 data['id'] = member.id
             if 'channel' in fields:
-                data['thread'] = member.channel_id._channel_format(fields=fields.get('channel')).get(member.channel_id)
+                data["thread"] = {"id": member.channel_id.id, "model": "discuss.channel"}
             if 'create_date' in fields:
                 data['create_date'] = odoo.fields.Datetime.to_string(member.create_date)
             if 'persona' in fields:

--- a/addons/mail/models/discuss/ir_attachment.py
+++ b/addons/mail/models/discuss/ir_attachment.py
@@ -17,8 +17,8 @@ class IrAttachment(models.Model):
             return guest
         return super()._bus_notification_target()
 
-    def _attachment_format(self):
-        attachment_format = super()._attachment_format()
+    def _attachment_format(self, **kwargs):
+        attachment_format = super()._attachment_format(**kwargs)
         for a in attachment_format:
         # sudo: discuss.voice.metadata - checking the existence of voice metadata for accessible attachments is fine
             a["voice"] = bool(self.browse(a["id"]).with_prefetch(self._prefetch_ids).sudo().voice_ids)

--- a/addons/mail/models/discuss/ir_attachment.py
+++ b/addons/mail/models/discuss/ir_attachment.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import models, fields
+from odoo.addons.mail.tools.discuss import Store
 
 
 class IrAttachment(models.Model):
@@ -17,12 +18,14 @@ class IrAttachment(models.Model):
             return guest
         return super()._bus_notification_target()
 
-    def _attachment_format(self, **kwargs):
-        attachment_format = super()._attachment_format(**kwargs)
-        for a in attachment_format:
-        # sudo: discuss.voice.metadata - checking the existence of voice metadata for accessible attachments is fine
-            a["voice"] = bool(self.browse(a["id"]).with_prefetch(self._prefetch_ids).sudo().voice_ids)
-        return attachment_format
+    def _to_store(self, store: Store, **kwargs):
+        super()._to_store(store, **kwargs)
+        for attachment in self:
+            store.add("Attachment", {
+                "id": attachment.id,
+                # sudo: discuss.voice.metadata - checking the existence of voice metadata for accessible attachments is fine
+                "voice": bool(attachment.sudo().voice_ids)
+            })
 
     def _post_add_create(self, **kwargs):
         super()._post_add_create()

--- a/addons/mail/models/mail_link_preview.py
+++ b/addons/mail/models/mail_link_preview.py
@@ -107,15 +107,12 @@ class LinkPreview(models.Model):
             ('source_url', '=', url),
             ('create_date', '>=', fields.Datetime.now() - timedelta(days=lifetime)),
         ], order='create_date DESC', limit=1)
-
         if not preview:
             preview_values = link_preview.get_link_preview_from_url(url)
             if not preview_values:
-                return
-
+                return self.env["mail.link.preview"]
             preview = self.env['mail.link.preview'].create(preview_values)
-
-        return preview._link_preview_format()[0]
+        return preview
 
     def _link_preview_format(self):
         return [{

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -1034,11 +1034,8 @@ class Message(models.Model):
                     {"id": notif.id}
                     for notif in message.notification_ids._filtered_for_web_client()
                 ],
-                "attachments": sorted(
-                    # sudo: mail.message - reading attachments on accessible message is allowed
-                    message.sudo().attachment_ids._attachment_format(),
-                    key=lambda a: a["id"],
-                ),
+                # sudo: mail.message - reading attachments on accessible message is allowed
+                "attachments": [{"id": a.id} for a in message.sudo().attachment_ids.sorted("id")],
                 "linkPreviews": link_previews._link_preview_format(),
                 "reactions": reaction_groups,
                 "pinned_at": message.pinned_at,
@@ -1076,6 +1073,8 @@ class Message(models.Model):
         # sudo: mail.message: access to author is allowed
         self.sudo()._author_to_store(store)
         store.add(self.notification_ids._filtered_for_web_client())
+        # sudo: mail.message - reading attachments on accessible message is allowed
+        store.add("Attachment", self.sudo().attachment_ids.sorted("id")._attachment_format())
         # Add extras at the end to guarantee order in result. In particular, the parent message
         # needs to be after the current message (client code assuming the first received message is
         # the one just posted for example, and not the message being replied to).

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -1036,7 +1036,7 @@ class Message(models.Model):
                 ],
                 # sudo: mail.message - reading attachments on accessible message is allowed
                 "attachments": [{"id": a.id} for a in message.sudo().attachment_ids.sorted("id")],
-                "linkPreviews": link_previews._link_preview_format(),
+                "linkPreviews": [{"id": p.id} for p in link_previews],
                 "reactions": reaction_groups,
                 "pinned_at": message.pinned_at,
                 "record_name": record_name,  # keep for iOS app
@@ -1073,6 +1073,8 @@ class Message(models.Model):
         # sudo: mail.message: access to author is allowed
         self.sudo()._author_to_store(store)
         store.add(self.notification_ids._filtered_for_web_client())
+        # sudo: mail.message - reading link preview on accessible message is allowed
+        store.add(self.sudo().link_preview_ids.filtered(lambda l: not l.is_hidden))
         # sudo: mail.message - reading attachments on accessible message is allowed
         store.add(self.sudo().attachment_ids.sorted("id"))
         # Add extras at the end to guarantee order in result. In particular, the parent message

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -1030,7 +1030,10 @@ class Message(models.Model):
                 "res_id": message.res_id,  # keep for iOS app
                 "subject": message.subject,
                 "default_subject": default_subject,
-                "notifications": message.notification_ids._filtered_for_web_client()._notification_format(),
+                "notifications": [
+                    {"id": notif.id}
+                    for notif in message.notification_ids._filtered_for_web_client()
+                ],
                 "attachments": sorted(
                     # sudo: mail.message - reading attachments on accessible message is allowed
                     message.sudo().attachment_ids._attachment_format(),
@@ -1072,6 +1075,7 @@ class Message(models.Model):
             store.add("Message", vals)
         # sudo: mail.message: access to author is allowed
         self.sudo()._author_to_store(store)
+        store.add(self.notification_ids._filtered_for_web_client())
         # Add extras at the end to guarantee order in result. In particular, the parent message
         # needs to be after the current message (client code assuming the first received message is
         # the one just posted for example, and not the message being replied to).
@@ -1150,7 +1154,10 @@ class Message(models.Model):
                 "date": message.date,
                 "message_type": message.message_type,
                 "body": message.body,
-                "notifications": message.notification_ids._filtered_for_web_client()._notification_format(),
+                "notifications": [
+                    {"id": notif.id}
+                    for notif in message.notification_ids._filtered_for_web_client()
+                ],
                 "thread": False,
             }
             if message.res_id:
@@ -1164,6 +1171,7 @@ class Message(models.Model):
                     },
                 )
             store.add("Message", message_data)
+        store.add(self.notification_ids._filtered_for_web_client())
 
     def _notify_message_notification_update(self):
         """Send bus notifications to update status of notifications in the web

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -1086,10 +1086,7 @@ class Message(models.Model):
             }
             # sudo: mail.message: access to author is allowed
             if guest_author := message.sudo().author_guest_id:
-                store.add(
-                    "Persona",
-                    guest_author._guest_format(fields={"id": True, "name": True}).get(guest_author),
-                )
+                store.add(guest_author, fields={"id": True, "name": True})
                 data["author"] = {"id": guest_author.id, "type": "guest"}
             # sudo: mail.message: access to author is allowed
             elif author := message.sudo().author_id:

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -1074,7 +1074,7 @@ class Message(models.Model):
         self.sudo()._author_to_store(store)
         store.add(self.notification_ids._filtered_for_web_client())
         # sudo: mail.message - reading attachments on accessible message is allowed
-        store.add("Attachment", self.sudo().attachment_ids.sorted("id")._attachment_format())
+        store.add(self.sudo().attachment_ids.sorted("id"))
         # Add extras at the end to guarantee order in result. In particular, the parent message
         # needs to be after the current message (client code assuming the first received message is
         # the one just posted for example, and not the message being replied to).

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -4521,7 +4521,7 @@ class MailThread(models.AbstractModel):
         empty_messages._cleanup_side_records()
         empty_messages.write({'pinned_at': None})
         attachments = message.attachment_ids.sorted("id")
-        broadcast_store = Store("Attachment", attachments._attachment_format())
+        broadcast_store = Store(attachments)
         res = {
             "attachments": {"id": attachment.id for attachment in attachments},
             "body": message.body,
@@ -4567,7 +4567,7 @@ class MailThread(models.AbstractModel):
             res["activities"] = [{"id": activity.id} for activity in activities]
         if 'attachments' in request_list:
             attachments = self._get_mail_thread_data_attachments()
-            store.add("Attachment", attachments._attachment_format())
+            store.add(attachments)
             res["attachments"] = [{"id": attachment.id} for attachment in attachments]
             res["areAttachmentsLoaded"] = True
             res["isLoadingAttachments"] = False

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -4566,7 +4566,9 @@ class MailThread(models.AbstractModel):
             store.add(activities)
             res["activities"] = [{"id": activity.id} for activity in activities]
         if 'attachments' in request_list:
-            res['attachments'] = self._get_mail_thread_data_attachments()._attachment_format()
+            attachments = self._get_mail_thread_data_attachments()
+            store.add("Attachment", attachments._attachment_format())
+            res["attachments"] = [{"id": attachment.id} for attachment in attachments]
             res["areAttachmentsLoaded"] = True
             res["isLoadingAttachments"] = False
         if 'followers' in request_list:

--- a/addons/mail/static/src/core/common/attachment_model.js
+++ b/addons/mail/static/src/core/common/attachment_model.js
@@ -19,9 +19,9 @@ export class Attachment extends FileModelMixin(Record) {
     static new(data) {
         /** @type {import("models").Attachment} */
         const attachment = super.new(data);
-        Record.onChange(attachment, ["extension", "name"], () => {
-            if (!attachment.extension && attachment.name) {
-                attachment.extension = attachment.name.split(".").pop();
+        Record.onChange(attachment, ["extension", "filename"], () => {
+            if (!attachment.extension && attachment.filename) {
+                attachment.extension = attachment.filename.split(".").pop();
             }
         });
         return attachment;

--- a/addons/mail/static/src/discuss/core/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/thread_model_patch.js
@@ -46,12 +46,12 @@ const threadPatch = {
         }
         this.isLoadingAttachments = true;
         try {
-            const rawAttachments = await rpc("/discuss/channel/attachments", {
+            const data = await rpc("/discuss/channel/attachments", {
                 before: Math.min(...this.attachments.map(({ id }) => id)),
                 channel_id: this.id,
                 limit,
             });
-            const attachments = this.store.Attachment.insert(rawAttachments);
+            const { Attachment: attachments = [] } = this.store.insert(data);
             if (attachments.length < limit) {
                 this.areAttachmentsLoaded = true;
             }

--- a/addons/mail/static/tests/chatter/web/chatter.test.js
+++ b/addons/mail/static/tests/chatter/web/chatter.test.js
@@ -233,14 +233,6 @@ test("chatter: drop attachment should refresh thread data with hasParentReloadOn
     const pyEnv = await startServer();
     const partnerId = pyEnv["res.partner"].create({});
 
-    onRpc(async ({ route }) => {
-        if (route === "/mail/attachment/upload") {
-            const attachmentId = pyEnv["ir.attachment"].create([
-                { res_id: partnerId, res_model: "res.partner", mimetype: "application/pdf" },
-            ]);
-            pyEnv["res.partner"].write([partnerId], { message_main_attachment_id: attachmentId });
-        }
-    });
     await start();
     await openFormView("res.partner", partnerId, {
         arch: `

--- a/addons/mail/static/tests/legacy/helpers/mock_server/controllers/channel.js
+++ b/addons/mail/static/tests/legacy/helpers/mock_server/controllers/channel.js
@@ -38,7 +38,7 @@ patch(MockServer.prototype, {
             .sort()
             .slice(0, limit)
             .map(({ id }) => id);
-        return this._mockIrAttachment_attachmentFormat(attachmentIds);
+        return { Attachment: this._mockIrAttachment_attachmentFormat(attachmentIds) };
     },
 
     /**

--- a/addons/mail/static/tests/legacy/helpers/mock_server/controllers/discuss.js
+++ b/addons/mail/static/tests/legacy/helpers/mock_server/controllers/discuss.js
@@ -26,7 +26,9 @@ patch(MockServer.prototype, {
             if (args.body.get("voice")) {
                 this.mockCreate("discuss.voice.metadata", { attachment_id: attachmentId });
             }
-            return this._mockIrAttachment_attachmentFormat([attachmentId])[0];
+            return {
+                data: { Attachment: this._mockIrAttachment_attachmentFormat([attachmentId]) },
+            };
         }
         return super.performRPC(...arguments);
     },

--- a/addons/mail/static/tests/legacy/helpers/mock_server/models/discuss_channel_member.js
+++ b/addons/mail/static/tests/legacy/helpers/mock_server/models/discuss_channel_member.js
@@ -49,10 +49,6 @@ patch(MockServer.prototype, {
             if (member.partner_id) {
                 persona = this._mockDiscussChannelMember_GetPartnerData([member.id]);
             }
-            if (member.guest_id) {
-                const [guest] = this.getRecords("mail.guest", [["id", "=", member.guest_id]]);
-                persona = this._mockMailGuestGuestFormat([guest.id]).get(guest.id);
-            }
             const data = {
                 create_date: member.create_date,
                 thread: { id: member.channel_id, model: "discuss.channel" },

--- a/addons/mail/static/tests/legacy/helpers/mock_server/models/mail_guest.js
+++ b/addons/mail/static/tests/legacy/helpers/mock_server/models/mail_guest.js
@@ -8,30 +8,4 @@ patch(MockServer.prototype, {
         const guestId = this.pyEnv?.cookie.get("dgid");
         return guestId ? this.pyEnv["mail.guest"].search_read([["id", "=", guestId]])[0] : null;
     },
-    /**
-     * Simulates `_guest_format` on `mail_guest`.
-     *
-     * @private
-     * @returns {Number[]} ids
-     * @returns {Map}
-     */
-    _mockMailGuestGuestFormat(ids) {
-        const guests = this.getRecords("mail.guest", [["id", "in", ids]], {
-            active_test: false,
-        });
-        return new Map(
-            guests.map((guest) => {
-                return [
-                    guest.id,
-                    {
-                        id: guest.id,
-                        im_status: guest.im_status,
-                        name: guest.name,
-                        type: "guest",
-                        write_date: guest.write_date,
-                    },
-                ];
-            })
-        );
-    },
 });

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -126,10 +126,7 @@ async function mail_attachment_upload(request) {
         DiscussVoiceMetadata.create({ attachment_id: attachmentId });
     }
     return {
-        data: new mailDataHelpers.Store(
-            "Attachment",
-            IrAttachment._attachment_format([attachmentId])
-        ).get_result(),
+        data: new mailDataHelpers.Store(IrAttachment.browse(attachmentId)).get_result(),
     };
 }
 
@@ -171,10 +168,7 @@ async function load_attachments(request) {
         .sort()
         .slice(0, limit)
         .map(({ id }) => id);
-    return new mailDataHelpers.Store(
-        "Attachment",
-        IrAttachment._attachment_format(attachmentIds)
-    ).get_result();
+    return new mailDataHelpers.Store(IrAttachment.browse(attachmentIds)).get_result();
 }
 
 registerRoute("/mail/rtc/channel/join_call", channel_call_join);
@@ -657,10 +651,7 @@ async function mail_message_update_content(request) {
         MailMessage._cleanup_side_records([message_id]);
     }
     const [message] = MailMessage.search_read([["id", "=", message_id]]);
-    const broadcast_store = new mailDataHelpers.Store(
-        "Attachment",
-        IrAttachment._attachment_format(attachment_ids)
-    );
+    const broadcast_store = new mailDataHelpers.Store(IrAttachment.browse(attachment_ids));
     broadcast_store.add("Message", {
         id: message_id,
         body,

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -171,7 +171,10 @@ async function load_attachments(request) {
         .sort()
         .slice(0, limit)
         .map(({ id }) => id);
-    return IrAttachment._attachment_format(attachmentIds);
+    return new mailDataHelpers.Store(
+        "Attachment",
+        IrAttachment._attachment_format(attachmentIds)
+    ).get_result();
 }
 
 registerRoute("/mail/rtc/channel/join_call", channel_call_join);

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -503,7 +503,6 @@ async function mail_link_preview(request) {
     const MailMessage = this.env["mail.message"];
 
     const { message_id } = await parseRequestParams(request);
-    const linkPreviews = [];
     const [message] = MailMessage.search_read([["id", "=", message_id]]);
     if (message.body.includes("https://make-link-preview.com")) {
         const linkPreviewId = MailLinkPreview.create({
@@ -513,11 +512,11 @@ async function mail_link_preview(request) {
             og_type: "article",
             source_url: "https://make-link-preview.com",
         });
-        const [linkPreview] = MailLinkPreview.search_read([["id", "=", linkPreviewId]]);
-        linkPreviews.push(MailLinkPreview._link_preview_format(linkPreview));
-        BusBus._sendone(MailMessage._bus_notification_target(message_id), "mail.record/insert", {
-            LinkPreview: linkPreviews,
-        });
+        BusBus._sendone(
+            MailMessage._bus_notification_target(message_id),
+            "mail.record/insert",
+            new mailDataHelpers.Store(MailLinkPreview.browse(linkPreviewId)).get_result()
+        );
     }
 }
 
@@ -1046,6 +1045,12 @@ class Store {
             }
         }
         return res;
+    }
+
+    toJSON() {
+        throw Error(
+            "Converting Store to JSON is not supported, you might want to call 'get_result()' instead."
+        );
     }
 }
 

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -125,7 +125,12 @@ async function mail_attachment_upload(request) {
     if (body.get("voice")) {
         DiscussVoiceMetadata.create({ attachment_id: attachmentId });
     }
-    return IrAttachment._attachment_format([attachmentId])[0];
+    return {
+        data: new mailDataHelpers.Store(
+            "Attachment",
+            IrAttachment._attachment_format([attachmentId])
+        ).get_result(),
+    };
 }
 
 registerRoute("/mail/attachment/delete", mail_attachment_delete);

--- a/addons/mail/static/tests/mock_server/mock_models/discuss_channel_member.js
+++ b/addons/mail/static/tests/mock_server/mock_models/discuss_channel_member.js
@@ -143,10 +143,7 @@ export class DiscussChannelMember extends models.ServerModel {
                     data.persona = { id: member.partner_id, type: "partner" };
                 }
                 if (member.guest_id) {
-                    store.add(
-                        "Persona",
-                        MailGuest._guest_format([member.guest_id])[member.guest_id]
-                    );
+                    store.add(MailGuest.browse(member.guest_id));
                     data.persona = { id: member.guest_id, type: "guest" };
                 }
             }

--- a/addons/mail/static/tests/mock_server/mock_models/ir_attachment.js
+++ b/addons/mail/static/tests/mock_server/mock_models/ir_attachment.js
@@ -30,26 +30,29 @@ export class IrAttachment extends webModels.IrAttachment {
     }
 
     /** @param {number} ids */
-    _attachment_format(ids) {
+    _to_store(ids, store) {
         /** @type {import("mock_models").DiscussVoiceMetadata} */
         const DiscussVoiceMetadata = this.env["discuss.voice.metadata"];
 
-        return this.read(ids).map((attachment) => {
+        for (const attachment of this.browse(ids)) {
             const res = {
-                create_date: attachment.create_date,
                 checksum: attachment.checksum,
+                create_date: attachment.create_date,
                 filename: attachment.name,
                 id: attachment.id,
                 mimetype: attachment.mimetype,
                 name: attachment.name,
                 size: attachment.file_size,
+                thread:
+                    attachment.res_id && attachment.model !== "mail.compose.message"
+                        ? { id: attachment.res_id, model: attachment.res_model }
+                        : false,
             };
-            res["thread"] = { id: attachment.res_id, model: attachment.res_model };
             const voice = DiscussVoiceMetadata._filter([["attachment_id", "=", attachment.id]])[0];
             if (voice) {
                 res.voice = true;
             }
-            return res;
-        });
+            store.add("Attachment", res);
+        }
     }
 }

--- a/addons/mail/static/tests/mock_server/mock_models/mail_guest.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_guest.js
@@ -12,22 +12,16 @@ export class MailGuest extends models.ServerModel {
      * @param {Number[]} ids
      * @returns {Record<string, ModelRecord>}
      */
-    _guest_format(ids) {
-        const guests = this._filter([["id", "in", ids]], { active_test: false });
-        return Object.fromEntries(
-            guests.map((guest) => {
-                return [
-                    guest.id,
-                    {
-                        id: guest.id,
-                        im_status: guest.im_status,
-                        name: guest.name,
-                        type: "guest",
-                        write_date: guest.write_date,
-                    },
-                ];
-            })
-        );
+    _to_store(ids, store) {
+        for (const guest of this._filter([["id", "in", ids]], { active_test: false })) {
+            store.add("Persona", {
+                id: guest.id,
+                im_status: guest.im_status,
+                name: guest.name,
+                type: "guest",
+                write_date: guest.write_date,
+            });
+        }
     }
 
     _set_auth_cookie(guestId) {

--- a/addons/mail/static/tests/mock_server/mock_models/mail_link_preview.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_link_preview.js
@@ -4,17 +4,19 @@ export class MailLinkPreview extends models.ServerModel {
     _name = "mail.link.preview";
 
     /** @param {object} linkPreview */
-    _link_preview_format(linkPreview) {
-        return {
-            id: linkPreview.id,
-            message: { id: linkPreview.message_id[0] || linkPreview.message_id },
-            image_mimetype: linkPreview.image_mimetype,
-            og_description: linkPreview.og_description,
-            og_image: linkPreview.og_image,
-            og_mimetype: linkPreview.og_mimetype,
-            og_title: linkPreview.og_title,
-            og_type: linkPreview.og_type,
-            source_url: linkPreview.source_url,
-        };
+    _to_store(ids, store) {
+        for (const linkPreview of this.browse(ids)) {
+            store.add("LinkPreview", {
+                id: linkPreview.id,
+                image_mimetype: linkPreview.image_mimetype,
+                message: linkPreview.message_id ? { id: linkPreview.message_id } : false,
+                og_description: linkPreview.og_description,
+                og_image: linkPreview.og_image,
+                og_mimetype: linkPreview.og_mimetype,
+                og_title: linkPreview.og_title,
+                og_type: linkPreview.og_type,
+                source_url: linkPreview.source_url,
+            });
+        }
     }
 }

--- a/addons/mail/static/tests/mock_server/mock_models/mail_message.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_message.js
@@ -106,10 +106,14 @@ export class MailMessage extends models.ServerModel {
         for (const message of messages) {
             const thread =
                 message.model && this.env[message.model]._filter([["id", "=", message.res_id]])[0];
-            const attachments = IrAttachment._filter([["id", "in", message.attachment_ids]]);
-            const formattedAttachments = IrAttachment._attachment_format(
-                attachments.map((attachment) => attachment.id)
-            ).sort((a1, a2) => (a1.id < a2.id ? -1 : 1)); // sort attachments from oldest to most recent
+            // sort attachments from oldest to most recent;
+            const attachments = IrAttachment._filter([["id", "in", message.attachment_ids]]).sort(
+                (a1, a2) => (a1.id < a2.id ? -1 : 1)
+            );
+            store.add(
+                "Attachment",
+                IrAttachment._attachment_format(attachments.map((attachment) => attachment.id))
+            );
             const partners = ResPartner._filter([["id", "in", message.partner_ids]]);
             const linkPreviews = MailLinkPreview._filter([["id", "in", message.link_preview_ids]]);
             const linkPreviewsFormatted = linkPreviews.map((linkPreview) =>
@@ -149,7 +153,7 @@ export class MailMessage extends models.ServerModel {
                 });
             }
             const response = {
-                attachments: formattedAttachments,
+                attachments: attachments.map((attachment) => ({ id: attachment.id })),
                 body: message.body,
                 create_date: message.create_date,
                 date: message.date,

--- a/addons/mail/static/tests/mock_server/mock_models/mail_message.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_message.js
@@ -100,6 +100,9 @@ export class MailMessage extends models.ServerModel {
         const messages = MailMessage._filter([["id", "in", ids]]).sort(
             (a, b) => ids.indexOf(a) - ids.indexOf(b)
         );
+        const notifications = MailNotification._filtered_for_web_client(
+            MailNotification._filter([["mail_message_id", "in", ids]]).map((n) => n.id)
+        );
         for (const message of messages) {
             const thread =
                 message.model && this.env[message.model]._filter([["id", "=", message.res_id]])[0];
@@ -107,15 +110,6 @@ export class MailMessage extends models.ServerModel {
             const formattedAttachments = IrAttachment._attachment_format(
                 attachments.map((attachment) => attachment.id)
             ).sort((a1, a2) => (a1.id < a2.id ? -1 : 1)); // sort attachments from oldest to most recent
-            const allNotifications = MailNotification._filter([
-                ["mail_message_id", "=", message.id],
-            ]);
-            let notifications = MailNotification._filtered_for_web_client(
-                allNotifications.map((notification) => notification.id)
-            );
-            notifications = MailNotification._notification_format(
-                notifications.map((notification) => notification.id)
-            );
             const partners = ResPartner._filter([["id", "in", message.partner_ids]]);
             const linkPreviews = MailLinkPreview._filter([["id", "in", message.link_preview_ids]]);
             const linkPreviewsFormatted = linkPreviews.map((linkPreview) =>
@@ -155,8 +149,10 @@ export class MailMessage extends models.ServerModel {
                 });
             }
             const response = {
-                ...message,
                 attachments: formattedAttachments,
+                body: message.body,
+                create_date: message.create_date,
+                date: message.date,
                 default_subject:
                     message.model &&
                     message.res_id &&
@@ -164,14 +160,26 @@ export class MailMessage extends models.ServerModel {
                         ? ResFake._message_compute_subject([message.res_id])
                         : MailThread._message_compute_subject([message.res_id])
                     ).get(message.res_id),
+                id: message.id,
+                is_discussion: message.is_discussion,
+                is_note: message.is_note,
                 linkPreviews: linkPreviewsFormatted,
-                reactions: reactionGroups,
-                notifications,
+                message_type: message.message_type,
+                model: message.model,
+                notifications: notifications
+                    .filter((notification) => notification.mail_message_id == message.id)
+                    .map((notification) => ({ id: notification.id })),
                 parentMessage: message.parent_id ? { id: message.parent_id } : false,
+                pinned_at: message.pinned_at,
+                reactions: reactionGroups,
                 recipients: partners.map((p) => ({ id: p.id, name: p.name, type: "partner" })),
                 record_name:
                     thread && (thread.name !== undefined ? thread.name : thread.display_name),
-                pinned_at: message.pinned_at,
+                res_id: message.res_id,
+                scheduledDatetime: false,
+                subject: message.subject,
+                subtype_description: message.subtype_description,
+                write_date: message.write_date,
             };
             delete response.author_id;
             if (message.subtype_id) {
@@ -190,10 +198,14 @@ export class MailMessage extends models.ServerModel {
                 Object.assign(response, { thread });
             }
             if (for_current_user) {
-                const notifications_partners = allNotifications
-                    .filter((notification) => !notification.is_read)
-                    .map((notification) => notification.res_partner_id);
-                response["needaction"] = notifications_partners.includes(this.env.user?.partner_id);
+                response["needaction"] = Boolean(
+                    this.env.user &&
+                        MailNotification.search([
+                            ["mail_message_id", "=", message.id],
+                            ["is_read", "=", false],
+                            ["res_partner_id", "=", this.env.user.partner_id],
+                        ]).length
+                );
                 response["starred"] = message.starred_partner_ids?.includes(
                     this.env.user?.partner_id
                 );
@@ -226,6 +238,7 @@ export class MailMessage extends models.ServerModel {
             }
         }
         this._author_to_store(ids, store);
+        store.add(notifications);
     }
     _author_to_store(ids, store) {
         /** @type {import("mock_models").MailGuest} */
@@ -510,21 +523,19 @@ export class MailMessage extends models.ServerModel {
         const MailNotification = this.env["mail.notification"];
 
         const messages = this._filter([["id", "in", ids]]);
+        const notifications = MailNotification._filtered_for_web_client(
+            MailNotification._filter([["mail_message_id", "in", ids]]).map((n) => n.id)
+        );
         for (const message of messages) {
-            let notifications = MailNotification._filter([["mail_message_id", "=", message.id]]);
-            notifications = MailNotification._filtered_for_web_client(
-                notifications.map((notification) => notification.id)
-            );
-            notifications = MailNotification._notification_format(
-                notifications.map((notification) => notification.id)
-            );
             const message_data = {
                 author: message.author_id ? { id: message.author_id, type: "partner" } : false,
                 body: message.body,
                 date: message.date,
                 id: message.id,
                 message_type: message.message_type,
-                notifications: notifications,
+                notifications: notifications
+                    .filter((notification) => notification.mail_message_id == message.id)
+                    .map((notification) => ({ id: notification.id })),
                 thread: false,
             };
             if (message.res_id) {
@@ -537,6 +548,7 @@ export class MailMessage extends models.ServerModel {
             }
             store.add("Message", message_data);
         }
+        store.add(notifications);
     }
 
     _cleanup_side_records([id]) {

--- a/addons/mail/static/tests/mock_server/mock_models/mail_message.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_message.js
@@ -245,9 +245,9 @@ export class MailMessage extends models.ServerModel {
                 type: "partner",
             };
             if (message.author_guest_id) {
-                const [guest] = MailGuest.search_read([["id", "=", message.author_guest_id]]);
-                store.add("Persona", { id: guest.id, name: guest.name, type: "guest" });
-                data.author = { id: guest.id, type: "guest" };
+                const [guestId] = MailGuest.search([["id", "=", message.author_guest_id]]);
+                store.add(MailGuest.browse(guestId));
+                data.author = { id: guestId, type: "guest" };
             } else if (message.author_id) {
                 const [partner] = ResPartner._filter([["id", "=", message.author_id]], {
                     active_test: false,

--- a/addons/mail/static/tests/mock_server/mock_models/mail_message.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_message.js
@@ -110,10 +110,7 @@ export class MailMessage extends models.ServerModel {
             const attachments = IrAttachment._filter([["id", "in", message.attachment_ids]]).sort(
                 (a1, a2) => (a1.id < a2.id ? -1 : 1)
             );
-            store.add(
-                "Attachment",
-                IrAttachment._attachment_format(attachments.map((attachment) => attachment.id))
-            );
+            store.add(IrAttachment.browse(attachments.map((attachment) => attachment.id)));
             const partners = ResPartner._filter([["id", "in", message.partner_ids]]);
             const linkPreviews = MailLinkPreview._filter([["id", "in", message.link_preview_ids]]);
             const linkPreviewsFormatted = linkPreviews.map((linkPreview) =>

--- a/addons/mail/static/tests/mock_server/mock_models/mail_message.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_message.js
@@ -113,9 +113,7 @@ export class MailMessage extends models.ServerModel {
             store.add(IrAttachment.browse(attachments.map((attachment) => attachment.id)));
             const partners = ResPartner._filter([["id", "in", message.partner_ids]]);
             const linkPreviews = MailLinkPreview._filter([["id", "in", message.link_preview_ids]]);
-            const linkPreviewsFormatted = linkPreviews.map((linkPreview) =>
-                MailLinkPreview._link_preview_format(linkPreview)
-            );
+            store.add(linkPreviews);
             const reactionsPerContent = {};
             for (const reactionId of message.reaction_ids ?? []) {
                 const [reaction] = MailMessageReaction._filter([["id", "=", reactionId]]);
@@ -164,7 +162,7 @@ export class MailMessage extends models.ServerModel {
                 id: message.id,
                 is_discussion: message.is_discussion,
                 is_note: message.is_note,
-                linkPreviews: linkPreviewsFormatted,
+                linkPreviews: linkPreviews.map((linkPreview) => ({ id: linkPreview.id })),
                 message_type: message.message_type,
                 model: message.model,
                 notifications: notifications

--- a/addons/mail/static/tests/mock_server/mock_models/mail_notification.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_notification.js
@@ -30,22 +30,28 @@ export class MailNotification extends models.ServerModel {
     }
 
     /** @param {number[]} ids */
-    _notification_format(ids) {
+    _to_store(ids, store) {
         /** @type {import("mock_models").ResPartner} */
         const ResPartner = this.env["res.partner"];
 
         const notifications = this._filter([["id", "in", ids]]);
-        return notifications.map((notification) => {
+        for (const notification of notifications) {
             const partner = ResPartner._filter([["id", "=", notification.res_partner_id]])[0];
-            return {
-                id: notification.id,
-                notification_type: notification.notification_type,
-                notification_status: notification.notification_status,
+            if (partner) {
+                store.add("Persona", {
+                    displayName: partner.display_name,
+                    id: partner.id,
+                    type: "partner",
+                });
+            }
+            store.add("Notification", {
                 failure_type: notification.failure_type,
-                persona: partner
-                    ? { id: partner.id, displayName: partner.display_name, type: "partner" }
-                    : undefined,
-            };
-        });
+                id: notification.id,
+                message: { id: notification.mail_message_id },
+                notification_status: notification.notification_status,
+                notification_type: notification.notification_type,
+                persona: partner ? { id: partner.id, type: "partner" } : false,
+            });
+        }
     }
 }

--- a/addons/mail/static/tests/mock_server/mock_models/mail_thread.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_thread.js
@@ -624,13 +624,15 @@ export class MailThread extends models.ServerModel {
             res["activities"] = activities.map((activity) => ({ id: activity }));
         }
         if (request_list.includes("attachments")) {
-            const attachments = IrAttachment.search_read([
+            const attachments = IrAttachment._filter([
                 ["res_id", "=", thread.id],
                 ["res_model", "=", this._name],
-            ]); // order not done for simplicity
-            res["attachments"] = IrAttachment._attachment_format(
-                attachments.map((attachment) => attachment.id)
+            ]).sort((a1, a2) => a1.id - a2.id);
+            store.add(
+                "Attachment",
+                IrAttachment._attachment_format(attachments.map((attachment) => attachment.id))
             );
+            res["attachments"] = attachments.map((attachment) => ({ id: attachment.id }));
             res["isLoadingAttachments"] = false;
             res["areAttachmentsLoaded"] = true;
             // Specific implementation of mail.thread.main.attachment

--- a/addons/mail/static/tests/mock_server/mock_models/mail_thread.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_thread.js
@@ -628,10 +628,7 @@ export class MailThread extends models.ServerModel {
                 ["res_id", "=", thread.id],
                 ["res_model", "=", this._name],
             ]).sort((a1, a2) => a1.id - a2.id);
-            store.add(
-                "Attachment",
-                IrAttachment._attachment_format(attachments.map((attachment) => attachment.id))
-            );
+            store.add(IrAttachment.browse(attachments.map((attachment) => attachment.id)));
             res["attachments"] = attachments.map((attachment) => ({ id: attachment.id }));
             res["isLoadingAttachments"] = false;
             res["areAttachmentsLoaded"] = true;

--- a/addons/mail/tests/discuss/test_message_controller.py
+++ b/addons/mail/tests/discuss/test_message_controller.py
@@ -57,7 +57,7 @@ class TestMessageController(HttpCaseWithUserDemo):
             data=json.dumps(
                 {
                     "params": {
-                        "thread_model": self.channel._name,
+                        "thread_model": "discuss.channel",
                         "thread_id": self.channel.id,
                         "post_data": {
                             "body": "test",
@@ -81,7 +81,7 @@ class TestMessageController(HttpCaseWithUserDemo):
             data=json.dumps(
                 {
                     "params": {
-                        "thread_model": self.channel._name,
+                        "thread_model": "discuss.channel",
                         "thread_id": self.channel.id,
                         "post_data": {
                             "body": "test",
@@ -98,7 +98,20 @@ class TestMessageController(HttpCaseWithUserDemo):
         data1 = res2.json()["result"]
         self.assertEqual(
             data1["Message"][0]["attachments"],
-            json.loads(json.dumps(self.attachments[0]._attachment_format(), default=date_utils.json_default)),
+            [
+                    {
+                    "checksum": False,
+                    "create_date": fields.Datetime.to_string(self.attachments[0].create_date),
+                    "id": self.attachments[0].id,
+                    "filename": "File 1",
+                    "name": "File 1",
+                    "size": 0,
+                    "res_name": "Test channel",
+                    "mimetype": "application/octet-stream",
+                    "thread": {"id": self.channel.id, "model": "discuss.channel"},
+                    "voice": False,
+                },
+            ],
             "guest should be allowed to add attachment with token when posting message",
         )
         # test message update: token error
@@ -141,7 +154,32 @@ class TestMessageController(HttpCaseWithUserDemo):
         data2 = res4.json()["result"]
         self.assertEqual(
             data2["Message"][0]["attachments"],
-            json.loads(json.dumps(self.attachments.sorted("id")._attachment_format(), default=date_utils.json_default)),
+            [
+                {
+                    "checksum": False,
+                    "create_date": fields.Datetime.to_string(self.attachments[0].create_date),
+                    "id": self.attachments[0].id,
+                    "filename": "File 1",
+                    "name": "File 1",
+                    "size": 0,
+                    "res_name": "Test channel",
+                    "mimetype": "application/octet-stream",
+                    "thread": {"id": self.channel.id, "model": "discuss.channel"},
+                    "voice": False,
+                },
+                {
+                    "checksum": False,
+                    "create_date": fields.Datetime.to_string(self.attachments[1].create_date),
+                    "id": self.attachments[1].id,
+                    "filename": "File 2",
+                    "name": "File 2",
+                    "size": 0,
+                    "res_name": "Test channel",
+                    "mimetype": "application/octet-stream",
+                    "thread": {"id": self.channel.id, "model": "discuss.channel"},
+                    "voice": False,
+                },
+            ],
             "guest should be allowed to add attachment with token when updating message",
         )
         # test message update: own attachment ok
@@ -162,7 +200,32 @@ class TestMessageController(HttpCaseWithUserDemo):
         data3 = res5.json()["result"]
         self.assertEqual(
             data3["Message"][0]["attachments"],
-            json.loads(json.dumps(self.attachments.sorted("id")._attachment_format(), default=date_utils.json_default)),
+            [
+                {
+                    "checksum": False,
+                    "create_date": fields.Datetime.to_string(self.attachments[0].create_date),
+                    "id": self.attachments[0].id,
+                    "filename": "File 1",
+                    "name": "File 1",
+                    "size": 0,
+                    "res_name": "Test channel",
+                    "mimetype": "application/octet-stream",
+                    "thread": {"id": self.channel.id, "model": "discuss.channel"},
+                    "voice": False,
+                },
+                {
+                    "checksum": False,
+                    "create_date": fields.Datetime.to_string(self.attachments[1].create_date),
+                    "id": self.attachments[1].id,
+                    "filename": "File 2",
+                    "name": "File 2",
+                    "size": 0,
+                    "res_name": "Test channel",
+                    "mimetype": "application/octet-stream",
+                    "thread": {"id": self.channel.id, "model": "discuss.channel"},
+                    "voice": False,
+                },
+            ],
             "guest should be allowed to add own attachment without token when updating message",
         )
 
@@ -220,7 +283,7 @@ class TestMessageController(HttpCaseWithUserDemo):
             data=json.dumps(
                 {
                     "params": {
-                        "thread_model": self.channel._name,
+                        "thread_model": "discuss.channel",
                         "thread_id": self.channel.id,
                         "emails": ["john@test.be"],
                     },
@@ -239,7 +302,7 @@ class TestMessageController(HttpCaseWithUserDemo):
             data=json.dumps(
                 {
                     "params": {
-                        "thread_model": self.channel._name,
+                        "thread_model": "discuss.channel",
                         "thread_id": self.channel.id,
                         "post_data": {
                             "body": "test",
@@ -262,7 +325,7 @@ class TestMessageController(HttpCaseWithUserDemo):
             data=json.dumps(
                 {
                     "params": {
-                        "thread_model": self.channel._name,
+                        "thread_model": "discuss.channel",
                         "thread_id": self.channel.id,
                         "emails": ["john@test.be"],
                         'additional_values': {"john@test.be": {'phone': '123456789'}},
@@ -283,7 +346,7 @@ class TestMessageController(HttpCaseWithUserDemo):
             data=json.dumps(
                 {
                     "params": {
-                        "thread_model": self.channel._name,
+                        "thread_model": "discuss.channel",
                         "thread_id": self.channel.id,
                         "emails": ["john@test.be"],
                     },
@@ -305,7 +368,7 @@ class TestMessageController(HttpCaseWithUserDemo):
             data=json.dumps(
                 {
                     "params": {
-                        "thread_model": self.channel._name,
+                        "thread_model": "discuss.channel",
                         "thread_id": self.channel.id,
                         "post_data": {
                             "body": "test",
@@ -329,7 +392,7 @@ class TestMessageController(HttpCaseWithUserDemo):
             data=json.dumps(
                 {
                     "params": {
-                        "thread_model": self.channel._name,
+                        "thread_model": "discuss.channel",
                         "thread_id": self.channel.id,
                         "post_data": {
                             "body": "test",

--- a/addons/mail/tests/discuss/test_message_controller.py
+++ b/addons/mail/tests/discuss/test_message_controller.py
@@ -97,7 +97,7 @@ class TestMessageController(HttpCaseWithUserDemo):
         self.assertEqual(res2.status_code, 200)
         data1 = res2.json()["result"]
         self.assertEqual(
-            data1["Message"][0]["attachments"],
+            data1["Attachment"],
             [
                     {
                     "checksum": False,
@@ -153,7 +153,7 @@ class TestMessageController(HttpCaseWithUserDemo):
         self.assertEqual(res4.status_code, 200)
         data2 = res4.json()["result"]
         self.assertEqual(
-            data2["Message"][0]["attachments"],
+            data2["Attachment"],
             [
                 {
                     "checksum": False,
@@ -199,7 +199,7 @@ class TestMessageController(HttpCaseWithUserDemo):
         self.assertEqual(res5.status_code, 200)
         data3 = res5.json()["result"]
         self.assertEqual(
-            data3["Message"][0]["attachments"],
+            data3["Attachment"],
             [
                 {
                     "checksum": False,

--- a/addons/mail/tests/test_link_preview.py
+++ b/addons/mail/tests/test_link_preview.py
@@ -77,7 +77,7 @@ class TestLinkPreview(MailCommon):
         content = b""""""
         return self._patched_get_html(None, content)
 
-    def test_search_or_create_from_url(self):
+    def test_get_link_preview_from_url(self):
         test_cases = [
             (self._patch_with_og_properties, self.source_url),
             (self._patch_without_og_properties, self.source_url),

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -321,9 +321,16 @@ class TestDiscussFullPerformance(HttpCase):
                 self._expected_result_for_message(self.channel_livechat_1),
                 self._expected_result_for_message(self.channel_livechat_2),
             ],
+            "Notification": [
+                self._expected_result_for_notification(self.channel_channel_public_1),
+            ],
             "Persona": [
                 self._expected_result_for_persona(self.users[2]),
-                self._expected_result_for_persona(self.users[0], also_livechat=True),
+                self._expected_result_for_persona(
+                    self.users[0],
+                    also_livechat=True,
+                    also_notification=True,
+                ),
                 self._expected_result_for_persona(self.users[12]),
                 self._expected_result_for_persona(self.users[14]),
                 self._expected_result_for_persona(self.users[15]),
@@ -1025,19 +1032,7 @@ class TestDiscussFullPerformance(HttpCase):
                 "message_type": "comment",
                 "model": "discuss.channel",
                 "needaction": True,
-                "notifications": [
-                    {
-                        "failure_type": False,
-                        "id": last_message.notification_ids.id,
-                        "notification_status": "sent",
-                        "notification_type": "inbox",
-                        "persona": {
-                            "displayName": "Ernest Employee",
-                            "id": self.users[0].partner_id.id,
-                            "type": "partner",
-                        },
-                    },
-                ],
+                "notifications": [{"id": last_message.notification_ids.id}],
                 "thread": {"id": channel.id, "model": "discuss.channel"},
                 "parentMessage": False,
                 "pinned_at": False,
@@ -1214,8 +1209,26 @@ class TestDiscussFullPerformance(HttpCase):
             }
         return {}
 
+    def _expected_result_for_notification(self, channel):
+        last_message = channel._get_last_messages()
+        if channel == self.channel_channel_public_1:
+            return {
+                "failure_type": False,
+                "id": last_message.notification_ids.id,
+                "message": {"id": last_message.id},
+                "notification_status": "sent",
+                "notification_type": "inbox",
+                "persona": {"id": self.users[0].partner_id.id, "type": "partner"},
+            }
+        return {}
+
     def _expected_result_for_persona(
-        self, user=None, guest=None, only_inviting=False, also_livechat=False
+        self,
+        user=None,
+        guest=None,
+        only_inviting=False,
+        also_livechat=False,
+        also_notification=False,
     ):
         if user == self.users[0]:
             res = {
@@ -1239,6 +1252,8 @@ class TestDiscussFullPerformance(HttpCase):
                         "is_public": False,
                     }
                 )
+            if also_notification:
+                res["displayName"] = "Ernest Employee"
             return res
         if user == self.users[1]:
             return {

--- a/addons/test_mail/tests/test_mail_followers.py
+++ b/addons/test_mail/tests/test_mail_followers.py
@@ -898,19 +898,7 @@ class UnfollowFromInboxTest(MailCommon, HttpCase):
                     "message_type": "notification",
                     "model": "mail.test.simple",
                     "needaction": True,
-                    "notifications": [
-                        {
-                            "failure_type": False,
-                            "id": notif.id,
-                            "notification_status": "sent",
-                            "notification_type": "inbox",
-                            "persona": {
-                                "displayName": "Ernest Employee",
-                                "id": self.env.user.partner_id.id,
-                                "type": "partner",
-                            },
-                        },
-                    ],
+                    "notifications": [{"id": notif.id}],
                     "pinned_at": False,
                     "reactions": [],
                     "recipients": [
@@ -927,6 +915,16 @@ class UnfollowFromInboxTest(MailCommon, HttpCase):
                     "write_date": fields.Datetime.to_string(message.write_date),
                 },
             ],
+            "Notification": [
+                {
+                    "failure_type": False,
+                    "id": notif.id,
+                    "message": {"id": message.id},
+                    "notification_status": "sent",
+                    "notification_type": "inbox",
+                    "persona": {"id": self.env.user.partner_id.id, "type": "partner"},
+                },
+            ],
             "Persona": [
                 {
                     "id": self.user_admin.partner_id.id,
@@ -936,6 +934,11 @@ class UnfollowFromInboxTest(MailCommon, HttpCase):
                     "type": "partner",
                     "userId": self.user_admin.id,
                     "write_date": fields.Datetime.to_string(self.user_admin.write_date),
+                },
+                {
+                    "displayName": "Ernest Employee",
+                    "id": self.env.user.partner_id.id,
+                    "type": "partner",
                 },
             ],
             "Thread": [

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -1387,30 +1387,7 @@ class TestMessageToStorePerformance(BaseMailPerformance):
                                     "message_type": "comment",
                                     "model": "mail.test.simple",
                                     "needaction": True,
-                                    "notifications": [
-                                        {
-                                            "id": notif_1.id,
-                                            "notification_type": "inbox",
-                                            "notification_status": "sent",
-                                            "failure_type": False,
-                                            "persona": {
-                                                "id": self.user_test_inbox.partner_id.id,
-                                                "displayName": "Paulette Testouille",
-                                                "type": "partner",
-                                            },
-                                        },
-                                        {
-                                            "id": notif_2.id,
-                                            "notification_type": "inbox",
-                                            "notification_status": "sent",
-                                            "failure_type": False,
-                                            "persona": {
-                                                "id": self.user_test_inbox_2.partner_id.id,
-                                                "displayName": "Jeannette Testouille",
-                                                "type": "partner",
-                                            },
-                                        },
-                                    ],
+                                    "notifications": [{"id": notif_1.id}, {"id": notif_2.id}],
                                     "pinned_at": False,
                                     "reactions": [],
                                     "recipients": [],
@@ -1425,6 +1402,30 @@ class TestMessageToStorePerformance(BaseMailPerformance):
                                     "write_date": fields.Datetime.to_string(message.write_date),
                                 },
                             ],
+                            "Notification": [
+                                {
+                                    "failure_type": False,
+                                    "id": notif_1.id,
+                                    "message": {"id": message.id},
+                                    "notification_status": "sent",
+                                    "notification_type": "inbox",
+                                    "persona": {
+                                        "id": self.user_test_inbox.partner_id.id,
+                                        "type": "partner",
+                                    },
+                                },
+                                {
+                                    "failure_type": False,
+                                    "id": notif_2.id,
+                                    "message": {"id": message.id},
+                                    "notification_status": "sent",
+                                    "notification_type": "inbox",
+                                    "persona": {
+                                        "id": self.user_test_inbox_2.partner_id.id,
+                                        "type": "partner",
+                                    },
+                                },
+                            ],
                             "Persona": [
                                 {
                                     "id": self.env.user.partner_id.id,
@@ -1434,7 +1435,17 @@ class TestMessageToStorePerformance(BaseMailPerformance):
                                     "type": "partner",
                                     "userId": self.env.user.id,
                                     "write_date": fields.Datetime.to_string(self.env.user.write_date),
-                                }
+                                },
+                                {
+                                    "displayName": "Paulette Testouille",
+                                    "id": self.user_test_inbox.partner_id.id,
+                                    "type": "partner",
+                                },
+                                {
+                                    "displayName": "Jeannette Testouille",
+                                    "id": self.user_test_inbox_2.partner_id.id,
+                                    "type": "partner",
+                                },
                             ],
                             "Thread": [
                                 {
@@ -1479,30 +1490,7 @@ class TestMessageToStorePerformance(BaseMailPerformance):
                                     "message_type": "comment",
                                     "model": "mail.test.simple",
                                     "needaction": True,
-                                    "notifications": [
-                                        {
-                                            "id": notif_1.id,
-                                            "notification_type": "inbox",
-                                            "notification_status": "sent",
-                                            "failure_type": False,
-                                            "persona": {
-                                                "id": self.user_test_inbox.partner_id.id,
-                                                "displayName": "Paulette Testouille",
-                                                "type": "partner",
-                                            },
-                                        },
-                                        {
-                                            "id": notif_2.id,
-                                            "notification_type": "inbox",
-                                            "notification_status": "sent",
-                                            "failure_type": False,
-                                            "persona": {
-                                                "id": self.user_test_inbox_2.partner_id.id,
-                                                "displayName": "Jeannette Testouille",
-                                                "type": "partner",
-                                            },
-                                        },
-                                    ],
+                                    "notifications": [{"id": notif_1.id}, {"id": notif_2.id}],
                                     "pinned_at": False,
                                     "reactions": [],
                                     "recipients": [],
@@ -1517,6 +1505,30 @@ class TestMessageToStorePerformance(BaseMailPerformance):
                                     "write_date": fields.Datetime.to_string(message.write_date),
                                 },
                             ],
+                            "Notification": [
+                                {
+                                    "failure_type": False,
+                                    "id": notif_1.id,
+                                    "message": {"id": message.id},
+                                    "notification_status": "sent",
+                                    "notification_type": "inbox",
+                                    "persona": {
+                                        "id": self.user_test_inbox.partner_id.id,
+                                        "type": "partner",
+                                    },
+                                },
+                                {
+                                    "failure_type": False,
+                                    "id": notif_2.id,
+                                    "message": {"id": message.id},
+                                    "notification_status": "sent",
+                                    "notification_type": "inbox",
+                                    "persona": {
+                                        "id": self.user_test_inbox_2.partner_id.id,
+                                        "type": "partner",
+                                    },
+                                },
+                            ],
                             "Persona": [
                                 {
                                     "id": self.env.user.partner_id.id,
@@ -1526,7 +1538,17 @@ class TestMessageToStorePerformance(BaseMailPerformance):
                                     "type": "partner",
                                     "userId": self.env.user.id,
                                     "write_date": fields.Datetime.to_string(self.env.user.write_date),
-                                }
+                                },
+                                {
+                                    "displayName": "Paulette Testouille",
+                                    "id": self.user_test_inbox.partner_id.id,
+                                    "type": "partner",
+                                },
+                                {
+                                    "displayName": "Jeannette Testouille",
+                                    "id": self.user_test_inbox_2.partner_id.id,
+                                    "type": "partner",
+                                },
                             ],
                             "Thread": [
                                 {


### PR DESCRIPTION
This will reduce data transferred to the client and processed in JS when the same guest, attachment or notification was appearing multiple times in result.

This also makes more clear what is transferred by avoiding nested values.

This is part 6, focusing on guest, attachment, notification, link preview.

Formatting code eventually becomes simpler too, by always adding data to the store rather than updating pre-existing dict manually.

Part of task-3605717

https://github.com/odoo/enterprise/pull/66327