### PR TITLE
[IMP] {test_}mail: show next activities and improve plan summary

### DIFF
--- a/addons/mail/models/mail_activity_plan_template.py
+++ b/addons/mail/models/mail_activity_plan_template.py
@@ -3,7 +3,7 @@
 
 from dateutil.relativedelta import relativedelta
 
-from odoo import api, fields, models, _
+from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
 
 
@@ -51,6 +51,9 @@ class MailActivityPlanTemplate(models.Model):
         'Assigned to',
         check_company=True, compute="_compute_responsible_id", store=True, readonly=False)
     note = fields.Html('Note', compute="_compute_note", store=True, readonly=False)
+    next_activity_ids = fields.Many2many(
+        'mail.activity.type', string='Next Activities',
+        compute='_compute_next_activity_ids', readonly=False, store=True)
 
     @api.constrains('activity_type_id', 'plan_id')
     def _check_activity_type_res_model(self):
@@ -76,6 +79,19 @@ class MailActivityPlanTemplate(models.Model):
         for template in self:
             if template.responsible_type == 'other' and not template.responsible_id:
                 raise ValidationError(_('When selecting "Default user" assignment, you must specify a responsible.'))
+
+    @api.depends('activity_type_id')
+    def _compute_next_activity_ids(self):
+        """ Update next activities only when changing activity type on template.
+        Any change on type configuration should not be propagated. """
+        for template in self:
+            activity_type = template.activity_type_id
+            if activity_type.triggered_next_type_id:
+                template.next_activity_ids = activity_type.triggered_next_type_id.ids
+            elif activity_type.suggested_next_type_ids:
+                template.next_activity_ids = activity_type.suggested_next_type_ids.ids
+            else:
+                template.next_activity_ids = False
 
     @api.depends('activity_type_id')
     def _compute_note(self):

