### PR TITLE
[FIX] mail: fix missing modal title after creating a template

### DIFF
--- a/addons/mail/i18n/mail.pot
+++ b/addons/mail/i18n/mail.pot
@@ -2374,9 +2374,11 @@ msgstr ""
 
 #. module: mail
 #. odoo-javascript
+#. odoo-python
 #: code:addons/mail/static/src/js/activity.js:0
 #: code:addons/mail/static/src/models/composer_view.js:0
 #: code:addons/mail/static/src/models/mail_template.js:0
+#: code:addons/mail/wizard/mail_compose_message.py:0
 #: model:ir.actions.act_window,name:mail.action_email_compose_message_wizard
 #: model_terms:ir.ui.view,arch_db:mail.email_compose_message_wizard_form
 #, python-format

--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -14,7 +14,8 @@ def _reopen(self, res_id, model, context=None):
     # save original model in context, because selecting the list of available
     # templates requires a model in context
     context = dict(context or {}, default_model=model)
-    return {'type': 'ir.actions.act_window',
+    return {'name': _('Compose Email'),
+            'type': 'ir.actions.act_window',
             'view_mode': 'form',
             'res_id': res_id,
             'res_model': self._name,


### PR DESCRIPTION
In the mail composer, the title of the modal changes to "Odoo" when the user clicks on the "SAVE AS NEW TEMPLATE" button. This commit will ensure that the modal will keep the title "Compose email" after the user clicks on the button.

Steps to reproduce the issue:
1. Open a lead from the CRM module
2. Open the mail composer from the chatter
3. In the composer, click on the "SAVE AS NEW TEMPLATE" button

=> The modal title changes from "Compose Email" to "Odoo"

TO BE: The modal title should display "Compose Email" after creating the template.

When the user clicks on the button, the system re-opens the composer by executing a dynamic action. This action does not specify any title. As a result, the modal fallbacks to the default title "Odoo" after executing the action. To fix the issue, we will simply set a name to the dynamic action.

task-3748652

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
