### PR TITLE
[FIX] pos_loyalty: fix tour helper

### DIFF
--- a/addons/pos_loyalty/static/src/tours/PosLoyaltyTourMethods.js
+++ b/addons/pos_loyalty/static/src/tours/PosLoyaltyTourMethods.js
@@ -41,6 +41,11 @@ odoo.define('pos_loyalty.tour.PosCouponTourMethods', function (require) {
                     content: 'confirm inputted code',
                     trigger: '.popup-textinput .button.confirm',
                 },
+                {
+                    content: 'verify popup is closed',
+                    trigger: 'body:not(:has(.popup-textinput))',
+                    run: function () {}, // it's a check
+                },
             ];
             return steps;
         }


### PR DESCRIPTION
Before this commit, the helper enter code wasn't checking if the popup was closed or not.

If the next step was about closing another popup, the test was running too fast an it try to re-close the first one.

After this commit, the helper enter code will check if the popup is closed or not.

runbot err: 71759, 71590, 71582



