### PR TITLE
[IMP] {website_}event{_sale}: batch confirmation email

### DIFF
--- a/addons/mail/static/src/utils/common/format.js
+++ b/addons/mail/static/src/utils/common/format.js
@@ -274,4 +274,22 @@ export function parseEmail(text) {
     return [text, false];
 }
 
+/**
+ * Split the string using the splitChar and find all the valid/invalid emails from it.
+ * It return a object containing the list of all the emails and the invalid emails from it.
+ * Validity is handled by the parseEmail function.
+ *
+ * @param {string} emailStr
+ * @param {string} splitPattern
+ * @return {object}
+ */
+export function extractEmailValidity(emailStr, splitPattern){
+    const emailList = emailStr.split(splitPattern);
+    const invalidEmails = emailList.filter(email => email !== '' && !parseEmail(email.trim())[1]);
+    return {
+        'invalidEmails': invalidEmails,
+        'emailList': emailList,
+    }
+}
+
 export const EMOJI_REGEX = /\p{Emoji_Presentation}|\p{Emoji}\uFE0F|\u200d/gu;

--- a/addons/website_event/__manifest__.py
+++ b/addons/website_event/__manifest__.py
@@ -55,6 +55,7 @@
             'website_event/static/tests/**/*',
         ],
         'web.assets_frontend': [
+            'mail/static/src/utils/common/format.js',
             'website_event/static/src/js/tours/**/*',
             'website_event/static/src/scss/event_templates_common.scss',
             'website_event/static/src/scss/event_templates_list.scss',
@@ -62,6 +63,7 @@
             'website_event/static/src/js/display_timer_widget.js',
             'website_event/static/src/js/register_toaster_widget.js',
             'website_event/static/src/js/website_event.js',
+            'website_event/static/src/js/website_event_send_email.js',
             'website_event/static/src/js/website_event_ticket_details.js',
         ],
         'website.assets_wysiwyg': [

--- a/addons/website_event/static/src/js/website_event_send_email.js
+++ b/addons/website_event/static/src/js/website_event_send_email.js
@@ -1,0 +1,92 @@
+/** @odoo-module **/
+
+import { rpc } from "@web/core/network/rpc";
+import { extractEmailValidity } from  "@mail/utils/common/format";
+import publicWidget from '@web/legacy/js/public/public_widget';
+
+publicWidget.registry.websiteEventSendEmail = publicWidget.Widget.extend({
+    selector: '.o_wevent_send_by_email_widget',
+    events: {
+        'click .o_wevent_send_by_email_button': '_onSendEmailButtonClick',
+        'click .o_wevent_send_by_email_info .btn-close': '_onCloseInfoClick',
+    },
+
+    //--------------------------------------------------------------------------
+    // Handlers
+    //--------------------------------------------------------------------------
+
+    /**
+     * @private
+     * @param {Event} ev
+     */
+    _onSendEmailButtonClick: async function (ev) {
+        ev.target.getElementsByTagName('i')[0].classList.remove('d-none');
+        ev.target.setAttribute('disabled', '');
+
+        const attendeesIds = JSON.parse(ev.target.dataset.attendeesIds) || [];
+        const eventId = parseInt(ev.target.dataset.eventId);
+        const ticketsHash = ev.target.dataset.ticketsHash;
+        const emails = document.querySelector('#o_wevent_send_by_email_input').value;
+        const emailInfo = extractEmailValidity(', ', emails)
+
+        if (emails === "" || emailInfo.invalidEmails.length) {
+            this._showEmailError();
+        } else {
+            this._hideEmailError();
+            await rpc(`/event/${ eventId }/my_tickets_by_email`, {
+                'emails': emails,
+                'registration_ids': attendeesIds,
+                'tickets_hash': ticketsHash,
+            });
+            this._showInfoMsg();
+        }
+        ev.target.removeAttribute('disabled');
+        ev.target.getElementsByTagName('i')[0].classList.add('d-none');
+    },
+
+    /**
+     * @private
+     * Show error message if email is invalid by adding the bootstrap class
+     * 'is-invalid' on the input field and its parent. The parent is the div that
+     * contains the input field and the error message and has the class 'has-validation'.
+     * For more information : https://getbootstrap.com/docs/5.3/forms/validation/#server-side
+     */
+    _showEmailError: function () {
+        const emailInputElement = document.querySelector('#o_wevent_send_by_email_input');
+        emailInputElement.classList.add('is-invalid');
+        emailInputElement.parentElement.classList.add('is-invalid');
+    },
+
+    /**
+     * @private
+     * Hide error message if email is valid by removing the bootstrap class
+     * 'is-invalid' on the input field and its parent. The parent is the div that
+     * contains the input field and the error message and has the class 'has-validation'.
+     * For more information : https://getbootstrap.com/docs/5.3/forms/validation/#server-side
+     */
+    _hideEmailError: function () {
+        const emailInputElement = document.querySelector('#o_wevent_send_by_email_input');
+        emailInputElement.classList.remove('is-invalid');
+        emailInputElement.parentElement.classList.remove('is-invalid');
+    },
+
+    _showInfoMsg: function () {
+        const emailInputContainer = document.querySelector('.o_wevent_send_by_email_input_container');
+        const infoMessageElement = document.querySelector('.o_wevent_send_by_email_info');
+        emailInputContainer.classList.add('d-none');
+        infoMessageElement.classList.remove('d-none');
+    },
+
+    _onCloseInfoClick: function () {
+        const emailInputContainer = document.querySelector('.o_wevent_send_by_email_input_container');
+        const emailInputElement = document.querySelector('#o_wevent_send_by_email_input');
+        const infoMessageElement = document.querySelector('.o_wevent_send_by_email_info');
+        emailInputElement.value = '';
+        emailInputContainer.classList.remove('d-none');
+        infoMessageElement.classList.add('d-none');
+    },
+});
+
+export default {
+    websiteEventSendEmail: publicWidget.registry.websiteEventSendEmail,
+};

--- a/addons/website_event/static/src/scss/event_templates_page.scss
+++ b/addons/website_event/static/src/scss/event_templates_page.scss
@@ -114,3 +114,20 @@
 .o_wevent_hide_sponsors .o_wevent_sponsor_wrapper {
     display: none !important;
 }
+
+/*
+ * Regitration Ticket Access also used by website_event_sale
+ */
+.o_wevent_registration_ticket_access {
+    .o_wevent_download_ticket_btn {
+        min-width: 9rem;
+    }
+
+    .o_wevent_send_by_email_widget {
+        max-width: 32rem;
+
+        .o_wevent_send_by_email_info .btn-close{
+            scale: 0.8
+        }
+    }
+}

--- a/addons/website_event/views/event_templates_page_registration.xml
+++ b/addons/website_event/views/event_templates_page_registration.xml
@@ -397,6 +397,46 @@
     </t>
 </template>
 
+<template id="registration_ticket_access" name="Registration Ticket Access">
+    <div class="row mb-3 o_wevent_registration_ticket_access">
+        <div class="col-12 mb-2">
+            <h5>Get your Tickets</h5>
+        </div>
+        <div class="col-12 mb-2 d-flex flex-column flex-md-row align-items-stretch align-items-md-baseline justify-content-md-start">
+            <a class="btn btn-primary o_wevent_download_ticket_btn" title="Download All Tickets" target="_blank"
+                t-attf-href="/event/{{ event.id }}/my_tickets?registration_ids={{ attendees.ids }}&amp;tickets_hash={{ event._get_tickets_access_hash(attendees.ids) }}">
+                Download <i class="ms-1 fa fa-download"/>
+            </a>
+            <span class="mx-3 d-flex justify-content-center">or</span>
+            <div class="o_wevent_send_by_email_widget ms-md-2 mt-2 mt-md-0">
+                <div class="o_wevent_send_by_email_input_container">
+                    <div class="input-group">
+                        <input id="o_wevent_send_by_email_input" type="text"
+                            placeholder="john@doe.com" class="form-control"/>
+                        <button class="o_wevent_send_by_email_button btn btn-primary"
+                            type="button"
+                            t-att-data-event-id="event.id"
+                            t-att-data-attendees-ids="attendees.ids"
+                            t-att-data-tickets-hash="event._get_tickets_access_hash(attendees.ids)">
+                            <i class="fa fa-circle-o-notch fa-spin me-1 d-none"></i>
+                            Send by Email
+                        </button>
+                    </div>
+                    <div class="invalid-feedback">
+                        Please enter valid email(s)
+                    </div>
+                </div>
+                <div class="o_wevent_send_by_email_info alert alert-info ms-md-2 mt-2 mt-md-0 mb-0 px-3 py-1 d-inline-flex align-items-center justify-content-center d-none" role="alert">
+                    <span class="d-flex">
+                        <span><strong>See you soon!</strong> Your tickets have been sent.</span>
+                        <button aria-label="Close" class="btn-close ms-2" type="button"/>
+                    </span>
+                </div>
+            </div>
+        </div>
+    </div>
+</template>
+
 <!-- Button to configure Tickets -->
 <template id="registration_configure_tickets_button" name="Registration Configure Ticket Button">
     <a t-attf-class="o_not_editable text-nowrap {{linkClasses or '' }}" t-attf-href="/web#id=#{event.id}&amp;menu_id=#{backend_menu_id}&amp;view_type=form&amp;model=event.event" role="link"  title="Configure event tickets">


### PR DESCRIPTION
ENT PR : https://github.com/odoo/enterprise/pull/66590
[task-3847374](https://www.odoo.com/odoo/my-tasks/4045775?cids=1)

### MOV 
Since "findInvalidEmailFromText" can be usefull in other modules than
appointment it has been moved into the mail module.
The function name has been changed to "checkEmailValidity" to match a
more general use.

A parameter has been added to choose what pattern should be used to split
the String.

### Send tickets to custom emails
Add _get_event_registration_ids_from_order() that return all the registrations from the same sale order and event than the one we are calling from.

Change the registration confirmation mail template so that :
- If the registration is in a sale order, we call the method defined above to get all the registration id from the SO instead of just the one from the record
- We can inject a context value to force the registration_ids we want to send.

Change the registration confirmation view (vanilla + sale)
- Add a feature to allow the user to send tickets to a list of email.
- Create a dedicated template for the "Download Ticket" + "Send by email" combination

task-3847374