### PR TITLE
[FIX] hr_recruitment : fix applicant's partner name

### DIFF
--- a/addons/hr_recruitment/models/hr_applicant.py
+++ b/addons/hr_recruitment/models/hr_applicant.py
@@ -354,7 +354,7 @@ class Applicant(models.Model):
                 if not applicant.partner_name:
                     raise UserError(_('You must define a Contact Name for this applicant.'))
                 applicant.partner_id = self.env['res.partner'].find_or_create(applicant.email_from)
-            if applicant.partner_name and not applicant.partner_id.name:
+            if applicant.partner_name and applicant.partner_id.name == applicant.email_from:
                 applicant.partner_id.name = applicant.partner_name
             if tools.email_normalize(applicant.email_from) != tools.email_normalize(applicant.partner_id.email):
                 # change email on a partner will trigger other heavy code, so avoid to change the email when


### PR DESCRIPTION
STEP TO REPRODUCE:
==================

1- Go on recruitment application
2- Click on applications/All applications
3- Click on new
4- Write this in the form view :
    A- "manager" in subject/application
    B- "Milly" in Applicant's name
    C- "thefunnyguys@example.com" in Email
5- Save it
6- Go in contact application
7- search thefunnyguys

Current Behaviour:
===================
You will find a partner with this name and this email.

Expected Behaviour:
===================
The name of this partner should be "Milly" not the email adress.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
