### PR TITLE
[FIX] point_of_sale: prevent spamming send email button

### DIFF
--- a/addons/point_of_sale/static/src/xml/Screens/ReceiptScreen/ReceiptScreen.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/ReceiptScreen/ReceiptScreen.xml
@@ -22,7 +22,7 @@
                         <form t-on-submit.prevent="onSendEmail" class="send-email">
                             <div class="input-email">
                                 <input type="email" placeholder="Email Receipt" t-model="orderUiState.inputEmail" />
-                                <button class="send" t-att-class="{ highlight: is_email(orderUiState.inputEmail) }" type="submit">
+                                <button class="send" t-att-class="{ highlight: !orderUiState.isSendingEmail and is_email(orderUiState.inputEmail) }" type="submit" t-att-disabled="orderUiState.isSendingEmail">
                                     <i class="fa fa-paper-plane" aria-hidden="true"/>
                                 </button>
                             </div>


### PR DESCRIPTION
User is allowed to send the receipt as email to the customer from the receipt screen. In this commit, we prevent the spamming of the send email button by:

1. Locking the `onSendEmail` method, such that when it's running, calling it again won't make another server request.
2. Disabling the button when the email is being sent plus one second of delay.
