### PR TITLE
[FIX] sale_product_configurator: product attribute name breaks

### DIFF
--- a/addons/sale_product_configurator/static/src/js/product_template_attribute_line/product_template_attribute_line.xml
+++ b/addons/sale_product_configurator/static/src/js/product_template_attribute_line/product_template_attribute_line.xml
@@ -12,7 +12,8 @@
                     t-if="showValuesChoice || (
                         this.props.attribute_values.length === 1 &amp;&amp; isSelectedPTAVCustom())"
                     t-out="this.props.attribute.name"
-                    t-attf-class="fw-bold text-break #{this.props.attribute_values.length === 1 &amp;&amp; hasPTAVCustom() ? '' : 'w-lg-25'}"/>
+                    t-attf-class="fw-bold text-break #{this.props.attribute_values.length === 1
+                        &amp;&amp; hasPTAVCustom() ? '' : 'col-lg-3'}"/>
                 <t t-if="showValuesChoice" t-call="{{getPTAVTemplate()}}"/>
             </div>
             <input


### PR DESCRIPTION
Steps to reproduce:
-Create a product.
-Add an attribute with a long name.
-Add a significant number of variants (around 15-20).
-Create a SO with this product.

Issue:
The attribute name is not easily readable.

Cause:
The use of the w-lg-25 class sets a fixed width.

Fix:
Use col-lg-3 to ensure the width adjusts according to the grid system.
