### PR TITLE
[FIX] project_todo: define emoji in HTML code

### DIFF
--- a/addons/project_todo/data/todo_template.xml
+++ b/addons/project_todo/data/todo_template.xml
@@ -147,7 +147,7 @@
 <hr />
 <p>
     <span style="font-size: 14px;">
-        Wherever you are, use the magic keyboard shortcut to add yourself a reminder 💡
+        Wherever you are, use the magic keyboard shortcut to add yourself a reminder &amp;#128161;
     </span>
     <br/>
     <ul>


### PR DESCRIPTION
Before this commit, it is impossible to install project_todo with demo data on Mac with Apple chip because lxml library cannot process correctly the emoji.

This commit defines the emoji in html code to be able to install the module with demo data on a Mac.
