### PR TITLE
[FIX] stock: block type change of archived products

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -908,13 +908,13 @@ class ProductTemplate(models.Model):
             raise UserError(_('You still have some active reordering rules on this product. Please archive or delete them first.'))
         if any('type' in vals and vals['type'] != prod_tmpl.type for prod_tmpl in self):
             existing_done_move_lines = self.env['stock.move.line'].sudo().search([
-                ('product_id', 'in', self.mapped('product_variant_ids').ids),
+                ('product_id', 'in', self.with_context(active_test=False).mapped('product_variant_ids').ids),
                 ('state', '=', 'done'),
             ], limit=1)
             if existing_done_move_lines:
                 raise UserError(_("You can not change the type of a product that was already used."))
             existing_reserved_move_lines = self.env['stock.move.line'].search([
-                ('product_id', 'in', self.mapped('product_variant_ids').ids),
+                ('product_id', 'in', self.with_context(active_test=False).mapped('product_variant_ids').ids),
                 ('state', 'in', ['partially_available', 'assigned']),
             ])
             if existing_reserved_move_lines:

--- a/addons/stock/tests/test_product.py
+++ b/addons/stock/tests/test_product.py
@@ -367,3 +367,18 @@ class TestVirtualAvailable(TestStockCommon):
         self.assertEqual(product.sudo().with_context(
             allowed_company_ids=[company_a.id, company_b.id]
         ).qty_available, 3)
+
+    def test_change_product_type_archived_product(self):
+        self.picking_out.action_confirm()
+        self.picking_out.action_assign()
+        # At this point product_3 should have the quantity reserved
+        self.product_3.active = False
+
+        # Should not be possible to change the product type when quantities are reserved
+        with self.assertRaises(UserError):
+            self.product_3.write({'type': 'consu'})
+
+        # Should not be possible to change the product type when moves are done.
+        self.picking_out.button_validate()
+        with self.assertRaises(UserError):
+            self.product_3.write({'type': 'consu'})


### PR DESCRIPTION
Steps to reproduce:
- Create a storable product.
- Create a picking with it and validate.
- Try to change the product type to consumable. Not allowed because there is a move done.
- Archive the product.
- Try to change the product type. No user error is raised...

Excepted behaviour: It should not be possible to change the product type even if the product is archived, as it causes inconsistencies.

Task 4058450

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
