### PR TITLE
[FIX] mrp: typo in mrp_bom kanban view

### DIFF
--- a/addons/mrp/views/mrp_bom_views.xml
+++ b/addons/mrp/views/mrp_bom_views.xml
@@ -185,7 +185,7 @@
                             <div t-attf-class="oe_kanban_global_click">
                                 <div class="o_kanban_record_top">
                                     <div class="o_kanban_record_headings mt4">
-                                        <strong class="o_kanban_record_title"><span clatt="mt4"><field name="product_tmpl_id"/></span></strong>
+                                        <strong class="o_kanban_record_title"><span class="mt4"><field name="product_tmpl_id"/></span></strong>
                                     </div>
                                     <span class="float-end badge rounded-pill"><t t-esc="record.product_qty.value"/> <small><t t-esc="record.product_uom_id.value"/></small></span>
                                 </div>


### PR DESCRIPTION
NOTE: to speed up the merge process of https://github.com/odoo/odoo/pull/170785, I've cherry-picked the changes that were not yet merged in other PRs.

In mrp bom kanban view, it is written "clatt" instead of "class". This commit changes that.

(cherry picked from commit 758d3b80d6b1ce035a48fab42b7cab68e4ed7024)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
