### PR TITLE
[FIX] stock_account: Fix account tag access error for inventory admin

### DIFF
--- a/addons/stock_account/security/ir.model.access.csv
+++ b/addons/stock_account/security/ir.model.access.csv
@@ -1,6 +1,7 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_account_account_stock_manager,account.account stock manager,account.model_account_account,stock.group_stock_manager,1,0,0,0
 access_account_journal_stock_manager,account.journal stock manager,account.model_account_journal,stock.group_stock_manager,1,0,0,0
+access_account_account_tag_stock_manager,account.account.tag stock manager,account.model_account_account_tag,stock.group_stock_manager,1,0,0,0
 access_stock_picking_invoicing_payments_readonly,stock.picking,stock.model_stock_picking,account.group_account_readonly,1,0,0,0
 access_stock_picking_invoicing_payments,stock.picking,stock.model_stock_picking,account.group_account_invoice,1,1,1,0
 access_stock_move_invoicing_payments_readonly,stock.move,model_stock_move,account.group_account_readonly,1,0,0,0


### PR DESCRIPTION
Problem
---------
Curently, an inventory admin cannot access a product that has a tax with a tax tag set.

1 - Have 'stock_account' installed with the requirements for it
2 - Have a loca such as l10n_cz installed
3a - Remove 'Demo' user's privilieges:
        - Purchase
        - Accounting
        - Sales
3b - Set Inventory as Administrator
4 - Make sure 'Demo' has access to the demo loca company (create one if
necessary)
5 - Connect with 'Demo' and change to the loca company
6 - Go to Inventory -> Products
7 - Open any product
-> Should be welcomed with a 'invalid access right' error.

Objective
---------
Allow an inventory admin to access the products.

Solution
---------
Add a new readonly access rule on account.account.tag for inventory admin.

opw-4038926

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
