### PR TITLE
[FIX] models: fix granularity explanation

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -2021,11 +2021,11 @@ class BaseModel(metaclass=MetaModel):
                            SQL | -----------------------
                     Monday  1  |  0     |  1    |  2
                     tuesday 2  |  1     |  2    |  3
-                    wed     3  |  3     |  4    |  4
+                    wed     3  |  2     |  3    |  4
                     thurs   4  |  3     |  4    |  5
                     friday  5  |  4     |  5    |  6
-                    sat     6  |  6     |  0    |  0
-                    sun     7  |  0     |  1    |  1
+                    sat     6  |  5     |  6    |  0
+                    sun     7  |  6     |  0    |  1
                     """
                     first_week_day = int(get_lang(self.env, self.env.context.get('tz')).week_start)
                     sql_expr = SQL("mod(7 - %s + date_part(%s, %s)::int, 7)", first_week_day, spec, sql_expr)


### PR DESCRIPTION
Commit d8fe54d9ac96fc0123ab997f4b4a3fc2f380d34d introduced granularity `day_of_week` with a wrong explanation. This commit fixes the explanation.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
