### PR TITLE
[IMP] l10n_in: gst number based State Auto-population and Mismatch Warning

### DIFF
--- a/addons/l10n_in/models/company.py
+++ b/addons/l10n_in/models/company.py
@@ -1,10 +1,33 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from odoo import fields, models
+from odoo import api, fields, models
+
+import re
 
 class ResCompany(models.Model):
     _inherit = 'res.company'
 
     l10n_in_upi_id = fields.Char(string="UPI Id")
+
+    l10n_in_gst_state_warning = fields.Json(compute="_compute_l10n_in_gst_state_warning")
+
+    @api.depends('vat', 'state_id', 'country_code')
+    def _compute_l10n_in_gst_state_warning(self):
+        warnings = {}
+        if self.vat and self.check_vat_in(self.vat) and self.country_code == "IN":
+            if self.vat[:2] == "99":
+                warnings['invalid_gst_type_on_overseas_invoice'] = {
+                    'message': "As per GSTN the country should be other than India, so it's recommended to update it.",
+                    'level': 'warning',
+                }
+
+            else:
+                state_id = self.env['res.country.state'].search([('l10n_in_tin', '=', self.vat[:2])], limit=1)
+                if state_id and state_id != self.state_id:
+                    warnings['invalid_gst_type_on_overseas_invoice'] = {
+                        'message': f"As per GSTN the state should be {state_id.name}, so it's recommended to update it.",
+                        'level': 'warning',
+                    }
+        self.l10n_in_gst_state_warning = warnings
 
     def create(self, vals):
         res = super().create(vals)
@@ -25,3 +48,23 @@ class ResCompany(models.Model):
             ChartTemplate = self.env['account.chart.template'].with_company(company)
             fiscal_position_data = ChartTemplate._get_in_account_fiscal_position()
             ChartTemplate._load_data({'account.fiscal.position': fiscal_position_data})
+
+    @api.onchange('vat')
+    def onchange_vat(self):
+        if self.vat and self.check_vat_in(self.vat):
+            state_id = self.env['res.country.state'].search([('l10n_in_tin', '=', self.vat[:2])], limit=1)
+            if state_id:
+                self.state_id = state_id
+
+    def check_vat_in(self, vat):
+        # reference from https://www.gstzen.in/a/format-of-a-gst-number-gstin.html
+        if vat and len(vat) == 15:
+            all_gstin_re = [
+                r'[0-9]{2}[a-zA-Z]{5}[0-9]{4}[a-zA-Z]{1}[1-9A-Za-z]{1}[Zz1-9A-Ja-j]{1}[0-9a-zA-Z]{1}',      # Normal, Composite, Casual GSTIN
+                r'[0-9]{4}[A-Z]{3}[0-9]{5}[UO]{1}[N][A-Z0-9]{1}',       # UN/ON Body GSTIN
+                r'[0-9]{4}[a-zA-Z]{3}[0-9]{5}[N][R][0-9a-zA-Z]{1}',         # NRI GSTIN
+                r'[0-9]{2}[a-zA-Z]{4}[a-zA-Z0-9]{1}[0-9]{4}[a-zA-Z]{1}[1-9A-Za-z]{1}[DK]{1}[0-9a-zA-Z]{1}',         # TDS GSTIN
+                r'[0-9]{2}[a-zA-Z]{5}[0-9]{4}[a-zA-Z]{1}[1-9A-Za-z]{1}[C]{1}[0-9a-zA-Z]{1}'         # TCS GSTIN
+            ]
+            return any(re.compile(rx).match(vat) for rx in all_gstin_re)
+        return False

--- a/addons/l10n_in/views/res_company_views.xml
+++ b/addons/l10n_in/views/res_company_views.xml
@@ -8,6 +8,9 @@
             <xpath expr="//field[@name='currency_id']" position="after">
                 <field name="l10n_in_upi_id" invisible="country_code != 'IN'"/>
             </xpath>
+            <xpath expr="//sheet" position="before">
+                <field name ="l10n_in_gst_state_warning"  widget="actionable_errors"/>
+            </xpath>
         </field>
     </record>
 </odoo>

--- a/addons/l10n_in/views/res_partner_views.xml
+++ b/addons/l10n_in/views/res_partner_views.xml
@@ -17,6 +17,7 @@
                 <field name="l10n_in_pan" placeholder="e.g. ABCTY1234D" invisible="'IN' not in fiscal_country_codes" />
             </xpath>
             <xpath expr="//sheet" position="before">
+                <field name ="l10n_in_gst_state_warning"  widget="actionable_errors"/>
                 <field name="display_pan_warning" invisible="1"/>
                 <div class="alert alert-warning" role="alert"
                         invisible="not display_pan_warning">


### PR DESCRIPTION
Before this commit:
1) The state field on the res_company form is not automatically populated based
 on the entered GST number
2) On the res_company and res_partner, even if there is a mismatch between the GST number and state no warning is shown

After this commit:
1) The state field on the res_company form now automatically populates based on
 the entered GST number
2) A validation check is implemented for both res_company and res_partner forms.
 Users will receive a warning if there's a discrepancy between the GST number
 and the corresponding state.

Task ID - 4055948
