### PR TITLE
[FIX] mail, web: placement of the attachment action button distorted

### DIFF
--- a/addons/mail/models/ir_attachment.py
+++ b/addons/mail/models/ir_attachment.py
@@ -76,6 +76,11 @@ class IrAttachment(models.Model):
     def _attachment_format(self):
         safari = request and request.httprequest.user_agent and request.httprequest.user_agent.browser == 'safari'
         return [{
+            'author': {
+                'id': attachment.create_uid.id,
+                'name': attachment.create_uid.name,
+                'partnerId': attachment.create_uid.partner_id.id,
+            },
             'checksum': attachment.checksum,
             'create_date': attachment.create_date,
             'id': attachment.id,

--- a/addons/mail/static/src/core/common/attachment_list.js
+++ b/addons/mail/static/src/core/common/attachment_list.js
@@ -97,8 +97,12 @@ export class AttachmentList extends Component {
         this.props.unlinkAttachment(attachment);
     }
 
-    onImageLoaded() {
-        this.env.onImageLoaded?.();
+    onImageLoaded({ ev, attachment }) {
+        this.env?.onImageLoaded?.();
+        const image = ev.target;
+        if (image) {
+            attachment.isSmallImg = image.height <= 30;
+        }
     }
 
     get isInChatWindowAndIsAlignedRight() {

--- a/addons/mail/static/src/core/common/attachment_list.scss
+++ b/addons/mail/static/src/core/common/attachment_list.scss
@@ -24,6 +24,10 @@
     }
 }
 
+.o-mail-AttachmentImage-actions {
+    z-index: 1;
+}
+
 .o-mail-AttachmentImage {
     min-width: 20px;
     min-height: 20px;

--- a/addons/mail/static/src/core/common/attachment_list.xml
+++ b/addons/mail/static/src/core/common/attachment_list.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="mail.AttachmentList">
-        <div class="o-mail-AttachmentList overflow-y-auto d-flex flex-column mt-1"
+        <div class="o-mail-AttachmentList d-flex flex-column mt-1"
             t-att-class="{
                 'o-inComposer': env.inComposer,
                 'o-inChatWindow': env.inChatWindow,
@@ -14,7 +14,7 @@
                 'justify-content-end': isInChatWindowAndIsAlignedRight and !env.inComposer,
             }" role="menu">
                 <div t-foreach="imagesAttachments" t-as="attachment" t-key="attachment.id" t-att-aria-label="attachment.filename"
-                    class="o-mail-AttachmentImage d-flex position-relative flex-shrink-0 mw-100 mb-1 me-1"
+                    class="o-mail-AttachmentImage mw-100 mb-1 me-1"
                     t-att-title="attachment.name"
                     t-att-class="{ 'o-isUploading': attachment.uploading }"
                     tabindex="0"
@@ -23,25 +23,27 @@
                     t-att-data-mimetype="attachment.mimetype"
                     t-on-click="() => this.fileViewer.open(attachment, props.attachments)"
                 >
-                    <img
-                        class="img img-fluid my-0 mx-auto o-viewable"
-                        t-att-class="{ 'opacity-25': attachment.uploading }"
-                        t-att-src="getImageUrl(attachment)"
-                        t-att-alt="attachment.name"
-                        t-attf-style="max-width: min(100%, {{ imagesWidth }}px); max-height: {{ props.imagesHeight }}px;"
-                        t-on-load="onImageLoaded"
-                    />
-                    <div t-if="attachment.uploading" class="position-absolute top-0 bottom-0 start-0 end-0 d-flex align-items-center justify-content-center" title="Uploading">
-                        <i class="fa fa-spin fa-spinner"/>
-                    </div>
-                    <div class="position-absolute top-0 bottom-0 start-0 end-0 p-2 text-white opacity-0 opacity-100-hover d-flex align-items-end flax-wrap flex-column">
-                        <div t-if="showDelete and !ui.isSmall"
-                            class="btn btn-sm btn-dark rounded opacity-75 opacity-100-hover"
-                            tabindex="0" aria-label="Remove" role="menuitem" t-on-click.stop="() => this.onClickUnlink(attachment)" title="Remove">
-                            <i class="fa fa-trash"/>
+                    <div class="d-flex position-relative flex-shrink-0">
+                        <img
+                            class="img img-fluid my-0 mx-auto o-viewable"
+                            t-att-class="{ 'opacity-25': attachment.uploading }"
+                            t-att-src="getImageUrl(attachment)"
+                            t-att-alt="attachment.name"
+                            t-attf-style="max-width: min(100%, {{ imagesWidth }}px); max-height: {{ props.imagesHeight }}px;"
+                            t-on-load="(ev) => this.onImageLoaded({ ev, attachment })"
+                        />
+                        <div t-if="attachment.uploading" class="position-absolute top-0 bottom-0 start-0 end-0 d-flex align-items-center justify-content-center" title="Uploading">
+                            <i class="fa fa-spin fa-spinner"/>
                         </div>
-                        <div t-if="canDownload(attachment) and !ui.isSmall" class="btn btn-sm btn-dark rounded opacity-75 opacity-100-hover mt-auto" t-on-click.stop="() => this.onClickDownload(attachment)" title="Download">
-                            <i class="fa fa-download"/>
+                        <div t-if="!attachment.isSmallImg" class="position-absolute top-0 bottom-0 start-0 end-0 p-2 text-white opacity-0 opacity-100-hover d-flex align-items-end flax-wrap flex-column">
+                            <div t-if="canDownload(attachment) and !ui.isSmall" class="btn btn-sm btn-dark rounded opacity-75 opacity-100-hover mt-auto" t-on-click.stop="() => this.onClickDownload(attachment)" title="Download">
+                                <i class="fa fa-download"/>
+                            </div>
+                            <div t-if="showDelete and !ui.isSmall"
+                                class="btn btn-sm btn-dark rounded opacity-75 opacity-100-hover"
+                                tabindex="0" aria-label="Remove" role="menuitem" t-on-click.stop="() => this.onClickUnlink(attachment)" title="Remove">
+                                <i class="fa fa-trash"/>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/addons/mail/static/src/core/common/attachment_model.js
+++ b/addons/mail/static/src/core/common/attachment_model.js
@@ -28,13 +28,23 @@ export class Attachment extends FileModelMixin(Record) {
         return attachment;
     }
 
+    author;
     originThread = Record.one("Thread", { inverse: "attachments" });
     res_name;
     message = Record.one("Message");
     /** @type {string} */
     create_date;
+    /** @type {string} */
+    isSmallImg;
 
     get isDeletable() {
+        if (this.originThread?.type === "chatter") {
+            if (this._store.user?.isAdmin) {
+                return true;
+            } else if (this.author?.partnerId !== this._store.user.id) {
+                return false;
+            }
+        }
         return true;
     }
 

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -1269,7 +1269,7 @@ class TestMailFormattersPerformance(BaseMailPerformance):
         """
         messages_all = self.messages_all.with_env(self.env)
 
-        with self.assertQueryCount(employee=27):
+        with self.assertQueryCount(employee=29):
             res = messages_all.message_format()
 
         self.assertEqual(len(res), 2*2)
@@ -1282,7 +1282,7 @@ class TestMailFormattersPerformance(BaseMailPerformance):
     def test_message_format_single(self):
         message = self.messages_all[0].with_env(self.env)
 
-        with self.assertQueryCount(employee=24):
+        with self.assertQueryCount(employee=26):
             res = message.message_format()
 
         self.assertEqual(len(res), 1)

--- a/addons/web/static/src/core/file_viewer/file_viewer.js
+++ b/addons/web/static/src/core/file_viewer/file_viewer.js
@@ -34,6 +34,7 @@ export class FileViewer extends Component {
         useAutofocus();
         this.imageRef = useRef("image");
         this.zoomerRef = useRef("zoomer");
+        this.attachmentService = useService("mail.attachment");
 
         this.isDragging = false;
         this.dragStartX = 0;
@@ -248,5 +249,10 @@ export class FileViewer extends Component {
                     </body>
                 </html>`);
         printWindow.document.close();
+    }
+
+    onDeleteAttachment() {
+        this.attachmentService.delete(this.state.file);
+        this.props.close();
     }
 }

--- a/addons/web/static/src/core/file_viewer/file_viewer.xml
+++ b/addons/web/static/src/core/file_viewer/file_viewer.xml
@@ -21,6 +21,12 @@
                             <span>Download</span>
                         </a>
                     </div>
+                    <div t-if="this.state.file.isDeletable" class="o-mail-AttachmentViewer-delete 0-mail-AttachmentViewer-headerButton d-flex align-items-center px-3 cursor-pointer">
+                        <a class="text-reset" t-on-click="() => this.onDeleteAttachment()">
+                            <i class="fa fa-trash fa-fw" role="img"/>
+                            <span>Delete</span>
+                        </a>
+                    </div>
 
                     <div t-on-click.stop="close" class="o-FileViewer-headerButton d-flex align-items-center mb-0 px-3 h4 text-reset cursor-pointer" role="button" title="Close (Esc)" aria-label="Close">
                         <i class="fa fa-fw fa-times" role="img"/>


### PR DESCRIPTION
Before this commit:
When the attachment size was too small, the download and delete 
buttons on the image overlay were incorrectly positioned, leading 
to a less user-friendly experience.

Aftert this commit:
The delete and download button is not shown shown for the small 
images and you get a delete option when the image is zommed in.

task-3563828
