### PR TITLE
[FIX] l10n_gcc_invoice: correct the duplication of terms in Arabic invoices

### DIFF
--- a/addons/l10n_gcc_invoice/views/report_invoice.xml
+++ b/addons/l10n_gcc_invoice/views/report_invoice.xml
@@ -445,7 +445,7 @@
                 <p t-if="o.invoice_payment_term_id" name="payment_term">
                     <div class="row">
                         <div class="col-6 text-start">
-                            <span t-out="o.invoice_payment_term_id.note"/>
+                            <span t-if="o.invoice_payment_term_id.note != o_sec.invoice_payment_term_id.note" t-out="o.invoice_payment_term_id.note"/>
                         </div>
                         <div class="col-6 text-end">
                             <span dir="rtl" t-out="o_sec.invoice_payment_term_id.note"/>
@@ -456,7 +456,7 @@
                 <p t-if="o.narration" name="comment">
                     <div class="row">
                         <div class="col-6 text-start">
-                            <span t-out="o.narration"/>
+                            <span t-if="o.narration != o_sec.narration" t-out="o.narration"/>
                         </div>
                         <div class="col-6 text-end">
                             <span t-out="o_sec.narration"/>
@@ -466,7 +466,7 @@
                 <p t-if="o.fiscal_position_id.note" name="note">
                     <div class="row">
                         <div class="col-6 text-start">
-                            <span t-out="o.fiscal_position_id.note"/>
+                            <span t-if="o.fiscal_position_id.note != o_sec.fiscal_position_id.note" t-out="o.fiscal_position_id.note"/>
                         </div>
                         <div class="col-6 text-end">
                             <span t-out="o_sec.fiscal_position_id.note"/>


### PR DESCRIPTION
### Steps to reproduce:
- Install the 'l10n_sa' module and switch to a Saudi company
- In the Settings of Accounting, tick the option "Default Terms & Conditions" and select "Add a Note"
- Write something in for the Terms & Conditions
- In the Accounting app create a new invoice, confirm and preview
- At the bottom of the preview, the Terms & Conditions are duplicated

### Cause:
The report is trying to print the Arabic and English translation of the Term & Conditions, but only one of the two exists, so they appear duplicated.

### Solution:
There is already a way to translate manually the Terms & Conditions (Have the 2 languages installed, and a button appear near the text). So the fix is simply to display only the Arabic language when there is only one translation.

A problem is that if the only translation is the English one, it will be printed as if it was written from right to left. But there is no way to know exactly the language of the text, and we can suppose the base language will be Arabic in most cases.

opw-4043175