### PR TITLE
[FIX] mass_mailing_sms: fix sms link placeholders tests

### DIFF
--- a/addons/mass_mailing_sms/tests/test_mailing_internals.py
+++ b/addons/mass_mailing_sms/tests/test_mailing_internals.py
@@ -77,8 +77,10 @@ class TestMassMailValues(MassSMSCommon):
         })
         base_url = self.env['mailing.mailing'].get_base_url()
 
+        link_trackers = bool(self.env['link.tracker'].search([], limit=1))  # depends on demo
+
         expected = {
-            'link': f'{base_url}/r/xxxx/s/xxxxx',
+            'link': f'{base_url}/r/xxx{"x" if link_trackers else ""}/s/xxxxx',
             'unsubscribe': f"\nSTOP SMS : {base_url}/sms/{'x' * len(str(mailing.id))}/{'x' * self.env['mailing.trace'].CODE_SIZE}",
         }
         self.assertDictEqual(mailing.get_sms_link_replacements_placeholders(), expected)


### PR DESCRIPTION
In no-demo tests, there is no link tracker, so
the expected length is not max+1 but 3.

Follow up of e5b88d3a

Task-3502174
