### PR TITLE
[FIX] mass_mailing: Simplified create form width fix

### DIFF
--- a/addons/mass_mailing/views/mailing_list_views.xml
+++ b/addons/mass_mailing/views/mailing_list_views.xml
@@ -108,16 +108,12 @@
         <field name="priority" eval="25"/>
         <field name="arch" type="xml">
             <form string="Contact List">
-                <group>
-                    <group>
-                        <div class="oe_title">
-                            <label for="name"/>
-                            <h1>
-                                <field name="name" placeholder="e.g. Consumer Newsletter"/>
-                            </h1>
-                        </div>
-                    </group>
-                </group>
+                <div class="oe_title">
+                    <label for="name"/>
+                    <h1>
+                        <field name="name" placeholder="e.g. Consumer Newsletter"/>
+                    </h1>
+                </div>
                 <group>
                     <field name="is_public"/>
                 </group>


### PR DESCRIPTION
16.0 update changes the back-end design interpretation, leading to a width display issue with mailing_list_view_form_simplified.
I remove some useless <group> tags in order to fix the width of the fields in the form

task-4042993