### PR TITLE
[FIX] mrp: assign backorder MOs

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -2046,6 +2046,15 @@ class MrpProduction(models.Model):
                 'state': 'done',
             })
 
+        # It is prudent to reserve any quantity that has become available to the backorder
+        # production's move_raw_ids after the production which spawned them has been marked done.
+        backorders_to_assign = backorders.filtered(
+            lambda order:
+            order.picking_type_id.reservation_method == 'at_confirm'
+        )
+        for backorder in backorders_to_assign:
+            backorder.action_assign()
+
         report_actions = self._get_autoprint_done_report_actions()
         if self.env.context.get('skip_redirection'):
             if report_actions:


### PR DESCRIPTION
**Current behavior:**
If a production spawns some backorder which has available
component quants in a package, the backorder will not have that
quantity reserved automatically.

**Expected behavior:**
This available quantity should be reserved by rule (based on the
manufacturing picking type's reservation configuration)
automatically.

**Steps to reproduce:**
1. Enable packages and 2-step manufacturing, use the default
    `at_confirm` option for the manufacturing method's
    `reservation_method`

2. Create an MO for 10 of some storable product that has 10 of
     some storable product as a component -> confirm the MO

3. In the generated pick operation for the MO, assign the 10
     units of the storable product to the move's quantity

4. In barcode, open the picking and manually add 1 of the
     components -> put it in a pack

5. Repeat step 3 an additional time

6. Validate the picking -> create the backorder

7. Open the initial manufacturing order in barcode

8. Consume one of the created packaged quants of the component,
     ensuring to also add the +1 quantity to the final product
     barcode line

9. Validate the MO -> create the backorder

10. In the backend, open the backorder to see that there is 0
     quantity reserved

**Cause of the issue:**
In this scenario, the backorder's raw move does not gain any
availability until after the original order is marked done,
after which there is never any logic for the reservation to
occur.

**Fix:**
During the backorder generation and the mark done for the
original order, attempt to assign any backorder productions at
the instant when some component quantity becomes available.

opw-3989977