### PR TITLE
 [FIX] [google_]calendar: X-named RRULE params

### DIFF
--- a/addons/google_calendar/tests/test_sync_google2odoo.py
+++ b/addons/google_calendar/tests/test_sync_google2odoo.py
@@ -913,7 +913,7 @@ class TestSyncGoogle2Odoo(TestSyncGoogle):
             'summary': 'Pricing new update',
             'visibility': 'public',
             'recurrence': ['EXDATE;TZID=Europe/Rome:20200113',
-                           'RRULE:FREQ=WEEKLY;COUNT=3;BYDAY=MO'],
+                           'RRULE;X-EVOLUTION-ENDDATE=20200120:FREQ=WEEKLY;COUNT=3;BYDAY=MO'],
             'reminders': {'useDefault': True},
             'start': {'date': '2020-01-6'},
             'end': {'date': '2020-01-7'},

--- a/addons/google_calendar/tests/test_sync_google2odoo.py
+++ b/addons/google_calendar/tests/test_sync_google2odoo.py
@@ -913,7 +913,7 @@ class TestSyncGoogle2Odoo(TestSyncGoogle):
             'summary': 'Pricing new update',
             'visibility': 'public',
             'recurrence': ['EXDATE;TZID=Europe/Rome:20200113',
-                           'RRULE;X-EVOLUTION-ENDDATE=20200120:FREQ=WEEKLY;COUNT=3;BYDAY=MO'],
+                           'RRULE;X-EVOLUTION-ENDDATE=20200120:FREQ=WEEKLY;X-FOO=BAR;COUNT=3;BYDAY=MO;X-RELATIVE=1'],
             'reminders': {'useDefault': True},
             'start': {'date': '2020-01-6'},
             'end': {'date': '2020-01-7'},


### PR DESCRIPTION
PLAYGROUND PR THAT SHOULD BE DELETED AND NOT MERGED AT THE END OF THE TESTS. SEE https://github.com/odoo/odoo/pull/171784

If you created an event using GNOME Evolution/Calendar, it could add an X-EVOLUTION-ENDDATE parameter to the event's RRULE.

When that happens, if the event is pushed to a Google Calendar and synced in Odoo, all participants' calendars stop syncing from there onwards.

In https://discourse.gnome.org/t/working-with-evolution-mail-and-web-calendar-using-rrule-fail-because-of-x-evolution-enddate-in-rrule/19710/3 it explains why this happens and how it's actually a supported feature of RFC 5545.

Dateutil doesn't support that feature. It just fails with ValueError. Progress is being tracked in https://github.com/dateutil/dateutil/pull/1374.

Regarding what matters to Odoo, we can just strip any X-named params from the RRULE prefix and live happy with the rest (or fail if there's really a wrongly-formatted RRULE param). This way we avoid dateutil to fail unnecessarily and unlock users Google calendars synchronizations.

https://github.com/moduon MT-6287


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
