### PR TITLE
[FIX] l10n_in: consider discounted price for HSN summary

### DIFF
--- a/addons/l10n_in/models/account_invoice.py
+++ b/addons/l10n_in/models/account_invoice.py
@@ -188,7 +188,7 @@ class AccountMove(models.Model):
             base_lines.append({
                 'l10n_in_hsn_code': line.l10n_in_hsn_code,
                 'quantity': line.quantity,
-                'price_unit': line.price_unit,
+                'price_unit': line.currency_id.round(line.price_unit * (1 - (line.discount / 100.0))),
                 'product_values': product_values,
                 'uom': {'id': line.product_uom_id.id, 'name': line.product_uom_id.name},
                 'taxes_data': taxes_data,

--- a/addons/l10n_in_pos/static/src/overrides/models/order.js
+++ b/addons/l10n_in_pos/static/src/overrides/models/order.js
@@ -3,6 +3,7 @@
 import { Order } from "@point_of_sale/app/store/models";
 import { patch } from "@web/core/utils/patch";
 import { accountTaxHelpers } from "@account/helpers/account_tax";
+import { roundPrecision as round_pr } from "@web/core/utils/numbers";
 
 patch(Order.prototype, {
     export_for_printing() {
@@ -24,6 +25,7 @@ patch(Order.prototype, {
     _prepareL10nInHsnSummary() {
         const fiscalPosition = this.fiscal_position;
         const baseLines = [];
+        var rounding = this.pos.currency.rounding;
         this.orderlines.forEach((line) => {
             const hsnCode = line.get_product()?.l10n_in_hsn_code;
             if (!hsnCode) {
@@ -37,7 +39,10 @@ patch(Order.prototype, {
 
             baseLines.push({
                 l10n_in_hsn_code: hsnCode,
-                price_unit: line.get_unit_price(),
+                price_unit: round_pr(
+                    line.get_unit_price() * (1 - line.get_discount() / 100),
+                    rounding
+                ),
                 quantity: line.get_quantity(),
                 uom: null,
                 taxes_data: this.pos.mapTaxValues(taxes),


### PR DESCRIPTION
*Before this commit:*
- The HSN summary was calculated based on the unit price of the line items, even if a discount was applied.

*After this commit:*
- The HSN summary is now calculated based on the discounted price of the line items.

opw: 4040478