### PR TITLE
[REV] mass_mailing: prevent snippet compressed mode

### DIFF
--- a/addons/mass_mailing/static/src/scss/mass_mailing.scss
+++ b/addons/mass_mailing/static/src/scss/mass_mailing.scss
@@ -23,11 +23,6 @@
 
 .o_form_view.o_mass_mailing_mailing_form .wysiwyg_iframe {
     border: none;
-    flex: auto 1 0;
-}
-
-.o_form_fullscreen_ancestor .wysiwyg_iframe {
-    width: calc(100% - #{$o-we-sidebar-width}) !important;
 }
 
 .o_form_view.o_mass_mailing_mailing_form .o_form_renderer {

--- a/addons/mass_mailing/static/src/scss/mass_mailing.wysiwyg.scss
+++ b/addons/mass_mailing/static/src/scss/mass_mailing.wysiwyg.scss
@@ -103,8 +103,3 @@
     // view. We reduce the width of the chatter to avoid this.
     width: $o-mail-Chatter-minWidth - $o-we-sidebar-width;
 }
-
-.o_mail_body div.d-flex:has(> iframe) {
-    // Center the content within the parent container of the iframe and snippet
-    justify-content: center;
-}


### PR DESCRIPTION
This PR reverts the changes from commit [170126](https://github.com/odoo/odoo/pull/170126/commits/5ee56608c0c397d03a82a8472dfdab46213f6a27)

Because the flex-shrink: 0 is making the iframe overflow and
introduces a horizontal scrollbar

Task-4050207