### PR TITLE
[FIX] html_editor: adapt tests for delete across paragraphs

### DIFF
--- a/addons/html_editor/static/tests/delete/backward.test.js
+++ b/addons/html_editor/static/tests/delete/backward.test.js
@@ -1981,11 +1981,11 @@ describe("Selection not collapsed", () => {
             });
         });
 
-        test.todo("should keep empty line and delete prefix of second line", async () => {
+        test("should remove empty paragraph and content from the second one", async () => {
             await testEditor({
                 contentBefore: "<p>ab</p><p>[<br></p><p>d]ef</p>",
                 stepFunction: deleteBackward,
-                contentAfter: "<p>ab</p><p>[]<br></p><p>ef</p>",
+                contentAfter: "<p>ab</p><p>[]ef</p>",
             });
         });
 

--- a/addons/html_editor/static/tests/delete/forward.test.js
+++ b/addons/html_editor/static/tests/delete/forward.test.js
@@ -1569,11 +1569,11 @@ describe("Selection not collapsed", () => {
         });
     });
 
-    test.todo("should keep empty line and delete prefix of second line", async () => {
+    test("should remove empty paragraph and content from the second one", async () => {
         await testEditor({
             contentBefore: "<p>ab</p><p>[<br></p><p>d]ef</p>",
             stepFunction: deleteForward,
-            contentAfter: "<p>ab</p><p>[]<br></p><p>ef</p>",
+            contentAfter: "<p>ab</p><p>[]ef</p>",
         });
     });
 });


### PR DESCRIPTION
This commit adapts two recently introduced [1] tests cases to the editor's current behavior, in which selecting content spanning two paragraphs results in merging them, regardless if one of them is an empty paragraph.

These tests had been transported from the old editor, and they are a consequence of a limitation of its deletion mechanism.

In any case, the motivation behind the commit [2] that introduced such tests in the former editor's test suite is respected: deleting a range starting on a empty paragraph and ending in the middle of the content of a paragraph next to it does not affect the content before the empty paragraph.

[1]: https://github.com/odoo/odoo/commit/493a6ece72da7a4f6f2ea29528f670b0b9d231c4
[2]: https://github.com/odoo/odoo/commit/5a39cf9b68fee1a7b750099ad658c9944f0176dd
