### PR TITLE
[FIX] point_of_sale,website_sale: create product from pos app

### DIFF
--- a/addons/point_of_sale/static/tests/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/product_screen_tour.js
@@ -274,6 +274,14 @@ registry.category("web_tour.tours").add("CheckProductInformation", {
     steps: () =>
         [
             Dialog.confirm("Open session"),
+
+            // Check that the product form is shown.
+            Chrome.clickMenuButton(),
+            Chrome.clickMenuDropdownOption("Create Product"),
+            Dialog.is({ title: "New Product" }),
+            Dialog.cancel(),
+
+            // Check margin on a product.
             ProductScreen.clickInfoProduct("product_a"),
             {
                 trigger: ".section-financials :contains('Margin')",

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -605,7 +605,12 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'TicketScreenTour', login="pos_user")
 
     def test_product_information_screen_admin(self):
+        '''Consider this test method to contain a test tour with miscellaneous tests/checks that require admin access.
+        '''
         self.product_a.available_in_pos = True
+        self.pos_admin.write({
+            'groups_id': [Command.link(self.env.ref('base.group_system').id)],
+        })
         self.main_pos_config.with_user(self.pos_admin).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'CheckProductInformation', login="pos_admin")
 

--- a/addons/website_sale/views/product_product_add.xml
+++ b/addons/website_sale/views/product_product_add.xml
@@ -4,6 +4,7 @@
     <record id="product_product_view_form_normalized_website_sale" model="ir.ui.view">
         <field name="name">product.product.view.form.normalized.website.sale.inherit</field>
         <field name="model">product.product</field>
+        <field name="mode">primary</field>
         <field name="inherit_id" ref="product.product_product_view_form_normalized"/>
         <field name="arch" type="xml">
             <xpath expr="//form" position="attributes">


### PR DESCRIPTION
Steps to reproduce:
1. Install `point_of_sale`, `product_barcodelookup` and `website_sale`.
2. Open a pos session.
3. Find and click the `Create Product` button from the burger menu at the top
   right of the app.
   -> The whole app crashes because of missing dependencies.

This is because we are trying to show a form view customized by
`website_new_content_form` but the pos app is not aware of the
`new_content_form.js` asset.

The pos app doesn't need the `website_new_content_form` customization so this
commit proposes a solution to convert the `website_sale`'s product form view
to become a primary view, so that it's customization is not incorporated in other
views that inherit the base view (which in this case is the
`product.product_product_view_form_normalized`).

Additionally, we incorporate a set of tour steps to make sure the product form
view is accessible whenever system user is logged in to open the pos app.

