### PR TITLE
[FIX] web: tests - speed up calendar tests

### DIFF
--- a/addons/web/static/tests/views/calendar/calendar_test_helpers.js
+++ b/addons/web/static/tests/views/calendar/calendar_test_helpers.js
@@ -1,5 +1,5 @@
-import { drag, hover, queryFirst, queryRect } from "@odoo/hoot-dom";
-import { animationFrame, runAllTimers } from "@odoo/hoot-mock";
+import { click, drag, hover, queryFirst, queryRect } from "@odoo/hoot-dom";
+import { advanceTime, animationFrame } from "@odoo/hoot-mock";
 import { EventBus } from "@odoo/owl";
 import { contains } from "@web/../tests/web_test_helpers";
 
@@ -310,8 +310,8 @@ export function findFilterPanelSectionFilter(sectionName) {
 export async function pickDate(date) {
     const day = date.split("-")[2];
     const iDay = parseInt(day, 10) - 1;
-    const cell = queryFirst`.o_datetime_picker .o_date_item_cell:not(.o_out_of_range):eq(${iDay})`;
-    await contains(cell).click();
+    click(`.o_datetime_picker .o_date_item_cell:not(.o_out_of_range):eq(${iDay})`);
+    await animationFrame();
 }
 
 /**
@@ -321,7 +321,7 @@ export async function pickDate(date) {
 export async function clickAllDaySlot(date) {
     const slot = findAllDaySlot(date);
     instantScrollTo(slot);
-    await contains(slot).click();
+    click(slot);
     await animationFrame();
 }
 
@@ -332,8 +332,8 @@ export async function clickAllDaySlot(date) {
 export async function clickDate(date) {
     const cell = findDateCell(date);
     instantScrollTo(cell);
-    await contains(cell).click();
-    await animationFrame();
+    click(cell);
+    await advanceTime(500);
 }
 
 /**
@@ -343,8 +343,8 @@ export async function clickDate(date) {
 export async function clickEvent(eventId) {
     const event = findEvent(eventId);
     instantScrollTo(event);
-    await contains(event).click();
-    await runAllTimers(); // wait for the popover to open (debounced)
+    click(event);
+    await advanceTime(500); // wait for the popover to open (debounced)
 }
 
 /**
@@ -496,8 +496,7 @@ export async function resizeEventToTime(eventId, dateTime) {
     moveTo(row, { relative: true, position: { y: -1, x: columnRect.x } });
     drop();
 
-    await animationFrame();
-    await animationFrame();
+    await advanceTime(500);
 }
 
 /**
@@ -526,7 +525,8 @@ export async function toggleFilter(sectionName, filterValue) {
     const root = findFilterPanelFilter(sectionName, filterValue);
     const input = queryFirst(`input`, { root });
     instantScrollTo(input);
-    await contains(input).click();
+    click(input);
+    await animationFrame();
 }
 
 /**
@@ -537,7 +537,8 @@ export async function toggleSectionFilter(sectionName) {
     const root = findFilterPanelSectionFilter(sectionName);
     const input = queryFirst(`input`, { root });
     instantScrollTo(input);
-    await contains(input).click();
+    click(input);
+    await animationFrame();
 }
 
 /**
@@ -549,5 +550,6 @@ export async function removeFilter(sectionName, filterValue) {
     const root = findFilterPanelFilter(sectionName, filterValue);
     const button = queryFirst(`.o_remove`, { root });
     instantScrollTo(button);
-    await contains(button).click();
+    click(button);
+    await animationFrame();
 }

--- a/addons/web/static/tests/views/calendar/calendar_view.test.js
+++ b/addons/web/static/tests/views/calendar/calendar_view.test.js
@@ -8,7 +8,7 @@ import {
     queryLast,
     queryRect,
 } from "@odoo/hoot-dom";
-import { Deferred, animationFrame, mockDate, mockTimeZone, runAllTimers } from "@odoo/hoot-mock";
+import { Deferred, advanceTime, animationFrame, mockDate, mockTimeZone } from "@odoo/hoot-mock";
 import { Component, onWillRender, onWillStart, xml } from "@odoo/owl";
 import {
     MockServer,
@@ -48,10 +48,10 @@ import {
 
 import { registry } from "@web/core/registry";
 import { zip } from "@web/core/utils/arrays";
-import { WebClient } from "@web/webclient/webclient";
-import { calendarView } from "@web/views/calendar/calendar_view";
 import { CalendarController } from "@web/views/calendar/calendar_controller";
+import { calendarView } from "@web/views/calendar/calendar_view";
 import { CalendarYearRenderer } from "@web/views/calendar/calendar_year/calendar_year_renderer";
+import { WebClient } from "@web/webclient/webclient";
 
 describe.current.tags("desktop");
 
@@ -394,7 +394,7 @@ test(`filter panel autocomplete: updates when typing`, async () => {
     ]);
 
     await contains(`${root} .o-autocomplete--input`).edit("partner 3", { confirm: false });
-    await runAllTimers();
+    await advanceTime(500);
     expect(`${root} .o-autocomplete--dropdown-menu`).toHaveCount(1);
     expect(`${root} .o-autocomplete--dropdown-item`).toHaveCount(1);
     expect(queryAllTexts(`${root} .o-autocomplete--dropdown-item`)).toEqual(["partner 3"]);
@@ -403,7 +403,7 @@ test(`filter panel autocomplete: updates when typing`, async () => {
         "a string that would yield to no result as it is too very much convoluted",
         { confirm: false }
     );
-    await runAllTimers();
+    await advanceTime(500);
     expect(`${root} .o-autocomplete--dropdown-menu`).toHaveCount(1);
     expect(`${root} .o-autocomplete--dropdown-item`).toHaveCount(1);
     expect(queryAllTexts(`${root} .o-autocomplete--dropdown-item`)).toEqual(["No records"]);
@@ -447,7 +447,7 @@ test(`add a filter with the search more dialog`, async () => {
     expect(`${section} .o-autocomplete--dropdown-menu`).toHaveCount(0);
     expect(`${section} .o-autocomplete--dropdown-item`).toHaveCount(0);
     await contains(`${section} .o-autocomplete--input`).click();
-    await runAllTimers();
+    await advanceTime(500);
     expect(`${section} .o-autocomplete--dropdown-menu`).toHaveCount(1);
     expect(`${section} .o-autocomplete--dropdown-item`).toHaveCount(9);
     expect(queryAllTexts`.o-autocomplete--dropdown-item`).toEqual([
@@ -464,7 +464,7 @@ test(`add a filter with the search more dialog`, async () => {
 
     // Change the search term
     await contains(`.o-autocomplete--input`).edit("foo", { confirm: false });
-    await runAllTimers();
+    await advanceTime(500);
     expect(`${section} .o-autocomplete--dropdown-menu`).toHaveCount(1);
     expect(`${section} .o-autocomplete--dropdown-item`).toHaveCount(9);
     expect(queryAllTexts`.o-autocomplete--dropdown-item`).toEqual([
@@ -514,7 +514,7 @@ test(`add a filter with the search more dialog`, async () => {
     expect(`${section} .o-autocomplete--dropdown-menu`).toHaveCount(0);
     expect(`${section} .o-autocomplete--dropdown-item`).toHaveCount(0);
     await contains(`${section} .o-autocomplete--input`).click();
-    await runAllTimers();
+    await advanceTime(500);
     expect(`${section} .o-autocomplete--dropdown-menu`).toHaveCount(1);
     expect(`${section} .o-autocomplete--dropdown-item`).toHaveCount(9);
     expect(queryAllTexts`.o-autocomplete--dropdown-item`).toEqual([
@@ -531,7 +531,7 @@ test(`add a filter with the search more dialog`, async () => {
 
     // Change the search term
     await contains(`.o-autocomplete--input`).edit("foo", { confirm: false });
-    await runAllTimers();
+    await advanceTime(500);
     expect(`${section} .o-autocomplete--dropdown-menu`).toHaveCount(1);
     expect(`${section} .o-autocomplete--dropdown-item`).toHaveCount(9);
     expect(queryAllTexts`.o-autocomplete--dropdown-item`).toEqual([
@@ -1012,7 +1012,7 @@ test(`render popover: inside fullcalendar popover`, async () => {
     expect(`.o_cw_popover`).toHaveCount(0);
 
     await contains(`.fc-popover .fc-daygrid-event-harness:nth-child(1) .fc-event`).click();
-    await runAllTimers();
+    await advanceTime(500);
     expect(`.o_cw_popover`).toHaveCount(1);
 
     await contains(`.o_cw_popover .o_cw_popover_edit`).click();


### PR DESCRIPTION
This commit adds small improvements to the calendar tests and test utility functions in an effort to speed up the execution of tests.

The main bottleneck was a bunch of calls to `runAllTimers()`, which interacts very badly with FullCalendar as it uses a lot of timers and this creates a large overhead.

This overhead is minimized through the use of more precise calls to `advanceTime()` and with less calls to `animationFrame()`.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
