### PR TITLE
[FIX] project: always evaluate column_invisible in action_project_sharing

### DIFF
--- a/addons/hr_timesheet/views/project_task_views.xml
+++ b/addons/hr_timesheet/views/project_task_views.xml
@@ -161,12 +161,12 @@
                 <field name="date_deadline" position="before">
                     <field name="progress" column_invisible="True"/>
                     <field name="effective_hours" column_invisible="True"/>
-                    <field name="allocated_hours" widget="timesheet_uom_no_toggle" sum="Total Allocated Time" invisible="allocated_hours == 0" optional="hide"/>
-                    <field name="effective_hours" widget="timesheet_uom" sum="Effective Hours" optional="show" invisible="effective_hours == 0"/>
-                    <field name="subtask_effective_hours" widget="timesheet_uom" sum="Sub-Tasks Total Effective Hours" optional="hide"/>
-                    <field name="total_hours_spent" widget="timesheet_uom" sum="Total Hours" optional="hide"/>
-                    <field name="remaining_hours" widget="timesheet_uom" sum="Total Remaining Hours" optional="hide" decoration-danger="progress &gt;= 100" decoration-warning="progress &gt;= 80 and progress &lt; 100" invisible="allocated_hours == 0"/>
-                    <field name="progress" widget="project_task_progressbar" avg="Average of Progress" optional="show" groups="hr_timesheet.group_hr_timesheet_user" invisible="allocated_hours == 0" options="{'overflow_class': 'bg-danger'}" />
+                    <field name="allocated_hours" widget="timesheet_uom_no_toggle" sum="Total Allocated Time" invisible="allocated_hours == 0" optional="hide" column_invisible="not context.get('allow_timesheets', True)"/>
+                    <field name="effective_hours" widget="timesheet_uom" sum="Effective Hours" optional="show" invisible="effective_hours == 0" column_invisible="not context.get('allow_timesheets', True)"/>
+                    <field name="subtask_effective_hours" widget="timesheet_uom" sum="Sub-Tasks Total Effective Hours" optional="hide" column_invisible="not context.get('allow_timesheets', True)"/>
+                    <field name="total_hours_spent" widget="timesheet_uom" sum="Total Hours" optional="hide" column_invisible="not context.get('allow_timesheets', True)"/>
+                    <field name="remaining_hours" widget="timesheet_uom" sum="Total Remaining Hours" optional="hide" decoration-danger="progress &gt;= 100" decoration-warning="progress &gt;= 80 and progress &lt; 100" invisible="allocated_hours == 0" column_invisible="not context.get('allow_timesheets', True)"/>
+                    <field name="progress" widget="project_task_progressbar" avg="Average of Progress" optional="show" groups="hr_timesheet.group_hr_timesheet_user" invisible="allocated_hours == 0" options="{'overflow_class': 'bg-danger'}" column_invisible="not context.get('allow_timesheets', True)"/>
                 </field>
             </field>
         </record>

--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -672,6 +672,7 @@ class Project(models.Model):
             'delete': False,
             'search_default_open_tasks': True,
             'active_id_chatter': self.id,
+            'allow_milestones': self.allow_milestones,
         }
         action['display_name'] = self.name
         return action

--- a/addons/project/static/src/project_sharing/views/list/list_renderer.js
+++ b/addons/project/static/src/project_sharing/views/list/list_renderer.js
@@ -1,34 +1,8 @@
 /** @odoo-module */
 
-import { evaluateBooleanExpr } from "@web/core/py_js/py";
 import { ListRenderer } from "@web/views/list/list_renderer";
-import { onWillUpdateProps } from "@odoo/owl";
 
 export class ProjectSharingListRenderer extends ListRenderer {
-    setup() {
-        super.setup(...arguments);
-        this.setColumns(this.allColumns);
-        onWillUpdateProps((nextProps) => {
-            this.setColumns(nextProps.archInfo.columns);
-        });
-    }
-
-    setColumns(columns) {
-        if (this.props.list.records.length) {
-            const allColumns = [];
-            const firstRecord = this.props.list.records[0];
-            for (const column of columns) {
-                if (evaluateBooleanExpr(column.column_invisible, firstRecord.evalContextWithVirtualIds)) {
-                    continue;
-                }
-                allColumns.push(column);
-            }
-            this.allColumns = allColumns;
-        } else {
-            this.allColumns = columns;
-        }
-        this.state.columns = this.allColumns.filter(
-            (col) => !col.optional || this.optionalActiveFields[col.name]
-        );
-    }
+    /* TODO: Remove me in master */
+    setColumns(columns) {}
 }

