### PR TITLE
[FIX] web: add utils_tests to the qunit_suite_tests bundle

### DIFF
--- a/addons/web/__manifest__.py
+++ b/addons/web/__manifest__.py
@@ -500,6 +500,7 @@ This module provides the core of the Odoo Web Client.
             'web/static/tests/env_tests.js',
             'web/static/tests/core/**/*.js',
             'web/static/tests/fields/**/*.js',
+            'web/static/tests/l10n/**/*.js',
             'web/static/tests/search/**/*.js',
             ('remove', 'web/static/tests/search/helpers.js'),
             'web/static/tests/views/**/*.js',

--- a/addons/web/static/src/core/l10n/utils.js
+++ b/addons/web/static/src/core/l10n/utils.js
@@ -20,8 +20,14 @@
  * @returns {string} The locale formatted for use on the JavaScript-side.
  */
 export function pyToJsLocale(locale) {
-    const regex = /^([a-z]+)(_[A-Z\d]+)?(@.+)?$/;
-    const [, language, territory, modifier] = locale.match(regex);
+    if (!locale) {
+        return "";
+    }
+    const match = locale.match(/^([a-z]+)(_[A-Z\d]+)?(@.+)?$/);
+    if (!match) {
+        return locale;
+    }
+    const [, language, territory, modifier] = match;
     const subtags = [language];
     if (modifier === "@latin") {
         subtags.push("Latn");


### PR DESCRIPTION
The file utils_tests.js was not listed in the web.qunit_suite_tests assets bundle, preventing it from loading and rendering it useless.

This commit updates the assets bundle definition to properly load utils_tests.js.

Follow-up of https://github.com/odoo/odoo/pull/171176