### PR TITLE
[FIX] web_editor: hide ghost overlay

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -4581,10 +4581,21 @@ var SnippetsMenu = Widget.extend({
             // This is async but using the main editor mutex, currently locked.
             this._updateInvisibleDOM();
 
+            // Updating options upon changing preview mode to avoid ghost overlay
+            const enabledInvisibleOverrideEl = this.options.wysiwyg.lastElement &&
+                this.options.wysiwyg.lastElement.closest(".o_snippet_mobile_invisible, .o_snippet_desktop_invisible");
+            const needDeactivate = enabledInvisibleOverrideEl && enabledInvisibleOverrideEl.dataset.invisible === "1";
+
             return new Promise(resolve => {
-                this.trigger_up('snippet_option_update', {
-                    onSuccess: () => resolve(),
-                });
+                // No need to trigger "snippet_option_update" when snippet is deactivated.
+                if (needDeactivate) {
+                    this._activateSnippet(false);
+                    resolve();
+                } else {
+                    this.trigger_up("snippet_option_update", {
+                        onSuccess: () => resolve(),
+                    });
+                }
             });
         }, false);
     },


### PR DESCRIPTION
Steps to reproduce:
- Add an snippet.
- Click the "show/hide on desktop"  button of visibility option.
- Click on the little eye on the "hidden elements" section to have it displayed again.
- Go to mobile preview mode.
- Come back to desktop view by toggling off mobile preview button.
- An empty overlay appears on the left of the screen. With dimensions similar to snippet in mobile view.

After this commit:
Empty overlays no longer appear when switching between preview modes.

task-3270034

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
