### PR TITLE
[FIX] web: Prevent concurrence issue with onDeleteRecord on dblclik

### DIFF
--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -1163,7 +1163,7 @@ export class ListRenderer extends Component {
         }
     }
 
-    async onDeleteRecord(record) {
+    async onDeleteRecord(record, ev) {
         this.keepColumnWidths = true;
         const editedRecord = this.props.list.editedRecord;
         if (editedRecord && editedRecord !== record) {
@@ -1173,6 +1173,14 @@ export class ListRenderer extends Component {
             }
         }
         if (this.activeActions.onDelete) {
+            if (ev) {
+                const element = ev.target.closest(".o_list_record_remove");
+                if (element.dataset.clicked) {
+                    return;
+                }
+                element.dataset.clicked = true;
+            }
+
             this.activeActions.onDelete(record);
         }
     }

--- a/addons/web/static/src/views/list/list_renderer.xml
+++ b/addons/web/static/src/views/list/list_renderer.xml
@@ -291,7 +291,7 @@
                 <t t-if="hasX2ManyAction">
                     <td class="o_list_record_remove text-center"
                         t-on-keydown="(ev) => this.onCellKeydown(ev, group, record)"
-                        t-on-click.stop="() => this.onDeleteRecord(record)"
+                        t-on-click.stop="(ev) => this.onDeleteRecord(record, ev)"
                         tabindex="-1"
                     >
                         <button class="fa"


### PR DESCRIPTION
Example of steps:

    - install `inventory`
    - Open a transfer/receipts
    - add a product
    - validate it
    - click on return
    - there is a modal with the product
    - double click quickly on remove button
    - click return
    - traceback

```
psycopg2.errors.InvalidTextRepresentation: invalid input syntax for type integer: "virtual_12"
LINE 1: ...ETE FROM "stock_return_picking_line" WHERE id IN ('virtual_1...
                                                            ^
```
When this modal is opened, a `one2many` is built with “virtual” records,
which are the products selected in the transfer.

These records are virtual because we don't know which ones the customer
will keep - we'll only know for sure when he clicks on “Return”.

So, when this o2m is loaded, the setup of the Record class populates it.

A first call to the `_applyCommands` function is made with a command to
create a record (product) (command 0/CREATE).

Once the o2m has been loaded, the customer (who quickly clicks to remove
several products) ends up at some point double-clicking on the remove
button of the same product will trigger two consecutive calls to `_applyCommands`.

The first call (which is the correct call)
will have the command: `[2, “virtual_12”]` which is a `DELETE`.

But as we've already asked to create the same “virtual_12” record,

we are here:

https://github.com/odoo/odoo/blob/7caddbb653aa8235725b48ff9f28d6119fdc3567/addons/web/static/src/model/relational_model/static_list.js#L580-L585

Here, given that we have a delete `virtual_12` command and that just before
the setup we asked to create `virtual_12`, this condition will just remove
the command that creates `virtual_12` to simplify the operation without
creating a `DELETE` command.

So instead of creating it and then deleting it, we just don't create it.

The problem arises with the second click, which triggers exactly the same
call to `_applyCommands`, asking to delete `virtual_12`.

As this time we don't have any more “record creation” pending, we'll
enter here


https://github.com/odoo/odoo/blob/7caddbb653aa8235725b48ff9f28d6119fdc3567/addons/web/static/src/model/relational_model/static_list.js#L583-L585


The second click will ask you to delete a record that never existed in
the `web_save`... so that's what the python server don't like!

To correct the problem, I apply a variable to the button in the dom,
which I set to true when the first click occurs, and which I check on
the second click to ignore it.

opw-[4043992](https://www.odoo.com/web#id=4043992&view_type=form&model=project.task)