### PR TITLE
[IMP] point_of_sale,pos_restaurant: simplify kanban archs

### DIFF
--- a/addons/point_of_sale/views/pos_category_view.xml
+++ b/addons/point_of_sale/views/pos_category_view.xml
@@ -42,21 +42,14 @@
         <field name="model">pos.category</field>
         <field name="arch" type="xml">
             <kanban class="o_kanban_mobile">
-                <field name="name"/>
-                <field name="id"/>
-                <field name="color"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div t-attf-class="oe_kanban_global_click">
-                            <div class="row">
-                                <div class="col-4">
-                                    <img height="100" width="100" t-att-src="kanban_image('pos.category', 'image_128', record.id.raw_value)" alt="Category"/>
-                                </div>
-                                <div class="col-8">
-                                    <strong class="o_kanban_record_title"><field name="name"/></strong>
-                                </div>
-                            </div>
-                        </div>
+                    <t t-name="kanban-card" class="row g-0">
+                        <aside class="col-4">
+                            <field name="image_128" widget="image" alt="Category" options="{'size': [100, 100], 'img_class': 'h-100'}"/>
+                        </aside>
+                        <main class="col ms-4">
+                            <field name="name" class="fw-bolder fs-5"/>
+                        </main>
                     </t>
                 </templates>
             </kanban>

--- a/addons/point_of_sale/views/pos_order_view.xml
+++ b/addons/point_of_sale/views/pos_order_view.xml
@@ -62,45 +62,23 @@
                     <page string="Products" name="products">
                       <field name="lines" colspan="4" nolabel="1" readonly="state != 'draft'" mode="tree,kanban">
                             <kanban class="o_kanban_mobile">
-                                <field name="price_subtotal"/>
-                                <field name="price_unit"/>
-                                <field name="company_id"/>
-                                <field name="full_product_name"/>
-                                <field name="qty"/>
-                                <field name="product_uom_id"/>
-                                <field name="price_subtotal_incl"/>
-                                <field name="refunded_orderline_id"/>
-                                <t t-name="kanban-box">
-                                    <div t-attf-class="oe_kanban_card oe_kanban_global_click">
-                                            <div class="row g-0">
-                                                <div class="col-2 pe-3">
-                                                    <img t-att-src="kanban_image('product.product', 'image_128', record.product_id.raw_value)" t-att-title="record.product_id.value" t-att-alt="record.product_id.value" style="max-width: 100%;"/>
-                                                </div>
-                                                <div class="col-8">
-                                                    <div class="row">
-                                                        <div class="col">
-                                                            <strong t-out="record.full_product_name.value" />
-                                                        </div>
-                                                    </div>
-                                                    <div class="row">
-                                                        <div class="col-12 text-muted">
-                                                            Quantity: <t t-out="record.qty.value"/> <t t-out="record.product_uom_id.value"/>
-                                                        </div>
-                                                    </div>
-                                                    <div class="row">
-                                                        <div class="col-12 text-muted">
-                                                            Unit price: <field name="price_unit" widget="monetary"/>
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                                <div class="col-2">
-                                                    <div class="col">
-                                                        <field name="price_subtotal_incl" widget="monetary" />
-                                                    </div>
-                                                </div>
-                                            </div>
+                                <t t-name="kanban-card" class="row g-0">
+                                    <aside class="col-2 pe-3">
+                                        <field name="product_id" widget="image" options="{'preview_image': 'image_128'}"/>
+                                    </aside>
+                                    <main class="col">
+                                        <div class="d-flex">
+                                            <field name="full_product_name" class="fw-bolder"/>
+                                            <field name="price_subtotal_incl" widget="monetary" class="ms-auto me-3"/>
                                         </div>
-                                    </t>
+                                        <div class="text-muted">
+                                            Quantity: <field name="qty"/> <field name="product_uom_id"/>
+                                        </div>
+                                        <div class="text-muted">
+                                            Unit price: <field name="price_unit" widget="monetary"/>
+                                        </div>
+                                    </main>
+                                </t>
                             </kanban>
                             <tree string="Order lines" editable="bottom">
                                 <field name="name" column_invisible="True"/>
@@ -217,47 +195,24 @@
         <field name="model">pos.order</field>
         <field name="arch" type="xml">
             <kanban class="o_kanban_mobile" create="0" sample="1">
-                <field name="name"/>
-                <field name="partner_id"/>
-                <field name="amount_total"/>
-                <field name="date_order"/>
-                <field name="state"/>
-                <field name="pos_reference"/>
-                <field name="partner_id"/>
                 <field name="currency_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div t-attf-class="oe_kanban_card oe_kanban_global_click">
-                            <div class="o_kanban_record_top">
-                                <div class="o_kanban_record_headings">
-                                    <strong class="o_kanban_record_title">
-                                        <span t-if="record.partner_id.value">
-                                            <t t-esc="record.partner_id.value"/>
-                                        </span>
-                                        <span t-else="">
-                                            <t t-esc="record.name.value"/>
-                                        </span>
-                                    </strong>
-                                </div>
-                                <strong><field name="amount_total" widget="monetary"/></strong>
+                    <t t-name="kanban-card">
+                            <div class="d-flex mb-1">
+                                <span t-if="record.partner_id.value">
+                                    <field name="partner_id" class="fw-bolder"/>
+                                </span>
+                                <span t-else="">
+                                    <field name="name" class="fw-bolder"/>
+                                </span>
+                                <field name="amount_total" widget="monetary" class="fw-bolder ms-auto"/>
                             </div>
