### PR TITLE
[FIX] website_forum: fix traceback on flag

### DIFF
--- a/addons/website_forum/static/src/js/website_forum.js
+++ b/addons/website_forum/static/src/js/website_forum.js
@@ -357,11 +357,13 @@ publicWidget.registry.websiteForum = publicWidget.Widget.extend({
                     }
                     $(elem).nextAll('.flag_validator').removeClass('d-none');
                 } else if (data.success === 'post_flagged_non_moderator') {
-                    const forumAnswer = elem.closest('.forum_answer');
                     elem.innerText = _t(' Flagged');
                     elem.prepend(child);
-                    forumAnswer.fadeIn(1000);
-                    forumAnswer.slideUp(1000);
+                    const $forumAnswer = $(elem).closest('.o_wforum_answer');
+                    if ($forumAnswer) {
+                        $forumAnswer.fadeIn(1000);
+                        $forumAnswer.slideUp(1000);
+                    }
                 }
             }
         });


### PR DESCRIPTION
Purpose
=======
Fix the traceback appearing when flagging a question or answer
without being a moderator.

Specification
=============
The .forum_answer class has been removed from the element when doing the
website_forum redesign (ref: https://github.com/odoo/odoo/commit/4b1cf2e06643171e5ae10ea44648c4db66d09319 )
The element is thus not found and a traceback occurs when trying to perform
the animation.

Now using the 'o_wforum_answer' element and making sure it exists before
calling the animation.

Task-4058832

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
