### PR TITLE
[IMP] html_editor: introduce embedded states for editor components

### DIFF
--- a/addons/html_editor/static/src/others/embedded_component_utils.js
+++ b/addons/html_editor/static/src/others/embedded_component_utils.js
@@ -1,4 +1,47 @@
-import { onMounted, onPatched, useRef } from "@odoo/owl";
+import {
+    onMounted,
+    onPatched,
+    onWillDestroy,
+    reactive,
+    toRaw,
+    useComponent,
+    useRef,
+    useState,
+} from "@odoo/owl";
+
+/**
+ * @typedef {HTMLElement} HostElement host element for an embedded component
+ * @typedef {Object} State state obtained from `useState` usage
+ * @typedef {Record<string, HTMLElement>} EditableDescendants
+ * @typedef {(state, previous, next) => void} PropertyUpdate function applying
+ *          a state change which can be computed from `previous` and `next`
+ *          to `state`.
+ * @typedef {Record<string, PropertyUpdate>} PropertyUpdater
+ *
+ * @typedef {Object} StateChangeManagerConfig
+ * @property {PropertyUpdater} [propertyUpdater] object mapping a key of the
+ *        state to a function which will compute how values from a stateChange
+ *        are applied to the current state. Defined in the embedding definition
+ *        of a component.
+ * @property {function(HostElement):State} [getEmbeddedState]
+ *        custom function to get the first embedded state (the one used during
+ *        setup), in case not all embedded props should be part of the state, or
+ *        if more properties should be added to it.
+ * @property {function(HostElement, State):Object} [stateToEmbeddedProps]
+ *        custom function to compute the props, i.e. in case the entire state
+ *        should not be converted to props.
+ *
+ * @typedef {Object} Embedding object provided to the instance which mounts
+ *          Embedded components (EmbeddedComponentPlugin, HtmlViewer, ...)
+ * @property {String} name
+ * @property {Component} Component
+ * @property {function(HostElement):Object} getProps props for the given
+ *           Component class instance.
+ * @property {function(HostElement):EditableDescendants} [getEditableDescendants]
+ *           @see useEditableDescendants
+ * @property {function(StateChangeManagerConfig):StateChangeManager} [getStateChangeManager]
+ *           @see useEmbeddedState
+ */
 
 /**
  * Get all element children with `data-embedded-editable` attribute which are
@@ -6,8 +49,8 @@ import { onMounted, onPatched, useRef } from "@odoo/owl";
  * embedded component descendant (an embedded component can contain others).
  * If multiple elements have the same `data-embedded-editable`, only the last
  * one is considered.
- * @param {HTMLElement} host
- * @returns {Object} editableDescendants
+ * @param {HostElement} host
+ * @returns {EditableDescendants} editableDescendants
  */
 export function getEditableDescendants(host) {
     const editableDescendants = {};
@@ -20,7 +63,7 @@ export function getEditableDescendants(host) {
 }
 
 /**
- * Handle the rendering of an editableDescendants:
+ * Handle the rendering of editableDescendants:
  * It is a node owned by the editor, which will be inserted under a ref of
  * the same name as the attribute `data-embedded-editable` of that node, in the
  * component's template. This allows to use editor features inside an embedded
@@ -31,10 +74,18 @@ export function getEditableDescendants(host) {
  * available at all times no matter the component state to guarantee that the
  * editor can save their values at any given time, synchronously.
  *
- * @param {HTMLElement} host for the embedded component
+ * @param {HostElement} host
+ * @returns {EditableDescendants} (HTMLElement) by the value of their
+ *          `data-embedded-editable` attribute.
  */
 export function useEditableDescendants(host) {
-    const editableDescendants = Object.freeze(getEditableDescendants(host));
+    const component = useComponent();
+    if (!component.env.getEditableDescendants) {
+        throw new Error(
+            "Missing `getEditableDescendants` function in the `embedding` provided to the `EmbeddedComponentPlugin`."
+        );
+    }
+    const editableDescendants = Object.freeze(component.env.getEditableDescendants(host));
     const refs = {};
     const renders = {};
     for (const name of Object.keys(editableDescendants)) {
@@ -55,4 +106,483 @@ export function useEditableDescendants(host) {
         }
     });
     return editableDescendants;
+}
+
+/**
+ * Create a ProxyHandler to manage a serializable "buffer" (Proxy target) for
+ * changes. The buffer must be a @see reactive which should update state
+ * with its callback (commit).
+ * @see useEmbeddedState
+ * The Proxy target and state must be serializable through JSON.stringify.
+ *
+ * @param {Object} state
+ * @param {Object} stateChangeManager
+ * @param {Object} stateChangeManager.previousEmbeddedState null, or a deep copy
+ *        of the target used as a reference point for comparison
+ *        (before <-> after) so that multiple synchronous changes can be handled
+ *        at once.
+ * @returns {ProxyHandler}
+ */
+function embeddedStateProxyHandler(state, stateChangeManager) {
+    return {
+        // Write operations are always done on the target ("buffer").
+        // During the first write operation before a commit, keep a deep copy of
+        // the target through serialization, which will be used as a reference
+        // point for a comparison (before <-> after).
+        set(target, key, value, receiver) {
+            if (!stateChangeManager.previousEmbeddedState) {
+                stateChangeManager.previousEmbeddedState = JSON.parse(
+                    JSON.stringify(stateChangeManager.embeddedState)
+                );
+            }
+            return Reflect.set(target, key, value, receiver);
+        },
+        deleteProperty(target, key) {
+            if (!stateChangeManager.previousEmbeddedState) {
+                stateChangeManager.previousEmbeddedState = JSON.parse(
+                    JSON.stringify(stateChangeManager.embeddedState)
+                );
+            }
+            return Reflect.deleteProperty(target, key);
+        },
+        // Read operations should also be done on state to register the
+        // rendering callback.
+        get(target, key, receiver) {
+            Reflect.get(state, key, state);
+            return Reflect.get(target, key, receiver);
+        },
+        ownKeys(target) {
+            Reflect.ownKeys(state);
+            return Reflect.ownKeys(target);
+        },
+        has(target, key) {
+            Reflect.has(state, key);
+            return Reflect.has(target, key);
+        },
+    };
+}
+
+function observeAllKeys(reactive) {
+    for (const key in reactive) {
+        const prop = reactive[key];
+        if (prop instanceof Object) {
+            observeAllKeys(prop);
+        }
+    }
+}
+
+/**
+ * Extract props serialized in `data-embedded-props` attribute.
+ *
+ * @param {HostElement} host
+ * @returns {Object} props
+ */
+export function getEmbeddedProps(host) {
+    return host.dataset.embeddedProps ? JSON.parse(host.dataset.embeddedProps) : {};
+}
+
+function sortedCopy(obj) {
+    const result = {};
+    const propNames = Object.keys(obj).sort();
+    for (const propName of propNames) {
+        result[propName] = obj[propName];
+    }
+    return result;
+}
+
+/**
+ * Compute the difference between next and previous, and apply that difference
+ * to container[key]. Comparison is done through JSON.stringify, so all values
+ * must be serializable.
+ *
+ * @param {Object} container
+ * @param {string} key
+ * @param {Object} previous
+ * @param {Object} next
+ */
+export function applyObjectPropertyDifference(container, key, previous, next) {
+    if (!container[key]) {
+        container[key] = {};
+    }
+    const obj1 = { ...(previous || {}) };
+    const obj2 = { ...(next || {}) };
+    const dest = container[key];
+    for (const key in obj2) {
+        if (JSON.stringify(obj1[key]) !== JSON.stringify(obj2[key])) {
+            dest[key] = obj2[key];
+        }
+        delete obj1[key];
+    }
+    for (const key in obj1) {
+        delete dest[key];
+    }
+    if (!Object.keys(dest).length && !next) {
+        delete container[key];
+    }
+}
+
+/**
+ * Overwrite container[key] with value.
+ *
+ * @param {Object} container
+ * @param {string} key
+ * @param {Object} value
+ */
+export function replaceProperty(container, key, value) {
+    if (value === undefined) {
+        delete container[key];
+    } else {
+        container[key] = value;
+    }
+}
+
+export class StateChangeManager {
+    /**
+     * @param {StateChangeManagerConfig} config
+     * @param {HostElement} config.host
+     * @param {Function} config.dispatch plugin dispatch to send editor commands
+     */
+    constructor(config) {
+        this.config = config;
+    }
+    setup() {
+        const defaultState = sortedCopy(this.getEmbeddedState());
+        const defaultStateChange = {
+            stateChangeId: null,
+            previous: defaultState,
+            next: defaultState,
+        };
+        // Used in case `data-embedded-state` is removed (i.e. when reverting
+        // the first mutation setting that attribute)
+        this.defaultStateChange = defaultStateChange;
+        // Used to keep track of the last applied stateChange, to avoid
+        // applying it multiple times (i.e. revertMutations + stageRecords
+        // during undo)
+        this.previousStateChange = defaultStateChange;
+        // Used to discard batch changes when a component is destroyed,
+        // pending state changes should not be applied
+        this.batchId = 0;
+        this.setupUnmounted();
+    }
+
+    /**
+     * Called at setup and when an embedded component is destroyed. This resets
+     * state values related to the mounted component. State changes will be
+     * handled differently when unmounted.
+     */
+    setupUnmounted() {
+        this.previousEmbeddedState = null;
+        this.state = null;
+        this.embeddedState = null;
+        this.embeddedStateProxy = null;
+        this.isLiveComponent = false;
+        this.batchId += 1;
+    }
+
+    /**
+     * Construct the proxy object to use inside an embedded component. It can
+     * be read on to register for rendering updates in the component template,
+     * and written on to trigger a re-rendering, sharing changes in
+     * collaboration and registering them for the history.
+     * @param {Object} state
+     * @returns {Proxy} embeddedStateProxy
+     */
+    constructEmbeddedState(state) {
+        this.state = state;
+        this.embeddedState = reactive(
+            this.assignDeepProxyCopy({}, state),
+            this.batchedChangeState()
+        );
+        this.embeddedStateProxy = new Proxy(
+            this.embeddedState,
+            embeddedStateProxyHandler(state, this)
+        );
+        // First subscription to changes.
+        observeAllKeys(this.embeddedStateProxy);
+        this.isLiveComponent = true;
+        return this.embeddedStateProxy;
+    }
+
+    /**
+     * Depending on whether the component is destroyed or started mounting,
+     * return its effective state.
+     * @returns {Object} state
+     */
+    getState() {
+        let state = this.state;
+        if (!this.isLiveComponent) {
+            state = this.getEmbeddedState();
+        }
+        return state;
+    }
+
+    /**
+     * Called when `data-embedded-state` attribute is being changed. This
+     * will update the state, the embedded state, the embedded props and
+     * recompute a new expression when necessary.
+     * @param {string} attrState JSON representation of a stateChange
+     * @param { Object } options
+     * @param {boolean} options.reverse whether to read the stateChange from
+     *        next to previous
+     * @param {boolean} options.forNewStep whether the attribute change is being
+     *        used to create a new step.
+     * @returns {string} new JSON representation of a stateChange, in case
+     *          it needs to be represented under another form to be shared
+     *          in collaboration (a local peer doing revertMutations implies
+     *          that collaborators will do applyMutations, so the stateChange
+     *          must be expressed with another form for them).
+     */
+    onStateChanged(attrState, { reverse = false, forNewStep = false } = {}) {
+        const stateChange = attrState ? JSON.parse(attrState) : this.defaultStateChange;
+        const state = this.getState();
+        if (reverse) {
+            this.reverseStateChange(stateChange);
+        }
+        if (!this.areStateChangesEqual(this.previousStateChange, stateChange)) {
+            const previous = JSON.stringify(sortedCopy(state));
+            this.commitStateChange(state, stateChange.previous, stateChange.next);
+            const sortedState = sortedCopy(state);
+            this.config.host.dataset.embeddedProps = JSON.stringify(
+                this.stateToEmbeddedProps(this.config.host, sortedState)
+            );
+            if (this.isLiveComponent && !this.previousEmbeddedState) {
+                // Update the embeddedState only if there is no pending change.
+                // If there is a pending change, it will be updated when the
+                // pending change is applied in `changeState`.
+                this.assignDeepProxyCopy(toRaw(this.embeddedState), sortedState);
+            }
+            if (!forNewStep) {
+                this.previousStateChange = stateChange;
+            } else {
+                // If mutations are being applied to create a new step, the
+                // state change must be expressed under another form for
+                // collaborators, since the collaborator will always
+                // "applyMutations" and never "revertMutations" when receiving
+                // external steps.
+                const next = JSON.stringify(sortedState);
+                if (previous !== next) {
+                    this.previousStateChange = {
+                        stateChangeId: this.generateId(),
+                        previous: JSON.parse(previous),
+                        next: JSON.parse(next),
+                    };
+                    return JSON.stringify(this.previousStateChange);
+                }
+            }
+        }
+    }
+
+    /**
+     * Allow to write on the embeddedState multiple times synchronously
+     * and batch all changes at once afterwards. A batch is discarded as soon
+     * as the component is destroyed.
+     * @returns {Function} batched changeState
+     */
+    batchedChangeState() {
+        let scheduled = false;
+        const batchId = this.batchId;
+        return async () => {
+            if (!scheduled) {
+                scheduled = true;
+                await Promise.resolve();
+                scheduled = false;
+                if (batchId === this.batchId) {
+                    this.changeState();
+                }
+            }
+        };
+    }
+
+    /**
+     * Apply a stateChange that was done on the embeddedState to the state,
+     * to trigger a re-rendering, and write the stateChange in
+     * `data-embedded-state` for the history and collaboration. Also
+     * recompute `data-embedded-props` for the next mounting operation.
+     */
+    changeState() {
+        const previousEmbeddedState = this.previousEmbeddedState;
+        this.previousEmbeddedState = null;
+        const previous = JSON.stringify(sortedCopy(this.state));
+        this.commitStateChange(
+            this.state,
+            previousEmbeddedState,
+            JSON.parse(JSON.stringify(this.embeddedState))
+        );
+        const sortedState = sortedCopy(this.state);
+        const next = JSON.stringify(sortedState);
+        this.assignDeepProxyCopy(toRaw(this.embeddedState), sortedState);
+        if (previous !== next) {
+            this.previousStateChange = {
+                stateChangeId: this.generateId(),
+                previous: JSON.parse(previous),
+                next: JSON.parse(next),
+            };
+            this.config.host.dataset.embeddedState = JSON.stringify(this.previousStateChange);
+            this.config.host.dataset.embeddedProps = JSON.stringify(
+                this.stateToEmbeddedProps(this.config.host, sortedState)
+            );
+            this.config.dispatch("ADD_STEP");
+        }
+        observeAllKeys(this.embeddedStateProxy);
+    }
+
+    areStateChangesEqual(sc1, sc2) {
+        return (
+            sc1.stateChangeId === sc2.stateChangeId &&
+            JSON.stringify(sc1.previous) === JSON.stringify(sc2.previous) &&
+            JSON.stringify(sc1.next) === JSON.stringify(sc2.next)
+        );
+    }
+
+    reverseStateChange(stateChange) {
+        const previous = stateChange.previous;
+        stateChange.previous = stateChange.next;
+        stateChange.next = previous;
+    }
+
+    /**
+     * Replace every key of target with deep proxy copies of source.
+     * This will make it so that any change at any level will pass by the
+     * embeddedStateProxyHandler traps.
+     * @param {Object} target
+     * @param {Object} source
+     * @returns {Object} copy with proxies as keys
+     */
+    assignDeepProxyCopy(target, source) {
+        for (const key of Object.keys(target)) {
+            delete target[key];
+        }
+        for (const key of Object.keys(source)) {
+            target[key] = this.deepProxyCopy(source[key]);
+        }
+        return target;
+    }
+
+    /**
+     * Create a deep proxy copy of value ensuring that any change at any level
+     * will pass by the embeddedStateProxyHandler traps.
+     * @param {Object} value
+     * @returns {Proxy} deep proxy copy of value
+     */
+    deepProxyCopy(value) {
+        if (value instanceof Object) {
+            const copy = value instanceof Array ? [] : {};
+            for (const prop in value) {
+                copy[prop] = this.deepProxyCopy(value[prop]);
+            }
+            return new Proxy(copy, embeddedStateProxyHandler(value, this));
+        }
+        return value;
+    }
+
+    generateId() {
+        return Math.floor(Math.random() * Math.pow(2, 52));
+    }
+
+    /**
+     * Apply a transaction to the active state. `previous` is the state
+     * before the transaction, and `next` is the state after the
+     * transaction was done. Keep in mind that the current state may have
+     * been changed after the transaction was done, but before it was
+     * applied. By default, will always accept nextState as
+     * the final state. `propertyUpdater` should be provided in the config
+     * to handle some keys differently, i.e. object composition.
+     * @see applyObjectPropertyDifference
+     * @param {Object} state current state
+     * @param {Object} previous state before the transaction
+     * @param {Object} next state after the transaction
+     */
+    commitStateChange(state, previous, next) {
+        const currentKeys = new Set([
+            ...Object.keys(state),
+            ...Object.keys(previous),
+            ...Object.keys(next),
+        ]);
+        for (const key of currentKeys) {
+            if (key in (this.config.propertyUpdater || {})) {
+                this.config.propertyUpdater[key](state, previous, next);
+            } else {
+                replaceProperty(state, key, next[key]);
+            }
+        }
+    }
+
+    /**
+     * Extract values to be used as the first embedded state (used for setup)
+     * from the host.
+     * Extract all values from `data-embedded-props` by default.
+     * @returns {Object} state
+     */
+    getEmbeddedState() {
+        const host = this.config.host;
+        return this.config.getEmbeddedState?.(host) || getEmbeddedProps(host);
+    }
+
+    /**
+     * Convert a state to an object containing the props to be
+     * saved in `data-embedded-props`, which will be used for the next mount
+     * operation, and saved in the database. The returned object should be
+     * serializable using JSON.
+     * Return the entire state by default.
+     * @param {HostElement} host
+     * @param {Object} state
+     * @returns {Object} props
+     */
+    stateToEmbeddedProps(host, state) {
+        const props = this.config.stateToEmbeddedProps?.(host, state) || state;
+        // Clean undefined values to save space
+        for (const key of Object.keys(props)) {
+            if (props[key] === undefined) {
+                delete props[key];
+            }
+        }
+        return props;
+    }
+}
+
+/**
+ * Manage updates to `data-embedded-props` (To change props given to an
+ * embedded component when it will be mounted in the future), through history
+ * and collaborative operations.
+ * This is done through a special `embeddedState` which can be used externally
+ * as a normal state.
+ * That state can be modified through 2 channels:
+ * - By the component itself, as with any normal state.
+ * - By the embedded_component_plugin, during history or collaborative
+ *   operations (undo/redo/resetStepsUntil/addExternalStep). The attribute
+ *   `data-embedded-state` will be used to contain a serialized representation
+ *   of a state change.
+ *
+ * While the embedded state evolves, the `data-embedded-props` attribute is
+ * always maintained to its relative value.
+ *
+ * `data-embedded-state` and `data-embedded-props` attributes are maintained
+ * even if the related component is in a destroyed state, in order to prepare
+ * the next mount operation if the host is re-inserted in the DOM through an
+ * history operation.
+ * If the component is currently mounted/being mounted, state changes are
+ * applied to the attribute and the embeddedState object.
+ *
+ * By default, a property change in the state is handled by replacing the
+ * previous value with the new one (overwrite). To change this behavior,
+ * provide a config extension in `getStateChangeManager` in the embedding
+ * definition, with a @see propertyUpdater mapping each state key to a change
+ * handler function.
+ *
+ * @param {HostElement} host
+ * @returns {Proxy} embeddedState state which can be used for rendering, and
+ *                  which is tied to the saved embedded props. Can only contain
+ *                  JSON serializable values.
+ */
+export function useEmbeddedState(host) {
+    const component = useComponent();
+    if (!component.env.getStateChangeManager) {
+        throw new Error(
+            "Missing `getStateChangeManager` function in the `embedding` provided to the `EmbeddedComponentPlugin`."
+        );
+    }
+    const stateChangeManager = component.env.getStateChangeManager(host);
+    onWillDestroy(() => stateChangeManager.setupUnmounted());
+    const state = useState(stateChangeManager.getEmbeddedState());
+    return stateChangeManager.constructEmbeddedState(state);
 }

