### PR TITLE
[FIX] mass_mailing: prevent horizontal scroll in snippet

### DIFF
--- a/addons/mass_mailing/static/src/scss/mass_mailing.scss
+++ b/addons/mass_mailing/static/src/scss/mass_mailing.scss
@@ -188,6 +188,7 @@
 
 .o_field_mass_mailing_html {
     display: block;
+    overflow-x: hidden;
 
     iframe {
         width: 100%;


### PR DESCRIPTION
Due to the changes made in [3916601](https://github.com/odoo/odoo/pull/170126/commits/5ee56608c0c397d03a82a8472dfdab46213f6a27) task, the flex-shrink property is causing a horizontal scrollbar to appear because the iframe is now much wider to avoid unnecessary compression in desktop mode.
This fix ensures that the horizontal scrollbar is not displayed while maintaining the appropriate layout for the snippet in desktop mode.

Task-4050207