### PR TITLE
[IMP] *: ir_asset: directive "include_files"

### DIFF
--- a/odoo/addons/base/models/ir_asset.py
+++ b/odoo/addons/base/models/ir_asset.py
@@ -22,6 +22,7 @@ BEFORE_DIRECTIVE = 'before'
 REMOVE_DIRECTIVE = 'remove'
 REPLACE_DIRECTIVE = 'replace'
 INCLUDE_DIRECTIVE = 'include'
+INCLUDE_FILES_DIRECTIVE = 'include_files'
 # Those are the directives used with a 'target' argument/field.
 DIRECTIVES_WITH_TARGET = [AFTER_DIRECTIVE, BEFORE_DIRECTIVE, REPLACE_DIRECTIVE]
 
@@ -207,6 +208,19 @@ class IrAsset(models.Model):
         if directive == INCLUDE_DIRECTIVE:
             # recursively call this function for each INCLUDE_DIRECTIVE directive.
             self._fill_asset_paths(path_def, asset_paths, seen + [bundle], addons, installed, **assets_params)
+            return
+        if directive == INCLUDE_FILES_DIRECTIVE:
+            sub_bundle_paths = AssetPaths()
+            # recursively call this function for each INCLUDE_FILES_DIRECTIVE directive.
+            self._fill_asset_paths(path_def, sub_bundle_paths, seen + [bundle], addons, installed, **assets_params)
+            asset_paths.append(
+                [
+                    (path, full_path, last_modified)
+                    for (path, full_path, _, last_modified)
+                    in sub_bundle_paths.list
+                ],
+                bundle
+            )
             return
         if can_aggregate(path_def):
             paths = self._get_paths(path_def, installed)

--- a/odoo/addons/test_assetsbundle/__manifest__.py
+++ b/odoo/addons/test_assetsbundle/__manifest__.py
@@ -78,6 +78,18 @@
         'test_assetsbundle.file_not_found':[
           'test_assetsbundle/static/invalid_src/xml/file_not_found.xml',
         ],
+        'test_assetsbundle.a_with_include': [
+            'test_assetsbundle/static/src/js/test_jsfile1.js',
+            ('include', 'test_assetsbundle.b'),
+        ],
+        'test_assetsbundle.a_with_include_files': [
+            'test_assetsbundle/static/src/js/test_jsfile1.js',
+            ('include_files', 'test_assetsbundle.b'),
+        ],
+        'test_assetsbundle.b': [
+            'test_assetsbundle/static/src/js/test_jsfile*',
+            ('remove', 'test_assetsbundle/static/src/js/test_jsfile1.js'),
+        ],
     },
     'license': 'LGPL-3',
 }

--- a/odoo/addons/test_assetsbundle/tests/test_assetsbundle.py
+++ b/odoo/addons/test_assetsbundle/tests/test_assetsbundle.py
@@ -1199,6 +1199,45 @@ class TestAssetsManifest(AddonManifestPatched):
             '''
         )
 
+    def test_13_include3(self):
+        bundle = self.env['ir.qweb']._get_asset_bundle('test_assetsbundle.a_with_include')
+        attach = bundle.js()
+        content = attach.raw.decode()
+        self.assertStringEqual(
+            content,
+            '''
+            /* /test_assetsbundle/static/src/js/test_jsfile2.js */
+            var b=2;;
+
+            /* /test_assetsbundle/static/src/js/test_jsfile3.js */
+            var c=3;;
+
+            /* /test_assetsbundle/static/src/js/test_jsfile4.js */
+            var d=4;
+            '''
+        )
+
+    def test_11_include_files(self):
+        bundle = self.env['ir.qweb']._get_asset_bundle('test_assetsbundle.a_with_include_files')
+        attach = bundle.js()
+        content = attach.raw.decode()
+        self.assertStringEqual(
+            content,
+            '''
+            /* /test_assetsbundle/static/src/js/test_jsfile1.js */
+            var a=1;;
+
+            /* /test_assetsbundle/static/src/js/test_jsfile2.js */
+            var b=2;;
+
+            /* /test_assetsbundle/static/src/js/test_jsfile3.js */
+            var c=3;;
+
+            /* /test_assetsbundle/static/src/js/test_jsfile4.js */
+            var d=4;
+            '''
+        )
+
     def test_14_other_module(self):
         self.installed_modules.add('test_other')
         self.manifests['test_other'] = {


### PR DESCRIPTION
Have 2 bundles

a = [
  	'web/static/src/my_file.js',
	​('include', 'b'),
]

b = [
	​'web/static/src/**'',
	​('remove', ​'web/static/src/my_file.js'),

]

The set of files in "a" will be all files matched by "web/static/src/\*\*" but "web/static/src/my_file.js".
Here we introduces a new directive "include_files". Using that new directive in "a" (instead of "include") will produce a different result: "a" will contain all files matched by "web/static/src/\*\*".

Task Id: 4019817