### PR TITLE
[REF] account_sepa: rename module to account_iso20022

### DIFF
--- a/addons/account/models/account_payment_method.py
+++ b/addons/account/models/account_payment_method.py
@@ -21,14 +21,16 @@ class AccountPaymentMethod(models.Model):
     def create(self, vals_list):
         payment_methods = super().create(vals_list)
         methods_info = self._get_payment_method_information()
+        return self._auto_link_payment_methods(payment_methods, methods_info)
+
+    def _auto_link_payment_methods(self, payment_methods, methods_info):
+        # This method was extracted from create so it can be overriden in the upgrade script.
+        # In said script we can then allow for a custom behavior for the payment.method.line on the journals.
         for method in payment_methods:
             information = methods_info.get(method.code, {})
-
             if information.get('mode') == 'multi':
                 method_domain = method._get_payment_method_domain(method.code)
-
                 journals = self.env['account.journal'].search(method_domain)
-
                 self.env['account.payment.method.line'].create([{
                     'name': method.name,
                     'payment_method_id': method.id,

--- a/addons/account/models/res_config_settings.py
+++ b/addons/account/models/res_config_settings.py
@@ -112,7 +112,7 @@ class ResConfigSettings(models.TransientModel):
     module_account_batch_payment = fields.Boolean(string='Use batch payments',
         help='This allows you grouping payments into a single batch and eases the reconciliation process.\n'
              '-This installs the account_batch_payment module.')
-    module_account_sepa = fields.Boolean(string='SEPA Credit Transfer (SCT)')
+    module_account_iso20022 = fields.Boolean(string='SEPA Credit Transfer / ISO20022')
     module_account_sepa_direct_debit = fields.Boolean(string='Use SEPA Direct Debit')
     module_account_bank_statement_import_qif = fields.Boolean("Import .qif files")
     module_account_bank_statement_import_ofx = fields.Boolean("Import in .ofx format")

--- a/addons/account/views/res_config_settings_views.xml
+++ b/addons/account/views/res_config_settings_views.xml
@@ -242,7 +242,7 @@
                             </setting>
                             <setting id="sepa_payments" title="If you check this box, you will be able to register your payment using SEPA." company_dependent="1" help="Pay your bills in one-click using Euro SEPA Service"
                                 documentation="/applications/finance/accounting/payables/pay/sepa.html">
-                                <field name="module_account_sepa" widget="upgrade_boolean"/>
+                                <field name="module_account_iso20022" widget="upgrade_boolean"/>
                             </setting>
                         </block>
 


### PR DESCRIPTION
[REF] account_sepa: rename module to account_iso20022
The Canadian EFT task (3472908) was the opportunity to refactor, clean up and adjust the account_sepa module, in order to ease its usability and maintainability.

The goal is both to refactor and better the account_sepa module, which has needed a facelift for quite some time, and to ease the canadian task by making the sepa module more generic.

The changes are mostly located in https://github.com/odoo/enterprise/pull/60393. In this PR, we manage a renaming and an override of _auto_link_payment_methods in order for the upgrade scripts to behave as intended.

task-3813884
