### PR TITLE
[FIX] spreadsheet: apply plain text format on char fields

### DIFF
--- a/addons/spreadsheet/static/src/list/list_functions.js
+++ b/addons/spreadsheet/static/src/list/list_functions.js
@@ -62,6 +62,9 @@ function odooListFormat(id, position, field, getters, locale) {
             return locale.dateFormat;
         case "datetime":
             return locale.dateFormat + " " + locale.timeFormat;
+        case "char":
+        case "text":
+            return "@";
         default:
             return undefined;
     }

--- a/addons/spreadsheet/static/tests/lists/list_plugin_test.js
+++ b/addons/spreadsheet/static/tests/lists/list_plugin_test.js
@@ -105,7 +105,7 @@ QUnit.module("spreadsheet > list plugin", {}, () => {
 
     QUnit.test("List formulas are correctly formatted at evaluation", async function (assert) {
         const { model } = await createSpreadsheetWithList({
-            columns: ["foo", "probability", "bar", "date", "create_date", "product_id", "pognon"],
+            columns: ["foo", "probability", "bar", "date", "create_date", "product_id", "pognon", "name"],
             linesNumber: 2,
         });
         await waitForDataSourcesLoaded(model);
@@ -117,6 +117,7 @@ QUnit.module("spreadsheet > list plugin", {}, () => {
         assert.strictEqual(getCell(model, "F2").format, undefined);
         assert.strictEqual(getCell(model, "G2").format, undefined);
         assert.strictEqual(getCell(model, "G3").format, undefined);
+        assert.strictEqual(getCell(model, "H2").format, undefined);
 
         assert.strictEqual(getEvaluatedCell(model, "A2").format, "0");
         assert.strictEqual(getEvaluatedCell(model, "B2").format, "#,##0.00");
@@ -126,6 +127,7 @@ QUnit.module("spreadsheet > list plugin", {}, () => {
         assert.strictEqual(getEvaluatedCell(model, "F2").format, undefined);
         assert.strictEqual(getEvaluatedCell(model, "G2").format, "#,##0.00[$€]");
         assert.strictEqual(getEvaluatedCell(model, "G3").format, "[$$]#,##0.00");
+        assert.strictEqual(getEvaluatedCell(model, "H2").format, "@");
     });
 
     QUnit.test("List formulas date formats are locale dependant", async function (assert) {


### PR DESCRIPTION
Steps to reproduce:
- install documents and inventory
- create a Lot/Serial Number which is a number e.g. "89787897894984"
- insert the Lot/Serial Number list in a spreadsheet
- download the excel file "File > Download"

=> "89787897894984" is displayed as "8.97879E+13"

This issue is present in all versions. But it can only be fixed very easily starting from 17.1 where we introduced the plain text format "@".
The report ticket is for saas-17.2 (according to James (jale)), so we go for the easy fix and don't backport in all version.

opw-4034386


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
