### PR TITLE
[FIX] payment: remove acss support in Stripe

### DIFF
--- a/addons/payment/data/payment_method_data.xml
+++ b/addons/payment/data/payment_method_data.xml
@@ -46,27 +46,6 @@
         />
     </record>
 
-    <record id="payment_method_acss_debit" model="payment.method">
-        <field name="name">Pre-authorized debit in Canada</field>
-        <field name="code">acss_debit</field>
-        <field name="sequence">1000</field>
-        <field name="active">False</field>
-        <field name="image" type="base64" file="payment/static/img/bank.png"/>
-        <field name="support_tokenization">False</field>
-        <field name="support_express_checkout">False</field>
-        <field name="support_refund">partial</field>
-        <field name="supported_country_ids"
-               eval="[Command.set([
-                         ref('base.ca'),
-                     ])]"
-        />
-        <field name="supported_currency_ids"
-               eval="[Command.set([
-                         ref('base.CAD'),
-                     ])]"
-        />
-    </record>
-
     <record id="payment_method_affirm" model="payment.method">
         <field name="name">Affirm</field>
         <field name="code">affirm</field>

--- a/addons/payment/data/payment_provider_data.xml
+++ b/addons/payment/data/payment_provider_data.xml
@@ -354,7 +354,6 @@
         <field name="payment_method_ids"
                eval="[Command.set([
                          ref('payment.payment_method_ach_direct_debit'),
-                         ref('payment.payment_method_acss_debit'),
                          ref('payment.payment_method_affirm'),
                          ref('payment.payment_method_afterpay'),
                          ref('payment.payment_method_alipay'),


### PR DESCRIPTION
Pre-authorized debit payments in Canada are using Automated Clearing Settlement System (ACSS), which our current integration does not support.

opw-4012861
