### PR TITLE
[IMP] web_tour: tour_interactive creation

### DIFF
--- a/addons/web_tour/static/src/tour_pointer/tour_pointer.js
+++ b/addons/web_tour/static/src/tour_pointer/tour_pointer.js
@@ -21,6 +21,7 @@ export class TourPointer extends Component {
                 content: { type: String, optional: true },
                 isOpen: { type: Boolean, optional: true },
                 isVisible: { type: Boolean, optional: true },
+                isZone: { type: Boolean, optional: true },
                 onClick: { type: [Function, { value: null }], optional: true },
                 onMouseEnter: { type: [Function, { value: null }], optional: true },
                 onMouseLeave: { type: [Function, { value: null }], optional: true },
@@ -98,10 +99,7 @@ export class TourPointer extends Component {
                     zone.style.minWidth = width + "px";
                     zone.style.minHeight = height + "px";
                     zone.style.left = left + "px";
-                    // Update the top only once. Like that it will not be above the header
-                    if (!lastAnchor) {
-                        zone.style.top = top + "px";
-                    }
+                    zone.style.top = top + "px";
                 }
 
                 // Content changed: we must re-measure the dimensions of the text.

--- a/addons/web_tour/static/src/tour_service/tour_compilers.js
+++ b/addons/web_tour/static/src/tour_service/tour_compilers.js
@@ -1,17 +1,13 @@
 /** @odoo-module **/
 
 import { browser } from "@web/core/browser/browser";
-import { debounce } from "@web/core/utils/timing";
 import { _legacyIsVisible, isVisible } from "@web/core/utils/ui";
 import { omit } from "@web/core/utils/objects";
 import { tourState } from "./tour_state";
 import * as hoot from "@odoo/hoot-dom";
-import { session } from "@web/session";
 import { setupEventActions } from "@web/../lib/hoot-dom/helpers/events";
-import { callWithUnloadCheck, getScrollParent } from "./tour_utils";
-import { utils } from "@web/core/ui/ui_service";
+import { callWithUnloadCheck, isActive } from "./tour_utils";
 import { TourHelpers } from "./tour_helpers";
-import { isMacOS } from "@web/core/browser/feature_detection";
 
 /**
  * @typedef {import("@web/core/macro").MacroDescriptor} MacroDescriptor
@@ -22,7 +18,6 @@ import { isMacOS } from "@web/core/browser/feature_detection";
  *
  * @typedef {(stepIndex: number, step: TourStep, options: TourCompilerOptions) => MacroDescriptor[]} TourStepCompiler
  *
- * @typedef {string | (actions: RunningTourActionHelper) => void | Promise<void>} RunCommand
  *
  * @typedef TourCompilerOptions
  * @property {Tour} tour
@@ -31,10 +26,6 @@ import { isMacOS } from "@web/core/browser/feature_detection";
  * @property {showPointerDuration} number
  * @property {*} pointer - used for controlling the pointer of the tour
  *
- * @typedef ConsumeEvent
- * @property {string} name
- * @property {Element} target
- * @property {(ev: Event) => boolean} conditional
  */
 
 /**
@@ -153,70 +144,6 @@ function describeFailedStepDetailed(tour, step) {
 }
 
 /**
- * Returns the element that will be used in listening to the `consumeEvent`.
- * @param {HTMLElement} el
- * @param {string} consumeEvent
- */
-function getAnchorEl(el, consumeEvent) {
-    if (consumeEvent === "drag") {
-        // jQuery-ui draggable triggers 'drag' events on the .ui-draggable element,
-        // but the tip is attached to the .ui-draggable-handle element which may
-        // be one of its children (or the element itself)
-        return el.closest(".ui-draggable, .o_draggable");
-    }
-
-    if (consumeEvent === "input" && !["textarea", "input"].includes(el.tagName.toLowerCase())) {
-        return el.closest("[contenteditable='true']");
-    }
-    if (consumeEvent === "sort") {
-        // when an element is dragged inside a sortable container (with classname
-        // 'ui-sortable'), jQuery triggers the 'sort' event on the container
-        return el.closest(".ui-sortable, .o_sortable");
-    }
-    return el;
-}
-
-/**
- * Check if a step is active dependant on step.isActive property
- * Note that when step.isActive is not defined, the step is active by default.
- * When a step is not active, it's just skipped and the tour continues to the next step.
- * @param {TourStep} step
- * @param {TourMode} mode TourMode manual means onboarding tour
- */
-function isActive(step, mode) {
-    const isSmall = utils.isSmall();
-    const standardKeyWords = ["enterprise", "community", "mobile", "desktop", "auto", "manual"];
-    const isActiveArray = Array.isArray(step.isActive) ? step.isActive : [];
-    if (isActiveArray.length === 0) {
-        return true;
-    }
-    const selectors = isActiveArray.filter((key) => !standardKeyWords.includes(key));
-    if (selectors.length) {
-        // if one of selectors is not found, step is skipped
-        for (const selector of selectors) {
-            const el = hoot.queryFirst(selector);
-            if (!el) {
-                return false;
-            }
-        }
-    }
-    const checkMode =
-        isActiveArray.includes(mode) ||
-        (!isActiveArray.includes("manual") && !isActiveArray.includes("auto"));
-    const edition = (session.server_version_info || "").at(-1) === "e" ? "enterprise" : "community";
-    const checkEdition =
-        isActiveArray.includes(edition) ||
-        (!isActiveArray.includes("enterprise") && !isActiveArray.includes("community"));
-    const onlyForMobile = isActiveArray.includes("mobile") && isSmall;
-    const onlyForDesktop = isActiveArray.includes("desktop") && !isSmall;
-    const checkDevice =
-        onlyForMobile ||
-        onlyForDesktop ||
-        (!isActiveArray.includes("mobile") && !isActiveArray.includes("desktop"));
-    return checkEdition && checkDevice && checkMode;
-}
-
-/**
  * IMPROVEMENT: Consider transitioning (moving) elements?
  * @param {Element} el
  * @param {TourStep} step
@@ -272,307 +199,6 @@ function throwError(tour, step, errors = []) {
         // eslint-disable-next-line no-debugger
         debugger;
     }
-}
-
-/**
- * @param {Object} params
- * @param {HTMLElement} params.anchorEl
- * @param {import("./tour_utils").ConsumeEvent[]} params.consumeEvents
- * @param {() => void} params.onMouseEnter
- * @param {() => void} params.onMouseLeave
- * @param {(ev: Event) => any} params.onScroll
- * @param {(ev: Event) => any} params.onConsume
- * @param {(ev: Event) => any | undefined} params.onMiss
- */
-function setupListeners({
-    anchorEl,
-    consumeEvents,
-    onMouseEnter,
-    onMouseLeave,
-    onScroll,
-    onConsume,
-}) {
-    let altOnConsume;
-    for (const event of consumeEvents) {
-        if (event.name === "pointerup") {
-            altOnConsume = (ev) => {
-                if (document.elementsFromPoint(ev.clientX, ev.clientY).includes(event.target)) {
-                    onConsume();
-                }
-            };
-            document.addEventListener(event.name, altOnConsume);
-            continue;
-        }
-
-        altOnConsume = !event.conditional
-            ? onConsume
-            : function (ev) {
-                  if (event.conditional(ev)) {
-                      onConsume();
-                  }
-              };
-        event.target.addEventListener(event.name, altOnConsume, true);
-    }
-    anchorEl.addEventListener("mouseenter", onMouseEnter);
-    anchorEl.addEventListener("mouseleave", onMouseLeave);
-
-    const cleanups = [
-        () => {
-            for (const event of consumeEvents) {
-                if (event.name === "pointerup") {
-                    document.removeEventListener(event.name, altOnConsume);
-                } else {
-                    event.target.removeEventListener(event.name, altOnConsume, true);
-                }
-            }
-            anchorEl.removeEventListener("mouseenter", onMouseEnter);
-            anchorEl.removeEventListener("mouseleave", onMouseLeave);
-        },
-    ];
-
-    const scrollEl = getScrollParent(anchorEl);
-    if (scrollEl) {
-        const debouncedOnScroll = debounce(onScroll, 50);
-        scrollEl.addEventListener("scroll", debouncedOnScroll);
-        cleanups.push(() => scrollEl.removeEventListener("scroll", debouncedOnScroll));
-    }
-
-    return () => {
-        while (cleanups.length) {
-            cleanups.pop()();
-        }
-    };
-}
-
-/**
- *
- * @param {TourStep} step
- * @returns {{
- *  event: string,
- *  anchor: string,
- *  altAnchor: string | undefined,
- * }[]}
- */
-function getSubActions(step) {
-    const actions = [];
-    if (!step.run || typeof step.run === "function") {
-        return [];
-    }
-
-    for (const todo of step.run.split("&&")) {
-        const m = String(todo)
-            .trim()
-            .match(/^(?<action>\w*) *\(? *(?<arguments>.*?)\)?$/);
-
-        const action = m.groups?.action;
-        const anchor = m.groups?.arguments || step.trigger;
-        if (action === "drag_and_drop") {
-            actions.push({
-                event: "drag",
-                anchor: step.trigger,
-            });
-            actions.push({
-                event: "drop",
-                anchor,
-            });
-        } else {
-            actions.push({
-                event: action,
-                anchor: action === "edit" ? step.trigger : anchor,
-                altAnchor: step.alt_trigger,
-            });
-        }
-    }
-
-    return actions;
-}
-
-/**
- * @param {HTMLElement} [element]
- * @param {RunCommand} [runCommand]
- * @returns {ConsumeEvent[]}
- */
-function getConsumeEventType(element, runCommand) {
-    const consumeEvents = [];
-    if (runCommand === "click") {
-        consumeEvents.push({
-            name: "click",
-            target: element,
-        });
-
-        // Use the hotkey should also consume
-        if (element.hasAttribute("data-hotkey")) {
-            consumeEvents.push({
-                name: "keydown",
-                target: element,
-                conditional: (ev) =>
-                    ev.key === element.getAttribute("data-hotkey") &&
-                    (isMacOS() ? ev.ctrlKey : ev.altKey),
-            });
-        }
-
-        // Click on a field widget with an autocomplete should be also completed with a selection though Enter or Tab
-        // This case is for the steps that click on field_widget
-        if (element.querySelector(".o-autocomplete--input")) {
-            consumeEvents.push({
-                name: "keydown",
-                target: element.querySelector(".o-autocomplete--input"),
-                conditional: (ev) =>
-                    ["Tab", "Enter"].includes(ev.key) &&
-                    ev.target.parentElement.querySelector(
-                        ".o-autocomplete--dropdown-item .ui-state-active"
-                    ),
-            });
-        }
-
-        // Click on an element of a dropdown should be also completed with a selection though Enter or Tab
-        // This case is for the steps that click on a dropdown-item
-        if (element.closest(".o-autocomplete--dropdown-menu")) {
-            consumeEvents.push({
-                name: "keydown",
-                target: element.closest(".o-autocomplete").querySelector("input"),
-                conditional: (ev) => ["Tab", "Enter"].includes(ev.key),
-            });
-        }
-
-        // Press enter on a button do the same as a click
-        if (element.tagName === "BUTTON") {
-            consumeEvents.push({
-                name: "keydown",
-                target: element,
-                conditional: (ev) => ev.key === "Enter",
-            });
-
-            // Pressing enter in the input group does the same as clicking on the button
-            if (element.closest(".input-group")) {
-                for (const inputEl of element.parentElement.querySelectorAll("input")) {
-                    consumeEvents.push({
-                        name: "keydown",
-                        target: inputEl,
-                        conditional: (ev) => ev.key === "Enter",
-                    });
-                }
-            }
-        }
-    }
-
-    if (["fill", "edit"].includes(runCommand)) {
-        if (
-            utils.isSmall() &&
-            element.closest(".o_field_widget")?.matches(".o_field_many2one, .o_field_many2many")
-        ) {
-            consumeEvents.push({
-                name: "click",
-                target: element,
-            });
-        } else {
-            consumeEvents.push({
-                name: "input",
-                target: element,
-            });
-        }
-    }
-
-    // Drag & drop run command
-    if (runCommand === "drag") {
-        consumeEvents.push({
-            name: "pointerdown",
-            target: element,
-        });
-    }
-
-    if (runCommand === "drop") {
-        consumeEvents.push({
-            name: "pointerup",
-            target: element,
-        });
-    }
-
-    return consumeEvents;
-}
-
-/** @type {TourStepCompiler} */
-export function compileStepManual(stepIndex, step, options) {
-    const { tour, pointer, onStepConsummed } = options;
-    let currentSubStep = 0;
-    const subSteps = [];
-    let anchorEl;
-    let removeListeners = () => {};
-
-    const subActions = getSubActions(step);
-    if (!subActions.length) {
-        return [];
-    }
-
-    for (const [subActionIndex, subAction] of subActions.entries()) {
-        subSteps.push({
-            trigger: () => {
-                removeListeners();
-
-                if (!isActive(step, "manual")) {
-                    return hoot.queryFirst(".o-main-components-container");
-                }
-
-                if (subActionIndex < currentSubStep) {
-                    return anchorEl;
-                }
-
-                anchorEl = hoot.queryFirst(subAction.anchor);
-                const debouncedToggleOpen = debounce(pointer.showContent, 50, true);
-
-                if (anchorEl && canContinue(anchorEl, step)) {
-                    anchorEl = getAnchorEl(anchorEl, subAction.event);
-                    const consumeEvents = getConsumeEventType(anchorEl, subAction.event);
-
-                    if (subAction.altAnchor) {
-                        let altAnchorEl = hoot.queryAll(subAction.altAnchor).at(0);
-                        altAnchorEl = getAnchorEl(altAnchorEl, subAction.event);
-                        consumeEvents.push(...getConsumeEventType(altAnchorEl, subAction.event));
-                    }
-
-                    const updatePointer = () => {
-                        pointer.pointTo(anchorEl, step, subAction.event === "drop");
-
-                        pointer.setState({
-                            onMouseEnter: () => debouncedToggleOpen(true),
-                            onMouseLeave: () => debouncedToggleOpen(false),
-                        });
-                    };
-
-                    removeListeners = setupListeners({
-                        anchorEl,
-                        consumeEvents,
-                        onMouseEnter: () => pointer.showContent(true),
-                        onMouseLeave: () => pointer.showContent(false),
-                        onScroll: updatePointer,
-                        onConsume: () => {
-                            currentSubStep++;
-                            pointer.hide();
-                        },
-                    });
-
-                    updatePointer();
-                } else {
-                    pointer.hide();
-                }
-            },
-        });
-    }
-
-    subSteps.at(-1)["action"] = () => {
-        tourState.set(tour.name, "currentIndex", stepIndex + 1);
-        tourState.set(tour.name, "stepState", "succeeded");
-        pointer.hide();
-        currentSubStep = 0;
-        onStepConsummed(tour, step);
-    };
-
-    return [
-        {
-            action: () => console.log(step.trigger),
-        },
-        ...subSteps,
-    ];
 }
 
 let tourTimeout;
@@ -722,7 +348,6 @@ export function compileStepAuto(stepIndex, step, options) {
 export function compileTourToMacro(tour, options) {
     const {
         filteredSteps,
-        mode,
         pointer,
         stepDelay,
         keepWatchBrowser,
@@ -731,12 +356,9 @@ export function compileTourToMacro(tour, options) {
         onTourEnd,
     } = options;
     const currentStepIndex = tourState.get(tour.name, "currentIndex");
-    const stepCompiler = mode === "auto" ? compileStepAuto : compileStepManual;
-    const checkDelay = mode === "auto" ? tour.checkDelay : 100;
 
     return {
         ...tour,
-        checkDelay,
         steps: filteredSteps
             .reduce((newSteps, step, i) => {
                 if (i < currentStepIndex) {
@@ -745,7 +367,7 @@ export function compileTourToMacro(tour, options) {
                 } else {
                     return [
                         ...newSteps,
-                        ...stepCompiler(i, step, {
+                        ...compileStepAuto(i, step, {
                             tour,
                             pointer,
                             stepDelay,
@@ -761,7 +383,6 @@ export function compileTourToMacro(tour, options) {
                     action() {
                         clearTimeout(tourTimeout);
                         if (tourState.get(tour.name, "stepState") === "succeeded") {
-                            tourState.clear(tour.name);
                             onTourEnd(tour);
                         } else {
                             console.error("tour not succeeded");

--- a/addons/web_tour/static/src/tour_service/tour_interactive.js
+++ b/addons/web_tour/static/src/tour_service/tour_interactive.js
@@ -1,0 +1,395 @@
+import { tourState } from "./tour_state";
+import { debounce } from "@web/core/utils/timing";
+import { isMacOS } from "@web/core/browser/feature_detection";
+import { getScrollParent, isActive } from "./tour_utils";
+import * as hoot from "@odoo/hoot-dom";
+import { utils } from "@web/core/ui/ui_service";
+
+/**
+ * @typedef ConsumeEvent
+ * @property {string} name
+ * @property {Element} target
+ * @property {(ev: Event) => boolean} conditional
+ */
+
+export class TourInteractive {
+    constructor() {
+        this.anchorEl;
+        this.currentAction;
+        this.currentActionIndex;
+        this.removeListeners = () => {};
+        this.observerOptions = {
+            attributes: true,
+            childList: true,
+            subtree: true,
+            characterData: true,
+        };
+        this.observer = new MutationObserver(() => {
+            if (this.currentAction) {
+                let tempAnchor = hoot.queryFirst(this.currentAction.anchor);
+                tempAnchor = tempAnchor && this.getAnchorEl(tempAnchor, this.currentAction.event);
+                if (
+                    (!this.anchorEl && tempAnchor) ||
+                    (this.anchorEl && tempAnchor && tempAnchor !== this.anchorEl)
+                ) {
+                    this.anchorEl = tempAnchor;
+                    this.removeListeners();
+                    this.setActionListeners();
+                } else if (!tempAnchor && this.anchorEl) {
+                    this.pointer.hide();
+                    this.anchorEl = tempAnchor;
+                    if (!hoot.queryFirst(".o_home_menu")) {
+                        this.backward();
+                    }
+                }
+                this.updatePointer();
+            }
+        });
+    }
+
+    /**
+     * @param {import("./tour_service").Tour} tour
+     * @param {import("@web_tour/tour_pointer/tour_pointer").TourPointer} pointer
+     * @param {Function} onTourEnd
+     */
+    loadTour(tour, pointer, onTourEnd) {
+        this.tourName = tour.name;
+        this.actions = tour.steps.flatMap((s) => this.getSubActions(s));
+        this.pointer = pointer;
+        this.debouncedToggleOpen = debounce(this.pointer.showContent, 50, true);
+        this.onTourEnd = onTourEnd;
+    }
+
+    /**
+     *
+     * @param {Number} stepAt Step to start at
+     */
+    start(stepAt = 0) {
+        this.pointer.start();
+        this.observer.observe(document.body, this.observerOptions);
+        this.currentActionIndex = stepAt;
+        this.play();
+    }
+
+    backward() {
+        let tempIndex = this.currentActionIndex;
+        let tempAction, tempAnchor;
+
+        while (!tempAnchor && tempIndex >= 0) {
+            tempIndex--;
+            tempAction = this.actions.at(tempIndex);
+            if (!isActive({ isActive: tempAction.isActive }, "manual")) {
+                continue;
+            }
+            tempAnchor = tempAction && hoot.queryFirst(tempAction.anchor);
+        }
+
+        if (tempIndex >= 0) {
+            this.currentActionIndex = tempIndex;
+            this.play();
+        }
+    }
+
+    play() {
+        this.removeListeners();
+        if (this.currentActionIndex === this.actions.length) {
+            this.observer.disconnect();
+            this.onTourEnd();
+            return;
+        }
+
+        this.currentAction = this.actions.at(this.currentActionIndex);
+        if (!isActive({ isActive: this.currentAction.isActive }, "manual")) {
+            this.currentActionIndex++;
+            this.play();
+            return;
+        }
+
+        console.log(this.currentAction.event, this.currentAction.anchor);
+        this.anchorEl = hoot.queryFirst(this.currentAction.anchor);
+        tourState.set(this.tourName, "currentIndex", this.currentActionIndex);
+        this.setActionListeners();
+    }
+
+    updatePointer() {
+        this.pointer.pointTo(
+            this.anchorEl,
+            this.currentAction.pointerInfo,
+            this.currentAction.event === "drop"
+        );
+        this.pointer.setState({
+            onMouseEnter: () => this.debouncedToggleOpen(true),
+            onMouseLeave: () => this.debouncedToggleOpen(false),
+        });
+    }
+
+    setActionListeners() {
+        if (this.anchorEl) {
+            this.anchorEl = this.getAnchorEl(this.anchorEl, this.currentAction.event);
+            const consumeEvents = this.getConsumeEventType(this.anchorEl, this.currentAction.event);
+            this.removeListeners = this.setupListeners({
+                anchorEl: this.anchorEl,
+                consumeEvents,
+                onMouseEnter: () => this.pointer.showContent(true),
+                onMouseLeave: () => this.pointer.showContent(false),
+                onScroll: () => this.updatePointer(),
+                onConsume: () => {
+                    this.pointer.hide();
+                    this.currentActionIndex++;
+                    this.play();
+                },
+                onError: () => {
+                    if (this.currentAction.event === "drop") {
+                        this.pointer.hide();
+                        this.currentActionIndex--;
+                        this.play();
+                    }
+                },
+            });
+            this.updatePointer();
+        }
+    }
+
+    /**
+     * @param {HTMLElement} params.anchorEl
+     * @param {import("./tour_utils").ConsumeEvent[]} params.consumeEvents
+     * @param {() => void} params.onMouseEnter
+     * @param {() => void} params.onMouseLeave
+     * @param {(ev: Event) => any} params.onScroll
+     * @param {(ev: Event) => any} params.onConsume
+     * @param {() => any} params.onError
+     */
+    setupListeners({
+        anchorEl,
+        consumeEvents,
+        onMouseEnter,
+        onMouseLeave,
+        onScroll,
+        onConsume,
+        onError = () => {},
+    }) {
+        consumeEvents = consumeEvents.map((c) => ({
+            target: c.target,
+            type: c.name,
+            listener: function (ev) {
+                if (!c.conditional || c.conditional(ev)) {
+                    onConsume();
+                } else {
+                    onError();
+                }
+            },
+        }));
+
+        for (const consume of consumeEvents) {
+            consume.target.addEventListener(consume.type, consume.listener, true);
+        }
+        anchorEl.addEventListener("mouseenter", onMouseEnter);
+        anchorEl.addEventListener("mouseleave", onMouseLeave);
+
+        const cleanups = [
+            () => {
+                for (const consume of consumeEvents) {
+                    consume.target.removeEventListener(consume.type, consume.listener, true);
+                }
+                anchorEl.removeEventListener("mouseenter", onMouseEnter);
+                anchorEl.removeEventListener("mouseleave", onMouseLeave);
+            },
+        ];
+
+        const scrollEl = getScrollParent(anchorEl);
+        if (scrollEl) {
+            const debouncedOnScroll = debounce(onScroll, 50);
+            scrollEl.addEventListener("scroll", debouncedOnScroll);
+            cleanups.push(() => scrollEl.removeEventListener("scroll", debouncedOnScroll));
+        }
+
+        return () => {
+            while (cleanups.length) {
+                cleanups.pop()();
+            }
+        };
+    }
+
+    /**
+     *
+     * @param {import("./tour_service").TourStep} step
+     * @returns {{
+     *  event: string,
+     *  anchor: string,
+     *  altAnchor: string?,
+     *  isActive: string[]?,
+     *  pointerInfo: { position: string?, content: string? },
+     * }[]}
+     */
+    getSubActions(step) {
+        const actions = [];
+        if (!step.run || typeof step.run === "function") {
+            return [];
+        }
+
+        for (const todo of step.run.split("&&")) {
+            const m = String(todo)
+                .trim()
+                .match(/^(?<action>\w*) *\(? *(?<arguments>.*?)\)?$/);
+
+            let action = m.groups?.action;
+            const anchor = m.groups?.arguments || step.trigger;
+            const pointerInfo = {
+                content: step.content,
+                position: step.position,
+            };
+
+            if (action === "drag_and_drop") {
+                actions.push({
+                    event: "drag",
+                    anchor: step.trigger,
+                    pointerInfo,
+                    isActive: step.isActive,
+                });
+                action = "drop";
+            }
+
+            actions.push({
+                event: action,
+                anchor: action === "edit" ? step.trigger : anchor,
+                altAnchor: step.alt_trigger,
+                pointerInfo,
+                isActive: step.isActive,
+            });
+        }
+
+        return actions;
+    }
+
+    /**
+     * @param {HTMLElement} [element]
+     * @param {string} [runCommand]
+     * @returns {ConsumeEvent[]}
+     */
+    getConsumeEventType(element, runCommand) {
+        const consumeEvents = [];
+        if (runCommand === "click") {
+            consumeEvents.push({
+                name: "click",
+                target: element,
+            });
+
+            // Use the hotkey should also consume
+            if (element.hasAttribute("data-hotkey")) {
+                consumeEvents.push({
+                    name: "keydown",
+                    target: element,
+                    conditional: (ev) =>
+                        ev.key === element.getAttribute("data-hotkey") &&
+                        (isMacOS() ? ev.ctrlKey : ev.altKey),
+                });
+            }
+
+            // Click on a field widget with an autocomplete should be also completed with a selection though Enter or Tab
+            // This case is for the steps that click on field_widget
+            if (element.querySelector(".o-autocomplete--input")) {
+                consumeEvents.push({
+                    name: "keydown",
+                    target: element.querySelector(".o-autocomplete--input"),
+                    conditional: (ev) =>
+                        ["Tab", "Enter"].includes(ev.key) &&
+                        ev.target.parentElement.querySelector(
+                            ".o-autocomplete--dropdown-item .ui-state-active"
+                        ),
+                });
+            }
+
+            // Click on an element of a dropdown should be also completed with a selection though Enter or Tab
+            // This case is for the steps that click on a dropdown-item
+            if (element.closest(".o-autocomplete--dropdown-menu")) {
+                consumeEvents.push({
+                    name: "keydown",
+                    target: element.closest(".o-autocomplete").querySelector("input"),
+                    conditional: (ev) => ["Tab", "Enter"].includes(ev.key),
+                });
+            }
+
+            // Press enter on a button do the same as a click
+            if (element.tagName === "BUTTON") {
+                consumeEvents.push({
+                    name: "keydown",
+                    target: element,
+                    conditional: (ev) => ev.key === "Enter",
+                });
+
+                // Pressing enter in the input group does the same as clicking on the button
+                if (element.closest(".input-group")) {
+                    for (const inputEl of element.parentElement.querySelectorAll("input")) {
+                        consumeEvents.push({
+                            name: "keydown",
+                            target: inputEl,
+                            conditional: (ev) => ev.key === "Enter",
+                        });
+                    }
+                }
+            }
+        }
+
+        if (["fill", "edit"].includes(runCommand)) {
+            if (
+                utils.isSmall() &&
+                element.closest(".o_field_widget")?.matches(".o_field_many2one, .o_field_many2many")
+            ) {
+                consumeEvents.push({
+                    name: "click",
+                    target: element,
+                });
+            } else {
+                consumeEvents.push({
+                    name: "input",
+                    target: element,
+                });
+            }
+        }
+
+        // Drag & drop run command
+        if (runCommand === "drag") {
+            consumeEvents.push({
+                name: "pointerdown",
+                target: element,
+            });
+        }
+
+        if (runCommand === "drop") {
+            consumeEvents.push({
+                name: "pointerup",
+                target: document,
+                conditional: (ev) =>
+                    element.ownerDocument
+                        .elementsFromPoint(ev.clientX, ev.clientY)
+                        .includes(element),
+            });
+        }
+
+        return consumeEvents;
+    }
+
+    /**
+     * Returns the element that will be used in listening to the `consumeEvent`.
+     * @param {HTMLElement} el
+     * @param {string} consumeEvent
+     */
+    getAnchorEl(el, consumeEvent) {
+        if (consumeEvent === "drag") {
+            // jQuery-ui draggable triggers 'drag' events on the .ui-draggable element,
+            // but the tip is attached to the .ui-draggable-handle element which may
+            // be one of its children (or the element itself)
+            return el.closest(".ui-draggable, .o_draggable, .o_we_draggable");
+        }
+
+        if (consumeEvent === "input" && !["textarea", "input"].includes(el.tagName.toLowerCase())) {
+            return el.closest("[contenteditable='true']");
+        }
+        if (consumeEvent === "sort") {
+            // when an element is dragged inside a sortable container (with classname
+            // 'ui-sortable'), jQuery triggers the 'sort' event on the container
+            return el.closest(".ui-sortable, .o_sortable");
+        }
+        return el;
+    }
+}

--- a/addons/web_tour_recorder/static/tests/tour_recorder.test.js
+++ b/addons/web_tour_recorder/static/tests/tour_recorder.test.js
@@ -6,6 +6,7 @@ import {
     defineWebModels,
     getService,
     mountWithCleanup,
+    onRpc,
     patchWithCleanup,
     serverState,
 } from "@web/../tests/web_test_helpers";
@@ -498,6 +499,9 @@ test("Run custom tour", async () => {
 });
 
 test("Run a custom tour twice doesn't trigger traceback", async () => {
+    onRpc("/web/dataset/call_kw/web_tour.tour/consume", async () => {
+        return Promise.resolve(true);
+    });
     await mountWithCleanup(
         `
         <div class="o_parent">
@@ -541,5 +545,8 @@ test("Run a custom tour twice doesn't trigger traceback", async () => {
 
     expect("table tr td:contains('tour_name')").toHaveCount(2);
     click(".o_start_tour:eq(1)");
+    await animationFrame();
+
+    click(".o_parent > div");
     await animationFrame();
 });


### PR DESCRIPTION
Before, the manual tour and auto tour were using the same mecanism. Now, it separate to be more appropriate.
The auto tour should keep using a macro engine because it's a automatically executing engine. But the manual tour is a functionality that is interacting with the user. So the use an interactive tour engine is more appropriate.

With this new engine, a new functionality has been added. The tour can now backward. It's used here for backward when the pointer lose the trigger of the step. It will backward until a step that have a trigger on the view.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
