### PR TITLE
[FIX] point_of_sale, pos_loyalty: add context when loading data params

### DIFF
--- a/addons/pos_loyalty/models/pos_session.py
+++ b/addons/pos_loyalty/models/pos_session.py
@@ -33,7 +33,6 @@ class PosSession(models.Model):
                     'discount', 'discount_mode', 'discount_applicability', 'all_discount_product_ids', 'is_global_discount',
                     'discount_max_amount', 'discount_line_product_id',
                     'multi_product', 'reward_product_ids', 'reward_product_qty', 'reward_product_uom_id', 'reward_product_domain'],
-                'context': {**self.env.context},
             },
             'loyalty.card': {
                 'domain': lambda data: [('program_id', 'in', [program["id"] for program in data["loyalty.program"]])],


### PR DESCRIPTION
Fix for 17.1 and 17.2 only

Problem:
en_US data is loaded while the user uses another language

Steps to reproduce:
- Install "point_of_sale" app and "pos_loyalty" module
- Change the language (e.g. to french)
- Go to POS -> Products -> Discount & Loyalty
- Create a new Loyalty Card
- In Rewards, set a discount of 20 $ on order and save
- Go to the shop and select a partner and a product (price must be expensive enough for the loyalty card to be applicable)
- Click on "Reward", the earlier created reward is there
- Go back to the form of the loyalty card and change the value and save
- Go back to the shop
- Click on "Reward" and the name of the loyalty card is still the same as before while it should be for the new price

Note:
This error has been already fixed but this commit generalize the solution to all the params. So the previous fix is replaced by this one.
See this PR for the previous fix and the test: https://github.com/odoo/odoo/pull/171049

Solution:
Set the environment context for each data param so that the language is loaded by creating a wrapper. Only apply a context if some has not already been defined for specific cases where a different context is needed. "_load_data_params_with_context" replaces "_load_data_params" only where the context is used to keep a bit of optimization.

opw-4039850


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
