### PR TITLE
[FIX] account_peppol: fix slow install on larger DBs

### DIFF
--- a/addons/account_peppol/models/res_partner.py
+++ b/addons/account_peppol/models/res_partner.py
@@ -9,6 +9,7 @@ from urllib import parse
 
 from odoo import api, fields, models
 from odoo.addons.account_peppol.tools.demo_utils import handle_demo
+from odoo.tools.sql import column_exists, create_column
 
 TIMEOUT = 10
 
@@ -39,6 +40,16 @@ class ResPartner(models.Model):
         copy=False,
     )  # field to compute the label to show for partner endpoint
     is_peppol_edi_format = fields.Boolean(compute='_compute_is_peppol_edi_format')
+
+    def _auto_init(self):
+        """Create columns `account_peppol_is_endpoint_valid` and `account_peppol_validity_last_check`
+        to avoid having them computed by the ORM on installation.
+        """
+        if not column_exists(self.env.cr, 'res_partner', 'account_peppol_is_endpoint_valid'):
+            create_column(self.env.cr, 'res_partner', 'account_peppol_is_endpoint_valid', 'boolean')
+        if not column_exists(self.env.cr, 'res_partner', 'account_peppol_validity_last_check'):
+            create_column(self.env.cr, 'res_partner', 'account_peppol_validity_last_check', 'timestamp')
+        return super()._auto_init()
 
     @api.model
     def fields_get(self, allfields=None, attributes=None):


### PR DESCRIPTION
In its override of res_partner, the module introduces 2 new stored compute fields, which trigger a slow recompute at install time.

Since those computations need to happen at some point to ensure that the module is working properly, changing the compute method was not an option.

The changes proposed in this commit bypass the compute during the installation, leading to more reasonable install times (from an estimated 59 days down to about 1 min in our encountered case).

A notable caveat is that the users will have to trigger this computation manually record by record or in small batches. For smaller DBs, this shouldn't be an issue.
For larger DBs, since the alternative is to not use the module at all or start from scratch with a new DB, the proposed solution seems acceptable.

opw-4027267