### PR TITLE
[FIX] l10n_cl: error message weird space

### DIFF
--- a/addons/l10n_cl/models/account_move.py
+++ b/addons/l10n_cl/models/account_move.py
@@ -71,8 +71,8 @@ class AccountMove(models.Model):
                     if not ((tax_payer_type == '4' and latam_document_type_code in ['110', '111', '112']) or (
                             tax_payer_type == '3' and latam_document_type_code in ['39', '41', '61', '56'])):
                         raise ValidationError(_(
-                            'Document types for foreign customers must be export type (codes 110, 111 or 112) or you \
-                            should define the customer as an end consumer and use receipts (codes 39 or 41)'))
+                            'Document types for foreign customers must be export type (codes 110, 111 or 112) or you '
+                            'should define the customer as an end consumer and use receipts (codes 39 or 41)'))
             if rec.journal_id.type == 'purchase' and rec.journal_id.l10n_latam_use_documents:
                 if vat != SII_VAT and latam_document_type_code == '914':
                     raise ValidationError(_('The DIN document is intended to be used only with RUT 60805000-0'


### PR DESCRIPTION
Before this commit, the '/' create a weird space in the error message.

task: 4041892

Enterprise: https://github.com/odoo/enterprise/pull/66767



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
