### PR TITLE
[FIX] l10n_gcc_invoice: fix traceback when creating a new product

### DIFF
--- a/addons/l10n_gcc_invoice/models/product.py
+++ b/addons/l10n_gcc_invoice/models/product.py
@@ -20,4 +20,6 @@ class ProductProduct(models.Model):
 
         super()._compute_display_name()
         for product in self:
-            product.display_name = re.sub(r'(\d)(\s)([\u0600-\u06FF])', repl, product.display_name)
+            if not product.display_name:
+                continue
+            product.display_name = re.sub(r'(\d)(\s)([\u0600-\u06FF])', repl, (product.display_name))


### PR DESCRIPTION
Currently, a traceback is occurring when the user tries to create a new product

To reproduce this issue:

1) install sales, `l10n_gcc_invoice`
2) Try to create a new `product variant` from sales

Error:- 

```TypeError: expected string or bytes-like object```

In this commit `product.display_name` is used in `re.sub()` in which `product display name` 
should be false when initially creating a product. which leads to a traceback.

After applying this commit, it will resolve this issue by giving a default value when the product.display_name is false.

commit:- https://github.com/odoo/odoo/pull/169267/commits/89ba4003eea350e9e2833744637b32cd67d62952

https://github.com/odoo/odoo/blob/69e3d9d48dfb138367039e650b826a4f44af5697/addons/l10n_gcc_invoice/models/product.py#L11-L23

sentry-5593088590