### PR TITLE
[IMP] hr_holidays: no error on allocation approval

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -689,7 +689,7 @@ class HolidaysAllocation(models.Model):
         # if allocation_validation_type == 'both': this method is the first approval
         # if allocation_validation_type != 'both': this method calls action_validate() below
 
-        if any(allocation.state != 'confirm' for allocation in self):
+        if any(allocation.validation_type != 'no_validation' and allocation.state != 'confirm' for allocation in self):
             raise UserError(_('Allocation must be confirmed ("To Approve") in order to approve it.'))
 
         current_employee = self.env.user.employee_id


### PR DESCRIPTION
When you have a Time Off Type that requires an allocation, but the allocation doesn't need to be approved﻿﻿,
and you create the allocation, it is automatically in the approved state when saving/confirming it.

However, when you create an allocation and you click on the Approve button, it gives you an error:
`Invalid Operation - Allocation must be confirmed ("To Approve") in order to approve it.` , because by confirming/saving the allocation, it is already moved to the 'approved' state and by clicking on the Approve button, we are actually approving it twice. When we close the error popup, the allocation is approved, so we have the required end result anyways.

This commit prevents the error, by not checking the allocations of time off types that don't need validation.

task: 4035895 ﻿﻿



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
