### PR TITLE
[IMP] account: preserve imported data

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3602,9 +3602,11 @@ class AccountMove(models.Model):
                 try:
                     with self.env.cr.savepoint():
                         with current_invoice._get_edi_creation() as invoice:
+                            existing_lines = invoice.invoice_line_ids
                             # pylint: disable=not-callable
                             success = decoder(invoice, file_data, new)
                         if success or file_data['type'] == 'pdf':
+                            (invoice.invoice_line_ids - existing_lines).is_imported = True
                             invoice._link_bill_origin_to_purchase_orders(timeout=4)
 
                             invoices |= invoice


### PR DESCRIPTION
After importing a vendor bill, data is extracted (via EDI/OCR) to complete the lines of the bill.
It's possible that the user might change the product, and in this case, the extracted data is lost because the product's data replaces it.
    
To avoid this, a flag indicating the line is imported is used to prevent recomputing the price and taxes.
    
Task-3837975