### PR TITLE
[FIX] project,lunch: let user to set a project/lunch product as favorite

### DIFF
--- a/addons/lunch/__manifest__.py
+++ b/addons/lunch/__manifest__.py
@@ -52,6 +52,7 @@ If you want to save your employees' time and avoid them to always have coins in 
             'lunch/static/tests/tours/*.js',
         ],
         'web.qunit_suite_tests': [
+            'lunch/static/tests/lunch_is_favorite_field_tests.js',
             'lunch/static/tests/lunch_kanban_tests.js',
         ],
     },

--- a/addons/lunch/static/src/components/lunch_is_favorite_field.js
+++ b/addons/lunch/static/src/components/lunch_is_favorite_field.js
@@ -1,0 +1,14 @@
+import { registry } from "@web/core/registry";
+import { booleanFavoriteField } from "@web/views/fields/boolean_favorite/boolean_favorite_field";
+
+export const lunchIsFavoriteField = {
+    ...booleanFavoriteField,
+    extractProps: (fieldsInfo, dynamicInfo) => {
+        return {
+            ...booleanFavoriteField.extractProps(fieldsInfo, dynamicInfo),
+            readonly: Boolean(fieldsInfo.attrs.readonly),
+        };
+    },
+};
+
+registry.category("fields").add("lunch_is_favorite", lunchIsFavoriteField);

--- a/addons/lunch/static/tests/lunch_is_favorite_field_tests.js
+++ b/addons/lunch/static/tests/lunch_is_favorite_field_tests.js
@@ -1,0 +1,97 @@
+import { getFixture, click } from "@web/../tests/helpers/utils";
+import { makeView, setupViewRegistries } from "@web/../tests/views/helpers";
+
+let makeViewParams, target;
+
+QUnit.module("Lunch", (hooks) => {
+    hooks.beforeEach(() => {
+        makeViewParams = {
+            type: "kanban",
+            resModel: "lunch.product",
+            serverData: {
+                models: {
+                    "lunch.product": {
+                        fields: {
+                            id: { string: "Id", type: "integer" },
+                            name: { string: "Name", type: "string" },
+                            is_favorite: { string: "Favorite", type: "boolean" },
+                        },
+                        records: [{ id: 1, name: "Product A" }],
+                    },
+                },
+            },
+            arch: `
+                <kanban class="o_kanban_test" edit="0">
+                    <template>
+                        <t t-name="kanban-box">
+                            <div>
+                                <field name="is_favorite" widget="lunch_is_favorite" nolabel="1"/>
+                                <field name="name"/>
+                            </div>
+                        </t>
+                    </template>
+                </kanban>`,
+        };
+        target = getFixture();
+        setupViewRegistries();
+    });
+    QUnit.module("Components", (hooks) => {
+        QUnit.module("lunch_is_favorite");
+        QUnit.test(
+            "Check is_favorite field is still editable even if the record/view is in readonly",
+            async function (assert) {
+                await makeView({
+                    ...makeViewParams,
+                    async mockRPC(route, { method, args }) {
+                        if (method === "web_save") {
+                            const [ids, vals] = args;
+                            if ("is_favorite" in vals) {
+                                assert.deepEqual(ids, [1]);
+                                assert.strictEqual(vals.is_favorite, true);
+                                assert.step(method);
+                            }
+                        }
+                    },
+                });
+
+                assert.containsOnce(
+                    target,
+                    'div[name="is_favorite"] .o_favorite',
+                    "The is_favorite field should be displayed"
+                );
+                await click(target, 'div[name="is_favorite"] .o_favorite');
+                assert.verifySteps(["web_save"]);
+            }
+        );
+
+        QUnit.test(
+            "Check is_favorite field is readonly if the field is readonly",
+            async function (assert) {
+                makeViewParams.arch = makeViewParams.arch.replace(
+                    'widget="lunch_is_favorite"',
+                    'widget="lunch_is_favorite" readonly="1"'
+                );
+                await makeView({
+                    ...makeViewParams,
+                    async mockRPC(route, { method, args }) {
+                        if (method === "web_save") {
+                            const [ids, vals] = args;
+                            if ("is_favorite" in vals) {
+                                assert.deepEqual(ids, [1]);
+                                assert.strictEqual(vals.is_favorite, true);
+                                assert.step(method);
+                            }
+                        }
+                    },
+                });
+                assert.containsOnce(
+                    target,
+                    'div[name="is_favorite"] .o_favorite',
+                    "The is_favorite field should be displayed"
+                );
+                await click(target, 'div[name="is_favorite"] .o_favorite');
+                assert.verifySteps([]);
+            }
+        );
+    });
+});

