### PR TITLE
[FIX] point_of_sale: missing discount note on pos invoice

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -207,11 +207,11 @@ class PosOrder(models.Model):
         invoice_lines = []
         for line in self.lines:
             invoice_lines.append((0, None, self._prepare_invoice_line(line)))
-            if line.order_id.pricelist_id.discount_policy == 'without_discount' and float_compare(line.price_unit, line.product_id.lst_price, precision_rounding=self.currency_id.rounding) < 0:
+            if line.order_id.pricelist_id.discount_policy == 'without_discount' and float_compare(line.price_subtotal_incl, line.product_id.lst_price * line.qty, precision_rounding=self.currency_id.rounding) < 0:
                 invoice_lines.append((0, None, {
                     'name': _('Price discount from %s -> %s',
-                              float_repr(line.product_id.lst_price, self.currency_id.decimal_places),
-                              float_repr(line.price_unit, self.currency_id.decimal_places)),
+                              float_repr(line.product_id.lst_price * line.qty, self.currency_id.decimal_places),
+                              float_repr(line.price_subtotal_incl, self.currency_id.decimal_places)),
                     'display_type': 'line_note',
                 }))
             if line.customer_note:

--- a/addons/point_of_sale/tests/test_anglo_saxon.py
+++ b/addons/point_of_sale/tests/test_anglo_saxon.py
@@ -347,3 +347,44 @@ class TestAngloSaxonFlow(TestAngloSaxonCommon):
         stock_output_amls = related_amls.filtered_domain([('account_id', '=', stock_output_account.id)])
 
         self.assertTrue(all(stock_output_amls.mapped('reconciled')))
+
+    def test_action_pos_order_invoice_with_discount(self):
+        """This test make sure that the line containing 'Discoun from' is correctly added to the invoice"""
+
+        # Setup a running session, with a paid pos order that is not invoiced
+        self.pos_config.open_session_cb(check_coa=False)
+        pricelist = self.env['product.pricelist'].create({
+            'name': 'Test Pricelist',
+            'discount_policy': 'without_discount',
+        })
+        self.product.lst_price = 100
+        self.pos_order_pos0 = self.PosOrder.create({
+            'company_id': self.company.id,
+            'partner_id': self.partner.id,
+            'session_id': self.pos_config.current_session_id.id,
+            'pricelist_id': pricelist.id,
+            'lines': [(0, 0, {
+                'product_id': self.product.id,
+                'price_unit': 100,
+                'qty': 1.0,
+                'price_subtotal': 95,
+                'price_subtotal_incl': 95,
+                'discount': 5,
+            })],
+            'amount_total': 95,
+            'amount_tax': 0,
+            'amount_paid': 0,
+            'amount_return': 0,
+            'to_invoice': True,
+        })
+        context_make_payment = {"active_ids": [self.pos_order_pos0.id], "active_id": self.pos_order_pos0.id}
+        self.pos_make_payment_0 = self.PosMakePayment.with_context(context_make_payment).create({
+            'amount': 450.0,
+            'payment_method_id': self.cash_payment_method.id,
+        })
+        context_payment = {'active_id': self.pos_order_pos0.id}
+        self.pos_make_payment_0.with_context(context_payment).check()
+
+        res = self.pos_order_pos0.action_pos_order_invoice()
+        invoice = self.env['account.move'].browse(res['res_id'])
+        self.assertTrue('Price discount from 100.00 -> 95.00' in invoice.invoice_line_ids.filtered(lambda l: l.display_type == "line_note").display_name)


### PR DESCRIPTION
Steps to reproduce:
-------------------
* Activate discount on lines on user parameters
* Change the pricelist config to show discount to the customers
* Open a PoS session with the modified pricelist
* Create an order and apply some discount on the lines
* Invoice and pay the order
> Observation: On the invoice pdf you should have a line saying
"Price discount from X -> X" but it's not there

Why the fix:
------------
Before the fix we were comparing the `price_unit` on the line and the `lst_price` of the product. But if a discount was applied on the line the price unit is not affected, and so the line was never shown. To fix this we compare the `total_price` of the line with the `lst_price` multiplied by the quantity on the line.

opw-4019107
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
