### PR TITLE
[FIX] project: fix text pasting in chatter on shared project portal

### DIFF
--- a/addons/project/static/src/project_sharing/views/form/project_sharing_form_controller.js
+++ b/addons/project/static/src/project_sharing/views/form/project_sharing_form_controller.js
@@ -35,8 +35,8 @@ export class ProjectSharingFormController extends FormController {
     }
 
     onGlobalPaste(ev) {
-        ev.preventDefault();
         if (ev.target.closest('.o_field_widget[name="description"]')) {
+            ev.preventDefault();
             const items = ev.clipboardData.items;
             for (let i = 0; i < items.length; i++) {
                 if (items[i].type.indexOf('image') !== -1 && !this.model.root.resId) {
@@ -52,8 +52,8 @@ export class ProjectSharingFormController extends FormController {
     }
 
     onGlobalDrop(ev) {
-        ev.preventDefault();
         if (ev.target.closest('.o_field_widget[name="description"]')) {
+            ev.preventDefault();
             if(ev.dataTransfer.files.length > 0 && !this.model.root.resId){
                 this.notification.add(
                     _t("Save the task to be able to drag images in description"),


### PR DESCRIPTION
Problem: When attempting to paste text (either via right-click -> paste or using CTRL-V) into the chatter of a shared project, the action fails.

This issue was caused by the addition of `event.preventDefault()` in the `ProjectSharingFormController` form. This does not affect the description field as it is also managed by `OdooEditor`.

Steps to reproduce:
1. Share a project with a user.
2. Impersonate the user and navigate to the project from the portal.
3. Select a task.
4. Attempt to paste something into the chatter.

opw-4046529
