### PR TITLE
[FIX] l10n_in_pos: add dependency on POS sessions for `l10n_in_state_id`

### DIFF
--- a/addons/l10n_in_pos/models/account_move.py
+++ b/addons/l10n_in_pos/models/account_move.py
@@ -1,5 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class AccountMove(models.Model):
@@ -7,6 +7,7 @@ class AccountMove(models.Model):
 
     l10n_in_pos_session_ids = fields.One2many("pos.session", "move_id", "POS Sessions")
 
+    @api.depends('l10n_in_pos_session_ids')
     def _compute_l10n_in_state_id(self):
         res = super()._compute_l10n_in_state_id()
         to_compute = self.filtered(lambda m: m.country_code == 'IN' and not m.l10n_in_state_id and m.journal_id.type == 'general' and m.l10n_in_pos_session_ids)


### PR DESCRIPTION
Enhanced the `_compute_l10n_in_state_id` method in the `AccountMove` model by adding a dependency on the `l10n_in_pos_session_ids` field.

This ensures that the state computation is triggered when POS sessions are updated, improving the accuracy of state determination for moves related to POS sessions.
