### PR TITLE
[FIX] web_editor: Encode Unsafe Characters for ir.attachment image_src

### DIFF
--- a/addons/web_editor/models/ir_attachment.py
+++ b/addons/web_editor/models/ir_attachment.py
@@ -46,7 +46,7 @@ class IrAttachment(models.Model):
                     # Local URL
                     attachment.image_src = attachment.url
                 else:
-                    name = url_quote(attachment.name)
+                    name = url_quote(attachment.name, unsafe="$!'()*+,;")
                     attachment.image_src = '/web/image/%s-redirect/%s' % (attachment.id, name)
             else:
                 # Adding unique in URLs for cache-control
@@ -57,7 +57,7 @@ class IrAttachment(models.Model):
                     separator = '&' if '?' in attachment.url else '?'
                     attachment.image_src = '%s%sunique=%s' % (attachment.url, separator, unique)
                 else:
-                    name = url_quote(attachment.name)
+                    name = url_quote(attachment.name, unsafe="$!'()*+,;")
                     attachment.image_src = '/web/image/%s-%s/%s' % (attachment.id, unique, name)
 
     @api.depends('datas')


### PR DESCRIPTION
Issue: Werkzeug changed the behavior of url_quote in version 2.1.0
(impact python 3.11 and 3.12), which caused issues in Odoo,
particularly breaking the website blog post cover background feature.

Rationale: The modified behavior of url_quote allowed invalid characters,
which should be percent-encoded. For example, a binary attachment's name
containing a single quote (e.g., "attachment'A'") results in an image_src
like "/web/image/1-aaaaaaaa/attachment'A'", where the single quote is not
encoded.
This breaks the feature because the embedded URL needs to be encoded.

Technical Choice: The decision to encode unsafe characters ensures
compatibility and functionality of Odoo's web editor, specifically for
handling image sources in blog post covers. The necessity of encoding is
highlighted by the fact that uploaded cover images always include a single
quote due to this code:
https://github.com/odoo/odoo/blob/17.0/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js#L976

This change addresses an issue similar to the one fixed in commit https://github.com/odoo/odoo/commit/f1942718231154627e2f891ee55a9e8879115ac0.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
