### PR TITLE
[IMP] hr_expense: payment_mode is required

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -89,9 +89,15 @@ class HrExpense(models.Model):
         default=_default_account_id, domain="[('internal_type', '=', 'other'), ('company_id', '=', company_id)]", help="An expense account is expected")
     description = fields.Text('Notes...', readonly=True, states={'draft': [('readonly', False)], 'reported': [('readonly', False)], 'refused': [('readonly', False)]})
     payment_mode = fields.Selection([
-        ("own_account", "Employee (to reimburse)"),
-        ("company_account", "Company")
-    ], default='own_account', tracking=True, states={'done': [('readonly', True)], 'approved': [('readonly', True)], 'reported': [('readonly', True)]}, string="Paid By")
+            ("own_account", "Employee (to reimburse)"),
+            ("company_account", "Company")
+        ],
+        default='own_account',
+        required=True,
+        tracking=True,
+        states={'done': [('readonly', True)], 'approved': [('readonly', True)], 'reported': [('readonly', True)]},
+        string="Paid By",
+    )
     attachment_number = fields.Integer('Number of Attachments', compute='_compute_attachment_number')
     state = fields.Selection([
         ('draft', 'To Submit'),
@@ -1070,6 +1076,9 @@ class HrExpenseSheet(models.Model):
                 raise UserError(_("You can't mix sample expenses and regular ones"))
             self.write({'state': 'post'})
             return
+
+        if False in self.mapped('payment_mode'):
+            raise UserError(_("Please specify who paid the expenses"))
 
         if any(sheet.state != 'approve' for sheet in self):
             raise UserError(_("You can only generate accounting entry for approved expense(s)."))


### PR DESCRIPTION
The aim of this commit is to improve error handling of the expense move posting step

Context:
The payment mode on the `hr.expense` model isn't required, but the interfaces forces a value to be set. Which allows it to work 99% of the time. When an `account.move` is created, it never checks that a value is set for this field.
If the interface is changed by the user,
then the error becomes harder to track and it still generates an `account.move`

After this commit:
`hr.expense.payment_mode` is required, and a check is added to the `account.move` creation that the `hr.expense.sheet.payment_mode` is set. We do not set the sheet `payment_mode` as required as it smooths the flow of expenses creation, when a sheet is created before the first expenses, allowing the expense to dictate which `payment_mode` to use.

opw-4044695

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
