### PR TITLE
[FIX] product: add sufix to pricelist name when duplicating

### DIFF
--- a/addons/product/i18n/product.pot
+++ b/addons/product/i18n/product.pot
@@ -73,6 +73,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/product/models/product_tag.py:0
 #: code:addons/product/models/product_template.py:0
+#: code:addons/product/models/product_pricelist.py:0
 #, python-format
 msgid "%s (copy)"
 msgstr ""

--- a/addons/product/models/product_pricelist.py
+++ b/addons/product/models/product_pricelist.py
@@ -81,6 +81,12 @@ class Pricelist(models.Model):
 
         return res
 
+    def copy_data(self, default=None):
+        default = default or {}
+        if not default.get('name'):
+            default['name'] = _('%s (copy)', self.name)
+        return super().copy_data(default=default)
+
     def _get_products_price(self, products, *args, **kwargs):
         """Compute the pricelist prices for the specified products, quantity & uom.
 


### PR DESCRIPTION
Before this commit, when user duplicate pricelist then new pricelist is created with same name.

After this commit, add sufix '(copy)' in newly created pricelist when user duplicate pricelist.

task-4035473




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
