### PR TITLE
[IMP] mass_mailing,mass_mailing_sms,membership: simplify kanban archs

### DIFF
--- a/addons/mass_mailing/static/src/scss/mass_mailing.scss
+++ b/addons/mass_mailing/static/src/scss/mass_mailing.scss
@@ -121,10 +121,10 @@
             .o_mailing_list_kanban_stats > a {
                 flex-wrap: wrap;
                 &:hover {
-                    font-weight: normal;
+                    font-weight: normal !important;
                 }
                 @include media-breakpoint-down(sm) {
-                    font-size: 1.4rem;
+                    font-size: 1.4rem !important;
                     height: 40px;
                     margin-bottom: 30px;
                     min-width: 90px;
@@ -147,11 +147,6 @@
                         text-align: right;
                     }
                 }
-            }
-            .text-large {
-                line-height: 1.1em;
-                font-size: 120%;
-                font-weight: 300;
             }
         }
     }

--- a/addons/mass_mailing/views/mailing_contact_views.xml
+++ b/addons/mass_mailing/views/mailing_contact_views.xml
@@ -70,37 +70,19 @@
                     <button name="action_import" string="Import" type="object" display="always"
                         context="{'from_mailing_list_ids': context.get('active_ids') if context.get('active_model') == 'mailing.list' else False}"/>
                 </header>
-                <field name="name"/>
-                <field name="company_name"/>
-                <field name="email"/>
-                <field name="message_bounce"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div t-attf-class="oe_kanban_global_click">
-                            <div class="o_kanban_record_top">
-                                <div class="o_kanban_record_headings">
-                                    <strong class="o_kanban_record_title">
-                                        <t t-esc="record.name.value"/>
-                                    </strong>
-                                </div>
-                                <span class="badge rounded-pill" title="Number of bounced email.">
-                                    <i class="fa fa-exclamation-triangle" role="img" aria-label="Warning" title="Warning"/> <t t-esc="record.message_bounce.value" title=""/>
-                                </span>
-                            </div>
-                            <div class="o_kanban_record_body">
-                                <field name="tag_ids"/>
-                            </div>
-                            <div class="o_kanban_record_bottom">
-                                <div class="oe_kanban_bottom_left">
-                                    <strong>
-                                        <t t-esc="record.email.value"/>
-                                    </strong>
-                                </div>
-                                <div class="oe_kanban_bottom_right">
-                                    <t t-esc="record.company_name.value"/>
-                                </div>
+                    <t t-name="kanban-card">
+                        <div class="d-flex">
+                            <field name="name" class="fw-bolder fs-5"/>
+                            <div class="badge rounded-pill ms-auto" title="Number of bounced email.">
+                                <i class="fa fa-exclamation-triangle" role="img" aria-label="Warning" title="Warning"/> <field name="message_bounce"/>
                             </div>
                         </div>
+                        <field name="tag_ids"/>
+                        <footer class="fs-6 pt-1">
+                            <field name="email" class="fw-bolder"/>
+                            <field name="company_name" class="ms-auto"/>
+                        </footer>
                     </t>
                 </templates>
             </kanban>

--- a/addons/mass_mailing/views/mailing_list_views.xml
+++ b/addons/mass_mailing/views/mailing_list_views.xml
@@ -108,115 +108,86 @@
         <field name="model">mailing.list</field>
         <field name="arch" type="xml">
             <kanban class="o_kanban_mobile o_kanban_mailing_list" sample="1">
-                <field name="name"/>
-                <field name="contact_count"/>
-                <field name="contact_count_email"/>
-                <field name="contact_count_opt_out"/>
-                <field name="contact_count_blacklisted"/>
-                <field name="contact_pct_bounce"/>
-                <field name="contact_pct_opt_out"/>
-                <field name="contact_pct_blacklisted"/>
                 <field name="active"/>
                 <templates>
-                    <t t-name="kanban-box">
+                    <t t-name="kanban-card">
                         <!-- Card when the Kanban view is grouped  -->
