### PR TITLE
[FIX] payment_asiapay: raise warning for unsupported currency in asiapay

### DIFF
--- a/addons/payment_asiapay/i18n/payment_asiapay.pot
+++ b/addons/payment_asiapay/i18n/payment_asiapay.pot
@@ -65,6 +65,13 @@ msgid "Code"
 msgstr ""
 
 #. module: payment_asiapay
+#. odoo-python
+#: code:addons/payment_asiapay/models/payment_transaction.py:0
+#, python-format
+msgid "Currency %s is not supported by asiapay payment provider"
+msgstr ""
+
+#. module: payment_asiapay
 #: model_terms:ir.ui.view,arch_db:payment_asiapay.payment_provider_form
 msgid "Merchant ID"
 msgstr ""

--- a/addons/payment_asiapay/models/payment_transaction.py
+++ b/addons/payment_asiapay/models/payment_transaction.py
@@ -80,6 +80,10 @@ class PaymentTransaction(models.Model):
         if self.provider_code != 'asiapay':
             return res
 
+        avaliable_currency_name = self.provider_id.available_currency_ids[0].name
+        if not avaliable_currency_name in const.CURRENCY_MAPPING:
+            raise ValidationError(_("Currency '%s' is not supported by asiapay payment provider", avaliable_currency_name))
+
         base_url = self.provider_id.get_base_url()
         # The lang is taken from the context rather than from the partner because it is not required
         # to be logged in to make a payment, and because the lang is not always set on the partner.
@@ -88,7 +92,7 @@ class PaymentTransaction(models.Model):
             'merchant_id': self.provider_id.asiapay_merchant_id,
             'amount': self.amount,
             'reference': self.reference,
-            'currency_code': const.CURRENCY_MAPPING[self.provider_id.available_currency_ids[0].name],
+            'currency_code': const.CURRENCY_MAPPING[avaliable_currency_name],
             'mps_mode': 'SCP',
             'return_url': urls.url_join(base_url, AsiaPayController._return_url),
             'payment_type': 'N',


### PR DESCRIPTION
This error occurs because the ``PKR`` currency is not present in the ``CURRENCY_MAPPING``. However, at [1], we are getting the ID of ``PKR``, which causes the error below to be raised.

Traceback:
``KeyError: 'PKR'``

[1]- https://github.com/odoo/odoo/blob/8b035af881a72048027072743f7ba80accd73109/addons/payment_asiapay/models/payment_transaction.py#L91

sentry-5604749493

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
