### PR TITLE
[IMP] stock_account: consume origin move SVL first for return receipts

### DIFF
--- a/addons/purchase_stock/tests/test_fifo_returns.py
+++ b/addons/purchase_stock/tests/test_fifo_returns.py
@@ -84,4 +84,4 @@ class TestFifoReturns(ValuationReconciliationTestCommon):
 
         #  After the return only 10 of the second purchase order should still be in stock as it applies fifo on the return too
         self.assertEqual(product_fiforet_icecream.qty_available, 10.0, 'Qty available should be 10.0')
-        self.assertEqual(product_fiforet_icecream.value_svl, 800.0, 'Stock value should be 800')
+        self.assertEqual(product_fiforet_icecream.value_svl, 500.0, 'Stock value should be 500')

--- a/addons/purchase_stock/tests/test_stockvaluation.py
+++ b/addons/purchase_stock/tests/test_stockvaluation.py
@@ -562,8 +562,8 @@ class TestStockValuationWithCOA(AccountTestInvoicingCommon):
         return_pick.move_ids[0].picked = True
         return_pick.button_validate()
 
-        # valuation of product1 should be 200 as the first items will be sent out
-        self.assertEqual(self.product1.value_svl, 200)
+        # valuation of product1 should be 100 as the second receipt is returned
+        self.assertEqual(self.product1.value_svl, 100)
         # create a credit note for po2
         move_form = Form(self.env['account.move'].with_context(default_move_type='in_refund'))
         move_form.invoice_date = move_form.date
@@ -586,7 +586,7 @@ class TestStockValuationWithCOA(AccountTestInvoicingCommon):
         price_diff_entry = self.env['account.move.line'].search([
             ('account_id', '=', self.stock_valuation_account.id),
             ('move_id.stock_move_id', '=', return_pick.move_ids[0].id)])
-        self.assertEqual(price_diff_entry.credit, 100)
+        self.assertEqual(price_diff_entry.credit, 200)
 
     def test_anglosaxon_valuation(self):
         self.env.company.anglo_saxon_accounting = True
@@ -3367,9 +3367,8 @@ class TestStockValuationWithCOA(AccountTestInvoicingCommon):
             {'debit': 10.0, 'credit': 0.0, 'reconciled': True},
             # Receive 1 @ 25
             {'debit': 0.0, 'credit': 25.0, 'reconciled': True},
-            # Return it (10 with valo, 15 with expense)
-            {'debit': 10.0, 'credit': 0.0, 'reconciled': True},
-            {'debit': 15.0, 'credit': 0.0, 'reconciled': True},
+            # Return it (25 with valo)
+            {'debit': 25.0, 'credit': 0.0, 'reconciled': True},
             # Receive all on the backorder (-> all based on PO price, we will not get the value of the returned one)
             {'debit': 0.0, 'credit': 100.0, 'reconciled': True},
             # Bill it
@@ -3412,14 +3411,12 @@ class TestStockValuationWithCOA(AccountTestInvoicingCommon):
             {'debit': 10.0, 'credit': 0.0, 'reconciled': True},
             # Receive 1 @ 25
             {'debit': 0.0, 'credit': 25.0, 'reconciled': True},
-            # Return it (10 with valo, 15 with expense)
-            {'debit': 10.0, 'credit': 0.0, 'reconciled': True},
-            {'debit': 15.0, 'credit': 0.0, 'reconciled': True},
+            # Return it (25 with valo)
+            {'debit': 25.0, 'credit': 0.0, 'reconciled': True},
             # Receive it again
             # The "return of a return" ignores the POL price and uses the value of the returned product
-            # So, same: 10 with valo, 15 with expense
-            {'debit': 0.0, 'credit': 10.0, 'reconciled': True},
-            {'debit': 0.0, 'credit': 15.0, 'reconciled': True},
+            # So, same: 25 with valo
+            {'debit': 0.0, 'credit': 25.0, 'reconciled': True},
             # Bill it
             {'debit': 25.0, 'credit': 0.0, 'reconciled': True},
         ])
