### PR TITLE
[IMP] project: improve task count and label in project updates

### DIFF
--- a/addons/hr_timesheet/data/hr_timesheet_demo.xml
+++ b/addons/hr_timesheet/data/hr_timesheet_demo.xml
@@ -3803,5 +3803,20 @@
         <field name="progress" eval="30"/>
         <field name="status">off_track</field>
     </record>
+    <record id="project.project_update_1" model="project.update">
+        <field name="uom_id" ref="uom.product_uom_hour"/>
+    </record>
+    <record id="project.project_update_3" model="project.update">
+        <field name="uom_id" ref="uom.product_uom_hour"/>
+    </record>
+    <record id="project.project_update_construction_1" model="project.update">
+        <field name="uom_id" ref="uom.product_uom_hour"/>
+    </record>
+    <record id="project.project_update_construction_2" model="project.update">
+        <field name="uom_id" ref="uom.product_uom_hour"/>
+    </record>
+    <record id="project.project_update_2" model="project.update">
+        <field name="uom_id" ref="uom.product_uom_hour"/>
+    </record>
 
 </odoo>

--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -881,7 +881,7 @@ class ProjectProject(models.Model):
             )
         buttons = [{
             'icon': 'check',
-            'text': self.env._('Tasks'),
+            'text': self.label_tasks,
             'number': number,
             'action_type': 'object',
             'action': 'action_view_tasks',

--- a/addons/project/models/project_update.py
+++ b/addons/project/models/project_update.py
@@ -62,6 +62,7 @@ class ProjectUpdate(models.Model):
     task_count = fields.Integer("Task Count", readonly=True, export_string_translation=False)
     closed_task_count = fields.Integer("Closed Task Count", readonly=True, export_string_translation=False)
     closed_task_percentage = fields.Integer("Closed Task Percentage", compute="_compute_closed_task_percentage", export_string_translation=False)
+    label_tasks = fields.Char(related="project_id.label_tasks")
 
     @api.depends('status')
     def _compute_color(self):

--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -42,7 +42,7 @@
                     <div class="oe_button_box" name="button_box" groups="base.group_user">
                         <button class="oe_stat_button" type="object" name="action_view_tasks" icon="fa-check">
                             <div class="o_field_widget o_stat_info">
-                                <span class="o_stat_text">Tasks</span>
+                                <field name="label_tasks" readonly="1"/>
                                 <span class="o_stat_value">
                                     <field name="closed_task_count"/> / <field name="task_count"/>
                                     (<field name="task_completion_percentage" widget="percentage" options="{'digits': [1, 0]}"/>)

--- a/addons/project/views/project_update_views.xml
+++ b/addons/project/views/project_update_views.xml
@@ -83,7 +83,10 @@
                         </div>
                         <div class="mr8 o_pupdate_kanban_width">
                             <b id="tasks_stats">
-                                <field name="closed_task_count"/> / <field name="task_count"/> Tasks<span invisible="not task_count"> (<field name="closed_task_percentage"/>%)</span>
+                                <span invisible="not task_count">
+                                    <field name="closed_task_count"/> / <field name="task_count"/> <field name="label_tasks"/> (<field name="closed_task_percentage"/>%)
+                                </span>
+                                <span invisible="task_count">0 <field name="label_tasks"/></span>
                             </b>
                         </div>
                         <div class="mr8 o_pupdate_kanban_width">


### PR DESCRIPTION
With this commit, we are displaying 0 and the task label (Name of the tasks)
if the number of tasks recorded is equal to 0 in the project updates.
Additionally, we are showing the same task label in the stat button on the
right side panel and smart button of task on the project.

task-3893332