### PR TITLE
[FIX] mrp: allow MO overview with component as byproduct

### DIFF
--- a/addons/mrp/report/mrp_report_mo_overview.py
+++ b/addons/mrp/report/mrp_report_mo_overview.py
@@ -543,6 +543,7 @@ class ReportMoOverview(models.AbstractModel):
                 'currency_id': currency.id,
                 'currency': currency,
             }
+            forecast_line['already_used'] = True
             if doc_in._name == 'mrp.production':
                 replenishment['components'] = self._get_components_data(doc_in, replenish_data, level + 2, replenishment_index)
                 replenishment['operations'] = self._get_operations_data(doc_in, level + 2, replenishment_index)
@@ -558,7 +559,6 @@ class ReportMoOverview(models.AbstractModel):
             replenishment['summary']['mo_cost_decorator'] = self._get_comparison_decorator(replenishment['summary']['real_cost'], replenishment['summary']['mo_cost'], replenishment['summary']['currency'].rounding)
             replenishment['summary']['formatted_state'] = self._format_state(doc_in, replenishment['components']) if doc_in._name == 'mrp.production' else self._format_state(doc_in)
             replenishments.append(replenishment)
-            forecast_line['already_used'] = True
             total_ordered += replenishment['summary']['quantity']
 
         # Add "In transit" line if necessary

--- a/addons/mrp/tests/test_stock_report.py
+++ b/addons/mrp/tests/test_stock_report.py
@@ -3,6 +3,7 @@
 
 from odoo.tests import Form
 from odoo.addons.stock.tests.test_report import TestReportsCommon
+from odoo import Command
 
 
 class TestMrpStockReports(TestReportsCommon):
@@ -361,3 +362,28 @@ class TestMrpStockReports(TestReportsCommon):
 
         overview_values = self.env['report.mrp.report_mo_overview'].get_report_values(mo.id)
         self.assertEqual(overview_values['data']['id'], mo.id, "computing overview value should work")
+
+    def test_overview_with_component_also_as_byproduct(self):
+        """ Check that opening he overview of an MO for which the BoM contains an element as both component and byproduct
+        does not cause an infinite recursion.
+        """
+        bom = self.env['mrp.bom'].create({
+            'product_tmpl_id': self.product.product_tmpl_id.id,
+            'product_qty': 1.0,
+            'bom_line_ids': [
+                Command.create({'product_id': self.product1.id, 'product_qty': 1.0}),
+                ],
+            'byproduct_ids': [
+                Command.create({'product_id': self.product1.id, 'product_qty': 1.0})
+                ]
+        })
+
+        mo = self.env['mrp.production'].create({
+            'product_id': self.product.id,
+            'bom_id': bom.id,
+            'product_qty': 1,
+        })
+
+        mo.action_confirm()
+        overview_values = self.env['report.mrp.report_mo_overview'].get_report_values(mo.id)
+        self.assertEqual(overview_values['data']['id'], mo.id, "Unexpected disparity between overview and MO data")


### PR DESCRIPTION
Steps to reproduce:
- Manufacturing > Products > Bills of Material > New
- Add any item as component then the same item as by-product
- Confirm
- Operations > Manufacturing Order > New
- Pick the product associated to your newly created BoM
- Confirm > Overview

What happens and why:
Odoo raises an RPC error due to an inifinite recursion between _get_components_data and _get_replenishment_lines. Both calls are made before the manufacturing order line is flagged as processed so the functions are mutually dependant on the other finishing first. The looping call is conitionally called when document_in and document_out are the same, which seems to be why the stock moves 'move_in' (component) and 'move_out' (by-product) need to be configured this way on the BoM.

Why is this an error:
This prevents the user from accessing the overview of a valid MO.

What this fix does:
Moves the flag to before the looping call can be made, so the recursive call does not propagate infiniely.

opw-4013371

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
