### PR TITLE
[FIX] project: make `_search_on_comodel` always return False when no `domain`

### DIFF
--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -1172,7 +1172,12 @@ class Task(models.Model):
         return {'date_end': False}
 
     def _search_on_comodel(self, domain, field, comodel, order=None, additional_domain=None):
-
+        """ This method is called by `group_expand` methods, whose purpose is to add empty groups to the `read_group`
+            (which otherwise returns groups containing records that match the domain).
+            When specifically filtering on a comodel's field, the result of the `read_group` should contain all matching groups.
+            However, if the search isn't filtered on any comodel's field, the result shouldn't be affected,
+            which explains why we return `False` if `filtered_domain` is empty.
+        """
         def _change_operator(domain):
             new_domain = []
             for dom in domain:
@@ -1203,9 +1208,11 @@ class Task(models.Model):
             f"{field}.name": "name",
         })
         filtered_domain = _change_operator(filtered_domain)
+        if not filtered_domain:
+            return False
         if additional_domain:
             filtered_domain = expression.AND([filtered_domain, additional_domain])
-        return self.env[comodel].search(filtered_domain, order=order) if filtered_domain else False
+        return self.env[comodel].search(filtered_domain, order=order)
 
     # ---------------------------------------------------
     # Subtasks


### PR DESCRIPTION
When `_search_on_comodel` is called with no `domain` and no `additional_domain`, it returns `False` (see added documentation for more explanation). However, when it is called with no `domain`, but an actual `additional_domain`, it returns something because both domains are merged before the `search`. Yet the `additional_domain` should filter the result even more, not expand it.

Fix:
First return `False` if there's no `filtered_domain`. Otherwise, and only then, merge both domains before the `search`.

task-3251630


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
