### PR TITLE
[FIX] html_editor: inde emoji command powerbox

### DIFF
--- a/addons/html_editor/static/tests/emoji.test.js
+++ b/addons/html_editor/static/tests/emoji.test.js
@@ -15,7 +15,7 @@ test("add an emoji with powerbox", async () => {
 
     insertText(editor, "/emoji");
     press("enter");
-    await waitFor(".o-EmojiPicker");
+    await waitFor(".o-EmojiPicker", { timeout: 500 });
     expect(".o-EmojiPicker").toHaveCount(1);
 
     await click(".o-EmojiPicker .o-Emoji");
@@ -32,7 +32,7 @@ test("click on emoji command to open emoji picker", async () => {
     insertText(editor, "/emoji");
     await animationFrame();
     click(".active .o-we-command-name");
-    await waitFor(".o-EmojiPicker");
+    await waitFor(".o-EmojiPicker", { timeout: 500 });
     expect(".o-EmojiPicker").toHaveCount(1);
 });
 
@@ -44,7 +44,7 @@ test("undo an emoji", async () => {
     insertText(editor, "test");
     insertText(editor, "/emoji");
     press("enter");
-    await waitFor(".o-EmojiPicker");
+    await waitFor(".o-EmojiPicker", { timeout: 500 });
     await click(".o-EmojiPicker .o-Emoji");
     expect(getContent(el)).toBe("<p>abtest😀[]</p>");
 


### PR DESCRIPTION
Sometimes the emoji picker takes longer to open than the default 200ms. We're therefore going to increase this limit for our tests.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
