### PR TITLE
[IMP] point_of_sale, pos_restaurant: place book/release table button inside ticket

### DIFF
--- a/addons/point_of_sale/static/src/app/generic_components/order_widget/order_widget.xml
+++ b/addons/point_of_sale/static/src/app/generic_components/order_widget/order_widget.xml
@@ -20,8 +20,10 @@
             </div>
         </t>
         <t t-else="">
-            <CenteredIcon icon="'fa-shopping-cart fa-4x'" text="emptyCartText()"/>
-            <t t-slot="details"/>
+            <div class="flex-grow-1 d-flex flex-column justify-content-center">
+                <CenteredIcon icon="'fa-shopping-cart fa-4x'" text="emptyCartText()" class="'h-unset'"/>
+                <t t-slot="details"/>
+            </div>
         </t>
     </t>
 </templates>

--- a/addons/pos_restaurant/static/src/app/product_screen/order_summary/order_summary.scss
+++ b/addons/pos_restaurant/static/src/app/product_screen/order_summary/order_summary.scss
@@ -1,0 +1,3 @@
+.h-unset {
+    height: unset !important;
+}

--- a/addons/pos_restaurant/static/src/app/product_screen/order_summary/order_summary.xml
+++ b/addons/pos_restaurant/static/src/app/product_screen/order_summary/order_summary.xml
@@ -2,8 +2,10 @@
 <templates id="template" xml:space="preserve">
     <t t-name="pos_restaurant.OrderSummary" t-inherit="point_of_sale.OrderSummary" t-inherit-mode="extension">
         <xpath expr="//OrderWidget/t[@t-set-slot='details']" position="inside">
-            <button t-if="showBookButton()" class="btn btn-primary py-2 rounded-0 book-table" style="border:none; font-size: 20px;" t-on-click="bookTable">Book table</button>
-            <button t-if="showUnbookButton()" class="btn btn-primary py-2 rounded-0 unbook-table" style="border:none; font-size: 20px;" t-on-click="unbookTable">Release table</button>
+            <div class="d-flex justify-content-center mt-2">
+                <button t-if="showBookButton()" class="btn btn-primary py-2 rounded-0 book-table" style="border:none; font-size: 20px;" t-on-click="bookTable">Book table</button>
+                <button t-if="showUnbookButton()" class="btn btn-primary py-2 rounded-0 unbook-table" style="border:none; font-size: 20px;" t-on-click="unbookTable">Release table</button>    
+            </div>
         </xpath>
         <xpath expr="//OrderWidget" position="attributes">
             <attribute name="isConfigRestaurant">pos.config.module_pos_restaurant</attribute>


### PR DESCRIPTION
Currently, when the ticket is empty, there "BOOK TABLE/RELEASE TABLE" button is placed underneath the ticket. The goal is to place it inside the ticket, below the Cart icon and text ""start adding product...".

### Before
<img width="500" alt="Screenshot 2024-07-16 at 1 45 07 PM" src="https://github.com/user-attachments/assets/682f6da3-be97-4c67-8ea9-cacf37ad5cb3">

### After
<img width="500" alt="Screenshot 2024-07-16 at 1 43 37 PM" src="https://github.com/user-attachments/assets/e224a507-a92e-4e8b-8888-bf1c72d4c43d">

task-4045935
