### PR TITLE
[FIX] Allow models None _order 

### DIFF
--- a/doc/cla/individual/mo7amed-3bdalla7.md
+++ b/doc/cla/individual/mo7amed-3bdalla7.md
@@ -1,0 +1,11 @@
+Egypt, 17/07/2024
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Mohamed Abdallah. mo7amed.3bdalla7@gmail.com https://github.com/mo7amed-3bdalla7

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -4637,13 +4637,14 @@ class BaseModel(metaclass=MetaModel):
 
         # flush the order fields
         order_spec = order or self._order
-        for order_part in order_spec.split(','):
-            order_field = order_part.split()[0]
-            field = self._fields.get(order_field)
-            if field is not None:
-                to_flush[self._name].add(order_field)
-                if field.relational:
-                    self.env[field.comodel_name]._flush_search([], seen=seen)
+        if order_spec:
+            for order_part in order_spec.split(','):
+                order_field = order_part.split()[0]
+                field = self._fields.get(order_field)
+                if field is not None:
+                    to_flush[self._name].add(order_field)
+                    if field.relational:
+                        self.env[field.comodel_name]._flush_search([], seen=seen)
 
         if self._active_name:
             to_flush[self._name].add(self._active_name)


### PR DESCRIPTION

Description of the issue/feature this PR addresses:
Sometimes adding _order to models with big-volume data causes slowness.

Current behavior before PR:
if we want to remove the default `id` order from any model by setting `self._order = None` is failing regarding the part updated in this PR.

Desired behavior after PR is merged:
Toggle the default order in the models.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
