### PR TITLE
[IMP] website_event: Include website base url on event url

### DIFF
--- a/addons/website_event/models/event_event.py
+++ b/addons/website_event/models/event_event.py
@@ -233,7 +233,7 @@ class Event(models.Model):
         super(Event, self)._compute_website_url()
         for event in self:
             if event.id:  # avoid to perform a slug on a not yet saved record in case of an onchange.
-                event.website_url = '/event/%s' % slug(event)
+                event.website_url = '%s/event/%s' % (event.website_id.get_base_url(), slug(event))
 
     # -------------------------------------------------------------------------
     # CONSTRAINT METHODS

--- a/addons/website_event/models/event_event.py
+++ b/addons/website_event/models/event_event.py
@@ -233,7 +233,7 @@ class Event(models.Model):
         super(Event, self)._compute_website_url()
         for event in self:
             if event.id:  # avoid to perform a slug on a not yet saved record in case of an onchange.
-                event.website_url = '%s/event/%s' % (event.website_id.get_base_url(), slug(event))
+                event.website_url = f'{event.get_base_url()}/event/{slug(event)}'
 
     # -------------------------------------------------------------------------
     # CONSTRAINT METHODS

--- a/addons/website_event_track/models/event_track.py
+++ b/addons/website_event_track/models/event_track.py
@@ -156,7 +156,7 @@ class Track(models.Model):
         super(Track, self)._compute_website_url()
         for track in self:
             if track.id:
-                track.website_url = '/event/%s/track/%s' % (slug(track.event_id), slug(track))
+                track.website_url = f'{track.get_base_url()}/event/{slug(track.event_id)}/track/{slug(track)}'
 
     # STAGES
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:
Odoo does not have the posibility to manage redirection of events to appropriate website in case of multi-company's multi-website.

Desired behavior after PR is merged:
Odoo should use the selected website to redirect events. 

Task: [4050674](https://www.odoo.com/odoo/project/809/tasks/3791743/project.project/809/tasks/4050674?cids=17)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
