### PR TITLE
[ADD] hr_homeworking_calendar_google: workLocation synchronization

### DIFF
--- a/addons/google_calendar/models/google_sync.py
+++ b/addons/google_calendar/models/google_sync.py
@@ -167,7 +167,10 @@ class GoogleCalendarSync(models.AbstractModel):
         """
         write_dates = dict(write_dates or {})
         existing = google_events.exists(self.env)
-        new = google_events - existing - google_events.cancelled()
+
+        # Pre-process new google events (e.g., sync working locations).
+        self._pre_process_google_events(google_events)
+        new = google_events - existing - google_events.cancelled() - self._get_skipped_google_events(google_events)
 
         odoo_values = [
             dict(self._odoo_values(e, default_reminders), need_sync=False)
@@ -190,7 +193,7 @@ class GoogleCalendarSync(models.AbstractModel):
 
         cancelled_odoo.exists()._cancel()
         synced_records = new_odoo + cancelled_odoo
-        pending = existing - cancelled
+        pending = existing - cancelled - self._get_skipped_google_events(existing)
         pending_odoo = self.browse(pending.odoo_ids(self.env)).exists()
         for gevent in pending:
             odoo_record = self.browse(gevent.odoo_id(self.env))
@@ -209,6 +212,14 @@ class GoogleCalendarSync(models.AbstractModel):
                 synced_records |= odoo_record
 
         return synced_records
+
+    def _pre_process_google_events(self, events):
+        """ Overridable method for pre-processing google events before sync. """
+        pass
+
+    def _get_skipped_google_events(self, events):
+        """ Overridable method for filtering google events to skip. """
+        return GoogleEvent([])
 
     def _google_error_handling(self, http_error):
         # We only handle the most problematic errors of sync events.

--- a/addons/google_calendar/utils/google_calendar.py
+++ b/addons/google_calendar/utils/google_calendar.py
@@ -28,7 +28,7 @@ class GoogleCalendarService():
         self.google_service = google_service
 
     @requires_auth_token
-    def get_events(self, sync_token=None, token=None, event_id=None, timeout=TIMEOUT):
+    def get_events(self, sync_token=None, token=None, event_id=None, search_params=None, timeout=TIMEOUT):
         url = "/calendar/v3/calendars/primary/events"
         if event_id:
             url += f"/{event_id}"
@@ -45,6 +45,8 @@ class GoogleCalendarService():
             upper_bound = fields.Datetime.add(fields.Datetime.now(), days=day_range)
             params['timeMin'] = lower_bound.isoformat() + 'Z'  # Z = UTC (RFC3339)
             params['timeMax'] = upper_bound.isoformat() + 'Z'  # Z = UTC (RFC3339)
+        if search_params:
+            params.update(search_params)
         try:
             status, data, time = self.google_service._do_request(url, params, headers, method='GET', timeout=timeout)
         except requests.HTTPError as e:

--- a/addons/google_calendar/utils/google_event.py
+++ b/addons/google_calendar/utils/google_event.py
@@ -38,6 +38,26 @@ class GoogleEvent(abc.Set):
     def __iter__(self) ->  Iterator['GoogleEvent']:
         return iter(GoogleEvent([vals]) for vals in self._events.values())
 
+    def __add__(self, other):
+        """ Combine two GoogleEvent sets into a new one.
+        :param other: GoogleEvent instance.
+        :return: A new GoogleEvent instance containing the events of both sets.
+        """
+        if not isinstance(other, GoogleEvent):
+            raise TypeError("Both instances must be of type GoogleEvent.")
+
+        # Fast path for empty sets.
+        if not self:
+            return other
+        if not other:
+            return self
+
+        # Merge the underlying dictionaries directly.
+        combined_events = {**self._events, **other._events}
+        result = GoogleEvent()
+        result._events = ReadonlyDict(combined_events)
+        return result
+
     def __contains__(self, google_event):
         return google_event.id in self._events
 

--- a/addons/google_calendar/utils/google_event.py
+++ b/addons/google_calendar/utils/google_event.py
@@ -39,24 +39,15 @@ class GoogleEvent(abc.Set):
         return iter(GoogleEvent([vals]) for vals in self._events.values())
 
     def __add__(self, other):
-        """ Combine two GoogleEvent sets into a new one.
-        :param other: GoogleEvent instance.
-        :return: A new GoogleEvent instance containing the events of both sets.
-        """
         if not isinstance(other, GoogleEvent):
             raise TypeError("Both instances must be of type GoogleEvent.")
-
-        # Fast path for empty sets.
+        # Fast path for empty sets, as event sets are immutable.
         if not self:
             return other
         if not other:
             return self
-
         # Merge the underlying dictionaries directly.
-        combined_events = {**self._events, **other._events}
-        result = GoogleEvent()
-        result._events = ReadonlyDict(combined_events)
-        return result
+        return GoogleEvent({**self._events, **other._events})
 
     def __contains__(self, google_event):
         return google_event.id in self._events

--- a/addons/hr_calendar_google/__init__.py
+++ b/addons/hr_calendar_google/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/addons/hr_calendar_google/__manifest__.py
+++ b/addons/hr_calendar_google/__manifest__.py
@@ -1,0 +1,13 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    'name': 'HR Calendar with Google Calendar',
+    'category': 'Human Resources/Remote Work',
+    'depends': ['hr_calendar', 'google_calendar'],
+    'data': [
+        'data/ir_cron_data.xml',
+    ],
+    'auto_install': True,
+    'author': 'Odoo S.A.',
+    'license': 'LGPL-3',
+}

--- a/addons/hr_calendar_google/data/ir_cron_data.xml
+++ b/addons/hr_calendar_google/data/ir_cron_data.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <data noupdate="1">
+        <record id="hr_calendar_locations_cron_sync" model="ir.cron">
+            <field name="name">HR Calendar Google: sync working locations</field>
+            <field name="model_id" ref="hr_calendar_google.model_res_users"/>
+            <field name="state">code</field>
+            <field name="code">model.cron_sync_working_locations()</field>
+            <field name="user_id" ref="base.user_root"/>
+            <field name="interval_number">1</field>
+            <field name="interval_type">days</field>
+            <field name="nextcall" eval="(DateTime.now() + timedelta(days=1)).strftime('%Y-%m-%d 00:00:00')" />
+            <field name="active" eval="True"/>
+        </record>
+    </data>
+</odoo>

--- a/addons/hr_calendar_google/models/__init__.py
+++ b/addons/hr_calendar_google/models/__init__.py
@@ -1,0 +1,2 @@
+from . import google_sync
+from . import res_users

--- a/addons/hr_calendar_google/models/google_sync.py
+++ b/addons/hr_calendar_google/models/google_sync.py
@@ -1,0 +1,68 @@
+from datetime import datetime, date
+
+from odoo import models
+from odoo.addons.google_calendar.utils.google_event import GoogleEvent
+
+
+class GoogleSync(models.AbstractModel):
+    _inherit = 'google.calendar.sync'
+
+    def _pre_process_google_events(self, gevents):
+        """ Update Employee locations based on Google events. """
+        super()._pre_process_google_events(gevents)
+        working_location_gevents = [e for e in gevents if e.eventType == 'workingLocation']
+        if working_location_gevents:
+            self._sync_employee_locations(working_location_gevents, self.env.user)
+
+    def _get_skipped_google_events(self, gevents):
+        """ Filter out workingLocation events so they don't become Calendar Events. """
+        ignored_gevents = [e for e in gevents if e.eventType == 'workingLocation']
+        return super()._get_skipped_google_events(gevents) + GoogleEvent(ignored_gevents)
+
+    def _get_location_data(self, gevent):
+        """ Extract (Odoo Type, Name) from Google event. """
+        props = gevent.workingLocationProperties
+        if props.get('type') == 'customLocation':
+            return 'other', props['customLocation'].get('label', self.env._('Custom'))
+        if props.get('type') == 'homeOffice':
+            return 'home', self.env._('Home')
+        if props.get('type') == 'officeLocation':
+            return 'office', props['officeLocation'].get('label', self.env._('Office'))
+        return None, None
+
+    def _sync_employee_locations(self, gevents, user):
+        """ Create missing locations and update the employee record. """
+        # 1. Create a map with the gevents by location and a map with the location name by their type.
+        gevents_by_location_data = {}
+        for e in gevents:
+            location_data = self._get_location_data(e)
+            if location_data[1]:
+                gevents_by_location_data.setdefault(location_data, []).append(e)
+        existing = self.env['hr.work.location'].search([('name', 'in', [loc[1] for loc in gevents_by_location_data])])
+        work_location_by_location_data = {(loc.location_type, loc.name): loc for loc in existing}
+
+        # 2. List working locations to be created, create them and update the location map.
+        to_create = []
+        for location_data in gevents_by_location_data:
+            if location_data not in work_location_by_location_data:
+                location_type, name = location_data
+                to_create.append({'name': name, 'location_type': location_type})
+        if to_create:
+            new_recs = self.env['hr.work.location'].sudo().create(to_create)
+            work_location_by_location_data.update({(rec.location_type, rec.name): rec for rec in new_recs})
+
+        # 3. Map the working locations updates.
+        updates = {}
+        days = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday']
+        for location_data, evs in gevents_by_location_data.items():
+            if location_data in work_location_by_location_data:
+                loc_id = work_location_by_location_data[location_data].id
+                for e in evs:
+                    dt_str = e.start.get('date') or e.start.get('dateTime')
+                    if dt_str:
+                        dt = datetime.fromisoformat(dt_str).date() if 'T' in dt_str else date.fromisoformat(dt_str)
+                        updates[f"{days[dt.weekday()]}_location_id"] = loc_id
+
+        # 4. Write the working location updates in the employee record.
+        if updates and user.employee_id:
+            user.employee_id.sudo().write(updates)

