### PR TITLE
[FIX] pos_self_order: fix self_order demo data

### DIFF
--- a/addons/pos_self_order/static/src/app/pages/landing_page/landing_page.js
+++ b/addons/pos_self_order/static/src/app/pages/landing_page/landing_page.js
@@ -29,7 +29,7 @@ export class LandingPage extends Component {
         });
 
         onMounted(() => {
-            if (this.selfOrder.config.self_ordering_image_home_ids.length > 1) {
+            if (this.selfOrder.config._self_ordering_image_home_ids.length > 1) {
                 // used to init carousel after components mount / unmount
                 const carousel = new Carousel(this.carouselRef.el);
 

--- a/addons/pos_self_order/static/src/app/pages/landing_page/landing_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/landing_page/landing_page.xml
@@ -5,11 +5,11 @@
             <img class="rounded" t-attf-src="{{currentLanguage.flag_image_url}}" />
             <span t-esc="currentLanguage.display_name" class="ms-3"></span>
         </div>
-        <div t-if="selfOrder.config.self_ordering_image_home_ids.length > 0" t-on-click="start" class="d-flex flex-column vh-100 align-items-center overflow-hidden">
+        <div t-if="selfOrder.config._self_ordering_image_home_ids.length > 0" t-on-click="start" class="d-flex flex-column vh-100 align-items-center overflow-hidden">
             <div id="carouselAutoplaying" t-ref="carousel" class="carousel slide w-100 h-100" data-bs-ride="true">
                 <div class="carousel-inner h-100 w-100">
                     <div
-                        t-foreach="selfOrder.config.self_ordering_image_home_ids"
+                        t-foreach="selfOrder.config._self_ordering_image_home_ids"
                         t-as="image"
                         t-key="image.id"
                         t-attf-class="carousel-item object-fit-cover h-100 w-100 {{activeImage}}"


### PR DESCRIPTION
Previously, in the self_order data demos, there was no button on the home page.

Now there are.

Another fix in this PR: images were no longer loaded since refactoring. This has now been fixed.

taskId: 4023864
