### PR TITLE
[FIX] mail: fix missing insertText replace

### DIFF
--- a/addons/mail/static/tests/tours/user_modify_own_profile_tour.js
+++ b/addons/mail/static/tests/tours/user_modify_own_profile_tour.js
@@ -21,7 +21,7 @@ registry.category("web_tour.tours").add("mail/static/tests/tours/user_modify_own
             content: "Update the email address",
             trigger: 'div[name="email"] input',
             async run() {
-                await insertText("div[name='email'] input", "updatedemail@example.com");
+                await insertText("div[name='email'] input", "updatedemail@example.com", { replace: true });
                 await contains(".o_form_dirty", { count: 1 });
             },
         },


### PR DESCRIPTION
Before this PR, this tour would crash because the input was not correctly changed.
This PR fix the issue by adding the replace param to insertText

runbot-70440

