### PR TITLE
[FIX] html_editor: improve cleaning steps for save

### DIFF
--- a/addons/html_editor/static/src/editor.js
+++ b/addons/html_editor/static/src/editor.js
@@ -216,8 +216,8 @@ export class Editor {
     getElContent() {
         const el = this.editable.cloneNode(true);
         this.dispatch("CLEAN", { root: el });
-        this.dispatch("CLEAN_FOR_SAVE", { root: el });
         this.dispatch("MERGE_ADJACENT_NODE", { node: el });
+        this.dispatch("CLEAN_FOR_SAVE", { root: el });
         return el;
     }
 


### PR DESCRIPTION
Before this commit, when getting the editor's content that is savable, we'd clean the element, then merge the nodes that are "similar" (command: `MERGE_ADJACENT_NODE`)

The problem was that when editing a document, one might want to add or alter some nodes and protect them with some of the available markers (ie: `class="oe_unbreakable" ` or the like), without saving them. Those markers are indeed hardly relevant outside of the editor's workflow.

With the code before this commit, there was no way to both alter the nodes and clean them from those markers for save.

After this commit, the order of the cleaning operation is slightly improved to allow for this use case.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
