### PR TITLE
[FIX] payment_custom: add payment method code to activate by default

### DIFF
--- a/addons/payment_custom/const.py
+++ b/addons/payment_custom/const.py
@@ -1,0 +1,6 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+# The codes of the payment methods to activate when Wire Transfer is activated.
+DEFAULT_PAYMENT_METHOD_CODES = [
+    'wire_transfer',
+]

--- a/addons/payment_custom/models/payment_provider.py
+++ b/addons/payment_custom/models/payment_provider.py
@@ -3,6 +3,8 @@
 from odoo import _, api, fields, models
 from odoo.osv.expression import OR
 
+from odoo.addons.payment_custom import const
+
 
 class PaymentProvider(models.Model):
     _inherit = 'payment.provider'
@@ -83,3 +85,10 @@ class PaymentProvider(models.Model):
         )
         if transfer_providers_without_msg:
             transfer_providers_without_msg.action_recompute_pending_msg()
+
+    def _get_default_payment_method_codes(self):
+        """ Override of `payment` to return the default payment method codes. """
+        default_codes = super()._get_default_payment_method_codes()
+        if self.custom_mode != 'wire_transfer':
+            return default_codes
+        return const.DEFAULT_PAYMENT_METHOD_CODES


### PR DESCRIPTION
Steps to reproduce:
1) Install and enable wire transfer.
2) Disable and enable it again.
3) Go to the payment form and see that wire transfer is not in the list of available payment methods.

Reason:
No default payment method codes were defined to activate with the provider.

opw-4042165