### PR TITLE
[ADD] base_vat, l10n_uy: vat validation for Uruguayan IDs

### DIFF
--- a/addons/base_vat/i18n/base_vat.pot
+++ b/addons/base_vat/i18n/base_vat.pot
@@ -4,16 +4,23 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 17.0\n"
+"Project-Id-Version: Odoo Server 17.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-13 10:27+0000\n"
-"PO-Revision-Date: 2024-08-13 10:27+0000\n"
+"POT-Creation-Date: 2024-08-19 12:28+0000\n"
+"PO-Revision-Date: 2024-08-19 12:28+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. module: base_vat
+#. odoo-python
+#: code:addons/base_vat/models/res_partner.py:0
+#, python-format
+msgid "'219999830019' (should be 12 digits)"
+msgstr "219999830019' (deberían ser 12 digitos)"
 
 #. module: base_vat
 #. odoo-python
@@ -28,6 +35,13 @@ msgstr ""
 #: code:addons/base_vat/models/res_partner.py:0
 #, python-format
 msgid "1792060346001 or 1792060346"
+msgstr ""
+
+#. module: base_vat
+#. odoo-python
+#: code:addons/base_vat/models/res_partner.py:0
+#, python-format
+msgid "3101012009"
 msgstr ""
 
 #. module: base_vat

