### PR TITLE
[FIX] hr_expense: re-allow edition for approved expenses

### DIFF
--- a/addons/hr_expense/i18n/hr_expense.pot
+++ b/addons/hr_expense/i18n/hr_expense.pot
@@ -2377,6 +2377,14 @@ msgstr ""
 
 #. module: hr_expense
 #. odoo-python
+#: code:addons/hr_expense/models/hr_expense_sheet.py:0
+msgid ""
+"You do not have the rights to add or remove any expenses on an approved or "
+"paid expense report."
+msgstr ""
+
+#. module: hr_expense
+#. odoo-python
 #: code:addons/hr_expense/models/hr_expense.py:0
 msgid "You have no expense to report"
 msgstr ""

--- a/addons/hr_expense/models/hr_expense_sheet.py
+++ b/addons/hr_expense/models/hr_expense_sheet.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, Command, models, _
-from odoo.exceptions import UserError, ValidationError, RedirectWarning
+from odoo.exceptions import AccessError, UserError, ValidationError, RedirectWarning
 from odoo.tools.misc import clean_context
 
 
@@ -391,7 +391,7 @@ class HrExpenseSheet(models.Model):
         )
         is_approver = self.env.user.has_group('hr_expense.group_hr_expense_user')
         for sheet in self:
-            if sheet.state not in {'draft', 'submit'}:
+            if sheet.state not in {'draft', 'submit', 'approve'}:
                 # Not editable
                 sheet.is_editable = False
                 continue
@@ -470,11 +470,19 @@ class HrExpenseSheet(models.Model):
 
     def write(self, values):
         res = super().write(values)
+
+        user_is_accountant = self.env.user.has_group('account.group_account_user')
+        edit_lines = 'expense_line_ids' in values
+        edit_states = 'state' in values or 'approval_state' in values
+        # Forbids (un)linking expenses from an approved sheet if you're not an accountant
+        if edit_lines and not user_is_accountant and set(self.mapped('state')) - {'draft', 'submit'}:
+            raise AccessError(_("You do not have the rights to add or remove any expenses on an approved or paid expense report."))
+
         # Ensures there is no empty expense report in a state different from draft or cancel
-        if 'state' in values or 'expense_line_ids' in values or 'approval_state' in values:
+        if edit_states or edit_lines:
             for sheet in self.filtered(lambda sheet: not sheet.expense_line_ids):
                 if sheet.state in {'submit', 'approve', 'post', 'done'}:  # Empty expense report in a state different from draft or cancel
-                    if 'expense_line_ids' in values and not sheet.expense_line_ids:  # If you try to remove all expenses from the sheet
+                    if edit_lines and not sheet.expense_line_ids:  # If you try to remove all expenses from the sheet
                         raise UserError(_("You cannot remove all expenses from a submitted, approved or paid expense report."))
                     else:  # If you try to submit, approve, post or pay an empty sheet
                         raise UserError(_("This expense report is empty. You cannot submit or approve an empty expense report."))


### PR DESCRIPTION
[FIX] hr_expense: re-allow edition for approved expenses

Partial revert of f892800

Context:
In f892800, too many editing rights were restricted,
not allowing accountants to properly edit important fields
that are related to the linked `account.move`s.
As there is no automatic synchronization between the two models,
the data may be different, but they may want to edit it by hand
and there is no reason why we shouldn't disallow it.

After this commit:
We revert the readonly state & re-allow edition of expenses & their 
sheets that are approved, only restricting the (un)linking of expenses 
from a sheet to accountants. To avoid having an expense paid twice.