### PR TITLE
[IMP] core: tools.mail.format_email_address

### DIFF
--- a/addons/account/tests/test_account_move_send.py
+++ b/addons/account/tests/test_account_move_send.py
@@ -10,7 +10,7 @@ from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.addons.mail.tests.common import MailCommon
 from odoo.exceptions import UserError
 from odoo.tests import users, warmup, tagged
-from odoo.tools import formataddr, mute_logger
+from odoo.tools import format_email_address, mute_logger
 
 
 @tagged('post_install_l10n', 'post_install', '-at_install')
@@ -193,10 +193,10 @@ class TestAccountComposerPerformance(AccountTestInvoicingCommon, MailCommon):
                         'body_content': _exp_body_tip,
                         'email_from': self.user_account_other.email_formatted,
                         'subject': _exp_subject,
-                        'reply_to': formataddr((
+                        'reply_to': format_email_address(
                             f'{move.company_id.name} {_exp_move_name}',
                             f'{self.alias_catchall}@{self.alias_domain}'
-                        )),
+                        ),
                     },
                     fields_values={
                         'auto_delete': True,
@@ -204,10 +204,10 @@ class TestAccountComposerPerformance(AccountTestInvoicingCommon, MailCommon):
                         'is_notification': True,  # should keep logs by default
                         'mail_server_id': self.mail_server_default,
                         'subject': _exp_subject,
-                        'reply_to': formataddr((
+                        'reply_to': format_email_address(
                             f'{move.company_id.name} {_exp_move_name}',
                             f'{self.alias_catchall}@{self.alias_domain}'
-                        )),
+                        ),
                     },
                 )
 
@@ -278,10 +278,10 @@ class TestAccountComposerPerformance(AccountTestInvoicingCommon, MailCommon):
                 'body_content': f'TemplateBody for {test_move.name}',
                 'email_from': self.user_account_other.email_formatted,
                 'subject': f'{self.env.user.company_id.name} Invoice (Ref {test_move.name})',
-                'reply_to': formataddr((
+                'reply_to': format_email_address(
                     f'{test_move.company_id.name} {test_move.display_name}',
                     f'{self.alias_catchall}@{self.alias_domain}'
-                )),
+                ),
             },
             fields_values={
                 'auto_delete': True,
@@ -289,10 +289,10 @@ class TestAccountComposerPerformance(AccountTestInvoicingCommon, MailCommon):
                 'is_notification': True,  # should keep logs by default
                 'mail_server_id': self.mail_server_default,
                 'subject': f'{self.env.user.company_id.name} Invoice (Ref {test_move.name})',
-                'reply_to': formataddr((
+                'reply_to': format_email_address(
                     f'{test_move.company_id.name} {test_move.display_name}',
                     f'{self.alias_catchall}@{self.alias_domain}'
-                )),
+                ),
             },
         )
 
@@ -364,10 +364,10 @@ class TestAccountComposerPerformance(AccountTestInvoicingCommon, MailCommon):
                 'body_content': f'SpanishBody for {test_move.name}',  # translated version
                 'email_from': self.user_account_other.email_formatted,
                 'subject': f'SpanishSubject for {test_move.name}',  # translated version
-                'reply_to': formataddr((
+                'reply_to': format_email_address(
                     f'{test_move.company_id.name} {test_move.display_name}',
                     f'{self.alias_catchall}@{self.alias_domain}'
-                )),
+                ),
             },
             fields_values={
                 'auto_delete': True,
@@ -375,10 +375,10 @@ class TestAccountComposerPerformance(AccountTestInvoicingCommon, MailCommon):
                 'is_notification': True,  # should keep logs by default
                 'mail_server_id': self.mail_server_default,
                 'subject': f'SpanishSubject for {test_move.name}',  # translated version
-                'reply_to': formataddr((
+                'reply_to': format_email_address(
                     f'{test_move.company_id.name} {test_move.display_name}',
                     f'{self.alias_catchall}@{self.alias_domain}'
-                )),
+                ),
             },
         )
 

--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -2069,9 +2069,10 @@ class Lead(models.Model):
             emails_normalized = tools.email_normalize_all(email)
             email_normalized = emails_normalized[0] if emails_normalized else False
             if email.lower() == self.email_from.lower() or (email_normalized and self.email_normalized == email_normalized):
-                partner_info['full_name'] = tools.formataddr((
+                partner_info['full_name'] = tools.format_email_address(
                     name_from_email,
-                    ','.join(emails_normalized) if emails_normalized else email))
+                    ','.join(emails_normalized) if emails_normalized else email,
+                )
                 break
         return result
 

--- a/addons/crm/tests/common.py
+++ b/addons/crm/tests/common.py
@@ -338,11 +338,11 @@ class TestCrmCommon(TestSalesCommon, MailCase):
         partners = []
         if partner_count:
             partners = self.env['res.partner'].create([{
-                'name': 'AutoPartner_%04d' % (x),
-                'email': tools.formataddr((
-                    'AutoPartner_%04d' % (x),
-                    'partner_email_%04d@example.com' % (x),
-                )),
+                'name': f'AutoPartner_{x:04}',
+                'email': tools.format_email_address(
+                    f'AutoPartner_{x:04}',
+                    f'partner_email_{x:04}@example.com',
+                ),
             } for x in range(partner_count)])
 
         # customer information
@@ -354,10 +354,10 @@ class TestCrmCommon(TestSalesCommon, MailCase):
                 if partner_count and idx < partner_count:
                     lead_data['partner_id'] = partners[idx].id
                 else:
-                    lead_data['email_from'] = tools.formataddr((
-                        'TestCustomer_%02d' % (idx),
-                        'customer_email_%04d@example.com' % (idx)
-                    ))
+                    lead_data['email_from'] = tools.format_email_address(
+                        f'TestCustomer_{idx:02}',
+                        f'customer_email_{idx:04}@example.com'
+                    )
 
         # country + phone information
         if country_ids:

--- a/addons/crm/tests/test_crm_lead_notification.py
+++ b/addons/crm/tests/test_crm_lead_notification.py
@@ -3,7 +3,7 @@
 
 from odoo.addons.crm.tests.common import TestCrmCommon
 from odoo.tests import tagged, users
-from odoo.tools import formataddr, mute_logger
+from odoo.tools import format_email_address, mute_logger
 
 
 @tagged('mail_thread', 'mail_gateway')
@@ -235,7 +235,7 @@ class NewLeadNotification(TestCrmCommon):
             ('Delivery Boy company', 'Test With Company', 'default_create_with_partner@example.com'),
             ('Delivery Boy company', '', 'default_create_with_partner_no_name@example.com'),
         ]:
-            formatted_email = formataddr((name, email)) if name else formataddr((partner_name, email))
+            formatted_email = format_email_address(name or partner_name, email)
             with self.subTest(partner_name=partner_name):
                 lang = self.env['res.lang'].sudo().search([], limit=1)[0]
                 description = '<p>Top</p>'

--- a/addons/event/tests/test_event_mail_schedule.py
+++ b/addons/event/tests/test_event_mail_schedule.py
@@ -10,7 +10,7 @@ from odoo.addons.base.tests.test_ir_cron import CronMixinCase
 from odoo.addons.event.tests.common import EventCase
 from odoo.addons.mail.tests.common import MockEmail
 from odoo.tests import tagged, users
-from odoo.tools import formataddr, mute_logger
+from odoo.tools import format_email_address, mute_logger
 
 
 @tagged('event_mail', 'post_install', '-at_install')
