### PR TITLE
[FIX] web_editor: handle connection error while searching media library

### DIFF
--- a/addons/web_editor/controllers/main.py
+++ b/addons/web_editor/controllers/main.py
@@ -678,7 +678,12 @@ class Web_Editor(http.Controller):
         ICP = request.env['ir.config_parameter'].sudo()
         endpoint = ICP.get_param('web_editor.media_library_endpoint', DEFAULT_LIBRARY_ENDPOINT)
         params['dbuuid'] = ICP.get_param('database.uuid')
-        response = requests.post('%s/media-library/1/search' % endpoint, data=params)
+        try:
+            response = requests.post('%s/media-library/1/search' % endpoint, data=params)
+        except requests.exceptions.ConnectionError:
+            error_msg = _("Unable to reach endpoint at %s", endpoint)
+            logger.warning(error_msg)
+            return {'error': error_msg}
         if response.status_code == requests.codes.ok and response.headers['content-type'] == 'application/json':
             return response.json()
         else:

--- a/addons/web_editor/i18n/web_editor.pot
+++ b/addons/web_editor/i18n/web_editor.pot
@@ -2781,6 +2781,12 @@ msgid "URL or Email"
 msgstr ""
 
 #. module: web_editor
+#: code:addons/web_editor/controllers/main.py:0
+#, python-format
+msgid "Unable to reach endpoint at %s"
+msgstr ""
+
+#. module: web_editor
 #: model_terms:ir.ui.view,arch_db:web_editor.snippet_options
 msgid "Unalign"
 msgstr ""


### PR DESCRIPTION
Currently, a connection error occurs when the IAP server is not available and the user tries to search the media library.

Error:-
```
ConnectionError: HTTPSConnectionPool(host='media-api.odoo.com', port=443):
 Max retries exceeded with url: /media-library/1/search (Caused by
 NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x7fa30ddc1e70>:
 Failed to establish a new connection: [Errno 111] Connection refused'))
```

This commit will handle connection errors that occur when requests reach the IAP server.

sentry-5563859529

