### PR TITLE
[FIX] website_event: open submenu in mobile view

### DIFF
--- a/addons/website_event/static/src/js/website_event.js
+++ b/addons/website_event/static/src/js/website_event.js
@@ -86,4 +86,14 @@ publicWidget.registry.EventRegistrationFormInstance = publicWidget.Widget.extend
     },
 });
 
+publicWidget.registry.EventPage = publicWidget.Widget.extend({
+    selector: '#o_wevent_event_submenu .dropdown-menu a.dropdown-toggle',
+    events: {
+        'click ': '_onClickSubDropDown',
+    },
+    _onClickSubDropDown:function(ev){
+        ev.stopPropagation()
+    }
+})
+
 export default EventRegistrationForm;

--- a/addons/website_event/views/event_templates_page.xml
+++ b/addons/website_event/views/event_templates_page.xml
@@ -33,7 +33,7 @@
                             <button class="dropdown-toggle btn btn-light" data-bs-toggle="dropdown">
                                 <t t-out="active_submenu.name if len(active_submenu) == 1 else ''"/>
                             </button>
-                            <ul class="dropdown-menu flex-md-wrap w-100" t-att-data-menu_name="editable and 'Event Menu'" t-att-data-content_menu_id="editable and event.menu_id.id">
+                            <ul class="dropdown-menu flex-md-wrap w-100 overflow-x-hidden" t-att-data-menu_name="editable and 'Event Menu'" t-att-data-content_menu_id="editable and event.menu_id.id">
                                 <t t-foreach="event.menu_id.child_id" t-as="submenu">
                                     <t t-call="website.submenu">
                                         <t t-set="link_class" t-value="'dropdown-item'"/>


### PR DESCRIPTION
In the multilevel dropdown, when the submenu dropdown is accessed within the parent dropdown, it closes the parent dropdown, making it inaccessible to the child dropdown menu.
We don't want the BS dropdown to close when the sub dropdown is clicked

Task-4037692
