### PR TITLE
[FIX] point_of_sale: prevent TypeError when closing pos session

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -1091,7 +1091,10 @@ class PosSession(models.Model):
         return account_payment.move_id.line_ids.filtered(lambda line: line.account_id == self._get_receivable_account(payment_method))
 
     def _apply_diff_on_account_payment_move(self, account_payment, payment_method, diff_amount):
-        source_vals, dest_vals = self._get_diff_vals(payment_method.id, diff_amount)
+        diff_vals = self._get_diff_vals(payment_method.id, diff_amount)
+        if not diff_vals:
+            return
+        source_vals, dest_vals = diff_vals
         outstanding_line = account_payment.move_id.line_ids.filtered(lambda line: line.account_id.id == source_vals['account_id'])
         new_balance = outstanding_line.balance + self._amount_converter(diff_amount, self.stop_at, False)
         new_balance_compare_to_zero = self.currency_id.compare_amounts(new_balance, 0)

--- a/addons/point_of_sale/tests/test_point_of_sale_flow.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_flow.py
@@ -2213,3 +2213,44 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
         purchase_order = self.env['purchase.order'].search([], limit=1)
         self.assertEqual(purchase_order.order_line.product_id.id, product.id)
         self.assertEqual(purchase_order.order_line.product_qty, 2)
+
+    def test_state_when_closing_register(self):
+        product = self.env['product.product'].create({
+            'name': 'Product A',
+            'is_storable': True,
+        })
+
+        self.pos_config.open_ui()
+        session_id = self.pos_config.current_session_id
+
+        order = self.env['pos.order'].create({
+            'company_id': self.env.company.id,
+            'session_id': session_id.id,
+            'partner_id': False,
+            'lines': [(0, 0, {
+                'name': 'OL/0001',
+                'product_id': product.id,
+                'price_unit': 10.00,
+                'discount': 0,
+                'qty': 1,
+                'tax_ids': False,
+                'price_subtotal': 10.00,
+                'price_subtotal_incl': 10.00,
+            })],
+            'pricelist_id': self.pos_config.pricelist_id.id,
+            'amount_paid': 10.00,
+            'amount_total': 10.00,
+            'amount_tax': 0.0,
+            'amount_return': 0.0,
+            'to_invoice': False,
+        })
+
+        payment_context = {"active_ids": order.ids, "active_id": order.id}
+        order_payment = self.env['pos.make.payment'].with_context(**payment_context).create({
+            'amount': order.amount_total,
+            'payment_method_id': self.bank_payment_method.id
+        })
+        order_payment.with_context(**payment_context).check()
+
+        session_id.action_pos_session_closing_control(bank_payment_method_diffs={self.bank_payment_method.id: 5.00})
+        self.assertEqual(session_id.state, 'closed')


### PR DESCRIPTION
When the customer tries to close the pos session,
a traceback will appear.

Steps to reproduce the error:
- Go to Point of Sale > Configuration > Payment Methods > Create new >
  In Journal: Bank > Save
- Open a session > Add a product > Payment > select that payment method >
  validate
- Close Register > Now in count, Add such a number so that the difference will
  become negative > Close Register > Proceed Anyway

Error: A traceback appears:
```
"TypeError: cannot unpack non-iterable bool object"
```

When the customer closes the pos session, ``_apply_diff_on_account_payment_move``
method will be called.
It will call ``_get_diff_vals`` method.

When ``_get_diff_vals`` method returns the ``False``,
https://github.com/odoo/odoo/blob/5a390fede312513a5c9b91d2d18d6d0cfdd43750/addons/point_of_sale/models/pos_session.py#L622-L634

So Here, ``source_vals``, ``dest_vals`` will be ``False``
https://github.com/odoo/odoo/blob/5a390fede312513a5c9b91d2d18d6d0cfdd43750/addons/point_of_sale/models/pos_session.py#L1094

So, It will lead to the above Traceback.

sentry-5607468115

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
