### PR TITLE
[FIX] survey: fix kanban content overlap

### DIFF
--- a/addons/survey/static/src/scss/survey_survey_views.scss
+++ b/addons/survey/static/src/scss/survey_survey_views.scss
@@ -74,6 +74,14 @@
             position: absolute;
             bottom: 4px;
             right: 19px;
+            @include media-breakpoint-down(lg) {
+                bottom: 19px;
+                right: 0;
+            }
+            @include media-breakpoint-down(sm) {
+                bottom: 10px;
+                right: 10px;
+            }
         }
     }
 

--- a/addons/survey/views/survey_survey_views.xml
+++ b/addons/survey/views/survey_survey_views.xml
@@ -337,23 +337,23 @@
                             <div class="row g-0">
                                 <div class="col-10 p-0 pb-1">
                                     <div class="container o_kanban_card_content" t-if="record.answer_count.raw_value != 0">
-                                        <div class="row mt-4 ms-5">
+                                        <div class="row mt-4 ms-2">
                                             <div class="col-4 p-0">
                                                 <a name="action_survey_user_input" type="object" class="d-flex flex-column align-items-center">
                                                     <span class="fw-bold"><field name="answer_count"/></span>
-                                                    <span class="text-muted">Registered</span>
+                                                    <span class="text-break text-muted">Registered</span>
                                                 </a>
                                             </div>
                                             <div class="col-4 p-0 border-start">
                                                 <a name="action_survey_user_input_completed" type="object" class="d-flex flex-column align-items-center">
                                                     <span class="fw-bold"><field name="answer_done_count"/></span>
-                                                    <span class="text-muted">Completed</span>
+                                                    <span class="text-break text-muted">Completed</span>
                                                 </a>
                                             </div>
                                             <div class="col-4 p-0 border-start" t-if="record.scoring_type.raw_value != 'no_scoring'" >
                                                 <a name="action_survey_user_input_certified" type="object" class="d-flex flex-column align-items-center">
                                                     <span class="fw-bold"> <t t-esc="Math.round(record.success_ratio.raw_value)"></t> %</span>
-                                                    <span class="text-muted" >Success</span>
+                                                    <span class="text-break text-muted" >Success</span>
                                                 </a>
                                             </div>
                                         </div>


### PR DESCRIPTION
Prevent the activity button from overlapping the "See results" button
in the ungrouped kanban mode on small screen sizes.

Prevent the stats text (registered, completed, passed) from overlapping
the separator and the other stats text on medium and larger screen sizes.

Task-4061131

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
