### PR TITLE
[FIX] bus: reduce concurrency when fetching notifications 

### DIFF
--- a/addons/bus/static/src/workers/websocket_worker.js
+++ b/addons/bus/static/src/workers/websocket_worker.js
@@ -34,7 +34,7 @@ export const WEBSOCKET_CLOSE_CODES = Object.freeze({
 });
 // Should be incremented on every worker update in order to force
 // update of the worker in browser cache.
-export const WORKER_VERSION = "1.0.7";
+export const WORKER_VERSION = "1.0.8";
 const MAXIMUM_RECONNECT_DELAY = 60000;
 
 /**
@@ -45,7 +45,7 @@ const MAXIMUM_RECONNECT_DELAY = 60000;
  * for SharedWorker and this class implements it.
  */
 export class WebsocketWorker {
-    INITIAL_RECONNECT_DELAY = 1000;
+    INITIAL_RECONNECT_DELAY = 10000 * Math.random();
     RECONNECT_JITTER = 1000;
 
     constructor() {
@@ -388,10 +388,10 @@ export class WebsocketWorker {
      * applied to the reconnect attempts.
      */
     _retryConnectionWithDelay() {
+        this.connectTimeout = setTimeout(this._start.bind(this), this.connectRetryDelay);
         this.connectRetryDelay =
             Math.min(this.connectRetryDelay * 1.5, MAXIMUM_RECONNECT_DELAY) +
             this.RECONNECT_JITTER * Math.random();
-        this.connectTimeout = setTimeout(this._start.bind(this), this.connectRetryDelay);
     }
 
     /**

--- a/addons/bus/static/src/workers/websocket_worker.js
+++ b/addons/bus/static/src/workers/websocket_worker.js
@@ -45,7 +45,7 @@ const MAXIMUM_RECONNECT_DELAY = 60000;
  * for SharedWorker and this class implements it.
  */
 export class WebsocketWorker {
-    INITIAL_RECONNECT_DELAY = 10000 * Math.random();
+    INITIAL_RECONNECT_DELAY = 30000 * Math.random();
     RECONNECT_JITTER = 1000;
 
     constructor() {


### PR DESCRIPTION
When no cursor is available to fetch bus notifications, websockets
retry up to 10 times to acquire one. However, when many websockets try
to acquire a cursor, the chances of getting one are very slim. Some
will disconnect and will need a cursor to reconnect, worsening the
cursor drought. As a result, there is minimal chance of recovery when
the connection pool is full.

This PR fixes this issue by wrapping cursor acquisition with a
semaphore. This way, trying to acquire a cursor when none is available
will make the caller wait until one is available.
