### PR TITLE
[REF] im_livechat, *: clean init data and get thread

### DIFF
--- a/addons/im_livechat/controllers/main.py
+++ b/addons/im_livechat/controllers/main.py
@@ -150,16 +150,23 @@ class LivechatController(http.Controller):
                 fields={"id": True, "user_livechat_username": True, "write_date": True},
             )
             channel_info = {
-                'id': -1, # only one temporary thread at a time, id does not matter.
+                "id": -1,  # only one temporary thread at a time, id does not matter.
                 "isLoaded": True,
-                'name': channel_vals['name'],
+                "name": channel_vals["name"],
+                "scrollUnread": False,
                 "operator": {"id": operator_partner.id, "type": "partner"},
-                'state': 'open',
-                'channel_type': 'livechat',
-                'chatbot': {
-                    'script': chatbot_script._format_for_frontend(),
-                    'steps': chatbot_script._get_welcome_steps().mapped(lambda s: {'scriptStep': {'id': s.id}}),
-                } if chatbot_script else None
+                "state": "open",
+                "channel_type": "livechat",
+                "chatbot": (
+                    {
+                        "script": chatbot_script._format_for_frontend(),
+                        "steps": chatbot_script._get_welcome_steps().mapped(
+                            lambda s: {"scriptStep": {"id": s.id}}
+                        ),
+                    }
+                    if chatbot_script
+                    else None
+                ),
             }
             store.add("discuss.channel", channel_info)
         else:
@@ -182,7 +189,10 @@ class LivechatController(http.Controller):
             if not chatbot_script or chatbot_script.operator_partner_id != channel.livechat_operator_id:
                 channel._broadcast([channel.livechat_operator_id.id])
             store.add(channel)
-            store.add("discuss.channel", {"id": channel.id, "isLoaded": not chatbot_script})
+            store.add(
+                "discuss.channel",
+                {"id": channel.id, "isLoaded": not chatbot_script, "scrollUnread": False},
+            )
             if guest:
                 store.add({"guest_token": guest._format_auth_cookie()})
         request.env["res.users"]._init_store_data(store)

--- a/addons/im_livechat/models/im_livechat_channel.py
+++ b/addons/im_livechat/models/im_livechat_channel.py
@@ -332,9 +332,6 @@ class ImLivechatChannel(models.Model):
         info['server_url'] = self.get_base_url()
         if info['available']:
             info['options'] = self._get_channel_infos()
-            info['options']['current_partner_id'] = (
-                self.env.user.partner_id.id if not self.env.user._is_public() else None
-            )
             info['options']["default_username"] = username
         return info
 

--- a/addons/im_livechat/static/src/embed/common/store_service_patch.js
+++ b/addons/im_livechat/static/src/embed/common/store_service_patch.js
@@ -3,7 +3,6 @@ import { SESSION_STATE } from "@im_livechat/embed/common/livechat_service";
 import { Store, storeService } from "@mail/core/common/store_service";
 
 import { patch } from "@web/core/utils/patch";
-import { session } from "@web/session";
 
 storeService.dependencies.push("im_livechat.initialized");
 
@@ -19,19 +18,10 @@ patch(Store.prototype, {
             }
             return;
         }
