### PR TITLE
[FIX] base: make the Manage Attachment option show all attachments

### DIFF
--- a/addons/web/static/src/views/debug_items.js
+++ b/addons/web/static/src/views/debug_items.js
@@ -394,6 +394,7 @@ export function manageAttachments({ component, env }) {
                 context: {
                     default_res_model: component.props.resModel,
                     default_res_id: resId,
+                    skip_res_field_check: true,
                 },
             });
         },

--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -524,7 +524,7 @@ class IrAttachment(models.Model):
         # add res_field=False in domain if not present; the arg[0] trick below
         # works for domain items and '&'/'|'/'!' operators too
         disable_binary_fields_attachments = False
-        if not any(arg[0] in ('id', 'res_field') for arg in domain):
+        if not self.env.context.get('skip_res_field_check') and not any(arg[0] in ('id', 'res_field') for arg in domain):
             disable_binary_fields_attachments = True
             domain = [('res_field', '=', False)] + domain
 


### PR DESCRIPTION
### Issue:
Generated invoices does not appear in the page 'Manage Attachments'.

### Steps to reproduce:
- Activate the developer mode
- In Accounting > Customers > Invoices create a new one
- Confirm and click on Send & Print, an invoice is generated and can be seen in the attachment of the chatter
- Click on the debug icon, then on 'Manage Attachments'
- The attachment does not show up

### Cause:
The domain used for the 'Manage Attachments' search does not contain restriction on res_field and id. So a new condition is added: ('res_field', '=', False). The logic behind this functionality is explained in this commit: https://github.com/odoo/odoo/commit/1bb61c970ed63eabe3821d21f3ed6f99c4b16daa In the case of invoices res_field is equal to invoice_pdf_report_file, so the invoice does not appear.

### Solution:
Add a context to the search request to skip the res_field test. Thus showing all attachments.

opw-3997094