--- a/addons/hr_calendar_google/models/res_users.py
+++ b/addons/hr_calendar_google/models/res_users.py
@@ -1,0 +1,56 @@
+import logging
+import datetime
+import requests
+
+from odoo import models
+from odoo.addons.google_calendar.utils.google_calendar import GoogleCalendarService
+from odoo.addons.google_calendar.models.google_sync import google_calendar_token
+
+_logger = logging.getLogger(__name__)
+
+
+class User(models.Model):
+    _inherit = 'res.users'
+
+    def _fetch_week_gevents(self, user):
+        """ Get working location events of the selected user for the current week. """
+        today = datetime.datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+
+        # Fetch the user's language or fallback to the environment default.
+        lang_code = user.lang or self.env.user.lang
+        lang = self.env['res.lang'].search([('code', '=', lang_code)], limit=1)
+
+        # Determine the start of the week based on the language.
+        lang_week_start = int(lang.week_start or '7') - 1
+
+        days_to_subtract = (today.weekday() - lang_week_start) % 7
+        week_start = today - datetime.timedelta(days=days_to_subtract)
+        week_end = week_start + datetime.timedelta(days=7)
+
+        service = GoogleCalendarService(self.env['google.service'].with_user(user))
+        with google_calendar_token(user) as token:
+            try:
+                events, _, _ = service.get_events(
+                    token=token,
+                    search_params={
+                        'timeMin': week_start.isoformat() + 'Z',
+                        'timeMax': week_end.isoformat() + 'Z',
+                        'eventTypes': ['workingLocation'],
+                        'singleEvents': True,
+                    }
+                )
+                return events
+            except requests.HTTPError as e:
+                _logger.error("Error syncing working locations: %s", e.response.content)
+                return []
+
+    def cron_sync_working_locations(self):
+        """ Synchronize working locations of users with active synchronization. """
+        # Optimization: Only search users with a valid token
+        users = self.search([('google_calendar_token', '!=', False)])
+        for user in users:
+            if user.is_google_calendar_synced():
+                events = self._fetch_week_gevents(user)
+                if events:
+                    self.env['calendar.event'].with_user(user)._pre_process_google_events(events)
+        return True

