### PR TITLE
[FIX] base_vat: correct the check and the reference of Israeli VAT numbers

### DIFF
--- a/addons/base_vat/i18n/base_vat.pot
+++ b/addons/base_vat/i18n/base_vat.pot
@@ -45,6 +45,13 @@ msgid "49-098-576 or 49098576"
 msgstr ""
 
 #. module: base_vat
+#. odoo-python
+#: code:addons/base_vat/models/res_partner.py:0
+#, python-format
+msgid "XXXXXXXXX [9 digits] and it should respect the Luhn algorithm checksum"
+msgstr ""
+
+#. module: base_vat
 #: model_terms:ir.ui.view,arch_db:base_vat.res_config_settings_view_form
 msgid ""
 "<span class=\"fa fa-lg fa-building-o\" title=\"Values set here are company-"

--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -48,6 +48,7 @@ _ref_vat = {
     'hu': _('HU12345676 or 12345678-1-11 or 8071592153'),
     'hr': 'HR01234567896',  # Croatia, contributed by Milan Tribuson
     'ie': 'IE1234567FA',
+    'il': _('XXXXXXXXX [9 digits] and it should respect the Luhn algorithm checksum'),
     'in': "12AAAAA1234AAZA",
     'is': 'IS062199',
     'it': 'IT12345670017',
@@ -819,6 +820,10 @@ class ResPartner(models.Model):
         is_valid_vat = stdnum.util.get_cc_module("de", "vat").is_valid
         is_valid_stnr = stdnum.util.get_cc_module("de", "stnr").is_valid
         return is_valid_vat(vat) or is_valid_stnr(vat)
+
+    def check_vat_il(self, vat):
+        check_func = stdnum.util.get_cc_module('il', 'hp').is_valid if self.is_company else stdnum.util.get_cc_module('il', 'idnr').is_valid
+        return check_func(vat)
 
     def format_vat_sm(self, vat):
         stdnum_vat_format = stdnum.util.get_cc_module('sm', 'vat').compact


### PR DESCRIPTION
### Issue:
The reference displayed when entering a non valid VAT number for Israel is incorrect. And the check used is not the right one.

### Steps to reproduce:
- In app Contact, create a new one
- Select Israel as country and enter a non-valid VAT number
- The default ref is displayed: 'CC##' (CC=Country Code, ##=VAT Number)
- And the number 039225313 should be accepted

### Cause:
he check used by the library stdnum is not up-to-date.
There is a PR to modify the library stdnum: https://github.com/arthurdejong/python-stdnum/ PR436 as the law has changed. Before only corporations could have a VAT number, now individuals can also have one.

### Solution:
Use the right check (tdnum.il.idnr), which is available in the library stdnum.

opw-3954674