### PR TITLE
[FIX] hr_holidays: only show user's public holidays

### DIFF
--- a/addons/hr_holidays/models/hr_employee.py
+++ b/addons/hr_holidays/models/hr_employee.py
@@ -321,15 +321,10 @@ class HrEmployee(models.Model):
             ('company_id', 'in', self.env.companies.ids),
             ('date_from', '<=', date_end),
             ('date_to', '>=', date_start),
+            '|',
+            ('calendar_id', '=', False),
+            ('calendar_id', '=', self.resource_calendar_id.id),
         ]
-
-        # a user with hr_holidays permissions will be able to see all public holidays from his calendar
-        if not self._is_leave_user():
-            domain += [
-                '|',
-                ('calendar_id', '=', False),
-                ('calendar_id', '=', self.resource_calendar_id.id),
-            ]
 
         return self.env['resource.calendar.leaves'].search(domain)
 
@@ -353,22 +348,18 @@ class HrEmployee(models.Model):
             ('start_date', '<=', end_date),
             ('end_date', '>=', start_date),
             ('company_id', 'in', self.env.companies.ids),
+            '|',
+            ('resource_calendar_id', '=', False),
+            ('resource_calendar_id', '=', self.resource_calendar_id.id),
         ]
 
-        # a user with hr_holidays permissions will be able to see all stress days from his calendar
-        if not self._is_leave_user():
+        if self.department_id:
             domain += [
                 '|',
-                ('resource_calendar_id', '=', False),
-                ('resource_calendar_id', '=', self.resource_calendar_id.id),
+                ('department_ids', '=', False),
+                ('department_ids', 'parent_of', self.department_id.id),
             ]
-            if self.department_id:
-                domain += [
-                    '|',
-                    ('department_ids', '=', False),
-                    ('department_ids', 'parent_of', self.department_id.id),
-                ]
-            else:
-                domain += [('department_ids', '=', False)]
+        else:
+            domain += [('department_ids', '=', False)]
 
         return self.env['hr.leave.stress.day'].search(domain)

--- a/addons/hr_holidays/tests/__init__.py
+++ b/addons/hr_holidays/tests/__init__.py
@@ -18,3 +18,4 @@ from . import test_stress_days
 from . import test_global_leaves
 from . import test_uninstall
 from . import test_holidays_calendar
+from . import test_dashboard

--- a/addons/hr_holidays/tests/test_dashboard.py
+++ b/addons/hr_holidays/tests/test_dashboard.py
@@ -1,0 +1,60 @@
+from datetime import datetime
+
+from odoo.addons.hr_holidays.tests.common import TestHrHolidaysCommon
+
+
+class TestDashboard(TestHrHolidaysCommon):
+    def test_dashboard_special_days(self):
+        self.env.user = self.user_hrmanager
+        employee = self.env.user.employee_id
+        other_calendar = employee.company_id.resource_calendar_ids[1]
+
+        stress_day_vals = [
+            {
+                'name': 'Super Event (employee schedule)',
+                'company_id': employee.company_id.id,
+                'start_date': datetime(2021, 6, 12),
+                'end_date': datetime(2021, 6, 12),
+                'resource_calendar_id': employee.resource_calendar_id.id,
+            },
+            {
+                'name': 'Super Event (no schedule)',
+                'company_id': employee.company_id.id,
+                'start_date': datetime(2021, 6, 12),
+                'end_date': datetime(2021, 6, 12),
+            },
+            {
+                'name': 'Super Event (other schedule)',
+                'company_id': employee.company_id.id,
+                'start_date': datetime(2021, 6, 12),
+                'end_date': datetime(2021, 6, 12),
+                'resource_calendar_id': other_calendar.id,
+            }
+        ]
+        self.env['hr.leave.stress.day'].create(stress_day_vals)
+
+        public_holiday_vals = [
+            {
+                'name': 'Public holiday (employee schedule)',
+                'date_from': "2021-06-15 06:00:00",
+                'date_to': "2021-06-15 15:00:00",
+                'calendar_id': employee.resource_calendar_id.id,
+            },
+            {
+                'name': 'Public holiday (no schedule)',
+                'date_from': "2021-06-16 06:00:00",
+                'date_to': "2021-06-16 15:00:00",
+            },
+            {
+                'name': 'Public holiday (other schedule)',
+                'date_from': "2021-06-17 06:00:00",
+                'date_to': "2021-06-17 15:00:00",
+                'calendar_id': other_calendar.id,
+            },
+        ]
+        self.env['resource.calendar.leaves'].create(public_holiday_vals)
+
+        dashboard_data = self.env['hr.employee'].get_special_days_data("2021/06/01", "2021/07/01")
+
+        self.assertEqual({d["title"] for d in dashboard_data["stressDays"]}, {'Super Event (employee schedule)', 'Super Event (no schedule)'})
+        self.assertEqual({d["title"] for d in dashboard_data["bankHolidays"]}, {'Public holiday (employee schedule)', 'Public holiday (no schedule)'})


### PR DESCRIPTION
Behaviour before this change
-----
In the "My time off" dashboard, an user belonging to "Administrator" or "Officer" groups will see a list of all public holidays regardless of which working hours they are defined for.
Confirmed to be unintended behaviour by HR PO (gmf).

Behaviour after this change
-----
The list of public holidays displayed on the time off dashboard is the same for
all users. The same change is also applied to stress days.

opw-4019868