### PR TITLE
[IMP] maintenance,hr_maintenance: simplify kanban archs

### DIFF
--- a/addons/hr_maintenance/views/maintenance_views.xml
+++ b/addons/hr_maintenance/views/maintenance_views.xml
@@ -38,7 +38,7 @@
         <field name="inherit_id" ref="maintenance.hr_equipment_request_view_kanban"/>
         <field name="arch" type="xml">
             <xpath expr="//span[@name='owner_user_id']" position="replace">
-                <span t-if="record.employee_id.raw_value"><field name="employee_id"/><br/></span>
+                <field name="employee_id"/>
             </xpath>
         </field>
     </record>
@@ -95,19 +95,14 @@
         <field name="model">maintenance.equipment</field>
         <field name="inherit_id" ref="maintenance.hr_equipment_view_kanban"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='technician_user_id']" position="after">
+            <xpath expr="//field[@name='owner_user_id']" position='replace'>
+                <field name="employee_id" widget="many2one_avatar_employee"/>
+            </xpath>
+            <xpath expr="//field[@name='serial_no']" position='after'>
+                <div t-if="!record.employee_id.raw_value">Unassigned</div>
                 <field name="employee_id"/>
                 <field name="department_id"/>
             </xpath>
-            <xpath expr="//templates//field[@name='owner_user_id']" position='replace'>
-                <field name="employee_id" widget="many2one_avatar_employee"/>
-            </xpath>
-            <div t-if="record.serial_no.raw_value" position='after'>
-                <div t-if="!record.employee_id.raw_value">Unassigned</div>
-                <div t-if="record.employee_id.value"><field name="employee_id"/></div>
-                <div t-if="record.department_id.value"><field name="department_id"/>
-            </div>
-            </div>
         </field>
     </record>
 

--- a/addons/maintenance/views/maintenance_views.xml
+++ b/addons/maintenance/views/maintenance_views.xml
@@ -156,54 +156,33 @@
         <field name="name">equipment.request.kanban</field>
         <field name="model">maintenance.request</field>
         <field name="arch" type="xml">
-            <kanban default_group_by="stage_id" sample="1">
-                <field name="stage_id"/>
-                <field name="color"/>
-                <field name="priority"/>
-                <field name="equipment_id"/>
-                <field name="user_id"/>
-                <field name="owner_user_id"/>
-                <field name="category_id"/>
-                <field name="kanban_state"/>
-                <field name="activity_ids" />
-                <field name="activity_state" />
+            <kanban highlight_color="color" default_group_by="stage_id" sample="1">
                 <field name="archive" />
                 <progressbar field="kanban_state" colors='{"done": "success", "blocked": "danger"}'/>
                 <templates>
                     <t t-name="kanban-menu">
-                        <t t-if="widget.editable"><a role="menuitem" type="edit" class="dropdown-item">Edit...</a></t>
+                        <t t-if="widget.editable"><a role="menuitem" type="open" class="dropdown-item">Edit...</a></t>
                         <t t-if="widget.deletable"><a role="menuitem" type="delete" class="dropdown-item">Delete</a></t>
-                        <ul class="oe_kanban_colorpicker" data-field="color"/>
+                        <field name="color" widget="kanban_color_picker"/>
                     </t>
