### PR TITLE
{sale,hr}_timesheet: improve timesheet analysis report

### DIFF
--- a/addons/hr_timesheet/report/hr_timesheet_report_view.xml
+++ b/addons/hr_timesheet/report/hr_timesheet_report_view.xml
@@ -5,7 +5,7 @@
             <field name="name">timesheets.analysis.report.list</field>
             <field name="model">timesheets.analysis.report</field>
             <field name="arch" type="xml">
-                <tree editable="bottom" edit="1">
+                <tree>
                     <field name="date"/>
                     <field name="employee_id"/>
                     <field name="project_id"/>
@@ -17,6 +17,31 @@
                         decoration-muted="unit_amount == 0"
                     />
                 </tree>
+            </field>
+        </record>
+
+        <record id="timesheets_analysis_report_form" model="ir.ui.view">
+            <field name="name">timesheets.analysis.report.form</field>
+            <field name="model">timesheets.analysis.report</field>
+            <field name="arch" type="xml">
+                <form string="Timesheets Analysis">
+                    <sheet>
+                        <group>
+                            <group>
+                                <field name="project_id"/>
+                                <field name="task_id"/>
+                            </group>
+                            <group>
+                                <field name="employee_id"/>
+                                <field name="date"/>
+                                <field name="amount" invisible="1"/>
+                                <field name="unit_amount" string="Time Spent" widget="timesheet_uom" decoration-danger="unit_amount &gt; 24"
+                                    decoration-muted="unit_amount == 0"/>
+                            </group>
+                        </group>
+                        <field name="name" widget="text" nolabel="1"/>
+                    </sheet>
+                </form>
             </field>
         </record>
 

--- a/addons/hr_timesheet/report/hr_timesheet_report_view.xml
+++ b/addons/hr_timesheet/report/hr_timesheet_report_view.xml
@@ -1,11 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <data>
+        <record id="timesheets_analysis_report_list" model="ir.ui.view">
+            <field name="name">timesheets.analysis.report.list</field>
+            <field name="model">timesheets.analysis.report</field>
+            <field name="arch" type="xml">
+                <tree editable="bottom" edit="1">
+                    <field name="date"/>
+                    <field name="employee_id"/>
+                    <field name="project_id"/>
+                    <field name="task_id"/>
+                    <field name="currency_id" column_invisible="1"/>
+                    <field name="amount" string="Timesheet Costs" optional="hide" sum="Total"/>
+                    <field name="unit_amount" optional="show" widget="timesheet_uom" sum="Total"
+                        decoration-danger="unit_amount &gt; 24 or unit_amount &lt; 0"
+                        decoration-muted="unit_amount == 0"
+                    />
+                </tree>
+            </field>
+        </record>
+
         <record id="timesheets_analysis_report_pivot_employee" model="ir.ui.view">
             <field name="name">timesheets.analysis.report.pivot</field>
             <field name="model">timesheets.analysis.report</field>
             <field name="arch" type="xml">
-                <pivot string="Timesheets Analysis" sample="1" disable_linking="True">
+                <pivot string="Timesheets Analysis" sample="1">
                     <field name="employee_id" type="row"/>
                     <field name="date" interval="month" type="col"/>
                     <field name="amount" string="Timesheet Costs"/>
@@ -18,7 +37,7 @@
             <field name="name">timesheets.analysis.report.graph</field>
             <field name="model">timesheets.analysis.report</field>
             <field name="arch" type="xml">
-                <graph string="Timesheets" sample="1" js_class="hr_timesheet_graphview" disable_linking="True">
+                <graph string="Timesheets" sample="1" js_class="hr_timesheet_graphview">
                     <field name="employee_id" type="row"/>
                     <field name="amount" string="Timesheet Costs"/>
                     <field name="unit_amount" type="measure" widget="timesheet_uom"/>
@@ -30,7 +49,7 @@
             <field name="name">timesheets.analysis.report.pivot</field>
             <field name="model">timesheets.analysis.report</field>
             <field name="arch" type="xml">
-                <pivot string="Timesheets Analysis" sample="1" disable_linking="True">
+                <pivot string="Timesheets Analysis" sample="1">
                     <field name="project_id" type="row"/>
                     <field name="date" interval="month" type="col"/>
                     <field name="amount" string="Timesheet Costs"/>
@@ -43,7 +62,7 @@
             <field name="name">timesheets.analysis.report.graph</field>
             <field name="model">timesheets.analysis.report</field>
             <field name="arch" type="xml">
