### PR TITLE
[FIX] payment_mollie: fix decimal places of amount sent to Mollie

### DIFF
--- a/addons/payment_mollie/models/payment_transaction.py
+++ b/addons/payment_mollie/models/payment_transaction.py
@@ -9,6 +9,7 @@ from werkzeug import urls
 from odoo import _, models
 from odoo.exceptions import ValidationError
 
+from odoo.addons.payment.const import CURRENCY_MINOR_UNITS
 from odoo.addons.payment_mollie.const import SUPPORTED_LOCALES
 from odoo.addons.payment_mollie.controllers.main import MollieController
 
@@ -58,12 +59,15 @@ class PaymentTransaction(models.Model):
         base_url = self.acquirer_id.get_base_url()
         redirect_url = urls.url_join(base_url, MollieController._return_url)
         webhook_url = urls.url_join(base_url, MollieController._notify_url)
+        decimal_places = CURRENCY_MINOR_UNITS.get(
+            self.currency_id.name, self.currency_id.decimal_places
+        )
 
         return {
             'description': self.reference,
             'amount': {
                 'currency': self.currency_id.name,
-                'value': f"{self.amount:.2f}",
+                'value': f"{self.amount:.{decimal_places}f}",
             },
             'locale': user_lang if user_lang in SUPPORTED_LOCALES else 'en_US',
 


### PR DESCRIPTION
Previously, the amount sent to Mollie always had 2 decimal places. However, Mollie supports 0 decimal places for amounts in ISK and JPY so it failed for payments in those currencies.

This fix adjusts the decimal places sent to Mollie according to the currency.

opw-4011259