### PR TITLE
[FIX] point_of_sale: fix pos test helper

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/action_pad/action_pad.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/action_pad/action_pad.xml
@@ -9,9 +9,9 @@
             <t t-if="ui.isSmall">
                 <SelectPartnerButton partner="props.partner"/>
             </t>
-            <button class="pay validation pay-order-button btn-primary"
+            <button class="pay validation pay-order-button"
                 t-attf-class="{{getMainButtonClasses()}}"
-                t-att-class="{'btn-secondary': !props.isActionButtonHighlighted, 'with-more-button': props.onClickMore and ui.isSmall}"
+                t-att-class="{'btn-secondary': !props.isActionButtonHighlighted, 'btn-primary': props.isActionButtonHighlighted,'with-more-button': props.onClickMore and ui.isSmall}"
                 t-on-click="props.actionToTrigger ? this.props.actionToTrigger : () => pos.pay()">
                 <div class="pay-circle d-flex align-items-center justify-content-center py-2 mb-2">
                     <i class="oi oi-chevron-right" role="img" aria-label="Pay" title="Pay" />

--- a/addons/point_of_sale/static/tests/tours/utils/ticket_screen_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/ticket_screen_util.js
@@ -111,7 +111,7 @@ export function confirmRefund() {
     return [
         ProductScreen.clickReview(),
         {
-            trigger: ".ticket-screen .button.pay-order-button",
+            trigger: ".ticket-screen .btn-primary.pay-order-button",
             run: "click",
         },
     ];


### PR DESCRIPTION
Before this commit, the pos test helper was not working properly because trigger of refund button was `.ticket-screen .button.pay-order-button`

Now the trigger is `.ticket-screen .btn-primary.pay-order-button`, it only allow the test to trigger the refund button when it is highlighted

rb err: 68712, 68711




