### PR TITLE
[FIX] pos_discount: ensure discount product is always loaded

### DIFF
--- a/addons/pos_discount/models/pos_session.py
+++ b/addons/pos_discount/models/pos_session.py
@@ -8,8 +8,14 @@ from odoo.osv.expression import OR
 class PosSession(models.Model):
     _inherit = 'pos.session'
 
-    def _loader_params_product_product(self):
-        result = super(PosSession, self)._loader_params_product_product()
-        if self.config_id.module_pos_discount:
-            result['search_params']['domain'] = OR([result['search_params']['domain'], [('id', '=', self.config_id.discount_product_id.id)]])
+    def _get_pos_ui_product_product(self, params):
+        result = super()._get_pos_ui_product_product(params)
+        discount_product_id = self.config_id.discount_product_id.id
+        product_ids_set = {product['id'] for product in result}
+
+        if self.config_id.module_pos_discount and discount_product_id not in product_ids_set:
+            productModel = self.env['product.product'].with_context(**params['context'])
+            product = productModel.search_read([('id', '=', discount_product_id)], fields=params['search_params']['fields'])
+            self._process_pos_ui_product_product(product)
+            result.extend(product)
         return result


### PR DESCRIPTION
Prior to this commit, enabling limited product loading could result in the discount product not being loaded.

opw-4057657

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
