### PR TITLE
[FIX] mail: admin can't resend mails he's not author of

### DIFF
--- a/addons/mail/views/mail_mail_views.xml
+++ b/addons/mail/views/mail_mail_views.xml
@@ -7,7 +7,7 @@
             <field name="arch" type="xml">
                 <form string="Email message" duplicate="0">
                     <header>
-                        <button name="send" string="Send Now" type="object" states='outgoing' class="oe_highlight"/>
+                        <button name="send" string="Send Now" type="object" class="oe_highlight" attrs="{'invisible': ['|', ('state', '!=', 'outgoing'), ('message_type', '=', 'user_notification')]}"/>
                         <button name="mark_outgoing" string="Retry" type="object" states='exception,cancel'/>
                         <button name="cancel" string="Cancel" type="object" states='outgoing'/>
                         <field name="state" widget="statusbar" statusbar_visible="outgoing,sent,received,exception,cancel"/>
@@ -80,7 +80,7 @@
                     <field name="email_from" invisible="1"/>
                     <field name="state" invisible="1"/>
                     <field name="message_type" invisible="1"/>
-                    <button name="send" string="Send Now" type="object" icon="fa-paper-plane" states='outgoing'/>
+                    <button name="send" string="Send Now" type="object" icon="fa-paper-plane" attrs="{'invisible': ['|', ('state', '!=', 'outgoing'), ('message_type', '=', 'user_notification')]}"/>
                     <button name="mark_outgoing" string="Retry" type="object" icon="fa-repeat" states='exception,cancel'/>
                     <button name="cancel" string="Cancel Email" type="object" icon="fa-times-circle" states='outgoing'/>
                 </tree>


### PR DESCRIPTION
Issue: When trying to resend a mail authored by any other user as an administrator, we are going to receive a "Delivery Failed" error even though the mail has been sent.

Steps to reproduce:

- Send any email as Demo, so they stay in queue for seding under mails.
- Go to mails as admin now and try to send the mail manually. (You can use a meeting for example to send the mail, create a meeting and send the mail to notify this meeting.)

Solution:

Since the issue is triggered when we try to write on the message_id, which is a related field we might want to specify it in 'mail.mail' so we ensure that message_id is available directly on the 'mail.mail' model. This, will also apply properly the related_sudo=True that we need in order to work with it as administrator.

opw-3963124

