### PR TITLE
[FIX] payment: prevent an error while payment session expired

### DIFF
--- a/addons/payment/controllers/post_processing.py
+++ b/addons/payment/controllers/post_processing.py
@@ -5,6 +5,7 @@ import logging
 import psycopg2
 
 from odoo import http
+from odoo.exceptions import ValidationError
 from odoo.http import request
 
 _logger = logging.getLogger(__name__)
@@ -45,7 +46,7 @@ class PaymentPostProcessing(http.Controller):
             self.get_monitored_transaction_id()
         ).exists()
         if not monitored_tx:  # The session might have expired, or the tx has never existed.
-            raise Exception('tx_not_found')
+            raise ValidationError('tx_not_found')
 
         # Finalize the post-processing of the transaction before redirecting the user to the landing
         # route and its document.


### PR DESCRIPTION
Currently, an exception occurs when a payment session has expired at [1], To handle this issue, raise a validation error instead of raise an exception.

link [1]: https://github.com/odoo/odoo/blob/677f7d0c6085dba4ab9c27a53b4c3fd2d88b190e/addons/payment/controllers/post_processing.py#L48

Traceback On Sentry:

```
Exception: tx_not_found
  File "odoo/http.py", line 2248, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1823, in _serve_db
    return self._transactioning(_serve_ir_http, readonly=ro)
  File "odoo/http.py", line 1843, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1821, in _serve_ir_http
    return self._serve_ir_http(rule, args)
  File "odoo/http.py", line 1828, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2053, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 220, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 756, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/payment/controllers/post_processing.py", line 48, in poll_status
    raise Exception('tx_not_found')

```

sentry-4992700034

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
