### PR TITLE
[FIX] l10n_it_edi: issue with negative lines and product price

### DIFF
--- a/addons/l10n_it_edi/models/account_move.py
+++ b/addons/l10n_it_edi/models/account_move.py
@@ -251,7 +251,7 @@ class AccountMove(models.Model):
                 gross_price = line['price_subtotal'] / (1 - line['discount'] / 100.0)
                 line['discount_amount_before_dispatching'] = (gross_price - line['price_subtotal']) * inverse_factor
                 line['gross_price_subtotal'] = line['currency'].round(gross_price * inverse_factor)
-                line['price_unit'] = line['currency'].round(gross_price / abs(line['quantity']))
+                line['price_unit'] = gross_price / abs(line['quantity'])
             else:
                 line['gross_price_subtotal'] = line['currency'].round(line['price_unit'] * line['quantity'])
                 line['discount_amount_before_dispatching'] = line['gross_price_subtotal']
@@ -289,7 +289,7 @@ class AccountMove(models.Model):
                 'description': description or 'NO NAME',
                 'subtotal_price': (line_dict['gross_price_subtotal'] - line_dict['discount_amount']) * inverse_factor,
                 'unit_price': line_dict['price_unit'],
-                'discount_amount': line_dict['discount_amount'] - line_dict['discount_amount_before_dispatching'],
+                'discount_amount': ((line_dict['discount_amount'] - line_dict['discount_amount_before_dispatching']) / line.quantity) if line.quantity else 0,
                 'vat_tax': line.tax_ids.flatten_taxes_hierarchy().filtered(lambda t: t._l10n_it_filter_kind('vat') and t.amount >= 0),
                 'downpayment_moves': downpayment_moves,
                 'discount_type': (

--- a/addons/l10n_it_edi/tests/export_xmls/invoice_decimal_precision_product.xml
+++ b/addons/l10n_it_edi/tests/export_xmls/invoice_decimal_precision_product.xml
@@ -58,36 +58,37 @@
     <FatturaElettronicaBody>
         <DatiGenerali>
             <DatiGeneraliDocumento>
-                <TipoDocumento>TD04</TipoDocumento>
+                <TipoDocumento>TD01</TipoDocumento>
                 <Divisa>EUR</Divisa>
                 <Data>2022-03-24</Data>
-                <Numero>RINV/2022/00001</Numero>
-                <ImportoTotaleDocumento>1830.98</ImportoTotaleDocumento>
+                <Numero>INV/2022/00001</Numero>
+                <ImportoTotaleDocumento>38.50</ImportoTotaleDocumento>
             </DatiGeneraliDocumento>
-            <DatiFattureCollegate>
-                <IdDocumento>___ignore___</IdDocumento>
-                <Data>___ignore___</Data>
-            </DatiFattureCollegate>
         </DatiGenerali>
         <DatiBeniServizi>
             <DettaglioLinee>
                 <NumeroLinea>1</NumeroLinea>
                 <Descrizione>standard_line</Descrizione>
-                <Quantita>2.00</Quantita>
-                <PrezzoUnitario>800.400000</PrezzoUnitario>
-                <ScontoMaggiorazione>
-                    <Tipo>SC</Tipo>
-                    <Importo>50.00</Importo>
-                </ScontoMaggiorazione>
-                <PrezzoTotale>1500.80</PrezzoTotale>
+                <Quantita>10.00</Quantita>
+                <PrezzoUnitario>3.156000</PrezzoUnitario>
+                <PrezzoTotale>31.56</PrezzoTotale>
                 <AliquotaIVA>22.00</AliquotaIVA>
             </DettaglioLinee>
             <DatiRiepilogo>
                 <AliquotaIVA>22.00</AliquotaIVA>
-                <ImponibileImporto>1500.80</ImponibileImporto>
-                <Imposta>330.18</Imposta>
+                <ImponibileImporto>31.56</ImponibileImporto>
+                <Imposta>6.94</Imposta>
                 <EsigibilitaIVA>I</EsigibilitaIVA>
             </DatiRiepilogo>
         </DatiBeniServizi>
+        <DatiPagamento>
+            <CondizioniPagamento>TP02</CondizioniPagamento>
+            <DettaglioPagamento>
+                <ModalitaPagamento>MP05</ModalitaPagamento>
+                <DataScadenzaPagamento>2022-03-24</DataScadenzaPagamento>
+                <ImportoPagamento>38.50</ImportoPagamento>
+                <CodicePagamento>INV/2022/00001</CodicePagamento>
+            </DettaglioPagamento>
+        </DatiPagamento>
     </FatturaElettronicaBody>
 </p:FatturaElettronica>

--- a/addons/l10n_it_edi/tests/export_xmls/invoice_negative_price.xml
+++ b/addons/l10n_it_edi/tests/export_xmls/invoice_negative_price.xml
@@ -62,26 +62,26 @@
                 <Divisa>EUR</Divisa>
                 <Data>2022-03-24</Data>
                 <Numero>INV/2022/00001</Numero>
-                <ImportoTotaleDocumento>854.49</ImportoTotaleDocumento>
+                <ImportoTotaleDocumento>1830.98</ImportoTotaleDocumento>
             </DatiGeneraliDocumento>
         </DatiGenerali>
         <DatiBeniServizi>
             <DettaglioLinee>
                 <NumeroLinea>1</NumeroLinea>
                 <Descrizione>standard_line</Descrizione>
-                <Quantita>1.00</Quantita>
+                <Quantita>2.00</Quantita>
                 <PrezzoUnitario>800.400000</PrezzoUnitario>
                 <ScontoMaggiorazione>
                     <Tipo>SC</Tipo>
-                    <Importo>100.00</Importo>
+                    <Importo>50.00</Importo>
                 </ScontoMaggiorazione>
-                <PrezzoTotale>700.40</PrezzoTotale>
+                <PrezzoTotale>1500.80</PrezzoTotale>
                 <AliquotaIVA>22.00</AliquotaIVA>
             </DettaglioLinee>
             <DatiRiepilogo>
                 <AliquotaIVA>22.00</AliquotaIVA>
-                <ImponibileImporto>700.40</ImponibileImporto>
-                <Imposta>154.09</Imposta>
+                <ImponibileImporto>1500.80</ImponibileImporto>
+                <Imposta>330.18</Imposta>
                 <EsigibilitaIVA>I</EsigibilitaIVA>
             </DatiRiepilogo>
         </DatiBeniServizi>
@@ -90,7 +90,7 @@
             <DettaglioPagamento>
                 <ModalitaPagamento>MP05</ModalitaPagamento>
                 <DataScadenzaPagamento>2022-03-24</DataScadenzaPagamento>
-                <ImportoPagamento>854.49</ImportoPagamento>
+                <ImportoPagamento>1830.98</ImportoPagamento>
                 <CodicePagamento>INV/2022/00001</CodicePagamento>
             </DettaglioPagamento>
         </DatiPagamento>

--- a/addons/l10n_it_edi/tests/test_edi_export.py
+++ b/addons/l10n_it_edi/tests/test_edi_export.py
@@ -313,6 +313,7 @@ class TestItEdiExport(TestItEdi):
             'invoice_line_ids': [
                 Command.create({
                     'name': 'standard_line',
+                    'quantity': 2,
                     'price_unit': 800.40,
                     'tax_ids': [Command.set(self.default_tax.ids)],
                 }),
@@ -364,3 +365,26 @@ class TestItEdiExport(TestItEdi):
 
         with self.assertRaises(UserError, msg="You have negative lines that we can't dispatch on others. They need to have the same tax."):
             self._assert_export_invoice(invoice, 'invoice_negative_price.xml')
+
+    def test_invoice_more_decimal_price_unit(self):
+        decimal_precision_name = self.env['account.move.line']._fields['price_unit']._digits
+        decimal_precision = self.env['decimal.precision'].search([('name', '=', decimal_precision_name)])
+        decimal_precision.digits = 4
+        invoice = self.env['account.move'].with_company(self.company).create({
+            'move_type': 'out_invoice',
+            'invoice_date': '2022-03-24',
+            'invoice_date_due': '2022-03-24',
+            'partner_id': self.italian_partner_a.id,
+            'partner_bank_id': self.test_bank.id,
+            'invoice_line_ids': [
+                Command.create({
+                    'name': 'standard_line',
+                    'price_unit': 3.156,
+                    'quantity': 10,
+                    'tax_ids': [Command.set(self.default_tax.ids)],
+                }),
+            ],
+        })
+        invoice.action_post()
+
+        self._assert_export_invoice(invoice, 'invoice_decimal_precision_product.xml')


### PR DESCRIPTION
This solves 2 issues.
The first is that the flat discount due to negative lines should be divided by the quantity. 
It's like a discount to the price unit.

The second issue is that we rounded by mistake the price unit. 
So an invoice with a product that had more than 2 decimals would be wrong.

opw-4039333
opw-4052821
and others



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
