### PR TITLE
[FIX] hr_calendar : fix unavailable partner computation

### DIFF
--- a/addons/hr_calendar/tests/__init__.py
+++ b/addons/hr_calendar/tests/__init__.py
@@ -1,3 +1,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_working_hours
+from . import test_event_interval

--- a/addons/hr_calendar/tests/test_event_interval.py
+++ b/addons/hr_calendar/tests/test_event_interval.py
@@ -41,3 +41,83 @@ class TestEventInterval(TestHrCalendarCommon):
                 self.env['resource.calendar']
             )
         ])
+
+    def test_allday_event_during_working_day(self):
+        event = self.env['calendar.event'].with_context(company_id=self.company_A.id).create([
+            {
+                'start': datetime(2024, 7, 12),
+                'stop': datetime(2024, 7, 12, 23, 59, 59),
+                'allday': True,
+                'name': "Event 1"
+            }
+        ])
+        result = event._get_events_interval()
+        self.assertEqual(result.get(event)._items, [
+            (
+                timezone('Europe/Brussels').localize(datetime(2024, 7, 12, 8, 0, 0)),
+                timezone('Europe/Brussels').localize(datetime(2024, 7, 12, 12, 0, 0)),
+                self.env['resource.calendar']
+            ),
+            (
+                timezone('Europe/Brussels').localize(datetime(2024, 7, 12, 13, 0, 0)),
+                timezone('Europe/Brussels').localize(datetime(2024, 7, 12, 16, 0, 0)),
+                self.env['resource.calendar']
+            )
+        ])
+
+    def test_allday_event_during_no_working_day(self):
+        """
+        An allday event is calculated using the company's calendar. If the event is scheduled on a day when the company
+        is closed, the duration of the event will be set to zero.
+        """
+
+        # A : Saturday
+        # B : Friday - Saturday
+        # C : Sunday - Monday
+        # D : Friday - Saturday - Sunday - Monday
+        events = self.env['calendar.event'].with_context(company_id=self.company_A.id).create([
+            {
+                'start': datetime(2024, 7, 13),
+                'stop': datetime(2024, 7, 13, 23, 59, 59),
+                'allday': True,
+                'name': "Event A"
+            },
+            {
+                'start': datetime(2024, 7, 12),
+                'stop': datetime(2024, 7, 13, 23, 59, 59),
+                'allday': True,
+                'name': "Event B"
+            },
+            {
+                'start': datetime(2024, 7, 14),
+                'stop': datetime(2024, 7, 15, 23, 59, 59),
+                'allday': True,
+                'name': "Event C"
+            },
+            {
+                'start': datetime(2024, 7, 12),
+                'stop': datetime(2024, 7, 15, 23, 59, 59),
+                'allday': True,
+                'name': "Event D"
+            }
+        ])
+        result = events._get_events_interval()
+        for interval in result.values():
+            self.assertEqual(interval._items, [])
+
+    def test_event_during_working_day(self):
+        event = self.env['calendar.event'].with_context(company_id=self.company_A.id).create([
+            {
+                'start': datetime(2024, 7, 12, 8, 30, 0),
+                'stop': datetime(2024, 7, 12, 9, 30, 0),
+                'name': "Event 3"
+            }
+        ])
+        result = event._get_events_interval()
+        self.assertEqual(result.get(event)._items, [
+            (
+                timezone('UTC').localize(datetime(2024, 7, 12, 8, 30, 0)),
+                timezone('UTC').localize(datetime(2024, 7, 12, 9, 30, 0)),
+                self.env['resource.calendar']
+            )
+        ])

--- a/addons/hr_calendar/tests/test_event_interval.py
+++ b/addons/hr_calendar/tests/test_event_interval.py
@@ -1,0 +1,43 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import tagged
+from datetime import datetime
+from pytz import timezone
+from odoo.addons.hr_calendar.tests.common import TestHrCalendarCommon
+
+
+@tagged('event_interval')
+class TestEventInterval(TestHrCalendarCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company_A.resource_calendar_id = cls.calendar_35h
+
+    def test_empty_event(self):
+        event, allday_event = self.env['calendar.event'].with_context(company_id=self.company_A.id).create([
+            {
+                'start': datetime(2024, 7, 12),
+                'stop': datetime(2024, 7, 12),
+                'name': "Event"
+            },
+            {
+                'start': datetime(2024, 7, 12),
+                'stop': datetime(2024, 7, 12),
+                'allday': True,
+                'name': "Event all day"
+            }
+        ])
+        result = (event + allday_event)._get_events_interval()
+        self.assertEqual(result.get(event)._items, [])
+        self.assertEqual(result.get(allday_event)._items, [
+            (
+                timezone('Europe/Brussels').localize(datetime(2024, 7, 12, 8, 0, 0)),
+                timezone('Europe/Brussels').localize(datetime(2024, 7, 12, 12, 0, 0)),
+                self.env['resource.calendar']
+            ),
+            (
+                timezone('Europe/Brussels').localize(datetime(2024, 7, 12, 13, 0, 0)),
+                timezone('Europe/Brussels').localize(datetime(2024, 7, 12, 16, 0, 0)),
+                self.env['resource.calendar']
+            )
+        ])


### PR DESCRIPTION
Issue 1:

    Step to reproduce:
    ==================
    
        1- Go on calendar application
        2- Go on List view
        3- Click on the event "Changes in Designing"
    
    A traceback will be raised

    Expected Behaviour:
    ===================
        This event is an allday event during a worked day for the company.
        So a partner will be available only if he works during the company's
        interval for this day.
    
    Issue explanation:
    ==================
        The event "Changes in Designing" is an all day event with a
        start_date equals to the stop_date. From the front_end with the
        method _inverse_dates, the sart_date will be equals to 8AM and the
        stop_date will be equals to 6PM.
        But this event is created with demo data; so the inverse method is
        not called.
        And, to be able to synchronise calendar application with google
        calendar and outlook calendar; it's mandatory to allow the user to
        create an event with a duration of 0.


Issue 2:

    STEP TO REPRODUCE:
    =================
        1- Go on calendar Application
        2- Click on sunday all day box
    
    You will have a traceback about unavailable partner computation.
    
    Expect Behaviour:
    =================
    If the employee is not supposed to work during an entire day; when you
    want to create an all day event during this day the employee's partner
    will be unavailable.

task-4042363

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
