### PR TITLE
[FIX] repair: create repair order from cross-company lots

### DIFF
--- a/addons/repair/models/stock_lot.py
+++ b/addons/repair/models/stock_lot.py
@@ -46,7 +46,7 @@ class StockLot(models.Model):
             'context': {
                 'default_product_id': self.product_id.id,
                 'default_lot_id': self.id,
-                'default_company_id': self.company_id.id,
+                'default_company_id': self.company_id.id or self.env.company.id,
             },
         })
         return action

--- a/addons/repair/tests/test_repair.py
+++ b/addons/repair/tests/test_repair.py
@@ -717,3 +717,16 @@ class TestRepair(common.TransactionCase):
         self.assertEqual(len(res), 1, "The invoice should have one line")
         self.assertEqual(res[0]['product_name'], self.product_storable_serial.display_name, "The product name should be the same")
         self.assertEqual(res[0]['lot_name'], quant.lot_id.name, "The lot name should be the same")
+
+    def test_create_repair_order_from_cross_company_sn(self):
+        """
+        Test that a repair order can be created from a cross-company SN.
+        """
+        sn_01 = self.env['stock.lot'].create({'name': 'sn_1', 'product_id': self.product_product_3.id})
+        action = sn_01.action_lot_open_repairs()
+        repair_order = self.env['repair.order'].with_context(action.get('context')).create({
+            'product_id': self.product_product_3.id,
+            'product_uom': self.product_product_3.uom_id.id,
+            'partner_id': self.res_partner_12.id,
+        })
+        self.assertEqual(repair_order.company_id, self.env.company)


### PR DESCRIPTION
**Steps to reproduce the bug:**
- Create a lot without company set with any product
- open the repairs list from this lot
- Try to save the repair

**Problem:**
An error is raised: “Invalide fields: Company”

Since this commit:

https://github.com/odoo/odoo/commit/99b39b72c7e65e85af6f06dcb6b02867623f3f69

A lot can be created without a company set, but the repair order still requires a company: https://github.com/odoo/odoo/blob/17.0/addons/repair/models/repair.py#L36-L39

This key is passed in the context as 'default_company_id', but since the lot does not have a company, the value is set to False, which triggers an error.

opw-4046897
