### PR TITLE
[FIX] base: PNGs are converted to a WEB palette when downsized

### DIFF
--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -349,7 +349,10 @@ class IrAttachment(models.Model):
                     nw, nh = map(int, max_resolution.split('x'))
                     if w > nw or h > nh:
                         img = img.resize(nw, nh)
-                        quality = int(ICP('base.image_autoresize_quality', 80))
+                        if _subtype == 'jpeg':  # Do not affect PNGs color palette
+                            quality = int(ICP('base.image_autoresize_quality', 80))
+                        else:
+                            quality = 0
                         image_data = img.image_quality(quality=quality)
                         if is_raw:
                             values['raw'] = image_data


### PR DESCRIPTION
When uploading a png image ir_attachment, the image is not modified if its resolution is under the maximum 1920x1920. However, if the resolution is bigger, it both gets resized and is converted to a WEB palette, which visibly degrades the quality of the image.

A workaround for this is to resize the image locally to be max 1920 on either dimensions and then upload it, which effectively bypasses this special treatment.

Steps to reproduce:
- Go to the website app
- Add a Text - Image snippet
- Double click the image
- Upload a .png image of a resolution strictly greater than 1920 in either width or height

Old behavior: the png is visibly degraded
New behavior: the png is not visibly degraded

opw-3935533