### PR TITLE
[IMP] core: build SQL with evaluated parameters

### DIFF
--- a/odoo/addons/base/tests/test_sql.py
+++ b/odoo/addons/base/tests/test_sql.py
@@ -54,11 +54,6 @@ class TestSQL(BaseCase):
         sql2 = SQL("SELECT id FROM table WHERE foo=%s", 421)
         self.assertNotEqual(sql1, sql2)
 
-    def test_sql_idempotence(self):
-        sql1 = SQL("SELECT id FROM table WHERE foo=%s AND bar=%s", 42, 'baz')
-        sql2 = SQL(sql1)
-        self.assertIs(sql1, sql2)
-
     def test_sql_unpacking(self):
         sql = SQL("SELECT id FROM table WHERE foo=%s AND bar=%s", 42, 'baz')
         string, params = sql


### PR DESCRIPTION
Implementation SQL that builds the outputs in the constructor so they are just returned as-is when accessed.
Creation by overwriting __init__ instead of __new__ is also a little bit faster for creation of these small objects and reference counting will free what is needed.

```python
from odoo.tools import SQL
def test(f):
    %timeit f()
    sql = f()
    %timeit [sql.code, sql.params]

test(lambda: SQL("hello world %s, %s", 4, "ok"))
# 1.67 μs ± 96.4 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
# 6 μs ± 1 μs per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
# after change
# 1.08 μs ± 64.7 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
# 273 ns ± 22.6 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

test(lambda: SQL("select * FROM %s WHERE %s", SQL.identifier("ok"), SQL('x > %s', 5)))
# 5.5 μs ± 918 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
# 8.95 μs ± 1.18 μs per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
# after change
# 5.2 μs ± 620 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
# 271 ns ± 27.2 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

test(lambda: SQL(",").join([SQL('ok'), *range(30), SQL("qbc%s", 5)]))
# 6.86 μs ± 451 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
# 21.1 μs ± 1.22 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
# after change
# 23.6 μs ± 297 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
# 269 ns ± 7.78 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

def complex_sql(size=20):
    if size > 0:
        return SQL("(%s, %s)", complex_sql(size - 1), complex_sql(size - 2))
    return SQL("res")
test(complex_sql)
# 25.5 ms ± 1.43 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
# 61.3 ms ± 1.53 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
# after change
# 61 ms ± 4.78 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
# 252 ns ± 18.5 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

```



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
