### PR TITLE
[FIX] web_editor: fix getTraversedNodes wih table cells selection

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
@@ -763,6 +763,7 @@ export function getTraversedNodes(editable, range = getDeepRange(editable)) {
     } while (node && node !== range.startContainer && !(selectedTableCells.length && node === selectedTableCells[0]));
     if (
         node &&
+        !(selectedTableCells.length && node === selectedTableCells[0]) &&
         !range.collapsed &&
         node.nodeType === Node.ELEMENT_NODE &&
         node.childNodes.length &&

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/utils.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/utils.test.js
@@ -1397,6 +1397,41 @@ describe('Utils', () => {
                 },
             });
         });
+        it("selection within table cells 1", async () => {
+            await testEditor(BasicEditor, {
+                contentBefore:
+                    "<table><tbody><tr><td>abcd[e</td><td>f]g</td></tr></tbody></table>",
+                stepFunction: editor => {
+                    const editable = editor.editable;
+                    const tr = editable.firstChild.firstChild.firstChild;
+                    const td1 = tr.firstChild;
+                    const abcde = td1.firstChild;
+                    const td2 = td1.nextSibling;
+                    const fg = td2.firstChild;
+                    const result = getTraversedNodes(editable);
+                    window.chai.expect(result).to.eql([td1, abcde, td2, fg]);
+                },
+            });
+        });
+        it("selection within table cells 2", async () => {
+            await testEditor(BasicEditor, {
+                contentBefore:
+                    "<table><tbody><tr><td>abcd<br>[<br>e</td><td>f]g</td></tr></tbody></table>",
+                stepFunction: editor => {
+                    const editable = editor.editable;
+                    const tr = editable.firstChild.firstChild.firstChild;
+                    const td1 = tr.firstChild;
+                    const abcd = td1.firstChild;
+                    const br1 = abcd.nextSibling;
+                    const br2 = br1.nextSibling;
+                    const e = br2.nextSibling;
+                    const td2 = td1.nextSibling;
+                    const fg = td2.firstChild;
+                    const result = getTraversedNodes(editable);
+                    window.chai.expect(result).to.eql([td1, abcd, br1, br2, e, td2, fg]);
+                },
+            });
+        });
     });
     describe('getSelectedNodes', () => {
         it('should return nothing if the range is collapsed', async () => {


### PR DESCRIPTION
Issue:
======
Traceback occurs when you select more than one table cell

Steps to reproduce the issue:
=============================
- Go to to-do
- Add a table 1row x 3cols
- Add some content with somewhat big length for example "abcde" in the first cell
- Add anything in the second cell
- Start the selection from the last character of the first cell
- Move the cursor to add selection from the second cell
- Traceback

Origin of the issue:
====================
When we have table cells selected, the first while loop stops at the `td` element and not the startContainer so we shouldn't enter in the if condition that handles the `br` elements

task-4043879