### PR TITLE
[FIX] l10n_in: change the logger error to warning

### DIFF
--- a/addons/l10n_in/demo/account_demo.py
+++ b/addons/l10n_in/demo/account_demo.py
@@ -28,7 +28,7 @@ class AccountChartTemplate(models.AbstractModel):
                     'mail.message': self._get_demo_data_mail_message(company),
                 }
             else:
-                _logger.error('Error while loading Indian-Accounting demo data in the company "%s".State is not set in the company.', company.name)
+                _logger.warning('Error while loading Indian-Accounting demo data in the company "%s".State is not set in the company.', company.name)
         else:
             demo_data = super()._get_demo_data(company)
         return demo_data


### PR DESCRIPTION
Currently, a logger error is occurring when the user tries to change the Chart of Account to India with Indian company having no state.

Clearly, it's related to demo data and it's not breaking the flow.

Error:-
```
Message
Error while loading Indian-Accounting demo data in the company "odoo".State is not set in the company.
```

So we can change the logger error to a warning to reduce the noise in the sentry

sentry-5610804086

