### PR TITLE
[FIX] pos_self_order: fix self test access right

### DIFF
--- a/addons/pos_self_order/tests/test_self_order_combo.py
+++ b/addons/pos_self_order/tests/test_self_order_combo.py
@@ -24,7 +24,7 @@ class TestSelfOrderCombo(SelfOrderCommonTest):
             'self_ordering_pay_after': 'each',
             'self_ordering_service_mode': 'counter',
         })
-        self.pos_user.groups_id += self.env.ref('account.group_account_invoice')
+        self.pos_admin.groups_id += self.env.ref('account.group_account_invoice')
         self.pos_config.with_user(self.pos_user).open_ui()
         self_route = self.pos_config._get_self_order_route()
 

--- a/addons/pos_self_order/tests/test_self_order_common.py
+++ b/addons/pos_self_order/tests/test_self_order_common.py
@@ -10,12 +10,14 @@ from odoo.addons.pos_self_order.tests.self_order_common_test import SelfOrderCom
 class TestSelfOrderCommon(SelfOrderCommonTest):
     def test_self_order_common(self):
         self.pos_config.write({
+            'self_ordering_default_user_id': self.pos_admin.id,
             'self_ordering_takeaway': True,
             'self_ordering_mode': 'kiosk',
             'self_ordering_pay_after': 'each',
             'self_ordering_service_mode': 'table',
         })
 
+        self.pos_admin.groups_id += self.env.ref('account.group_account_invoice')
         self_route = self.pos_config._get_self_order_route()
 
         # Verify behavior when self Order is closed


### PR DESCRIPTION
Before this commit, the self test was failing because the user used to run the test didn't have the right access rights.

This commit fixes the access rights for the user used to run the test.

Rb error: 71576, 71757, 70420, 71598

