### PR TITLE
[FIX] web: reset property values after changing type

### DIFF
--- a/addons/web/static/src/views/fields/properties/properties_field.js
+++ b/addons/web/static/src/views/fields/properties/properties_field.js
@@ -15,6 +15,7 @@ import { reposition } from "@web/core/position_hook";
 import { archParseBoolean } from "@web/views/utils";
 import { pick } from "@web/core/utils/objects";
 import { useSortable } from "@web/core/utils/sortable_owl";
+import { useRecordObserver } from "@web/model/relational_model/utils";
 
 import { Component, useRef, useState, useEffect, onWillStart } from "@odoo/owl";
 
@@ -48,7 +49,13 @@ export class PropertiesField extends Component {
         });
         this.propertiesRef = useRef("properties");
 
-        this._saveInitialPropertiesValues();
+        let currentResId;
+        useRecordObserver((record) => {
+            if (currentResId !== record.resId) {
+                currentResId = record.resId;
+                this._saveInitialPropertiesValues();
+            }
+        });
 
         const field = this.props.record.fields[this.props.name];
         this.definitionRecordField = field.definition_record;

--- a/addons/web/static/tests/views/fields/properties_field_tests.js
+++ b/addons/web/static/tests/views/fields/properties_field_tests.js
@@ -377,9 +377,9 @@ QUnit.module("Fields", (hooks) => {
         assert.containsOnce(
             target,
             ".o_cp_action_menus span:contains(Add Properties)",
-            "Show Add Properties btn in cog menu",
+            "Show Add Properties btn in cog menu"
         );
-        const menuItems = target.querySelectorAll(".o_cp_action_menus span.o_menu_item")
+        const menuItems = target.querySelectorAll(".o_cp_action_menus span.o_menu_item");
         for (const item of menuItems) {
             if (item.textContent === "Add Properties") {
                 await click(item, null);
@@ -430,7 +430,7 @@ QUnit.module("Fields", (hooks) => {
         assert.containsOnce(
             target,
             ".o_cp_action_menus span:contains(Add Properties)",
-            "The add button must be in the cog menu",
+            "The add button must be in the cog menu"
         );
 
         const editButton = field.querySelectorAll(".o_field_property_open_popover");
@@ -2582,7 +2582,7 @@ QUnit.module("Fields", (hooks) => {
         assert.containsOnce(
             target,
             ".o_field_property_add button",
-            "The add button must be in the view",
+            "The add button must be in the view"
         );
     });
 
@@ -2599,7 +2599,7 @@ QUnit.module("Fields", (hooks) => {
             });
             await toggleActionMenu(target);
             assert.containsNone(target, ".o_cp_action_menus span:contains(Add Properties)");
-        },
+        }
     );
 
     QUnit.test("properties: onChange return new properties", async function (assert) {
@@ -2665,6 +2665,69 @@ QUnit.module("Fields", (hooks) => {
                 (el) => el.value
             ),
             ["Hello"]
+        );
+    });
+
+    QUnit.test("new property, change record, change property type", async (assert) => {
+        const records = serverData.models.partner.records;
+        records[0].properties = [];
+        records[1].properties = [];
+        async function mockRPC(route, { method, args }) {
+            if (["check_access_rights", "check_access_rule"].includes(method)) {
+                return true;
+            }
+            if (method === "web_save") {
+                if (args[0][0] === 1) {
+                    // On property creation in first record, add a copy with empty value in
+                    // second record
+                    records[1].properties.push({
+                        ...args[1].properties[0],
+                    });
+                    records[1].properties[0].value = "";
+                } else {
+                    // When changing type of second record's properties, also apply it to
+                    // first record and the property's value should be reset on name change
+                    records[0].properties[0].type = args[1].properties[0].type;
+                    if (records[0].properties[0].name !== args[1].properties[0].name) {
+                        records[0].properties[0].value = null;
+                    }
+                    records[0].properties[0].name = args[1].properties[0].name;
+                }
+            }
+        }
+
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            resId: 1,
+            resIds: [1, 2],
+            serverData,
+            arch: `
+                <form>
+                    <field name="company_id"/>
+                    <field name="properties"/>
+                </form>`,
+            mockRPC,
+            actionMenus: {},
+        });
+        // Add a new property
+        await toggleActionMenu(target);
+        await click(target, ".o_cp_action_menus span .fa-cogs");
+
+        await editInput(target, ".o_property_field .o_property_field_value input", "aze");
+        await click(target, ".o_pager_next");
+        assert.strictEqual(
+            target.querySelector(".o_property_field .o_property_field_value input").value,
+            ""
+        );
+        // Change second record's property type
+        await click(target, ".o_property_field:nth-child(1) .o_field_property_open_popover");
+        await changeType(target, "integer");
+
+        await click(target, ".o_pager_previous");
+        assert.strictEqual(
+            target.querySelector(".o_property_field .o_property_field_value input").value,
+            "0"
         );
     });
 });


### PR DESCRIPTION
This commit fixes an issue where the property values were not reset after creating a property, setting its value, using the pager to access another record and changing the property's type. When going back to the initial record, the old value would still be there and it could trigger a traceback depending on the type change (e.g. from string to integer).

The issue is fixed by using a record observer to trigger _saveInitialPropertiesValues on record id change in the properties field component. This allows to keep coherent values inside the initialValues and to generate a new property name properly when the property's definition changes. In case of a change in the property's name, the value of the property for all other records using it will be properly reset to default.

OPW-4015949
