### PR TITLE
[IMP] stock, mrp: Flexible rules

### DIFF
--- a/addons/purchase_stock/models/purchase_order.py
+++ b/addons/purchase_stock/models/purchase_order.py
@@ -228,7 +228,7 @@ class PurchaseOrder(models.Model):
 
     def _get_destination_location(self):
         self.ensure_one()
-        if self.dest_address_id:
+        if self.dest_address_id and self.picking_type_id.code == "dropship":
             return self.dest_address_id.property_stock_customer.id
         return self.picking_type_id.default_location_dest_id.id
 

--- a/addons/sale_mrp/models/__init__.py
+++ b/addons/sale_mrp/models/__init__.py
@@ -6,4 +6,5 @@ from . import mrp_production
 from . import sale_order
 from . import sale_order_line
 from . import stock_move
+from . import stock_rule
 from . import mrp_bom

--- a/addons/sale_mrp/models/mrp_production.py
+++ b/addons/sale_mrp/models/mrp_production.py
@@ -11,15 +11,16 @@ class MrpProduction(models.Model):
         "Count of Source SO",
         compute='_compute_sale_order_count',
         groups='sales_team.group_sale_salesman')
+    sale_line_id = fields.Many2one('sale.order.line', 'Origin sale order line')
 
     @api.depends('procurement_group_id.mrp_production_ids.move_dest_ids.group_id.sale_id')
     def _compute_sale_order_count(self):
         for production in self:
-            production.sale_order_count = len(production.procurement_group_id.mrp_production_ids.move_dest_ids.group_id.sale_id)
+            production.sale_order_count = len(production.procurement_group_id.mrp_production_ids.move_dest_ids.group_id.sale_id | production.sale_line_id.order_id)
 
     def action_view_sale_orders(self):
         self.ensure_one()
-        sale_order_ids = self.procurement_group_id.mrp_production_ids.move_dest_ids.group_id.sale_id.ids
+        sale_order_ids = self.procurement_group_id.mrp_production_ids.move_dest_ids.group_id.sale_id.ids + self.sale_line_id.order_id.ids
         action = {
             'res_model': 'sale.order',
             'type': 'ir.actions.act_window',
@@ -36,3 +37,12 @@ class MrpProduction(models.Model):
                 'view_mode': 'tree,form',
             })
         return action
+
+    def action_confirm(self):
+        res = super().action_confirm()
+        for production in self:
+            if production.sale_line_id:
+                production.move_finished_ids.filtered(
+                    lambda m: m.product_id == production.product_id
+                ).sale_line_id = production.sale_line_id
+        return res

--- a/addons/sale_mrp/models/sale_order.py
+++ b/addons/sale_mrp/models/sale_order.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from collections import defaultdict
 from odoo import api, fields, models, _
 
 
@@ -20,11 +21,14 @@ class SaleOrder(models.Model):
     @api.depends('procurement_group_id.stock_move_ids.created_production_id.procurement_group_id.mrp_production_ids')
     def _compute_mrp_production_ids(self):
         data = self.env['procurement.group']._read_group([('sale_id', 'in', self.ids)], ['sale_id'], ['id:recordset'])
-        mrp_productions = {}
+        production_order_by_sale_line = self.env['mrp.production']._read_group([('sale_line_id', 'in', self.order_line.ids)], ['sale_line_id'], ['id:recordset'])
+        mrp_productions = defaultdict(self.env['mrp.production'].browse)
         for sale, procurement_groups in data:
-            mrp_productions[sale.id] = procurement_groups.stock_move_ids.created_production_id.procurement_group_id.mrp_production_ids | procurement_groups.mrp_production_ids
+            mrp_productions[sale.id] |= procurement_groups.stock_move_ids.created_production_id.procurement_group_id.mrp_production_ids | procurement_groups.mrp_production_ids
+        for sale_line, production_id in production_order_by_sale_line:
+            mrp_productions[sale_line.order_id.id] |= production_id
         for sale in self:
-            mrp_production_ids = mrp_productions.get(sale.id, self.env['mrp.production'])
+            mrp_production_ids = mrp_productions[sale.id]
             sale.mrp_production_count = len(mrp_production_ids)
             sale.mrp_production_ids = mrp_production_ids
 

--- a/addons/sale_mrp/models/stock_rule.py
+++ b/addons/sale_mrp/models/stock_rule.py
@@ -1,0 +1,11 @@
+from odoo import models
+
+
+class StockRule(models.Model):
+    _inherit = 'stock.rule'
+
+    def _prepare_mo_vals(self, product_id, product_qty, product_uom, location_dest_id, name, origin, company_id, values, bom):
+        res = super()._prepare_mo_vals(product_id, product_qty, product_uom, location_dest_id, name, origin, company_id, values, bom)
+        if values.get('sale_line_id'):
+            res['sale_line_id'] = values['sale_line_id']
+        return res

