### PR TITLE
[IMP] base_import, web: add drag-and-drop support for import record view

### DIFF
--- a/addons/base_import/static/src/import_action/import_action.xml
+++ b/addons/base_import/static/src/import_action/import_action.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="ImportAction">
-        <div class="h-100 d-flex flex-column">
+        <div t-ref="root" class="h-100 d-flex flex-column">
             <Layout className="'o_import_action d-flex h-100 overflow-auto'" display="display">
                 <t t-set-slot="control-panel-create-button">
                     <t t-if="isPreviewing">
@@ -14,7 +14,7 @@
                         onUpload.bind="(data, files) => this.handleFilesUpload(files)"
                         resId="model.id"
                         resModel="this.resModel"
-                        route="'/base_import/set_file'"
+                        route="this.uploadFilesRoute"
                     >
                         <button t-if="isPreviewing" type="button" class="btn btn-secondary">Load File</button>
                         <button t-else="" type="button" class="btn btn-primary o_import_file">Upload File</button>
@@ -44,18 +44,20 @@
                 <div t-else="" class="o_view_nocontent">
                     <div class="o_nocontent_help">
                         <p class="o_view_nocontent_smiling_face">
-                            Upload an Excel or CSV file to import
+                            Drop or upload a file to import
                         </p>
                         <p>
-                            Excel files are recommended as formatting is automatic.
+                            Excel files are recommended as formatting is automatic.<br/>
+                            But, you can also use .csv files
                         </p>
-                        <div class="mt16 mb4">Need Help?</div>
+                        <div class="mt16 mb4">
+                            Need Help? <DocumentationLink path="'/applications/general/export_import_data.html'" label.translate="Import FAQ"/>
+                        </div>
                         <div t-foreach="importTemplates" t-as="template" t-key="template">
                             <a class="btn btn-outline-primary mb32 mt8" t-att-href="template.template" aria-label="Download" data-tooltip="Download">
                                 <i class="fa fa-download"/> <span><t t-esc="template.label"/></span>
                             </a>
                         </div>
-                        <DocumentationLink path="'/applications/general/export_import_data.html'" label.translate="Import FAQ"/>
                     </div>
                 </div>
             </Layout>

--- a/addons/base_import/static/tests/import_action_tests.js
+++ b/addons/base_import/static/tests/import_action_tests.js
@@ -11,6 +11,7 @@ import {
     patchWithCleanup,
 } from "@web/../tests/helpers/utils";
 import { createWebClient, doAction } from "@web/../tests/webclient/helpers";
+import { dragenterFiles, dropFiles } from "@web/../tests/legacy/utils";
 import { registry } from "@web/core/registry";
 import { makeFakeNotificationService } from "@web/../tests/helpers/mock_services";
 import { ImportDataProgress } from "../src/import_data_progress/import_data_progress";
