### PR TITLE
[FIX] mail: avoid markup on an empty string

### DIFF
--- a/addons/mail/static/src/model/store_internal.js
+++ b/addons/mail/static/src/model/store_internal.js
@@ -174,7 +174,7 @@ export class StoreInternal extends RecordInternal {
             shouldChange =
                 record[fieldName]?.toString() !== value?.toString() ||
                 !(record[fieldName] instanceof Markup);
-            newValue = typeof value === "string" ? markup(value) : value;
+            newValue = value && typeof value === "string" ? markup(value) : value;
         }
         if (shouldChange) {
             record._.updatingAttrs.set(fieldName, true);


### PR DESCRIPTION
Before this commit, a field with an empty string and html option (eg: `message.body`), would `markup` an empty string.

This is an issue because `markup` will return an empty object that is `true` by default whereas an empty string is `false`.

This PR adds a value check before doing the `markup`.
