### PR TITLE
[IMP] core, web: override readonly route callables

### DIFF
--- a/addons/web/controllers/dataset.py
+++ b/addons/web/controllers/dataset.py
@@ -14,20 +14,20 @@ from .utils import clean_action
 _logger = logging.getLogger(__name__)
 
 
-def _call_kw_readonly(registry, request):
-    params = request.get_json_data()['params']
-    try:
-        model_class = registry[params['model']]
-    except KeyError as e:
-        raise NotFound() from e
-    method_name = params['method']
-    for cls in model_class.mro():
-        method = getattr(cls, method_name, None)
-        if method is not None and hasattr(method, '_readonly'):
-            return method._readonly
-    return False
-
 class DataSet(http.Controller):
+
+    def _call_kw_readonly(self, registry, request):
+        params = request.get_json_data()['params']
+        try:
+            model_class = registry[params['model']]
+        except KeyError as e:
+            raise NotFound() from e
+        method_name = params['method']
+        for cls in model_class.mro():
+            method = getattr(cls, method_name, None)
+            if method is not None and hasattr(method, '_readonly'):
+                return method._readonly
+        return False
 
     @http.route(['/web/dataset/call_kw', '/web/dataset/call_kw/<path:path>'], type='json', auth="user", readonly=_call_kw_readonly)
     def call_kw(self, model, method, args, kwargs, path=None):

--- a/addons/web/controllers/home.py
+++ b/addons/web/controllers/home.py
@@ -34,8 +34,11 @@ class Home(http.Controller):
             return request.redirect_query('/web/login_successful', query=request.params)
         return request.redirect_query('/odoo', query=request.params)
 
+    def _web_client_readonly(self, registry, request):
+        return False
+
     # ideally, this route should be `auth="user"` but that don't work in non-monodb mode.
-    @http.route(['/web', '/odoo', '/odoo/<path:subpath>'], type='http', auth="none")
+    @http.route(['/web', '/odoo', '/odoo/<path:subpath>'], type='http', auth="none", readonly=_web_client_readonly)
     def web_client(self, s_action=None, **kw):
 
         # Ensure we have both a database and a user

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -888,7 +888,7 @@ def _check_and_complete_route_definition(controller_cls, submethod, merged_routi
     default_mode = submethod.original_routing.get('readonly', default_auth == 'none')
     parent_readonly = merged_routing.setdefault('readonly', default_mode)
     child_readonly = submethod.original_routing.get('readonly')
-    if child_readonly not in (None, parent_readonly):
+    if child_readonly not in (None, parent_readonly) and not callable(child_readonly):
         _logger.warning(
             "The endpoint %s made the route %s altough its parent was defined as %s. Setting the route read/write.",
             f'{controller_cls.__module__}.{controller_cls.__name__}.{submethod.__name__}',
@@ -1829,7 +1829,7 @@ class Request:
         self._set_request_dispatcher(rule)
         readonly = rule.endpoint.routing['readonly']
         if callable(readonly):
-            readonly = readonly(self.registry, request)
+            readonly = readonly(rule.endpoint.func.__self__, self.registry, request)
         return self._transactioning(
             functools.partial(self._serve_ir_http, rule, args),
             readonly=readonly,


### PR DESCRIPTION
The `@route(readonly=)` argument can take either a finite bool, either a function whoose job is to return a bool. The function was not composable, i.e. it was not possible for a child controller to override the function to enrich it with new stuffs.

In this work we change the API, the function now must be a method defined on the controller, this way the method can be overriden by child controllers.

Task-3373836

Enterprise: https://github.com/odoo-dev/enterprise/pull/711