### PR TITLE
[FIX] mail: message preview not closed

### DIFF
--- a/addons/mail/static/src/utils/common/hooks.js
+++ b/addons/mail/static/src/utils/common/hooks.js
@@ -86,7 +86,20 @@ export function useHover(refNames, callback = () => {}) {
             withDirectParent,
         });
     }
-    const state = useState({ isHover: false });
+    const state = useState({
+        set isHover(newIsHover) {
+            if (this._isHover !== newIsHover) {
+                this._isHover = newIsHover;
+                this._count++;
+            }
+        },
+        get isHover() {
+            void this._count;
+            return this._isHover;
+        },
+        _count: 0,
+        _isHover: false,
+    });
     function onHover(hovered) {
         state.isHover = hovered;
         callback(hovered);


### PR DESCRIPTION
Before this commit, chat bubble preview was sometimes not closing itself on hover away.

When a chat window is folded, it shows a bubble. By mouse-hovering it, it previews the last message in conversation. This preview is expected to be shown until mousehovering on chat bubble and in the preview itself.

This was sometimes not working because the inner-code of `useHover()` required syncing with a rendering. If the hover action is quick enough, the rendering does not observe the transition from
```
isHover: true -> isHover: false -> isHover: true
```
And thus it thinks the chat bubble is kept hovering.

This worked sometimes because by changes the "X" to close a chat bubble triggers a delayed rendering.

This commit fixes the issue by ensuring that all transition of `isHover` are fully observed, so that the UI always matches its inner value. `isHover` is kept as a boolean, but the trick is for read to side-effect a read on a indefinitely increasing integer, so that the inner `useState` properly observes all transition change to sync the rendering.

The pattern used looks like well-known `autofocus` pattern but this is hidden in implementation detail of a plain boolean value.
