### PR TITLE
[FIX] base, mail: base don't know html_mail

### DIFF
--- a/addons/mail/views/res_users_views.xml
+++ b/addons/mail/views/res_users_views.xml
@@ -12,6 +12,9 @@
                     <field name="email" position="before">
                         <field name="notification_type" widget="radio" readonly="0"/>
                     </field>
+                    <field name="signature" position="attributes">
+                        <attribute name="widget">html_mail</attribute>
+                    </field>
                 </data>
             </field>
         </record>
@@ -26,6 +29,9 @@
                     <field name="signature" position="before">
                         <field name="notification_type" widget="radio"
                             invisible="share"/>
+                    </field>
+                    <field name="signature" position="attributes">
+                        <attribute name="widget">html_mail</attribute>
                     </field>
                 </data>
             </field>

--- a/odoo/addons/base/views/res_users_views.xml
+++ b/odoo/addons/base/views/res_users_views.xml
@@ -240,7 +240,7 @@
                                     </group>
                                 </group>
                                 <group name="messaging">
-                                    <field name="signature" widget="html_mail" options="{'codeview': true}"/>
+                                    <field name="signature" options="{'codeview': true}"/>
                                 </group>
                             </page>
                             <page string="Account Security" name="account_security" invisible="not id"/>
@@ -445,7 +445,7 @@
                                 </group>
                             </group>
                             <group name="signature">
-                                <field name="signature" widget="html_mail" readonly="0" options="{'codeview': true}"/>
+                                <field name="signature" readonly="0" options="{'codeview': true}"/>
                             </group>
                             <group name="status" string="Status" invisible="1">
                                 <field name="company_id" options="{'no_create': True}" readonly="0"


### PR DESCRIPTION
When just the "base" addon is installed, a warning is triggered when the user's preference is accessed. This is because the "html_field" widget is unknown. You therefore need to use the "html" widget in base and when "mail" is installed use "html_mail".

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
