### PR TITLE
[FIX] l10n_it_edi: remove rounding on XML unit price

### DIFF
--- a/addons/l10n_it_edi/models/account_move.py
+++ b/addons/l10n_it_edi/models/account_move.py
@@ -251,7 +251,7 @@ class AccountMove(models.Model):
                 gross_price = line['price_subtotal'] / (1 - line['discount'] / 100.0)
                 line['discount_amount_before_dispatching'] = (gross_price - line['price_subtotal']) * inverse_factor
                 line['gross_price_subtotal'] = line['currency'].round(gross_price * inverse_factor)
-                line['price_unit'] = line['currency'].round(gross_price / abs(line['quantity']))
+                line['price_unit'] = gross_price / abs(line['quantity'])
             else:
                 line['gross_price_subtotal'] = line['currency'].round(line['price_unit'] * line['quantity'])
                 line['discount_amount_before_dispatching'] = line['gross_price_subtotal']


### PR DESCRIPTION
**Problem:**

The unit price on the XML invoices created for the italian localization are rounded based on the currency’s rounding. However if the decimal.precision record “Product Price” has more digits than the currency’s rounding, then there will be a problem.

Say that the currency’s rounding is at 2 digits and the “Produce Price” precision is at 3 digits. The user can enter 1.111 as the unit price on an invoice line, but Odoo will round it to 1.11 on the XML invoice due to rounding by the currency.

The problem now will be the discrepancy on the XML between the unit price * quantity and the total of the invoice line. Say that the quantity on the invoice line is 999999. Unit price (`PrezzoUnitario`) * quantity (`Quantita`) is 1109998.89, but the total of the invoice line (`PrezzoTotale`) is 1110998.89, which is 1000 more.

Based on the FeX page, this is the formula for `<PrezzoTotale>`:

`<Quantita>` * (`<PrezzoUnitario>` + `<ScontoMaggiorazione>`)

In the example given here, since there is no discount (`ScontoMaggiorazione`) applied, the equation in this example can be simplified to `<Quantita>` * `<PrezzoUnitario>`.

The tolerance for error in the calculation of `<PrezzoTotale>` is 0.01 euro, which is why the SDI is rejecting some of these XML invoices.

FeX page: https://fex-app.com/FatturaElettronica/FatturaElettronicaBody/DatiBeniServizi/DettaglioLinee/PrezzoTotale

**Purpose:**

Remove the rounding on the XML unit price to remove the difference between unit price * quantity and the total of the invoice line.

**Steps to Reproduce on Runbot:**

1. Install l10n_it_edi
2. Go to the “IT Company”
3. Go to “Decimal Accuracy” and set “Product Price” to be 3 digits
4. Create a vendor bill
5. Set the partner to be “IT Company”
6. Add a line for any product. Set the unit price to be 1.111 and the quantity to be 999999
7. Add the tax “22% G RC (Goods)” to the line
8. Confirm the vendor bill
9. Click on “Send Tax Integration” to generate the XML file
10. Notice that the element “`PrezzoUnitario`” is only 1.110000 since it is rounded to 2 decimal places based on the currency’s rounding. As a result, `PrezzoUnitario` * `Quantita` = 1109998.89 is 1000 off from `PrezzoTotale`, which is 1110998.89

opw-4041057

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
