### PR TITLE
[FIX] web: SelectMenu: correct btn class (Bootstrap 5.3)

### DIFF
--- a/addons/web/static/src/core/select_menu/select_menu.xml
+++ b/addons/web/static/src/core/select_menu/select_menu.xml
@@ -11,7 +11,7 @@
                 onStateChanged.bind="onStateChanged"
                 navigationOptions="{ virtualFocus: this.props.searchable }"
             >
-                <button t-att-class="`o_select_menu_toggler btn w-100 bg-light ${props.togglerClass || ''} ${canDeselect ? 'o_can_deselect' : ''}`">
+                <button t-att-class="`o_select_menu_toggler btn btn-light w-100 bg-light ${props.togglerClass || ''} ${canDeselect ? 'o_can_deselect' : ''}`">
                     <t t-if="props.multiSelect">
                         <div class="text-wrap text-start">
                             <TagsList tags="multiSelectChoices"/>


### PR DESCRIPTION
As of Bootstrap 5.3 (commit 058212e12b5079eba870bde9775fe98f27928935), buttons with class `.btn` should have an additional class specifying the subtype of button (https://getbootstrap.com/docs/5.3/components/buttons/#base-class)

Before this commit, when hovering a SelectMenu, no specific behavior was set, and sometimes (in Studio -- View Selector in XMLEditor), hovering the button made the text disappear.

After this commit, this is fixed. A few instances of SelectMenu were tested (Studio, knowledge), and in dark mode as well.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
