### PR TITLE
[IMP] web: view: check view type

### DIFF
--- a/addons/hr_holidays/static/src/views/view_dialog/form_view_dialog.js
+++ b/addons/hr_holidays/static/src/views/view_dialog/form_view_dialog.js
@@ -87,7 +87,6 @@ export class TimeOffFormViewDialog extends FormViewDialog {
         super.setup();
 
         this.viewProps = Object.assign(this.viewProps, {
-            type: "timeoff_dialog_form",
             buttonTemplate: 'hr_holidays.FormViewDialog.buttons',
             onCancelLeave: () => {
                 this.props.close();

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -374,13 +374,26 @@
         </field>
     </record>
 
+    <record id="hr_leave_view_form_dialog_new_time_off" model="ir.ui.view">
+        <field name="name">hr.leave.view.form.dialog.new.time.off</field>
+        <field name="model">hr.leave</field>
+        <field name="inherit_id" ref="hr_holidays.hr_leave_view_form_dashboard_new_time_off"/>
+        <field name="mode">primary</field>
+        <field name="priority">17</field>
+        <field name="arch" type="xml">
+            <xpath expr="." position="attributes">
+                <attribute name="js_class">timeoff_dialog_form</attribute>
+            </xpath>
+        </field>
+    </record>
+
     <record id="hr_leave_view_dashboard" model="ir.ui.view">
         <field name="name">hr.leave.view.dashboard</field>
         <field name="model">hr.leave</field>
         <field name="arch" type="xml">
             <calendar js_class="time_off_calendar_dashboard"
                     string="Time Off Request"
-                    form_view_id="%(hr_holidays.hr_leave_view_form_dashboard_new_time_off)d"
+                    form_view_id="%(hr_holidays.hr_leave_view_form_dialog_new_time_off)d"
                     event_open_popup="true"
                     date_start="date_from"
                     date_stop="date_to"
@@ -406,7 +419,7 @@
         <field name="arch" type="xml">
             <calendar string="Time Off Request"
                     js_class="time_off_calendar_dashboard"
-                    form_view_id="%(hr_holidays.hr_leave_view_form_dashboard_new_time_off)d"
+                    form_view_id="%(hr_holidays.hr_leave_view_form_dialog_new_time_off)d"
                     event_open_popup="true"
                     date_start="date_from"
                     date_stop="date_to"
@@ -459,7 +472,7 @@
         <field name="arch" type="xml">
             <calendar js_class="time_off_calendar"
                     string="Time Off Request"
-                    form_view_id="%(hr_holidays.hr_leave_view_form_dashboard_new_time_off)d"
+                    form_view_id="%(hr_holidays.hr_leave_view_form_dialog_new_time_off)d"
                     event_open_popup="true"
                     date_start="date_from"
                     date_stop="date_to"

--- a/addons/onboarding/static/tests/onboarding_banner_tests.js
+++ b/addons/onboarding/static/tests/onboarding_banner_tests.js
@@ -66,6 +66,9 @@ QUnit.module("Onboarding banner", (hooks) => {
             ...session,
             onboarding_to_display: ["animal"],
         });
+        patchWithCleanup(session.view_info, {
+            toy: { multi_record: true, display_name: "Toy", icon: "fab fa-android" },
+        });
 
         const mockRPC = (route) => {
             if (route === "/onboarding/animal") {
@@ -89,6 +92,9 @@ QUnit.module("Onboarding banner", (hooks) => {
 
     QUnit.test("OnboardingBanner does not fetch the banner when the route is not in the session", async (assert) => {
         assert.expect(2);
+        patchWithCleanup(session.view_info, {
+            toy: { multi_record: true, display_name: "Toy", icon: "fab fa-android" },
+        });
 
         const mockRPC = (route) => {
             if (route === "/onboarding/animal") {

--- a/addons/web/static/src/views/view.js
+++ b/addons/web/static/src/views/view.js
@@ -229,6 +229,10 @@ export class View extends Component {
     async loadView(props) {
         const type = props.type;
 
+        if (!session.view_info[type]) {
+            throw new Error(`Invalid view type: ${type}`);
+        }
+
         // determine views for which descriptions should be obtained
         let { viewId, searchViewId } = props;
 


### PR DESCRIPTION
With https://github.com/odoo/odoo/commit/2b46bfdf63b316ffb5fd57b57b3c6aa16c7d0ba6, the prop type of the View component can no longer be a js_class.
Here we make the errors to be detected sooner.