### PR TITLE
[IMP] base: improve performances of commercial fields

### DIFF
--- a/doc/cla/corporate/phytocontrol-group.md
+++ b/doc/cla/corporate/phytocontrol-group.md
@@ -1,0 +1,15 @@
+France, 2024-07-17
+
+Phytocontrol Group agrees to the terms of the Odoo Corporate Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Benoît Fontaine benoitfontaine@phytocontrol.com https://github.com/benoit-phytocontrol
+
+List of contributors:
+
+Benoît Fontaine benoitfontaine@phytocontrol.com https://github.com/benoit-phytocontrol

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -607,15 +607,16 @@ class Partner(models.Model):
             self.write(sync_vals)
             self._commercial_sync_to_children()
 
-    def _commercial_sync_to_children(self):
+    def _commercial_sync_to_children(self, fields_to_sync=None):
         """ Handle sync of commercial fields to descendants """
         commercial_partner = self.commercial_partner_id
-        sync_vals = commercial_partner._update_fields_values(self._commercial_fields())
+        if fields_to_sync is None:
+            fields_to_sync = self._commercial_fields()
+        sync_vals = commercial_partner._update_fields_values(fields_to_sync)
         sync_children = self.child_ids.filtered(lambda c: not c.is_company)
         for child in sync_children:
-            child._commercial_sync_to_children()
+            child._commercial_sync_to_children(fields_to_sync)
         res = sync_children.write(sync_vals)
-        sync_children._compute_commercial_partner()
         return res
 
     def _fields_sync(self, values):
@@ -639,13 +640,8 @@ class Partner(models.Model):
             return
         # 2a. Commercial Fields: sync if commercial entity
         if self.commercial_partner_id == self:
-            commercial_fields = self._commercial_fields()
-            if any(field in values for field in commercial_fields):
-                self.sudo()._commercial_sync_to_children()
-        for child in self.child_ids.filtered(lambda c: not c.is_company):
-            if child.commercial_partner_id != self.commercial_partner_id:
-                self.sudo()._commercial_sync_to_children()
-                break
+            fields_to_sync = values.keys() & self._commercial_fields()
+            self.sudo()._commercial_sync_to_children(fields_to_sync)
         # 2b. Address fields: sync if address changed
         address_fields = self._address_fields()
         if any(field in values for field in address_fields):


### PR DESCRIPTION
This PR improve performances by reducing the number of SQL queries when writing a res.partner's commercial field.
    
Test case: write property_account_position_id on a partner with 10 children (tested with the code above)

Before this PR: 120 SQL queries
After this PR: 12 SQL queries

I tested on all versions 14.0 to 17.0:

  | Odoo 14.0 | Odoo 15.0 | Odoo 16.0 | Odoo 17.0
-- | -- | -- | -- | --
queries before this commit | 252 | 263 | 142 | 120
queries after this commit | 22 | 22 | 12 | 12


The difference is even greater if specific modules have added additional commercial fields