--- a/addons/hr_calendar_google/tests/__init__.py
+++ b/addons/hr_calendar_google/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_work_location_sync

--- a/addons/hr_calendar_google/tests/test_work_location_sync.py
+++ b/addons/hr_calendar_google/tests/test_work_location_sync.py
@@ -1,0 +1,112 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tools import frozendict
+from odoo.tests.common import new_test_user
+from odoo.addons.google_calendar.models.res_users import ResUsers
+from odoo.addons.google_calendar.tests.test_sync_common import TestSyncGoogle, patch_api
+from odoo.addons.google_calendar.utils.google_calendar import GoogleEvent
+from unittest.mock import patch
+
+
+@patch.object(ResUsers, '_get_google_calendar_token', lambda user: 'dummy-token')
+class TestSyncWorkLocationsGoogle(TestSyncGoogle):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.work_location_user = new_test_user(cls.env, login='work_location-user')
+
+        cls.hr_employee = cls.env['hr.employee'].create({
+            'name': 'Employee for HR Work Location Test',
+            'user_id': cls.work_location_user.id,
+            'work_contact_id': cls.work_location_user.partner_id.id,
+        })
+
+        cls.work_location_simple_values = frozendict({
+            "eventType": "workingLocation",
+            'description': 'Working location',
+            'summary': 'Working location',
+            'organizer': {'email': 'odoocalendarref@gmail.com', 'self': True},
+            'visibility': 'public',
+            'attendees': [],
+            'reminders': {'useDefault': True},
+            'transparency': 'transparent',
+            'extendedProperties': {
+                'shared':  {'%s_owner_id' % cls.env.cr.dbname: str(cls.work_location_user.id)}
+            },
+        })
+
+    @patch_api
+    def test_work_locations_google_allday_to_odoo_hr(self):
+        with self.mock_datetime_and_now("2025-04-28"):
+            office_location_values = {
+                **self.work_location_simple_values,
+                'id': 'workingLocation_office',
+                'start': {'date': '2025-04-28', 'dateTime': None},
+                'end': {'date': '2025-04-29', 'dateTime': None},
+                'workingLocationProperties': {
+                    'type': 'officeLocation',
+                    'officeLocation': {
+                        'label': 'Odoo Farm 1: R&D Vidange Office'
+                    }
+                }
+            }
+
+            home_location_values = {
+                **self.work_location_simple_values,
+                'id': 'workingLocation_home',
+                'start': {'date': '2025-04-29', 'dateTime': None},
+                'end': {'date': '2025-04-30', 'dateTime': None},
+                'workingLocationProperties': {
+                    'type': 'homeOffice',
+                    'homeOffice': {
+                        'label': 'Home'
+                    }
+                }
+            }
+
+            custom_location_values = {
+                **self.work_location_simple_values,
+                'id': 'workingLocation_custom',
+                'start': {'date': '2025-04-30', 'dateTime': None},
+                'end': {'date': '2025-05-01', 'dateTime': None},
+                'workingLocationProperties': {
+                    'type': 'customLocation',
+                    'customLocation': {
+                        'label': 'Odoo Louvain-la-Neuve Office'
+                    }
+                }
+            }
+
+            custom_location_same_values = {
+                **self.work_location_simple_values,
+                'id': 'workingLocation_custom_same',
+                'start': {'date': '2025-05-01', 'dateTime': None},
+                'end': {'date': '2025-05-02', 'dateTime': None},
+                'workingLocationProperties': {
+                    'type': 'customLocation',
+                    'customLocation': {
+                        'label': 'Odoo Louvain-la-Neuve Office'
+                    }
+                }
+            }
+
+            previous_work_locations_count = self.env['hr.work.location'].search_count([])
+
+            self.env['calendar.event'].with_user(self.work_location_user)._sync_google2odoo(
+                GoogleEvent([office_location_values, home_location_values, custom_location_values, custom_location_same_values])
+            )
+
+            current_work_locations_count = self.env['hr.work.location'].search_count([])
+            self.assertEqual(
+                current_work_locations_count,
+                previous_work_locations_count + 2,
+            )
+            office_location = self.env['hr.work.location'].search([('name', '=', 'Odoo Farm 1: R&D Vidange Office')])
+            home_location = self.env['hr.work.location'].search([('name', '=', 'Home')])
+            custom_location = self.env['hr.work.location'].search([('name', '=', 'Odoo Louvain-la-Neuve Office')])
+
+            self.assertEqual(self.hr_employee.monday_location_id, office_location)
+            self.assertEqual(self.hr_employee.tuesday_location_id, home_location)
+            self.assertEqual(self.hr_employee.wednesday_location_id, custom_location)
+            self.assertEqual(self.hr_employee.thursday_location_id, custom_location)


### PR DESCRIPTION
This module allows synchronizing the work locations from Google Calendar to Odoo Calendar through the synchronization of events with 'eventType' attribute 'workLocation'. When fetching these events, we create the new work locations in Odoo using the labels described there and set the most recent work location positions in the 'Employee' model.

For avoiding duplicating the information (synchronizing workLocation events and also setting the work location in the Employee model), we decided to not synchronize this type of event anymore and only use the information they provide: the work location itself.

A cron job is defined for executing the fetching from Google and work location update in Odoo every sunday for keeping the synchronization up-to-date.

task-3809350