### PR TITLE
[FIX] hr_recruitment: use context lang for partner creation

### DIFF
--- a/addons/hr_recruitment/models/hr_applicant.py
+++ b/addons/hr_recruitment/models/hr_applicant.py
@@ -321,7 +321,7 @@ class Applicant(models.Model):
             if not applicant.partner_id:
                 if not applicant.partner_name:
                     raise UserError(_('You must define a Contact Name for this applicant.'))
-                applicant.partner_id = self.env['res.partner'].find_or_create(applicant.email_from)
+                applicant.partner_id = self.env['res.partner'].with_context(default_lang=self.env.lang).find_or_create(applicant.email_from)
             if applicant.partner_name and not applicant.partner_id.name:
                 applicant.partner_id.name = applicant.partner_name
             if tools.email_normalize(applicant.email_from) != tools.email_normalize(applicant.partner_id.email):

--- a/addons/hr_recruitment/tests/test_recruitment.py
+++ b/addons/hr_recruitment/tests/test_recruitment.py
@@ -6,6 +6,21 @@ from odoo.tests import tagged, TransactionCase
 @tagged('recruitment')
 class TestRecruitment(TransactionCase):
 
+    def test_infer_applicant_lang_from_context(self):
+        # Prerequisites
+        self.env['res.lang']._activate_lang('pl_PL')
+        self.env['res.lang']._activate_lang('en_US')
+        self.env['ir.default'].set('res.partner', 'lang', 'en_US')
+
+        # Creating an applicant will create a partner (email_from inverse)
+        applicant = self.env['hr.applicant'].sudo().with_context(lang='pl_PL').create({
+            'name': 'Test Applicant',
+            'partner_name': 'Test Applicant',
+            'email_from': "test_aplicant@example.com"
+
+        })
+        self.assertEqual(applicant.partner_id.lang, 'pl_PL', 'Context langague not used for partner creation')
+
     def test_duplicate_email(self):
         # Tests that duplicate email match ignores case
         # And that no match is found when there is none


### PR DESCRIPTION
### [FIX] hr_recruitment: use context lang for partner creation

When partner is created from Applicant's email_from inverse, in a situation when
job application is submitted, we should use context lang for him.

Useful when submiting application for multi-lang website and becuase
partner's lang is used to send appropriate translations of recruitment
templates.

### [Reproduce Original Error]
- Install website,hr_recruitment
- Set couple of languages on the website (e.g., en_US as default, es_MX as the second language).
- In incognito, using non-default language, apply for some position (url: /es_MX/jobs )
- BUG: The email sent to the applicant is in the default language

opw-3984176