### PR TITLE
[IMP] event: auto-close registration confirmation dialog

### DIFF
--- a/addons/event/static/src/client_action/event_barcode.js
+++ b/addons/event/static/src/client_action/event_barcode.js
@@ -55,7 +55,10 @@ export class EventScanView extends Component {
             });
         } else {
             this.registrationId = result.id;
-            this.dialog.add(EventRegistrationSummaryDialog, { registration: result });
+            this.closeLastDialog?.();
+            this.closeLastDialog = this.dialog.add(EventRegistrationSummaryDialog, {
+                registration: result
+            });
         }
     }
 


### PR DESCRIPTION
When a user scans an attendee's QR code with a barcode reader, the system opens a registration confirmation dialog. If multiple QR codes are scanned in succession, the dialogs stack on top of each other. This requires the user to manually close each one, which is time-consuming.

To streamline this process, the system will now automatically close the previous registration confirmation dialog when a new QR code is scanned. This change should expedite the ticket scanning process.

task-4047455

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
