### PR TITLE
[FIX] hr_calendar: correctly compute intervals when allday=True

### DIFF
--- a/addons/hr_calendar/models/calendar_event.py
+++ b/addons/hr_calendar/models/calendar_event.py
@@ -44,15 +44,18 @@ class CalendarEvent(models.Model):
         global_interval = company_calendar._work_intervals_batch(start, stop)[False]
         interval_by_event = {}
         for event in self:
-            event_interval = Intervals([(
-                timezone_datetime(event.start),
-                timezone_datetime(event.stop),
-                self.env['resource.calendar']
-            )])
             if event.allday:
-                interval_by_event[event] = event_interval & global_interval
+                interval_by_event[event] = Intervals([(
+                    timezone_datetime(event.start).replace(hour=0, minute=0, second=0),
+                    timezone_datetime(event.stop).replace(hour=23, minute=59, second=59),
+                    self.env['resource.calendar']
+                )]) & global_interval
             else:
-                interval_by_event[event] = event_interval
+                interval_by_event[event] = Intervals([(
+                    timezone_datetime(event.start),
+                    timezone_datetime(event.stop),
+                    self.env['resource.calendar']
+                )])
         return interval_by_event
 
     def _check_employees_availability_for_event(self, schedule_by_partner, event_interval):


### PR DESCRIPTION
Full day events on a single day get the same value for `start` and `stop`: the 00:00:00 time of the date. Thus an interval based on them is empty.
```
> select id,name,start_date,start,stop_date,stop,allday from calendar_event where id=5
+----+----------------------+------------+---------------------+------------+---------------------+--------+
| id | name                 | start_date | start               | stop_date  | stop                | allday |
|----+----------------------+------------+---------------------+------------+---------------------+--------|
| 5  | Changes in Designing | 2024-07-22 | 2024-07-22 00:00:00 | 2024-07-22 | 2024-07-22 00:00:00 | True   |
+----+----------------------+------------+---------------------+------------+---------------------+--------+
```

This avoids the following error while accesing such events:
```
Traceback (most recent call last):
...
  File "/data/build/odoo/addons/hr_calendar/models/calendar_event.py", line 26, in _compute_unavailable_partner_ids
    start = event_interval._items[0][0]
IndexError: list index out of range

The above server error caused the following client error:
OwlError: An error occured in the owl lifecycle (see this Error's "cause" property)
    OwlError@https://65549950-master-all.runbot111.odoo.com/web/assets/808ceca/web.assets_web.min.js:715:1
    handleError@https://65549950-master-all.runbot111.odoo.com/web/assets/808ceca/web.assets_web.min.js:947:101
    handleError@https://65549950-master-all.runbot111.odoo.com/web/assets/808ceca/web.assets_web.min.js:1574:29
    initiateRender@https://65549950-master-all.runbot111.odoo.com/web/assets/808ceca/web.assets_web.min.js:1037:19

Caused by: RPC_ERROR: Odoo Server Error
    RPCError@https://65549950-master-all.runbot111.odoo.com/web/assets/808ceca/web.assets_web.min.js:2940:338
    makeErrorFromResponse@https://65549950-master-all.runbot111.odoo.com/web/assets/808ceca/web.assets_web.min.js:2943:163
    rpc._rpc/promise</<@https://65549950-master-all.runbot111.odoo.com/web/assets/808ceca/web.assets_web.min.js:2948:34
```

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
