### PR TITLE
[IMP] base: Zip not required in Chile E-commerce

### DIFF
--- a/odoo/addons/base/data/res_country_data.xml
+++ b/odoo/addons/base/data/res_country_data.xml
@@ -295,6 +295,7 @@
             <field name="code">cl</field>
             <field name="currency_id" ref="CLP" />
             <field eval="56" name="phone_code" />
+            <field name='zip_required'>0</field>
         </record>
         <record id="cm" model="res.country">
             <field name="name">Cameroon</field>


### PR DESCRIPTION
Chilean customers are not required to provide a Zip Code, as this information is not commonly used in the country.

task-4048931



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