@@ -3462,9 +3459,8 @@ class TestStockValuationWithCOA(AccountTestInvoicingCommon):
             {'debit': 0.0, 'credit': 25.0, 'reconciled': True},
             # Bill
             {'debit': 25.0, 'credit': 0.0, 'reconciled': True},
-            # Return (10 with valo, 15 with expense)
-            {'debit': 10.0, 'credit': 0.0, 'reconciled': True},
-            {'debit': 15.0, 'credit': 0.0, 'reconciled': True},
+            # Return (25 with valo)
+            {'debit': 25.0, 'credit': 0.0, 'reconciled': True},
             # Refund
             {'debit': 0.0, 'credit': 25.0, 'reconciled': True},
         ])

--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -333,7 +333,16 @@ class ProductProduct(models.Model):
 
     def _get_fifo_candidates(self, company):
         candidates_domain = self._get_fifo_candidates_domain(company)
-        return self.env["stock.valuation.layer"].sudo().search(candidates_domain)
+        candidates = self.env["stock.valuation.layer"].sudo().search(candidates_domain)
+        returned_moves = self.env.context.get("origin_returned_moves")
+        if not returned_moves:
+            return candidates
+        returned_moves = returned_moves.filtered(lambda x: x.product_id == self)
+        origin_svl = returned_moves.stock_valuation_layer_ids.filtered(
+            lambda x: x.remaining_qty > 0.0
+        )
+        candidates = origin_svl | candidates
+        return candidates
 
     def _run_fifo(self, quantity, company):
         self.ensure_one()

--- a/addons/stock_account/models/stock_move.py
+++ b/addons/stock_account/models/stock_move.py
@@ -249,6 +249,13 @@ class StockMove(models.Model):
         return self._create_dropshipped_svl(forced_quantity=forced_quantity)
 
     def _action_done(self, cancel_backorder=False):
+        origin_returned_moves = self.browse()
+        for move in self:
+            if move._is_out():
+                origin_returned_moves |= move.origin_returned_move_id
+        if origin_returned_moves:
+            self = self.with_context(origin_returned_moves=origin_returned_moves)
+
         # Init a dict that will group the moves by valuation type, according to `move._is_valued_type`.
         valued_moves = {valued_type: self.env['stock.move'] for valued_type in self._get_valued_types()}
         for move in self:

--- a/addons/stock_account/models/stock_move_line.py
+++ b/addons/stock_account/models/stock_move_line.py
@@ -70,7 +70,10 @@ class StockMoveLine(models.Model):
             stock_valuation_layers |= move._create_in_svl(forced_quantity=abs(diff))
             if move.product_id.cost_method in ('average', 'fifo'):
                 move.product_id._run_fifo_vacuum(move.company_id)
-        elif move._is_in() and diff < 0 or move._is_out() and diff > 0:
+        elif move._is_in() and diff < 0:
+            move = move.with_context(origin_returned_moves=move)
+            stock_valuation_layers |= move._create_out_svl(forced_quantity=abs(diff))
+        elif move._is_out() and diff > 0:
             stock_valuation_layers |= move._create_out_svl(forced_quantity=abs(diff))
         elif move._is_dropshipped() and diff > 0 or move._is_dropshipped_returned() and diff < 0:
             stock_valuation_layers |= move._create_dropshipped_svl(forced_quantity=abs(diff))

--- a/addons/stock_account/tests/test_stockvaluationlayer.py
+++ b/addons/stock_account/tests/test_stockvaluationlayer.py
@@ -752,7 +752,7 @@ class TestStockValuationFIFO(TestStockValuationCommon):
         move4 = self._make_return(move3, 1)
         move5 = self._make_return(move4, 1)
 
-        self.assertEqual(self.product1.value_svl, 10)
+        self.assertEqual(self.product1.value_svl, 20)
         self.assertEqual(self.product1.quantity_svl, 1)
 
     def test_dropship_1(self):


### PR DESCRIPTION
This PR makes adjustments for the candidate SVLs used in purchase returns. If the SVL linked to the origin move (receipt) has remaining quantity, that SVL will be consumed first.

@qrtl QT4657