### PR TITLE
[IMP] mail, mail_group: simplify kanban archs

### DIFF
--- a/addons/mail/static/src/scss/kanban_view.scss
+++ b/addons/mail/static/src/scss/kanban_view.scss
@@ -7,25 +7,14 @@ $o-kanban-attachement-image-size: 80px;
 }
 
 .o_kanban_renderer {
-    .o_kanban_record.o_kanban_attachment,
-    .o_kanban_record .o_kanban_attachment {
+    .o_kanban_record.o_kanban_attachment {
         padding: map-get($spacers, 0);
 
         .o_kanban_image {
             width: $o-kanban-attachement-image-size;
 
-            + div {
-                padding-left: $o-kanban-attachement-image-size + $o-kanban-inside-hgutter;
-                @include media-breakpoint-down(md) {
-                    padding-left:  $o-kanban-attachement-image-size + $o-kanban-inside-hgutter-mobile;
-                }
-            }
-
             .o_kanban_image_wrapper {
                 min-height: $o-kanban-attachement-image-size;
-                display: flex;
-                align-items: center;
-                justify-content: center;
             }
 
             .o_attachment_image {
@@ -41,30 +30,8 @@ $o-kanban-attachement-image-size: 80px;
 
         .o_kanban_details {
             .o_kanban_details_wrapper {
-                display: flex;
-                flex-direction: column;
                 min-height: $o-kanban-attachement-image-size;
                 padding: $o-kanban-inside-vgutter $o-kanban-inside-hgutter;
-
-                .o_kanban_record_title {
-                    margin-bottom: $o-kanban-inside-vgutter*0.5;
-                    white-space: nowrap;
-                    text-overflow: ellipsis;
-                    overflow: hidden;
-                    width: 95%;
-                }
-
-                .o_kanban_record_body {
-                    flex: 1 1 auto;
-                    white-space: nowrap;
-                    text-overflow: ellipsis;
-                    overflow: hidden;
-                    font-size: smaller;
-                }
-
-                .oe_kanban_avatar {
-                    border: 1px solid $component-active-color;
-                }
             }
         }
     }

--- a/addons/mail/static/tests/legacy/web/fields/m2x_avatar_user_tests.js
+++ b/addons/mail/static/tests/legacy/web/fields/m2x_avatar_user_tests.js
@@ -60,17 +60,9 @@ test("many2many_avatar_user in kanban view", async () => {
         "m2x.avatar.user,false,kanban": `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="user_id"/>
-                            <div class="oe_kanban_footer">
-                                <div class="o_kanban_record_bottom">
-                                    <div class="oe_kanban_bottom_right">
-                                        <field name="user_ids" widget="many2many_avatar_user"/>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="user_id"/>
+                        <field name="user_ids" widget="many2many_avatar_user"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -339,10 +331,8 @@ test("avatar_user widget displays the appropriate user image in kanban view", as
         "m2x.avatar.user,false,kanban": `
                 <kanban>
                     <templates>
-                        <t t-name="kanban-box">
-                            <div>
-                                <field name="user_id" widget="many2one_avatar_user"/>
-                            </div>
+                        <t t-name="kanban-card">
+                            <field name="user_id" widget="many2one_avatar_user"/>
                         </t>
                     </templates>
                 </kanban>`,
@@ -384,10 +374,8 @@ test("avatar card preview", async (assert) => {
         "m2x.avatar.user,false,kanban": `
                 <kanban>
                     <templates>
-                        <t t-name="kanban-box">
-                            <div>
-                                <field name="user_id" widget="many2one_avatar_user"/>
-                            </div>
+                        <t t-name="kanban-card">
+                            <field name="user_id" widget="many2one_avatar_user"/>
                         </t>
                     </templates>
                 </kanban>`,

--- a/addons/mail/views/discuss_channel_views.xml
+++ b/addons/mail/views/discuss_channel_views.xml
@@ -8,35 +8,22 @@
             <field name="priority" eval="10"/>
             <field name="arch" type="xml">
                 <kanban>
-                    <field name="id"/>
-                    <field name="description"/>
                     <field name="is_member"/>
                     <field name="group_ids"/>
                     <field name="active"/>
                     <templates>
-                        <t t-name="kanban-description">
-                            <div class="oe_group_description" t-if="record.description.raw_value">
-                                <field name="description"/>
-                            </div>
-                        </t>
-                        <t t-name="kanban-box">
-                            <div class="o_discuss_channel_kanban oe_module_vignette oe_kanban_global_click">
-                                <div class="ribbon ribbon-top-right o_small" invisible="active">
-                                    <span class="text-bg-danger">Archived</span>
-                                </div>
-                                <div class="d-flex align-items-center">
-                                    <img t-att-src="kanban_image('discuss.channel', 'avatar_128', record.id.raw_value)" class="oe_module_icon" alt="Channel"/>
-                                    <div class="oe_module_desc">
-                                        <h4 class="o_kanban_record_title">#<field name="name"/></h4>
-                                        <field name="channel_type" groups="base.group_no_one"/>
-                                        <p class="oe_module_name" t-att-class="!record.active.raw_value ? 'o_module_desc_short': ''">
-                                            <field name="description"/>
-                                        </p>
-                                        <button type="object" invisible="is_member or group_ids" class="btn btn-primary float-end" name="channel_join">Join</button>
-                                        <button type="object" invisible="not is_member or group_ids" class="btn btn-secondary float-end" name="action_unfollow">Leave</button>
-                                    </div>
-                                </div>
-                            </div>
+                        <t t-name="kanban-card" class="row g-0">
+                            <widget name="web_ribbon" class="d-flex" title="Archived" bg_color="text-bg-danger" invisible="active"/>
+                            <aside class="col-2 my-auto">
+                                <field name="avatar_128" widget="image" options="{'size': [50, 50]}" alt="Channel"/>
+                            </aside>
+                            <main class="col me-4 ms-2">
+                                <span class="fw-bold fs-5">#<field name="name"/></span>
+                                <field name="channel_type" groups="base.group_no_one"/>
+                                <field name="description" class="text-muted lh-1 small"/>
+                                <button type="object" invisible="is_member or group_ids" class="btn btn-primary ms-auto mt-auto" name="channel_join">Join</button>
+                                <button type="object" invisible="not is_member or group_ids" class="btn btn-secondary ms-auto mt-auto" name="action_unfollow">Leave</button>
+                            </main>
                         </t>
                     </templates>
                 </kanban>

--- a/addons/mail/views/mail_activity_plan_views.xml
+++ b/addons/mail/views/mail_activity_plan_views.xml
@@ -82,29 +82,24 @@
                                         <field name="delay_from"/>
                                     </tree>
                                     <kanban class="o_kanban_mobile">
-                                        <field name="company_id"/>
                                         <field name="icon"/>
                                         <templates>
-                                            <t t-name="kanban-box">
-                                                <div class="oe_kanban_global_click d-flex flex-column justify-content-between">
-                                                    <div>
-                                                        <strong class="o_kanban_record_title">
-                                                            <i t-if="record.icon.value"
-                                                               t-attf-class="fa #{record.icon.value} fa-fw"
-                                                               role="img" aria-label="Activity Type" title="Activity Type"/>
-                                                            <field name="activity_type_id"/>
-                                                        </strong>
-                                                        <div><field name="summary"/></div>
-                                                        <div>
-                                                            <field name="delay_count"/> <field name="delay_unit"/>
-                                                            (<field name="delay_from"/>)
-                                                        </div>
-                                                    </div>
-                                                    <div class="o_kanban_record_bottom">
-                                                        <field class="oe_kanban_bottom_left" name="responsible_type"/>
-                                                        <field class="oe_kanban_bottom_right" name="responsible_id" widget="many2one_avatar_user" readonly="1"/>
-                                                    </div>
+                                            <t t-name="kanban-card">
+                                                <div class="fw-bold fs-5">
+                                                    <i t-if="record.icon.value"
+                                                        t-attf-class="fa #{record.icon.value} fa-fw "
+                                                        role="img" aria-label="Activity Type" title="Activity Type"/>
+                                                    <field name="activity_type_id"/>
                                                 </div>
+                                                <field name="summary"/>
+                                                <div>
+                                                    <field name="delay_count"/> <field name="delay_unit"/>
+                                                    (<field name="delay_from"/>)
+                                                </div>
+                                                <footer class="p-0 fs-6">
+                                                    <field name="responsible_type"/>
+                                                    <field class="ms-auto" name="responsible_id" widget="many2one_avatar_user" readonly="1"/>
+                                                </footer>
                                             </t>
                                         </templates>
                                     </kanban>
@@ -122,20 +117,12 @@
             <field name="arch" type="xml">
                 <kanban class="o_kanban_mobile">
                     <templates>
-                        <t t-name="kanban-box">
-                            <div class="oe_kanban_global_click">
-                                <div>
-                                    <strong><field name="name"/></strong>
-                                </div>
-                                <div title="Applies to">
-                                    <field name="res_model_id"/>
-                                </div>
-                                <div>
-                                    <span>
-                                        <i class="fa fa-cogs fa-fw me-2" role="img" aria-label="Steps count" title="Steps count"/>
-                                        <field name="steps_count"/>
-                                    </span>
-                                </div>
+                        <t t-name="kanban-card">
+                            <field name="name" class="fw-bolder"/>
+                            <field name="res_model_id"/>
+                            <div>
+                                <i class="fa fa-cogs fa-fw me-2" role="img" aria-label="Steps count" title="Steps count"/>
+                                <field name="steps_count"/>
                             </div>
                         </t>
                     </templates>

--- a/addons/mail/views/mail_activity_views.xml
+++ b/addons/mail/views/mail_activity_views.xml
@@ -108,28 +108,21 @@
         <field name="arch" type="xml">
             <kanban class="o_kanban_mobile">
                 <field name="icon"/>
-                <field name="res_model"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div class="oe_kanban_global_click d-flex justify-content-end">
-                            <div class="flex-grow-1">
-                                <div class="o_kanban_record_title fw-bold">
-                                    <i t-if="record.icon.value" t-attf-class="fa #{record.icon.value} fa-fw"
-                                       role="img" aria-label="Activity Type Name" title="Activity Type Name"/>
-                                    <field name="name"/>
-                                </div>
-                                <div t-if="record.res_model.value" title="Applies to">
-                                    <field name="res_model"/>
-                                </div>
-                                <div t-if="record.summary.raw_value">
-                                    Default Summary: <field name="summary"/>
-                                </div>
-                            </div>
-                            <div class="d-flex align-items-end">
-                                <field class="oe_kanban_bottom_right" name="default_user_id"
-                                       widget="many2one_avatar_user" readonly="1"/>
-                            </div>
+                    <t t-name="kanban-card">
+                        <div class="fw-bold fs-5">
+                            <i t-if="record.icon.value" t-attf-class="fa #{record.icon.value} fa-fw"
+                               role="img" aria-label="Activity Type Name" title="Activity Type Name"/>
+                            <field name="name"/>
                         </div>
+                        <field t-if="record.res_model.value" name="res_model"/>
+                        <div t-if="record.summary.raw_value">
+                            Default Summary: <field name="summary"/>
+                        </div>
+                        <footer>
+                            <field class="ms-auto" name="default_user_id"
+                                   widget="many2one_avatar_user" readonly="1"/>
+                        </footer>
                     </t>
                 </templates>
             </kanban>
@@ -359,34 +352,25 @@
             <kanban string="Activity" action="action_open_document" type="object">
                 <templates>
                     <field name="active" invisible="1"/>
-                    <t t-name="kanban-box">
-                        <div t-attf-class="oe_kanban_card oe_kanban_global_click d-flex flex-column justify-content-between">
-                            <div class="d-flex justify-content-between">
-                                <span>
-                                    <field name="res_name"
-                                        class="fw-bold" /> (<field class="text-muted" name="res_model_id" />)</span>
-                                <field name="activity_type_id" widget="badge" />
-                            </div>
-                            <div class="d-flex flex-row gap-2">
-                                <div class="text-truncate">
-                                    <field name="summary" />
-                                </div>
-                            </div>
-                            <div class="d-flex justify-content-between align-items-center">
-                                <div class="d-flex gap-2 align-items-center">
-                                    <field name="user_id" widget="many2one_avatar_user" />
-                                    <field name="date_deadline" widget="remaining_days" />
-                                </div>
-                                <div class="d-flex flex-row gap-2">
-                                    <button type="object" name="action_done" class="btn btn-link btn-sm" invisible="active == False">
-                                        <i class="fa fa-check" /> Done
-                                    </button>
-                                    <button type="object" name="unlink" class="btn btn-link text-danger btn-sm">
-                                        <i class="fa fa-times" /> Cancel
-                                    </button>
-                                </div>
-                            </div>
+                    <t t-name="kanban-card">
+                        <div class="d-flex justify-content-between">
+                            <span>
+                                <field name="res_name" class="fw-bold" />
+                                (<field class="text-muted" name="res_model_id" />)
+                            </span>
+                            <field name="activity_type_id" widget="badge" />
                         </div>
+                        <field class="text-truncate" name="summary" />
+                        <footer class="align-items-center">
+                            <field name="user_id" widget="many2one_avatar_user" />
+                            <field name="date_deadline" widget="remaining_days" class="ms-2"/>
+                            <button type="object" name="action_done" class="btn btn-link btn-sm ms-auto me-1" invisible="active == False">
+                                <i class="fa fa-check" /> Done
+                            </button>
+                            <button type="object" name="unlink" class="btn btn-link text-danger btn-sm">
+                                <i class="fa fa-times" /> Cancel
+                            </button>
+                        </footer>
                     </t>
                 </templates>
             </kanban>

--- a/addons/mail/views/mail_message_views.xml
+++ b/addons/mail/views/mail_message_views.xml
@@ -139,47 +139,34 @@
                     <field name="id"/>
                     <field name="mimetype"/>
                     <field name="type"/>
-                    <field name="create_uid"/>
-                    <field name="url"/>
-                    <field name="create_date"/>
-                    <field name="name"/>
                     <templates>
                         <t t-name="kanban-menu">
                             <a t-attf-href="/web/content/ir.attachment/#{record.id.raw_value}/datas?download=true" download="" class="dropdown-item">Download</a>
                             <a t-if="widget.deletable" role="menuitem" type="delete" class="dropdown-item">Delete</a>
                         </t>
-                        <t t-name="kanban-box">
-                            <div class="oe_kanban_global_area oe_kanban_global_click o_kanban_attachment">
-                                <div class="o_kanban_image">
-                                    <div class="o_kanban_image_wrapper">
-                                        <t t-set="webimage" t-value="new RegExp('image.*(gif|jpeg|jpg|png|webp)').test(record.mimetype.value)"/>
-                                        <div t-if="record.type.raw_value == 'url'" class="o_url_image fa fa-link fa-3x text-muted" aria-label="Image is a link"/>
-                                        <img t-elif="webimage" t-attf-src="/web/image/#{record.id.raw_value}" width="100" height="100" alt="Document" class="o_attachment_image"/>
-                                        <div t-else="!webimage" class="o_image o_image_thumbnail" t-att-data-mimetype="record.mimetype.value"/>
+                        <t t-name="kanban-card" class="o_kanban_attachment flex-row">
+                            <aside class="o_kanban_image m-1">
+                                <div class="o_kanban_image_wrapper d-flex align-items-center justify-content-center">
+                                    <t t-set="webimage" t-value="new RegExp('image.*(gif|jpeg|jpg|png|webp)').test(record.mimetype.value)"/>
+                                    <div t-if="record.type.raw_value == 'url'" class="fa fa-link fa-3x text-muted" aria-label="Image is a link"/>
+                                    <img t-elif="webimage" t-attf-src="/web/image/#{record.id.raw_value}" width="100" height="100" alt="Document" class="o_attachment_image"/>
+                                    <div t-else="!webimage" class="o_image o_image_thumbnail" t-att-data-mimetype="record.mimetype.value"/>
+                                </div>
+                            </aside>
+                            <main class="o_kanban_details ms-1">
+                                <div class="o_kanban_details_wrapper d-flex flex-column">
+                                    <field name="name" class="text-truncate fw-bold fs-5"/>
+                                    <div class="d-flex flex-grow-1 align-items-center">
+                                        <t t-if="record.type.raw_value == 'url'">
+                                            <i class="fa fa-globe" aria-label="Document url"/> <field name="url" widget="url"/>
+                                        </t>
+                                    </div>
+                                    <div class="d-flex">
+                                        <field name="create_date"/>
+                                        <field name="create_uid" widget="many2one_avatar_user" class="ms-auto"/>
                                     </div>
                                 </div>
-                                <div class="o_kanban_details">
-                                    <div class="o_kanban_details_wrapper">
-                                        <div t-att-title="record.name.raw_value" class="o_kanban_record_title">
-                                            <field name="name" class="o_text_overflow"/>
-                                        </div>
-                                        <div class="o_kanban_record_body">
-                                            <t t-if="record.type.raw_value == 'url'">
-                                                <span class="o_document_url"><i class="fa fa-globe" aria-label="Document url"/> <field name="url" widget="url"/></span>
-                                            </t>
-                                            <samp t-else="" class="text-muted"> </samp>
-                                        </div>
-                                        <div class="o_kanban_record_bottom">
-                                            <time class="oe_kanban_bottom_left">
-                                                <field name="create_date"/>
-                                            </time>
-                                            <div class="oe_kanban_bottom_right">
-                                                <field name="create_uid" widget="many2one_avatar_user"/>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
+                            </main>
                         </t>
                     </templates>
                 </kanban>

--- a/addons/mail_group/views/mail_group_views.xml
+++ b/addons/mail_group/views/mail_group_views.xml
@@ -17,32 +17,23 @@
         <field name="model">mail.group</field>
         <field name="arch" type="xml">
             <kanban string="Mail Groups" sample="1">
-                <field name="id"/>
-                <field name="description"/>
                 <field name="is_member"/>
-                <field name="member_count"/>
                 <templates>
-                    <t t-name="kanban-description">
-                        <div class="oe_group_description" t-if="record.description.raw_value">
-                            <field name="description"/>
-                        </div>
-                    </t>
-                    <t t-name="kanban-box">
-                        <div class="oe_module_vignette oe_kanban_global_click">
-                            <img t-att-src="kanban_image('mail.group', 'image_128', record.id.raw_value)" class="oe_module_icon" alt="Group"/>
-                            <div class="oe_module_desc">
-                                <h4 class="o_kanban_record_title">#<field name="name"/></h4>
-                                <p class="o_mg_description text-truncate text-nowrap" t-esc="record.description.raw_value or ''"/>
-                                <span>
-                                    <t t-esc="record.member_count.raw_value"/>
-                                    <t t-if="record.member_count.raw_value > 1">Members</t>
-                                    <t t-else="">Member</t>
-                                </span>
-                                <field name="is_member" invisible="1"/>
-                                <button type="object" invisible="is_member" class="btn btn-primary float-end" name="action_join">Join</button>
-                                <button type="object" invisible="not is_member" class="btn btn-secondary float-end" name="action_leave">Leave</button>
-                            </div>
-                        </div>
+                    <t t-name="kanban-card" class="flex-row">
+                        <aside>
+                            <field name="image_128" widget="image" alt="Group"/>
+                        </aside>
+                        <main>
+                            <span class="fw-bold fs-5">#<field name="name"/></span>
+                            <field class="text-truncate text-nowrap" name="description"/>
+                            <span>
+                                <field name="member_count"/>
+                                <t t-if="record.member_count.raw_value > 1">Members</t>
+                                <t t-else="">Member</t>
+                            </span>
+                            <button type="object" invisible="is_member" class="btn btn-primary ms-auto" name="action_join">Join</button>
+                            <button type="object" invisible="not is_member" class="btn btn-secondary ms-auto" name="action_leave">Leave</button>
+                        </main>
                     </t>
                 </templates>
             </kanban>


### PR DESCRIPTION
In this commit we have simplified the kanban arch for the mail and mail_group modules.  The goal is to simplify them, make them easier to read, and use bootstrap utility classnames.
- Previously, we used `kanban-box`, but now we are using `kanban-card` instead.
- Deprecated `oe_kanban_global_click` and `oe_kanban_global_click_edit`.
- More use of `<field/>` tags
- Removed the `oe_kanban_colorpicker` class and replaced it with the `kanban_color_picker` widget.
- Changed type='edit' to type='open' to open records. since version 16, records always open in edit mode by default.
- `kanban_image` from rendering context, is deprecated so we use `<field name=... widget=image/>` instead

Task-3992107

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
