### PR TITLE
[FIX] base: cascade removal of ir.cron.progress on cron removal

### DIFF
--- a/odoo/addons/base/models/ir_cron.py
+++ b/odoo/addons/base/models/ir_cron.py
@@ -760,7 +760,7 @@ class ir_cron_progress(models.Model):
     _description = 'Progress of Scheduled Actions'
     _rec_name = 'cron_id'
 
-    cron_id = fields.Many2one("ir.cron", required=True, index=True)
+    cron_id = fields.Many2one("ir.cron", required=True, index=True, ondelete='cascade')
     remaining = fields.Integer(default=0)
     done = fields.Integer(default=0)
     timed_out_counter = fields.Integer(default=0)


### PR DESCRIPTION
It prevents the removal of a cron at module uninstall for example. If the cron is being removed it makes sense to drop their associated progress entries.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
