### PR TITLE
[IMP] web: stat_buttons dropdown on smaller screens

### DIFF
--- a/addons/web/static/src/views/form/button_box/button_box.js
+++ b/addons/web/static/src/views/form/button_box/button_box.js
@@ -17,7 +17,7 @@ export class ButtonBox extends Component {
     setup() {
         const ui = useService("ui");
         onWillRender(() => {
-            const maxVisibleButtons = [3, 4, 5, 7, 4, 5, 8][ui.size] || 8;
+            const maxVisibleButtons = [0, 0, 0, 7, 4, 5, 8][ui.size] ?? 8;
             const allVisibleButtons = Object.entries(this.props.slots)
                 .filter(([_, slot]) => this.isSlotVisible(slot))
                 .map(([slotName]) => slotName);
@@ -27,8 +27,9 @@ export class ButtonBox extends Component {
                 this.isFull = allVisibleButtons.length === maxVisibleButtons;
             } else {
                 // -1 for "More" dropdown
-                this.visibleButtons = allVisibleButtons.slice(0, maxVisibleButtons - 1);
-                this.additionalButtons = allVisibleButtons.slice(maxVisibleButtons - 1);
+                const splitIndex = Math.max(maxVisibleButtons - 1, 0);
+                this.visibleButtons = allVisibleButtons.slice(0, splitIndex);
+                this.additionalButtons = allVisibleButtons.slice(splitIndex);
                 this.isFull = true;
             }
         });

--- a/addons/web/static/src/views/form/button_box/button_box.scss
+++ b/addons/web/static/src/views/form/button_box/button_box.scss
@@ -103,24 +103,26 @@
         }
     }
 
