### PR TITLE
[IMP] web, *: allow user's to quick login

### DIFF
--- a/addons/auth_oauth/views/auth_oauth_templates.xml
+++ b/addons/auth_oauth/views/auth_oauth_templates.xml
@@ -13,18 +13,12 @@
         </template>
 
         <template id="login" inherit_id="web.login" name="OAuth Login buttons">
-            <xpath expr="//form" position="before">
-                <t t-set="form_small" t-value="True" t-if="len(providers) &gt; 2"/>
-            </xpath>
             <xpath expr="//div[hasclass('o_login_auth')]" position="inside">
                 <t t-call="auth_oauth.providers"/>
             </xpath>
         </template>
 
         <template id="signup" inherit_id="auth_signup.signup" name="OAuth Signup buttons">
-            <xpath expr="//form" position="before">
-                <t t-set="form_small" t-value="True"/>
-            </xpath>
             <xpath expr="//div[hasclass('o_login_auth')]" position="inside">
                 <t t-call="auth_oauth.providers"/>
             </xpath>

--- a/addons/auth_passkey/views/auth_passkey_login_templates.xml
+++ b/addons/auth_passkey/views/auth_passkey_login_templates.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <template priority="32" id="auth_passkey_login" inherit_id="web.login">
-        <xpath expr="//button[@type='submit']" position="after">
-            <div class="text-start mt-2">
-                <button class="btn btn-link passkey_login_link btn-sm p-0 border-0" type="button" style="font-size: 0.875em;">Login with Passkey</button>
+        <xpath expr="//div[hasclass('oe_login_buttons')]" position="after">
+            <em t-attf-class="d-block text-center text-muted small my-1">- or -</em>
+            <div class="text-center mt-2">
+                <button class="btn btn-link btn-sm passkey_login_link p-0 border-0" type="button">Log in with Passkey</button>
             </div>
         </xpath>
         <xpath expr="//input[@name='redirect']" position="before">

--- a/addons/auth_signup/views/auth_signup_login_templates.xml
+++ b/addons/auth_signup/views/auth_signup_login_templates.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
         <template id="auth_signup.login" inherit_id="web.login" name="Sign up - Reset Password">
-            <xpath expr="//button[@type='submit']" position="after">
-                <div class="justify-content-between mt-2 d-flex small">
-                    <a t-if="signup_enabled" t-attf-href="/web/signup?{{ keep_query() }}">Don't have an account?</a>
-                    <a t-if="reset_password_enabled" t-attf-href="/web/reset_password?{{ keep_query() }}">Reset Password</a>
-                </div>
+            <xpath expr="//div[hasclass('oe_login_buttons')]" position="after">
+                <p class="mt-2 text-center">
+                    <a t-if="signup_enabled" class="btn btn-link btn-sm" t-attf-href="/web/signup?{{ keep_query() }}">Don't have an account?</a>
+                </p>
+            </xpath>
+            <xpath expr="//label[@for='password']" position="inside">
+                <a t-if="reset_password_enabled" class="btn btn-link btn-sm" tabindex="1" t-attf-href="/web/reset_password?{{ keep_query() }}">Reset Password</a>
             </xpath>
         </template>
 

