### PR TITLE
[FIX] html_editor: remove correctTripleClick in delete_plugin

### DIFF
--- a/addons/html_editor/static/src/core/delete_plugin.js
+++ b/addons/html_editor/static/src/core/delete_plugin.js
@@ -9,7 +9,6 @@ import {
     isShrunkBlock,
     isTangible,
     isUnbreakable,
-    isVisibleTextNode,
     isWhitespace,
     isZWS,
     nextLeaf,
@@ -129,7 +128,6 @@ export class DeletePlugin extends Plugin {
         }
 
         let range = this.adjustRange(selection, [
-            this.correctTripleClick,
             this.expandRangeToIncludeNonEditables,
             this.includeEndOrStartBlock,
             this.fullyIncludeLinks,
@@ -906,33 +904,6 @@ export class DeletePlugin extends Plugin {
             startContainer.textContent[startOffset - 1] === "\u200B"
         ) {
             range.setStart(startContainer, startOffset - 1);
-        }
-        return range;
-    }
-
-    // @phoenix @todo: triple click correction is now done by the selection
-    // plugin, and this is no longer necessary. Adapt tests that rely on it and
-    // remove this method.
-    /**
-     * @param {Range} range
-     * @returns {Range}
-     */
-    correctTripleClick(range) {
-        const { startContainer, startOffset, endContainer, endOffset } = range;
-        const endLeaf = firstLeaf(endContainer);
-        const beforeEnd = endLeaf.previousSibling;
-        if (
-            !endOffset &&
-            (startContainer !== endContainer || startOffset !== endOffset) &&
-            (!beforeEnd ||
-                (beforeEnd.nodeType === Node.TEXT_NODE &&
-                    !isVisibleTextNode(beforeEnd) &&
-                    !isZWS(beforeEnd)))
-        ) {
-            const previous = previousLeaf(endLeaf, this.editable, true);
-            if (previous && closestElement(previous).isContentEditable) {
-                range.setEnd(previous, nodeSize(previous));
-            }
         }
         return range;
     }

--- a/addons/html_editor/static/tests/delete/forward.test.js
+++ b/addons/html_editor/static/tests/delete/forward.test.js
@@ -1,7 +1,9 @@
-import { describe, test } from "@odoo/hoot";
-import { testEditor } from "../_helpers/editor";
+import { describe, expect, test } from "@odoo/hoot";
+import { testEditor, setupEditor } from "../_helpers/editor";
 import { unformat } from "../_helpers/format";
-import { deleteForward, insertText } from "../_helpers/user_actions";
+import { tick } from "@odoo/hoot-mock";
+import { deleteForward, insertText, tripleClick } from "../_helpers/user_actions";
+import { getContent } from "../_helpers/selection";
 
 /**
  * content of the "deleteForward" sub suite in editor.test.js
@@ -1303,28 +1305,38 @@ describe("Selection not collapsed", () => {
         });
     });
 
-    test("should delete a heading (triple click delete)", async () => {
-        await testEditor({
-            contentBefore: "<h1>[abc</h1><p>]def</p>",
-            stepFunction: deleteForward,
-            // JW cAfter: '<p>[]def</p>',
-            contentAfter: "<h1>[]<br></h1><p>def</p>",
-        });
-        await testEditor({
-            contentBefore: "<h1>[abc</h1><p>]<br></p><p>def</p>",
-            stepFunction: deleteForward,
-            contentAfter: "<h1>[]<br></h1><p><br></p><p>def</p>",
-        });
+    test("should delete a heading (triple click delete) (1)", async () => {
+        const { editor, el } = await setupEditor("<h1>abc</h1><p>def</p>", {});
+        tripleClick(el.querySelector("h1"));
+        // Chrome puts the cursor at the start of next sibling
+        expect(getContent(el)).toBe("<h1>[abc</h1><p>]def</p>");
+        await tick();
+        // The Editor corrects it on selection change
+        expect(getContent(el)).toBe("<h1>[abc]</h1><p>def</p>");
+        deleteForward(editor);
+        expect(getContent(el)).toBe(
+            '<h1 placeholder="Heading 1" class="o-we-hint">[]<br></h1><p>def</p>'
+        );
+    });
+    test("should delete a heading (triple click delete) (2)", async () => {
+        const { editor, el } = await setupEditor("<h1>abc</h1><p><br></p><p>def</p>", {});
+        tripleClick(el.querySelector("h1"));
+        // Chrome puts the cursor at the start of next sibling
+        expect(getContent(el)).toBe("<h1>[abc</h1><p>]<br></p><p>def</p>");
+        await tick();
+        // The Editor corrects it on selection change
+        expect(getContent(el)).toBe("<h1>[abc]</h1><p><br></p><p>def</p>");
+        deleteForward(editor);
+        expect(getContent(el)).toBe(
+            '<h1 placeholder="Heading 1" class="o-we-hint">[]<br></h1><p><br></p><p>def</p>'
+        );
     });
 
-    test("should delete last character of paragraph, ignoring the selected paragraph break", async () => {
+    test("should delete last character of paragraph, as well as selected paragraph break", async () => {
         await testEditor({
             contentBefore: "<p>ab[c</p><p>]def</p>",
-            // This type of selection (typically done with a triple
-            // click) is "corrected" before remove so triple clicking
-            // doesn't remove a paragraph break.
             stepFunction: deleteForward,
-            contentAfter: "<p>ab[]</p><p>def</p>",
+            contentAfter: "<p>ab[]def</p>",
         });
     });
 

--- a/addons/html_editor/static/tests/insert/text.test.js
+++ b/addons/html_editor/static/tests/insert/text.test.js
@@ -49,13 +49,13 @@ describe("not collapsed selection", () => {
     test("should insert a character in a fully selected font in a heading, preserving its style", async () => {
         await testEditor({
             contentBefore:
-                '<h1><font style="background-color: red;">[abc</font><br></h1><p>]def</p>',
+                '<h1><font style="background-color: red;">[abc]</font><br></h1><p>def</p>',
             stepFunction: async (editor) => insertText(editor, "g"),
             contentAfter: '<h1><font style="background-color: red;">g[]</font><br></h1><p>def</p>',
         });
         await testEditor({
             contentBefore:
-                '<h1><font style="background-color: red;">[abc</font><br></h1><p>]def</p>',
+                '<h1><font style="background-color: red;">[abc]</font><br></h1><p>def</p>',
             stepFunction: async (editor) => {
                 deleteBackward(editor);
                 insertText(editor, "g");

--- a/addons/html_editor/static/tests/unbreakable/delete.test.js
+++ b/addons/html_editor/static/tests/unbreakable/delete.test.js
@@ -263,29 +263,22 @@ describe("backward", () => {
             });
         });
 
-        describe("triple click", () => {
-            test("should delete last character of paragraph, ignoring the selected paragraph break leading to an unbreakable (1)", async () => {
-                await testEditor({
-                    contentBefore: `<p>ab[c</p><p class="oe_unbreakable">]def</p>`,
-                    // This type of selection (typically done with a triple
-                    // click) is "corrected" before remove so triple clicking
-                    // doesn't remove a paragraph break.
-                    stepFunction: deleteBackward,
-                    contentAfter: `<p>ab[]</p><p class="oe_unbreakable">def</p>`,
-                });
-            });
-
-            test("should delete last character of paragraph, ignoring the selected paragraph break leading to an unbreakable (2)", async () => {
-                await testEditor({
-                    contentBefore: `<p>ab[c</p><p class="oe_unbreakable">]<br></p><p>def</p>`,
-                    // This type of selection (typically done with a triple
-                    // click) is "corrected" before remove so triple clicking
-                    // doesn't remove a paragraph break.
-                    stepFunction: deleteBackward,
-                    contentAfter: `<p>ab[]</p><p class="oe_unbreakable"><br></p><p>def</p>`,
-                });
+        test("should delete last character of paragraph but not merge it with unbreakable", async () => {
+            await testEditor({
+                contentBefore: `<p>ab[c</p><p class="oe_unbreakable">]def</p>`,
+                stepFunction: deleteBackward,
+                contentAfter: `<p>ab[]</p><p class="oe_unbreakable">def</p>`,
             });
         });
+
+        test("should delete last character of paragraph and fully selected empty unbreakable", async () => {
+            await testEditor({
+                contentBefore: `<p>ab[c</p><p class="oe_unbreakable">]<br></p><p>def</p>`,
+                stepFunction: deleteBackward,
+                contentAfter: `<p>ab[]</p><p>def</p>`,
+            });
+        });
+
         test("should delete first character of unbreakable, ignoring selected paragraph break (backward)", async () => {
             await testEditor({
                 contentBefore: `<p>abc[</p><p class="oe_unbreakable">d]ef</p>`,
@@ -441,19 +434,6 @@ describe("forward", () => {
                 contentAfter: unformat(`
                         <p class="oe_unbreakable">a[]</p>
                         <p class="oe_unbreakable">d</p>`), // JW without oe_breakable classes of course
-            });
-        });
-
-        describe("triple click", () => {
-            test("should delete last character of paragraph, ignoring the selected paragraph break leading to an unbreakable", async () => {
-                await testEditor({
-                    contentBefore: "<p>ab[c</p><p>]def</p>",
-                    // This type of selection (typically done with a triple
-                    // click) is "corrected" before remove so triple clicking
-                    // doesn't remove a paragraph break.
-                    stepFunction: deleteForward,
-                    contentAfter: "<p>ab[]</p><p>def</p>",
-                });
             });
         });
 


### PR DESCRIPTION
Issue:
======
Traceback raised when delete_backward

Steps to reproduce the issue:
=============================
- Put the cursor in a cell in the middle of the table
- Press shift and arrow left/up until you have the selection outside of the table
- Delete backward

Origin of the issue:
====================
`correctTripleClick` moves the endContainer to be  the `br` element in the cell just before where we put the cursor. Since we remove fake brs in deleteRange and then we removeNodes, we have the endContainer is not connected anymore and raises an error when we want to get it's `childNodeIndex`.

It's safe to remove the function `correctTripleClick` since the correction is now handled by `selection_plugin`.