### PR TITLE
[FIX] point_of_sale: prevent error with an archived parent category

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -2005,7 +2005,8 @@ class PosSession(models.Model):
         categories = self.env['product.category'].search_read(**params['search_params'])
         category_by_id = {category['id']: category for category in categories}
         for category in categories:
-            category['parent'] = category_by_id[category['parent_id'][0]] if category['parent_id'] else None
+            parent_id = category['parent_id'][0] if category['parent_id'] else None
+            category['parent'] = category_by_id.get(parent_id)
         return categories
 
     def _loader_params_res_currency(self):


### PR DESCRIPTION
Before this commit, attempting to open a PoS session with a product category whose parent category was archived would result in an error.

opw-4050863

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
