### PR TITLE
[FIX] purchase,*: fix purchase order line column width

### DIFF
--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -234,7 +234,6 @@
                                         name="product_id"
                                         readonly="state in ('purchase', 'to approve', 'done', 'cancel')"
                                         required="not display_type"
-                                        width="35%"
                                         context="{'partner_id':parent.partner_id, 'quantity':product_qty, 'company_id': parent.company_id}"
                                         force_save="1" domain="[('purchase_ok', '=', True)]"/>
                                     <field name="name" widget="section_and_note_text" optional="show"/>

--- a/addons/purchase_product_matrix/views/purchase_views.xml
+++ b/addons/purchase_product_matrix/views/purchase_views.xml
@@ -14,7 +14,6 @@
                     string="Product"
                     readonly="state in ('purchase', 'to approve', 'done', 'cancel')"
                     required="not display_type"
-                    width="35%"
                     context="{'partner_id': parent.partner_id}"
                     widget="pol_product_many2one"/>
                 <field name="product_template_attribute_value_ids" column_invisible="1"/>


### PR DESCRIPTION
*purchase_product_matrix

This commit removes two hardcoded widths in purchase list archs. Setting a width in percentage isn't supported. Before [1], it was bypassed by the list column widths mecanism. Now, it is considered as a width in pixels, which is obviously too narrow. We simply remove it, s.t. the default column widths logic applies.

[1] https://github.com/odoo/odoo/pull/170511

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
