### PR TITLE
[FIX] account: analytic distribution on tax lines

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -956,7 +956,7 @@ class AccountMoveLine(models.Model):
                     'group_tax_id': tax['group'] and tax['group'].id or False,
                     'account_id': tax['account_id'] or line.account_id.id,
                     'currency_id': line.currency_id.id,
-                    'analytic_distribution': ((tax['analytic'] or not tax['use_in_tax_closing']) and line.move_id.state == 'draft') and line.analytic_distribution,
+                    'analytic_distribution': ((tax['analytic'] or (not tax['account_id'] and not tax['use_in_tax_closing'])) and line.move_id.state == 'draft') and line.analytic_distribution,
                     'tax_ids': [(6, 0, tax['tax_ids'])],
                     'tax_tag_ids': [(6, 0, tax['tag_ids'])],
                     'partner_id': line.move_id.partner_id.id or line.partner_id.id,


### PR DESCRIPTION
Have a tax having on repartition line for tax 'Tax Closing Entry' set to False
Create an invoice
On a line add the tax and analytic distribution
Save
Check journal items

Issue: tax line will have analytic items
This occurs because we add the analytic to tax lines generated from repartition lines when use_in_tax_closing for cases where the tax is actually part of the product price
In these cases the account is set to False so we should add also this condition to avoid adding the analytics to normal tax lines

opw-3977674