### PR TITLE
[FIX] hr_org_chart: avoid fetching image field

### DIFF
--- a/addons/web_hierarchy/static/src/hierarchy_model.js
+++ b/addons/web_hierarchy/static/src/hierarchy_model.js
@@ -544,6 +544,13 @@ export class HierarchyModel extends Model {
         return fieldsToFetch;
     }
 
+    get context() {
+        return {
+            bin_size: true,
+            ...(this.config.context || {}),
+        };
+    }
+
     /**
      * Load the config and data for hierarchy view
      *
@@ -694,7 +701,7 @@ export class HierarchyModel extends Model {
             "hierarchy_read",
             [config.domain, this.fieldsToFetch, this.parentFieldName, this.childFieldName],
             {
-                context: config.context,
+                context: this.context,
             },
         );
         const resultStringified = JSON.stringify(result);
@@ -764,7 +771,7 @@ export class HierarchyModel extends Model {
             this.resModel,
             domain.toList({}),
             this.fieldsToFetch,
-            { context: this.config.context },
+            { context: this.context },
         );
         let managerData = {};
         const children = [];
@@ -800,7 +807,7 @@ export class HierarchyModel extends Model {
             this.resModel,
             childrenResIds,
             this.fieldsToFetch,
-            { context: this.config.context },
+            { context: this.context },
         )
         if (!this.childFieldName) {
             await this._fetchDescendants(data);
@@ -821,7 +828,7 @@ export class HierarchyModel extends Model {
                 [[this.parentFieldName, "in", resIds]],
                 ['id:array_agg'],
                 [this.parentFieldName],
-                { context: this.config.context || {} },
+                { context: this.context },
             );
             const childIdsPerId = Object.fromEntries(
                 fetchChildren.map((r) => [r[this.parentFieldName][0], r.id])
@@ -887,7 +894,7 @@ export class HierarchyModel extends Model {
                     this.resModel,
                     [node.resId],
                     { [this.parentFieldName]: parentResId || parentNode?.resId || false },
-                    { context: this.config.context }
+                    { context: this.context }
                 );
             });
             if (descendantsParentIds.length) {
@@ -900,7 +907,7 @@ export class HierarchyModel extends Model {
                     this.resModel,
                     domain,
                     this.fieldsToFetch,
-                    { context: this.config.context },
+                    { context: this.context },
                 );
                 const children = [];
                 for (const d of data) {


### PR DESCRIPTION
Before this commit, the avatar for the employees in the org chart is loaded by the URL but also when we fetched the data.

This commit avoid fetching image fields with `hierarchy_read`.
