### PR TITLE
[FIX] im_livechat: add missing `view_info` in test suite

### DIFF
--- a/addons/im_livechat/controllers/webclient.py
+++ b/addons/im_livechat/controllers/webclient.py
@@ -8,9 +8,13 @@ from odoo.addons.mail.models.discuss.mail_guest import add_guest_to_context
 class WebClient(WebclientController):
     @route("/web/tests/livechat", type="http", auth="user")
     def test_external_livechat(self, **kwargs):
-        return request.render("im_livechat.unit_embed_suite", {
-            "server_url": request.env["ir.config_parameter"].get_base_url(),
-        })
+        return request.render(
+            "im_livechat.unit_embed_suite",
+            {
+                "server_url": request.env["ir.config_parameter"].get_base_url(),
+                "session_info": {"view_info": request.env["ir.ui.view"].get_view_info()},
+            },
+        )
 
     def _process_request_for_internal_user(self, store, **kwargs):
         super()._process_request_for_internal_user(store, **kwargs)

--- a/addons/im_livechat/views/webclient_templates.xml
+++ b/addons/im_livechat/views/webclient_templates.xml
@@ -6,6 +6,11 @@
             <t t-set="title">Livechat External Tests</t>
             <t t-set="head">
                 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no"/>
+
+                <script type="text/javascript">
+                    odoo.__session_info__ = <t t-out="json.dumps(session_info)"/>;
+                </script>
+
                 <t t-call-assets="im_livechat.embed_assets_unit_tests_setup" />
                 <t t-call-assets="im_livechat.embed_assets_unit_tests" />
             </t>


### PR DESCRIPTION
Follow up of https://github.com/odoo/odoo/pull/171073 and https://github.com/odoo/odoo/issues/171919

Fixes a crash with livechat test suite when run locally.

```
module_loader.js:139 Uncaught (in promise) Error: Error while loading "@web/views/form/form_view":
TypeError: Cannot use 'in' operator to search for 'form' in undefined
    at ModuleSetLoader.startModule (module_loader.js:139:1)
    at ModuleSetLoader.startModule (module_set.hoot.js:466:1)
    at ModuleSetLoader.setup (module_set.hoot.js:448:1)
    at describeDrySuite (module_set.hoot.js:117:1)
    at async Runner.dryRun (runner.js:660:1)
    at async Promise.all (:8069/web/tests/index 0)
    at async runTests (module_set.hoot.js:332:1)
```
at
```js
viewRegistry.addValidation({
    type: { validate: (t) => t in session.view_info },
    Controller: { validate: (c) => c.prototype instanceof Component },
    "*": true,
});
```