### PR TITLE
[FIX] web: HOOT spinner glitch on small screen

### DIFF
--- a/addons/web/static/lib/hoot/ui/hoot_status_panel.js
+++ b/addons/web/static/lib/hoot/ui/hoot_status_panel.js
@@ -105,7 +105,7 @@ export class HootStatusPanel extends Component {
                     <i t-if="state.debug" class="text-skip fa fa-bug" title="Debugging" />
                     <div
                         t-else=""
-                        class="animate-spin w-4 h-4 border-2 border-pass border-t-transparent rounded-full"
+                        class="animate-spin shrink-0 grow-0 w-4 h-4 border-2 border-pass border-t-transparent rounded-full"
                         role="status"
                         title="Running"
                     />

--- a/addons/web/static/lib/hoot/ui/hoot_style.css
+++ b/addons/web/static/lib/hoot/ui/hoot_style.css
@@ -599,6 +599,20 @@ input[type="checkbox"]:checked {
     flex-direction: row;
 }
 
+.shrink-0 {
+    flex-shrink: 0;
+}
+.shrink {
+    flex-shrink: 1;
+}
+
+.grow-0 {
+    flex-grow: 0;
+}
+.grow {
+    flex-grow: 1;
+}
+
 .items-center {
     align-items: center;
 }


### PR DESCRIPTION
This commit fixes a glitch in the animated spinner when running HOOT tests on small/mobile screen.

Note: adding flex grow/shrink variants for consistency's sake.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
