### PR TITLE
[IMP] base: ir.http _authenticate_explicit

### DIFF
--- a/odoo/addons/base/models/ir_http.py
+++ b/odoo/addons/base/models/ir_http.py
@@ -153,7 +153,10 @@ class IrHttp(models.AbstractModel):
     @classmethod
     def _authenticate(cls, endpoint):
         auth = 'none' if http.is_cors_preflight(request, endpoint) else endpoint.routing['auth']
+        cls._authenticate_explicit(auth)
 
+    @classmethod
+    def _authenticate_explicit(cls, auth):
         try:
             if request.session.uid is not None:
                 if not security.check_session(request.session, request.env):


### PR DESCRIPTION
Offer a simple way for fake auth='none' controllers to auth as public or as user.

Task-4014623
