### PR TITLE
[FIX] hr_work_entry_holidays: Prevent multicompany error

### DIFF
--- a/addons/hr_work_entry_holidays/models/hr_leave.py
+++ b/addons/hr_work_entry_holidays/models/hr_leave.py
@@ -46,7 +46,7 @@ class HrLeave(models.Model):
                         'calendar_id': contract.resource_calendar_id.id,
                     }]
 
-        return resource_leaves | self.env['resource.calendar.leaves'].create(resource_leave_values)
+        return resource_leaves | self.env['resource.calendar.leaves'].sudo().create(resource_leave_values)
 
     def _get_overlapping_contracts(self, contract_states=None):
         self.ensure_one()


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
hr_work_entry_holidays does not use sudo() for its creation of resource.calendar.leaves entries, possibly causing multicompany rights issues.

Current behavior before PR:
If a hr.contract or the resource.calendar on an hr.employee record have a different company_id, attempting to confirm a hr.leave request for the employee results in an error message due to multicompany rights

Desired behavior after PR is merged:
The hr.leave request can be confirmed even if the underlying data is not perfectly consistent.
Using sudo() does not cause rights issues in this case, and is consistent with the use of sudo() in the function _create_resource_leave of hr_holidays, called in parallel to the function corrected here.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
