### PR TITLE
[FIX] base: stdnum library timeout

### DIFF
--- a/addons/base_vat/tests/test_validate_ruc.py
+++ b/addons/base_vat/tests/test_validate_ruc.py
@@ -1,9 +1,13 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from odoo.tests.common import TransactionCase, tagged
+from odoo.tools._monkeypatches import new_get_soap_client
 from odoo.exceptions import ValidationError
 from unittest.mock import patch
 
 import stdnum.eu.vat
+from lxml import etree
+from zeep import Client, Transport
+from zeep.wsdl import Document
 
 
 class TestStructure(TransactionCase):
@@ -96,6 +100,14 @@ class TestStructure(TransactionCase):
         # Test invalid VAT (should raise a ValidationError)
         with self.assertRaises(ValidationError):
             test_partner.write({'vat': "136695978"})
+
+    def test_soap_client_for_vies_loads(self):
+        # Test of stdnum get_soap_client monkeypatch. This test is mostly to
+        # see that no unexpected import errors are thrown and not caught.
+        with patch.object(Document, '_get_xml_document', return_value=etree.Element("root")), \
+             patch.object(Client, 'service', return_value=None):
+            doc = Document(location=None, transport=Transport())
+            new_get_soap_client(doc, 30)
 
 @tagged('-standard', 'external')
 class TestStructureVIES(TestStructure):

--- a/addons/partner_autocomplete/models/res_partner.py
+++ b/addons/partner_autocomplete/models/res_partner.py
@@ -135,7 +135,7 @@ class ResPartner(models.Model):
         else:
             vies_result = None
             try:
-                vies_result = check_vies(vat)
+                vies_result = check_vies(vat, timeout=timeout)
             except Exception:
                 _logger.exception("Failed VIES VAT check.")
             if vies_result:

--- a/odoo/tools/_monkeypatches.py
+++ b/odoo/tools/_monkeypatches.py
@@ -13,6 +13,11 @@ from werkzeug.wrappers import Request, Response
 from .json import scriptsafe
 
 try:
+    from stdnum import util
+except ImportError:
+    util = None
+
+try:
     from xlrd import xlsx
 except ImportError:
     pass
@@ -65,3 +70,54 @@ def literal_eval(expr):
     return orig_literal_eval(expr)
 
 ast.literal_eval = literal_eval
+
+_soap_clients = {}
+
+
+def new_get_soap_client(wsdlurl, timeout=30):
+    # stdnum library does not set the timeout for the zeep Transport class correctly
+    # (timeout is to fetch the wsdl and operation_timeout is to perform the call),
+    # requiring us to monkey patch the get_soap_client function.
+    # Can be removed when https://github.com/arthurdejong/python-stdnum/issues/444 is
+    # resolved and the version of the dependency is updated.
+    # The code is a copy of the original apart for the line related to the Transport class.
+    # This was done to keep the code as similar to the original and to reduce the possibility
+    # of introducing import errors, even though some imports are not in the requirements.
+    # See https://github.com/odoo/odoo/pull/173359 for a more thorough explanation.
+    if (wsdlurl, timeout) not in _soap_clients:
+        try:
+            from zeep.transports import Transport
+            transport = Transport(operation_timeout=timeout, timeout=timeout)  # operational_timeout added here
+            from zeep import CachingClient
+            client = CachingClient(wsdlurl, transport=transport).service
+        except ImportError:
+            # fall back to non-caching zeep client
+            try:
+                from zeep import Client
+                client = Client(wsdlurl, transport=transport).service
+            except ImportError:
+                # other implementations require passing the proxy config
+                try:
+                    from urllib import getproxies
+                except ImportError:
+                    from urllib.request import getproxies
+                # fall back to suds
+                try:
+                    from suds.client import Client
+                    client = Client(
+                        wsdlurl, proxy=getproxies(), timeout=timeout).service
+                except ImportError:
+                    # use pysimplesoap as last resort
+                    try:
+                        from pysimplesoap.client import SoapClient
+                        client = SoapClient(
+                            wsdl=wsdlurl, proxy=getproxies(), timeout=timeout)
+                    except ImportError:
+                        raise ImportError(
+                            'No SOAP library (such as zeep) found')
+        _soap_clients[(wsdlurl, timeout)] = client
+    return _soap_clients[(wsdlurl, timeout)]
+
+
+if util:
+    util.get_soap_client = new_get_soap_client


### PR DESCRIPTION
`stdnum` library incorrectly sets `zeep` `Transport` timeout, resulting in
some requests hanging for 15 minutes. With this monkeypatch the timeout
will be set correctly. The monkeypatch is a full copy of the original
code except for adding `operational_timeout` to the `Transport` initialization.

The monkeypatch can be removed when https://github.com/arthurdejong/python-stdnum/issues/444 is resolved and the version is upgraded.

Related zeep github issue: https://github.com/mvantellingen/python-zeep/issues/140
This fix was already merged but reverted due to an unexpected side-effect:
Original commit: https://github.com/odoo-dev/odoo/commit/11062f6f77ed1292c6db9d64985dddeb46d354c8
Revert: https://github.com/odoo-dev/odoo/commit/de9df2ba5c15d399d6906ef54f3e4ac9f063a175

The issue originated from a dependency issue in the `zeep` library in [Ubuntu 22.04](https://packages.ubuntu.com/jammy/python3-zeep).
The `python3-platformdirs` dependency is missing in there, yet it is used in that version of `zeep`. This missing dependency used to be hidden by the [chains of `try ... except ImporError` of `stdnum`](https://github.com/arthurdejong/python-stdnum/blob/d5666b8bfe379688a38bb0fd6764a8c536dd3c75/stdnum/util.py#L254).
That means that it's another import from the chain that was used. So to reduce the possibility of introducing a similar bug and catch such errors, the original code from `get_soap_client` of `stdnum` has been fully copied.

opw-3980718