-    > * + * {
+    &:not(.o-form-buttonbox-small) > * + * {
         margin-left: -$border-width;
     }
 
-    .oe_stat_button,
-    .oe_stat_button > button {
-        border-radius: 0;
-    }
+    @include media-breakpoint-up(md) {
+        .oe_stat_button,
+        .oe_stat_button > button {
+            border-radius: 0;
+        }
 
-    > .oe_stat_button:first-child,
-    > div:first-child > .oe_stat_button {
-        @include border-start-radius($border-radius);
-    }
+        > .oe_stat_button:first-child,
+        > div:first-child > .oe_stat_button {
+            @include border-start-radius($border-radius);
+        }
 
-    > button.oe_stat_button:last-child,
-    > div:last-child > .oe_stat_button,
-    > div.oe_stat_button:last-child > button {
-        @include border-end-radius($border-radius);
+        > button.oe_stat_button:last-child,
+        > div:last-child > .oe_stat_button,
+        > div.oe_stat_button:last-child > button {
+            @include border-end-radius($border-radius);
+        }
     }
 
     // "More" button and dropdown
@@ -156,6 +158,32 @@
 
     .o_pie_value {
         @extend %-stat-button-value;
+    }
+}
+
+.o-form-buttonbox-small {
+    --button-box-gap: 1px;
+    --button-box-per-row: 2;
+    --button-box-border-color: #{map-get(map-get($o-btns-bs-outline-override, 'secondary'), 'border')};
+
+    display: grid;
+    grid-template-columns: repeat(var(--button-box-per-row), minmax(0, 1fr));
+    overflow: hidden;
+    inset-inline-end: $spacer;
+    gap: var(--button-box-gap);
+
+    > span .o_field_widget, .o_stat_info, .o_stat_value {
+        @include text-truncate;
+    }
+
+    .oe_stat_button,
+    .oe_stat_button > button {
+        border-color: transparent;
+        border-radius: 0;
+    }
+
+    > .o-dropdown-item {
+        outline: $btn-border-width solid var(--button-box-border-color);
     }
 }
 

--- a/addons/web/static/src/views/form/button_box/button_box.xml
+++ b/addons/web/static/src/views/form/button_box/button_box.xml
@@ -5,9 +5,10 @@
     <div class="o-form-buttonbox d-print-none position-relative d-flex w-md-auto" t-attf-class="{{ isFull ? 'o_full w-100' : 'o_not_full'}} {{this.props.class}}">
         <t t-slot="{{ button_value }}" t-foreach="visibleButtons" t-as="button" t-key="button_value"/>
         <div t-if="additionalButtons.length" class="oe_stat_button btn position-relative p-0 border-0">
-            <Dropdown position="'bottom-end'" menuClass="'o-form-buttonbox o_dropdown_more p-0 border-0'">
-                <button class="o_button_more btn btn-outline-secondary d-flex justify-content-center align-items-center o-dropdown-caret">
-                    <span>More</span>
+            <Dropdown position="!env.isSmall ? 'bottom-end' : ''" menuClass="'o-form-buttonbox p-0 border-0 ' + (!env.isSmall ? 'o_dropdown_more' : 'o-form-buttonbox-small')">
+                <button class="o_button_more btn d-flex justify-content-center align-items-center" t-att-class="!env.isSmall ? 'o-dropdown-caret btn-outline-secondary' : 'btn-secondary'">
+                    <span t-if="!env.isSmall">More</span>
+                    <i t-else="" class="fa fa-bolt" aria-hidden="true"/>
                 </button>
                 <t t-set-slot="content">
                     <DropdownItem t-foreach="additionalButtons" t-as="button" t-key="button_value" class="'d-flex flex-column p-0'">

--- a/addons/web/static/tests/legacy/mobile/views/form_view_tests.js
+++ b/addons/web/static/tests/legacy/mobile/views/form_view_tests.js
@@ -468,38 +468,4 @@ QUnit.module("Mobile Views", ({ beforeEach }) => {
         await nextTick();
         assert.verifySteps(["post"]);
     });
-
-    QUnit.test("button box with 3/4 buttons (close to threshold)", async (assert) => {
-        await makeView({
-            type: "form",
-            resModel: "partner",
-            serverData,
-            arch: `
-                <form>
-                    <sheet>
-                        <div name="button_box">
-                            <button>MyButton</button>
-                            <button>MyButton2</button>
-                            <button>MyButton3</button>
-                            <button invisible="not boolean">MyButton4</button>
-                        </div>
-                        <field name="boolean"/>
-                    </sheet>
-                </form>`,
-            resId: 2,
-        });
-
-        // 3 buttons to display -> no "More" dropdown
-        assert.containsNone(fixture, ".o_field_widget[name=boolean] input:checked");
-        assert.containsN(fixture, ".o-form-buttonbox > .oe_stat_button", 3);
-        assert.containsNone(fixture, ".o-form-buttonbox .o_button_more");
-
-        // 4 buttons to display -> 2 buttons visible + 2 inside the "More" dropdown
-        await click(fixture.querySelector(".o_field_widget[name=boolean] input"));
-        assert.containsN(fixture, ".o-form-buttonbox > .oe_stat_button", 3);
-        assert.containsOnce(fixture, ".o-form-buttonbox .oe_stat_button .o_button_more");
-
-        await click(fixture.querySelector(".o_button_more"));
-        assert.containsN(fixture, ".o_dropdown_more .oe_stat_button", 2);
-    });
 });

--- a/addons/web/static/tests/views/fields/stat_info_field.test.js
+++ b/addons/web/static/tests/views/fields/stat_info_field.test.js
@@ -1,5 +1,5 @@
 import { expect, test } from "@odoo/hoot";
