### PR TITLE
[FIX] microsoft_calendar: Query restructuring in util to improve perf

### DIFF
--- a/addons/microsoft_calendar/tests/test_microsoft_event.py
+++ b/addons/microsoft_calendar/tests/test_microsoft_event.py
@@ -1,3 +1,7 @@
+from datetime import datetime
+from dateutil.relativedelta import relativedelta
+from pytz import UTC
+
 from odoo.addons.microsoft_calendar.utils.microsoft_event import MicrosoftEvent
 from odoo.addons.microsoft_calendar.tests.common import TestCommon, patch_api
 
@@ -311,3 +315,94 @@ class TestMicrosoftEvent(TestCommon):
             event._events.update({'foo': 'bar'})
         with self.assertRaises(TypeError):
             dict.update(event._events, {'foo': 'bar'})
+
+    def test_performance_check(self):
+        # Test what happens when microsoft returns a lot of data
+        # This test does not aim to check what we do with the data but it ensure that we are able to process it.
+        # Other tests take care of how we update odoo records with the api result.
+
+        start_date = datetime(2023, 9, 25, 17, 25)
+        record_count = 10000
+        single_event_data = [{
+            '@odata.type': '#microsoft.graph.event',
+            '@odata.etag': f'W/"AAAAAA{x}"',
+            'type': 'singleInstance',
+            'createdDateTime': (start_date + relativedelta(minutes=x)).isoformat(),
+            'lastModifiedDateTime': (datetime.now().astimezone(UTC) + relativedelta(days=3)).isoformat(),
+            'changeKey': f'ZS2uEVAVyU6BMZ3m6cH{x}mtgAADI/Dig==',
+            'categories': [],
+            'originalStartTimeZone': 'Romance Standard Time',
+            'originalEndTimeZone': 'Romance Standard Time',
+            'id': f'AA{x}',
+            'subject': f"Subject of {x}",
+            'bodyPreview': f"Body of {x}",
+            'start': {'dateTime': (start_date + relativedelta(minutes=x)).isoformat(), 'timeZone': 'UTC'},
+            'end': {'dateTime': (start_date + relativedelta(minutes=x)).isoformat(), 'timeZone': 'UTC'},
+            'isOrganizer': True,
+            'organizer': {'emailAddress': {'name': f'outlook_{x}@outlook.com', 'address': f'outlook_{x}@outlook.com'}},
+        } for x in range(record_count)]
+
+        events = MicrosoftEvent(single_event_data)
+        mapped = events._load_odoo_ids_from_db(self.env)
+        self.assertFalse(mapped, "No odoo record should correspond to the microsoft values")
+
+        recurring_event_data = [{
+            '@odata.type': '#microsoft.graph.event',
+            '@odata.etag': f'W/"{x}IaZKQ=="',
+            'createdDateTime': (start_date + relativedelta(minutes=(2 * x))).isoformat(),
+            'lastModifiedDateTime': (datetime.now().astimezone(UTC) + relativedelta(days=3)).isoformat(),
+            'changeKey': 'ZS2uEVAVyU6BMZ3m6cHmtgAADIaZKQ==',
+            'categories': [],
+            'originalStartTimeZone': 'Romance Standard Time',
+            'originalEndTimeZone': 'Romance Standard Time',
+            'iCalUId': f'XX{x}',
+            'id': f'AAA{x}',
+            'reminderMinutesBeforeStart': 15,
+            'isReminderOn': True,
+            'hasAttachments': False,
+            'subject': f'My recurrent event {x}',
+            'bodyPreview': '', 'importance':
+            'normal', 'sensitivity': 'normal',
+            'isAllDay': False, 'isCancelled': False,
+            'isOrganizer': True, 'IsRoomRequested': False,
+            'AutoRoomBookingStatus': 'None',
+            'responseRequested': True,
+            'seriesMasterId': None,
+            'showAs': 'busy',
+            'type': 'seriesMaster',
+            'webLink': f'https://outlook.live.com/owa/?itemid={x}&exvsurl=1&path=/calendar/item',
+            'onlineMeetingUrl': None,
+            'isOnlineMeeting': False,
+            'onlineMeetingProvider': 'unknown', 'AllowNewTimeProposals': True,
+            'IsDraft': False,
+            'responseStatus': {'response': 'organizer', 'time': '0001-01-01T00:00:00Z'},
+            'body': {'contentType': 'html', 'content': ''},
+            'start': {'dateTime': '2020-05-03T14:30:00.0000000', 'timeZone': 'UTC'},
+            'end': {'dateTime': '2020-05-03T16:00:00.0000000', 'timeZone': 'UTC'},
+            'location': {'displayName': '',
+                         'locationType': 'default',
+                         'uniqueIdType': 'unknown',
+                         'address': {},
+                         'coordinates': {}},
+            'locations': [],
+            'recurrence': {'pattern':
+                               {'type': 'daily',
+                                'interval': 1,
+                                'month': 0,
+                                'dayOfMonth': 0,
+                                'firstDayOfWeek': 'sunday',
+                                'index': 'first'},
+                                'range': {'type': 'endDate',
+                                          'startDate': '2020-05-03',
+                                          'endDate': '2020-05-05',
+                                          'recurrenceTimeZone': 'Romance Standard Time',
+                                          'numberOfOccurrences': 0}
+                           },
+            'attendees': [],
+            'organizer': {'emailAddress': {'name': f'outlook_{x}@outlook.com',
+                                           'address': f'outlook_{x}@outlook.com'}}
+            } for x in range(record_count)]
+
+        recurrences = MicrosoftEvent(recurring_event_data)
+        mapped = recurrences._load_odoo_ids_from_db(self.env)
+        self.assertFalse(mapped, "No odoo record should correspond to the microsoft values")

