### PR TITLE
[I18N][FIX] base: fix Lithuania translation to Slovak

### DIFF
--- a/doc/cla/individual/Rad0van.md
+++ b/doc/cla/individual/Rad0van.md
@@ -1,0 +1,11 @@
+Slovakia, 2024-01-25
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Radovan Skolnik radovan@skolnik.info https://github.com/Rad0van

--- a/odoo/addons/base/i18n/sk.po
+++ b/odoo/addons/base/i18n/sk.po
@@ -13608,7 +13608,7 @@ msgstr ""
 #. module: base
 #: model:res.country,name:base.lt
 msgid "Lithuania"
-msgstr "Lotyško"
+msgstr "Litva"
 
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_currency_rate_live


### PR DESCRIPTION
Description of the issue/feature this PR addresses: current translation is bastardized (missing one letter) translation of Latvia (sk: Lotyšsko).

Current behavior before PR:

Desired behavior after PR is merged: Correct translation of Lithuania

This has gone unnoticed from 10.0 to current...