### PR TITLE
[IMP] point_of_sale: split click on pricelist button

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/pricelist_button/pricelist_button.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/pricelist_button/pricelist_button.js
@@ -21,10 +21,13 @@ export class SetPricelistButton extends Component {
         const order = this.currentOrder;
         return order && order.pricelist ? order.pricelist.display_name : _t("Pricelist");
     }
-    async click() {
-        // Create the list to be passed to the SelectionPopup.
-        // Pricelist object is passed as item in the list because it
-        // is the object that will be returned when the popup is confirmed.
+    /**
+     * Create the list to be passed to the SelectionPopup on the `click` function.
+     * Pricelist object is passed as item in the list because it
+     * is the object that will be returned when the popup is confirmed.
+     * @returns {Array}
+     */
+    getPricelistList() {
         const selectionList = this.pos.pricelists.map((pricelist) => ({
             id: pricelist.id,
             label: pricelist.name,
@@ -41,6 +44,10 @@ export class SetPricelistButton extends Component {
                 item: null,
             });
         }
+        return selectionList;
+    }
+    async click() {
+        const selectionList = this.getPricelistList();
 
         const { confirmed, payload: selectedPricelist } = await this.popup.add(SelectionPopup, {
             title: _t("Select the pricelist"),


### PR DESCRIPTION
Splitting the function `click` on the Pricelist Button to make it inheritable, by creating a new function called `getPricelistList` that will allow filtering them whenever needed.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr