### PR TITLE
[FIX] web: prevent owl patch before action from ActionSwiper is done

### DIFF
--- a/addons/web/static/src/core/action_swiper/action_swiper.js
+++ b/addons/web/static/src/core/action_swiper/action_swiper.js
@@ -167,14 +167,14 @@ export class ActionSwiper extends Component {
     handleSwipe(action) {
         if (this.props.animationType === "bounce") {
             this.state.containerStyle = `transform: translateX(${this.swipedDistance}px)`;
-            this.actionTimeoutId = browser.setTimeout(() => {
-                action();
+            this.actionTimeoutId = browser.setTimeout(async () => {
+                await action();
                 this._reset();
             }, 500);
         } else if (this.props.animationType === "forwards") {
             this.state.containerStyle = `transform: translateX(${this.swipedDistance}px)`;
-            this.actionTimeoutId = browser.setTimeout(() => {
-                action();
+            this.actionTimeoutId = browser.setTimeout(async () => {
+                await action();
                 this.state.isSwiping = true;
                 this.state.containerStyle = `transform: translateX(${-this.swipedDistance}px)`;
                 this.resetTimeoutId = browser.setTimeout(() => {

--- a/addons/web/static/tests/mobile/core/action_swiper_tests.js
+++ b/addons/web/static/tests/mobile/core/action_swiper_tests.js
@@ -11,9 +11,12 @@ import {
     triggerEvent,
     getFixture,
     mockTimeout,
+    patchWithCleanup,
 } from "@web/../tests/helpers/utils";
+import { swipeRight } from "@web/../tests/mobile/helpers";
+import { Deferred } from "@web/core/utils/concurrency";
 
-import { Component, xml } from "@odoo/owl";
+import { Component, xml, onPatched } from "@odoo/owl";
 const serviceRegistry = registry.category("services");
 
 let env;
@@ -920,5 +923,51 @@ QUnit.module("ActionSwiper", ({ beforeEach }) => {
             "target doesn't have translateX after action is performed"
         );
         assert.verifySteps(["swipeInvalid"]);
+    });
+
+    QUnit.test("action should be done before a new render", async (assert) => {
+        let executingAction = false;
+        const prom = new Deferred();
+        const { execRegisteredTimeouts } = mockTimeout();
+        patchWithCleanup(ActionSwiper.prototype, {
+            setup() {
+                this._super(...arguments);
+                onPatched(() => {
+                    if (executingAction) {
+                        assert.step("ActionSwiper patched");
+                    }
+                });
+            },
+        });
+
+        class Parent extends Component {
+            async onRightSwipe() {
+                await nextTick();
+                assert.step("action done");
+                prom.resolve();
+            }
+        }
+
+        Parent.props = [];
+        Parent.components = { ActionSwiper };
+        Parent.template = xml`
+            <div class="d-flex">
+               <ActionSwiper animationType="'forwards'" onRightSwipe = "{
+                   action: onRightSwipe.bind(this),
+                   icon: 'fa-circle',
+                   bgColor: 'bg-warning',
+               }">
+                   <span>test</span>
+               </ActionSwiper>
+           </div>
+        `;
+
+        await mount(Parent, target, { env });
+        await swipeRight(target, ".o_actionswiper");
+        executingAction = true;
+        execRegisteredTimeouts();
+        await prom;
+        await nextTick();
+        assert.verifySteps(["action done", "ActionSwiper patched"]);
     });
 });


### PR DESCRIPTION
Steps to reproduce
==================

In 17.2:
- Install calendar,hr_homeworking
- Use the emulated mobile view from the devtools
- Go to calendar
- Swipe horizontally to change the displayed week

=> A crash occurs here

https://github.com/odoo/odoo/blob/saas-17.2/addons/hr_homeworking/static/src/calendar/common/calendar_common_renderer.js#L108

Cause of the issue
==================

The `AttendeeCalendarCommonRenderer` is rendered before the data for the next week has been loaded.

This means that `this.props.model.worklocations` has no entry for the `parsedDate`.

Solution
========

Await the action before modifying the ActionSwiper state

opw-4047632