### PR TITLE
[FIX] l10n_es_edi_facturae: validation of facturae xml

### DIFF
--- a/addons/l10n_es_edi_facturae/data/facturae_templates.xml
+++ b/addons/l10n_es_edi_facturae/data/facturae_templates.xml
@@ -131,12 +131,12 @@
                     </t>
                 </Charges>
                 <GrossAmount t-out="float_repr(refund_multiplier*line['GrossAmount'], file_currency.decimal_places)"/>
-                <TaxesOutputs>
-                    <t t-foreach="line['TaxesOutputs']" t-as="tax"><t t-call="l10n_es_edi_facturae.tax_type"/></t>
-                </TaxesOutputs>
                 <TaxesWithheld t-if="line.get('TaxesWithheld')">
                     <t t-foreach="line['TaxesWithheld']" t-as="tax"><t t-call="l10n_es_edi_facturae.tax_type"/></t>
                 </TaxesWithheld>
+                <TaxesOutputs>
+                    <t t-foreach="line['TaxesOutputs']" t-as="tax"><t t-call="l10n_es_edi_facturae.tax_type"/></t>
+                </TaxesOutputs>
                 <LineItemPeriod t-if="line.get('LineItemPeriod')">
                     <StartDate t-out="line['LineItemPeriod']['StartDate']"/>
                     <EndDate t-out="line['LineItemPeriod']['EndDate']"/>

--- a/addons/l10n_es_edi_facturae/tests/data/expected_tax_withholding.xml
+++ b/addons/l10n_es_edi_facturae/tests/data/expected_tax_withholding.xml
@@ -151,18 +151,6 @@
           <UnitPriceWithoutTax>100.00</UnitPriceWithoutTax>
           <TotalCost>100.00</TotalCost>
           <GrossAmount>100.00</GrossAmount>
-          <TaxesOutputs>
-            <Tax>
-              <TaxTypeCode>01</TaxTypeCode>
-              <TaxRate>21.000</TaxRate>
-              <TaxableBase>
-                <TotalAmount>100.00</TotalAmount>
-              </TaxableBase>
-              <TaxAmount>
-                <TotalAmount>21.00</TotalAmount>
-              </TaxAmount>
-            </Tax>
-          </TaxesOutputs>
           <TaxesWithheld>
             <Tax>
               <TaxTypeCode>01</TaxTypeCode>
@@ -175,6 +163,18 @@
               </TaxAmount>
             </Tax>
           </TaxesWithheld>
+          <TaxesOutputs>
+            <Tax>
+              <TaxTypeCode>01</TaxTypeCode>
+              <TaxRate>21.000</TaxRate>
+              <TaxableBase>
+                <TotalAmount>100.00</TotalAmount>
+              </TaxableBase>
+              <TaxAmount>
+                <TotalAmount>21.00</TotalAmount>
+              </TaxAmount>
+            </Tax>
+          </TaxesOutputs>
         </InvoiceLine>
         <InvoiceLine>
           <FileDate>2023-01-01</FileDate>
@@ -184,18 +184,6 @@
           <UnitPriceWithoutTax>100.00</UnitPriceWithoutTax>
           <TotalCost>100.00</TotalCost>
           <GrossAmount>100.00</GrossAmount>
-          <TaxesOutputs>
-            <Tax>
-              <TaxTypeCode>01</TaxTypeCode>
-              <TaxRate>21.000</TaxRate>
-              <TaxableBase>
-                <TotalAmount>100.00</TotalAmount>
-              </TaxableBase>
-              <TaxAmount>
-                <TotalAmount>21.00</TotalAmount>
-              </TaxAmount>
-            </Tax>
-          </TaxesOutputs>
           <TaxesWithheld>
             <Tax>
               <TaxTypeCode>01</TaxTypeCode>
@@ -208,6 +196,18 @@
               </TaxAmount>
             </Tax>
           </TaxesWithheld>
+          <TaxesOutputs>
+            <Tax>
+              <TaxTypeCode>01</TaxTypeCode>
+              <TaxRate>21.000</TaxRate>
+              <TaxableBase>
+                <TotalAmount>100.00</TotalAmount>
+              </TaxableBase>
+              <TaxAmount>
+                <TotalAmount>21.00</TotalAmount>
+              </TaxAmount>
+            </Tax>
+          </TaxesOutputs>
         </InvoiceLine>
         <InvoiceLine>
           <FileDate>2023-01-01</FileDate>
@@ -217,18 +217,6 @@
           <UnitPriceWithoutTax>200.00</UnitPriceWithoutTax>
           <TotalCost>200.00</TotalCost>
           <GrossAmount>200.00</GrossAmount>
-          <TaxesOutputs>
-            <Tax>
-              <TaxTypeCode>01</TaxTypeCode>
-              <TaxRate>21.000</TaxRate>
-              <TaxableBase>
-                <TotalAmount>200.00</TotalAmount>
-              </TaxableBase>
-              <TaxAmount>
-                <TotalAmount>42.00</TotalAmount>
-              </TaxAmount>
-            </Tax>
-          </TaxesOutputs>
           <TaxesWithheld>
             <Tax>
               <TaxTypeCode>01</TaxTypeCode>
@@ -241,6 +229,18 @@
               </TaxAmount>
             </Tax>
           </TaxesWithheld>
+          <TaxesOutputs>
+            <Tax>
+              <TaxTypeCode>01</TaxTypeCode>
+              <TaxRate>21.000</TaxRate>
+              <TaxableBase>
+                <TotalAmount>200.00</TotalAmount>
+              </TaxableBase>
+              <TaxAmount>
+                <TotalAmount>42.00</TotalAmount>
+              </TaxAmount>
+            </Tax>
+          </TaxesOutputs>
         </InvoiceLine>
       </Items>
       <PaymentDetails>


### PR DESCRIPTION
With an ES company setup
Create an invoice having line with taxes: 21% and 15% WHI
Send&Print
Download the facturae xml
Validate the xml on the face website [1]

Issue: validation will fail with error
"""
Línea xyz: Element 'TaxesWithheld': This element is not expected.
Expected is one of ( LineItemPeriod, TransactionDate, AdditionalLineItemInformation,
SpecialTaxableEvent, ArticleCode, Extensions ).
"""
This occurs because, according to official specs [2] in element
InvoiceLine (3.1.6.1) TaxesWithheld (3.1.6.1.21) should precede 'TaxesOutput' (3.1.6.1.22)

[1] https://face.gob.es/es/facturas/validar-visualizar-facturas
[2] https://www.facturae.gob.es/formato/Versiones/Esquema_castellano_v3_2_x_06_06_2017_unificado.pdf

opw-3981213