### PR TITLE
[FIX] l10n_gcc_invoice: updating outdated method name on report

### DIFF
--- a/addons/l10n_gcc_invoice/views/report_invoice.xml
+++ b/addons/l10n_gcc_invoice/views/report_invoice.xml
@@ -282,7 +282,7 @@
                                     </td>
                                     <td name="account_invoice_line_name">
                                         <t t-set="line_name" t-value="line.with_context(lang=o.partner_id.lang).product_id.display_name or line.name"/>
-                                        <span t-out="line_name" t-options="{'widget': 'text'}" t-att-dir="o.env['res.lang']._lang_get_direction(o.partner_id.lang)"/>
+                                        <span t-out="line_name" t-options="{'widget': 'text'}" t-att-dir="o.env['res.lang']._get_data(code=o.partner_id.lang).direction"/>
                                     </td>
 
                                 </t>


### PR DESCRIPTION
Problem: The `l10n_gcc_invoice.arabic_english_invoice` report was recently updated to fix (https://github.com/odoo/odoo/pull/169267) an issue related to RTL ordering. However, this fix uses the `_lang_get_direction` method. While fine on theoriginally targeted version, in 17.2 this method was reworked into a new api `_get_data`. FW ports for 17.2+ had this older method still.

Purpose: Swap `_lang_get_direction` with new `_get_data` method in report

opw-4045879