### PR TITLE
[IMP] hr_holidays: restraint allocation_type choice

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -113,10 +113,19 @@ class HrLeaveAllocation(models.Model):
     nextcall = fields.Date("Date of the next accrual allocation", readonly=True, default=False)
     already_accrued = fields.Boolean()
     yearly_accrued_amount = fields.Float(export_string_translation=False)
-    allocation_type = fields.Selection([
-        ('regular', 'Regular Allocation'),
-        ('accrual', 'Accrual Allocation')
-    ], string="Allocation Type", default="regular", required=True, readonly=True)
+    allocation_type = fields.Selection(
+        selection=[
+            ('regular', 'Regular Allocation'),
+            ('accrual', 'Accrual Allocation')
+        ],
+        compute="_compute_allocation_type", store=True,
+        string="Allocation Type", default="regular", required=True, readonly=True,
+        help="""
+            Only one allocation type can be set for a given employee and a given time off type.
+            If an employee already has an allocation of the same leave type, the field is not editable.
+        """)
+    can_edit_type = fields.Boolean(compute="_compute_can_edit_type", export_string_translation=False)
+    allocation_type_discrepancy = fields.Boolean(compute="_compute_can_edit_type", export_string_translation=False)
     is_officer = fields.Boolean(compute='_compute_is_officer')
     accrual_plan_id = fields.Many2one('hr.leave.accrual.plan',
         compute="_compute_accrual_plan_id", store=True, readonly=False, tracking=True,
@@ -134,6 +143,23 @@ class HrLeaveAllocation(models.Model):
     def _check_date_from_date_to(self):
         if any(allocation.date_to and allocation.date_from > allocation.date_to for allocation in self):
             raise UserError(_("The Start Date of the Validity Period must be anterior to the End Date."))
+
+    @api.constrains('employee_id', 'holiday_status_id', 'allocation_type', 'state')
+    def _check_allocation_type_unicity(self):
+        existing_allocations_list = self.search([
+            ('employee_id', 'in', self.employee_id.ids),
+            ('holiday_status_id', 'in', self.holiday_status_id.ids),
+            ('state', '=', 'validate'),
+        ])
+        for allocation in self:
+            if allocation.state != 'validate':
+                continue
+            existing_allocations = existing_allocations_list.filtered_domain([
+                ('employee_id', '=', allocation.employee_id.id),
+                ('holiday_status_id', '=', allocation.holiday_status_id.id),
+            ]) | allocation
+            if len(set(existing_allocations.mapped('allocation_type'))) > 1:
+                raise UserError(_("An employee cannot have two different allocation types for a same time off type."))
 
     # The compute does not get triggered without a depends on record creation
     # aka keep the 'useless' depends
@@ -239,6 +265,47 @@ class HrLeaveAllocation(models.Model):
     def _compute_department_id(self):
         for allocation in self:
             allocation.department_id = allocation.employee_id.department_id
+
+    @api.depends('employee_id', 'holiday_status_id')
+    def _compute_allocation_type(self):
+        existing_allocations_list = self.search([
+            ('employee_id', 'in', self.employee_id.ids),
+            ('holiday_status_id', 'in', self.holiday_status_id.ids),
+            ('state', '=', 'validate'),
+        ])
+        for allocation in self:
+            existing_allocations = existing_allocations_list.filtered_domain([
+                ('id', '!=', allocation.id),
+                ('employee_id', '=', allocation.employee_id.id),
+                ('holiday_status_id', '=', allocation.holiday_status_id.id),
+            ])
+            if not existing_allocations or not allocation.employee_id or not allocation.holiday_status_id:
+                continue
+            allocation.allocation_type = existing_allocations.mapped('allocation_type')[0]
+
+    @api.depends('employee_id', 'holiday_status_id')
+    def _compute_can_edit_type(self):
+        self.allocation_type_discrepancy = False
+        existing_allocations_list = self.search([
+            ('employee_id', 'in', self.employee_id.ids),
+            ('holiday_status_id', 'in', self.holiday_status_id.ids),
+        ])
+        if not existing_allocations_list:
+            self.can_edit_type = True
+            return
+        for allocation in self:
+            existing_allocations = existing_allocations_list.filtered_domain([
+                ('id', '!=', allocation.id),
+                ('employee_id', '=', allocation.employee_id.id),
+                ('holiday_status_id', '=', allocation.holiday_status_id.id),
+                ('state', '=', 'validate'),
+            ])
+            if not existing_allocations or not allocation.employee_id or not allocation.holiday_status_id:
+                allocation.can_edit_type = True
+            else:
+                allocation.can_edit_type = False
+            if len(set(existing_allocations.mapped('allocation_type'))) > 1:
+                allocation.allocation_type_discrepancy = True
 
     @api.depends('employee_id')
     def _compute_manager_id(self):

--- a/addons/hr_holidays/tests/test_accrual_allocations.py
+++ b/addons/hr_holidays/tests/test_accrual_allocations.py
@@ -1999,53 +1999,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             accrual_allocation._update_accrual()
             self.assertAlmostEqual(accrual_allocation.number_of_days, 4.0, places=0)
 
-    def test_cancel_invalid_leaves_with_regular_and_accrual_allocations(self):
-        accrual_plan = self.env['hr.leave.accrual.plan'].with_context(tracking_disable=True).create({
-            'name': 'Monthly accrual',
-            'carryover_date': 'year_start',
-            'accrued_gain_time': 'start',
-            'level_ids': [(0, 0, {
-                'added_value_type': 'day',
-                'start_count': 0,
-                'start_type': 'day',
-                'added_value': 1,
-                'frequency': 'monthly',
-                'first_day_display': '1',
-                'cap_accrued_time': False,
-            })],
-        })
-        allocations = self.env['hr.leave.allocation'].create([
-            {
-                'name': 'Regular allocation',
-                'allocation_type': 'regular',
-                'date_from': '2024-05-01',
-                'holiday_status_id': self.leave_type.id,
-                'employee_id': self.employee_emp.id,
-                'number_of_days': 2,
-            },
-            {
-                'name': 'Accrual allocation',
-                'allocation_type': 'accrual',
-                'date_from': '2024-05-01',
-                'holiday_status_id': self.leave_type.id,
-                'employee_id': self.employee_emp.id,
-                'accrual_plan_id': accrual_plan.id,
-                'number_of_days': 3,
-            }
-        ])
-        allocations.action_approve()
-        leave = self.env['hr.leave'].create({
-                'name': 'Leave',
-                'employee_id': self.employee_emp.id,
-                'holiday_status_id': self.leave_type.id,
-                'request_date_from': '2024-05-13',
-                'request_date_to': '2024-05-17',
-            })
-        leave.action_validate()
-        with freeze_time('2024-05-06'):
-            self.env['hr.leave']._cancel_invalid_leaves()
-        self.assertEqual(leave.state, 'validate', "Leave must not be canceled")
-
     def test_accrual_leaves_cancel_cron(self):
         leave_type_no_negative = self.env['hr.leave.type'].create({
             'name': 'Test Accrual - No negative',

--- a/addons/hr_holidays/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays/views/hr_leave_allocation_views.xml
@@ -122,7 +122,7 @@
                             <field name="allocation_type"
                                 widget="radio"
                                 invisible="1"
-                                readonly="not is_officer or state == 'validate'"/>
+                                readonly="not can_edit_type or not is_officer or state == 'validate'"/>
                             <field name="is_officer" invisible="1"/>
                             <field name="accrual_plan_id"
                                 invisible="allocation_type == 'regular'"
@@ -195,6 +195,14 @@
                 <button string="Mark as ready to approve" name="action_set_to_confirm" type="object"
                         invisible="not can_approve or state != 'refuse' or not active_employee"/>
             </field>
+            <div id="title" position="before">
+                <div invisible="not allocation_type_discrepancy">
+                    <span class="alert alert-warning" role="alert">
+                        This employee has validated allocations of regular and accrual type for this time off type.
+                        This might lead to computation issues.
+                    </span>
+                </div>
+            </div>
             <div id="title" position="replace">
                 <div class="oe_title">
                     <h2><field name="name" placeholder="e.g. Time Off type (From validity start to validity end / no limit)" required="1"/></h2>
@@ -288,7 +296,7 @@
                 <field name="duration_display" string="Amount"/>
                 <field name="date_from" string="Validity Start" optional="hide"/>
                 <field name="date_to" string="Validity Stop" optional="hide" readonly="state in ['refuse', 'validate', 'validate1']"/>
-                <field name="allocation_type" readonly="state not in ['confirm']"/>
+                <field name="allocation_type" readonly="not can_edit_type or state not in ['confirm']"/>
                 <field name="notes" string="Reason" optional="hide"/>
                 <field name="message_needaction" column_invisible="True"/>
                 <field name="active_employee" column_invisible="True"/>

--- a/addons/hr_holidays/wizard/hr_leave_allocation_generate_multi_wizard.py
+++ b/addons/hr_holidays/wizard/hr_leave_allocation_generate_multi_wizard.py
@@ -28,10 +28,19 @@ class HrLeaveAllocationGenerateMultiWizard(models.TransientModel):
     company_id = fields.Many2one('res.company', default=lambda self: self.env.company, required=True)
     department_id = fields.Many2one('hr.department')
     category_id = fields.Many2one('hr.employee.category', string='Employee Tag')
-    allocation_type = fields.Selection([
-        ('regular', 'Regular Allocation'),
-        ('accrual', 'Accrual Allocation')
-    ], string="Allocation Type", default="regular", required=True)
+    allocation_type = fields.Selection(
+        selection=[
+            ('regular', 'Regular Allocation'),
+            ('accrual', 'Accrual Allocation')
+        ],
+        compute="_compute_allocation_type",
+        string="Allocation Type", default="regular", required=True,
+        help="""
+            Only one allocation type can be set for a given employee and a given time off type.
+            If at least one employee already has an allocation of the same leave type, the field is not editable.
+        """)
+    can_edit_type = fields.Boolean(compute="_compute_allocation_type", export_string_translation=False)
+    allocation_type_discrepancy = fields.Boolean(compute='_compute_allocation_type', export_string_translation=False)
     accrual_plan_id = fields.Many2one('hr.leave.accrual.plan',
         domain="['|', ('time_off_type_id', '=', False), ('time_off_type_id', '=', holiday_status_id)]")
     date_from = fields.Date('Start Date', default=fields.Date.context_today, required=True)
@@ -54,16 +63,52 @@ class HrLeaveAllocationGenerateMultiWizard(models.TransientModel):
             request_unit=self.request_unit
         )
 
+    @api.depends(
+        'holiday_status_id',
+        'allocation_mode',
+        'employee_ids',
+        'company_id',
+        'department_id',
+        'category_id',
+        'allocation_type',
+    )
+    def _compute_allocation_type(self):
+        self.allocation_type = 'regular'
+        self.can_edit_type = True
+        self.allocation_type_discrepancy = False
+        employees = self._get_employees_from_allocation_mode()
+        existing_allocations_list = self.env['hr.leave.allocation'].search([
+            ('employee_id', 'in', employees.ids),
+            ('holiday_status_id', 'in', self.holiday_status_id.ids),
+        ])
+        if not existing_allocations_list:
+            return
+        for wizard in self:
+            existing_allocations = existing_allocations_list.filtered_domain([
+                ('employee_id', 'in', employees.ids),
+                ('holiday_status_id', '=', wizard.holiday_status_id.id),
+            ])
+            if not existing_allocations or not employees or not wizard.holiday_status_id:
+                continue
+            allocation_types = list(set(existing_allocations.mapped('allocation_type')))
+            wizard.can_edit_type = False
+            wizard.allocation_type = allocation_types[0]
+            wizard.allocation_type_discrepancy = len(allocation_types) > 1\
+                or wizard.allocation_type != allocation_types[0]
+
     def _get_employees_from_allocation_mode(self):
-        self.ensure_one()
+        employees = self.env['hr.employee']
+        companies = self.env['res.company']
         if self.allocation_mode == 'employee':
-            employees = self.employee_ids
+            employees |= self.employee_ids
         elif self.allocation_mode == 'category':
-            employees = self.category_id.employee_ids.filtered(lambda e: e.company_id in self.env.companies)
+            employees |= self.category_id.employee_ids.filtered(lambda e: e.company_id in self.env.companies)
         elif self.allocation_mode == 'company':
-            employees = self.env['hr.employee'].search([('company_id', '=', self.company_id.id)])
+            companies |= self.company_id
         else:
-            employees = self.department_id.member_ids
+            employees |= self.department_id.member_ids
+        if companies:
+            employees |= self.env['hr.employee'].search([('company_id', 'in', companies.ids)])
         return employees
 
     def _prepare_allocation_values(self, employees):

--- a/addons/hr_holidays/wizard/hr_leave_allocation_generate_multi_wizard_views.xml
+++ b/addons/hr_holidays/wizard/hr_leave_allocation_generate_multi_wizard_views.xml
@@ -17,8 +17,7 @@
                         <field name="department_id" invisible="allocation_mode != 'department'" required="allocation_mode == 'department'"/>
                         <field name="category_id" invisible="allocation_mode != 'category'" required="allocation_mode == 'category'"/>
                         <field name="holiday_status_id"/>
-                        <field name="allocation_type" widget="radio"/>
-                        <field name="request_unit" invisible="1"/>
+                        <field name="allocation_type" widget="radio" readonly="not can_edit_type"/>
                         <field name="accrual_plan_id"
                             invisible="allocation_type == 'regular'"
                             required="allocation_type == 'accrual'"/>
@@ -45,8 +44,15 @@
                     </group>
                 </group>
                 <field name="notes" placeholder="Add a reason..." nolabel="1"/>
+                <div class="alert alert-warning m-0" role="alert" invisible="not allocation_type_discrepancy">
+                    <span>
+                        There are existing allocations for some employees that are not compatible with the allocations you're trying to create.
+                        Only one allocation type can be set for a given employee and a given time off type.
+                    </span>
+                </div>
                 <footer>
-                    <button name="action_generate_allocations" type="object" class="btn-primary" string="Create Allocations" accesskey="c"/>
+                    <button name="action_generate_allocations" type="object" class="btn-primary"
+                        invisible="allocation_type_discrepancy" string="Create Allocations" accesskey="c"/>
                     <button special="cancel" string="Discard" close="1" accesskey="j" />
                 </footer>
             </form>


### PR DESCRIPTION
Before this commit, a user could select freely an
allocation type for a new allocation. However, using both types for a same employee and a same leave type would make the balance computation wrong since both types are used differently.

This commit add some constraints to prevent that. If an employee already has an allocation for the same leave type, he will be prevented from editing the allocation_type, which will be automatically set. The same applies for the create-multi wizard, which will prevent also prevent for creating multiple allocations if two selected employees already have allocations with different allocation types for the leave type chosen.

task-3412869