### PR TITLE
[FIX] account: make bank accounts accessible to branches from invoices

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1311,7 +1311,7 @@
                                         <field name="invoice_origin" string="Source Document" force_save="1" invisible="1"/>
                                         <field name="partner_bank_id"
                                                context="{'default_partner_id': bank_partner_id, 'display_account_trust': True}"
-                                               domain="[('partner_id', '=', bank_partner_id)]"
+                                               domain="[('partner_id.ref_company_ids', 'parent_of', company_id)]"
                                                readonly="state != 'draft'"/>
                                         <field name="qr_code_method"
                                                invisible="not display_qr_code"/>


### PR DESCRIPTION
### Issue:
The bank accounts of a company are not accessible from the branches of this company.

### Steps to reproduce:
- In Settings, create a company and a branch company
- In the contact app, add a bank account for the company
- Switch to the branch company
- In the Accounting app, create a Customer invoice
- In the "Other Info", change the Company to the branch
- The bank account created does not show up in the selection of the field "Recipient Bank"

### Cause:
The current domain is `domain="[('partner_id', '=', bank_partner_id)]"` which is only taking the res.partner.bank record linked with the partner of the company (bank_partner_id).

### Solution:
The solution must work on companies not partners and use the 'parent_of' keyword so that the branches can access the records. Changing the domain to `[('partner_id.ref_company_ids', 'parent_of', company_id)]` works.

### Note:
- The field `ref_company_ids` is an old field that is almost not used anymore, but it is the only link between res.partner.bank and the company it is linked to.
- This domain used `partner_id.ref_company_ids` in an old version of Odoo, but it was changed in this commit: https://github.com/odoo/odoo/commit/1db371721f3549276ee622e8b4369db7ce13863c because of a bug. I did not manage to reproduce the bug in v17 with this fix.

Ticket [link](https://www.odoo.com/odoo/project.task/4027680)
opw-4027680