### PR TITLE
[FIX] website_slides: answers not saved after reload

### DIFF
--- a/addons/website_slides/static/src/js/slides_course_quiz.js
+++ b/addons/website_slides/static/src/js/slides_course_quiz.js
@@ -332,6 +332,7 @@
 
                 courseJoinWidget.appendTo($widgetLocation);
                 if (!this.publicUser && courseJoinWidget.channel.channelEnroll === 'public' && this.slide.sessionAnswers) {
+                    this._applySessionAnswers();
                     courseJoinWidget.joinChannel(this.channel.channelId);
                 }
             }


### PR DESCRIPTION
Current behaviour:
---
After clicking on the Join & Submit button in a quiz, then creating an account, 
after redirection to the quiz, the answers are erased, and the form is still submitted.

Expected behaviour:
---
After redirection, the answers should appear again before the form being submitted automatically.

Steps to reproduce:
---
1. Connect as admin
2. Go to settings > Website > Customer account
3. Set on "Free sign up"
4. Log out of Admin
5. Go to the website > Courses
6. Click on "Basics of Gardening"
7. Click on "Test your knowledge"
8. Fill in some answers
9. Click on the Join & Submit button
10. Click on "Don't have an account?"
11. Create a new account
12. The page will redirect you to the quiz
13. No answers > "All questions must be answered" error

Cause of the issue:
---
To call `_renderJoinWidget`, we check for `isMember`. Initially `isMember` is false, so the Join button is rendered. 
After redirection, `isMember` is still false, so `renderJoinWidget` is called again, but this time `joinChannel` is called, 
because `publicUser` is false, which calls `_saveQuizAnswersToSession`. 
This last function uses `_getQuizAnswers`, which fetches the answers from the page, 
but after redirection => no answers, so empty answers are saved in the session.
After `_saveQuizAnswersToSession`, the page reloads. 
After reload `isMember` is true, so the button is not rendered again, the empty answers are applied then submitted.

Fix:
---
Call `_applySessionAnswers` before joining the channel, so when `_saveQuizAnswersToSession` 
is called, it can take the answers from the page.

opw-4035229

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
