### PR TITLE
[IMP] mrp, test_main_flows: simplify kanban archs

### DIFF
--- a/addons/mrp/static/tests/mrp_document_kanban.test.js
+++ b/addons/mrp/static/tests/mrp_document_kanban.test.js
@@ -18,10 +18,8 @@ describe.current.tags("desktop");
 defineMrpModels();
 
 const newArchs = {
-    "product.document,false,kanban": `<kanban js_class="product_documents_kanban" create="false"><templates><t t-name="kanban-box">
-                    <div>
-                        <field name="name"/>
-                    </div>
+    "product.document,false,kanban": `<kanban js_class="product_documents_kanban" create="false"><templates><t t-name="kanban-card">
+                    <field name="name"/>
                 </t></templates></kanban>`,
 };
 
@@ -76,17 +74,13 @@ test("mrp: click on image opens attachment viewer", async () => {
         "product.document,false,kanban": `
                 <kanban js_class="product_documents_kanban" create="false">
                     <templates>
-                        <t t-name="kanban-box">
-                            <div class="o_kanban_image" t-if="record.ir_attachment_id.raw_value">
-                                <div class="o_kanban_previewer">
-                                    <field name="ir_attachment_id" invisible="1"/>
-                                    <img t-attf-src="/web/image/#{record.ir_attachment_id.raw_value}" width="100" height="100" alt="Document" class="o_attachment_image"/>
-                                </div>
+                        <t t-name="kanban-card">
+                            <div class="o_kanban_previewer" t-if="record.ir_attachment_id.raw_value">
+                                <field name="ir_attachment_id" invisible="1"/>
+                                <img t-attf-src="/web/image/#{record.ir_attachment_id.raw_value}" width="100" height="100" alt="Document" class="o_attachment_image"/>
                             </div>
-                            <div>
-                                <field name="name"/>
-                                <field name="mimetype"/>
-                            </div>
+                            <field name="name"/>
+                            <field name="mimetype"/>
                         </t>
                     </templates>
                 </kanban>`,

--- a/addons/mrp/views/mrp_bom_views.xml
+++ b/addons/mrp/views/mrp_bom_views.xml
@@ -200,22 +200,15 @@
             <field name="model">mrp.bom</field>
             <field name="arch" type="xml">
                 <kanban class="o_kanban_mobile" sample="1">
-                    <field name="product_tmpl_id"/>
-                    <field name="product_qty"/>
-                    <field name="product_uom_id"/>
                     <templates>
-                        <t t-name="kanban-box">
-                            <div t-attf-class="oe_kanban_global_click">
-                                <div class="o_kanban_record_top">
-                                    <div class="o_kanban_record_headings mt4">
-                                        <strong class="o_kanban_record_title"><span class="mt4"><field name="product_tmpl_id"/></span></strong>
-                                    </div>
-                                    <span class="float-end badge rounded-pill"><t t-esc="record.product_qty.value"/> <small><t t-esc="record.product_uom_id.value"/></small></span>
-                                </div>
-                                <div class="o_kanban_record_bottom">
-                                    <field name="code"/>
-                                </div>
+                        <t t-name="kanban-card">
+                            <div>
+                                <field name="product_tmpl_id" class="fw-medium fs-5"/>
+                                <span class="float-end badge rounded-pill"><field name="product_qty"/> <field name="product_uom_id" class="small"/></span>
                             </div>
+                            <footer class="fs-6 pt-1">
+                                <field name="code"/>
+                            </footer>
                         </t>
                     </templates>
                 </kanban>

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -565,36 +565,26 @@
             <field name="model">mrp.production</field>
             <field name="arch" type="xml">
                 <kanban class="o_kanban_mobile" sample="1">
-                    <field name="name"/>
-                    <field name="product_id"/>
-                    <field name="product_qty"/>
-                    <field name="product_uom_id" options="{'no_open':True,'no_create':True}"/>
                     <field name="date_start"/>
                     <field name="state"/>
-                    <field name="activity_state"/>
                     <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}'/>
                     <templates>
-                        <t t-name="kanban-box">
-                            <div t-attf-class="oe_kanban_card oe_kanban_global_click">
-                                <div class="o_kanban_record_top">
-                                    <field name="priority" widget="priority"/>
-                                    <div class="o_kanban_record_headings ms-1">
-                                        <strong class="o_kanban_record_title"><span><t t-esc="record.product_id.value"/></span></strong>
-                                    </div>
-                                    <span class="float-end text-end"><t t-esc="record.product_qty.value"/> <small><t t-esc="record.product_uom_id.value"/></small></span>
-                                </div>
-                                <div class="o_kanban_record_bottom">
-                                    <div class="oe_kanban_bottom_left text-muted">
-                                        <span><t t-esc="record.name.value"/> <t t-esc="record.date_start.value and record.date_start.value.split(' ')[0] or False"/></span>
-                                        <field name="activity_ids" widget="kanban_activity"/>
-                                        <field name="delay_alert_date" invisible="1"/>
-                                        <field nolabel="1" name="json_popover" widget="stock_rescheduling_popover" invisible="not json_popover"/>
-                                    </div>
-                                    <div class="oe_kanban_bottom_right">
-                                        <span t-attf-class="badge #{['cancel'].indexOf(record.state.raw_value) > -1 ? 'text-bg-danger' : ['draft'].indexOf(record.state.raw_value) > -1 ? 'bg-200' : ['progress'].indexOf(record.state.raw_value) > -1 ? 'text-bg-warning' : ['done', 'to_close'].indexOf(record.state.raw_value) > -1 ? 'text-bg-success' : 'text-bg-primary'}"><t t-esc="record.state.value"/></span>
-                                    </div>
-                                </div>
+                        <t t-name="kanban-card">
+                            <div class="d-flex mb-1">
+                                <field name="priority" widget="priority"/>
+                                <field name="product_id" class="fw-bolder fs-6 ms-1"/>
+                                <field name="product_qty" class="ms-auto"/>
+                                <field name="product_uom_id" class="small ms-1"/>
                             </div>
+                            <footer class="fs-6 text-muted">
+                                <div class="d-flex">
+                                    <field name="name" class="me-1"/>
+                                    <field name="date_start" widget="datetime" options="{'show_time': false}"/>
+                                    <field name="activity_ids" widget="kanban_activity"/>
+                                </div>
+                                <field name="json_popover" widget="stock_rescheduling_popover" invisible="not json_popover"/>
+                                <span t-attf-class="ms-auto badge #{['cancel'].indexOf(record.state.raw_value) > -1 ? 'text-bg-danger' : ['draft'].indexOf(record.state.raw_value) > -1 ? 'bg-200' : ['progress'].indexOf(record.state.raw_value) > -1 ? 'text-bg-warning' : ['done', 'to_close'].indexOf(record.state.raw_value) > -1 ? 'text-bg-success' : 'text-bg-primary'}"><field name="state"/></span>
+                            </footer>
                         </t>
                     </templates>
                 </kanban>

--- a/addons/mrp/views/mrp_unbuild_views.xml
+++ b/addons/mrp/views/mrp_unbuild_views.xml
@@ -48,33 +48,17 @@
             <field name="model">mrp.unbuild</field>
             <field name="arch" type="xml">
                 <kanban class="o_kanban_mobile" sample="1">
-                    <field name="name"/>
-                    <field name="product_id"/>
-                    <field name="product_qty"/>
-                    <field name="product_uom_id"/>
-                    <field name="state"/>
-                    <field name="location_id"/>
-                    <field name="activity_state"/>
                     <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}'/>
                     <templates>
-                        <t t-name="kanban-box">
-                            <div t-attf-class="oe_kanban_global_click">
-                                <div class="o_kanban_record_top">
-                                    <div class="o_kanban_record_headings mt4">
-                                        <strong class="o_kanban_record_title"><span><field name="name"/></span></strong>
-                                    </div>
-                                    <strong><t t-esc="record.product_qty.value"/> <small><t t-esc="record.product_uom_id.value"/></small></strong>
-                                </div>
-                                <div class="row">
-                                    <div class="col-8 text-muted">
-                                        <span><t t-esc="record.product_id.value"/></span>
-                                    </div>
-                                    <div class="col-4">
-                                        <span class="float-end text-end">
-                                            <field name="state" widget="label_selection" options="{'classes': {'draft': 'default', 'done': 'success'}}" readonly="1"/>
-                                        </span>
-                                    </div>
-                                </div>
+                        <t t-name="kanban-card">
+                            <div class="d-flex fw-bold mb-1">
+                                <field name="name" class="fs-5"/>
+                                <field name="product_qty" class="ms-auto me-1 fs-6"/>
+                                <field name="product_uom_id" class="small"/>
+                            </div>
+                            <div class="d-flex text-muted">
+                                <field name="product_id"/>
+                                <field name="state" class="ms-auto" widget="label_selection" options="{'classes': {'draft': 'default', 'done': 'success'}}" readonly="1"/>
                             </div>
                         </t>
                     </templates>

--- a/addons/mrp/views/mrp_workcenter_views.xml
+++ b/addons/mrp/views/mrp_workcenter_views.xml
@@ -57,17 +57,9 @@
             <field name="arch" type="xml">
                 <kanban class="o_kanban_mobile">
                     <templates>
-                        <t t-name="kanban-box">
-                            <div t-attf-class="oe_kanban_content oe_kanban_global_click">
-                                <div class="row">
-                                    <div class="col-12">
-                                        <strong><field name="name"/></strong>
-                                    </div>
-                                    <div class="col-12" t-if="record.code.raw_value">
-                                        <span><field name="code"/></span>
-                                    </div>
-                                </div>
-                            </div>
+                        <t t-name="kanban-card">
+                            <field name="name" class="fw-bolder"/>
+                            <field t-if="record.code.raw_value" name="code"/>
                         </t>
                     </templates>
                 </kanban>
@@ -495,23 +487,17 @@
         <field name="model">mrp.workcenter.productivity.loss</field>
         <field name="arch" type="xml">
             <kanban>
-                <field name="name"/>
-                <field name="manual"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div t-attf-class="oe_kanban_global_click">
-                            <div>
-                                <strong>Reason: </strong><field name="name"/>
-                            </div>
-                            <div>
-                                <strong>Effectiveness Category: </strong><field name="loss_type"/>
-                            </div>
-                            <div>
-                                <strong>Is a Blocking Reason? </strong>
-                                <span class="float-end" title="Is a Blocking Reason?">
-                                    <field name="manual" widget="boolean"/>
-                                </span>
-                            </div>
+                    <t t-name="kanban-card">
+                        <div>
+                            <strong>Reason: </strong><field name="name"/>
+                        </div>
+                        <div>
+                            <strong>Effectiveness Category: </strong><field name="loss_type"/>
+                        </div>
+                        <div class="d-flex">
+                            <strong>Is a Blocking Reason? </strong>
+                            <field name="manual" class="ms-auto" widget="boolean"/>
                         </div>
                     </t>
                 </templates>

--- a/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
+++ b/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
@@ -998,7 +998,7 @@ stepUtils.autoExpandMoreButtons(),
 },
 {
     isActive: ["mobile"],
-    trigger: '.o_kanban_record .o_kanban_record_title:contains("the_flow.product"):first',
+    trigger: '.o_kanban_record:contains("the_flow.product"):first',
     content: _t('Select the generated manufacturing order'),
     tooltipPosition: 'bottom',
     run: "click",


### PR DESCRIPTION
In this commit we have simplified the kanban arch for the mrp module. The goal is to simplify them, make them easier to read, and use bootstrap utility classnames.
- Previously, we used `kanban-box`, but now we are using `kanban-card` instead.
- Deprecated `oe_kanban_global_click` and `oe_kanban_global_click_edit`.
- More use of `<field/>` tags
- Removed the `oe_kanban_colorpicker` class and replaced it with the `kanban_color_picker` widget.
- Changed type='edit' to type='open' to open records. since version 16, records always open in edit mode by default.
- `kanban_image` from rendering context, is deprecated so we use `<field name=... widget=image/>` instead

Task-3992107

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