@@ -154,7 +154,7 @@ class TestMailSchedule(EventCase, MockEmail, CronMixinCase):
         # check emails effectively sent
         self.assertEqual(len(self._new_mails), 2, 'event: should have 2 scheduled emails (1 / registration)')
         self.assertMailMailWEmails(
-            [formataddr((reg1.name, reg1.email)), formataddr((reg2.name, reg2.email))],
+            [format_email_address(reg1.name, reg1.email), format_email_address(reg2.name, reg2.email)],
             'outgoing',
             content=None,
             fields_values={
@@ -193,7 +193,7 @@ class TestMailSchedule(EventCase, MockEmail, CronMixinCase):
         # check emails effectively sent
         self.assertEqual(len(self._new_mails), 2, 'event: should have 2 scheduled emails (1 / registration)')
         self.assertMailMailWEmails(
-            [formataddr((reg1.name, reg1.email)), formataddr((reg2.name, reg2.email))],
+            [format_email_address(reg1.name, reg1.email), format_email_address(reg2.name, reg2.email)],
             'outgoing',
             content=None,
             fields_values={
@@ -229,7 +229,7 @@ class TestMailSchedule(EventCase, MockEmail, CronMixinCase):
         # check emails effectively sent
         self.assertEqual(len(self._new_mails), 2, 'event: should have scheduled 2 mails (1 / registration)')
         self.assertMailMailWEmails(
-            [formataddr((reg1.name, reg1.email)), formataddr((reg2.name, reg2.email))],
+            [format_email_address(reg1.name, reg1.email), format_email_address(reg2.name, reg2.email)],
             'outgoing',
             content=None,
             fields_values={
@@ -285,7 +285,7 @@ class TestMailSchedule(EventCase, MockEmail, CronMixinCase):
             self.assertEqual(mail.email_from, self.user_eventmanager.company_id.email_formatted)
             self.assertEqual(mail.subject, f'Confirmation for {test_event.name}')
             self.assertEqual(mail.state, 'outgoing')
-            self.assertEqual(mail.email_to, formataddr((reg3.name, reg3.email)))
+            self.assertEqual(mail.email_to, format_email_address(reg3.name, reg3.email))
 
         # POST SCHEDULERS (MOVE FORWARD IN TIME)
         # --------------------------------------------------
@@ -306,7 +306,7 @@ class TestMailSchedule(EventCase, MockEmail, CronMixinCase):
         # check emails effectively sent
         self.assertEqual(len(self._new_mails), 3, 'event: should have scheduled 3 mails, one for each registration')
         self.assertMailMailWEmails(
-            [formataddr((reg1.name, reg1.email)), formataddr((reg2.name, reg2.email)), formataddr((reg3.name, reg3.email))],
+            [format_email_address(reg1.name, reg1.email), format_email_address(reg2.name, reg2.email), format_email_address(reg3.name, reg3.email)],
             'outgoing',
             content=None,
             fields_values={
@@ -398,7 +398,7 @@ class TestMailSchedule(EventCase, MockEmail, CronMixinCase):
              self.mock_mail_gateway():
             cron.sudo().method_direct_trigger()
         self.assertMailMailWEmails(
-            [formataddr((reg.name, reg.email)) for reg in existing],
+            [format_email_address(reg.name, reg.email) for reg in existing],
             "outgoing",
             content=f"Hello your registration to {test_event.name} is confirmed",
             fields_values={

--- a/addons/hr_recruitment/models/hr_applicant.py
+++ b/addons/hr_recruitment/models/hr_applicant.py
@@ -608,7 +608,7 @@ class Applicant(models.Model):
         elif self.email_from:
             email_from = tools.email_normalize(self.email_from)
             if email_from and self.partner_name:
-                email_from = tools.formataddr((self.partner_name, email_from))
+                email_from = tools.format_email_address(self.partner_name, email_from)
                 self._message_add_suggested_recipient(recipients, email=email_from, reason=_('Contact Email'))
         return recipients
 

--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -457,11 +457,11 @@ class MailMail(models.Model):
             emails_normalized = tools.email_normalize_all(partner.email)
             if emails_normalized:
                 email_to = [
-                    tools.formataddr((partner.name or "", email or "False"))
+                    tools.format_email_address(partner.name or "", email or "False")
                     for email in emails_normalized
                 ]
             else:
-                email_to = [tools.formataddr((partner.name or "", partner.email or "False"))]
+                email_to = [tools.format_email_address(partner.name or "", partner.email or "False")]
             email_list.append({
                 'email_cc': [],
                 'email_to': email_to,
@@ -692,7 +692,7 @@ class MailMail(models.Model):
                     # see rev. 56596e5240ef920df14d99087451ce6f06ac6d36
                     notifs.flush_recordset(['notification_status', 'failure_type', 'failure_reason'])
 
-                # protect against ill-formatted email_from when formataddr was used on an already formatted email
+                # protect against ill-formatted email_from when format_email_address was used on an already formatted email
                 emails_from = tools.mail.email_split_and_format(mail.email_from)
                 email_from = emails_from[0] if emails_from else mail.email_from
 

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -39,7 +39,7 @@ from odoo.tools import (
 )
 from odoo.tools.mail import (
     append_content_to_html, decode_message_header, email_normalize, email_split,
-    email_split_and_format, formataddr, html_sanitize,
+    email_split_and_format, format_email_address, html_sanitize,
     generate_tracking_message_id, mail_header_msgid_re,
 )
 
@@ -720,13 +720,13 @@ class MailThread(models.AbstractModel):
         # find an email_from for the bounce email
         email_from = False
         if bounce_from := self.env.company.bounce_email:
-            email_from = formataddr(('MAILER-DAEMON', bounce_from))
+            email_from = format_email_address('MAILER-DAEMON', bounce_from)
         if not email_from:
             catchall_aliases = self.env['mail.alias.domain'].search([]).mapped('catchall_email')
             if not any(catchall_email in message['To'] for catchall_email in catchall_aliases):
                 email_from = decode_message_header(message, 'To')
         if not email_from:
-            email_from = formataddr(('MAILER-DAEMON', self.env.user.email_normalized))
+            email_from = format_email_address('MAILER-DAEMON', self.env.user.email_normalized)
 
         bounce_mail_values['email_from'] = email_from
         bounce_mail_values.update(mail_values)

--- a/addons/mail/models/mail_thread_cc.py
+++ b/addons/mail/models/mail_thread_cc.py
@@ -16,7 +16,7 @@ class MailCCMixin(models.AbstractModel):
         if not cc_string:
             return {}
         return {
-            tools.email_normalize(email): tools.formataddr((name, tools.email_normalize(email)))
+            tools.email_normalize(email): tools.format_email_address(name, tools.email_normalize(email))
             for (name, email) in tools.mail.email_split_tuples(cc_string)
         }
 

--- a/addons/mail/models/models.py
+++ b/addons/mail/models/models.py
@@ -298,15 +298,15 @@ class BaseModel(models.AbstractModel):
         This creates an issue in certain DKIM tech stacks that will
         incorrectly read the reply-to value as empty and fail the verification.
 
-        To avoid that issue when formataddr would return more than 68 chars we
+        To avoid that issue when format_email_address would return more than 68 chars we
         return a simplified name/email to try to stay under 68 chars. If not
-        possible we return only the email and skip the formataddr which causes
+        possible we return only the email and skip the format_email_address which causes
         the issue in python. We do not use hacks like crop the name part as
         encoding and quoting would be error prone.
 
         :param <res.company> company: if given, setup the company used to
-          complete name in formataddr. Otherwise fallback on 'company_id'
-          of self or environment company;
+          complete name in format_email_address.
+          Otherwise fallback on 'company_id' of self or environment company;
         """
         length_limit = 68  # 78 - len('Reply-To: '), 78 per RFC
         # address itself is too long : return only email and log warning
@@ -327,9 +327,9 @@ class BaseModel(models.AbstractModel):
         # try company.name + record_name, or record_name alone (or company.name alone)
         name = f"{company.name} {record_name}" if record_name else company.name
 
-        formatted_email = tools.formataddr((name, record_email))
+        formatted_email = tools.format_email_address(name, record_email)
         if len(formatted_email) > length_limit:
-            formatted_email = tools.formataddr((record_name or company.name, record_email))
+            formatted_email = tools.format_email_address(record_name or company.name, record_email)
         if len(formatted_email) > length_limit:
             formatted_email = record_email
         return formatted_email

--- a/addons/mail/models/res_company.py
+++ b/addons/mail/models/res_company.py
@@ -42,7 +42,7 @@ class Company(models.Model):
         for company in self.filtered('alias_domain_id'):
             bounce_email = company.alias_domain_id.bounce_email
             company.bounce_email = bounce_email
-            company.bounce_formatted = tools.formataddr((company.name, bounce_email))
+            company.bounce_formatted = tools.format_email_address(company.name, bounce_email)
 
     @api.depends('alias_domain_id', 'name')
     def _compute_catchall(self):
@@ -52,7 +52,7 @@ class Company(models.Model):
         for company in self.filtered('alias_domain_id'):
             catchall_email = company.alias_domain_id.catchall_email
             company.catchall_email = catchall_email
-            company.catchall_formatted = tools.formataddr((company.name, catchall_email))
+            company.catchall_formatted = tools.format_email_address(company.name, catchall_email)
 
     @api.depends('partner_id', 'catchall_formatted')
     def _compute_email_formatted(self):

--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -24,7 +24,7 @@ from odoo.addons.mail.models.mail_notification import MailNotification
 from odoo.addons.mail.models.res_users import Users
 from odoo.addons.mail.tools.discuss import Store
 from odoo.tests import common, new_test_user
-from odoo.tools import email_normalize, formataddr, mute_logger, pycompat
+from odoo.tools import email_normalize, format_email_address, mute_logger, pycompat
 from odoo.tools.translate import code_translations
 
 mail_new_test_user = partial(new_test_user, context={'mail_create_nolog': True,
@@ -159,7 +159,7 @@ class MockEmail(common.BaseCase, MockSmtplibCase):
             })
 
         # mailer daemon email preformatting
-        cls.mailer_daemon_email = formataddr(('MAILER-DAEMON', f'{cls.alias_bounce}@{cls.alias_domain}'))
+        cls.mailer_daemon_email = format_email_address('MAILER-DAEMON', f'{cls.alias_bounce}@{cls.alias_domain}')
 
     @classmethod
     def _init_alias_domain(cls, name, values):
@@ -664,7 +664,7 @@ class MockEmail(common.BaseCase, MockSmtplibCase):
             raise NotImplementedError('Unsupported %s' % ', '.join(unknown))
 
         if isinstance(author, self.env['res.partner'].__class__):
-            expected['email_from'] = formataddr((author.name, email_normalize(author.email, strict=False) or author.email))
+            expected['email_from'] = format_email_address(author.name, email_normalize(author.email, strict=False) or author.email)
         else:
             expected['email_from'] = author
 
@@ -674,7 +674,7 @@ class MockEmail(common.BaseCase, MockSmtplibCase):
             email_to_list = []
             for email_to in recipients:
                 if isinstance(email_to, self.env['res.partner'].__class__):
-                    email_to_list.append(formataddr((email_to.name, email_normalize(email_to.email, strict=False) or email_to.email)))
+                    email_to_list.append(format_email_address(email_to.name, email_normalize(email_to.email, strict=False) or email_to.email))
                 else:
                     email_to_list.append(email_to)
         expected['email_to'] = email_to_list

--- a/addons/mail_group/tests/common.py
+++ b/addons/mail_group/tests/common.py
@@ -13,7 +13,7 @@ class TestMailListCommon(MailCommon):
         super(TestMailListCommon, cls).setUpClass()
 
         # Test credentials / from
-        cls.email_from_unknown = tools.formataddr(("Bob Lafrite", "bob.email@test.example.com"))
+        cls.email_from_unknown = tools.format_email_address("Bob Lafrite", "bob.email@test.example.com")
         cls.user_employee_2 = mail_new_test_user(
             cls.env, login='employee_2',
             company_id=cls.company_admin.id,

--- a/addons/mail_group/tests/test_mail_group_moderation.py
+++ b/addons/mail_group/tests/test_mail_group_moderation.py
@@ -264,7 +264,7 @@ class TestModeration(TestMailListCommon):
         with self.mock_mail_gateway():
             self.format_and_process(
                 GROUP_TEMPLATE,
-                tools.formataddr(("Another Name", "bob.email@test.example.com")),
+                tools.format_email_address("Another Name", "bob.email@test.example.com"),
                 self.test_group.alias_id.display_name,
                 subject='Another email', target_model='mail.group')
 
@@ -272,7 +272,7 @@ class TestModeration(TestMailListCommon):
         self.assertEqual(len(mail_group.mail_group_message_ids), 6)
         new_email_message = mail_group.mail_group_message_ids[-1]
 
-        self.assertEqual(new_email_message.email_from, tools.formataddr(("Another Name", "bob.email@test.example.com")))
+        self.assertEqual(new_email_message.email_from, tools.format_email_address("Another Name", "bob.email@test.example.com"))
         self.assertEqual(new_email_message.moderation_status, 'accepted', msg='Should have automatically accepted the email')
         self.assertEqual(new_email_message.subject, 'Another email')
 
@@ -325,7 +325,7 @@ class TestModeration(TestMailListCommon):
         with self.mock_mail_gateway():
             self.format_and_process(
                 GROUP_TEMPLATE,
-                tools.formataddr(("Another Name", "bob.email@test.example.com")),
+                tools.format_email_address("Another Name", "bob.email@test.example.com"),
                 self.test_group.alias_id.display_name,
                 subject='Another email', target_model='mail.group')
 

--- a/addons/mass_mailing/tests/test_mailing_controllers.py
+++ b/addons/mass_mailing/tests/test_mailing_controllers.py
@@ -71,7 +71,7 @@ class TestMailingControllers(TestMailingControllersCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.test_email = tools.formataddr(('Déboulonneur', '<fleurus@example.com>'))
+        cls.test_email = tools.format_email_address('Déboulonneur', '<fleurus@example.com>')
         cls.test_email_normalized = 'fleurus@example.com'
 
     def test_assert_initial_values(self):
@@ -269,7 +269,7 @@ class TestMailingControllers(TestMailingControllersCommon):
         # update user to link it with existing mailing contacts and allow the tour
         # to run; test without and with mailing group
         self.user_marketing.write({
-            'email': tools.formataddr(("Déboulonneur", "fleurus@example.com")),
+            'email': tools.format_email_address("Déboulonneur", "fleurus@example.com"),
             'groups_id': [(3, self.env.ref('mass_mailing.group_mass_mailing_user').id)],
         })
         test_mailing = self.test_mailing_on_documents.with_env(self.env)
@@ -478,7 +478,7 @@ class TestMailingControllers(TestMailingControllersCommon):
         test_feedback = "My feedback"
         portal_user = mail_new_test_user(
             self.env,
-            email=tools.formataddr(("Déboulonneur", "fleurus@example.com")),
+            email=tools.format_email_address("Déboulonneur", "fleurus@example.com"),
             groups='base.group_portal',
             login='user_portal_fleurus',
             name='Déboulonneur User',

--- a/addons/test_mail/tests/test_mail_alias.py
+++ b/addons/test_mail/tests/test_mail_alias.py
@@ -9,7 +9,7 @@ from odoo import exceptions
 from odoo.addons.mail.tests.common import MailCommon
 from odoo.tests import tagged
 from odoo.tests.common import users
-from odoo.tools import formataddr, mute_logger
+from odoo.tools import format_email_address, mute_logger
 
 
 class TestMailAliasCommon(MailCommon):
@@ -449,12 +449,12 @@ class TestAliasCompany(TestMailAliasCommon):
         self.assertEqual(self.company_admin.bounce_email, f'{self.alias_bounce}@{self.alias_domain}')
         self.assertEqual(
             self.company_admin.bounce_formatted,
-            formataddr((self.company_admin.name, f'{self.alias_bounce}@{self.alias_domain}'))
+            format_email_address(self.company_admin.name, f'{self.alias_bounce}@{self.alias_domain}')
         )
         self.assertEqual(self.company_admin.catchall_email, f'{self.alias_catchall}@{self.alias_domain}')
         self.assertEqual(
             self.company_admin.catchall_formatted,
-            formataddr((self.company_admin.name, f'{self.alias_catchall}@{self.alias_domain}'))
+            format_email_address(self.company_admin.name, f'{self.alias_catchall}@{self.alias_domain}')
         )
         self.assertEqual(self.company_admin.default_from_email, f'{self.default_from}@{self.alias_domain}')
 
@@ -462,12 +462,12 @@ class TestAliasCompany(TestMailAliasCommon):
         self.assertEqual(self.company_2.bounce_email, f'{self.alias_bounce_c2}@{self.alias_domain_c2_name}')
         self.assertEqual(
             self.company_2.bounce_formatted,
-            formataddr((self.company_2.name, f'{self.alias_bounce_c2}@{self.alias_domain_c2_name}'))
+            format_email_address(self.company_2.name, f'{self.alias_bounce_c2}@{self.alias_domain_c2_name}')
         )
         self.assertEqual(self.company_2.catchall_email, f'{self.alias_catchall_c2}@{self.alias_domain_c2_name}')
         self.assertEqual(
             self.company_2.catchall_formatted,
-            formataddr((self.company_2.name, f'{self.alias_catchall_c2}@{self.alias_domain_c2_name}'))
+            format_email_address(self.company_2.name, f'{self.alias_catchall_c2}@{self.alias_domain_c2_name}')
         )
         self.assertEqual(self.company_2.default_from_email, f'{self.alias_default_from_c2}@{self.alias_domain_c2_name}')
 
@@ -475,12 +475,12 @@ class TestAliasCompany(TestMailAliasCommon):
         self.assertEqual(self.company_3.bounce_email, f'{self.alias_bounce_c3}@{self.alias_domain_c3_name}')
         self.assertEqual(
             self.company_3.bounce_formatted,
-            formataddr((self.company_3.name, f'{self.alias_bounce_c3}@{self.alias_domain_c3_name}'))
+            format_email_address(self.company_3.name, f'{self.alias_bounce_c3}@{self.alias_domain_c3_name}')
         )
         self.assertEqual(self.company_3.catchall_email, f'{self.alias_catchall_c3}@{self.alias_domain_c3_name}')
         self.assertEqual(
             self.company_3.catchall_formatted,
-            formataddr((self.company_3.name, f'{self.alias_catchall_c3}@{self.alias_domain_c3_name}'))
+            format_email_address(self.company_3.name, f'{self.alias_catchall_c3}@{self.alias_domain_c3_name}')
         )
         self.assertEqual(self.company_3.default_from_email, f'{self.alias_default_from_c3}@{self.alias_domain_c3_name}')
 

--- a/addons/test_mail/tests/test_mail_composer.py
+++ b/addons/test_mail/tests/test_mail_composer.py
@@ -17,7 +17,7 @@ from odoo.addons.test_mail.tests.common import TestRecipients
 from odoo.fields import Datetime as FieldDatetime
 from odoo.exceptions import AccessError
 from odoo.tests import Form, tagged, users
-from odoo.tools import email_normalize, mute_logger, formataddr
+from odoo.tools import email_normalize, mute_logger, format_email_address
 
 
 @tagged('mail_composer')
@@ -2124,12 +2124,12 @@ class TestComposerResultsComment(TestMailComposer, CronMixinCase):
             email_values={
                 'body_content': f'TemplateBody {self.test_record.name}',
                 # single email event if email field is multi-email
-                'email_from': formataddr((self.user_employee.name, 'email.from.1@test.example.com')),
+                'email_from': format_email_address(self.user_employee.name, 'email.from.1@test.example.com'),
                 'subject': f'TemplateSubject {self.test_record.name}',
             },
             fields_values={
                 # currently holding multi-email 'email_from'
-                'email_from': formataddr((self.user_employee.name, 'email.from.1@test.example.com,email.from.2@test.example.com')),
+                'email_from': format_email_address(self.user_employee.name, 'email.from.1@test.example.com,email.from.2@test.example.com'),
             },
             mail_message=self.test_record.message_ids[0],
         )
@@ -2145,12 +2145,12 @@ class TestComposerResultsComment(TestMailComposer, CronMixinCase):
             email_values={
                 'body_content': f'TemplateBody {self.test_record.name}',
                 # single email event if email field is multi-email
-                'email_from': formataddr((self.user_employee.name, 'email.from.1@test.example.com')),
+                'email_from': format_email_address(self.user_employee.name, 'email.from.1@test.example.com'),
                 'subject': f'TemplateSubject {self.test_record.name}',
             },
             fields_values={
                 # currently holding multi-email 'email_from'
-                'email_from': formataddr((self.user_employee.name, 'email.from.1@test.example.com,email.from.2@test.example.com')),
+                'email_from': format_email_address(self.user_employee.name, 'email.from.1@test.example.com,email.from.2@test.example.com'),
             },
             mail_message=self.test_record.message_ids[0],
         )
@@ -2669,10 +2669,10 @@ class TestComposerResultsMass(TestMailComposer):
                                         fields_values={
                                             'email_from': self.partner_employee_2.email_formatted,
                                             'mail_server_id': self.mail_server_domain,
-                                            'reply_to': formataddr((
+                                            'reply_to': format_email_address(
                                                 f'{self.env.user.company_id.name} {record.name}',
                                                 f'{self.alias_catchall}@{self.alias_domain}'
-                                            )),
+                                            ),
                                             'subject': exp_subject,
                                         },
                                        )
@@ -2683,14 +2683,14 @@ class TestComposerResultsMass(TestMailComposer):
                     # to ease translations checks.
                     sent_mail = self._find_sent_email(
                         self.partner_employee_2.email_formatted,
-                        [formataddr((record.customer_id.name, email_normalize(record.customer_id.email, strict=False)))]
+                        [format_email_address(record.customer_id.name, email_normalize(record.customer_id.email, strict=False))]
                     )
                     debug_info = ''
                     if not sent_mail:
                         debug_info = '-'.join('From: %s-To: %s' % (mail['email_from'], mail['email_to']) for mail in self._mails)
                     self.assertTrue(
                         bool(sent_mail),
-                        f'Expected mail from {self.partner_employee_2.email_formatted} to {formataddr((record.customer_id.name, record.customer_id.email))} not found in {debug_info}'
+                        f'Expected mail from {self.partner_employee_2.email_formatted} to {format_email_address(record.customer_id.name, record.customer_id.email)} not found in {debug_info}'
                     )
                     if record == self.test_records[0]:
                         self.assertEqual(sent_mail['email_to'], ['"Partner_0" <test_partner_0@example.com>'],
@@ -3078,20 +3078,20 @@ class TestComposerResultsMass(TestMailComposer):
                 email_values={
                     'body_content': f'TemplateBody {record.name}',
                     # single email event if email field is multi-email
-                    'email_from': formataddr((self.user_employee.name, 'email.from.1@test.example.com')),
-                    'reply_to': formataddr((
+                    'email_from': format_email_address(self.user_employee.name, 'email.from.1@test.example.com'),
+                    'reply_to': format_email_address(
                         f'{self.env.user.company_id.name} {record.name}',
                         f'{self.alias_catchall}@{self.alias_domain}'
-                    )),
+                    ),
                     'subject': f'TemplateSubject {record.name}',
                 },
                 fields_values={
                     # currently holding multi-email 'email_from'
                     'email_from': self.partner_employee.email_formatted,
-                    'reply_to': formataddr((
+                    'reply_to': format_email_address(
                         f'{self.env.user.company_id.name} {record.name}',
                         f'{self.alias_catchall}@{self.alias_domain}'
-                    )),
+                    ),
                 },
                 mail_message=record.message_ids[0],  # message copy is kept
             )
@@ -3188,18 +3188,18 @@ class TestComposerResultsMass(TestMailComposer):
                                 email_values={
                                     'body_content': 'TemplateBody %s' % record.name,
                                     'email_from': self.partner_employee_2.email_formatted,
-                                    'reply_to': formataddr((
+                                    'reply_to': format_email_address(
                                         f'{record.name}',
                                         'dynamic.reply.to@test.mycompany.com'
-                                    )),
+                                    ),
                                     'subject': 'TemplateSubject %s' % record.name,
                                 },
                                 fields_values={
                                     'email_from': self.partner_employee_2.email_formatted,
-                                    'reply_to': formataddr((
+                                    'reply_to': format_email_address(
                                         f'{record.name}',
                                         'dynamic.reply.to@test.mycompany.com'
-                                    )),
+                                    ),
                                 },
                                )
 

--- a/addons/test_mail/tests/test_mail_gateway.py
+++ b/addons/test_mail/tests/test_mail_gateway.py
@@ -19,7 +19,7 @@ from odoo.addons.test_mail.models.test_mail_models import MailTestGateway
 from odoo.sql_db import Cursor
 from odoo.tests import tagged, RecordCapturer
 from odoo.tools import mute_logger
-from odoo.tools.mail import email_split_and_format, formataddr
+from odoo.tools.mail import email_split_and_format, format_email_address
 
 
 @tagged('mail_gateway')
@@ -706,10 +706,10 @@ class TestMailgateway(MailCommon):
             'alias_parent_thread_id': self.test_record.id,
         })
         self.test_record.message_subscribe(partner_ids=[self.partner_1.id])
-        email_from = formataddr(("Another Name", self.partner_1.email_normalized))
+        email_from = format_email_address("Another Name", self.partner_1.email_normalized)
 
         for partner_email, passed in [
-            (formataddr((self.partner_1.name, self.partner_1.email_normalized)), True),
+            (format_email_address(self.partner_1.name, self.partner_1.email_normalized), True),
             (f'{self.partner_1.email_normalized}, "Multi Email" <multi.email@test.example.com>', True),
             (f'"Multi Email" <multi.email@test.example.com>, {self.partner_1.email_normalized}', False),
         ]:
@@ -1586,8 +1586,8 @@ class TestMailgateway(MailCommon):
         )
         self.assertEqual(
             record_msg.reply_to,
-            formataddr((f'{self.user_employee.company_id.name} {first_record.name}',
-                        f'{self.alias_catchall}@{self.alias_domain}'))
+            format_email_address(f'{self.user_employee.company_id.name} {first_record.name}',
+                        f'{self.alias_catchall}@{self.alias_domain}')
         )
         mail_msg = first_record.message_post(
             subject='Replies to Record',

--- a/addons/test_mail/tests/test_mail_mail.py
+++ b/addons/test_mail/tests/test_mail_mail.py
@@ -19,7 +19,7 @@ from odoo.addons.base.models.ir_mail_server import MailDeliveryException
 from odoo.addons.mail.tests.common import MailCommon
 from odoo.exceptions import AccessError
 from odoo.tests import common, tagged, users
-from odoo.tools import formataddr, mute_logger
+from odoo.tools import format_email_address, mute_logger
 
 
 @tagged('mail_mail')
@@ -740,8 +740,8 @@ class TestMailMailServer(MailCommon):
         self.assertEqual(
             sorted(sorted(_mail['email_to']) for _mail in self._mails),
             sorted([sorted(['"Raoul, le Grand" <test.email.1@test.example.com>', '"Micheline, l\'immense" <test.email.2@test.example.com>']),
-                    [formataddr((self.user_employee.name, self.user_employee.email_normalized))],
-                    [formataddr(("Tony Customer", 'tony.customer@test.example.com'))]
+                    [format_email_address(self.user_employee.name, self.user_employee.email_normalized)],
+                    [format_email_address("Tony Customer", 'tony.customer@test.example.com')]
                    ]),
             'Mail: formatting issues should have been removed as much as possible'
         )
@@ -772,9 +772,9 @@ class TestMailMailServer(MailCommon):
         self.assertEqual(
             sorted(sorted(_mail['email_to']) for _mail in self._mails),
             sorted([sorted(['test.email.1@test.example.com', 'test.email.2@test.example.com']),
-                   [formataddr((self.user_employee.name, self.user_employee.email_normalized))],
-                    sorted([formataddr(("Tony Customer", 'tony.customer@test.example.com')),
-                            formataddr(("Tony Customer", 'norbert.customer@test.example.com'))]),
+                   [format_email_address(self.user_employee.name, self.user_employee.email_normalized)],
+                    sorted([format_email_address("Tony Customer", 'tony.customer@test.example.com'),
+                            format_email_address("Tony Customer", 'norbert.customer@test.example.com')]),
                    ]),
             'Mail: formatting issues should have been removed as much as possible (multi emails in a single address are managed '
             'like separate emails when sending with recipient_ids'
@@ -802,9 +802,9 @@ class TestMailMailServer(MailCommon):
         self.assertEqual(
             sorted(sorted(_mail['email_to']) for _mail in self._mails),
             sorted([sorted(['test.email.1@test.example.com', 'test.email.2@test.example.com']),
-                   [formataddr((self.user_employee.name, self.user_employee.email_normalized))],
-                    sorted([formataddr(("Tony Customer", 'tony.customer@test.example.com')),
-                            formataddr(("Tony Customer", 'norbert.customer@test.example.com'))]),
+                   [format_email_address(self.user_employee.name, self.user_employee.email_normalized)],
+                    sorted([format_email_address("Tony Customer", 'tony.customer@test.example.com'),
+                            format_email_address("Tony Customer", 'norbert.customer@test.example.com')]),
                    ]),
             'Mail: formatting issues should have been removed as much as possible (multi emails in a single address are managed '
             'like separate emails when sending with recipient_ids (and partner name is always used as name part)'

--- a/addons/test_mail/tests/test_mail_thread_mixins.py
+++ b/addons/test_mail/tests/test_mail_thread_mixins.py
@@ -38,7 +38,7 @@ class TestMailThread(MailCommon, TestRecipients):
         # test data: source email, expected email normalized
         valid_pairs = [
             (base_email, base_email),
-            (tools.formataddr(('Another Name', base_email)), base_email),
+            (tools.format_email_address('Another Name', base_email), base_email),
             (f'Name That Should Be Escaped <{base_email}>', base_email),
             ('test.😊@example.com', 'test.😊@example.com'),
             ('"Name 😊" <test.😊@example.com>', 'test.😊@example.com'),
@@ -49,7 +49,7 @@ class TestMailThread(MailCommon, TestRecipients):
         multi_pairs = [
             (f'{base_email}, other.email@test.example.com',
              base_email),  # multi supports first found
-            (f'{tools.formataddr(("Another Name", base_email))}, other.email@test.example.com',
+            (f'{tools.format_email_address("Another Name", base_email)}, other.email@test.example.com',
              base_email),  # multi supports first found
         ]
         for email_from, exp_email_normalized in valid_pairs + void_pairs + multi_pairs:

--- a/addons/test_mail/tests/test_message_post.py
+++ b/addons/test_mail/tests/test_message_post.py
@@ -18,7 +18,7 @@ from odoo.addons.test_mail.tests.common import TestRecipients
 from odoo.api import call_kw
 from odoo.exceptions import AccessError
 from odoo.tests import tagged
-from odoo.tools import mute_logger, formataddr
+from odoo.tools import mute_logger, format_email_address
 from odoo.tests.common import users
 
 
@@ -288,16 +288,16 @@ class TestMailNotifyAPI(TestMessagePostCommon):
         test_record = self.test_record.with_env(self.env)
         self.assertEqual(
             test_record._notify_get_reply_to()[test_record.id],
-            formataddr((
+            format_email_address(
                 f"{self.user_employee_c2.company_id.name} {test_record.name}",
-                f"{self.alias_catchall_c2}@{self.alias_domain_c2_name}"))
+                f"{self.alias_catchall_c2}@{self.alias_domain_c2_name}")
         )
         test_record_c1 = test_record.with_user(self.user_employee)
         self.assertEqual(
             test_record_c1._notify_get_reply_to()[test_record_c1.id],
-            formataddr((
+            format_email_address(
                 f"{self.user_employee.company_id.name} {test_record_c1.name}",
-                f"{self.alias_catchall}@{self.alias_domain}"))
+                f"{self.alias_catchall}@{self.alias_domain}")
         )
 
         # Test2: MC environment get default value from env
@@ -320,7 +320,7 @@ class TestMailNotifyAPI(TestMessagePostCommon):
 
             self.assertEqual(
                 res[test_record.id],
-                formataddr((f"{company.name} {test_record.name}", f"{alias_catchall}@{alias_domain}"))
+                format_email_address(f"{company.name} {test_record.name}", f"{alias_catchall}@{alias_domain}")
             )
 
         # Test3: get company from record (company_id field)
@@ -335,9 +335,9 @@ class TestMailNotifyAPI(TestMessagePostCommon):
         for test_record in test_records:
             self.assertEqual(
                 res[test_record.id],
-                formataddr((
+                format_email_address(
                     f"{self.company_3.name} {test_record.name}",
-                    f"{self.alias_catchall_c3}@{self.alias_domain_c3_name}"))
+                    f"{self.alias_catchall_c3}@{self.alias_domain_c3_name}")
             )
 
 
@@ -359,7 +359,7 @@ class TestMessageNotify(TestMessagePostCommon):
                 'message_values': {
                     'author_id': self.partner_employee,
                     'body': '<p>You have received a notification</p>',
-                    'email_from': formataddr((self.partner_employee.name, self.partner_employee.email_normalized)),
+                    'email_from': format_email_address(self.partner_employee.name, self.partner_employee.email_normalized),
                     'message_type': 'user_notification',
                     'model': test_record._name,
                     'notified_partner_ids': self.partner_1 | self.partner_employee_2 | self.partner_admin,
@@ -484,7 +484,7 @@ class TestMessageNotify(TestMessagePostCommon):
                     'message_type': 'user_notification',
                     'message_values': {
                         'author_id': self.partner_employee,
-                        'email_from': formataddr((self.partner_employee.name, self.partner_employee.email_normalized)),
+                        'email_from': format_email_address(self.partner_employee.name, self.partner_employee.email_normalized),
                         'model': test_record._name,
                         'notified_partner_ids': self.partner_employee_2,
                         'res_id': test_record.id,
@@ -550,7 +550,7 @@ class TestMessageNotify(TestMessagePostCommon):
                 'message_values': {
                     'author_id': self.partner_employee,
                     'body': '<p>You have received a notification</p>',
-                    'email_from': formataddr((self.partner_employee.name, self.partner_employee.email_normalized)),
+                    'email_from': format_email_address(self.partner_employee.name, self.partner_employee.email_normalized),
                     'model': False,
                     'res_id': False,
                     'notified_partner_ids': self.partner_1 | self.partner_employee_2 | self.partner_admin,
@@ -599,12 +599,12 @@ class TestMessageLog(TestMessagePostCommon):
                 'message_values': {
                     'author_id': self.partner_employee,
                     'body': '<p>Labrador</p>',
-                    'email_from': formataddr((self.partner_employee.name, self.partner_employee.email_normalized)),
+                    'email_from': format_email_address(self.partner_employee.name, self.partner_employee.email_normalized),
                     'is_internal': True,
                     'model': test_record._name,
                     'notified_partner_ids': self.env['res.partner'],
                     'partner_ids': self.env['res.partner'],
-                    'reply_to': formataddr((self.company_admin.name, f'{self.alias_catchall}@{self.alias_domain}')),
+                    'reply_to': format_email_address(self.company_admin.name, f'{self.alias_catchall}@{self.alias_domain}'),
                     'res_id': test_record.id,
                 },
                 'notif': [],
@@ -633,12 +633,12 @@ class TestMessageLog(TestMessagePostCommon):
                     'message_values': {
                         'author_id': self.partner_employee,
                         'body': '<p>Test _message_log_batch</p>',
-                        'email_from': formataddr((self.partner_employee.name, self.partner_employee.email_normalized)),
+                        'email_from': format_email_address(self.partner_employee.name, self.partner_employee.email_normalized),
                         'is_internal': True,
                         'model': test_record._name,
                         'notified_partner_ids': self.env['res.partner'],
                         'partner_ids': self.env['res.partner'],
-                        'reply_to': formataddr((self.company_admin.name, f'{self.alias_catchall}@{self.alias_domain}')),
+                        'reply_to': format_email_address(self.company_admin.name, f'{self.alias_catchall}@{self.alias_domain}'),
                         'res_id': test_record.id,
                     },
                     'notif': [],
@@ -670,12 +670,12 @@ class TestMessageLog(TestMessagePostCommon):
                     'message_values': {
                         'author_id': self.partner_employee,
                         'body': '<p>Test _message_log_batch</p>',
-                        'email_from': formataddr((self.partner_employee.name, self.partner_employee.email_normalized)),
+                        'email_from': format_email_address(self.partner_employee.name, self.partner_employee.email_normalized),
                         'is_internal': True,
                         'model': test_record._name,
                         'notified_partner_ids': self.env['res.partner'],
                         'partner_ids': self.test_partners[:5],
-                        'reply_to': formataddr((self.company_admin.name, f'{self.alias_catchall}@{self.alias_domain}')),
+                        'reply_to': format_email_address(self.company_admin.name, f'{self.alias_catchall}@{self.alias_domain}'),
                         'res_id': test_record.id,
                     },
                     'notif': [],
@@ -702,11 +702,11 @@ class TestMessageLog(TestMessagePostCommon):
                     'message_values': {
                         'author_id': self.partner_employee,
                         'body': f'<p>Hello {self.user_employee.name}, this comes from {test_record.name}.</p>',
-                        'email_from': formataddr((self.partner_employee.name, self.partner_employee.email_normalized)),
+                        'email_from': format_email_address(self.partner_employee.name, self.partner_employee.email_normalized),
                         'is_internal': True,
                         'model': test_record._name,
                         'notified_partner_ids': self.env['res.partner'],
-                        'reply_to': formataddr((self.company_admin.name, f'{self.alias_catchall}@{self.alias_domain}')),
+                        'reply_to': format_email_address(self.company_admin.name, f'{self.alias_catchall}@{self.alias_domain}'),
                         'res_id': test_record.id,
                     },
                     'notif': [],
@@ -737,12 +737,12 @@ class TestMessagePost(TestMessagePostCommon, CronMixinCase):
                     'message_values': {
                         'author_id': self.partner_employee,
                         'body': '<p>Body</p>',
-                        'email_from': formataddr((self.partner_employee.name, self.partner_employee.email_normalized)),
+                        'email_from': format_email_address(self.partner_employee.name, self.partner_employee.email_normalized),
                         'is_internal': False,
                         'message_type': 'comment',
                         'model': test_record._name,
                         'notified_partner_ids': self.partner_employee_2,
-                        'reply_to': formataddr((f'{self.company_admin.name} {test_record.name}', f'{self.alias_catchall}@{self.alias_domain}')),
+                        'reply_to': format_email_address(f'{self.company_admin.name} {test_record.name}', f'{self.alias_catchall}@{self.alias_domain}'),
                         'res_id': test_record.id,
                         'subtype_id': self.env.ref('mail.mt_comment'),
                     },
@@ -812,11 +812,11 @@ class TestMessagePost(TestMessagePostCommon, CronMixinCase):
                     'content': 'Body',
                     'mail_mail_values': {
                         'author_id': self.partner_employee_2,
-                        'email_from': formataddr((self.partner_employee_2.name, self.partner_employee_2.email_normalized)),
+                        'email_from': format_email_address(self.partner_employee_2.name, self.partner_employee_2.email_normalized),
                     },
                     'message_values': {
                         'author_id': self.partner_employee_2,
-                        'email_from': formataddr((self.partner_employee_2.name, self.partner_employee_2.email_normalized)),
+                        'email_from': format_email_address(self.partner_employee_2.name, self.partner_employee_2.email_normalized),
                         'message_type': 'comment',
                         'notified_partner_ids': self.partner_admin,
                         'subtype_id': self.env.ref('mail.mt_comment'),
@@ -893,13 +893,13 @@ class TestMessagePost(TestMessagePostCommon, CronMixinCase):
                 'message_values': {
                     'author_id': self.partner_employee,
                     'body': '<p>Body</p>',
-                    'email_from': formataddr((self.partner_employee.name, self.partner_employee.email_normalized)),
+                    'email_from': format_email_address(self.partner_employee.name, self.partner_employee.email_normalized),
                     'is_internal': False,
                     'model': test_record._name,
                     'notified_partner_ids': self.partner_employee_2,
                     'parent_id': creation_msg,
                     'record_name': test_record.name,
-                    'reply_to': formataddr((f'{self.company_admin.name} {test_record.name}', f'{self.alias_catchall}@{self.alias_domain}')),
+                    'reply_to': format_email_address(f'{self.company_admin.name} {test_record.name}', f'{self.alias_catchall}@{self.alias_domain}'),
                     'res_id': test_record.id,
                     'subject': test_record.name,
                 },
@@ -984,14 +984,12 @@ class TestMessagePost(TestMessagePostCommon, CronMixinCase):
                             },
                             'message_values': {
                                 'author_id': self.user_erp_manager.partner_id,
-                                'email_from': formataddr((self.user_erp_manager.name, self.user_erp_manager.email_normalized)),
+                                'email_from': format_email_address(self.user_erp_manager.name, self.user_erp_manager.email_normalized),
                                 'is_internal': False,
                                 'notified_partner_ids': self.partner_employee_2,
-                                'reply_to': formataddr(
-                                    (
-                                        f'{expected_company.name} {record.name}',
-                                        f'{expected_alias_domain.catchall_alias}@{expected_alias_domain.name}'
-                                    )
+                                'reply_to': format_email_address(
+                                    f'{expected_company.name} {record.name}',
+                                    f'{expected_alias_domain.catchall_alias}@{expected_alias_domain.name}'
                                 ),
                             },
                         }
@@ -1519,7 +1517,7 @@ class TestMessagePostHelpers(TestMessagePostCommon):
                     'model': test_record._name,
                     'notified_partner_ids': self.env['res.partner'],
                     'subtype_id': self.env['mail.message.subtype'],
-                    'reply_to': formataddr((f'{self.company_admin.name} {test_record.name}', f'{self.alias_catchall}@{self.alias_domain}')),
+                    'reply_to': format_email_address(f'{self.company_admin.name} {test_record.name}', f'{self.alias_catchall}@{self.alias_domain}'),
                     'res_id': test_record.id,
                 }
             )
@@ -1560,7 +1558,7 @@ class TestMessagePostHelpers(TestMessagePostCommon):
                     'notified_partner_ids': self.env['res.partner'],
                     'recipient_ids': test_record.customer_id,
                     'subtype_id': self.env['mail.message.subtype'],
-                    'reply_to': formataddr((f'{self.company_admin.name} {test_record.name}', f'{self.alias_catchall}@{self.alias_domain}')),
+                    'reply_to': format_email_address(f'{self.company_admin.name} {test_record.name}', f'{self.alias_catchall}@{self.alias_domain}'),
                     'res_id': test_record.id,
                 }
             )
@@ -1605,10 +1603,10 @@ class TestMessagePostHelpers(TestMessagePostCommon):
                 'message_type': 'comment',
                 'message_values': {
                     'author_id': self.partner_employee,
-                    'email_from': formataddr((self.partner_employee.name, self.partner_employee.email_normalized)),
+                    'email_from': format_email_address(self.partner_employee.name, self.partner_employee.email_normalized),
                     'is_internal': False,
                     'model': test_record._name,
-                    'reply_to': formataddr((f'{self.company_admin.name} {test_record.name}', f'{self.alias_catchall}@{self.alias_domain}')),
+                    'reply_to': format_email_address(f'{self.company_admin.name} {test_record.name}', f'{self.alias_catchall}@{self.alias_domain}'),
                     'res_id': test_record.id,
                 },
                 'notif': [
@@ -1645,10 +1643,10 @@ class TestMessagePostHelpers(TestMessagePostCommon):
             'message_type': 'notification',
             'message_values': {
                 'author_id': self.partner_employee,
-                'email_from': formataddr((self.partner_employee.name, self.partner_employee.email_normalized)),
+                'email_from': format_email_address(self.partner_employee.name, self.partner_employee.email_normalized),
                 'is_internal': False,
                 'model': test_record._name,
-                'reply_to': formataddr((f'{self.company_admin.name} {test_record.name}', f'{self.alias_catchall}@{self.alias_domain}')),
+                'reply_to': format_email_address(f'{self.company_admin.name} {test_record.name}', f'{self.alias_catchall}@{self.alias_domain}'),
                 'res_id': test_record.id,
              },
             'notif': [
@@ -1682,11 +1680,11 @@ class TestMessagePostHelpers(TestMessagePostCommon):
             'message_type': 'comment',
             'message_values': {
                 'author_id': self.partner_employee,
-                'email_from': formataddr((self.partner_employee.name, self.partner_employee.email_normalized)),
+                'email_from': format_email_address(self.partner_employee.name, self.partner_employee.email_normalized),
                 'is_internal': False,
                 'message_type': 'comment',
                 'model': test_record._name,
-                'reply_to': formataddr((f'{self.company_admin.name} {test_record.name}', f'{self.alias_catchall}@{self.alias_domain}')),
+                'reply_to': format_email_address(f'{self.company_admin.name} {test_record.name}', f'{self.alias_catchall}@{self.alias_domain}'),
                 'res_id': test_record.id,
              },
             'notif': [
@@ -1716,11 +1714,11 @@ class TestMessagePostHelpers(TestMessagePostCommon):
             'message_type': 'notification',
             'message_values': {
                 'author_id': self.partner_employee,
-                'email_from': formataddr((self.partner_employee.name, self.partner_employee.email_normalized)),
+                'email_from': format_email_address(self.partner_employee.name, self.partner_employee.email_normalized),
                 'is_internal': False,
                 'message_type': 'notification',
                 'model': test_record._name,
-                'reply_to': formataddr((f'{self.company_admin.name} {test_record.name}', f'{self.alias_catchall}@{self.alias_domain}')),
+                'reply_to': format_email_address(f'{self.company_admin.name} {test_record.name}', f'{self.alias_catchall}@{self.alias_domain}'),
                 'res_id': test_record.id,
             },
             'notif': [

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -9,7 +9,7 @@ from odoo.addons.base.tests.common import TransactionCaseWithUserDemo
 from odoo.addons.mail.tests.common import MailCommon
 from odoo.addons.mail.tools.discuss import Store
 from odoo.tests import Form, users, warmup, tagged
-from odoo.tools import mute_logger, formataddr
+from odoo.tools import mute_logger, format_email_address
 
 
 @tagged('mail_performance', 'post_install', '-at_install')
@@ -775,10 +775,10 @@ class TestBaseAPIPerformance(BaseMailPerformance):
         for record in test_records:
             self.assertEqual(
                 reply_to[record.id],
-                formataddr((
+                format_email_address(
                     f"{record.env.company.name} {record.name}",
                     f"{record.alias_name}@{self.alias_domain}"
-                ))
+                )
             )
 
 

--- a/addons/website_event_booth/controllers/event_booth.py
+++ b/addons/website_event_booth/controllers/event_booth.py
@@ -122,7 +122,7 @@ class WebsiteEventBoothController(WebsiteEventController):
     def _prepare_booth_registration_partner_values(self, event, kwargs):
         if request.env.user._is_public():
             conctact_email_normalized = tools.email_normalize(kwargs['contact_email'])
-            contact_name_email = tools.formataddr((kwargs['contact_name'], conctact_email_normalized))
+            contact_name_email = tools.format_email_address(kwargs['contact_name'], conctact_email_normalized)
             partner = request.env['res.partner'].sudo().find_or_create(contact_name_email)
             if not partner.name and kwargs.get('contact_name'):
                 partner.name = kwargs['contact_name']

--- a/addons/website_event_sale/controllers/main.py
+++ b/addons/website_event_sale/controllers/main.py
@@ -82,7 +82,7 @@ class WebsiteEventSaleController(WebsiteEventController):
                 if order_sudo.partner_id.is_public:
                     first_registration = registrations[0]
                     if first_registration.get('name') and first_registration.get('email'):
-                        formatted_address = tools.formataddr((first_registration['name'], first_registration['email']))
+                        formatted_address = tools.format_email_address(first_registration['name'], first_registration['email'])
                         partner = request.env['res.partner'].sudo().find_or_create(formatted_address)
                         if not partner.phone and first_registration.get('phone'):
                             partner.phone = first_registration['phone']

--- a/odoo/addons/base/models/ir_mail_server.py
+++ b/odoo/addons/base/models/ir_mail_server.py
@@ -22,7 +22,7 @@ from urllib3.contrib.pyopenssl import PyOpenSSLContext
 
 from odoo import api, fields, models, tools, _
 from odoo.exceptions import UserError
-from odoo.tools import ustr, pycompat, formataddr, email_normalize, encapsulate_email, email_domain_extract, email_domain_normalize, human_size
+from odoo.tools import ustr, pycompat, format_email_address, email_normalize, encapsulate_email, email_domain_extract, email_domain_normalize, human_size
 
 
 _logger = logging.getLogger(__name__)
@@ -102,7 +102,7 @@ def extract_rfc2822_addresses(text):
     valid_addresses = []
     for c in candidates:
         try:
-            valid_addresses.append(formataddr(('', c), charset='ascii'))
+            valid_addresses.append(format_email_address('', c, charset='ascii'))
         except idna.IDNAError:
             pass
     return valid_addresses

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -508,7 +508,7 @@ class Partner(models.Model):
 
     @api.depends('name', 'email')
     def _compute_email_formatted(self):
-        """ Compute formatted email for partner, using formataddr. Be defensive
+        """ Compute formatted email for partner, using format_email_address. Be defensive
         in computation, notably
 
           * double format: if email already holds a formatted email like
@@ -529,15 +529,15 @@ class Partner(models.Model):
             if emails_normalized:
                 # note: multi-email input leads to invalid email like "Name" <email1, email2>
                 # but this is current behavior in Odoo 14+ and some servers allow it
-                partner.email_formatted = tools.formataddr((
-                    partner.name or u"False",
+                partner.email_formatted = tools.format_email_address(
+                    partner.name or "False",
                     ','.join(emails_normalized)
-                ))
+                )
             elif partner.email:
-                partner.email_formatted = tools.formataddr((
-                    partner.name or u"False",
+                partner.email_formatted = tools.format_email_address(
+                    partner.name or "False",
                     partner.email
-                ))
+                )
 
     @api.depends('is_company')
     def _compute_company_type(self):

--- a/odoo/addons/base/tests/test_mail.py
+++ b/odoo/addons/base/tests/test_mail.py
@@ -15,7 +15,7 @@ from odoo.tools.mail import (
     email_domain_normalize, email_normalize, email_re,
     email_split, email_split_and_format, email_split_tuples,
     single_email_re,
-    formataddr,
+    format_email_address,
     prepend_html_content,
 )
 
@@ -599,11 +599,11 @@ class TestEmailTools(BaseCase):
         for source, expected, expected_utf8_fmt, expected_ascii_fmt in zip(sources, expected_list, expected_fmt_utf8_list, expected_fmt_ascii_list):
             with self.subTest(source=source):
                 self.assertEqual(email_normalize(source, strict=True), expected)
-                # standard usage of formataddr
-                self.assertEqual(formataddr((format_name, (expected or '')), charset='utf-8'), expected_utf8_fmt)
+                # standard usage of format_email_address
+                self.assertEqual(format_email_address(format_name, (expected or ''), charset='utf-8'), expected_utf8_fmt)
                 # check using INDA at format time, using ascii charset as done when
                 # sending emails (see extract_rfc2822_addresses)
-                self.assertEqual(formataddr((format_name, (expected or '')), charset='ascii'), expected_ascii_fmt)
+                self.assertEqual(format_email_address(format_name, (expected or ''), charset='ascii'), expected_ascii_fmt)
 
     def test_email_re(self):
         """ Test 'email_re', finding emails in a given text """
@@ -773,8 +773,8 @@ class TestEmailTools(BaseCase):
                 'Seems email_split_tuples is broken with %s (expected %r, received %r)' % (src, exp, res)
             )
 
-    def test_email_formataddr(self):
-        """ Test custom 'formataddr', notably with IDNA support """
+    def test_format_email_address(self):
+        """ Test custom 'format_email_address', notably with IDNA support """
         email_base = 'joe@example.com'
         email_idna = 'joe@examplé.com'
         cases = [
@@ -795,7 +795,7 @@ class TestEmailTools(BaseCase):
         for pair, charsets, expected in cases:
             for charset in charsets:
                 with self.subTest(pair=pair, charset=charset):
-                    self.assertEqual(formataddr(pair, charset), expected)
+                    self.assertEqual(format_email_address(*pair, charset), expected)
 
     def test_extract_rfc2822_addresses(self):
         cases = [

--- a/odoo/tools/__init__.py
+++ b/odoo/tools/__init__.py
@@ -26,7 +26,13 @@ from .float_utils import *
 from .func import *
 from .i18n import format_list
 from .image import image_process
-from .mail import *
+from .mail import (
+    email_domain_extract, email_domain_normalize, email_normalize, email_normalize_all,
+    email_split, encapsulate_email, format_email_address,
+    html2plaintext, html_normalize, html_sanitize,
+    is_html_empty, parse_contact_from_email, plaintext2html,
+    single_email_re, email_re,
+)
 from .misc import *
 from .query import Query
 from .sql import *


### PR DESCRIPTION
Rename `formatadd` which is exposed in `odoo.tools` with a more descriptive name. Also update the parameters to accept 2 arguments instead of a tuple.

odoo/enterprise#66803

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
