### PR TITLE
[FIX] web: make translate icon appear for html fields

### DIFF
--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -632,10 +632,12 @@
             visibility: hidden;
     }
 
-    div {
-        div:focus-within > span.o_field_translate, div:hover > span.o_field_translate {
-            visibility: visible !important;
-        }
+    div:focus-within > span.o_field_translate, div:hover > span.o_field_translate {
+        visibility: visible;
+    }
+
+    div.o_field_html:focus-within span.o_field_translate, div.o_field_html:hover span.o_field_translate {
+        visibility: visible;
     }
 
     input, textarea {


### PR DESCRIPTION
The focus/hover does not work the same way for html fields (filiation is different)
So, the icon is always hidden currently.

Let's add specific logic for these html fields




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
