### PR TITLE
[IMP] web: quoted search in search bar is an exact match

### DIFF
--- a/addons/web/static/src/search/search_bar/search_bar.js
+++ b/addons/web/static/src/search/search_bar/search_bar.js
@@ -302,8 +302,14 @@ export class SearchBar extends Component {
                 ? searchItem.propertyFieldDefinition.comodel
                 : field.relation;
 
+        let nameSearchOperator = "ilike";
+        if (query && query[0] === '"' && query[query.length - 1] === '"') {
+            query = query.slice(1, -1);
+            nameSearchOperator = "=";
+        }
         const options = await this.orm.call(relation, "name_search", [], {
             args: domain,
+            operator: nameSearchOperator,
             context,
             limit: 8,
             name: query.trim(),
@@ -379,7 +385,14 @@ export class SearchBar extends Component {
 
         if (!item.unselectable) {
             const { searchItemId, label, operator, value } = item;
-            this.env.searchModel.addAutoCompletionValues(searchItemId, { label, operator, value });
+            const autoCompleteValues = { label, operator, value };
+            if (value && value[0] === '"' && value[value.length - 1] === '"') {
+                autoCompleteValues.value = value.slice(1, -1);
+                autoCompleteValues.label = label.slice(1, -1);
+                autoCompleteValues.operator = "=";
+                autoCompleteValues.enforceEqual = true;
+            }
+            this.env.searchModel.addAutoCompletionValues(searchItemId, autoCompleteValues);
         }
         this.resetState();
     }

--- a/addons/web/static/src/search/search_model.js
+++ b/addons/web/static/src/search/search_model.js
@@ -1844,10 +1844,16 @@ export class SearchModel extends EventBus {
      * of a search item of type 'field'.
      */
     _getFieldDomain(field, autocompleteValues) {
-        const domains = autocompleteValues.map(({ label, value, operator }) => {
+        const domains = autocompleteValues.map(({ label, value, operator, enforceEqual }) => {
             let domain;
             if (field.filterDomain) {
-                domain = new Domain(field.filterDomain).toList({
+                let filterDomain = field.filterDomain;
+                if (enforceEqual) {
+                    filterDomain = field.filterDomain
+                        .replaceAll("'ilike'", "'='")
+                        .replaceAll('"ilike"', '"="');
+                }
+                domain = new Domain(filterDomain).toList({
                     self: label.trim(),
                     raw_value: value,
                 });

--- a/addons/web/static/tests/_framework/mock_server/mock_model.js
+++ b/addons/web/static/tests/_framework/mock_server/mock_model.js
@@ -1667,7 +1667,13 @@ export class Model extends Array {
         const result = [];
         for (const record of this) {
             const isInDomain = actualDomain.contains(record);
-            if (isInDomain && (!name || record.display_name?.includes(name))) {
+            if (
+                isInDomain &&
+                (!name ||
+                    (operator === "="
+                        ? record.display_name === name
+                        : record.display_name?.includes(name)))
+            ) {
                 result.push([record.id, record.display_name]);
             }
         }

--- a/addons/web/static/tests/search/search_bar.test.js
+++ b/addons/web/static/tests/search/search_bar.test.js
@@ -690,6 +690,7 @@ test("check kwargs of a rpc call with a domain", async () => {
                 args: [["bool", "=", true]],
                 context: { lang: "en", uid: 7, tz: "taht", allowed_company_ids: [1] },
                 limit: 8,
+                operator: "ilike",
                 name: "F",
             },
         });
@@ -1700,4 +1701,52 @@ test("order by count resets when there is no group left", async () => {
     await toggleMenuItem("Bar");
     expect(".fa-sort-numeric-asc").toHaveCount(0);
     expect(".fa-sort").toHaveCount(1);
+});
+
+test("quoted search term performs an exact match search", async () => {
+    const searchBar = await mountWithSearch(SearchBar, {
+        resModel: "partner",
+        searchMenuTypes: [],
+        searchViewId: false,
+    });
+    await editSearch(`"yop"`);
+    keyDown("Enter");
+    await animationFrame();
+    expect(searchBar.env.searchModel._domain).toEqual([["foo", "=", "yop"]]);
+});
+
+test(`quoted search term performs an exact match search on view defined's "filter_domain"`, async () => {
+    const searchBar = await mountWithSearch(SearchBar, {
+        resModel: "partner",
+        searchMenuTypes: [],
+        searchViewId: false,
+        searchViewArch: `
+            <search>
+                <field string="Foo" name="foo" filter_domain="[('name', 'ilike', self)]"/>
+            </search>
+        `,
+    });
+    await editSearch(`"Second record"`);
+    keyDown("Enter");
+    await animationFrame();
+    expect(searchBar.env.searchModel._domain).toEqual([["name", "=", "Second record"]]);
+});
+
+test(`quoted search term performs a name_search with operator = for subitems`, async () => {
+    await mountWithSearch(SearchBar, {
+        resModel: "partner",
+        searchMenuTypes: [],
+        searchViewId: false,
+        searchViewArch: `
+            <search>
+                <field string="Company" name="company"/>
+            </search>
+        `,
+    });
+    await editSearch(`"First"`);
+    await contains(".o_expand").click();
+    expect(".o_searchview_autocomplete li.o_menu_item.o_indent").toHaveText("(no result)");
+    await editSearch(`"First record"`);
+    await contains(".o_expand").click();
+    expect(".o_searchview_autocomplete li.o_menu_item.o_indent").toHaveText("First record");
 });


### PR DESCRIPTION
Any quoted search in the control panel search bar is now an exact match. It also impacts the filter_domain set on the search view, replacing the ilike by equals.

Task id 3821281