--- a/addons/lunch/views/lunch_product_views.xml
+++ b/addons/lunch/views/lunch_product_views.xml
@@ -121,7 +121,7 @@
                                         <strong class="o_kanban_record_title">
                                             <div class="d-flex align-items-center justify-content-between">
                                                 <div>
-                                                    <field class="pe-1" name="is_favorite" widget="boolean_favorite" nolabel="1"/>
+                                                    <field class="pe-1" name="is_favorite" widget="lunch_is_favorite" nolabel="1"/>
                                                     <strong><span t-esc="record.name.value"/></strong>
                                                 </div>
                                                 <div class="text-primary">

--- a/addons/project/static/src/components/project_is_favorite/project_is_favorite_field.js
+++ b/addons/project/static/src/components/project_is_favorite/project_is_favorite_field.js
@@ -1,0 +1,14 @@
+import { registry } from "@web/core/registry";
+import { booleanFavoriteField } from "@web/views/fields/boolean_favorite/boolean_favorite_field";
+
+export const projectIsFavoriteField = {
+    ...booleanFavoriteField,
+    extractProps: (fieldsInfo, dynamicInfo) => {
+        return {
+            ...booleanFavoriteField.extractProps(fieldsInfo, dynamicInfo),
+            readonly: Boolean(fieldsInfo.attrs.readonly),
+        };
+    },
+};
+
+registry.category("fields").add("project_is_favorite", projectIsFavoriteField);

--- a/addons/project/static/tests/project_is_favorite_field_tests.js
+++ b/addons/project/static/tests/project_is_favorite_field_tests.js
@@ -1,0 +1,97 @@
+import { getFixture, click } from "@web/../tests/helpers/utils";
+import { makeView, setupViewRegistries } from "@web/../tests/views/helpers";
+
+let makeViewParams, target;
+
+QUnit.module("Project", (hooks) => {
+    hooks.beforeEach(() => {
+        makeViewParams = {
+            type: "kanban",
+            resModel: "project.project",
+            serverData: {
+                models: {
+                    "project.project": {
+                        fields: {
+                            id: { string: "Id", type: "integer" },
+                            name: { string: "Name", type: "string" },
+                            is_favorite: { string: "Favorite", type: "boolean" },
+                        },
+                        records: [{ id: 1, name: "Project A" }],
+                    },
+                },
+            },
+            arch: `
+                <kanban class="o_kanban_test" edit="0">
+                    <template>
+                        <t t-name="kanban-box">
+                            <div>
+                                <field name="is_favorite" widget="project_is_favorite" nolabel="1"/>
+                                <field name="name"/>
+                            </div>
+                        </t>
+                    </template>
+                </kanban>`,
+        };
+        target = getFixture();
+        setupViewRegistries();
+    });
+    QUnit.module("Components", (hooks) => {
+        QUnit.module("project_is_favorite");
+        QUnit.test(
+            "Check is_favorite field is still editable even if the field is in readonly",
+            async function (assert) {
+                await makeView({
+                    ...makeViewParams,
+                    async mockRPC(route, { method, args }) {
+                        if (method === "web_save") {
+                            const [ids, vals] = args;
+                            if ("is_favorite" in vals) {
+                                assert.deepEqual(ids, [1]);
+                                assert.strictEqual(vals.is_favorite, true);
+                                assert.step(method);
+                            }
+                        }
+                    },
+                });
+
+                assert.containsOnce(
+                    target,
+                    'div[name="is_favorite"] .o_favorite',
+                    "The is_favorite field should be displayed"
+                );
+                await click(target, 'div[name="is_favorite"] .o_favorite');
+                assert.verifySteps(["web_save"]);
+            }
+        );
+
+        QUnit.test(
+            "Check is_favorite field is readonly if the field is readonly",
+            async function (assert) {
+                makeViewParams.arch = makeViewParams.arch.replace(
+                    'widget="project_is_favorite"',
+                    'widget="project_is_favorite" readonly="1"'
+                );
+                await makeView({
+                    ...makeViewParams,
+                    async mockRPC(route, { method, args }) {
+                        if (method === "web_save") {
+                            const [ids, vals] = args;
+                            if ("is_favorite" in vals) {
+                                assert.deepEqual(ids, [1]);
+                                assert.strictEqual(vals.is_favorite, true);
+                                assert.step(method);
+                            }
+                        }
+                    },
+                });
+                assert.containsOnce(
+                    target,
+                    'div[name="is_favorite"] .o_favorite',
+                    "The is_favorite field should be displayed"
+                );
+                await click(target, 'div[name="is_favorite"] .o_favorite');
+                assert.verifySteps([]);
+            }
+        );
+    });
+});