--- a/addons/mail/models/mail_activity_type.py
+++ b/addons/mail/models/mail_activity_type.py
@@ -38,7 +38,7 @@ class MailActivityType(models.Model):
         ('months', 'months')], string="Delay units", help="Unit of delay", required=True, default='days')
     delay_label = fields.Char(compute='_compute_delay_label')
     delay_from = fields.Selection([
-        ('current_date', 'after completion date'),
+        ('current_date', 'after previous activity completion date'),
         ('previous_activity', 'after previous activity deadline')], string="Delay Type", help="Type of delay", required=True, default='previous_activity')
     icon = fields.Char('Icon', help="Font awesome icon e.g. fa-tasks")
     decoration_type = fields.Selection([

--- a/addons/mail/views/mail_activity_plan_template_views.xml
+++ b/addons/mail/views/mail_activity_plan_template_views.xml
@@ -6,7 +6,7 @@
             <field name="model">mail.activity.plan.template</field>
             <field name="arch" type="xml">
                 <list string="Activities">
-                    <field name="activity_type_id" context="{'form_view_ref': 'mail.mail_activity_type_form_inherit'}"/>
+                    <field name="activity_type_id"/>
                     <field name="summary" placeholder="e.g. Discuss Proposal"/>
                     <field name="responsible_type"/>
                     <field name="delay_count"/>
@@ -25,7 +25,7 @@
                     <field name="res_model" invisible="1"/>
                     <sheet>
                         <group>
-                            <field name="activity_type_id" context="{'form_view_ref': 'mail.mail_activity_type_form_inherit'}"/>
+                            <field name="activity_type_id"/>
                             <field name="summary" placeholder="e.g. Discuss Proposal"/>
                             <field name="responsible_type"/>
                             <field name="responsible_id" invisible="responsible_type != 'other'"/>

--- a/addons/mail/views/mail_activity_plan_views.xml
+++ b/addons/mail/views/mail_activity_plan_views.xml
@@ -71,7 +71,7 @@
                                         <field name="company_id" column_invisible="1"/>
                                         <field name="note" column_invisible="1"/>
                                         <field name="sequence" widget="handle"/>
-                                        <field name="activity_type_id" context="{'form_view_ref': 'mail.mail_activity_type_form_inherit'}"
+                                        <field name="activity_type_id"
                                                options="{'no_quick_create': True}"/>
                                         <field name="summary" placeholder="e.g. Discuss Proposal"/>
                                         <field name="responsible_type"/>
@@ -80,6 +80,14 @@
                                         <field name="delay_count"/>
                                         <field name="delay_unit" string="Unit"/>
                                         <field name="delay_from"/>
+                                        <field name="next_activity_ids"
+                                            widget="many2many_tags"
+                                            invisible="not next_activity_ids"
+                                            options="{
+                                                'no_quick_create': True,
+                                                'edit_tags': True,
+                                            }"
+                                        />
                                     </list>
                                     <kanban class="o_kanban_mobile">
                                         <field name="icon"/>
@@ -96,6 +104,7 @@
                                                     <field name="delay_count"/> <field name="delay_unit"/>
                                                     (<field name="delay_from"/>)
                                                 </div>
+                                                <field name="next_activity_ids" widget="many2many_tags" invisible="not next_activity_ids"/>
                                                 <footer class="p-0">
                                                     <field name="responsible_type"/>
                                                     <field class="ms-auto" name="responsible_id" widget="many2one_avatar_user" readonly="1"/>

--- a/addons/mail/views/mail_activity_views.xml
+++ b/addons/mail/views/mail_activity_views.xml
@@ -25,6 +25,12 @@
                             <field name="icon" groups="base.group_no_one"/>
                             <field name="decoration_type" groups="base.group_no_one"/>
                             <field name="keep_done"/>
+                            <label for="delay_count"/>
+                            <div>
+                                <field class="oe_inline pe-1 o_input_3ch" name="delay_count"/>
+                                <field class="oe_inline ps-1 pe-2" name="delay_unit"/>
+                                <field class="oe_inline" name="delay_from"/>
+                            </div>
                         </group>
                         <group name="activity_planning" string="Next Activity">
                             <field name="chaining_type" invisible="category == 'upload_file'"/>
@@ -37,12 +43,6 @@
                                 domain="[('model_id.model', '=', res_model)]"
                                 invisible="not res_model"
                                 context="{'default_model': res_model}"/>
-                            <label for="delay_count"/>
-                            <div>
-                                <field class="oe_inline pe-1 o_input_3ch" name="delay_count"/>
-                                <field class="oe_inline ps-1 pe-2" name="delay_unit"/>
-                                <field class="oe_inline" name="delay_from"/>
-                            </div>
                         </group>
                     </group>
                     <label for="default_note" class="fw-bold"/>
@@ -50,28 +50,6 @@
                     <p class="alert alert-info" role="alert" invisible="not res_model_change">Modifying the model can have an impact on existing activities using this activity type, be careful.</p>
                 </sheet>
             </form>
-        </field>
-    </record>
-
-    <record id="mail_activity_type_form_inherit" model="ir.ui.view">
-        <field name="name">mail.activity.type.form.inherit</field>
-        <field name="model">mail.activity.type</field>
-        <field name="inherit_id" ref="mail.mail_activity_type_view_form"/>
-        <field name="mode">primary</field>
-        <field name="priority">50</field>
-        <field name="arch" type="xml">
-            <xpath expr="//label[@for='delay_count']" position="attributes">
-                <attribute name="invisible">chaining_type == 'suggest' and not suggested_next_type_ids or chaining_type == 'trigger' and not triggered_next_type_id</attribute>
-            </xpath>
-            <field name="delay_count" position="attributes">
-                <attribute name="invisible">chaining_type == 'suggest' and not suggested_next_type_ids or chaining_type == 'trigger' and not triggered_next_type_id</attribute>
-            </field>
-            <field name="delay_from" position="attributes">
-                <attribute name="invisible">chaining_type == 'suggest' and not suggested_next_type_ids or chaining_type == 'trigger' and not triggered_next_type_id</attribute>
-            </field>
-            <field name="delay_unit" position="attributes">
-                <attribute name="invisible">chaining_type == 'suggest' and not suggested_next_type_ids or chaining_type == 'trigger' and not triggered_next_type_id</attribute>
-            </field>
         </field>
     </record>
 
@@ -98,6 +76,10 @@
                 <field name="delay_from" string="Type"/>
                 <field name="res_model" groups="base.group_no_one"/>
                 <field name="icon" groups="base.group_no_one"/>
+                <field name="triggered_next_type_id" optional="hide"
+                    string="Triggered Next"/>
+                <field name="suggested_next_type_ids" optional="hide" widget="many2many_tags"
+                    string="Suggested Next"/>
             </list>
         </field>
     </record>

--- a/addons/mail/wizard/mail_activity_schedule.py
+++ b/addons/mail/wizard/mail_activity_schedule.py
@@ -342,11 +342,48 @@ class MailActivitySchedule(models.TransientModel):
         self.ensure_one()
         summaries = []
         for template in templates:
-            summary_line = template.activity_type_id.name
+            activity_type = template.activity_type_id
+            summary_line = activity_type.name
             if template.summary:
                 summary_line += f": {template.summary}"
             # We don't display deadlines when the user doesn't specify a plan_date
             if self.plan_date:
                 summary_line += f" ({format_date(self.env, template._get_date_deadline(self.plan_date))})"
+            next_activities = []
+            # Triggered next activity
+            if activity_type.triggered_next_type_id:
+                triggered_activity = activity_type.triggered_next_type_id
+                triggered_delay_unit = dict(triggered_activity._fields['delay_unit']._description_selection(self.env))[triggered_activity.delay_unit]
+                triggered_delay_from = dict(triggered_activity._fields['delay_from']._description_selection(self.env))[triggered_activity.delay_from]
+
+                next_activities.append(
+                    _("%(activity_name)s %(delay_count)s %(delay_unit)s %(delay_from)s",
+                    activity_name=triggered_activity.name,
+                    delay_count=triggered_activity.delay_count,
+                    delay_unit=triggered_delay_unit,
+                    delay_from=triggered_delay_from
+                    )
+                )
+            # Suggested next activities
+            elif activity_type.suggested_next_type_ids:
+                suggested_activities = []
+                for suggested_activity in activity_type.suggested_next_type_ids:
+                    suggested_delay_unit = dict(suggested_activity._fields['delay_unit']._description_selection(self.env))[suggested_activity.delay_unit]
+                    suggested_delay_from = dict(suggested_activity._fields['delay_from']._description_selection(self.env))[suggested_activity.delay_from]
+                    suggested_activities.append(
+                        _("%(activity_name)s %(delay_count)s %(delay_unit)s %(delay_from)s",
+                        activity_name=suggested_activity.name,
+                        delay_count=suggested_activity.delay_count,
+                        delay_unit=suggested_delay_unit,
+                        delay_from=suggested_delay_from
+                        )
+                    )
+                next_activities.append(_(" or ").join(suggested_activities))
+            # Add next activities as nested list for each activity type
+            if next_activities:
+                nested_summary_line = Markup('<ul>%s</ul>') % Markup().join(
+                    Markup('<li>%s</li>') % activity for activity in next_activities
+                )
+                summary_line += nested_summary_line
             summaries.append(Markup('<li>%s</li>') % summary_line)
         return Markup('<ul>%s</ul>') % Markup().join(summaries) if summaries else ''


### PR DESCRIPTION
### Purpose
---
Show all the activities that will be triggered in the plan overview, as some activities can trigger others.
Also, which activities will be triggered next in the plan, should be display in Plan Summary.

### After this PR
---
Added 'Next Activities' Field in Activity Plan form view, that will show activities that will be triggered/suggested next.

Added activities that will be triggered next in Plan Summary, with format,

>  "Activity Name(Separated by 'or' if many)  + x days/weeks/months + Delay From"

Task-4001164
