### PR TITLE
[FIX] base: raise a valid valueerror when the report is deleted

### DIFF
--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -532,7 +532,7 @@ class IrActionsReport(models.Model):
         report = ReportSudo.search([('report_name', '=', report_ref)], limit=1)
         if report:
             return report
-        report = self.env.ref(report_ref)
+        report = self.env.ref(report_ref, raise_if_not_found=False)
         if report:
             if report._name != "ir.actions.report":
                 raise ValueError("Fetching report %r: type %s, expected ir.actions.report" % (report_ref, report._name))


### PR DESCRIPTION
Currently a value error is raised with inappropriate information to the end user when he deleted the reports

To reproduce this issue:

1) Install sales
2) Delete the `Quotation / Order `record from settings/Technical/Actions/Reports 
3) Now open the portal for any sale order
4) Try to print/Download the sale order through the portal 
5) Traceback will occur.

Error:
```
ValueError: External ID not found in the system: sale.action_report_saleorder
```

The error is raised when the report is referenced from line `535`
 but it is not a valid and appropriate error we show to the end user.

The error should be raised from line `540` which has the proper message

https://github.com/odoo/odoo/blob/4d154a9f08cb2204df8566ed5c1e4f5e59e5d212/odoo/addons/base/models/ir_actions_report.py#L535-L540

sentry-5241203228