-                        <div class="oe_kanban_global_click o_mailing_list_kanban_grouped">
-                            <div class="oe_kanban_content d-flex flex-column h-100">
-                                <h2 class="mb-3 o_text_overflow">
-                                    <field name="name"/>
-                                </h2>
-                                <div class="d-flex align-items-center">
-                                    <div class="me-3">
-                                        <button class="btn btn-primary" name="action_view_contacts" type="object">
-                                            <t t-esc="record.contact_count.value"/> <span>Contacts</span>
-                                        </button>
-                                    </div>
-                                    <div class="flex-grow-1 d-flex flex-column align-items-end o_mass_mailing_kanban_contact_links">
-                                        <a name="action_view_contacts_email" type="object">
-                                            <span>Valid Email Recipients</span>
-                                            <span t-esc="record.contact_count_email.value" class="ms-3"/>
-                                        </a>
-                                    </div>
+                        <div class="o_mailing_list_kanban_grouped d-flex flex-column h-100">
+                            <field name="name" class="fw-bold fs-2 mb-3 text-truncate"/>
+                            <div class="d-flex align-items-center">
+                                <button class="btn btn-primary me-3" name="action_view_contacts" type="object">
+                                    <field name="contact_count"/> <span>Contacts</span>
+                                </button>
+                                <div class="flex-grow-1 d-flex flex-column align-items-end o_mass_mailing_kanban_contact_links">
+                                    <a name="action_view_contacts_email" type="object">
+                                        <span>Valid Email Recipients</span>
+                                        <field name="contact_count_email" class="ms-3"/>
+                                    </a>
                                 </div>
-                                <div class="flex-grow-1 d-flex align-items-end mt-4">
-                                    <div class="col-12">
-                                        <div class="row mt3">
-                                            <div class="col-3 border-end">
-                                                <a name="action_view_mailings" type="object" class="d-flex flex-column align-items-center">
-                                                    <span><field name="mailing_count"/></span>
-                                                    <span class="text-muted">Mailings</span>
-                                                </a>
-                                            </div>
-                                            <div class="col-3 border-end">
-                                                <a name="action_view_contacts_bouncing" type="object" class="d-flex flex-column align-items-center">
-                                                    <span><field name="contact_pct_bounce"/>%</span>
-                                                    <span class="text-muted">Bounce</span>
-                                                </a>
-                                            </div>
-                                            <div class="col-3 border-end">
-                                                <a name="action_view_contacts_opt_out" type="object" class="d-flex flex-column align-items-center">
-                                                    <span><field name="contact_pct_opt_out"/>%</span>
-                                                    <span class="text-muted">Opt-out</span>
-                                                </a>
-                                            </div>
-                                            <div class="col-3">
-                                                <a name="action_view_contacts_blacklisted" type="object" class="d-flex flex-column align-items-center">
-                                                    <span><field name="contact_pct_blacklisted"/>%</span>
-                                                    <span class="text-muted">Blacklist</span>
-                                                </a>
-                                            </div>
-                                        </div>
-                                    </div>
+                            </div>
+                            <div class="flex-grow-1 d-flex mt-4 row g-0">
+                                <div class="col-3 border-end">
+                                    <a name="action_view_mailings" type="object" class="d-flex flex-column align-items-center">
+                                        <field name="mailing_count"/>
+                                        <span class="text-muted">Mailings</span>
+                                    </a>
+                                </div>
+                                <div class="col-3 border-end">
+                                    <a name="action_view_contacts_bouncing" type="object" class="d-flex flex-column align-items-center">
+                                        <span><field name="contact_pct_bounce"/>%</span>
+                                        <span class="text-muted">Bounce</span>
+                                    </a>
+                                </div>
+                                <div class="col-3 border-end">
+                                    <a name="action_view_contacts_opt_out" type="object" class="d-flex flex-column align-items-center">
+                                        <span><field name="contact_pct_opt_out"/>%</span>
+                                        <span class="text-muted">Opt-out</span>
+                                    </a>
+                                </div>
+                                <div class="col-3">
+                                    <a name="action_view_contacts_blacklisted" type="object" class="d-flex flex-column align-items-center">
+                                        <span><field name="contact_pct_blacklisted"/>%</span>
+                                        <span class="text-muted">Blacklist</span>
+                                    </a>
                                 </div>
                             </div>
                         </div>
                         <!-- Card when the Kanban view is not grouped -->
