### PR TITLE
[FIX] hr_contract: Contract job info not passed down to employee

### DIFF
--- a/addons/hr_contract/models/hr_contract.py
+++ b/addons/hr_contract/models/hr_contract.py
@@ -147,6 +147,15 @@ class Contract(models.Model):
                     contract=contract.name, start=contract.date_start, end=contract.date_end,
                 ))
 
+    def _get_employee_vals_to_update(self):
+        self.ensure_one()
+        vals = {'contract_id': self.id}
+        if self.job_id and self.job_id != self.employee_id.job_id:
+            vals['job_id'] = self.job_id.id
+        if self.department_id:
+            vals['department_id'] = self.department_id.id
+        return vals
+
     @api.model
     def update_state(self):
         from_cron = 'from_cron' in self.env.context
@@ -223,7 +232,8 @@ class Contract(models.Model):
 
     def _assign_open_contract(self):
         for contract in self:
-            contract.employee_id.sudo().write({'contract_id': contract.id})
+            vals = contract._get_employee_vals_to_update()
+            contract.employee_id.sudo().write(vals)
 
     @api.depends('wage')
     def _compute_contract_wage(self):


### PR DESCRIPTION
Steps to reproduce:
- Create an employee, leave job position / department empty
- Add a contract (top-right of form)
- Set job position / department
- Set the contract to 'Running'

What happens:
The employee's job position / department fields stay empty

Why is this an issue:
The contract autofills with employee information so the same is expected of the opposite interaction.

What was done:
We should be fine to assume an employee's job is determined by their active contract but to err of caution this autofill has been set NOT to overwrite the employee's current job if it is already filled in.

opw-4037757

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
