### PR TITLE
[IMP] l10n_es_edi_tbai: fallback on invoice_date for refund of import…

### DIFF
--- a/addons/l10n_es_edi_tbai/data/template_invoice.xml
+++ b/addons/l10n_es_edi_tbai/data/template_invoice.xml
@@ -100,7 +100,7 @@
                             <t t-set="seq_and_num" t-value="credit_note_invoice._get_l10n_es_tbai_sequence_and_number()"/>
                             <SerieFactura t-out="seq_and_num[0]"/>
                             <NumFactura t-out="seq_and_num[1]"/>
-                            <FechaExpedicionFactura t-out="format_date(credit_note_invoice._get_l10n_es_tbai_signature_and_date()[1])"/>
+                            <FechaExpedicionFactura t-out="format_date(credit_note_invoice.l10n_es_tbai_post_xml and credit_note_invoice._get_l10n_es_tbai_signature_and_date()[1] or credit_note_invoice.invoice_date)"/>
                         </IDFacturaRectificadaSustituida>
                     </FacturasRectificadasSustituidas>
                 </t>

--- a/addons/l10n_es_edi_tbai/models/account_edi_format.py
+++ b/addons/l10n_es_edi_tbai/models/account_edi_format.py
@@ -112,7 +112,12 @@ class AccountEdiFormat(models.Model):
             error_msg = ''
             if chain_head and chain_head != invoice and not chain_head._l10n_es_tbai_is_in_chain():
                 error_msg = _("TicketBAI: Cannot post invoice while chain head (%s) has not been posted", chain_head.name)
-            if invoice.move_type == 'out_refund' and not invoice.reversed_entry_id._l10n_es_tbai_is_in_chain():
+            if (
+                invoice.move_type == 'out_refund'
+                and not invoice.reversed_entry_id or (
+                    not invoice.reversed_entry_id._l10n_es_tbai_is_in_chain()
+                    and invoice.reversed_entry_id.edi_document_ids.filtered(lambda d: d.edi_format_id.code == 'es_tbai'))  # avoid imported ones
+            ):
                 error_msg = _("TicketBAI: Cannot post a reversal move while the source document (%s) has not been posted", invoice.reversed_entry_id.name)
 
             # Tax configuration check: In case of foreign customer we need the tax scope to be set


### PR DESCRIPTION
…ed invoice

When invoices are imported before we use ticketbai in Odoo, we do not have the date from the XML of that imported invoice, so we should be able to fallback on the invoice_date of that original invoice to ease transitioning from one system to the other.

However, there is a check in Odoo that the original invoice should be sent as well.  That is why we check if there are edi documents to see if the file was meant to be sent.

From feedback from Landoo.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
