### PR TITLE
 [FIX] hr_holidays: search for leaves in user's tz

### DIFF
--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -116,8 +116,19 @@ class HolidaysType(models.Model):
             or that don't need an allocation
             return [('id', domain_operator, [x['id'] for x in res])]
         """
-        date_to = self._context.get('default_date_from') or fields.Date.today().strftime('%Y-1-1')
-        date_from = self._context.get('default_date_to') or fields.Date.today().strftime('%Y-12-31')
+
+        if {'default_date_from', 'default_date_to', 'tz'} <= set(self._context):
+            default_date_from_dt = fields.Datetime.to_datetime(self._context.get('default_date_from'))
+            default_date_to_dt = fields.Datetime.to_datetime(self._context.get('default_date_to'))
+
+            # Cast: Datetime -> Date using user's tz
+            date_to = fields.Date.context_today(self, default_date_from_dt)
+            date_from = fields.Date.context_today(self, default_date_to_dt)
+
+        else:
+            date_to = fields.Date.today().strftime('%Y-1-1')
+            date_from = fields.Date.today().strftime('%Y-12-31')
+
         employee_id = self._context.get('default_employee_id', self._context.get('employee_id')) or self.env.user.employee_id.id
 
         if not isinstance(value, bool):

--- a/addons/hr_holidays/tests/test_hr_leave_type.py
+++ b/addons/hr_holidays/tests/test_hr_leave_type.py
@@ -40,3 +40,34 @@ class TestHrLeaveType(TestHrHolidaysCommon):
                 'name': 'UserCheats',
                 'requires_allocation': 'no',
             })
+
+    def test_users_tz_shift_back(self):
+        """This test follows closely related bug report and simulates its situation.
+        We're located in Saipan (GMT+10) and we allocate some employee a leave from 19Aug-20Aug.
+        Then we simulate opening the employee's calendar and attempting to allocate 21August.
+        We should not get any valid allocation there as is it outsite of valid alocation period.
+
+        2024-08-19      2024-08-20        2024-08-21
+        ────┬─────────────────┬─────────────────┬─────►
+            └─────────────────┘             requested
+          Valid allocation period              day
+        """
+        employee = self.env['hr.employee'].create({'name': 'Test Employee'})
+        leave_type = self.env['hr.leave.type'].create({'name': 'Test Leave'})
+
+        self.env['hr.leave.allocation'].create({
+            'state': 'validate',
+            'holiday_status_id': leave_type.id,
+            'employee_id': employee.id,
+            'date_from': '2024-08-19',
+            'date_to': '2024-08-20',
+        })
+
+        leave_types = self.env['hr.leave.type'].with_context(
+            default_date_from='2024-08-20 21:00:00',
+            default_date_to='2024-08-21 09:00:00',
+            tz='Pacific/Saipan',
+            employee_id=employee.id,
+            ).search([('has_valid_allocation', '=', True)], limit=1)
+
+        self.assertFalse(leave_types, "Got valid leaves outside vaild period")


### PR DESCRIPTION
### [FIX] hr_holidays: search for leaves in user's tz

For the sake of simplicity we'd assume 3 days: Mon, Tue, Wed.
Let's also assume that the everything happens in GMT+10

Now if we have a valid leave allocation for Mon and Tue, we should
NOT be able to able to take it on Wed. However, because of the way
Timestamps are casted to dates it is possible. It happens as follow:
user "asking" server for leave on Wed, defines requested day by passing by
the datetimes in the context ranging from Tue 21:00 to Wed 09:00

Why such datetime range? Firstly because we have hardcoded devault values
for events that range from 07:00 to 19:00 in local time (ref.1).
Secondly because we're in GMT+10 so this range gets shifted:
 07:00 on Wed becomes 21:00 on Tue
 19:00 on Wed becomes 09:00 also on Wed

Then because allocations ranges are defined by dates not datetimes,
implicit casting is performed that causes cut-off of the time from the datetime
and in the end instead of checking if leave is allowed on Wed we check if
it is allowed on Tue and Wed.

### [FIX]
Shifting back into the user's timezone before casting.

### [Reproduction of the original issue]
- install hr_holidays
- create employee E
- create & validate new Allocation A  (in TimeOff/Allocations):
        - of type T (creating new type will help identify the issue)
        - for employee E
        - valid from Mon to Tue
- Open E's time off (Employee E -> Time Off)
- Switch your browser TZ that is +10
- Attempt to book time off for E on Wed
- BUG: you are allowed to do so

opw-3850159

(ref.1)
calendarEventToRecord from calendar_model
https://github.com/odoo/odoo/blob/15.0/addons/web/static/src/legacy/js/views/calendar/calendar_model.js#L74-L75


![3850159 Can apply for a leave with expired allocissueation; Timezone  _0 excalidraw](https://github.com/user-attachments/assets/ed06411b-7403-4676-bd8b-82ebb203090e)


