### PR TITLE
[PERF] utm: improve performance

### DIFF
--- a/addons/link_tracker/models/link_tracker.py
+++ b/addons/link_tracker/models/link_tracker.py
@@ -276,7 +276,7 @@ class LinkTrackerClick(models.Model):
     _description = "Link Tracker Click"
 
     campaign_id = fields.Many2one(
-        'utm.campaign', 'UTM Campaign',
+        'utm.campaign', 'UTM Campaign', index='btree_not_null',
         related="link_id.campaign_id", store=True, ondelete="set null")
     link_id = fields.Many2one(
         'link.tracker', 'Link',

--- a/addons/utm/models/utm_mixin.py
+++ b/addons/utm/models/utm_mixin.py
@@ -15,11 +15,11 @@ class UtmMixin(models.AbstractModel):
     _name = 'utm.mixin'
     _description = 'UTM Mixin'
 
-    campaign_id = fields.Many2one('utm.campaign', 'Campaign',
+    campaign_id = fields.Many2one('utm.campaign', 'Campaign', index='btree_not_null',
                                   help="This is a name that helps you keep track of your different campaign efforts, e.g. Fall_Drive, Christmas_Special")
-    source_id = fields.Many2one('utm.source', 'Source',
+    source_id = fields.Many2one('utm.source', 'Source', index='btree_not_null',
                                 help="This is the source of the link, e.g. Search Engine, another domain, or name of email list")
-    medium_id = fields.Many2one('utm.medium', 'Medium',
+    medium_id = fields.Many2one('utm.medium', 'Medium', index='btree_not_null',
                                 help="This is the method of delivery, e.g. Postcard, Email, or Banner Ad")
 
     @api.model


### PR DESCRIPTION
The commit adds indexing to frequently accessed fields as records tend
to be lare which causes long waiting loading.

fetching and counting benchmarks:
~11M reords were created:
- 4k with campaign_id = 4
- 11M with campaign_id = 5

before indexing:
- 1889.532 ms

after indexing:
- 10.617 ms

task-3980514

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
