### PR TITLE
[FIX] server: limit concurrent including cron thread

### DIFF
--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -144,7 +144,7 @@ class ThreadedWSGIServerReloadable(LoggingBaseWSGIServerMixIn, werkzeug.serving.
                 # If the value can't be parsed to an integer then it's computed in an automated way to
                 # half the size of db_maxconn because while most requests won't borrow cursors concurrently
                 # there are some exceptions where some controllers might allocate two or more cursors.
-                self.max_http_threads = config['db_maxconn'] // 2
+                self.max_http_threads = max((config['db_maxconn'] - config['max_cron_threads']) // 2, 1)
             self.http_threads_sem = threading.Semaphore(self.max_http_threads)
         super(ThreadedWSGIServerReloadable, self).__init__(host, port, app,
                                                            handler=RequestHandler)


### PR DESCRIPTION
When using a non parsable ODOO_MAX_HTTP_THREADS value, take into account max_cron_threads.

When a lot of xmlrpc or jsonrpc calls are made, 2 cursor are used per call due to the authentification so it maxes out and the pool limit. 
If the cron_thread are using a cursor we end up with a "Pool Is Full" error.