-                <graph string="Timesheets" sample="1" js_class="hr_timesheet_graphview" disable_linking="True">
+                <graph string="Timesheets" sample="1" js_class="hr_timesheet_graphview">
                     <field name="project_id" type="row"/>
                     <field name="amount" string="Timesheet Costs"/>
                     <field name="unit_amount" type="measure" widget="timesheet_uom"/>
@@ -55,7 +74,7 @@
             <field name="name">timesheets.analysis.report.pivot</field>
             <field name="model">timesheets.analysis.report</field>
             <field name="arch" type="xml">
-                <pivot string="Timesheets Analysis" sample="1" disable_linking="True">
+                <pivot string="Timesheets Analysis" sample="1">
                     <field name="amount" string="Timesheet Costs"/>
                     <field name="project_id" type="row"/>
                     <field name="task_id" type="row"/>
@@ -69,7 +88,7 @@
             <field name="name">timesheets.analysis.report.graph</field>
             <field name="model">timesheets.analysis.report</field>
             <field name="arch" type="xml">
-                <graph string="Timesheets" sample="1" js_class="hr_timesheet_graphview" disable_linking="True">
+                <graph string="Timesheets" sample="1" js_class="hr_timesheet_graphview">
                     <field name="project_id" type="row"/>
                     <field name="task_id" type="row"/>
                     <field name="amount" string="Timesheet Costs"/>
@@ -123,6 +142,13 @@
             <field name="act_window_id" ref="act_hr_timesheet_report"/>
         </record>
 
+        <record id="timesheet_action_view_report_by_employee_list" model="ir.actions.act_window.view">
+            <field name="sequence" eval="10"/>
+            <field name="view_mode">tree</field>
+            <field name="view_id" ref="hr_timesheet.timesheets_analysis_report_list"/>
+            <field name="act_window_id" ref="act_hr_timesheet_report"/>
+        </record>
+
         <!-- Group by project-->
         <record id="timesheet_action_report_by_project" model="ir.actions.act_window">
             <field name="name">Timesheets by Project</field>
@@ -156,6 +182,13 @@
             <field name="act_window_id" ref="timesheet_action_report_by_project"/>
         </record>
 
+        <record id="timesheet_action_view_report_by_project_list" model="ir.actions.act_window.view">
+            <field name="sequence" eval="10"/>
+            <field name="view_mode">tree</field>
+            <field name="view_id" ref="hr_timesheet.timesheets_analysis_report_list"/>
+            <field name="act_window_id" ref="timesheet_action_report_by_project"/>
+        </record>
+
         <!-- Group by task -->
         <record id="timesheet_action_report_by_task" model="ir.actions.act_window">
             <field name="name">Timesheets by Task</field>
@@ -186,6 +219,13 @@
             <field name="sequence" eval="6"/>
             <field name="view_mode">graph</field>
             <field name="view_id" ref="hr_timesheet.timesheets_analysis_report_graph_task"/>
+            <field name="act_window_id" ref="timesheet_action_report_by_task"/>
+        </record>
+
+        <record id="timesheet_action_view_report_by_task_list" model="ir.actions.act_window.view">
+            <field name="sequence" eval="10"/>
+            <field name="view_mode">tree</field>
+            <field name="view_id" ref="hr_timesheet.timesheets_analysis_report_list"/>
             <field name="act_window_id" ref="timesheet_action_report_by_task"/>
         </record>
     </data>

--- a/addons/hr_timesheet/report/timesheets_analysis_report.py
+++ b/addons/hr_timesheet/report/timesheets_analysis_report.py
@@ -21,7 +21,7 @@ class TimesheetsAnalysisReport(models.Model):
     department_id = fields.Many2one("hr.department", string="Department", readonly=True)
     currency_id = fields.Many2one('res.currency', string="Currency", readonly=True)
     date = fields.Date("Date", readonly=True)
-    amount = fields.Monetary("Amount", readonly=True)
+    amount = fields.Monetary("Amount", currency_field="currency_id", readonly=True)
     unit_amount = fields.Float("Time Spent", readonly=True)
     partner_id = fields.Many2one('res.partner', string="Partner", readonly=True)
     milestone_id = fields.Many2one('project.milestone', related='task_id.milestone_id')

