### PR TITLE
[FIX] Expand check_indexes with new index method: btrin, index keys for where clauses and reindex

### DIFF
--- a/addons/module_reindex
+++ b/addons/module_reindex
@@ -1,1 +1,0 @@
-/opt/odoo/oca/odoo-17.0/server-tools/module_reindex/

--- a/addons/module_reindex
+++ b/addons/module_reindex
@@ -1,0 +1,1 @@
+/opt/odoo/oca/odoo-17.0/server-tools/module_reindex/

--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -46,7 +46,8 @@ class StockQuant(models.Model):
     product_id = fields.Many2one(
         'product.product', 'Product',
         domain=lambda self: self._domain_product_id(),
-        ondelete='restrict', required=True, index=True, check_company=True)
+        ondelete='restrict', required=True, index=True, check_company=True,
+        index_keys='product_id,location_id')
     product_tmpl_id = fields.Many2one(
         'product.template', string='Product Template',
         related='product_id.product_tmpl_id')
@@ -65,13 +66,16 @@ class StockQuant(models.Model):
     lot_id = fields.Many2one(
         'stock.lot', 'Lot/Serial Number', index=True,
         ondelete='restrict', check_company=True,
-        domain=lambda self: self._domain_lot_id())
+        domain=lambda self: self._domain_lot_id(),
+        index_keys='product_id,lot_id,location_id'
+    )
     lot_properties = fields.Properties(related='lot_id.lot_properties', definition='product_id.lot_properties_definition', readonly=True)
     sn_duplicated = fields.Boolean(string="Duplicated Serial Number", compute='_compute_sn_duplicated', help="If the same SN is in another Quant")
     package_id = fields.Many2one(
         'stock.quant.package', 'Package',
         domain="[('location_id', '=', location_id)]",
-        help='The package containing this quant', ondelete='restrict', check_company=True, index=True)
+        help='The package containing this quant', ondelete='restrict', check_company=True, index=True,
+        index_keys='product_id,package_id,location_id')
     owner_id = fields.Many2one(
         'res.partner', 'Owner',
         help='This is the owner of the quant', check_company=True,

--- a/doc/cla/individual/RosenVladimirov.md
+++ b/doc/cla/individual/RosenVladimirov.md
@@ -1,0 +1,11 @@
+Bulgaria, 2024-07-16
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Rosen Vladimirov vladimirov.rosen@gmail.com https://github.com/rosenvladimirov

--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -529,6 +529,7 @@ class IrModelFields(models.Model):
     required = fields.Boolean()
     readonly = fields.Boolean()
     index = fields.Boolean(string='Indexed')
+    index_keys = fields.Char(string='Indexed Keys')
     translate = fields.Boolean(string='Translatable', help="Whether values for this field can be translated (enables the translation mechanism for that field)")
     size = fields.Integer()
     state = fields.Selection([('manual', 'Custom Field'), ('base', 'Base Field')], string='Type', default='manual', required=True, readonly=True, index=True)
@@ -1099,6 +1100,7 @@ class IrModelFields(models.Model):
             'state': 'manual' if field.manual else 'base',
             'relation': field.comodel_name or None,
             'index': bool(field.index),
+            'index_keys': field.index_keys,
             'store': bool(field.store),
             'copied': bool(field.copy),
             'on_delete': field.ondelete if field.type == 'many2one' else None,

--- a/odoo/addons/base/views/ir_model_views.xml
+++ b/odoo/addons/base/views/ir_model_views.xml
@@ -56,6 +56,7 @@
                                     <field name="required"/>
                                     <field name="readonly"/>
                                     <field name="index" groups="base.group_no_one"/>
+                                    <field name="index_keys" groups="base.group_no_one"/>
                                     <field name="state" groups="base.group_no_one"/>
                                 </tree>
                                 <form string="Fields Description">
@@ -77,6 +78,7 @@
                                                     <field name="readonly"/>
                                                     <field name="store" groups="base.group_no_one"/>
                                                     <field name="index" groups="base.group_no_one"/>
+                                                    <field name="index_keys" groups="base.group_no_one"/>
                                                     <field name="copied" groups="base.group_no_one"/>
                                                 </group>
                                                 <group>
@@ -268,6 +270,7 @@
                                         <field name="readonly"/>
                                         <field name="store" groups="base.group_no_one"/>
                                         <field name="index" groups="base.group_no_one"/>
+                                        <field name="index_keys" groups="base.group_no_one" readonly="0"/>
                                         <field name="copied" groups="base.group_no_one"/>
                                     </group>
                                     <group>
@@ -404,6 +407,7 @@
                     <field name="ttype"/>
                     <field name="state"/>
                     <field name="index"/>
+                    <field name="index_keys"/>
                     <field name="store"/>
                     <field name="readonly"/>
                     <field name="relation"/>

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -158,7 +158,7 @@ class Field(MetaField('DummyField', (object,), {})):
                                 values are NULL, or when NULL is never searched for)
         * ``"trigram"``: Generalized Inverted Index (GIN) with trigrams (good for full-text search)
         * ``None`` or ``False``: no index (default)
