### PR TITLE
[IMP] sale_timesheet: hide time-related fields

### DIFF
--- a/addons/sale_project/models/project_project.py
+++ b/addons/sale_project/models/project_project.py
@@ -841,7 +841,7 @@ class ProjectProject(models.Model):
 
         action = super().action_view_tasks()
         action['context']['hide_partner'] = self._get_hide_partner()
-        action['context']['hide_sale_line'] = not self.allow_billable
+        action['context']['allow_billable'] = self.allow_billable
         return action
 
     def action_open_project_vendor_bills(self):

--- a/addons/sale_project/views/project_task_views.xml
+++ b/addons/sale_project/views/project_task_views.xml
@@ -262,8 +262,8 @@
         <field name="inherit_id" ref="project.project_task_view_tree_base"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='partner_id']" position="after">
-                <field name="sale_line_id" optional="hide" groups="sales_team.group_sale_salesman" options="{'no_create': True}" column_invisible="context.get('hide_sale_line')"/>
-                <field name="sale_line_id" optional="hide" options="{'no_open': True}" readonly="1" groups="!sales_team.group_sale_salesman" column_invisible="context.get('hide_sale_line')"/>
+                <field name="sale_line_id" optional="hide" groups="sales_team.group_sale_salesman" options="{'no_create': True}" column_invisible="not context.get('allow_billable')"/>
+                <field name="sale_line_id" optional="hide" options="{'no_open': True}" readonly="1" groups="!sales_team.group_sale_salesman" column_invisible="not context.get('allow_billable')"/>
             </xpath>
         </field>
     </record>

--- a/addons/sale_timesheet/views/project_task_views.xml
+++ b/addons/sale_timesheet/views/project_task_views.xml
@@ -151,7 +151,8 @@
                 <xpath expr="//field[@name='remaining_hours']" position="after">
                     <field name="sale_line_id" column_invisible="True"/>
                     <field name="remaining_hours_available" column_invisible="True"/>
-                    <field name="remaining_hours_so" invisible="not sale_line_id or not remaining_hours_available" widget="timesheet_uom" optional="hide" groups="hr_timesheet.group_hr_timesheet_user"/>
+                    <field name="remaining_hours_so" invisible="not sale_line_id or not remaining_hours_available" widget="timesheet_uom" optional="hide"
+                        groups="hr_timesheet.group_hr_timesheet_user" column_invisible="not (context.get('allow_billable', True) and context.get('allow_timesheets', True))"/>
                 </xpath>
             </field>
         </record>


### PR DESCRIPTION
In this commit, time-related fields are hidden in the task's list view when both allow_billable and allow_timesheets are disabled in the project.

task-4038178