### PR TITLE
[FIX] website_sale_slides: avoid access error in portal slides

### DIFF
--- a/addons/website_sale_slides/controllers/slides.py
+++ b/addons/website_sale_slides/controllers/slides.py
@@ -12,6 +12,6 @@ class WebsiteSaleSlides(WebsiteSlides):
         channel = values['channel']
         if channel.enroll == 'payment' and channel.product_id:
             pricelist = request.website.get_current_pricelist()
-            values['product_info'] = channel.product_id.product_tmpl_id._get_combination_info(product_id=channel.product_id.id, pricelist=pricelist)
+            values['product_info'] = channel.product_id.sudo().product_tmpl_id._get_combination_info(product_id=channel.product_id.id, pricelist=pricelist)
             values['product_info']['currency_id'] = request.website.currency_id
         return values

--- a/doc/cla/corporate/braintec.md
+++ b/doc/cla/corporate/braintec.md
@@ -17,3 +17,4 @@ Raul Martin raul.martin@braintec.com https://github.com/BT-rmartin
 Frédéric Garbely frederic.garbely@braintec.com https://github.com/BT-fgarbely
 Carlos Serra Toro carlos.serra@braintec.com https://github.com/BT-cserra
 Cristian Rodriguez Navarro cristian.rodriguez@braintec.com https://github.com/BT-crodriguez
+Simon Schmid simon.schmid@braintec.com https://github.com/BT-sschmid


### PR DESCRIPTION
Steps to reproduce:
- As portal user, buy a slide.
- As internal user, unpublish the linked product of the slide or remove the Sale-OK flag

Current Behavior:
- When the portal user tries to open the slide an access error appears, because he has no read-access to the product.

Expected behavior:
- No error. Portal users can see their slides independently of the product's master data.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
