### PR TITLE
Master imp tour recorder ipb

### DIFF
--- a/addons/web/static/lib/hoot-dom/helpers/dom.js
+++ b/addons/web/static/lib/hoot-dom/helpers/dom.js
@@ -920,7 +920,6 @@ export function cleanupDOM() {
     // Observers
     const remainingObservers = observers.size;
     if (remainingObservers) {
-        console.warn(`${remainingObservers} observers still running`);
         for (const { observer } of observers.values()) {
             observer.disconnect();
         }

--- a/addons/web_tour/static/src/tour_service/tour_interactive.js
+++ b/addons/web_tour/static/src/tour_service/tour_interactive.js
@@ -17,33 +17,6 @@ export class TourInteractive {
         this.currentAction;
         this.currentActionIndex;
         this.removeListeners = () => {};
-        this.observerOptions = {
-            attributes: true,
-            childList: true,
-            subtree: true,
-            characterData: true,
-        };
-        this.observer = new MutationObserver(() => {
-            if (this.currentAction) {
-                let tempAnchor = hoot.queryFirst(this.currentAction.anchor, { visible: true });
-                tempAnchor = tempAnchor && this.getAnchorEl(tempAnchor, this.currentAction.event);
-                if (
-                    (!this.anchorEl && tempAnchor) ||
-                    (this.anchorEl && tempAnchor && tempAnchor !== this.anchorEl)
-                ) {
-                    this.anchorEl = tempAnchor;
-                    this.removeListeners();
-                    this.setActionListeners();
-                } else if (!tempAnchor && this.anchorEl) {
-                    this.pointer.hide();
-                    this.anchorEl = tempAnchor;
-                    if (!hoot.queryFirst(".o_home_menu", { visible: true })) {
-                        this.backward();
-                    }
-                }
-                this.updatePointer();
-            }
-        });
     }
 
     /**
@@ -65,7 +38,7 @@ export class TourInteractive {
      */
     start(stepAt = 0) {
         this.pointer.start();
-        this.observer.observe(document.body, this.observerOptions);
+        this.observerDisconnect = hoot.observe(document.body, () => this._onMutation());
         this.currentActionIndex = stepAt;
         this.play();
     }
@@ -92,7 +65,7 @@ export class TourInteractive {
     play() {
         this.removeListeners();
         if (this.currentActionIndex === this.actions.length) {
-            this.observer.disconnect();
+            this.observerDisconnect();
             this.onTourEnd();
             return;
         }
@@ -383,5 +356,27 @@ export class TourInteractive {
             return el.closest(".ui-sortable, .o_sortable");
         }
         return el;
+    }
+
+    _onMutation() {
+        if (this.currentAction) {
+            let tempAnchor = hoot.queryFirst(this.currentAction.anchor, { visible: true });
+            tempAnchor = tempAnchor && this.getAnchorEl(tempAnchor, this.currentAction.event);
+            if (
+                (!this.anchorEl && tempAnchor) ||
+                (this.anchorEl && tempAnchor && tempAnchor !== this.anchorEl)
+            ) {
+                this.anchorEl = tempAnchor;
+                this.removeListeners();
+                this.setActionListeners();
+            } else if (!tempAnchor && this.anchorEl) {
+                this.pointer.hide();
+                this.anchorEl = tempAnchor;
+                if (!hoot.queryFirst(".o_home_menu", { visible: true })) {
+                    this.backward();
+                }
+            }
+            this.updatePointer();
+        }
     }
 }

--- a/addons/web_tour/static/src/tour_service/tour_service.js
+++ b/addons/web_tour/static/src/tour_service/tour_service.js
@@ -389,6 +389,7 @@ export const tourService = {
         return {
             bus,
             startTour,
+            resumeTour,
             getSortedTours,
         };
     },

--- a/addons/web_tour_recorder/static/src/tour_recorder/tour_recorder_service.js
+++ b/addons/web_tour_recorder/static/src/tour_recorder/tour_recorder_service.js
@@ -15,7 +15,7 @@ import { _t } from "@web/core/l10n/translation";
  */
 
 const CUSTOM_TOURS_LOCAL_STORAGE_KEY = "custom_tours";
-const CUSTOM_RUNNING_TOURS_LOCAL_STORAGE_KEY = "custom_running_tours";
+export const CUSTOM_RUNNING_TOURS_LOCAL_STORAGE_KEY = "custom_running_tours";
 export const TOUR_RECORDER_ACTIVE_LOCAL_STORAGE_KEY = "tour_recorder.active";
 
 export const tourRecorderService = {
@@ -104,6 +104,23 @@ export const tourRecorderService = {
                 );
             }
             tour_service.startTour(customTour.name, options);
+        }
+
+        if (!window.frameElement) {
+            // Resume running tours.
+            let runningCustomTour = browser.localStorage.getItem(
+                CUSTOM_RUNNING_TOURS_LOCAL_STORAGE_KEY
+            );
+            if (runningCustomTour) {
+                runningCustomTour = JSON.parse(runningCustomTour);
+                if (!registry.category("web_tour.tours").contains(runningCustomTour.name)) {
+                    registry.category("web_tour.tours").add(runningCustomTour.name, {
+                        ...runningCustomTour,
+                        steps: () => runningCustomTour.steps,
+                    });
+                }
+                tour_service.resumeTour(runningCustomTour.name);
+            }
         }
 
         return {


### PR DESCRIPTION
Before this commit, if running a custom tour in manual with an url, it would not start.
If you wanted to disable a custom tour with the "Disable Tour" debug menu item, it didn't work.

Selecting record in an autocomplete input through Enter or Tab was not recorded by the tour recorder.
Furthermore, is the focus was automatically in a field (like when we arrive on a form view) and that you start typing your text without clicking on this field before, the text would not be recorded.

After this commit, this behaviour are fixed. A manual tour with url can be started and disabled.
Pressing Enter or Tab to select an item in an autocomplete field will be recorder as a click on this item.
If you start typing in a text field before clicking on it (with an autofocus, for example), the text will be recorded.

Task-ID: 4058532
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
