### PR TITLE
[IMP] stock: don't reserve after putting in pack

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -1745,7 +1745,6 @@ class Picking(models.Model):
                 res = self._pre_put_in_pack_hook(move_line_ids)
                 if not res:
                     package = self._put_in_pack(move_line_ids)
-                    self.action_assign()
                     return self._post_put_in_pack_hook(package)
                 return res
             raise UserError(_("There is nothing eligible to put in a pack. Either there are no quantities to put in a pack or all products are already in a pack."))

--- a/addons/stock/tests/test_move.py
+++ b/addons/stock/tests/test_move.py
@@ -5666,6 +5666,7 @@ class StockMove(TransactionCase):
         self.assertEqual(self.env['stock.quant']._get_available_quantity(self.product, self.stock_location), 0)
         move1.quantity = 1
         picking.action_put_in_pack()
+        picking.action_assign()
 
         self.assertEqual(self.env['stock.quant']._get_available_quantity(self.product, self.stock_location), 0)
         self.assertEqual(len(picking.move_line_ids), 2)
@@ -6016,6 +6017,7 @@ class StockMove(TransactionCase):
         self.assertEqual(len(picking.move_line_ids), 1)
 
         picking.action_put_in_pack()  # Create a first package
+        picking.action_assign()
         self.assertEqual(len(picking.move_line_ids), 2)
 
         unpacked_ml = picking.move_line_ids.filtered(lambda ml: not ml.result_package_id)


### PR DESCRIPTION
This commit removes the call to `action_assign` after putting a stock picking in pack. This is mainly to avoid reserving quantities undesirably when clicking on "Put in Pack" action.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
