### PR TITLE
[FIX] website_sale: issue when editing address after selecting a pickup point

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1637,6 +1637,10 @@ class WebsiteSale(payment_portal.PaymentPortal):
         if redirection:
             return redirection
 
+        # Prevents a pickup point from remaining selected when
+        # editing an address after a pickup point has been chosen.
+        order.access_point_address = {}
+
         order.order_line._compute_tax_id()
         request.session['sale_last_order_id'] = order.id
         request.website.sale_get_order(update_pricelist=True)


### PR DESCRIPTION
Problem: When a pickup point is selected for delivery and the shipping address is then modified, the pickup point remains selected in the frontend but not in the backend, allowing an order to be validated with an unselected pickup point.

Steps to Reproduce:
1. Configure a pickup point provider (ex: Sendcloud).
2. Add a product to the cart.
3. Proceed to checkout.
4. Select a pickup point for delivery.
5. Enter in the page to edit address.
6. Confirm to return to the payment page -> As you will see, a pickup point address is selected, but pickup point addresses list are also visible.
7. Pay -> The shipping address will be the last selected shipping address instead of the pickup point address.

Solution:
Reset ´access_point_address´ in ´/shop/confirm_order´ endpoint to prevent the pickup point from remaining selected when editing an address.

opw-4040321
