### PR TITLE
[FIX] stock_account: create initial valuation layers on installation

### DIFF
--- a/addons/stock_account/__init__.py
+++ b/addons/stock_account/__init__.py
@@ -5,6 +5,8 @@ from . import models
 from . import report
 from . import wizard
 
+from odoo import _
+
 
 def _configure_journals(env):
     # if we already have a coa installed, create journal and set property field
@@ -40,3 +42,30 @@ def _configure_journals(env):
         ChartTemplate._load_data(data)
         ChartTemplate._post_load_data(template_code, company, template_data)
         ChartTemplate._load_wip_accounts(company, full_data['res.company'])
+
+    # if we already have quantity on hand for storable product, create an initial valuation layer
+    valued_locations = env["stock.location"].search([]).filtered(lambda loc: loc._should_be_valued())
+    qty_by_product = env["stock.quant"]._read_group(
+        [
+            ("product_id.is_storable", "=", True),
+            ("location_id", "in", valued_locations.ids),
+            ("owner_id", "=", False),
+        ],
+        groupby=["company_id", "product_id"],
+        aggregates=["quantity:sum"],
+        having=[("quantity:sum", "!=", 0)],
+    )
+    svl_vals = []
+    for company, product, quantity in qty_by_product:
+        value = quantity * product.with_company(company).standard_price
+        svl_vals.append({
+            "company_id": company.id,
+            "product_id": product.id,
+            "description": env._("Adjustment: Accounting installation"),
+            "quantity": quantity,
+            "value": value,
+            "remaining_qty": quantity,
+            "remaining_value": max(value, 0),
+        })
+
+    env["stock.valuation.layer"].create(svl_vals)


### PR DESCRIPTION
Installing `stock_account` after the creation of stock quants, leads to a discrepancy in the stock valuation. For example, you could have five quantities on hand but none in your valuation. This difference will create issues after a sale because the valuation will go negative despite your current stock.
It is not a common issue, as it only affects users who use one app (MRP or Inventory), and after configuration, they install additional modules, such as Accounting or Purchase, that depend on `stock_account`.

### After this commit:
Create an initial layer when installing `stock_account` to ensure the quantity matches between the `stock.quant` and `stock.valuation.layer` models.