### PR TITLE
[FIX] hw_drivers: remove added parameter due to WIoT incompatibility

### DIFF
--- a/addons/hw_drivers/websocket_client.py
+++ b/addons/hw_drivers/websocket_client.py
@@ -14,7 +14,7 @@ _logger = logging.getLogger(__name__)
 websocket.enableTrace(True, level=logging.getLevelName(_logger.getEffectiveLevel()))
 
 
-def send_to_controller(print_id, device_identifier, iot_mac):
+def send_to_controller(print_id, device_identifier):
     """
     Send back to odoo's server the completion of the operation
     """
@@ -29,7 +29,7 @@ def send_to_controller(print_id, device_identifier, iot_mac):
                 {'params': {
                     'print_id': print_id,
                     'device_identifier': device_identifier,
-                    'iot_mac': iot_mac,
+                    'iot_mac': helpers.get_mac_address(),
                     }}).encode('utf8'),
             headers={
                 'Content-type': 'application/json',
@@ -49,13 +49,12 @@ def on_message(ws, messages):
     for document in messages:
         if (document['message']['type'] in ['print', 'iot_action']):
             payload = document['message']['payload']
-            iot_mac = helpers.get_mac_address()
-            if iot_mac in payload['iotDevice']['iotIdentifiers']:
+            if helpers.get_mac_address() in payload['iotDevice']['iotIdentifiers']:
                 #send box confirmation
                 for device in payload['iotDevice']['identifiers']:
                     if device['identifier'] in main.iot_devices:
                         main.iot_devices[device["identifier"]]._action_default(payload)
-                        send_to_controller(payload['print_id'], device['identifier'], iot_mac)
+                        send_to_controller(payload['print_id'], device['identifier'])
 
 
 def on_error(ws, error):


### PR DESCRIPTION
If a 17.2 database use a windows IoT (in version 17). Then it will cause issue as the send_to_controller function is called from the printer drivers in 17.2 which would be missing the mac parameter as such, the 17 code have to adapt to 17.2 drivers syntax. This would cause errors such as:
```
websocket: error from callback <function on_message at 0x0000016400FE0540>: send_to_controller() missing 1 required positional argument: 'iot_mac'
odoo.addons.hw_drivers.websocket_client: websocket received an error: send_to_controller() missing 1 required positional argument: 'iot_mac'
```

(and the idea of putting the mac address as a parameter was pretty bad to start with)
Related PR: https://github.com/odoo/odoo/pull/172000