### PR TITLE
[FIX] hr_holidays: take time into account during deserialization

### DIFF
--- a/addons/hr_holidays/static/tests/time_off_dashboard_tests.js
+++ b/addons/hr_holidays/static/tests/time_off_dashboard_tests.js
@@ -23,8 +23,7 @@ QUnit.module("leave dashboard", {
                     show_unusual_days="True"
                     color="color"
                     hide_time="True"
-                    mode="year"
-                    all_day="last_several_days">
+                    mode="year">
                 <field name="name"/>
                 <field name="holiday_status_id" filters="1" invisible="1" color="color"/>
                 <field name="state" invisible="1"/>

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -416,8 +416,7 @@
                     show_unusual_days="True"
                     color="color"
                     hide_time="True"
-                    mode="year"
-                    all_day="last_several_days">
+                    mode="year">
                 <field name="display_name"/>
                 <field name="holiday_status_id" filters="1" invisible="1" color="color"/>
                 <field name="state" invisible="1"/>
@@ -442,8 +441,7 @@
                     quick_create="0"
                     show_unusual_days="True"
                     color="color"
-                    hide_time="True"
-                    all_day="last_several_days">
+                    hide_time="True">
                 <field name="display_name"/>
                 <field name="holiday_status_id" filters="1" invisible="1" color="color"/>
                 <field name="state" invisible="1"/>
@@ -499,8 +497,7 @@
                     mode="month"
                     show_unusual_days="True"
                     quick_create="0"
-                    color="color"
-                    all_day="last_several_days">
+                    color="color">
                 <field name="display_name"/>
                 <field name="holiday_status_id" color="color" filters="1" invisible="1"/>
                 <field name="employee_id" filters="1" invisible="1"/>


### PR DESCRIPTION
[FIX] hr_holidays: take time into account during deserialization

Steps to reproduce:
- Install Time Off
- Set your time-zone to UTC+1
- Modify your working schedules for Monday Morning to start at 00:30
- Create a leave for Monday and Tuesday in the Time Off app

Issues:
The calendar show 3 days for the leave. This is due to the field
`all_day`, since it's set we will deserialize the record with the
function `deserializeDate`.

https://github.com/odoo/odoo/blob/44a1b163481b0b781028ce337d72fbb0c8730475/addons/web/static/src/views/calendar/calendar_model.js#L503-L509

This function doesn't take into account the time in the record, which
means that it will just deserialize the date which is Sunday in our
case because of the timezone conversion to UTC.

Because of this the frontend thinks that the leave takes place from
Sunday to Tuesday.

We can remove `all_day` thanks to this [fix](https://github.com/odoo/odoo/commit/3ccc6bfa86618b0ca13c13960c15b60f8f75f3ce) which enable `allDaySlot`
options by default which allow us to preserve the original behavior of
the calendar view in hr_holidays while correctly deserializing the
datetime.

opw-4043180