### PR TITLE
[15.0][FIX] l10n_fr_invoice_addr: update translation

### DIFF
--- a/addons/l10n_fr_invoice_addr/i18n/fr.po
+++ b/addons/l10n_fr_invoice_addr/i18n/fr.po
@@ -18,7 +18,7 @@ msgstr ""
 #. module: l10n_fr_invoice_addr
 #: model_terms:ir.ui.view,arch_db:l10n_fr_invoice_addr.report_invoice_document
 msgid "Customer Address:"
-msgstr "Adresse du client\u00a0:"
+msgstr "Adresse du client :"
 
 #. module: l10n_fr_invoice_addr
 #: model_terms:ir.ui.view,arch_db:l10n_fr_invoice_addr.report_invoice_document
@@ -33,7 +33,7 @@ msgstr "Opération mixte"
 #. module: l10n_fr_invoice_addr
 #: model_terms:ir.ui.view,arch_db:l10n_fr_invoice_addr.report_invoice_document
 msgid "Operation Type:"
-msgstr "Type d'opération\u00a0:"
+msgstr "Type d'opération :"
 
 #. module: l10n_fr_invoice_addr
 #: model_terms:ir.ui.view,arch_db:l10n_fr_invoice_addr.report_invoice_document
@@ -43,7 +43,7 @@ msgstr "Option pour le paiement de la taxe d'après les débits"
 #. module: l10n_fr_invoice_addr
 #: model_terms:ir.ui.view,arch_db:l10n_fr_invoice_addr.report_invoice_document
 msgid "SIRET:"
-msgstr "SIRET\u00a0:"
+msgstr "SIRET :"
 
 #. module: l10n_fr_invoice_addr
 #: model_terms:ir.ui.view,arch_db:l10n_fr_invoice_addr.report_invoice_document


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Translations added with https://github.com/odoo/odoo/commit/e76453bf869f0a5bc2edfe861d3628b6695a205b contains unicode \u00a0 which are rendered as \u00a0 on PDF

Current behavior before PR: PDF show the unicode characters
![image](https://github.com/odoo/odoo/assets/30716308/73f3b03a-0ccc-4ca4-bc51-dab7c9f557b6)


Desired behavior after PR is merged: no more unicode characters




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
