### PR TITLE
[REM] sale: remove unused code

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -942,12 +942,6 @@ class SaleOrder(models.Model):
 
         return True
 
-    def _should_be_locked(self):
-        self.ensure_one()
-        # Public user can confirm SO, so we check the group on any record creator.
-        user = self[:1].create_uid
-        return user and user.sudo().has_group('sale.group_auto_done_setting')
-
     def _can_be_confirmed(self):
         self.ensure_one()
         return self.state in {'draft', 'sent'}


### PR DESCRIPTION
This commit removes unused code that checks whether to lock a sale order upon confirmation. The logic has been moved directly to `action_confirm`, and the `_should_be_locked` method is no longer called from anywhere."

