### PR TITLE
[FIX] web: skip check validity on unchanged records

### DIFF
--- a/addons/web/static/src/model/relational_model/record.js
+++ b/addons/web/static/src/model/relational_model/record.js
@@ -987,13 +987,13 @@ export class Record extends DataPoint {
                 this.data[fieldName]._abandonRecords();
             }
         }
-        if (!this._checkValidity({ displayNotification: true })) {
-            return false;
-        }
         const changes = this._getChanges();
         delete changes.id; // id never changes, and should not be written
         if (!creation && !Object.keys(changes).length) {
             return true;
+        }
+        if (!this._checkValidity({ displayNotification: true })) {
+            return false;
         }
         if (this.model._urgentSave && this.model.useSendBeaconToSaveUrgently) {
             // We are trying to save urgently because the user is closing the page. To


### PR DESCRIPTION
Before this commit, opening a record from the list view triggered field validity checks, resulting in unnecessary notifications. This commit optimizes the process by bypassing the _checkValidity function when no changes to the record have been made.

opw-3987849

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
