### PR TITLE
[IMP] website: redesign `s_form` snippet

### DIFF
--- a/addons/website/data/website_data.xml
+++ b/addons/website/data/website_data.xml
@@ -127,7 +127,7 @@
                                                         </div>
                                                     </div>
                                                 </div>
-                                                <div class="mb-0 py-2 col-12 s_website_form_submit" data-name="Submit Button">
+                                                <div class="mb-0 py-2 col-12 s_website_form_submit s_website_form_no_submit_label text-end" data-name="Submit Button">
                                                     <div style="width: 200px;" class="s_website_form_label"/>
                                                     <a href="#" role="button" class="btn btn-primary s_website_form_send">Submit</a>
                                                     <span id="s_website_form_result"></span>

--- a/addons/website/static/src/xml/website_form.xml
+++ b/addons/website/static/src/xml/website_form.xml
@@ -3,15 +3,15 @@
 
     <!-- Success status -->
     <t t-name="website.s_website_form_status_success">
-        <span id="s_website_form_result" class="text-success ml8">
-            <i class="fa fa-check mr4" role="img" aria-label="Success" title="Success"/>The form has been sent successfully.
+        <span id="s_website_form_result" class="me-2 small text-success">
+            <i class="fa fa-paper-plane me-1" role="img" aria-hidden="true" title="Success"/>The form has been sent successfully.
         </span>
     </t>
 
     <!-- Error status -->
     <t t-name="website.s_website_form_status_error">
-        <span id="s_website_form_result" class="text-danger ml8">
-            <i class="fa fa-close mr4" role="img" aria-label="Error" title="Error"/>
+        <span id="s_website_form_result" class="me-2 small text-danger">
+            <i class="fa fa-close me-1" role="img" aria-hidden="true" title="Error"/>
             <t t-esc="message"/>
         </span>
     </t>

--- a/addons/website/static/src/xml/website_form_editor.xml
+++ b/addons/website/static/src/xml/website_form_editor.xml
@@ -5,17 +5,11 @@
     <t t-name="website.s_website_form_end_message">
         <div class="s_website_form_end_message d-none">
             <div class="oe_structure">
-                <section class="s_text_block pt64 pb64 o_colored_level o_cc o_cc2" data-snippet="s_text_block">
-                    <div class="container">
-                        <h2 class="text-center">
-                            <span class="fa fa-check-circle"/>
-                                Thank You For Your Feedback
-                        </h2>
-                        <p class="text-center">
-                            Our team will message you back as soon as possible.<br/>
-                            In the meantime we invite you to visit our <a href="/">website</a>.<br/>
-                        </p>
-                    </div>
+                <section class="s_text_block o_colored_level rounded px-5 text-center" data-snippet="s_text_block">
+                    <i class="fa fa-paper-plane fa-2x mb-3 rounded-circle text-bg-success" role="img" aria-hidden="true" title="Success"/>
+                    <h1 class="fw-bolder">Thank you for your feedback!</h1>
+                    <p class="lead mb-0">Our team will message you back as soon as possible.</p>
+                    <p class="lead">In the meantime we invite you to visit our <a href="/">website</a>.</p>
                 </section>
             </div>
         </div>

--- a/addons/website/views/new_page_template_templates.xml
+++ b/addons/website/views/new_page_template_templates.xml
@@ -1050,9 +1050,6 @@ overridden by modules), because:
         <attribute name="data-success-page">/contactus-thank-you</attribute>
         <attribute name="data-model_name">mail.mail</attribute>
     </xpath>
-    <xpath expr="//div[hasclass('s_website_form_submit')]" position="attributes">
-        <attribute name="class" add="text-end" separator=" "/>
-    </xpath>
 </template>
 
 <!-- Map: change height -->

--- a/addons/website/views/snippets/s_website_form.xml
+++ b/addons/website/views/snippets/s_website_form.xml
@@ -2,9 +2,15 @@
 <odoo>
 
 <template id="s_website_form" name="Form">
-    <section class="s_website_form pt16 pb16" data-vcss="001" data-snippet="s_website_form">
-        <div class="container">
+    <section class="s_website_form o_cc o_cc2 pt64 pb64" data-vcss="001" data-snippet="s_website_form">
+        <div class="o_container_small">
             <form action="/website/form/" method="post" enctype="multipart/form-data" class="o_mark_required" data-mark="*" data-pre-fill="true" data-model_name="mail.mail" data-success-mode="redirect" data-success-page="/contactus-thank-you">
+                <div class="row text-center">
+                    <div class="col-12 pb16">
+                        <h2>Let's Connect</h2>
+                        <p class="lead">Get in touch with your customers to provide them with better service. You can modify the form fields to gather more precise information.</p>
+                    </div>
+                </div>
                 <div class="s_website_form_rows row s_col_no_bgcolor">
                     <div data-name="Field" class="s_website_form_field mb-3 col-12 s_website_form_dnone">
                         <div class="row s_col_no_resize s_col_no_bgcolor">
@@ -80,10 +86,10 @@
                             </div>
                         </div>
                     </div>
-                    <div class="mb-0 py-2 col-12 s_website_form_submit" data-name="Submit Button">
+                    <div class="mb-0 py-2 col-12 s_website_form_submit text-end s_website_form_no_submit_label" data-name="Submit Button">
                         <div style="width: 200px;" class="s_website_form_label"/>
+                        <span id="s_website_form_result"/>
                         <a href="#" role="button" class="btn btn-primary s_website_form_send">Submit</a>
-                        <span id="s_website_form_result"></span>
                     </div>
                 </div>
             </form>


### PR DESCRIPTION
This PR is handled by @Brieuc-brd 

---

The goal of this commit is to improve the visual design of the default `s_form` snippet.

task-4048101
Part of task-3619705

Requires: 
- https://github.com/odoo/design-themes/pull/832

| Before | After |
|--------|--------|
| ![Capture d’écran 2024-07-16 à 13 07 55](https://github.com/user-attachments/assets/b2da6bbb-5dfe-4dd1-8a67-b34446b3cad9) | ![Capture d’écran 2024-07-16 à 13 07 05](https://github.com/user-attachments/assets/a2033c28-5735-401d-b09f-584764683465) |


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
