### PR TITLE
[FIX] account_audit_trail: do not block inherits creation

### DIFF
--- a/addons/account_audit_trail/models/mail_message.py
+++ b/addons/account_audit_trail/models/mail_message.py
@@ -179,6 +179,10 @@ class Message(models.Model):
                 raise UserError(_("You cannot remove parts of the audit trail. Archive the record instead."))
 
     def write(self, vals):
-        if vals.keys() & {'res_id', 'res_model', 'subject', 'message_type', 'subtype_id'}:
+        if (
+            vals.keys() & {'res_id', 'res_model', 'message_type', 'subtype_id'}
+            or ('subject' in vals and any(self.mapped('subject')))
+            or ('body' in vals and any(self.mapped('body')))
+        ):
             self._except_audit_log()
         return super().write(vals)

--- a/addons/account_audit_trail/tests/test_audit_trail.py
+++ b/addons/account_audit_trail/tests/test_audit_trail.py
@@ -1,7 +1,7 @@
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.exceptions import UserError
 from odoo.fields import Command
-from odoo.tests import tagged
+from odoo.tests import tagged, new_test_user
 from odoo.tools.mail import html2plaintext
 
 
@@ -121,3 +121,13 @@ class TestAuditTrail(AccountTestInvoicingCommon):
             r"deleted 101402 Bank Suspense Account  \(Account\) -45.0 0.0 \(Balance\) Automatic Balancing Line False \(Label\)",
         ])
         self.assertTrail(self.get_trail(self.move), messages)
+
+    def test_partner_notif(self):
+        """Audit trail should not block partner notification."""
+        user = new_test_user(
+            self.env, 'test-user-notif', groups="base.group_portal",
+            notification_type='email',
+        )
+        # identify that user as being a customer
+        user.partner_id._increase_rank('customer_rank', 1)
+        user.partner_id.message_post(body='Test', partner_ids=user.partner_id.ids)


### PR DESCRIPTION
Since we are using an existing record as `mail_message_id` in `_notify_thread_by_email`, and we need to allow the creation of new `mail.mail` that will add new values to the `mail.message`, as long as it doesn't modify existing values.
We are already writing on `subject` only if it was different than previously, but we are not forbidding to write on it only if there was a previous value set.

