### PR TITLE
[IMP] point_of_sale: toggle numpad visibility

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -460,14 +460,6 @@ export class PosOrder extends Base {
     }
 
     get_selected_orderline() {
-        const selected = this.lines.find(
-            (line) => line.uuid === this.uiState.selected_orderline_uuid
-        );
-
-        if (!selected && this.lines.length > 0) {
-            this.select_orderline(this.get_last_orderline());
-        }
-
         return this.lines.find((line) => line.uuid === this.uiState.selected_orderline_uuid);
     }
 

--- a/addons/point_of_sale/static/src/app/screens/product_screen/order_summary/order_summary.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/order_summary/order_summary.xml
@@ -6,7 +6,7 @@
           tax="!env.utils.floatIsZero(currentOrder.get_total_tax()) and env.utils.formatCurrency(currentOrder.get_total_tax()) or ''">
           <t t-set="line" t-value="scope.line" />
           <Orderline line="line.getDisplayData()"
-              t-on-click="() => this.selectLine(line)"
+              t-on-click="(event) => this.clickLine(event, line)"
               class="{ ...line.getDisplayClasses(), 'selected' : line.isSelected() }">
               <t t-set-slot="product-name">
                 <!-- FIXME: pos_sale does not always correctly import orders -->

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.xml
@@ -13,7 +13,7 @@
                             actionName="constructor.numpadActionName"
                             actionType="'payment'"
                             onClickMore.bind="displayAllControlPopup" />
-                        <Numpad buttons="getNumpadButtons()" onClick.bind="onNumpadClick"/>
+                        <Numpad t-if="pos.get_order().uiState.selected_orderline_uuid" buttons="getNumpadButtons()" onClick.bind="onNumpadClick"/>
                     </div>
                 </div>
             </div>

--- a/addons/pos_sale/static/src/overrides/models/pos_store.js
+++ b/addons/pos_sale/static/src/overrides/models/pos_store.js
@@ -63,8 +63,9 @@ patch(PosStore.prototype, {
             this.get_order().set_partner(sale_order.partner_id);
         }
         selectedOption == "settle"
-            ? this.settleSO(sale_order, orderFiscalPos)
-            : this.downPaymentSO(sale_order, selectedOption == "dpPercentage");
+            ? await this.settleSO(sale_order, orderFiscalPos)
+            : await this.downPaymentSO(sale_order, selectedOption == "dpPercentage");
+        this.selectOrderLine(this.get_order(), this.get_order().lines.at(-1));
     },
     async _getSaleOrder(id) {
         const sale_order = (await this.data.read("sale.order", [id]))[0];

--- a/addons/pos_sale/static/tests/tours/utils/pos_sale_utils.js
+++ b/addons/pos_sale/static/tests/tours/utils/pos_sale_utils.js
@@ -38,7 +38,7 @@ export function downPaymentFirstOrder() {
             run: "click",
         },
         Numpad.click("+10"),
-        Dialog.confirm(),
+        Dialog.confirm("Ok"),
     ];
 }
 


### PR DESCRIPTION
In this commit we add the ability to temporarily hide the numpad, by
clicking on the selected orderline. Clicking the selected line will
unselect it and hide the numpad. Clicking on any line will then select
that line, thus bringing back the numpad.

Task: 4045935




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
