### PR TITLE
[FIX] l10n_es_edi_facturae: add name field for individual seller

### DIFF
--- a/addons/l10n_es_edi_facturae/data/facturae_templates.xml
+++ b/addons/l10n_es_edi_facturae/data/facturae_templates.xml
@@ -288,7 +288,7 @@
                             <t t-set="partner" t-value="self_party if is_outstanding else other_party"/>
                             <t t-set="partner_country_code" t-value="self_party_country_code if is_outstanding else other_party_country_code"/>
                             <t t-set="partner_phone" t-value="False if is_outstanding else other_party_phone"/>
-                            <t t-set="partner_name" t-value="{} if is_outstanding else other_party_name"/>
+                            <t t-set="partner_name" t-value="self_party_name if is_outstanding else other_party_name"/>
                         </t>
                     </SellerParty>
                     <BuyerParty>
@@ -296,7 +296,7 @@
                             <t t-set="partner" t-value="other_party if is_outstanding else self_party"/>
                             <t t-set="partner_country_code" t-value="other_party_country_code if is_outstanding else self_party_country_code"/>
                             <t t-set="partner_phone" t-value="other_party_phone if is_outstanding else False"/>
-                            <t t-set="partner_name" t-value="other_party_name if is_outstanding else {}"/>
+                            <t t-set="partner_name" t-value="other_party_name if is_outstanding else self_party_name"/>
                         </t>
                     </BuyerParty>
                 </Parties>

--- a/addons/l10n_es_edi_facturae/models/account_move.py
+++ b/addons/l10n_es_edi_facturae/models/account_move.py
@@ -284,6 +284,18 @@ class AccountMove(models.Model):
 
         :return: (data needed to render the full template, data needed to render the signature template)
         """
+        def extract_party_name(party):
+            name = {'firstname': 'UNKNOWN', 'surname': 'UNKNOWN', 'surname2': ''}
+            if not party.is_company:
+                name_split = [part for part in party.name.replace(', ', ' ').split(' ') if part]
+                if len(name_split) > 2:
+                    name['firstname'] = ' '.join(name_split[:-2])
+                    name['surname'], name['surname2'] = name_split[-2:]
+                elif len(name_split) == 2:
+                    name['firstname'] = ' '.join(name_split[:-1])
+                    name['surname'] = name_split[-1]
+            return name
+
         self.ensure_one()
         company = self.company_id
         partner = self.commercial_partner_id
@@ -302,16 +314,6 @@ class AccountMove(models.Model):
         legal_literals = self.narration.striptags() if self.narration else False
         legal_literals = legal_literals.split(";") if legal_literals else False
 
-        partner_name = {'firstname': 'UNKNOWN', 'surname': 'UNKNOWN', 'surname2': ''}
-        if not partner.is_company:
-            name_split = [part for part in partner.name.replace(', ', ' ').split(' ') if part]
-            if len(name_split) > 2:
-                partner_name['firstname'] = ' '.join(name_split[:-2])
-                partner_name['surname'], partner_name['surname2'] = name_split[-2:]
-            elif len(name_split) == 2:
-                partner_name['firstname'] = ' '.join(name_split[:-1])
-                partner_name['surname'] = name_split[-1]
-
         invoice_issuer_signature_type = 'supplier' if self.move_type == 'out_invoice' else 'customer'
         need_conv = bool(inv_curr != eur_curr)
         conversion_rate = abs(self.amount_total_in_currency_signed / self.amount_total_signed) if self.amount_total_signed else 0.
@@ -323,10 +325,11 @@ class AccountMove(models.Model):
         template_values = {
             'self_party': company.partner_id,
             'self_party_country_code': COUNTRY_CODE_MAP[company.country_id.code],
+            'self_party_name': extract_party_name(company.partner_id),
             'other_party': partner,
             'other_party_country_code': COUNTRY_CODE_MAP[partner.country_id.code],
             'other_party_phone': partner.phone.translate(PHONE_CLEAN_TABLE) if partner.phone else False,
-            'other_party_name': partner_name,
+            'other_party_name': extract_party_name(partner),
             'is_outstanding': self.move_type.startswith('out_'),
             'float_repr': float_repr,
             'file_currency': inv_curr,


### PR DESCRIPTION
To replicate the issue:
- Go to the partner page of the current company (Invoicing > Customers > Customers > Look for the company)
- Change type from Company to Individual
- Create and post an invoice
- Click on Send & Print. Download the Facturae
- NAME should appear in line 30, before AddressInSpain, but it doesn't

Cause of the issue:
The template values do not include a value for self_party_name, only for other_party_name. In the template, when partner_name is set, no value is passed for self_party.

Fix:
Instead of only extracting the partner name for partner (other_party), the code is used in a new function, which can be called for both partner and company (self_party). Then, self_party_name can be used as a value in the template.

opw-4053023

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
