### PR TITLE
[FIX] l10n_de: Add missing return in write override

### DIFF
--- a/addons/l10n_de/models/account_account.py
+++ b/addons/l10n_de/models/account_account.py
@@ -9,4 +9,4 @@ class AccountAccount(models.Model):
         if 'code' in vals and 'DE' in self.company_id.account_fiscal_country_id.mapped('code'):
             if self.env['account.move.line'].search_count([('account_id', 'in', self.ids)], limit=1):
                 raise UserError(_("You can not change the code of an account."))
-        super().write(vals)
+        return super().write(vals)


### PR DESCRIPTION
Turns out there's a test that checks that the return value from the super() call in write is returned in the override.

See `TestOverrides.test_write()`.

So we need to return the value from the super().write().