### PR TITLE
[IMP] website: redesign `s_timeline` snippet

### DIFF
--- a/addons/website/static/src/snippets/s_timeline/000.scss
+++ b/addons/website/static/src/snippets/s_timeline/000.scss
@@ -1,4 +1,4 @@
-.s_timeline {
+.s_timeline:not([data-vcss]) {
     --spacing: #{$grid-gutter-width * .5};
 
     .s_timeline_line {

--- a/addons/website/static/src/snippets/s_timeline/001.scss
+++ b/addons/website/static/src/snippets/s_timeline/001.scss
@@ -1,0 +1,34 @@
+.s_timeline[data-vcss="001"] {
+    .s_timeline_dot {
+        width: var(--o-timeline-dot-size, 24px);
+        height: var(--o-timeline-dot-size, 24px);
+
+        @include media-breakpoint-up(md) {
+            left: 50%;
+        }
+
+        &:before, &:after {
+            position: absolute;
+            border-radius: $border-radius-pill;
+            background-color: currentColor;
+            content: '';
+        }
+
+        &:before {
+            inset: 0;
+            opacity: .1;
+        }
+
+        &:after {
+            inset: 8px;
+        }
+    }
+
+    .s_timeline_line {
+        margin-top: calc(var(--o-timeline-dot-size, 24px) + #{map-get($spacers, 1)});
+
+        @include media-breakpoint-up(md) {
+            left: 50%;
+        }
+    }
+}

--- a/addons/website/static/src/snippets/s_timeline/options.js
+++ b/addons/website/static/src/snippets/s_timeline/options.js
@@ -25,8 +25,10 @@ options.registry.Timeline = options.Class.extend({
      *
      * @see this.selectClass for parameters
      */
-    timelineCard: function (previewMode, widgetValue, params) {
-        const $timelineRow = this.$target.closest('.s_timeline_row');
-        $timelineRow.toggleClass('flex-row-reverse flex-row');
+    timelineCard(previewMode, widgetValue, params) {
+        const timelineRowEl = this.$target[0].closest(".s_timeline_row");
+        timelineRowEl.classList.toggle("flex-md-row-reverse");
+        timelineRowEl.classList.toggle("flex-md-row");
+        this.$target[0].classList.toggle("text-md-end");
     },
 });

--- a/addons/website/views/snippets/s_timeline.xml
+++ b/addons/website/views/snippets/s_timeline.xml
@@ -2,51 +2,60 @@
 <odoo>
 
 <template name="Timeline" id="s_timeline">
-    <section class="s_timeline pt24 pb48">
-        <div class="container s_timeline_line">
-            <div class="s_timeline_row d-block d-md-flex flex-row" data-name="Row">
-                <div class="s_timeline_date"><b>2019</b></div>
-                <div class="s_timeline_content d-flex">
-                    <div class="s_timeline_card s_card card bg-white w-100" data-name="Card" data-snippet="s_card">
-                        <div class="card-body">
-                            <h5 class="card-title">Your title</h5>
-                            <p class="card-text">A timeline is a graphical representation on which important events are marked.</p>
-                        </div>
-                    </div>
-                    <i class="fa fa-1x fa-child bg-o-color-2 rounded-circle s_timeline_icon"/>
-                </div>
-                <div class="s_timeline_content"/>
-            </div>
-            <div class="s_timeline_row d-block d-md-flex flex-row" data-name="Row">
-                <div class="s_timeline_date"><b>2018</b></div>
-                <div class="s_timeline_content d-flex">
-                    <div class="s_timeline_card s_card card bg-white w-100" data-name="Card" data-snippet="s_card">
-                        <div class="card-body">
-                            <p class="card-text">You can edit, duplicate...</p>
-                        </div>
-                    </div>
-                    <i class="fa fa-1x fa-graduation-cap bg-o-color-2 rounded-circle s_timeline_icon"/>
-                </div>
-                <div class="s_timeline_content d-flex">
-                    <i class="fa fa-1x fa-asterisk bg-o-color-2 rounded-circle s_timeline_icon"/>
-                    <div class="s_timeline_card s_card card bg-white w-100" data-name="Card" data-snippet="s_card">
-                        <div class="card-body">
-                            <p class="card-text">...and switch the timeline contents to fit your needs.</p>
-                        </div>
-                    </div>
+    <section class="s_timeline pt48 pb48" data-vcss="001">
+        <div class="o_container_small">
+            <div class="row">
+                <div class="col-lg-12 pb24 text-center" data-name="Heading">
+                    <h2 class="h3-fs">Latest news</h2>
+                    <p class="lead">Highlight your history, showcase growth and key milestones.</p>
                 </div>
             </div>
-            <div class="s_timeline_row d-block d-md-flex flex-row-reverse" data-name="Row">
-                <div class="s_timeline_date"><b>2015</b></div>
-                <div class="s_timeline_content d-flex">
-                    <div class="s_timeline_card s_card card bg-white w-100" data-name="Card" data-snippet="s_card">
-                        <div class="card-body">
-                            <p class="card-text">Use this timeline as a part of your resume, to show your visitors what you've done in the past.</p>
+            <div class="position-relative pt-3">
+                <div class="s_timeline_row position-relative d-flex gap-md-5 flex-column flex-md-row pb-4" data-name="Milestone">
+                    <div class="s_timeline_line position-absolute top-0 bottom-0 w-0 mb-1 border-start pe-none"/>
+                    <span class="s_timeline_dot o_not_editable position-absolute translate-middle-x rounded-circle pe-none text-o-color-1" contenteditable="false"/>
+                    <div class="s_timeline_content w-100 ps-4 ps-md-0">
+                        <div class="s_timeline_card s_card card my-0 ms-auto text-md-end" style="border-width: 0px !important;" data-vcss="001" data-vxml="001" data-snippet="s_card" data-name="Milestone Event">
+                            <div class="card-body">
+                                <small class="text-muted">13/06/2019</small>
+                                <h3 class="h4-fs card-title">First Feature</h3>
+                                <p class="card-text">A timeline is a graphical representation on which important events are marked.</p>
+                                <a href="#" class="btn btn-primary">See more</a>
+                            </div>
                         </div>
                     </div>
-                    <i class="fa fa-1x fa-bolt bg-o-color-2 rounded-circle s_timeline_icon"/>
+                    <div class="s_timeline_content w-0 w-md-100 h-0"/>
                 </div>
-                <div class="s_timeline_content"/>
+                <div class="s_timeline_row position-relative d-flex gap-md-5 flex-column flex-md-row-reverse pb-4" data-name="Milestone">
+                    <div class="s_timeline_line position-absolute top-0 bottom-0 w-0 mb-1 border-start pe-none"/>
+                    <span class="s_timeline_dot o_not_editable position-absolute translate-middle-x rounded-circle pe-none text-o-color-1" contenteditable="false"/>
+                    <div class="s_timeline_content w-100 ps-4 ps-md-0">
+                        <div class="s_timeline_card s_card card my-0 me-auto" style="border-width: 0px !important;" data-vcss="001" data-vxml="001" data-snippet="s_card" data-name="Milestone Event">
+                            <div class="card-body">
+                                <small class="text-muted">21/03/2021</small>
+                                <h3 class="h4-fs card-title">Second Feature</h3>
+                                <p class="card-text">A timeline is a graphical representation on which important events are marked.</p>
+                                <a href="#" class="btn btn-primary">See more</a>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="s_timeline_content w-0 w-md-100 h-0"/>
+                </div>
+                <div class="s_timeline_row position-relative d-flex flex-column flex-md-row gap-md-5 pb-4" data-name="Milestone">
+                    <div class="s_timeline_line position-absolute top-0 bottom-0 w-0 mb-1 border-start pe-none"/>
+                    <span class="s_timeline_dot o_not_editable position-absolute translate-middle-x rounded-circle pe-none text-o-color-1" contenteditable="false"/>
+                    <div class="s_timeline_content w-100 ps-4 ps-md-0">
+                        <div class="s_timeline_card s_card card my-0 ms-auto text-md-end" style="border-width: 0px !important;" data-vcss="001" data-vxml="001" data-snippet="s_card" data-name="Milestone Event">
+                            <div class="card-body">
+                                <small class="text-muted">25/12/2024</small>
+                                <h3 class="h4-fs card-title">Latest Feature</h3>
+                                <p class="card-text">A timeline is a graphical representation on which important events are marked.</p>
+                                <a href="#" class="btn btn-primary">See more</a>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="s_timeline_content w-0 w-md-100 h-0"/>
+                </div>
             </div>
         </div>
     </section>
@@ -55,9 +64,9 @@
 <template id="s_timeline_options" inherit_id="website.snippet_options">
     <xpath expr="//t[@t-call='website.snippet_options_background_options']" position="before">
         <div data-js="MultipleItems" data-selector=".s_timeline">
-            <we-row string="Year">
+            <we-row string="Date">
                 <we-button data-add-item="" data-item=".s_timeline_row:first" data-select-item="" data-add-before="true" data-no-preview="true" class="o_we_bg_brand_primary">
-                    Add Year
+                    Add Date
                 </we-button>
             </we-row>
         </div>
@@ -70,6 +79,9 @@
         <div data-selector=".s_timeline">
             <we-colorpicker string="Line Color" data-select-style="true" data-css-property="border-color" data-color-prefix="border-" data-apply-to=".s_timeline_line"/>
         </div>
+        <div data-selector=".s_timeline_row">
+            <we-colorpicker string="Dot Color" data-select-style="true" data-css-property="color" data-color-prefix="text-" data-apply-to=".s_timeline_dot"/>
+        </div>
     </xpath>
     <xpath expr="//div[@data-js='SnippetMove'][contains(@data-selector,'section')]" position="attributes">
         <attribute name="data-selector" add=".s_timeline_row" separator=","/>
@@ -80,6 +92,13 @@
     <field name="name">Timeline 000 SCSS</field>
     <field name="bundle">web.assets_frontend</field>
     <field name="path">website/static/src/snippets/s_timeline/000.scss</field>
+    <field name="active" eval="False"/>
+</record>
+
+<record id="website.s_timeline_001_scss" model="ir.asset">
+    <field name="name">Timeline 001 SCSS</field>
+    <field name="bundle">web.assets_frontend</field>
+    <field name="path">website/static/src/snippets/s_timeline/001.scss</field>
 </record>
 
 </odoo>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -637,7 +637,7 @@
     <div data-js="layout_column"
         data-selector="section, section.s_carousel_wrapper .carousel-item"
         data-target="> *:has(> .row), > .s_allow_columns"
-        data-exclude=".s_masonry_block, .s_features_grid, .s_media_list, .s_table_of_content, .s_process_steps, .s_image_gallery">
+        data-exclude=".s_masonry_block, .s_features_grid, .s_media_list, .s_table_of_content, .s_process_steps, .s_image_gallery, .s_timeline">
         <we-row>
             <we-button-group string="Layout" data-no-preview="true">
                 <we-button data-select-layout="grid" data-name="grid_mode">Grid</we-button>


### PR DESCRIPTION
---
this PR/task is handled by @Brieuc-brd 

---


The goal of this commit is to improve the visual design of the default `s_timeline` snippet.

task-3657763
Part of task-3619705

| Before | After |
|--------|--------|
| ![Capture d’écran 2024-07-25 à 17 30 18](https://github.com/user-attachments/assets/8704f347-82ad-4ae4-9a83-36bdcddb1b71) | ![Capture d’écran 2024-07-25 à 17 29 51](https://github.com/user-attachments/assets/746fca11-b11d-4cf8-94e6-5fc0fe16d78d) |
---
Requires: 
- https://github.com/odoo/design-themes/pull/845

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
