### PR TITLE
[FIX] html_editor: fix traceback delete fully selected nested tables

### DIFF
--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -363,8 +363,10 @@ export class TablePlugin extends Plugin {
         // optimized by keeping in memory the state of selected cells/tables.
         const fullySelectedTables = [...this.editable.querySelectorAll(".o_selected_table")].filter(
             (table) =>
-                [...table.querySelectorAll("td")].every((td) =>
-                    td.classList.contains("o_selected_td")
+                [...table.querySelectorAll("td")].every(
+                    (td) =>
+                        closestElement(td, "table") !== table ||
+                        td.classList.contains("o_selected_td")
                 )
         );
         if (fullySelectedTables.length) {

--- a/addons/html_editor/static/tests/delete/backward.test.js
+++ b/addons/html_editor/static/tests/delete/backward.test.js
@@ -1609,6 +1609,28 @@ describe("Selection not collapsed", () => {
         });
     });
 
+    test("should remove a fully selected nested table", async () => {
+        await testEditor({
+            contentBefore: unformat(
+                `<p>a[b</p>
+                    <table><tbody>
+                        <tr>
+                            <td>
+                                <table><tbody>
+                                    <tr><td><br></td><td><br></td></tr>
+                                    <tr><td><br></td><td><br></td></tr>
+                                </tbody></table>
+                            </td>
+                        <td>ef</td></tr>
+                        <tr><td>gh</td><td>ij</td></tr>
+                    </tbody></table>
+                    <p>k]l</p>`
+            ),
+            stepFunction: deleteBackward,
+            contentAfter: "<p>a[]l</p>",
+        });
+    });
+
     test("should delete nothing when in an empty table cell", async () => {
         await testEditor({
             contentBefore:


### PR DESCRIPTION
Issue:
======
Traceback when deleting fully selected nested tables

Steps to reproduce the issue:
=============================
- Add a table
- Add a table in a cell in the first table
- ctrl+a
- delete
- Traceback

Origin of the issue:
====================
The fully selected table wasn't working properly as it checks for every td to have `o_selected_td` but in this case the nested table doesn't have the selection classes and it will remove them column by column and the selection of `td` then will have both of the parent table and child table. We set the cursor at a column of the nested table which is deleted when we deleted the td that contains it and then raises an error since the column isn't connected to the dom anymore.