-                    <t t-name="kanban-box">
-                        <div t-attf-class="{{!selection_mode ? 'oe_kanban_color_' + kanban_getcolor(record.color.raw_value) : ''}} oe_kanban_card oe_kanban_global_click oe_semantic_html_override">
-                            <div class="oe_kanban_content">
-                                <div class="o_kanban_record_top">
-                                    <b class="o_kanban_record_title"><field name="name"/></b>
-                                </div>
-                                <div class="o_kanban_record_body">
-                                    <span name="owner_user_id" t-if="record.owner_user_id.raw_value">Requested by: <field name="owner_user_id"/><br/></span>
-                                    <span class="oe_grey" t-if="record.equipment_id.raw_value"><field name="equipment_id"/><span t-if="record.category_id.raw_value"> (<field name="category_id"/>)</span><br/></span>
-                                    <span name="schedule_date" t-if="record.schedule_date.raw_value"><field name="schedule_date"/><br/></span>
-                                </div>
-                                <div class="o_kanban_record_bottom">
-                                    <div class="oe_kanban_bottom_left">
-                                        <field name="priority" widget="priority"/>
-                                        <div class="o_kanban_inline_block ml4 mr4">
-                                            <field name="activity_ids" widget="kanban_activity" />
-                                        </div>
-                                    </div>
-                                    <div class="oe_kanban_bottom_right">
-                                        <div invisible="not archive">
-                                            <span class="badge text-bg-warning float-end">Cancelled</span>
-                                        </div>
-                                        <field name="kanban_state" widget="state_selection"/>
-                                        <field name="user_id" widget="many2one_avatar_user"/>
-                                    </div>
-                                </div>
+                    <t t-name="kanban-card">
+                        <field name="name" class="fw-bold fs-5"/>
+                        <span name="owner_user_id" t-if="record.owner_user_id.raw_value">Requested by: <field name="owner_user_id"/></span>
+                        <span t-if="record.equipment_id.raw_value"><field name="equipment_id"/><span t-if="record.category_id.raw_value"> (<field name="category_id"/>)</span></span>
+                        <field name="schedule_date"/>
+                        <footer class="fs-6">
+                            <div class="d-flex">
+                                <field name="priority" widget="priority"/>
+                                <field name="activity_ids" widget="kanban_activity" class="ms-3"/>
                             </div>
-                            <div class="clearfix"></div>
-                        </div>
+                            <div class="d-flex ms-auto align-items-center">
+                                <div class="badge text-bg-warning float-end" invisible="not archive">
+                                    Cancelled
+                                </div>
+                                <field name="kanban_state" widget="state_selection" class="ms-1"/>
+                                <field name="user_id" widget="many2one_avatar_user" class="ms-1"/>
+                            </div>
+                        </footer>
                     </t>
                 </templates>
             </kanban>
@@ -471,52 +450,31 @@
         <field name="name">equipment.kanban</field>
         <field name="model">maintenance.equipment</field>
         <field name="arch" type="xml">
-            <kanban sample="1">
-                <field name="name"/>
-                <field name="color"/>
-                <field name="technician_user_id"/>
-                <field name="owner_user_id"/>
-                <field name="category_id"/>
-                <field name="serial_no"/>
-                <field name="model"/>
-                <field name="maintenance_ids"/>
-                <field name="maintenance_open_count"/>
-                <field name="activity_ids" />
-                <field name="activity_state" />
+            <kanban highlight_color="color" sample="1">
                 <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}'/>
                 <templates>
                     <t t-name="kanban-menu">
-                        <t t-if="widget.editable"><a role="menuitem" type="edit" class="dropdown-item">Edit...</a></t>
+                        <t t-if="widget.editable"><a role="menuitem" type="open" class="dropdown-item">Edit...</a></t>
                         <t t-if="widget.deletable"><a role="menuitem" type="delete" class="dropdown-item">Delete</a></t>
                         <div role="separator" class="dropdown-divider"></div>
                         <div role="separator" class="dropdown-header">Record Colour</div>
-                        <ul class="oe_kanban_colorpicker" data-field="color"/>
+                        <field name="color" widget="kanban_color_picker"/>
                     </t>
-                    <t t-name="kanban-box">
-                        <div t-attf-class="{{!selection_mode ? 'oe_kanban_color_' + kanban_getcolor(record.color.raw_value) : ''}} oe_kanban_card oe_kanban_global_click">
-                            <div class="oe_kanban_content">
-                                <div class="o_kanban_record_top">
-                                    <b class="o_kanban_record_title"><field name="name"/><small><span t-if="record.model.raw_value"> (<field name="model"/>)</span></small></b>
-                                </div>
-                                <div class="o_kanban_record_body">
-                                    <div t-if="record.serial_no.raw_value"><field name="serial_no"/></div>
-                                </div>
-                                <div class="o_kanban_record_bottom">
-                                    <div class="oe_kanban_bottom_left">
-                                        <div class="badge text-bg-danger" t-if="!selection_mode and record.maintenance_open_count.raw_value" >
-                                            <t t-out="record.maintenance_open_count.raw_value"/> Request
-                                        </div>
-                                    </div>
-                                    <div class="oe_kanban_bottom_right">
-                                        <div class="o_kanban_inline_block" t-if="!selection_mode">
-                                            <field name="activity_ids" widget="kanban_activity" />
-                                        </div>
-                                        <field name="owner_user_id" widget="many2one_avatar_user"/>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="clearfix"></div>
+                    <t t-name="kanban-card">
+                        <div>
+                            <field name="name" class="fw-bold fs-5"/>
+                            <span t-if="record.model.raw_value" class="fw-bold small"> (<field name="model"/>)</span>
                         </div>
