### PR TITLE
[FIX] base: convert view raise for inconsistency into a warning message

### DIFF
--- a/odoo/addons/base/tests/test_views.py
+++ b/odoo/addons/base/tests/test_views.py
@@ -2279,7 +2279,7 @@ class TestViews(ViewCase):
 
         self.assertInvalid(
             arch % ('', '<field name="inherit_id"/>', 'view_access', 'view_access'),
-            """Field 'view_access' does not exist in model 'ir.ui.view'.""",
+            """field `view_access` does not exist in model `ir.ui.view`.""",
         )
         self.assertInvalid(
             arch % ('', '<field name="inherit_id"/>', 'inherit_id', 'inherit_id'),

--- a/odoo/addons/base/views/ir_ui_view_views.xml
+++ b/odoo/addons/base/views/ir_ui_view_views.xml
@@ -25,6 +25,9 @@
                         Be aware that editing the architecture of a standard view is not advised, since the changes will be overwritten during future module updates.<br/>
                         We recommend applying modifications to standard views through inherited views or customization with Odoo Studio.
                     </div>
+                    <div class="alert alert-warning" role="alert" invisible="not warning_info">
+                        <field name="warning_info"/>
+                    </div>
                     <notebook>
                         <page string="Architecture" name="architecture">
                             <field name="arch_db" class="oe_edit_only oe_no_translation_content"/>


### PR DESCRIPTION
View validation has been improved to take into account groups and access rights (during create and write). see: https://github.com/odoo/odoo/commit/6f06420e4a9443c52dc0cb427f8f55eb4aecabce

Issue: When an administrator modifies the involvement of groups, access rights or during migration, certain views trigger errors (because there are inconsistencies and the view will not work for certain users). This error is triggered when modifying views and not when modifying groups. Furthermore, errors can be complicated to understand (for example a person activating a view ends up with the group inconsistency error).

From this commit, non-critical errors (the view can be used for some users) no longer trigger an error but trigger a warning, this warning is also displayed in the interface.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
