### PR TITLE
[FIX] base: force None values to be False

### DIFF
--- a/odoo/addons/test_new_api/tests/test_properties.py
+++ b/odoo/addons/test_new_api/tests/test_properties.py
@@ -2069,6 +2069,30 @@ class PropertiesSearchCase(TestPropertiesMixin):
         with self.assertRaises(ValueError):
             self.env['test_new_api.message'].search([('attributes', '=', '"Test"')])
 
+    @mute_logger('odoo.fields')
+    def test_properties_field_search_read_false(self):
+        Model = self.env['test_new_api.message']
+
+        discussion = self.env['test_new_api.discussion'].create({
+            'name': 'Test Discussion',
+            'participants': [Command.link(self.user.id)],
+        })
+
+        message = self.env['test_new_api.message'].create({
+            'name': 'Test Message',
+            'discussion': discussion.id,
+            'author': self.user.id,
+        })
+
+        discussion.attributes_definition = [{
+            'name': 'discussion_test',
+            'string': 'Discussion Test',
+            'type': 'char',
+        }]
+
+        message_values = Model.search_read([('id', '=', message.id)])
+        self.assertEqual(message_values[0]['attributes'][0]['value'], False, 'Value should be set as False')
+
 
 class PropertiesGroupByCase(TestPropertiesMixin):
     @classmethod

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -3731,8 +3731,7 @@ class Properties(Field):
                 # E.G. convert zero to False
                 property_value = bool(property_value)
 
-            elif property_type == 'char' and not isinstance(property_value, str) \
-                    and property_value is not None:
+            elif property_type == 'char' and not isinstance(property_value, str):
                 property_value = False
 
             elif property_value and property_type == 'selection':


### PR DESCRIPTION
Current behaviour:
---
When trying to make a xmlrpc call to search_read a crm lead that has a property, we get a traceback.

Steps to reproduce:
---
1. Install CRM
2. Go to the Pipeline
3. Open any lead
4. Click on Actions > Add properties
5. Input anything as value, then save
6. Make a xmlrpc call to retrieve leads (see below)
7. Traceback

`models.execute_kw(db, uid, password, 'crm.lead', 'search_read', [])`

Cause of the issue:
---
Feature introduction: https://github.com/odoo/odoo/commit/87307a9010c6c872fe6c746d5ece378ad90d038f 
Change from `None` to `False`: https://github.com/odoo/odoo/commit/608bffff59c9444f59a282dbdc43c207704223cc 
Issue caused by: https://github.com/odoo/odoo/commit/da48700b59da49cdc810eac31a8617fcaa0dc2a8 
(Due to the modification of `convert_to_read_multi`)

When adding `PropertiesDefinition` to an existing record, it doesn't go through 
`_add_default_values` again, thus making `None` not being replaced by `False`.
https://github.com/odoo/odoo/blob/cd9c69bd7d9b21e6220a49f88f22160de33c5e06/odoo/fields.py#L3616

opw-3940841

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