-                        <div class="oe_kanban_global_click o_mailing_list_kanban_ungrouped d-flex gap-1 flex-row justify-content-between align-items-center flex-wrap">
+                        <div class="o_mailing_list_kanban_ungrouped d-flex gap-1 flex-row justify-content-between align-items-center flex-wrap">
                             <div class="col-lg-3 col-sm-6 col-12 py-0 my-auto">
-                                <div class="d-flex text-large">
-                                    <span class="d-inline-block text-truncate fw-normal text-large"
-                                          t-att-title="record.name.value">
-                                        <field name="name"/>
-                                    </span>
-                                </div>
+                                <span class="d-inline-block text-truncate fs-2 fw-normal lh-sm" t-att-title="record.name.value">
+                                    <field name="name"/>
+                                </span>
                             </div>
-                            <div class="o_mailing_list_kanban_counts col-lg-1 col-6 my-auto d-flex">
+                            <div class="col-lg-1 col-6 my-auto d-flex">
                                 <div class="d-flex flex-row justify-content-start justify-content-md-end">
-                                    <div class="my-auto p-0">
-                                        <button name="action_view_contacts" type="object"
-                                            class="o_mailing_list_kanban_button o_mailing_list_kanban_big_nb text-primary fw-bold">
-                                            <field name="contact_count"/>
-                                        </button>
-                                   </div>
-                                    <div class="my-auto px-0">
-                                        <button name="action_view_contacts" type="object"
-                                            class="o_mailing_list_kanban_button text-large text-start ms-2">
-                                            Total <br/>Contacts
-                                        </button>
-                                    </div>
+                                    <button name="action_view_contacts" type="object"
+                                        class="o_mailing_list_kanban_button o_mailing_list_kanban_big_nb text-primary fw-bold">
+                                        <field name="contact_count"/>
+                                    </button>
+                                    <button name="action_view_contacts" type="object"
+                                        class="o_mailing_list_kanban_button fs-4 lh-1 text-start ms-2">
+                                        Total <br/>Contacts
+                                    </button>
                                 </div>
                             </div>
                             <div class="o_mailing_list_kanban_stats order-4 order-lg-3 col-lg-5 col-sm-12 col-12 py-0 my-3 my-sm-auto d-flex justify-content-sm-between justify-content-start flex-wrap">
-                                <a class="me-sm-0 me-3 text-large" tabindex="-1"
+                                <a class="me-sm-0 me-3 fs-4 fw-light lh-1" tabindex="-1"
                                     name="action_view_contacts_email" type="object">
-                                    <span class="fw-normal">
-                                        <field name="contact_count_email"/>
-                                    </span>
+                                    <field name="contact_count_email" class="fw-normal"/>
                                     <br/>
                                     <span class="text-muted">
                                         <i class="fa fa-envelope-o"/> Contacts
                                     </span>
                                 </a>
-                                <a class="me-sm-0 me-3 text-large" tabindex="-1"
+                                <a class="me-sm-0 me-3 fs-4 fw-light lh-1" tabindex="-1"
                                     name="action_view_mailings" type="object">
-                                    <span class="fw-normal">
-                                        <field name="mailing_count"/>
-                                    </span>
+                                    <field name="mailing_count" class="fw-normal"/>
                                     <br/>
                                     <span class="text-muted">Mailings</span>
                                 </a>
                                 <hr class="w-100 d-block d-sm-none opacity-0 m-0 p-0"/>
-                                <a class="me-sm-0 me-3 text-large" tabindex="-1"
+                                <a class="me-sm-0 me-3 fs-4 fw-light lh-1" tabindex="-1"
                                     name="action_view_contacts_bouncing" type="object">
                                     <span class="fw-normal">
                                         <field name="contact_pct_bounce"/> %
@@ -224,7 +195,7 @@
                                     <br/>
                                     <span class="text-muted">Bounce</span>
                                 </a>
-                                <a class="me-sm-0 me-3 text-large" tabindex="-1"
+                                <a class="me-sm-0 me-3 fs-4 fw-light lh-1" tabindex="-1"
                                     name="action_view_contacts_opt_out" type="object">
                                     <span class="fw-normal">
                                         <field name="contact_pct_opt_out"/> %
@@ -232,7 +203,7 @@
                                     <br/>
                                     <span class="text-muted">Opt-Out</span>
                                 </a>
