### PR TITLE
[IMP] purchase: consolidate bills in purchase orders

### DIFF
--- a/addons/purchase/__init__.py
+++ b/addons/purchase/__init__.py
@@ -5,3 +5,4 @@ from . import controllers
 from . import models
 from . import report
 from . import populate
+from . import wizard

--- a/addons/purchase/__manifest__.py
+++ b/addons/purchase/__manifest__.py
@@ -17,6 +17,7 @@
         'data/purchase_data.xml',
         'data/ir_cron_data.xml',
         'report/purchase_reports.xml',
+        'wizard/purchase_make_invoice.xml',
         'views/purchase_views.xml',
         'views/res_config_settings_views.xml',
         'views/product_views.xml',

--- a/addons/purchase/security/ir.model.access.csv
+++ b/addons/purchase/security/ir.model.access.csv
@@ -37,3 +37,4 @@ access_account_account_purchase_manager,account.account purchase manager,account
 access_purchase_bill_union,access_purchase_bill_union,model_purchase_bill_union,purchase.group_purchase_user,1,0,0,0
 access_report_purchase_order,purchase.stock.report,model_purchase_report,purchase.group_purchase_manager,1,0,0,0
 access_report_purchase_order_user,purchase.stock.report user,model_purchase_report,purchase.group_purchase_user,1,0,0,0
+purchase.access_purchase_advance_payment_inv,access_purchase_advance_payment_inv,purchase.model_purchase_advance_payment_inv,base.group_user,1,1,1,0

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -598,7 +598,7 @@
                 decoration-muted="state == 'cancel'"
                 class="o_purchase_order" js_class="purchase_dashboard_list" sample="1">
                     <header>
-                        <button name="action_create_invoice" type="object" string="Create Bills"/>
+                        <button name="action_create_invoice_wizard" type="object" string="Create Bills"/>
                     </header>
                     <field name="priority" optional="show" widget="priority" nolabel="1"/>
                     <field name="partner_ref" optional="hide"/>

--- a/addons/purchase/wizard/__init__.py
+++ b/addons/purchase/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import purchase_make_invoice

--- a/addons/purchase/wizard/purchase_make_invoice.py
+++ b/addons/purchase/wizard/purchase_make_invoice.py
@@ -1,0 +1,29 @@
+from odoo import api, fields, models
+
+
+class PurchaseAdvancePaymentInv(models.TransientModel):
+    _name = 'purchase.advance.payment.inv'
+    _description = "Purchase Advance Payment Invoice"
+
+    count = fields.Integer(string="Order Count", compute='_compute_count')
+    purchase_order_ids = fields.Many2many(
+        'purchase.order', default=lambda self: self.env.context.get('active_ids'))
+    consolidated_billing = fields.Boolean(
+        string="Consolidated Billing", default=True,
+        help="Create one invoice for all orders related to same vendor and same invoicing address"
+    )
+
+    @api.depends('purchase_order_ids')
+    def _compute_count(self):
+        for wizard in self:
+            wizard.count = len(wizard.purchase_order_ids)
+
+    def create_invoices(self):
+        self.ensure_one()
+        # Set the context for consolidated billing
+        ctx = self.env.context.copy()
+        ctx.update({
+            'consolidated_billing': self.consolidated_billing
+        })
+        invoices = self.purchase_order_ids.with_context(ctx).action_create_invoice()
+        return invoices

--- a/addons/purchase/wizard/purchase_make_invoice.xml
+++ b/addons/purchase/wizard/purchase_make_invoice.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_purchase_advance_payment_inv" model="ir.ui.view">
+        <field name="name">Invoice Orders</field>
+        <field name="model">purchase.advance.payment.inv</field>
+        <field name="arch" type="xml">
+            <form string="Invoice Purchase Order">
+                <group>
+                    <field name="purchase_order_ids" invisible="1"/>
+                    <field name="count"/>
+                    <field name="consolidated_billing" invisible="count == 1"/>
+                </group>
+                <footer>
+                    <button name="create_invoices" type="object"
+                        id="create_invoice_open"
+                        string="Create Draft Invoice"
+                        class="btn-primary" data-hotkey="q"/>
+                    <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_view_purchase_advance_payment_inv" model="ir.actions.act_window">
+        <field name="name">Create invoice(s)</field>
+        <field name="res_model">purchase.advance.payment.inv</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+        <field name="binding_model_id" ref="purchase.model_purchase_order"/>
+        <field name="binding_view_types">list</field>
+    </record>
+</odoo>


### PR DESCRIPTION
In this commit:
===================

- Consolidate bills for purchase orders from the same contact when selecting multiple purchase orders for improvement streamline the workflow, making it faster and more intuitive for users to create invoices based on the same contact of selected purchase orders.

task-3986451
