### PR TITLE
[FIX] pos_loyalty: remove the use of demo data in test

### DIFF
--- a/addons/pos_loyalty/static/tests/tours/PosLoyaltyTour.js
+++ b/addons/pos_loyalty/static/tests/tours/PosLoyaltyTour.js
@@ -470,7 +470,7 @@ registry.category("web_tour.tours").add('ChangeRewardValueWithLanguage', {
             ProductScreen.clickDisplayedProduct('Desk Organizer'),
             ProductScreen.selectedOrderlineHas('Desk Organizer', '1.00', '5.10'),
             ProductScreen.clickPartnerButton(),
-            ProductScreen.clickCustomer('Colleen Diaz'),
+            ProductScreen.clickCustomer('Partner Test 1'),
             PosLoyalty.isRewardButtonHighlighted(true),
             PosLoyalty.claimReward('$ 2 on your order'),
             PosLoyalty.hasRewardLine('$ 2 on your order', '-2.00'),


### PR DESCRIPTION
Before this commit, the test `test_change_reward_value_with_language` was using a partner only available in demo data.

This commit removes the use of demo data in the test by using a partner created in the test itself.

Runbot error: 70611, 70477, 70419, 70480

