### PR TITLE
[FIX] core: fix numeric field comparison for null

### DIFF
--- a/odoo/addons/test_new_api/tests/test_domain.py
+++ b/odoo/addons/test_new_api/tests/test_domain.py
@@ -73,6 +73,13 @@ class TestDomain(common.TransactionCase):
         self.assertListEqual(self._search(EmptyInt, [('number', '=', False)]).mapped('number'), [0, 0, 0])
         self.assertListEqual(self._search(EmptyInt, [('number', '!=', False)]).mapped('number'), [42])
 
+        self.assertListEqual(self._search(EmptyInt, [('number', '<', 1)]).mapped('number'), [0, 0, 0])
+        self.assertListEqual(self._search(EmptyInt, [('number', '>', -1)]).mapped('number'), [42, 0, 0, 0])
+        self.assertListEqual(self._search(EmptyInt, [('number', '<=', 0)]).mapped('number'), [0, 0, 0])
+        self.assertListEqual(self._search(EmptyInt, [('number', '>=', 0)]).mapped('number'), [42, 0, 0, 0])
+        self.assertListEqual(self._search(EmptyInt, [('number', '>', 1)]).mapped('number'), [42])
+        self.assertListEqual(self._search(EmptyInt, [('number', '<', -1)]).mapped('number'), [])
+
         # check ('number', 'in', subset) for every subset of {42, 0, False}
         values = [42, 0, False]
         for length in range(4):

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -3097,6 +3097,16 @@ class BaseModel(metaclass=MetaModel):
         ):
             sql = SQL("(%s OR %s IS NULL)", sql, sql_field)
 
+        if not need_wildcard and is_number_field:
+            cmp_value = field.convert_to_record(field.convert_to_cache(value, self), self)
+            if (
+                operator == '>=' and cmp_value <= 0
+                or operator == '<=' and cmp_value >= 0
+                or operator == '<' and cmp_value > 0
+                or operator == '>' and cmp_value < 0
+            ):
+                sql = SQL("(%s OR %s IS NULL)", sql, sql_field)
+
         return sql
 
     @api.model


### PR DESCRIPTION
for numeric fields, NULL in database should be treated as 0 this commit fix the issue when search NULL value in the database

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
