### PR TITLE
[FIX] l10n_fr_invoice_addr: fix document styling and improve consistency

### DIFF
--- a/addons/l10n_fr_invoice_addr/views/report_invoice.xml
+++ b/addons/l10n_fr_invoice_addr/views/report_invoice.xml
@@ -14,8 +14,8 @@
         <xpath expr="//div[@id='informations']" position="inside">
             <t t-if="o.l10n_fr_is_company_french and o.partner_id.commercial_partner_id != o.partner_id and o.move_type.startswith('out_')">
                 <t t-set="partner" t-value="o.partner_id.commercial_partner_id"/>
-                <div class="col-auto col-3 mw-100 mb-2">
-                    <div class="font-weight-bold">Customer Address:</div>
+                <div class="col-auto col-3 mw-100 mb-2" name="customer_address">
+                    <strong>Customer Address:</strong>
                     <address t-field="partner.self" class="m-0" t-options="{'widget': 'contact', 'fields': ['address'], 'no_marker': True}"/>
                 </div>
             </t>
@@ -27,20 +27,18 @@
                 <t t-set="has_service" t-value="'service' in tax_scopes"/>
                 <t t-set="has_consu" t-value="'consu' in tax_scopes"/>
 
-                <t t-if="has_service or has_consu">
-                    <div class="col-auto col-3 mw-100 mb-2">
-                        <div class="font-weight-bold">Operation Type:</div>
-                        <t t-if="has_service and has_consu">
-                            Mixed Operation
-                        </t>
-                        <t t-elif="has_service and not has_consu">
-                            Service Delivery
-                        </t>
-                        <t t-else="">
-                            Goods Delivery
-                        </t>
-                    </div>
-                </t>
+                <div t-if="has_service or has_consu" class="col-auto col-3 mw-100 mb-2" name="operation_type">
+                    <strong>Operation Type:</strong>
+                    <p t-if="has_service and has_consu" class="m-0">
+                        Mixed Operation
+                    </p>
+                    <p t-elif="has_service and not has_consu" class="m-0">
+                        Service Delivery
+                    </p>
+                    <p t-else="" class="m-0">
+                        Goods Delivery
+                    </p>
+                </div>
             </t>
         </xpath>
 


### PR DESCRIPTION
Steps to reproduce:
- Install `l10n_fr_invoice_addr`
- Switch to french company
- Change "Colors" in "Document Layout" settings
- Go to an invoice and click the "Preview" button

Because of the inconsistent HTML tags used, the invoice styling wouldn't get applied to the columns added by `l10n_fr_invoice_addr`. This commit improves consistency with the pre-existing HTML hence fixing that issue

See: #172497

task-4056046