### PR TITLE
[REV] sale: revert tracking override

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1441,18 +1441,6 @@ class SaleOrder(models.Model):
 
     # MAIL #
 
-    def _track_finalize(self):
-        """ Override of `mail` to prevent logging changes when the SO is in a draft state. """
-        if (len(self) == 1
-            # The method _track_finalize is sometimes called too early or too late and it
-            # might cause a desynchronization with the cache, thus this condition is needed.
-            and self.env.cache.contains(self, self._fields['state']) and self.state == 'draft'
-            and not self.env['ir.config_parameter'].sudo().get_param('sale.track_draft_orders')):
-            self.env.cr.precommit.data.pop(f'mail.tracking.{self._name}', {})
-            self.env.flush_all()
-            return
-        return super()._track_finalize()
-
     @api.returns('mail.message', lambda value: value.id)
     def message_post(self, **kwargs):
         if self.env.context.get('mark_so_as_sent'):


### PR DESCRIPTION
This commit revert tracking overide changes to keep tracking changes of order in draft state.

Reverted of commit: https://github.com/odoo/odoo/commit/19e2e1502742b506a56501468374e4faca9e8334

opw-4011179

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
