### PR TITLE
[FIX] point_of_sale: pass order line name to the product widget

### DIFF
--- a/addons/point_of_sale/views/pos_order_view.xml
+++ b/addons/point_of_sale/views/pos_order_view.xml
@@ -101,6 +101,7 @@
                                     </t>
                             </kanban>
                             <tree string="Order lines" editable="bottom">
+                                <field name="name" column_invisible="True"/>
                                 <field name="full_product_name" optional="hide" readonly="1"/>
                                 <field name="product_id" widget="product_label_section_and_note_field" />
                                 <field name="pack_lot_ids" widget="many2many_tags" groups="stock.group_production_lot"/>


### PR DESCRIPTION
Currently, there's a client error when trying to access the form view of a `pos.order`.

The form view uses the widget `product_label_section_and_note_field` to display the `product_id` of an order line, but this widget requires a name to be passed.

The fix here is to add the name of the order line in the view and make it invisible.

Note:
This wasn't an issue until https://github.com/odoo/odoo/pull/172186, which added some logic on the name.

Backport of https://github.com/odoo/odoo/pull/172779
