### PR TITLE
[FIX] website: adapt page properties dialog view type

### DIFF
--- a/addons/website/static/src/components/dialog/page_properties.js
+++ b/addons/website/static/src/components/dialog/page_properties.js
@@ -176,7 +176,6 @@ export class PagePropertiesDialog extends FormViewDialog {
 
         this.viewProps = {
             ...this.viewProps,
-            type: "page_properties_dialog_form",
             resId: this.resId,
             buttonTemplate: "website.PagePropertiesDialogButtons",
             clonePage: this.clonePage.bind(this),

--- a/addons/website/views/website_pages_views.xml
+++ b/addons/website/views/website_pages_views.xml
@@ -32,7 +32,7 @@
     <field name="name">website.page.properties.form.view</field>
     <field name="model">website.page</field>
     <field name="arch" type="xml">
-        <form>
+        <form js_class="page_properties_dialog_form">
             <notebook>
                 <page string="Name" name="page_name">
                     <group class="mt-4">


### PR DESCRIPTION
Steps to reproduce [17.4+]:

- Website > Site > This page > Properties > Traceback.

After [1], the `props.type` of the `View` component can no longer be a `js_class`.

The goal of this PR is to adapt the page properties dialog form to this change.

[1]: https://github.com/odoo/odoo/commit/2b46bfdf63b316ffb5fd57b57b3c6aa16c7d0ba6

task-4056538