--- a/addons/project/static/tests/tours/project_sharing_tour.js
+++ b/addons/project/static/tests/tours/project_sharing_tour.js
@@ -89,6 +89,12 @@ const projectSharingSteps = [...stepUtils.goToAppSteps("project.menu_main_pm", '
     trigger: 'iframe button.o_switch_view.o_list',
     content: 'Go to the list view',
 }, {
+    extra_trigger: 'iframe .o_list_view',
+    trigger: 'iframe .o_optional_columns_dropdown_toggle',
+}, {
+    trigger: 'iframe .o_optional_columns_dropdown .dropdown-item:contains("Milestone")',
+    isCheck: true,
+}, {
     trigger: 'iframe .o_list_view',
     content: 'Check the list view',
     isCheck: true,
@@ -110,4 +116,41 @@ registry.category("web_tour.tours").add("portal_project_sharing_tour", {
         const projectSharingStepIndex = projectSharingSteps.findIndex(s => s?.id === 'project_sharing_feature');
         return projectSharingSteps.slice(projectSharingStepIndex, projectSharingSteps.length);
     }
+});
+
+registry.category("web_tour.tours").add("portal_project_sharing_tour_with_disallowed_milestones", {
+    test: true,
+    url: "/my/projects",
+    steps: () => [
+        {
+            id: 'project_sharing_feature',
+            trigger: 'table > tbody > tr a:has(span:contains(Project Sharing))',
+            content: 'Select "Project Sharing" project to go to project sharing feature for this project.',
+        },
+        {
+            trigger: 'iframe .o_project_sharing',
+            content: 'Wait the project sharing feature be loaded',
+            isCheck: true,
+        },
+        {
+            trigger: 'iframe button.o_switch_view.o_list',
+            content: 'Go to the list view',
+        },
+        {
+            extra_trigger: 'iframe .o_list_view',
+            trigger: 'iframe .o_optional_columns_dropdown_toggle',
+        },
+        {
+            extra_trigger: 'iframe .o_optional_columns_dropdown .dropdown-item',
+            trigger: 'iframe .o_optional_columns_dropdown',
+            run: function() {
+                const optionalFields = Array.from(this.$anchor[0].ownerDocument.querySelectorAll(".dropdown-item"))
+                    .map(e => e.textContent);
+
+                if (optionalFields.includes("Milestone")) {
+                    throw new Error("the Milestone field should be absent as allow_milestones is set to False");
+                }
+            }
+        },
+    ]
 });

--- a/addons/project/tests/test_project_sharing_ui.py
+++ b/addons/project/tests/test_project_sharing_ui.py
@@ -66,3 +66,23 @@ class TestProjectSharingUi(HttpCase):
             })],
         })
         self.start_tour("/my/projects", 'portal_project_sharing_tour', login='georges1')
+
+    def test_03_project_sharing(self):
+        project_share_wizard = self.env['project.share.wizard'].create({
+            'access_mode': 'edit',
+            'res_model': 'project.project',
+            'res_id': self.project_portal.id,
+            'partner_ids': [
+                Command.link(self.partner_portal.id),
+            ],
+        })
+        project_share_wizard.action_send_mail()
+
+        self.project_portal.write({
+            'task_ids': [Command.create({
+                'name': "Test Project Sharing",
+                'stage_id': self.project_portal.type_ids.filtered(lambda stage: stage.sequence == 10)[:1].id,
+            })],
+            'allow_milestones': False,
+        })
+        self.start_tour("/my/projects", 'portal_project_sharing_tour_with_disallowed_milestones', login='georges1')

--- a/addons/project/views/project_sharing_project_task_views.xml
+++ b/addons/project/views/project_sharing_project_task_views.xml
@@ -116,6 +116,9 @@
             <field name="user_ids" position="replace">
                 <field name="portal_user_names" string="Assignees"/>
             </field>
+            <xpath expr="//field[@name='milestone_id']" position="attributes">
+                <attribute name="column_invisible">not context.get('allow_milestones', True)</attribute>
+            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
Steps to reproduce
==================

As Admin:
- Install project
- Go to project
- Click on the three dots on a project card
- Select "Share"
- Copy the link
- Select the edit mode
- Add "Joel Willis" to the recipients
- Click on "Send"

As portal in another browser (or in private navigation)
- Paste the link
- Type some random characters in the search bar so that no records are matched
- remove the current filter => Every single column is displayed, for example
  `<field name="sequence" readonly="1" column_invisible="True"/>`

As Admin:
- Go to the shared project settings
- Disable the "Milestones" checkbox

As portal:
- Refresh the page => The milestone column is still displayed

Cause of the issue
==================

The difference between invisible and column_invisible is that

`invisible` is meant to hide a cell in a row and is evaluated with the record data (`record.evalContextWithVirtualIds`).

`column_invisible` is meant to remove a column completely for the list, but is is not evaluated with the record. It only uses the context and a few more keys (`this.model.root.evalContext`).

It is thus not possible to hide an entire column depending on record values. It makes sense as the values could be different for every record displayed.

In this case though, there are a few fields that have the same values for every record. They are in fact related fields, declared on the project.

Those fields are
- allow_milestones
- allow_timesheets

The [ProjectSharingListRenderer] has been created to hide some columns from being displayed when a feature is disabled on the project displayed.

It works by evaluating the column_invisible with the first record. If there are no records, we skip any column_invisible processing,

When calling `setColumns` from `onWillUpdateProps`, we use `nextProps` for the columns, but still `this.props` to get the first record.

This means that we use an outdated first record, and this is why every column is displayed after removing the filter.

Another issue is that

During [View-Pocalypse],
In 16.0, the milestone_id field was

```xml
<field name="milestone_id" attrs="{'column_invisible': [('allow_milestones', '=', False)]}"/>
```

In 17.0, it is

```xml
<field name="milestone_id" invisible="not allow_milestones" context="{'default_project_id': project_id}" groups="project.group_project_milestone" optional="hide"/>
```

Solution
========

As there are some limitations to the js approach (when no records are in the list for example) and there is already a context key for the [allow_timesheets], we use a simpler approach to add the missing keys.

Finally, we put back the column_invisible attributes

---

[ProjectSharingListRenderer]: https://github.com/odoo/odoo/commit/ab2b5d1fd1f09d804ab410bc326cfebf26d5a7c6
[View-Pocalypse]: https://github.com/odoo/odoo/pull/104741
[allow_timesheets]: https://github.com/odoo/odoo/blob/d2a428c07fd728691e3ddd60fe4b7cc5e94455a6/addons/hr_timesheet/models/project_project.py#L290

opw-4015035