-                            <div class="row">
-                                <div class="col-12">
-                                <span><t t-esc="record.pos_reference.value"/></span>
+                            <field name="pos_reference" />
+                            <div class="d-flex">
+                                <field name="date_order" class="text-muted"/>
+                                <field name="state" widget="label_selection" options="{'classes': {'draft': 'default',
+                                'invoiced': 'success', 'cancel': 'danger'}}" class="ms-auto"/>
                             </div>
-                            </div>
-                            <div class="row">
-                                <div class="col-8 text-muted">
-                                    <span><t t-esc="record.date_order.value"/></span>
-                                </div>
-                                <div class="col-4">
-                                    <span class="float-end text-end">
-                                        <field name="state" widget="label_selection" options="{'classes': {'draft': 'default',
-                                        'invoiced': 'success', 'cancel': 'danger'}}"/>
-                                    </span>
-                                </div>
-                            </div>
-                        </div>
                     </t>
                 </templates>
             </kanban>

--- a/addons/point_of_sale/views/pos_session_view.xml
+++ b/addons/point_of_sale/views/pos_session_view.xml
@@ -101,33 +101,18 @@
         <field name="model">pos.session</field>
         <field name="arch" type="xml">
             <kanban class="o_kanban_mobile" create="0" sample="1">
-                <field name="config_id" />
-                <field name="name" />
-                <field name="user_id" />
-                <field name="start_at" />
-                <field name="state" />
                 <templates>
-                    <t t-name="kanban-box">
-                        <div t-attf-class="oe_kanban_card oe_kanban_global_click">
-                            <div class="o_kanban_record_top">
-                                <div class="o_kanban_record_headings">
-                                    <strong class="o_kanban_record_title"><span><field name="config_id"/></span></strong>
-                                </div>
-                                <field name="state" widget="label_selection" options="{'classes': {'opening_control': 'default',
-                                        'opened': 'success', 'closing_control': 'warning', 'closed': 'warning'}}"/>
-                            </div>
-                            <div class="o_kanban_record_body">
-                                <field name="name" />
-                            </div>
-                            <div class="o_kanban_record_bottom">
-                                <div class="oe_kanban_bottom_left">
-                                    <span><field name="start_at" /></span>
-                                </div>
-                                <div class="oe_kanban_bottom_right">
-                                    <field name="user_id" widget="many2one_avatar_user" readonly="state != 'opening_control'"/>
-                                </div>
-                            </div>
+                    <t t-name="kanban-card">
+                        <div class="d-flex">
+                            <field name="config_id" class="fw-bolder mb-1"/>
+                            <field name="state" widget="label_selection" options="{'classes': {'opening_control': 'default',
+                                    'opened': 'success', 'closing_control': 'warning', 'closed': 'warning'}}" class="ms-auto"/>
                         </div>
+                        <field name="name" />
+                        <footer class="fs-6 pt-1">
+                            <field name="start_at" />
+                            <field name="user_id" widget="many2one_avatar_user" readonly="state != 'opening_control'" class="ms-auto"/>
+                        </footer>
                     </t>
                 </templates>
             </kanban>

--- a/addons/pos_restaurant/views/pos_restaurant_views.xml
+++ b/addons/pos_restaurant/views/pos_restaurant_views.xml
@@ -56,13 +56,11 @@
             <field name="model">restaurant.floor</field>
             <field name="arch" type="xml">
                 <kanban class="o_kanban_mobile">
-                    <field name="name"/>
-                    <field name="pos_config_ids" />
                     <templates>
-                        <t t-name="kanban-box">
-                            <div t-attf-class="oe_kanban_global_click">
-                                <div><strong>Floor Name: </strong><t t-esc="record.name.value"/></div>
-                                <div><strong>Point of Sales: </strong><t t-esc="record.pos_config_ids.value"/></div>
+                        <t t-name="kanban-card">
+                            <div><strong>Floor Name: </strong><field name="name"/></div>
+                            <div class="d-flex">
+                                <strong>Point of Sales:</strong><field name="pos_config_ids" class="ms-1"/>
                             </div>
                         </t>
                     </templates>


### PR DESCRIPTION
In this commit we have simplified the kanban arch for the point_of_sale and pos_restaurant module the goal is to simplify them,make them easier to read and use bootstrap utility classnames.

- Previously, we used kanban-box, but now we are using kanban-card instead.
- Deprecated oe_kanban_global_click and oe_kanban_global_click_edit.
- More use of <field/> tags
- Removed the oe_kanban_colorpicker class and replaced it with the kanban_color_picker widget.
- Changed type='edit' to type='open' to open records. since version 16, records always open in edit mode by default.
- kanban_image from rendering context, is deprecated so we use <field name=... widget=image/> instead
- kanban_color, kanban_getcolor and kanban_getcolorname are deprecated use new attribute highlight_color=color_field_name on root node
- oe_kanban_colorpicker is deprecated, use kanban_color_picker widget instead

Task-3992107

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
