### PR TITLE
[IMP] mail: message read more/less without jQuery

### DIFF
--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -166,15 +166,15 @@ export class Message extends Component {
         useEffect(
             () => {
                 if (this.shadowBody.el) {
-                    const body = document.createElement("span");
-                    body.innerHTML = this.state.showTranslation
+                    const bodyEl = document.createElement("span");
+                    bodyEl.innerHTML = this.state.showTranslation
                         ? this.message.translationValue
                         : this.props.messageSearch?.highlight(this.message.body) ??
                           this.message.body;
-                    this.prepareMessageBody(body);
-                    this.shadowRoot.appendChild(body);
+                    this.prepareMessageBody(bodyEl);
+                    this.shadowRoot.appendChild(bodyEl);
                     return () => {
-                        this.shadowRoot.removeChild(body);
+                        this.shadowRoot.removeChild(bodyEl);
                     };
                 }
             },
@@ -461,10 +461,8 @@ export class Message extends Component {
         }
     }
 
-    /**
-     * @param {HTMLElement} element
-     */
-    prepareMessageBody(element) {}
+    /** @param {HTMLElement} bodyEl */
+    prepareMessageBody(bodyEl) {}
 
     enterEditMode() {
         const message = toRaw(this.props.message);

--- a/addons/mail/static/src/core/web_portal/message_patch.js
+++ b/addons/mail/static/src/core/web_portal/message_patch.js
@@ -1,6 +1,7 @@
 import { patch } from "@web/core/utils/patch";
 import { Message } from "@mail/core/common/message";
 import { onWillUnmount } from "@odoo/owl";
+import { _t } from "@web/core/l10n/translation";
 
 patch(Message.prototype, {
     setup() {
@@ -14,12 +15,11 @@ patch(Message.prototype, {
 
     /**
      * @override
-     * @param {HTMLElement} element
+     * @param {HTMLElement} bodyEl
      */
-    prepareMessageBody(element) {
-        const $el = $(element);
-        $el.find(".o-mail-read-more-less").remove();
-        this.insertReadMoreLess($el);
+    prepareMessageBody(bodyEl) {
+        Array.from(bodyEl.querySelectorAll(".o-mail-read-more-less")).forEach((el) => el.remove());
+        this.insertReadMoreLess(bodyEl);
     },
 
     /**
@@ -29,62 +29,108 @@ patch(Message.prototype, {
      * Those text nodes need to be wrapped in a span (toggle functionality).
      * All consecutive elements are joined in one 'read more/read less'.
      *
-     * FIXME This method should be rewritten (task-2308951)
-     *
-     * @param {jQuery} $element
+     * @param {HTMLElement} bodyEl
      */
-    insertReadMoreLess($element) {
+    insertReadMoreLess(bodyEl) {
+        /**
+         * @param {HTMLElement} e
+         * @param {string} selector
+         */
+        function prevAll(e, selector) {
+            const res = [];
+            while ((e = e.previousElementSibling)) {
+                if (e.matches(selector)) {
+                    res.push(e);
+                }
+            }
+            return res;
+        }
+
+        /**
+         * @param {HTMLElement} e
+         * @param {string} selector
+         */
+        function prev(e, selector) {
+            while ((e = e.previousElementSibling)) {
+                if (e.matches(selector)) {
+                    return e;
+                }
+            }
+        }
+
+        /** @param {HTMLElement} el */
+        function hide(el) {
+            el.dataset.oMailDisplay = el.style.display;
+            el.style.display = "none";
+        }
+
+        /**
+         * @param {HTMLElement} el
+         * @param {boolean} condition
+         */
+        function toggle(el, condition = false) {
+            if (condition) {
+                let newDisplay = el.dataset.oMailDisplay;
+                if (newDisplay === "none") {
+                    newDisplay = null;
+                }
+                el.style.display = newDisplay;
+            } else {
+                hide(el);
+            }
+        }
+
         const groups = [];
         let readMoreNodes;
-
-        // nodeType 1: element_node
-        // nodeType 3: text_node
-        const $children = $element
-            .contents()
-            .filter(
-                (index, content) =>
-                    content.nodeType === 1 || (content.nodeType === 3 && content.nodeValue.trim())
-            );
-
-        for (const child of $children) {
-            let $child = $(child);
-
-            // Hide Text nodes if "stopSpelling"
-            if (child.nodeType === 3 && $child.prevAll('[id*="stopSpelling"]').length > 0) {
-                // Convert Text nodes to Element nodes
-                $child = $("<span>", {
-                    text: child.textContent,
-                    "data-o-mail-quote": "1",
-                });
-                child.parentNode.replaceChild($child[0], child);
+        const ELEMENT_NODE = 1;
+        const TEXT_NODE = 3;
+        /** @type {ChildNode[]} childrenEl */
+        const childrenEl = Array.from(bodyEl.childNodes).filter(
+            /** @param {ChildNode} childEl */
+            function (childEl) {
+                return (
+                    childEl.nodeType === ELEMENT_NODE ||
+                    (childEl.nodeType === TEXT_NODE && childEl.nodeValue.trim())
+                );
             }
-
+        );
+        for (const childEl of childrenEl) {
+            // Hide Text nodes if "stopSpelling"
+            if (
+                childEl.nodeType === TEXT_NODE &&
+                prevAll(childEl, '[id*="stopSpelling"]').length > 0
+            ) {
+                // Convert Text nodes to Element nodes
+                const newChildEl = document.createElement("span");
+                newChildEl.textContent = childEl.textContent;
+                newChildEl.dataset.oMailQuote = "1";
+                childEl.parentNode.replaceChild(newChildEl, childEl);
+            }
             // Create array for each 'read more' with nodes to toggle
             if (
-                $child.attr("data-o-mail-quote") ||
-                ($child.get(0).nodeName === "BR" &&
-                    $child.prev('[data-o-mail-quote="1"]').length > 0)
+                (childEl.nodeType === ELEMENT_NODE && childEl.getAttribute("data-o-mail-quote")) ||
+                (childEl.nodeName === "BR" && prev(childEl, '[data-o-mail-quote="1"]'))
             ) {
                 if (!readMoreNodes) {
                     readMoreNodes = [];
                     groups.push(readMoreNodes);
                 }
-                $child.hide();
-                readMoreNodes.push($child);
+                hide(childEl);
+                readMoreNodes.push(childEl);
             } else {
                 readMoreNodes = undefined;
-                this.insertReadMoreLess($child);
+                this.insertReadMoreLess(childEl);
             }
         }
 
         for (const group of groups) {
             const index = this.state.lastReadMoreIndex++;
             // Insert link just before the first node
-            const $readMoreLess = $("<a>", {
-                class: "o-mail-read-more-less d-block",
-                href: "#",
-                text: "Read More",
-            }).insertBefore(group[0]);
+            const readMoreLessEl = document.createElement("a");
+            readMoreLessEl.className = "o-mail-read-more-less d-block";
+            readMoreLessEl.href = "#";
+            readMoreLessEl.textContent = _t("Read More");
+            group[0].parentNode.insertBefore(readMoreLessEl, group[0]);
 
             // Toggle All next nodes
             if (!this.state.isReadMoreByIndex.has(index)) {
@@ -92,13 +138,15 @@ patch(Message.prototype, {
             }
             const updateFromState = () => {
                 const isReadMore = this.state.isReadMoreByIndex.get(index);
-                for (const $child of group) {
-                    $child.hide();
-                    $child.toggle(!isReadMore);
+                for (const childEl of group) {
+                    hide(childEl);
+                    toggle(childEl, !isReadMore);
                 }
-                $readMoreLess.text(isReadMore ? "Read More" : "Read Less");
+                readMoreLessEl.textContent = isReadMore
+                    ? _t("Read More").toString()
+                    : _t("Read Less").toString();
             };
-            $readMoreLess.click((e) => {
+            readMoreLessEl.addEventListener("click", (e) => {
                 e.preventDefault();
                 this.state.isReadMoreByIndex.set(index, !this.state.isReadMoreByIndex.get(index));
                 updateFromState();


### PR DESCRIPTION
Before this commit, discuss code was using jQuery to inject toggleable read more/less links on messages.

There's plan to remove all jQuery in whole web client, so these LOCs must be adapted to not rely on jQuery.

This commit converts them to equivalent browser native DOM manipulations.