### PR TITLE
[FIX] l10n_zm_account: installation traceback

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -201,6 +201,9 @@ class AccountChartTemplate(models.AbstractModel):
                     self.env[model].sudo().with_context(active_test=False).search([('company_id', 'child_of', company.id)]).with_context({MODULE_UNINSTALL_FLAG: True}).unlink()
 
         data = self._get_chart_template_data(template_code)
+        if not data.get('template_data'):
+            return
+
         template_data = data.pop('template_data')
         if company.parent_id:
             data = {

--- a/addons/l10n_zm_account/__manifest__.py
+++ b/addons/l10n_zm_account/__manifest__.py
@@ -14,6 +14,7 @@ This is the basic Zambian localization necessary to run Odoo in ZM:
     - Fiscal Positions
     - Default Settings
     """,
+    'auto_install': ['account'],
     "depends": [
         "account",
     ],


### PR DESCRIPTION
Before this commit when installing the zambian chart template without the country of the company set, a traceback appeared.

Since the auto install was missing the search of module in the _get_chart_template_mapping function didn't fetch the zambian localisation and so it caused a KeyError: 'zm'

opw: 4051050




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
