### PR TITLE
[FIX] mrp_workorder: prevent null value for date_to

### DIFF
--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -250,7 +250,8 @@ class MrpWorkorder(models.Model):
                     'date_to': wo.date_finished,
                 })
             elif wo.date_start:
-                wo.date_finished = wo._calculate_date_finished()
+                if not wo.date_finished:
+                    wo.date_finished = wo._calculate_date_finished()
                 wo.leave_id = wo.env['resource.calendar.leaves'].create({
                     'name': wo.display_name,
                     'calendar_id': wo.workcenter_id.resource_calendar_id.id,


### PR DESCRIPTION
Problem: When the user inputs a value greater than 490,000 minutes for expected duration on a workorder, a Validation Error is thrown signifying that date_to is null but it's a required field when "Produce All" button is clicked. The workorder's date_finished gets recalculated always so it'll evaluate to False with a large value.

Purpose: To stay consistent with v16, the ValidationError should not occur and date_finished should not be recalculated if a value exists already. Produce All should execute smoothly

fix based on v16: https://github.com/odoo/odoo/blob/4d154a9f08cb2204df8566ed5c1e4f5e59e5d212/addons/mrp/models/mrp_workorder.py#L273

Steps to Reproduce on Runbot:
1. Install MRP
2. Enabled Work Orders in Settings > Manufacturing
3. Input a value greater than 490,000 on a workorder for expected duration
4. Click "Produce All" and ValidationError is thrown

opw-3959230
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
