### PR TITLE
[IMP] pos_loyalty: allow to select a reward without orderlines

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/models/pos_store.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_store.js
@@ -517,17 +517,13 @@ patch(PosStore.prototype, {
             }
 
             const points = order._getRealCouponPoints(couponProgram.coupon_id);
-            const hasLine = order.lines.filter((line) => !line.is_reward_line).length > 0;
             for (const reward of program.reward_ids.filter(
                 (reward) => reward.reward_type == "product"
             )) {
                 if (points < reward.required_points) {
                     continue;
                 }
-                // Loyalty program (applies_on == 'both') should needs an orderline before it can apply a reward.
-                const considerTheReward =
-                    program.applies_on !== "both" || (program.applies_on == "both" && hasLine);
-                if (reward.reward_type === "product" && considerTheReward) {
+                if (reward.reward_type === "product") {
                     let hasPotentialQty = true;
                     let potentialQty;
                     for (const { id } of reward.reward_product_ids) {


### PR DESCRIPTION
Before this commit it was not possible to select a reward without any lines in the order.

But if the selected partner already have some points, it should be possible to select a reward.

This commit allows to select a reward without any lines in the order.

taskId: 4024282



