### PR TITLE
[IMP] lunch: simplify kanban archs

### DIFF
--- a/addons/lunch/report/lunch_cashmove_report_views.xml
+++ b/addons/lunch/report/lunch_cashmove_report_views.xml
@@ -80,36 +80,23 @@
         <field name="model">lunch.cashmove.report</field>
         <field name="arch" type="xml">
             <kanban class="o_kanban_mobile">
-                <field name="date"/>
-                <field name="user_id"/>
-                <field name="description"/>
-                <field name="amount"/>
-                <field name="currency_id" invisible="1"/>
+                <field name="currency_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div t-attf-class="oe_kanban_global_click">
-                            <div class="row mb4">
-                                <div class="col-8">
-                                    <span>
-                                        <strong class="o_kanban_record_title"><t t-esc="record.description.value"/></strong>
-                                    </span>
-                                </div>
-                                <div class="col-4 text-end">
-                                    <span class="badge rounded-pill">
-                                        <strong><i class="fa fa-money" role="img" aria-label="Amount" title="Amount"/> <field name="amount" widget="monetary"/></strong>
-                                    </span>
-                                </div>
+                    <t t-name="kanban-card">
+                        <div class="row mb4">
+                            <div class="col-8 fw-bold fs-5">
+                                <field name="description" />
                             </div>
-                            <div class="row">
-                                <div class="col-6">
-                                    <i class="fa fa-clock-o" role="img" aria-label="Date" title="Date"/>
-                                    <t t-esc="record.date.value"/>
-                                </div>
-                                <div class="col-6">
-                                    <div class="float-end">
-                                        <field name="user_id" widget="many2one_avatar_user"/>
-                                    </div>
-                                </div>
+                            <div class="col-4 text-end badge rounded-pill fw-bolder pe-3 pt-1">
+                                <i class="fa fa-money" role="img" aria-label="Amount" title="Amount"/> <field name="amount" widget="monetary"/>
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-6">
+                                <i class="fa fa-clock-o" role="img" aria-label="Date" title="Date"/> <field name="date"/>
+                            </div>
+                            <div class="col-6">
+                                <field name="user_id" widget="many2one_avatar_user" class="float-end"/>
                             </div>
                         </div>
                     </t>

