### PR TITLE
[FIX] mail: fix field does not exist in _mail_track_get_field_sequence

### DIFF
--- a/addons/mail/models/models.py
+++ b/addons/mail/models/models.py
@@ -177,6 +177,8 @@ class BaseModel(models.AbstractModel):
         """ Find tracking sequence of a given field, given their name. Current
         parameter 'tracking' should be an integer, but attributes with True
         are still supported; old naming 'track_sequence' also. """
+        if fname not in self._fields:
+            return 100
         sequence = getattr(
             self._fields[fname], 'tracking',
             getattr(self._fields[fname], 'track_sequence', 100)


### PR DESCRIPTION
I encountered an error when upgrading the database.
This error is because the `fname` does not exist in `self._fields` after the field has been removed in the code.

Here is all the traceback :
```
Traceback (most recent call last):
  File "/home/do/my_projects/odoo-17/odoo17/odoo/service/server.py", line 1313, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
  File "<decorator-gen-16>", line 2, in new
  File "/home/do/my_projects/odoo-17/odoo17/odoo/tools/func.py", line 87, in locked
    return func(inst, *args, **kwargs)
  File "/home/do/my_projects/odoo-17/odoo17/odoo/modules/registry.py", line 113, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/home/do/my_projects/odoo-17/odoo17/odoo/modules/loading.py", line 536, in load_modules
    env['ir.model.data']._process_end(processed_modules)
  File "/home/do/my_projects/odoo-17/OpenUpgrade/openupgrade_framework/odoo_patch/odoo/addons/base/models/ir_model.py", line 77, in _process_end
    return IrModelData._process_end._original_method(self, modules)
  File "/home/do/my_projects/odoo-17/odoo17/odoo/addons/base/models/ir_model.py", line 2558, in _process_end
    self._process_end_unlink_record(record)
  File "/home/do/my_projects/odoo-17/odoo17/odoo/addons/base/models/ir_model.py", line 2487, in _process_end_unlink_record
    record.unlink()
  File "/home/do/my_projects/odoo-17/odoo17/addons/mail/models/ir_model_fields.py", line 52, in unlink
    'sequence': self.env[field.model_id.model]._mail_track_get_field_sequence(field.name),
  File "/home/do/my_projects/odoo-17/odoo17/addons/mail/models/models.py", line 181, in _mail_track_get_field_sequence
    if isinstance(fname, IrModelFields):
KeyError: 'date_process'
```


close: https://github.com/odoo/odoo/issues/172891

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr



