### PR TITLE
[REF] web_tour: remove alt_trigger from step tour structure

### DIFF
--- a/addons/web_tour/static/src/tour_service/tour_service.js
+++ b/addons/web_tour/static/src/tour_service/tour_service.js
@@ -34,7 +34,6 @@ import { callWithUnloadCheck } from "./tour_utils";
  * @property {"enterprise"|"community"|"mobile"|"desktop"|HootSelector[][]} isActive Active the step following {@link isActiveStep} filter
  * @property {string} [id]
  * @property {HootSelector} trigger The node on which the action will be executed.
- * @property {HootSelector} [alt_trigger] An alternative node to the trigger (trigger or alt_trigger).
  * @property {string} [content] Description of the step.
  * @property {"top" | "botton" | "left" | "right"} [position] The position where the UI helper is shown.
  * @property {"community" | "enterprise"} [edition]
@@ -64,7 +63,6 @@ function checkTourStepKeyValues(tourStep) {
     const stepschema = {
         id: { type: String, optional: true },
         trigger: { type: String },
-        alt_trigger: { type: String, optional: true },
         isActive: { type: Array, element: String, optional: true },
         content: { type: [String, Object], optional: true }, //allow object for _t && markup
         position: { type: String, optional: true },

--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -60,8 +60,8 @@ function changeBackgroundColor(position = "bottom") {
 
 function selectColorPalette(position = "left") {
     return {
-        trigger: ".o_we_customize_panel .o_we_so_color_palette we-selection-items",
-        alt_trigger: ".o_we_customize_panel .o_we_color_preview",
+        trigger:
+            ".o_we_customize_panel .o_we_so_color_palette we-selection-items, .o_we_customize_panel .o_we_color_preview",
         content: markup(_t(`<b>Select</b> a Color Palette.`)),
         position: position,
         run: 'click',
@@ -108,13 +108,12 @@ function changeOption(optionName, weName = '', optionTooltipLabel = '', position
     };
 }
 
-function selectNested(trigger, optionName, alt_trigger = null, optionTooltipLabel = '', position = "top", allowPalette = false) {
+function selectNested(trigger, optionName, altTrigger = null, optionTooltipLabel = '', position = "top", allowPalette = false) {
     const noPalette = allowPalette ? '' : '.o_we_customize_panel:not(:has(.o_we_so_color_palette.o_we_widget_opened))';
     const option_block = `${noPalette} we-customizeblock-option[class='snippet-option-${optionName}']`;
     return {
-        trigger: trigger,
+        trigger: trigger + (altTrigger ? `, ${option_block} ${altTrigger}` : ""),
         content: markup(_t("<b>Select</b> a %s.", optionTooltipLabel)),
-        alt_trigger: alt_trigger == null ? undefined : `${option_block} ${alt_trigger}`,
         position: position,
         run: 'click',
     };


### PR DESCRIPTION
In this commit, we remove the alt_trigger key from the structure of a
tour step. For all cases in codebase, only adding a comma to selector
is enough.

task~3974087

https://github.com/odoo/enterprise/pull/66636