### PR TITLE
[IMP] point_of_sale: preserve input data on receipt_screen

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
@@ -49,7 +49,7 @@ export class ReceiptScreen extends Component {
     }
     changeMode(mode) {
         this.state.mode = mode;
-        this.state.input = this.currentOrder.partner_id?.email || "";
+        this.state.input = this.currentOrder.partner_id?.email || this.state.input || "";
     }
     get isValidInput() {
         return this.isValidEmail(this.state.input);

--- a/addons/pos_sms/static/src/overrides/receipt_screen.js
+++ b/addons/pos_sms/static/src/overrides/receipt_screen.js
@@ -29,7 +29,7 @@ patch(ReceiptScreen.prototype, {
         }
 
         this.state.mode = mode;
-        this.state.input = this.currentOrder.partner_id?.phone || "";
+        this.state.input = this.currentOrder.partner_id?.phone || this.state.input || "";
     },
     get isValidInput() {
         return this.state.mode === "phone"


### PR DESCRIPTION
Before this commit:
====================
When switching the send options (email, WhatsApp, SMS) on the receipt screen, any manually entered input (such as email or phone number) would be erased if a customer was not selected or if customer data (email or mobile number) was not present.

Example:
Enter an email address manually.
Switch the send option to WhatsApp or SMS.
The manually entered email address would be erased.

After this commit:
=================
Manually entered input will be preserved when switching between send options on the receipt screen.

Task-4038000