--- a/addons/html_editor/static/src/wysiwyg.js
+++ b/addons/html_editor/static/src/wysiwyg.js
@@ -50,6 +50,11 @@ export class Wysiwyg extends Component {
         this.editor = this.props.editor;
         const config = {
             ...this.props.config,
+            // TODO ABD TODO @phoenix: check if there is too much info in the wysiwyg env.
+            // i.e.: env has X because of parent component,
+            // embedded component descendant sometimes uses X from env which is set conditionally:
+            // -> it will override the one one from the parent => OK.
+            // -> it will not => the embedded component still has X in env because of its ancestors => Issue.
             embeddedComponentInfo: { app: this.__owl__.app, env: this.env },
             getLocalOverlayContainer: () => overlayRef?.el,
             disableFloatingToolbar: this.props.toolbar,

--- a/addons/html_editor/static/tests/_helpers/collaboration.js
+++ b/addons/html_editor/static/tests/_helpers/collaboration.js
@@ -66,7 +66,9 @@ export const setupMultiEditor = async (spec) => {
         };
         peerInfos[peerId] = peerInfo;
         let n = 0;
-        HistoryPlugin.prototype.generateId = () => `fake_id_${n++}`;
+        HistoryPlugin.prototype.generateId = () => {
+            return `fake_id_${n++}`;
+        };
         let selection;
         const defaultPlugins = MAIN_PLUGINS;
         const base = await setupEditor(spec.contentBefore, {
@@ -103,6 +105,8 @@ export const setupMultiEditor = async (spec) => {
         } else {
             base.editor.document.getSelection().removeAllRanges();
         }
+        peerInfo.plugins = base.plugins;
+        // TODO @phoenix refactor tests, no need to assign every plugin individually
         const getPlugin = (name) => base.editor.plugins.find((x) => x.constructor.name === name);
         peerInfo.collaborationPlugin = getPlugin("collaboration");
         peerInfo.historyPlugin = getPlugin("history");

--- a/addons/html_editor/static/tests/_helpers/embedded_component.js
+++ b/addons/html_editor/static/tests/_helpers/embedded_component.js
@@ -1,4 +1,10 @@
-import { useEditableDescendants } from "@html_editor/others/embedded_component_utils";
+import {
+    applyObjectPropertyDifference,
+    getEmbeddedProps,
+    useEditableDescendants,
+    useEmbeddedState,
+    StateChangeManager,
+} from "@html_editor/others/embedded_component_utils";
 import { Component, useRef, useState, xml } from "@odoo/owl";
 
 export class Counter extends Component {
@@ -47,11 +53,170 @@ export class EmbeddedWrapper extends Component {
     }
 }
 
-export function embedding(name, Component, getProps, getEditableDescendants) {
+export class OffsetCounter extends Component {
+    static props = ["*"];
+    static template = xml`
+        <span class="counter" t-on-click="increment">Counter:<t t-esc="counterValue"/></span>`;
+
+    setup() {
+        this.embeddedState = useEmbeddedState(this.props.host);
+        this.state = useState({
+            value: 0,
+        });
+    }
+
+    get counterValue() {
+        return this.state.value + this.embeddedState.baseValue;
+    }
+
+    increment() {
+        this.state.value++;
+    }
+}
+
+export const offsetCounter = {
+    name: "counter",
+    Component: OffsetCounter,
+    getProps: (host) => ({ host }),
+    getStateChangeManager: (config) => {
+        return new StateChangeManager(
+            Object.assign(config, {
+                propertyUpdater: {
+                    baseValue: (state, previous, next) => {
+                        const offset = next.baseValue - previous.baseValue;
+                        state.baseValue += offset;
+                    },
+                },
+            })
+        );
+    },
+};
+
+export class SavedCounter extends Component {
+    static props = ["*"];
+    static template = xml`
+        <span class="counter" t-on-click="increment">Counter:<t t-esc="counterValue"/></span>`;
+
+    setup() {
+        this.embeddedState = useEmbeddedState(this.props.host);
+    }
+
+    get counterValue() {
+        return this.embeddedState.value || 0;
+    }
+
+    increment() {
+        if (!this.embeddedState.value) {
+            this.embeddedState.value = 0;
+        }
+        this.embeddedState.value++;
+    }
+}
+
+export const savedCounter = {
+    name: "counter",
+    Component: SavedCounter,
+    getProps: (host) => ({ host }),
+    getStateChangeManager: (config) => {
+        return new StateChangeManager(config);
+    },
+};
+
+export class CollaborativeObject extends Component {
+    static props = ["*"];
+    static template = xml`
+        <div class="obj"><t t-esc="collaborativeObject"/></div>`;
+
+    setup() {
+        this.embeddedState = useEmbeddedState(this.props.host);
+    }
+
+    get collaborativeObject() {
+        return Object.entries(this.embeddedState.obj || {})
+            .map(([key, value]) => `${key}_${value}`)
+            .join(",");
+    }
+}
+
+export const collaborativeObject = {
+    name: "obj",
+    Component: CollaborativeObject,
+    getProps: (host) => ({ host }),
+    getStateChangeManager: (config) => {
+        return new StateChangeManager(
+            Object.assign(config, {
+                propertyUpdater: {
+                    obj: (state, previous, next) => {
+                        applyObjectPropertyDifference(state, "obj", previous.obj, next.obj);
+                    },
+                },
+            })
+        );
+    },
+};
+
+export class NamedCounter extends Component {
+    static props = ["*"];
+    static template = xml`
+        <span class="counter" t-on-click="increment"><t t-esc="props.name"/>:<t t-esc="counterValue"/></span>`;
+
+    setup() {
+        this.embeddedState = useEmbeddedState(this.props.host);
+    }
+
+    get counterValue() {
+        return this.embeddedState.value + this.embeddedState.baseValue;
+    }
+
+    increment() {
+        this.embeddedState.value++;
+    }
+}
+
+export const namedCounter = {
+    name: "counter",
+    Component: NamedCounter,
+    getProps: (host) => ({
+        host,
+        ...getEmbeddedProps(host),
+    }),
+    getStateChangeManager: (config) => {
+        return new StateChangeManager(
+            Object.assign(config, {
+                propertyUpdater: {
+                    baseValue: (state, previous, next) => {
+                        const offset = next.baseValue - previous.baseValue;
+                        state.baseValue += offset;
+                    },
+                },
+                getEmbeddedState: (host) => {
+                    const props = getEmbeddedProps(host);
+                    return {
+                        value: props.value,
+                        baseValue: 3,
+                    };
+                },
+                stateToEmbeddedProps: (host, state) => {
+                    return {
+                        ...getEmbeddedProps(host),
+                        value: state.value,
+                    };
+                },
+            })
+        );
+    },
+};
+
+export function embedding(
+    name,
+    Component,
+    getProps = undefined,
+    { getEditableDescendants, getStateChangeManager } = {}
+) {
     return {
         name,
         Component,
-        getProps,
-        getEditableDescendants,
+        ...(getProps ? { getProps } : {}),
+        ...arguments[3],
     };
 }

--- a/addons/html_editor/static/tests/_helpers/selection.js
+++ b/addons/html_editor/static/tests/_helpers/selection.js
@@ -72,7 +72,8 @@ function getElemContent(el, selection, options) {
     }
     const attrs = [];
     for (const attr of attributes) {
-        attrs.push(`${attr.name}="${attr.value}"`);
+        const valueLimiter = attr.value.includes('"') ? "'" : '"';
+        attrs.push(`${attr.name}=${valueLimiter}${attr.value}${valueLimiter}`);
     }
     const attrStr = (attrs.length ? " " : "") + attrs.join(" ");
     return VOID_ELEMS.has(el.tagName)

--- a/addons/html_editor/static/tests/banner.test.js
+++ b/addons/html_editor/static/tests/banner.test.js
@@ -16,7 +16,7 @@ test("should insert a banner with focus inside followed by a paragraph", async (
         `<p>Test</p><div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" contenteditable="false">
                 <i class="o_editor_banner_icon mb-3 fst-normal" aria-label="Banner Info">💡</i>
                 <div class="w-100 px-3" contenteditable="true">
-                    <p placeholder="Type "/" for commands" class="o-we-hint">[]<br></p>
+                    <p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>
                 </div>
             </div><p><br></p>`
     );
@@ -75,7 +75,7 @@ test("remove all content should preserves the first paragraph tag inside the ban
     expect(getContent(el)).toBe(
         `<p>Test</p><div class="o_editor_banner user-select-none o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" contenteditable="false">
                 <i class="o_editor_banner_icon mb-3 fst-normal" aria-label="Banner Info">💡</i>
-                <div class="w-100 px-3" contenteditable="true"><p placeholder="Type "/" for commands" class="o-we-hint">[]<br></p></div>
+                <div class="w-100 px-3" contenteditable="true"><p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p></div>
             </div><p><br></p>`
     );
 });
@@ -104,7 +104,7 @@ test("Everything gets selected with ctrl+a, including a contenteditable=false as
 
     press("Backspace");
     expect(getContent(el)).toBe(
-        `<p placeholder="Type "/" for commands" class="o-we-hint">[]<br></p>`
+        `<p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>`
     );
 });
 
@@ -119,7 +119,7 @@ test("Everything gets selected with ctrl+a, including a contenteditable=false as
 
     press("Backspace");
     expect(getContent(el)).toBe(
-        `<p placeholder="Type "/" for commands" class="o-we-hint">[]<br></p>`
+        `<p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>`
     );
 });
 

--- a/addons/html_editor/static/tests/hint.test.js
+++ b/addons/html_editor/static/tests/hint.test.js
@@ -11,7 +11,7 @@ import {
 
 test("hints are removed when editor is destroyed", async () => {
     const { el, editor } = await setupEditor("<p>[]</p>", {});
-    expect(getContent(el)).toBe(`<p placeholder="Type "/" for commands" class="o-we-hint">[]</p>`);
+    expect(getContent(el)).toBe(`<p placeholder='Type "/" for commands' class="o-we-hint">[]</p>`);
     editor.destroy();
     expect(getContent(el)).toBe("<p>[]</p>");
 });
@@ -22,7 +22,7 @@ test("powerbox hint is display when the selection is in the editor", async () =>
 
     setContent(el, "<p>[]</p>");
     await tick();
-    expect(getContent(el)).toBe(`<p placeholder="Type "/" for commands" class="o-we-hint">[]</p>`);
+    expect(getContent(el)).toBe(`<p placeholder='Type "/" for commands' class="o-we-hint">[]</p>`);
 
     moveSelectionOutsideEditor();
     await tick();
@@ -35,7 +35,7 @@ test("placeholder is display when the selection is outside of the editor", async
 
     setContent(el, "<p>[]</p>");
     await tick();
-    expect(getContent(el)).toBe(`<p placeholder="Type "/" for commands" class="o-we-hint">[]</p>`);
+    expect(getContent(el)).toBe(`<p placeholder='Type "/" for commands' class="o-we-hint">[]</p>`);
 
     moveSelectionOutsideEditor();
     await tick();
@@ -49,13 +49,13 @@ test("placeholder must not be visible if there is content in the editor", async 
 
 test("should not lose track of temporary hints on split block", async () => {
     const { el, editor } = await setupEditor("<p>[]</p>", {});
-    expect(getContent(el)).toBe(`<p placeholder="Type "/" for commands" class="o-we-hint">[]</p>`);
+    expect(getContent(el)).toBe(`<p placeholder='Type "/" for commands' class="o-we-hint">[]</p>`);
     editor.dispatch("SPLIT_BLOCK");
     await animationFrame();
     expect(getContent(el)).toBe(
         unformat(`
             <p><br></p>
-            <p placeholder="Type "/" for commands" class="o-we-hint">[]<br></p>
+            <p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>
         `)
     );
     const [firstP, secondP] = el.children;
@@ -63,7 +63,7 @@ test("should not lose track of temporary hints on split block", async () => {
     await animationFrame();
     expect(getContent(el)).toBe(
         unformat(`
-            <p placeholder="Type "/" for commands" class="o-we-hint">[]<br></p>
+            <p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>
             <p><br></p>
         `)
     );
@@ -72,7 +72,7 @@ test("should not lose track of temporary hints on split block", async () => {
     expect(getContent(el)).toBe(
         unformat(`
             <p><br></p>
-            <p placeholder="Type "/" for commands" class="o-we-hint">[]<br></p>
+            <p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>
         `)
     );
 });
@@ -80,7 +80,7 @@ test("should not lose track of temporary hints on split block", async () => {
 test("temporary hint should not be displayed where there's a permanent one", async () => {
     const { el, editor } = await setupEditor("<p>[]<br></p>", {});
     expect(getContent(el)).toBe(
-        `<p placeholder="Type "/" for commands" class="o-we-hint">[]<br></p>`
+        `<p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>`
     );
     editor.dispatch("SET_TAG", { tagName: "H1" });
     await animationFrame();
@@ -91,7 +91,7 @@ test("temporary hint should not be displayed where there's a permanent one", asy
     expect(getContent(el)).toBe(
         unformat(`
             <h1 placeholder="Heading 1" class="o-we-hint"><br></h1>
-            <p placeholder="Type "/" for commands" class="o-we-hint">[]<br></p>
+            <p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>
         `)
     );
     const h1 = el.firstElementChild;

--- a/addons/html_editor/static/tests/insert/paragraph_break.test.js
+++ b/addons/html_editor/static/tests/insert/paragraph_break.test.js
@@ -410,8 +410,7 @@ describe("Selection collapsed", () => {
             await testEditor({
                 contentBefore: "<p><a>ab[]</a></p>",
                 stepFunction: splitBlock,
-                contentAfterEdit:
-                    '<p>\ufeff<a>\ufeffab\ufeff</a>\ufeff</p><p placeholder="Type "/" for commands" class="o-we-hint">[]<br></p>',
+                contentAfterEdit: `<p>\ufeff<a>\ufeffab\ufeff</a>\ufeff</p><p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>`,
                 contentAfter: "<p><a>ab</a></p><p>[]<br></p>",
             });
             await testEditor({

--- a/addons/html_editor/static/tests/insert/separator.test.js
+++ b/addons/html_editor/static/tests/insert/separator.test.js
@@ -11,8 +11,7 @@ describe("insert separator", () => {
         await testEditor({
             contentBefore: "<p>[]<br></p>",
             stepFunction: insertSeparator,
-            contentAfterEdit:
-                '<hr contenteditable="false"><p placeholder="Type "/" for commands" class="o-we-hint">[]<br></p>',
+            contentAfterEdit: `<hr contenteditable="false"><p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>`,
             contentAfter: "<hr><p>[]<br></p>",
         });
     });
@@ -21,8 +20,7 @@ describe("insert separator", () => {
         await testEditor({
             contentBefore: "<p>content</p><p>[]<br></p>",
             stepFunction: insertSeparator,
-            contentAfterEdit:
-                '<p>content</p><hr contenteditable="false"><p placeholder="Type "/" for commands" class="o-we-hint">[]<br></p>',
+            contentAfterEdit: `<p>content</p><hr contenteditable="false"><p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>`,
             contentAfter: "<p>content</p><hr><p>[]<br></p>",
         });
     });
@@ -58,7 +56,7 @@ describe("insert separator", () => {
         el.append(div);
         editor.dispatch("ADD_STEP");
         expect(getContent(el)).toBe(
-            '<p placeholder="Type "/" for commands" class="o-we-hint">[]<br></p><div><hr contenteditable="false"></div>'
+            `<p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p><div><hr contenteditable="false"></div>`
         );
     });
 });

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -278,7 +278,7 @@ describe("Link creation", () => {
             // press("Enter");
             splitBlock(editor);
             expect(cleanLinkArtifacts(getContent(el))).toBe(
-                '<p>ab<a href="#">link</a></p><p placeholder="Type "/" for commands" class="o-we-hint">[]<br></p>'
+                `<p>ab<a href="#">link</a></p><p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>`
             );
         });
         test("should insert a link then create a new <p>, and another character", async () => {

--- a/addons/html_editor/static/tests/list/toggle_ol.test.js
+++ b/addons/html_editor/static/tests/list/toggle_ol.test.js
@@ -8,7 +8,7 @@ describe("Range collapsed", () => {
         test("should turn an empty paragraph into a list", async () => {
             await testEditor({
                 contentBefore: "<p>[]<br></p>",
-                contentBeforeEdit: `<p placeholder="Type "/" for commands" class="o-we-hint">[]<br></p>`,
+                contentBeforeEdit: `<p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>`,
                 stepFunction: toggleOrderedList,
                 contentAfterEdit: `<ol><li placeholder="List" class="o-we-hint">[]<br></li></ol>`,
                 contentAfter: "<ol><li>[]<br></li></ol>",
@@ -157,7 +157,7 @@ describe("Range collapsed", () => {
                 contentBefore: "<ol><li>[]<br></li></ol>",
                 contentBeforeEdit: `<ol><li placeholder="List" class="o-we-hint">[]<br></li></ol>`,
                 stepFunction: toggleOrderedList,
-                contentAfterEdit: `<p placeholder="Type "/" for commands" class="o-we-hint">[]<br></p>`,
+                contentAfterEdit: `<p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>`,
                 contentAfter: "<p>[]<br></p>",
             });
         });

--- a/addons/html_editor/static/tests/list/toggle_ul.test.js
+++ b/addons/html_editor/static/tests/list/toggle_ul.test.js
@@ -8,7 +8,7 @@ describe("Range collapsed", () => {
         test("should turn an empty paragraph into a list", async () => {
             await testEditor({
                 contentBefore: "<p>[]<br></p>",
-                contentBeforeEdit: `<p placeholder="Type "/" for commands" class="o-we-hint">[]<br></p>`,
+                contentBeforeEdit: `<p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>`,
                 stepFunction: toggleUnorderedList,
                 contentAfterEdit: `<ul><li placeholder="List" class="o-we-hint">[]<br></li></ul>`,
                 contentAfter: "<ul><li>[]<br></li></ul>",
@@ -164,7 +164,7 @@ describe("Range collapsed", () => {
                 contentBefore: "<ul><li>[]<br></li></ul>",
                 contentBeforeEdit: `<ul><li placeholder="List" class="o-we-hint">[]<br></li></ul>`,
                 stepFunction: toggleUnorderedList,
-                contentAfterEdit: `<p placeholder="Type "/" for commands" class="o-we-hint">[]<br></p>`,
+                contentAfterEdit: `<p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>`,
                 contentAfter: "<p>[]<br></p>",
             });
         });

--- a/addons/html_editor/static/tests/misc.test.js
+++ b/addons/html_editor/static/tests/misc.test.js
@@ -16,13 +16,13 @@ test("can instantiate a Editor", async () => {
 
 test("cannot reattach an editor", async () => {
     const { el, editor } = await setupEditor("<p>[]</p>", {});
-    expect(getContent(el)).toBe(`<p placeholder="Type "/" for commands" class="o-we-hint">[]</p>`);
+    expect(getContent(el)).toBe(`<p placeholder='Type "/" for commands' class="o-we-hint">[]</p>`);
     expect(() => editor.attachTo(el)).toThrow("Cannot re-attach an editor");
 });
 
 test("cannot reattach a destroyed editor", async () => {
     const { el, editor } = await setupEditor("<p>[]</p>", {});
-    expect(getContent(el)).toBe(`<p placeholder="Type "/" for commands" class="o-we-hint">[]</p>`);
+    expect(getContent(el)).toBe(`<p placeholder='Type "/" for commands' class="o-we-hint">[]</p>`);
     editor.destroy();
     expect(getContent(el)).toBe(`<p>[]</p>`);
     expect(() => editor.attachTo(el)).toThrow("Cannot re-attach an editor");
@@ -44,7 +44,7 @@ test("with an empty selector", async () => {
         `<div placeholder="Type &quot;/&quot; for commands" class="o-we-hint"></div>`
     );
     expect(getContent(el)).toBe(
-        `<div placeholder="Type "/" for commands" class="o-we-hint">[]</div>`
+        `<div placeholder='Type "/" for commands' class="o-we-hint">[]</div>`
     );
 });
 
@@ -63,7 +63,7 @@ test("inverse selection", async () => {
 test("with an empty selector and a <br>", async () => {
     const { el } = await setupEditor("<p>[]<br></p>", {});
     expect(getContent(el)).toBe(
-        `<p placeholder="Type "/" for commands" class="o-we-hint">[]<br></p>`
+        `<p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>`
     );
 });
 

--- a/addons/html_editor/static/tests/odoo_collaboration.test.js
+++ b/addons/html_editor/static/tests/odoo_collaboration.test.js
@@ -1118,11 +1118,11 @@ describe("History steps Ids", () => {
         await peers.p1.focus();
         editor.dispatch("SPLIT_BLOCK");
         expect(getContent(editor.editable)).toBe(
-            `<p>a</p><p placeholder="Type "/" for commands" class="o-we-hint">[]<br></p>`
+            `<p>a</p><p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>`
         );
         editor.dispatch("SPLIT_BLOCK");
         expect(getContent(editor.editable)).toBe(
-            `<p>a</p><p><br></p><p placeholder="Type "/" for commands" class="o-we-hint">[]<br></p>`
+            `<p>a</p><p><br></p><p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>`
         );
         editor.destroy();
     });

--- a/addons/html_editor/static/tests/powerbox.test.js
+++ b/addons/html_editor/static/tests/powerbox.test.js
@@ -48,7 +48,7 @@ test.tags("iframe")("in iframe: should open the Powerbox on type `/`", async () 
 test("should correctly hint in iframes", async () => {
     const { el } = await setupEditor("<p>[]<br></p>", { props: { iframe: true } });
     expect(getContent(el)).toBe(
-        `<p placeholder="Type "/" for commands" class="o-we-hint">[]<br></p>`
+        `<p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>`
     );
 });
 
@@ -56,7 +56,7 @@ test("should open the Powerbox on type `/`, but in an empty paragraph", async ()
     const { el, editor } = await setupEditor("<p>[]<br></p>");
     expect(".o-we-powerbox").toHaveCount(0);
     expect(getContent(el)).toBe(
-        `<p placeholder="Type "/" for commands" class="o-we-hint">[]<br></p>`
+        `<p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>`
     );
     press("/");
     insertText(editor, "/");
@@ -283,7 +283,7 @@ describe("search", () => {
             await animationFrame();
             expect(".o-we-powerbox").toHaveCount(0);
             expect(getContent(el)).toBe(
-                `<p placeholder="Type "/" for commands" class="o-we-hint">[]<br></p>`
+                `<p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>`
             );
 
             insertText(editor, "a");
@@ -343,7 +343,7 @@ test.todo("should close the powerbox if keyup event is called on other block", a
 
 test.tags("desktop")("should insert a 3x3 table on type `/table`", async () => {
     const { el, editor } = await setupEditor("<p>[]</p>");
-    expect(getContent(el)).toBe(`<p placeholder="Type "/" for commands" class="o-we-hint">[]</p>`);
+    expect(getContent(el)).toBe(`<p placeholder='Type "/" for commands' class="o-we-hint">[]</p>`);
 
     insertText(editor, "/table");
     await waitFor(".o-we-powerbox ");
@@ -354,7 +354,7 @@ test.tags("desktop")("should insert a 3x3 table on type `/table`", async () => {
     press("Enter");
     await tick();
     expect(getContent(el)).toBe(
-        `<table class="table table-bordered o_table"><tbody><tr><td><p placeholder="Type "/" for commands" class="o-we-hint">[]<br></p></td><td><p><br></p></td><td><p><br></p></td></tr><tr><td><p><br></p></td><td><p><br></p></td><td><p><br></p></td></tr><tr><td><p><br></p></td><td><p><br></p></td><td><p><br></p></td></tr></tbody></table><p><br></p>`
+        `<table class="table table-bordered o_table"><tbody><tr><td><p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p></td><td><p><br></p></td><td><p><br></p></td></tr><tr><td><p><br></p></td><td><p><br></p></td><td><p><br></p></td></tr><tr><td><p><br></p></td><td><p><br></p></td><td><p><br></p></td></tr></tbody></table><p><br></p>`
     );
 });
 
@@ -365,7 +365,7 @@ test.tags("mobile")("should insert a 3x3 table on type `/table` in mobile view",
     press("Enter");
     await tick();
     expect(getContent(el)).toBe(
-        `<table class="table table-bordered o_table"><tbody><tr><td><p placeholder="Type "/" for commands" class="o-we-hint">[]<br></p></td><td><p><br></p></td><td><p><br></p></td></tr><tr><td><p><br></p></td><td><p><br></p></td><td><p><br></p></td></tr><tr><td><p><br></p></td><td><p><br></p></td><td><p><br></p></td></tr></tbody></table><p><br></p>`
+        `<table class="table table-bordered o_table"><tbody><tr><td><p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p></td><td><p><br></p></td><td><p><br></p></td></tr><tr><td><p><br></p></td><td><p><br></p></td><td><p><br></p></td></tr><tr><td><p><br></p></td><td><p><br></p></td><td><p><br></p></td></tr></tbody></table><p><br></p>`
     );
 });
 
@@ -425,7 +425,7 @@ test("should restore state before /command insertion when command is executed (2
         config: { Plugins: [...MAIN_PLUGINS, NoOpPlugin] },
     });
     expect(getContent(el)).toBe(
-        `<p placeholder="Type "/" for commands" class="o-we-hint">[]<br></p>`
+        `<p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>`
     );
     insertText(editor, "/");
     // @todo @phoenix: remove this once we manage inputs.
@@ -438,14 +438,14 @@ test("should restore state before /command insertion when command is executed (2
     expect(commandNames(el)).toEqual(["No-op"]);
     press("Enter");
     expect(getContent(el)).toBe(
-        '<p class="o-we-hint" placeholder="Type "/" for commands">[]<br></p>'
+        `<p class="o-we-hint" placeholder='Type "/" for commands'>[]<br></p>`
     );
 });
 
 test("should discard /command insertion from history when command is executed", async () => {
     const { el, editor } = await setupEditor("<p>[]<br></p>");
     expect(getContent(el)).toBe(
-        `<p placeholder="Type "/" for commands" class="o-we-hint">[]<br></p>`
+        `<p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>`
     );
     // @todo @phoenix: remove this once we manage inputs.
     // Simulate <br> removal by contenteditable when something is inserted
@@ -469,7 +469,7 @@ test("should discard /command insertion from history when command is executed", 
     expect(getContent(el)).toBe("<p>a[]</p>");
     editor.dispatch("HISTORY_UNDO");
     expect(getContent(el)).toBe(
-        `<p class="o-we-hint" placeholder="Type "/" for commands">[]<br></p>`
+        `<p class="o-we-hint" placeholder='Type "/" for commands'>[]<br></p>`
     );
 });
 

--- a/addons/html_editor/static/tests/table/adding_table.test.js
+++ b/addons/html_editor/static/tests/table/adding_table.test.js
@@ -40,7 +40,7 @@ test.tags("desktop")("can add a table using the powerbox and keyboard", async ()
         <table class="table table-bordered o_table">
             <tbody>
                 <tr>
-                    <td><p placeholder="Type "/" for commands" class="o-we-hint">[]<br></p></td>
+                    <td><p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p></td>
                     <td><p><br></p></td>
                     <td><p><br></p></td>
                 </tr>

--- a/addons/html_editor/static/tests/table/children.test.js
+++ b/addons/html_editor/static/tests/table/children.test.js
@@ -484,7 +484,7 @@ describe("tab", () => {
                     <td>ef</td>
                 </tr>
                 <tr style="height: 20px;">
-                    <td><p placeholder="Type "/" for commands" class="o-we-hint">[]<br></p></td>
+                    <td><p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p></td>
                     <td><p><br></p></td>
                     <td><p><br></p></td>
                 </tr>

--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -48,12 +48,11 @@ safe_attrs = defs.safe_attrs | frozenset(
     ['style',
      'data-o-mail-quote', 'data-o-mail-quote-node',  # quote detection
      'data-oe-model', 'data-oe-id', 'data-oe-field', 'data-oe-type', 'data-oe-expression', 'data-oe-translation-source-sha', 'data-oe-nodeid',
-     'data-last-history-steps', 'data-oe-protected', 'data-embedded', 'data-embedded-editable',
-     'data-oe-transient-content',  # legacy editor
+     'data-last-history-steps', 'data-oe-protected', 'data-embedded', 'data-embedded-editable', 'data-embedded-props',
+     'data-oe-transient-content', 'data-behavior-props', 'data-prop-name',  # legacy editor
      'data-publish', 'data-id', 'data-res_id', 'data-interval', 'data-member_id', 'data-scroll-background-ratio', 'data-view-id',
      'data-class', 'data-mimetype', 'data-original-src', 'data-original-id', 'data-gl-filter', 'data-quality', 'data-resize-width',
      'data-shape', 'data-shape-colors', 'data-file-name', 'data-original-mimetype',
-     'data-behavior-props', 'data-prop-name',  # knowledge commands
      'data-mimetype-before-conversion',
      ])
 SANITIZE_TAGS = {


### PR DESCRIPTION
In order to ease development of embedded components in Knowledge, there was a
need to integrate some OWL concepts and some Editor concepts:

A user may want to share part of the state of a component with other
collaborators, and that state should be able to evolve alongside history
manipulations.
  - i.e. a user renames an embedded view in Knowledge, he wants others to see
    that the name changed without them having to reload the entire article for
    that. When going back in the history, he may also want to recover the
    previous title of that view.

A user may want to update the props from which an embedded component is mounted
from the next time he opens an article.
  - i.e. a user renames an embedded view, he wants to see that same title
    when he opens the article again.

There was a need to dissociate the editor manipulations from the actual
implementation of the embedded component: it is tedious to think about writing
the props on an embedded component host attribute when the state of a view
changed, not forgetting to dispatch an history step, define what happens if that
step is undone: does the new title stay here, does it go back to its previous
value, where should that previous value be stored, etc.

This commit introduces a hook: `useEmbeddedState` which will handle all of these
needs. That hook provides a state, which, much like `useState` is an object that
can be read in a component template, then written on to trigger a re-rendering
of the template.

But that special state also has a secondary function: write a state change
representation in a special attribute of the host: `data-embedded-state`, which
will then be registered as a history step mutation, and will be part of the
editor history and shared in collaboration.

That hook interacts with the `EmbeddedComponentPlugin` and the `HistoryPlugin`
to react to those mutation changes, and apply them to the object state. This
means that when a step is received from a collaborator and contains a state
change, the current user component will be re-rendered with the new information.

This also means that history manipulations such as `undo` and `redo` will make
that state evolve in both directions.

The purpose of this commit is to present a first implementation for this
specification which is defined by tests, with a usable API hopefully independent
from that implementation, so that we can improve on it in the future without
changing how it behaves.

task-3672747