### PR TITLE
[IMP] core: complement comparison with empty str

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -915,7 +915,7 @@ class MailThread(models.AbstractModel):
         bounce_aliases = self.env['mail.alias.domain'].search([]).mapped('bounce_email')
         email_to_list = [
             email_normalize(e) or e
-            for e in (email_split(message_dict['to']) or [''])
+            for e in email_split(message_dict['to'])
         ]
         if bounce_aliases and any(email in bounce_aliases for email in email_to_list):
             return True
@@ -1034,7 +1034,7 @@ class MailThread(models.AbstractModel):
         else:
             catchall_aliases = self.env['mail.alias.domain'].search([]).mapped('catchall_email')
 
-        email_to_list = [email_normalize(e) or e for e in (email_split(msg_dict['to']) or [''])]
+        email_to_list = [email_normalize(e) or e for e in email_split(msg_dict['to'])]
         # check it does not directly contact catchall; either (legacy) strict aka
         # all TOs belong are catchall, either (optional) any catchall in all TOs
         if self.env.context.get("mail_catchall_write_any_to"):
@@ -1120,11 +1120,11 @@ class MailThread(models.AbstractModel):
 
         # author and recipients
         email_from = message_dict['email_from']
-        email_to_list = [e.lower() for e in (email_split(message_dict['to']) or [''])]
+        email_to_list = [e.lower() for e in email_split(message_dict['to'])]
         email_to_localparts = list(filter(None, (_filter_excluded_local_part(email_to) for email_to in email_to_list)))
         # Delivered-To is a safe bet in most modern MTAs, but we have to fallback on To + Cc values
         # for all the odd MTAs out there, as there is no standard header for the envelope's `rcpt_to` value.
-        rcpt_tos_list = [e.lower() for e in (email_split(message_dict['recipients']) or [''])]
+        rcpt_tos_list = [e.lower() for e in email_split(message_dict['recipients'])]
         rcpt_tos_localparts = list(filter(None, (_filter_excluded_local_part(email_to) for email_to in rcpt_tos_list)))
         rcpt_tos_valid_list = list(rcpt_tos_list)
 

--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -883,7 +883,8 @@ options.Class.include({
      */
     async _customizeWebsiteData(value, params, isViewData) {
         const allDataKeys = this._getDataKeysFromPossibleValues(params.possibleValues);
-        const enableDataKeys = value.split(/\s*,\s*/);
+        const keysToEnable = value.split(/\s*,\s*/);
+        const enableDataKeys = allDataKeys.filter(value => keysToEnable.includes(value));
         const disableDataKeys = allDataKeys.filter(value => !enableDataKeys.includes(value));
         const resetViewArch = !!params.resetViewArch;
 
@@ -902,7 +903,8 @@ options.Class.include({
         for (const dataKeysStr of possibleValues) {
             allDataKeys.push(...dataKeysStr.split(/\s*,\s*/));
         }
-        return allDataKeys.filter((v, i, arr) => arr.indexOf(v) === i);
+        // return only unique non-empty strings
+        return allDataKeys.filter((v, i, arr) => v && arr.indexOf(v) === i);
     },
     /**
      * @private

--- a/odoo/addons/test_new_api/tests/test_search.py
+++ b/odoo/addons/test_new_api/tests/test_search.py
@@ -565,7 +565,7 @@ class TestSubqueries(TransactionCase):
                 ("test_new_api_related"."foo_id" IN (
                     SELECT "test_new_api_related_foo"."id"
                     FROM "test_new_api_related_foo"
-                    WHERE "test_new_api_related_foo"."name" IS NULL
+                    WHERE (("test_new_api_related_foo"."name" = %s) OR "test_new_api_related_foo"."name" IS NULL)
                 ))
                 OR "test_new_api_related"."foo_id" IS NULL
             )
@@ -579,7 +579,7 @@ class TestSubqueries(TransactionCase):
             WHERE ("test_new_api_related"."foo_id" IN (
                 SELECT "test_new_api_related_foo"."id"
                 FROM "test_new_api_related_foo"
-                WHERE "test_new_api_related_foo"."name" IS NOT NULL
+                WHERE ("test_new_api_related_foo"."name" != %s)
             ))
             ORDER BY "test_new_api_related"."id"
         """]):
@@ -659,7 +659,7 @@ class TestSubqueries(TransactionCase):
                         ("test_new_api_related_foo"."bar_id" IN (
                             SELECT "test_new_api_related_bar"."id"
                             FROM "test_new_api_related_bar"
-                            WHERE "test_new_api_related_bar"."name" IS NULL
+                            WHERE (("test_new_api_related_bar"."name" = %s) OR "test_new_api_related_bar"."name" IS NULL)
                         ))
                         OR "test_new_api_related_foo"."bar_id" IS NULL
                     )
@@ -679,7 +679,7 @@ class TestSubqueries(TransactionCase):
                 WHERE ("test_new_api_related_foo"."bar_id" IN (
                     SELECT "test_new_api_related_bar"."id"
                     FROM "test_new_api_related_bar"
-                    WHERE "test_new_api_related_bar"."name" IS NOT NULL
+                    WHERE ("test_new_api_related_bar"."name" != %s)
                 ))
             ))
             ORDER BY "test_new_api_related"."id"


### PR DESCRIPTION
Comparing a char field to "" or to False should result in the same result. This is the first step to make char fields always return strings even if there is a null in the database; just like we do for integers.

task-4013641


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
