### PR TITLE
[FIX] sale: adapt saleorder_document to studio report editor

### DIFF
--- a/addons/sale/report/ir_actions_report_templates.xml
+++ b/addons/sale/report/ir_actions_report_templates.xml
@@ -176,12 +176,14 @@
                 <p t-if="not is_html_empty(doc.payment_term_id.note)">
                     <span t-field="doc.payment_term_id.note">The payment should also be transmitted with love</span>
                 </p>
+                <div class="oe_structure"/>
                 <p t-if="doc.fiscal_position_id and not is_html_empty(doc.fiscal_position_id.sudo().note)"
                     id="fiscal_position_remark">
                     <strong>Fiscal Position Remark:</strong>
                     <span t-field="doc.fiscal_position_id.sudo().note">No further requirements for this payment</span>
                 </p>
             </div>
+            <div class="oe_structure"/>
         </div>
     </t>
 </template>


### PR DESCRIPTION
similar to https://github.com/odoo/odoo/pull/129310

Currently, users cannot edit the bottom part of `payment_terms` and `fiscal_position`, as these are conditional blocks.

This commit adds empty divs that will be interpreted by odoo-editor as editable.

opw-3558001