### PR TITLE
[FIX] pos_online_payment: error while paying online by razorpay

### DIFF
--- a/addons/pos_online_payment/controllers/payment_portal.py
+++ b/addons/pos_online_payment/controllers/payment_portal.py
@@ -29,10 +29,7 @@ class PaymentPortal(payment_portal.PaymentPortal):
             raise AccessError(_("The POS session is not opened."))
 
     def _get_partner_sudo(self, user_sudo):
-        partner_sudo = user_sudo.partner_id
-        if not partner_sudo and user_sudo._is_public():
-            partner_sudo = self.env.ref('base.public_user')
-        return partner_sudo
+        return user_sudo.partner_id
 
     def _redirect_login(self):
         return request.redirect('/web/login?' + url_encode({'redirect': request.httprequest.full_path}))
@@ -98,6 +95,8 @@ class PaymentPortal(payment_portal.PaymentPortal):
         self._ensure_session_open(pos_order_sudo)
 
         user_sudo = request.env.user
+        if not pos_order_sudo.partner_id:
+            user_sudo = request.env.ref('base.public_user')
         logged_in = not user_sudo._is_public()
         partner_sudo = pos_order_sudo.partner_id or self._get_partner_sudo(user_sudo)
         if not partner_sudo:
@@ -178,6 +177,8 @@ class PaymentPortal(payment_portal.PaymentPortal):
         self._ensure_session_open(pos_order_sudo)
         exit_route = request.httprequest.args.get('exit_route')
         user_sudo = request.env.user
+        if not pos_order_sudo.partner_id:
+            user_sudo = request.env.ref('base.public_user')
         logged_in = not user_sudo._is_public()
         partner_sudo = pos_order_sudo.partner_id or self._get_partner_sudo(user_sudo)
         if not partner_sudo:


### PR DESCRIPTION
Steps:
---------
- Install the Point of Sale module with demo data.
- Set up online payment provider (e.g. Razorpay) for the Indian company.
- Enable online payment method in Point of sale app configuration
- Add the payment method in Point of sale shop configuration.
- Make a successful online payment in the Point of sale app.

Issue:
---------
- Error occurs after successful payment, preventing the payment from being
  processed and confirmed in POS module and the payment entry from being posted.

Cause:
---------
- Payment transactions status were failing due to company mismatch between the
  partner(admin)'s company and the pos order's company.

FIX:
---------
- If customer is not selected in pos order, we consider the order and payment
  from public user not from the admin user.

Improvement:
---------
- env is not accessible with self in controller for self.env.ref('base.public_user')
  fixed with request.env.ref('base.public_user')
- Unused code removed from `_get_partner_sudo` method

task-3989409