--- a/addons/sale_purchase_stock/models/purchase_order.py
+++ b/addons/sale_purchase_stock/models/purchase_order.py
@@ -13,3 +13,25 @@ class PurchaseOrder(models.Model):
 
     def _get_sale_orders(self):
         return super(PurchaseOrder, self)._get_sale_orders() | self.order_line.move_dest_ids.group_id.sale_id | self.order_line.move_ids.move_dest_ids.group_id.sale_id
+
+
+class PurchaseOrderLine(models.Model):
+    _inherit = 'purchase.order.line'
+
+    def _prepare_stock_moves(self, picking):
+        res = super()._prepare_stock_moves(picking)
+        for re in res:
+            re['sale_line_id'] = self.sale_line_id.id
+        return res
+
+    def _find_candidate(self, product_id, product_qty, product_uom, location_id, name, origin, company_id, values):
+        # if this is defined, this is a dropshipping line, so no
+        # this is to correctly map delivered quantities to the so lines
+        lines = self.filtered(lambda po_line: po_line.sale_line_id.id == values['sale_line_id']) if values.get('sale_line_id') else self
+        return super(PurchaseOrderLine, lines)._find_candidate(product_id, product_qty, product_uom, location_id, name, origin, company_id, values)
+
+    @api.model
+    def _prepare_purchase_order_line_from_procurement(self, product_id, product_qty, product_uom, location_dest_id, name, origin, company_id, values, po):
+        res = super()._prepare_purchase_order_line_from_procurement(product_id, product_qty, product_uom, location_dest_id, name, origin, company_id, values, po)
+        res['sale_line_id'] = values.get('sale_line_id', False)
+        return res

--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -102,6 +102,7 @@ class StockRule(models.Model):
         help="The 'Manual Operation' value will create a stock move after the current one. "
              "With 'Automatic No Step Added', the location is replaced in the original move.")
     rule_message = fields.Html(compute='_compute_action_message')
+    push_domain = fields.Char('Push Applicability')
 
     def copy_data(self, default=None):
         default = dict(default or {})

--- a/addons/stock/views/stock_rule_views.xml
+++ b/addons/stock/views/stock_rule_views.xml
@@ -52,6 +52,7 @@
                     <field name="location_dest_id" options="{'no_create': True}"/>
                     <field name="route_id"/>
                     <field name="company_id" groups="base.group_multi_company"/>
+                    <field name="name" optional="hide"/>
                 </tree>
             </field>
         </record>
@@ -109,6 +110,7 @@
                                 <div><field name="delay" class="oe_inline"/> days</div>
                             </group>
                         </group>
+                        <field name="push_domain" invisible="action not in ['push', 'pull_push']" widget="domain" options="{'model': 'stock.move'}"/>
                     </sheet>
                 </form>
             </field>

--- a/addons/stock_dropshipping/models/purchase.py
+++ b/addons/stock_dropshipping/models/purchase.py
@@ -22,25 +22,3 @@ class PurchaseOrder(models.Model):
 
     def action_view_dropship(self):
         return self._get_action_view_picking(self.picking_ids.filtered(lambda p: p.is_dropship))
-
-
-class PurchaseOrderLine(models.Model):
-    _inherit = 'purchase.order.line'
-
-    def _prepare_stock_moves(self, picking):
-        res = super(PurchaseOrderLine, self)._prepare_stock_moves(picking)
-        for re in res:
-            re['sale_line_id'] = self.sale_line_id.id
-        return res
-
-    def _find_candidate(self, product_id, product_qty, product_uom, location_id, name, origin, company_id, values):
-        # if this is defined, this is a dropshipping line, so no
-        # this is to correctly map delivered quantities to the so lines
-        lines = self.filtered(lambda po_line: po_line.sale_line_id.id == values['sale_line_id']) if values.get('sale_line_id') else self
-        return super(PurchaseOrderLine, lines)._find_candidate(product_id, product_qty, product_uom, location_id, name, origin, company_id, values)
-
-    @api.model
-    def _prepare_purchase_order_line_from_procurement(self, product_id, product_qty, product_uom, location_dest_id, name, origin, company_id, values, po):
-        res = super()._prepare_purchase_order_line_from_procurement(product_id, product_qty, product_uom, location_dest_id, name, origin, company_id, values, po)
-        res['sale_line_id'] = values.get('sale_line_id', False)
-        return res


### PR DESCRIPTION
Add a create draft option on manufacturing order rule. The purpose is to delay the propagation until the user now perfectly the place where he will produce the goods. In draft he can switch the picking type, it will update the location and at confirmation the rules will be base on the new location

Add a sale order line id on purchase order for the config in MTO and everything in push. This way, the SO triggers the RFQ. The user could update the picking type to deliver to another warehouse and it will keep the link to the SO in order to update it when it's delivered.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
