### PR TITLE
[FIX] payment: raise validation error instead of an exception

### DIFF
--- a/addons/payment/controllers/post_processing.py
+++ b/addons/payment/controllers/post_processing.py
@@ -5,7 +5,9 @@ import logging
 import psycopg2
 
 from odoo import http
+from odoo.exceptions import ValidationError
 from odoo.http import request
+from odoo.tools.translate import _
 
 _logger = logging.getLogger(__name__)
 
@@ -54,7 +56,7 @@ class PaymentPostProcessing(http.Controller):
                 monitored_tx._finalize_post_processing()
             except psycopg2.OperationalError:  # The database cursor could not be committed.
                 request.env.cr.rollback()  # Rollback and try later.
-                raise Exception('retry')
+                raise ValidationError(_('retry'))
             except Exception as e:
                 request.env.cr.rollback()
                 _logger.exception(

--- a/addons/payment/i18n/payment.pot
+++ b/addons/payment/i18n/payment.pot
@@ -2232,6 +2232,13 @@ msgid "success"
 msgstr ""
 
 #. module: payment
+#. odoo-python
+#: code:addons/payment/controllers/post_processing.py:0
+#, python-format
+msgid "retry"
+msgstr ""
+
+#. module: payment
 #: model_terms:ir.ui.view,arch_db:payment.company_mismatch_warning
 msgid ""
 "to make this\n"


### PR DESCRIPTION
Currently, we are showing an exception to the end user when the transaction operation fails
from the below line

https://github.com/odoo/odoo/blob/8b035af881a72048027072743f7ba80accd73109/addons/payment/controllers/post_processing.py#L57

Error:
```
Exception: retry
```
Which is not a valid case to show traceback to the end user,
Instead of a traceback, it's better to raise a validation error.

After applying this commit, the message should be shown as ValidationError

sentry-5512362745