### PR TITLE
[FIX] point_of_sale,pos_self_order: Fix tax assignation

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -471,7 +471,7 @@ export class PosStore extends Reactive {
             price_unit: 0,
             order_id: this.get_order(),
             qty: 1,
-            tax_ids: product.taxes_id[0] ? [["link", product.taxes_id[0]]] : [],
+            tax_ids: product.taxes_id.map((tax) => ["link", tax]),
             ...vals,
         };
 
@@ -548,9 +548,10 @@ export class PosStore extends Reactive {
                 "create",
                 {
                     product_id: comboLine.combo_line_id.product_id,
-                    tax_ids: comboLine.combo_line_id.product_id.taxes_id[0]
-                        ? [["link", comboLine.combo_line_id.product_id.taxes_id[0]]]
-                        : [],
+                    tax_ids: comboLine.combo_line_id.product_id.taxes_id.map((tax) => [
+                        "link",
+                        tax,
+                    ]),
                     combo_line_id: comboLine.combo_line_id,
                     price_unit: comboLine.price_unit,
                     order_id: order,

--- a/addons/pos_self_order/static/src/app/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/self_order_service.js
@@ -206,7 +206,7 @@ export class SelfOrder extends Reactive {
         const values = {
             order_id: this.currentOrder,
             product_id: product,
-            tax_ids: product.taxes_id[0] ? [["link", product.taxes_id[0]]] : [],
+            tax_ids: product.taxes_id.map((tax) => ["link", tax]),
             qty: qty,
             note: customer_note || "",
             price_unit: product.lst_price,
@@ -242,9 +242,10 @@ export class SelfOrder extends Reactive {
                 "create",
                 {
                     product_id: comboLine.combo_line_id.product_id,
-                    tax_ids: comboLine.combo_line_id.product_id.taxes_id[0]
-                        ? [["link", comboLine.combo_line_id.product_id.taxes_id[0]]]
-                        : [],
+                    tax_ids: comboLine.combo_line_id.product_id.taxes_id.map((tax) => [
+                        "link",
+                        tax,
+                    ]),
                     combo_line_id: comboLine.combo_line_id,
                     price_unit: comboLine.price_unit,
                     order_id: this.currentOrder,


### PR DESCRIPTION
Before this commit, the tax assignation was not working properly when a product has multiple taxes.

This commit fixes the issue by adding all taxes to the product line.

