### PR TITLE
[FIX] repair, mrp_repair: count removed and added SN products

### DIFF
--- a/addons/repair/models/product.py
+++ b/addons/repair/models/product.py
@@ -8,11 +8,18 @@ class Product(models.Model):
     _inherit = "product.product"
 
     def _count_returned_sn_products(self, sn_lot):
-        res = self.env['repair.line'].search_count([
+        remove_count = self.env['repair.line'].search_count([
             ('type', '=', 'remove'),
             ('product_uom_qty', '=', 1),
             ('lot_id', '=', sn_lot.id),
             ('state', '=', 'done'),
             ('location_dest_id.usage', '=', 'internal'),
         ])
-        return super()._count_returned_sn_products(sn_lot) + res
+        add_count = self.env['repair.line'].search_count([
+            ('type', '=', 'add'),
+            ('product_uom_qty', '=', 1),
+            ('lot_id', '=', sn_lot.id),
+            ('state', '=', 'done'),
+            ('location_dest_id.usage', '=', 'production'),
+        ])
+        return super()._count_returned_sn_products(sn_lot) + (remove_count - add_count)


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a storable product “P1” with BoM
    - Component: 1 unit of C1 tracked by Serial Number
- Update the quantity of P1 with “SN1”

- Create a MO to produce one unit of P1:
    - Confirm it
    - Select “SN1” for C1
    - Validate the MO

- Create a repair order to remove C1 from P1 and confirm, start, and complete the repair:
    - Destination location: WH/Stock
    - Serial Number: “SN1”

- Perform the same steps to add C1 (SN1) into P1 again.
- Remove C1 (SN1) a second time.

* After these steps, C1 with SN1 is available in stock.

- Create a new MO to produce one unit of P1:
   - Confirm and select “SN1” for C1
   - Try to validate it

Problem:
When checking the availability on the MO, SN1 is correctly
reserved. However, when marking the second MO as done, a User Error is
displayed: "The serial number SN1 used for component C1
has already been consumed."

opw-4029309
