### PR TITLE
[IMP] pos_restaurant: imp order merge/split

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -44,6 +44,7 @@ export class PosStore extends Reactive {
         "notification",
         "printer",
         "action",
+        "alert",
     ];
     constructor() {
         super();
@@ -63,6 +64,7 @@ export class PosStore extends Reactive {
             bus_service,
             pos_data,
             action,
+            alert,
         }
     ) {
         this.env = env;
@@ -74,6 +76,7 @@ export class PosStore extends Reactive {
         this.bus = bus_service;
         this.data = pos_data;
         this.action = action;
+        this.alert = alert;
         this.notification = notification;
         this.unwatched = markRaw({});
         this.pushOrderMutex = new Mutex();

--- a/addons/point_of_sale/static/tests/unit/pos_app_tests.js
+++ b/addons/point_of_sale/static/tests/unit/pos_app_tests.js
@@ -40,6 +40,11 @@ QUnit.module("Chrome", {
             .add("ui", uiService)
             .add("dialog", dialogService)
             .add("contextual_utils_service", mockContextualUtilsService)
+            .add("alert", {
+                start() {
+                    return { add: () => {}, dismiss: () => {} };
+                },
+            })
             .add("barcode", {
                 start() {
                     return { bus: new EventBus() };

--- a/addons/pos_restaurant/static/src/app/control_buttons/control_buttons.js
+++ b/addons/pos_restaurant/static/src/app/control_buttons/control_buttons.js
@@ -11,6 +11,7 @@ import { BillScreen } from "@pos_restaurant/app/bill_screen/bill_screen";
 patch(ControlButtons.prototype, {
     setup() {
         super.setup(...arguments);
+        this.alert = useService("alert");
         this.printer = useService("printer");
         this.clickPrintBill = useAsyncLockedMethod(this.clickPrintBill);
     },

--- a/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.js
+++ b/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.js
@@ -65,7 +65,7 @@ export class FloorScreen extends Component {
             selectedFloorId: floor ? floor.id : null,
             floorHeight: "100%",
             floorWidth: "100%",
-            selectedTableIds: this.getTablesSelectedByDefault(),
+            selectedTableIds: [],
             isColorPicker: false,
             potentialLink: null,
         });
@@ -161,7 +161,7 @@ export class FloorScreen extends Component {
                 const oToTrans = this.pos.getActiveOrdersOnTable(table)[0];
                 if (oToTrans) {
                     this.pos.orderToTransferUuid = oToTrans.uuid;
-                    this.pos.transferTable(newParentTable);
+                    this.pos.transferOrder(newParentTable);
                 }
                 this.pos.data.write("restaurant.table", [table.id], {
                     parent_id: newParentTable.id,
@@ -272,10 +272,6 @@ export class FloorScreen extends Component {
             this.state.floorWidth = `${positionH}px`;
         }
     }
-    getTablesSelectedByDefault() {
-        const oToTrans = this.pos.models["pos.order"].getBy("uuid", this.pos.orderToTransferUuid);
-        return oToTrans?.table_id ? [oToTrans.table_id.id] : [];
-    }
     async onWillStart() {
         this.pos.searchProductWord = "";
         const table = this.pos.selectedTable;
@@ -320,7 +316,7 @@ export class FloorScreen extends Component {
                 ...table.serialize({ orm: true }),
             });
         }
-        this.state.selectedTableIds = this.getTablesSelectedByDefault();
+        this.state.selectedTableIds = [];
         this.state.isColorPicker = false;
     }
     _computePinchHypo(ev, callbackFunction) {
@@ -544,7 +540,7 @@ export class FloorScreen extends Component {
         }
         const oToTrans = this.pos.models["pos.order"].getBy("uuid", this.pos.orderToTransferUuid);
         if (oToTrans) {
-            await this.pos.transferTable(table);
+            await this.pos.transferOrder(table);
             this.pos.showScreen("ProductScreen");
         } else {
             try {
@@ -693,13 +689,6 @@ export class FloorScreen extends Component {
                 });
             },
         });
-    }
-    stopOrderTransfer() {
-        const order = this.pos.models["pos.order"].getBy("uuid", this.pos.orderToTransferUuid);
-        this.pos.set_order(order);
-        this.pos.showScreen("ProductScreen");
-        this.pos.isTableToMerge = false;
-        this.pos.orderToTransferUuid = null;
     }
     changeShape(form) {
         for (const table of this.selectedTables) {

--- a/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.xml
+++ b/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.xml
@@ -3,17 +3,6 @@
     <t t-name="pos_restaurant.FloorScreen">
         <div class="floor-screen screen h-100 position-relative d-flex flex-column flex-nowrap m-0 bg-100 text-start overflow-hidden">
             <t t-set="editButtonClass" t-value="'text-center d-flex flex-column align-items-center btn btn-light text-uppercase'" />
-            <div t-if="pos.orderToTransferUuid" class="d-flex align-items-center justify-content-between px-3 border-bottom bg-view overflow-x-auto w-100">
-                <button t-attf-class="ms-auto {{editButtonClass}}" t-att-class="{active: !pos.isTableToMerge}" t-on-click="() => this.pos.isTableToMerge = false">
-                    <i class="fa fa-arrow-right" role="img" aria-label="Transfer" title="Transfer" />Transfer</button>
-                <button
-                    t-if="pos.models['pos.order'].find(o => o.uuid === pos.orderToTransferUuid).table_id"
-                    t-attf-class="{{editButtonClass}}" t-att-class="{active: pos.isTableToMerge}"
-                    t-on-click="() => this.pos.isTableToMerge = true">
-                    <i class="fa fa-link" role="img" aria-label="Merge" title="Merge" />Merge</button>
-                <button t-attf-class="ms-auto {{editButtonClass}}" t-on-click.stop="stopOrderTransfer">
-                    <i class="fa fa-times" role="img" aria-label="Close" title="Close" />Discard</button>
-            </div>
             <div t-if="pos.isEditMode" class="edit-buttons d-flex px-3 border-bottom bg-view overflow-x-auto w-100">
                 <button t-attf-class="ms-auto {{editButtonClass}}" t-on-click.stop="createTable">
                     <i class="fa fa-plus" role="img" aria-label="Add" title="Add" />Table</button>
@@ -122,7 +111,7 @@
                                                         left: ${table.getX()}px;
                                                     `
                                                 }}
-                                                "
+                                            "
                                     >
                                     <t t-set="offset" t-value="getTableHandleOffset(table)"/>
                                     <div class="info position-relative w-100 h-100" t-att-class="{'opacity-25': table.parent_id}">

--- a/addons/pos_restaurant/static/src/app/models/restaurant_table.js
+++ b/addons/pos_restaurant/static/src/app/models/restaurant_table.js
@@ -59,6 +59,8 @@ export class RestaurantTable extends Base {
             y: this.getY() + this.height / 2,
         };
     }
+    getOrder() {
+        return this["<-pos.order.table_id"][0];
+    }
 }
-
 registry.category("pos_available_models").add(RestaurantTable.pythonModel, RestaurantTable);

--- a/addons/pos_restaurant/static/src/app/split_bill_screen/split_bill_screen.xml
+++ b/addons/pos_restaurant/static/src/app/split_bill_screen/split_bill_screen.xml
@@ -26,13 +26,13 @@
                     <div class="controls border-start flex-column flex-nowrap flex-grow-1 flex-shrink-1 flex-basis-0">
                         <div class="order-info py-4 border-bottom text-center text-success">
                             <span class="subtotal">
-                                <t t-esc="env.utils.formatCurrency(this.newOrderPrice)" />
+                                <t t-esc="env.utils.formatCurrency(newOrderPrice)" />
                             </span>
                         </div>
                         <div class="pay-button m-3">
                             <div class="button btn btn-lg btn-secondary py-3 w-100" t-on-click="createSplittedOrder">
                                 <i class="oi oi-chevron-right me-2" />
-                                <span>Payment</span>
+                                <span>Split Order</span>
                             </div>
                         </div>
                     </div>

--- a/addons/pos_restaurant/static/src/overrides/components/navbar/navbar.js
+++ b/addons/pos_restaurant/static/src/overrides/components/navbar/navbar.js
@@ -11,6 +11,16 @@ patch(Navbar, {
 });
 patch(Navbar.prototype, {
     async onClickBackButton() {
+        if (this.pos.orderToTransferUuid) {
+            const order = this.pos.models["pos.order"].getBy("uuid", this.pos.orderToTransferUuid);
+            this.pos.set_order(order);
+            if (order.table_id) {
+                this.pos.setTable(order.table_id);
+            }
+            this.pos.orderToTransferUuid = false;
+            this.pos.showScreen("ProductScreen");
+            return;
+        }
         if (this.pos.mainScreen.component && this.pos.config.module_pos_restaurant) {
             if (
                 (this.pos.mainScreen.component === ProductScreen &&
@@ -29,14 +39,21 @@ patch(Navbar.prototype, {
      * If no table is set to pos, which means the current main screen
      * is floor screen, then the order count should be based on all the orders.
      */
+
     get orderCount() {
         if (this.pos.config.module_pos_restaurant && this.pos.selectedTable) {
             return this.pos.getTableOrders(this.pos.selectedTable.id).length;
         }
         return super.orderCount;
     },
+    getTable() {
+        return this.pos.orderToTransferUuid
+            ? this.pos.models["pos.order"].find((o) => o.uuid == this.pos.orderToTransferUuid)
+                  ?.table_id
+            : this.pos.selectedTable;
+    },
     get showTableIcon() {
-        return this.pos.selectedTable?.name && this.pos.showBackButton();
+        return this.getTable()?.name && this.pos.showBackButton();
     },
     onSwitchButtonClick() {
         const mode = this.pos.floorPlanStyle === "kanban" ? "default" : "kanban";

--- a/addons/pos_restaurant/static/src/overrides/components/navbar/navbar.xml
+++ b/addons/pos_restaurant/static/src/overrides/components/navbar/navbar.xml
@@ -11,22 +11,29 @@
                 Switch Floor View
             </DropdownItem>
         </xpath>
-        <xpath expr="//button[hasclass('back-button')]" position="inside">
-            <span class="mx-1 fs-4" t-if="!ui.isSmall and pos.config.module_pos_restaurant" t-esc="backBtnName" />
-        </xpath>
         <xpath expr="//div[hasclass('pos-rightheader')]" position="before">
             <div t-if="pos.config.module_pos_restaurant" class="ms-1 d-flex overflow-hidden position-relative">
-                <span t-if="showTableIcon" t-esc="pos.selectedTable.name" t-attf-style="background-color: {{pos.selectedTable.color}};border-radius: 0.25rem;" class="table-name text-white fw-bolder px-3 my-2 py-1 d-flex align-items-center" />
-                <button t-if="!pos.selectedOrderUuid" class="btn btn-primary mx-2" t-on-click="newFloatingOrder">
-                    <i class="fa fa-plus-circle" aria-hidden="true"/>
-                </button>
-                <ListContainer t-if="!pos.selectedOrderUuid and !pos.selectedTable" items="getFloatingOrders()" t-slot-scope="scope">
-                    <t t-set="order" t-value="scope.item"/>
-                    <button t-esc="order.getFloatingOrderName()" class="btn btn-secondary" t-on-click="() => this.selectFloatingOrder(order)"/>
-                </ListContainer>
-                <button t-if="pos.get_order() and !pos.get_order()?.table_id" class="btn btn-secondary ms-2" t-on-click="() => this.editOrderNote(this.pos.get_order())">
-                    <i class="fa fa-pencil-square-o me-1" aria-hidden="true" /><t t-if="!ui.isSmall" t-esc="pos.get_order().getFloatingOrderName()"/>
-                </button>
+                <span t-if="showTableIcon"
+                    t-esc="getTable().name"
+                    t-attf-style="background-color: {{getTable().color}};border-radius: 0.25rem;"
+                    class="table-name text-white fw-bolder px-3 my-2 me-1 py-1 d-flex align-items-center" />
+                <t t-if="!pos.orderToTransferUuid">
+                    <button t-if="!pos.selectedOrderUuid" class="btn btn-primary mx-2" t-on-click="newFloatingOrder">
+                        <i class="fa fa-plus-circle" aria-hidden="true"/>
+                    </button>
+                    <ListContainer t-if="!pos.selectedOrderUuid and !pos.selectedTable" items="getFloatingOrders()" t-slot-scope="scope">
+                        <t t-set="order" t-value="scope.item"/>
+                        <button t-esc="order.getFloatingOrderName()" class="btn btn-secondary tab" t-on-click="() => this.selectFloatingOrder(order)"/>
+                    </ListContainer>
+                    <button t-if="pos.get_order() and !pos.get_order()?.table_id" class="btn btn-secondary ms-2" t-on-click="() => this.editOrderNote(this.pos.get_order())">
+                        <i class="fa fa-pencil-square-o me-1" aria-hidden="true" /><t t-if="!ui.isSmall" t-esc="pos.get_order().getFloatingOrderName()"/>
+                    </button>
+                </t>
+                <div class="d-flex align-items-center" t-else="">
+                    <strong class="ms-2">
+                        Select table to transfer order
+                    </strong>
+                </div>
             </div>
         </xpath>
     </t>

--- a/addons/pos_restaurant/static/tests/tours/split_bill_screen_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/split_bill_screen_tour.js
@@ -42,7 +42,6 @@ registry.category("web_tour.tours").add("SplitBillScreenTour", {
 
             // click pay to split, go back to check the lines
             SplitBillScreen.clickPay(),
-            PaymentScreen.clickBack(),
             ProductScreen.clickOrderline("Water", "3.0"),
             ProductScreen.clickOrderline("Coca-Cola", "1.0"),
 
@@ -110,13 +109,15 @@ registry.category("web_tour.tours").add("SplitBillScreenTour3", {
 
             // click pay to split, and pay
             SplitBillScreen.clickPay(),
+            ProductScreen.clickPayButton(),
             PaymentScreen.clickPaymentMethod("Bank"),
             PaymentScreen.clickValidate(),
-            // Check if the receiptscreen suggests us to continue the order
-            ReceiptScreen.clickContinueOrder(),
+            ReceiptScreen.clickNextOrder(),
 
             // Check if there is still water in the order
-            ProductScreen.isShown(),
+            FloorScreen.isShown(),
+            FloorScreen.clickTable("2"),
+
             ProductScreen.selectedOrderlineHas("Water", "1.0"),
             ProductScreen.clickPayButton(true),
             PaymentScreen.clickPaymentMethod("Bank"),
@@ -167,11 +168,14 @@ registry.category("web_tour.tours").add("SplitBillScreenTour4PosCombo", {
 
             ...SplitBillScreen.subtotalIs("53.80"),
             ...SplitBillScreen.clickPay(),
+            ProductScreen.clickPayButton(),
             ...PaymentScreen.clickPaymentMethod("Bank"),
             ...PaymentScreen.clickValidate(),
-            ...ReceiptScreen.clickContinueOrder(),
+            ...ReceiptScreen.clickNextOrder(),
+
             // Check if there is still water in the order
-            ...ProductScreen.isShown(),
+            ...FloorScreen.isShown(),
+            FloorScreen.clickTable("2"),
             // now we check that all the lines that remained in the order are correct
             ...ProductScreen.selectedOrderlineHas("Minute Maid", "1.0"),
             ...ProductScreen.clickOrderline("Office Combo"),


### PR DESCRIPTION
Currently, the "Transfer/Merge" button allows the user to either
transfer the order to another table, or to link the table of the
current order with another table. When linking, the order of the old
table will be moved to the new table, but the 2 orders will not be
merged into one.

With the new changes, clicking on the button and then selecting a new
table will either perform a transfer, if the destination table does not
have an order on it, or an actual merging of the 2 orders into one, if
the destination table has an order. In this case, the tables will also
be automatically linked.

We also fix the issue that prevented floating orders to be transfered to
tables.

Task: 3996948




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
