### PR TITLE
[FIX] Holiday allocation fails to recalculate on weird calendars

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -319,10 +319,10 @@ class HolidaysAllocation(models.Model):
         for allocation in self:
             allocation.number_of_days = allocation.number_of_days_display
             if allocation.type_request_unit == 'hour':
-                allocation.number_of_days = allocation.number_of_hours_display / \
-                    (allocation.employee_id.sudo().resource_calendar_id.hours_per_day \
-                    or allocation.holiday_status_id.company_id.resource_calendar_id.hours_per_day \
-                    or HOURS_PER_DAY)
+                allocation_hours_per_day = allocation.holiday_status_id.company_id.resource_calendar_id.hours_per_day or HOURS_PER_DAY
+                if allocation.holiday_type == 'employee' and allocation.employee_id:
+                    allocation_hours_per_day = allocation.employee_id.sudo().resource_calendar_id.hours_per_day
+                allocation.number_of_days = allocation.number_of_hours_display / allocation_hours_per_day
             if allocation.accrual_plan_id.time_off_type_id.id not in (False, allocation.holiday_status_id.id):
                 allocation.accrual_plan_id = False
             if allocation.allocation_type == 'accrual' and not allocation.accrual_plan_id:

--- a/doc/cla/individual/Ismaw34.md
+++ b/doc/cla/individual/Ismaw34.md
@@ -1,0 +1,11 @@
+Spain, 2024/07/09
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Ismael Navarro. ismaw34@hotmail.com https://github.com/Ismaw34


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When using a calendar with hours different than 8 per day, the calculation of the days to hours fails.

Current behavior before PR:
Set an employee calendar to less or more than 8 hours per day.
Set the company to another value, not 8 and not the same as the employee.
Set a new allocate time off with type of hours.
Put any kind of hours.
The calculation fails and sets the hours at whatever conversion is the 8 per day.

Desired behavior after PR is merged:
The calculations are made now the same way forward and backwards (hours to days and days to hours). Using the calendar from the employee or company based on the target calendar.

What is made:
The original code searched the employee's calendar by default then the company's calendar and then the 8 hours default without using the desired calendar type.
Now the code does the same check and uses the appropriate calendar when converting the hours to days.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
