### PR TITLE
[REF] mail, *: use real python model name in Store insert

### DIFF
--- a/addons/bus/models/ir_websocket.py
+++ b/addons/bus/models/ir_websocket.py
@@ -9,15 +9,6 @@ class IrWebsocket(models.AbstractModel):
     _name = 'ir.websocket'
     _description = 'websocket message handling'
 
-    def _get_im_status(self, im_status_ids_by_model):
-        im_status = {}
-        if 'res.partner' in im_status_ids_by_model:
-            im_status['Persona'] = [{**p, 'type': "partner"} for p in self.env['res.partner'].with_context(active_test=False).search_read(
-                [('id', 'in', im_status_ids_by_model['res.partner'])],
-                ['im_status']
-            )]
-        return im_status
-
     def _build_bus_channel_list(self, channels):
         """
             Return the list of channels to subscribe to. Override this
@@ -49,9 +40,6 @@ class IrWebsocket(models.AbstractModel):
                 identity_field='user_id',
                 identity_value=self.env.uid
             )
-            im_status_notification = self._get_im_status(im_status_ids_by_model)
-            if im_status_notification:
-                self.env['bus.bus']._sendone(self.env.user.partner_id, 'mail.record/insert', im_status_notification)
 
     @classmethod
     def _authenticate(cls):

--- a/addons/bus/static/tests/legacy/helpers/mock_server/models/ir_websocket.js
+++ b/addons/bus/static/tests/legacy/helpers/mock_server/models/ir_websocket.js
@@ -31,10 +31,14 @@ patch(MockServer.prototype, {
         const imStatus = {};
         const { "res.partner": partnerIds } = imStatusIdsByModel;
         if (partnerIds) {
-            imStatus["Persona"] = this.mockSearchRead("res.partner", [[["id", "in", partnerIds]]], {
-                context: { active_test: false },
-                fields: ["im_status"],
-            }).map((p) => ({ ...p, type: "partner" }));
+            imStatus["res.partner"] = this.mockSearchRead(
+                "res.partner",
+                [[["id", "in", partnerIds]]],
+                {
+                    context: { active_test: false },
+                    fields: ["im_status"],
+                }
+            ).map((p) => ({ id: p.id, im_status: p.im_status }));
         }
         return imStatus;
     },

--- a/addons/bus/static/tests/mock_server/mock_models/bus_bus.js
+++ b/addons/bus/static/tests/mock_server/mock_models/bus_bus.js
@@ -89,7 +89,10 @@ export class BusBus extends models.Model {
         }
         for (const notification of notifications) {
             const [type, payload] = notification.slice(1, notification.length);
-            values.push({ id: ++this.lastBusNotificationId, message: { payload, type } });
+            values.push({
+                id: ++this.lastBusNotificationId,
+                message: { payload: JSON.parse(JSON.stringify(payload)), type },
+            });
         }
         this.wsWorker.broadcast("notification", values);
     }

--- a/addons/bus/static/tests/mock_server/mock_models/ir_websocket.js
+++ b/addons/bus/static/tests/mock_server/mock_models/ir_websocket.js
@@ -1,5 +1,3 @@
-/** @odoo-module **/
-
 import { makeKwArgs, models } from "@web/../tests/web_test_helpers";
 
 export class IrWebSocket extends models.ServerModel {
@@ -9,31 +7,7 @@ export class IrWebSocket extends models.ServerModel {
      * @param {number} inactivityPeriod
      * @param {number[]} imStatusIdsByModel
      */
-    _update_presence(inactivityPeriod, imStatusIdsByModel) {
-        /** @type {import("mock_models").BusBus} */
-        const BusBus = this.env["bus.bus"];
-        /** @type {import("mock_models").ResPartner} */
-        const ResPartner = this.env["res.partner"];
-
-        const imStatusNotifications = this._get_im_status(imStatusIdsByModel);
-        if (Object.keys(imStatusNotifications).length > 0) {
-            if (this.env.user) {
-                const [partner] = ResPartner.read(this.env.user.partner_id);
-                BusBus._sendone(partner, "mail.record/insert", imStatusNotifications);
-            }
-        }
-    }
-
-    /** @param {Record<string, number[]>} imStatusIdsByModel */
-    _get_im_status({ "res.partner": partnerIds }) {
-        const imStatus = {};
-        if (partnerIds) {
-            imStatus["Persona"] = this.env["res.partner"]
-                .search_read([["id", "in", partnerIds]], ["im_status"])
-                .map((p) => ({ ...p, type: "partner" }));
-        }
-        return imStatus;
-    }
+    _update_presence(inactivityPeriod, imStatusIdsByModel) {}
 
     /**
      * @returns {string[]}

--- a/addons/crm_livechat/tests/test_chatbot_lead.py
+++ b/addons/crm_livechat/tests/test_chatbot_lead.py
@@ -39,7 +39,9 @@ class CrmChatbotCase(chatbot_common.CrmChatbotCase):
             'chatbot_script_id': self.chatbot_script.id,
             'user_id': user.id,
         })
-        discuss_channel = self.env['discuss.channel'].sudo().browse(data["Thread"][0]['id'])
+        discuss_channel = (
+            self.env["discuss.channel"].sudo().browse(data["discuss.channel"][0]["id"])
+        )
 
         self._post_answer_and_trigger_next_step(
             discuss_channel,

--- a/addons/crm_livechat/tests/test_crm_lead.py
+++ b/addons/crm_livechat/tests/test_crm_lead.py
@@ -35,7 +35,7 @@ class TestLivechatLead(HttpCase, TestCrmCommon):
             'channel_id': self.livechat_channel.id,
             'persisted': True,
         })
-        channel = self.env['discuss.channel'].browse(data["Thread"][0]['id'])
+        channel = self.env["discuss.channel"].browse(data["discuss.channel"][0]["id"])
         lead = channel._convert_visitor_to_lead(self.env.user.partner_id, '/lead TestLead command')
 
         self.assertTrue(any(m.partner_id == self.user_sales_leads.partner_id for m in channel.channel_member_ids))
@@ -52,7 +52,7 @@ class TestLivechatLead(HttpCase, TestCrmCommon):
             'channel_id': self.livechat_channel.id,
             'persisted': True,
         })
-        channel = self.env['discuss.channel'].browse(data["Thread"][0]['id'])
+        channel = self.env["discuss.channel"].browse(data["discuss.channel"][0]["id"])
         lead = channel._convert_visitor_to_lead(self.env.user.partner_id, '/lead TestLead command')
 
         self.assertTrue(any(m.partner_id == self.user_sales_leads.partner_id for m in channel.channel_member_ids))
@@ -75,7 +75,7 @@ class TestLivechatLead(HttpCase, TestCrmCommon):
             'channel_id': self.livechat_channel.id,
             'persisted': True,
         })
-        channel = self.env['discuss.channel'].browse(data["Thread"][0]['id'])
+        channel = self.env["discuss.channel"].browse(data["discuss.channel"][0]["id"])
         lead = channel._convert_visitor_to_lead(self.env.user.partner_id, '/lead TestLead command')
 
         self.assertEqual(

--- a/addons/hr_holidays/models/res_partner.py
+++ b/addons/hr_holidays/models/res_partner.py
@@ -37,12 +37,11 @@ class ResPartner(models.Model):
                 date = sorted(dates)[0] if dates and all(dates) else False
                 state = sorted(states)[0] if states and all(states) else False
                 store.add(
-                    "Persona",
+                    "res.partner",
                     {
                         "id": partner.id,
                         "out_of_office_date_end": (
                             odoo.fields.Date.to_string(date) if state == "validate" else False
                         ),
-                        "type": "partner",
                     },
                 )

--- a/addons/hr_holidays/static/tests/mock_server/mock_models/res_partner.js
+++ b/addons/hr_holidays/static/tests/mock_server/mock_models/res_partner.js
@@ -15,11 +15,10 @@ export class ResPartner extends mailModels.ResPartner {
             active_test: false,
         });
         for (const partner of partners) {
-            store.add("Persona", {
+            store.add("res.partner", {
                 id: partner.id,
                 // Not a real field but ease the testing
                 out_of_office_date_end: partner.out_of_office_date_end,
-                type: "partner",
             });
         }
     }

--- a/addons/hr_holidays/tests/test_out_of_office.py
+++ b/addons/hr_holidays/tests/test_out_of_office.py
@@ -49,8 +49,8 @@ class TestOutOfOffice(TestHrHolidaysCommon):
             'name': 'test'
         })
         data = Store(channel).get_result()
-        partner_info = next(p for p in data["Persona"] if p["id"] == partner.id)
-        partner2_info = next(p for p in data["Persona"] if p["id"] == partner2.id)
+        partner_info = next(p for p in data["res.partner"] if p["id"] == partner.id)
+        partner2_info = next(p for p in data["res.partner"] if p["id"] == partner2.id)
         self.assertFalse(
             partner2_info["out_of_office_date_end"], "current user should not be out of office"
         )

--- a/addons/hr_holidays/tests/test_res_partner.py
+++ b/addons/hr_holidays/tests/test_res_partner.py
@@ -56,13 +56,13 @@ class TestPartner(TransactionCase):
     def test_res_partner_to_store(self):
         self.leaves.write({'state': 'validate'})
         self.assertEqual(
-            Store(self.partner).get_result()["Persona"][0]["out_of_office_date_end"],
+            Store(self.partner).get_result()["res.partner"][0]["out_of_office_date_end"],
             fields.Date.to_string(self.today + relativedelta(days=2)),
             'Return date is the first return date of all users associated with a partner',
         )
         self.leaves[1].action_refuse()
         self.assertEqual(
-            Store(self.partner).get_result()["Persona"][0]["out_of_office_date_end"],
+            Store(self.partner).get_result()["res.partner"][0]["out_of_office_date_end"],
             False,
             'Partner is not considered out of office if one of their users is not on holiday',
         )

--- a/addons/im_livechat/controllers/main.py
+++ b/addons/im_livechat/controllers/main.py
@@ -152,7 +152,6 @@ class LivechatController(http.Controller):
             channel_info = {
                 'id': -1, # only one temporary thread at a time, id does not matter.
                 "isLoaded": True,
-                'model': 'discuss.channel',
                 'name': channel_vals['name'],
                 "operator": {"id": operator_partner.id, "type": "partner"},
                 'state': 'open',
@@ -162,7 +161,7 @@ class LivechatController(http.Controller):
                     'steps': chatbot_script._get_welcome_steps().mapped(lambda s: {'scriptStep': {'id': s.id}}),
                 } if chatbot_script else None
             }
-            store.add("Thread", channel_info)
+            store.add("discuss.channel", channel_info)
         else:
             channel = request.env['discuss.channel'].with_context(
                 mail_create_nosubscribe=False,
@@ -183,7 +182,7 @@ class LivechatController(http.Controller):
             if not chatbot_script or chatbot_script.operator_partner_id != channel.livechat_operator_id:
                 channel._broadcast([channel.livechat_operator_id.id])
             store.add(channel)
-            store.add("Thread", {"id": channel.id, "model": "discuss.channel", "isLoaded": not chatbot_script})
+            store.add("discuss.channel", {"id": channel.id, "isLoaded": not chatbot_script})
             if guest:
                 store.add({"guest_token": guest._format_auth_cookie()})
         request.env["res.users"]._init_store_data(store)

--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -41,7 +41,7 @@ class DiscussChannel(models.Model):
         super()._to_store(store)
         chatbot_lang = self.env["chatbot.script"]._get_chatbot_language()
         for channel in self:
-            channel_info = {"id": channel.id, "model": "discuss.channel"}
+            channel_info = {"id": channel.id}
             if channel.chatbot_current_step_id:
                 # sudo: chatbot.script.step - returning the current script/step of the channel
                 current_step_sudo = channel.chatbot_current_step_id.sudo().with_context(lang=chatbot_lang)
@@ -76,7 +76,7 @@ class DiscussChannel(models.Model):
                 channel_info["operator"] = {"id": operator.id, "type": "partner"}
             if channel.channel_type == "livechat" and channel.livechat_channel_id and self.env.user._is_internal():
                 channel_info['livechatChannel'] = {"id": channel.livechat_channel_id.id, "name": channel.livechat_channel_id.name}
-            store.add("Thread", channel_info)
+            store.add("discuss.channel", channel_info)
 
     @api.autovacuum
     def _gc_empty_livechat_sessions(self):

--- a/addons/im_livechat/models/discuss_channel_member.py
+++ b/addons/im_livechat/models/discuss_channel_member.py
@@ -27,7 +27,6 @@ class ChannelMember(models.Model):
             data = {
                 'active': self.partner_id.active,
                 'id': self.partner_id.id,
-                'type': "partner",
                 'is_public': self.partner_id.is_public,
                 'is_bot': self.partner_id.id in self.channel_id.livechat_channel_id.rule_ids.mapped('chatbot_script_id.operator_partner_id.id')
             }
@@ -41,6 +40,6 @@ class ChannelMember(models.Model):
                     'id': self.partner_id.country_id.id,
                     'name': self.partner_id.country_id.name,
                 } if self.partner_id.country_id else False
-            store.add("Persona", data)
+            store.add("res.partner", data)
         else:
             super()._partner_data_to_store(store, fields=fields)

--- a/addons/im_livechat/models/mail_message.py
+++ b/addons/im_livechat/models/mail_message.py
@@ -43,7 +43,7 @@ class MailMessage(models.Model):
                 )
                 if chatbot_message.script_step_id:
                     store.add(
-                        "Message",
+                        "mail.message",
                         {
                             "id": message.id,
                             "chatbotStep": {
@@ -90,7 +90,7 @@ class MailMessage(models.Model):
                 },
             )
             store.add(
-                "Message",
+                "mail.message",
                 {
                     "id": message.id,
                     "author": {"id": message.author_id.id, "type": "partner"},

--- a/addons/im_livechat/models/res_partner.py
+++ b/addons/im_livechat/models/res_partner.py
@@ -27,13 +27,12 @@ class Partners(models.Model):
         )
         for partner in self:
             store.add(
-                "Persona",
+                "res.partner",
                 {
                     "invite_by_self_count": invite_by_self_count_by_partner_id.get(partner, 0),
                     "is_available": partner in active_livechat_partners,
                     "lang_name": lang_name_by_code[partner.lang],
                     "id": partner.id,
-                    "type": "partner",
                 },
             )
 
@@ -46,9 +45,9 @@ class Partners(models.Model):
         super()._to_store(store, fields=fields)
         if fields and fields.get("user_livechat_username"):
             for partner in self:
-                data = {"id": partner.id, "type": "partner"}
+                data = {"id": partner.id}
                 if partner.user_livechat_username:
                     data["user_livechat_username"] = partner.user_livechat_username
                 else:
                     data["name"] = partner.name
-                store.add("Persona", data)
+                store.add("res.partner", data)

--- a/addons/im_livechat/static/src/embed/common/livechat_service.js
+++ b/addons/im_livechat/static/src/embed/common/livechat_service.js
@@ -181,7 +181,9 @@ export class LivechatService {
         expirableStorage.setItem(
             SAVED_STATE_STORAGE_KEY,
             JSON.stringify({
-                threadData: persisted ? { id: threadData.id, model: threadData.model } : threadData,
+                threadData: persisted
+                    ? { id: threadData.id, model: "discuss.channel" }
+                    : threadData,
                 persisted,
                 livechatUserId: this.savedState?.livechatUserId ?? session.user_id,
             }),
@@ -212,7 +214,7 @@ export class LivechatService {
             },
             { shadow: true }
         );
-        const threadData = data.Thread?.[0];
+        const threadData = data["discuss.channel"]?.[0];
         if (!threadData?.operator) {
             this.notificationService.add(_t("No available collaborator, please try again later."));
             this.leave({ notifyServer: false });
@@ -221,6 +223,7 @@ export class LivechatService {
         threadData["scrollUnread"] = false;
         // clean copy of data for saving in storage, because store insert will add cyclic references
         const saveThreadData = JSON.parse(JSON.stringify(threadData));
+        saveThreadData["model"] = "discuss.channel";
         this.state = persist ? SESSION_STATE.PERSISTED : SESSION_STATE.CREATED;
         this.store.insert(data); // before save to have guest_token in store
         this._saveLivechatState(saveThreadData, { persisted: persist });

--- a/addons/im_livechat/static/src/embed/common/store_service_patch.js
+++ b/addons/im_livechat/static/src/embed/common/store_service_patch.js
@@ -20,8 +20,8 @@ patch(Store.prototype, {
             return;
         }
         const messagingData = {
+            "discuss.channel": [],
             Store: { settings: {} },
-            Thread: [],
         };
         if (session.livechatData?.options.current_partner_id) {
             messagingData.Store.current_partner = {
@@ -29,7 +29,7 @@ patch(Store.prototype, {
             };
         }
         if (livechatService.savedState?.threadData) {
-            messagingData.Thread.push(livechatService.savedState.threadData);
+            messagingData["discuss.channel"].push(livechatService.savedState.threadData);
         }
         this.insert(messagingData);
         this.isReady.resolve();

--- a/addons/im_livechat/static/tests/mock_server/livechat_mock_server.js
+++ b/addons/im_livechat/static/tests/mock_server/livechat_mock_server.js
@@ -69,9 +69,8 @@ async function get_session(request) {
         const store = new mailDataHelpers.Store();
         ResUsers._init_store_data(store);
         store.add(ResPartner.browse(operatorPartner.id));
-        store.add("Thread", {
+        store.add("discuss.channel", {
             id: -1,
-            model: "discuss.channel",
             isLoaded: true,
             name: channelVals["name"],
             chatbot_current_step_id: channelVals.chatbot_current_step_id,
@@ -94,7 +93,7 @@ async function get_session(request) {
     const store = new mailDataHelpers.Store();
     ResUsers._init_store_data(store);
     store.add(DiscussChannel.browse(channelId).map((record) => record.id));
-    store.add("Thread", { id: channelId, model: "discuss.channel", isLoaded: true });
+    store.add("discuss.channel", { id: channelId, isLoaded: true });
     return store.get_result();
 }
 

--- a/addons/im_livechat/static/tests/mock_server/mock_models/discuss_channel.js
+++ b/addons/im_livechat/static/tests/mock_server/mock_models/discuss_channel.js
@@ -17,7 +17,7 @@ export class DiscussChannel extends mailModels.DiscussChannel {
         super._to_store(...arguments);
         const channels = this._filter([["id", "in", ids]]);
         for (const channel of channels) {
-            const channelInfo = { id: channel.id, model: "discuss.channel" };
+            const channelInfo = { id: channel.id };
             channelInfo["anonymous_name"] = channel.anonymous_name;
             // add the last message date
             if (channel.channel_type === "livechat") {
@@ -39,7 +39,7 @@ export class DiscussChannel extends mailModels.DiscussChannel {
                     }))[0];
                 }
             }
-            store.add("Thread", channelInfo);
+            store.add("discuss.channel", channelInfo);
         }
     }
     /** @param {import("mock_models").DiscussChannel} channel */

--- a/addons/im_livechat/static/tests/mock_server/mock_models/discuss_channel_member.js
+++ b/addons/im_livechat/static/tests/mock_server/mock_models/discuss_channel_member.js
@@ -22,7 +22,6 @@ export class DiscussChannelMember extends mailModels.DiscussChannelMember {
             const data = {
                 id: partner.id,
                 is_public: partner.is_public,
-                type: "partner",
             };
             if (partner.user_livechat_username) {
                 data["user_livechat_username"] = partner.user_livechat_username;
@@ -40,7 +39,7 @@ export class DiscussChannelMember extends mailModels.DiscussChannelMember {
                     : false;
             }
             data["write_date"] = partner.write_date;
-            store.add("Persona", data);
+            store.add("res.partner", data);
         } else {
             super._partner_data_to_store(...arguments);
         }

--- a/addons/im_livechat/static/tests/mock_server/mock_models/res_partner.js
+++ b/addons/im_livechat/static/tests/mock_server/mock_models/res_partner.js
@@ -38,12 +38,11 @@ export class ResPartner extends mailModels.ResPartner {
                     ["create_uid", "=", serverState.userId],
                 ]),
                 is_available: activeLivechatPartners.includes(partner.id),
-                type: "partner",
             };
             if (partner.lang) {
                 data.lang_name = ResLang.search_read([["code", "=", partner.lang]])[0].name;
             }
-            store.add("Persona", data);
+            store.add("res.partner", data);
         }
     }
     /**
@@ -59,9 +58,8 @@ export class ResPartner extends mailModels.ResPartner {
             active_test: false,
         });
         for (const partner of partners) {
-            store.add("Persona", {
+            store.add("res.partner", {
                 id: partner.id,
-                type: "partner",
                 // Not a real field but ease the testing
                 user_livechat_username: partner.user_livechat_username,
             });

--- a/addons/im_livechat/tests/test_chatbot_internals.py
+++ b/addons/im_livechat/tests/test_chatbot_internals.py
@@ -49,7 +49,7 @@ class ChatbotCase(chatbot_common.ChatbotCase):
             'chatbot_script_id': self.chatbot_script.id,
             'channel_id': self.livechat_channel.id,
         })
-        discuss_channel = self.env['discuss.channel'].browse(data["Thread"][0]['id'])
+        discuss_channel = self.env["discuss.channel"].browse(data["discuss.channel"][0]["id"])
 
         self.assertEqual(discuss_channel.chatbot_current_step_id, self.step_dispatch)
 

--- a/addons/im_livechat/tests/test_cors_livechat.py
+++ b/addons/im_livechat/tests/test_cors_livechat.py
@@ -34,7 +34,7 @@ class TestCorsLivechat(HttpCase):
                 "persisted": True,
             },
         )
-        channel = self.env["discuss.channel"].browse(data["Thread"][0]["id"])
+        channel = self.env["discuss.channel"].browse(data["discuss.channel"][0]["id"])
         self.assertEqual(channel.channel_member_ids[0].partner_id, self.operator.partner_id)
         self.assertFalse(channel.channel_member_ids[1].partner_id)
         self.assertTrue(channel.channel_member_ids[1].guest_id)
@@ -50,7 +50,7 @@ class TestCorsLivechat(HttpCase):
             },
             headers={"Cookie": f"{guest._cookie_name}={guest.id}{guest._cookie_separator}{guest.access_token};"},
         )
-        channel = self.env["discuss.channel"].browse(data["Thread"][0]["id"])
+        channel = self.env["discuss.channel"].browse(data["discuss.channel"][0]["id"])
         channel_guest = channel.channel_member_ids.filtered(lambda member: member.guest_id).guest_id
         self.assertNotEqual(channel_guest, guest)
 
@@ -68,7 +68,7 @@ class TestCorsLivechat(HttpCase):
             "/im_livechat/cors/channel/messages",
             {
                 "guest_token": data["Store"]["guest_token"],
-                "channel_id": data["Thread"][0]["id"],
+                "channel_id": data["discuss.channel"][0]["id"],
             },
         )
 
@@ -88,6 +88,6 @@ class TestCorsLivechat(HttpCase):
                 "/im_livechat/cors/channel/messages",
                 {
                     "guest_token": guest.access_token,
-                    "channel_id": data["Thread"][0]["id"],
+                    "channel_id": data["discuss.channel"][0]["id"],
                 },
             )

--- a/addons/im_livechat/tests/test_get_discuss_channel.py
+++ b/addons/im_livechat/tests/test_get_discuss_channel.py
@@ -39,7 +39,7 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
                     'country_id': belgium.id,
                 },
             )
-        channel_info = data["Thread"][0]
+        channel_info = data["discuss.channel"][0]
         self.assertEqual(channel_info['anonymous_name'], "Visitor 22")
         self.assertEqual(channel_info['anonymous_country'], {'code': 'BE', 'id': belgium.id, 'name': 'Belgium'})
 
@@ -47,37 +47,43 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
         channel = self.env["discuss.channel"].browse(channel_info["id"])
         guest = channel.channel_member_ids.guest_id[0]
         self.assertEqual(
-            data["Persona"],
+            data["mail.guest"],
             [
                 {
                     "id": guest.id,
                     "im_status": "offline",
                     "name": "Visitor",
-                    "type": "guest",
                     "write_date": fields.Datetime.to_string(guest.write_date),
                 },
+            ],
+        )
+        self.assertEqual(
+            data["res.partner"],
+            [
                 {
                     "active": True,
                     "country": False,
                     "id": operator.partner_id.id,
                     "is_bot": False,
                     "is_public": False,
-                    "type": "partner",
                     "user_livechat_username": "Michel Operator",
                     "write_date": fields.Datetime.to_string(operator.write_date),
                 },
-                self._filter_persona_fields({
-                    "active": False,
-                    "id": self.user_root.partner_id.id,
-                    "im_status": "bot",
-                    "isInternalUser": True,
-                    "is_company": False,
-                    "name": "OdooBot",
-                    "out_of_office_date_end": False,
-                    "type": "partner",
-                    "userId": self.user_root.id,
-                    "write_date": fields.Datetime.to_string(self.user_root.partner_id.write_date),
-                }),
+                self._filter_persona_fields(
+                    {
+                        "active": False,
+                        "id": self.user_root.partner_id.id,
+                        "im_status": "bot",
+                        "isInternalUser": True,
+                        "is_company": False,
+                        "name": "OdooBot",
+                        "out_of_office_date_end": False,
+                        "userId": self.user_root.id,
+                        "write_date": fields.Datetime.to_string(
+                            self.user_root.partner_id.write_date
+                        ),
+                    }
+                ),
             ],
         )
 
@@ -89,7 +95,7 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
             'user_id': test_user.id,
             'channel_id': self.livechat_channel.id,
         })
-        channel_info = data["Thread"][0]
+        channel_info = data["discuss.channel"][0]
         self.assertFalse(channel_info['anonymous_name'])
         self.assertEqual(channel_info['anonymous_country'], {'code': 'BE', 'id': belgium.id, 'name': 'Belgium'})
         operator_member_domain = [
@@ -103,7 +109,7 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
         ]
         visitor_member = self.env['discuss.channel.member'].search(visitor_member_domain)
         self.assertEqual(
-            data["Persona"],
+            data["res.partner"],
             [
                 {
                     "active": True,
@@ -119,7 +125,6 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
                     "is_public": False,
                     "name": "Roger",
                     "notification_preference": "email",
-                    "type": "partner",
                     "userId": test_user.id,
                     "write_date": fields.Datetime.to_string(test_user.write_date),
                 },
@@ -129,27 +134,29 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
                     "id": operator.partner_id.id,
                     "is_bot": False,
                     "is_public": False,
-                    "type": "partner",
                     "user_livechat_username": "Michel Operator",
                     "write_date": fields.Datetime.to_string(operator.write_date),
                 },
-                self._filter_persona_fields({
-                    "active": False,
-                    "email": "odoobot@example.com",
-                    "id": self.user_root.partner_id.id,
-                    "im_status": "bot",
-                    "isInternalUser": True,
-                    "is_company": False,
-                    "name": "OdooBot",
-                    "out_of_office_date_end": False,
-                    "type": "partner",
-                    "userId": self.user_root.id,
-                    "write_date": fields.Datetime.to_string(self.user_root.partner_id.write_date),
-                }),
+                self._filter_persona_fields(
+                    {
+                        "active": False,
+                        "email": "odoobot@example.com",
+                        "id": self.user_root.partner_id.id,
+                        "im_status": "bot",
+                        "isInternalUser": True,
+                        "is_company": False,
+                        "name": "OdooBot",
+                        "out_of_office_date_end": False,
+                        "userId": self.user_root.id,
+                        "write_date": fields.Datetime.to_string(
+                            self.user_root.partner_id.write_date
+                        ),
+                    }
+                ),
             ],
         )
         self.assertEqual(
-            data["ChannelMember"],
+            data["discuss.channel.member"],
             [
                 {
                     "create_date": fields.Datetime.to_string(visitor_member.create_date),
@@ -185,7 +192,7 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
             'user_id': operator.id,
             'channel_id': self.livechat_channel.id,
         })
-        channel_info = data["Thread"][0]
+        channel_info = data["discuss.channel"][0]
         operator_member_domain = [
             ('channel_id', '=', channel_info['id']),
             ('partner_id', '=', operator.partner_id.id),
@@ -198,7 +205,7 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
         self.assertFalse(channel_info['anonymous_name'])
         self.assertEqual(channel_info['anonymous_country'], False)
         self.assertEqual(
-            data["Persona"],
+            data["res.partner"],
             [
                 {
                     "active": True,
@@ -210,28 +217,30 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
                     "is_public": False,
                     "name": "Michel",
                     "notification_preference": "email",
-                    "type": "partner",
                     "userId": operator.id,
                     "user_livechat_username": "Michel Operator",
-                    "write_date": fields.Datetime.to_string(operator.partner_id.write_date)
+                    "write_date": fields.Datetime.to_string(operator.partner_id.write_date),
                 },
-                self._filter_persona_fields({
-                    "active": False,
-                    "email": "odoobot@example.com",
-                    "id": self.user_root.partner_id.id,
-                    "im_status": "bot",
-                    "isInternalUser": True,
-                    "is_company": False,
-                    "name": "OdooBot",
-                    "out_of_office_date_end": False,
-                    "type": "partner",
-                    "userId": self.user_root.id,
-                    "write_date": fields.Datetime.to_string(self.user_root.partner_id.write_date),
-                }),
+                self._filter_persona_fields(
+                    {
+                        "active": False,
+                        "email": "odoobot@example.com",
+                        "id": self.user_root.partner_id.id,
+                        "im_status": "bot",
+                        "isInternalUser": True,
+                        "is_company": False,
+                        "name": "OdooBot",
+                        "out_of_office_date_end": False,
+                        "userId": self.user_root.id,
+                        "write_date": fields.Datetime.to_string(
+                            self.user_root.partner_id.write_date
+                        ),
+                    }
+                ),
             ],
         )
         self.assertEqual(
-            data["ChannelMember"],
+            data["discuss.channel.member"],
             [
                 {
                     "create_date": fields.Datetime.to_string(operator_member.create_date),
@@ -253,9 +262,11 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
         discuss_channels = []
         for i in range(5):
             data = self.make_jsonrpc_request('/im_livechat/get_session', {'anonymous_name': 'Anonymous', 'channel_id': self.livechat_channel.id})
-            discuss_channels.append(data["Thread"][0])
+            discuss_channels.append(data["discuss.channel"][0])
             # send a message to mark this channel as 'active'
-            self.env['discuss.channel'].browse(data["Thread"][0]['id']).message_post(body='cc')
+            self.env["discuss.channel"].browse(data["discuss.channel"][0]["id"]).message_post(
+                body="cc"
+            )
         return discuss_channels
 
     def test_channel_not_pinned_for_operator_before_first_message(self):
@@ -265,7 +276,9 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
             "channel_id": self.livechat_channel.id,
             "previous_operator_id": operator.partner_id.id
         }
-        channel_id = self.make_jsonrpc_request("/im_livechat/get_session", params)["Thread"][0]["id"]
+        channel_id = self.make_jsonrpc_request("/im_livechat/get_session", params)[
+            "discuss.channel"
+        ][0]["id"]
         member_domain = [("channel_id", "=", channel_id), ("is_self", "=", True)]
         member = self.env["discuss.channel.member"].with_user(operator).search(member_domain)
         self.assertEqual(len(member), 1, "operator should be member of channel")
@@ -273,14 +286,25 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
         self.env["discuss.channel"].browse(channel_id).message_post(body="cc")
         self.assertTrue(member.is_pinned, "channel should be pinned for operator after visitor sent a message")
         self.authenticate(operator.login, self.password)
-        operator_channels = self.make_jsonrpc_request("/mail/data", {"channels_as_member": True})["Thread"]
+        operator_channels = self.make_jsonrpc_request("/mail/data", {"channels_as_member": True})[
+            "discuss.channel"
+        ]
         channel_ids = [channel["id"] for channel in operator_channels]
         self.assertIn(channel_id, channel_ids, "channel should be fetched by operator on new page")
 
     def test_read_channel_unpined_for_operator_after_one_day(self):
         data = self.make_jsonrpc_request('/im_livechat/get_session', {'anonymous_name': 'visitor', 'channel_id': self.livechat_channel.id})
-        member_of_operator = self.env['discuss.channel.member'].search([('channel_id', '=', data["Thread"][0]['id']), ('partner_id', 'in', self.operators.partner_id.ids)])
-        message = self.env['discuss.channel'].browse(data["Thread"][0]['id']).message_post(body='cc')
+        member_of_operator = self.env["discuss.channel.member"].search(
+            [
+                ("channel_id", "=", data["discuss.channel"][0]["id"]),
+                ("partner_id", "in", self.operators.partner_id.ids),
+            ]
+        )
+        message = (
+            self.env["discuss.channel"]
+            .browse(data["discuss.channel"][0]["id"])
+            .message_post(body="cc")
+        )
         member_of_operator._mark_as_read(message.id)
         with freeze_time(fields.Datetime.to_string(fields.Datetime.now() + timedelta(days=1))):
             member_of_operator._gc_unpin_livechat_sessions()
@@ -288,8 +312,13 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
 
     def test_unread_channel_not_unpined_for_operator_after_autovacuum(self):
         data = self.make_jsonrpc_request('/im_livechat/get_session', {'anonymous_name': 'visitor', 'channel_id': self.livechat_channel.id})
-        member_of_operator = self.env['discuss.channel.member'].search([('channel_id', '=', data["Thread"][0]['id']), ('partner_id', 'in', self.operators.partner_id.ids)])
-        self.env['discuss.channel'].browse(data["Thread"][0]['id']).message_post(body='cc')
+        member_of_operator = self.env["discuss.channel.member"].search(
+            [
+                ("channel_id", "=", data["discuss.channel"][0]["id"]),
+                ("partner_id", "in", self.operators.partner_id.ids),
+            ]
+        )
+        self.env["discuss.channel"].browse(data["discuss.channel"][0]["id"]).message_post(body="cc")
         with freeze_time(fields.Datetime.to_string(fields.Datetime.now() + timedelta(days=1))):
             member_of_operator._gc_unpin_livechat_sessions()
         self.assertTrue(member_of_operator.is_pinned, "unread channel should not be unpinned after autovacuum")
@@ -304,7 +333,7 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
                 "previous_operator_id": self.operators[1].partner_id.id
             },
         )
-        channel = self.env["discuss.channel"].browse(data["Thread"][0]["id"])
+        channel = self.env["discuss.channel"].browse(data["discuss.channel"][0]["id"])
         self.env['bus.bus'].sudo().search([]).unlink()
         with self.assertBus(
             [(self.env.cr.dbname, "res.partner", self.env.user.partner_id.id)],
@@ -344,7 +373,7 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
                     "channel_id": livechat_channel.id,
                     "persisted": True,
                 },
-            )["Thread"][0]["id"]
+            )["discuss.channel"][0]["id"]
         )
         self.make_jsonrpc_request(
             "/im_livechat/visitor_leave_session", {"channel_id": inactive_livechat.id}
@@ -361,14 +390,14 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
                     "channel_id": livechat_channel.id,
                     "persisted": True,
                 },
-            )["Thread"][0]["id"]
+            )["discuss.channel"][0]["id"]
         )
         init_messaging_result = self.make_jsonrpc_request("/mail/action", {"init_messaging": {}})
-        self.assertEqual(len(init_messaging_result["Thread"]), 2)
-        self.assertEqual(init_messaging_result["Thread"][0]["channel_type"], "channel")
-        self.assertEqual(init_messaging_result["Thread"][1]["channel_type"], "livechat")
+        self.assertEqual(len(init_messaging_result["discuss.channel"]), 2)
+        self.assertEqual(init_messaging_result["discuss.channel"][0]["channel_type"], "channel")
+        self.assertEqual(init_messaging_result["discuss.channel"][1]["channel_type"], "livechat")
         init_messaging_result = self.make_jsonrpc_request("/mail/action", {"init_messaging": {
             "channel_types": ["livechat"],
         }})
-        self.assertEqual(len(init_messaging_result["Thread"]), 1)
-        self.assertEqual(init_messaging_result["Thread"][0]["id"], active_livechat.id)
+        self.assertEqual(len(init_messaging_result["discuss.channel"]), 1)
+        self.assertEqual(init_messaging_result["discuss.channel"][0]["id"], active_livechat.id)

--- a/addons/im_livechat/tests/test_im_livechat_report.py
+++ b/addons/im_livechat/tests/test_im_livechat_report.py
@@ -17,7 +17,10 @@ class TestImLivechatReport(TestImLivechatCommon):
                 record.available_operator_ids = self.operators
 
         with patch.object(type(self.env['im_livechat.channel']), '_compute_available_operator_ids', _compute_available_operator_ids):
-            channel_id = self.make_jsonrpc_request("/im_livechat/get_session", {'anonymous_name': 'Anonymous', 'channel_id': self.livechat_channel.id})["Thread"][0]['id']
+            channel_id = self.make_jsonrpc_request(
+                "/im_livechat/get_session",
+                {"anonymous_name": "Anonymous", "channel_id": self.livechat_channel.id},
+            )["discuss.channel"][0]["id"]
 
         channel = self.env['discuss.channel'].browse(channel_id)
         self.operator = channel.livechat_operator_id

--- a/addons/im_livechat/tests/test_message.py
+++ b/addons/im_livechat/tests/test_message.py
@@ -52,12 +52,17 @@ class TestImLivechatMessage(HttpCase):
         im_livechat_channel = self.env['im_livechat.channel'].sudo().create({'name': 'support', 'user_ids': [Command.link(self.users[0].id)]})
         self.env['bus.presence'].create({'user_id': self.users[0].id, 'status': 'online'})  # make available for livechat (ignore leave)
         self.authenticate(self.users[1].login, self.password)
-        channel_livechat_1 = self.env['discuss.channel'].browse(self.make_jsonrpc_request("/im_livechat/get_session", {
-            'anonymous_name': 'anon 1',
-            'previous_operator_id': self.users[0].partner_id.id,
-            'country_id': self.env.ref('base.in').id,
-            'channel_id': im_livechat_channel.id,
-        })["Thread"][0]['id'])
+        channel_livechat_1 = self.env["discuss.channel"].browse(
+            self.make_jsonrpc_request(
+                "/im_livechat/get_session",
+                {
+                    "anonymous_name": "anon 1",
+                    "previous_operator_id": self.users[0].partner_id.id,
+                    "country_id": self.env.ref("base.in").id,
+                    "channel_id": im_livechat_channel.id,
+                },
+            )["discuss.channel"][0]["id"]
+        )
         record_rating = self.env['rating.rating'].create({
             'res_model_id': self.env['ir.model']._get('discuss.channel').id,
             'res_id': channel_livechat_1.id,
@@ -77,7 +82,7 @@ class TestImLivechatMessage(HttpCase):
         self.assertEqual(
             Store(message, for_current_user=True).get_result(),
             {
-                "Message": [
+                "mail.message": [
                     {
                         "attachments": [],
                         "author": {"id": self.users[1].partner_id.id, "type": "partner"},
@@ -113,22 +118,21 @@ class TestImLivechatMessage(HttpCase):
                         "trackingValues": [],
                     },
                 ],
-                "Persona": [
-                    {
-                        "id": self.users[1].partner_id.id,
-                        "is_company": False,
-                        "isInternalUser": True,
-                        "type": "partner",
-                        "user_livechat_username": "chuck",
-                        "userId": self.users[1].id,
-                        "write_date": fields.Datetime.to_string(self.users[1].write_date),
-                    },
-                ],
-                "Thread": [
+                "mail.thread": [
                     {
                         "id": channel_livechat_1.id,
                         "model": "discuss.channel",
                         "module_icon": "/mail/static/description/icon.png",
+                    },
+                ],
+                "res.partner": [
+                    {
+                        "id": self.users[1].partner_id.id,
+                        "is_company": False,
+                        "isInternalUser": True,
+                        "user_livechat_username": "chuck",
+                        "userId": self.users[1].id,
+                        "write_date": fields.Datetime.to_string(self.users[1].write_date),
                     },
                 ],
             },

--- a/addons/im_livechat/tests/test_session_history.py
+++ b/addons/im_livechat/tests/test_session_history.py
@@ -16,6 +16,6 @@ class TestImLivechatSessionHistory(TestImLivechatCommon):
             "anonymous_name": "Visitor",
             "previous_operator_id": operator.partner_id.id
         })
-        channel = self.env["discuss.channel"].browse(data["Thread"][0]["id"])
+        channel = self.env["discuss.channel"].browse(data["discuss.channel"][0]["id"])
         channel.with_user(operator).message_post(body="Hello, how can I help you?")
         self.start_tour("/web", "im_livechat_history_back_and_forth_tour", login="operator", step_delay=25)

--- a/addons/im_livechat/tests/test_upload_attachment.py
+++ b/addons/im_livechat/tests/test_upload_attachment.py
@@ -22,13 +22,15 @@ class TestUploadAttachment(HttpCase):
                 "persisted": True,
             },
         )
-        self.make_jsonrpc_request("/im_livechat/visitor_leave_session", {"channel_id": data["Thread"][0]["id"]})
+        self.make_jsonrpc_request(
+            "/im_livechat/visitor_leave_session", {"channel_id": data["discuss.channel"][0]["id"]}
+        )
         with mute_logger("odoo.http"), file_open("addons/web/__init__.py") as file:
             response = self.url_open(
                 "/mail/attachment/upload",
                 {
                     "csrf_token": http.Request.csrf_token(self),
-                    "thread_id": data["Thread"][0]["id"],
+                    "thread_id": data["discuss.channel"][0]["id"],
                     "thread_model": "discuss.channel",
                 },
                 files={"ufile": file},

--- a/addons/mail/controllers/discuss/rtc.py
+++ b/addons/mail/controllers/discuss/rtc.py
@@ -130,14 +130,17 @@ class RtcController(http.Controller):
             ]
             channel_member_sudo.channel_id.rtc_session_ids.filtered_domain(domain).write({})  # update write_date
         current_rtc_sessions, outdated_rtc_sessions = channel_member_sudo._rtc_sync_sessions(check_rtc_session_ids)
-        store = Store(current_rtc_sessions)
-        channel_info = {
-            "id": member.channel_id.id,
-            "model": "discuss.channel",
-            "rtcSessions": [
-                ("ADD", [{"id": session.id} for session in current_rtc_sessions]),
-                ("DELETE", [{"id": session.id} for session in outdated_rtc_sessions]),
-            ],
-        }
-        store.add("Thread", channel_info)
-        return store.get_result()
+        return (
+            Store(current_rtc_sessions)
+            .add(
+                "discuss.channel",
+                {
+                    "id": member.channel_id.id,
+                    "rtcSessions": [
+                        ("ADD", [{"id": session.id} for session in current_rtc_sessions]),
+                        ("DELETE", [{"id": session.id} for session in outdated_rtc_sessions]),
+                    ],
+                },
+            )
+            .get_result()
+        )

--- a/addons/mail/models/discuss/ir_attachment.py
+++ b/addons/mail/models/discuss/ir_attachment.py
@@ -21,7 +21,7 @@ class IrAttachment(models.Model):
     def _to_store(self, store: Store, **kwargs):
         super()._to_store(store, **kwargs)
         for attachment in self:
-            store.add("Attachment", {
+            store.add("ir.attachment", {
                 "id": attachment.id,
                 # sudo: discuss.voice.metadata - checking the existence of voice metadata for accessible attachments is fine
                 "voice": bool(attachment.sudo().voice_ids)

--- a/addons/mail/models/discuss/mail_message.py
+++ b/addons/mail/models/discuss/mail_message.py
@@ -25,7 +25,7 @@ class MailMessage(models.Model):
                 if message.parent_id:
                     store.add(message.parent_id, format_reply=False)
                 store.add(
-                    "Message",
+                    "mail.message",
                     {
                         "id": message.id,
                         "parentMessage": (

--- a/addons/mail/models/ir_attachment.py
+++ b/addons/mail/models/ir_attachment.py
@@ -103,4 +103,4 @@ class IrAttachment(models.Model):
             }
             if access_token:
                 res["accessToken"] = attachment.access_token
-            store.add("Attachment", res)
+            store.add("ir.attachment", res)

--- a/addons/mail/models/ir_websocket.py
+++ b/addons/mail/models/ir_websocket.py
@@ -1,0 +1,25 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+from odoo.addons.mail.tools.discuss import Store
+
+
+class IrWebsocket(models.AbstractModel):
+    _inherit = "ir.websocket"
+
+    def _im_status_to_store(self, store: Store, /, *, im_status_ids_by_model):
+        if partner_ids := im_status_ids_by_model.get("res.partner"):
+            store.add(
+                "res.partner",
+                self.env["res.partner"]
+                .with_context(active_test=False)
+                .search_read([("id", "in", partner_ids)], ["im_status"]),
+            )
+
+    def _update_bus_presence(self, inactivity_period, im_status_ids_by_model):
+        super()._update_bus_presence(inactivity_period, im_status_ids_by_model)
+        if self.env.user and not self.env.user._is_public():
+            store = Store()
+            self._im_status_to_store(store, im_status_ids_by_model=im_status_ids_by_model)
+            if res := store.get_result():
+                self.env["bus.bus"]._sendone(self.env.user.partner_id, "mail.record/insert", res)

--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -601,7 +601,7 @@ class MailActivity(models.Model):
                 for attachment in record.attachment_ids
             ]
             activity["persona"] = {"id": record.user_id.partner_id.id, "type": "partner"}
-            store.add("Activity", activity)
+            store.add("mail.activity", activity)
 
     @api.model
     def get_activity_data(self, res_model, domain, limit=None, offset=0, fetch_done=False):

--- a/addons/mail/models/mail_followers.py
+++ b/addons/mail/models/mail_followers.py
@@ -516,7 +516,7 @@ GROUP BY fol.id%s%s""" % (
         store.add(self.partner_id)
         for follower in self:
             store.add(
-                "Follower",
+                "mail.followers",
                 {
                     "display_name": follower.display_name,
                     "email": follower.email,

--- a/addons/mail/models/mail_notification.py
+++ b/addons/mail/models/mail_notification.py
@@ -133,15 +133,14 @@ class MailNotification(models.Model):
         for notif in self:
             if notif.res_partner_id:
                 store.add(
-                    "Persona",
+                    "res.partner",
                     {
                         "displayName": notif.res_partner_id.display_name,
                         "id": notif.res_partner_id.id,
-                        "type": "partner",
                     },
                 )
             store.add(
-                "Notification",
+                "mail.notification",
                 {
                     "failure_type": notif.failure_type,
                     "id": notif.id,

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -4411,7 +4411,7 @@ class MailThread(models.AbstractModel):
         if not reset:
             followers_data = [("ADD", followers_data)]
         relation = "recipients" if filter_recipients else "followers"
-        store.add("Thread", {"id": self.id, "model": self._name, relation: followers_data})
+        store.add("mail.thread", {"id": self.id, "model": self._name, relation: followers_data})
 
     # ------------------------------------------------------
     # THREAD MESSAGE UPDATE
@@ -4534,7 +4534,7 @@ class MailThread(models.AbstractModel):
             # sudo: mail.message.translation - discarding translations of message after editing it
             self.env["mail.message.translation"].sudo().search([("message_id", "=", message.id)]).unlink()
             res["translationValue"] = False
-        broadcast_store.add("Message", res)
+        broadcast_store.add("mail.message", res)
         self.env["bus.bus"]._sendone(
             message._bus_notification_target(), "mail.record/insert", broadcast_store.get_result()
         )
@@ -4595,7 +4595,7 @@ class MailThread(models.AbstractModel):
             self._message_followers_to_store(store, filter_recipients=True, reset=True)
         if 'suggestedRecipients' in request_list:
             res['suggestedRecipients'] = self._message_get_suggested_recipients()
-        store.add("Thread", res)
+        store.add("mail.thread", res)
 
     @api.model
     def get_views(self, views, options=None):

--- a/addons/mail/models/mail_thread_main_attachment.py
+++ b/addons/mail/models/mail_thread_main_attachment.py
@@ -53,7 +53,7 @@ class MailMainAttachmentMixin(models.AbstractModel):
         super()._thread_to_store(store, request_list=request_list, **kwargs)
         if 'attachments' in request_list:
             store.add(
-                "Thread",
+                "mail.thread",
                 {
                     "id": self.id,
                     "model": self._name,

--- a/addons/mail/models/res_partner.py
+++ b/addons/mail/models/res_partner.py
@@ -219,8 +219,8 @@ class Partner(models.Model):
             data = {"id": partner.id}
             if 'name' in fields:
                 data['name'] = partner.name
-            if 'email' in fields:
-                data['email'] = partner.email
+            if "email" in fields and self.env.user._is_internal():
+                data["email"] = partner.email
             if 'active' in fields:
                 data['active'] = partner.active
             if 'im_status' in fields:
@@ -235,10 +235,7 @@ class Partner(models.Model):
                 main_user = internal_users[0] if len(internal_users) > 0 else users[0] if len(users) > 0 else self.env['res.users']
                 data['userId'] = main_user.id
                 data["isInternalUser"] = not main_user.share if main_user else False
-            if not self.env.user._is_internal():
-                data.pop('email', None)
-            data['type'] = "partner"
-            store.add("Persona", data)
+            store.add("res.partner", data)
 
     @api.model
     def get_mention_suggestions(self, search, limit=8):

--- a/addons/mail/static/src/core/common/mail_core_common_service.js
+++ b/addons/mail/static/src/core/common/mail_core_common_service.js
@@ -41,9 +41,7 @@ export class MailCoreCommon {
             }
         });
         this.busService.subscribe("mail.record/insert", (payload) => {
-            for (const Model in payload) {
-                this.store[Model].insert(payload[Model], { html: true });
-            }
+            this.store.insert(payload, { html: true });
         });
         this.busService.subscribe("mail.record/delete", (payload) => {
             for (const Model in payload) {

--- a/addons/mail/static/tests/chatter/web/follower.test.js
+++ b/addons/mail/static/tests/chatter/web/follower.test.js
@@ -31,7 +31,7 @@ test("base rendering not editable", async () => {
         _thread_to_store(ids, store) {
             // mimic user without write access
             super._thread_to_store(...arguments);
-            store.add("Thread", { hasWriteAccess: false, id: ids[0], model: this._name });
+            store.add("mail.thread", { hasWriteAccess: false, id: ids[0], model: this._name });
         },
     });
     await start();

--- a/addons/mail/static/tests/chatter/web/follower_list_menu.test.js
+++ b/addons/mail/static/tests/chatter/web/follower_list_menu.test.js
@@ -33,7 +33,7 @@ test("base rendering editable", async () => {
         _thread_to_store(ids, store) {
             // mimic user with write access
             super._thread_to_store(...arguments);
-            store.add("Thread", { hasWriteAccess: true, id: ids[0], model: this._name });
+            store.add("mail.thread", { hasWriteAccess: true, id: ids[0], model: this._name });
         },
     });
     await start();
@@ -64,7 +64,7 @@ test('click on "add followers" button', async () => {
         _thread_to_store(ids, store) {
             // mimic user with write access
             super._thread_to_store(...arguments);
-            store.add("Thread", { hasWriteAccess: true, id: ids[0], model: this._name });
+            store.add("mail.thread", { hasWriteAccess: true, id: ids[0], model: this._name });
         },
     });
     mockService("action", {
@@ -122,7 +122,7 @@ test("click on remove follower", async () => {
         _thread_to_store(ids, store) {
             // mimic user with write access
             super._thread_to_store(...arguments);
-            store.add("Thread", { hasWriteAccess: true, id: ids[0], model: this._name });
+            store.add("mail.thread", { hasWriteAccess: true, id: ids[0], model: this._name });
         },
     });
     onRpc("res.partner", "message_unsubscribe", ({ args, method }) => {
@@ -163,7 +163,7 @@ test('Hide "Add follower" and subtypes edition/removal buttons except own user o
         _thread_to_store(ids, store) {
             // mimic user without write access
             super._thread_to_store(...arguments);
-            store.add("Thread", { hasWriteAccess: false, id: ids[0], model: this._name });
+            store.add("mail.thread", { hasWriteAccess: false, id: ids[0], model: this._name });
         },
     });
     await start();
@@ -301,7 +301,7 @@ test('Show "Add follower" and subtypes edition/removal buttons on all followers 
         _thread_to_store(ids, store) {
             // mimic user with write access
             super._thread_to_store(...arguments);
-            store.add("Thread", { hasWriteAccess: true, id: ids[0], model: this._name });
+            store.add("mail.thread", { hasWriteAccess: true, id: ids[0], model: this._name });
         },
     });
     await start();
@@ -323,7 +323,7 @@ test('Show "No Followers" dropdown-item if there are no followers and user does 
         _thread_to_store(ids, store) {
             // mimic user without write access
             super._thread_to_store(...arguments);
-            store.add("Thread", { hasWriteAccess: false, id: ids[0], model: this._name });
+            store.add("mail.thread", { hasWriteAccess: false, id: ids[0], model: this._name });
         },
     });
     await start();

--- a/addons/mail/static/tests/chatter/web/follower_subtype.test.js
+++ b/addons/mail/static/tests/chatter/web/follower_subtype.test.js
@@ -31,7 +31,7 @@ test("simplest layout of a followed subtype", async () => {
         _thread_to_store(ids, store) {
             // mimic user with write access
             super._thread_to_store(...arguments);
-            store.add("Thread", { hasWriteAccess: true, id: ids[0], model: this._name });
+            store.add("mail.thread", { hasWriteAccess: true, id: ids[0], model: this._name });
         },
     });
     await start();
@@ -63,7 +63,7 @@ test("simplest layout of a not followed subtype", async () => {
         _thread_to_store(ids, store) {
             // mimic user with write access
             super._thread_to_store(...arguments);
-            store.add("Thread", { hasWriteAccess: true, id: ids[0], model: this._name });
+            store.add("mail.thread", { hasWriteAccess: true, id: ids[0], model: this._name });
         },
     });
     await start();
@@ -91,7 +91,7 @@ test("toggle follower subtype checkbox", async () => {
         _thread_to_store(ids, store) {
             // mimic user with write access
             super._thread_to_store(...arguments);
-            store.add("Thread", { hasWriteAccess: true, id: ids[0], model: this._name });
+            store.add("mail.thread", { hasWriteAccess: true, id: ids[0], model: this._name });
         },
     });
     await start();

--- a/addons/mail/static/tests/legacy/helpers/mock_server/controllers/channel.js
+++ b/addons/mail/static/tests/legacy/helpers/mock_server/controllers/channel.js
@@ -38,7 +38,7 @@ patch(MockServer.prototype, {
             .sort()
             .slice(0, limit)
             .map(({ id }) => id);
-        return { Attachment: this._mockIrAttachment_attachmentFormat(attachmentIds) };
+        return { "ir.attachment": this._mockIrAttachment_attachmentFormat(attachmentIds) };
     },
 
     /**

--- a/addons/mail/static/tests/legacy/helpers/mock_server/controllers/discuss.js
+++ b/addons/mail/static/tests/legacy/helpers/mock_server/controllers/discuss.js
@@ -27,7 +27,7 @@ patch(MockServer.prototype, {
                 this.mockCreate("discuss.voice.metadata", { attachment_id: attachmentId });
             }
             return {
-                data: { Attachment: this._mockIrAttachment_attachmentFormat([attachmentId]) },
+                data: { "ir.attachment": this._mockIrAttachment_attachmentFormat([attachmentId]) },
             };
         }
         return super.performRPC(...arguments);
@@ -90,7 +90,7 @@ patch(MockServer.prototype, {
                     this._mockMailMessage__busNotificationTarget(linkPreview.message_id[0]),
                     "mail.record/insert",
                     {
-                        Message: {
+                        "mail.message": {
                             id: linkPreview.message_id[0],
                             linkPreviews: [["DELETE", [{ id: linkPreview.id }]]],
                         },
@@ -137,14 +137,14 @@ patch(MockServer.prototype, {
                 this._mockMailMessage__busNotificationTarget(args.message_id),
                 "mail.record/insert",
                 {
-                    Message: {
+                    "mail.message": {
                         id: args.message_id,
                         body: args.body,
                         attachments: this._mockIrAttachment_attachmentFormat(args.attachment_ids),
                     },
                 }
             );
-            return { Message: this._mockMailMessageMessageFormat([args.message_id]) };
+            return { "mail.message": this._mockMailMessageMessageFormat([args.message_id]) };
         }
         if (route === "/mail/partner/from_email") {
             return this._mockRouteMailPartnerFromEmail(args.emails, args.additional_values);
@@ -202,7 +202,7 @@ patch(MockServer.prototype, {
             ["res_id", "=", channel_id],
             ["pinned_at", "!=", false],
         ]);
-        return { Message: this._mockMailMessageMessageFormat(messageIds) };
+        return { "mail.message": this._mockMailMessageMessageFormat(messageIds) };
     },
     /**
      * Simulates the `/mail/attachment/delete` route.
@@ -254,11 +254,11 @@ patch(MockServer.prototype, {
         return {
             ...res,
             data: {
-                Message: this._mockMailMessageMessageFormat(
+                "mail.message": this._mockMailMessageMessageFormat(
                     res.messages.map((message) => message.id)
                 ),
             },
-            message: res.messages.map((message) => ({ id: message.id })),
+            "mail.message": res.messages.map((message) => ({ id: message.id })),
         };
     },
     /**
@@ -279,13 +279,8 @@ patch(MockServer.prototype, {
             mute_until_dt = false;
         }
         this.pyEnv["discuss.channel.member"].write([member.id], { mute_until_dt });
-        const channel_data = {
-            id: member.channel_id[0],
-            model: "discuss.channel",
-            mute_until_dt,
-        };
         this.pyEnv["bus.bus"]._sendone(this.pyEnv.currentPartner, "mail.record/insert", {
-            Thread: channel_data,
+            "discuss.channel": [{ id: member.channel_id[0], mute_until_dt }],
         });
         return "dummy";
     },
@@ -330,7 +325,7 @@ patch(MockServer.prototype, {
             this.pyEnv["bus.bus"]._sendone(
                 this._mockMailMessage__busNotificationTarget(message_id),
                 "mail.record/insert",
-                { LinkPreview: linkPreviews }
+                { "mail.link.preview": linkPreviews }
             );
         }
     },
@@ -368,7 +363,7 @@ patch(MockServer.prototype, {
         return {
             ...res,
             data: {
-                Message: this._mockMailMessageMessageFormat(
+                "mail.message": this._mockMailMessageMessageFormat(
                     messagesWithNotification.map((message) => message.id)
                 ),
             },
@@ -399,7 +394,7 @@ patch(MockServer.prototype, {
         return {
             ...res,
             data: {
-                Message: this._mockMailMessageMessageFormat(
+                "mail.message": this._mockMailMessageMessageFormat(
                     res.messages.map((message) => message.id)
                 ),
             },
@@ -532,10 +527,9 @@ patch(MockServer.prototype, {
                 channel,
                 "mail.record/insert",
                 {
-                    Thread: [
+                    "discuss.channel": [
                         {
                             id: Number(channelId), // JS object keys are strings, but the type from the server is number
-                            model: "discuss.channel",
                             rtcSessions: [["DELETE", notificationRtcSessions]],
                         },
                     ],
@@ -626,7 +620,7 @@ patch(MockServer.prototype, {
                 thread.id
             );
         }
-        return { Thread: [res] };
+        return { "mail.thread": [res] };
     },
     /**
      * Simulates the `/mail/thread/messages` route.
@@ -665,7 +659,7 @@ patch(MockServer.prototype, {
         return {
             ...res,
             data: {
-                Message: this._mockMailMessageMessageFormat(
+                "mail.message": this._mockMailMessageMessageFormat(
                     res.messages.map((message) => message.id)
                 ),
             },

--- a/addons/mail/static/tests/legacy/helpers/mock_server/controllers/discuss/channel.js
+++ b/addons/mail/static/tests/legacy/helpers/mock_server/controllers/discuss/channel.js
@@ -12,7 +12,7 @@ patch(MockServer.prototype, {
         if (args.channels_as_member) {
             const channels = this._mockDiscussChannel__get_channels_as_member();
             this._addToRes(res, {
-                Message: channels
+                "mail.message": channels
                     .map((channel) => {
                         const channelMessages = this.getRecords("mail.message", [
                             ["model", "=", "discuss.channel"],
@@ -29,7 +29,9 @@ patch(MockServer.prototype, {
                             : false;
                     })
                     .filter((lastMessage) => lastMessage),
-                Thread: this._mockDiscussChannelChannelInfo(channels.map((channel) => channel.id)),
+                "discuss.channel": this._mockDiscussChannelChannelInfo(
+                    channels.map((channel) => channel.id)
+                ),
             });
         }
         return res;

--- a/addons/mail/static/tests/legacy/helpers/mock_server/controllers/webclient.js
+++ b/addons/mail/static/tests/legacy/helpers/mock_server/controllers/webclient.js
@@ -39,7 +39,7 @@ patch(MockServer.prototype, {
                 channelsDomain.push(["channel_type", "in", channelTypes]);
             }
             this._addToRes(res, {
-                Thread: this._mockDiscussChannelChannelInfo(
+                "discuss.channel": this._mockDiscussChannelChannelInfo(
                     this.pyEnv["discuss.channel"].search(channelsDomain)
                 ),
             });

--- a/addons/mail/static/tests/legacy/helpers/mock_server/models/discuss_channel_member.js
+++ b/addons/mail/static/tests/legacy/helpers/mock_server/models/discuss_channel_member.js
@@ -30,7 +30,11 @@ patch(MockServer.prototype, {
             Object.assign(data, {
                 isTyping: is_typing,
             });
-            notifications.push([channel, "mail.record/insert", { ChannelMember: [data] }]);
+            notifications.push([
+                channel,
+                "mail.record/insert",
+                { "discuss.channel.member": [data] },
+            ]);
         }
         this.pyEnv["bus.bus"]._sendmany(notifications);
     },

--- a/addons/mail/static/tests/legacy/helpers/mock_server/models/discuss_channel_rtc_session.js
+++ b/addons/mail/static/tests/legacy/helpers/mock_server/models/discuss_channel_rtc_session.js
@@ -20,11 +20,10 @@ patch(MockServer.prototype, {
                 channel,
                 "mail.record/insert",
                 {
-                    RtcSession: [sessionData],
-                    Thread: [
+                    "discuss.channel.rtc.session": [sessionData],
+                    "discuss.channel": [
                         {
                             id: channel.id,
-                            model: "discuss.channel",
                             rtcSessions: [
                                 ["ADD", sessionData.map((session) => ({ id: session.id }))],
                             ],
@@ -100,7 +99,7 @@ patch(MockServer.prototype, {
         this.pyEnv["bus.bus"]._sendone(
             channel,
             "discuss.channel.rtc.session/update_and_broadcast",
-            { data: { RtcSession: [sessionData] }, channelId: channel.id }
+            { data: { "discuss.channel.rtc.session": [sessionData] }, channelId: channel.id }
         );
     },
 });

--- a/addons/mail/static/tests/legacy/helpers/mock_server/models/ir_websocket.js
+++ b/addons/mail/static/tests/legacy/helpers/mock_server/models/ir_websocket.js
@@ -18,14 +18,12 @@ patch(MockServer.prototype, {
         const imStatus = super._mockIrWebsocket__getImStatus(imStatusIdsByModel);
         const { "mail.guest": guestIds } = imStatusIdsByModel;
         if (guestIds) {
-            imStatus["Persona"] = imStatus["Persona"].concat(
-                this.pyEnv["mail.guest"]
-                    .search_read([["id", "in", guestIds]], {
-                        context: { active_test: false },
-                        fields: ["im_status"],
-                    })
-                    .map((g) => ({ ...g, type: "guest" }))
-            );
+            imStatus["mail.guest"] = this.pyEnv["mail.guest"]
+                .search_read([["id", "in", guestIds]], {
+                    context: { active_test: false },
+                    fields: ["im_status"],
+                })
+                .map((g) => ({ id: g.id, im_status: g.im_status }));
         }
         return imStatus;
     },

--- a/addons/mail/static/tests/legacy/helpers/mock_server/models/mail_activity.js
+++ b/addons/mail/static/tests/legacy/helpers/mock_server/models/mail_activity.js
@@ -20,7 +20,7 @@ patch(MockServer.prototype, {
         }
         if (args.model === "mail.activity" && args.method === "activity_format") {
             const ids = args.args[0];
-            return { Activity: this._mockMailActivityActivityFormat(ids) };
+            return { "mail.activity": this._mockMailActivityActivityFormat(ids) };
         }
         if (args.model === "mail.activity" && args.method === "get_activity_data") {
             const res_model = args.args[0] || args.kwargs.res_model;

--- a/addons/mail/static/tests/legacy/helpers/mock_server/models/mail_message.js
+++ b/addons/mail/static/tests/legacy/helpers/mock_server/models/mail_message.js
@@ -87,7 +87,7 @@ patch(MockServer.prototype, {
         this.pyEnv["bus.bus"]._sendone(
             this._mockMailMessage__busNotificationTarget(messageId),
             "mail.record/insert",
-            { Message: result }
+            { "mail.message": result }
         );
     },
     /**

--- a/addons/mail/static/tests/legacy/helpers/mock_server/models/mail_thread.js
+++ b/addons/mail/static/tests/legacy/helpers/mock_server/models/mail_thread.js
@@ -243,7 +243,7 @@ patch(MockServer.prototype, {
             });
         }
         this._mockMailThread_NotifyThread(model, ids, messageId, context?.temporary_id);
-        return { Message: this._mockMailMessageMessageFormat([messageId]) };
+        return { "mail.message": this._mockMailMessageMessageFormat([messageId]) };
     },
     /**
      * Simulates `message_subscribe` on `mail.thread`.
@@ -308,29 +308,17 @@ patch(MockServer.prototype, {
                 notifications.push([
                     [channel, "members"],
                     "mail.record/insert",
-                    {
-                        Thread: {
-                            id: channel.id,
-                            is_pinned: true,
-                            model: "discuss.channel",
-                        },
-                    },
+                    { "discuss.channel": [{ id: channel.id, is_pinned: true }] },
                 ]);
                 notifications.push([
                     channel,
                     "mail.record/insert",
-                    {
-                        Thread: {
-                            id: channel.id,
-                            last_interest_dt: now,
-                            model: "discuss.channel",
-                        },
-                    },
+                    { "discuss.channel": [{ id: channel.id, last_interest_dt: now }] },
                 ]);
                 notifications.push([
                     channel,
                     "discuss.channel/new_message",
-                    { data: { Message: messageFormat }, id: channel.id, temporary_id },
+                    { data: { "mail.message": messageFormat }, id: channel.id, temporary_id },
                 ]);
             }
         }

--- a/addons/mail/static/tests/legacy/helpers/mock_server/models/res_partner.js
+++ b/addons/mail/static/tests/legacy/helpers/mock_server/models/res_partner.js
@@ -228,7 +228,7 @@ patch(MockServer.prototype, {
             (partner) => !excluded_ids.includes(partner.id)
         );
         return {
-            Persona: [
+            "res.partner": [
                 ...this._mockResPartnerMailPartnerFormat(
                     resultPartners.map((partner) => partner.id)
                 ).values(),

--- a/addons/mail/static/tests/message/message_seen_indicator.test.js
+++ b/addons/mail/static/tests/message/message_seen_indicator.test.js
@@ -6,6 +6,8 @@ import {
     start,
     startServer,
 } from "@mail/../tests/mail_test_helpers";
+import { mailDataHelpers } from "@mail/../tests/mock_server/mail_mock_server";
+
 import { describe, expect, test } from "@odoo/hoot";
 import { Command, serverState, withUser } from "@web/../tests/web_test_helpers";
 
@@ -241,15 +243,17 @@ test("mark channel as seen from the bus", async () => {
     await contains(".o-mail-MessageSeenIndicator i", { count: 0 });
     const channel = pyEnv["discuss.channel"].search_read([["id", "=", channelId]])[0];
     // Simulate received channel seen notification
-    pyEnv["bus.bus"]._sendone(channel, "mail.record/insert", {
-        ChannelMember: {
+    pyEnv["bus.bus"]._sendone(
+        channel,
+        "mail.record/insert",
+        new mailDataHelpers.Store("discuss.channel.member", {
             id: pyEnv["discuss.channel.member"].search([
                 ["channel_id", "=", channelId],
                 ["partner_id", "=", partnerId],
             ])[0],
             seen_message_id: messageId,
-        },
-    });
+        }).get_result()
+    );
     await contains(".o-mail-MessageSeenIndicator i", { count: 2 });
 });
 
@@ -287,15 +291,17 @@ test("should display message indicator when message is fetched/seen", async () =
     });
     await contains(".o-mail-MessageSeenIndicator i");
     // Simulate received channel seen notification
-    pyEnv["bus.bus"]._sendone(channel, "mail.record/insert", {
-        ChannelMember: {
+    pyEnv["bus.bus"]._sendone(
+        channel,
+        "mail.record/insert",
+        new mailDataHelpers.Store("discuss.channel.member", {
             id: pyEnv["discuss.channel.member"].search([
                 ["channel_id", "=", channelId],
                 ["partner_id", "=", partnerId],
             ])[0],
             seen_message_id: messageId,
-        },
-    });
+        }).get_result()
+    );
     await contains(".o-mail-MessageSeenIndicator i", { count: 2 });
 });
 

--- a/addons/mail/static/tests/mock_server/mock_models/discuss_channel_member.js
+++ b/addons/mail/static/tests/mock_server/mock_models/discuss_channel_member.js
@@ -36,7 +36,7 @@ export class DiscussChannelMember extends models.ServerModel {
             const store = new mailDataHelpers.Store(
                 DiscussChannelMember.browse(member.id).map((record) => record.id)
             );
-            store.add("ChannelMember", { id: member.id, isTyping: is_typing });
+            store.add("discuss.channel.member", { id: member.id, isTyping: is_typing });
             notifications.push([channel, "mail.record/insert", store.get_result()]);
         }
         BusBus._sendmany(notifications);
@@ -171,7 +171,7 @@ export class DiscussChannelMember extends models.ServerModel {
             if ("new_message_separator" in fields) {
                 data.new_message_separator = member.new_message_separator;
             }
-            store.add("ChannelMember", data);
+            store.add("discuss.channel.member", data);
         }
     }
 
@@ -319,7 +319,7 @@ export class DiscussChannelMember extends models.ServerModel {
                 },
             })
         );
-        store.add("ChannelMember", { id: member.id, syncUnread: sync });
+        store.add("discuss.channel.member", { id: member.id, syncUnread: sync });
         const [partner, guest] = this.env["res.partner"]._get_current_persona();
         this.env["bus.bus"]._sendone(guest ?? partner, "mail.record/insert", store.get_result());
     }

--- a/addons/mail/static/tests/mock_server/mock_models/discuss_channel_rtc_session.js
+++ b/addons/mail/static/tests/mock_server/mock_models/discuss_channel_rtc_session.js
@@ -27,9 +27,8 @@ export class DiscussChannelRtcSession extends models.ServerModel {
         const notifications = [];
         for (const [channelId, sessions] of Object.entries(sessionsByChannelId)) {
             const [channel] = DiscussChannel.search_read([["id", "=", Number(channelId)]]);
-            const store = new mailDataHelpers.Store("Thread", {
+            const store = new mailDataHelpers.Store("discuss.channel", {
                 id: channel.id,
-                model: "discuss.channel",
                 rtcSessions: [["ADD", sessions.map((session) => ({ id: session.id }))]],
             });
             store.add(sessions.map((session) => session.id));
@@ -68,7 +67,7 @@ export class DiscussChannelRtcSession extends models.ServerModel {
                     isScreenSharingOn: rtcSession.is_screen_sharing_on,
                 });
             }
-            store.add("RtcSession", vals);
+            store.add("discuss.channel.rtc.session", vals);
         }
     }
 

--- a/addons/mail/static/tests/mock_server/mock_models/ir_attachment.js
+++ b/addons/mail/static/tests/mock_server/mock_models/ir_attachment.js
@@ -52,7 +52,7 @@ export class IrAttachment extends webModels.IrAttachment {
             if (voice) {
                 res.voice = true;
             }
-            store.add("Attachment", res);
+            store.add("ir.attachment", res);
         }
     }
 }

--- a/addons/mail/static/tests/mock_server/mock_models/mail_activity.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_activity.js
@@ -104,7 +104,7 @@ export class MailActivity extends models.ServerModel {
             const [user] = ResUsers._filter([["id", "=", record.user_id[0]]]);
             record.persona = { id: user.partner_id, type: "partner" };
             store.add(ResPartner.browse(user.partner_id));
-            store.add("Activity", record);
+            store.add("mail.activity", record);
         }
     }
 

--- a/addons/mail/static/tests/mock_server/mock_models/mail_followers.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_followers.js
@@ -14,7 +14,7 @@ export class MailFollowers extends models.ServerModel {
         followers.sort((f1, f2) => (f1.id < f2.id ? -1 : 1));
         store.add(ResPartner.browse(followers.map((follower) => follower.partner_id)));
         for (const follower of followers) {
-            store.add("Follower", {
+            store.add("mail.followers", {
                 display_name: follower.display_name,
                 email: follower.email,
                 id: follower.id,

--- a/addons/mail/static/tests/mock_server/mock_models/mail_guest.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_guest.js
@@ -14,11 +14,10 @@ export class MailGuest extends models.ServerModel {
      */
     _to_store(ids, store) {
         for (const guest of this._filter([["id", "in", ids]], { active_test: false })) {
-            store.add("Persona", {
+            store.add("mail.guest", {
                 id: guest.id,
                 im_status: guest.im_status,
                 name: guest.name,
-                type: "guest",
                 write_date: guest.write_date,
             });
         }

--- a/addons/mail/static/tests/mock_server/mock_models/mail_link_preview.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_link_preview.js
@@ -6,7 +6,7 @@ export class MailLinkPreview extends models.ServerModel {
     /** @param {object} linkPreview */
     _to_store(ids, store) {
         for (const linkPreview of this.browse(ids)) {
-            store.add("LinkPreview", {
+            store.add("mail.link.preview", {
                 id: linkPreview.id,
                 image_mimetype: linkPreview.image_mimetype,
                 message: linkPreview.message_id ? { id: linkPreview.message_id } : false,

--- a/addons/mail/static/tests/mock_server/mock_models/mail_notification.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_notification.js
@@ -38,13 +38,12 @@ export class MailNotification extends models.ServerModel {
         for (const notification of notifications) {
             const partner = ResPartner._filter([["id", "=", notification.res_partner_id]])[0];
             if (partner) {
-                store.add("Persona", {
+                store.add("res.partner", {
                     displayName: partner.display_name,
                     id: partner.id,
-                    type: "partner",
                 });
             }
-            store.add("Notification", {
+            store.add("mail.notification", {
                 failure_type: notification.failure_type,
                 id: notification.id,
                 message: { id: notification.mail_message_id },

--- a/addons/mail/static/tests/mock_server/mock_models/mail_thread.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_thread.js
@@ -81,7 +81,7 @@ export class MailThread extends models.ServerModel {
             followers_data = [["ADD", followers_data]];
         }
         const relation = filter_recipients ? "recipients" : "followers";
-        store.add("Thread", { id: ids[0], model: this._name, [relation]: followers_data });
+        store.add("mail.thread", { id: ids[0], model: this._name, [relation]: followers_data });
     }
 
     /** @param {number[]} ids */
@@ -447,13 +447,10 @@ export class MailThread extends models.ServerModel {
                 notifications.push([
                     [channel, "members"],
                     "mail.record/insert",
-                    {
-                        Thread: {
-                            id: channel.id,
-                            is_pinned: true,
-                            model: "discuss.channel",
-                        },
-                    },
+                    new mailDataHelpers.Store("discuss.channel", {
+                        id: channel.id,
+                        is_pinned: true,
+                    }).get_result(),
                 ]);
                 notifications.push([
                     channel,
@@ -669,6 +666,6 @@ export class MailThread extends models.ServerModel {
                 id,
             ]);
         }
-        store.add("Thread", res);
+        store.add("mail.thread", res);
     }
 }

--- a/addons/mail/static/tests/mock_server/mock_models/res_partner.js
+++ b/addons/mail/static/tests/mock_server/mock_models/res_partner.js
@@ -235,14 +235,13 @@ export class ResPartner extends webModels.ResPartner {
             } else if (users.length > 0) {
                 mainUser = users[0];
             }
-            store.add("Persona", {
+            store.add("res.partner", {
                 active: partner.active,
                 email: partner.email,
                 id: partner.id,
                 im_status: partner.im_status,
                 is_company: partner.is_company,
                 name: partner.name,
-                type: "partner",
                 userId: mainUser ? mainUser.id : false,
                 isInternalUser: mainUser ? !mainUser.share : false,
                 write_date: partner.write_date,

--- a/addons/mail/static/tests/mock_server/mock_models/res_users.js
+++ b/addons/mail/static/tests/mock_server/mock_models/res_users.js
@@ -34,14 +34,13 @@ export class ResUsers extends webModels.ResUsers {
         });
         if (!this._is_public(this.env.uid)) {
             const userSettings = ResUsersSettings._find_or_create_for_user(this.env.uid);
-            store.add("Persona", {
+            store.add("res.partner", {
                 id: this.env.user?.partner_id,
                 isAdmin: true, // mock server simplification
                 active: true,
                 isInternalUser: !this.env.user?.share,
                 name: this.env.user?.name,
                 notification_preference: this.env.user?.notification_type,
-                type: "partner",
                 userId: this.env.user?.id,
                 write_date: this.env.user?.write_date,
             });
@@ -51,10 +50,9 @@ export class ResUsers extends webModels.ResUsers {
             });
         } else if (this.env.cookie.get("dgid")) {
             const [guest] = MailGuest.read(this.env.cookie.get("dgid"));
-            store.add("Persona", {
+            store.add("mail.guest", {
                 id: guest.id,
                 name: guest.name,
-                type: "guest",
                 write_date: guest.write_date,
             });
             store.add({ self: { id: guest.id, type: "guest" } });

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -68,33 +68,30 @@ class TestChannelInternals(MailCommon, HttpCase):
                     {
                         "type": "mail.record/insert",
                         "payload": {
-                            "Thread": {
-                                "id": channel.id,
-                                "model": "discuss.channel",
-                                "last_interest_dt": "2020-03-22 10:42:06",
-                            },
+                            "discuss.channel": [
+                                {"id": channel.id, "last_interest_dt": "2020-03-22 10:42:06"},
+                            ],
                         },
                     },
                     {
                         "type": "mail.record/insert",
-                        "payload": {
-                            "Thread": {
-                                "id": channel.id,
-                                "is_pinned": True,
-                                "model": "discuss.channel",
-                            }
-                        },
+                        "payload": {"discuss.channel": [{"id": channel.id, "is_pinned": True}]},
                     },
                     {
                         "type": "discuss.channel/new_message",
                         "payload": {
                             "data": {
-                                "Message": [
+                                "mail.message": [
                                     {
                                         "attachments": [],
-                                        "author": {"id": self.env.user.partner_id.id, "type": "partner"},
+                                        "author": {
+                                            "id": self.env.user.partner_id.id,
+                                            "type": "partner",
+                                        },
                                         "body": f'<div class="o_mail_notification">invited <a href="#" data-oe-model="res.partner" data-oe-id="{self.test_partner.id}">Test Partner</a> to the channel</div>',
-                                        "create_date": fields.Datetime.to_string(message.create_date),
+                                        "create_date": fields.Datetime.to_string(
+                                            message.create_date
+                                        ),
                                         "date": "2020-03-22 10:42:06",
                                         "default_subject": "Channel",
                                         "email_from": '"Ernest Employee" <e.e@example.com>',
@@ -118,22 +115,21 @@ class TestChannelInternals(MailCommon, HttpCase):
                                         "write_date": fields.Datetime.to_string(message.write_date),
                                     },
                                 ],
-                                "Persona": [
+                                "mail.thread": [
+                                    {
+                                        "id": channel.id,
+                                        "model": "discuss.channel",
+                                        "module_icon": "/mail/static/description/icon.png",
+                                    },
+                                ],
+                                "res.partner": [
                                     {
                                         "id": self.env.user.partner_id.id,
                                         "isInternalUser": True,
                                         "is_company": False,
                                         "name": "Ernest Employee",
-                                        "type": "partner",
                                         "userId": self.env.user.id,
                                         "write_date": emp_partner_write_date,
-                                    },
-                                ],
-                                "Thread": [
-                                    {
-                                        "id": channel.id,
-                                        "model": "discuss.channel",
-                                        "module_icon": "/mail/static/description/icon.png",
                                     },
                                 ],
                             },
@@ -143,7 +139,8 @@ class TestChannelInternals(MailCommon, HttpCase):
                     {
                         "type": "mail.record/insert",
                         "payload": {
-                            "ChannelMember": [
+                            "discuss.channel": [{"id": channel.id, "memberCount": 2}],
+                            "discuss.channel.member": [
                                 {
                                     "create_date": fields.Datetime.to_string(member.create_date),
                                     "fetched_message_id": False,
@@ -154,27 +151,21 @@ class TestChannelInternals(MailCommon, HttpCase):
                                     "thread": {"id": channel.id, "model": "discuss.channel"},
                                 },
                             ],
-                            "Persona": [
-                                self._filter_persona_fields({
-                                    "active": True,
-                                    "email": "test_customer@example.com",
-                                    "id": self.test_partner.id,
-                                    "im_status": "im_partner",
-                                    "isInternalUser": False,
-                                    "is_company": False,
-                                    "name": "Test Partner",
-                                    "out_of_office_date_end": False,
-                                    "type": "partner",
-                                    "userId": False,
-                                    "write_date": test_partner_write_date,
-                                }),
-                            ],
-                            "Thread": [
-                                {
-                                    "id": channel.id,
-                                    "memberCount": 2,
-                                    "model": "discuss.channel",
-                                },
+                            "res.partner": [
+                                self._filter_persona_fields(
+                                    {
+                                        "active": True,
+                                        "email": "test_customer@example.com",
+                                        "id": self.test_partner.id,
+                                        "im_status": "im_partner",
+                                        "isInternalUser": False,
+                                        "is_company": False,
+                                        "name": "Test Partner",
+                                        "out_of_office_date_end": False,
+                                        "userId": False,
+                                        "write_date": test_partner_write_date,
+                                    }
+                                ),
                             ],
                         },
                     },
@@ -194,7 +185,8 @@ class TestChannelInternals(MailCommon, HttpCase):
                     {
                         "type": "mail.record/insert",
                         "payload": {
-                            "ChannelMember": [
+                            "discuss.channel": [{"id": channel.id, "memberCount": 2}],
+                            "discuss.channel.member": [
                                 {
                                     "create_date": fields.Datetime.to_string(member.create_date),
                                     "fetched_message_id": False,
@@ -205,27 +197,21 @@ class TestChannelInternals(MailCommon, HttpCase):
                                     "thread": {"id": channel.id, "model": "discuss.channel"},
                                 }
                             ],
-                            "Persona": [
-                                self._filter_persona_fields({
-                                    "active": True,
-                                    "email": "test_customer@example.com",
-                                    "id": self.test_partner.id,
-                                    "im_status": "im_partner",
-                                    "isInternalUser": False,
-                                    "is_company": False,
-                                    "name": "Test Partner",
-                                    "out_of_office_date_end": False,
-                                    "type": "partner",
-                                    "userId": False,
-                                    "write_date": test_partner_write_date,
-                                }),
-                            ],
-                            "Thread": [
-                                {
-                                    "id": channel.id,
-                                    "memberCount": 2,
-                                    "model": "discuss.channel",
-                                }
+                            "res.partner": [
+                                self._filter_persona_fields(
+                                    {
+                                        "active": True,
+                                        "email": "test_customer@example.com",
+                                        "id": self.test_partner.id,
+                                        "im_status": "im_partner",
+                                        "isInternalUser": False,
+                                        "is_company": False,
+                                        "name": "Test Partner",
+                                        "out_of_office_date_end": False,
+                                        "userId": False,
+                                        "write_date": test_partner_write_date,
+                                    }
+                                ),
                             ],
                         },
                     },
@@ -320,21 +306,21 @@ class TestChannelInternals(MailCommon, HttpCase):
         # `channel_get` should return a new channel the first time a partner is given
         channel = self.env["discuss.channel"].channel_get(partners_to=self.test_partner.ids)
         init_data = Store(channel).get_result()
-        initial_channel_info = init_data["Thread"][0]
+        initial_channel_info = init_data["discuss.channel"][0]
         self.assertEqual(
-            {persona["id"] for persona in init_data["Persona"]},
+            {persona["id"] for persona in init_data["res.partner"]},
             {self.partner_employee_nomail.id, self.test_partner.id}
         )
 
         # `channel_get` should return the existing channel every time the same partner is given
         same_channel = self.env['discuss.channel'].channel_get(partners_to=self.test_partner.ids)
-        same_channel_info = Store(same_channel).get_result()["Thread"][0]
+        same_channel_info = Store(same_channel).get_result()["discuss.channel"][0]
         self.assertEqual(same_channel_info['id'], initial_channel_info['id'])
 
         # `channel_get` should return the existing channel when the current partner is given together with the other partner
         together_pids = (self.partner_employee_nomail + self.test_partner).ids
         together_channel = self.env['discuss.channel'].channel_get(partners_to=together_pids)
-        together_channel_info = Store(together_channel).get_result()["Thread"][0]
+        together_channel_info = Store(together_channel).get_result()["discuss.channel"][0]
         self.assertEqual(together_channel_info['id'], initial_channel_info['id'])
 
         # `channel_get` should return a new channel the first time just the current partner is given,
@@ -342,17 +328,17 @@ class TestChannelInternals(MailCommon, HttpCase):
         solo_pids = self.partner_employee_nomail.ids
         solo_channel = self.env['discuss.channel'].channel_get(partners_to=solo_pids)
         solo_channel_data = Store(solo_channel).get_result()
-        solo_channel_info = solo_channel_data["Thread"][0]
+        solo_channel_info = solo_channel_data["discuss.channel"][0]
         self.assertNotEqual(solo_channel_info['id'], initial_channel_info['id'])
         self.assertEqual(
-            {persona["id"] for persona in solo_channel_data["Persona"]},
+            {persona["id"] for persona in solo_channel_data["res.partner"]},
             {self.partner_employee_nomail.id},
         )
 
         # `channel_get` should return the existing channel every time the current partner is given
         same_solo_pids = self.partner_employee_nomail.ids
         same_solo_channel = self.env['discuss.channel'].channel_get(partners_to=same_solo_pids)
-        same_solo_channel_info = Store(same_solo_channel).get_result()["Thread"][0]
+        same_solo_channel_info = Store(same_solo_channel).get_result()["discuss.channel"][0]
         self.assertEqual(same_solo_channel_info['id'], solo_channel_info['id'])
 
     # `channel_get` will pin the channel by default and thus last interest will be updated.
@@ -386,7 +372,9 @@ class TestChannelInternals(MailCommon, HttpCase):
         self_member = chat.channel_member_ids.filtered(lambda m: m.partner_id == self.user_admin.partner_id)
         self_member._mark_as_read(msg_2.id)
         init_data = Store(chat).get_result()
-        self_member_info = next(filter(lambda d: d['id'] == self_member.id, init_data["ChannelMember"]))
+        self_member_info = next(
+            filter(lambda d: d["id"] == self_member.id, init_data["discuss.channel.member"])
+        )
         self.assertEqual(
             self_member_info['seen_message_id']['id'],
             msg_2.id,
@@ -394,7 +382,9 @@ class TestChannelInternals(MailCommon, HttpCase):
         )
         self_member._mark_as_read(msg_1.id)
         final_data = Store(chat).get_result()
-        self_member_info = next(filter(lambda d: d['id'] == self_member.id, final_data["ChannelMember"]))
+        self_member_info = next(
+            filter(lambda d: d["id"] == self_member.id, final_data["discuss.channel.member"])
+        )
         self.assertEqual(
             self_member_info['seen_message_id']['id'],
             msg_2.id,
@@ -418,7 +408,7 @@ class TestChannelInternals(MailCommon, HttpCase):
                 {
                     "type": "mail.record/insert",
                     "payload": {
-                        "ChannelMember": [
+                        "discuss.channel.member": [
                             {
                                 "id": member.id,
                                 "message_unread_counter": 0,
@@ -432,11 +422,10 @@ class TestChannelInternals(MailCommon, HttpCase):
                                 },
                             },
                         ],
-                        "Persona": [
+                        "res.partner": [
                             {
                                 "id": self.user_admin.partner_id.id,
                                 "name": self.user_admin.partner_id.name,
-                                "type": "partner",
                             },
                         ],
                     },
@@ -444,7 +433,7 @@ class TestChannelInternals(MailCommon, HttpCase):
                 {
                     "type": "mail.record/insert",
                     "payload": {
-                        "ChannelMember": [
+                        "discuss.channel.member": [
                             {
                                 "id": member.id,
                                 "persona": {"id": self.user_admin.partner_id.id, "type": "partner"},
@@ -452,11 +441,10 @@ class TestChannelInternals(MailCommon, HttpCase):
                                 "thread": {"id": chat.id, "model": "discuss.channel"},
                             },
                         ],
-                        "Persona": [
+                        "res.partner": [
                             {
                                 "id": self.user_admin.partner_id.id,
                                 "name": self.user_admin.partner_id.name,
-                                "type": "partner",
                             },
                         ],
                     },
@@ -596,17 +584,13 @@ class TestChannelInternals(MailCommon, HttpCase):
         channel = self.env['discuss.channel'].create({"name": "test", "description": "test"})
         self.env['bus.bus'].search([]).unlink()
         with self.assertBus(
-            [(self.cr.dbname, 'discuss.channel', channel.id)],
-            [{
-                "type": "mail.record/insert",
-                "payload": {
-                    'Thread': {
-                        "id": channel.id,
-                        "model": "discuss.channel",
-                        "name": "test test",
-                    }
-                },
-            }]
+            [(self.cr.dbname, "discuss.channel", channel.id)],
+            [
+                {
+                    "type": "mail.record/insert",
+                    "payload": {"discuss.channel": [{"id": channel.id, "name": "test test"}]},
+                }
+            ],
         ):
             channel.name = "test test"
 
@@ -618,17 +602,15 @@ class TestChannelInternals(MailCommon, HttpCase):
         channel.image_128 = False
         self.env['bus.bus'].search([]).unlink()
         with self.assertBus(
-            [(self.cr.dbname, 'discuss.channel', channel.id)],
-            [{
-                "type": "mail.record/insert",
-                "payload": {
-                    'Thread': {
-                        "id": channel.id,
-                        'model': "discuss.channel",
-                        "avatarCacheKey": avatar_cache_key,
-                    }
-                },
-            }]
+            [(self.cr.dbname, "discuss.channel", channel.id)],
+            [
+                {
+                    "type": "mail.record/insert",
+                    "payload": {
+                        "discuss.channel": [{"avatarCacheKey": avatar_cache_key, "id": channel.id}],
+                    },
+                }
+            ],
         ):
             channel.image_128 = base64.b64encode(("<svg/>").encode())
 

--- a/addons/mail/tests/discuss/test_discuss_channel_member.py
+++ b/addons/mail/tests/discuss/test_discuss_channel_member.py
@@ -224,8 +224,8 @@ class TestDiscussChannelMember(MailCommon):
         data = self.env["res.partner"].search_for_channel_invite(
             partner.name, channel_id=self.public_channel.id
         )["data"]
-        self.assertEqual(len(data["Persona"]), 1)
-        self.assertEqual(data["Persona"][0]["id"], partner.id)
+        self.assertEqual(len(data["res.partner"]), 1)
+        self.assertEqual(data["res.partner"][0]["id"], partner.id)
 
     # ------------------------------------------------------------
     # UNREAD COUNTER TESTS

--- a/addons/mail/tests/discuss/test_message_controller.py
+++ b/addons/mail/tests/discuss/test_message_controller.py
@@ -97,7 +97,7 @@ class TestMessageController(HttpCaseWithUserDemo):
         self.assertEqual(res2.status_code, 200)
         data1 = res2.json()["result"]
         self.assertEqual(
-            data1["Attachment"],
+            data1["ir.attachment"],
             [
                     {
                     "checksum": False,
@@ -120,7 +120,7 @@ class TestMessageController(HttpCaseWithUserDemo):
             data=json.dumps(
                 {
                     "params": {
-                        "message_id": data1["Message"][0]["id"],
+                        "message_id": data1["mail.message"][0]["id"],
                         "body": "test",
                         "attachment_ids": [self.attachments[1].id],
                         "attachment_tokens": ["wrong token"],
@@ -141,7 +141,7 @@ class TestMessageController(HttpCaseWithUserDemo):
             data=json.dumps(
                 {
                     "params": {
-                        "message_id": data1["Message"][0]["id"],
+                        "message_id": data1["mail.message"][0]["id"],
                         "body": "test",
                         "attachment_ids": [self.attachments[1].id],
                         "attachment_tokens": [self.attachments[1].access_token],
@@ -153,7 +153,7 @@ class TestMessageController(HttpCaseWithUserDemo):
         self.assertEqual(res4.status_code, 200)
         data2 = res4.json()["result"]
         self.assertEqual(
-            data2["Attachment"],
+            data2["ir.attachment"],
             [
                 {
                     "checksum": False,
@@ -188,7 +188,7 @@ class TestMessageController(HttpCaseWithUserDemo):
             data=json.dumps(
                 {
                     "params": {
-                        "message_id": data2["Message"][0]["id"],
+                        "message_id": data2["mail.message"][0]["id"],
                         "body": "test",
                         "attachment_ids": [self.attachments[1].id],
                     },
@@ -199,7 +199,7 @@ class TestMessageController(HttpCaseWithUserDemo):
         self.assertEqual(res5.status_code, 200)
         data3 = res5.json()["result"]
         self.assertEqual(
-            data3["Attachment"],
+            data3["ir.attachment"],
             [
                 {
                     "checksum": False,
@@ -463,7 +463,7 @@ class TestMessageController(HttpCaseWithUserDemo):
                 "body": "A great message",
             }
         })
-        self.assertIn("A great message", data["Message"][0]["body"])
+        self.assertIn("A great message", data["mail.message"][0]["body"])
 
         # 2. attach a file
         response = self.url_open(

--- a/addons/mail/tests/discuss/test_rtc.py
+++ b/addons/mail/tests/discuss/test_rtc.py
@@ -24,24 +24,22 @@ class TestChannelRTC(MailCommon):
         self.env['bus.bus'].sudo().search([]).unlink()
         with self.assertBus(
             [
-                (self.cr.dbname, 'discuss.channel', channel.id),  # update sessions
-                (self.cr.dbname, 'res.partner', self.user_employee.partner_id.id),  # end of previous session
-                (self.cr.dbname, 'discuss.channel', channel.id),  # update sessions
+                (self.cr.dbname, "discuss.channel", channel.id),  # update sessions
+                # end of previous session
+                (self.cr.dbname, "res.partner", self.user_employee.partner_id.id),
+                (self.cr.dbname, "discuss.channel", channel.id),  # update sessions
             ],
             [
                 {
-                    'type': 'discuss.channel.rtc.session/ended',
-                    'payload': {
-                        'sessionId': channel_member.rtc_session_ids.id,
-                    },
+                    "type": "discuss.channel.rtc.session/ended",
+                    "payload": {"sessionId": channel_member.rtc_session_ids.id},
                 },
                 {
                     "type": "mail.record/insert",
                     "payload": {
-                        "Thread": [
+                        "discuss.channel": [
                             {
                                 "id": channel.id,
-                                "model": "discuss.channel",
                                 "rtcSessions": [
                                     ("DELETE", [{"id": channel_member.rtc_session_ids.id}]),
                                 ],
@@ -52,7 +50,15 @@ class TestChannelRTC(MailCommon):
                 {
                     "type": "mail.record/insert",
                     "payload": {
-                        "ChannelMember": [
+                        "discuss.channel": [
+                            {
+                                "id": channel.id,
+                                "rtcSessions": [
+                                    ("ADD", [{"id": channel_member.rtc_session_ids.id + 1}]),
+                                ],
+                            },
+                        ],
+                        "discuss.channel.member": [
                             {
                                 "id": channel_member.id,
                                 "persona": {"id": channel_member.partner_id.id, "type": "partner"},
@@ -62,27 +68,17 @@ class TestChannelRTC(MailCommon):
                                 },
                             },
                         ],
-                        "Persona": [
-                            {
-                                "id": channel_member.partner_id.id,
-                                "im_status": channel_member.partner_id.im_status,
-                                "name": channel_member.partner_id.name,
-                                "type": "partner",
-                            },
-                        ],
-                        "RtcSession": [
+                        "discuss.channel.rtc.session": [
                             {
                                 "channelMember": {"id": channel_member.id},
                                 "id": channel_member.rtc_session_ids.id + 1,
                             },
                         ],
-                        "Thread": [
+                        "res.partner": [
                             {
-                                "id": channel.id,
-                                "model": "discuss.channel",
-                                "rtcSessions": [
-                                    ("ADD", [{"id": channel_member.rtc_session_ids.id + 1}]),
-                                ],
+                                "id": channel_member.partner_id.id,
+                                "im_status": channel_member.partner_id.im_status,
+                                "name": channel_member.partner_id.name,
                             },
                         ],
                     },
@@ -95,7 +91,16 @@ class TestChannelRTC(MailCommon):
         self.assertEqual(
             res,
             {
-                "ChannelMember": [
+                "discuss.channel": [
+                    {
+                        "id": channel.id,
+                        "rtcSessions": [
+                            ("ADD", [{"id": channel_member.rtc_session_ids.id}]),
+                            ("DELETE", [{"id": channel_member.rtc_session_ids.id - 1}]),
+                        ],
+                    },
+                ],
+                "discuss.channel.member": [
                     {
                         "id": channel_member.id,
                         "persona": {"id": channel_member.partner_id.id, "type": "partner"},
@@ -105,12 +110,17 @@ class TestChannelRTC(MailCommon):
                         },
                     },
                 ],
-                "Persona": [
+                "discuss.channel.rtc.session": [
+                    {
+                        "channelMember": {"id": channel_member.id},
+                        "id": channel_member.rtc_session_ids.id,
+                    },
+                ],
+                "res.partner": [
                     {
                         "id": channel_member.partner_id.id,
                         "im_status": channel_member.partner_id.im_status,
                         "name": channel_member.partner_id.name,
-                        "type": "partner",
                     },
                 ],
                 "Rtc": {
@@ -118,22 +128,6 @@ class TestChannelRTC(MailCommon):
                     "selfSession": {"id": channel_member.rtc_session_ids.id},
                     "serverInfo": None,
                 },
-                "RtcSession": [
-                    {
-                        "channelMember": {"id": channel_member.id},
-                        "id": channel_member.rtc_session_ids.id,
-                    },
-                ],
-                "Thread": [
-                    {
-                        "id": channel.id,
-                        "model": "discuss.channel",
-                        "rtcSessions": [
-                            ("ADD", [{"id": channel_member.rtc_session_ids.id}]),
-                            ("DELETE", [{"id": channel_member.rtc_session_ids.id - 1}]),
-                        ],
-                    },
-                ],
             },
         )
 
@@ -163,7 +157,13 @@ class TestChannelRTC(MailCommon):
                 {
                     "type": "mail.record/insert",
                     "payload": {
-                        "ChannelMember": [
+                        "discuss.channel": [
+                            {
+                                "id": channel.id,
+                                "rtcSessions": [("ADD", [{"id": last_rtc_session_id + 1}])],
+                            },
+                        ],
+                        "discuss.channel.member": [
                             {
                                 "id": channel_member.id,
                                 "persona": {"id": channel_member.partner_id.id, "type": "partner"},
@@ -173,25 +173,17 @@ class TestChannelRTC(MailCommon):
                                 },
                             },
                         ],
-                        "Persona": [
-                            {
-                                "id": channel_member.partner_id.id,
-                                "im_status": channel_member.partner_id.im_status,
-                                "name": channel_member.partner_id.name,
-                                "type": "partner",
-                            },
-                        ],
-                        "RtcSession": [
+                        "discuss.channel.rtc.session": [
                             {
                                 "channelMember": {"id": channel_member.id},
                                 "id": last_rtc_session_id + 1,
                             },
                         ],
-                        "Thread": [
+                        "res.partner": [
                             {
-                                "id": channel.id,
-                                "model": "discuss.channel",
-                                "rtcSessions": [("ADD", [{"id": last_rtc_session_id + 1}])],
+                                "id": channel_member.partner_id.id,
+                                "im_status": channel_member.partner_id.im_status,
+                                "name": channel_member.partner_id.name,
                             },
                         ],
                     },
@@ -199,7 +191,13 @@ class TestChannelRTC(MailCommon):
                 {
                     "type": "mail.record/insert",
                     "payload": {
-                        "ChannelMember": [
+                        "discuss.channel": [
+                            {
+                                "id": channel.id,
+                                "invitedMembers": [("ADD", [{"id": channel_member_test_user.id}])],
+                            }
+                        ],
+                        "discuss.channel.member": [
                             {
                                 "id": channel_member_test_user.id,
                                 "persona": {
@@ -212,20 +210,12 @@ class TestChannelRTC(MailCommon):
                                 },
                             },
                         ],
-                        "Persona": [
+                        "res.partner": [
                             {
                                 "id": channel_member_test_user.partner_id.id,
                                 "im_status": channel_member_test_user.partner_id.im_status,
                                 "name": channel_member_test_user.partner_id.name,
-                                "type": "partner",
                             },
-                        ],
-                        "Thread": [
-                            {
-                                "id": channel.id,
-                                "invitedMembers": [("ADD", [{"id": channel_member_test_user.id}])],
-                                "model": "discuss.channel",
-                            }
                         ],
                     },
                 },
@@ -265,7 +255,13 @@ class TestChannelRTC(MailCommon):
                 {
                     "type": "mail.record/insert",
                     "payload": {
-                        "ChannelMember": [
+                        "discuss.channel": [
+                            {
+                                "id": channel.id,
+                                "rtcSessions": [("ADD", [{"id": last_rtc_session_id + 1}])],
+                            },
+                        ],
+                        "discuss.channel.member": [
                             {
                                 "id": channel_member.id,
                                 "persona": {"id": channel_member.partner_id.id, "type": "partner"},
@@ -275,25 +271,17 @@ class TestChannelRTC(MailCommon):
                                 },
                             },
                         ],
-                        "Persona": [
-                            {
-                                "id": channel_member.partner_id.id,
-                                "im_status": channel_member.partner_id.im_status,
-                                "name": channel_member.partner_id.name,
-                                "type": "partner",
-                            },
-                        ],
-                        "RtcSession": [
+                        "discuss.channel.rtc.session": [
                             {
                                 "channelMember": {"id": channel_member.id},
                                 "id": last_rtc_session_id + 1,
                             },
                         ],
-                        "Thread": [
+                        "res.partner": [
                             {
-                                "id": channel.id,
-                                "model": "discuss.channel",
-                                "rtcSessions": [("ADD", [{"id": last_rtc_session_id + 1}])],
+                                "id": channel_member.partner_id.id,
+                                "im_status": channel_member.partner_id.im_status,
+                                "name": channel_member.partner_id.name,
                             },
                         ],
                     },
@@ -301,7 +289,13 @@ class TestChannelRTC(MailCommon):
                 {
                     "type": "mail.record/insert",
                     "payload": {
-                        "ChannelMember": [
+                        "discuss.channel": [
+                            {
+                                "id": channel.id,
+                                "rtcSessions": [("ADD", [{"id": last_rtc_session_id + 1}])],
+                            },
+                        ],
+                        "discuss.channel.member": [
                             {
                                 "id": channel_member.id,
                                 "persona": {"id": channel_member.partner_id.id, "type": "partner"},
@@ -311,25 +305,17 @@ class TestChannelRTC(MailCommon):
                                 },
                             },
                         ],
-                        "Persona": [
-                            {
-                                "id": channel_member.partner_id.id,
-                                "im_status": channel_member.partner_id.im_status,
-                                "name": channel_member.partner_id.name,
-                                "type": "partner",
-                            },
-                        ],
-                        "RtcSession": [
+                        "discuss.channel.rtc.session": [
                             {
                                 "channelMember": {"id": channel_member.id},
                                 "id": last_rtc_session_id + 1,
                             },
                         ],
-                        "Thread": [
+                        "res.partner": [
                             {
-                                "id": channel.id,
-                                "model": "discuss.channel",
-                                "rtcSessions": [("ADD", [{"id": last_rtc_session_id + 1}])],
+                                "id": channel_member.partner_id.id,
+                                "im_status": channel_member.partner_id.im_status,
+                                "name": channel_member.partner_id.name,
                             },
                         ],
                     },
@@ -337,7 +323,21 @@ class TestChannelRTC(MailCommon):
                 {
                     "type": "mail.record/insert",
                     "payload": {
-                        "ChannelMember": [
+                        "discuss.channel": [
+                            {
+                                "id": channel.id,
+                                "invitedMembers": [
+                                    (
+                                        "ADD",
+                                        [
+                                            {"id": channel_member_test_user.id},
+                                            {"id": channel_member_test_guest.id},
+                                        ],
+                                    )
+                                ],
+                            },
+                        ],
+                        "discuss.channel.member": [
                             {
                                 "id": channel_member_test_user.id,
                                 "persona": {
@@ -361,33 +361,18 @@ class TestChannelRTC(MailCommon):
                                 },
                             },
                         ],
-                        "Persona": [
-                            {
-                                "id": channel_member_test_user.partner_id.id,
-                                "im_status": channel_member_test_user.partner_id.im_status,
-                                "name": channel_member_test_user.partner_id.name,
-                                "type": "partner",
-                            },
+                        "mail.guest": [
                             {
                                 "id": channel_member_test_guest.guest_id.id,
                                 "im_status": channel_member_test_guest.guest_id.im_status,
                                 "name": channel_member_test_guest.guest_id.name,
-                                "type": "guest",
                             },
                         ],
-                        "Thread": [
+                        "res.partner": [
                             {
-                                "id": channel.id,
-                                "invitedMembers": [
-                                    (
-                                        "ADD",
-                                        [
-                                            {"id": channel_member_test_user.id},
-                                            {"id": channel_member_test_guest.id},
-                                        ],
-                                    )
-                                ],
-                                "model": "discuss.channel",
+                                "id": channel_member_test_user.partner_id.id,
+                                "im_status": channel_member_test_user.partner_id.im_status,
+                                "name": channel_member_test_user.partner_id.name,
                             },
                         ],
                     },
@@ -412,62 +397,29 @@ class TestChannelRTC(MailCommon):
         self.env['bus.bus'].sudo().search([]).unlink()
         with self.assertBus(
             [
-                (self.cr.dbname, 'res.partner', test_user.partner_id.id),  # update invitation
-                (self.cr.dbname, 'discuss.channel', channel.id),  # update list of invitations
-                (self.cr.dbname, 'discuss.channel', channel.id),  # update sessions
+                (self.cr.dbname, "res.partner", test_user.partner_id.id),  # update invitation
+                (self.cr.dbname, "discuss.channel", channel.id),  # update list of invitations
+                (self.cr.dbname, "discuss.channel", channel.id),  # update sessions
             ],
             [
                 {
                     "type": "mail.record/insert",
                     "payload": {
-                        "Thread": [
-                            {
-                                "id": channel.id,
-                                "model": "discuss.channel",
-                                "rtcInvitingSession": False,
-                            },
-                        ],
+                        "discuss.channel": [{"id": channel.id, "rtcInvitingSession": False}]
                     },
                 },
                 {
                     "type": "mail.record/insert",
                     "payload": {
-                        "ChannelMember": [
-                            {
-                                "id": channel_member_test_user.id,
-                                "persona": {
-                                    "id": channel_member_test_user.partner_id.id,
-                                    "type": "partner",
-                                },
-                                "thread": {
-                                    "id": channel_member_test_user.channel_id.id,
-                                    "model": "discuss.channel",
-                                },
-                            },
-                        ],
-                        "Persona": [
-                            {
-                                "id": channel_member_test_user.partner_id.id,
-                                "im_status": channel_member_test_user.partner_id.im_status,
-                                "name": channel_member_test_user.partner_id.name,
-                                "type": "partner",
-                            },
-                        ],
-                        "Thread": [
+                        "discuss.channel": [
                             {
                                 "id": channel.id,
                                 "invitedMembers": [
-                                    ("DELETE", [{"id": channel_member_test_user.id}]),
+                                    ("DELETE", [{"id": channel_member_test_user.id}])
                                 ],
-                                "model": "discuss.channel",
                             },
                         ],
-                    },
-                },
-                {
-                    "type": "mail.record/insert",
-                    "payload": {
-                        "ChannelMember": [
+                        "discuss.channel.member": [
                             {
                                 "id": channel_member_test_user.id,
                                 "persona": {
@@ -480,27 +432,50 @@ class TestChannelRTC(MailCommon):
                                 },
                             },
                         ],
-                        "Persona": [
+                        "res.partner": [
                             {
                                 "id": channel_member_test_user.partner_id.id,
                                 "im_status": channel_member_test_user.partner_id.im_status,
                                 "name": channel_member_test_user.partner_id.name,
-                                "type": "partner",
                             },
                         ],
-                        "RtcSession": [
+                    },
+                },
+                {
+                    "type": "mail.record/insert",
+                    "payload": {
+                        "discuss.channel": [
+                            {
+                                "id": channel.id,
+                                "rtcSessions": [
+                                    ("ADD", [{"id": channel_member.rtc_session_ids.id + 1}]),
+                                ],
+                            },
+                        ],
+                        "discuss.channel.member": [
+                            {
+                                "id": channel_member_test_user.id,
+                                "persona": {
+                                    "id": channel_member_test_user.partner_id.id,
+                                    "type": "partner",
+                                },
+                                "thread": {
+                                    "id": channel_member_test_user.channel_id.id,
+                                    "model": "discuss.channel",
+                                },
+                            },
+                        ],
+                        "discuss.channel.rtc.session": [
                             {
                                 "channelMember": {"id": channel_member_test_user.id},
                                 "id": channel_member.rtc_session_ids.id + 1,
                             },
                         ],
-                        "Thread": [
+                        "res.partner": [
                             {
-                                "id": channel.id,
-                                "model": "discuss.channel",
-                                "rtcSessions": [
-                                    ("ADD", [{"id": channel_member.rtc_session_ids.id + 1}]),
-                                ],
+                                "id": channel_member_test_user.partner_id.id,
+                                "im_status": channel_member_test_user.partner_id.im_status,
+                                "name": channel_member_test_user.partner_id.name,
                             },
                         ],
                     },
@@ -513,62 +488,29 @@ class TestChannelRTC(MailCommon):
         self.env['bus.bus'].sudo().search([]).unlink()
         with self.assertBus(
             [
-                (self.cr.dbname, 'mail.guest', test_guest.id),  # update invitation
-                (self.cr.dbname, 'discuss.channel', channel.id),  # update list of invitations
-                (self.cr.dbname, 'discuss.channel', channel.id),  # update sessions
+                (self.cr.dbname, "mail.guest", test_guest.id),  # update invitation
+                (self.cr.dbname, "discuss.channel", channel.id),  # update list of invitations
+                (self.cr.dbname, "discuss.channel", channel.id),  # update sessions
             ],
             [
                 {
                     "type": "mail.record/insert",
                     "payload": {
-                        "Thread": [
-                            {
-                                "id": channel.id,
-                                "model": "discuss.channel",
-                                "rtcInvitingSession": False,
-                            },
-                        ],
+                        "discuss.channel": [{"id": channel.id, "rtcInvitingSession": False}]
                     },
                 },
                 {
                     "type": "mail.record/insert",
                     "payload": {
-                        "ChannelMember": [
-                            {
-                                "id": channel_member_test_guest.id,
-                                "persona": {
-                                    "id": channel_member_test_guest.guest_id.id,
-                                    "type": "guest",
-                                },
-                                "thread": {
-                                    "id": channel_member_test_guest.channel_id.id,
-                                    "model": "discuss.channel",
-                                },
-                            },
-                        ],
-                        "Persona": [
-                            {
-                                "id": channel_member_test_guest.guest_id.id,
-                                "im_status": channel_member_test_guest.guest_id.im_status,
-                                "name": channel_member_test_guest.guest_id.name,
-                                "type": "guest",
-                            },
-                        ],
-                        "Thread": [
+                        "discuss.channel": [
                             {
                                 "id": channel.id,
                                 "invitedMembers": [
                                     ("DELETE", [{"id": channel_member_test_guest.id}]),
                                 ],
-                                "model": "discuss.channel",
                             },
                         ],
-                    },
-                },
-                {
-                    "type": "mail.record/insert",
-                    "payload": {
-                        "ChannelMember": [
+                        "discuss.channel.member": [
                             {
                                 "id": channel_member_test_guest.id,
                                 "persona": {
@@ -581,27 +523,50 @@ class TestChannelRTC(MailCommon):
                                 },
                             },
                         ],
-                        "Persona": [
+                        "mail.guest": [
                             {
                                 "id": channel_member_test_guest.guest_id.id,
                                 "im_status": channel_member_test_guest.guest_id.im_status,
                                 "name": channel_member_test_guest.guest_id.name,
-                                "type": "guest",
                             },
                         ],
-                        "RtcSession": [
+                    },
+                },
+                {
+                    "type": "mail.record/insert",
+                    "payload": {
+                        "discuss.channel": [
+                            {
+                                "id": channel.id,
+                                "rtcSessions": [
+                                    ("ADD", [{"id": channel_member.rtc_session_ids.id + 2}]),
+                                ],
+                            },
+                        ],
+                        "discuss.channel.member": [
+                            {
+                                "id": channel_member_test_guest.id,
+                                "persona": {
+                                    "id": channel_member_test_guest.guest_id.id,
+                                    "type": "guest",
+                                },
+                                "thread": {
+                                    "id": channel_member_test_guest.channel_id.id,
+                                    "model": "discuss.channel",
+                                },
+                            },
+                        ],
+                        "discuss.channel.rtc.session": [
                             {
                                 "channelMember": {"id": channel_member_test_guest.id},
                                 "id": channel_member.rtc_session_ids.id + 2,
                             },
                         ],
-                        "Thread": [
+                        "mail.guest": [
                             {
-                                "id": channel.id,
-                                "model": "discuss.channel",
-                                "rtcSessions": [
-                                    ("ADD", [{"id": channel_member.rtc_session_ids.id + 2}]),
-                                ],
+                                "id": channel_member_test_guest.guest_id.id,
+                                "im_status": channel_member_test_guest.guest_id.im_status,
+                                "name": channel_member_test_guest.guest_id.name,
                             },
                         ],
                     },
@@ -624,26 +589,28 @@ class TestChannelRTC(MailCommon):
         self.env['bus.bus'].sudo().search([]).unlink()
         with self.assertBus(
             [
-                (self.cr.dbname, 'res.partner', test_user.partner_id.id),  # update invitation
-                (self.cr.dbname, 'discuss.channel', channel.id),  # update list of invitations
+                (self.cr.dbname, "res.partner", test_user.partner_id.id),  # update invitation
+                (self.cr.dbname, "discuss.channel", channel.id),  # update list of invitations
             ],
             [
                 {
                     "type": "mail.record/insert",
                     "payload": {
-                        "Thread": [
-                            {
-                                "id": channel.id,
-                                "model": "discuss.channel",
-                                "rtcInvitingSession": False,
-                            },
-                        ],
+                        "discuss.channel": [{"id": channel.id, "rtcInvitingSession": False}]
                     },
                 },
                 {
                     "type": "mail.record/insert",
                     "payload": {
-                        "ChannelMember": [
+                        "discuss.channel": [
+                            {
+                                "id": channel.id,
+                                "invitedMembers": [
+                                    ("DELETE", [{"id": channel_member_test_user.id}]),
+                                ],
+                            },
+                        ],
+                        "discuss.channel.member": [
                             {
                                 "id": channel_member_test_user.id,
                                 "persona": {
@@ -656,21 +623,11 @@ class TestChannelRTC(MailCommon):
                                 },
                             },
                         ],
-                        "Persona": [
+                        "res.partner": [
                             {
                                 "id": channel_member_test_user.partner_id.id,
                                 "im_status": channel_member_test_user.partner_id.im_status,
                                 "name": channel_member_test_user.partner_id.name,
-                                "type": "partner",
-                            },
-                        ],
-                        "Thread": [
-                            {
-                                "id": channel.id,
-                                "invitedMembers": [
-                                    ("DELETE", [{"id": channel_member_test_user.id}]),
-                                ],
-                                "model": "discuss.channel",
                             },
                         ],
                     },
@@ -683,26 +640,28 @@ class TestChannelRTC(MailCommon):
         self.env['bus.bus'].sudo().search([]).unlink()
         with self.assertBus(
             [
-                (self.cr.dbname, 'mail.guest', test_guest.id),  # update invitation
-                (self.cr.dbname, 'discuss.channel', channel.id),  # update list of invitations
+                (self.cr.dbname, "mail.guest", test_guest.id),  # update invitation
+                (self.cr.dbname, "discuss.channel", channel.id),  # update list of invitations
             ],
             [
                 {
                     "type": "mail.record/insert",
                     "payload": {
-                        "Thread": [
-                            {
-                                "id": channel.id,
-                                "model": "discuss.channel",
-                                "rtcInvitingSession": False,
-                            },
-                        ],
+                        "discuss.channel": [{"id": channel.id, "rtcInvitingSession": False}]
                     },
                 },
                 {
                     "type": "mail.record/insert",
                     "payload": {
-                        "ChannelMember": [
+                        "discuss.channel": [
+                            {
+                                "id": channel.id,
+                                "invitedMembers": [
+                                    ("DELETE", [{"id": channel_member_test_guest.id}]),
+                                ],
+                            },
+                        ],
+                        "discuss.channel.member": [
                             {
                                 "id": channel_member_test_guest.id,
                                 "persona": {
@@ -715,21 +674,11 @@ class TestChannelRTC(MailCommon):
                                 },
                             },
                         ],
-                        "Persona": [
+                        "mail.guest": [
                             {
                                 "id": channel_member_test_guest.guest_id.id,
                                 "im_status": channel_member_test_guest.guest_id.im_status,
                                 "name": channel_member_test_guest.guest_id.name,
-                                "type": "guest",
-                            },
-                        ],
-                        "Thread": [
-                            {
-                                "id": channel.id,
-                                "invitedMembers": [
-                                    ("DELETE", [{"id": channel_member_test_guest.id}]),
-                                ],
-                                "model": "discuss.channel",
                             },
                         ],
                     },
@@ -753,47 +702,47 @@ class TestChannelRTC(MailCommon):
         self.env['bus.bus'].sudo().search([]).unlink()
         with self.assertBus(
             [
-                (self.cr.dbname, 'res.partner', test_user.partner_id.id),  # update invitation
-                (self.cr.dbname, 'mail.guest', test_guest.id),  # update invitation
-                (self.cr.dbname, 'discuss.channel', channel.id),  # update list of invitations
-                (self.cr.dbname, 'discuss.channel', channel.id),  # update sessions
-                (self.cr.dbname, 'res.partner', self.user_employee.partner_id.id),  # end session
+                (self.cr.dbname, "res.partner", test_user.partner_id.id),  # update invitation
+                (self.cr.dbname, "mail.guest", test_guest.id),  # update invitation
+                (self.cr.dbname, "discuss.channel", channel.id),  # update list of invitations
+                (self.cr.dbname, "discuss.channel", channel.id),  # update sessions
+                (self.cr.dbname, "res.partner", self.user_employee.partner_id.id),  # end session
             ],
             [
                 {
-                    'type': 'discuss.channel.rtc.session/ended',
-                    'payload': {
-                        'sessionId': channel_member.rtc_session_ids.id,
+                    "type": "discuss.channel.rtc.session/ended",
+                    "payload": {"sessionId": channel_member.rtc_session_ids.id},
+                },
+                {
+                    "type": "mail.record/insert",
+                    "payload": {
+                        "discuss.channel": [{"id": channel.id, "rtcInvitingSession": False}]
                     },
                 },
                 {
                     "type": "mail.record/insert",
                     "payload": {
-                        "Thread": [
+                        "discuss.channel": [{"id": channel.id, "rtcInvitingSession": False}]
+                    },
+                },
+                {
+                    "type": "mail.record/insert",
+                    "payload": {
+                        "discuss.channel": [
                             {
                                 "id": channel.id,
-                                "model": "discuss.channel",
-                                "rtcInvitingSession": False,
+                                "invitedMembers": [
+                                    (
+                                        "DELETE",
+                                        [
+                                            {"id": channel_member_test_user.id},
+                                            {"id": channel_member_test_guest.id},
+                                        ],
+                                    )
+                                ],
                             },
                         ],
-                    },
-                },
-                {
-                    "type": "mail.record/insert",
-                    "payload": {
-                        "Thread": [
-                            {
-                                "id": channel.id,
-                                "model": "discuss.channel",
-                                "rtcInvitingSession": False,
-                            },
-                        ],
-                    },
-                },
-                {
-                    "type": "mail.record/insert",
-                    "payload": {
-                        "ChannelMember": [
+                        "discuss.channel.member": [
                             {
                                 "id": channel_member_test_user.id,
                                 "persona": {
@@ -817,33 +766,18 @@ class TestChannelRTC(MailCommon):
                                 },
                             },
                         ],
-                        "Persona": [
-                            {
-                                "id": channel_member_test_user.partner_id.id,
-                                "im_status": channel_member_test_user.partner_id.im_status,
-                                "name": channel_member_test_user.partner_id.name,
-                                "type": "partner",
-                            },
+                        "mail.guest": [
                             {
                                 "id": channel_member_test_guest.guest_id.id,
                                 "im_status": channel_member_test_guest.guest_id.im_status,
                                 "name": channel_member_test_guest.guest_id.name,
-                                "type": "guest",
                             },
                         ],
-                        "Thread": [
+                        "res.partner": [
                             {
-                                "id": channel.id,
-                                "invitedMembers": [
-                                    (
-                                        "DELETE",
-                                        [
-                                            {"id": channel_member_test_user.id},
-                                            {"id": channel_member_test_guest.id},
-                                        ],
-                                    )
-                                ],
-                                "model": "discuss.channel",
+                                "id": channel_member_test_user.partner_id.id,
+                                "im_status": channel_member_test_user.partner_id.im_status,
+                                "name": channel_member_test_user.partner_id.name,
                             },
                         ],
                     },
@@ -851,10 +785,9 @@ class TestChannelRTC(MailCommon):
                 {
                     "type": "mail.record/insert",
                     "payload": {
-                        "Thread": [
+                        "discuss.channel": [
                             {
                                 "id": channel.id,
-                                "model": "discuss.channel",
                                 "rtcSessions": [
                                     ("DELETE", [{"id": channel_member.rtc_session_ids.id}]),
                                 ],
@@ -904,7 +837,13 @@ class TestChannelRTC(MailCommon):
                 {
                     "type": "mail.record/insert",
                     "payload": {
-                        "ChannelMember": [
+                        "discuss.channel": [
+                            {
+                                "id": channel.id,
+                                "rtcInvitingSession": {"id": channel_member.rtc_session_ids.id},
+                            },
+                        ],
+                        "discuss.channel.member": [
                             {
                                 "id": channel_member.id,
                                 "persona": {"id": channel_member.partner_id.id, "type": "partner"},
@@ -914,25 +853,17 @@ class TestChannelRTC(MailCommon):
                                 },
                             },
                         ],
-                        "Persona": [
-                            {
-                                "id": channel_member.partner_id.id,
-                                "im_status": channel_member.partner_id.im_status,
-                                "name": channel_member.partner_id.name,
-                                "type": "partner",
-                            },
-                        ],
-                        "RtcSession": [
+                        "discuss.channel.rtc.session": [
                             {
                                 "channelMember": {"id": channel_member.id},
                                 "id": channel_member.rtc_session_ids.id,
                             },
                         ],
-                        "Thread": [
+                        "res.partner": [
                             {
-                                "id": channel.id,
-                                "model": "discuss.channel",
-                                "rtcInvitingSession": {"id": channel_member.rtc_session_ids.id},
+                                "id": channel_member.partner_id.id,
+                                "im_status": channel_member.partner_id.im_status,
+                                "name": channel_member.partner_id.name,
                             },
                         ],
                     },
@@ -940,7 +871,13 @@ class TestChannelRTC(MailCommon):
                 {
                     "type": "mail.record/insert",
                     "payload": {
-                        "ChannelMember": [
+                        "discuss.channel": [
+                            {
+                                "id": channel.id,
+                                "rtcInvitingSession": {"id": channel_member.rtc_session_ids.id},
+                            },
+                        ],
+                        "discuss.channel.member": [
                             {
                                 "id": channel_member.id,
                                 "persona": {"id": channel_member.partner_id.id, "type": "partner"},
@@ -950,25 +887,17 @@ class TestChannelRTC(MailCommon):
                                 },
                             },
                         ],
-                        "Persona": [
-                            {
-                                "id": channel_member.partner_id.id,
-                                "im_status": channel_member.partner_id.im_status,
-                                "name": channel_member.partner_id.name,
-                                "type": "partner",
-                            },
-                        ],
-                        "RtcSession": [
+                        "discuss.channel.rtc.session": [
                             {
                                 "channelMember": {"id": channel_member.id},
                                 "id": channel_member.rtc_session_ids.id,
                             },
                         ],
-                        "Thread": [
+                        "res.partner": [
                             {
-                                "id": channel.id,
-                                "model": "discuss.channel",
-                                "rtcInvitingSession": {"id": channel_member.rtc_session_ids.id},
+                                "id": channel_member.partner_id.id,
+                                "im_status": channel_member.partner_id.im_status,
+                                "name": channel_member.partner_id.name,
                             },
                         ],
                     },
@@ -976,7 +905,21 @@ class TestChannelRTC(MailCommon):
                 {
                     "type": "mail.record/insert",
                     "payload": {
-                        "ChannelMember": [
+                        "discuss.channel": [
+                            {
+                                "id": channel.id,
+                                "invitedMembers": [
+                                    (
+                                        "ADD",
+                                        [
+                                            {"id": channel_member_test_user.id},
+                                            {"id": channel_member_test_guest.id},
+                                        ],
+                                    )
+                                ],
+                            }
+                        ],
+                        "discuss.channel.member": [
                             {
                                 "id": channel_member_test_user.id,
                                 "persona": {
@@ -1000,34 +943,19 @@ class TestChannelRTC(MailCommon):
                                 },
                             },
                         ],
-                        "Persona": [
-                            {
-                                "id": channel_member_test_user.partner_id.id,
-                                "im_status": channel_member_test_user.partner_id.im_status,
-                                "name": channel_member_test_user.partner_id.name,
-                                "type": "partner",
-                            },
+                        "mail.guest": [
                             {
                                 "id": channel_member_test_guest.guest_id.id,
                                 "im_status": channel_member_test_guest.guest_id.im_status,
                                 "name": channel_member_test_guest.guest_id.name,
-                                "type": "guest",
                             },
                         ],
-                        "Thread": [
+                        "res.partner": [
                             {
-                                "id": channel.id,
-                                "invitedMembers": [
-                                    (
-                                        "ADD",
-                                        [
-                                            {"id": channel_member_test_user.id},
-                                            {"id": channel_member_test_guest.id},
-                                        ],
-                                    )
-                                ],
-                                "model": "discuss.channel",
-                            }
+                                "id": channel_member_test_user.partner_id.id,
+                                "im_status": channel_member_test_user.partner_id.im_status,
+                                "name": channel_member_test_user.partner_id.name,
+                            },
                         ],
                     },
                 },
@@ -1044,23 +972,20 @@ class TestChannelRTC(MailCommon):
         self.env['bus.bus'].sudo().search([]).unlink()
         with self.assertBus(
             [
-                (self.cr.dbname, 'discuss.channel', channel.id),  # update list of sessions
-                (self.cr.dbname, 'res.partner', self.user_employee.partner_id.id),  # end session
+                (self.cr.dbname, "discuss.channel", channel.id),  # update list of sessions
+                (self.cr.dbname, "res.partner", self.user_employee.partner_id.id),  # end session
             ],
             [
                 {
-                    'type': 'discuss.channel.rtc.session/ended',
-                    'payload': {
-                        'sessionId': channel_member.rtc_session_ids.id,
-                    },
+                    "type": "discuss.channel.rtc.session/ended",
+                    "payload": {"sessionId": channel_member.rtc_session_ids.id},
                 },
                 {
                     "type": "mail.record/insert",
                     "payload": {
-                        "Thread": [
+                        "discuss.channel": [
                             {
                                 "id": channel.id,
-                                "model": "discuss.channel",
                                 "rtcSessions": [
                                     ("DELETE", [{"id": channel_member.rtc_session_ids.id}]),
                                 ],
@@ -1086,23 +1011,20 @@ class TestChannelRTC(MailCommon):
         self.env['bus.bus'].sudo().search([]).unlink()
         with self.assertBus(
             [
-                (self.cr.dbname, 'discuss.channel', channel.id),  # update list of sessions
-                (self.cr.dbname, 'res.partner', self.user_employee.partner_id.id),  # session ended
+                (self.cr.dbname, "discuss.channel", channel.id),  # update list of sessions
+                (self.cr.dbname, "res.partner", self.user_employee.partner_id.id),  # session ended
             ],
             [
                 {
-                    'type': 'discuss.channel.rtc.session/ended',
-                    'payload': {
-                        'sessionId': channel_member.rtc_session_ids.id,
-                    },
+                    "type": "discuss.channel.rtc.session/ended",
+                    "payload": {"sessionId": channel_member.rtc_session_ids.id},
                 },
                 {
                     "type": "mail.record/insert",
                     "payload": {
-                        "Thread": [
+                        "discuss.channel": [
                             {
                                 "id": channel.id,
-                                "model": "discuss.channel",
                                 "rtcSessions": [
                                     ("DELETE", [{"id": channel_member.rtc_session_ids.id}]),
                                 ],
@@ -1124,23 +1046,20 @@ class TestChannelRTC(MailCommon):
         self.env['bus.bus'].sudo().search([]).unlink()
         with self.assertBus(
             [
-                (self.cr.dbname, 'discuss.channel', channel.id),  # update list of sessions
-                (self.cr.dbname, 'res.partner', self.user_employee.partner_id.id),  # session ended
+                (self.cr.dbname, "discuss.channel", channel.id),  # update list of sessions
+                (self.cr.dbname, "res.partner", self.user_employee.partner_id.id),  # session ended
             ],
             [
                 {
-                    'type': 'discuss.channel.rtc.session/ended',
-                    'payload': {
-                        'sessionId': channel_member.rtc_session_ids.id,
-                    },
+                    "type": "discuss.channel.rtc.session/ended",
+                    "payload": {"sessionId": channel_member.rtc_session_ids.id},
                 },
                 {
                     "type": "mail.record/insert",
                     "payload": {
-                        "Thread": [
+                        "discuss.channel": [
                             {
                                 "id": channel.id,
-                                "model": "discuss.channel",
                                 "rtcSessions": [
                                     ("DELETE", [{"id": channel_member.rtc_session_ids.id}]),
                                 ],
@@ -1173,23 +1092,20 @@ class TestChannelRTC(MailCommon):
         self.env['bus.bus'].sudo().search([]).unlink()
         with self.assertBus(
             [
-                (self.cr.dbname, 'discuss.channel', channel.id),  # update list of sessions
-                (self.cr.dbname, 'mail.guest', test_guest.id),  # session ended
+                (self.cr.dbname, "discuss.channel", channel.id),  # update list of sessions
+                (self.cr.dbname, "mail.guest", test_guest.id),  # session ended
             ],
             [
                 {
-                    'type': 'discuss.channel.rtc.session/ended',
-                    'payload': {
-                        'sessionId': test_session.id,
-                    },
+                    "type": "discuss.channel.rtc.session/ended",
+                    "payload": {"sessionId": test_session.id},
                 },
                 {
                     "type": "mail.record/insert",
                     "payload": {
-                        "Thread": [
+                        "discuss.channel": [
                             {
                                 "id": channel.id,
-                                "model": "discuss.channel",
                                 "rtcSessions": [("DELETE", [{"id": test_session.id}])],
                             },
                         ],

--- a/addons/mail/tests/test_discuss_tools.py
+++ b/addons/mail/tests/test_discuss_tools.py
@@ -172,31 +172,31 @@ class TestDiscussTools(TransactionCase):
     def test_210_store_thread_dict(self):
         """Test Thread dict is present in result."""
         store = Store()
-        store.add("Thread", {"id": 1, "model": "res.partner", "test": True})
+        store.add("mail.thread", {"id": 1, "model": "res.partner", "test": True})
         self.assertEqual(
-            store.get_result(), {"Thread": [{"id": 1, "model": "res.partner", "test": True}]}
+            store.get_result(), {"mail.thread": [{"id": 1, "model": "res.partner", "test": True}]}
         )
 
     def test_211_store_thread_dict_update_same_id(self):
         """Test Thread dict update same id."""
         store = Store()
-        store.add("Thread", {"id": 1, "model": "res.partner", "test": True})
-        store.add("Thread", {"id": 1, "model": "res.partner", "test": False, "abc": 1})
+        store.add("mail.thread", {"id": 1, "model": "res.partner", "test": True})
+        store.add("mail.thread", {"id": 1, "model": "res.partner", "test": False, "abc": 1})
         self.assertEqual(
             store.get_result(),
-            {"Thread": [{"id": 1, "model": "res.partner", "test": False, "abc": 1}]},
+            {"mail.thread": [{"id": 1, "model": "res.partner", "test": False, "abc": 1}]},
         )
 
     def test_212_store_thread_dict_update_multiple_ids(self):
         """Test Thread dict update multiple ids."""
         store = Store()
-        store.add("Thread", {"id": 1, "model": "res.partner", "test": True})
-        store.add("Thread", {"id": 2, "model": "res.partner", "test": True})
-        store.add("Thread", {"id": 2, "model": "res.partner", "test": False, "abc": 1})
+        store.add("mail.thread", {"id": 1, "model": "res.partner", "test": True})
+        store.add("mail.thread", {"id": 2, "model": "res.partner", "test": True})
+        store.add("mail.thread", {"id": 2, "model": "res.partner", "test": False, "abc": 1})
         self.assertEqual(
             store.get_result(),
             {
-                "Thread": [
+                "mail.thread": [
                     {"id": 1, "model": "res.partner", "test": True},
                     {"id": 2, "model": "res.partner", "test": False, "abc": 1},
                 ]
@@ -206,15 +206,15 @@ class TestDiscussTools(TransactionCase):
     def test_213_store_thread_dict_update_multiple_models(self):
         """Test Thread dict update multiple models."""
         store = Store()
-        store.add("Thread", {"id": 1, "model": "res.partner", "test": True})
-        store.add("Thread", {"id": 2, "model": "res.partner", "test": True})
-        store.add("Thread", {"id": 2, "model": "discuss.channel", "test": True, "abc": 1})
-        store.add("Thread", {"id": 2, "model": "discuss.channel", "test": False, "abc": 2})
-        store.add("Thread", {"id": 1, "model": "res.partner", "test": False})
+        store.add("mail.thread", {"id": 1, "model": "res.partner", "test": True})
+        store.add("mail.thread", {"id": 2, "model": "res.partner", "test": True})
+        store.add("mail.thread", {"id": 2, "model": "discuss.channel", "test": True, "abc": 1})
+        store.add("mail.thread", {"id": 2, "model": "discuss.channel", "test": False, "abc": 2})
+        store.add("mail.thread", {"id": 1, "model": "res.partner", "test": False})
         self.assertEqual(
             store.get_result(),
             {
-                "Thread": [
+                "mail.thread": [
                     {"id": 1, "model": "res.partner", "test": False},
                     {"id": 2, "model": "res.partner", "test": True},
                     {"id": 2, "model": "discuss.channel", "test": False, "abc": 2},
@@ -226,7 +226,7 @@ class TestDiscussTools(TransactionCase):
         """Test Thread dict update multiple models with a single list."""
         store = Store()
         store.add(
-            "Thread",
+            "mail.thread",
             [
                 {"id": 1, "model": "res.partner", "test": True},
                 {"id": 2, "model": "res.partner", "test": True},
@@ -238,7 +238,7 @@ class TestDiscussTools(TransactionCase):
         self.assertEqual(
             store.get_result(),
             {
-                "Thread": [
+                "mail.thread": [
                     {"id": 1, "model": "res.partner", "test": False},
                     {"id": 2, "model": "res.partner", "test": True},
                     {"id": 2, "model": "discuss.channel", "test": False, "abc": 2},
@@ -249,21 +249,27 @@ class TestDiscussTools(TransactionCase):
     def test_220_store_thread_list(self):
         """Test Thread list is present in result."""
         store = Store()
-        store.add("Thread", [{"id": 1, "model": "res.partner"}, {"id": 2, "model": "res.partner"}])
+        store.add(
+            "mail.thread", [{"id": 1, "model": "res.partner"}, {"id": 2, "model": "res.partner"}]
+        )
         self.assertEqual(
             store.get_result(),
-            {"Thread": [{"id": 1, "model": "res.partner"}, {"id": 2, "model": "res.partner"}]},
+            {"mail.thread": [{"id": 1, "model": "res.partner"}, {"id": 2, "model": "res.partner"}]},
         )
 
     def test_221_store_thread_list_append(self):
         """Test Thread list append."""
         store = Store()
-        store.add("Thread", [{"id": 1, "model": "res.partner"}, {"id": 2, "model": "res.partner"}])
-        store.add("Thread", [{"id": 4, "model": "res.partner"}, {"id": 5, "model": "res.partner"}])
+        store.add(
+            "mail.thread", [{"id": 1, "model": "res.partner"}, {"id": 2, "model": "res.partner"}]
+        )
+        store.add(
+            "mail.thread", [{"id": 4, "model": "res.partner"}, {"id": 5, "model": "res.partner"}]
+        )
         self.assertEqual(
             store.get_result(),
             {
-                "Thread": [
+                "mail.thread": [
                     {"id": 1, "model": "res.partner"},
                     {"id": 2, "model": "res.partner"},
                     {"id": 4, "model": "res.partner"},
@@ -276,12 +282,17 @@ class TestDiscussTools(TransactionCase):
         """Test Thread adding several keys."""
         store = Store()
         store.add("key1", {"id": 1, "test": True})
-        store.add("Thread", [{"id": 4, "model": "res.partner"}, {"id": 5, "model": "res.partner"}])
+        store.add(
+            "mail.thread", [{"id": 4, "model": "res.partner"}, {"id": 5, "model": "res.partner"}]
+        )
         self.assertEqual(
             store.get_result(),
             {
                 "key1": [{"id": 1, "test": True}],
-                "Thread": [{"id": 4, "model": "res.partner"}, {"id": 5, "model": "res.partner"}],
+                "mail.thread": [
+                    {"id": 4, "model": "res.partner"},
+                    {"id": 5, "model": "res.partner"},
+                ],
             },
         )
 
@@ -289,55 +300,55 @@ class TestDiscussTools(TransactionCase):
         """Test Thread adding invalid bool value."""
         store = Store()
         with self.assertRaises(AssertionError):
-            store.add("Thread", True)
+            store.add("mail.thread", True)
 
     def test_241_store_thread_invalid_list(self):
         """Test Thread adding invalid list value."""
         store = Store()
         with self.assertRaises(AssertionError):
-            store.add("Thread", [True])
+            store.add("mail.thread", [True])
 
     def test_242_store_thread_invalid_missing_id(self):
         """Test Thread adding invalid list value."""
         store = Store()
         with self.assertRaises(AssertionError):
-            store.add("Thread", {"model": "res.partner"})
+            store.add("mail.thread", {"model": "res.partner"})
 
     def test_243_store_thread_invalid_missing_model(self):
         """Test Thread adding invalid list value."""
         store = Store()
         with self.assertRaises(AssertionError):
-            store.add("Thread", {"id": 1})
+            store.add("mail.thread", {"id": 1})
 
     def test_250_store_thread_dict_to_list(self):
         """Test Thread adding dict to a list."""
         store = Store()
-        store.add("Thread", [{"id": 2, "model": "res.partner"}])
-        store.add("Thread", {"id": 1, "model": "res.partner"})
+        store.add("mail.thread", [{"id": 2, "model": "res.partner"}])
+        store.add("mail.thread", {"id": 1, "model": "res.partner"})
         self.assertEqual(
             store.get_result(),
-            {"Thread": [{"id": 2, "model": "res.partner"}, {"id": 1, "model": "res.partner"}]},
+            {"mail.thread": [{"id": 2, "model": "res.partner"}, {"id": 1, "model": "res.partner"}]},
         )
 
     def test_251_store_thread_list_to_dict(self):
         """Test Thread adding list to a dict."""
         store = Store()
-        store.add("Thread", {"id": 1, "model": "res.partner"})
-        store.add("Thread", [{"id": 2, "model": "res.partner"}])
+        store.add("mail.thread", {"id": 1, "model": "res.partner"})
+        store.add("mail.thread", [{"id": 2, "model": "res.partner"}])
         self.assertEqual(
             store.get_result(),
-            {"Thread": [{"id": 1, "model": "res.partner"}, {"id": 2, "model": "res.partner"}]},
+            {"mail.thread": [{"id": 1, "model": "res.partner"}, {"id": 2, "model": "res.partner"}]},
         )
 
     def test_260_store_thread_data_empty_val(self):
         """Test Thread empty values are not present in result."""
         store = Store()
-        store.add("Thread", {})
+        store.add("mail.thread", {})
         self.assertEqual(store.get_result(), {})
 
     def test_261_store_thread_data_empty_not_empty(self):
         """Test Thread mixing empty and non-empty values."""
         store = Store()
         store.add("key1", {})
-        store.add("Thread", {"id": 1, "model": "res.partner"})
-        self.assertEqual(store.get_result(), {"Thread": [{"id": 1, "model": "res.partner"}]})
+        store.add("mail.thread", {"id": 1, "model": "res.partner"})
+        self.assertEqual(store.get_result(), {"mail.thread": [{"id": 1, "model": "res.partner"}]})

--- a/addons/mail/tests/test_link_preview.py
+++ b/addons/mail/tests/test_link_preview.py
@@ -133,7 +133,7 @@ class TestLinkPreview(MailCommon):
                         {
                             "type": "mail.record/insert",
                             "payload": {
-                                "LinkPreview": [
+                                "mail.link.preview": [
                                     {
                                         "id": message.link_preview_ids.id,
                                         "image_mimetype": False,
@@ -147,7 +147,7 @@ class TestLinkPreview(MailCommon):
                                         "source_url": self.source_url,
                                     },
                                 ],
-                                "Message": [
+                                "mail.message": [
                                     {
                                         "id": message.id,
                                         "linkPreviews": [{"id": message.link_preview_ids.id}],

--- a/addons/mail/tests/test_res_partner.py
+++ b/addons/mail/tests/test_res_partner.py
@@ -121,7 +121,9 @@ class TestPartner(MailCommon):
         for i in range(0, 2):
             mail_new_test_user(self.env, login=f'{name}-{i}-portal-user', groups='base.group_portal')
             mail_new_test_user(self.env, login=f'{name}-{i}-internal-user', groups='base.group_user')
-        partners_format = self.env['res.partner'].get_mention_suggestions(name, limit=5)["Persona"]
+        partners_format = self.env["res.partner"].get_mention_suggestions(name, limit=5)[
+            "res.partner"
+        ]
         self.assertEqual(len(partners_format), 5, "should have found limit (5) partners")
         # return format for user is either a dict (there is a user and the dict is data) or a list of command (clear)
         self.assertEqual(list(map(lambda p: p['isInternalUser'], partners_format)), [True, True, False, False, False], "should return internal users in priority")

--- a/addons/mail/tools/discuss.py
+++ b/addons/mail/tools/discuss.py
@@ -35,10 +35,9 @@ def get_sfu_key(env) -> str | None:
 ids_by_model = defaultdict(lambda: ("id",))
 ids_by_model.update(
     {
-        "Persona": ("type", "id"),
+        "mail.thread": ("model", "id"),
         "Rtc": (),
         "Store": (),
-        "Thread": ("model", "id"),
     }
 )
 

--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -1024,7 +1024,7 @@ class Project(models.Model):
         super()._thread_to_store(store, request_list=request_list, **kwargs)
         if "followers" in request_list:
             store.add(
-                "Thread",
+                "mail.thread",
                 {
                     "collaborator_ids": [
                         {"id": partner.id, "type": "partner"}

--- a/addons/rating/models/mail_message.py
+++ b/addons/rating/models/mail_message.py
@@ -37,7 +37,7 @@ class MailMessage(models.Model):
             ratings = self.env['rating.rating'].sudo().search([('message_id', 'in', rating_mixin_messages.ids), ('consumed', '=', True)])
             for rating in ratings:
                 store.add(
-                    "Message",
+                    "mail.message",
                     {
                         "id": rating.message_id.id,
                         "rating": {

--- a/addons/rating/static/tests/mock_server/models/mail_message.js
+++ b/addons/rating/static/tests/mock_server/models/mail_message.js
@@ -23,7 +23,7 @@ export class MailMessage extends mailModels.MailMessage {
         for (const message of messages) {
             const [rating] = this.env["rating.rating"]._filter([["message_id", "=", message.id]]);
             if (rating) {
-                store.add("Message", {
+                store.add("mail.message", {
                     id: message.id,
                     rating: {
                         id: rating.id,

--- a/addons/test_mail/static/tests/chatter.test.js
+++ b/addons/test_mail/static/tests/chatter.test.js
@@ -36,8 +36,8 @@ test("Send message button activation (access rights dependent)", async () => {
     let userAccess = {};
     onRpc("/mail/thread/data", async (req) => {
         const res = await mail_thread_data.bind(MockServer.current)(req);
-        res["Thread"][0].hasWriteAccess = userAccess.hasWriteAccess;
-        res["Thread"][0].hasReadAccess = userAccess.hasReadAccess;
+        res["mail.thread"][0].hasWriteAccess = userAccess.hasWriteAccess;
+        res["mail.thread"][0].hasReadAccess = userAccess.hasReadAccess;
         return res;
     });
     await start();

--- a/addons/test_mail/tests/test_mail_followers.py
+++ b/addons/test_mail/tests/test_mail_followers.py
@@ -882,7 +882,7 @@ class UnfollowFromInboxTest(MailCommon, HttpCase):
         self.authenticate(self.env.user.login, self.env.user.login)
         data = self.make_jsonrpc_request("/mail/inbox/messages")["data"]
         expected = {
-            "Message": [
+            "mail.message": [
                 {
                     "attachments": [],
                     "author": {"id": self.user_admin.partner_id.id, "type": "partner"},
@@ -915,7 +915,7 @@ class UnfollowFromInboxTest(MailCommon, HttpCase):
                     "write_date": fields.Datetime.to_string(message.write_date),
                 },
             ],
-            "Notification": [
+            "mail.notification": [
                 {
                     "failure_type": False,
                     "id": notif.id,
@@ -925,29 +925,27 @@ class UnfollowFromInboxTest(MailCommon, HttpCase):
                     "persona": {"id": self.env.user.partner_id.id, "type": "partner"},
                 },
             ],
-            "Persona": [
-                {
-                    "id": self.user_admin.partner_id.id,
-                    "isInternalUser": True,
-                    "is_company": False,
-                    "name": "Mitchell Admin",
-                    "type": "partner",
-                    "userId": self.user_admin.id,
-                    "write_date": fields.Datetime.to_string(self.user_admin.write_date),
-                },
-                {
-                    "displayName": "Ernest Employee",
-                    "id": self.env.user.partner_id.id,
-                    "type": "partner",
-                },
-            ],
-            "Thread": [
+            "mail.thread": [
                 {
                     "id": test_record.id,
                     "model": "mail.test.simple",
                     "module_icon": "/base/static/description/icon.png",
                     "name": "Test",
                     "selfFollower": False,
+                },
+            ],
+            "res.partner": [
+                {
+                    "id": self.user_admin.partner_id.id,
+                    "isInternalUser": True,
+                    "is_company": False,
+                    "name": "Mitchell Admin",
+                    "userId": self.user_admin.id,
+                    "write_date": fields.Datetime.to_string(self.user_admin.write_date),
+                },
+                {
+                    "displayName": "Ernest Employee",
+                    "id": self.env.user.partner_id.id,
                 },
             ],
         }
@@ -960,14 +958,14 @@ class UnfollowFromInboxTest(MailCommon, HttpCase):
         )
         data = self.make_jsonrpc_request("/mail/inbox/messages")["data"]
         expected_with_follower = copy.deepcopy(expected)
-        expected_with_follower["Follower"] = [
+        expected_with_follower["mail.followers"] = [
             {
                 "id": follower.id,
                 "is_active": True,
                 "partner": {"id": self.env.user.partner_id.id, "type": "partner"},
             },
         ]
-        expected_with_follower["Thread"][0]["selfFollower"] = {"id": follower.id}
+        expected_with_follower["mail.thread"][0]["selfFollower"] = {"id": follower.id}
         self.assertEqual(data, expected_with_follower)
 
         # The user doesn't follow the record anymore

--- a/addons/test_mail/tests/test_mail_message.py
+++ b/addons/test_mail/tests/test_mail_message.py
@@ -105,10 +105,10 @@ class TestMessageValues(MailCommon):
         } for record in [record1, record2]])
         for message, record in zip(messages, [record1, record2]):
             with self.subTest(record=record):
-                formatted = Store(message, for_current_user=True).get_result()["Message"][0]
+                formatted = Store(message, for_current_user=True).get_result()["mail.message"][0]
                 self.assertEqual(formatted['record_name'], record.name)
                 record.write({'name': 'Just Test'})
-                formatted = Store(message, for_current_user=True).get_result()["Message"][0]
+                formatted = Store(message, for_current_user=True).get_result()["mail.message"][0]
                 self.assertEqual(formatted['record_name'], 'Just Test')
 
     @mute_logger('odoo.models.unlink')
@@ -129,7 +129,7 @@ class TestMessageValues(MailCommon):
         self.env.flush_all()
         self.env.invalidate_all()
         res = Store(message.with_user(self.user_employee), for_current_user=True).get_result()
-        self.assertEqual(res["Message"][0].get("record_name"), "Test1")
+        self.assertEqual(res["mail.message"][0].get("record_name"), "Test1")
 
     def test_mail_message_values_body_base64_image(self):
         msg = self.env['mail.message'].with_user(self.user_employee).create({

--- a/addons/test_mail/tests/test_mail_thread_internals.py
+++ b/addons/test_mail/tests/test_mail_thread_internals.py
@@ -388,7 +388,7 @@ class TestDiscuss(MailCommon, TestRecipients):
                 {
                     "type": "mail.record/insert",
                     "payload": {
-                        "Thread": {
+                        "mail.thread": {
                             "id": "starred",
                             "messages": [["DELETE", [{"id": msg.id}]]],
                             "model": "mail.box",
@@ -400,7 +400,7 @@ class TestDiscuss(MailCommon, TestRecipients):
                 {
                     "type": "mail.record/insert",
                     "payload": {
-                        "Thread": {
+                        "mail.thread": {
                             "id": "starred",
                             "messages": [["DELETE", [{"id": msg.id}]]],
                             "model": "mail.box",
@@ -518,12 +518,12 @@ class TestNoThread(MailCommon, TestRecipients):
             'record_name': 'Not used in message _to_store',
             'res_id': test_record.id,
         })
-        formatted = Store(message, for_current_user=True).get_result()["Message"][0]
+        formatted = Store(message, for_current_user=True).get_result()["mail.message"][0]
         self.assertEqual(formatted['default_subject'], test_record.name)
         self.assertEqual(formatted['record_name'], test_record.name)
 
         test_record.write({'name': 'Just Test'})
-        formatted = Store(message, for_current_user=True).get_result()["Message"][0]
+        formatted = Store(message, for_current_user=True).get_result()["mail.message"][0]
         self.assertEqual(formatted['default_subject'], 'Just Test')
         self.assertEqual(formatted['record_name'], 'Just Test')
 

--- a/addons/test_mail/tests/test_message_track.py
+++ b/addons/test_mail/tests/test_message_track.py
@@ -101,14 +101,14 @@ class TestTracking(MailCommon):
             )
         # first record: tracking value should be hidden
         message_0 = records[0].message_ids[0]
-        formatted = Store(message_0, for_current_user=True).get_result()["Message"][0]
+        formatted = Store(message_0, for_current_user=True).get_result()["mail.message"][0]
         self.assertEqual(formatted['trackingValues'], [], 'Hidden values should not be formatted')
         mail_render = records[0]._notify_by_email_prepare_rendering_context(message_0, {})
         self.assertEqual(mail_render['tracking_values'], [])
 
         # second record: all values displayed
         message_1 = records[1].message_ids[0]
-        formatted = Store(message_1, for_current_user=True).get_result()["Message"][0]
+        formatted = Store(message_1, for_current_user=True).get_result()["mail.message"][0]
         self.assertEqual(len(formatted['trackingValues']), 1)
         self.assertDictEqual(
             formatted['trackingValues'][0],
@@ -711,17 +711,17 @@ class TestTrackingInternals(MailCommon):
             },
         }]
         self.assertEqual(
-            msg_emp["Message"][0].get("trackingValues"),
+            msg_emp["mail.message"][0].get("trackingValues"),
             [],
             "should not have protected tracking values",
         )
         self.assertEqual(
-            msg_admin["Message"][0].get("trackingValues"),
+            msg_admin["mail.message"][0].get("trackingValues"),
             formatted_tracking_values,
             "should have protected tracking values",
         )
         self.assertEqual(
-            msg_sudo["Message"][0].get("trackingValues"),
+            msg_sudo["mail.message"][0].get("trackingValues"),
             formatted_tracking_values,
             "should have protected tracking values",
         )

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -1286,8 +1286,8 @@ class TestMessageToStorePerformance(BaseMailPerformance):
         with self.assertQueryCount(employee=27):
             res = Store(messages_all, for_current_user=True).get_result()
 
-        self.assertEqual(len(res["Message"]), 2 * 2)
-        for message in res["Message"]:
+        self.assertEqual(len(res["mail.message"]), 2 * 2)
+        for message in res["mail.message"]:
             self.assertEqual(len(message['attachments']), 2)
 
     @mute_logger('odoo.tests', 'odoo.addons.mail.models.mail_mail', 'odoo.models.unlink')
@@ -1299,8 +1299,8 @@ class TestMessageToStorePerformance(BaseMailPerformance):
         with self.assertQueryCount(employee=24):
             res = Store(message, for_current_user=True).get_result()
 
-        self.assertEqual(len(res["Message"]), 1)
-        self.assertEqual(len(res["Message"][0]["attachments"]), 2)
+        self.assertEqual(len(res["mail.message"]), 1)
+        self.assertEqual(len(res["mail.message"][0]["attachments"]), 2)
 
     @mute_logger('odoo.tests', 'odoo.addons.mail.models.mail_mail', 'odoo.models.unlink')
     @users('employee')
@@ -1319,14 +1319,14 @@ class TestMessageToStorePerformance(BaseMailPerformance):
 
         with self.assertQueryCount(employee=7):
             res = Store(messages, for_current_user=True).get_result()
-            self.assertEqual(len(res["Message"]), 6)
+            self.assertEqual(len(res["mail.message"]), 6)
 
         self.env.flush_all()
         self.env.invalidate_all()
 
         with self.assertQueryCount(employee=15):
             res = Store(messages, for_current_user=True).get_result()
-            self.assertEqual(len(res["Message"]), 6)
+            self.assertEqual(len(res["mail.message"]), 6)
 
     @warmup
     def test_message_to_store_multi_followers_inbox(self):
@@ -1358,7 +1358,7 @@ class TestMessageToStorePerformance(BaseMailPerformance):
                     {
                         "type": "mail.message/inbox",
                         "payload": {
-                            "Follower": [
+                            "mail.followers": [
                                 {
                                     "id": follower_1.id,
                                     "is_active": True,
@@ -1368,7 +1368,7 @@ class TestMessageToStorePerformance(BaseMailPerformance):
                                     },
                                 },
                             ],
-                            "Message": [
+                            "mail.message": [
                                 {
                                     "attachments": [],
                                     "author": {
@@ -1402,7 +1402,7 @@ class TestMessageToStorePerformance(BaseMailPerformance):
                                     "write_date": fields.Datetime.to_string(message.write_date),
                                 },
                             ],
-                            "Notification": [
+                            "mail.notification": [
                                 {
                                     "failure_type": False,
                                     "id": notif_1.id,
@@ -1426,28 +1426,7 @@ class TestMessageToStorePerformance(BaseMailPerformance):
                                     },
                                 },
                             ],
-                            "Persona": [
-                                {
-                                    "id": self.env.user.partner_id.id,
-                                    "isInternalUser": True,
-                                    "is_company": False,
-                                    "name": "OdooBot",
-                                    "type": "partner",
-                                    "userId": self.env.user.id,
-                                    "write_date": fields.Datetime.to_string(self.env.user.write_date),
-                                },
-                                {
-                                    "displayName": "Paulette Testouille",
-                                    "id": self.user_test_inbox.partner_id.id,
-                                    "type": "partner",
-                                },
-                                {
-                                    "displayName": "Jeannette Testouille",
-                                    "id": self.user_test_inbox_2.partner_id.id,
-                                    "type": "partner",
-                                },
-                            ],
-                            "Thread": [
+                            "mail.thread": [
                                 {
                                     "id": record.id,
                                     "model": "mail.test.simple",
@@ -1456,12 +1435,30 @@ class TestMessageToStorePerformance(BaseMailPerformance):
                                     "selfFollower": {"id": follower_1.id},
                                 },
                             ],
+                            "res.partner": [
+                                {
+                                    "id": self.env.user.partner_id.id,
+                                    "isInternalUser": True,
+                                    "is_company": False,
+                                    "name": "OdooBot",
+                                    "userId": self.env.user.id,
+                                    "write_date": fields.Datetime.to_string(self.env.user.write_date),
+                                },
+                                {
+                                    "displayName": "Paulette Testouille",
+                                    "id": self.user_test_inbox.partner_id.id,
+                                },
+                                {
+                                    "displayName": "Jeannette Testouille",
+                                    "id": self.user_test_inbox_2.partner_id.id,
+                                },
+                            ],
                         },
                     },
                     {
                         "type": "mail.message/inbox",
                         "payload": {
-                            "Follower": [
+                            "mail.followers": [
                                 {
                                     "id": follower_2.id,
                                     "is_active": True,
@@ -1471,7 +1468,7 @@ class TestMessageToStorePerformance(BaseMailPerformance):
                                     },
                                 },
                             ],
-                            "Message": [
+                            "mail.message": [
                                 {
                                     "attachments": [],
                                     "author": {
@@ -1505,7 +1502,7 @@ class TestMessageToStorePerformance(BaseMailPerformance):
                                     "write_date": fields.Datetime.to_string(message.write_date),
                                 },
                             ],
-                            "Notification": [
+                            "mail.notification": [
                                 {
                                     "failure_type": False,
                                     "id": notif_1.id,
@@ -1529,34 +1526,31 @@ class TestMessageToStorePerformance(BaseMailPerformance):
                                     },
                                 },
                             ],
-                            "Persona": [
-                                {
-                                    "id": self.env.user.partner_id.id,
-                                    "isInternalUser": True,
-                                    "is_company": False,
-                                    "name": "OdooBot",
-                                    "type": "partner",
-                                    "userId": self.env.user.id,
-                                    "write_date": fields.Datetime.to_string(self.env.user.write_date),
-                                },
-                                {
-                                    "displayName": "Paulette Testouille",
-                                    "id": self.user_test_inbox.partner_id.id,
-                                    "type": "partner",
-                                },
-                                {
-                                    "displayName": "Jeannette Testouille",
-                                    "id": self.user_test_inbox_2.partner_id.id,
-                                    "type": "partner",
-                                },
-                            ],
-                            "Thread": [
+                            "mail.thread": [
                                 {
                                     "id": record.id,
                                     "model": "mail.test.simple",
                                     "module_icon": "/base/static/description/icon.png",
                                     "name": "Test",
                                     "selfFollower": {"id": follower_2.id},
+                                },
+                            ],
+                            "res.partner": [
+                                {
+                                    "id": self.env.user.partner_id.id,
+                                    "isInternalUser": True,
+                                    "is_company": False,
+                                    "name": "OdooBot",
+                                    "userId": self.env.user.id,
+                                    "write_date": fields.Datetime.to_string(self.env.user.write_date),
+                                },
+                                {
+                                    "displayName": "Paulette Testouille",
+                                    "id": self.user_test_inbox.partner_id.id,
+                                },
+                                {
+                                    "displayName": "Jeannette Testouille",
+                                    "id": self.user_test_inbox_2.partner_id.id,
                                 },
                             ],
                         },

--- a/addons/website_livechat/models/discuss_channel.py
+++ b/addons/website_livechat/models/discuss_channel.py
@@ -32,7 +32,6 @@ class DiscussChannel(models.Model):
         for channel in self.filtered('livechat_visitor_id'):
             channel_info = {
                 "id": channel.id,
-                "model": "discuss.channel",
                 "requested_by_operator": channel.create_uid in channel.livechat_operator_id.user_ids
             }
             visitor = channel.livechat_visitor_id
@@ -51,7 +50,7 @@ class DiscussChannel(models.Model):
                 }
             except AccessError:
                 pass
-            store.add("Thread", channel_info)
+            store.add("discuss.channel", channel_info)
 
     def _get_visitor_history(self, visitor):
         """

--- a/addons/website_livechat/static/tests/mock_server/mock_models/discuss_channel.js
+++ b/addons/website_livechat/static/tests/mock_server/mock_models/discuss_channel.js
@@ -24,7 +24,7 @@ export class DiscussChannel extends livechatModels.DiscussChannel {
         const channels = this._filter([["id", "in", ids]]);
         for (const channel of channels) {
             if (channel.channel_type === "livechat" && channel.livechat_visitor_id) {
-                const channelInfo = { id: channel.id, model: "discuss.channel" };
+                const channelInfo = { id: channel.id };
                 const [visitor] = WebsiteVisitor._filter([
                     ["id", "=", channel.livechat_visitor_id],
                 ]);
@@ -45,7 +45,7 @@ export class DiscussChannel extends livechatModels.DiscussChannel {
                         ? Website.read(visitor.website_id)[0].name
                         : false,
                 };
-                store.add("Thread", channelInfo);
+                store.add("discuss.channel", channelInfo);
             }
         }
     }

--- a/addons/website_livechat/tests/test_livechat_basic_flow.py
+++ b/addons/website_livechat/tests/test_livechat_basic_flow.py
@@ -100,13 +100,13 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
         # Retrieve channels information, visitor info should be there
         params = {"channels_as_member": True}
         init_messaging = self.make_jsonrpc_request(f"{self.livechat_base_url}/mail/data", params=params)
-        livechat_info = next(c for c in init_messaging['Thread'] if c['id'] == channel.id)
+        livechat_info = next(c for c in init_messaging["discuss.channel"] if c["id"] == channel.id)
         self.assertIn('visitor', livechat_info)
 
         # Remove access to visitors and try again, visitors info shouldn't be included
         self.operator.groups_id -= self.group_livechat_user
         init_messaging = self.make_jsonrpc_request(f"{self.livechat_base_url}/mail/data", params=params)
-        livechat_info = next(c for c in init_messaging['Thread'] if c['id'] == channel.id)
+        livechat_info = next(c for c in init_messaging["discuss.channel"] if c["id"] == channel.id)
         self.assertNotIn('visitor', livechat_info)
 
     def _common_basic_flow(self):


### PR DESCRIPTION
Not having the correct name based on python model name makes it much harder to implement future improvement such as auto-formatting of relations (PR in progress: https://github.com/odoo/odoo/pull/172863) due to python having no knowledge of JS model definitions.

This also allows to remove a lot of unnecessary type and model keys for channel and persona, because they can be deduced from the model name.

Part of task-3605717

https://github.com/odoo/enterprise/pull/66478