### PR TITLE
[FIX] account: add specific payments in balance on journal dashboard

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -98,6 +98,7 @@ class AccountPayment(models.Model):
         comodel_name='account.account',
         string="Outstanding Account",
         store=True,
+        index='btree_not_null',
         compute='_compute_outstanding_account_id',
         check_company=True)
     destination_account_id = fields.Many2one(


### PR DESCRIPTION
On Bank/Cash journals, there is some inconsistencies between
Balance value and what we see in GL when opening it.
This is due to a specific configuration when the default account of
the journal is used as outstanding payments/receipts account of the
journal.

Steps:

- Create a bank journal and set the default account to be the same as
  the outstanding payments account
- Create a customer payment in this journal
- Go to Accounting Dashboard
-> The payment value is not taken into account in the Balance value

opw-3882204
