### PR TITLE
[FIX] account_payment: fix infinite creation of account.payment.method.line

### DIFF
--- a/addons/account_payment/models/payment_provider.py
+++ b/addons/account_payment/models/payment_provider.py
@@ -57,6 +57,7 @@ class Paymentprovider(models.Model):
             pay_method_line_same_code = self.env['account.payment.method.line'].search(
                 [
                     ('company_id', '=', self.company_id.id),
+                    # FIXME: this is likely broken, as the code is not unique and it's a related non stored field
                     ('code', '=', self.code),
                 ],
                 limit=1,

--- a/addons/account_payment/models/payment_provider.py
+++ b/addons/account_payment/models/payment_provider.py
@@ -24,7 +24,7 @@ class Paymentprovider(models.Model):
             return
 
         pay_method_line = self.env['account.payment.method.line'].search(
-            [('code', '=', self.code), ('payment_provider_id', '=', self.id)],
+            [('payment_provider_id', '=', self.id)],
             limit=1,
         )
 


### PR DESCRIPTION
The code field on the line is related to the code of the provider and is not stored.
You cannot search for it, thus the search is broken.
In any case, since the code comes from the provider,
it's pointless to search for the provider and its code.

Currently this bug causes infinite creation of account.payment.method.line when the journal is computed.

See screen recording:

![odoo-payment-provider-conf-dup](https://github.com/user-attachments/assets/d81772c3-b5eb-4e1f-92e8-9190923a7d72)

There's another search that I think is broken. I added a FIXME comment in a separated commit for it.
