### PR TITLE
[FIX] l10n_es_edi_facutrae: fix LegalReference length

### DIFF
--- a/addons/l10n_es_edi_facturae/data/facturae_templates.xml
+++ b/addons/l10n_es_edi_facturae/data/facturae_templates.xml
@@ -252,7 +252,7 @@
                     </Installment>
                 </PaymentDetails>
                 <LegalLiterals t-if="invoice.get('LegalLiterals')">
-                    <t t-foreach="invoice['LegalLiterals']" t-as="reference"><LegalReference t-out="reference"/></t>
+                    <t t-foreach="invoice['LegalLiterals']" t-as="reference"><LegalReference t-out="reference[:250]"/></t>
                 </LegalLiterals>
             </Invoice>
         </template>


### PR DESCRIPTION
Customers are unable to submit their invoice if the LegalReference is more than 250 letters. This commit fixes this.

task-4043343