### PR TITLE
[FIX] web_editor: ensure CSS consistency in printed PDFs

### DIFF
--- a/addons/web_editor/__manifest__.py
+++ b/addons/web_editor/__manifest__.py
@@ -239,6 +239,7 @@ Odoo Web Editor widget.
             'web_editor/static/src/js/frontend/loadWysiwygFromTextarea.js',
         ],
         'web.report_assets_common': [
+            'web_editor/static/src/js/editor/odoo-editor/src/base_style.scss',
             'web_editor/static/src/scss/bootstrap_overridden.scss',
             'web_editor/static/src/scss/web_editor.common.scss',
         ],


### PR DESCRIPTION
Current behavior before PR:

-Nested list numbering appeared differently in the preview compared to printed
 PDFs, causing inconsistencies in document appearance.

Desired behavior after PR is merged:

-Nested list numbering appears consistent between the preview and printed PDFs.

task-4008883



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
