### PR TITLE
[IMP] website_sale: remove the edit icons from product search bar

### DIFF
--- a/addons/website_sale/static/src/xml/website_sale_utils.xml
+++ b/addons/website_sale/static/src/xml/website_sale_utils.xml
@@ -4,7 +4,6 @@
 <!-- Products Search Bar autocomplete item -->
 <we-button t-name="website_sale.ribbonSelectItem" t-att-data-set-ribbon="ribbon.id">
     <t t-out="ribbon.name"/>
-    <span t-attf-class="fa fa-arrow-#{isLeft ? 'left' : 'right'} ms-1"></span>
     <span
         t-attf-class="o_wsale_color_preview ms-1"
         t-attf-style="background-color: #{ribbon.bg_color}"


### PR DESCRIPTION
Basically this is the second part of the task. The first part was the bug so it 
solved in these 
PR : https://github.com/odoo/odoo/pull/168265

Step to reproduce:
- Go to the Shop page on the website
- Enable edit mode
- Pick a product and create a new Badge/Ribbon
- There are the edit icons(Arrow)

Before this commit:
When we try to set the ribbon we find that there is "Edit" icon (arrow).

After this commit:
Removed the "Edit" icons (arrow).

task-3964071

