### PR TITLE
[IMP] hr_referral: change the search views

### DIFF
--- a/addons/website_hr_recruitment/views/hr_job_views.xml
+++ b/addons/website_hr_recruitment/views/hr_job_views.xml
@@ -68,7 +68,7 @@
         <field name="arch" type="xml">
             <xpath expr="//filter[@name='message_needaction']" position="before">
                 <filter name="published" string="Published" domain="[('is_published', '=', True)]"/>
-                <separator/>
+                <separator name="published_separator"/>
             </xpath>
             <xpath expr="//group" position="inside">
                 <filter string="Published" name="groupby_published" domain="[]" context="{'group_by': 'is_published'}"/>


### PR DESCRIPTION
The original search was the same one as the one used in the job search view from hr_recruitment. This search was not adapted to the referral because it was including filters that were already enforced by the referral domain.

task-3607159

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
