### PR TITLE
[FIX] pos_loyalty: make sure gift card is paid before using it

### DIFF
--- a/addons/pos_loyalty/static/src/tours/GiftCardProgramTours.js
+++ b/addons/pos_loyalty/static/src/tours/GiftCardProgramTours.js
@@ -1,6 +1,5 @@
 /** @odoo-module **/
 
-import { Chrome } from "point_of_sale.tour.ChromeTourMethods";
 import { PosLoyalty } from 'pos_loyalty.tour.PosCouponTourMethods';
 import { ProductScreen } from 'point_of_sale.tour.ProductScreenTourMethods';
 import { TextInputPopup } from 'point_of_sale.tour.TextInputPopupTourMethods';
@@ -72,9 +71,14 @@ Tour.register("PosLoyaltyPointsGiftcard", { test: true, url: "/pos/web" }, getSt
 startSteps();
 ProductScreen.do.confirmOpeningPopup();
 ProductScreen.do.clickHomeCategory();
+ProductScreen.do.clickDisplayedProduct('Gift Card');
+TextInputPopup.check.isShown();
+TextInputPopup.do.inputText('044123456');
+TextInputPopup.do.clickConfirm();
+PosLoyalty.check.orderTotalIs('50.00');
+PosLoyalty.exec.finalizeOrder('Cash', '50');
 ProductScreen.do.clickDisplayedProduct("Test Product A");
 PosLoyalty.do.enterCode("044123456");
-Chrome.do.confirmPopup();
 PosLoyalty.check.orderTotalIs("50.00");
 ProductScreen.check.checkTaxAmount("-6.52");
 Tour.register("PosLoyaltyGiftCardTaxes", { test: true }, getSteps());


### PR DESCRIPTION
This fix make sure that the gift card is paid before using it in the tour.

https://runbot.odoo.com/web#id=71581&view_type=form&model=runbot.build.error&menu_id=405&cids=1

opw-3916989
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
