### PR TITLE
[IMP] analytic: apply all relevant distribution models

### DIFF
--- a/addons/account/models/account_analytic_distribution_model.py
+++ b/addons/account/models/account_analytic_distribution_model.py
@@ -24,6 +24,19 @@ class AccountAnalyticDistributionModel(models.Model):
         help="Select a product category which will use analytic account specified in analytic default (e.g. create new customer invoice or Sales order if we select this product, it will automatically take this as an analytic account)",
     )
 
+    def _get_default_search_domain_vals(self):
+        return super()._get_default_search_domain_vals() | {
+            'product_id': False,
+            'product_categ_id': False,
+        }
+
+    def _get_applicable_models(self, vals):
+        applicable_models = super()._get_applicable_models(vals)
+        return applicable_models.filtered(lambda m:
+            not m.account_prefix or vals.get('account_prefix', '').startswith(m.account_prefix)
+        )
+
     def _create_domain(self, fname, value):
-        if not fname == 'account_prefix':
-            return super()._create_domain(fname, value)
+        if fname == 'account_prefix':
+            return []
+        return super()._create_domain(fname, value)

--- a/addons/analytic/views/analytic_distribution_model_views.xml
+++ b/addons/analytic/views/analytic_distribution_model_views.xml
@@ -4,7 +4,8 @@
         <field name="name">account.analytic.distribution.model.tree</field>
         <field name="model">account.analytic.distribution.model</field>
         <field name="arch" type="xml">
-            <tree string="Analytic Distribution Model" editable="top" multi_edit="1">
+            <tree string="Analytic Distribution Model" editable="top" multi_edit="1" default_order="sequence, id desc">
+                <field name="sequence" widget="handle"/>
                 <field name="partner_id" optional="show"/>
                 <field name="partner_category_id" optional="hide"/>
                 <field name="company_id" column_invisible="True"/>


### PR DESCRIPTION
Before:
Only the distribution model with the highest matching score would apply.

After:
All models that have a matching field will be applied in reverse sequence. In other words the highest priority model will overwrite any other model with the same distribution.

Task-3926461