### PR TITLE
[16.0][FIX] base: pass base domain for name_search

### DIFF
--- a/odoo/addons/base/models/ir_fields.py
+++ b/odoo/addons/base/models/ir_fields.py
@@ -390,6 +390,11 @@ class IrFieldsConverter(models.AbstractModel):
             {'moreinfo': [_label or str(item) for item, _label in selection if _label or item]}
         )
 
+    def _get_base_name_search_domain(self, model):
+        if hasattr(model, "company_id"):
+            return ["|", ("company_id", "=", False), ("company_id", "=", self.env.company.id)]
+        return []
+
     @api.model
     def db_id_for(self, model, field, subfield, value):
         """ Finds a database id for the reference ``value`` in the referencing
@@ -459,7 +464,8 @@ class IrFieldsConverter(models.AbstractModel):
             if value == '':
                 return False, field_type, warnings
             flush(model=field.comodel_name)
-            ids = RelatedModel.name_search(name=value, operator='=')
+            args = self._get_base_name_search_domain(RelatedModel)
+            ids = RelatedModel.name_search(name=value, operator='=', args=args)
             if ids:
                 if len(ids) > 1:
                     warnings.append(ImportWarning(


### PR DESCRIPTION
This PR adds the base domain for name_search to avoid searching all records across all companies.

Before this commit, when records had the same name across multiple companies (e.g., location name), importing a record (e.g., stock move) with locations would return all matching location records from all companies. This led to multiple records being found, causing import failures.

@qrtl QT4715
