### PR TITLE
[IMP] pos_loyalty: sell physical giftcard from terminal

### DIFF
--- a/addons/point_of_sale/static/src/app/models/related_models.js
+++ b/addons/point_of_sale/static/src/app/models/related_models.js
@@ -152,6 +152,9 @@ export class Base {
     setup(_vals) {
         // Allow custom fields
         for (const [key, val] of Object.entries(_vals)) {
+            if (key in this.model.modelFields) {
+                continue;
+            }
             if (key.startsWith("_") && !key.startsWith("__")) {
                 this[key] = val;
             }

--- a/addons/pos_loyalty/models/pos_order.py
+++ b/addons/pos_loyalty/models/pos_order.py
@@ -87,7 +87,7 @@ class PosOrder(models.Model):
         for coupon_vals in gift_cards_to_update:
             gift_card = self.env['loyalty.card'].browse(coupon_vals.get('giftCardId'))
             gift_card.write({
-                'points': coupon_vals['points'],
+                'points': coupon_vals['points'] + gift_card.points,
                 'source_pos_order_id': self.id,
                 'partner_id': get_partner_id(coupon_vals.get('partner_id', False)),
             })

--- a/addons/pos_loyalty/static/src/app/popup/manage_giftcard_popup/manage_giftcard_popup.js
+++ b/addons/pos_loyalty/static/src/app/popup/manage_giftcard_popup/manage_giftcard_popup.js
@@ -1,0 +1,63 @@
+import { Component, onMounted, useRef, useState } from "@odoo/owl";
+import { Dialog } from "@web/core/dialog/dialog";
+
+export class ManageGiftCardPopup extends Component {
+    static template = "pos_loyalty.ManageGiftCardPopup";
+    static components = { Dialog };
+    static props = {
+        title: String,
+        placeholder: { type: String, optional: true },
+        rows: { type: Number, optional: true },
+        getPayload: Function,
+        close: Function,
+    };
+    static defaultProps = {
+        startingValue: "",
+        placeholder: "",
+        rows: 1,
+    };
+
+    setup() {
+        this.state = useState({
+            inputValue: this.props.startingValue,
+            amountValue: "",
+            error: false,
+            amountError: false,
+        });
+        this.inputRef = useRef("input");
+        this.amountInputRef = useRef("amountInput");
+        onMounted(this.onMounted);
+    }
+
+    onMounted() {
+        this.inputRef.el.focus();
+    }
+
+    addBalance() {
+        if (!this.validateCode()) {
+            return;
+        }
+        this.props.getPayload({
+            code: this.state.inputValue.trim(),
+            amount: parseFloat(this.state.amountValue),
+        });
+        this.props.close();
+    }
+
+    close() {
+        this.props.close();
+    }
+
+    validateCode() {
+        const { inputValue, amountValue } = this.state;
+        if (inputValue.trim() === "") {
+            this.state.error = true;
+            return false;
+        }
+        if (amountValue.trim() === "") {
+            this.state.amountError = true;
+            return false;
+        }
+        return true;
+    }
+}

--- a/addons/pos_loyalty/static/src/app/popup/manage_giftcard_popup/manage_giftcard_popup.xml
+++ b/addons/pos_loyalty/static/src/app/popup/manage_giftcard_popup/manage_giftcard_popup.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-name="pos_loyalty.ManageGiftCardPopup">
+        <Dialog title="props.title" size="'md'">
+            <input id="code" t-att-rows="props.rows" class="form-control form-control-lg mx-auto" type="text" t-model="state.inputValue" t-ref="input" t-att-placeholder="props.placeholder" t-att-style="state.error ? 'border-color: red;' : ''" />
+            <div class="mt-3">
+                <div class="col align-items-center d-flex">
+                    <div class="col-form-label text-center pe-0 me-3 fs-5">Amount</div>
+                    <div class="flex-grow-1">
+                        <input id="amount" class="form-control form-control-lg" type="number" t-model="state.amountValue" t-ref="amountInput" placeholder="Enter amount" t-att-style="state.amountError ? 'border-color: red;' : ''"/>
+                    </div>
+                </div>
+            </div>
+            <t t-set-slot="footer">
+                <button class="btn btn-primary o-default-button" t-on-click="addBalance">Add Balance</button>
+            </t>
+        </Dialog>
+    </t>
+</templates>

--- a/addons/pos_loyalty/static/src/overrides/components/payment_screen/payment_screen.js
+++ b/addons/pos_loyalty/static/src/overrides/components/payment_screen/payment_screen.js
@@ -120,6 +120,12 @@ patch(PaymentScreen.prototype, {
                 .map(([key, value]) => [key, omit(value, "appliedRules")])
         );
         if (Object.keys(couponData || {}).length > 0) {
+            for (const index in couponData) {
+                const data = couponData[index];
+                if (data.giftCardId && typeof data.giftCardId !== "number") {
+                    delete couponData[index].giftCardId;
+                }
+            }
             const payload = await this.pos.data.call("pos.order", "confirm_coupon_programs", [
                 order.id,
                 couponData,

--- a/addons/pos_loyalty/static/src/overrides/components/product_screen/order_summary/order_summary.js
+++ b/addons/pos_loyalty/static/src/overrides/components/product_screen/order_summary/order_summary.js
@@ -1,13 +1,16 @@
 import { _t } from "@web/core/l10n/translation";
 import { OrderSummary } from "@point_of_sale/app/screens/product_screen/order_summary/order_summary";
 import { patch } from "@web/core/utils/patch";
-import { ask } from "@point_of_sale/app/store/make_awaitable_dialog";
+import { ask, makeAwaitable } from "@point_of_sale/app/store/make_awaitable_dialog";
 import { useService } from "@web/core/utils/hooks";
+import { ManageGiftCardPopup } from "@pos_loyalty/app/popup/manage_giftcard_popup/manage_giftcard_popup";
+import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 
 patch(OrderSummary.prototype, {
     setup() {
         super.setup(...arguments);
         this.notification = useService("notification");
+        this.dialog = useService("dialog");
     },
     async updateSelectedOrderline({ buffer, key }) {
         const selectedLine = this.currentOrder.get_selected_orderline();
@@ -46,6 +49,54 @@ patch(OrderSummary.prototype, {
             }
         }
         return super.updateSelectedOrderline({ buffer, key });
+    },
+    async handlePhysicalGiftCard(line) {
+        const giftCardProduct = line.product_id;
+        const data = await makeAwaitable(this.dialog, ManageGiftCardPopup, {
+            title: _t("Sell/Manage physical gift card"),
+            placeholder: _t("Enter Gift Card Number"),
+        });
+
+        const res = await this.pos.data.searchRead(
+            "loyalty.card",
+            ["&", ["program_type", "=", "gift_card"], ["code", "=", data.code]],
+            []
+        );
+
+        if (this.currentOrder.duplicateCouponChanges(data.code)) {
+            this.dialog.add(ConfirmationDialog, {
+                title: _t("Validation Error"),
+                body: _t("A coupon/loyalty card must have a unique code."),
+            });
+            return;
+        }
+
+        let giftCard;
+        if (!res.length) {
+            giftCard = this.pos.models["loyalty.card"].create({
+                code: data.code,
+                program_type: "gift_card",
+                amount: data.amount,
+            });
+        } else {
+            giftCard = res[0];
+        }
+
+        line.delete();
+        await this.pos.addLineToCurrentOrder(
+            {
+                product_id: giftCardProduct,
+                quantity: 1,
+                price_unit: data.amount,
+            },
+            {
+                giftCardManual: true,
+                giftCardCode: data.code,
+                giftCardId: giftCard,
+            }
+        );
+
+        // This will automatically update coupon point changes.
     },
     /**
      * 1/ Perform the usual set value operation (super._setValue(val)) if the line being modified

--- a/addons/pos_loyalty/static/src/overrides/components/product_screen/order_summary/order_summary.xml
+++ b/addons/pos_loyalty/static/src/overrides/components/product_screen/order_summary/order_summary.xml
@@ -5,6 +5,10 @@
             <li t-if="line.isGiftCardOrEWalletReward()">
                 Current Balance: <t t-esc="line.getGiftCardOrEWalletBalance()"/>
             </li>
+            <t t-if="!line.isGiftCardOrEWalletReward() and line.getEWalletGiftCardProgramType() === 'gift_card'">
+                <a t-if="!line._gift_card_id?.code" class="text-wrap text-primary" t-on-click="() => this.handlePhysicalGiftCard(line)">Sell physical gift card?</a>
+                <div t-if="line._gift_card_id?.code" class="text-wrap" t-esc="line._gift_card_id?.code"/>
+            </t>
         </xpath>
         <xpath expr="//OrderWidget/t[@t-set-slot='details']" position="inside">
             <t t-foreach="pos.get_order()?.getLoyaltyPoints() or []" t-as="_loyaltyStat" t-key="_loyaltyStat.couponId">

--- a/addons/pos_loyalty/static/src/overrides/models/data_service_options.js
+++ b/addons/pos_loyalty/static/src/overrides/models/data_service_options.js
@@ -8,7 +8,9 @@ patch(DataServiceOptions.prototype, {
             name: "loyalty.card",
             key: "id",
             condition: (record) => {
-                return record.models["pos.order.line"].find((l) => l.coupon_id?.id === record.id);
+                return record.models["pos.order.line"].find(
+                    (l) => l.coupon_id?.id === record.id || l._gift_card_id?.id === record.id
+                );
             },
         });
         return data;

--- a/addons/pos_loyalty/static/src/overrides/models/pos_order.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_order.js
@@ -624,7 +624,6 @@ patch(PosOrder.prototype, {
                                             return {
                                                 points: pointsPerUnit,
                                                 barcode: line._gift_barcode,
-                                                giftCardId: line._gift_card_id.id,
                                             };
                                         }
                                         return { points: pointsPerUnit };
@@ -847,6 +846,16 @@ patch(PosOrder.prototype, {
             });
         }
         return true;
+    },
+
+    duplicateCouponChanges(code) {
+        return Object.keys(this.uiState.couponPointChanges).some((key) => {
+            const change = this.uiState.couponPointChanges[key];
+            return (
+                (change.existing_code === code && change.manual) ||
+                (change.code === code && change.coupon_id < 0)
+            );
+        });
     },
 
     /**

--- a/addons/pos_loyalty/static/src/overrides/models/pos_order_line.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_order_line.js
@@ -1,5 +1,6 @@
 import { PosOrderline } from "@point_of_sale/app/models/pos_order_line";
 import { formatCurrency } from "@point_of_sale/app/models/utils/currency";
+import { _t } from "@web/core/l10n/translation";
 import { patch } from "@web/core/utils/patch";
 
 patch(PosOrderline, {
@@ -51,7 +52,7 @@ patch(PosOrderline.prototype, {
             this.update({ _gift_barcode: options.giftBarcode });
         }
         if (options.giftCardId) {
-            this.update({ _gift_card_id: this.models["loyalty.card"].get(options.giftCardId) });
+            this.update({ _gift_card_id: options.giftCardId });
         }
         return super.setOptions(...arguments);
     },
@@ -80,5 +81,23 @@ patch(PosOrderline.prototype, {
             ...super.getDisplayClasses(),
             "fst-italic": this.is_reward_line,
         };
+    },
+    set_quantity(quantity, keep_price) {
+        if (this._gift_card_id && this._gift_card_id.code && quantity) {
+            return {
+                title: _t("Error"),
+                body: _t("You cannot edit the quantity of a custom gift card."),
+            };
+        }
+        return super.set_quantity(...arguments);
+    },
+    set_unit_price() {
+        if (this._gift_card_id && this._gift_card_id.code) {
+            return {
+                title: _t("Error"),
+                body: _t("You cannot edit the price of a custom gift card."),
+            };
+        }
+        return super.set_unit_price(...arguments);
     },
 });

--- a/addons/pos_loyalty/static/src/overrides/models/pos_store.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_store.js
@@ -402,6 +402,11 @@ patch(PosStore.prototype, {
         options.merge = false;
         options.eWalletGiftCardProgram = program;
 
+        if (options.giftCardManual === true) {
+            options.giftBarcode = options.giftCardCode;
+            return true;
+        }
+
         // If gift card program setting is 'scan_use', ask for the code.
         if (this.config.gift_card_settings == "scan_use") {
             const code = await makeAwaitable(this.dialog, TextInputPopup, {

--- a/addons/pos_loyalty/static/tests/tours/gift_card_program_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/gift_card_program_tour.js
@@ -99,16 +99,29 @@ registry.category("web_tour.tours").add("PosLoyaltyPointsGiftcard", {
         [
             Dialog.confirm("Open session"),
             ProductScreen.clickDisplayedProduct("Gift Card"),
-            TextInputPopup.inputText("044123456"),
+            TextInputPopup.inputText("044123457"),
             Dialog.confirm(),
             PosLoyalty.orderTotalIs("50.00"),
             PosLoyalty.finalizeOrder("Cash", "50"),
             ProductScreen.clickPartnerButton(),
             ProductScreen.clickCustomer("AAAA"),
             ProductScreen.addOrderline("product_a", "1"),
-            PosLoyalty.enterCode("044123456"),
+            PosLoyalty.enterCode("044123457"),
             PosLoyalty.orderTotalIs("50.00"),
             PosLoyalty.pointsAwardedAre("100"),
             PosLoyalty.finalizeOrder("Cash", "50"),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("PosLoyaltyPhysicalGiftcard", {
+    test: true,
+    url: "/pos/ui",
+    steps: () =>
+        [
+            ProductScreen.addOrderline("Gift Card", "3", "50", "150.00"),
+            PosLoyalty.createManualGiftCard("test-card-0000", 100),
+            PosLoyalty.clickPhysicalGiftCard("test-card-0000"),
+            ProductScreen.selectedOrderlineHas("Gift Card", "1.00", "100"),
+            PosLoyalty.finalizeOrder("Cash", "100"),
         ].flat(),
 });

--- a/addons/pos_loyalty/static/tests/tours/utils/pos_loyalty_util.js
+++ b/addons/pos_loyalty/static/tests/tours/utils/pos_loyalty_util.js
@@ -120,3 +120,35 @@ export function checkAddedLoyaltyPoints(points) {
         },
     ];
 }
+
+export function createManualGiftCard(code, amount) {
+    return [
+        {
+            trigger: `a:contains("Sell physical gift card?")`,
+            run: "click",
+        },
+        {
+            content: `Input code '${code}'`,
+            trigger: `input[id="code"]`,
+            run: `edit ${code}`,
+        },
+        {
+            content: `Input amount '${amount}'`,
+            trigger: `input[id="amount"]`,
+            run: `edit ${amount}`,
+        },
+        {
+            trigger: `.btn-primary`,
+            run: "click",
+        },
+    ];
+}
+
+export function clickPhysicalGiftCard(code = "Sell physical gift card?") {
+    return [
+        {
+            trigger: `ul.info-list:contains("${code}")`,
+            run: "click",
+        },
+    ];
+}


### PR DESCRIPTION
Before the commit:
---
Gift card codes were generated automatically, without any option for manual input or selling physical gift cards.

After the commit:
---
- Added the "Sell Physical Gift Card" option under gift card products in POS.
- Allows for the manual input of gift card numbers.
- Orders generate gift cards with entered numbers.
- Existing gift cards can have amounts added.

Original PR: 161234
task-3647760
