### PR TITLE
[FIX] account_check_printing: traceback on confirm payment with check

### DIFF
--- a/addons/account_check_printing/models/account_payment.py
+++ b/addons/account_check_printing/models/account_payment.py
@@ -83,7 +83,7 @@ class AccountPayment(models.Model):
               JOIN account_journal journal ON journal.id = move.journal_id,
                    account_payment other_payment
               JOIN account_move other_move ON other_move.id = other_payment.move_id
-             WHERE payment.check_number::BIGINT = other_payment.check_number::BIGINT
+             WHERE payment.check_number = other_payment.check_number
                AND move.journal_id = other_move.journal_id
                AND payment.id != other_payment.id
                AND payment.id IN %(ids)s


### PR DESCRIPTION
Simplification of this https://github.com/odoo/odoo/pull/131841 This is for databases where they have old check with more things that just numbers.

Another option would be to use try_cast or similar

Actually this approach is the one on latam check for v18+

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
