### PR TITLE
[FIX] pos_self_order: always use the self user for the self order

### DIFF
--- a/addons/pos_self_order/controllers/orders.py
+++ b/addons/pos_self_order/controllers/orders.py
@@ -327,7 +327,7 @@ class PosSelfOrderController(http.Controller):
         if not pos_config_sudo or (not pos_config_sudo.self_ordering_mode == 'mobile' and not pos_config_sudo.self_ordering_mode == 'kiosk') or not pos_config_sudo.has_active_session:
             raise Unauthorized("Invalid access token")
         company = pos_config_sudo.company_id
-        user = pos_config_sudo.current_session_id.user_id or pos_config_sudo.self_ordering_default_user_id
+        user = pos_config_sudo.self_ordering_default_user_id
         return pos_config_sudo.sudo(False).with_company(company).with_user(user).with_context(allowed_company_ids=company.ids)
 
     def _verify_authorization(self, access_token, table_identifier, take_away):
@@ -342,6 +342,6 @@ class PosSelfOrderController(http.Controller):
             raise Unauthorized("Table not found")
 
         company = pos_config.company_id
-        user = pos_config.current_session_id.user_id or pos_config.self_ordering_default_user_id
+        user = pos_config.self_ordering_default_user_id
         table = table_sudo.sudo(False).with_company(company).with_user(user).with_context(allowed_company_ids=company.ids)
         return pos_config, table

--- a/addons/pos_self_order/controllers/self_entry.py
+++ b/addons/pos_self_order/controllers/self_entry.py
@@ -26,7 +26,7 @@ class PosSelfKiosk(http.Controller):
             raise werkzeug.exceptions.NotFound()
 
         company = pos_config_sudo.company_id
-        user = pos_config_sudo.current_session_id.user_id or pos_config_sudo.self_ordering_default_user_id
+        user = pos_config_sudo.self_ordering_default_user_id
         pos_config = pos_config_sudo.sudo(False).with_company(company).with_user(user).with_context(allowed_company_ids=company.ids)
 
         if not pos_config:


### PR DESCRIPTION
Before this commit, the self order was created with the user of the
current session. This is not the expected behavior, as the self order
is always accessed by a public user.

This commit fixes this by always using the self user for the self order.