### PR TITLE
[FIX] web: search panel: many2many not groupable

### DIFF
--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -7,7 +7,7 @@ import json
 
 from odoo import _, _lt, api, fields, models
 from odoo.osv.expression import AND, TRUE_DOMAIN, normalize_domain
-from odoo.tools import date_utils, lazy
+from odoo.tools import date_utils, lazy, OrderedSet
 from odoo.tools.misc import get_lang
 from odoo.exceptions import UserError
 from collections import defaultdict
@@ -682,8 +682,16 @@ class Base(models.AbstractModel):
 
         if field.type == 'many2many':
             if not expand:
-                domain_image = self._search_panel_domain_image(field_name, model_domain, limit=limit)
-                image_element_ids = list(domain_image.keys())
+                if field.base_field.groupable:
+                    domain_image = self._search_panel_domain_image(field_name, model_domain, limit=limit)
+                    image_element_ids = list(domain_image.keys())
+                else:
+                    model_records = self.search_read(model_domain, [field_name])
+                    image_element_ids = OrderedSet()
+                    for rec in model_records:
+                        if rec[field_name]:
+                            image_element_ids.update(rec[field_name])
+                    image_element_ids = list(image_element_ids)
                 comodel_domain = AND([
                     comodel_domain,
                     [('id', 'in', image_element_ids)],

--- a/odoo/addons/test_search_panel/models/models.py
+++ b/odoo/addons/test_search_panel/models/models.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class SourceModel(models.Model):
@@ -13,7 +13,14 @@ class SourceModel(models.Model):
         'test_search_panel.category_target_model_no_parent_name')
     tag_ids = fields.Many2many(
         'test_search_panel.filter_target_model', 'rel_table', string="Tags")
+    computed_tag_ids = fields.Many2many(
+        'test_search_panel.filter_target_model', string="Computed Tags", compute="_compute_computed_tag_ids")
     tag_id = fields.Many2one('test_search_panel.filter_target_model', string="Tag")
+
+    @api.depends('tag_ids')
+    def _compute_computed_tag_ids(self):
+        for record in self:
+            record.computed_tag_ids = record.tag_ids
 
 
 class CategoryTargetModel(models.Model):

--- a/odoo/addons/test_search_panel/tests/test_search_panel_select_multi_range.py
+++ b/odoo/addons/test_search_panel/tests/test_search_panel_select_multi_range.py
@@ -590,6 +590,25 @@ class TestSelectRangeMulti(odoo.tests.TransactionCase):
             ]
         )
 
+        result = self.SourceModel.search_panel_select_multi_range(
+            'computed_tag_ids',
+            search_domain=[['id', '=', r5_id]],
+            limit=2,
+        )
+        self.assertEqual(result, SEARCH_PANEL_ERROR)
+
+        result = self.SourceModel.search_panel_select_multi_range(
+            'computed_tag_ids',
+            search_domain=[['id', '=', r6_id]],
+            limit=2,
+        )
+        self.assertEqual(
+            result['values'],
+            [
+                {'display_name': 'Tag 3', 'id': t3_id},
+            ]
+        )
+
     # Selection case
 
     def test_selection_empty(self):


### PR DESCRIPTION
As observed in https://github.com/odoo/odoo/pull/173442, the commit https://github.com/odoo/odoo/commit/6336366f772b18cd3731cc03f7ff3fc1eeca204a has introduced a bug for search panel filters that are based on many2many that are not groupable. Indeed, the computation of the domain image is done via _search_panel_domain_image that uses read_group and for many2many that are not groupable it is not allowed to use read_group. We fix that bug by computing the domain image via a search_read when the many2many is not groupable.

opw-4055494

