### PR TITLE
[FIX] repair: don’t link the part of repair to the return

### DIFF
--- a/addons/repair/models/stock_picking.py
+++ b/addons/repair/models/stock_picking.py
@@ -153,7 +153,7 @@ class Picking(models.Model):
         ctx = clean_context(self.env.context.copy())
         ctx.update({
             'default_location_id': self.location_dest_id.id,
-            'default_picking_id': self.id,
+            'default_repair_picking_id': self.id,
             'default_picking_type_id': self.picking_type_id.warehouse_id.repair_type_id.id,
             'default_partner_id': self.partner_id and self.partner_id.id or False,
         })

--- a/addons/repair/tests/test_repair.py
+++ b/addons/repair/tests/test_repair.py
@@ -457,31 +457,6 @@ class TestRepair(common.TransactionCase):
             else:
                 self.assertTrue(float_is_zero(sol.qty_delivered, 2))
 
-    def test_repair_return(self):
-        """Tests functionality of creating a repair directly from a return picking,
-        i.e. repair can be made and defaults to appropriate return values. """
-        # test return
-        # Required for `location_dest_id` to be visible in the view
-        self.env.user.groups_id += self.env.ref('stock.group_stock_multi_locations')
-        picking_form = Form(self.env['stock.picking'])
-        picking_form.picking_type_id = self.stock_warehouse.in_type_id
-        picking_form.partner_id = self.res_partner_1
-        picking_form.location_dest_id = self.stock_location_14
-        return_picking = picking_form.save()
-
-        # create repair
-        res_dict = return_picking.action_repair_return()
-        repair_form = Form(self.env[(res_dict.get('res_model'))].with_context(res_dict['context']))
-        repair_form.product_id = self.product_product_3
-        repair = repair_form.save()
-
-        # test that the resulting repairs are correctly created
-        self.assertEqual(len(return_picking.repair_ids), 1, "A repair order should have been created and linked to original return.")
-        for repair in return_picking.repair_ids:
-            self.assertEqual(repair.location_id, return_picking.location_dest_id, "Repair location should have defaulted to return destination location")
-            self.assertEqual(repair.partner_id, return_picking.partner_id, "Repair customer should have defaulted to return customer")
-            self.assertEqual(repair.picking_type_id, return_picking.picking_type_id.warehouse_id.repair_type_id)
-
     def test_repair_compute_product_uom(self):
         repair = self.env['repair.order'].create({
             'product_id': self.product_product_3.id,
@@ -577,6 +552,9 @@ class TestRepair(common.TransactionCase):
         res_dict = return_picking.action_repair_return()
         repair_form = Form(self.env[(res_dict.get('res_model'))].with_context(res_dict['context']), view=res_dict['view_id'])
         repair_form.product_id = product
+        # The repair needs to be saved to ensure the context is correctly set.
+        repair = repair_form.save()
+        repair_form = Form(repair)
         with repair_form.move_ids.new() as move:
             move.product_id = self.product_product_5
             move.product_uom_qty = 1.0
@@ -587,6 +565,9 @@ class TestRepair(common.TransactionCase):
         repair.action_repair_end()
         self.assertEqual(repair.state, 'done')
         self.assertEqual(len(return_picking.move_ids), 1, "Parts added to the repair order shoudln't be added to the return picking")
+        self.assertEqual(repair.location_id, return_picking.location_dest_id, "Repair location should have defaulted to return destination location")
+        self.assertEqual(repair.partner_id, return_picking.partner_id, "Repair customer should have defaulted to return customer")
+        self.assertEqual(repair.picking_type_id, return_picking.picking_type_id.warehouse_id.repair_type_id)
 
     def test_repair_with_product_in_package(self):
         """

--- a/addons/repair/views/repair_views.xml
+++ b/addons/repair/views/repair_views.xml
@@ -129,7 +129,7 @@
                 <notebook>
                     <page string="Parts" name="parts">
                         <field name="move_ids" readonly="state == 'cancel' or state == 'done'"
-                        context="{'default_repair_id': id, 'default_product_uom_qty': 1, 'default_company_id': company_id, 'default_date': schedule_date, 'default_repair_line_type': 'add', 'default_picking_id': False}">
+                        context="{'default_repair_id': id, 'default_product_uom_qty': 1, 'default_company_id': company_id, 'default_date': schedule_date, 'default_repair_line_type': 'add'}">
                             <tree string="Operations" editable="bottom">
                                 <field name="company_id" column_invisible="True"/>
                                 <field name="name" column_invisible="True"/>


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a storable product “P1”
- Go to Operation Type > Return > Enable "Create repair from return"
- Create a delivery order with one unit of "P1" and validate it
- Return the delivered "P1"
- Create a repair order from this return
- Select "P1" as the product to repair
- Save (important step)
- Add any product as a part of the repair, e.g., "Part 1”
- Save
- Go back to the return picking

Problem:
The product “Part 1” is linked to the return-picking.

When the "repair" button is clicked to create the repair order,
the function `action_repair_return` is triggered, adding
`default_picking_id` in the context to link the repair to the picking.
https://github.com/odoo/odoo/blob/bee32f88d42d9b945ec7216e2496e0167d3904b4/addons/repair/models/stock_picking.py#L40

However, this context is not cleared after the creation of the repair,
therefore, when creating the stock move, this picking is added to the
values of the moves due to the `_add_missing_default_values` function.
Despite attempting to set `default_picking_id = False` for these moves,
this will be ignored because the field `picking_id` is not present in
this list view.

**Solution:**
Using `default_picking_id` in the context to create the repair order
does not seem to be a good idea. This is the third issue related to this
problem; two other fixes have already been made to address the
propagation of these default keys. Therefore, it seems more logical to
use the `default_get` function instead to avoid bugs related to this.

https://github.com/odoo/odoo/commit/e822ec35c37237a9c137771d1d7266188a1877e8

https://github.com/odoo/odoo/commit/a32fb7b3e12ddae1ef7ebd78fa4877b2dbdbe6b1

opw-[4029460](https://www.odoo.com/web#id=4029460&view_type=form&model=project.task)