--- a/addons/microsoft_calendar/utils/microsoft_event.py
+++ b/addons/microsoft_calendar/utils/microsoft_event.py
@@ -101,12 +101,27 @@ class MicrosoftEvent(abc.Set):
 
         unmapped_events = self.filter(lambda e: e.id not in mapped_events)
 
+        # Query events OR recurrences, get organizer_id and universal_id values by splitting microsoft_id.
         model_env = force_model if force_model is not None else self._get_model(env)
-        odoo_events = model_env.with_context(active_test=False).search([
-            '|',
-            ('ms_universal_event_id', "in", unmapped_events.uids),
-            ('ms_organizer_event_id', "in", unmapped_events.ids)
-        ]).with_env(env)
+        organiser_ids = tuple(str(v) for v in unmapped_events.ids if v) or ('NULL',)
+        universal_ids = tuple(str(v) for v in unmapped_events.uids if v) or ('NULL',)
+        model_env.flush(['microsoft_id'])
+        env.cr.execute(
+            """
+                SELECT id, organizer_id, universal_id
+                FROM (
+                        SELECT id,
+                                split_part(microsoft_id, ':', 1) AS organizer_id,
+                                split_part(microsoft_id, ':', 2) AS universal_id
+                            FROM %s
+                            WHERE microsoft_id IS NOT NULL) AS splitter
+                WHERE organizer_id IN %%s
+                OR universal_id IN %%s
+            """ % model_env._table, (organiser_ids, universal_ids))
+
+        res = env.cr.fetchall()
+        odoo_events_ids = [val[0] for val in res]
+        odoo_events = model_env.browse(odoo_events_ids)
 
         # 1. try to match unmapped events with Odoo events using their iCalUId
         unmapped_events_with_uids = unmapped_events.filter(lambda e: e.iCalUId)


### PR DESCRIPTION
When syncing microsoft calendar, a query is triggered to fetch the events from calendar. The query that fetches the records is unoptimized and results in very slow sql times.

```SELECT "calendar_event".id FROM "calendar_event" WHERE (((((([...]((((((((unaccent("calendar_event"."microsoft_id"::text) like unaccent('%:[....]')) OR (unaccent("calendar_event"."microsoft_id"::text) like unaccent('%:[.....]'))) OR [...]```

The query is refactored for better timing on large number of events.

Backport of this commit: https://github.com/odoo/odoo/commit/2b089ce43a6290865699c3b9167edc9eb9648a3d
Ticket: opw-4036935


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
