### PR TITLE
[FIX] html_editor: prevent traceback on save

### DIFF
--- a/addons/html_editor/static/src/fields/html_field.js
+++ b/addons/html_editor/static/src/fields/html_field.js
@@ -85,7 +85,7 @@ export class HtmlField extends Component {
             const value = record.data[this.props.dynamicPlaceholderModelReferenceField || "model"];
             // update Dynamic Placeholder reference model
             if (this.props.dynamicPlaceholder && this.editor) {
-                this.editor.shared.updateDphDefaultModel(value);
+                this.editor.shared.updateDphDefaultModel?.(value);
             }
         });
     }


### PR DESCRIPTION
When the user create a new record containing an html editor. Then trigger a save but without any value inside the editable, The `editor.shared` object is somehow empty even tho this.editor is present. At the same time the save process trigger the `useRecordObserver` and throw an error because `updateDphDefaultModel()` is undefined in this case.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
