### PR TITLE
[FIX] pos_loyalty: exclude rewards with archived reward products

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/models/pos_store.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_store.js
@@ -183,7 +183,7 @@ patch(PosStore.prototype, {
             const points = order._getRealCouponPoints(couponProgram.coupon_id);
             const hasLine = order.orderlines.filter((line) => !line.is_reward_line).length > 0;
             for (const reward of program.rewards.filter(
-                (reward) => reward.reward_type == "product"
+                (reward) => reward.reward_type == "product" && reward.reward_product_ids.length > 0
             )) {
                 if (points < reward.required_points) {
                     continue;


### PR DESCRIPTION
Before this commit, rewards associated with archived products were still accessible, leading to errors when attempting to claim them due to the non-existence of the reward product.

opw-4055792

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
