### PR TITLE
[ADD] hr_recruitment_event{,_salary_contract} : add report between event and applications

### DIFF
--- a/addons/hr_recruitment_event/__init__.py
+++ b/addons/hr_recruitment_event/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import report

--- a/addons/hr_recruitment_event/__manifest__.py
+++ b/addons/hr_recruitment_event/__manifest__.py
@@ -1,0 +1,15 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    'name': 'Recruitment - Event',
+    'category': 'Human Resources/Recruitment',
+    'version': '1.0',
+    'depends': ['event', 'hr_recruitment'],
+    'data': [
+        'security/ir.model.access.csv',
+        'report/hr_applicant_event_report.xml',
+    ],
+    'installable': True,
+    'auto_install': True,
+    'license': 'LGPL-3',
+}

--- a/addons/hr_recruitment_event/report/__init__.py
+++ b/addons/hr_recruitment_event/report/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import hr_applicant_event_report

--- a/addons/hr_recruitment_event/report/hr_applicant_event_report.py
+++ b/addons/hr_recruitment_event/report/hr_applicant_event_report.py
@@ -1,0 +1,69 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models, tools
+
+
+class HrApplicantEventReport(models.Model):
+    _auto = False
+    _name = 'hr.applicant.event.report'
+    _description = 'Applicant Event Report'
+
+    active = fields.Boolean(readonly=True)
+    event_id = fields.Many2one('event.event', readonly=True)
+    event_name = fields.Char(readonly=True)
+    applicant_name = fields.Char(readonly=True)
+    event_country_id = fields.Many2one('res.country', readonly=True)
+    number_of_attendees = fields.Integer('Number of participants', readonly=True)
+    number_of_applicants = fields.Integer('Number of applicants', readonly=True)
+    number_of_signed_contracts = fields.Integer('Number of signed contracts', readonly=True)
+    date_begin = fields.Date(readonly=True)
+
+    def _select(self):
+        return """
+                event.active AS active,
+                e.event_id AS event_id,
+                event.name AS event_name,
+                a.name AS applicant_name,
+                date_begin AS date_begin,
+                event.country_id AS event_country_id,
+                COUNT(e.id) AS number_of_attendees,
+                COUNT(a.id) AS number_of_applicants,
+                COUNT(a.id) FILTER (
+                                    WHERE a.active
+                                          AND refuse_reason_id IS NULL
+                                          AND a.date_closed IS NOT NULL ) AS number_of_signed_contracts
+        """
+
+    def _from(self):
+        return """
+                event_registration e
+                LEFT JOIN hr_applicant a ON e.email = a.email_from
+                LEFT JOIN event_event event ON e.event_id = event.id
+        """
+
+    def _where(self):
+        return """
+                e.state = 'done'
+        """
+
+    def _group_by(self):
+        return """
+                event_id,
+                date_begin,
+                event.active,
+                event.name,
+                a.name,
+                event.country_id
+        """
+
+    def init(self):
+        tools.drop_view_if_exists(self.env.cr, self._table)
+
+        self.env.cr.execute("""
+        CREATE OR REPLACE VIEW %s AS (
+            SELECT %s
+            FROM %s
+            WHERE %s
+            GROUP BY %s
+        )
+        """ % (self._table, self._select(), self._from(), self._where(), self._group_by()))

--- a/addons/hr_recruitment_event/report/hr_applicant_event_report.xml
+++ b/addons/hr_recruitment_event/report/hr_applicant_event_report.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0"?>
+<odoo>
+
+    <record id="hr_applicant_event_report_view_search" model="ir.ui.view">
+        <field name="name">hr.applicant.event.report.view.search</field>
+        <field name="model">hr.applicant.event.report</field>
+        <field name="arch" type="xml">
+            <search string="Event Analysis">
+                <field name="applicant_name"/>
+                <field name="event_name"/>
+                <filter name="this_month" string="This Month" domain="[
+                ('date_begin', '>=', (context_today() + relativedelta(day=1)).strftime('%Y-%m-%d')),
+                ('date_begin', '&lt;', (context_today() + relativedelta(months=1, day=1)).strftime('%Y-%m-%d'))]"/>
+                <filter name="this_year" string="This Year" domain="[
+                ('date_begin', '>=', (context_today() + relativedelta(month=1, day=1)).strftime('%Y-%m-%d')),
+                ('date_begin', '&lt;', (context_today() + relativedelta(years=1, months=1, day=1)).strftime('%Y-%m-%d'))]"/>
+                <separator/>
+                <filter string="Event date" name="date_begin" date="date_begin"/>
+                <separator/>
+                <filter name="active" string="Arhived"/>
+                <filter string="Event Country" name="event_country_group" context="{'group_by': 'event_country_id'}"/>
+            </search>
+        </field>
+    </record>
+
+    <record id="hr_applicant_event_report_view_pivot" model="ir.ui.view">
+        <field name="name">hr.applicant.event.report.view.pivot</field>
+        <field name="model">hr.applicant.event.report</field>
+        <field name="arch" type="xml">
+            <pivot string="Time off Summary" sample="1" disable_linking="1">
+                <field name="event_id" type="row"/>
+                <field name="number_of_attendees" type="measure"/>
+                <field name="number_of_applicants" type="measure"/>
+                <field name="number_of_signed_contracts" type="measure"/>
+            </pivot>
+        </field>
+    </record>
+
+    <record id="hr_recruitment_event_report_action" model="ir.actions.act_window">
+        <field name="name">Event Audience</field>
+        <field name="res_model">hr.applicant.event.report</field>
+        <field name="search_view_id" ref="hr_applicant_event_report_view_search"/>
+        <field name="view_mode">pivot</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                No data yet!
+            </p>
+        </field>
+    </record>
+
+    <menuitem
+    id="menu_hr_recruitment_event"
+    name="Event Audience"
+    parent="hr_recruitment.report_hr_recruitment"
+    action="hr_recruitment_event_report_action"
+    sequence="5"/>
+</odoo>

--- a/addons/hr_recruitment_event/security/ir.model.access.csv
+++ b/addons/hr_recruitment_event/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_hr_applicant_event_report,access_hr_applicant_event_report,model_hr_applicant_event_report,hr_recruitment.group_hr_recruitment_user,1,0,0,0


### PR DESCRIPTION
When you create an event to hire you can't see the impact of your event. With this new feature, this will be possible. When an applicant will apply with the same email adress as when he registered for an event, the popularity of an event will be increased.

task-3964569

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
