### PR TITLE
[IMP] hr_holidays: Raise an error if taking time off without employee

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -727,6 +727,8 @@ Attempting to double-book your time off won't magically make your vacation 2x be
                 if mapped_validation_type[leave_type_id] == 'both':
                     self._check_double_validation_rules(employee_id, values.get('state', False))
 
+        if any(not vals.get('employee_id') for vals in vals_list):
+            raise UserError(_("There is no selected employee on the time off request."))
         holidays = super(HrLeave, self.with_context(mail_create_nosubscribe=True)).create(vals_list)
         holidays._check_validity()
 


### PR DESCRIPTION
If a user that doesn't have a linked employee tries to take a time off from the time off dashboard, an error occurs.

To mitigate that, an informative message is now shown to the user stating that they cannot take a time off without having a linked employee.

task-4034228