### PR TITLE
[FIX] project: properly set the default company for task

### DIFF
--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -773,6 +773,8 @@ class Task(models.Model):
             project = self.env['project.project'].browse(project_id)
             if project.analytic_account_id:
                 vals['analytic_account_id'] = project.analytic_account_id.id
+            if 'company_id' in default_fields and 'default_project_id' not in self.env.context:
+                vals['company_id'] = project.sudo().company_id
         elif 'default_user_ids' not in self.env.context and 'user_ids' in default_fields:
             user_ids = vals.get('user_ids', [])
             user_ids.append(Command.link(self.env.user.id))

--- a/addons/project/tests/test_project_task_quick_create.py
+++ b/addons/project/tests/test_project_task_quick_create.py
@@ -69,3 +69,14 @@ class TestProjectTaskQuickCreate(TestProjectCommon):
             'project_id': self.project_pigs.id,
         })
         self.assertEqual(self.project_pigs.type_ids, new_stage, "Task stage is not set in project")
+
+    def test_create_task_with_default_value(self):
+        self.project_pigs.write({
+            'company_id': self.env.company,
+        })
+        project_ids = self.env['project.project'].search([]).ids
+        self.env['ir.default'].discard_values('project.task', 'project_id', project_ids)
+        self.env['ir.default'].set('project.task', 'project_id', self.project_pigs.id)
+        field_specs = {'project_id': {}, 'company_id': {'fields': {}}}
+        task_values = self.env['project.task'].onchange({}, [], field_specs)['value']
+        self.assertEqual(task_values['project_id'], self.project_pigs.id, "The task project_id should be set")


### PR DESCRIPTION
[FIX] project: add a validation to _onchange_task_company
Steps to reproduce the bug:
1. Activate developer mode.
2. Create a project 'project x' and link it to a company.
3. Create a task for 'project x'.
4. Set the default project for tasks to 'project x'.
5. Create a new task and check the default project.

The default project is not set correctly. This issue occurs due to how default values are assigned. Initially, a record
is created, and then the default values are populated, which triggers the onchange methods.

By default `company_id` is not set even when the task is affiliated with a project witch means when
`_onchange_task_company` is triggered, the value of `self.company_id` is False, which inturn sets `self.project_id` to
False.

Reference: opw-4004172 (gavb: fix ticket id)