-                                <a class="me-sm-0 me-3 text-large" tabindex="-1"
+                                <a class="me-sm-0 me-3 fs-4 fw-light lh-1" tabindex="-1"
                                     name="action_view_contacts_blacklisted" type="object">
                                     <span class="fw-normal">
                                         <field name="contact_pct_blacklisted"/> %
@@ -241,7 +212,7 @@
                                     <span class="text-muted">Blacklist</span>
                                 </a>
                             </div>
-                            <div class="o_kanban_ungrouped_action_buttons order-3 order-lg-4 col-5 col-lg-2 py-0 my-auto d-none d-md-flex flex-wrap justify-content-end gap-1">
+                            <div class="order-3 order-lg-4 col-5 col-lg-2 py-0 my-auto d-none d-md-flex flex-wrap justify-content-end gap-1">
                                 <button name="action_open_import" string="Import Contacts"
                                     type="object" class="btn btn-secondary text-nowrap">
                                     Import Contacts

--- a/addons/mass_mailing/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views.xml
@@ -403,23 +403,13 @@
             <field name="name">mailing.mailing.kanban</field>
             <field name="model">mailing.mailing</field>
             <field name="arch" type="xml">
-                <kanban default_group_by="state" quick_create="false" sample="1">
-                    <field name='state' readonly="1"/>
-                    <field name='email_from'/>
-                    <field name='color'/>
-                    <field name='user_id'/>
-                    <field name='expected'/>
-                    <field name='failed'/>
-                    <field name='total'/>
-                    <field name='mailing_model_id'/>
+                <kanban highlight_color="color" default_group_by="state" quick_create="false" sample="1">
                     <field name='mailing_on_mailing_list'/>
-                    <field name='sent_date'/>
-                    <field name='schedule_date'/>
                     <field name='next_departure'/>
                     <field name='active'/>
                     <templates>
                         <t t-name="kanban-menu" t-if="!selection_mode">
-                            <ul class="oe_kanban_colorpicker" data-field="color"/>
+                            <field name="color" widget="kanban_color_picker"/>
                             <t t-if="widget.deletable">
                                 <a role="menuitem" type="delete" class="dropdown-item">Delete</a>
                             </t>
@@ -428,60 +418,37 @@
                                 <t t-if="!record.active.raw_value">Restore</t>
                             </a>
                         </t>
-                        <t t-name="kanban-box">
-                            <div t-attf-class="{{!selection_mode ? 'oe_kanban_color_' + kanban_getcolor(record.color.raw_value) : ''}} oe_kanban_card oe_kanban_global_click oe_kanban_mass_mailing">
-                                 <div class="oe_kanban_content">
-                                    <div class="o_kanban_record_top">
-                                        <div class="o_kanban_record_headings">
-                                            <div class="row"  invisible="not sent_date">
-                                                <h3 class="my-1 col-8 o_text_overflow">
-                                                    <field name="subject"/>
-                                                </h3>
-                                            </div>
-                                            <h3 class="my-1"  invisible="sent_date">
-                                                <field name="subject"/>
-                                            </h3>
-                                            <field name="mailing_type" invisible="1"/>
-                                            <div class="o_kanban_record_subtitle" invisible="not sent_date">
-                                                <h5 style="display: inline;">
-                                                    <field name="campaign_id" groups="mass_mailing.group_mass_mailing_campaign"/>
-                                                </h5>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
+                        <t t-name="kanban-card">
+                            <field name="subject" class="my-1 text-truncate fs-3 fw-bold"/>
+                            <field name="campaign_id" invisible="not sent_date" class="fw-bold fs-5" groups="mass_mailing.group_mass_mailing_campaign"/>
+                            <div>
                                 <i class="fa fa-bullseye me-2" role="img" aria-label="Lead/Opportunity"/>
                                 <field name='mailing_model_id' invisible="mailing_on_mailing_list"/>
                                 <span invisible="not mailing_on_mailing_list">Mailing Contact</span>