+                        <field t-if="record.serial_no.raw_value" name="serial_no"/>
+                        <footer class="fs-6">
+                            <div class="badge text-bg-danger" t-if="record.maintenance_open_count.raw_value">
+                                <field name="maintenance_open_count" /> Request
+                            </div>
+                            <div class="d-flex ms-auto align-items-center">
+                                <field name="activity_ids" widget="kanban_activity"/>
+                                <field name="owner_user_id" widget="many2one_avatar_user" class="ms-1"/>
+                            </div>
+                        </footer>
                     </t>
                 </templates>
             </kanban>
@@ -697,26 +655,14 @@
         <field name="model">maintenance.equipment.category</field>
         <field name="arch" type="xml">
             <kanban>
-                <field name="name"/>
-                <field name="technician_user_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div t-attf-class="oe_kanban_global_click">
-                            <div class="mb4">
-                                <strong><field name="name"/></strong>
-                            </div>
-                            <div class="row mt4">
-                                <div class="col-6">
-                                    <span class="badge rounded-pill">
-                                        <strong>Equipment:</strong> <field name="equipment_count"/>
-                                    </span>
-                                </div>
-                                <div class="col-6 text-end">
-                                    <span class="badge rounded-pill">
-                                        <strong>Maintenance:</strong> <field name="maintenance_open_count"/>
-                                    </span>
-                                    <field name="technician_user_id" widget="many2one_avatar_user"/>
-                                </div>
+                    <t t-name="kanban-card">
+                        <field name="name" class="fw-bolder mb-1"/>
+                        <div class="d-flex mt-1 align-items-center smaller">
+                            <strong>Equipment:</strong><field name="equipment_count" class="ms-1"/>
+                            <div class="d-flex ms-auto align-items-center">
+                                <strong>Maintenance: </strong><field name="maintenance_open_count" class="ms-1"/>
+                                <field name="technician_user_id" widget="many2one_avatar_user" class="ms-2 small"/>
                             </div>
                         </div>
                     </t>
@@ -767,12 +713,8 @@
         <field name="arch" type="xml">
             <kanban class="o_kanban_mobile">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div t-attf-class="oe_kanban_global_click">
-                            <div>
-                                <strong><field name="name"/></strong>
-                            </div>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="name" class="fw-bolder"/>
                     </t>
                 </templates>
             </kanban>
@@ -837,12 +779,8 @@
         <field name="arch" type="xml">
             <kanban class="o_kanban_mobile">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div t-attf-class="oe_kanban_global_click">
-                            <div>
-                                <strong><field name="name"/></strong>
-                            </div>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="name" class="fw-bold"/>
                     </t>
                 </templates>
             </kanban>


### PR DESCRIPTION
In this commit we have simplified the kanban arch for the maintenance and hr_maintenance module.the goal is to simplify them,make them easier to read and use bootstrap utility classnames.

- Previously, we used kanban-box, but now we are using kanban-card instead.
- Deprecated oe_kanban_global_click and oe_kanban_global_click_edit.
- More use of <field/> tags
- Removed the oe_kanban_colorpicker class and replaced it with the kanban_color_picker widget.
- Changed type='edit' to type='open' to open records. since version 16, records always open in edit mode by default.
- kanban_image from rendering context, is deprecated so we use <field name="..." widget="image"/> instead
- kanban_color, kanban_getcolor and kanban_getcolorname are deprecated use new attribute highlight_color="color_field_name" on root node
- oe_kanban_colorpicker is deprecated, use kanban_color_picker widget instead

Task-3992107

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
