### PR TITLE
[IMP] mail: local call settings

### DIFF
--- a/addons/mail/static/src/core/common/settings_model.js
+++ b/addons/mail/static/src/core/common/settings_model.js
@@ -20,30 +20,9 @@ export class Settings extends Record {
             typeof document.createElement("canvas").getContext("2d").filter !== "undefined";
         this._loadLocalSettings();
     }
-    volumes = Record.many("Volume");
-    showOnlyVideo = false;
+
+    // Notification settings
     /**
-     * DeviceId of the audio input selected by the user
-     */
-    audioInputDeviceId = "";
-    backgroundBlurAmount = 10;
-    edgeBlurAmount = 10;
-    /**
-     * true if listening to keyboard input to register the push to talk key.
-     */
-    isRegisteringKey = false;
-    logRtc = false;
-    push_to_talk_key;
-    use_push_to_talk = false;
-    voice_active_duration = 200;
-    useBlur = false;
-    volumeSettingsTimeouts = new Map();
-    /**
-     * Normalized [0, 1] volume at which the voice activation system must consider the user as "talking".
-     */
-    voiceActivationThreshold = 0.05;
-    /**
-     * General notification settings for channels
      * @type {"mentions"|"all"|"no_notif"}
      */
     channel_notifications = Record.attr("mentions", {
@@ -52,6 +31,27 @@ export class Settings extends Record {
         },
     });
     mute_until_dt = Record.attr(false, { type: "datetime" });
+
+    // Voice settings
+    // DeviceId of the audio input selected by the user
+    audioInputDeviceId = "";
+    use_push_to_talk = false;
+    voice_active_duration = 200;
+    volumes = Record.many("Volume");
+    volumeSettingsTimeouts = new Map();
+    // Normalized [0, 1] volume at which the voice activation system must consider the user as "talking".
+    voiceActivationThreshold = 0.05;
+    // true if listening to keyboard input to register the push to talk key.
+    isRegisteringKey = false;
+    push_to_talk_key;
+
+    // Video settings
+    backgroundBlurAmount = 10;
+    edgeBlurAmount = 10;
+    showOnlyVideo = false;
+    useBlur = false;
+
+    logRtc = false;
     /**
      * @returns {Object} MediaTrackConstraints
      */
@@ -277,17 +277,15 @@ export class Settings extends Record {
         this.audioInputDeviceId = browser.localStorage.getItem(
             "mail_user_setting_audio_input_device_id"
         );
-    }
-    /**
-     * @private
-     * @param {Event} ev
-     *
-     * Syncs the setting across tabs.
-     */
-    _onStorage(ev) {
-        if (ev.key === "mail_user_setting_voice_threshold") {
-            this.voiceActivationThreshold = ev.newValue;
-        }
+        this.showOnlyVideo =
+            browser.localStorage.getItem("mail_user_setting_show_only_video") === "true";
+        this.useBlur = browser.localStorage.getItem("mail_user_setting_use_blur") === "true";
+        const backgroundBlurAmount = browser.localStorage.getItem(
+            "mail_user_setting_background_blur_amount"
+        );
+        this.backgroundBlurAmount = backgroundBlurAmount ? parseInt(backgroundBlurAmount) : 10;
+        const edgeBlurAmount = browser.localStorage.getItem("mail_user_setting_edge_blur_amount");
+        this.edgeBlurAmount = edgeBlurAmount ? parseInt(edgeBlurAmount) : 10;
     }
     /**
      * @private

--- a/addons/mail/static/src/discuss/call/common/call_settings.js
+++ b/addons/mail/static/src/discuss/call/common/call_settings.js
@@ -2,6 +2,7 @@ import { Component, onWillStart, useExternalListener, useState } from "@odoo/owl
 
 import { _t } from "@web/core/l10n/translation";
 import { browser } from "@web/core/browser/browser";
+import { debounce } from "@web/core/utils/timing";
 import { isMobileOS } from "@web/core/browser/feature_detection";
 import { useService } from "@web/core/utils/hooks";
 
@@ -18,6 +19,18 @@ export class CallSettings extends Component {
             userDevices: [],
         });
         this.pttExtService = useState(useService("discuss.ptt_extension"));
+        this.saveBackgroundBlurAmount = debounce(() => {
+            browser.localStorage.setItem(
+                "mail_user_setting_background_blur_amount",
+                this.store.settings.backgroundBlurAmount.toString()
+            );
+        }, 2000);
+        this.saveEdgeBlurAmount = debounce(() => {
+            browser.localStorage.setItem(
+                "mail_user_setting_edge_blur_amount",
+                this.store.settings.edgeBlurAmount.toString()
+            );
+        }, 2000);
         useExternalListener(browser, "keydown", this._onKeyDown, { capture: true });
         useExternalListener(browser, "keyup", this._onKeyUp, { capture: true });
         onWillStart(async () => {
@@ -101,11 +114,16 @@ export class CallSettings extends Component {
 
     onChangeBlur(ev) {
         this.store.settings.useBlur = ev.target.checked;
+        browser.localStorage.setItem("mail_user_setting_use_blur", this.store.settings.useBlur);
     }
 
     onChangeShowOnlyVideo(ev) {
         const showOnlyVideo = ev.target.checked;
         this.store.settings.showOnlyVideo = showOnlyVideo;
+        browser.localStorage.setItem(
+            "mail_user_setting_show_only_video",
+            this.store.settings.showOnlyVideo
+        );
         const activeRtcSessions = this.store.allActiveRtcSessions;
         if (showOnlyVideo && activeRtcSessions) {
             activeRtcSessions
@@ -118,9 +136,11 @@ export class CallSettings extends Component {
 
     onChangeBackgroundBlurAmount(ev) {
         this.store.settings.backgroundBlurAmount = Number(ev.target.value);
+        this.saveBackgroundBlurAmount();
     }
 
     onChangeEdgeBlurAmount(ev) {
         this.store.settings.edgeBlurAmount = Number(ev.target.value);
+        this.saveEdgeBlurAmount();
     }
 }


### PR DESCRIPTION
backgroundBlurAmount, edgeBlurAmount, showOnlyVideo, useBlur are neither stored in the database nor in the browser's local storage. It can be confusing for the user to have these settings reset every time.

This commit stores these settings in the browser's local storage.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
