### PR TITLE
[IMP] hr_timesheet: improve the project settings UI

### DIFF
--- a/addons/hr_timesheet/views/project_project_views.xml
+++ b/addons/hr_timesheet/views/project_project_views.xml
@@ -37,7 +37,7 @@
                     <attribute name="invisible">0</attribute>
                 </xpath>
                 <xpath expr="//group[@name='group_time_managment']" position="inside">
-                    <setting id="timesheet_settings" string="Timesheets" help="Log time on tasks">
+                    <setting class="col-lg-12" id="timesheet_settings" string="Timesheets" help="Log time on tasks">
                         <field name="allow_timesheets"/>
                     </setting>
                 </xpath>


### PR DESCRIPTION
### Description:
Currently, the fields and descriptions do not appear at the full width in the project settings.
    
### Technical Description:
Currently, the content does not appear in a full row because col-lg-6 is given in the settings component, leaving the
other col-lg-6 empty. In this commit, we have adjusted the content to display in a full row.

Effected PR - https://github.com/odoo/odoo/pull/111720

task-4050113






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
