### PR TITLE
[FIX] loyalty: error when adding product tag to loyalty

### DIFF
--- a/addons/loyalty/models/loyalty_reward.py
+++ b/addons/loyalty/models/loyalty_reward.py
@@ -168,7 +168,7 @@ class LoyaltyReward(models.Model):
                 elif len(products) == 1:
                     reward_string = _('Free Product - %s', reward.reward_product_id.with_context(display_default_code=False).display_name)
                 else:
-                    reward_string = _('Free Product - [%s]', ', '.join(products.with_context(display_default_code=False).mapped('display_name')))
+                    reward_string = _('Free Product - [%s]', ', '.join(products._origin.with_context(display_default_code=False).mapped('display_name')))
             elif reward.reward_type == 'discount':
                 format_string = '%(amount)g %(symbol)s'
                 if reward.currency_id.position == 'before':


### PR DESCRIPTION
Steps:
- Create a loyalty program with reward_type product
- add a product in product field
- add a tag in product tag field which is linked to multiple products
- change the product in product field

Issue:
- returns access error : Database fetch misses ids

Cause:
- the _compute_reward_description function set the description for multi-reward
  products as reward.reward_product_ids which is a many2many field hence it
  generates virtual records so when we try to access it, it gives access error

Fix:
- changed the line so that it accesses it from _origin (original records)
  instead of virtual record

opw-4060066

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
