### PR TITLE
[FIX] web_edtior: fix getTraversedNodes traceback

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
@@ -712,6 +712,9 @@ export function getTraversedNodes(editable, range = getDeepRange(editable)) {
         // Handle the case: <p>ab[<br>cd</p><p>ef</p>] => [br, cd, p2, ef]
         node = iterator.nextNode();
     }
+    if (!node) {
+        return [];
+    }
     const traversedNodes = new Set([node, ...descendants(node)]);
     while (node && node !== range.endContainer) {
         node = iterator.nextNode();

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/utils.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/utils.test.js
@@ -1219,6 +1219,16 @@ describe('Utils', () => {
                 },
             });
         });
+        it('selection collapsed after br', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<p><br>[]</p>',
+                stepFunction: editor => {
+                    const editable = editor.editable;
+                    const result = getTraversedNodes(editable);
+                    window.chai.expect(result).to.eql([]);
+                },
+            });
+        });
     });
     describe('getSelectedNodes', () => {
         it('should return nothing if the range is collapsed', async () => {


### PR DESCRIPTION
Issue:
======
Traceback raised when saving/editing notes

Steps to reproduce the issue:
=============================
Follow them exactly
- Create a new note
- Type www.odoo.com -> space -> deletebackward -> enter
- Save
- Exit the note and go back to it again
- Click on top next to save/discard button
- Traceback

Origin of the issue:
====================
In this case `sanitize` have a call to `getTraversedNodes` with a collapsed selection on the `br` element. so we shouldn't consider the conditions that handles `br` elements in this case.

opw-4048219