### PR TITLE
[IMP] mail: quick search in messaging menu

### DIFF
--- a/addons/mail/static/src/core/common/discuss_app_model.js
+++ b/addons/mail/static/src/core/common/discuss_app_model.js
@@ -42,6 +42,7 @@ export class DiscussApp extends Record {
 
     /** @type {'main'|'channel'|'chat'|'livechat'} */
     activeTab = "main";
+    searchTerm = "";
     isActive = false;
     allCategories = Record.many("DiscussAppCategory", {
         inverse: "app",

--- a/addons/mail/static/src/core/web/messaging_menu.js
+++ b/addons/mail/static/src/core/web/messaging_menu.js
@@ -1,5 +1,6 @@
 import { ImStatus } from "@mail/core/common/im_status";
 import { NotificationItem } from "@mail/core/web/notification_item";
+import { MessagingMenuQuickSearch } from "@mail/core/web/messaging_menu_quick_search";
 import { onExternalClick, useDiscussSystray } from "@mail/utils/common/hooks";
 
 import { Component, useState } from "@odoo/owl";
@@ -12,7 +13,7 @@ import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
 
 export class MessagingMenu extends Component {
-    static components = { Dropdown, NotificationItem, ImStatus };
+    static components = { Dropdown, NotificationItem, ImStatus, MessagingMenuQuickSearch };
     static props = [];
     static template = "mail.MessagingMenu";
 
@@ -28,6 +29,7 @@ export class MessagingMenu extends Component {
         this.state = useState({
             addingChat: false,
             addingChannel: false,
+            searchOpen: false,
         });
         this.dropdown = useDropdownState();
 
@@ -37,6 +39,8 @@ export class MessagingMenu extends Component {
     }
 
     beforeOpen() {
+        this.state.searchOpen = false;
+        this.store.discuss.searchTerm = "";
         this.store.isReady.then(() => {
             if (
                 !this.store.inbox.isLoaded &&
@@ -220,6 +224,11 @@ export class MessagingMenu extends Component {
         if (this.store.discuss.activeTab !== "main") {
             this.store.discuss.thread = undefined;
         }
+    }
+
+    toggleSearch() {
+        this.store.discuss.searchTerm = "";
+        this.state.searchOpen = !this.state.searchOpen;
     }
 
     get counter() {

--- a/addons/mail/static/src/core/web/messaging_menu.xml
+++ b/addons/mail/static/src/core/web/messaging_menu.xml
@@ -20,9 +20,13 @@
     <div t-if="!(ui.isSmall and env.inDiscussApp and store.discuss.activeTab === 'main')" t-att-class="`${discussSystray.contentClass} o-mail-MessagingMenu`">
         <div class="o-mail-MessagingMenu-header d-flex" t-att-class="{'text-uppercase border-start-0 border-end-0': ui.isSmall, 'bg-view border-bottom': !ui.isSmall, 'flex-shrink-0': !env.inDiscussApp }">
             <t t-if="!ui.isSmall">
-                <button class="btn btn-link py-1 rounded-0" t-att-class="store.discuss.activeTab === 'main' ? 'fw-bold o-active' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'main'">All</button>
-                <button class="btn btn-link py-1 rounded-0" t-att-class="store.discuss.activeTab === 'chat' ? 'fw-bold o-active' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'chat'">Chats</button>
-                <button class="btn btn-link py-1 rounded-0" t-att-class="store.discuss.activeTab === 'channel' ? 'fw-bold o-active' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'channel'">Channels</button>
+                <MessagingMenuQuickSearch t-if="state.searchOpen" onClose.bind="toggleSearch"/>
+                <t t-else="">
+                    <button class="btn btn-link py-1 rounded-0" t-att-class="store.discuss.activeTab === 'main' ? 'fw-bold o-active' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'main'">All</button>
+                    <button class="btn btn-link py-1 rounded-0" t-att-class="store.discuss.activeTab === 'chat' ? 'fw-bold o-active' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'chat'">Chats</button>
+                    <button class="btn btn-link py-1 rounded-0" t-att-class="store.discuss.activeTab === 'channel' ? 'fw-bold o-active' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'channel'">Channels</button>
+                    <button t-if="threads.length >= 20" class="btn btn-link py-1 rounded-0 text-muted" type="button" t-on-click="toggleSearch"><i class="fa fa-fw fa-search"/></button>
+                </t>
             </t>
         </div>
         <div t-if="!env.inDiscussApp or store.discuss.activeTab !== 'main'" class="d-flex flex-column overflow-auto flex-grow-1 list-group list-group-flush">
@@ -61,7 +65,7 @@
                     </t>
                 </NotificationItem>
             </t>
-            <t t-if="store.discuss.activeTab === 'main' and !env.inDiscussApp">
+            <t t-if="store.discuss.activeTab === 'main' and !env.inDiscussApp and !store.discuss.searchTerm">
                 <t t-foreach="store.failures" t-as="failure" t-key="failure.id">
                     <NotificationItem
                         body="failure.body"

--- a/addons/mail/static/src/core/web/messaging_menu_quick_search.js
+++ b/addons/mail/static/src/core/web/messaging_menu_quick_search.js
@@ -1,0 +1,27 @@
+import { onExternalClick } from "@mail/utils/common/hooks";
+import { Component, useState } from "@odoo/owl";
+import { getActiveHotkey } from "@web/core/hotkeys/hotkey_service";
+
+import { useAutofocus, useService } from "@web/core/utils/hooks";
+
+export class MessagingMenuQuickSearch extends Component {
+    static components = {};
+    static props = ["onClose"];
+    static template = "mail.MessagingMenuQuickSearch";
+
+    setup() {
+        super.setup();
+        this.store = useState(useService("mail.store"));
+        useAutofocus();
+        onExternalClick("search", () => this.props.onClose());
+    }
+
+    onKeydownInput(ev) {
+        const hotkey = getActiveHotkey(ev);
+        if (hotkey === "escape") {
+            ev.stopPropagation();
+            ev.preventDefault();
+            this.props.onClose();
+        }
+    }
+}

--- a/addons/mail/static/src/core/web/messaging_menu_quick_search.xml
+++ b/addons/mail/static/src/core/web/messaging_menu_quick_search.xml
@@ -1,0 +1,6 @@
+<t t-name="mail.MessagingMenuQuickSearch">
+    <div class="position-relative w-50 m-1" t-ref="search" t-on-keydown="onKeydownInput">
+        <input t-model="store.discuss.searchTerm" t-ref="autofocus" class="form-control px-1 py-0" placeholder="Quick search..." type="text" />
+        <button class="btn btn-link text-muted p-1 position-absolute top-50 end-0 translate-middle-y" t-on-click="props.onClose"><i class="oi oi-close"/></button>
+    </div>
+</t>

--- a/addons/mail/static/src/core/web/store_service_patch.js
+++ b/addons/mail/static/src/core/web/store_service_patch.js
@@ -1,5 +1,6 @@
 import { Record } from "@mail/core/common/record";
 import { Store } from "@mail/core/common/store_service";
+import { cleanTerm } from "@mail/utils/common/format";
 import { compareDatetime } from "@mail/utils/common/misc";
 import { browser } from "@web/core/browser/browser";
 import { _t } from "@web/core/l10n/translation";
@@ -30,10 +31,13 @@ const StorePatch = {
             /** @this {import("models").Store} */
             compute() {
                 /** @type {import("models").Thread[]} */
+                const searchTerm = cleanTerm(this.discuss.searchTerm);
                 let threads = Object.values(this.Thread.records).filter(
                     (thread) =>
-                        thread.displayToSelf ||
-                        (thread.needactionMessages.length > 0 && thread.model !== "mail.box")
+                        (thread.displayToSelf ||
+                            (thread.needactionMessages.length > 0 &&
+                                thread.model !== "mail.box")) &&
+                        cleanTerm(thread.displayName).includes(searchTerm)
                 );
                 const tab = this.discuss.activeTab;
                 if (tab !== "main") {

--- a/addons/mail/static/tests/messaging_menu/messaging_menu.test.js
+++ b/addons/mail/static/tests/messaging_menu/messaging_menu.test.js
@@ -1141,3 +1141,30 @@ test("Latest needaction is shown in thread preview", async () => {
     await contains(".o-mail-NotificationItem", { text: serverState.partnerName });
     await contains(".o-mail-NotificationItem", { text: "You: message 2" });
 });
+
+test("Can quick search when more than 20 items", async () => {
+    const pyEnv = await startServer();
+    for (let id = 1; id <= 20; id++) {
+        pyEnv["discuss.channel"].create({ name: `channel${id}` });
+    }
+    pyEnv["discuss.channel"].create([
+        { channel_type: "chat" },
+        { name: "Cool channel" },
+        { name: "Nice channel" },
+    ]);
+    await start();
+    await click(".o_menu_systray .dropdown-toggle:has(i[aria-label='Messages'])");
+    await contains(".o-mail-NotificationItem", { count: 23 });
+    await contains(".o-mail-NotificationItem", { text: "Mitchell Admin" });
+    await contains(".o-mail-NotificationItem", { text: "Cool channel" });
+    await contains(".o-mail-NotificationItem", { text: "Nice channel" });
+    await click(".o-mail-MessagingMenu button .fa-search");
+    await insertText(".o-mail-MessagingMenu-header input", "nice");
+    await contains(".o-mail-NotificationItem", { count: 1 });
+    await contains(".o-mail-NotificationItem", { text: "Nice channel" });
+    await click(".o-mail-MessagingMenu button .oi-close");
+    await click(".o-mail-MessagingMenu button .fa-search");
+    await insertText(".o-mail-MessagingMenu-header input", "admin");
+    await contains(".o-mail-NotificationItem", { count: 1 });
+    await contains(".o-mail-NotificationItem", { text: "Mitchell Admin" });
+});


### PR DESCRIPTION
This commit adds a new item in messaging menu when there are more than 20 items, which allows to quickly search an item matching the search.

task-4045727

<img width="458" alt="1" src="https://github.com/user-attachments/assets/d4d2ee89-6191-4690-9cd2-92720be67031">
<img width="460" alt="2" src="https://github.com/user-attachments/assets/63bdd9cd-da7c-4f38-acd3-6fd18d9292ad">