### PR TITLE
[REF] html_editor: prevent history plugin to make useless work

### DIFF
--- a/addons/html_editor/static/src/core/history_plugin.js
+++ b/addons/html_editor/static/src/core/history_plugin.js
@@ -268,8 +268,10 @@ export class HistoryPlugin extends Plugin {
      */
     setIdOnRecords(records) {
         for (const record of records) {
-            if (record.type === "childList") {
-                this.setNodeId(record.target);
+            if (record.type === "childList" && record.addedNodes.length) {
+                for (const node of record.addedNodes) {
+                    this.setNodeId(node);
+                }
             }
         }
     }
@@ -439,11 +441,11 @@ export class HistoryPlugin extends Plugin {
             id = node === this.editable ? "root" : this.generateId();
             this.nodeToIdMap.set(node, id);
             this.idToNodeMap.set(id, node);
-        }
-        node = node.firstChild;
-        while (node) {
-            this.setNodeId(node);
-            node = node.nextSibling;
+            node = node.firstChild;
+            while (node) {
+                this.setNodeId(node);
+                node = node.nextSibling;
+            }
         }
         return id;
     }


### PR DESCRIPTION
Before this commit, the history plugin would check each mutation, and if a mutation is of type "childlist", it would then traverse the node and all its children to assign an internal id, if necessary.

However, in some cases, the mutation does not introduce any new node, it only removes them.  With this commit, we check that there are new nodes before working on assigning ids.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
