### PR TITLE
[FIX] web: prevent overflow in x2many list

### DIFF
--- a/addons/hr_expense/static/src/views/expense_line_widget.js
+++ b/addons/hr_expense/static/src/views/expense_line_widget.js
@@ -47,6 +47,7 @@ export const expenseLinesWidget = {
     ...x2ManyField,
     component: ExpenseLinesWidget,
     relatedFields: [{ name: "message_main_attachment_checksum", type: "char" }],
+    additionalClasses: ["o_field_many2many"],
 };
 
 registry.category("fields").add("expense_lines_widget", expenseLinesWidget);

--- a/addons/project/static/src/components/subtask_one2many_field/subtask_one2many_field.js
+++ b/addons/project/static/src/components/subtask_one2many_field/subtask_one2many_field.js
@@ -15,6 +15,7 @@ SubtaskOne2ManyField.components = {
 export const subtaskOne2ManyField = {
     ...x2ManyField,
     component: SubtaskOne2ManyField,
+    additionalClasses: ["o_field_one2many"],
 }
 
 registry.category("fields").add("subtasks_one2many", subtaskOne2ManyField);

--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -717,6 +717,11 @@
         }
     }
 
+    // Prevent table overflow when having long chars in x2many list and the o_field_{one,many}2many class is not applied
+    .o_field_widget:has(.o_field_x2many.o_field_x2many_list) {
+        width: 100%;
+    }
+
     // Specific style classes
     .o_inner_group.oe_subtotal_footer {
         grid-template-columns: 1fr auto;


### PR DESCRIPTION
Steps to reproduce
==================

Example A)

- Install project
- In the settings, enable subtasks
- Open any project
- Open any task
- Switch to the "Sub-Tasks" notebook tab
- Add a new line with a very long name
- Save

=> The list overflows to the right and does not allow to scroll

Example B)

- Install Expenses
- Go to Expense Report
- Open any record
- Enable every optional column
- Reduce the window width

=> Same issue

Cause of the issue
==================

Without a custom widget, the classes on a one2many field are `o_field_widget `o_field_one2many`.

With a custom widget, the classes are for example
`o_field_widget o_field_subtasks_one2many`.

This means that this [css] snippet is not applied. An attempt has been made to pass those classes in [additionalClasses], but it's missing in the examples used to reproduce this issue.

In the example B, the list is wider than the allowed space, because the minimum width for a column is [92px] and if we sum them all, it is more than the total space.

Those issues have become more apparent since a [fix] for Safari. The allowed width was computed with a fixed table layout, which means in most cases, it was a bit less.

We can see though that even before the [fix] for Safari, there were still issues, for example in the example B.

Solution
========

We add back the css removed from the [additionalClasses] fix.
It was removed initially since `:has` was not supported in Firefox.
It is now supported since 2023-12-19.
Still, if someone has an old version, it will not fix the issue.
For that, we still add the classes to the two reported widgets.

---

[css]: https://github.com/odoo/odoo/blob/6abd479dcae0e206155d8d7171b62e384fa61740/addons/web/static/src/views/form/form_controller.scss#L710-L718
[additionalClasses]: https://github.com/odoo/odoo/pull/121182
[92px]: https://github.com/odoo/odoo/blob/ae5de53c3f4009d23ec556be4abb9eefd111f9b7/addons/web/static/src/views/list/list_renderer.js#L395
[fix]: https://github.com/odoo/odoo/commit/ae5de53c3f4009d23ec556be4abb9eefd111f9b7

opw-4010760
opw-4028675