-                                <div name="div_responsible_avatar" class="o_kanban_record_bottom">
-                                    <div class="oe_kanban_bottom_left">
-                                        <span invisible="not sent_date"
-                                            t-attf-title="Sent on #{record.sent_date.value}" class="d-inline-flex">
-                                            <span class="fa fa-paper-plane me-2 small my-auto" aria-label="Sent date"/>
-                                            <span class="align-self-baseline"><field name="sent_date"/></span>
-                                        </span>
-                                        <span invisible="not schedule_date"
-                                            t-attf-title="Scheduled on #{record.schedule_date.value}" class="d-inline-flex">
-                                            <span class="fa fa-hourglass-half me-2 small my-auto" aria-label="Scheduled date"/>
-                                            <span class="align-self-baseline"><field name="schedule_date" readonly="state not in ['draft', 'in_queue']"/></span>
-                                        </span>
-                                        <span invisible="sent_date or schedule_date or state == 'in_queue'"
-                                            class="clearfix">
-                                            <b><field name='total' class="me-1"/></b>
-                                            <field name='mailing_model_id' invisible="mailing_on_mailing_list"/>
-                                            <span invisible="not mailing_on_mailing_list">Mailing Contact</span>
-                                        </span>
-                                        <span invisible="schedule_date or state != 'in_queue' or not next_departure"
-                                            t-attf-title="Scheduled on #{record.next_departure.value}" class="d-inline-flex">
-                                            <span class="fa fa-hourglass-o me-2 small my-auto" aria-label="Scheduled date"/>
-                                            <span class="align-self-baseline">Next Batch</span>
-                                        </span>
-                                    </div>
-                                    <div class="oe_kanban_bottom_right">
-                                        <field name="user_id" widget="many2one_avatar_user"/>
-                                    </div>
-                                </div>
                             </div>
+                            <footer class="fs-6 pt-0">
+                                <div>
+                                    <span invisible="not sent_date" t-attf-title="Sent on #{record.sent_date.value}">
+                                        <span class="fa fa-paper-plane me-2 small my-auto" aria-label="Sent date"/>
+                                        <field name="sent_date"/>
+                                    </span>
+                                    <span invisible="not schedule_date" t-attf-title="Scheduled on #{record.schedule_date.value}">
+                                        <span class="fa fa-hourglass-half me-2 small my-auto" aria-label="Scheduled date"/>
+                                        <field name="schedule_date" readonly="state not in ['draft', 'in_queue']"/>
+                                    </span>
+                                    <span invisible="sent_date or schedule_date or state == 'in_queue'">
+                                        <field name='total' class="me-1 fw-bold"/>
+                                        <field name='mailing_model_id' invisible="mailing_on_mailing_list"/>
+                                        <span invisible="not mailing_on_mailing_list">Mailing Contact</span>
+                                    </span>
+                                    <span invisible="schedule_date or state != 'in_queue' or not next_departure"
+                                        t-attf-title="Scheduled on #{record.next_departure.value}" >
+                                        <span class="fa fa-hourglass-o me-2 small my-auto" aria-label="Scheduled date"/>
+                                        <span>Next Batch</span>
+                                    </span>
+                                </div>
+                                <field name="user_id" widget="many2one_avatar_user" class="ms-auto"/>
+                            </footer>
                         </t>
                     </templates>
                 </kanban>

--- a/addons/mass_mailing_sms/views/mailing_contact_views.xml
+++ b/addons/mass_mailing_sms/views/mailing_contact_views.xml
@@ -68,11 +68,7 @@
         <field name="inherit_id" ref="mass_mailing.mailing_contact_view_kanban"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='email']" position="after">
-                <field name="mobile" widget="phone"/>
-                <field name="phone_sanitized" invisible="1"/>
-            </xpath>
-            <xpath expr="//t[@t-esc='record.email.value']" position="after">
-                <t t-esc="record.mobile.value"/>
+                <field name="mobile" class="fw-bolder"/>
             </xpath>
         </field>
     </record>

--- a/addons/mass_mailing_sms/views/mailing_list_views.xml
+++ b/addons/mass_mailing_sms/views/mailing_list_views.xml
@@ -5,21 +5,16 @@
         <field name="model">mailing.list</field>
         <field name="inherit_id" ref="mass_mailing.mailing_list_view_kanban"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='contact_count_email']" position="after">
