### PR TITLE
[FIX] im_livechat: do not show unread banner with chat bot

### DIFF
--- a/addons/im_livechat/static/src/embed/common/thread_model_patch.js
+++ b/addons/im_livechat/static/src/embed/common/thread_model_patch.js
@@ -64,4 +64,11 @@ patch(Thread.prototype, {
         this.store.env.services["im_livechat.chatbot"].bus.trigger("MESSAGE_POST", message);
         return message;
     },
+
+    get showUnreadBanner() {
+        if (this.chatbot && !this.chatbot.currentStep?.operatorFound) {
+            return false;
+        }
+        return super.showUnreadBanner;
+    },
 });

--- a/addons/mail/static/src/core/common/thread.xml
+++ b/addons/mail/static/src/core/common/thread.xml
@@ -107,7 +107,7 @@
 </t>
 
 <t t-name="mail.Thread.jumpUnread">
-    <span t-if="props.thread.selfMember?.localMessageUnreadCounter > 0" class="o-mail-Thread-banner d-flex cursor-pointer shadow-sm small fw-bold">
+    <span t-if="props.thread.showUnreadBanner" class="o-mail-Thread-banner d-flex cursor-pointer shadow-sm small fw-bold">
         <t t-set="alertClass" t-value="'alert alert-info m-0 border-start-0 o-mail-Thread-bannerHover rounded-0 py-1'"/>
         <span t-attf-class="{{ alertClass }} flex-grow-1" t-on-click="onClickUnreadMessagesBanner" t-esc="newMessageBannerText"/>
         <span t-attf-class="{{ alertClass }}" t-on-click="() => props.thread.markAsRead({ sync: true })">Mark as Read<i class="ms-2 fa fa-check-square"/></span>

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -562,6 +562,10 @@ export class Thread extends Record {
         return this.isChatChannel ? "@" : "#";
     }
 
+    get showUnreadBanner() {
+        return this.selfMember?.localMessageUnreadCounter > 0;
+    }
+
     /** @type {undefined|number[]} */
     lastMessageSeenByAllId = Record.attr(undefined, {
         compute() {


### PR DESCRIPTION
The unread message banner helps users keep track of which messages
they have read in a conversation. However, this does not make sense
with the chat bot: the bot waits for the visitor's input at each step,
so users do not need to remember where they left off when returning to
the discussion. In this case, the banner is just unnecessary visual
noise.

This PR removes the banner when the chat bot handles the discussion
with the visitor.