### PR TITLE
[IMP] website: make link to plausible docs more explicit

### DIFF
--- a/addons/website/static/src/client_actions/website_dashboard/website_dashboard.xml
+++ b/addons/website/static/src/client_actions/website_dashboard/website_dashboard.xml
@@ -43,7 +43,7 @@
                 </div>
                 <div class="o_buttons text-center">
                     <h3>Easily track your visitor with Plausible</h3>
-                    <DocumentationLink path="'/applications/websites/website/reporting/plausible.html'" label.translate="Connect Plausible"/>
+                    <DocumentationLink path="'/applications/websites/website/reporting/plausible.html'" label.translate="How to connect Plausible ?" icon="'oi oi-arrow-right me-1'"/>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
The links pointing to the documentation have been refactored. Previously, the link labeled "Connect Plausible" lacked explicit clarity. We have now updated this link to follow a more recognizable Odoo style, incorporating an arrow icon and a question mark to enhance its visibility and intuitiveness.

For examples of similar links, refer to the settings section in Odoo.

task-3956742

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
