### PR TITLE
[FIX] hr_expense: fix traceback when posting journal entries in hr expense

### DIFF
--- a/addons/hr_expense/models/hr_expense_sheet.py
+++ b/addons/hr_expense/models/hr_expense_sheet.py
@@ -653,7 +653,7 @@ class HrExpenseSheet(models.Model):
         self.activity_update()
 
     def _do_reset_approval(self):
-        self.sudo().write({'approval_state': False})
+        self.sudo().write({'approval_state': False, 'accounting_date': False})
         self.activity_update()
 
     def _do_refuse(self, reason):
@@ -727,7 +727,7 @@ class HrExpenseSheet(models.Model):
             # force the name to the default value, to avoid an eventual 'default_name' in the context
             # to set it to '' which cause no number to be given to the account.move when posted.
             'name': '/',
-            'date': self.accounting_date or max(self.expense_line_ids.mapped('date')) or fields.Date.context_today(self),
+            'date': self.accounting_date or max(self.expense_line_ids.filtered(lambda exp: exp.date).mapped('date'), default=fields.Date.context_today(self)),
             'expense_sheet_id': self.id,
         }
 

--- a/addons/hr_expense/tests/test_expenses.py
+++ b/addons/hr_expense/tests/test_expenses.py
@@ -1063,3 +1063,66 @@ class TestExpenses(TestExpenseCommon):
 
         expense_sheet.expense_line_ids.analytic_distribution = {self.analytic_account_1.id: 100.00}
         expense_sheet.with_context(validate_analytic=True).action_approve_expense_sheets()
+
+    def test_expense_sheet_with_line_ids(self):
+        """
+        Test to create an expense sheet with no account date and having multiple expenses
+        in which one of the expense doesn't have date to get the account date from the max date of expenses.
+        """
+        expense_sheet = self.env['hr.expense.sheet'].create({
+            'name': 'Expense for John Smith',
+            'employee_id': self.expense_employee.id,
+            'payment_method_line_id': self.outbound_payment_method_line.id,
+            'expense_line_ids': [
+                Command.create({
+                    'name': 'Car Travel Expenses',
+                    'employee_id': self.expense_employee.id,
+                    'product_id': self.product_c.id,
+                    'total_amount': 350.00,
+                    'date': False,
+                }),
+                Command.create({
+                    'name': 'Lunch expense',
+                    'employee_id': self.expense_employee.id,
+                    'product_id': self.product_c.id,
+                    'total_amount': 90.00,
+                    'date': '2024-04-30',
+                }),
+            ]
+        })
+        # Validate the values before submitting and approving
+        self.assertRecordValues(expense_sheet, [
+            {'total_amount': 440.00, 'accounting_date': False, 'state': 'draft', 'employee_id': self.expense_employee.id}
+        ])
+        self.assertRecordValues(expense_sheet.expense_line_ids, [
+            {'name': 'Car Travel Expenses', 'total_amount': 350.00, 'date': False},
+            {'name': 'Lunch expense', 'total_amount': 90.00, 'date': date(2024, 4, 30)},
+        ])
+        expense_sheet.action_submit_sheet()
+        expense_sheet.action_approve_expense_sheets()
+        expense_sheet.action_sheet_move_create()
+
+        # Validate the record values after submitting and approving
+        self.assertRecordValues(expense_sheet, [
+            {'total_amount': 440.00, 'accounting_date': date(2024, 4, 30), 'state': 'post', 'employee_id': self.expense_employee.id}
+        ])
+        self.assertRecordValues(expense_sheet.expense_line_ids, [
+            {'name': 'Car Travel Expenses', 'total_amount': 350.00, 'date': False},
+            {'name': 'Lunch expense', 'total_amount': 90.00, 'date': date(2024, 4, 30)},
+        ])
+
+        # Reset to draft to make the accounting_date to False and then recompute it
+        expense_sheet.action_reset_expense_sheets()
+
+        # Validate the accounting_date value to be false
+        self.assertFalse(expense_sheet.accounting_date)
+
+        # Update one of the expense sheet line date
+        expense_sheet.expense_line_ids[1].write({'date': '2024-05-30'})
+
+        expense_sheet.action_submit_sheet()
+        expense_sheet.action_approve_expense_sheets()
+        expense_sheet.action_sheet_move_create()
+
+        # Validate the acction_date value after subitting and approving
+        self.assertTrue(expense_sheet.accounting_date, date(2024, 5, 30))


### PR DESCRIPTION
Currently, a traceback occurs when the user `posts journal entries` with `multiple expenses` 
in which one of the expense doesn't have a `date`.

To reproduce this issue:

1) Install `Expense`
2) Create an expense report(expense sheet) with multiple expense lines 
3) Remove one of the expense's date
4) Click Submit to Manager> Approve> Post Journal Entries

Error:
```
TypeError: '>' not supported between instances of 'datetime.date' and 'bool'
  File "odoo/http.py", line 2248, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1823, in _serve_db
    return self._transactioning(_serve_ir_http, readonly=ro)
  File "odoo/http.py", line 1843, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1821, in _serve_ir_http
    return self._serve_ir_http(rule, args)
  File "odoo/http.py", line 1828, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2053, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 220, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 756, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 42, in call_button
    action = self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 34, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 458, in call_kw
    result = getattr(recs, name)(*args, **kwargs)
  File "home/odoo/src/enterprise/saas-17.2/hr_expense_extract/models/hr_expense.py", line 199, in action_sheet_move_create
    return super().action_sheet_move_create()
  File "addons/hr_expense/models/hr_expense_sheet.py", line 558, in action_sheet_move_create
    self._do_create_moves()
  File "addons/sale_expense/models/hr_expense_sheet.py", line 119, in _do_create_moves
    return super()._do_create_moves()
  File "addons/hr_expense/models/hr_expense_sheet.py", line 700, in _do_create_moves
    moves = self.env['account.move'].create([sheet._prepare_bills_vals() for sheet in own_account_sheets])
  File "addons/hr_expense/models/hr_expense_sheet.py", line 700, in <listcomp>
    moves = self.env['account.move'].create([sheet._prepare_bills_vals() for sheet in own_account_sheets])
  File "addons/hr_expense/models/hr_expense_sheet.py", line 728, in _prepare_bills_vals
    **self._prepare_move_vals(),
  File "addons/hr_expense/models/hr_expense_sheet.py", line 749, in _prepare_move_vals
    'date': self.accounting_date or max(self.expense_line_ids.mapped('date')) or fields.Date.context_today(self),
```


When the user clicks on the `Post Journal Entries` Button, it tries to create an expense report in which `_prepare_move_vals` method triggers.

In this method, the `max` function is used to get the date from `expense_line_ids`. 
If any one of the expense lines doesn't have a date(date is not required) it leads to a traceback.

https://github.com/odoo/odoo/blob/607e454f65c2c60c4ee5169bc53706f24a8bc625/addons/hr_expense/models/hr_expense_sheet.py#L725-L732

After applying this commit, it will resolve this issue by filtering records with date and then the max function is used to get the maximum date.

sentry-5616738740