### PR TITLE
[FIX] web: adapt Many2OneField to new URL format

### DIFF
--- a/addons/web/static/src/views/fields/many2one/many2one_field.js
+++ b/addons/web/static/src/views/fields/many2one/many2one_field.js
@@ -166,6 +166,12 @@ export class Many2OneField extends Component {
     get relation() {
         return this.props.relation || this.props.record.fields[this.props.name].relation;
     }
+    get urlRelation() {
+        if (!this.relation.includes(".")) {
+            return "m-" + this.relation;
+        }
+        return this.relation
+    }
     get string() {
         return this.props.string || this.props.record.fields[this.props.name].string || "";
     }

--- a/addons/web/static/src/views/fields/many2one/many2one_field.xml
+++ b/addons/web/static/src/views/fields/many2one/many2one_field.xml
@@ -28,7 +28,7 @@
                 <a
                     t-if="value"
                     t-attf-class="o_form_uri #{classFromDecoration}"
-                    t-att-href="value ? `#id=${value[0]}&amp;model=${relation}` : '#'"
+                    t-att-href="value ? `/odoo/${urlRelation}/${value[0]}` : '/'"
                     t-on-click.prevent="onClick"
                 >
                     <span t-esc="displayName" />

--- a/addons/web/static/tests/legacy/views/fields/many2one_field_tests.js
+++ b/addons/web/static/tests/legacy/views/fields/many2one_field_tests.js
@@ -71,6 +71,7 @@ QUnit.module("Fields", (hooks) => {
                             relation_field: "turtle_trululu",
                         },
                         trululu: { string: "Trululu", type: "many2one", relation: "partner" },
+                        res_trululu: { string: "Res Trululu", type: "many2one", relation: "res.partner" },
                         timmy: { string: "pokemon", type: "many2many", relation: "partner_type" },
                         product_id: { string: "Product", type: "many2one", relation: "product" },
                         date: { string: "Some Date", type: "date" },
@@ -88,6 +89,7 @@ QUnit.module("Fields", (hooks) => {
                             turtles: [2],
                             timmy: [],
                             trululu: 4,
+                            res_trululu: 1,
                             user_id: 17,
                         },
                         {
@@ -200,6 +202,17 @@ QUnit.module("Fields", (hooks) => {
                         {
                             id: 19,
                             name: "Christine",
+                        },
+                    ],
+                },
+                "res.partner": {
+                    fields: {
+                        name: { string: "Res Partner Name", type: "char" },
+                    },
+                    records: [
+                        {
+                            id: 1,
+                            name: "res partner",
                         },
                     ],
                 },
@@ -1331,16 +1344,24 @@ QUnit.module("Fields", (hooks) => {
             serverData,
             arch: `
                 <form edit="0">
+                    <field name="res_trululu" />
                     <field name="trululu" />
                 </form>`,
         });
 
-        assert.containsOnce(target, "a.o_form_uri", "should display 1 m2o link in form");
+        assert.containsN(target, "a.o_form_uri", 2, "should display 2 m2o links in form");
+        const links = target.querySelectorAll("a.o_form_uri")
         assert.hasAttrValue(
-            target.querySelector("a.o_form_uri"),
+            links[0],
             "href",
-            "#id=4&model=partner",
+            "/odoo/res.partner/1",
             "href should contain id and model"
+        );
+        assert.hasAttrValue(
+            links[1],
+            "href",
+            "/odoo/m-partner/4",
+            "models that do not contain a '.' should be prefixed with 'm-'"
         );
     });
 


### PR DESCRIPTION
Currently, links created with the `Many2OneField` component won't work properly if opened in a new tab.

### Steps to reproduce

* create two partners with the same Tax ID
* each partner should display a link to the other partner, indicating a duplicate Tax ID.
* open one of those links in a new tab

When the link is opened in a new tab, it displays the record you were originally viewing instead of the intended partner.

opw-4050312