### PR TITLE
[FIX] google_calendar: fix account reset for specific policies

### DIFF
--- a/addons/google_calendar/wizard/reset_account.py
+++ b/addons/google_calendar/wizard/reset_account.py
@@ -38,8 +38,7 @@ class ResetGoogleAccount(models.TransientModel):
         if self.delete_policy in ('delete_odoo', 'delete_both'):
             events.google_id = False
             events.unlink()
-
-        if self.sync_policy == 'all':
+        elif self.sync_policy == 'all':
             events.write({
                 'google_id': False,
                 'need_sync': True,


### PR DESCRIPTION
Before this commit, attempting to reset an account with the policies "Delete from Odoo" and "Synchronize all existing events" set would fail. This was due to a write operation being performed on records after they had been unlinked, resulting in a "Missing Record: Record does not exist or has been deleted." error.

opw-4043858

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
