### PR TITLE
[FIX] website: prevent a traceback when publishing

### DIFF
--- a/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
+++ b/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
@@ -1146,7 +1146,8 @@ export class WysiwygAdapterComponent extends Wysiwyg {
             if (
                 isDirty &&
                 (!canPublish ||
-                    (canPublish && this.websiteService.currentWebsite.metadata.isPublished))
+                    (canPublish && this.websiteService.currentWebsite.metadata.isPublished)) &&
+                this.websiteService.currentWebsite.metadata.canOptimizeSeo
             ) {
                 const {
                     mainObject: { id, model },

--- a/addons/website/static/src/systray_items/publish.js
+++ b/addons/website/static/src/systray_items/publish.js
@@ -60,7 +60,7 @@ class PublishSystray extends Component {
         ).then(
             async (published) => {
                 this.state.published = published;
-                if (published) {
+                if (published && this.website.currentWebsite.metadata.canOptimizeSeo) {
                     const seo_data = await rpc("/website/get_seo_data", {
                         res_id: mainObject.id,
                         res_model: mainObject.model,


### PR DESCRIPTION
Steps to reproduce 
1. Go to an event.
2. Click on the 'Sponsors' stat button.
3. Create a sponsor.
4. Go to the website and publish it.
5. Traceback occurs.

Technical Reason:
When creating a new page on the front-end from any model and publishing, certain expected fields were missing, causing errors during the process.
It seems introduced by https://github.com/odoo/odoo/commit/45ea6e4a4a5c8e314b110a45198fbe3d57bb996e

After this commit:
No traceback will occur.

Task-4049539