### PR TITLE
[IMP] website_sale_wishlist: add wishlist to cart page

### DIFF
--- a/addons/website_sale/views/snippets/snippets.xml
+++ b/addons/website_sale/views/snippets/snippets.xml
@@ -366,7 +366,14 @@
             </we-row>
         </div>
         <!-- Checkout page  -->
-        <div data-selector="main:has(.oe_website_sale .o_wizard)" data-page-options="true" groups="website.group_website_designer" data-no-check="true" string="Checkout Pages">
+        <div
+            string="Checkout Pages"
+            name="o_wsale_checkout_pages"
+            data-selector="main:has(.oe_website_sale .o_wizard)"
+            data-page-options="true"
+            data-no-check="true"
+            groups="website.group_website_designer"
+        >
             <we-checkbox string="Extra Step"
                          data-customize-website-views="website_sale.extra_info"
                          data-no-preview="true"

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1911,7 +1911,7 @@
                         <t t-call="website_sale.cart_line_description_following_lines">
                             <t t-set="div_class" t-valuef="d-none d-md-block"/>
                         </t>
-                        <div>
+                        <div name="o_wsale_cart_line_button_container">
                             <a href='#'
                                class="js_delete_product d-none d-md-inline-block small"
                                aria-label="Remove from cart"

--- a/addons/website_sale_wishlist/views/snippets.xml
+++ b/addons/website_sale_wishlist/views/snippets.xml
@@ -23,6 +23,14 @@
             Wishlist
         </we-button>
     </xpath>
+    <div name="o_wsale_checkout_pages" position="inside">
+        <we-checkbox
+            string="Add to Wishlist"
+            data-customize-website-views="website_sale_wishlist.product_cart_lines"
+            data-no-preview="true"
+            data-reload="/"
+        />
+    </div>
 </template>
 
 </odoo>

--- a/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
+++ b/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
@@ -18,6 +18,31 @@
         </xpath>
     </template>
 
+    <template id="product_cart_lines" inherit_id="website_sale.cart_lines" active="True">
+        <div name="o_wsale_cart_line_button_container" position="inside">
+            <span class="d-none d-md-inline-block ms-1">
+                <a
+                    href="#"
+                    class="small o_add_wishlist js_delete_product px-2 border-start"
+                    t-att-data-product-template-id="line.product_id.product_tmpl_id.id"
+                    t-att-data-product-product-id="line.product_id.id"
+                    data-action="o_wishlist"
+                >
+                    Save for Later
+                </a>
+            </span>
+            <button
+                class="o_add_wishlist js_delete_product btn btn-light d-inline-block d-md-none"
+                t-att-data-product-template-id="line.product_id.product_tmpl_id.id"
+                t-att-data-product-product-id="line.product_id.id"
+                data-action="o_wishlist"
+                title="Wishlist"
+            >
+                <i class="fa fa-heart-o"/>
+            </button>
+        </div>
+    </template>
+
     <template id="product_add_to_wishlist" inherit_id="website_sale.product" name="Wishlist Button" priority="20">
         <xpath expr="//div[@id='product_option_block']" position="inside">
             <t t-nocache="The wishlist depends on the user and must not be shared with other users. The product come from the controller.">


### PR DESCRIPTION
**Prior this commit:**
- The cart page did not support save for later / add to wishlist option

**Post this commit:**
- Add to wishlist button is added to cart page.
- The button will appear only when toggled from Edit tab.
- On clicking, product will be removed from the cart and moved to the wishlist.
- The mobile view is updated accordingly showing only the icon for small screen.

**Affected version**-master
Task-3213424