### PR TITLE
[FIX] account: Add domain to tags in COA and Journal Items list views

### DIFF
--- a/addons/account/views/account_account_views.xml
+++ b/addons/account/views/account_account_views.xml
@@ -99,7 +99,7 @@
                     <field name="reconcile" widget="boolean_toggle" attrs="{'invisible': ['|', ('account_type', 'in', ('asset_cash', 'liability_credit_card')), ('internal_group', '=', 'off_balance')]}"/>
                     <field name="non_trade" widget="boolean_toggle" attrs="{'invisible': [('account_type', 'not in', ('liability_payable', 'asset_receivable'))]}" optional="hide"/>
                     <field name="tax_ids" optional="hide" widget="many2many_tags"/>
-                    <field name="tag_ids" optional="hide" widget="many2many_tags"/>
+                    <field name="tag_ids" domain="[('applicability', '=', 'accounts')]" optional="hide" widget="many2many_tags"/>
                     <field name="allowed_journal_ids" optional="hide" widget="many2many_tags"/>
                     <field name="currency_id" options="{'no_create': True}" groups="base.group_multi_currency"/>
                     <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -177,7 +177,7 @@
                     <field name="currency_id" readonly="1" groups="base.group_multi_currency" optional="hide" string="Currency" attrs="{'invisible':[('is_same_currency', '=', True)]}"/>
                     <field name="debit" sum="Total Debit" readonly="1"/>
                     <field name="credit" sum="Total Credit" readonly="1"/>
-                    <field name="tax_tag_ids" string="Tax Grids" widget="many2many_tags" width="0.5" optional="hide"/>
+                    <field name="tax_tag_ids" string="Tax Grids" domain="[('applicability', '=', 'taxes')]" widget="many2many_tags" width="0.5" optional="hide"/>
                     <field name="discount_date" string="Discount Date" optional="hide" />
                     <field name="discount_amount_currency" string="Discount Amount" optional="hide" />
                     <field name="tax_line_id" string="Originator Tax" optional="hide" readonly="1"/>


### PR DESCRIPTION
In the list view of the Chart of Accounts, the only available tags in the field Tags are the ones applicable to Accounts.
In the list view of journal items, the only available tags in the field Tax Grids are the ones applicable to Taxes.

task-4016899

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
