### PR TITLE
[IMP] core: remove odoo.multi_process

### DIFF
--- a/odoo/__init__.py
+++ b/odoo/__init__.py
@@ -50,13 +50,6 @@ if len(sys.argv) > 1 and sys.argv[1] == 'gevent':
     psycopg2.extensions.set_wait_callback(gevent_wait_callback)
     evented = True
 
-# Is the server running in prefork mode (e.g. behind Gunicorn).
-# If this is True, the processes have to communicate some events,
-# e.g. database update or cache invalidation. Each process has also
-# its own copy of the data structure and we don't need to care about
-# locks between threads.
-multi_process = False
-
 #----------------------------------------------------------
 # libc UTC hack
 #----------------------------------------------------------

--- a/odoo/cli/server.py
+++ b/odoo/cli/server.py
@@ -165,11 +165,6 @@ def main(args):
         import_translation()
         sys.exit(0)
 
-    # This needs to be done now to ensure the use of the multiprocessing
-    # signaling mechanism for registries loaded with -d
-    if config['workers']:
-        odoo.multi_process = True
-
     stop = config["stop_after_init"]
 
     setup_pid_file()

--- a/setup/odoo-wsgi.example.py
+++ b/setup/odoo-wsgi.example.py
@@ -17,7 +17,6 @@ import odoo
 #----------------------------------------------------------
 # Common
 #----------------------------------------------------------
-odoo.multi_process = True # Nah!
 
 # Equivalent of --load command-line option
 odoo.conf.server_wide_modules = ['base', 'web']


### PR DESCRIPTION
Current behavior before PR:
The variable is never used. And defined directly in the `odoo` package.

Desired behavior after PR is merged:
Just remove it.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
