### PR TITLE
[PERF] stock: improve _process_decrease with serial numbers

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -358,6 +358,7 @@ class StockMove(models.Model):
 
     def _set_quantity(self):
         def _process_decrease(move, quantity):
+            mls_to_unlink = set()
             for ml in move.move_line_ids:
                 if float_is_zero(quantity, precision_rounding=move.product_uom.rounding):
                     break
@@ -365,10 +366,11 @@ class StockMove(models.Model):
                 if float_is_zero(qty_ml_dec, precision_rounding=ml.product_uom_id.rounding):
                     continue
                 if float_compare(ml.quantity, qty_ml_dec, precision_rounding=ml.product_uom_id.rounding) == 0 and ml.state not in ['done', 'cancel']:
-                    ml.unlink()
+                    mls_to_unlink.add(ml.id)
                 else:
                     ml.quantity -= qty_ml_dec
                 quantity -= move.product_uom._compute_quantity(qty_ml_dec, move.product_uom, round=False)
+            self.env['stock.move.line'].browse(mls_to_unlink).unlink()
 
         def _process_increase(move, quantity):
             # move._action_assign(quantity)


### PR DESCRIPTION
Description
On a 'stock.move' with a lot of move lines (serial numbers), setting the 'stock.move' quantity to 0 could take a few minutes due to the number of unlink calls.

Solution:
Extract unlink call outside the "for" loop.

| Move Lines | Without Fix | With Fix |
| --- | --- | ---|
| 10 | 321 ms | 102 ms |
| 100 | 2.60 s | 108 ms |
| 1.000 | 31.71 s | 380 ms |
| 10.000 | 20.7 min | 1.41 s |
| 100.000 | no idea | 17.47 |

---

OPW-4043076




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