@@ -539,6 +540,29 @@ QUnit.module("Base Import Tests", (hooks) => {
             ".o_import_data_sidepanel .o_import_formatting",
             "formatting options are present in the side panel"
         );
+        assert.containsOnce(
+            target,
+            ".o_import_action .o_import_data_content",
+            "content panel is visible"
+        );
+    });
+
+    QUnit.test("Import view: drag-and-drop file support", async function (assert) {
+        registerFakeHTTPService((route, params) => {
+            assert.strictEqual(route, "/base_import/set_file");
+            assert.strictEqual(
+                params.ufile[0].name,
+                "fake_file.csv",
+                "file is correctly uploaded to the server"
+            );
+        });
+        await createImportAction();
+        const file = new File(["fake_file"], "fake_file.csv", {
+            type: "text/plain"
+        });
+        await dragenterFiles(".o_import_action", [file]);
+        await dropFiles(".o-Dropzone", [file]);
+        await nextTick();
         assert.containsOnce(
             target,
             ".o_import_action .o_import_data_content",

--- a/addons/mail/static/src/chatter/web/chatter_patch.js
+++ b/addons/mail/static/src/chatter/web/chatter_patch.js
@@ -7,7 +7,7 @@ import { isDragSourceExternalFile } from "@mail/utils/common/misc";
 import { RecipientList } from "@mail/core/web/recipient_list";
 import { SearchMessagesPanel } from "@mail/core/common/search_messages_panel";
 import { useAttachmentUploader } from "@mail/core/common/attachment_uploader_hook";
-import { useDropzone } from "@mail/core/common/dropzone_hook";
+import { useDropzone } from "@web/core/dropzone/dropzone_hook";
 import { useHover, useMessageHighlight } from "@mail/utils/common/hooks";
 
 import { markup, useEffect } from "@odoo/owl";

--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -1,6 +1,6 @@
 import { AttachmentList } from "@mail/core/common/attachment_list";
 import { useAttachmentUploader } from "@mail/core/common/attachment_uploader_hook";
-import { useDropzone } from "@mail/core/common/dropzone_hook";
+import { useDropzone } from "@web/core/dropzone/dropzone_hook";
 import { Picker, usePicker } from "@mail/core/common/picker";
 import { MessageConfirmDialog } from "@mail/core/common/message_confirm_dialog";
 import { NavigableList } from "@mail/core/common/navigable_list";

--- a/addons/mail/static/tests/chatter/web/chatter.test.js
+++ b/addons/mail/static/tests/chatter/web/chatter.test.js
@@ -201,13 +201,13 @@ test("chatter: drop attachments", async () => {
     await openFormView("res.partner", partnerId);
     const files = [text, text2];
     await dragenterFiles(".o-mail-Chatter", files);
-    await contains(".o-mail-Dropzone");
+    await contains(".o-Dropzone");
     await contains(".o-mail-AttachmentCard", { count: 0 });
-    await dropFiles(".o-mail-Dropzone", files);
+    await dropFiles(".o-Dropzone", files);
     await contains(".o-mail-AttachmentCard", { count: 2 });
     const extraFiles = [text3];
     await dragenterFiles(".o-mail-Chatter", extraFiles);
-    await dropFiles(".o-mail-Dropzone", extraFiles);
+    await dropFiles(".o-Dropzone", extraFiles);
     await contains(".o-mail-AttachmentCard", { count: 3 });
 });
 
@@ -229,7 +229,7 @@ test("chatter: drop attachment should refresh thread data with hasParentReloadOn
             </form>`,
     });
     await dragenterFiles(".o-mail-Chatter", [textPdf]);
-    await dropFiles(".o-mail-Dropzone", [textPdf]);
+    await dropFiles(".o-Dropzone", [textPdf]);
     await contains(".o-mail-Attachment iframe", { count: 1 });
 });
 
@@ -627,7 +627,7 @@ test("upload attachment on draft record", async () => {
     await contains("button[aria-label='Attach files']");
     await contains("button[aria-label='Attach files']", { count: 0, text: "1" });
     await dragenterFiles(".o-mail-Chatter", [text]);
-    await dropFiles(".o-mail-Dropzone", [text]);
+    await dropFiles(".o-Dropzone", [text]);
     await contains("button[aria-label='Attach files']", { text: "1" });
 });
 

--- a/addons/mail/static/tests/composer/composer.test.js
+++ b/addons/mail/static/tests/composer/composer.test.js
@@ -567,18 +567,18 @@ test("composer: drop attachments", async () => {
     await start();
     await openDiscuss(channelId);
     await contains(".o-mail-Composer-input");
-    await contains(".o-mail-Dropzone", { count: 0 });
+    await contains(".o-Dropzone", { count: 0 });
     await contains(".o-mail-AttachmentCard", { count: 0 });
     const files = [text, text2];
     await dragenterFiles(".o-mail-Composer-input", files);
-    await contains(".o-mail-Dropzone");
+    await contains(".o-Dropzone");
     await contains(".o-mail-AttachmentCard", { count: 0 });
-    await dropFiles(".o-mail-Dropzone", files);
-    await contains(".o-mail-Dropzone", { count: 0 });
+    await dropFiles(".o-Dropzone", files);
+    await contains(".o-Dropzone", { count: 0 });
     await contains(".o-mail-AttachmentCard", { count: 2 });
     const extraFiles = [text3];
     await dragenterFiles(".o-mail-Composer-input", extraFiles);
-    await dropFiles(".o-mail-Dropzone", extraFiles);
+    await dropFiles(".o-Dropzone", extraFiles);
     await contains(".o-mail-AttachmentCard", { count: 3 });
 });
 

--- a/addons/mail/static/tests/thread/thread.test.js
+++ b/addons/mail/static/tests/thread/thread.test.js
@@ -39,7 +39,7 @@ test("dragover files on thread with composer", async () => {
     await start();
     await openDiscuss(channelId);
     await dragenterFiles(".o-mail-Thread", [text3]);
-    await contains(".o-mail-Dropzone");
+    await contains(".o-Dropzone");
 });
 
 test("load more messages from channel (auto-load on scroll)", async () => {

--- a/addons/web/static/src/core/dropzone/dropzone.js
+++ b/addons/web/static/src/core/dropzone/dropzone.js
@@ -6,7 +6,7 @@ export class Dropzone extends Component {
         onDrop: { type: Function, optional: true },
         ref: Object,
     };
-    static template = "mail.Dropzone";
+    static template = "web.Dropzone";
 
     setup() {
         super.setup();

--- a/addons/web/static/src/core/dropzone/dropzone.scss
+++ b/addons/web/static/src/core/dropzone/dropzone.scss
@@ -1,4 +1,4 @@
-.o-mail-Dropzone {
+.o-Dropzone {
     border: 2px dashed;
     z-index: 1000; // above chat window
 

--- a/addons/web/static/src/core/dropzone/dropzone.xml
+++ b/addons/web/static/src/core/dropzone/dropzone.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
 
-<t t-name="mail.Dropzone">
-    <div class="o-mail-Dropzone position-fixed align-items-center justify-content-center d-flex border-primary bg-100 text-primary opacity-75"
+<t t-name="web.Dropzone">
+    <div class="o-Dropzone position-fixed align-items-center justify-content-center d-flex border-primary bg-100 text-primary opacity-75"
         t-att-class="{ 'o-dragging-inside': state.isDraggingInside }"
         t-attf-class="{{ props.extraClass }}"
         t-on-dragenter="() => state.isDraggingInside = true"

--- a/addons/web/static/src/core/dropzone/dropzone_hook.js
+++ b/addons/web/static/src/core/dropzone/dropzone_hook.js
@@ -1,4 +1,4 @@
-import { Dropzone } from "@mail/core/common/dropzone";
+import { Dropzone } from "@web/core/dropzone/dropzone";
 
 import { useEffect, useExternalListener } from "@odoo/owl";
 
@@ -8,7 +8,7 @@ const componentRegistry = registry.category("main_components");
 
 let id = 1;
 export function useDropzone(targetRef, onDrop, extraClass, isDropzoneEnabled = () => true) {
-    const dropzoneId = `mail.dropzone_${id++}`;
+    const dropzoneId = `web.dropzone_${id++}`;
     let dragCount = 0;
     let hasTarget = false;
 

--- a/addons/web/static/src/core/file_input/file_input.js
+++ b/addons/web/static/src/core/file_input/file_input.js
@@ -1,7 +1,5 @@
-import { useService } from "@web/core/utils/hooks";
-
 import { Component, onMounted, useRef, useState } from "@odoo/owl";
-import { checkFileSize } from "@web/core/utils/files";
+import { useFileUploader } from "@web/core/utils/files";
 
 /**
  * Custom file input
@@ -45,8 +43,7 @@ export class FileInput extends Component {
     };
 
     setup() {
-        this.http = useService("http");
-        this.notification = useService("notification");
+        this.uploadFiles = useFileUploader();
         this.fileInputRef = useRef("file-input");
         this.state = useState({
             // Disables upload button if currently uploading.
@@ -75,21 +72,6 @@ export class FileInput extends Component {
         return params;
     }
 
-    async uploadFiles(params) {
-        if ((params.ufile && params.ufile.length) || params.file) {
-            const fileSize = (params.ufile && params.ufile[0].size) || params.file.size;
-            if (!checkFileSize(fileSize, this.notification)) {
-                return null;
-            }
-        }
-        const fileData = await this.http.post(this.props.route, params, "text");
-        const parsedFileData = JSON.parse(fileData);
-        if (parsedFileData.error) {
-            throw new Error(parsedFileData.error);
-        }
-        return parsedFileData;
-    }
-
     //--------------------------------------------------------------------------
     // Handlers
     //--------------------------------------------------------------------------
@@ -103,7 +85,7 @@ export class FileInput extends Component {
      */
     async onFileInputChange() {
         this.state.isDisable = true;
-        const parsedFileData = await this.uploadFiles(this.httpParams);
+        const parsedFileData = await this.uploadFiles(this.props.route, this.httpParams);
         if (parsedFileData) {
             // When calling onUpload, also pass the files to allow to get data like their names
             this.props.onUpload(

--- a/addons/web/static/src/core/utils/files.js
+++ b/addons/web/static/src/core/utils/files.js
@@ -1,4 +1,5 @@
 import { humanNumber } from "@web/core/utils/numbers";
+import { useService } from "@web/core/utils/hooks";
 import { session } from "@web/session";
 import { _t } from "@web/core/l10n/translation";
 
@@ -25,4 +26,31 @@ export function checkFileSize(fileSize, notificationService) {
         return false;
     }
     return true;
+}
+
+/**
+ * Hook to upload a file to the server.
+ * @returns {function}
+ */
+export function useFileUploader() {
+    const http = useService("http");
+    const notification = useService("notification");
+    /**
+     * @param {string} route
+     * @param {Object} params
+     */
+    return async (route, params) => {
+        if ((params.ufile && params.ufile.length) || params.file) {
+            const fileSize = (params.ufile && params.ufile[0].size) || params.file.size;
+            if (!checkFileSize(fileSize, notification)) {
+                return null;
+            }
+        }
+        const fileData = await http.post(route, params, "text");
+        const parsedFileData = JSON.parse(fileData);
+        if (parsedFileData.error) {
+            throw new Error(parsedFileData.error);
+        }
+        return parsedFileData;
+    };
 }


### PR DESCRIPTION
To simplify the process of importing records into Odoo, we will turn the import view into a dropzone. This will allow users to import records by dragging a file from their computer directly into the import view. This enhancement simplifies the import process, making it more convenient and user-friendly.

Even after a file is imported, the drag-and-drop feature will remain active, allowing users to drag and drop a new file to load new records.

task-3956293

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