--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -71,7 +71,7 @@
                     <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
                     <div class="oe_title">
                         <h1 class="d-flex flex-row">
-                            <field name="is_favorite" nolabel="1" widget="boolean_favorite" class="me-2"/>
+                            <field name="is_favorite" nolabel="1" widget="project_is_favorite" class="me-2"/>
                             <field name="name" options="{'line_breaks': False}" widget="text" class="o_text_overflow" placeholder="e.g. Office Party"/>
                         </h1>
                     </div>
@@ -225,7 +225,7 @@
                     <field name="can_mark_milestone_as_done" column_invisible="True"/>
                     <field name="is_milestone_deadline_exceeded" column_invisible="1"/>
                     <field name="allow_milestones" column_invisible="True"/>
-                    <field name="is_favorite" string="Favorite" nolabel="1" widget="boolean_favorite" optional="hide"/>
+                    <field name="is_favorite" string="Favorite" nolabel="1" widget="project_is_favorite" optional="hide"/>
                     <field name="display_name" string="Name" class="fw-bold"/>
                     <field name="partner_id" optional="show" string="Customer"/>
                     <field name="company_id" optional="show" groups="base.group_multi_company" options="{'no_create': True, 'no_open': True}"/>
@@ -467,7 +467,7 @@
                         <t t-name="kanban-box">
                             <div t-attf-class="#{kanban_color(record.color.raw_value)} oe_kanban_global_click o_has_icon oe_kanban_content oe_kanban_card">
                                 <div class="o_project_kanban_main d-flex align-items-baseline gap-1">
-                                    <field name="is_favorite" widget="boolean_favorite" nolabel="1" force_save="1"/>
+                                    <field name="is_favorite" widget="project_is_favorite" nolabel="1" force_save="1"/>
                                     <div class="o_kanban_card_content mw-100">
                                         <div class="o_kanban_primary_left">
                                             <div class="o_primary me-5">
@@ -588,7 +588,7 @@
                     js_class="project_project_calendar">
                     <field name="partner_id" invisible="not partner_id"/>
                     <field name="user_id" widget="many2one_avatar_user" invisible="not user_id"/>
-                    <field name="is_favorite" widget="boolean_favorite" nolabel="1" string="Favorite"/>
+                    <field name="is_favorite" widget="project_is_favorite" nolabel="1" string="Favorite"/>
                     <field name="stage_id" groups="project.group_project_stages" invisible="not stage_id"/>
                     <field name="last_update_color" invisible="1"/>
                     <field name="last_update_status" string="Status" widget="status_with_color" invisible="last_update_status == 'to_define'"/>


### PR DESCRIPTION
## [FIX] project: let project user to set a project as favorite

Before this commit, since the project user cannot edit a project and a
recent fix (https://github.com/odoo/odoo/pull/168464) ensures the boolean_favorite widget is readonly is the field
is readonly or if the record is readonly then the project user can no
longer mark a project in favorite.

This commit overrides the standard widget `boolean_favorite` for project
to make sure the widget is always editable if the field is not in
readonly.

task-4041969

## [FIX] lunch: allow employee to save as favorite a product in lunch

Before this commit, the current user could have no access to lunch app
to add/edit product, etc. Since the user cannot edit `lunch.product`
model, he can no longer save as favorite a product since a recent bug
fix (https://github.com/odoo/odoo/pull/168464) to ensure the button is in readonly when the field or the record is
in readonly.

This commit makes sure the user can always save as favorite even if the
record is readonly for the user since the user just has to choose what
he would like to eat during lunch break and so he just needs to select
and save as favorite.

task-4041969
