### PR TITLE
[FIX] l10n_in: consider discounts in hsn summary

### DIFF
--- a/addons/l10n_in/models/account_invoice.py
+++ b/addons/l10n_in/models/account_invoice.py
@@ -189,6 +189,7 @@ class AccountMove(models.Model):
                 'l10n_in_hsn_code': line.l10n_in_hsn_code,
                 'quantity': line.quantity,
                 'price_unit': line.price_unit,
+                'discount': line.discount or 0.0,
                 'product_values': product_values,
                 'uom': {'id': line.product_uom_id.id, 'name': line.product_uom_id.name},
                 'taxes_data': taxes_data,

--- a/addons/l10n_in/models/account_tax.py
+++ b/addons/l10n_in/models/account_tax.py
@@ -43,14 +43,17 @@ class AccountTax(models.Model):
                 continue
 
             price_unit = base_line['price_unit']
+            discount = base_line['discount']
             quantity = base_line['quantity']
             product_values = base_line['product_values']
             uom = base_line['uom'] or {}
             taxes_data = base_line['taxes_data']
 
+            final_unit_price = price_unit * (1 - (discount / 100.0))
+
             # Compute the taxes.
             evaluation_context = self.env['account.tax']._eval_taxes_computation_prepare_context(
-                price_unit,
+                final_unit_price,
                 quantity,
                 product_values,
                 rounding_method='round_per_line',

--- a/addons/l10n_in/static/src/helpers/hsn_summary.js
+++ b/addons/l10n_in/static/src/helpers/hsn_summary.js
@@ -17,14 +17,17 @@ patch(accountTaxHelpers, {
             }
 
             const price_unit = base_line.price_unit;
+            const discount = base_line.discount;
             const quantity = base_line.quantity;
             const product_values = base_line.product_values;
             const uom = base_line.uom || {};
             const taxes_data = base_line.taxes_data;
 
+            const final_unit_price = price_unit * (1 - discount / 100);
+
             // Compute the taxes.
             const evaluation_context = this.eval_taxes_computation_prepare_context(
-                price_unit,
+                final_unit_price,
                 quantity,
                 product_values,
                 {

--- a/addons/l10n_in/tests/test_hsn_summary.py
+++ b/addons/l10n_in/tests/test_hsn_summary.py
@@ -57,7 +57,7 @@ class TestHSNsummary(TestTaxCommon):
         else:
             super()._assert_sub_test(test, results)
 
-    def create_base_line_dict(self, l10n_in_hsn_code, quantity, price_unit, uom, taxes=None, product=None):
+    def create_base_line_dict(self, l10n_in_hsn_code, quantity, price_unit, discount, uom, taxes=None, product=None):
         AccountTax = self.env['account.tax']
         taxes_data = (taxes or AccountTax)._convert_to_dict_for_taxes_computation()
         product_fields = AccountTax._eval_taxes_computation_prepare_product_fields(taxes_data)
@@ -70,6 +70,7 @@ class TestHSNsummary(TestTaxCommon):
             'l10n_in_hsn_code': l10n_in_hsn_code,
             'quantity': quantity,
             'price_unit': price_unit,
+            'discount': discount,
             'product_values': product_values,
             'uom': {'id': uom.id, 'name': uom.name},
             'taxes_data': taxes_data,
@@ -89,12 +90,12 @@ class TestHSNsummary(TestTaxCommon):
         """ Test GST/IGST taxes. """
         tests = []
         base_lines1 = [
-            self.create_base_line_dict(self.test_hsn_code_1, 2.0, 100.0, self.uom_unit, self.gst_5),
-            self.create_base_line_dict(self.test_hsn_code_1, 1.0, 600.0, self.uom_unit, self.gst_5),
-            self.create_base_line_dict(self.test_hsn_code_1, 5.0, 300.0, self.uom_unit, self.gst_5),
-            self.create_base_line_dict(self.test_hsn_code_1, 2.0, 100.0, self.uom_unit, self.gst_18),
-            self.create_base_line_dict(self.test_hsn_code_1, 1.0, 600.0, self.uom_unit, self.gst_18),
-            self.create_base_line_dict(self.test_hsn_code_1, 5.0, 300.0, self.uom_unit, self.gst_18),
+            self.create_base_line_dict(self.test_hsn_code_1, 2.0, 100.0, 0.0, self.uom_unit, self.gst_5),
+            self.create_base_line_dict(self.test_hsn_code_1, 1.0, 600.0, 0.0, self.uom_unit, self.gst_5),
+            self.create_base_line_dict(self.test_hsn_code_1, 5.0, 300.0, 0.0, self.uom_unit, self.gst_5),
+            self.create_base_line_dict(self.test_hsn_code_1, 2.0, 100.0, 0.0, self.uom_unit, self.gst_18),
+            self.create_base_line_dict(self.test_hsn_code_1, 1.0, 600.0, 0.0, self.uom_unit, self.gst_18),
+            self.create_base_line_dict(self.test_hsn_code_1, 5.0, 300.0, 0.0, self.uom_unit, self.gst_18),
         ]
         tests.append(self._prepare_l10n_in_hsn_summary_test(
             base_lines1,
@@ -135,7 +136,7 @@ class TestHSNsummary(TestTaxCommon):
         # Change the UOM of the second line.
         base_lines2 = [
             base_lines1[0],
-            self.create_base_line_dict(self.test_hsn_code_1, 1.0, 12000.0, self.uom_dozen, self.gst_5),
+            self.create_base_line_dict(self.test_hsn_code_1, 1.0, 12000.0, 0.0, self.uom_dozen, self.gst_5),
         ] + base_lines1[2:]
         tests.append(self._prepare_l10n_in_hsn_summary_test(
             base_lines2,
@@ -186,9 +187,9 @@ class TestHSNsummary(TestTaxCommon):
 
         # Change GST 5% taxes to IGST.
         base_lines3 = [
-            self.create_base_line_dict(self.test_hsn_code_1, 2.0, 100.0, self.uom_unit, self.igst_5),
-            self.create_base_line_dict(self.test_hsn_code_1, 1.0, 12000.0, self.uom_dozen, self.igst_5),
-            self.create_base_line_dict(self.test_hsn_code_1, 5.0, 300.0, self.uom_unit, self.igst_5),
+            self.create_base_line_dict(self.test_hsn_code_1, 2.0, 100.0, 0.0, self.uom_unit, self.igst_5),
+            self.create_base_line_dict(self.test_hsn_code_1, 1.0, 12000.0, 0.0, self.uom_dozen, self.igst_5),
+            self.create_base_line_dict(self.test_hsn_code_1, 5.0, 300.0, 0.0, self.uom_unit, self.igst_5),
         ] + base_lines1[3:]
         tests.append(self._prepare_l10n_in_hsn_summary_test(
             base_lines3,
@@ -240,7 +241,7 @@ class TestHSNsummary(TestTaxCommon):
         # Put back the UOM of the second line to unit.
         base_lines4 = [
             base_lines3[0],
-            self.create_base_line_dict(self.test_hsn_code_1, 1.0, 600.0, self.uom_unit, self.igst_5),
+            self.create_base_line_dict(self.test_hsn_code_1, 1.0, 600.0, 0.0, self.uom_unit, self.igst_5),
         ] + base_lines3[2:]
         tests.append(self._prepare_l10n_in_hsn_summary_test(
             base_lines4,
@@ -280,9 +281,9 @@ class TestHSNsummary(TestTaxCommon):
 
         # Change GST 18% taxes to IGST.
         base_lines5 = base_lines4[:3] + [
-            self.create_base_line_dict(self.test_hsn_code_1, 2.0, 100.0, self.uom_unit, self.igst_18),
-            self.create_base_line_dict(self.test_hsn_code_1, 1.0, 600.0, self.uom_unit, self.igst_18),
-            self.create_base_line_dict(self.test_hsn_code_1, 5.0, 300.0, self.uom_unit, self.igst_18),
+            self.create_base_line_dict(self.test_hsn_code_1, 2.0, 100.0, 0.0, self.uom_unit, self.igst_18),
+            self.create_base_line_dict(self.test_hsn_code_1, 1.0, 600.0, 0.0, self.uom_unit, self.igst_18),
+            self.create_base_line_dict(self.test_hsn_code_1, 5.0, 300.0, 0.0, self.uom_unit, self.igst_18),
         ]
         tests.append(self._prepare_l10n_in_hsn_summary_test(
             base_lines5,
@@ -329,7 +330,7 @@ class TestHSNsummary(TestTaxCommon):
         self.cess_5_plus_1591.sequence = 100
 
         base_lines1 = [
-            self.create_base_line_dict(self.test_hsn_code_1, 1.0, 15.80, self.uom_unit, self.gst_18 + self.cess_5_plus_1591),
+            self.create_base_line_dict(self.test_hsn_code_1, 1.0, 15.80, 0.0, self.uom_unit, self.gst_18 + self.cess_5_plus_1591),
         ]
         tests.append(self._prepare_l10n_in_hsn_summary_test(
             base_lines1,
@@ -358,7 +359,7 @@ class TestHSNsummary(TestTaxCommon):
 
         # Change GST 18% taxes to IGST.
         base_lines2 = [
-            self.create_base_line_dict(self.test_hsn_code_1, 1.0, 15.80, self.uom_unit, self.igst_18 + self.cess_5_plus_1591),
+            self.create_base_line_dict(self.test_hsn_code_1, 1.0, 15.80, 0.0, self.uom_unit, self.igst_18 + self.cess_5_plus_1591),
         ]
         tests.append(self._prepare_l10n_in_hsn_summary_test(
             base_lines2,
@@ -390,10 +391,10 @@ class TestHSNsummary(TestTaxCommon):
         """ Test with mixed HSN codes. """
         tests = []
         base_lines1 = [
-            self.create_base_line_dict(self.test_hsn_code_1, 1.0, 100.0, self.uom_unit, self.gst_18),
-            self.create_base_line_dict(self.test_hsn_code_1, 2.0, 50.0, self.uom_unit, self.gst_18),
-            self.create_base_line_dict(self.test_hsn_code_2, 1.0, 100.0, self.uom_unit, self.gst_18),
-            self.create_base_line_dict(self.test_hsn_code_2, 2.0, 50.0, self.uom_unit, self.gst_18),
+            self.create_base_line_dict(self.test_hsn_code_1, 1.0, 100.0, 0.0, self.uom_unit, self.gst_18),
+            self.create_base_line_dict(self.test_hsn_code_1, 2.0, 50.0, 0.0, self.uom_unit, self.gst_18),
+            self.create_base_line_dict(self.test_hsn_code_2, 1.0, 100.0, 0.0, self.uom_unit, self.gst_18),
+            self.create_base_line_dict(self.test_hsn_code_2, 2.0, 50.0, 0.0, self.uom_unit, self.gst_18),
         ]
         tests.append(self._prepare_l10n_in_hsn_summary_test(
             base_lines1,
@@ -433,10 +434,10 @@ class TestHSNsummary(TestTaxCommon):
 
         # Change GST 18% taxes to IGST.
         base_lines2 = [
-            self.create_base_line_dict(self.test_hsn_code_1, 1.0, 100.0, self.uom_unit, self.igst_18),
-            self.create_base_line_dict(self.test_hsn_code_1, 2.0, 50.0, self.uom_unit, self.igst_18),
-            self.create_base_line_dict(self.test_hsn_code_2, 1.0, 100.0, self.uom_unit, self.igst_18),
-            self.create_base_line_dict(self.test_hsn_code_2, 2.0, 50.0, self.uom_unit, self.igst_18),
+            self.create_base_line_dict(self.test_hsn_code_1, 1.0, 100.0, 0.0, self.uom_unit, self.igst_18),
+            self.create_base_line_dict(self.test_hsn_code_1, 2.0, 50.0, 0.0, self.uom_unit, self.igst_18),
+            self.create_base_line_dict(self.test_hsn_code_2, 1.0, 100.0, 0.0, self.uom_unit, self.igst_18),
+            self.create_base_line_dict(self.test_hsn_code_2, 2.0, 50.0, 0.0, self.uom_unit, self.igst_18),
         ]
         tests.append(self._prepare_l10n_in_hsn_summary_test(
             base_lines2,
@@ -479,8 +480,8 @@ class TestHSNsummary(TestTaxCommon):
         """ Zero rated GST or no taxes at all."""
         tests = []
         base_lines1 = [
-            self.create_base_line_dict(self.test_hsn_code_1, 1.0, 350.0, self.uom_unit),
-            self.create_base_line_dict(self.test_hsn_code_1, 1.0, 350.0, self.uom_unit),
+            self.create_base_line_dict(self.test_hsn_code_1, 1.0, 350.0, 0.0, self.uom_unit),
+            self.create_base_line_dict(self.test_hsn_code_1, 1.0, 350.0, 0.0, self.uom_unit),
         ]
         tests.append(self._prepare_l10n_in_hsn_summary_test(
             base_lines1,
@@ -509,8 +510,8 @@ class TestHSNsummary(TestTaxCommon):
 
         # No tax to IGST 0%/exempt.
         base_lines2 = [
-            self.create_base_line_dict(self.test_hsn_code_1, 1.0, 350.0, self.uom_unit, self.igst_0),
-            self.create_base_line_dict(self.test_hsn_code_1, 1.0, 350.0, self.uom_unit, self.exempt_0),
+            self.create_base_line_dict(self.test_hsn_code_1, 1.0, 350.0, 0.0, self.uom_unit, self.igst_0),
+            self.create_base_line_dict(self.test_hsn_code_1, 1.0, 350.0, 0.0, self.uom_unit, self.exempt_0),
         ]
         tests.append(self._prepare_l10n_in_hsn_summary_test(
             base_lines2,
@@ -539,7 +540,7 @@ class TestHSNsummary(TestTaxCommon):
 
         # Put one IGST 18% to get a value on the IGST column.
         base_lines3 = [
-            self.create_base_line_dict(self.test_hsn_code_1, 1.0, 350.0, self.uom_unit, self.igst_18),
+            self.create_base_line_dict(self.test_hsn_code_1, 1.0, 350.0, 0.0, self.uom_unit, self.igst_18),
             base_lines2[1],
         ]
         tests.append(self._prepare_l10n_in_hsn_summary_test(
@@ -569,6 +570,38 @@ class TestHSNsummary(TestTaxCommon):
                         'uom_name': self.uom_unit.name,
                         'rate': 0.0,
                         'amount_untaxed': 350.0,
+                        'tax_amount_igst': 0.0,
+                        'tax_amount_cgst': 0.0,
+                        'tax_amount_sgst': 0.0,
+                        'tax_amount_cess': 0.0,
+                    },
+                ],
+            },
+        ))
+        self._assert_tests(tests)
+
+    def test_l10n_in_hsn_summary_5(self):
+        """ Line with discount """
+        tests = []
+        base_lines = [
+            self.create_base_line_dict(self.test_hsn_code_1, 1.0, 100.0, 10.0, self.uom_unit),
+        ]
+        tests.append(self._prepare_l10n_in_hsn_summary_test(
+            base_lines,
+            False,
+            {
+                'has_igst': False,
+                'has_gst': False,
+                'has_cess': False,
+                'nb_columns': 5,
+                'display_uom': False,
+                'items': [
+                    {
+                        'l10n_in_hsn_code': self.test_hsn_code_1,
+                        'quantity': 1.0,
+                        'uom_name': self.uom_unit.name,
+                        'rate': 0.0,
+                        'amount_untaxed': 90.0,
                         'tax_amount_igst': 0.0,
                         'tax_amount_cgst': 0.0,
                         'tax_amount_sgst': 0.0,


### PR DESCRIPTION
### Steps to reproduce:
- Install l10n_in module and switch to an Indian company
- Create a new customer invoice
- Add a line with a discount
- Click "Preview"
- In the document under HSN Summary the "Taxable Value" does not take the discount into account

### Cause:
To form the hsm_summary table, only the price_unit is given without taking the discount into account.

### Solution:
Instead of giving the price_unit, we can calculate the price_unit with discount.

opw-4045609
