### PR TITLE
[IMP] pos_razorpay: prevent fallback to force done on error

### DIFF
--- a/addons/pos_razorpay/models/pos_payment_method.py
+++ b/addons/pos_razorpay/models/pos_payment_method.py
@@ -56,7 +56,8 @@ class PosPaymentMethod(models.Model):
                     'createdTime': response.get('createdTime'),
                 }
             elif payment_status == 'FAILED' or payment_messageCode == 'P2P_DEVICE_CANCELED':
-                return {'error': str(response.get('message', _('Razorpay POS transaction failed')))}
+                return {'error': str(response.get('message', _('Razorpay POS transaction failed'))),
+                        'payment_messageCode': payment_messageCode}
             elif payment_messageCode in ['P2P_DEVICE_RECEIVED', 'P2P_DEVICE_SENT', 'P2P_STATUS_QUEUED']:
                 return {'status': payment_messageCode.split('_')[-1]}
         default_error_msg = _('Razorpay POS payment status request expected errorCode not found in the response')

--- a/addons/pos_razorpay/static/src/app/payment_razorpay.js
+++ b/addons/pos_razorpay/static/src/app/payment_razorpay.js
@@ -61,6 +61,9 @@ export class PaymentRazorpay extends PaymentInterface {
             this.payment_stopped
                 ? this._showError(_t("Transaction failed due to inactivity"))
                 : this._showError(response.error);
+            if (response.payment_messageCode === "P2P_DEVICE_CANCELED") {
+                line.set_payment_status("retry");
+            }
             this._removePaymentHandler(["p2pRequestId", "referenceId"]);
             return Promise.resolve(false);
         }
@@ -126,7 +129,7 @@ export class PaymentRazorpay extends PaymentInterface {
             //Within 90 seconds, inactivity will result in transaction cancellation and payment termination.
             if (this.payment_stopped) {
                 this._razorpay_cancel().then(() => {
-                    paymentLine.set_payment_status("force_done");
+                    paymentLine.set_payment_status("retry");
                     this.payment_stopped = false;
                 });
                 return resolve(false);


### PR DESCRIPTION
Before this commit:
=====================
When an error occurred in the POS payment terminal through Razorpay, the payment would erroneously go into a "Force Done" state. This behavior was incorrect because a failed payment due to an error should not be considered complete.

After this commit:
===================
Errors are now visibly indicated, and a "Retry" button is presented instead of marking the payment as "Force Done".

Task-4029382
