### PR TITLE
[FIX] pos_loyalty: display the customer loyalty points

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/components/partner_line/partner_line.js
+++ b/addons/pos_loyalty/static/src/overrides/components/partner_line/partner_line.js
@@ -10,7 +10,7 @@ patch(PartnerLine.prototype, {
         this.pos = usePos();
     },
     _getLoyaltyPointsRepr(loyaltyCard) {
-        const program = this.pos.models["loyalty.program"].get(loyaltyCard.program_id);
+        const program = loyaltyCard.program_id;
         if (program.program_type === "ewallet") {
             return `${program.name}: ${this.env.utils.formatCurrency(loyaltyCard.points)}`;
         }

--- a/addons/pos_loyalty/static/src/overrides/components/partner_list_screen/partner_list_screen.js
+++ b/addons/pos_loyalty/static/src/overrides/components/partner_list_screen/partner_list_screen.js
@@ -9,4 +9,13 @@ patch(PartnerList.prototype, {
     get isBalanceDisplayed() {
         return true;
     },
+
+    async searchPartner() {
+        const res = await super.searchPartner();
+        const coupons = this.pos.fetchCoupons([
+            ["partner_id", "in", res.map((partner) => partner.id)],
+        ]);
+        this.pos.computePartnerCouponIds(coupons);
+        return res;
+    },
 });

--- a/addons/pos_loyalty/static/tests/tours/pos_loyalty_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/pos_loyalty_tour.js
@@ -488,3 +488,24 @@ registry.category("web_tour.tours").add("PosLoyaltyArchivedRewardProductsActive"
             PosLoyalty.finalizeOrder("Cash", "100"),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("CustomerLoyaltyPointsDisplayed", {
+    test: true,
+    url: "/pos/web",
+    steps: () =>
+        [
+            Dialog.confirm("Open session"),
+
+            ProductScreen.clickDisplayedProduct("product_a"),
+            ProductScreen.selectedOrderlineHas("product_a", "1.00", "100.00"),
+
+            ProductScreen.clickPartnerButton(),
+            ProductScreen.clickCustomer("John Doe"),
+
+            PosLoyalty.orderTotalIs("100.00"),
+            PosLoyalty.pointsAwardedAre("100"),
+            PosLoyalty.finalizeOrder("Cash", "100.00"),
+
+            PosLoyalty.checkPartnerPoints("John Doe", "100.00"),
+        ].flat(),
+});

--- a/addons/pos_loyalty/static/tests/tours/utils/pos_loyalty_util.js
+++ b/addons/pos_loyalty/static/tests/tours/utils/pos_loyalty_util.js
@@ -120,3 +120,14 @@ export function checkAddedLoyaltyPoints(points) {
         },
     ];
 }
+
+export function checkPartnerPoints(name, points) {
+    return [
+        ...ProductScreen.clickPartnerButton(),
+        {
+            content: `Check '${name}' has ${points} Loyalty Points`,
+            trigger: `.partner-list .partner-line:contains(${name}) .partner-line-balance:contains(${points} Loyalty Point(s))`,
+            in_modal: true,
+        },
+    ];
+}

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -2127,3 +2127,28 @@ class TestUi(TestPointOfSaleHttpCommon):
             login="accountman",
         )
         self.main_pos_config.current_session_id.close_session_from_ui()
+
+    def test_customer_loyalty_points_displayed(self):
+        """
+        Verify that the loyalty points of a customer are well displayed.
+        This test will only work on big screens because the balance column is not shown when 'ui.isSmall == True'.
+        """
+        self.env['loyalty.program'].search([]).write({'active': False})
+
+        john_doe = self.env['res.partner'].create({'name': 'John Doe'})
+
+        loyalty_program = self.create_programs([('Loyalty P', 'loyalty')])['Loyalty P']
+        self.env['loyalty.card'].create({
+            'partner_id': john_doe.id,
+            'program_id': loyalty_program.id,
+            'points': 0
+        })
+
+        self.product_a.write({
+            'list_price': 100,
+            'available_in_pos': True,
+            'taxes_id': False,
+        })
+
+        self.main_pos_config.open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, "CustomerLoyaltyPointsDisplayed", login="pos_user")


### PR DESCRIPTION
Problem:
The loyalty points of customers are not displayed in the partner list

Steps to reproduce:
- Install "point_of_sale" app and "pos_loyalty" module
- Click on Customer
- The loyalty points are not shown

Solution:
The content of the mutex of checkMissingCoupons is executed only once at the beginning of the order. "this.models["loyalty.card"]" contains all the loyalty cards and then allow to fetch them. In previous version, the coupons were loaded with json which doesn't exist anymore.

opw-4035387


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
