### PR TITLE
[FIX] base: prevent singletonerror when unarchiving views

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -376,7 +376,7 @@ actual arch.
                 err = ValidationError(_(
                     "Error while parsing or validating view:\n\n%(error)s",
                     error=tools.ustr(e),
-                    view=self.key or self.id,
+                    view=view.key or view.id,
                 )).with_traceback(e.__traceback__)
                 err.context = getattr(e, 'context', None)
                 raise err from None


### PR DESCRIPTION
When the user tries to unarchive the multiple views,
a traceback will appear.

Steps to reproduce the error:
- Install 'website'
- Go to Settings > Technical > Views
- Open archived views > unarchive multiple views

Traceback:
```
ValueError: Expected singleton: ir.ui.view(534, 535, 537)
  File "odoo/http.py", line 2248, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1823, in _serve_db
    return self._transactioning(_serve_ir_http, readonly=ro)
  File "odoo/http.py", line 1843, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1821, in _serve_ir_http
    return self._serve_ir_http(rule, args)
  File "odoo/http.py", line 1828, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2053, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 220, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 756, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 38, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 34, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 458, in call_kw
    result = getattr(recs, name)(*args, **kwargs)
  File "odoo/models.py", line 5771, in action_unarchive
    return self.filtered(lambda record: not record[self._active_name]).toggle_active()
  File "odoo/models.py", line 5759, in toggle_active
    (self - active_recs)[self._active_name] = True
  File "odoo/models.py", line 6619, in __setitem__
    return self._fields[key].__set__(self, value)
  File "odoo/fields.py", line 1376, in __set__
    records.write({self.name: write_value})
  File "addons/website/models/theme_models.py", line 366, in write
    return super().write(vals)
  File "addons/website/models/ir_ui_view.py", line 95, in write
    return super(View, self).write(vals)
  File "odoo/addons/base/models/ir_ui_view.py", line 529, in write
    self._validate_fields(['arch_db'])
  File "odoo/models.py", line 1484, in _validate_fields
    check(self)
  File "odoo/addons/base/models/ir_ui_view.py", line 371, in _check_xml
    view=self.key or self.id,
  File "odoo/fields.py", line 1202, in __get__
    record.ensure_one()
  File "odoo/models.py", line 5856, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
```

https://github.com/odoo/odoo/blob/9be0c5348bfeb338bcba95b2a9c01e0d7dd14306/odoo/addons/base/models/ir_ui_view.py#L379 Here, self is used in place of view.
So it will lead to the above traceback.

sentry-5604174783

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
