### PR TITLE
[IMP] website: redesign `s_color_blocks_2` snippet

### DIFF
--- a/addons/website/views/new_page_template_templates.xml
+++ b/addons/website/views/new_page_template_templates.xml
@@ -837,7 +837,7 @@ overridden by modules), because:
 
 <template id="new_page_template_landing_s_color_blocks_2" inherit_id="website.new_page_template_s_color_blocks_2" primary="True">
     <xpath expr="//h2" position="replace">
-        <h2>Crystal Clear Sound</h2>
+        <h2 class="h3-fs">Crystal Clear Sound</h2>
     </xpath>
 </template>
 

--- a/addons/website/views/snippets/s_color_blocks_2.xml
+++ b/addons/website/views/snippets/s_color_blocks_2.xml
@@ -5,15 +5,13 @@
     <section class="s_color_blocks_2">
         <div class="container-fluid">
             <div class="row">
-                <div class="col-lg-6 o_cc o_cc3 text-center">
-                    <i class="fa fa-shield fa-5x m-3"/>
-                    <h2>A color block</h2>
+                <div class="col-lg-6 o_cc o_cc4">
+                    <h2 class="h3-fs">A color block</h2>
                     <p>Color blocks are a simple and effective way to <b>present and highlight your content</b>. Choose an image or a color for the background. You can even resize and duplicate the blocks to create your own layout. Add images or icons to customize the blocks.</p>
                     <a href="#" class="btn btn-primary">More Details</a>
                 </div>
-                <div class="col-lg-6 o_cc o_cc5 text-center">
-                    <i class="fa fa-cube fa-5x m-3"/>
-                    <h2>Another color block</h2>
+                <div class="col-lg-6 o_cc o_cc5">
+                    <h2 class="h3-fs">Another color block</h2>
                     <p>Color blocks are a simple and effective way to <b>present and highlight your content</b>. Choose an image or a color for the background. You can even resize and duplicate the blocks to create your own layout. Add images or icons to customize the blocks.</p>
                     <a href="#" class="btn btn-primary">More Details</a>
                 </div>


### PR DESCRIPTION
The goal of this commit is to improve the visual design of the default s_color_blocks_2 snippet.

task-3665302
Part of task-3619705

| Before | After |
|--------|--------|
| ![Capture d’écran 2024-07-17 à 08 50 05](https://github.com/user-attachments/assets/2463f309-600c-4f1f-9133-88089e40544c) | <img width="1783" alt="Capture d’écran 2024-07-17 à 15 50 44" src="https://github.com/user-attachments/assets/09c22884-c493-4a64-9617-a057aed0e69a"> |

Requires:
- https://github.com/odoo/design-themes/pull/834

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
