### PR TITLE
[FIX] website: popup and newsletter popup options

### DIFF
--- a/addons/website/static/src/js/content/adapt_content.js
+++ b/addons/website/static/src/js/content/adapt_content.js
@@ -17,12 +17,16 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
     // Hack: we move the '#o_search_modal' from the '#header' to
-    // '#o_shared_blocks'. Without this change, when the header has a
+    // '#o_search_modal_block'. Without this change, when the header has a
     // 'transform: translate' (when it's fixed), the modal, which is positioned
     // absolutely, takes the dimensions of the header instead of those of the
     // 'body'.
     const searchModalEl = document.querySelector("header#top .modal#o_search_modal");
     if (searchModalEl) {
-        document.querySelector("#o_shared_blocks").appendChild(searchModalEl);
+        const mainEl = document.querySelector("main");
+        const searchDivEl = document.createElement('div');
+        searchDivEl.id = "o_search_modal_block";
+        searchDivEl.appendChild(searchModalEl);
+        mainEl.appendChild(searchDivEl);
     }
 });

--- a/addons/website/static/src/js/content/menu.js
+++ b/addons/website/static/src/js/content/menu.js
@@ -897,11 +897,12 @@ publicWidget.registry.HeaderGeneral = publicWidget.Widget.extend({
      * @override
      */
     start() {
-        this.searchModalEl = document.querySelector("#o_shared_blocks #o_search_modal");
+        this.searchModalEl = document.querySelector("#o_search_modal_block");
         if (this.searchModalEl) {
             // Fix in stable because we moved '#o_search_modal' within
-            // '#o_shared_blocks' (see 'adapt_content.js'). TODO: remove this in
-            // master and add a new 'publicWidget' for '#o_search_modal'.
+            // '#o_search_modal_block' (see 'adapt_content.js'). TODO: remove
+            // this in master and add a new 'publicWidget' for
+            // '#o_search_modal'.
             this.__onSearchModalShow = this._onSearchModalShow.bind(this);
             this.searchModalEl.addEventListener("show.bs.modal", this.__onSearchModalShow);
             this.__onSearchModalShown = this._onSearchModalShown.bind(this);


### PR DESCRIPTION
Steps to reproduce:

1.  Drop a pop-up snippet
2. Change the Shown on: This Page to All Pages
3. Save and Edit again
4. Changing Shown on: All Pages to This Page won't work and Snippet Duplicate and Remove options are not visible.

Issue reason:
Commit [1] relocates the `#o_search_modal` element to `#o_shared_blocks`. Once the Shown on option of popup is changed to All Pages and Saved then again when you Go to Edit mode it adds `o_editable`and `o_dirty` class to popup even when no changes are made. So after changing the option, the observer checks for `o_dirty` and changes get rollbacked.

Solution:
Instead of adding `#o_search_modal` element to `#o_shared_blocks` it is relocated to the new element `#o_search_block` inside the `main` element.

This commit ensures that the popup/newsletter popup Shown on option and Snippet Duplicate and Remove options are visible and working.

[1] : https://github.com/odoo/odoo/commit/a1858a

task-4011237