--- a/addons/sale_timesheet/models/hr_timesheet.py
+++ b/addons/sale_timesheet/models/hr_timesheet.py
@@ -52,7 +52,7 @@ class AccountAnalyticLine(models.Model):
                 elif timesheet.so_line.product_id.type == 'service':
                     if timesheet.so_line.product_id.invoice_policy == 'delivery':
                         if timesheet.so_line.product_id.service_type == 'timesheet':
-                            invoice_type = 'timesheet_revenues' if timesheet.amount > 0 else 'billable_time'
+                            invoice_type = 'timesheet_revenues' if timesheet.amount > 0 and timesheet.unit_amount > 0 else 'billable_time'
                         else:
                             service_type = timesheet.so_line.product_id.service_type
                             invoice_type = f'billable_{service_type}' if service_type in ['milestones', 'manual'] else 'billable_fixed'
@@ -60,7 +60,7 @@ class AccountAnalyticLine(models.Model):
                         invoice_type = 'billable_fixed'
                 timesheet.timesheet_invoice_type = invoice_type
             else:
-                if timesheet.amount >= 0:
+                if timesheet.amount >= 0 and timesheet.unit_amount >= 0:
                     if timesheet.so_line and timesheet.so_line.product_id.type == 'service':
                         timesheet.timesheet_invoice_type = 'service_revenues'
                     else:

--- a/addons/sale_timesheet/report/timesheets_analysis_report.py
+++ b/addons/sale_timesheet/report/timesheets_analysis_report.py
@@ -13,8 +13,8 @@ class TimesheetsAnalysisReport(models.Model):
     so_line = fields.Many2one("sale.order.line", string="Sales Order Item", readonly=True)
     timesheet_invoice_type = fields.Selection(TIMESHEET_INVOICE_TYPES, string="Billable Type", readonly=True)
     timesheet_invoice_id = fields.Many2one("account.move", string="Invoice", readonly=True, help="Invoice created from the timesheet")
-    timesheet_revenues = fields.Float("Timesheet Revenues", readonly=True, help="Number of hours spent multiplied by the unit price per hour/day.")
-    margin = fields.Float("Margin", readonly=True, help="Timesheets revenues minus the costs")
+    timesheet_revenues = fields.Monetary("Timesheet Revenues", currency_field="currency_id", readonly=True, help="Number of hours spent multiplied by the unit price per hour/day.")
+    margin = fields.Monetary("Margin", currency_field="currency_id", readonly=True, help="Timesheets revenues minus the costs")
     billable_time = fields.Float("Billable Time", readonly=True, help="Number of hours/days linked to a SOL.")
     non_billable_time = fields.Float("Non-billable Time", readonly=True, help="Number of hours/days not linked to a SOL.")
 

--- a/addons/sale_timesheet/report/timesheets_analysis_views.xml
+++ b/addons/sale_timesheet/report/timesheets_analysis_views.xml
@@ -19,6 +19,17 @@
         </field>
     </record>
 
+    <record id="timesheete_analysis_report_form" model="ir.ui.view">
+        <field name="name">timesheets.analysis.report.form</field>
+        <field name="model">timesheets.analysis.report</field>
+        <field name="inherit_id" ref="hr_timesheet.timesheets_analysis_report_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//sheet/group/group" position="inside">
+                <field name="so_line" widget="so_line_field" placeholder="Non-billable"/>
+            </xpath>
+        </field>
+    </record>
+
     <record id="timesheets_analysis_report_pivot_inherit" model="ir.ui.view">
         <field name="name">timesheets.analysis.report.pivot</field>
         <field name="model">timesheets.analysis.report</field>

--- a/addons/sale_timesheet/report/timesheets_analysis_views.xml
+++ b/addons/sale_timesheet/report/timesheets_analysis_views.xml
@@ -1,5 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
+    <record id="timesheets_analysis_report_list_inherited" model="ir.ui.view">
+        <field name="name">timesheets.analysis.report.list.inherited</field>
+        <field name="model">timesheets.analysis.report</field>
+        <field name="inherit_id" ref="hr_timesheet.timesheets_analysis_report_list"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='task_id']" position="after">
+                <field name="so_line"
+                       optional="show"
+                       options="{'no_open': True}"
+                       placeholder="Non-billable"
+                />
+                <field name="timesheet_invoice_type" optional="hide"/>
+                <field name="timesheet_invoice_id" optional="hide"/>
+                <field name="timesheet_revenues" optional="hide" sum="Total"/>
+                <field name="margin" optional="hide" sum="Total"/>
+            </xpath>
+        </field>
+    </record>
 
     <record id="timesheets_analysis_report_pivot_inherit" model="ir.ui.view">
         <field name="name">timesheets.analysis.report.pivot</field>
