### PR TITLE
[FIX] *: dark mode for lazy views

### DIFF
--- a/addons/web/__manifest__.py
+++ b/addons/web/__manifest__.py
@@ -132,12 +132,16 @@ This module provides the core of the Odoo Web Client.
         ],
         'web.assets_backend_lazy': [
             ('include', 'web._assets_helpers'),
+            ('include', 'web._assets_backend_helpers'),
             'web/static/src/scss/pre_variables.scss',
             'web/static/lib/bootstrap/scss/_variables.scss',
             'web/static/lib/bootstrap/scss/_variables-dark.scss',
             'web/static/lib/bootstrap/scss/_maps.scss',
 
             'web/static/src/views/graph/**',
+        ],
+        'web.assets_backend_lazy_dark': [
+            ('include', 'web.assets_backend_lazy'),
         ],
         'web.assets_web': [
             ('include', 'web.assets_backend'),

--- a/addons/web/static/src/views/view.js
+++ b/addons/web/static/src/views/view.js
@@ -11,6 +11,7 @@ import { OnboardingBanner } from "@web/views/onboarding_banner";
 import { useActionLinks } from "@web/views/view_hook";
 import { computeViewClassName } from "./utils";
 import { loadBundle } from "@web/core/assets";
+import { cookie } from "@web/core/browser/cookie";
 import {
     Component,
     markRaw,
@@ -29,7 +30,6 @@ viewRegistry.addValidation({
     Controller: { validate: (c) => c.prototype instanceof Component },
     "*": true,
 });
-const DEFAULT_LAZY_BUNDLE = "web.assets_backend_lazy";
 
 /** @typedef {Object} Config
  *  @property {integer|false} actionId
@@ -321,7 +321,11 @@ export class View extends Component {
             ? archXmlDoc.getAttribute("js_class")
             : props.jsClass || type;
         if (!viewRegistry.contains(jsClass)) {
-            await loadBundle(DEFAULT_LAZY_BUNDLE);
+            await loadBundle(
+                cookie.get("color_scheme") === "dark"
+                    ? "web.assets_backend_lazy_dark"
+                    : "web.assets_backend_lazy"
+            );
         }
         const descr = viewRegistry.get(jsClass);
 


### PR DESCRIPTION
In https://github.com/odoo/odoo/commit/f1749d3299957e2949e0b78653266a5397bb213c, we forgot to prepare a bundle for the dark mode.
Here we add a bundle 'web.assets_backend_lazy_dark'.
It will be first used in enterprise and soon in community.