### PR TITLE
[FIX] spreadsheet: reduce payload for list requests

### DIFF
--- a/addons/spreadsheet/static/src/list/list_data_source.js
+++ b/addons/spreadsheet/static/src/list/list_data_source.js
@@ -104,7 +104,7 @@ export class ListDataSource extends OdooViewsDataSource {
                     };
                     break;
                 default:
-                    spec[field.name] = field;
+                    spec[field.name] = {};
                     break;
             }
         }

--- a/addons/spreadsheet/static/tests/lists/list_plugin_test.js
+++ b/addons/spreadsheet/static/tests/lists/list_plugin_test.js
@@ -582,6 +582,45 @@ QUnit.module("spreadsheet > list plugin", {}, () => {
         }
     );
 
+    QUnit.test("Spec of web_search_read is minimal", async function (assert) {
+        const spreadsheetData = {
+            lists: {
+                1: {
+                    id: 1,
+                    columns: ["currency_id", "pognon", "foo"],
+                    model: "partner",
+                    orderBy: [],
+                },
+            },
+        };
+        const model = await createModelWithDataSource({
+            spreadsheetData,
+            mockRPC: function (route, args) {
+                if (args.method === "web_search_read") {
+                    assert.deepEqual(args.kwargs.specification, {
+                        pognon: {},
+                        currency_id: {
+                            fields: {
+                                name: {},
+                                symbol: {},
+                                decimal_places: {},
+                                display_name: {},
+                                position: {},
+                            },
+                        },
+                        foo: {},
+                    });
+                    assert.step("web_search_read");
+                }
+            },
+        });
+        setCellContent(model, "A1", '=ODOO.LIST(1, 1, "pognon")');
+        setCellContent(model, "A2", '=ODOO.LIST(1, 1, "currency_id")');
+        setCellContent(model, "A3", '=ODOO.LIST(1, 1, "foo")');
+        await waitForDataSourcesLoaded(model);
+        assert.verifySteps(["web_search_read"]);
+    });
+
     QUnit.test(
         "List record limit is computed during the import and UPDATE_CELL",
         async function (assert) {


### PR DESCRIPTION
Since 8777973edd25314df6ed0327d3f27edcf62f274b, the list data are retrieved with `web_search_read`. However, the payload was not minimal as it contains all attributes of the fields (name, store, sortable, etc.).

This commit reduces the payload by only requesting what is needed.

Task: 4052706

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
