### PR TITLE
[IMP] point_of_sale: resize customer display image

### DIFF
--- a/addons/point_of_sale/static/src/app/generic_components/orderline/orderline.xml
+++ b/addons/point_of_sale/static/src/app/generic_components/orderline/orderline.xml
@@ -3,7 +3,9 @@
     <t t-name="point_of_sale.Orderline">
         <t t-set="line" t-value="props.line" />
         <li class="orderline p-2 d-flex align-items-center lh-sm cursor-pointer" t-attf-class="{{ line.comboParent ? 'border-start border-3 ms-4' : '' }}" t-att-class="props.class">
-            <img class="" t-attf-style="width: 4rem; border-radius: 1rem;" t-if="line.imageSrc" t-att-src="line.imageSrc"/>
+            <div t-if="line.imageSrc" class="o_line_container d-flex align-items-center justify-content-center">
+                <img t-attf-style="border-radius: 1rem;" t-att-src="line.imageSrc"/>
+            </div>
             <div class=" d-flex flex-column w-100">
                 <div class="d-flex">
                     <div class="product-name d-inline-block flex-grow-1 fw-bolder pe-1">

--- a/addons/point_of_sale/static/src/customer_display/styles.scss
+++ b/addons/point_of_sale/static/src/customer_display/styles.scss
@@ -43,3 +43,13 @@ li {
         opacity: 1;
     }
 }
+
+.o_line_container {
+    width: 4rem;
+    height: 60px;
+
+    img {
+        max-height: 100%;
+        max-width: 100%;
+    }
+}


### PR DESCRIPTION
When a product image had a higher height than width it deformed the customer display product line.

This commit adds a new class to the customer display product line to resize the image to fit the container.

Before: 
![Screenshot from 2024-07-12 15-21-30](https://github.com/user-attachments/assets/941f8aaf-fa6d-41ff-85ce-86fa84e62509)

After:
![image](https://github.com/user-attachments/assets/bdec784f-beac-45d5-82f3-720c14847a56)
