### PR TITLE
[FIX] account,*: Rename field reversal_move_id (one2many) to reversal…

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -487,7 +487,7 @@ class AccountMove(models.Model):
         copy=False,
         check_company=True,
     )
-    reversal_move_id = fields.One2many('account.move', 'reversed_entry_id')
+    reversal_move_ids = fields.One2many('account.move', 'reversed_entry_id')
 
     # === Vendor bill fields === #
     invoice_vendor_bill_id = fields.Many2one(

--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -3784,7 +3784,7 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
 
                 line_receivable.remove_move_reconcile()
 
-                exchange_move_reversal = exchange_move.reversal_move_id
+                exchange_move_reversal = exchange_move.reversal_move_ids
 
                 # Date of the reversal of the exchange move should be the last day of the month/year of the payment depending on the sequence format
                 self.assertEqual(exchange_move_reversal.date, fields.Date.to_date(expected_date))

--- a/addons/hr_expense/models/hr_expense_sheet.py
+++ b/addons/hr_expense/models/hr_expense_sheet.py
@@ -243,7 +243,7 @@ class HrExpenseSheet(models.Model):
                     # when the sheet is paid by the company, the state/amount of the related account_move_ids are not relevant
                     # unless all moves have been reversed
                     sheet.amount_residual = 0.
-                    if sheet.account_move_ids - sheet.account_move_ids.filtered('reversal_move_id'):
+                    if sheet.account_move_ids - sheet.account_move_ids.filtered('reversal_move_ids'):
                         sheet.payment_state = 'paid'
                     else:
                         sheet.payment_state = 'reversed'

--- a/addons/l10n_es_edi_facturae/tests/test_edi_xml.py
+++ b/addons/l10n_es_edi_facturae/tests/test_edi_xml.py
@@ -258,7 +258,7 @@ class TestEdiFacturaeXmls(AccountTestInvoicingCommon):
                 'l10n_es_edi_facturae_reason_code': '01'
             })
             reversal_wizard.modify_moves()
-            refund = invoice.reversal_move_id
+            refund = invoice.reversal_move_ids
             refund.ref = 'ABCD-2023-001'
             generated_file, errors = refund._l10n_es_edi_facturae_render_facturae()
             self.assertFalse(errors)

--- a/addons/l10n_hu_edi/models/account_move.py
+++ b/addons/l10n_hu_edi/models/account_move.py
@@ -258,7 +258,7 @@ class AccountMove(models.Model):
         """ Given base invoices, get all invoices in the chain. """
         chain_invoices = self
         next_invoices = self
-        while (next_invoices := next_invoices.reversal_move_id | next_invoices.debit_note_ids):
+        while (next_invoices := next_invoices.reversal_move_ids | next_invoices.debit_note_ids):
             chain_invoices |= next_invoices
         return chain_invoices
 

--- a/addons/l10n_hu_edi/tests/test_flows_mocked.py
+++ b/addons/l10n_hu_edi/tests/test_flows_mocked.py
@@ -142,7 +142,7 @@ class L10nHuEdiTestFlowsMocked(L10nHuEdiTestCommon, TestAccountMoveSendCommon):
                 new_invoice = self.create_reversal(invoice, is_modify=True)
                 self.assertRecordValues(new_invoice, [{'debit_origin_id': invoice.id}])
                 new_invoice.action_post()
-                credit_note = invoice.reversal_move_id
+                credit_note = invoice.reversal_move_ids
 
                 send_and_print = self.create_send_and_print(credit_note, l10n_hu_edi_enable_nav_30=True)
                 send_and_print.action_send_and_print()

--- a/addons/l10n_id_efaktur/models/account_move.py
+++ b/addons/l10n_id_efaktur/models/account_move.py
@@ -22,7 +22,7 @@ class AccountMove(models.Model):
     _inherit = "account.move"
 
     l10n_id_tax_number = fields.Char(string="Tax Number", copy=False)
-    l10n_id_replace_invoice_id = fields.Many2one('account.move', string="Replace Invoice", domain="['|', '&', '&', ('state', '=', 'posted'), ('partner_id', '=', partner_id), ('reversal_move_id', '!=', False), ('state', '=', 'cancel')]", copy=False, index='btree_not_null')
+    l10n_id_replace_invoice_id = fields.Many2one('account.move', string="Replace Invoice", domain="['|', '&', '&', ('state', '=', 'posted'), ('partner_id', '=', partner_id), ('reversal_move_ids', '!=', False), ('state', '=', 'cancel')]", copy=False, index='btree_not_null')
     l10n_id_attachment_id = fields.Many2one('ir.attachment', readonly=True, copy=False)
     l10n_id_csv_created = fields.Boolean('CSV Created', compute='_compute_csv_created', copy=False)
     l10n_id_kode_transaksi = fields.Selection([

--- a/addons/l10n_it_edi_doi/tests/test_amounts_and_warnings.py
+++ b/addons/l10n_it_edi_doi/tests/test_amounts_and_warnings.py
@@ -408,7 +408,7 @@ class TestItEdiDoiRemaining(TestItEdiDoi):
         ).reverse_moves()
 
         # The invoice we reversed invoiced more than the sales order amount.
-        credit_note = invoice.reversal_move_id
+        credit_note = invoice.reversal_move_ids
         self.assertEqual(
             credit_note.l10n_it_edi_doi_warning,
             "Pay attention, the threshold of your Declaration of Intent test 2019-threshold 1000 of 1,000.00\xa0€ is exceeded by 2,000.00\xa0€, this document included.\n"

--- a/addons/purchase_stock/tests/test_anglo_saxon_valuation_reconciliation.py
+++ b/addons/purchase_stock/tests/test_anglo_saxon_valuation_reconciliation.py
@@ -117,7 +117,7 @@ class TestValuationReconciliation(ValuationReconciliationTestCommon):
             'journal_id': invoice.journal_id.id,
         })
         new_invoice = self.env['account.move'].browse(refund_invoice_wiz.modify_moves()['res_id'])
