### PR TITLE
[IMP] account_rewrite_tax_tags: rewrite existing journal entries's tax tags wizard

### DIFF
--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -156,7 +156,7 @@ class AccountTestInvoicingCommon(TransactionCase):
             'company_id': False,
         })
         cls.partner_agrolait = cls.env['res.partner'].create({
-            'name': 'Deco Addict',
+            'name': 'Agrolait',
             'is_company': True,
             'country_id': cls.env.ref('base.us').id,
         })
@@ -426,7 +426,7 @@ class AccountTestInvoicingCommon(TransactionCase):
 
         invoice_vals = {
             'move_type': move_type,
-            'partner_id': partner_id or self.partner_agrolait_id,
+            'partner_id': partner_id or self.partner_agrolait.id,
             'invoice_date': date_invoice,
             'date': date_invoice,
             'invoice_line_ids': [(0, 0, {
@@ -444,7 +444,10 @@ class AccountTestInvoicingCommon(TransactionCase):
             invoice_vals['currency_id'] = currency_id
 
         invoice = self.env['account.move'].with_context(default_move_type=move_type).create(invoice_vals)
-        if auto_validate:
+
+        if state == 'cancel':
+            invoice.write({'state': 'cancel'})
+        elif auto_validate or state == 'posted':
             invoice.action_post()
         return invoice
 
@@ -456,11 +459,11 @@ class AccountTestInvoicingCommon(TransactionCase):
         return cls.env['account.account.tag'].create({
             'name': name,
             'applicability': 'taxes',
-            'country_id': country_id if country_id else cls.company.country_id.id,
+            'country_id': country_id if country_id else cls.company_data['company'].country_id.id,
         })
 
     @classmethod
-    def _create_tax(cls, name, amount=15, amount_type='percent', type_tax_use='sale', tag_names=None, children_taxes=None, tax_exigibility='on_invoice'):
+    def _create_tax(cls, name, amount, amount_type='percent', type_tax_use='sale', tag_names=None, children_taxes=None, tax_exigibility='on_invoice', **kwargs):
         if not tag_names:
             tag_names = {}
         tag_commands = {
@@ -498,6 +501,7 @@ class AccountTestInvoicingCommon(TransactionCase):
                     'tag_ids': tag_commands.get('refund_tax'),
                 }),
             ] if not children_taxes else None,
+            **kwargs,
         }
         return cls.env['account.tax'].create(vals)
 
@@ -745,7 +749,7 @@ class TestAccountReconciliationCommon(AccountTestInvoicingCommon):
             'name': 'payment' + invoice_record.name,
             'line_ids': [(0, 0, {
                 'payment_ref': 'payment',
-                'partner_id': self.partner_agrolait_id,
+                'partner_id': self.partner_agrolait.id,
                 'amount': amount,
                 'amount_currency': amount_currency,
                 'foreign_currency_id': currency_id,

--- a/addons/account_update_tax_tags/__init__.py
+++ b/addons/account_update_tax_tags/__init__.py
@@ -1,0 +1,2 @@
+from . import tests
+from . import wizard

--- a/addons/account_update_tax_tags/__manifest__.py
+++ b/addons/account_update_tax_tags/__manifest__.py
@@ -1,0 +1,20 @@
+{
+    'name': 'Account - Allow updating tax grids',
+    'category': 'Accounting/Accounting',
+    'summary': 'Allow updating tax grids on existing entries',
+    'version': '1.0',
+    'description': """
+    This module allows updating tax grids on existing accounting entries.
+    In debug mode a button to update your entries' tax grids will be available
+    in Accounting settings.
+    This is typically useful after some legal changes were done on the tax report,
+    requiring a new tax configuration. 
+    """,
+    'depends': ['account'],
+    'data': [
+        'security/ir.model.access.csv',
+        'views/res_config_settings_views.xml',
+        'wizard/account_update_tax_tags_wizard.xml',
+    ],
+    'license': 'LGPL-3',
+}

--- a/addons/account_update_tax_tags/i18n/account_update_tax_tags.pot
+++ b/addons/account_update_tax_tags/i18n/account_update_tax_tags.pot
@@ -1,0 +1,108 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* account_update_tax_tags
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 14.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-02-02 11:37+0000\n"
+"PO-Revision-Date: 2024-02-02 11:37+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: account_update_tax_tags
+#: model:ir.model.fields,field_description:account_update_tax_tags.field_account_update_tax_tags_wizard__company_id
+msgid "Company"
+msgstr ""
+
+#. module: account_update_tax_tags
+#: model:ir.model.fields,field_description:account_update_tax_tags.field_account_update_tax_tags_wizard__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: account_update_tax_tags
+#: model:ir.model.fields,field_description:account_update_tax_tags.field_account_update_tax_tags_wizard__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: account_update_tax_tags
+#: model:ir.model.fields,help:account_update_tax_tags.field_account_update_tax_tags_wizard__date_from
+msgid "Date from which journal items will be updated."
+msgstr ""
+
+#. module: account_update_tax_tags
+#: model_terms:ir.ui.view,arch_db:account_update_tax_tags.view_account_update_tax_tags_wizard_form
+msgid "Discard"
+msgstr ""
+
+#. module: account_update_tax_tags
+#: model:ir.model.fields,field_description:account_update_tax_tags.field_account_update_tax_tags_wizard__display_lock_date_warning
+msgid "Display Lock Date Warning"
+msgstr ""
+
+#. module: account_update_tax_tags
+#: model:ir.model.fields,field_description:account_update_tax_tags.field_account_update_tax_tags_wizard__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: account_update_tax_tags
+#: model:ir.model.fields,field_description:account_update_tax_tags.field_account_update_tax_tags_wizard__id
+msgid "ID"
+msgstr ""
+
+#. module: account_update_tax_tags
+#: model:ir.model.fields,field_description:account_update_tax_tags.field_account_update_tax_tags_wizard____last_update
+msgid "Last Modified on"
+msgstr ""
+
+#. module: account_update_tax_tags
+#: model:ir.model.fields,field_description:account_update_tax_tags.field_account_update_tax_tags_wizard__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: account_update_tax_tags
+#: model:ir.model.fields,field_description:account_update_tax_tags.field_account_update_tax_tags_wizard__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: account_update_tax_tags
+#: model:ir.model.fields,field_description:account_update_tax_tags.field_account_update_tax_tags_wizard__date_from
+msgid "Starting from"
+msgstr ""
+
+#. module: account_update_tax_tags
+#: model_terms:ir.ui.view,arch_db:account_update_tax_tags.view_account_update_tax_tags_wizard_form
+msgid ""
+"The date you chose is violating the tax lock date, do this at your own risk."
+msgstr ""
+
+#. module: account_update_tax_tags
+#: model_terms:ir.ui.view,arch_db:account_update_tax_tags.view_account_update_tax_tags_wizard_form
+msgid "Update"
+msgstr ""
+
+#. module: account_update_tax_tags
+#: model:ir.model,name:account_update_tax_tags.model_account_update_tax_tags_wizard
+msgid "Update Tax Tags Wizard"
+msgstr ""
+
+#. module: account_update_tax_tags
+#: model:ir.actions.act_window,name:account_update_tax_tags.action_open_wizard
+#: model_terms:ir.ui.view,arch_db:account_update_tax_tags.res_config_settings_view_form
+msgid "Update tax tags on existing Journal Entries"
+msgstr ""
+
+#. module: account_update_tax_tags
+#: model_terms:ir.ui.view,arch_db:account_update_tax_tags.view_account_update_tax_tags_wizard_form
+msgid ""
+"Updating tax tags on existing Journal Entries is an <b>irreversible</b> action that will impact\n"
+"                    your reports.<br/>\n"
+"                    It is highly recommended to backup your database beforehand.<br/>\n"
+"                    The update will change tax tags on your accounting history, starting from and including selected date,\n"
+"                    so that it matches with the current configuration of your taxes.<br/>"
+msgstr ""

--- a/addons/account_update_tax_tags/security/ir.model.access.csv
+++ b/addons/account_update_tax_tags/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_account_update_tax_tags_wizard,access.account.update.tax.tags.wizard,model_account_update_tax_tags_wizard,account.group_account_manager,1,1,1,0

--- a/addons/account_update_tax_tags/tests/__init__.py
+++ b/addons/account_update_tax_tags/tests/__init__.py
@@ -1,0 +1,2 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from . import test_account_update_tax_tags_wizard

--- a/addons/account_update_tax_tags/tests/test_account_update_tax_tags_wizard.py
+++ b/addons/account_update_tax_tags/tests/test_account_update_tax_tags_wizard.py
@@ -1,0 +1,319 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from freezegun import freeze_time
+
+from odoo.exceptions import UserError
+from odoo.tests import Form, tagged
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+
+
+@freeze_time('2023-12-31')
+@tagged('post_install', '-at_install')
+class TestAccountUpdateTaxTagsWizard(AccountTestInvoicingCommon):
+
+    @classmethod
+    def setUpClass(cls, chart_template_ref=None):
+        super().setUpClass(chart_template_ref=chart_template_ref)
+
+        be_country_id = cls.env.ref('base.be').id
+        cls.company = cls.company_data['company']
+        cls.company.write({'country_id': be_country_id})
+        cls.tag_names = {
+            'invoice_base': 'invoice_base_tag',
+            'invoice_tax': 'invoice_tax_tag',
+            'refund_base': 'refund_base_tag',
+            'refund_tax': 'refund_tax_tag',
+        }
+        cls.tax_1 = cls._create_tax('update_test_tax', 15, tag_names=cls.tag_names)
+        cls.wizard = cls.env['account.update.tax.tags.wizard'].create({'date_from': '2023-02-01'})
+
+    @classmethod
+    def _change_tax_tag(cls, tax, new_tag, invoice=True, base=True):
+        rep_lines = tax.invoice_repartition_line_ids if invoice else tax.refund_repartition_line_ids
+        filtered_rep_lines = rep_lines.filtered(lambda rep_line: rep_line.repartition_type == ('base' if base else 'tax'))
+        filtered_rep_lines.write({'tag_ids': [(6, 0, cls._create_tax_tag(new_tag).ids)]})
+
+    def _get_amls_by_type(self, moves):
+        invoice_lines = moves.invoice_line_ids
+        tax_lines = moves.line_ids.filtered('tax_line_id')
+        counterpart_lines = moves.line_ids - invoice_lines - tax_lines
+        return invoice_lines, tax_lines, counterpart_lines
+
+    def test_update_tax_tags(self):
+        """ When we change the tags on the taxes and use the wizard to update history,
+        tags should be updated on amls within the wizard date range.
+        """
+        moves = self._create_invoice(taxes=self.tax_1) + self._create_invoice(taxes=self.tax_1)
+        self._change_tax_tag(self.tax_1, 'invoice_tax_tag_changed', invoice=True, base=False)
+        self.wizard.update_amls_tax_tags()
+
+        invoice_lines, tax_lines, counterpart_lines = self._get_amls_by_type(moves)
+        self.assertTrue(all('invoice_tax_tag_changed' in tax_line.tax_audit for tax_line in tax_lines), 'Tax audit string should have changed.')
+        self.assertEqual(invoice_lines.tax_tag_ids.name, 'invoice_base_tag', 'Base lines tags should not have changed.')
+        self.assertEqual(tax_lines.tax_tag_ids.name, 'invoice_tax_tag_changed', 'Tax lines tags should have changed.')
+        self.assertFalse(counterpart_lines.tax_tag_ids, 'Counterpart lines should not have changed.')
+
+    def test_update_date_from(self):
+        """ Only the amls that are concerned by the date_from constraint should be updated. """
+        move_included = self._create_invoice(date_invoice='2023-02-23', taxes=self.tax_1)
+        move_not_included = self._create_invoice(date_invoice='2023-01-23', taxes=self.tax_1)
+        self._change_tax_tag(self.tax_1, 'invoice_tax_tag_changed', invoice=True, base=False)
+        self.wizard.update_amls_tax_tags()
+
+        tax_line_included = move_included.line_ids.filtered(lambda aml: aml.tax_line_id)
+        self.assertEqual(tax_line_included.tax_tag_ids.name, 'invoice_tax_tag_changed', 'Move within the date constraint should be updated.')
+        tax_line_not_included = move_not_included.line_ids.filtered(lambda aml: aml.tax_line_id)
+        self.assertEqual(tax_line_not_included.tax_tag_ids.name, 'invoice_tax_tag', 'Move outside the date constraint should not be updated.')
+
+    def test_update_multiple_taxes(self):
+        """ Test in case there are multiple taxes set on the invoice line. """
+        tax_2 = self._create_tax('update_test_tax_2', 15, tag_names={
+            'invoice_base': 'invoice_base_tag_2',
+            'invoice_tax': 'invoice_tax_tag_2',
+            'refund_base': 'refund_base_tag_2',
+            'refund_tax': 'refund_tax_tag_2',
+        })
+        move = self._create_invoice(taxes=self.tax_1 + tax_2)
+        self._change_tax_tag(self.tax_1, 'invoice_tax_tag_changed', invoice=True, base=False)
+        self._change_tax_tag(tax_2, 'invoice_tax_tag_changed_2', invoice=True, base=False)
+        self.wizard.update_amls_tax_tags()
+
+        invoice_line, tax_line, counterpart_line = self._get_amls_by_type(move)
+        self.assertEqual(
+            invoice_line.tax_tag_ids.mapped('name'),
+            ['invoice_base_tag', 'invoice_base_tag_2'],
+            'Base lines tags should not have changed.'
+        )
+        self.assertEqual(
+            tax_line.tax_tag_ids.mapped('name'),
+            ['invoice_tax_tag_changed', 'invoice_tax_tag_changed_2'],
+            'Tax lines tags should have changed.'
+        )
+        self.assertFalse(counterpart_line.tax_tag_ids, 'Counterpart lines tags should not have changed.')
+
+    def test_update_multi_company(self):
+        """ Tests that only the company that is selected when opening the wizard will have its amls updated. """
+        move_1 = self._create_invoice(taxes=self.tax_1)
+        self._change_tax_tag(self.tax_1, 'invoice_tax_tag_changed_for_company_1', invoice=True, base=False)
+        be_country_id = self.env.ref('base.be').id
+        company_2 = self.company_data_2['company']
+        company_2.write({'country_id': be_country_id})
+        self.env.user.company_id = company_2
+        tax_2 = self._create_tax(
+            'update_test_tax_2',
+            15,
+            tag_names={'invoice_tax': 'update_test_invoice_tax_tag_company_2'}
+        )
+        move_2 = self._create_invoice(taxes=tax_2)
+        self._change_tax_tag(tax_2, 'invoice_tax_tag_changed_for_company_2', invoice=True, base=False)
+        self.wizard.update_amls_tax_tags()
+
+        tax_line_1 = move_1.line_ids.filtered(lambda aml: aml.tax_line_id)
+        tax_line_2 = move_2.line_ids.filtered(lambda aml: aml.tax_line_id)
+        # Only the first move_id should be updated since it belongs to first company which was initialized in the wizard
+        self.assertEqual(tax_line_1.tax_tag_ids.name, 'invoice_tax_tag_changed_for_company_1')
+        self.assertEqual(tax_line_2.tax_tag_ids.name, 'update_test_invoice_tax_tag_company_2')
+
+    def test_update_all_move_type(self):
+        """ Tests that all move type are correctly updated with the corresponding tags. """
+        move_types = [
+            # 'entry' tested in test_update_move_type_entry since it's more complex
+            'out_invoice',
+            'in_invoice',
+            'out_refund',
+            'in_refund',
+            'in_receipt',
+            'out_receipt',
+        ]
+        for move_type in move_types:
+            for line_type in ['base', 'tax']:
+                with self.subTest(f'Update tax tag on {move_type}-{line_type}'):
+                    type_tax_use = 'sale' if move_type.startswith('out_') else 'purchase'
+                    tax_2 = self._create_tax('update_test_tax_2', 15, type_tax_use=type_tax_use, tag_names={
+                        'invoice_base': 'test_tag_invoice_base',
+                        'invoice_tax': 'test_tag_invoice_tax',
+                        'refund_base': 'test_tag_refund_base',
+                        'refund_tax': 'test_tag_refund_tax',
+                    })
+                    move = self._create_invoice(move_type=move_type, taxes=tax_2)
+                    super_type = move_type.split('_')[1]
+                    if super_type == 'receipt':
+                        super_type = 'invoice'  # receipt type acts just like invoice one
+                    self._change_tax_tag(tax_2, f'{move_type}_{line_type}_tag_changed', invoice=super_type == 'invoice', base=line_type == 'base')
+                    self.wizard.update_amls_tax_tags()
+
+                    invoice_line, tax_line, counterpart_line = self._get_amls_by_type(move)
+                    if line_type == 'base':
+                        self.assertEqual(invoice_line.tax_tag_ids.name, f'{move_type}_{line_type}_tag_changed', 'Base lines tags should have changed.')
+                        self.assertEqual(tax_line.tax_tag_ids.name, f'test_tag_{super_type}_tax', 'Tax lines tags should not have changed.')
+                        self.assertFalse(counterpart_line.tax_tag_ids, 'Counterpart lines tags should not have changed.')
+                    else:
+                        self.assertEqual(invoice_line.tax_tag_ids.name, f'test_tag_{super_type}_base', 'Base lines tags should not have changed.')
+                        self.assertEqual(tax_line.tax_tag_ids.name, f'{move_type}_{line_type}_tag_changed', 'Tax lines tags should have changed.')
+                        self.assertFalse(counterpart_line.tax_tag_ids, 'Counterpart lines tags should not have changed.')
+
+    def test_update_move_type_entry(self):
+        """ Test that move of type 'entry' are correctly updated.
+        If a move has negative balance and use a sale tax, it should act as an invoice.
+        If a move has positive balance and use a sale tax, it should act as a refund.
+        If a move has negative balance and use a purchase tax, it should act as a refund.
+        If a move has positive balance and use a purchase tax, it should be treated as an invoice.
+        """
+        account = self.company_data['default_account_assets']  # Account is not relevant for the test but must be set.
+        for tax_type in ['sale', 'purchase']:
+            tax = self._create_tax(f'test_{tax_type}_tax', 10, type_tax_use=tax_type, tag_names=self.tag_names)
+            for balance in [-1000, 1000]:
+                with self.subTest(f'Testing move type entry {tax_type}: {balance}'):
+                    # Create one entry and it's reverse.
+                    move_form = Form(self.env['account.move'].with_context(default_move_type='entry'))
+                    with move_form.line_ids.new() as line:
+                        line.account_id = account
+                        if balance < 0:
+                            line.credit = abs(balance)
+                        else:
+                            line.debit = abs(balance)
+                        line.tax_ids.add(tax)
+
+                    # Create a third account.move.line for balance. It will be automatically filled given above lines.
+                    move_form.line_ids.new().save()
+                    move = move_form.save()
+
+                    self._change_tax_tag(tax, 'invoice_base_tag_changed', invoice=True, base=True)
+                    self._change_tax_tag(tax, 'refund_base_tag_changed', invoice=False, base=True)
+
+                    self.wizard.update_amls_tax_tags()
+                    invoice_line, tax_line, _ = self._get_amls_by_type(move)
+                    if (balance < 0 and tax_type == 'sale') or (balance > 0 and tax_type == 'purchase'):
+                        self.assertEqual(invoice_line.tax_tag_ids.name, 'invoice_base_tag_changed')
+                        self.assertEqual(tax_line.tax_tag_ids.name, 'invoice_tax_tag')
+                    elif (balance < 0 and tax_type == 'purchase') or (balance > 0 and tax_type == 'sale'):
+                        self.assertEqual(invoice_line.tax_tag_ids.name, 'refund_base_tag_changed')
+                        self.assertEqual(tax_line.tax_tag_ids.name, 'refund_tax_tag')
+
+    def test_update_amls_all_states(self):
+        """ Tests that moves are correctly updated, regardless of their state. """
+        move_states = ('posted', 'cancel', 'draft')
+        moves = [self._create_invoice(partner_id=self.partner_a.id, taxes=self.tax_1, state=state) for state in move_states]
+        self._change_tax_tag(self.tax_1, 'invoice_base_tag_changed', invoice=True, base=True)
+        self._change_tax_tag(self.tax_1, 'invoice_tax_tag_changed', invoice=True, base=False)
+        self.wizard.update_amls_tax_tags()
+        for move in moves:
+            with self.subTest(f'Update tax tag on move with state: {move.state}'):
+                invoice_line, tax_line, counterpart_line = self._get_amls_by_type(move)
+                self.assertEqual(invoice_line.tax_tag_ids.name, 'invoice_base_tag_changed', 'Base lines tags should have changed.')
+                self.assertEqual(tax_line.tax_tag_ids.name, 'invoice_tax_tag_changed', 'Tax lines tags should have changed.')
+                self.assertFalse(counterpart_line.tax_tag_ids, 'Counterpart lines tags should not have changed.')
+
+    def test_update_no_tag_before(self):
+        """ Tests that update happens on aml that had no tag previously. """
+        tax = self._create_tax('test_tax_no_tag', 15)
+        move = self._create_invoice(taxes=tax)
+        self._change_tax_tag(tax, 'new_tag_name', invoice=True, base=True)
+        self.wizard.update_amls_tax_tags()
+
+        self.assertEqual(move.invoice_line_ids.tax_tag_ids.name, 'new_tag_name')
+
+    def test_update_no_tag_after(self):
+        move = self._create_invoice(taxes=self.tax_1)
+        self.tax_1.invoice_repartition_line_ids.write({'tag_ids': [(5, 0, 0)]})  # Command.CLEAR both base and tax lines
+        self.wizard.update_amls_tax_tags()
+
+        invoice_line, tax_line, counterpart_line = self._get_amls_by_type(move)
+        self.assertFalse(invoice_line.tax_tag_ids, 'Base lines tags should be empty.')
+        self.assertFalse(tax_line.tax_tag_ids, 'Tax lines should be empty.')
+        self.assertFalse(counterpart_line.tax_tag_ids, 'Counterpart lines tags should not have changed.')
+
+    def test_update_child_tax(self):
+        """ Make sure groups of taxes are correctly handled. """
+        tax_child_1 = self._create_tax('tax_child_1', 15, type_tax_use='purchase', tag_names={
+            'invoice_base': 'invoice_base_tag_child_1',
+            'invoice_tax': 'invoice_tax_tag_child_1',
+            'refund_base': 'refund_base_tag_child_1',
+            'refund_tax': 'refund_tax_tag_child_1',
+        })
+        tax_child_2 = self._create_tax('tax_child_2', 15, type_tax_use='none', tag_names={
+            'invoice_base': 'invoice_base_tag_child_2',
+            'invoice_tax': 'invoice_tax_tag_child_2',
+            'refund_base': 'refund_base_tag_child_2',
+            'refund_tax': 'refund_tax_tag_child_2',
+        })
+        tax_parent = self._create_tax('tax_parent', 15, amount_type='group', type_tax_use='purchase', children_taxes=(tax_child_1 + tax_child_2))
+        move = self._create_invoice(taxes=tax_parent)
+
+        # Check that lines are set as expected before update.
+        invoice_line, tax_lines, counterpart_line = self._get_amls_by_type(move)
+        self.assertEqual(invoice_line.tax_tag_ids.mapped('name'), ['invoice_base_tag_child_1', 'invoice_base_tag_child_2'])
+        self.assertEqual(tax_lines.tax_tag_ids.mapped('name'), ['invoice_tax_tag_child_1', 'invoice_tax_tag_child_2'])
+        self.assertFalse(counterpart_line.tax_tag_ids)
+
+        self._change_tax_tag(tax_child_1, 'invoice_base_tag_1_changed', invoice=True, base=True)
+        self._change_tax_tag(tax_child_1, 'invoice_tax_tag_1_changed', invoice=True, base=False)
+        self._change_tax_tag(tax_child_2, 'invoice_base_tag_2_changed', invoice=True, base=True)
+        self._change_tax_tag(tax_child_2, 'invoice_tax_tag_2_changed', invoice=True, base=False)
+        self.wizard.update_amls_tax_tags()
+
+        invoice_line, tax_lines, counterpart_line = self._get_amls_by_type(move)
+        self.assertEqual(invoice_line.tax_tag_ids.mapped('name'), ['invoice_base_tag_1_changed', 'invoice_base_tag_2_changed'])
+        self.assertEqual(tax_lines.tax_tag_ids.mapped('name'), ['invoice_tax_tag_1_changed', 'invoice_tax_tag_2_changed'])
+        self.assertFalse(counterpart_line.tax_tag_ids)
+
+    def test_update_with_caba_taxes(self):
+        self.env.company.tax_exigibility = True
+        tax = self._create_tax('caba_tax', 15, tag_names=self.tag_names, tax_exigibility='on_payment')
+        invoice = self._create_invoice(taxes=tax, state='posted')
+        # make payment
+        self.env['account.payment.register'].with_context(active_model='account.move', active_ids=invoice.ids).create({
+            'payment_date': invoice.date,
+        })._create_payments()
+        partial_rec = invoice.mapped('line_ids.matched_credit_ids')
+        caba_move = self.env['account.move'].search([('tax_cash_basis_rec_id', '=', partial_rec.id)])
+
+        self._change_tax_tag(tax, 'invoice_base_tag_changed', invoice=True, base=True)
+        self._change_tax_tag(tax, 'invoice_tax_tag_changed', invoice=True, base=False)
+        self.wizard.update_amls_tax_tags()
+
+        invoice_lines, tax_lines, counterpart_lines = self._get_amls_by_type(invoice)
+        self.assertEqual(invoice_lines.tax_tag_ids.name, 'invoice_base_tag_changed', 'Base lines tags should have changed.')
+        self.assertEqual(tax_lines.tax_tag_ids.name, 'invoice_tax_tag_changed', 'Tax lines tags should have changed.')
+        self.assertFalse(counterpart_lines.tax_tag_ids, 'Counterpart lines should not have changed.')
+
+        caba_base_line = caba_move.line_ids.filtered('tax_ids')
+        caba_tax_line = caba_move.line_ids.filtered('tax_line_id')
+        caba_counterpart_lines = caba_move.line_ids - caba_base_line - caba_tax_line
+        self.assertEqual(caba_base_line.tax_tag_ids.name, 'invoice_base_tag_changed', 'CABA base lines tags should have changed.')
+        self.assertEqual(caba_tax_line.tax_tag_ids.name, 'invoice_tax_tag_changed', 'CABA tax lines tags should have changed.')
+        self.assertFalse(caba_counterpart_lines.tax_tag_ids, 'CABA counterpart lines should not have changed.')
+
+    def test_update_with_caba_taxes_with_negative_line(self):
+        self.company.tax_exigibility = True
+        tax = self._create_tax('caba_tax', 15, tag_names=self.tag_names, tax_exigibility='on_payment')
+        invoice = self.init_invoice('out_invoice', invoice_date='2023-02-23', amounts=[-50, 100], taxes=tax, post=True)
+        # make payment
+        self.env['account.payment.register'].with_context(active_model='account.move', active_ids=invoice.ids).create({
+            'payment_date': invoice.date,
+        })._create_payments()
+        partial_rec = invoice.mapped('line_ids.matched_credit_ids')
+        caba_move = self.env['account.move'].search([('tax_cash_basis_rec_id', '=', partial_rec.id)])
+
+        self._change_tax_tag(tax, 'invoice_base_tag_changed', invoice=True, base=True)
+        self._change_tax_tag(tax, 'invoice_tax_tag_changed', invoice=True, base=False)
+        self.wizard.update_amls_tax_tags()
+
+        invoice_lines, tax_lines, counterpart_lines = self._get_amls_by_type(invoice)
+        self.assertEqual(invoice_lines.tax_tag_ids.name, 'invoice_base_tag_changed', 'Base lines tags should have changed.')
+        self.assertEqual(tax_lines.tax_tag_ids.name, 'invoice_tax_tag_changed', 'Tax lines tags should have changed.')
+        self.assertFalse(counterpart_lines.tax_tag_ids, 'Counterpart lines should not have changed.')
+
+        caba_base_line = caba_move.line_ids.filtered('tax_ids')
+        caba_tax_line = caba_move.line_ids.filtered('tax_line_id')
+        caba_counterpart_lines = caba_move.line_ids - caba_base_line - caba_tax_line
+        self.assertEqual(caba_base_line.tax_tag_ids.name, 'invoice_base_tag_changed', 'CABA base lines tags should have changed.')
+        self.assertEqual(caba_tax_line.tax_tag_ids.name, 'invoice_tax_tag_changed', 'CABA tax lines tags should have changed.')
+        self.assertFalse(caba_counterpart_lines.tax_tag_ids, 'CABA counterpart lines should not have changed.')
+
+    def test_child_tax_multiple_parent_raises(self):
+        tax_child = self._create_tax('tax_child_1', 15)
+        tax_parent_1 = self._create_tax('tax_parent', 15, amount_type='group', children_taxes=tax_child)
+        self._create_tax('tax_parent_2', 15, amount_type='group', children_taxes=tax_child)
+        self._create_invoice(taxes=tax_parent_1)
+        with self.assertRaisesRegex(UserError, 'Update with children taxes that are child of multiple parents is not supported.'):
+            self.wizard.update_amls_tax_tags()

--- a/addons/account_update_tax_tags/views/res_config_settings_views.xml
+++ b/addons/account_update_tax_tags/views/res_config_settings_views.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="action_open_wizard" model="ir.actions.act_window">
+            <field name="name">Update tax tags on existing Journal Entries</field>
+            <field name="res_model">account.update.tax.tags.wizard</field>
+            <field name="view_mode">form</field>
+            <field name="target">new</field>
+        </record>
+
+        <record id="res_config_settings_view_form" model="ir.ui.view">
+            <field name="name">res.config.settings.view.form.inherit.account_update_tax_tags</field>
+            <field name="model">res.config.settings</field>
+            <field name="inherit_id" ref="account.res_config_settings_view_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//div[@name='default_taxes_setting_container']" position="inside">
+                    <button name="%(account_update_tax_tags.action_open_wizard)d" icon="fa-refresh" type="action" class="btn-link"
+                            groups="base.group_no_one"
+                            string="Update tax tags on existing Journal Entries"/>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/addons/account_update_tax_tags/wizard/__init__.py
+++ b/addons/account_update_tax_tags/wizard/__init__.py
@@ -1,0 +1,2 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from . import account_update_tax_tags_wizard

--- a/addons/account_update_tax_tags/wizard/account_update_tax_tags_wizard.py
+++ b/addons/account_update_tax_tags/wizard/account_update_tax_tags_wizard.py
@@ -1,0 +1,237 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from datetime import timedelta
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
+from odoo.tools.sql import column_exists
+
+
+class AccountUpdateTaxTagsWizard(models.TransientModel):
+    _name = 'account.update.tax.tags.wizard'
+    _description = 'Update Tax Tags Wizard'
+
+    company_id = fields.Many2one(comodel_name='res.company', required=True, readonly=True, default=lambda self: self.env.company)
+    date_from = fields.Date(
+        string='Starting from',
+        help='Date from which journal items will be updated.',
+        compute='_compute_date_from',
+        store=True,
+        readonly=False,
+        required=True,
+    )
+    display_lock_date_warning = fields.Boolean(compute='_compute_display_lock_date_warning')
+
+    # ==== Compute methods ====
+    @api.depends('company_id')
+    def _compute_date_from(self):
+        for wizard in self:
+            tax_lock_date = self.company_id.tax_lock_date
+            wizard.date_from = tax_lock_date + timedelta(days=1) if tax_lock_date else fields.Date.context_today(self)
+
+    @api.depends('date_from')
+    def _compute_display_lock_date_warning(self):
+        for wizard in self:
+            tax_lock_date = self.company_id.tax_lock_date
+            wizard.display_lock_date_warning = tax_lock_date and wizard.date_from < tax_lock_date
+
+    # ==== Business methods ====
+    def _recompute_tax_audit_string(self, aml_ids):
+        """Taken from #odoo/upgrade account/saas~12.3.1.1/end-20-recompute.py """
+        self.flush()
+        pos_order_condition = """
+            (
+                EXISTS(SELECT id FROM pos_order WHERE pos_order.account_move = aml.move_id)
+                AND move.id IS NULL
+                AND debit > 0
+            )
+        """ if column_exists(self.env.cr, "pos_order", "account_move") else "false"
+        batch_size = 10000
+        for i in range(0, len(aml_ids), batch_size):
+            ids = aml_ids[i:i+batch_size]
+            query = f"""
+                WITH tags AS (
+                    SELECT 
+                        aml.id,
+                        TRIM(LEADING FROM to_char((CASE WHEN t.tax_negate THEN -1 ELSE 1 END)
+                                                 *(CASE WHEN move.tax_cash_basis_rec_id IS NULL AND j.type = 'sale' THEN -1 ELSE 1 END)
+                                                 *(CASE WHEN move.tax_cash_basis_rec_id IS NULL AND (move.move_type IN ('in_refund', 'out_refund')
+                                                     OR {pos_order_condition})
+                                                 THEN -1 ELSE 1 END)
+                                                 * aml.balance,
+                                                 '999,999,999,999,999,999,990.99')  -- should be enough, even for IRR
+                         ) AS tag_amount,
+                         cur.symbol AS currency,
+                         cur.position AS cur_pos,
+                         COALESCE(trl.tag_name, t.name) AS name
+                    FROM account_move_line aml
+                    INNER JOIN account_account_tag_account_move_line_rel t_rel ON t_rel.account_move_line_id = aml.id
+                    INNER JOIN account_account_tag t ON t.id = t_rel.account_account_tag_id
+                    INNER JOIN account_journal j ON j.id = aml.journal_id
+                    INNER JOIN account_move move ON move.id = aml.move_id
+                    INNER JOIN res_company c ON aml.company_id = c.id
+                    INNER JOIN res_currency cur ON c.currency_id = cur.id
+                    LEFT JOIN account_tax_report_line_tags_rel tr ON tr.account_account_tag_id = t.id
+                    LEFT JOIN account_tax_report_line trl ON tr.account_tax_report_line_id = trl.id
+                    WHERE aml.id IN %s -- FIXME @oco is this really ok ? :/ probably we should "explode" it manually ?
+                ),
+                tag_values AS (
+                    SELECT id,
+                        array_to_string(
+                            array_agg(name || ': ' || CASE WHEN cur_pos = 'before' THEN   currency || ' ' || tag_amount
+                                                           ELSE                         tag_amount || ' ' || currency
+                                                           END
+                            ),
+                            '        '
+                       ) AS tax_audit
+                    FROM tags
+                    GROUP BY id
+                )
+                UPDATE account_move_line
+                SET tax_audit = tag_values.tax_audit
+                FROM tag_values
+                WHERE tag_values.id = account_move_line.id
+            """
+            self.env.cr.execute(query, (tuple(ids),))
+        self.invalidate_cache()
+
+    def _modify_tag_to_aml_relation(self, company_id, date_from):
+        """ Update Journal Items' tax grids to match current taxes' configuration.
+        The next query work in 3 steps.
+        1) Get a duo: (aml_id, tag_id or NULL) for each aml involved with the tax.
+            This first step is achieved in the 3 first table: base line, tax line, fusion.
+            a) As the base line and tax line aren't linked to tax in the same way, we need to gather them separately.
+            The base line get its repartition line by going through the tax.
+            b) The tax lines already have their repartition line linked.
+        2) Delete the previous relation aml - tag for each aml appearing in the previous queries.
+        3) Insert the new relation aml - tag.
+        4) Gather the ids of impacted amls into an array and return it.
+        :param: int company_id id of company
+        :return: list of impacted account.move.line ids
+        """
+        self.flush()
+        self.env.cr.execute("""
+            -- 1.a) Handle base line: relation aml <-> tag, if no relation, tag is NULL
+            WITH base_aml_id_rep_tag_to_insert AS (
+                SELECT aml.id AS aml_id, rep_tags.account_account_tag_id AS tag_id
+                FROM account_move_line aml
+                JOIN account_move move 
+                ON aml.move_id = move.id AND move.company_id = %(company_id)s AND aml.date >= %(date_from)s
+                LEFT JOIN account_move caba_origin_move
+                ON move.tax_cash_basis_origin_move_id = caba_origin_move.id
+                JOIN account_move_line_account_tax_rel aml_to_tax 
+                ON aml_to_tax.account_move_line_id = aml.id
+                -- Handle possible children_tax_ids
+                LEFT JOIN account_tax_filiation_rel taxes_filiation 
+                ON taxes_filiation.parent_tax = aml_to_tax.account_tax_id
+                JOIN account_tax tax 
+                ON tax.id = COALESCE(taxes_filiation.child_tax, aml_to_tax.account_tax_id)
+                JOIN account_tax parent_tax
+                ON aml_to_tax.account_tax_id = parent_tax.id
+                JOIN account_tax_repartition_line tax_to_rep_line
+                -- the repartition line to join depends of the move_type
+                -- also, as this is the base line query, we only join for the base repartition type
+                ON
+                    tax_to_rep_line.repartition_type = 'base'
+                    AND (
+                        -- invoice type doc
+                        (COALESCE(caba_origin_move.move_type, move.move_type) IN ('in_invoice','out_invoice', 'in_receipt', 'out_receipt') AND tax_to_rep_line.invoice_tax_id = tax.id)
+                        OR
+                        -- refund type doc
+                        (COALESCE(caba_origin_move.move_type, move.move_type) IN ('in_refund','out_refund') AND tax_to_rep_line.refund_tax_id = tax.id) 
+                        OR
+                        -- entry type doc: depends on the tax type
+                        -- for base line:
+                        -- balance < 0 and sale tax --> invoice
+                        -- balance > 0 and sale tax --> refund
+                        -- balance > 0 and purchase tax --> invoice
+                        -- balance < 0 and purchase tax --> refund
+                        -- impossible to decide for balance at 0 --> invoice by default
+                        (
+                            COALESCE(caba_origin_move.move_type, move.move_type) = 'entry' 
+                            AND (
+                                (
+                                    COALESCE(parent_tax.type_tax_use, tax.type_tax_use) = 'sale'
+                                    AND (
+                                        aml.balance <= 0 AND tax_to_rep_line.invoice_tax_id = tax.id
+                                        OR aml.balance > 0 AND tax_to_rep_line.refund_tax_id = tax.id 
+                                    )
+                                )
+                                OR
+                                (
+                                    COALESCE(parent_tax.type_tax_use, tax.type_tax_use) = 'purchase'
+                                    AND (
+                                        aml.balance >= 0 AND tax_to_rep_line.invoice_tax_id = tax.id
+                                        OR aml.balance < 0 AND tax_to_rep_line.refund_tax_id = tax.id
+                                    )
+                                )
+                            )
+                        ) 
+                    )
+                -- LEFT to allow keeping all aml even those without relation. The NULL will symbolize no relation
+                LEFT JOIN account_account_tag_account_tax_repartition_line_rel rep_tags 
+                ON rep_tags.account_tax_repartition_line_id = tax_to_rep_line.id
+            ), 
+            
+            -- 1.b) Handle tax line: relation aml <-> tag, if no relation, tag is NULL
+            tax_aml_id_rep_tag_to_insert AS (
+                SELECT aml.id AS aml_id, rep_tags.account_account_tag_id AS tag_id
+                FROM account_move_line aml
+                JOIN account_tax_repartition_line rep_ln ON rep_ln.id = aml.tax_repartition_line_id
+                LEFT JOIN account_account_tag_account_tax_repartition_line_rel rep_tags 
+                ON rep_tags.account_tax_repartition_line_id = aml.tax_repartition_line_id
+                WHERE aml.company_id = %(company_id)s AND aml.date >= %(date_from)s
+            ),
+            
+            base_and_tax_aml_tag_id AS (
+                SELECT aml_id, tag_id FROM base_aml_id_rep_tag_to_insert
+                UNION
+                SELECT aml_id, tag_id FROM tax_aml_id_rep_tag_to_insert
+            ), 
+            
+            -- 2) Delete previous tags from amls
+            delete_statement AS (
+                DELETE FROM account_account_tag_account_move_line_rel aml_tags
+                USING base_and_tax_aml_tag_id btat
+                WHERE btat.aml_id = aml_tags.account_move_line_id
+                RETURNING account_move_line_id AS aml_id
+            ), 
+            
+            -- 3) Insert new tag on amls
+            insert_statement AS (
+                INSERT INTO account_account_tag_account_move_line_rel
+                SELECT btat.aml_id, btat.tag_id
+                FROM base_and_tax_aml_tag_id btat
+                WHERE btat.tag_id NOTNULL
+                RETURNING account_move_line_id AS aml_id
+            ), 
+            
+            -- 4) Return impacted amls
+            impacted_aml as (
+                SELECT aml_id
+                FROM delete_statement
+                UNION
+                SELECT aml_id
+                FROM insert_statement
+            )
+            
+            SELECT ARRAY_AGG(impacted_aml.aml_id)
+              FROM impacted_aml
+        """, params={
+            'date_from': date_from,
+            'company_id': company_id,
+        })
+        self.invalidate_cache()
+        return self.env.cr.fetchone()[0]
+
+    def update_amls_tax_tags(self):
+        parent_taxes = self.env['account.tax'].search([
+            ('company_id', '=', self.company_id.id),
+            ('children_tax_ids', '!=', False),
+        ])
+        children_taxes = []
+        for tax in parent_taxes:
+            children_taxes += tax.children_tax_ids.ids
+        if len(children_taxes) > len(parent_taxes.children_tax_ids.ids):
+            raise UserError(_('Update with children taxes that are child of multiple parents is not supported.'))
+        aml_ids = self._modify_tag_to_aml_relation(self.company_id.id, self.date_from)
+        if aml_ids:
+            self._recompute_tax_audit_string(aml_ids)

--- a/addons/account_update_tax_tags/wizard/account_update_tax_tags_wizard.xml
+++ b/addons/account_update_tax_tags/wizard/account_update_tax_tags_wizard.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_account_update_tax_tags_wizard_form" model="ir.ui.view">
+        <field name="name">account.update.tax.tags.wizard.form</field>
+        <field name="model">account.update.tax.tags.wizard</field>
+        <field name="arch" type="xml">
+            <form>
+                <field name="company_id" invisible="1"/>
+                <field name="display_lock_date_warning" invisible="1"/>
+                <div class="alert alert-warning" role="alert">
+                    Updating tax tags on existing Journal Entries is an <b>irreversible</b> action that will impact
+                    your reports.<br/>
+                    It is highly recommended to backup your database beforehand.<br/>
+                    The update will change tax tags on your accounting history, starting from and including selected date,
+                    so that it matches with the current configuration of your taxes.<br/>
+                </div>
+                <div class="alert alert-warning" role="alert" attrs="{'invisible': [('display_lock_date_warning', '=', False)]}">
+                    The date you chose is violating the tax lock date, do this at your own risk.
+                </div>
+                <group>
+                    <field name="date_from"/>
+                </group>
+                <footer>
+                    <button string="Update" class="btn-primary" name="update_amls_tax_tags" type="object" data-hotkey="v"/>
+                    <button string="Discard" special="cancel" data-hotkey="z"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
After updating taxes, we didn't update already existing journal entries
tags to map correctly into new reports.
We let the user change his data which can be very time consuming.
To tackle that we introduce a new wizard accessible in accounting settings
in which user can set a date from which we will update tags on his journal entries
for him, so that they are synchronized with current taxes configuration.

Note: initial script is part of support tools' scripts, written by Brice (bib), slightly
modified for this wizard's purpose.

task-3330327