### PR TITLE
[FIX] web: list display field label and help in tooltip

### DIFF
--- a/addons/web/static/src/views/fields/field_tooltip.js
+++ b/addons/web/static/src/views/fields/field_tooltip.js
@@ -12,6 +12,7 @@ export function getTooltipInfo(params) {
         debug: Boolean(odoo.debug),
         field: {
             name: params.field.name,
+            label: params.field.string,
             help: params.fieldInfo.help ?? params.field.help,
             type: params.field.type,
             widget: params.fieldInfo.widget,

--- a/addons/web/static/src/views/list/list_renderer.xml
+++ b/addons/web/static/src/views/list/list_renderer.xml
@@ -25,8 +25,8 @@
                                 t-on-pointerup="onColumnTitleMouseUp"
                                 t-on-click="() => this.onClickSortColumn(column)"
                                 t-on-keydown="(ev) => this.onCellKeydown(ev)"
-                                t-att-data-tooltip-template="isDebugMode ? 'web.FieldTooltip' : false"
-                                t-att-data-tooltip-info="isDebugMode ? makeTooltip(column) : false"
+                                t-att-data-tooltip-template="isDebugMode ? 'web.FieldTooltip' : 'web.ListHeaderTooltip'"
+                                t-att-data-tooltip-info="makeTooltip(column)"
                                 data-tooltip-delay="1000"
                                 tabindex="-1">
                                 <t t-if="column.hasLabel and column.widget !== 'handle'">
@@ -315,6 +315,11 @@
             <attribute name="t-portal">`.${props.listRendererClass}`</attribute>
             <attribute name="class" add="o_optional_columns_dropdown" separator=" "/>
         </xpath>
+    </t>
+
+    <t t-name="web.ListHeaderTooltip">
+        <t t-esc="field.label"/>
+        <div t-if="field.help" class="mt-2" t-esc="field.help"/>
     </t>
 
 </templates>

--- a/addons/web/static/tests/views/form/form_view_tests.js
+++ b/addons/web/static/tests/views/form/form_view_tests.js
@@ -10937,7 +10937,7 @@ QUnit.module("Views", (hooks) => {
         await nextTick();
         assert.deepEqual(
             getNodesTextContent(target.querySelectorAll(".o-tooltip--technical > li")),
-            ["Field:product_id", "Type:many2one", "Context:{}", "Relation:product"]
+            ["Label:Product", "Field:product_id", "Type:many2one", "Context:{}", "Relation:product"]
         );
     });
 

--- a/addons/web/static/tests/views/list_view_tests.js
+++ b/addons/web/static/tests/views/list_view_tests.js
@@ -1819,16 +1819,6 @@ QUnit.module("Views", (hooks) => {
         assert.containsNone(target, ".o_selected_row");
     });
 
-    QUnit.test("boolean field has no title (data-tooltip)", async function (assert) {
-        await makeView({
-            type: "list",
-            resModel: "foo",
-            serverData,
-            arch: '<tree><field name="bar"/></tree>',
-        });
-        assert.strictEqual(target.querySelector(".o_data_cell").getAttribute("data-tooltip"), null);
-    });
-
     QUnit.test("field with nolabel has no title", async function (assert) {
         await makeView({
             type: "list",
@@ -7617,11 +7607,8 @@ QUnit.module("Views", (hooks) => {
 
         await mouseEnter(target.querySelector("th[data-name=foo]"));
         await nextTick(); // GES: see next nextTick comment
-        assert.strictEqual(
-            target.querySelectorAll(".o-tooltip .o-tooltip--technical").length,
-            0,
-            "should not have rendered a tooltip"
-        );
+        assert.strictEqual(target.querySelectorAll(".o-tooltip").length, 1);
+        assert.strictEqual(target.querySelector(".o-tooltip").innerText, "Foo");
 
         patchWithCleanup(odoo, {
             debug: true,
@@ -7650,6 +7637,28 @@ QUnit.module("Views", (hooks) => {
             ]),
             ["Widget:Favorite (boolean_favorite) "],
             "widget description should be correct"
+        );
+    });
+
+    QUnit.test("field (with help) tooltip in non debug mode", async function (assert) {
+        patchWithCleanup(odoo, {
+            debug: false,
+        });
+
+        serverData.models.foo.fields.foo.help = "This is a foo field";
+        await makeView({
+            type: "list",
+            resModel: "foo",
+            serverData,
+            arch: `<tree><field name="foo"/></tree>`,
+        });
+
+        await mouseEnter(target.querySelector("th[data-name=foo]"));
+        await nextTick();
+        assert.strictEqual(target.querySelectorAll(".o-tooltip").length, 1);
+        assert.strictEqual(
+            target.querySelector(".o-tooltip").innerText,
+            "Foo\nThis is a foo field"
         );
     });
 


### PR DESCRIPTION
In list views, the label of a field, displayed in the thead, is sometimes truncated (especially as we apply our own column widths logic). Moreover, fields might sometimes be unclear to the user, and in the list view we don't benefit from the "help" that might be defined on the field.

This commit helps with those two issues. In non debug mode, there's now a tooltip on the field's label. This tooltip contains the (never truncated) label and the help when there's one.

Note that in debug, nothing changes: we still display a big tooltip with a lot more information.

task 4049882

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
