### PR TITLE
[FIX] pos_loyalty: ensure PoS opens when a program lacks rewards

### DIFF
--- a/addons/pos_loyalty/models/loyalty_program.py
+++ b/addons/pos_loyalty/models/loyalty_program.py
@@ -79,7 +79,7 @@ class LoyaltyProgram(models.Model):
         res = {k['program_id']: k['sum'] for k in res}
 
         for rec in self:
-            rec.pos_order_count = res[rec.id] or 0
+            rec.pos_order_count = res.get(rec.id) or 0
 
     def _compute_total_order_count(self):
         super()._compute_total_order_count()


### PR DESCRIPTION
Before this commit, the absence of rewards in a loyalty program would trigger an error, preventing the Point of Sale from opening. Although the current design does not support removing all rewards from a program, there exist databases in this state.

opw-4045063

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
