### PR TITLE
[FIX] html_editor: delete at start/end of line inside banner

### DIFF
--- a/addons/html_editor/static/src/core/delete_plugin.js
+++ b/addons/html_editor/static/src/core/delete_plugin.js
@@ -1011,17 +1011,18 @@ export class DeletePlugin extends Plugin {
         // If the non-editable is not a block and there was a block switch, reduce the
         // selection to keep it instead, since the position moved from another block next
         // to that inline root, there was a sufficient position change.
-        let closestUneditable = closestElement(leaf, isNotEditableNode);
-        if (closestUneditable) {
+        let leafClosestUneditable = closestElement(leaf, isNotEditableNode);
+        const nodeClosestUneditable = closestElement(node, isNotEditableNode);
+        if (leafClosestUneditable && leafClosestUneditable !== nodeClosestUneditable) {
             // handle nested contenteditable=false elements
-            while (!closestUneditable.parentNode.isContentEditable) {
-                closestUneditable = closestUneditable.parentNode;
+            while (!leafClosestUneditable.parentNode.isContentEditable) {
+                leafClosestUneditable = leafClosestUneditable.parentNode;
             }
             return blockSwitch &&
-                !isBlock(closestUneditable) &&
-                closestBlock(closestUneditable) !== endNodeClosestBlock
-                ? rightPos(closestUneditable)
-                : leftPos(closestUneditable);
+                !isBlock(leafClosestUneditable) &&
+                closestBlock(leafClosestUneditable) !== endNodeClosestBlock
+                ? rightPos(leafClosestUneditable)
+                : leftPos(leafClosestUneditable);
         }
 
         if (leaf.nodeType === Node.ELEMENT_NODE) {
@@ -1070,17 +1071,18 @@ export class DeletePlugin extends Plugin {
         // If the non-editable is not a block and there was a block switch, reduce the
         // selection to keep it instead, since the position moved from another block to
         // that inline root, there was a sufficient position change.
-        let closestUneditable = closestElement(leaf, isNotEditableNode);
-        if (closestUneditable) {
+        let leafClosestUneditable = closestElement(leaf, isNotEditableNode);
+        const nodeClosestUneditable = closestElement(node, isNotEditableNode);
+        if (leafClosestUneditable && leafClosestUneditable !== nodeClosestUneditable) {
             // handle nested contenteditable=false elements
-            while (!closestUneditable.parentNode.isContentEditable) {
-                closestUneditable = closestUneditable.parentNode;
+            while (!leafClosestUneditable.parentNode.isContentEditable) {
+                leafClosestUneditable = leafClosestUneditable.parentNode;
             }
             return blockSwitch &&
-                !isBlock(closestUneditable) &&
-                closestBlock(closestUneditable) !== startNodeClosestBlock
-                ? leftPos(closestUneditable)
-                : rightPos(closestUneditable);
+                !isBlock(leafClosestUneditable) &&
+                closestBlock(leafClosestUneditable) !== startNodeClosestBlock
+                ? leftPos(leafClosestUneditable)
+                : rightPos(leafClosestUneditable);
         }
 
         if (leaf.nodeType === Node.ELEMENT_NODE) {

--- a/addons/html_editor/static/tests/delete/backward.test.js
+++ b/addons/html_editor/static/tests/delete/backward.test.js
@@ -451,6 +451,14 @@ describe("Selection collapsed", () => {
                 contentAfter: `<p contenteditable="false">ab[]cdef</p>`,
             });
         });
+
+        test("should merge p elements inside conteneditbale=true inside contenteditable=false", async () => {
+            await testEditor({
+                contentBefore: `<div contenteditable="false"><div contenteditable="true"><p>abc</p><p>[]def</p></div></div>`,
+                stepFunction: deleteBackward,
+                contentAfter: `<div contenteditable="false"><div contenteditable="true"><p>abc[]def</p></div></div>`,
+            });
+        });
     });
 
     describe("Line breaks", () => {

--- a/addons/html_editor/static/tests/delete/forward.test.js
+++ b/addons/html_editor/static/tests/delete/forward.test.js
@@ -321,6 +321,13 @@ describe("Selection collapsed", () => {
                 contentAfter: `<p>[]&nbsp;def</p>`,
             });
         });
+        test("should merge p elements inside conteneditbale=true inside contenteditable=false", async () => {
+            await testEditor({
+                contentBefore: `<div contenteditable="false"><div contenteditable="true"><p>abc[]</p><p>def</p></div></div>`,
+                stepFunction: deleteForward,
+                contentAfter: `<div contenteditable="false"><div contenteditable="true"><p>abc[]def</p></div></div>`,
+            });
+        });
     });
 
     describe("white spaces", () => {


### PR DESCRIPTION
Issue:
======
We can't delete backward at the start of a line inside banner

Steps to reproduce the issue:
=============================
- Add a banner
- Add content in the first line
- Add content in the second line
- Put the cursor at the start of the second line
- Delete backward
- Nothing happens

Origin of the issue:
====================
We were checking if the leaf is inside `contenteditable=false` we delete the root, but we overlooked the case where both of them are inside contenteditable=true which is inside contenteditable=false. In this case we should be able to merge the 2 p elements as usual.

Same reasoning for deleteForward.