### PR TITLE
[FIX] purchase_product_matrix: create only selected dynamic variants

### DIFF
--- a/addons/purchase_product_matrix/models/purchase.py
+++ b/addons/purchase_product_matrix/models/purchase.py
@@ -48,9 +48,7 @@ class PurchaseOrder(models.Model):
                 no_variant_attribute_values = combination - combination._without_no_variant_attributes()
 
                 # create or find product variant from combination
-                product = product_template._create_product_variant(combination)
-                # TODO replace the check on product_id by a first check on the ptavs and pnavs?
-                # and only create/require variant after no line has been found ???
+                product = product_template._create_product_variant(combination) if cell['qty'] else product_template._get_variant_for_combination(combination)
                 order_lines = self.order_line.filtered(lambda line: (line._origin or line).product_id == product and (line._origin or line).product_no_variant_attribute_value_ids == no_variant_attribute_values)
 
                 # if product variant already exist in order lines

--- a/addons/purchase_product_matrix/static/tests/tours/purchase_product_matrix_tour.js
+++ b/addons/purchase_product_matrix/static/tests/tours/purchase_product_matrix_tour.js
@@ -30,7 +30,9 @@ tour.register('purchase_matrix_tour', {
     trigger: '.o_product_variant_matrix',
     run: function () {
         // fill the whole matrix with 1's
-        $('.o_matrix_input').val(1);
+        // except 8th and last so one dynamic variant won't be created
+        $('.o_matrix_input').slice(0, 7).val(1);
+        $('.o_matrix_input').slice(8, 15).val(1);
     }
 }, {
     trigger: 'span:contains("Confirm")',
@@ -62,7 +64,7 @@ tour.register('purchase_matrix_tour', {
     trigger: '.o_product_variant_matrix',
     run: function () {
         // update some of the matrix values.
-        $('.o_matrix_input').slice(8, 16).val(4);
+        $('.o_matrix_input').slice(8, 15).val(4);
     } // set the qty to 4 for half of the matrix products.
 }, {
     trigger: 'span:contains("Confirm")',

--- a/addons/purchase_product_matrix/tests/test_purchase_matrix.py
+++ b/addons/purchase_product_matrix/tests/test_purchase_matrix.py
@@ -14,13 +14,13 @@ class TestPurchaseMatrixUi(TestMatrixCommon):
         # Ensures some dynamic create variants have been created by the matrix
         # Ensures a PO has been created with exactly x lines ...
 
-        self.assertEqual(len(self.matrix_template.product_variant_ids), 8)
+        self.assertEqual(len(self.matrix_template.product_variant_ids), 7)
         self.assertEqual(len(self.matrix_template.product_variant_ids.product_template_attribute_value_ids), 6)
         self.assertEqual(len(self.matrix_template.attribute_line_ids.product_template_value_ids), 8)
         self.env['purchase.order.line'].search([('product_id', 'in', self.matrix_template.product_variant_ids.ids)]).order_id.button_confirm()
 
         self.matrix_template.flush()
-        self.assertEqual(round(self.matrix_template.purchased_product_qty, 2), 56.8)
+        self.assertEqual(round(self.matrix_template.purchased_product_qty, 2), 51.8)
         for variant in self.matrix_template.product_variant_ids:
             # 5 and 9.2 because of no variant attributes
             self.assertIn(round(variant.purchased_product_qty, 2), [5, 9.2])


### PR DESCRIPTION
Steps to reproduce:
- Enable grid entry in purchase settings
- Create 2 attributes and set to dynamic creation
- Create a new product and add the attributes
- Use one of the variants in a purchase order

Bug:
all variants will be created not just the selected one like in sales

Fix:
only create the variants that have been selected

opw-3987284

