### PR TITLE
[FIX] pos_loaylty: fix traceback when loading demo data

### DIFF
--- a/addons/pos_loyalty/models/pos_session.py
+++ b/addons/pos_loyalty/models/pos_session.py
@@ -100,9 +100,10 @@ class PosSession(models.Model):
             products = self.env['product.product'].search_read([('id', 'in', products)], fields=product_params['fields'], load=False)
             self._process_pos_ui_product_product(products)
 
-            result['custom']['pos_special_products_ids'].extend(
-                [product.id for product in reward_products if product.id not in [p["id"] for p in result['data']['product.product']]]
-            )
+            if not only_data:
+                result['custom']['pos_special_products_ids'].extend(
+                    [product.id for product in reward_products if product.id not in [p["id"] for p in result['data']['product.product']]]
+                )
             result['data']['product.product'].extend(products)
 
         # adapt loyalty


### PR DESCRIPTION
Currently a traceback is occurring when the user tries to load demo data in POS.

To reproduce this issue:

1) Install `POS`, `pos_loyalty` without demo data
2) Make sure no products are available in `POS` by disabling
   the `Available in POS` for `products` in the `POS`
3) Now open a session and click the explore `demo data` button

Error:- 
```
KeyError: 'pos_special_products_ids'
  File "odoo/http.py", line 2248, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1823, in _serve_db
    return self._transactioning(_serve_ir_http, readonly=ro)
  File "odoo/http.py", line 1843, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1821, in _serve_ir_http
    return self._serve_ir_http(rule, args)
  File "odoo/http.py", line 1828, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2053, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 220, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 756, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 38, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 34, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 458, in call_kw
    result = getattr(recs, name)(*args, **kwargs)
  File "addons/point_of_sale/models/pos_session.py", line 2127, in load_product_frontend
    return self.get_onboarding_data()
  File "home/odoo/src/enterprise/saas-17.2/pos_preparation_display/models/pos_session.py", line 20, in get_onboarding_data
    result = super().get_onboarding_data()
  File "addons/point_of_sale/models/pos_session.py", line 1902, in get_onboarding_data
    response = self.load_data(['pos.category', 'product.product'], True)
  File "home/odoo/src/enterprise/saas-17.2/pos_settle_due/models/pos_session.py", line 20, in load_data
    response = super().load_data(models_to_load, only_data)
  File "addons/pos_loyalty/models/pos_session.py", line 103, in load_data
    result['custom']['pos_special_products_ids'].extend(
```

When the user clicks on the `load demo` button, it triggers with `only_data` as a truthy value from `[1]`

But the `pos_special_products_ids` value assigns only if no `only_data` from `[2]`

which leads to a traceback from `[3]`

[1]
https://github.com/odoo/odoo/blob/d0cf45dc6bb472907f6b8542992f717c699f5a34/addons/point_of_sale/models/pos_session.py#L1904-L1905

[2]
https://github.com/odoo/odoo/blob/d0cf45dc6bb472907f6b8542992f717c699f5a34/addons/point_of_sale/models/pos_session.py#L289-L307

[3]
https://github.com/odoo/odoo/blob/d0cf45dc6bb472907f6b8542992f717c699f5a34/addons/pos_loyalty/models/pos_session.py#L103-L105

After applying this commit, it will resolve this issue by only accessing the value when the only_data value is falsy.

sentry-5588106710