### PR TITLE
[FIX] account: fix mail alias issues

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4762,8 +4762,11 @@ class AccountMove(models.Model):
             for invoice in invoices:
                 attachments_per_invoice[invoice] |= attachment
 
-        # Unlink the unused attachments
-        (attachments - attachments_in_invoices).unlink()
+        if len(attachments_per_invoice) == 1:
+            attachments_per_invoice = {self: attachments}
+        else:
+            # Unlink the unused attachments
+            (attachments - attachments_in_invoices).unlink()
 
         for invoice, attachments in attachments_per_invoice.items():
             if invoice == self:


### PR DESCRIPTION
These commits fix some of the lingering issue when receiving a mail with attachments.
---

Currently, when an XML is received through the mail alias and it has no
decoder, is it being deleted. However, similarly to PDFs, when want it
to part of its own invoice, creating one if needs be.

It commit also updates the test to encompass for this case and makes
it easier to read as it became a bit packed and unreadable.

---

Currently, when receiving an email with several attachments. Only XMLs
and PDFs are kept, the rest are unlink.

However, in some cases, we want to keep those attachment:
- When receiving a mail with 1 PDF and non-XMLs attachments
- When receiving a mail with 1 XML and non-PDFs attachments
- When receiving a mail with 1 PDF and 1 XML and other type-attachments

In those situations, only 1 invoice will be created instead of several
(1/attachment). For those, we keep all the attachments and link them to
the unique invoice.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
