### PR TITLE
[FIX] web: search panel: limit for many2many fields

### DIFF
--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -317,7 +317,7 @@ class Base(models.AbstractModel):
                     }
         """
         field = self._fields[field_name]
-        if field.type == 'many2one':
+        if field.type in ('many2one', 'many2many'):
             def group_id_name(value):
                 return value
 
@@ -681,8 +681,16 @@ class Base(models.AbstractModel):
         expand = kwargs.get('expand')
 
         if field.type == 'many2many':
+            if not expand:
+                domain_image = self._search_panel_domain_image(field_name, model_domain, limit=limit)
+                image_element_ids = list(domain_image.keys())
+                comodel_domain = AND([
+                    comodel_domain,
+                    [('id', 'in', image_element_ids)],
+                ])
+
             comodel_records = Comodel.search_read(comodel_domain, field_names, limit=limit)
-            if expand and limit and len(comodel_records) == limit:
+            if limit and len(comodel_records) == limit:
                 return {'error_msg': str(SEARCH_PANEL_ERROR_MESSAGE)}
 
             group_domain = kwargs.get('group_domain')
@@ -698,7 +706,7 @@ class Base(models.AbstractModel):
                     values['group_id'] = group_id
                     values['group_name'] = group_name
 
-                if enable_counters or not expand:
+                if enable_counters:
                     search_domain = AND([
                             model_domain,
                             [(field_name, 'in', record_id)],
@@ -713,21 +721,8 @@ class Base(models.AbstractModel):
                         search_domain,
                         local_extra_domain
                     ])
-                    if enable_counters:
-                        count = self.search_count(search_count_domain)
-                    if not expand:
-                        if enable_counters and is_true_domain(local_extra_domain):
-                            inImage = count
-                        else:
-                            inImage = self.search(search_domain, limit=1)
-
-                if expand or inImage:
-                    if enable_counters:
-                        values['__count'] = count
-                    field_range.append(values)
-
-            if not expand and limit and len(field_range) == limit:
-                return {'error_msg': str(SEARCH_PANEL_ERROR_MESSAGE)}
+                    values['__count'] = self.search_count(search_count_domain)
+                field_range.append(values)
 
             return { 'values': field_range, }
 

--- a/odoo/addons/test_search_panel/tests/test_search_panel_select_multi_range.py
+++ b/odoo/addons/test_search_panel/tests/test_search_panel_select_multi_range.py
@@ -558,13 +558,37 @@ class TestSelectRangeMulti(odoo.tests.TransactionCase):
             ]
         )
 
-        # no counters, no expand, no group_by, and search_domain
+        # no counters, no expand, no group_by, no search_domain, and limit
         result = self.SourceModel.search_panel_select_multi_range(
             'tag_ids',
             limit=2,
         )
-        self.assertEqual(result, SEARCH_PANEL_ERROR, )
+        self.assertEqual(result, SEARCH_PANEL_ERROR)
 
+        records = self.SourceModel.create([
+            {'name': 'Rec 5', 'tag_ids': [t2_id, t3_id]},
+            {'name': 'Rec 6', 'tag_ids': [t3_id]},
+        ])
+        r5_id, r6_id = records.ids
+
+        result = self.SourceModel.search_panel_select_multi_range(
+            'tag_ids',
+            search_domain=[['id', '=', r5_id]],
+            limit=2,
+        )
+        self.assertEqual(result, SEARCH_PANEL_ERROR)
+
+        result = self.SourceModel.search_panel_select_multi_range(
+            'tag_ids',
+            search_domain=[['id', '=', r6_id]],
+            limit=2,
+        )
+        self.assertEqual(
+            result['values'],
+            [
+                {'display_name': 'Tag 3', 'id': t3_id},
+            ]
+        )
 
     # Selection case
 


### PR DESCRIPTION
In a call to search_panel_select_multi_range for a many2many with a
limit set and expand=False (default), 2 filterings of comodel records
(more precisely records in comodel_domain) are done. First only up to
L=limit records are fetched, then only those that are in the domain
image are used to create values in field_range. The limit check is done
after the 2 filterings.

Let us write
- C for the set of comodel records
- F for the set of comodel records obtained by the first filtering
- I fot the set of comodel records in the domain image
The code to be valid should do the check on C ⋂ I while it
does it on F ⋂ I so that 2 bad things can happen:
    - #(F ⋂ I) < L but #(C ⋂ I) = #(F ⋂ I) + #((C ∖ F) ⋂ I) >= L
        so that the error_msg is not returned while it should
    - #(C ⋂ I) < L and #((C ∖ F) ⋂ I) >= 1
        so that some records that should be shown are not

We use the fact that it is possible in 15.0 and after to use many2many
fields in read_group to make a single correct filtering, that is get C ⋂ I
and do the limit check on it.

opw-3827751
