### PR TITLE
[FIX] website_event_sale: don't browse unpublished products

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -457,6 +457,8 @@ class WebsiteSale(http.Controller):
 
     @http.route(['/shop/<model("product.template"):product>'], type='http', auth="public", website=True, sitemap=True)
     def product(self, product, category='', search='', **kwargs):
+        if not product.website_published or request.env.user.has_group("base.group_user"):
+            raise Forbidden()
         return request.render("website_sale.product", self._prepare_product_values(product, category, search, **kwargs))
 
     @http.route(['/shop/product/<model("product.template"):product>'], type='http', auth="public", website=True, sitemap=False)


### PR DESCRIPTION

Description of the issue/feature this PR addresses:

Since the products are added to the sitemap, sometimes search engines index those pages and users land there, even when they are not displayed in e-commerce search results.

With this fix, if that happens, users will receive a "nice" forbidden error.

@moduon MT-6740 OPW-4040667

Current behavior before PR:
https://www.loom.com/share/d76dce841f024422828efb8bc0ecc31a?sid=f4181d45-d0d2-4415-aecd-eccd01d92e63

Desired behavior after PR is merged:
Visitors shouldn't be able to buy ticket products directly. Instead, they should buy them from the event. Thus, browsing those products should be forbidden.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
