### PR TITLE
[FIX] account: fix cross currency calculation

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1954,12 +1954,14 @@ class AccountMoveLine(models.Model):
         )
         if is_cross_currency_payment:
             AccountMove = self.env['account.move']
+            is_invoice = debit_aml['move_type'] in AccountMove.get_sale_types()
+            is_bill = credit_aml['move_type'] in AccountMove.get_purchase_types()
             if any(aml['move_type'] == 'entry' for aml in (credit_aml, debit_aml)) :
                 debit_currency_rate_during_payment, credit_currency_rate_during_payment = (
                     self._get_currency_debit_and_credit_rates(
                         debit_currency,
                         credit_currency,
-                        credit_aml['payment_date'] or debit_aml['payment_date']
+                        is_invoice and credit_aml['payment_date'] or debit_aml['payment_date']
                     )
                 )
             else:
@@ -1972,8 +1974,6 @@ class AccountMoveLine(models.Model):
                     or credit_currency['rate']
                 )
 
-            is_invoice = debit_aml['move_type'] in AccountMove.get_sale_types()
-            is_bill = credit_aml['move_type'] in AccountMove.get_purchase_types()
             if is_invoice or is_bill:
                 invoice_date = is_invoice and debit_aml['invoice_date'] or credit_aml['invoice_date']
                 debit_currency_rate_during_creation, credit_currency_rate_during_creation = (
@@ -2035,7 +2035,6 @@ class AccountMoveLine(models.Model):
         else:
             recon_debit_amount = debit_recon_values['residual']
             recon_credit_amount = -credit_recon_values['residual']
-
 
         # ==== Match both lines together and compute amounts to reconcile ====
 

--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -547,6 +547,15 @@ class AccountPaymentRegister(models.TransientModel):
             return abs(residual_amount), False
         else:
             # Foreign currency on payment different than the one set on the journal entries.
+            if self.env.context.get('active_model') == 'account.move.line':
+                if invoices := self.env['account.move.line'].search([('id', 'in', self.env.context.get('active_ids', []))]):
+                    residual_amount = invoices[0].move_id.amount_residual
+                    return self.source_currency_id._convert(
+                        residual_amount,
+                        self.currency_id,
+                        self.company_id,
+                        self.payment_date,
+                    ), False
             return comp_curr._convert(
                 self.source_amount,
                 self.currency_id,


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This commit fixes the currency calculation when there are three different currencies involved in a payment (Invoice or Bill)  and the exchange rates have changed between the duration when invoice was created and payment was registered. System was calculating inconsistent currency rates.

For instance: let the company currency be INR. The invoice is generated in USD. Now, the currency in which payment is registered is GBP.
Let the currency rates of USD and GBP be as follows:
10/07/24: 1 USD = 80 INR, 1 GBP = 100 INR
17/07/24: 1 USD = 81 INR, 1 GBP = 100 INR
If an invoice of 100 USD is created on 10/07/24. So the payment amount to register is 80*100 = 8000 INR. 
The payment is registered on 17/07/24 and payment currency is GBP. At this time, the currency rate has increased by 81 - 80 = 1 INR. So an exchange difference of 1 * 100 = 100 INR has occured.
Ideally, it should register a payment of 81*100 = 8100 INR = 81 GBP (8000 INR as invoice payment and 100 INR as exchange difference)
But, the system currently accepts payment of 8000 INR (the invoice amount) and skips on creating a journal entry for an exchange difference.

Desired behaviour after this PR is merged:
This PR fixes issue at two places: 
- It fixes the currency value in the register payment wizard when clicked on register payment button.
- It creates a journal entry of exchange difference when there are three currencies involved in a payment and an exchange difference has occured.
 
TaskID: 3916628

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
