### PR TITLE
[FIX] auth_passkey: missing dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -24,6 +24,7 @@ Depends:
  libjs-underscore,
  lsb-base,
  postgresql-client,
+ python3-asn1crypto,
  python3-babel,
  python3-cbor2,
  python3-chardet,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 # The officially supported versions of the following packages are their
 # python3-* equivalent distributed in Ubuntu 22.04 and Debian 11
+asn1crypto==1.4.0 ; python_version < '3.11'
+asn1crypto==1.5.1 ; python_version >= '3.11'
 Babel==2.9.1 ; python_version < '3.11'  # min version = 2.6.0 (Focal with security backports)
 Babel==2.10.3 ; python_version >= '3.11'
 cbor2==5.4.2 ; python_version < '3.12'

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
     package_dir={'%s' % lib_name: 'odoo'},
     include_package_data=True,
     install_requires=[
+        'asn1crypto',
         'babel >= 1.0',
         'cbor2',
         'chardet',

--- a/setup/package.dfdebian
+++ b/setup/package.dfdebian
@@ -23,6 +23,7 @@ RUN apt-get update -qq &&  \
         postgresql \
         postgresql-client \
         python3 \
+        python3-asn1crypto \
         python3-babel \
         python3-cbor2 \
         python3-dateutil \

--- a/setup/package.dffedora
+++ b/setup/package.dffedora
@@ -14,10 +14,11 @@ RUN dnf update -d 0 -e 0 -y && \
         postgresql-libs \
         postgresql-server \
         python3-PyPDF2 \
-        python3-cryptography \
+        python3-asn1crypto \
         python3-babel \
         python3-cbor2 \
         python3-chardet \
+        python3-cryptography \
         python3-dateutil \
         python3-decorator \
         python3-devel \


### PR DESCRIPTION
Py_webauthn depended on asn1crypto which was not in our dependency list.