### PR TITLE
[IMP] point_of_sale: whatsapp and email marketing UI/UX

### DIFF
--- a/addons/point_of_sale/models/__init__.py
+++ b/addons/point_of_sale/models/__init__.py
@@ -41,3 +41,4 @@ from . import account_fiscal_position
 from . import account_fiscal_position_tax
 from . import res_currency
 from . import ir_ui_view
+from . import mail_compose_message

--- a/addons/point_of_sale/models/mail_compose_message.py
+++ b/addons/point_of_sale/models/mail_compose_message.py
@@ -1,0 +1,19 @@
+from odoo import models, _
+
+
+class MailComposer(models.TransientModel):
+    _inherit = 'mail.compose.message'
+
+    def action_send_mail(self):
+        res = super().action_send_mail()
+        if self.filtered(lambda l: l.model == 'pos.order'):
+            return {
+                'type': 'ir.actions.client',
+                'tag': 'display_notification',
+                'params': {
+                    'title': _('Email triggered successfully!'),
+                    'type': 'success',
+                    'next': res
+                }
+            }
+        return res

--- a/addons/point_of_sale/views/pos_order_view.xml
+++ b/addons/point_of_sale/views/pos_order_view.xml
@@ -197,8 +197,17 @@
                                 <field name="pricelist_id" groups="product.group_product_pricelist" readonly="state != 'draft'"/>
                             </group>
                             <group string="Contact Info">
-                                <field name="email"/>
-                                <field name="mobile"/>
+                                <group class="w-75">
+                                    <label for="email"/>
+                                    <div class="o_row">
+                                        <field name="email"/>
+                                        <button name="action_send_mail" icon="fa-envelope fa-lg" type="object" class="btn-link" title="email" invisible="not email"/>
+                                    </div>
+                                    <label for="mobile"/>
+                                    <div class="o_row">
+                                        <field name="mobile"/>
+                                    </div>
+                                </group>
                             </group>
                         </group>
                     </page>


### PR DESCRIPTION
Before this commit:
==========
- There is no confirmation notification while using WhatsApp and Email marketing.
- Also, there is no option for standalone marketing from the PoS order form view.

After this commit:
==========
- Confirmation notification appears after successfully triggering WhatsApp and Email marketing.
- Now, we have an option for standalone marketing from the PoS order form view.

task-4037963