### PR TITLE
[IMP] fleet: exclude vehicles with new contracts from reminders

### DIFF
--- a/addons/fleet/models/fleet_vehicle.py
+++ b/addons/fleet/models/fleet_vehicle.py
@@ -211,7 +211,6 @@ class FleetVehicle(models.Model):
             if prepared_data.get(vehicle_id.id):
                 if prepared_data[vehicle_id.id]['expiration_date'] < expiration_date:
                     prepared_data[vehicle_id.id]['expiration_date'] = expiration_date
-                if prepared_data[vehicle_id.id]['state'] == 'futur' and state == 'open':
                     prepared_data[vehicle_id.id]['state'] = state
             else:
                 prepared_data[vehicle_id.id] = {
@@ -263,12 +262,22 @@ class FleetVehicle(models.Model):
         else:
             search_operator = 'not in'
         today = fields.Date.context_today(self)
-        res_ids = self.env['fleet.vehicle.log.contract'].search([
-            ('expiration_date', '!=', False),
-            ('expiration_date', '<', today),
-            ('state', 'in', ['open', 'expired'])
-        ]).mapped('vehicle_id').ids
-        res.append(('id', search_operator, res_ids))
+        # get the id of vehicles that have overdue contracts
+        # but exclude those for which a new contract has already been created for them
+        vehicle_ids = self.env['fleet.vehicle']._search([
+            ("log_contracts", "any", [
+                ('expiration_date', '!=', False),
+                ('expiration_date', '<', today),
+                ('state', 'in', ['open', 'expired'])
+            ]),
+            "!",
+                ("log_contracts", "any", [
+                    ('expiration_date', '!=', False),
+                    ('expiration_date', '>=', today),
+                    ('state', 'in', ['open', 'futur'])
+                ]),
+        ])
+        res.append(('id', search_operator, vehicle_ids))
         return res
 
     def _clean_vals_internal_user(self, vals):

--- a/addons/fleet/models/fleet_vehicle_log_contract.py
+++ b/addons/fleet/models/fleet_vehicle_log_contract.py
@@ -39,6 +39,7 @@ class FleetVehicleLogContract(models.Model):
         help='Date when the coverage of the contract expirates (by default, one year after begin date)')
     days_left = fields.Integer(compute='_compute_days_left', string='Warning Date')
     expires_today = fields.Boolean(compute='_compute_days_left')
+    has_open_contract = fields.Boolean(compute='_compute_has_open_contract')
     insurer_id = fields.Many2one('res.partner', 'Vendor')
     purchaser_id = fields.Many2one(related='vehicle_id.driver_id', string='Driver')
     ins_ref = fields.Char('Reference', size=64, copy=False)
@@ -69,6 +70,17 @@ class FleetVehicleLogContract(models.Model):
             if name and record.cost_subtype_id.name:
                 name = record.cost_subtype_id.name + ' ' + name
             record.name = name
+
+    @api.depends('vehicle_id')
+    def _compute_has_open_contract(self):
+        today = fields.Date.today()
+        open_contracts = self.env['fleet.vehicle.log.contract'].search([
+            ('vehicle_id', 'in', self.vehicle_id.ids),
+            ('state', '=', 'open'),
+            ('expiration_date', '>=', today)
+        ])
+        for log_contract in self:
+            log_contract.has_open_contract = log_contract.vehicle_id in open_contracts.vehicle_id
 
     @api.depends('expiration_date', 'state')
     def _compute_days_left(self):

--- a/addons/fleet/tests/test_overdue.py
+++ b/addons/fleet/tests/test_overdue.py
@@ -43,3 +43,35 @@ class TestFleet(common.TransactionCase):
         })
         res = self.env["fleet.vehicle"].search([('contract_renewal_overdue', '=', True), ('id', '=', car_1.id)])
         self.assertEqual(res, car_1)
+
+    def test_exclude_resolved_vehicles_from_overdue(self):
+        """
+            if there is an expired contract for the car, but it also has an open contract
+            it should not be considered overdue
+        """
+        user = new_test_user(self.env, "test base user", groups="base.group_user")
+        brand = self.env["fleet.vehicle.model.brand"].create({
+            "name": "Audi",
+        })
+        model = self.env["fleet.vehicle.model"].create({
+            "brand_id": brand.id,
+            "name": "A3",
+        })
+        car_1 = self.env["fleet.vehicle"].create({
+            "model_id": model.id,
+            "driver_id": user.partner_id.id,
+            "plan_to_change_car": False
+        })
+
+        Log = self.env['fleet.vehicle.log.contract']
+        Log.create({
+            'vehicle_id': car_1.id,
+            'expiration_date': fields.Date.add(fields.Date.today(), days=-2)
+        })
+        Log.create({
+            'vehicle_id': car_1.id,
+            'expiration_date': fields.Date.add(fields.Date.today(), days=365)
+        })
+
+        res = self.env["fleet.vehicle"].search([('contract_renewal_overdue', '=', True), ('id', '=', car_1.id)])
+        self.assertFalse(res)

--- a/addons/fleet/views/fleet_vehicle_cost_views.xml
+++ b/addons/fleet/views/fleet_vehicle_cost_views.xml
@@ -68,7 +68,7 @@
         <field name="arch" type="xml">
             <tree string="Contract logs"
                 decoration-warning="expires_today"
-                decoration-danger="days_left==0 and not expires_today"
+                decoration-danger="days_left==0 and not expires_today and not has_open_contract"
                 decoration-muted="state=='closed'"
                 default_order="expiration_date"
                 sample="1">
@@ -84,7 +84,7 @@
                 <field name="cost_generated" widget="monetary"/>
                 <field name="currency_id" column_invisible="True"/>
                 <field name="cost_frequency"/>
-                <field name="state" widget="badge" decoration-info="state == 'open'" decoration-danger="state == 'expired'" />
+                <field name="state" widget="badge" decoration-info="state == 'open'" decoration-danger="state == 'expired' and not has_open_contract" />
                 <field name="activity_exception_decoration" widget="activity_exception"/>
             </tree>
         </field>


### PR DESCRIPTION
Before this commit, if a new contract was created for a vehicle which had an overdue one, it always showed up in the "Need Action" filter.

This commit excludes the vehicles that are resolved from the reminders.

task: 4016972



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