@@ -91,7 +109,7 @@
         <field name="name">timesheets.analysis.report.pivot</field>
         <field name="model">timesheets.analysis.report</field>
         <field name="arch" type="xml">
-            <pivot string="Timesheets Analysis" sample="1" disable_linking="True">
+            <pivot string="Timesheets Analysis" sample="1">
                 <field name="date" interval="month" type="row"/>
                 <field name="timesheet_invoice_type" type="col"/>
                 <field name="amount" string="Timesheet Costs"/>
@@ -106,7 +124,7 @@
         <field name="name">timesheets.analysis.report.graph</field>
         <field name="model">timesheets.analysis.report</field>
         <field name="arch" type="xml">
-            <graph string="Timesheets" sample="1" js_class="hr_timesheet_graphview" disable_linking="True">
+            <graph string="Timesheets" sample="1" js_class="hr_timesheet_graphview">
                 <field name="amount" string="Timesheet Costs"/>
                 <field name="unit_amount" type="measure" widget="timesheet_uom"/>
                 <field name="billable_time" widget="timesheet_uom"/>
@@ -161,6 +179,13 @@
         <field name="sequence" eval="6"/>
         <field name="view_mode">graph</field>
         <field name="view_id" ref="timesheets_analysis_report_graph_invoice_type"/>
+        <field name="act_window_id" ref="timesheet_action_billing_report"/>
+    </record>
+
+    <record id="timesheet_action_view_report_by_billing_rate_list" model="ir.actions.act_window.view">
+        <field name="sequence" eval="10"/>
+        <field name="view_mode">tree</field>
+        <field name="view_id" ref="hr_timesheet.timesheets_analysis_report_list"/>
         <field name="act_window_id" ref="timesheet_action_billing_report"/>
     </record>
 

--- a/addons/sale_timesheet/tests/test_sale_timesheet.py
+++ b/addons/sale_timesheet/tests/test_sale_timesheet.py
@@ -1125,3 +1125,24 @@ class TestSaleTimesheet(TestCommonSaleTimesheet):
             'employee_id': self.employee_manager.id,
             'so_line': so_line.id,
         })
+
+    def test_timesheet_with_negative_time_spent(self):
+        """ Check the billable type of a timesheet with negative time spent """
+        sale_order = self.env['sale.order'].create([{
+            'partner_id': self.partner_a.id,
+            'order_line': [Command.create({
+                'product_id': self.product_delivery_timesheet2.id,
+            })],
+        }])
+        sale_order.action_confirm()
+        task1 = sale_order.tasks_ids
+        timesheet = self.env['account.analytic.line'].create([
+            {
+                'name': 'Timesheet',
+                'task_id': task1.id,
+                'project_id': task1.project_id.id,
+                'unit_amount': -1,
+                'employee_id': self.employee_user.id,
+            },
+        ])
+        self.assertEqual(timesheet.timesheet_invoice_type, 'billable_time')


### PR DESCRIPTION
## [IMP] sale_timesheet: consider timesheet as revenues if amount and quantity > 0

Before this commit, when the user made a timesheet with a negative
number set in unit_amount field (Time spent), the billable type of that
timesheet is timesheet revenues instead of a cost since we cancel some
hours/days spent to a timesheet validated for instance.

This commit makes sure the timesheets with negative time spent are not
considered as a revenue.

## [IMP] {hr,sale}_timesheet: allow to open the list in pivot/graph timesheets analysis report

Before this commit, when the user goes to Timesheets > Reporting, and
click on any menus inside Reporting then he will have access to pivot
and graph of Timesheets Analysis report but he cannot click on a cell
inside the pivot or a data displayed in the graph view to show the
records contained in the cell/data.

This commit allows to click on pivot cell and data in graph to show the
records in a list view. The list view is also defined to have a list
view with all the useful information instead of just having the default
list view with only the name field displayed.

## [IMP] {hr,sale}_timesheet: add form view for timesheet analysis report

Before this commit, the form view was the default one that is the one
displaying all the fields defined inside the report, also the list view
cannot avoid opening the form view when the user clicks on a row without
being editable and so if the list view is editable, the save and discard
buttons are displayed even if all fields are not editable.

This commit defined a form view to have the same render than one defined
for timesheets and makes sure the list view is not editable to allow to
open the form view.

task-4053021
