### PR TITLE
[FIX] account_peppol: mock company check

### DIFF
--- a/addons/account_peppol/models/account_edi_proxy_user.py
+++ b/addons/account_peppol/models/account_edi_proxy_user.py
@@ -79,6 +79,7 @@ class AccountEdiProxyClientUser(models.Model):
     def _get_can_send_domain(self):
         return ('sender', 'smp_registration', 'receiver')
 
+    @handle_demo
     def _check_company_on_peppol(self, company, edi_identification):
         if (
             not company.account_peppol_migration_key

--- a/addons/account_peppol/models/res_partner.py
+++ b/addons/account_peppol/models/res_partner.py
@@ -48,7 +48,7 @@ class ResPartner(models.Model):
         hash_participant = md5(edi_identification.lower().encode()).hexdigest()
         endpoint_participant = parse.quote_plus(f"iso6523-actorid-upis::{edi_identification}")
         peppol_user = self.env.company.sudo().account_edi_proxy_client_ids.filtered(lambda user: user.proxy_type == 'peppol')
-        edi_mode = peppol_user and peppol_user.edi_mode or self.env['ir.config_parameter'].sudo().get_param('account_peppol.edi.mode')
+        edi_mode = peppol_user and peppol_user.edi_mode or 'prod'
         sml_zone = 'acc.edelivery' if edi_mode == 'test' else 'edelivery'
         smp_url = f"http://B-{hash_participant}.iso6523-actorid-upis.{sml_zone}.tech.ec.europa.eu/{endpoint_participant}"
 

--- a/addons/account_peppol/tools/demo_utils.py
+++ b/addons/account_peppol/tools/demo_utils.py
@@ -146,6 +146,11 @@ def _mock_update_user_data(func, self, *args, **kwargs):
 def _mock_migrate_participant(func, self, *args, **kwargs):
     self.account_peppol_migration_key = 'I9cz9yw*ruDM%4VSj94s'
 
+
+def _mock_check_company_on_peppol(func, self, *args, **kwargs):
+    pass
+
+
 _demo_behaviour = {
     '_make_request': _mock_make_request,
     'button_account_peppol_check_partner_endpoint': _mock_button_verify_partner_endpoint,
@@ -155,6 +160,7 @@ _demo_behaviour = {
     'button_update_peppol_user_data': _mock_update_user_data,
     'button_peppol_smp_registration': _mock_receiver_registration,
     'button_check_peppol_verification_code': _mock_check_verification_code,
+    '_check_company_on_peppol': _mock_check_company_on_peppol,
 }
 
 # -------------------------------------------------------------------------


### PR DESCRIPTION
Since the last refactor, when we are in demo mode, we still really check whether a company exists on Peppol network before registration. We should skip the check in demo mode.

This commit mocks the company check when in demo mode, and also defaults to verifying partner on production Peppol network when the current company is not registered on Peppol.

no task



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
