### PR TITLE
[IMP] hr_expense: payment_mode is required

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -174,6 +174,7 @@ class HrExpense(models.Model):
         ],
         string="Paid By",
         default='own_account',
+        required=True,
         tracking=True,
     )
     vendor_id = fields.Many2one(comodel_name='res.partner', string="Vendor")

--- a/addons/hr_expense/models/hr_expense_sheet.py
+++ b/addons/hr_expense/models/hr_expense_sheet.py
@@ -657,6 +657,11 @@ class HrExpenseSheet(models.Model):
         if any(not sheet.journal_id for sheet in self):
             raise UserError(_("Specify expense journal to generate accounting entries."))
 
+        if False in self.mapped('payment_mode'):
+            raise UserError(_(
+                "Please specify if the expenses for this report were paid by the company, or the employee"
+            ))
+
         missing_email_employees = self.filtered(lambda sheet: not sheet.employee_id.work_email).employee_id
         if missing_email_employees:
             action = self.env['ir.actions.actions']._for_xml_id('hr.open_view_employee_list_my')


### PR DESCRIPTION
The aim of this commit is to improve error handling of the expense move posting step

Context:
The payment mode on the `hr.expense` model isn't required, but the interfaces forces a value to be set. Which allows it to work 99% of the time. When an `account.move` is created, it never checks that a value is set for this field.
If the interface is changed by the user,
then the error becomes harder to track and it still generates an `account.move`

After this commit:
`hr.expense.payment_mode` is required, and a check is added to the `account.move` creation that the `hr.expense.sheet.payment_mode` is set. We do not set the sheet `payment_mode` as required as it smooths the flow of expenses creation, when a sheet is created before the first expenses, allowing the expense to dictate which `payment_mode` to use.

opw-4044695

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
