### PR TITLE
[FIX] website_{customer,crm_partner_assign}: partner image elongated

### DIFF
--- a/addons/website_crm_partner_assign/views/website_crm_partner_assign_templates.xml
+++ b/addons/website_crm_partner_assign/views/website_crm_partner_assign_templates.xml
@@ -246,7 +246,7 @@
         <div t-foreach="partner.implemented_partner_ids" t-if="reference.website_published" t-as="reference" class="card mt-3 border-0">
             <div class="row">
                 <div class="col-md-2">
-                    <span t-field="reference.avatar_128" class="d-flex justify-content-center h-100" t-options='{"widget": "image", "qweb_img_responsive": False, "class": "img-fluid rounded"}'/>
+                    <span t-field="reference.avatar_128" class="d-flex justify-content-center" t-options='{"widget": "image", "qweb_img_responsive": False, "class": "img-fluid rounded mw-100"}'/>
                 </div>
                 <div class="card-body col-md-10">
                     <span t-field="reference.self"/>

--- a/addons/website_customer/views/website_customer_templates.xml
+++ b/addons/website_customer/views/website_customer_templates.xml
@@ -311,9 +311,9 @@
                 <t t-if="reference.website_published">
                     <div class="row">
                         <div class="col-md-2">
-                            <span t-field="reference.avatar_128" 
-                                class="d-flex justify-content-center justify-content-center h-100" 
-                                t-options='{"widget": "image", "qweb_img_responsive": False, "class": "img-fluid rounded"}'/>
+                            <span t-field="reference.avatar_128"
+                                class="d-flex justify-content-center"
+                                t-options='{"widget": "image", "qweb_img_responsive": False, "class": "img-fluid rounded mw-100"}'/>
                         </div>
                         <div class="card-body col-md-10">
                             <a t-attf-href="/customers/#{slug(reference)}">


### PR DESCRIPTION
Current behaviour:
---
When going to /customers or /partners and selecting a partner, 
in the References section, if the text is too long, the image will be taking the text height

Expected behaviour:
---
The image fits the width but not the height

Steps to reproduce:
---
1. Go to Website
2. Go to /customers
3. Select a partner that has references
4. Open the editor (top left)
5. Add long text to one of the reference
6. The image will match the text height

Cause of the issue:
---
Caused by: https://github.com/odoo/odoo/commit/1efdb96227dab8f1b3bcb8e8854dbad5dd874e69

Fix:
---
Removed h-100 and added w-100

opw-3970462

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
