### PR TITLE
[FIX] mrp,stock: save kit bom location

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -323,8 +323,7 @@ class StockMoveLine(models.Model):
             if move_line.move_id or not move_line.picking_id:
                 continue
             if move_line.picking_id.state != 'done':
-                moves = move_line.picking_id.move_ids.filtered(lambda x: x.product_id == move_line.product_id)
-                moves = sorted(moves, key=lambda m: m.quantity < m.product_qty, reverse=True)
+                moves = move_line._get_linkable_moves()
                 if moves:
                     move_line.write({
                         'move_id': moves[0].id,
@@ -987,3 +986,8 @@ class StockMoveLine(models.Model):
                 'message': _("The inventory adjustments have been reverted."),
             }
         }
+
+    def _get_linkable_moves(self):
+        self.ensure_one()
+        moves = self.picking_id.move_ids.filtered(lambda x: x.product_id == self.product_id)
+        return sorted(moves, key=lambda m: m.quantity < m.product_qty, reverse=True)


### PR DESCRIPTION
**Current behavior:**
When a kit bom product move line is broken down into move lines
for its component products, changes written to the move line
(not on the move) will not carry over to the new move nor move
lines.

**Expected behavior:**
The change should be observed beyond the decomposition.

**Steps to reproduce:**
1. Create a new internal transfer in barcode

2. Add a product with some bom via form, also edit the
     destination location in the form to be something
     non-default.

3. Save the form, validate the transfer

4. See that the broken down move lines don't keep the changed
     destination location

**Cause of the issue:**
When the kit bom moves are exploded, the location information of
its move lines is not taken into account at any point- and thus
it's lost.

**Fix:**
For kit bom products, use a move line's location information
during creation of a move as opposed to the picking. Only link a
new move line for a kit bom product to an existing move if (in
addition to the product) the location source and destination
values match.

opw-4016702