### PR TITLE
[FIX] account_edi_ubl_cii: deprecate eas 0037, 0215

### DIFF
--- a/addons/account_edi_ubl_cii/i18n/account_edi_ubl_cii.pot
+++ b/addons/account_edi_ubl_cii/i18n/account_edi_ubl_cii.pot
@@ -748,6 +748,15 @@ msgstr ""
 #: code:addons/account_edi_ubl_cii/models/res_partner.py:0
 #, python-format
 msgid ""
+"Peppol EAS codes 0037, 0212, 0213, 0215 are deprecated. Please use 0216 "
+"instead."
+msgstr ""
+
+#. module: account_edi_ubl_cii
+#. odoo-python
+#: code:addons/account_edi_ubl_cii/models/res_partner.py:0
+#, python-format
+msgid ""
 "Peppol EAS codes 0212 and 0213 are deprecated. Please use 0216 instead."
 msgstr ""
 

--- a/addons/account_edi_ubl_cii/models/res_partner.py
+++ b/addons/account_edi_ubl_cii/models/res_partner.py
@@ -130,8 +130,8 @@ class ResPartner(models.Model):
     @api.constrains('peppol_eas')
     def _check_peppol_eas(self):
         for partner in self:
-            if partner.peppol_eas in ('0212', '0213'):
-                raise ValidationError(_("Peppol EAS codes 0212 and 0213 are deprecated. Please use 0216 instead."))
+            if partner.peppol_eas in ('0037', '0212', '0213', '0215'):
+                raise ValidationError(_("Peppol EAS codes 0037, 0212, 0213, 0215 are deprecated. Please use 0216 instead."))
             elif partner.peppol_eas == '9955':
                 raise ValidationError(_("Peppol EAS code 9955 is deprecated. Please use 0007 instead."))
             elif partner.peppol_eas == '9901':


### PR DESCRIPTION
EAS codes 0037 and 0215 have been deprecated as of OpenPeppol eDEC codelists v8.9
https://docs.peppol.eu/edelivery/codelists/changelog.html

We will place a warning in stable and remove it in master.

no task