### PR TITLE
[FIX] html_editor: stepElement mutations should be reversible

### DIFF
--- a/addons/html_editor/static/src/core/split_plugin.js
+++ b/addons/html_editor/static/src/core/split_plugin.js
@@ -3,7 +3,7 @@ import { isBlock } from "../utils/blocks";
 import { fillEmpty } from "../utils/dom";
 import { isUnbreakable, isVisible } from "../utils/dom_info";
 import { prepareUpdate } from "../utils/dom_state";
-import { closestElement, firstLeaf, lastLeaf } from "../utils/dom_traversal";
+import { childNodes, closestElement, firstLeaf, lastLeaf } from "../utils/dom_traversal";
 import { DIRECTIONS, childNodeIndex } from "../utils/position";
 
 export class SplitPlugin extends Plugin {
@@ -137,13 +137,13 @@ export class SplitPlugin extends Plugin {
         /** @type {HTMLElement} **/
         const before = element.cloneNode();
         const after = /** @type {HTMLElement} **/ (element.cloneNode());
+        element.before(before);
+        element.after(after);
         let index = 0;
-        for (const child of [...element.childNodes]) {
+        for (const child of childNodes(element)) {
             index < offset ? before.appendChild(child) : after.appendChild(child);
             index++;
         }
-        element.before(before);
-        element.after(after);
         element.remove();
         return [before, after];
     }


### PR DESCRIPTION
Currently, the editor does not support "hidden mutations":
- remove a node from the dom
- insert that node in a newly created node which is not in the dom
- insert the created node in the dom

This process implies that the removal of the node is observed, and the insertion
of the node is not. Meaning that when using `revertMutations` then
`applyMutations`, we are missing one information to ensure that the result is
strictly equivalent to the starting point.

As long as these hidden mutations are not properly handled, editor manipulations
should:
- either disable the observer to remove nodes that are destined to be processed
  outside of the DOM
- do the processing inside the DOM so that all mutations are observed.

In this commit, `splitElement` is modified so that `before` and `after` are
inserted in the DOM before they are filled with other nodes coming from the DOM,
allowing to observe all of these mutations.
