### PR TITLE
[FIX] pos_loyalty: compute available rewards when using tags

### DIFF
--- a/addons/pos_loyalty/static/src/js/Loyalty.js
+++ b/addons/pos_loyalty/static/src/js/Loyalty.js
@@ -1463,8 +1463,14 @@ const PosLoyaltyOrder = (Order) => class PosLoyaltyOrder extends Order {
         let available = 0;
         let shouldCorrectRemainingPoints = false;
         for (const line of this.get_orderlines()) {
-            if (line.get_product().id === product.id) {
-                available += line.get_quantity();
+            if (reward.reward_product_ids.includes(product.id) && reward.reward_product_ids.includes(line.product.id)) {
+                if (this._get_reward_lines() == 0) {
+                    if (line.get_product().id === product.id) {
+                        available += line.get_quantity();
+                    }
+                } else {
+                    available += line.get_quantity();
+                }
             } else if (reward.reward_product_ids.includes(line.reward_product_id)) {
                 if (line.reward_id == reward.id ) {
                     remainingPoints += line.points_cost;

--- a/addons/pos_loyalty/static/src/tours/PosLoyaltyRewardButtonTour.js
+++ b/addons/pos_loyalty/static/src/tours/PosLoyaltyRewardButtonTour.js
@@ -203,3 +203,33 @@ ProductScreen.check.selectedOrderlineHas('Product B', '1.00', '50.00');
 PosLoyalty.check.orderTotalIs('40.00');
 
 Tour.register('PosLoyaltySpecificDiscountCategoryTour', { test: true, url: '/pos/web' }, getSteps());
+
+startSteps();
+ProductScreen.do.confirmOpeningPopup();
+ProductScreen.do.clickHomeCategory();
+
+ProductScreen.do.clickDisplayedProduct("Desk Organizer");
+ProductScreen.do.clickDisplayedProduct("Desk Organizer");
+PosLoyalty.check.isRewardButtonHighlighted(true);
+PosLoyalty.do.clickRewardButton();
+SelectionPopup.do.clickItem("product_a");
+PosLoyalty.check.hasRewardLine("Free Product", "-2", "1.00");
+PosLoyalty.check.isRewardButtonHighlighted(false);
+
+ProductScreen.do.clickDisplayedProduct("Desk Organizer");
+ProductScreen.do.clickDisplayedProduct("Desk Organizer");
+PosLoyalty.check.isRewardButtonHighlighted(true);
+PosLoyalty.do.clickRewardButton();
+SelectionPopup.do.clickItem("product_b");
+PosLoyalty.check.hasRewardLine("Free Product", "-5", "1.00");
+PosLoyalty.check.isRewardButtonHighlighted(false);
+
+ProductScreen.do.clickDisplayedProduct("Desk Organizer");
+ProductScreen.do.clickDisplayedProduct("Desk Organizer");
+PosLoyalty.check.isRewardButtonHighlighted(true);
+PosLoyalty.do.clickRewardButton();
+SelectionPopup.do.clickItem("product_b");
+PosLoyalty.check.hasRewardLine("Free Product", "-10", "2.00");
+PosLoyalty.check.isRewardButtonHighlighted(false);
+
+Tour.register("PosLoyaltyRewardProductTag", { test: true, url: "/pos/web" }, getSteps());


### PR DESCRIPTION
Currently, when a loyalty program has a reward of type product and uses `reward_product_tag_id` (set up for at least 2 products), the addition of rewards to the pos order will have mismatched reward lines when adding the second free product (the first product needed to be added first).

Steps to reproduce:
-------------------
* Go to **Point of Sale** App
* Go to **Products** and add a tag (the same) for two products
* Under **Products** select `Discount & Loyalty`
* Create a new program of type **Buy X Get Y**
* Rule:
  * Min qty: 2 products $0.00
  * Among Products: Put all chairs products for example
* Reward:
  * Type: Free Product
  * Product: None
  * Product tag: The tag put on the products previously
* Open shop session
* Add 2 chairs
* Select reward, add the first one
> Everything ok until now
* Add 2 chairs
* Select reward, add the second one
> Observation: Reward computation is wrong we have the following lines:
  ```
  4 Chairs,
  Reward 1,
  Reward 2,
  Free product reward 1
  ```
  > We are missing the free product line related to the second product added and the button to select reward is still highlighted.

Why the fix:
------------
To explain this fix I will use the example given above.

Here are the steps that have been executed already
* Add 2 chairs
* Add the first reward product
* Add 2 chairs

We are currently in the middle of the step "Add second reward product". During that process, we end up in the function `_computeUnclaimedFreeProductQty` while computing values for the reward line. At this very moment in time, the order has the following lines:
* 4 Chairs
* Product 1
* Free product (related to Product 1)
* Product 2 

Where Product 1 and Product 2 are the reward products, having the same tag.

Let's focus on this piece of code, with the current example: https://github.com/odoo/odoo/blob/76023820c4d725c81677d2bf3e010c8cee1edd19/addons/pos_loyalty/static/src/js/Loyalty.js#L1464-L1475

Where `product` in this case is `Product 2`. What is happening here at the end is that we have `available = 1` because of line 4 and `claimed = 1` because of line 3. The program considers that we have already claimed the quantity and is the reason why it is not adding the reward line.

The first idea to fix this issue was to write the condition:
```js
if (reward.reward_product_ids.includes(product.id) && reward.reward_product_ids.includes(line.product.id)) {
```

instead of this one
```js
if (line.get_product().id === product.id) {
```

Now both line 2 and 4 are counted toward the `available` quantity. This way the code knows that we have two availaible free product but only 1 was claimed.

While this fixed the original issue, a new issue was created. Now, when we add the second product, the two reward lines were grouped together, using the price of the first free product added. Why was this happening?

Well, once the fist call to the function `_computeUnclaimedFreeProductQty` was done and the reward line was added we had the following order (temporarily)
* 4 Chairs
* Product 1
* Free product (related to Product 1)
* Product 2
* Free product (related to Product 2)

Which is what we expect but we face an issue when the loyalty programs are updated. When the programs update, we go through the function `_updateRewardLines`. In this function we discard the reward lines from the order and then for each claimed reward (Product 1 and Product 2) we re-apply the reward.

While applying the reward for Product 1, we again go through the function `_computeUnclaimedFreeProductQty`. In this case, the order looks like this:
* 4 Chairs
* Product 1
* Product 2

and the function will say that there are 2 available free product and 0 claimed. Were it is technically true, in this case we want to have the available quantity to 1. We want the initial condition:
```js
if (line.get_product().id === product.id) {
```

In the second passage, for product 2, we have `available = 2` and `claimed = 2`.

opw-3587020