### PR TITLE
[IMP] hw_drivers: send MAC address on subscribing

### DIFF
--- a/addons/hw_drivers/websocket_client.py
+++ b/addons/hw_drivers/websocket_client.py
@@ -69,7 +69,7 @@ class WebsocketClient(Thread):
             When the client is setup, this function send a message to subscribe to the iot websocket channel
         """
         ws.send(
-            json.dumps({'event_name': 'subscribe', 'data': {'channels': [self.iot_channel], 'last': 0}})
+            json.dumps({'event_name': 'subscribe', 'data': {'channels': [self.iot_channel], 'last': 0, 'mac_address': helpers.get_mac_address()}})
         )
 
     def __init__(self, url):


### PR DESCRIPTION
By sending the MAC address with the subscribe message, the IOT module can keep track of which IoT boxes have a websocket connection active (see enterprise PR)

Enterprise PR: https://github.com/odoo/enterprise/pull/66722
Task ID: 4045291

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
