### PR TITLE
[IMP] website_event: improvement events page readability

### DIFF
--- a/addons/website_event/models/event_event.py
+++ b/addons/website_event/models/event_event.py
@@ -568,7 +568,7 @@ class Event(models.Model):
             if country == 'online':
                 domain.append([("country_id", "=", False)])
             elif country != 'all':
-                domain.append(['|', ("country_id", "=", int(country)), ("country_id", "=", False)])
+                domain.append([("country_id", "=", int(country))])
 
         no_date_domain = domain.copy()
         dates = self._search_build_dates()

--- a/addons/website_event/static/src/scss/event_templates_list.scss
+++ b/addons/website_event/static/src/scss/event_templates_list.scss
@@ -66,6 +66,28 @@
             &.left{
                 left: $card-spacer-x;
             }
+
+            &.o_wevent_date_with_flag {
+                .o_wevent_event_country_flag {
+                    height: 20px;
+                    margin-top: 2px;
+                    i {
+                        font-size: 20px;
+                    }
+                    img {
+                        max-width: 2.4rem;
+                    }
+                }
+                .o_wevent_event_date_text {
+                    line-height: .8rem;
+                }
+                .o_wevent_event_day, .o_wevent_event_month {
+                    @include font-size(.8rem);
+                }
+                .o_wevent_event_day {
+                    font-weight: 400;
+                }
+            }
         }
     }
     .o_wevent_sidebar_title {
@@ -95,5 +117,10 @@
     .o_half_screen_height {
         // Set min-height to the same value as the header
         min-height: 200px !important;
+    }
+    .o_wevent_search {
+        @include media-breakpoint-up(lg) {
+            max-width: 300px;
+        }
     }
 }

--- a/addons/website_event/views/event_templates_list.xml
+++ b/addons/website_event/views/event_templates_list.xml
@@ -51,10 +51,17 @@
                 <h2 class="h4 my-0 me-auto pe-sm-4">Events</h2>
                     <t t-foreach="categories" t-as="category">
                         <div t-if="category.is_published and category.tag_ids and any(tag.color for tag in category.tag_ids)" class="dropdown d-none d-lg-block">
+                            <t t-set="searched_category_tags" t-value="search_tags.filtered(lambda tag: tag.category_id == category)"/>
                             <a href="#" role="button" class="btn btn-light dropdown-toggle" data-bs-toggle="dropdown">
                                 <t t-out="category.name"/>
+                                <span t-if="len(searched_category_tags)" t-out="len(searched_category_tags)"
+                                    class="badge rounded-pill text-bg-primary ms-1"/>
                             </a>
                             <div class="dropdown-menu">
+                                <span t-att-data-post="'/event?%s' % keep_query('*', tags=str((search_tags - searched_category_tags).ids), prevent_redirect=True)"
+                                   t-attf-class="post_link cursor-pointer dropdown-item d-flex align-items-center justify-content-between #{'active' if not searched_category_tags else ''}">
+                                   All
+                                </span>
                                 <t t-foreach="category.tag_ids" t-as="tag">
                                     <span t-if="tag.color"
                                         t-att-data-post="'/event?%s' % keep_query('*', tags=str((search_tags - tag).ids if tag in search_tags else (tag | search_tags).ids), prevent_redirect=True)"
@@ -127,7 +134,7 @@
 </template>
 
 <template id="searched_tags" name="Searched tags">
-    <div class="d-flex align-items-center flex-wrap gap-2 mt-2">
+    <div class="d-lg-none d-flex align-items-center flex-wrap gap-2 mt-2">
         <t t-foreach="search_tags" t-as="tag">
             <span t-attf-class="d-inline-flex align-items-baseline rounded border ps-2 #{'o_badge_color_%s' % tag.color if tag.color else ''}">
                 <t t-out="tag.display_name"/>

--- a/addons/website_event/views/event_templates_list.xml
+++ b/addons/website_event/views/event_templates_list.xml
@@ -65,7 +65,7 @@
                             </div>
                         </div>
                     </t>
-                <div class="o_wevent_search d-flex w-100 w-lg-auto">
+                <div class="o_wevent_search d-flex w-100">
                     <div class="w-100 flex-grow-1">
                         <t t-call="website_event.events_search_box_input"/>
                     </div>
@@ -271,6 +271,7 @@
 <template id="events_list" name="Events list">
     <!-- Options -->
     <t t-set="opt_index_sidebar" t-value="is_view_active('website_event.opt_index_sidebar')"/>
+    <t t-set="opt_events_event_location" t-value="is_view_active('website_event.event_location')"/>
     <t t-if="opt_events_list_columns" t-set="opt_event_size" t-value="opt_index_sidebar and 'col-md-6' or 'col-md-6 col-lg-4 col-xl-3'"/>
     <t t-else="" t-set="opt_event_size" t-value="opt_index_sidebar and 'col-12' or 'col-xl-12'"/>
     <!-- No events -->
@@ -301,9 +302,20 @@
                         <div class="d-block h-100 w-100">
                             <t t-call="website.record_cover">
                                 <t t-set="_record" t-value="event"/>
-                                <!-- Short Date -->
                                 <meta itemprop="startDate" t-att-content="event.date_begin.isoformat()"/>
-                                <div t-attf-class="o_wevent_event_date position-absolute shadow-sm o_not_editable #{(not opt_events_list_columns) and 'left'} ">
+                                <!-- Short date + Country Flag -->
+                                <div t-if="opt_events_event_location" t-attf-class="o_wevent_date_with_flag o_wevent_event_date position-absolute shadow-sm o_not_editable #{(not opt_events_list_columns) and 'left'} ">
+                                    <div class="o_wevent_event_date_text">
+                                        <span t-out="event.date_begin" t-options="{'widget': 'datetime', 'tz_name': event.date_tz, 'format': 'LLL'}" class="o_wevent_event_month"/>
+                                        <span t-out="event.date_begin" t-options="{'widget': 'datetime', 'tz_name': event.date_tz, 'format': 'dd'}" class="o_wevent_event_day oe_hide_on_date_edit"/>
+                                    </div>
+                                    <div class="o_wevent_event_country_flag">
+                                        <img t-if="event.country_id and event.country_id.image_url" class="h-100 align-baseline" t-att-src="event.country_id.image_url" t-att-alt="event.country_id.name"/>
+                                        <i t-elif="not event.country_id" class="fa fa-video-camera h-100"/>
+                                    </div>
+                                </div>
+                                <!-- Short Date -->
+                                <div t-else="" t-attf-class="o_wevent_event_date position-absolute shadow-sm o_not_editable #{(not opt_events_list_columns) and 'left'} ">
                                     <span t-out="event.date_begin" t-options="{'widget': 'datetime', 'tz_name': event.date_tz, 'format': 'LLL'}" class="o_wevent_event_month"/>
                                     <span t-out="event.date_begin" t-options="{'widget': 'datetime', 'tz_name': event.date_tz, 'format': 'dd'}" class="o_wevent_event_day oe_hide_on_date_edit"/>
                                 </div>


### PR DESCRIPTION
1. Add country flag when filter option is on
   ( & Reduce search bar width for >lg screens )
2. Show pill with number of category tags searched. Add an 'all' option to remove all search from a category at once. This replaces the color tags shown on a separate line ONLY for larger screens. Smaller ones use a different search panel.
3. Exclude online events when searching for a given country

See underlying commits for details.

Task-3869922