### PR TITLE
[FIX] point_of_sale: raise a warning when opening session with superuser

### DIFF
--- a/addons/point_of_sale/i18n/point_of_sale.pot
+++ b/addons/point_of_sale/i18n/point_of_sale.pot
@@ -7311,6 +7311,15 @@ msgstr ""
 #: code:addons/point_of_sale/models/pos_session.py:0
 #, python-format
 msgid ""
+"You do not have permission to open a POS session. Please try opening a "
+"session with a different user"
+msgstr ""
+
+#. module: point_of_sale
+#. odoo-python
+#: code:addons/point_of_sale/models/pos_session.py:0
+#, python-format
+msgid ""
 "You don't have the access rights to get the point of sale closing control "
 "data."
 msgstr ""

--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -1851,7 +1851,10 @@ class PosSession(models.Model):
         }
 
     def _get_pos_ui_res_users(self, params):
-        user = self.env['res.users'].search_read(**params['search_params'])[0]
+        user = self.env['res.users'].search_read(**params['search_params'], limit=1)
+        if not user:
+            raise UserError(_("You do not have permission to open a POS session. Please try opening a session with a different user"))
+        user = user[0]
         user['role'] = 'manager' if any(id == self.config_id.group_pos_manager_id.id for id in user['groups_id']) else 'cashier'
         del user['groups_id']
         return user


### PR DESCRIPTION
The following error occurs when you try to open a session as the superuser.

Steps to reproduce:

- Install the ``Point_of_sale`` module
- Activate developer mode / click on debugger / Become superuser
- Point of sale / click on open Register

Traceback: 
``IndexError: list index out of range``

This error occurs when we open a session as a superuser. When we attempt to open it, at line [1] ``res.users`` is returned as empty.

[1]- https://github.com/odoo/odoo/blob/585635e8afa531b8a66295a4afe0fcdd369ed188/addons/point_of_sale/models/pos_session.py#L379

sentry-5082852453

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
