### PR TITLE
[FIX] web: correctly break title in xss form views

### DIFF
--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -1098,9 +1098,6 @@
 }
 
 .o_form_view.o_xxs_form_view {
-    .oe_title {
-        word-break: break-all;
-    }
     .o_group {
         .o_inner_group {
             margin-bottom: $o-form-spacing-unit * 4;


### PR DESCRIPTION
Before this commit, there was a (xss specific) form view rule preventing the oe_title content to be displayed properly. In the task form view, in mobile, the title is a textarea, and long titles were displayed with words cut in the middle. The removed rule had been introduced a long time ago, for the kanban quick create form view [1], but it was probably a mistake.

[1] https://github.com/odoo/odoo/commit/d18d08f01a589053e40c7af1fd4dd59c13aaa625

Task 4045168

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
