### PR TITLE
[FIX] pos_sale: correctly unreserve sale order before reserving pos line

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1494,9 +1494,11 @@ class PosOrderLine(models.Model):
             pickings_to_confirm = order.picking_ids
             if pickings_to_confirm:
                 # Trigger the Scheduler for Pickings
-                pickings_to_confirm.action_confirm()
                 tracked_lines = order.lines.filtered(lambda l: l.product_id.tracking != 'none')
                 lines_by_tracked_product = groupby(sorted(tracked_lines, key=lambda l: l.product_id.id), key=lambda l: l.product_id.id)
+                for line in order.lines:
+                    line.sale_order_line_id.move_ids.mapped("move_line_ids").unlink()
+                pickings_to_confirm.action_confirm()
                 for product_id, lines in lines_by_tracked_product:
                     lines = self.env['pos.order.line'].concat(*lines)
                     moves = pickings_to_confirm.move_ids.filtered(lambda m: m.product_id.id == product_id)

--- a/addons/pos_sale/models/pos_order.py
+++ b/addons/pos_sale/models/pos_order.py
@@ -102,6 +102,9 @@ class PosOrder(models.Model):
             for picking in self.env['stock.picking'].browse(waiting_picking_ids):
                 if all(is_product_uom_qty_zero(move) for move in picking.move_ids):
                     picking.action_cancel()
+                else:
+                    # We make sure that the original picking still has the correct quantity reserved
+                    picking.action_assign()
 
         return order_ids
 

--- a/addons/pos_sale/tests/__init__.py
+++ b/addons/pos_sale/tests/__init__.py
@@ -3,3 +3,4 @@
 
 from . import test_pos_sale_flow
 from . import test_pos_sale_report
+from . import test_pos_sale_lot

--- a/addons/pos_sale/tests/test_pos_sale_lot.py
+++ b/addons/pos_sale/tests/test_pos_sale_lot.py
@@ -1,0 +1,101 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import odoo
+from odoo import fields
+from odoo.addons.point_of_sale.tests.common import TestPointOfSaleCommon
+
+
+@odoo.tests.tagged('post_install', '-at_install')
+class TestPointOfSaleFlow(TestPointOfSaleCommon):
+    def test_ship_later_lots(self):
+        # open pos session
+        self.pos_config.open_ui()
+        current_session = self.pos_config.current_session_id
+
+        # set up product iwith SN tracing and create two lots (1001, 1002)
+        self.stock_location = self.company_data['default_warehouse'].lot_stock_id
+        self.product = self.env['product.product'].create({
+            'name': 'Product A',
+            'type': 'product',
+            'tracking': 'serial',
+            'lst_price': 10,
+            'categ_id': self.env.ref('product.product_category_all').id,
+        })
+
+        lot1 = self.env['stock.lot'].create({
+            'name': '1001',
+            'product_id': self.product.id,
+            'company_id': self.env.company.id,
+        })
+        lot2 = self.env['stock.lot'].create({
+            'name': '1002',
+            'product_id': self.product.id,
+            'company_id': self.env.company.id,
+        })
+
+        self.env['stock.quant'].with_context(inventory_mode=True).create({
+            'product_id': self.product.id,
+            'inventory_quantity': 1,
+            'location_id': self.stock_location.id,
+            'lot_id': lot1.id
+        }).action_apply_inventory()
+        self.env['stock.quant'].with_context(inventory_mode=True).create({
+            'product_id': self.product.id,
+            'inventory_quantity': 1,
+            'location_id': self.stock_location.id,
+            'lot_id': lot2.id
+        }).action_apply_inventory()
+
+        partner_test = self.env['res.partner'].create({'name': 'Test Partner'})
+
+        sale_order = self.env['sale.order'].create({
+            'partner_id': partner_test.id,
+            'order_line': [(0, 0, {
+                'product_id': self.product.id,
+                'name': self.product.name,
+                'product_uom_qty': 2,
+                'product_uom': self.product.uom_id.id,
+                'price_unit': self.product.lst_price,
+            })],
+        })
+        sale_order.action_confirm()
+        self.pos_config.open_ui()
+        current_session = self.pos_config.current_session_id
+
+        pos_order = {'data':
+          {'amount_paid': 10,
+           'amount_return': 0,
+           'amount_tax': 0,
+           'amount_total': 10,
+           'date_order': fields.Datetime.to_string(fields.Datetime.now()),
+           'fiscal_position_id': False,
+           'to_invoice': True,
+           'partner_id': partner_test.id,
+           'lines': [[0,
+             0,
+             {'discount': 0,
+              'pack_lot_ids': [[0, 0, {'lot_name': lot1.name}]],
+              'price_unit': 10,
+              'product_id': self.product.id,
+              'price_subtotal': 10,
+              'price_subtotal_incl': 10,
+              'sale_order_line_id': sale_order.order_line[0],
+              'sale_order_origin_id': sale_order,
+              'qty': 1,
+              'tax_ids': []}]],
+           'name': 'Order 00044-003-0014',
+           'pos_session_id': current_session.id,
+           'sequence_number': self.pos_config.journal_id.id,
+           'shipping_date': fields.Date.today(),
+           'statement_ids': [[0,
+             0,
+             {'amount': 10,
+              'name': fields.Datetime.now(),
+              'payment_method_id': self.pos_config.payment_method_ids[0].id}]],
+           'uid': '00044-003-0014',
+           'user_id': self.env.uid},
+            }
+
+        order = self.env['pos.order'].create_from_ui([pos_order])
+        self.assertEqual(self.env['pos.order'].browse(order[0]['id']).picking_ids.move_line_ids.lot_id, lot1)
+        self.assertEqual(sale_order.picking_ids.move_line_ids.lot_id, lot2)


### PR DESCRIPTION
When settling a sale order in PoS and using shiplater, there was no serial number on the ship later picking

Steps to reproduce:
-------------------
* Setup a product to be tracked by serial number
* Update stock for this product and create 2 SN
* Create an order with 2 quants of this product
* Setup the PoS to allow ship later
* Open PoS and load the sale order
* Validate the order with ship later
> Observation: The picking created for the pos order has no serial
number

Why the fix:
------------
There is no serial number on the pos order picking because at the moment we try to create it the quantities are still reserved for the sale order To fix it we unreserve the quantities before creating the new picking. We also make sure that if not all the quantities are paid in the PoS, they are reserved again. https://github.com/odoo/odoo/pull/173389/files#diff-3f2dda6b95e58f16fb47dc8e8d49e369cc93ee700fbef7975c472514b1888a8aR105-R107

opw-4005925
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
