### PR TITLE
[FIX] hr_holidays: cast allocation's date to timestamps

### DIFF
--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -134,8 +134,8 @@ class HolidaysType(models.Model):
         WHERE
             alloc.employee_id = %s AND
             alloc.active = True AND alloc.state = 'validate' AND
-            (alloc.date_to >= %s OR alloc.date_to IS NULL) AND
-            alloc.date_from <= %s 
+            (CAST(alloc.date_to AS TIMESTAMP) >= %s OR alloc.date_to IS NULL) AND
+            CAST(alloc.date_from AS TIMESTAMP) <= %s
         '''
 
         self._cr.execute(query, (employee_id or None, date_to, date_from))


### PR DESCRIPTION
... in order to prevent the following tz issue:
```
     Allocation validity
  ┌───────────────────────┐
  │///////////////////////│        15:00                    16:00
──x───────────────────────x──────────┬──────────x─────────────┬────►
Monday                 Tuesday       │       Wednesday        │
                                     │                        │
                                     └────────────────────────┘
                                       Requested Leave 
```
Before my change requesting leave in the above scenario will return valid allocation. Why? Cause in postgress when we compare dates to timestamps the latter is casted to the first one. I.E. this comparision
    2024-07-16 >= 2024-07-16 09:00:00
becomes this one:
    2024-07-16 >= 2024-07-16

[Reproduction of the original issue]
- install hr_holidays
- in Time Off / Allocations create/validate new Allocation:
	- of type T
	- for employee E
	- valid from some Monday to the following Tuesday
- Open E time off (Employee E -> Time Off)
- Switch your browser TZ that is +10
- Attempt to book time off for E on Wednesday
- BUG: you are allowed to do so

opw-3850159
