### PR TITLE
[IMP] web: action service: throw when view type not found

### DIFF
--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -1101,11 +1101,24 @@ export function makeActionManager(env, router = _router) {
      */
     async function _executeActWindowAction(action, options) {
         const views = [];
+        const unknown = [];
         for (const [, type] of action.views) {
-            if (type !== "search" && session.view_info[type]) {
+            if (type === "search") {
+                continue;
+            }
+            if (session.view_info[type]) {
                 const { icon, display_name, multi_record: multiRecord } = session.view_info[type];
                 views.push({ icon, display_name, multiRecord, type });
+            } else {
+                unknown.push(type);
             }
+        }
+        if (unknown.length) {
+            throw new Error(
+                `View types not defined ${unknown.join(", ")} found in act_window action ${
+                    action.id
+                }`
+            );
         }
         if (!views.length) {
             throw new Error(`No view found for act_window action ${action.id}`);

--- a/addons/web/static/tests/webclient/actions/window_action.test.js
+++ b/addons/web/static/tests/webclient/actions/window_action.test.js
@@ -1484,7 +1484,6 @@ test("switch request to unknown view type", async () => {
 });
 
 test.tags("desktop")("execute action with unknown view type", async () => {
-    Partner._views["unknown,false"] = "<unknown/>";
     defineActions([
         {
             id: 33,
@@ -1500,9 +1499,9 @@ test.tags("desktop")("execute action with unknown view type", async () => {
         },
     ]);
     await mountWithCleanup(WebClient);
-    await getService("action").doAction(33);
-    expect(".o_list_view").toHaveCount(1);
-    expect("nav.o_cp_switch_buttons button").toHaveCount(2);
+    await expect(getService("action").doAction(33)).rejects.toThrow(
+        /View types not defined unknown found in act_window action 33/
+    );
 });
 
 test("flags field of ir.actions.act_window is used", async () => {


### PR DESCRIPTION
With https://github.com/odoo/odoo/commit/2b46bfdf63b316ffb5fd57b57b3c6aa16c7d0ba6, the prop type of the View component can no longer be a js_class.
Here we make the errors to be detected sooner.