-        refund_invoice = invoice.reversal_move_id
+        refund_invoice = invoice.reversal_move_ids
         # Check the result
         self.assertEqual(invoice.payment_state, 'reversed', "Invoice should be in 'reversed' state")
         self.assertEqual(refund_invoice.payment_state, 'paid', "Refund should be in 'paid' state")

--- a/addons/sale_mrp/models/account_move.py
+++ b/addons/sale_mrp/models/account_move.py
@@ -22,7 +22,7 @@ class AccountMoveLine(models.Model):
                 account_moves = so_line.invoice_lines.move_id.filtered(lambda m: m.state == 'posted' and bool(m.reversed_entry_id) == is_line_reversing)
                 posted_invoice_lines = account_moves.line_ids.filtered(lambda l: l.display_type == 'cogs' and l.product_id == self.product_id and l.balance > 0)
                 qty_invoiced = sum([x.product_uom_id._compute_quantity(x.quantity, x.product_id.uom_id) for x in posted_invoice_lines])
-                reversal_cogs = posted_invoice_lines.move_id.reversal_move_id.line_ids.filtered(lambda l: l.display_type == 'cogs' and l.product_id == self.product_id and l.balance > 0)
+                reversal_cogs = posted_invoice_lines.move_id.reversal_move_ids.line_ids.filtered(lambda l: l.display_type == 'cogs' and l.product_id == self.product_id and l.balance > 0)
                 qty_invoiced -= sum([line.product_uom_id._compute_quantity(line.quantity, line.product_id.uom_id) for line in reversal_cogs])
 
                 moves = so_line.move_ids

--- a/addons/sale_stock/models/account_move.py
+++ b/addons/sale_stock/models/account_move.py
@@ -165,7 +165,7 @@ class AccountMoveLine(models.Model):
                     qty_invoiced += line.product_uom_id._compute_quantity(line.quantity, line.product_id.uom_id)
             value_invoiced = sum(posted_cogs.mapped('balance'))
 
-            reversal_cogs = posted_cogs.move_id.reversal_move_id.line_ids.filtered(lambda l: l.display_type == 'cogs' and l.product_id == self.product_id and l.balance > 0)
+            reversal_cogs = posted_cogs.move_id.reversal_move_ids.line_ids.filtered(lambda l: l.display_type == 'cogs' and l.product_id == self.product_id and l.balance > 0)
             for line in reversal_cogs:
                 if float_compare(line.quantity, 0, precision_rounding=product_uom.rounding) and line.move_id.move_type == 'out_refund' and any(line.move_id.invoice_line_ids.sale_line_ids.mapped('is_downpayment')):
                     qty_invoiced -= line.product_uom_id._compute_quantity(abs(line.quantity), line.product_id.uom_id)

--- a/addons/sale_stock/tests/test_anglo_saxon_valuation_reconciliation.py
+++ b/addons/sale_stock/tests/test_anglo_saxon_valuation_reconciliation.py
@@ -121,9 +121,9 @@ class TestValuationReconciliation(TestValuationReconciliationCommon):
         })
         new_invoice = self.env['account.move'].browse(refund_invoice_wiz.modify_moves()['res_id'])
         self.assertEqual(invoice.payment_state, 'reversed', "Invoice should be in 'reversed' state.")
-        self.assertEqual(invoice.reversal_move_id.payment_state, 'paid', "Refund should be in 'paid' state.")
+        self.assertEqual(invoice.reversal_move_ids.payment_state, 'paid', "Refund should be in 'paid' state.")
         self.assertEqual(new_invoice.state, 'draft', "New invoice should be in 'draft' state.")
-        self.check_reconciliation(invoice.reversal_move_id, return_pick, operation='sale')
+        self.check_reconciliation(invoice.reversal_move_ids, return_pick, operation='sale')
 
     def test_multiple_shipments_invoices(self):
         """ Tests the case into which we deliver part of the goods first, then 2 invoices at different rates, and finally the remaining quantities


### PR DESCRIPTION
…_move_ids

*: hr_expense, l10n_es_edi_facturae, l10n_hu_edi,l10n_id_efaktur, l10n_it_edi_doi, purchase_stock, sale_mrp, sale_stock

We introduced this field with a typo, now it causes misunderstanding as it is interpreted as a many2one and not a one2many.

Related: https://github.com/odoo/odoo/commit/09a6a4da116059414baeb7e663d8a503c3ae082e task-no

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
