### PR TITLE
[FIX] website_sale: assign the product snippet to its js

### DIFF
--- a/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/000.js
+++ b/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/000.js
@@ -8,7 +8,7 @@ const DynamicSnippetCarousel = require('website.s_dynamic_snippet_carousel');
 var wSaleUtils = require('website_sale.utils');
 
 const DynamicSnippetProducts = DynamicSnippetCarousel.extend({
-    selector: '.s_dynamic_snippet_products',
+    selector: '.s_dynamic_snippet',
     read_events: {
         'click .js_add_cart': '_onAddToCart',
         'click .js_remove': '_onRemoveFromRecentlyViewed',


### PR DESCRIPTION
 To reproduce the bug:
 - Activate the Developers mode
 - Go to website > Shop > Click on Edit at the top right corner > Dynamic Snippet > Add a layout.
 - Switch the snippet layout to 'Borderless Product n°2'
 - Back to Shop click on Add to Card bellow the product images

 The product is not added to the cart when using the "Add to cart" button from the Dynamic Content block. That's because
 no javascript action or eventhandler is assigned to it. Rather the whole js file for the dynamic product snippet is not
 assigned due to the selector being wrong.

 opw-3993050
