### PR TITLE
[IMP] web: view: check prop type

### DIFF
--- a/addons/onboarding/static/tests/onboarding_banner_tests.js
+++ b/addons/onboarding/static/tests/onboarding_banner_tests.js
@@ -66,6 +66,9 @@ QUnit.module("Onboarding banner", (hooks) => {
             ...session,
             onboarding_to_display: ["animal"],
         });
+        patchWithCleanup(session.view_info, {
+            toy: { multi_record: true, display_name: "Toy", icon: "fab fa-android" },
+        });
 
         const mockRPC = (route) => {
             if (route === "/onboarding/animal") {
@@ -89,6 +92,9 @@ QUnit.module("Onboarding banner", (hooks) => {
 
     QUnit.test("OnboardingBanner does not fetch the banner when the route is not in the session", async (assert) => {
         assert.expect(2);
+        patchWithCleanup(session.view_info, {
+            toy: { multi_record: true, display_name: "Toy", icon: "fab fa-android" },
+        });
 
         const mockRPC = (route) => {
             if (route === "/onboarding/animal") {

--- a/addons/web/static/src/views/view.js
+++ b/addons/web/static/src/views/view.js
@@ -230,6 +230,10 @@ export class View extends Component {
     async loadView(props) {
         const type = props.type;
 
+        if (!session.view_info[type]) {
+            throw new Error(`Invalid view type: ${type}`);
+        }
+
         // determine views for which descriptions should be obtained
         let { viewId, searchViewId } = props;
 


### PR DESCRIPTION
With https://github.com/odoo/odoo/commit/2b46bfdf63b316ffb5fd57b57b3c6aa16c7d0ba6, the prop type of the View component can no longer be a js_class. Here we improve the validation of the prop type.