--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -75,6 +75,7 @@ _ref_vat = {
     'sk': 'SK2022749619',
     'sm': 'SM24165',
     'tr': _('TR1234567890 (VERGINO) or TR17291716060 (TCKIMLIKNO)'),  # Levent Karakas @ Eska Yazilim A.S.
+    'uy': _("'219999830019' (should be 12 digits)"),
     've': 'V-12345678-1, V123456781, V-12.345.678-1',
     'xi': 'XI123456782',
     'sa': _('310175397400003 [Fifteen digits, first and last digits should be "3"]')

--- a/addons/base_vat/tests/test_validate_ruc.py
+++ b/addons/base_vat/tests/test_validate_ruc.py
@@ -114,6 +114,18 @@ class TestStructure(TransactionCase):
             doc = Document(location=None, transport=Transport())
             new_get_soap_client(doc, 30)
 
+    def test_rut_uy(self):
+        test_partner = self.env["res.partner"].create({"name": "UY Company", "country_id": self.env.ref("base.uy").id})
+        # Set a valid Number
+        test_partner.write({"vat": "215521750017"})
+        test_partner.write({"vat": "21-55217500-17"})
+        test_partner.write({"vat": "21 55217500 17"})
+        test_partner.write({"vat": "UY215521750017"})
+
+        # Test invalid VAT (should raise a ValidationError)
+        with self.assertRaisesRegex(ValidationError, "The VAT number.*does not seem to be valid."):
+            test_partner.write({"vat": "215521750018"})
+
 
 @tagged('-standard', 'external')
 class TestStructureVIES(TestStructure):

--- a/addons/l10n_uy/i18n/es.po
+++ b/addons/l10n_uy/i18n/es.po
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 16.5alpha1+e\n"
+"Project-Id-Version: Odoo Server 17.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-09 17:47+0000\n"
-"PO-Revision-Date: 2023-10-09 17:47+0000\n"
+"POT-Creation-Date: 2024-07-26 14:45+0000\n"
+"PO-Revision-Date: 2024-07-26 14:45+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,9 +16,23 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: l10n_uy
+#: model_terms:res.company,report_footer:l10n_uy.demo_company_uy
+msgid ""
+"+598 94 231 234 info@company.uyexample.com http://www.uyexample.com "
+"218296790015"
+msgstr ""
+
+#. module: l10n_uy
+#. odoo-python
+#: code:addons/l10n_uy/models/res_partner.py:0
+#, python-format
+msgid "3:402.010-2 or 93:402.010-1 (CI or NIE)"
+msgstr "3:402.010-2 o 93:402.010-1 (CI o NIE)"
+
+#. module: l10n_uy
 #: model:ir.model,name:l10n_uy.model_account_chart_template
 msgid "Account Chart Template"
-msgstr "Plantilla de Plan de Cuentas"
+msgstr "Plantilla de plan de cuentas"
 
 #. module: l10n_uy
 #: model:account.report.column,name:l10n_uy.tax_report_balance
@@ -66,6 +80,13 @@ msgid "CI"
 msgstr ""
 
 #. module: l10n_uy
+#. odoo-python
+#: code:addons/l10n_uy/models/res_partner.py:0
+#, python-format
+msgid "CI/NIE"
+msgstr ""
+
+#. module: l10n_uy
 #: model:l10n_latam.document.type,name:l10n_uy.dc_recibo_cobranza
 msgid "Collection Receipt"
 msgstr "Recibo Cobranza"
@@ -73,7 +94,12 @@ msgstr "Recibo Cobranza"
 #. module: l10n_uy
 #: model:ir.model,name:l10n_uy.model_res_company
 msgid "Companies"
-msgstr "Compañías"
+msgstr "Empresas"
+
+#. module: l10n_uy
+#: model:ir.model,name:l10n_uy.model_res_partner
+msgid "Contact"
+msgstr "Contacto"
 
 #. module: l10n_uy
 #: model:l10n_latam.document.type,name:l10n_uy.dc_e_remito_de_exportación_contingencia
@@ -396,10 +422,43 @@ msgid "Taxable income"
 msgstr "Ingreso Imponible"
 
 #. module: l10n_uy
+#. odoo-python
+#: code:addons/l10n_uy/models/res_partner.py:0
+#, python-format
+msgid ""
+"The %(vat_label)s number [%(wrong_vat)s] does not seem to be valid.\n"
+"Note: the expected format is %(expected_format)s"
+msgstr ""
+"El %(vat_label)s número [%(wrong_vat)s] no parece válido.\n"
+"Nota: el formato esperoado es %(expected_format)s"
+
+#. module: l10n_uy
+#. odoo-python
+#: code:addons/l10n_uy/models/res_partner.py:0
+#, python-format
+msgid ""
+"The %(vat_label)s number [%(wrong_vat)s] for %(partner_label)s does not seem to be valid.\n"
+"Note: the expected format is %(expected_format)s"
+msgstr ""
+"El %(vat_label)s número [%(wrong_vat)s] para %(partner_label)s no parece válido.\n"
+"Nota: el formato esperoado es %(expected_format)s"
+
+#. module: l10n_uy
+#: model_terms:res.company,company_details:l10n_uy.demo_company_uy
+msgid ""
+"UY Company<br>\n"
+"Calle Falsa 123<br>\n"
+"Montevideo MO 12800<br>\n"
+"Uruguay"
+msgstr ""
+
+#. module: l10n_uy
 #: model:ir.model.fields,help:l10n_uy.field_account_tax__l10n_uy_tax_category
 msgid ""
 "UY: Use to group the transactions in the Financial Reports required by DGI"
-msgstr "UY: Utilizado para agrupar transacciones en Reportes Financieros requeridos por DGI"
+msgstr ""
+"UY: Utilizado para agrupar transacciones en Reportes Financieros requeridos "
+"por DGI"
 
 #. module: l10n_uy
 #: model:l10n_latam.identification.type,description:l10n_uy.it_rut
@@ -526,3 +585,10 @@ msgstr "Nota de Crédito e-Ticket Venta por Cuenta Ajena"
 #: model:l10n_latam.document.type,name:l10n_uy.dc_nota_de_debito_e_ticket_venta_por_cuenta_ajena
 msgid "e-Ticket Sale By Third Party Debit Note"
 msgstr "Nota de Débito e-Ticket Venta por Cuenta Ajena"
+
+#. module: l10n_uy
+#. odoo-python
+#: code:addons/l10n_uy/models/res_partner.py:0
+#, python-format
+msgid "partner [%s]"
+msgstr "empresa [%s]"

--- a/addons/l10n_uy/i18n/l10n_uy.pot
+++ b/addons/l10n_uy/i18n/l10n_uy.pot
@@ -4,16 +4,30 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 16.5alpha1+e\n"
+"Project-Id-Version: Odoo Server 17.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-09 17:46+0000\n"
-"PO-Revision-Date: 2023-10-09 17:46+0000\n"
+"POT-Creation-Date: 2024-08-02 22:43+0000\n"
+"PO-Revision-Date: 2024-08-02 22:43+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. module: l10n_uy
+#: model_terms:res.company,report_footer:l10n_uy.demo_company_uy
+msgid ""
+"+598 94 231 234 info@company.uyexample.com http://www.uyexample.com "
+"218296790015"
+msgstr ""
+
+#. module: l10n_uy
+#. odoo-python
+#: code:addons/l10n_uy/models/res_partner.py:0
+#, python-format
+msgid "3:402.010-2 or 93:402.010-1 (CI or NIE)"
+msgstr ""
 
 #. module: l10n_uy
 #: model:ir.model,name:l10n_uy.model_account_chart_template
@@ -66,6 +80,13 @@ msgid "CI"
 msgstr ""
 
 #. module: l10n_uy
+#. odoo-python
+#: code:addons/l10n_uy/models/res_partner.py:0
+#, python-format
+msgid "CI/NIE"
+msgstr ""
+
+#. module: l10n_uy
 #: model:l10n_latam.document.type,name:l10n_uy.dc_recibo_cobranza
 msgid "Collection Receipt"
 msgstr ""
@@ -73,6 +94,11 @@ msgstr ""
 #. module: l10n_uy
 #: model:ir.model,name:l10n_uy.model_res_company
 msgid "Companies"
+msgstr ""
+
+#. module: l10n_uy
+#: model:ir.model,name:l10n_uy.model_res_partner
+msgid "Contact"
 msgstr ""
 
 #. module: l10n_uy
@@ -393,6 +419,33 @@ msgid "Taxable income"
 msgstr ""
 
 #. module: l10n_uy
+#. odoo-python
+#: code:addons/l10n_uy/models/res_partner.py:0
+#, python-format
+msgid ""
+"The %(vat_label)s number [%(wrong_vat)s] does not seem to be valid.\n"
+"Note: the expected format is %(expected_format)s"
+msgstr ""
+
+#. module: l10n_uy
+#. odoo-python
+#: code:addons/l10n_uy/models/res_partner.py:0
+#, python-format
+msgid ""
+"The %(vat_label)s number [%(wrong_vat)s] for %(partner_label)s does not seem to be valid.\n"
+"Note: the expected format is %(expected_format)s"
+msgstr ""
+
+#. module: l10n_uy
+#: model_terms:res.company,company_details:l10n_uy.demo_company_uy
+msgid ""
+"UY Company<br>\n"
+"Calle Falsa 123<br>\n"
+"Montevideo MO 12800<br>\n"
+"Uruguay"
+msgstr ""
+
+#. module: l10n_uy
 #: model:ir.model.fields,help:l10n_uy.field_account_tax__l10n_uy_tax_category
 msgid ""
 "UY: Use to group the transactions in the Financial Reports required by DGI"
@@ -522,4 +575,11 @@ msgstr ""
 #. module: l10n_uy
 #: model:l10n_latam.document.type,name:l10n_uy.dc_nota_de_debito_e_ticket_venta_por_cuenta_ajena
 msgid "e-Ticket Sale By Third Party Debit Note"
+msgstr ""
+
+#. module: l10n_uy
+#. odoo-python
+#: code:addons/l10n_uy/models/res_partner.py:0
+#, python-format
+msgid "partner [%s]"
 msgstr ""

--- a/addons/l10n_uy/models/__init__.py
+++ b/addons/l10n_uy/models/__init__.py
@@ -3,5 +3,6 @@ from . import account_move
 from . import account_tax
 from . import l10n_latam_identification_type
 from . import res_company
+from . import res_partner
 from . import template_uy
 from . import l10n_latam_document_type

--- a/addons/l10n_uy/models/res_partner.py
+++ b/addons/l10n_uy/models/res_partner.py
@@ -1,0 +1,100 @@
+import logging
+import re
+
+from odoo import api, models, _
+
+from odoo.exceptions import ValidationError
+
+_logger = logging.getLogger(__name__)
+
+
+class ResPartner(models.Model):
+    _inherit = "res.partner"
+
+    @api.constrains("vat", "l10n_latam_identification_type_id")
+    def check_vat(self):
+        # EXTEND account/base_vat
+        """ Add validation of UY document types CI and NIE """
+        ci_nie_types = self.filtered(
+            lambda p: p.l10n_latam_identification_type_id.l10n_uy_dgi_code in ("1", "3")
+            and p.l10n_latam_identification_type_id.country_id.code == "UY" and p.vat)
+        for partner in ci_nie_types:
+            if not partner._l10n_uy_ci_nie_is_valid():
+                raise ValidationError(self._l10n_uy_build_vat_error_message(partner))
+        return super(ResPartner, self - ci_nie_types).check_vat()
+
+    @api.model
+    def _l10n_uy_build_vat_error_message(self, partner):
+        """ Similar to _build_vat_error_message but using latam doc type name instead of vat_label
+        NOTE: maybe can be implemented in master to l10n_latam_base for the use of different doc types """
+        vat_label = _("CI/NIE")
+        expected_format = _("3:402.010-2 or 93:402.010-1 (CI or NIE)")
+
+        # Catch use case where the record label is about the public user (name: False)
+        if partner.name:
+            msg = "\n" + _(
+                "The %(vat_label)s number [%(wrong_vat)s] for %(partner_label)s does not seem to be valid."
+                "\nNote: the expected format is %(expected_format)s",
+                vat_label=vat_label,
+                wrong_vat=partner.vat,
+                partner_label=_("partner [%s]", partner.name),
+                expected_format=expected_format,
+            )
+        else:
+            msg = "\n" + _(
+                "The %(vat_label)s number [%(wrong_vat)s] does not seem to be valid."
+                "\nNote: the expected format is %(expected_format)s",
+                vat_label=vat_label,
+                wrong_vat=partner.vat,
+                expected_format=expected_format,
+            )
+        return msg
+
+    def _l10n_uy_ci_nie_is_valid(self):
+        """ Check if the partner's CI or NIE number is a valid one.
+
+        CI:
+            1) The ID number is taken up to the second to last position, that is, the first 6 or 7 digits.
+            2) Each digit is multiplied by a different factor starting from right to left, the factors are:
+                2, 9, 8, 7, 6, 3, 4.
+            3) The products obtained are added:
+            4) The base module 10 is calculated on this result to obtain the check digit, expressed in another way,
+            the next number ending in zero is taken that follows the result of the addition (for the example
+            would be 60) subtracting the sum itself: 60 - 59 = 1. The verification digit of the example ID is 1.
+
+            NOTE: If the ID has fewer digits, it is preceded with zeros and the mechanism described above is applied
+
+        NIE:
+            The calculation for the NIE is the same as that used for the CI. The only difference is that we skip the
+            first number
+
+        Both algorithms where extracted from Uruware's Technical Manual (section 9.2 and 9.3)
+
+        Return: False is not valid, True is valid
+        """
+        self.ensure_one()
+
+        # The VAT must consist only numbers (format could have these characters ":., " we can skip them later)
+        invalid_chars = re.findall(r"[^0-9:., \-]", self.vat)
+        if invalid_chars:
+            return False
+
+        ci_nie_number = re.sub("[^0-9]", "", self.vat)
+
+        # we get the validation digit, if NIE doc type we skip the first digit
+        is_nie = self.l10n_latam_identification_type_id.l10n_uy_dgi_code == "1"
+        verif_digit = int(ci_nie_number[-1])
+        ci_nie_number = ci_nie_number[1:-1] if is_nie else ci_nie_number[0:-1]
+
+        # If number is < 7 digits we add 0 to the left
+        ci_nie_number = "%07d" % int(ci_nie_number)
+
+        # If NIE > 7 digits is not valid
+        if len(ci_nie_number) > 7:
+            return False
+
+        verification_vector = (2, 9, 8, 7, 6, 3, 4)
+        num_sum = sum(int(ci_nie_number[i]) * verification_vector[i] for i in range(7))
+
+        res = -num_sum % 10
+        return res == verif_digit

--- a/addons/l10n_uy/tests/__init__.py
+++ b/addons/l10n_uy/tests/__init__.py
@@ -1,1 +1,2 @@
+from . import test_check_vat
 from . import test_doc_types

--- a/addons/l10n_uy/tests/test_check_vat.py
+++ b/addons/l10n_uy/tests/test_check_vat.py
@@ -1,0 +1,79 @@
+from odoo.exceptions import ValidationError
+from odoo.tests import tagged
+
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+
+
+@tagged("post_install_l10n", "post_install", "-at_install")
+class CheckUyVat(AccountTestInvoicingCommon):
+
+    @classmethod
+    def setUpClass(cls, chart_template_ref="uy"):
+        super().setUpClass(chart_template_ref=chart_template_ref)
+
+    @classmethod
+    def _create_partner(cls, identification_type, vat):
+        return cls.env["res.partner"].create({
+            "name": "Uruguayan Partner",
+            "l10n_latam_identification_type_id": cls.env.ref(f"l10n_uy.{identification_type}").id,
+            "vat": vat,
+            "country_id": cls.env.ref("base.uy").id
+        })
+
+    def test_valid_ci(self):
+        # Valid CI
+        partner = self._create_partner("it_ci", "3:402.010-1")
+        self.assertTrue(partner._l10n_uy_ci_nie_is_valid())
+
+        partner = self._create_partner("it_ci", "3 402 010 1")
+        self.assertTrue(partner._l10n_uy_ci_nie_is_valid())
+
+        partner = self._create_partner("it_ci", "34020101")
+        self.assertTrue(partner._l10n_uy_ci_nie_is_valid())
+
+    def test_valid_nie(self):
+        partner = self._create_partner("it_nie", "93:402.010-1")
+        self.assertTrue(partner._l10n_uy_ci_nie_is_valid())
+
+        partner = self._create_partner("it_nie", "934020101")
+        self.assertTrue(partner._l10n_uy_ci_nie_is_valid())
+
+        partner = self._create_partner("it_nie", "93 402 010 1")
+        self.assertTrue(partner._l10n_uy_ci_nie_is_valid())
+
+    def test_valid_rut(self):
+        self._create_partner("it_rut", "215521750017")
+        self._create_partner("it_rut", "21-55217500-17")
+        self._create_partner("it_rut", "21 55217500 17")
+        self._create_partner("it_rut", "UY215521750017")
+
+    def test_invalid_ci(self):
+        common_msg = "The CI/NIE number.*does not seem to be valid"
+        with self.assertRaisesRegex(ValidationError, common_msg, msg="not valid verification digit"):
+            self._create_partner("it_ci", "3:402.010-2")
+        with self.assertRaisesRegex(ValidationError, common_msg, msg="should not contain letters"):
+            self._create_partner("it_ci", " ABC 3:402  asas .010-1")
+
+    def test_invalid_nie(self):
+        common_msg = "The CI/NIE number.*does not seem to be valid"
+        with self.assertRaisesRegex(ValidationError, common_msg, msg="not valid verification digit"):
+            self._create_partner("it_nie", "93:402.010-2")
+        with self.assertRaisesRegex(ValidationError, common_msg, msg="should not contain letters"):
+            self._create_partner("it_nie", "ABC 93:402. asas 010-1")
+
+    def test_invalid_rut(self):
+        common_msg = "The RUT number.*does not seem to be valid."
+        with self.assertRaisesRegex(ValidationError, common_msg, msg="invalid number"):
+            self._create_partner("it_rut", "215521750018")
+        with self.assertRaisesRegex(ValidationError, common_msg, msg="do not accept dot ('.') character"):
+            self._create_partner("it_rut", "21.55217500.17")
+        with self.assertRaisesRegex(ValidationError, common_msg, msg="should not contain letters"):
+            self._create_partner("it_rut", "2155 ABC 21750017")
+
+        with self.assertRaisesRegex(ValidationError, common_msg, msg="Validation not working with generic VAT id type"):
+            self.env["res.partner"].create({
+                "name": "Uruguayan Partner",
+                "country_id": self.env.ref("base.uy").id,
+                "l10n_latam_identification_type_id": self.env.ref("l10n_latam_base.it_vat").id,
+                "vat": "215521750018",
+            })


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

1. Add validation to CI and NIE identification types.
2. Improve the RUT message to more clear message about the expected format.

Before this change only RUT document type was validated. With this new change we are able to validate also NIE and CI Uruguayan document types

### Current behavior before PR:

1. Trying to set an invalid NIE to a contact, there is not warning for the user and we let the user to store the number.
2. RUT: If we set an invalid number we receive the warning but the suggested format is not ok ![image](https://github.com/user-attachments/assets/a28ef04b-f5ff-42d7-b8ce-3d744175cf96)

### Desired behavior after PR is merged:

1. If invalid RUT: improve error message:  ![image](https://github.com/user-attachments/assets/3a3680ad-75b9-49b5-829c-b5df207890f7)

2. If we set an invalid NIE to a contact we receive message warning that is not a valid one ![image](https://github.com/user-attachments/assets/a03f46e1-519b-4679-9e06-e3b9de220065)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
