### PR TITLE
[FIX] stock_delivery: incorrect shipping weight for partial transfers

### DIFF
--- a/addons/stock_delivery/tests/test_packing_delivery.py
+++ b/addons/stock_delivery/tests/test_packing_delivery.py
@@ -51,13 +51,14 @@ class TestPacking(TestPackingCommon):
             'location_dest_id': self.customer_location.id,
             'carrier_id': self.test_carrier.id
         })
-        self.env['stock.move.line'].create({
+        move_line = self.env['stock.move.line'].create({
             'product_id': self.product_aw.id,
             'product_uom_id': self.uom_kg.id,
             'picking_id': picking_ship.id,
             'quantity': 5,
             'location_id': self.stock_location.id,
-            'location_dest_id': self.customer_location.id
+            'location_dest_id': self.customer_location.id,
+            'picked': True,
         })
         self.env['stock.move.line'].create({
             'product_id': self.product_bw.id,
@@ -65,7 +66,7 @@ class TestPacking(TestPackingCommon):
             'picking_id': picking_ship.id,
             'quantity': 5,
             'location_id': self.stock_location.id,
-            'location_dest_id': self.customer_location.id
+            'location_dest_id': self.customer_location.id,
         })
         pack_action = picking_ship.action_put_in_pack()
         pack_action_ctx = pack_action['context']
@@ -78,6 +79,17 @@ class TestPacking(TestPackingCommon):
         # default weight was set.
         pack_wiz = self.env['choose.delivery.package'].with_context(pack_action_ctx).create({})
         self.assertEqual(pack_wiz.shipping_weight, 13.5)
+
+        # unpick the move lines and check that the weight is correctly updated
+        move_line.write({'picked': False})
+
+        pack_action = picking_ship.action_put_in_pack()
+        pack_action_ctx = pack_action['context']
+        pack_action_model = pack_action['res_model']
+        self.assertEqual(pack_action_model, 'choose.delivery.package')
+
+        pack_wiz = self.env['choose.delivery.package'].with_context(pack_action_ctx).create({})
+        self.assertEqual(pack_wiz.shipping_weight, 1.5)
 
     def test_send_to_shipper_without_sale_order(self):
         """

--- a/addons/stock_delivery/wizard/choose_delivery_package.py
+++ b/addons/stock_delivery/wizard/choose_delivery_package.py
@@ -24,7 +24,8 @@ class ChooseDeliveryPackage(models.TransientModel):
     def _compute_shipping_weight(self):
         for rec in self:
             move_line_ids = rec.picking_id.move_line_ids.filtered(lambda m:
-                float_compare(m.quantity, 0.0, precision_rounding=m.product_uom_id.rounding) > 0
+                m.picked or not m.move_id.picked
+                and float_compare(m.quantity, 0.0, precision_rounding=m.product_uom_id.rounding) > 0
                 and not m.result_package_id
             )
             # Add package weights to shipping weight, package base weight is defined in package.type


### PR DESCRIPTION
### Steps to reproduce:
1. Create a product
   - Tracked by serial numbers
   - Set the weight to 2kg
   - Update the quantity on hands to 2 (with serials numbers)
2. Create a transfer of 2 quantities of the product
3. Open the detailed operations
5. Set the quantity done on a single line
6. Go back to the transfer and click put in pack
7. Select any package

### Before this commit:
The shipping weight is 4 kg instead of 2 kg, as it takes all lines regardless of their picked state.

### After this commit:
Only the picked move lines are used to compute the shipping weight.

opw-4028054