### PR TITLE
[FIX] mail: reaction button overlap with MessageSeenIndicator

### DIFF
--- a/addons/mail/static/src/core/common/message_reactions.xml
+++ b/addons/mail/static/src/core/common/message_reactions.xml
@@ -6,7 +6,7 @@
             'flex-row-reverse me-3': env.inChatWindow and env.alignedRight,
             'ms-3': !(env.inChatWindow and env.alignedRight) and (props.message.is_discussion),
         }"
-        t-attf-class="{{ props.message.is_discussion ? 'mt-n2' : 'mt-1' }}">
+        t-attf-class="{{ props.message.is_discussion ? 'mt-n1' : 'mt-1' }}">
         <button t-foreach="props.message.reactions" t-as="reaction" t-key="reaction.content" class="o-mail-MessageReaction btn d-flex p-0 border rounded-1 mb-1"
             t-on-click="() => this.onClickReaction(reaction)"
             t-on-contextmenu="onContextMenu"


### PR DESCRIPTION
Before this commit:
The message seen indicator was inside the message bubble, causing reactions 
positioned below it to overlap when there were many reactions.

After this commit:
The reaction buttons no longer overlap with the message seen indicator. This 
was done by reducing their negative margin from -8px to -4px.

Before:
![image](https://github.com/odoo/odoo/assets/120459796/f548d0db-7471-46a5-8ca6-41d99324373b)

After:
![image](https://github.com/odoo/odoo/assets/120459796/45e7659d-1781-4812-bcff-e2f5a1a84666)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
