### PR TITLE
[FIX] point_of_sale: related_models.js prevent extra fields override

### DIFF
--- a/addons/point_of_sale/static/src/app/models/related_models.js
+++ b/addons/point_of_sale/static/src/app/models/related_models.js
@@ -150,6 +150,11 @@ export class Base {
     setup(_vals) {
         // Allow custom fields
         for (const [key, val] of Object.entries(_vals)) {
+            // Prevent extra fields that begin by _ to be overrided
+            if (key in this.model.modelFields) {
+                continue;
+            }
+
             if (key.startsWith("_") && !key.startsWith("__")) {
                 this[key] = val;
             }


### PR DESCRIPTION
Before this commit, extra fields that begin by `_` were not correctly handled in the `related_models.js` file.

This commit fixes this issue by adding a condition to prevent extra fields that begin by `_` from being overridden.

