### PR TITLE
[IMP] account_payment_term: Days end of month on the 0

### DIFF
--- a/addons/account_payment_term/models/account_payment_term.py
+++ b/addons/account_payment_term/models/account_payment_term.py
@@ -2,6 +2,7 @@ from dateutil.relativedelta import relativedelta
 
 from odoo import api, fields, models, _
 from odoo.exceptions import ValidationError
+from odoo.tools import date_utils
 
 
 class AccountPaymentTermLine(models.Model):
@@ -43,5 +44,9 @@ class AccountPaymentTermLine(models.Model):
                 days_next_month = int(self.days_next_month)
             except ValueError:
                 days_next_month = 1
+
+            if not days_next_month:
+                return date_utils.end_of(due_date + relativedelta(days=self.nb_days), 'month')
+
             return due_date + relativedelta(days=self.nb_days) + relativedelta(months=1, day=days_next_month)
         return res

--- a/addons/account_payment_term/tests/test_payment_term.py
+++ b/addons/account_payment_term/tests/test_payment_term.py
@@ -60,6 +60,18 @@ class TestAccountPaymentTerms(AccountTestInvoicingCommon):
                 }),
             ],
         })
+        cls.pay_term_days_end_of_month_days_next_month_0 = cls.env['account.payment.term'].create({
+            'name': "special case days next month 0",
+            'line_ids': [
+                Command.create({
+                    'value': 'percent',
+                    'value_amount': 100,
+                    'delay_type': 'days_end_of_month_on_the',
+                    'days_next_month': 0,
+                    'nb_days': 30,
+                }),
+            ],
+        })
 
     def test_payment_term_days_end_of_month_on_the(self):
         """
@@ -147,3 +159,11 @@ class TestAccountPaymentTerms(AccountTestInvoicingCommon):
 
         expected_date_case_2 = self.invoice.line_ids.filtered(lambda l: l.account_id == self.company_data['default_account_receivable']).mapped('date_maturity')
         self.assertEqual(expected_date_case_2, [fields.Date.from_string('2024-07-31')])
+
+    def test_payment_term_days_end_of_month_days_next_month_0(self):
+        with Form(self.invoice) as case_1:
+            case_1.invoice_payment_term_id = self.pay_term_days_end_of_month_days_next_month_0
+            case_1.invoice_date = '2024-04-22'
+
+        expected_date_case_1 = self.invoice.line_ids.filtered(lambda l: l.account_id == self.company_data['default_account_receivable']).mapped('date_maturity')
+        self.assertEqual(expected_date_case_1, [fields.Date.from_string('2024-05-31')])


### PR DESCRIPTION
This commit https://github.com/odoo/odoo/pull/166560/commits/fc2ee9e003f317e34dcc1d01e8e1a34acdb3b8dd fixed the due date which was wrong in some case, but one case was not dealt with.

When using the days end of month payment term with a days_next_month to 0, the calculation was wrong.

Ex:
With the current implementation, If we do a case with 30 end of month 1 with a start date the 22/04, we will add 30 days and end up the 22/05 then we add 1 month (22/06) and fix the day at 1, so we will end up the 01/06.

With a days_next_month to 0, the problem is that the relative delta will keep the 22/06 which is not what we wanted.

task: 4045689




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
