### PR TITLE
[FIX] stock: don't reserve after putting in pack

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -1532,7 +1532,6 @@ class Picking(models.Model):
                 res = self._pre_put_in_pack_hook(move_line_ids)
                 if not res:
                     package = self._put_in_pack(move_line_ids)
-                    self.action_assign()
                     return self._post_put_in_pack_hook(package)
                 return res
             raise UserError(_("There is nothing eligible to put in a pack. Either there are no quantities to put in a pack or all products are already in a pack."))


### PR DESCRIPTION
Steps to reproduce:
- Create a lot tracked product.
- Update the "On Hands" quantity of the product and assign it a lot name.
- Create a delivery order with this product with a quantity that is available in the stock.
- Mark it as to do.
- Click on "Detailed Operations" smart button.
- Decrease the quantity of the move line.
- Select it and click on "Put in Pack".

Expected behavior:
The new quantity is put in pack and the quantity of the move line remains the same.

Actual behavior:
The whole quantity is reserved again. The original move line is split into two move lines: one with the packed quantity and another one with the remaining quantity.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
