### PR TITLE
[FIX] stock_picking_batch: update and create commands

### DIFF
--- a/addons/stock_picking_batch/models/stock_picking_batch.py
+++ b/addons/stock_picking_batch/models/stock_picking_batch.py
@@ -37,7 +37,7 @@ class StockPickingBatch(models.Model):
         'stock.move', string="Stock moves", compute='_compute_move_ids')
     move_line_ids = fields.One2many(
         'stock.move.line', string='Stock move lines',
-        compute='_compute_move_ids', inverse='_set_move_line_ids')
+        compute='_compute_move_line_ids', inverse='_set_move_line_ids')
     state = fields.Selection([
         ('draft', 'Draft'),
         ('in_progress', 'In progress'),
@@ -93,8 +93,12 @@ class StockPickingBatch(models.Model):
     def _compute_move_ids(self):
         for batch in self:
             batch.move_ids = batch.picking_ids.move_ids
-            batch.move_line_ids = batch.picking_ids.move_line_ids
             batch.show_check_availability = any(m.state not in ['assigned', 'cancel', 'done'] for m in batch.move_ids)
+
+    @api.depends('picking_ids', 'picking_ids.move_line_ids')
+    def _compute_move_line_ids(self):
+        for batch in self:
+            batch.move_line_ids = batch.picking_ids.move_line_ids
 
     @api.depends('state', 'move_ids', 'picking_type_id')
     def _compute_show_allocation(self):


### PR DESCRIPTION
Before this commit, when calling `_getSaveLineCommand` to get the save commands for the move lines, we do each line one by one, in the order where they were marked as to save, which means we can have an update command followed by a create command, itself followed by another update command for example.

In the module `stock_barcode_picking_batch`, we add the test `test_barcode_batch_scan_lots`. In this test, we got a situation where we will write on the batch a command like that:

```python
{
    'move_line_ids': [
        [UPDATE command],
        [CREATE command],
        [UPDATE command],
        [CREATE command],
        [CREATE command]
]}
```
The 2 first commands are for the move lines in the first batch's picking. The 3 last commands are for the move lines i the second batch's picking.

The issue is, the first CREATE command won't happen. The two move lines for the second picking will be created but the move line who should be created for the first commit will not.

It fails because the compute has a depends on himself. And it's recomputed on picking_ids that have a different cache than the batch. So the second UPDATE will trigger the compute that will rewrite the move_line_ids fields and cancel the first CREATE. So it means every CREATE commands before the last UPDATE will be ignored

Enterprise PR: odoo/enterprise#65182