### PR TITLE
[FIX] html_editor: prevent default browser commands in editable

### DIFF
--- a/addons/html_editor/static/src/core/history_plugin.js
+++ b/addons/html_editor/static/src/core/history_plugin.js
@@ -105,6 +105,9 @@ export class HistoryPlugin extends Plugin {
 
     setup() {
         this.mutationFilteredClasses = new Set(this.resources["mutation_filtered_classes"]);
+        this._onKeyupResetContenteditableNodes = [];
+        this.addDomListener(this.document, "beforeinput", this._onDocumentBeforeInput.bind(this));
+        this.addDomListener(this.document, "input", this._onDocumentInput.bind(this));
         this.addDomListener(this.editable, "pointerup", () => {
             this.stageSelection();
             this.stageNextSelection = true;
@@ -295,6 +298,9 @@ export class HistoryPlugin extends Plugin {
             if (record.type === "attributes") {
                 // Skip the attributes change on the dom.
                 if (record.target === this.editable) {
+                    continue;
+                }
+                if (record.attributeName === "contenteditable") {
                     continue;
                 }
                 // @todo @phoenix test attributeCache
@@ -654,6 +660,9 @@ export class HistoryPlugin extends Plugin {
             this.revertMutations(stepToRevert.mutations);
         }
         this.applyMutations(newStep.mutations);
+        this.dispatch("NORMALIZE", {
+            node: this.getMutationsRoot(newStep.mutations) || this.editable,
+        });
         this.steps.splice(index, 0, newStep);
         for (const stepToApply of stepsAfterNewStep) {
             this.applyMutations(stepToApply.mutations);
@@ -1028,5 +1037,35 @@ export class HistoryPlugin extends Plugin {
         }
         _map.set(node, serializedNode.nodeId);
         return [node, _map];
+    }
+
+    _onDocumentBeforeInput(ev) {
+        if (this.editable.contains(ev.targget)) {
+            return;
+        }
+        if (["historyUndo", "historyRedo"].includes(ev.inputType)) {
+            this._onKeyupResetContenteditableNodes.push(
+                ...this.editable.querySelectorAll("[contenteditable=true]")
+            );
+            if (this.editable.getAttribute("contenteditable") === "true") {
+                this._onKeyupResetContenteditableNodes.push(this.editable);
+            }
+
+            for (const node of this._onKeyupResetContenteditableNodes) {
+                node.setAttribute("contenteditable", false);
+            }
+        }
+    }
+
+    _onDocumentInput(ev) {
+        if (
+            ["historyUndo", "historyRedo"].includes(ev.inputType) &&
+            this._onKeyupResetContenteditableNodes.length
+        ) {
+            for (const node of this._onKeyupResetContenteditableNodes) {
+                node.setAttribute("contenteditable", true);
+            }
+            this._onKeyupResetContenteditableNodes = [];
+        }
     }
 }

--- a/addons/html_editor/static/tests/collaboration.test.js
+++ b/addons/html_editor/static/tests/collaboration.test.js
@@ -624,6 +624,49 @@ describe("data-oe-protected", () => {
             },
         });
     });
+
+    test("should properly apply `contenteditable` attribute on received protected nodes", async () => {
+        const peerInfos = await setupMultiEditor({
+            peerIds: ["c1", "c2"],
+            contentBefore: `<p>[c1}{c1][c2}{c2]a</p>`,
+        });
+        const e1 = peerInfos.c1.editor;
+        const e2 = peerInfos.c2.editor;
+        e1.shared.domInsert(
+            parseHTML(
+                e1.document,
+                unformat(`
+                    <div data-oe-protected="true">
+                        <div data-oe-protected="false">
+                            <p>d</p>
+                        </div>
+                    </div>
+                `)
+            )
+        );
+        e1.dispatch("ADD_STEP");
+        mergePeersSteps(peerInfos);
+        expect(getContent(e1.editable, { sortAttrs: true })).toBe(
+            unformat(`
+                <div contenteditable="false" data-oe-protected="true">
+                    <div contenteditable="true" data-oe-protected="false">
+                        <p>d</p>
+                    </div>
+                </div>
+                <p>[]a</p>
+            `)
+        );
+        expect(getContent(e2.editable, { sortAttrs: true })).toBe(
+            unformat(`
+                <div contenteditable="false" data-oe-protected="true">
+                    <div contenteditable="true" data-oe-protected="false">
+                        <p>d</p>
+                    </div>
+                </div>
+                <p>[]a</p>
+            `)
+        );
+    });
 });
 describe("post process external steps", () => {
     test("should properly await a processing promise before accepting new external steps.", async () => {


### PR DESCRIPTION
Issue:
======
Undo doesn't work properly.

Step to reproduce the issue:
============================
First case:
- Add some content in todo
- Click on top outside the editable
- Press `ctrl+z` -> the content gets removed
-> Nothing should happen in this case.

Second case:
- Add a table
- Add some content in table cell
- Insert a column to left
- Press `ctrl+z` -> the content is removed and not even the added
  column.
-> Nothing should happen since the focus is outside the editable.

Origin of the issue:
====================
When the target is outside the editable, the default `undo` of the
browser is triggered that's why in the 2 cases the content gets removed.

Solution:
=========
When `historyUndo` and `historyRedo` of the browser are triggered
outside the editable we switch the editable to be
`contenteditable=fasle` so it doesn't affect it and then we switch them
back.