### PR TITLE
[FIX] project: prevent word break in long titles

### DIFF
--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -74,7 +74,7 @@
                     <div class="oe_title">
                         <h1 class="d-flex flex-row">
                             <field name="is_favorite" nolabel="1" widget="boolean_favorite" class="me-2"/>
-                            <field name="name" options="{'line_breaks': False}" widget="text" class="o_text_overflow" placeholder="e.g. Office Party"/>
+                            <field name="name" options="{'line_breaks': False}" widget="text" class="o_text_overflow text-break" placeholder="e.g. Office Party"/>
                         </h1>
                     </div>
                     <group>

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -320,7 +320,7 @@
                         <h1 class="d-flex justify-content-between align-items-center">
                             <div class="d-flex w-100">
                                 <field name="priority" widget="priority_switch" class="me-3"/>
-                                <field name="name" options="{'line_breaks': False}" widget="text" class="o_task_name text-truncate w-md-75 w-100 pe-2" placeholder="Task Title..."/>
+                                <field name="name" options="{'line_breaks': False}" widget="text" class="o_task_name text-truncate w-md-75 w-100 pe-2 text-break" placeholder="Task Title..."/>
                             </div>
                             <div class="d-flex justify-content-end o_state_container" invisible="not active">
                                 <field name="state" widget="project_task_state_selection" class="o_task_state_widget" />


### PR DESCRIPTION
- Ensure that long task titles wrap to the next line without breaking words in the task and project form view.

task-4045168

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
