### PR TITLE
[FIX] calendar : Check for ids not users when event is not created yet

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -293,7 +293,7 @@ class Meeting(models.Model):
             # Right before saving the event, old partners must be able to save changes.
             if event._origin:
                 editor_candidates += event._origin.partner_ids.user_ids
-            event.user_can_edit = self.env.user in editor_candidates
+            event.user_can_edit = self.env.user.id in editor_candidates.ids
 
     @api.depends('attendee_ids')
     def _compute_invalid_email_partner_ids(self):


### PR DESCRIPTION
### Steps to reproduce:
	- Install Calendar module
	- Create a new event
	- Change the organzier to Marc Demo and then add him as attendee
	- Save the event

### Current behavior before PR:
When changing the organizer of an event that you are creating and then add a new attendee and save the event the organizer will not be saved and will be back to the default user.
This is happening because when getting the changed values to use it in the create operation it will check if the organizer field is readonly https://github.com/odoo/odoo/blob/17.0/addons/web/static/src/model/relational_model/record.js#L592:L597 It will be true and it is readonly because of the computed field in the calendar.event 'user_can_edit' where when it checks who can edit the event before creating it the 'partner_ids' will be found as 'NewId' not yet 'res.partner'
https://github.com/odoo/odoo/blob/17.0/addons/calendar/models/calendar_event.py#L296

### Desired behavior after PR is merged:
We can change the organizer of the event before assign the attendees or creating the event. As we are now checking the ids itself not the whole object of the partner_ids

opw-3908333