### PR TITLE
[FIX] mail: empty attachment is added when message is edited/deleted

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -4523,7 +4523,7 @@ class MailThread(models.AbstractModel):
         attachments = message.attachment_ids.sorted("id")
         broadcast_store = Store(attachments)
         res = {
-            "attachments": {"id": attachment.id for attachment in attachments},
+            "attachments": [{"id": attachment.id} for attachment in attachments],
             "body": message.body,
             "id": message.id,
             "pinned_at": message.pinned_at,


### PR DESCRIPTION
**Current behavior before PR:**

When an already posted message is edited or deleted, an empty attachment is
added to the thread. This empty attachment disappears upon page reload.

**Desired behavior after PR is merged:**

The issue of empty attachments appearing when a message is edited or deleted has
been fixed.

Task-4049791

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
