### PR TITLE
[FIX] mail: preserve letter case and accents when creating channel

### DIFF
--- a/addons/mail/static/src/discuss/core/web/channel_selector.js
+++ b/addons/mail/static/src/discuss/core/web/channel_selector.js
@@ -96,7 +96,7 @@ export class ChannelSelector extends Component {
                 choices.push({
                     channelId: "__create__",
                     classList: "o-discuss-ChannelSelector-suggestion",
-                    label: cleanedTerm,
+                    label: this.state.value,
                 });
                 this.state.navigableListProps.options = choices;
                 return;

--- a/addons/mail/static/tests/discuss/core/web/discuss_tests.js
+++ b/addons/mail/static/tests/discuss/core/web/discuss_tests.js
@@ -203,3 +203,12 @@ QUnit.test("no conversation selected when opening non-existing channel in discus
     await click(".o-mail-DiscussSidebar .btn", { text: "Channels" }); // check no crash
     await contains(".o-mail-DiscussSidebarCategory-channel .oi-chevron-right");
 });
+
+QUnit.test("Preserve letter case and accents when creating channel from sidebar", async () => {
+    const { openDiscuss } = await start();
+    openDiscuss();
+    await click(".o-mail-DiscussSidebar i[title='Add or join a channel']");
+    await insertText(".o-discuss-ChannelSelector input", "Crème brûlée Fan Club");
+    await click(".o-discuss-ChannelSelector-suggestion");
+    await contains(".o-mail-Discuss-threadName", { value: "Crème brûlée Fan Club" });
+});


### PR DESCRIPTION
Before this commit, when creating a channel from the discuss sidebar, the name of the channel would be transformed to lower case and stripped of accents.

This happens because the same cleaned term used for searching gets used to define the name of the new channel.

This commit fixes the issue by using the unaltered search term.

Before:
![image](https://github.com/odoo/odoo/assets/32620115/c0fb9a31-d8ae-4607-9c14-cd26cda34a0c)

After:
![image](https://github.com/odoo/odoo/assets/32620115/58d1480d-3818-4aab-baac-b8617958cf13)