### PR TITLE
[FIX] point_of_sale: fix missing productScanner widget

### DIFF
--- a/addons/point_of_sale/views/product_view.xml
+++ b/addons/point_of_sale/views/product_view.xml
@@ -217,9 +217,6 @@
         <field name="mode">primary</field>
         <field name="inherit_id" ref="product.product_product_view_form_normalized"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='barcode']" position="attributes">
-                <attribute name="widget">productScanner</attribute>
-            </xpath>
             <xpath expr="//div[@name='sales_price']" position="after">
                 <field name="available_in_pos"/>
                 <field name="pos_categ_ids" widget="many2many_tags"/>


### PR DESCRIPTION
Runbot error: 71442

The error "Missing widget: productScanner for field of type char" is raised in community builds. This is linked to the fact that the widget is called in community but declared in enterprise.

Enterprise PR: odoo/enterprise#66721

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
