### PR TITLE
[FIX] web: view: className for lazy views

### DIFF
--- a/addons/web/static/src/views/view.js
+++ b/addons/web/static/src/views/view.js
@@ -318,17 +318,17 @@ export class View extends Component {
         const jsClass = archXmlDoc.hasAttribute("js_class")
             ? archXmlDoc.getAttribute("js_class")
             : type;
+        if (!viewRegistry.contains(jsClass)) {
+            await loadBundle(DEFAULT_LAZY_BUNDLE);
+        }
+        const descr = viewRegistry.get(jsClass);
+
         const bannerRoute = archXmlDoc.getAttribute("banner_route");
         const sample = archXmlDoc.getAttribute("sample");
         const className = computeViewClassName(type, archXmlDoc, [
             "o_view_controller",
             ...(props.className || "").split(" "),
         ]);
-
-        if (!viewRegistry.contains(jsClass)) {
-            await loadBundle(DEFAULT_LAZY_BUNDLE);
-        }
-        const descr = viewRegistry.get(jsClass);
 
         Object.assign(this.env.config, {
             rawArch: arch,


### PR DESCRIPTION
The computation of className in View is done via computeViewClassName and is based on the content of the view registry (getViewClass looks at it). So for lazy views, we have to compute className only when we are sure that the bundle "web.assets_backend_lazy" has been loaded.