-
+    :index_keys str index keys: key expression for index, semicolon separated
     :param default: the default value for the field; this is either a static
         value, or a function taking a recordset and returning a value; use
         ``default=None`` to discard default values for the field
@@ -295,7 +295,8 @@ class Field(MetaField('DummyField', (object,), {})):
     comodel_name = None                 # name of the model of values (if relational)
 
     store = True                        # whether the field is stored in database
-    index = None                        # how the field is indexed in database
+    index = None                        # how the field is indexed in database ('btree', 'btree_not_null', 'brin', 'brin_not_null', 'trigram', True, False, None)
+    index_keys = None                   # index key for indexing used semicolon separator (example: where name like self and default_code ilike self: (name, default_code))
     manual = False                      # whether the field is a custom field
     copy = True                         # whether the field is copied over by BaseModel.copy()
     _depends = None                     # collection of field dependencies

--- a/odoo/modules/registry.py
+++ b/odoo/modules/registry.py
@@ -722,7 +722,6 @@ class Registry(Mapping):
     def re_index(self, cr, model_names, value_fields=False):
         indexes = self._check_indexes(cr, model_names, info=True, value_fields=value_fields)
         for index_name, table_name, expression, method, where, field_name in indexes or []:
-            _logger.info(f"{index_name}, {table_name}, {expression}, {method}, {where}, {field_name} {type(expression)} {isinstance(expression, list)}")
             if not isinstance(expression, list):
                 expression = [expression]
             try:

--- a/odoo/modules/registry.py
+++ b/odoo/modules/registry.py
@@ -708,7 +708,7 @@ class Registry(Mapping):
         # If you use index keys possible to add more combinations. In future is better to add analise of where clause to
         # add automatic index_keys in fields.
         indexes = self._check_indexes(cr, model_names)
-        for index_name, table_name, expression, method, where, field_name in indexes:
+        for index_name, table_name, expression, method, where, field_name in indexes or []:
             try:
                 with cr.savepoint(flush=False):
                     sql.create_index(cr, index_name, table_name, [expression], method, where)

--- a/odoo/tools/sql.py
+++ b/odoo/tools/sql.py
@@ -543,6 +543,12 @@ def drop_index(cr, indexname, tablename):
     _schema.debug("Table %r: dropped index %r", tablename, indexname)
 
 
+def re_index(cr, indexname, tablename, expressions, method='btree', where=''):
+    drop_index(cr, indexname, tablename)
+    create_index(cr, indexname, tablename, expressions, method=method, where=where)
+    _schema.debug("Table %r: reindex %r", tablename, indexname)
+
+
 def drop_view_if_exists(cr, viewname):
     kind = table_kind(cr, viewname)
     if kind == TableKind.View:


### PR DESCRIPTION
Description of the issue/feature this PR addresses: This PR focuses on enhancing PostgreSQL index support by adding compatibility with the brin method. The brin is an low-cost index and quicker for extensive databases. In registry.py, an update has been made to automatically generate indexes for many2one field. This feature enhances the speed for updating or deleting interconnected tables. Functionality related to index key base has been incorporated into fields. Using the index key allows for the configuration of multiple column indexes by separating them with semicolons. 

Current behavior before PR: Not support brin, index keys and reindex

Desired behavior after PR is merged: More fast database operations




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
