### PR TITLE
[FIX] account: account group with branches

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -907,7 +907,9 @@ class AccountGroup(models.Model):
             company_ids = account_ids.company_id.root_id.ids
             account_ids = account_ids.ids
         else:
-            company_ids = self.company_id.ids
+            company_ids = []
+            for company in self.company_id:
+                company_ids.extend(company._accessible_branches().ids)
             account_ids = []
         if not company_ids and not account_ids:
             return


### PR DESCRIPTION
Before this commit when being in a branches environment, creating an account group on the main company was not propagated to the account of the child companies

opw: 4055582




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