-        const messagingData = {
-            "discuss.channel": [],
-            Store: { settings: {} },
-        };
-        if (session.livechatData?.options.current_partner_id) {
-            messagingData.Store.current_partner = {
-                id: session.livechatData.options.current_partner_id,
-            };
+        if (livechatService.savedState?.store) {
+            const { Thread = [] } = this.store.insert(livechatService.savedState.store);
+            livechatService.thread = Thread[0];
         }
-        if (livechatService.savedState?.threadData) {
-            messagingData["discuss.channel"].push(livechatService.savedState.threadData);
-        }
-        this.insert(messagingData);
         this.isReady.resolve();
     },
     get initMessagingParams() {

--- a/addons/im_livechat/static/tests/embed/autopopup.test.js
+++ b/addons/im_livechat/static/tests/embed/autopopup.test.js
@@ -26,7 +26,7 @@ test("persisted session", async () => {
     });
     expirableStorage.setItem(
         "im_livechat.saved_state",
-        JSON.stringify({ threadData: { id: channelId, model: "discuss.channel" }, persisted: true })
+        JSON.stringify({ store: { "discuss.channel": [{ id: channelId }] }, persisted: true })
     );
     await start({
         authenticateAs: { ...pyEnv["mail.guest"].read(guestId)[0], _name: "mail.guest" },

--- a/addons/im_livechat/static/tests/embed/livechat_service.test.js
+++ b/addons/im_livechat/static/tests/embed/livechat_service.test.js
@@ -37,7 +37,7 @@ test("persisted session history", async () => {
     });
     expirableStorage.setItem(
         "im_livechat.saved_state",
-        JSON.stringify({ threadData: { id: channelId, model: "discuss.channel" }, persisted: true })
+        JSON.stringify({ store: { "discuss.channel": [{ id: channelId }] }, persisted: true })
     );
     pyEnv["mail.message"].create({
         author_id: serverState.partnerId,

--- a/addons/im_livechat/static/tests/embed/unread_messages.test.js
+++ b/addons/im_livechat/static/tests/embed/unread_messages.test.js
@@ -41,7 +41,7 @@ test("new message from operator displays unread counter", async () => {
     });
     expirableStorage.setItem(
         "im_livechat.saved_state",
-        JSON.stringify({ threadData: { id: channelId, model: "discuss.channel" }, persisted: true })
+        JSON.stringify({ store: { "discuss.channel": [{ id: channelId }] }, persisted: true })
     );
     onRpcBefore("/mail/action", (args) => {
         if (args.init_messaging) {

--- a/addons/im_livechat/static/tests/mock_server/livechat_mock_server.js
+++ b/addons/im_livechat/static/tests/mock_server/livechat_mock_server.js
@@ -75,6 +75,7 @@ async function get_session(request) {
             name: channelVals["name"],
             chatbot_current_step_id: channelVals.chatbot_current_step_id,
             state: "open",
+            scrollUnread: false,
             operator: { id: operatorPartner.id, type: "partner" },
             channel_type: "livechat",
         });
@@ -92,8 +93,8 @@ async function get_session(request) {
     DiscussChannelMember.write([memberId], { fold_state: "open" });
     const store = new mailDataHelpers.Store();
     ResUsers._init_store_data(store);
-    store.add(DiscussChannel.browse(channelId).map((record) => record.id));
-    store.add("discuss.channel", { id: channelId, isLoaded: true });
+    store.add(DiscussChannel.browse(channelId));
+    store.add("discuss.channel", { id: channelId, isLoaded: true, scrollUnread: false });
     return store.get_result();
 }
 

--- a/addons/im_livechat/views/im_livechat_chatbot_templates.xml
+++ b/addons/im_livechat/views/im_livechat_chatbot_templates.xml
@@ -7,7 +7,7 @@
                 <t t-set="head">
                     <script>
                         <t t-call="im_livechat.loader">
-                            <t t-set="info" t-value="{ 'available': True, 'options': { 'init': { 'available_for_me': True, 'rule': { 'chatbot': chatbot_data }, 'storeData': storeData }, 'isTestChatbot': True, 'force_thread': channel_data, 'current_partner_id': current_partner_id  }, 'server_url': server_url }"/>
+                            <t t-set="info" t-value="{ 'available': True, 'options': { 'init': { 'available_for_me': True, 'rule': { 'chatbot': chatbot_data }, 'storeData': storeData }, 'isTestChatbot': True, 'force_thread': channel_data }, 'server_url': server_url }"/>
                         </t>
                     </script>
                 </t>

--- a/addons/website_livechat/controllers/chatbot.py
+++ b/addons/website_livechat/controllers/chatbot.py
@@ -61,6 +61,5 @@ class WebsiteLivechatChatbotScriptController(http.Controller):
             'server_url': chatbot_script.get_base_url(),
             'channel_data': {'id': discuss_channel.id, 'model': 'discuss.channel'},
             'chatbot_data': chatbot_script._format_for_frontend(),
-            'current_partner_id': request.env.user.partner_id.id,
             'storeData': store.get_result(),
         })

--- a/addons/website_livechat/static/tests/mock_server/mock_models/website_visitor.js
+++ b/addons/website_livechat/static/tests/mock_server/mock_models/website_visitor.js
@@ -51,9 +51,7 @@ export class WebsiteVisitor extends models.ServerModel {
             BusBus._sendone(
                 partner,
                 "website_livechat.send_chat_request",
-                new mailDataHelpers.Store(
-                    DiscussChannel.browse(livechatId).map((record) => record.id)
-                ).get_result()
+                new mailDataHelpers.Store(DiscussChannel.browse(livechatId)).get_result()
             );
         }
     }


### PR DESCRIPTION
\* = website_livechat

- `scrollUnread` is moved to python to avoid post-processing data
- `get thread` with side effect is changed into assignation
- save state to save full store instead of thread (lacking relations)
- `current_partner`, `current_partner_id` is dead code since refactoring

Part of task-3605717

Preparation for https://github.com/odoo/odoo/pull/172863