-                <field name="contact_count_sms"/>
-            </xpath>
             <xpath expr="//div[hasclass('o_mass_mailing_kanban_contact_links')]" position="inside">
               <a name="action_view_contacts_sms" type="object">
                   <span >Valid SMS Recipients</span>
-                  <span t-esc="record.contact_count_sms.value" class="ms-3"/>
+                  <field name="contact_count_sms" class="ms-3"/>
               </a>
             </xpath>
             <xpath expr="//div[hasclass('o_mailing_list_kanban_stats')]//a" position="after">
-                <a class="me-sm-0 me-3 text-large" tabindex="-1"
+                <a class="me-sm-0 me-3 fs-4 fw-light lh-1" tabindex="-1"
                     name="action_view_contacts_sms" type="object">
-                    <span class="fw-normal">
-                        <field name="contact_count_sms"/>
-                    </span>
+                    <field name="contact_count_sms" class="fw-normal"/>
                     <br/>
                     <span class="text-muted">
                         <i class="fa fa-phone"/> Contacts

--- a/addons/mass_mailing_sms/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing_sms/views/mailing_mailing_views.xml
@@ -229,7 +229,7 @@
                 <field name="sms_has_insufficient_credit"/>
                 <field name="sms_has_unregistered_account"/>
             </xpath>
-            <xpath expr="//div[@name='div_responsible_avatar']" position="after">
+            <xpath expr="//footer" position="after">
                 <div class="alert alert-warning mb-0 mt-3 o-hidden-ios" role="alert" invisible="not sms_has_insufficient_credit">
                     <a name="action_buy_sms_credits" type="object">Insufficient credits</a>
                 </div>

--- a/addons/membership/views/product_views.xml
+++ b/addons/membership/views/product_views.xml
@@ -44,22 +44,14 @@
             <field name="model">product.template</field>
             <field name="arch" type="xml">
                 <kanban class="o_kanban_mobile">
-                    <field name="name"/>
-                    <field name="membership_date_from"/>
-                    <field name="membership_date_to"/>
-                    <field name="list_price"/>
                     <templates>
-                        <t t-name="kanban-box">
-                            <div t-attf-class="oe_kanban_card oe_kanban_global_click">
-                                <div class="o_kanban_record_top">
-                                    <div class="o_kanban_record_headings">
-                                        <strong class="o_kanban_record_title"><span class="mt4"><field name="name"/></span></strong>
-                                    </div>
-                                    <span class="badge rounded-pill"><i class="fa fa-money" role="img" aria-label="Price" title="Price"/> <field name="list_price"/></span>
-                                </div>
-                                <div class="o_kanban_record_body">
-                                    <i class="fa fa-clock-o" role="img" aria-label="Period" title="Period"></i><strong> From: </strong><field name="membership_date_from"/><strong> To:</strong> <field name="membership_date_to"/>
-                                </div>
+                        <t t-name="kanban-card">
+                            <div class="d-flex">
+                                <field name="name" class="fw-bolder fs-5"/>
+                                <span class="badge rounded-pill ms-auto"><i class="fa fa-money" role="img" aria-label="Price" title="Price"/> <field name="list_price"/></span>
+                            </div>
+                            <div>
+                                <i class="fa fa-clock-o" role="img" aria-label="Period" title="Period"></i><strong> From: </strong><field name="membership_date_from"/><strong> To:</strong> <field name="membership_date_to"/>
                             </div>
                         </t>
                     </templates>


### PR DESCRIPTION
In this commit we have simplified the kanban arch for the mass_mailing and membership module.the goal is to simplify them,make them easier to read and use bootstrap utility classnames.

- Previously, we used kanban-box, but now we are using kanban-card instead.
- Deprecated oe_kanban_global_click and oe_kanban_global_click_edit.
- More use of <field/> tags
- Removed the oe_kanban_colorpicker class and replaced it with the kanban_color_picker widget.
- Changed type='edit' to type='open' to open records. since version 16, records always open in edit mode by default.
- kanban_image from rendering context, is deprecated so we use `<field name=... widget=image/>` instead
- kanban_color, kanban_getcolor and kanban_getcolorname are deprecated use new attribute highlight_color=color_field_name on root node
- oe_kanban_colorpicker is deprecated, use kanban_color_picker widget instead

Task-3992107

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
