### PR TITLE
[FIX] account: fix sending invoice email without attachments

### DIFF
--- a/addons/account/wizard/account_move_send.py
+++ b/addons/account/wizard/account_move_send.py
@@ -476,7 +476,8 @@ class AccountMoveSend(models.TransientModel):
 
         # Prevent duplicated attachments linked to the invoice.
         new_message.attachment_ids.invalidate_recordset(['res_id', 'res_model'], flush=False)
-        self.env.cr.execute("UPDATE ir_attachment SET res_id = NULL WHERE id IN %s", [tuple(new_message.attachment_ids.ids)])
+        if new_message.attachment_ids.ids:
+            self.env.cr.execute("UPDATE ir_attachment SET res_id = NULL WHERE id IN %s", [tuple(new_message.attachment_ids.ids)])
         new_message.attachment_ids.write({
             'res_model': new_message._name,
             'res_id': new_message.id,


### PR DESCRIPTION
Before this commit:
When you click `Send & Print` for an invoice with removing the attachments 
=> It shows an error with a traceback `psycopg2.errors.SyntaxError: syntax error at or near ")" LINE 1: UPDATE ir_attachment SET res_id = NULL WHERE id IN ()`

After this commit:
`Send & Print` process works properly with removing attachments.

opw-4047545
