### PR TITLE
[FIX] website_sale: fix issue with address update

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1646,8 +1646,8 @@ class WebsiteSale(payment_portal.PaymentPortal):
         ], limit=1)
         address.update(country_id=country.id, state_id=state.id)
 
-    @route('/shop/cart/update_address', type='json', auth='public', website=True)
-    def update_cart_address(self, partner_id, address_type='billing', **kw):
+    @route('/shop/update_address', type='json', auth='public', website=True)
+    def shop_update_address(self, partner_id, address_type='billing', **kw):
         partner_id = int(partner_id)
 
         order_sudo = request.website.sale_get_order()

--- a/addons/website_sale/tests/test_address.py
+++ b/addons/website_sale/tests/test_address.py
@@ -153,7 +153,7 @@ class TestCheckoutAddress(BaseUsersCommon, WebsiteSaleCommon):
         ) as rate_shipment_mock:
             # Change a shipping address of the order in the checkout.
             shipping_partner2 = shipping_partner.copy()
-            self.WebsiteSaleController.update_cart_address(
+            self.WebsiteSaleController.shop_update_address(
                 partner_id=shipping_partner2.id, address_type='delivery'
             )
             self.assertGreaterEqual(
@@ -397,7 +397,7 @@ class TestCheckoutAddress(BaseUsersCommon, WebsiteSaleCommon):
             with self.assertRaises(Forbidden):
                 self.WebsiteSaleController.shop_address_submit(partner_id=self.env.user.partner_id.id, address_type='delivery')
 
-    def test_09_update_cart_address(self):
+    def test_09_shop_update_address(self):
         self.env['ir.config_parameter'].sudo().set_param('auth_password_policy.minlength', 4)
         user = self.env['res.users'].create({
             'name': 'test',
@@ -479,28 +479,28 @@ class TestCheckoutAddress(BaseUsersCommon, WebsiteSaleCommon):
             # Invalid addresses unaccessible to current customer
             with self.assertRaises(Forbidden):
                 # cannot use contact type addresses
-                self.WebsiteSaleController.update_cart_address(partner_id=colleague.id)
+                self.WebsiteSaleController.shop_update_address(partner_id=colleague.id)
             with self.assertRaises(Forbidden):
                 # unrelated partner
-                self.WebsiteSaleController.update_cart_address(partner_id=self.env.user.partner_id.id)
+                self.WebsiteSaleController.shop_update_address(partner_id=self.env.user.partner_id.id)
 
             # Good addresses
-            self.WebsiteSaleController.update_cart_address(
+            self.WebsiteSaleController.shop_update_address(
                 partner_id=colleague_shipping.id, address_type='delivery')
             self.assertEqual(so.partner_shipping_id, colleague_shipping)
-            self.WebsiteSaleController.update_cart_address(
+            self.WebsiteSaleController.shop_update_address(
                 partner_id=shipping.id, address_type='delivery',
             )
             self.assertEqual(so.partner_shipping_id, shipping)
 
-            self.WebsiteSaleController.update_cart_address(
+            self.WebsiteSaleController.shop_update_address(
                 partner_id=invoicing.id, address_type='billing',
             )
             self.assertEqual(so.partner_shipping_id, shipping)
             self.assertEqual(so.partner_invoice_id, invoicing)
 
             # Using invalid addresses --> change and the customer is forced to update the address
-            self.WebsiteSaleController.update_cart_address(
+            self.WebsiteSaleController.shop_update_address(
                 partner_id=bad_invoicing.id, address_type='billing')
             self.assertEqual(so.partner_invoice_id, bad_invoicing)
             redirection = self.WebsiteSaleController._check_addresses(so)
@@ -508,11 +508,11 @@ class TestCheckoutAddress(BaseUsersCommon, WebsiteSaleCommon):
             self.assertEqual(redirection.location, f'/shop/address?partner_id={bad_invoicing.id}&address_type=billing')
 
             # reset to valid one
-            self.WebsiteSaleController.update_cart_address(
+            self.WebsiteSaleController.shop_update_address(
                 partner_id=invoicing.id, address_type='billing',
             )
 
-            self.WebsiteSaleController.update_cart_address(
+            self.WebsiteSaleController.shop_update_address(
                 partner_id=bad_shipping.id, address_type='delivery')
             self.assertEqual(so.partner_shipping_id, bad_shipping)
             redirection = self.WebsiteSaleController._check_addresses(so)
@@ -520,16 +520,16 @@ class TestCheckoutAddress(BaseUsersCommon, WebsiteSaleCommon):
             self.assertEqual(redirection.location, f'/shop/address?partner_id={bad_shipping.id}&address_type=delivery')
 
             # reset to valid one
-            self.WebsiteSaleController.update_cart_address(
+            self.WebsiteSaleController.shop_update_address(
                 partner_id=shipping.id, address_type='delivery',
             )
 
             # Using commercial partner address
-            self.WebsiteSaleController.update_cart_address(
+            self.WebsiteSaleController.shop_update_address(
                 partner_id=partner_company.id, address_type='billing',
             )
             self.assertEqual(so.partner_invoice_id, partner_company)
-            self.WebsiteSaleController.update_cart_address(
+            self.WebsiteSaleController.shop_update_address(
                 partner_id=partner_company.id, address_type='delivery',
             )
             self.assertEqual(so.partner_shipping_id, partner_company)


### PR DESCRIPTION
https://github.com/odoo/odoo/commit/453cfab758505ae15135703fb7be8bdb54981444#diff-ecbd12f8bbcc7e08a87d7edba111301bb0ca5197137d193323d156809651fcb6R74

In this commit, we address a problem where updating an address does not trigger the expected RPC call. The issue arose because of a recent refactoring where the controller name was updated but the actual controller reference in the code was not corrected accordingly.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
