### PR TITLE
[FIX] pos_self_order: fix default user for self order

### DIFF
--- a/addons/pos_self_order/models/pos_config.py
+++ b/addons/pos_self_order/models/pos_config.py
@@ -25,8 +25,13 @@ class PosConfig(models.Model):
 
     def _self_order_default_user(self):
         user_ids = self.env["res.users"].search(['|', ('company_id', '=', self.env.company.id), ('company_id', '=', False)])
+        admin_user_ids = user_ids.filtered(lambda u: u.has_group("point_of_sale.group_pos_manager"))
+
+        if admin_user_ids:
+            return admin_user_ids[0]
+
         for user_id in user_ids:
-            if user_id.has_group("point_of_sale.group_pos_user") or user_id.has_group("point_of_sale.group_pos_manager"):
+            if user_id.has_group("point_of_sale.group_pos_user"):
                 return user_id
 
     status = fields.Selection(

--- a/addons/pos_self_order/tests/self_order_common_test.py
+++ b/addons/pos_self_order/tests/self_order_common_test.py
@@ -141,7 +141,6 @@ class SelfOrderCommonTest(odoo.tests.HttpCase):
         self.pos_config = self.env["pos.config"].create(
             {
                 "name": "BarTest",
-                "self_ordering_default_user_id": self.pos_user.id,
                 "module_pos_restaurant": True,
                 "self_ordering_mode": "consultation",
                 "floor_ids": self.env["restaurant.floor"].search([]),


### PR DESCRIPTION
Before, the default user assigned to the self order was a standard pos user.

This commit changes the default user to pos_manager to avoid any access rights issues.

RB error: 70391

