### PR TITLE
[FIX] l10n_fr_invoice_addr: remove groups for shipping_field

### DIFF
--- a/addons/l10n_fr_invoice_addr/models/account_move.py
+++ b/addons/l10n_fr_invoice_addr/models/account_move.py
@@ -14,7 +14,7 @@ class AccountMove(models.Model):
         company = self.env.company
         if view_type == 'form' and company.country_code in company._get_france_country_codes():
             shipping_field = arch.xpath("//field[@name='partner_shipping_id']")[0]
-            shipping_field.set('groups', '')
+            shipping_field.attrib.pop("groups")
         return arch, view
 
     @api.depends('company_id.country_code')


### PR DESCRIPTION
**Description**

- From 16.0, while opening invoices of accounting and clicking on the web studio button, it is showing traceback for French localization of the "l10n_fr" module. As per [this](https://github.com/odoo/odoo/pull/171275) file in V16, module [l10n_fr_invoice_addr] has been optimized to adapt the documents as per new French law. Although, the traceback is showing due to the fact that while performing the "l10n_fr_invoice_addr" module's view, the "shipping_field" has set the groups to null in this [account_move.py](https://github.com/odoo/odoo/pull/171275/files#diff-5125aad1cd2220c7e0c4cfe80ec0541acf5e9f4dbce46fb370e94cd281012b36R17) file which should not be the case. Due to this, as per this [condition](https://github.com/odoo/odoo/blob/16.0/odoo/models.py#L1464), it is trying to find groups in V16.0, which will lead to traceback as the groups are set null here. Whereas in stable version 15.0, it was working due to the fact that previously the groups were set to null through the [account_move.xml](https://github.com/odoo/odoo/blob/15.0/addons/l10n_fr_invoice_addr/views/account_move_views.xml#L9) file.

- As a result, to resolve this issue this commit will pop the groups of "shipping_field" instead of setting it to null to bypass the traceback for the invoices of "l10n_fr" localization. 

**Steps to Reproduce (V16.0)**

- Change the language to French. 
- Install "l10n_fr" module
- Get an FR company.
- Create an invoice, it's partner(customer) should be of FR , then confirm the invoice.
- Open the invoice and then click on the web studio button.

**Solution**

- To resolve this issue this commit will pop the groups of "shipping_field" instead of setting it to null to bypass the traceback for the invoices of "l10n_fr" localization. 

**Current behavior before PR:**

![V16_behavior](https://github.com/user-attachments/assets/de318ec6-664c-427e-a497-3322b6ee445c)

---
opw-[4044861](https://www.odoo.com/odoo/project.task/4044861?cids=2)

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
