### PR TITLE
[FIX] web: round ProgressBarField values to prevent progress bar overflow due to inaccuracies from floating point arithmetic

### DIFF
--- a/addons/web/static/src/views/fields/progress_bar/progress_bar_field.js
+++ b/addons/web/static/src/views/fields/progress_bar/progress_bar_field.js
@@ -3,6 +3,7 @@
 import { _lt } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { useNumpadDecimal } from "../numpad_decimal_hook";
+import { formatFloat } from "../formatters";
 import { parseFloat } from "../parsers";
 import { standardFieldProps } from "../standard_field_props";
 
@@ -50,11 +51,11 @@ export class ProgressBarField extends Component {
     }
 
     getCurrentValue(p) {
-        return p.record.data[this.getCurrentValueField(p)] || 0;
+        return parseFloat(formatFloat(p.record.data[this.getCurrentValueField(p)], { digits: [false, 8] })) || 0;
     }
     getMaxValue(p) {
         if (p.maxValueField) {
-            return p.record.data[p.maxValueField] || 100;
+            return parseFloat(formatFloat(p.record.data[p.maxValueField], { digits: [false, 8] })) || 100;
         }
         return 100;
     }


### PR DESCRIPTION
Problem:

Progress bars in Odoo will show one color when it is between 0% and 100% and another color when it overflows (goes past 100%).

The fields total_margin_rate and expected_margin_rate, which are progress bars, can sometimes show the overflow color even though it looks like it is at 100% because of floating point arithmetic inaccuracies. For example, 24166.67 * 100 / 24166.67 = 100.00000000000001. The arithmetic representation error in Python will make it seem like the result is greater than 100, which will make the progress bar appear in the overflow color, when it should actually just be represented in the original color.

Purpose:

Rounding the ProgressBarField value to eight decimal places will allow arithmetic representation errors to be ignored. Also rounded the ProgressBarField’s max value for consistency.

Steps to Reproduce on Runbot:

1. Open “Product Margins” and find a product where the Total Margin Rate(%) and Expected Margin(%) are 0%
2. Set the Sales Price (list_price) of the product to be 24166.67 [this causes the overflow for Expected Margin(%)]
3. Create an invoice for that product and set the price to be 24166.67 [this causes the overflow for Total Margin Rate(%)]. Make sure to remove any taxes and make sure that the total or the invoice is 24166.67
4. Confirm the invoice
5. Open “Product Margins” and find that the progress bars of the fields Total Margin Rate(%) and Expected Margin(%) for the product look to be a different color than the progress bars for the other products

Notes:

Although this arithmetic representation issue is also present in version 15.0, it is not a visual issue there because progress bars do not have a different color scheme for when the percentage overflows past 100%

opw-3997376