### PR TITLE
[FIX] pos_event: assign default event category to product ticket

### DIFF
--- a/addons/pos_event/models/event_ticket.py
+++ b/addons/pos_event/models/event_ticket.py
@@ -19,7 +19,7 @@ class EventTicket(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         tickets = super().create(vals_list)
-        self.make_product_event_available_in_pos()
+        tickets.make_product_event_available_in_pos()
         return tickets
 
     def write(self, vals):


### PR DESCRIPTION
Before this commit, when creating a new product ticket, the default event category was not correctly assigned to the product.

This commit fixes this issue by assigning the default event category to the product ticket.

taskId: 4032781