--- a/addons/lunch/static/tests/lunch_kanban_tests.js
+++ b/addons/lunch/static/tests/lunch_kanban_tests.js
@@ -18,11 +18,9 @@ async function makeLunchView(extraArgs = {}) {
             arch: `
             <kanban js_class="lunch_kanban">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="name"/>
-                            <field name="price"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="name"/>
+                        <field name="price"/>
                     </t>
                 </templates>
             </kanban>`,

--- a/addons/lunch/views/lunch_alert_views.xml
+++ b/addons/lunch/views/lunch_alert_views.xml
@@ -76,25 +76,17 @@
         <field name="arch" type="xml">
             <kanban class="o_kanban_mobile">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div class="oe_kanban_card oe_kanban_global_click">
-                            <div class="oe_kanban_content">
-                                <div class="o_kanban_record_top">
-                                    <div class="o_kanban_record_headings">
-                                        <strong class="o_kanban_record_title"><field name="name"/></strong>
-                                        <span><br/><field name="mode"/></span>
-                                        <span invisible="mode != 'chat'">
-                                            to <field name="recipients"/>
-                                            on <field name="notification_time"/>
-                                            <field name="notification_moment"/>
-                                        </span>
-                                    </div>
-                                </div>
-                                <div class="o_kanban_record_body">
-                                    <field name="location_ids" widget="many2many_tags"/>
-                                </div>
-                            </div>
+                    <t t-name="kanban-card">
+                        <field class="fw-bold fs-5" name="name"/>
+                        <div>
+                            <field name="mode"/>
+                            <span invisible="mode != 'chat'">
+                                to <field name="recipients"/>
+                                on <field name="notification_time"/>
+                                <field name="notification_moment"/>
+                            </span>
                         </div>
+                        <field name="location_ids" widget="many2many_tags"/>
                     </t>
                 </templates>
             </kanban>

--- a/addons/lunch/views/lunch_cashmove_views.xml
+++ b/addons/lunch/views/lunch_cashmove_views.xml
@@ -51,36 +51,23 @@
         <field name="model">lunch.cashmove</field>
         <field name="arch" type="xml">
             <kanban class="o_kanban_mobile">
-                <field name="date"/>
-                <field name="user_id"/>
-                <field name="description"/>
-                <field name="amount"/>
-                <field name="currency_id" invisible="1"/>
+                <field name="currency_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div t-attf-class="oe_kanban_global_click">
-                            <div class="row mb4">
-                                <div class="col-8">
-                                    <span>
-                                        <strong class="o_kanban_record_title"><t t-esc="record.description.value"/></strong>
-                                    </span>
-                                </div>
-                                <div class="col-4 text-end">
-                                    <span class="badge rounded-pill">
-                                        <strong><i class="fa fa-money" role="img" aria-label="Amount" title="Amount"/> <field name="amount" widget="monetary"/></strong>
-                                    </span>
-                                </div>
+                    <t t-name="kanban-card">
+                        <div class="row mb4">
+                            <div class="col-8 fw-bold fs-5">
+                                <field name="description" />
                             </div>
-                            <div class="row">
-                                <div class="col-6">
-                                    <i class="fa fa-clock-o" role="img" aria-label="Date" title="Date"/>
-                                    <t t-esc="record.date.value"/>
-                                </div>
-                                <div class="col-6">
-                                    <div class="float-end">
-                                        <field name="user_id" widget="many2one_avatar_user"/>
-                                    </div>
-                                </div>
+                            <div class="col-4 text-end badge rounded-pill fw-bolder pe-3 pt-1">
+                                <i class="fa fa-money" role="img" aria-label="Amount" title="Amount"/> <field name="amount" widget="monetary"/>
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-6">
+                                <i class="fa fa-clock-o" role="img" aria-label="Date" title="Date"/> <field name="date" />
+                            </div>
+                            <div class="col-6">
+                                <field name="user_id" widget="many2one_avatar_user" class="float-end"/>
                             </div>
                         </div>
                     </t>

--- a/addons/lunch/views/lunch_location_views.xml
+++ b/addons/lunch/views/lunch_location_views.xml
@@ -47,20 +47,10 @@
         <field name="arch" type="xml">
             <kanban class="o_kanban_mobile">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div class="oe_kanban_card oe_kanban_global_click">
-                            <div class="oe_kanban_content">
-                                <div class="o_kanban_record_top">
-                                    <div class="o_kanban_record_headings">
-                                        <strong class="o_kanban_record_title"><field name="name"/></strong>
-                                    </div>
-                                </div>
-                                <div class="o_kanban_record_body">
-                                    <field name="company_id" groups="base.group_multi_company"/><br/>
-                                    <field name="address"/>
-                                </div>
-                            </div>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="name" class="fw-bold fs-5"/>
+                        <field name="company_id" groups="base.group_multi_company"/>
+                        <field name="address"/>
                     </t>
                 </templates>
             </kanban>

--- a/addons/lunch/views/lunch_orders_views.xml
+++ b/addons/lunch/views/lunch_orders_views.xml
@@ -67,57 +67,43 @@
         <field name="model">lunch.order</field>
         <field name="arch" type="xml">
             <kanban create="false" edit="false">
-                <field name="product_id"/>
-                <field name="note"/>
-                <field name="state"/>
-                <field name="user_id"/>
-                <field name="date"/>
-                <field name="company_id"/>
                 <field name="currency_id"/>
                 <field name="notified"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div class="oe_kanban_global_click">
-                            <div class="o_kanban_record_top">
-                                <div class="o_kanban_record_headings">
-                                    <strong class="o_kanban_record_title"><field name="product_id"/></strong>
-                                </div>
-                                <field name="state" widget="label_selection" options="{'classes': {'new': 'default', 'confirmed': 'success', 'cancelled':'danger'}}"/>
+                    <t t-name="kanban-card">
+                        <div class="d-flex">
+                            <field name="product_id" class="fw-bold fs-5"/>
+                            <field name="state" widget="label_selection" options="{'classes': {'new': 'default', 'confirmed': 'success', 'cancelled':'danger'}}" class="ms-auto"/>
+                        </div>
+                        <field name="note"/>
+                        <div class="row">
+                            <div class="col-6">
+                                <i class="fa fa-money" role="img" aria-label="Money" title="Money"/> <field name="price"/>
                             </div>
-                            <div>
-                                <field name="note"/>
+                            <div class="col-6 text-end">
+                                <i class="fa fa-clock-o" role="img" aria-label="Date" title="Date"/> <field name="date" readonly="state != 'new'"/>
                             </div>
-                            <div class="row">
-                                <div class="col-6">
-                                    <i class="fa fa-money" role="img" aria-label="Money" title="Money"/> <field name="price"/>
-                                </div>
-                                <div class="col-6 text-end">
-                                    <i class="fa fa-clock-o" role="img" aria-label="Date" title="Date"/> <field name="date" readonly="state != 'new'"/>
-                                </div>
+                        </div>
+                        <div class="row mt4">
+                            <div class="col-6">
+                                <a class="btn btn-sm btn-success" role="button" name="action_order" string="Order" type="object" invisible="state in ['sent', 'ordered', 'confirmed']" groups="lunch.group_lunch_manager">
+                                    <i class="fa fa-phone" role="img" aria-label="Order button" title="Order button"/>
+                                </a>
+                                <a class="btn btn-sm btn-primary" role="button" name="action_send" string="Send" type="object" invisible="state != 'ordered'" groups="lunch.group_lunch_manager">
+                                    <i class="fa fa-paper-plane" role="img" aria-label="Send button" title="Send button"/>
+                                </a>
+                                <a class="btn btn-sm btn-info" role="button" name="action_confirm" string="Receive" type="object" invisible="state != 'sent'" groups="lunch.group_lunch_manager">
+                                    <i class="fa fa-check" role="img" aria-label="Receive button" title="Receive button"/>
+                                </a>
+                                <a class="btn btn-sm btn-danger" role="button" name="action_cancel" string="Cancel" type="object" invisible="state in ['cancelled', 'confirmed']" groups="lunch.group_lunch_manager">
+                                    <i class="fa fa-times" role="img" aria-label="Cancel button" title="Cancel button"/>
+                                </a>
+                                <a class="btn btn-sm btn-info" role="button" name="action_notify" string="Send Notification" type="object" invisible="state != 'confirmed' or notified" groups="lunch.group_lunch_manager">
+                                    <i class="fa fa-envelope" role="img" aria-label="Send notification" title="Send notification"/>
+                                </a>
                             </div>
-                            <div class="row mt4">
-                                <div class="col-6">
-                                    <a class="btn btn-sm btn-success" role="button" name="action_order" string="Order" type="object" invisible="state in ['sent', 'ordered', 'confirmed']" groups="lunch.group_lunch_manager">
-                                        <i class="fa fa-phone" role="img" aria-label="Order button" title="Order button"/>
-                                    </a>
-                                    <a class="btn btn-sm btn-primary" role="button" name="action_send" string="Send" type="object" invisible="state != 'ordered'" groups="lunch.group_lunch_manager">
-                                        <i class="fa fa-paper-plane" role="img" aria-label="Send button" title="Send button"/>
-                                    </a>
-                                    <a class="btn btn-sm btn-info" role="button" name="action_confirm" string="Receive" type="object" invisible="state != 'sent'" groups="lunch.group_lunch_manager">
-                                        <i class="fa fa-check" role="img" aria-label="Receive button" title="Receive button"/>
-                                    </a>
-                                    <a class="btn btn-sm btn-danger" role="button" name="action_cancel" string="Cancel" type="object" invisible="state in ['cancelled', 'confirmed']" groups="lunch.group_lunch_manager">
-                                        <i class="fa fa-times" role="img" aria-label="Cancel button" title="Cancel button"/>
-                                    </a>
-                                    <a class="btn btn-sm btn-info" role="button" name="action_notify" string="Send Notification" type="object" invisible="state != 'confirmed' or notified" groups="lunch.group_lunch_manager">
-                                        <i class="fa fa-envelope" role="img" aria-label="Send notification" title="Send notification"/>
-                                    </a>
-                                </div>
-                                <div class="col-6">
-                                    <span class="float-end">
-                                        <field name="user_id" widget="many2one_avatar_user" readonly="state != 'new'"/>
-                                    </span>
-                                </div>
+                            <div class="col-6">
+                                <field name="user_id" widget="many2one_avatar_user" readonly="state != 'new'" class="float-end"/>
                             </div>
                         </div>
                     </t>

--- a/addons/lunch/views/lunch_product_views.xml
+++ b/addons/lunch/views/lunch_product_views.xml
@@ -103,45 +103,31 @@
         <field name="priority">999</field>
         <field name="arch" type="xml">
             <kanban js_class="lunch_kanban" create="0" edit="0" group_create="0" class="o_kanban_mobile">
-                <field name="id"/>
-                <field name="name"/>
-                <field name="category_id"/>
-                <field name="supplier_id"/>
-                <field name="description"/>
                 <field name="currency_id"/>
-                <field name="company_id"/>
                 <field name="is_new"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div class="oe_kanban_global_click o_kanban_record_has_image_fill">
-                            <field name="image_128" class="o_lunch_image o_kanban_image_fill_left" options="{'placeholder': '/lunch/static/img/lunch.png', 'size': [94, 94]}" widget="image"/>
-                            <div class="oe_kanban_details ml8">
-                                <div class="o_kanban_record_top">
-                                    <div class="o_kanban_record_headings">
-                                        <strong class="o_kanban_record_title">
-                                            <div class="d-flex align-items-center justify-content-between">
-                                                <div>
-                                                    <field class="pe-1" name="is_favorite" widget="lunch_is_favorite" nolabel="1"/>
-                                                    <strong><span t-esc="record.name.value"/></strong>
-                                                </div>
-                                                <div class="text-primary">
-                                                    <div t-if="record.is_new.raw_value" class="o_lunch_new_product me-1 py-1 fs-6 badge rounded-pill text-bg-success">
-                                                        New
-                                                    </div>
-                                                    <field name="price" widget="monetary"/>
-                                                </div>
-                                            </div>
-                                        </strong>
-                                        <span class="o_kanban_record_subtitle"><span t-esc="record.supplier_id.value"/></span>
-                                    </div>
+                    <t t-name="kanban-card" class="row g-0">
+                        <aside class="col-4">
+                            <field name="image_128" options="{'placeholder': '/lunch/static/img/lunch.png', 'size': [94, 94], 'img_class': 'w-100 h-100'}" widget="image"/>
+                        </aside>
+                        <main class="col">
+                            <div class="d-flex">
+                                <div class="d-flex">
+                                    <field class="pe-1 pt-1" name="is_favorite" widget="lunch_is_favorite" nolabel="1"/>
+                                    <field name="name" class="fw-bolder fs-5" />
                                 </div>
-                                <div class="o_kanban_record_bottom">
-                                    <ul>
-                                        <li t-out="record.description.value" class="text-muted"/>
-                                    </ul>
+                                <div class="text-primary ms-auto">
+                                    <div t-if="record.is_new.raw_value" class="o_lunch_new_product me-1 py-1 fs-6 badge rounded-pill text-bg-success">
+                                        New
+                                    </div>
+                                    <field name="price" widget="monetary" class="fw-bold "/>
                                 </div>
                             </div>
-                        </div>
+                            <field name="supplier_id" />
+                            <footer class="fs-6 pt-0 mt-0">
+                                <field name="description" class="text-muted"/>
+                            </footer>
+                        </main>
                     </t>
                 </templates>
             </kanban>
@@ -161,32 +147,20 @@
                 <field name="description"/>
                 <field name="currency_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div class="oe_kanban_global_click o_kanban_record_has_image_fill">
-                            <div class="o_kanban_image_fill_left d-none d-md-block">
-                                <img t-attf-src="#{kanban_image('lunch.product', 'image_128', record.id.raw_value)}" t-att-alt="record.id.value"/>
+                    <t t-name="kanban-card" class="flex-row">
+                        <aside class="o_kanban_aside_full d-none d-md-block">
+                            <field name="image_128" widget="image" t-att-alt="record.id.value"/>
+                        </aside>
+                        <main>
+                            <div class="d-flex">
+                                <field name="name" class="fw-bold fs-5"/>
+                                <field name="price" widget="monetary" class="fw-bold ms-auto"/>
                             </div>
-                            <div class="oe_kanban_details">
-                                <div class="o_kanban_record_top">
-                                    <div class="o_kanban_record_headings">
-                                        <strong class="o_kanban_record_title">
-                                            <div>
-                                                <div class="float-end">
-                                                    <field name="price" widget="monetary"/>
-                                                </div>
-                                                <strong><span t-esc="record.name.value"/></strong>
-                                            </div>
-                                        </strong>
-                                        <span class="o_kanban_record_subtitle"><span t-esc="record.supplier_id.value"/></span>
-                                    </div>
-                                </div>
-                                <div class="o_kanban_record_bottom">
-                                    <ul>
-                                        <li t-out="record.description.value" class="text-muted"/>
-                                    </ul>
-                                </div>
-                            </div>
-                        </div>
+                            <field name="supplier_id" />
+                            <footer class="fs-6 pt-0 mt-0">
+                                <field name="description" class="text-muted"/>
+                            </footer>
+                        </main>
                     </t>
                 </templates>
             </kanban>
@@ -251,32 +225,21 @@
         <field name="model">lunch.product.category</field>
         <field name="arch" type="xml">
             <kanban class="o_kanban_mobile">
-                <field name="id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div class="oe_kanban_global_click o_kanban_record_has_image_fill o_kanban_record">
-                            <div class="o_kanban_image_fill_left d-none d-md-block">
-                                <img t-attf-src="#{kanban_image('lunch.product.category', 'image_128', record.id.raw_value)}" t-att-alt="record.id.value"/>
-                            </div>
-                            <div class="oe_kanban_details">
-                                <div class="o_kanban_record_top">
-                                    <div class="o_kanban_record_headings">
-                                        <div class="float-end">
-                                            <button class="badge text-bg-primary" type="action"
-                                                name="%(lunch.lunch_product_action_statbutton)d"
-                                                context="{'search_default_category_id': id,'default_category_id': id}"
-                                                invisible="product_count == 0">
-                                                <field string="Products" name="product_count" widget="statinfo"/>
-                                            </button>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div class="o_kanban_record_body">
-                                    <strong><field name="name"/></strong><br/>
-                                    <field name="company_id" groups="base.group_multi_company"/>
-                                </div>
-                            </div>
-                        </div>
+                    <t t-name="kanban-card">
+                        <aside class="d-none d-md-block">
+                            <field name="image_128" widget="image"/>
+                        </aside>
+                        <main>
+                            <button class="badge text-bg-primary ms-auto" type="action"
+                                name="%(lunch.lunch_product_action_statbutton)d"
+                                context="{'search_default_category_id': id,'default_category_id': id}"
+                                invisible="product_count == 0">
+                                <field string="Products" name="product_count" widget="statinfo"/>
+                            </button>
+                            <field name="name" class="fw-bold"/>
+                            <field name="company_id" groups="base.group_multi_company"/>
+                        </main>
                     </t>
                 </templates>
             </kanban>

--- a/addons/lunch/views/lunch_supplier_views.xml
+++ b/addons/lunch/views/lunch_supplier_views.xml
@@ -116,23 +116,17 @@
         <field name="model">lunch.supplier</field>
         <field name="arch" type="xml">
             <kanban>
-                <field name="partner_id"/>
-                <field name="city"/>
-                <field name="country_id"/>
-                <field name="email"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div class="oe_kanban_global_click o_kanban_record_has_image_fill o_res_partner_kanban">
-                            <div class="oe_kanban_details">
-                                <strong class="o_kanban_record_title oe_partner_heading"><field name="display_name"/></strong>
-                                <ul>
-                                    <li t-if="record.city.raw_value and !record.country_id.raw_value"><field name="city"/></li>
-                                    <li t-if="!record.city.raw_value and record.country_id.raw_value"><field name="country_id"/></li>
-                                    <li t-if="record.city.raw_value and record.country_id.raw_value"><field name="city"/>, <field name="country_id"/></li>
-                                    <li t-if="record.email.raw_value" class="o_text_overflow"><field name="email"/></li>
-                                </ul>
+                    <t t-name="kanban-card">
+                        <main>
+                            <field name="display_name" class="fw-bold fs-5"/>
+                            <field t-if="record.city.raw_value and !record.country_id.raw_value" name="city"/>
+                            <field t-if="!record.city.raw_value and record.country_id.raw_value" name="country_id"/>
+                            <div t-if="record.city.raw_value and record.country_id.raw_value">
+                                <field name="city"/>, <field name="country_id"/>
                             </div>
-                        </div>
+                            <field t-if="record.email.raw_value" class="o_text_overflow" name="email"/>
+                        </main>
                     </t>
                 </templates>
             </kanban>


### PR DESCRIPTION
In this commit we have simplified the kanban arch for the lunch module.the goal is to simplify them,make them easier to read and use bootstrap utility classnames.

- Previously, we used kanban-box, but now we are using kanban-card instead.
- Deprecated oe_kanban_global_click and oe_kanban_global_click_edit.
- More use of <field/> tags
- Removed the oe_kanban_colorpicker class and replaced it with the kanban_color_picker widget.
- Changed type='edit' to type='open' to open records. since version 16, records always open in edit mode by default.
- kanban_image from rendering context, is deprecated so we use <field name=... widget=image/> instead
- kanban_color, kanban_getcolor and kanban_getcolorname are deprecated use new attribute highlight_color=color_field_name on root node
- oe_kanban_colorpicker is deprecated, use kanban_color_picker widget instead

Task-3992107

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
