### PR TITLE
[FIX] l10n_be_pos_sale: prevent error when IntraCommunity fp is missing

### DIFF
--- a/addons/l10n_be_pos_sale/models/pos_session.py
+++ b/addons/l10n_be_pos_sale/models/pos_session.py
@@ -9,5 +9,5 @@ class PosSession(models.Model):
         if self.company_id.country_code == 'BE':
             intracom_fpos = self.env["account.chart.template"].with_company(
                 self.company_id).ref("fiscal_position_template_3", False)
-            loaded_data['intracom_tax_ids'] = intracom_fpos.tax_ids.tax_dest_id.ids
+            loaded_data['intracom_tax_ids'] = intracom_fpos.tax_ids.tax_dest_id.ids if intracom_fpos else []
         return res


### PR DESCRIPTION
Before this commit, the absence of `fiscal_position_template_3` would result in an AttributeError, hindering the opening of the PoS.

opw-4052324

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