-import { defineModels, fields, models, mountView } from "@web/../tests/web_test_helpers";
+import { contains, defineModels, fields, models, mountView } from "@web/../tests/web_test_helpers";
 
 class Partner extends models.Model {
     foo = fields.Char({ default: "My little Foo Value" });
@@ -33,15 +33,15 @@ test("StatInfoField formats decimal precision", async () => {
     });
 
     // formatFloat renders according to this.field.digits
-    expect(".oe_stat_button .o_field_widget .o_stat_value:eq(0)").toHaveText("0.4", {
+    expect("button.oe_stat_button .o_field_widget .o_stat_value:eq(0)").toHaveText("0.4", {
         message: "Default precision should be [16,1]",
     });
-    expect(".oe_stat_button .o_field_widget .o_stat_value:eq(1)").toHaveText("10.00", {
+    expect("button.oe_stat_button .o_field_widget .o_stat_value:eq(1)").toHaveText("10.00", {
         message: "Currency decimal precision should be 2",
     });
 });
 
-test("StatInfoField in form view", async () => {
+test.tags("desktop")("StatInfoField in form view on desktop", async () => {
     await mountView({
         type: "form",
         resModel: "partner",
@@ -57,18 +57,46 @@ test("StatInfoField in form view", async () => {
         `,
     });
 
-    expect(".oe_stat_button .o_field_widget .o_stat_info").toHaveCount(1, {
+    expect("button.oe_stat_button .o_field_widget .o_stat_info").toHaveCount(1, {
         message: "should have one stat button",
     });
-    expect(".oe_stat_button .o_field_widget .o_stat_value").toHaveText("10", {
+    expect("button.oe_stat_button .o_field_widget .o_stat_value").toHaveText("10", {
         message: "should have 10 as value",
     });
-    expect(".oe_stat_button .o_field_widget .o_stat_text").toHaveText("int_field", {
+    expect("button.oe_stat_button .o_field_widget .o_stat_text").toHaveText("int_field", {
         message: "should have 'int_field' as text",
     });
 });
 
-test("StatInfoField in form view with specific label_field", async () => {
+test.tags("mobile")("StatInfoField in form view on mobile", async () => {
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 1,
+        arch: /* xml */ `
+            <form>
+                <div class="oe_button_box" name="button_box">
+                    <button class="oe_stat_button" name="items" type="object" icon="fa-gear">
+                        <field name="int_field" widget="statinfo" />
+                    </button>
+                </div>
+            </form>
+        `,
+    });
+
+    await contains(".o-form-buttonbox .o_button_more").click();
+    expect("button.oe_stat_button .o_field_widget .o_stat_info").toHaveCount(1, {
+        message: "should have one stat button",
+    });
+    expect("button.oe_stat_button .o_field_widget .o_stat_value").toHaveText("10", {
+        message: "should have 10 as value",
+    });
+    expect("button.oe_stat_button .o_field_widget .o_stat_text").toHaveText("int_field", {
+        message: "should have 'int_field' as text",
+    });
+});
+
+test.tags("desktop")("StatInfoField in form view with specific label_field on desktop", async () => {
     await mountView({
         type: "form",
         resModel: "partner",
@@ -89,18 +117,51 @@ test("StatInfoField in form view with specific label_field", async () => {
         `,
     });
 
-    expect(".oe_stat_button .o_field_widget .o_stat_info").toHaveCount(1, {
+    expect("button.oe_stat_button .o_field_widget .o_stat_info").toHaveCount(1, {
         message: "should have one stat button",
     });
-    expect(".oe_stat_button .o_field_widget .o_stat_value").toHaveText("10", {
+    expect("button.oe_stat_button .o_field_widget .o_stat_value").toHaveText("10", {
         message: "should have 10 as value",
     });
-    expect(".oe_stat_button .o_field_widget .o_stat_text").toHaveText("yop", {
+    expect("button.oe_stat_button .o_field_widget .o_stat_text").toHaveText("yop", {
         message: "should have 'yop' as text, since it is the value of field foo",
     });
 });
 
-test("StatInfoField in form view with no label", async () => {
+test.tags("mobile")("StatInfoField in form view with specific label_field on mobile", async () => {
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 1,
+        arch: /* xml */ `
+            <form>
+                <sheet>
+                    <div class="oe_button_box" name="button_box">
+                        <button class="oe_stat_button" name="items" type="object" icon="fa-gear">
+                            <field string="Useful stat button" name="int_field" widget="statinfo" options="{'label_field': 'foo'}" />
+                        </button>
+                    </div>
+                    <group>
+                        <field name="foo" invisible="1" />
+                    </group>
+                </sheet>
+            </form>
+        `,
+    });
+
+    await contains(".o-form-buttonbox .o_button_more").click();
+    expect("button.oe_stat_button .o_field_widget .o_stat_info").toHaveCount(1, {
+        message: "should have one stat button",
+    });
+    expect("button.oe_stat_button .o_field_widget .o_stat_value").toHaveText("10", {
+        message: "should have 10 as value",
+    });
+    expect("button.oe_stat_button .o_field_widget .o_stat_text").toHaveText("yop", {
+        message: "should have 'yop' as text, since it is the value of field foo",
+    });
+});
+
+test.tags("desktop")("StatInfoField in form view with no label on desktop", async () => {
     await mountView({
         type: "form",
         resModel: "partner",
@@ -117,13 +178,42 @@ test("StatInfoField in form view with no label", async () => {
             </form>
         `,
     });
-    expect(".oe_stat_button .o_field_widget .o_stat_info").toHaveCount(1, {
+    expect("button.oe_stat_button .o_field_widget .o_stat_info").toHaveCount(1, {
         message: "should have one stat button",
     });
-    expect(".oe_stat_button .o_field_widget .o_stat_value").toHaveText("10", {
+    expect("button.oe_stat_button .o_field_widget .o_stat_value").toHaveText("10", {
         message: "should have 10 as value",
     });
-    expect(".oe_stat_button .o_field_widget .o_stat_text").toHaveCount(0, {
+    expect("button.oe_stat_button .o_field_widget .o_stat_text").toHaveCount(0, {
+        message: "should not have any label",
+    });
+});
+
+test.tags("mobile")("StatInfoField in form view with no label on mobile", async () => {
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 1,
+        arch: /* xml */ `
+            <form>
+                <sheet>
+                    <div class="oe_button_box" name="button_box">
+                        <button class="oe_stat_button" name="items" type="object" icon="fa-gear">
+                            <field string="Useful stat button" name="int_field" widget="statinfo" nolabel="1" />
+                        </button>
+                    </div>
+                </sheet>
+            </form>
+        `,
+    });
+    await contains(".o-form-buttonbox .o_button_more").click();
+    expect("button.oe_stat_button .o_field_widget .o_stat_info").toHaveCount(1, {
+        message: "should have one stat button",
+    });
+    expect("button.oe_stat_button .o_field_widget .o_stat_value").toHaveText("10", {
+        message: "should have 10 as value",
+    });
+    expect("button.oe_stat_button .o_field_widget .o_stat_text").toHaveCount(0, {
         message: "should not have any label",
     });
 });

--- a/addons/web/static/tests/webclient/actions/window_action.test.js
+++ b/addons/web/static/tests/webclient/actions/window_action.test.js
@@ -1022,7 +1022,7 @@ test.tags("desktop")("execute smart button and back", async () => {
     expect.verifySteps(["web_read", "web_search_read", "web_read"]);
 });
 
-test("execute smart button and fails", async () => {
+test.tags("desktop")("execute smart button and fails on desktop", async () => {
     expect.errors(1);
     onRpc("web_search_read", () => {
         throw makeServerError({ message: "Oups" });
@@ -1034,7 +1034,37 @@ test("execute smart button and fails", async () => {
     expect(".o_form_view").toHaveCount(1);
     expect(".o_form_button_create:not([disabled]):visible").toHaveCount(1);
 
-    await contains(".oe_stat_button").click();
+    await contains("button.oe_stat_button").click();
+    expect(".o_form_view").toHaveCount(1);
+    expect(".o_form_button_create:not([disabled]):visible").toHaveCount(1);
+    expect.verifySteps([
+        "/web/webclient/translations",
+        "/web/webclient/load_menus",
+        "/web/action/load",
+        "get_views",
+        "web_read",
+        "/web/action/load",
+        "get_views",
+        "web_search_read",
+        "web_read",
+    ]);
+    expect.verifyErrors(["Oups"]);
+});
+
+test.tags("mobile")("execute smart button and fails on mobile", async () => {
+    expect.errors(1);
+    onRpc("web_search_read", () => {
+        throw makeServerError({ message: "Oups" });
+    });
+    stepAllNetworkCalls();
+
+    await mountWithCleanup(WebClient);
+    await getService("action").doAction(2);
+    expect(".o_form_view").toHaveCount(1);
+    expect(".o_form_button_create:not([disabled]):visible").toHaveCount(1);
+
+    await contains(".o-form-buttonbox .o_button_more").click();
+    await contains("button.oe_stat_button").click();
     expect(".o_form_view").toHaveCount(1);
     expect(".o_form_button_create:not([disabled]):visible").toHaveCount(1);
     expect.verifySteps([


### PR DESCRIPTION
The form view's stat buttons easily take a lot of space, especially for smaller screens.

This commit groups the stat buttons into a dropdown to reclaim as much space as possible in the Control Panel on smaller/mobile screens.

task-3336242

Co-authored-by: Pierre Paridans <app@odoo.com>


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
