### PR TITLE
[FIX] web: don't show separator properties

### DIFF
--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -289,6 +289,7 @@ export class ListRenderer extends Component {
                 (field) =>
                     field.relatedPropertyField &&
                     field.relatedPropertyField.fieldName === column.name
+                    && field.type !== 'separator'
             )
             .map((propertyField) => {
                 return {

--- a/addons/web/static/tests/views/list_view_tests.js
+++ b/addons/web/static/tests/views/list_view_tests.js
@@ -19687,17 +19687,22 @@ QUnit.module("Views", (hooks) => {
             string: "Property char",
         };
         const definition1 = {
+            type: "separator",
+            name: "property_separator",
+            string: "Group 1",
+        };
+        const definition2 = {
             type: "boolean",
             name: "property_boolean",
             string: "Property boolean",
         };
         serverData.models.bar.records[0].definitions = [definition0];
-        serverData.models.bar.records[1].definitions = [definition1];
+        serverData.models.bar.records[1].definitions = [definition1, definition2];
         for (const record of serverData.models.foo.records) {
             if (record.m2o === 1) {
                 record.properties = [{ ...definition0, value: "0" }];
             } else if (record.m2o === 2) {
-                record.properties = [{ ...definition1, value: true }];
+                record.properties = [definition1, { ...definition2, value: true }];
             }
         }
 
@@ -19714,6 +19719,7 @@ QUnit.module("Views", (hooks) => {
         });
 
         await click(target, ".o_optional_columns_dropdown_toggle");
+        assert.containsN(target, ".o_optional_columns_dropdown input[type='checkbox']", 2)
 
         await click(
             target.querySelectorAll(".o_optional_columns_dropdown input[type='checkbox']")[0]


### PR DESCRIPTION
Since https://github.com/odoo/odoo/issues/113974, Properties fields can contain separator (virtual `<group>`) 
information inside its value. But in the view list, these separator can be selected in the optional fields. It doesn't make sense because there no value associated.

Also it avoids a warning in the JS console ("Missing widget: separator
for field of type separator").

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
