### PR TITLE
[FIX] account: Fix invoice reversing default bank

### DIFF
--- a/addons/account/tests/test_account_move_in_invoice.py
+++ b/addons/account/tests/test_account_move_in_invoice.py
@@ -1240,6 +1240,11 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
     def test_in_invoice_create_refund(self):
         self.invoice.action_post()
 
+        bank1 = self.env['res.partner.bank'].create({
+            'acc_number': 'BE43798822936101',
+            'partner_id': self.partner_a.id,
+        })
+
         move_reversal = self.env['account.move.reversal'].with_context(active_model="account.move", active_ids=self.invoice.ids).create({
             'date': fields.Date.from_string('2019-02-01'),
             'reason': 'no reason',
@@ -1300,6 +1305,7 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
             'state': 'draft',
             'ref': 'Reversal of: %s, %s' % (self.invoice.name, move_reversal.reason),
             'payment_state': 'not_paid',
+            'partner_bank_id': bank1.id,
         })
 
         move_reversal = self.env['account.move.reversal'].with_context(active_model="account.move", active_ids=self.invoice.ids).create({

--- a/addons/account/wizard/account_move_reversal.py
+++ b/addons/account/wizard/account_move_reversal.py
@@ -113,9 +113,17 @@ class AccountMoveReversal(models.TransientModel):
         moves = self.move_ids
 
         # Create default values.
+        bank_ids = self.env['res.partner.bank'].search([
+            ('partner_id', 'in', moves.commercial_partner_id.ids),
+            ('company_id', 'in', moves.company_id.ids + [False]),
+        ], order='sequence DESC')
+        partner_to_bank = {bank.partner_id: bank for bank in bank_ids}
         default_values_list = []
         for move in moves:
-            default_values_list.append(self._prepare_default_reversal(move))
+            default_values_list.append({
+                'partner_bank_id': partner_to_bank.get(move.commercial_partner_id, self.env['res.partner.bank']).id,
+                **self._prepare_default_reversal(move),
+            })
 
         batches = [
             [self.env['account.move'], [], True],   # Moves to be cancelled by the reverses.


### PR DESCRIPTION
Problem
---------
Currently, when reversing a move, the current company is used as recipient bank.

1. Set a bank on a partner A
2. Go to Accounting
3. Set A as the customer of the invoice
4. Set a bank under 'recipient bank' in Other Info tab
5. Post the invoice
6. "Add Credit Note"
7. Fill in with wathever and press Reverse -> The Other Info tab of the reverse move has the company bank and not the customer's

Objective
---------
Obtain a similar behavior as when a credit note is created directly: have the customer's bank set as recipient bank.

Solution
---------
Provide a default bank id that is set, if possible, to one of the customer's bank.

opw-4035448

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
