### PR TITLE
[FIX] crm: count lost lead for daily quota

### DIFF
--- a/addons/crm/models/crm_team_member.py
+++ b/addons/crm/models/crm_team_member.py
@@ -30,7 +30,7 @@ class TeamMember(models.Model):
     @api.depends('user_id', 'crm_team_id')
     def _compute_lead_day_count(self):
         day_date = fields.datetime.now() - datetime.timedelta(hours=24)
-        daily_leads_counts = self._get_lead_from_date(day_date, active_test=True)
+        daily_leads_counts = self._get_lead_from_date(day_date)
 
         for member in self:
             member.lead_day_count = daily_leads_counts.get((member.user_id.id, member.crm_team_id.id), 0)


### PR DESCRIPTION
before the commit
https://github.com/odoo/odoo/commit/f8d246ae1e794aa1d29319a783b9ed237b33c62d the quota was based on monthly count that took into account the lost lead.

After the commit https://github.com/odoo/odoo/commit/f8d246ae1e794aa1d29319a783b9ed237b33c62d, the quota is daily and based on daily count. The daily count didn't take into account lost lead. It changes the behavior and allow users to directly lost leads in order to receive more lead than other members of their teams.

This commit fix this behavior and count the lost lead as well





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
