### PR TITLE
[REV] web: revert #172963 search panel: limit for many2many fields

### DIFF
--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -317,7 +317,7 @@ class Base(models.AbstractModel):
                     }
         """
         field = self._fields[field_name]
-        if field.type in ('many2one', 'many2many'):
+        if field.type == 'many2one':
             def group_id_name(value):
                 return value
 
@@ -681,16 +681,8 @@ class Base(models.AbstractModel):
         expand = kwargs.get('expand')
 
         if field.type == 'many2many':
-            if not expand:
-                domain_image = self._search_panel_domain_image(field_name, model_domain, limit=limit)
-                image_element_ids = list(domain_image.keys())
-                comodel_domain = AND([
-                    comodel_domain,
-                    [('id', 'in', image_element_ids)],
-                ])
-
             comodel_records = Comodel.search_read(comodel_domain, field_names, limit=limit)
-            if limit and len(comodel_records) == limit:
+            if expand and limit and len(comodel_records) == limit:
                 return {'error_msg': str(SEARCH_PANEL_ERROR_MESSAGE)}
 
             group_domain = kwargs.get('group_domain')
@@ -706,7 +698,7 @@ class Base(models.AbstractModel):
                     values['group_id'] = group_id
                     values['group_name'] = group_name
 
-                if enable_counters:
+                if enable_counters or not expand:
                     search_domain = AND([
                             model_domain,
                             [(field_name, 'in', record_id)],
@@ -721,8 +713,21 @@ class Base(models.AbstractModel):
                         search_domain,
                         local_extra_domain
                     ])
-                    values['__count'] = self.search_count(search_count_domain)
-                field_range.append(values)
+                    if enable_counters:
+                        count = self.search_count(search_count_domain)
+                    if not expand:
+                        if enable_counters and is_true_domain(local_extra_domain):
+                            inImage = count
+                        else:
+                            inImage = self.search(search_domain, limit=1)
+
+                if expand or inImage:
+                    if enable_counters:
+                        values['__count'] = count
+                    field_range.append(values)
+
+            if not expand and limit and len(field_range) == limit:
+                return {'error_msg': str(SEARCH_PANEL_ERROR_MESSAGE)}
 
             return { 'values': field_range, }
 

--- a/odoo/addons/test_search_panel/tests/test_search_panel_select_multi_range.py
+++ b/odoo/addons/test_search_panel/tests/test_search_panel_select_multi_range.py
@@ -558,37 +558,13 @@ class TestSelectRangeMulti(odoo.tests.TransactionCase):
             ]
         )
 
-        # no counters, no expand, no group_by, no search_domain, and limit
+        # no counters, no expand, no group_by, and search_domain
         result = self.SourceModel.search_panel_select_multi_range(
             'tag_ids',
             limit=2,
         )
-        self.assertEqual(result, SEARCH_PANEL_ERROR)
+        self.assertEqual(result, SEARCH_PANEL_ERROR, )
 
-        records = self.SourceModel.create([
-            {'name': 'Rec 5', 'tag_ids': [t2_id, t3_id]},
-            {'name': 'Rec 6', 'tag_ids': [t3_id]},
-        ])
-        r5_id, r6_id = records.ids
-
-        result = self.SourceModel.search_panel_select_multi_range(
-            'tag_ids',
-            search_domain=[['id', '=', r5_id]],
-            limit=2,
-        )
-        self.assertEqual(result, SEARCH_PANEL_ERROR)
-
-        result = self.SourceModel.search_panel_select_multi_range(
-            'tag_ids',
-            search_domain=[['id', '=', r6_id]],
-            limit=2,
-        )
-        self.assertEqual(
-            result['values'],
-            [
-                {'display_name': 'Tag 3', 'id': t3_id},
-            ]
-        )
 
     # Selection case
 


### PR DESCRIPTION
This reverts commit 6336366f772b18cd3731cc03f7ff3fc1eeca204a.

This commit causes an error when opening any of the `sign.request` Document Views due to `template_tags` being a non-stored `many2many` field. `read_group` was reworked in 17+, but in older versions these types of field are not considered `groupable`. As such, we'll encounter a similar error any time we enter `read_group_raw` for such a field.

opw-4055494