### PR TITLE
[FIX] web: notify function needs to be marked as asynchronous

### DIFF
--- a/addons/web/static/src/views/model.js
+++ b/addons/web/static/src/views/model.js
@@ -58,8 +58,8 @@ export class Model extends EventBus {
         return null;
     }
 
-    notify() {
-        this.trigger("update");
+    async notify() {
+        await this.trigger("update");
     }
 }
 Model.services = [];


### PR DESCRIPTION
**Problem**
- When adding or removing an attachment from the chat of a record, using the attribute `options="{'post_refresh':'always'}"` for the message_ids field in the chat, will need to reload the parent record ( record in that form view). However, the flow does not work really well when the form view is compiled before the update trigger is completed

**Solution**
- The notify function needs to be used asynchronously

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
