### PR TITLE
[FIX] project: grant portal user access right to project task

### DIFF
--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -125,7 +125,7 @@ class Project(models.Model):
             "- All internal users: all internal users can access the project and all of its tasks without distinction.\n\n"
             "- Invited portal users and all internal users: all internal users can access the project and all of its tasks without distinction.\n"
             "When following a project, portal users will only get access to the specific tasks they are following.\n\n"
-            "When a project is shared in read-only, the portal user is redirected to their portal. They can view the tasks they are following, but not edit them.\n"
+            "When a project is shared in read-only, the portal user is redirected to their portal. They can view the tasks, but not edit them.\n"
             "When a project is shared in edit, the portal user is redirected to the kanban and list views of the tasks. They can modify a selected number of fields on the tasks.\n\n"
             "In any case, an internal user with no project access rights can still access a task, "
             "provided that they are given the corresponding URL (and that they are part of the followers if the project is private).")
@@ -976,13 +976,14 @@ class Project(models.Model):
 
         dict_tasks_per_partner = {}
         dict_partner_ids_to_subscribe_per_partner = {}
+        access_mode = self.env.context.get('access_mode')
         for task in self.task_ids:
             if task.partner_id in dict_tasks_per_partner:
                 dict_tasks_per_partner[task.partner_id] |= task
             else:
                 partner_ids_to_subscribe = [
                     partner.id for partner in partners
-                    if partner == task.partner_id or partner in task.partner_id.child_ids
+                    if partner == task.partner_id or partner in task.partner_id.child_ids or access_mode == 'read'
                 ]
                 if partner_ids_to_subscribe:
                     dict_tasks_per_partner[task.partner_id] = task

--- a/addons/project/wizard/project_share_wizard.py
+++ b/addons/project/wizard/project_share_wizard.py
@@ -69,6 +69,6 @@ class ProjectShareWizard(models.TransientModel):
             # send mail to users
             self._send_public_link(portal_partners)
             self._send_signup_link(partners=self.with_context({'signup_valid': True}).partner_ids - portal_partners)
-            self.resource_ref._add_followers(self.partner_ids)
+            self.resource_ref.with_context(access_mode=self.access_mode)._add_followers(self.partner_ids)
             return {'type': 'ir.actions.act_window_close'}
         return super().action_send_mail()


### PR DESCRIPTION
To reproduce the bug:
- Have a project with no customer on it
- In the project setting switch the 'Visibility' to 'Invited portal users and all internal users (public)'
- Share the project with readonly access mode with a portal user (Joel)
- Sign in as Joel and check the project page 

We can see that contrary to the page a public client get with using the share link with access token, we can't see the project tasks. More specifcly we need to be followers of these tasks to see them.

This fonctionnement is already implimented in the case of adding follower from the chat section instead of the Share button, furthermore it means that the public user.

This commit aim to change that behavior and make the share with readonly mode imply following all the project task.

opw-4038154
