### PR TITLE
[FIX] website_crm_partner_assign: Prevent resellers page fallback failure when reseller has no assigned country

### DIFF
--- a/addons/website_crm_partner_assign/controllers/main.py
+++ b/addons/website_crm_partner_assign/controllers/main.py
@@ -242,7 +242,8 @@ class WebsiteCrmPartnerAssign(WebsitePartnerPage):
         if grade:
             country_domain += [('grade_id', '=', grade.id)]
         countries = partner_obj.sudo().read_group(
-            country_domain, ["id", "country_id"],
+            country_domain + [('country_id', '!=', False)],
+            ["id", "country_id"],
             groupby="country_id", orderby="country_id")
 
         # Fallback: Show all partners when country has no associates.


### PR DESCRIPTION
Steps to reproduce:
- Go to Contact
- Select Abigail Peterson
- Set her as a company, don't fill the field country
- In Partner assignment, set partner level, activation, level weight
- Cick on go to website
- Back to Resellers

What happens:
Error with traceback ending in "TypeError: 'bool' object is not subscriptable".
This is due to the country field of a reseller not being filled in,
the resellers page tries to load the list of all countries with
resellers and displays either resellers of the user's country or all
resellers if no match is found. If any reseller's country is not filled
in there is no 'country.id' to access leading to the error above.

Expected behavior:
Fallback: Show all partners when user's country has no resellers (as
described in the file itself by comments).

opw-4042404

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
