### PR TITLE
[FIX] mail: Fix security error in multi-companies mode

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -2662,7 +2662,7 @@ class MailThread(models.AbstractModel):
         # add default-like values afterwards, to avoid useless queries
         if self:
             if 'record_alias_domain_id' not in msg_values:
-                msg_values['record_alias_domain_id'] = self._mail_get_alias_domains(default_company=self.env.company)[self.id].id
+                msg_values['record_alias_domain_id'] = self.sudo()._mail_get_alias_domains(default_company=self.env.company)[self.id].id
             if 'record_company_id' not in msg_values:
                 msg_values['record_company_id'] = self._mail_get_companies(default=self.env.company)[self.id].id
         if 'reply_to' not in msg_values:


### PR DESCRIPTION
## Steps to reproduce:
1. Archive the multi-company security rule of model `project.task` to be able to collaborate between companies
2. Task X in Company 1, assigned to User A in Company 1
3. User A reassigns the task to User B in Company 2
4. User B reassigns the task to another user => error appears

## Causes:
- When User B reassigns the task, the system will send a notification to the new user, and `message_notify` method will be called. In the step of getting alias domain for the company of the task (method `_mail_get_alias_domains`), User B cannot read `alias_domain_id` field of Company 1 and will get error.

## Solution:
- Use `sudo` when calling `_mail_get_alias_domains` method

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
