### PR TITLE
[FIX] hr_skills: prevent demo data inside reports outside studio

### DIFF
--- a/addons/hr_skills/views/hr_employee_cv_templates.xml
+++ b/addons/hr_skills/views/hr_employee_cv_templates.xml
@@ -84,7 +84,7 @@
                             </div>
                         </div>
                         <div class="o_main_panel_resume_description ps-5 w-auto">
-                            <p t-field="resume_line.description">Odoo India pvt. Ltd</p>
+                            <p t-field="resume_line.description" data-oe-demo="Odoo India pvt. Ltd"/>
                         </div>
                     </t>
                 </div>


### PR DESCRIPTION
Steps to reproduce
==================

- Install hr_skills,web_studio
- Go to Employees
- Open any record
- Add a new resume entry without description
- Save
- Click on the actions gear
- Print > Print Resume

=> `Odoo India pvt. Ltd` is displayed in the report in place of the
   missing description

Solution
========

Use the new data-oe-demo attribute made for demo data inside studio

opw-4033434