### PR TITLE
[PERF] analytic: faster _check_company_consistency

### DIFF
--- a/addons/analytic/models/analytic_account.py
+++ b/addons/analytic/models/analytic_account.py
@@ -92,7 +92,7 @@ class AccountAnalyticAccount(models.Model):
     @api.constrains('company_id')
     def _check_company_consistency(self):
         for company, accounts in groupby(self, lambda account: account.company_id):
-            if company and self.env['account.analytic.line'].sudo().search([
+            if company and self.env['account.analytic.line'].sudo().search_count([
                 ('auto_account_id', 'in', [account.id for account in accounts]),
                 '!', ('company_id', 'child_of', company.id),
             ], limit=1):


### PR DESCRIPTION
A search_count is enough in this use case, especially because a classic search adds a (useless here) order by to the query.

Description of the issue/feature this PR addresses:
Creating an analytic account is slow on a db with 1.5M account.analytic.line.

Current behavior before PR:
Slow query (2.0 s) https://explain.dalibo.com/plan/dgf46e2gd03gcf39

Desired behavior after PR is merged:
Fast query (0.2 ms) https://explain.dalibo.com/plan/464363de3f09eff9


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
