### PR TITLE
[FIX] mail: activity_search should return recordset

### DIFF
--- a/addons/mail/models/mail_activity_mixin.py
+++ b/addons/mail/models/mail_activity_mixin.py
@@ -359,12 +359,12 @@ class MailActivityMixin(models.AbstractModel):
         :param additional_domain: if set, filter on that domain;
         """
         if self.env.context.get('mail_activity_automation_skip'):
-            return False
+            return self.env['mail.activity']
 
         Data = self.env['ir.model.data'].sudo()
         activity_types_ids = [type_id for type_id in (Data._xmlid_to_res_id(xmlid, raise_if_not_found=False) for xmlid in act_type_xmlids) if type_id]
         if not any(activity_types_ids):
-            return False
+            return self.env['mail.activity']
 
         domain = [
             '&', '&', '&',


### PR DESCRIPTION
In some places, `unlink()` and `mapped()` are used on the result. To avoid error, let's return empty recordset.

Examples:

![Selection_3565](https://github.com/user-attachments/assets/86691039-1536-4e54-8d1a-83ef941ef859)

![Selection_3564](https://github.com/user-attachments/assets/049aa4f1-1cc0-4e5f-bcdd-4c64aeb3e52c)



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr