### PR TITLE
[FIX] phone_validation: check for `pg_trgm` before creating trgm index

### DIFF
--- a/addons/phone_validation/models/mail_thread_phone.py
+++ b/addons/phone_validation/models/mail_thread_phone.py
@@ -65,13 +65,14 @@ class PhoneMixin(models.AbstractModel):
                          tablename=self._table,
                          expressions=[regex_expression],
                          where=f'{fname} IS NOT NULL')
-            # The trigram index covers operators 'like', 'ilike' and '=like' starting with a wildcard
-            create_index(self.env.cr,
-                         indexname=f'{self._table}_{fname}_partial_gin_idx',
-                         tablename=self._table,
-                         method='gin',
-                         expressions=[regex_expression + ' gin_trgm_ops'],
-                         where=f'{fname} IS NOT NULL')
+            if self.env.registry.has_trigram:
+                # The trigram index covers operators 'like', 'ilike' and '=like' starting with a wildcard
+                create_index(self.env.cr,
+                             indexname=f'{self._table}_{fname}_partial_gin_idx',
+                             tablename=self._table,
+                             method='gin',
+                             expressions=[regex_expression + ' gin_trgm_ops'],
+                             where=f'{fname} IS NOT NULL')
 
     def _search_phone_mobile_search(self, operator, value):
         value = value.strip() if isinstance(value, str) else value


### PR DESCRIPTION
## Description
Following https://github.com/odoo/odoo/commit/19d97aeb262e99f8f31d66d7411793e9807e4522, installing modules that inherit from `mail.thread.phone` mixin on a db that doesn't have the `pg_trgm` extension will fail at module installation when trying to create the trigram index.

## Fix
Add a check with `has_trigram` before the creation of the trigram index.

## References
opw-4052670

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