--- a/addons/auth_totp/static/tests/totp_flow.js
+++ b/addons/auth_totp/static/tests/totp_flow.js
@@ -223,13 +223,9 @@ registry.category("web_tour.tours").add('totp_login_device', {
     trigger: '.dropdown-item[data-menu=logout]',
     run: "click",
 }, {
-    content: "check that we're back on the login page or go to it",
-    trigger: 'input#login, a:contains(Log in)', 
-    run: "edit Test",
-}, {
-    content: "input login again",
-    trigger: 'input#login',
-    run: "edit demo",
+    content: "check that we're back on the quick login page",
+    trigger: ".o_user_switch .o_user_avatar",
+    run: "click",
 }, {
     content: 'input password again',
     trigger: 'input#password',

--- a/addons/web/__manifest__.py
+++ b/addons/web/__manifest__.py
@@ -426,11 +426,11 @@ This module provides the core of the Odoo Web Client.
         # ---------------------------------------------------------------------
 
         'web.assets_tests': [
-            # No tours are defined in web, but the bundle "assets_tests" is
-            # first called in web.
+            # the bundle "assets_tests" is first called in web.
             'web/static/tests/legacy/helpers/cleanup.js',
             'web/static/tests/legacy/helpers/utils.js',
             'web/static/tests/legacy/utils.js',
+            'web/static/tests/tours/**/*'
         ],
         'web.__assets_tests_call__': [
             'web/static/tests/legacy/ignore_missing_deps_start.js',
@@ -466,6 +466,7 @@ This module provides the core of the Odoo Web Client.
             'web/static/tests/**/*',
 
             ('remove', 'web/static/tests/_framework/mock_module_loader.js'),
+            ('remove', 'web/static/tests/tours/**/*'),
             ('remove', 'web/static/tests/legacy/**/*'), # to remove when all legacy tests are ported
         ],
         'web.tests_assets': [

--- a/addons/web/static/src/core/user.js
+++ b/addons/web/static/src/core/user.js
@@ -1,3 +1,4 @@
+import { browser } from "@web/core/browser/browser";
 import { rpc } from "@web/core/network/rpc";
 import { Cache } from "@web/core/utils/cache";
 import { session } from "@web/session";
@@ -126,3 +127,29 @@ export function _makeUser(session) {
 }
 
 export const user = _makeUser(session);
+
+const LAST_CONNECTED_USER_KEY = "web.lastConnectedUser";
+
+export const getLastConnectedUsers = () => {
+    const lastConnectedUsers = browser.localStorage.getItem(LAST_CONNECTED_USER_KEY);
+    return lastConnectedUsers ? JSON.parse(lastConnectedUsers) : [];
+};
+
+export const setLastConnectedUsers = (users) => {
+    browser.localStorage.setItem(LAST_CONNECTED_USER_KEY, JSON.stringify(users.slice(0, 5)));
+};
+
+if (user.login && user.login !== "__system__") {
+    const users = getLastConnectedUsers();
+    const lastConnectedUsers = [
+        {
+            login: user.login,
+            name: user.name,
+            partnerId: user.partnerId,
+            partnerWriteDate: user.writeDate,
+            userId: user.userId,
+        },
+        ...users.filter((u) => u.userId !== user.userId),
+    ];
+    setLastConnectedUsers(lastConnectedUsers);
+}

--- a/addons/web/static/src/core/user_switch/user_switch.js
+++ b/addons/web/static/src/core/user_switch/user_switch.js
@@ -1,0 +1,50 @@
+import { Component, useRef, useState, useEffect } from "@odoo/owl";
+import { registry } from "@web/core/registry";
+import { getLastConnectedUsers, setLastConnectedUsers } from "@web/core/user";
+import { imageUrl } from "@web/core/utils/urls";
+
+export class UserSwitch extends Component {
+    static template = "web.login_user_switch";
+    static props = {};
+
+    setup() {
+        const users = getLastConnectedUsers();
+        this.root = useRef("root");
+        this.state = useState({
+            users,
+            displayUserChoice: users.length,
+        });
+        this.form = document.querySelector("form.oe_login_form");
+        this.form.classList.toggle("d-none", users.length);
+        useEffect(
+            (el) => el?.querySelector("button.list-group-item-action")?.focus(),
+            () => [this.root.el]
+        );
+    }
+
+    toggleFormDisplay() {
+        this.state.displayUserChoice = !this.state.displayUserChoice && this.state.users.length;
+        this.form.classList.toggle("d-none", this.state.displayUserChoice);
+        this.form.querySelector(":placeholder-shown")?.focus();
+    }
+
+    getAvatarUrl({ partnerId, partnerWriteDate: unique }) {
+        return imageUrl("res.partner", partnerId, "avatar_128", { unique });
+    }
+
+    remove(deletedUser) {
+        this.state.users = this.state.users.filter((user) => user !== deletedUser);
+        setLastConnectedUsers(this.state.users);
+        if (!this.state.users.length) {
+            this.fillForm();
+        }
+    }
+
+    fillForm(login = "") {
+        this.form.querySelector("input#login").value = login;
+        this.form.querySelector("input#password").value = "";
+        this.toggleFormDisplay();
+    }
+}
+
+registry.category("public_components").add("web.user_switch", UserSwitch);

--- a/addons/web/static/src/core/user_switch/user_switch.xml
+++ b/addons/web/static/src/core/user_switch/user_switch.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="web.login_user_switch">
+        <t t-if="state.users.length">
+            <t t-if="state.displayUserChoice">
+                <div class="oe_login_form o_user_switch user-select-none my-4" t-ref="root">
+                    <p>Choose a user</p>
+                    <div class="list-group my-3">
+                        <t t-foreach="state.users" t-as="user" t-key="user">
+                            <button type="button" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center" t-on-click="() => this.fillForm(user.login)">
+                                <span class="d-flex justify-content-begin align-items-center">
+                                    <img class="o_avatar o_user_avatar rounded me-2" t-attf-src="{{getAvatarUrl(user)}}" t-att-alt="user.login"/>
+                                    <t t-esc="user.name" />
+                                </span>
+                                <i class="fa fa-times" title="Remove user from switcher" t-on-click.stop="() => this.remove(user)"/>
+                            </button>
+                        </t>
+                    </div>
+                    <button type="button" class="btn btn-link btn-sm w-100" t-on-click="() => this.fillForm()">
+                        <i class="fa fa-user-circle-o"/> <span class="ms-1">Use another user</span>
+                    </button>
+                </div>
+            </t>
+            <t t-else="" t-portal="'label.form-label'">
+                <button type="button" class="o_user_switch_btn btn btn-sm btn-link m-0 p-0" tabindex="1" t-on-click="() => this.toggleFormDisplay()">
+                    Choose a user
+                </button>
+            </t>
+        </t>
+    </t>
+</templates>

--- a/addons/web/static/tests/tours/user_switch_tour.js
+++ b/addons/web/static/tests/tours/user_switch_tour.js
@@ -1,0 +1,138 @@
+import { registry } from "@web/core/registry";
+
+function logout() {
+    return [
+        {
+            content: "check we're logged in",
+            trigger: ".o_user_menu .dropdown-toggle",
+            run: "click",
+        },
+        {
+            content: "click the Log out button",
+            trigger: ".dropdown-item[data-menu=logout]",
+            run: "click",
+        },
+    ];
+}
+
+registry.category("web_tour.tours").add("test_user_switch", {
+    test: true,
+    url: "/web",
+    steps: () => [
+        ...logout(),
+        {
+            content: "Click on Marc Demo on the quick login page",
+            trigger:
+                ".o_user_switch:not(:has(.list-group-item:nth-child(2))) .list-group-item:contains('Marc Demo')",
+            run: "click",
+        },
+        {
+            content: "Check user choice button to back on the quick login page",
+            trigger: ".oe_login_form .o_user_switch_btn",
+            run: "click",
+        },
+        {
+            content: "Display the login form",
+            trigger: ".o_user_switch .fa-user-circle-o",
+            run: "click",
+        },
+        {
+            content: "fill the login",
+            trigger: "input#login",
+            run: "edit admin",
+        },
+        {
+            content: "fill the password",
+            trigger: "input#password",
+            run: "edit admin",
+        },
+        {
+            content: "click on login button",
+            trigger: 'button:contains("Log in")',
+            run: "click",
+        },
+        ...logout(),
+        {
+            content: "Check if there is Mitchell Admin in user list selection",
+            trigger: ".o_user_switch .list-group-item:nth-child(1):contains('Mitchell Admin')",
+        },
+        {
+            content: "Check if there is Marc Demo in user list selection",
+            trigger: ".o_user_switch .list-group-item:nth-child(2):contains('Marc Demo')",
+        },
+        {
+            content: "Choice demo",
+            trigger: ".o_user_switch .list-group-item:contains('Marc Demo')",
+            run: "click",
+        },
+        {
+            content: "check the login for demo",
+            trigger: "input#login:value('demo')",
+        },
+        {
+            content: "fill the password",
+            trigger: "input#password",
+            run: "edit demo",
+        },
+        {
+            content: "Check back button to back on the quick login page",
+            trigger: ".oe_login_form .o_user_switch_btn",
+            run: "click",
+        },
+        {
+            content: "Check have 2 users",
+            trigger: ".o_user_switch .list-group-item:nth-child(2)",
+        },
+        {
+            content: "Click on Mitchell Admin",
+            trigger: ".o_user_switch .list-group-item:nth-child(1):contains('Mitchell Admin')",
+            run: "click",
+        },
+        {
+            content: "check the login for admin",
+            trigger: "input#login:value('admin')",
+        },
+        {
+            content: "fill the password",
+            trigger: "input#password",
+            run: "edit admin",
+        },
+        {
+            content: "Check back button to back on the quick login page",
+            trigger: ".oe_login_form .o_user_switch_btn",
+            run: "click",
+        },
+        {
+            content: "Display the login form",
+            trigger: ".o_user_switch .fa-user-circle-o",
+            run: "click",
+        },
+        {
+            content: "the login form is display",
+            trigger: "form.oe_login_form:not(.d-none)",
+        },
+        {
+            content: "check if the login input is empty",
+            trigger: "input#login:empty",
+        },
+        {
+            content: "check if the password input is empty",
+            trigger: "input#password:empty",
+        },
+        {
+            content: "Back to user switch",
+            trigger: ".oe_login_form .o_user_switch_btn",
+            run: "click",
+        },
+        {
+            content: "Remove the admin user from page",
+            trigger: ".o_user_switch .d-flex:first-child .fa-times",
+            run: "click",
+        },
+        {
+            content: "only one user is left on quick login",
+            trigger:
+                ".o_user_switch:not(:has(.list-group-item:nth-child(2))) .list-group-item:contains('Marc Demo')",
+        },
+    ],
+});

--- a/addons/web/tests/test_login.py
+++ b/addons/web/tests/test_login.py
@@ -1,7 +1,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import http
-from odoo.tests.common import get_db_name, HOST, HttpCase, new_test_user, Opener
+from odoo.addons.base.tests.common import HttpCaseWithUserDemo
+from odoo.tests.common import get_db_name, HOST, HttpCase, new_test_user, Opener, tagged
 
 
 class TestWebLoginCommon(HttpCase):
@@ -58,3 +59,9 @@ class TestWebLogin(TestWebLoginCommon):
 
         # log in using the above form, it should still be valid
         self.login('internal_user', 'internal_user', csrf_token)
+
+
+@tagged('post_install', '-at_install')
+class TestUserSwitch(HttpCaseWithUserDemo):
+    def test_user_switch(self):
+        self.start_tour('/web', 'test_user_switch', login='demo')

--- a/addons/web/views/webclient_templates.xml
+++ b/addons/web/views/webclient_templates.xml
@@ -119,7 +119,7 @@
             <div class="container py-5">
                 <div t-attf-class="card border-0 mx-auto bg-100 {{login_card_classes}} o_database_list" style="max-width: 300px;">
                     <div class="card-body">
-                        <div t-attf-class="text-center pb-3 border-bottom {{'mb-3' if form_small else 'mb-4'}}">
+                        <div class="text-center pb-3 border-bottom mb-4">
                             <img t-attf-src="/web/binary/company_logo{{ '?dbname='+db if db else '' }}" alt="Logo" style="max-height:120px; max-width: 100%; width:auto"/>
                         </div>
                         <t t-out="0"/>
@@ -137,25 +137,26 @@
 
     <template id="web.login" name="Login">
         <t t-call="web.login_layout">
-            <form class="oe_login_form" role="form" t-attf-action="/web/login" method="post" onsubmit="this.action = '/web/login' + location.hash">
+            <owl-component t-if="not login" name="web.user_switch" />
+            <form t-attf-class="oe_login_form #{'' if login else 'd-none'}" role="form" t-attf-action="/web/login" method="post" onsubmit="this.action = '/web/login' + location.hash">
                 <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
 
                 <div class="mb-3" t-if="databases and len(databases) &gt; 1">
                     <label for="db" class="col-form-label">Database</label>
-                    <div t-attf-class="input-group {{'input-group-sm' if form_small else ''}}">
-                        <input type="text" name="db" t-att-value="request.db" id="db" t-attf-class="form-control #{'form-control-sm' if form_small else ''}" required="required" readonly="readonly"/>
+                    <div class="input-group">
+                        <input type="text" name="db" t-att-value="request.db" id="db" class="form-control" required="required" readonly="readonly"/>
                         <a role="button" href="/web/database/selector" class="btn btn-secondary">Select <i class="fa fa-database" role="img" aria-label="Database" title="Database"></i></a>
                     </div>
                 </div>
 
                 <div class="mb-3 field-login">
-                    <label for="login" class="form-label">Email</label>
-                    <input type="text" placeholder="Email" name="login" t-att-value="login" id="login" t-attf-class="form-control #{'form-control-sm' if form_small else ''}" required="required" autofocus="autofocus" autocapitalize="off"/>
+                    <label for="login" class="form-label d-flex justify-content-between">Email</label>
+                    <input type="text" placeholder="Email" name="login" t-att-value="login" id="login" class="form-control" required="required" autocapitalize="off"/>
                 </div>
 
                 <div class="mb-3">
-                    <label for="password" class="form-label">Password</label>
-                    <input type="password" placeholder="Password" name="password" id="password" t-attf-class="form-control #{'form-control-sm' if form_small else ''}" required="required" autocomplete="current-password" t-att-autofocus="'autofocus' if login else None" maxlength="4096"/>
+                    <label for="password" class="form-label d-flex justify-content-between">Password</label>
+                    <input type="password" placeholder="Password" name="password" id="password" class="form-control" required="required" autocomplete="current-password" t-att-autofocus="'autofocus' if login else None" maxlength="4096"/>
                 </div>
 
                 <p class="alert alert-danger" t-if="error" role="alert">
@@ -165,7 +166,7 @@
                     <t t-esc="message"/>
                 </p>
 
-                <div t-attf-class="clearfix oe_login_buttons text-center gap-1 d-grid mb-1 {{'pt-2' if form_small else 'pt-3'}}">
+                <div class="oe_login_buttons text-center gap-1 d-grid mb-1 pt-3">
                     <button type="submit" class="btn btn-primary">Log in</button>
                     <t t-if="debug">
                         <button type="submit" name="redirect" value="/web/become" class="btn btn-link btn-sm">Log in as superuser</button>


### PR DESCRIPTION
*: auth_oauth, auth_passkey, auth_signup, auth_totp

When several users share the same device, the login/logout process can
be boring, so we added a quick login feature.

For a security propose it doesn't store the session or the password of
the user. No data is sent to the server, everything is stored inside
the browser localStorage[1] . It only stores the login of the user and
the avatar of the user for the last 5 users connected to the device.

We also lightly redesign the login screen

task-3953707

[1]: https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage