### PR TITLE
[IMP] base: improve performances of commercial fields

### DIFF
--- a/doc/cla/corporate/phytocontrol-group.md
+++ b/doc/cla/corporate/phytocontrol-group.md
@@ -1,0 +1,15 @@
+France, 2024-07-17
+
+Phytocontrol Group agrees to the terms of the Odoo Corporate Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Benoît Fontaine benoitfontaine@phytocontrol.com https://github.com/benoit-phytocontrol
+
+List of contributors:
+
+Benoît Fontaine benoitfontaine@phytocontrol.com https://github.com/benoit-phytocontrol


### PR DESCRIPTION
This PR improve performances by reducing the number of SQL queries when writing a res.partner's commercial field.
    
Test case: write property_account_position_id on a partner with 10 children

Before this PR: 120 SQL queries
After this PR: 12 SQL queries

I tested on all versions 14.0 to 17.0:

  | Odoo 14.0 | Odoo 15.0 | Odoo 16.0 | Odoo 17.0 | Odoo master
-- | -- | -- | -- | -- | --
queries before this commit | 252 | 263 | 142 | 120 | 155
queries after this commit | 22 | 22 | 12 | 12 | 12


The difference is even greater if specific modules have added additional commercial fields

