### PR TITLE
[FIX] account: properly update tag names without l10n_multilang

### DIFF
--- a/addons/account/models/account_report.py
+++ b/addons/account/models/account_report.py
@@ -557,8 +557,12 @@ class AccountReportExpression(models.Model):
                     if former_tax_tags and all(tag_expr in self for tag_expr in former_tax_tags._get_related_tax_report_expressions()):
                         # If we're changing the formula of all the expressions using that tag, rename the tag
                         positive_tags, negative_tags = former_tax_tags.sorted(lambda x: x.tax_negate)
-                        positive_tags._update_field_translations('name', {'en_US': f"+{vals['formula']}"})
-                        negative_tags._update_field_translations('name', {'en_US': f"-{vals['formula']}"})
+                        if self.pool['account.tax'].name.translate:
+                            positive_tags._update_field_translations('name', {'en_US': f"+{vals['formula']}"})
+                            negative_tags._update_field_translations('name', {'en_US': f"-{vals['formula']}"})
+                        else:
+                            positive_tags.name = f"+{vals['formula']}"
+                            negative_tags.name = f"-{vals['formula']}"
                     else:
                         # Else, create a new tag. Its the compute functions will make sure it is properly linked to the expressions
                         tag_vals = self.env['account.report.expression']._get_tags_create_vals(vals['formula'], country.id)


### PR DESCRIPTION
When l10n_multilang isn't installed, the rewriting of the tag name due to the modification of a tax_tags expression did not work. This was due to the fact we called _update_field_translations on a not translatable field, which had no effect.

Because of that test_write_single_line_tagname_not_shared failed on Community builds of the nightly tests.
