### PR TITLE
[FIX] sale_loyalty : Don't show discounts that are already claimed

### DIFF
--- a/addons/sale_loyalty/models/sale_order.py
+++ b/addons/sale_loyalty/models/sale_order.py
@@ -675,6 +675,9 @@ class SaleOrder(models.Model):
                 # If the total is 0 again without the payment reward it will be removed.
                 if reward.reward_type == 'discount' and total_is_zero and (not has_payment_reward or reward.program_id.is_payment_program):
                     continue
+                # Skip discount that has already been applied
+                if reward.reward_type == 'discount' and coupon in self.order_line.coupon_id:
+                    continue
                 if reward.reward_type == 'product' and not reward.filtered_domain(
                     active_products_domain
                 ):

--- a/addons/sale_loyalty/tests/test_loyalty.py
+++ b/addons/sale_loyalty/tests/test_loyalty.py
@@ -873,3 +873,34 @@ class TestLoyalty(TestSaleCouponCommon):
         order._update_programs_and_rewards()
         rewards = [value.ids for value in order._get_claimable_rewards().values()]
         self.assertTrue(any(loyalty_program_tag.reward_ids[0].id in r for r in rewards))
+
+    def test_discount_reward_claimable_only_once(self):
+        """
+        Check that discount rewards already applied won't be shown in the claimable rewards anymore.
+        """
+        program = self.env['loyalty.program'].create({
+            'name': '10% Discount',
+            'applies_on': 'current',
+            'trigger': 'with_code',
+            'program_type': 'promotion',
+            'rule_ids': [(0, 0, {'mode': 'with_code', 'code': '10PERCENT'})],
+            'reward_ids': [(0, 0, {
+                'reward_type': 'discount',
+                'discount': 10,
+                'discount_mode': 'percent',
+                'discount_applicability': 'specific',
+            })],
+        })
+
+        coupon = self.env['loyalty.card'].create({
+            'program_id': program.id, 'points': 20, 'code': 'GIFT_CARD'
+        })
+
+        order = self.env['sale.order'].create({
+            'partner_id': self.partner_a.id,
+            'order_line': [Command.create({'product_id': self.product_a.id})]
+        })
+
+        self._claim_reward(order, program, coupon)
+        rewards = order._get_claimable_rewards()
+        self.assertFalse(rewards, "No program should be applicable")


### PR DESCRIPTION
### Steps to reproduce:
	- Install eCommerce and Loyalty module
	- Create a Discount that is applied using code
	- Generate coupon codes
	- Modify the balance of the codes to be more than 1
	- Go to website and create an order
	- Proceed to checkout and apply one of the codes

### Current behavior before PR:
The reward will be shown as claimable even after we already applied its code. This will lead that the user can be able to claim it more than once in the same order. This is happening becuase when getting the claimable rewards we are fetching the rewards that already got applied. https://github.com/odoo/odoo/blob/16.0/addons/sale_loyalty/models/sale_order.py#L655

### Desired behavior after PR is merged:
We are excluding the already-applied coupons on the order to avoid using them more than once in the same order.

opw-4018909