### PR TITLE
[FIX] l10n_gcc_invoice: prevent AttributeError while printing invoice

### DIFF
--- a/addons/l10n_gcc_invoice/views/report_invoice.xml
+++ b/addons/l10n_gcc_invoice/views/report_invoice.xml
@@ -282,7 +282,7 @@
                                     </td>
                                     <td name="account_invoice_line_name">
                                         <t t-set="line_name" t-value="line.with_context(lang=o.partner_id.lang).product_id.display_name or line.name"/>
-                                        <span t-out="line_name" t-options="{'widget': 'text'}" t-att-dir="o.env['res.lang']._lang_get_direction(o.partner_id.lang)"/>
+                                        <span t-out="line_name" t-options="{'widget': 'text'}" t-att-dir="o.env['res.lang']._get_data(code=o.partner_id.lang).direction == 'rtl'"/>
                                     </td>
 
                                 </t>


### PR DESCRIPTION
When the user tries to print the invoice for the Saudi company,
a traceback will appear.

Steps to reproduce the error:
- Install "l10n_sa"
- Switch to "SA Company"
- Create a new invoice > Confirm > Print the invoice

```
Error: A traceback appears:
"AttributeError: 'res.lang' object has no attribute '_lang_get_direction'"
```

https://github.com/odoo/odoo/blob/382e79857535cc0a404a8f70fbef071b79afea86/addons/l10n_gcc_invoice/views/report_invoice.xml#L285
Here, "_lang_get_direction" method is still used,
this method is replaced by "_get_data" method in commit odoo@9f5470f.

sentry-5596797662

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
