### PR TITLE
[FIX] core: prevent ValueError when saving view

### DIFF
--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -304,7 +304,7 @@ def xml_translate(callback, value):
         root = parse_xml(value)
         result = translate_xml_node(root, callback, parse_xml, serialize_xml)
         return serialize_xml(result)
-    except etree.ParseError:
+    except (etree.ParseError, ValueError):
         # fallback for translated terms: use an HTML parser and wrap the term
         root = parse_html(u"<div>%s</div>" % value)
         result = translate_xml_node(root, callback, parse_xml, serialize_xml)


### PR DESCRIPTION
Currently, a ValueError occurs when the user adds an xml tag with encoding (e.g., `<?xml version="1.0" encoding="UTF-8"?>`) and trying to save it.

Error:  
```
ValueError: Unicode strings with encoding declaration are not supported. Please use bytes input or XML fragments without declaration.
  File "odoo/http.py", line 2248, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1823, in _serve_db
    return self._transactioning(_serve_ir_http, readonly=ro)
  File "odoo/http.py", line 1843, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1821, in _serve_ir_http
    return self._serve_ir_http(rule, args)
  File "odoo/http.py", line 1828, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2053, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 220, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 756, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 38, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 34, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 458, in call_kw
    result = getattr(recs, name)(*args, **kwargs)
  File "addons/web/models/models.py", line 71, in web_save
    self.write(vals)
  File "odoo/addons/base/models/ir_ui_view.py", line 518, in write
    res = super(View, self).write(self._compute_defaults(vals))
  File "odoo/models.py", line 4499, in write
    fields[0].determine_inverse(real_recs)
  File "odoo/fields.py", line 1452, in determine_inverse
    determine(self.inverse, records)
  File "odoo/fields.py", line 100, in determine
    return needle(*args)
  File "odoo/addons/base/models/ir_ui_view.py", line 280, in _inverse_arch_base
    view_wo_lang.arch = view.arch_base
  File "odoo/fields.py", line 1376, in __set__
    records.write({self.name: write_value})
  File "odoo/addons/base/models/ir_ui_view.py", line 518, in write
    res = super(View, self).write(self._compute_defaults(vals))
  File "odoo/models.py", line 4499, in write
    fields[0].determine_inverse(real_recs)
  File "odoo/fields.py", line 1452, in determine_inverse
    determine(self.inverse, records)
  File "odoo/fields.py", line 100, in determine
    return needle(*args)
  File "odoo/addons/base/models/ir_ui_view.py", line 262, in _inverse_arch
    view.write(data)
  File "odoo/addons/base/models/ir_ui_view.py", line 518, in write
    res = super(View, self).write(self._compute_defaults(vals))
  File "odoo/models.py", line 4467, in write
    field.write(self, value)
  File "odoo/fields.py", line 1876, in write
    cache_value = self.translate(lambda t: None, cache_value)
  File "odoo/tools/translate.py", line 355, in xml_translate
    root = parse_xml(value)
  File "odoo/tools/translate.py", line 288, in parse_xml
    return etree.fromstring(text)
  File "src/lxml/etree.pyx", line 3255, in lxml.etree.fromstring
  File "src/lxml/parser.pxi", line 1908, in lxml.etree._parseMemoryDocument
```

This commit handles the above issue by handling ValueError with an except block during the translate node.

sentry-5612156388


