### PR TITLE
[IMP] website default fontpair

### DIFF
--- a/addons/test_website_slides_full/static/tests/tours/slides_certification_member.js
+++ b/addons/test_website_slides_full/static/tests/tours/slides_certification_member.js
@@ -2,6 +2,7 @@
 
 import { registry } from "@web/core/registry";
 import tourUtils from '@website_sale/js/tours/tour_utils';
+import wTourUtils from "@website/js/tours/tour_utils";
 
 /**
  * The purpose of this tour is to check the whole certification flow:
@@ -51,9 +52,10 @@ var buyCertificationSteps = [{
     tourUtils.goToCart(),
     tourUtils.goToCheckout(),
     ...tourUtils.payWithDemo(),
+    wTourUtils.clickOnExtraMenuItem({}),
 {
     content: 'eCommerce: go back to e-learning home page',
-    trigger: '.nav-link:contains("Courses")',
+    trigger: '.nav-item a:contains("Courses")',
     run: "click",
 }, {
     content: 'eLearning: go into bought course',
@@ -143,9 +145,11 @@ var certificationCompletionSteps = [{
     content: 'Survey: back to course home page',
     trigger: 'a:contains("Go back to course")',
     run: "click",
-}, {
+},
+    wTourUtils.clickOnExtraMenuItem({}),
+{
     content: 'eLearning: back to e-learning home page',
-    trigger: '.nav-link:contains("Courses")',
+    trigger: '.nav-item a:contains("Courses")',
     run: "click",
 }, {
     content: 'eLearning: course should be completed',

--- a/addons/website/static/src/scss/primary_variables.scss
+++ b/addons/website/static/src/scss/primary_variables.scss
@@ -2094,8 +2094,9 @@ $o-website-values-palettes: (
         // By default, the $o-base-website-values-palette for fonts are "null"
         // but will actually automatically be filled with the first font themes
         // define in $o-theme-font-configs (for the base one). For the default
-        // website, we want to specifically use the system fonts.
-        'font': 'SYSTEM_FONTS',
+        // website, we use a combination of Inter Tight for headings and Inter.
+        'headings-font': 'Inter Tight',
+        'font': 'Inter',
 
         'btn-padding-x': 1rem,
         'btn-padding-x-sm': .5rem,
@@ -2172,6 +2173,14 @@ $o-theme-font-configs: (
     'Arvo': (
         'family': ('Arvo', Times, serif),
         'url': 'Arvo:300,300i,400,400i,700,700i',
+    ),
+    'Inter Tight': (
+        'family': ('Inter Tight', sans-serif),
+        'url': 'Inter+Tight:300,300i,400,400i,500,500i,700,700i',
+    ),
+    'Inter': (
+        'family': ('Inter', sans-serif),
+        'url': 'Inter:300,300i,400,400i,700,700i',
     ),
 ) !default;
 


### PR DESCRIPTION
This PR/task is handled by @chgo-odoo 

--- 

This PR reintroduces a pair of fonts for the default website theme.

Since Odoo 16 and Commit[1], we switched the default theme fonts from
a pair (heading/body) to system fonts, for optimization purposes.

As Odoo 18 will introduce lots of design update to the default theme
including an update of the snippets design as well as new building
blocks allowing users to pick from a variety of layouts, we want to
showcase our default theme, by using two fonts, enforcing visual
hierarchy, as well as aesthetic.

This PR introduces two new fonts:

1- "Inter Tight" for the headings.
2- "Inter" as the "body" one.

Important:

The new default fonts are also slightly affecting the menu "auto hide"
`width` computation, which leads to have more items added to the "extra
menu dropdown" in some viewports.

In this PR, we also adapt affected tour steps trying to reach menu
items but not taking the "auto hide" mechanism into consideration.

Commit[1]: https://github.com/odoo/odoo/commit/c0f2f670eb087991cc9a6a67f4beea5f12bd15f2

---

task-4043383