### PR TITLE
[FIX] core: exit when http port already in use

### DIFF
--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -496,14 +496,13 @@ class ThreadedServer(CommonServer):
             t.start()
             _logger.debug("cron%d started!" % i)
 
-    def http_thread(self):
-        self.httpd = ThreadedWSGIServerReloadable(self.interface, self.port, self.app)
-        self.httpd.serve_forever()
-
     def http_spawn(self):
-        t = threading.Thread(target=self.http_thread, name="odoo.service.httpd")
-        t.daemon = True
-        t.start()
+        self.httpd = ThreadedWSGIServerReloadable(self.interface, self.port, self.app)
+        threading.Thread(
+            target=self.httpd.serve_forever,
+            name="odoo.service.httpd",
+            daemon=True,
+        ).start()
 
     def start(self, stop=False):
         _logger.debug("Setting signal handlers")


### PR DESCRIPTION
Start odoo twice on the same port. In the second process you get a message on stderr "address in use" with a short explanation and the http thread daemon exits but the main process goes on.

The behavior only applies to the multithreaded (dev) server. The multiworker one crashes with a very explicit error.

The multithreaded server used to print a very large an explicit traceback. This changed upstream at [pallets/werkzeug:74601150b](https://github.com/pallets/werkzeug/commit/74601150b) to replace the traceback with a more user friendly message. Someone oblivious (me) can spend an entire day using the wrong terminal, never noticing the "address in use" error.

The multithreaded server now crashes with a traceback just like the multiworker one.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
