### PR TITLE
 [FIX] *: js_class for form view in TimeOffFormViewDialog

### DIFF
--- a/addons/hr_holidays/static/src/views/view_dialog/form_view_dialog.js
+++ b/addons/hr_holidays/static/src/views/view_dialog/form_view_dialog.js
@@ -87,7 +87,7 @@ export class TimeOffFormViewDialog extends FormViewDialog {
         super.setup();
 
         this.viewProps = Object.assign(this.viewProps, {
-            type: "timeoff_dialog_form",
+            jsClass: "timeoff_dialog_form",
             buttonTemplate: 'hr_holidays.FormViewDialog.buttons',
             onCancelLeave: () => {
                 this.props.close();

--- a/addons/web/static/src/views/view.js
+++ b/addons/web/static/src/views/view.js
@@ -133,6 +133,7 @@ const CALLBACK_RECORDER_NAMES = [
 const STANDARD_PROPS = [
     "resModel",
     "type",
+    "jsClass",
 
     "arch",
     "fields",
@@ -318,7 +319,7 @@ export class View extends Component {
 
         const jsClass = archXmlDoc.hasAttribute("js_class")
             ? archXmlDoc.getAttribute("js_class")
-            : type;
+            : props.jsClass || type;
         if (!viewRegistry.contains(jsClass)) {
             await loadBundle(DEFAULT_LAZY_BUNDLE);
         }

--- a/addons/web/static/tests/views/view.test.js
+++ b/addons/web/static/tests/views/view.test.js
@@ -931,6 +931,24 @@ test("real life banner", async () => {
 // js_class
 ////////////////////////////////////////////////////////////////////////////
 
+test("rendering with given jsClass", async function () {
+    expect.assertions(4);
+    onRpc("get_views", ({ kwargs }) => {
+        expect(kwargs.views).toEqual([[false, "toy"]]);
+        expect(pick(kwargs.options, "action_id", "load_filters", "toolbar")).toEqual({
+            action_id: false,
+            load_filters: false,
+            toolbar: false,
+        });
+    });
+
+    await mountWithCleanup(View, {
+        props: { resModel: "animal", type: "toy", jsClass: "toy_imp" },
+    });
+    expect(".o_toy_view.toy_imp").toHaveCount(1);
+    expect(".o_toy_view.toy_imp").toHaveText("Arch content (id=false)");
+});
+
 test("rendering with loaded arch attribute 'js_class'", async function () {
     expect.assertions(4);
     onRpc("get_views", ({ kwargs }) => {
@@ -961,6 +979,64 @@ test("rendering with given arch attribute 'js_class'", async function () {
     });
     expect(".o_toy_view.toy_imp").toHaveCount(1);
     expect(".o_toy_view.toy_imp").toHaveText("Specific arch content for specific class");
+});
+
+test("rendering with loaded arch attribute 'js_class' and given jsClass", async function () {
+    expect.assertions(3);
+    viewRegistry.add("toy_2", {
+        type: "toy",
+        Controller: class extends Component {
+            static props = ["*"];
+            static template = xml`<div class="o_toy_view_2"/>`;
+            static type = "toy";
+        },
+    });
+    onRpc("get_views", ({ kwargs }) => {
+        expect(kwargs.views).toEqual([[2, "toy"]]);
+        expect(pick(kwargs.options, "action_id", "load_filters", "toolbar")).toEqual({
+            action_id: false,
+            load_filters: false,
+            toolbar: false,
+        });
+    });
+    await mountWithCleanup(View, {
+        props: {
+            resModel: "animal",
+            type: "toy",
+            jsClass: "toy_2",
+            viewId: 2,
+        },
+    });
+    expect(".o_toy_view.toy_imp").toHaveCount(1);
+});
+
+test("rendering with given arch attribute 'js_class' and given jsClass", async function () {
+    expect.assertions(1);
+    viewRegistry.add(
+        "toy_2",
+        {
+            type: "toy",
+            Controller: class extends Component {
+                static props = ["*"];
+                static template = xml`<div class="o_toy_view_2"/>`;
+                static type = "toy";
+            },
+        },
+        { force: true }
+    );
+    onRpc("get_views", () => {
+        throw new Error("no get_views expected");
+    });
+    await mountWithCleanup(View, {
+        props: {
+            resModel: "animal",
+            type: "toy",
+            jsClass: "toy_2",
+            arch: `<toy js_class="toy_imp"/>`,
+            fields: {},
+        },
+    });
+    expect(".o_toy_view.toy_imp").toHaveCount(1);
 });
 
 ////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
With https://github.com/odoo/odoo/commit/2b46bfdf63b316ffb5fd57b57b3c6aa16c7d0ba6, the prop type of the View component can no longer be a js_class.
Here we fix an error in hr_holidays where the basic form view was used instead of
the view timeoff_dialog_form when opening the TimeOffFormViewDialog.
For that we use a new View prop "jsClass".

Task ID: 4055929