### PR TITLE
[IMP] point_of_sale: Display scenario when no result

### DIFF
--- a/addons/point_of_sale/data/demo_data.xml
+++ b/addons/point_of_sale/data/demo_data.xml
@@ -4,6 +4,5 @@
         <function model="pos.config" name="load_onboarding_furniture_scenario" />
         <function model="pos.config" name="load_onboarding_clothes_scenario" />
         <function model="pos.config" name="load_onboarding_bakery_scenario" />
-        <function model="pos.config" name="hide_predefined_scenarios" />
     </data>
 </odoo>

--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -997,10 +997,6 @@ class PosConfig(models.Model):
             return f"{ref_name}_{self.env.company.id}"
 
     @api.model
-    def hide_predefined_scenarios(self):
-        self.env.company.point_of_sale_show_predefined_scenarios = False
-
-    @api.model
     def get_pos_kanban_view_state(self):
         has_pos_config = bool(self.env['pos.config'].search_count(
             self._check_company_domain(self.env.company)
@@ -1011,7 +1007,6 @@ class PosConfig(models.Model):
             "has_pos_config": has_pos_config,
             "has_chart_template": has_chart_template,
             "is_restaurant_installed": bool(self.env['ir.module.module'].search_count([('name', '=', 'pos_restaurant'), ('state', '=', 'installed')])),
-            "show_predefined_scenarios": self.env.company.point_of_sale_show_predefined_scenarios,
             "is_main_company": main_company and self.env.company.id == main_company.id or False
         }
 

--- a/addons/point_of_sale/models/res_company.py
+++ b/addons/point_of_sale/models/res_company.py
@@ -26,7 +26,6 @@ class ResCompany(models.Model):
         string='Print',
         help="Choose how the URL to the portal will be print on the receipt.",
         required=True)
-    point_of_sale_show_predefined_scenarios = fields.Boolean("Show Predefined Scenarios", default=True)
 
     @api.model
     def _load_pos_data_domain(self, data):

--- a/addons/point_of_sale/static/src/backend/pos_kanban_view/pos_kanban_view.xml
+++ b/addons/point_of_sale/static/src/backend/pos_kanban_view/pos_kanban_view.xml
@@ -10,9 +10,6 @@
         <div class="d-flex flex-column">
             <t t-call="web.KanbanRenderer" />
             <div class="position-relative container" t-att-class="{ 'border-top mt-2': showTopBorder() }" t-if="this.posState.show_predefined_scenarios">
-                <button class="btn btn-link position-absolute top-0 end-0 py-2 px-3 h2" title="Close the scenario choices" t-on-click="() => this.hidePredefinedScenarios.call()">
-                    <i class="oi oi-close"></i>
-                </button>
                 <div class="flex-grow-1 text-center" t-att-class="{ 'disable-buttons': !posState.has_chart_template || loadScenario.status === 'loading' }">
                     <p class="h1 text-primary mt-4" t-if="!posState.has_pos_config">Want to try with sample products?</p>
                     <p t-if="!posState.has_chart_template" class="h2 m-3">


### PR DESCRIPTION
Before when the user searches for a config and no result is found, the user saw an empty screen.

Now, the user will see a message that no result was found and different buttons with options to create a new config or to create new products.

Upgrade PR: [6238](https://github.com/odoo/upgrade/pull/6238)
taskId: 4035349


