### PR TITLE
[FIX] account_edi_ubl_cii: map SE endpoint to company_registry

### DIFF
--- a/addons/account_edi_ubl_cii/i18n/account_edi_ubl_cii.pot
+++ b/addons/account_edi_ubl_cii/i18n/account_edi_ubl_cii.pot
@@ -789,6 +789,15 @@ msgstr ""
 #. odoo-python
 #: code:addons/account_edi_ubl_cii/models/res_partner.py:0
 #, python-format
+msgid ""
+"The Peppol endpoint is not valid. It should contain exactly 10 digits "
+"(Company Registry number).The expected format is: 1234567890"
+msgstr ""
+
+#. module: account_edi_ubl_cii
+#. odoo-python
+#: code:addons/account_edi_ubl_cii/models/res_partner.py:0
+#, python-format
 msgid "The Peppol endpoint is not valid. The expected format is: 0239843188"
 msgstr ""
 

--- a/addons/account_edi_ubl_cii/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_common.py
@@ -82,7 +82,7 @@ EAS_MAPPING = {
     'PT': {'9946': 'vat'},
     'RO': {'9947': 'vat'},
     'RS': {'9948': 'vat'},
-    'SE': {'0007': 'vat'},
+    'SE': {'0007': 'company_registry'},
     'SI': {'9949': 'vat'},
     'SK': {'9950': 'vat'},
     'SM': {'9951': 'vat'},

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
@@ -96,6 +96,8 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
                 # DK-R-014: For Danish Suppliers it is mandatory to specify schemeID as "0184" (DK CVR-number) when
                 # PartyLegalEntity/CompanyID is used for AccountingSupplierParty
                 vals['company_id_attrs'] = {'schemeID': '0184'}
+            if partner.country_code == 'SE' and partner.company_registry:
+                vals['company_id'] = ''.join(char for char in partner.company_registry if char.isdigit())
             if not vals['company_id']:
                 vals['company_id'] = partner.peppol_endpoint
 

--- a/addons/account_edi_ubl_cii/models/res_partner.py
+++ b/addons/account_edi_ubl_cii/models/res_partner.py
@@ -214,6 +214,10 @@ class ResPartner(models.Model):
             return _("The Peppol endpoint is not valid. The expected format is: 0239843188")
         if eas == '0009' and not siret.is_valid(endpoint):
             return _("The Peppol endpoint is not valid. The expected format is: 73282932000074")
+        if eas == '0007' and not re.match(r"^\d{10}$", endpoint):
+            return _("The Peppol endpoint is not valid. "
+                     "It should contain exactly 10 digits (Company Registry number)."
+                     "The expected format is: 1234567890")
 
     def _get_edi_builder(self):
         self.ensure_one()


### PR DESCRIPTION
In Sweden, Peppol endpoint is required to be exactly 10 digits - no other characters are allowed. Currently, we're mapping SE peppol endpoint to be the VAT number, which contains the country code prefix and a 12-digit number. As a result, a lot of our invoices are being rejected by the Swedish access points. Let's map it to the company registry number and add a check in constrains.

See:
https://docs.peppol.eu/poacc/billing/3.0/codelist/eas/

no task, customer feedback



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
