### PR TITLE
[FIX] point_of_sale: modify AddInternalNotes tour method

### DIFF
--- a/addons/point_of_sale/static/tests/tours/helpers/ProductScreenTourMethods.js
+++ b/addons/point_of_sale/static/tests/tours/helpers/ProductScreenTourMethods.js
@@ -399,10 +399,10 @@ export function addInternalNote(note) {
                 mobile: true,
             },
             {
-                content: "click customer note button",
+                content: "click internal note button",
                 trigger: '.control-buttons .control-button span:contains("Internal Note")',
             },
-            TextAreaPopup.inputText(note),
+            ...( note ?  TextAreaPopup.inputText(note) : []),
             TextAreaPopup.clickConfirm(),
         ].flat()
     );


### PR DESCRIPTION
This commit modifies the AddInternalNotes tour method to support 
empty internal note.

Related enterprise PR: https://github.com/odoo/enterprise/pull/66145

sentry-5494183916

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
