### PR TITLE
[FIX] mrp_workorder: don't start a finished work order

### DIFF
--- a/addons/mrp/i18n/mrp.pot
+++ b/addons/mrp/i18n/mrp.pot
@@ -6672,6 +6672,13 @@ msgstr ""
 
 #. module: mrp
 #. odoo-python
+#: code:addons/mrp/models/mrp_workorder.py:0
+#, python-format
+msgid "You cannot start a work order that is already done or cancelled"
+msgstr ""
+
+#. module: mrp
+#. odoo-python
 #: code:addons/mrp/models/mrp_unbuild.py:0
 #, python-format
 msgid "You cannot unbuild a undone manufacturing order."

--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -591,9 +591,8 @@ class MrpWorkorder(models.Model):
         for wo in self:
             if any(not time.date_end for time in wo.time_ids.filtered(lambda t: t.user_id.id == self.env.user.id)):
                 continue
-            # As button_start is automatically called in the new view
             if wo.state in ('done', 'cancel'):
-                continue
+                raise UserError(_('You cannot start a work order that is already done or cancelled'))
 
             if wo.product_tracking == 'serial' and wo.qty_producing == 0:
                 wo.qty_producing = 1.0


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a storable product P1 with BoM:
    - Component: Add any component
    - operation: OP1

- Create a MO with P1:
    - Confirm it
    - Start the workorder and mark it as done
- Come back to the dashboard >  workorders list
- Select the finished workorder
- Try to start it

Problem:
The work order can be started while it is in the 'done' state.

When the function `button_start` is called, we will check if we need to
skip the employee check or not. However, since the current user is also
an employee, we will use them:
https://github.com/odoo/enterprise/blob/c4604d8b398713898b014e6073219d6202c154c3/mrp_workorder/models/mrp_workorder.py#L258-L259
The function start_employee will then be called:
https://github.com/odoo/enterprise/blob/c4604d8b398713898b014e6073219d6202c154c3/mrp_workorder/models/mrp_workorder.py#L284-L286
The state of the work order will then be updated:
https://github.com/odoo/enterprise/blob/c4604d8b398713898b014e6073219d6202c154c3/mrp_workorder/models/mrp_workorder.py#L740"

opw-[4024904](https://www.odoo.com/web#id=4024904&view_type=form&model=project.task)