### PR TITLE
[FIX] pos_sale: handle AccessError when loading missing products

### DIFF
--- a/addons/pos_sale/static/src/app/order_management_screen/sale_order_management_screen/sale_order_management_screen.js
+++ b/addons/pos_sale/static/src/app/order_management_screen/sale_order_management_screen/sale_order_management_screen.js
@@ -166,9 +166,15 @@ export class SaleOrderManagementScreen extends Component {
                     cancelLabel: _t("No"),
                 });
                 if (confirmed) {
-                    await this.pos.data.ormWrite("product.product", product_to_add_in_pos, {
-                        available_in_pos: true,
-                    });
+                    try {
+                        await this.pos.data.ormWrite("product.product", product_to_add_in_pos, {
+                            available_in_pos: true,
+                        });
+                    } catch (e) {
+                        if (e.exceptionName !== "odoo.exceptions.AccessError") {
+                            throw e;
+                        }
+                    }
                     await this.pos.loadProducts([...product_to_add_in_pos]);
                 }
             }

--- a/addons/pos_sale/static/tests/tours/PosSaleTour.js
+++ b/addons/pos_sale/static/tests/tours/PosSaleTour.js
@@ -198,3 +198,17 @@ registry.category("web_tour.tours").add("PosQuotationSaving", {
             ProductScreen.controlButton("Park Order"),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("PosLoadOrder", {
+    test: true,
+    url: "/pos/ui",
+    steps: () =>
+        [
+            Dialog.confirm("Open session"),
+            ProductScreen.controlButton("Quotation/Order"),
+            ProductScreen.selectFirstOrder(),
+            Dialog.is({ title: "Products not available in POS" }),
+            Dialog.confirm("Yes"),
+            ProductScreen.selectedOrderlineHas("Product A", "1.00", "10.00"),
+        ].flat(),
+});

--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -540,3 +540,38 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
         self.env['pos.order'].create_from_ui([pos_order])
         self.assertEqual(sale_order.order_line[0].untaxed_amount_invoiced, 10, "Untaxed invoiced amount should be 10")
         self.assertEqual(sale_order.order_line[1].untaxed_amount_invoiced, 0, "Untaxed invoiced amount should be 0")
+
+    def test_pos_user_load_order(self):
+        product_a = self.env['product.product'].create({
+            'name': 'Product A',
+            'available_in_pos': False,
+            'type': 'product',
+            'lst_price': 10.0,
+            'taxes_id': [],
+        })
+
+        partner_test = self.env['res.partner'].create({'name': 'Test Partner'})
+
+        sale_order = self.env['sale.order'].create({
+            'partner_id': partner_test.id,
+            'order_line': [(0, 0, {
+                'product_id': product_a.id,
+                'name': product_a.name,
+                'product_uom_qty': 1,
+                'product_uom': product_a.uom_id.id,
+                'price_unit': product_a.lst_price,
+            })],
+        })
+        sale_order.action_confirm()
+
+        self.pos_user.write({
+            'groups_id': [
+                (4, self.env.ref('sales_team.group_sale_salesman_all_leads').id),
+            ]
+        })
+
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+
+        with self.assertLogs(level="WARNING") as log_catcher:
+            self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PosLoadOrder', login="pos_user")
+        self.assertEqual(len(log_catcher.output), 1)


### PR DESCRIPTION
Before this commit, attempting to load a sale order into the PoS with products not available in the PoS would fail if the user lacked write access to the product, preventing the sale order from being loaded.

opw-4057869

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
