### PR TITLE
[IMP] pos_restaurant: dropdown when selecting colors

### DIFF
--- a/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.js
+++ b/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.js
@@ -17,6 +17,8 @@ import { hasTouch } from "@web/core/browser/feature_detection";
 import { makeDraggableHook } from "@web/core/utils/draggable_hook_builder_owl";
 import { pick } from "@web/core/utils/objects";
 import { getOrderChanges } from "@point_of_sale/app/models/utils/order_change";
+import { Dropdown } from "@web/core/dropdown/dropdown";
+import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 export function constrain(num, min, max) {
     return Math.min(Math.max(num, min), max);
 }
@@ -53,6 +55,7 @@ const useDraggable = makeDraggableHook({
     onDrop: ({ ctx }) => pick(ctx.current, "element"),
 });
 export class FloorScreen extends Component {
+    static components = { Dropdown, DropdownItem };
     static template = "pos_restaurant.FloorScreen";
     static props = { floor: { type: true, optional: true } };
     static storeOnOrder = false;
@@ -851,6 +854,10 @@ export class FloorScreen extends Component {
     }
     async uploadImage(event) {
         const file = event.target.files[0];
+        if (!file) {
+            // Don't proceed if there are no selected files.
+            return;
+        }
         if (!file.type.match(/image.*/)) {
             this.dialog.add(AlertDialog, {
                 title: _t("Unsupported File Format"),

--- a/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.scss
+++ b/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.scss
@@ -23,17 +23,8 @@
     }
 }
 .floor-picture {
-    height: 48px;
-    width: 48px;
-    & > img {
-        position: absolute;
-        top: -9999px;
-        bottom: -9999px;
-        right: -9999px;
-        left: -9999px;
-        max-height: 64px;
-        margin: auto;
-    }
+    height: 50px;
+    width: 50px;
     .image-uploader {
         position: absolute;
         z-index: 1000;
@@ -44,4 +35,8 @@
         opacity: 0;
         cursor: pointer;
     }
+}
+
+.pos-dropdown-menu .dropdown-item.o-dropdown-item {
+    padding: 0px;
 }

--- a/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.xml
+++ b/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.xml
@@ -12,8 +12,32 @@
                     <i class="fa fa-circle-o" role="img" aria-label="MakeRound" title="Round Shape" />Shape</button>
                 <button t-attf-class="{{editButtonClass}}" t-else="" t-att-disabled="selectedTables.length == 0" t-on-click.stop="() => this.changeShape('square')">
                     <i class="fa fa-square-o" role="img" aria-label="MakeSquare" title="Square Shape" />Shape</button>
-                <button t-attf-class="{{editButtonClass}}" t-att-class="{active: state.isColorPicker}" t-on-click="() => this.state.isColorPicker = !this.state.isColorPicker">
-                    <i class="fa fa-paint-brush" role="img" aria-label="Tint" title="Tint" />Fill</button>
+                <t t-set="noSelectedTable" t-value="selectedTables.length === 0" />
+                <Dropdown menuClass="'pos-dropdown-menu px-1'">
+                    <button t-attf-class="{{editButtonClass}}" t-att-class="{active: state.isColorPicker}" t-on-click="() => this.state.isColorPicker = !this.state.isColorPicker">
+                        <i class="fa fa-paint-brush" role="img" aria-label="Tint" title="Tint" />
+                        Fill
+                    </button>
+                    <t t-set-slot="content">
+                        <div class="d-grid gap-1" style="grid-template-columns: repeat(3, 1fr);">
+                            <t t-foreach="Object.entries(getColors())" t-as="color" t-key="color[0]">
+                                <DropdownItem closingMode="'none'" onSelected="() => this.setColor(noSelectedTable ? this.getLighterShade(color[0]) : color[1])">
+                                    <button
+                                        class="p-4 border-1 rounded"
+                                        t-attf-style="background-color: {{noSelectedTable ? getLighterShade(color[0]) : color[1]}}"
+                                    />
+                                </DropdownItem>
+                            </t>
+                            <DropdownItem closingMode="'none'" t-if="noSelectedTable">
+                                <button class="floor-picture border-1 rounded position-relative text-center overflow-hidden d-flex flex-column align-items-center justify-content-center">
+                                    <i class="fa fa-camera" role="img" aria-label="Picture" title="Picture"></i>
+                                    File
+                                    <input type="file" class="image-uploader" t-on-change="uploadImage" />
+                                </button>
+                            </DropdownItem>
+                        </div>
+                    </t>
+                </Dropdown>
                 <button t-attf-class="{{editButtonClass}}" t-att-disabled="selectedTables.length > 1" t-on-click.stop="rename">
                     <i class="fa fa-pencil-square-o" role="img" aria-label="Rename" title="Rename" />Rename</button>
                 <button t-attf-class="{{editButtonClass}}" t-on-click.stop="duplicateTableOrFloor">
@@ -22,21 +46,6 @@
                     <i class="fa fa-trash" role="img" aria-label="Delete" title="Delete" />Delete</button>
                 <button t-attf-class="ms-auto {{editButtonClass}}" t-on-click.stop="closeEditMode">
                     <i class="fa fa-times" role="img" aria-label="Close" title="Close" />Close</button>
-            </div>
-            <div t-if="pos.isEditMode and state.isColorPicker" class="d-flex justify-content-center align-items-center bg-200">
-                <t t-set="lighter" t-value="selectedTables.length === 0" />
-                <button t-foreach="Object.entries(getColors())" t-as="color" t-key="color[0]" class="p-4 border-0"
-                    t-attf-style="background-color: {{lighter ? getLighterShade(color[0]) : color[1]}}" t-on-click.stop="() => this.setColor(lighter ? this.getLighterShade(color[0]) : color[1])" />
-                <div class="floor-picture position-relative text-center overflow-hidden d-flex flex-column align-items-center justify-content-center">
-                    <t t-if="activeFloor?.floor_background_image">
-                        <img t-att-src="floorBackround" style="width: 48px; height: 48px; object-fit: cover;" />
-                    </t>
-                    <t t-else="">
-                        <i class="fa fa-camera" role="img" aria-label="Picture" title="Picture"></i>
-                        File
-                    </t>
-                    <input type="file" class="image-uploader" t-on-change="uploadImage" />
-                </div>
             </div>
             <div class="floor-selector d-flex text-center bg-100 fs-3 w-100">
                 <t t-foreach="pos.models['restaurant.floor'].getAll()" t-as="floor" t-key="floor.id">


### PR DESCRIPTION
Previously, when the "Fill" button is clicked to change the color of a floor (or a table), a bar containing the color options is shown. In this commit, we are changing this to a dropdown menu to prevent the floor map from shifting down because of the original color palette bar.

Before:

<img width="570" alt="Screenshot 2024-07-17 at 13 29 32" src="https://github.com/user-attachments/assets/88d37746-15ba-4435-9865-1617db9ad59c">

After:

<img width="472" alt="Screenshot 2024-07-17 at 13 27 26" src="https://github.com/user-attachments/assets/d2f00afa-0712-41dc-a5d6-1d385958261c">
