### PR TITLE
[FIX] hr: prevent error when computing avatar_128 for resource

### DIFF
--- a/addons/hr/models/resource.py
+++ b/addons/hr/models/resource.py
@@ -28,7 +28,10 @@ class ResourceResource(models.Model):
 
         for resource in self:
             employee = resource.employee_id
+            if not employee:
+                resource.avatar_128 = False
+                continue
             if is_hr_user:
-                resource.avatar_128 = employee and employee[0].avatar_128
+                resource.avatar_128 = employee[0].avatar_128
             else:
                 resource.avatar_128 = avatar_per_employee_id[employee[0].id]


### PR DESCRIPTION
Steps to reproduce:
---
- Install ``planning`` module
- Give the demo user as ``administrator`` in planning.
- Log in as Demo user > Go to planning
- Click on ``New`` > click on the ``Resource`` field


Traceback:
---
``IndexError: tuple index out of range``

The error occurs at [1] because we couldn't find an employee in ``avatar_per_employee_id``. This happens when a new resource is created in the first tab, but the ``employee_id`` is not found in the ``resource`` in the second tab.

This commit resolves the above error by returning false if an employee is not present.

[1]- https://github.com/odoo/odoo/blob/fb4d758ed78211a61ea797759e1fb3b02b51be60/addons/hr/models/resource.py#L34

sentry-5508268100, 6134007941

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
