### PR TITLE
[IMP] point_of_sale: remove image when default one is set

### DIFF
--- a/addons/point_of_sale/static/src/app/generic_components/orderline/orderline.xml
+++ b/addons/point_of_sale/static/src/app/generic_components/orderline/orderline.xml
@@ -6,7 +6,7 @@
             <div t-if="line.imageSrc" class="o_line_container d-flex align-items-center justify-content-center">
                 <img t-attf-style="border-radius: 1rem;" t-att-src="line.imageSrc"/>
             </div>
-            <div class=" d-flex flex-column w-100">
+            <div class="o_line_infos d-flex flex-column w-100">
                 <div class="d-flex">
                     <div class="product-name d-inline-block flex-grow-1 fw-bolder pe-1">
                         <span class="text-wrap" t-esc="line.productName"/>

--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -1054,7 +1054,9 @@ export class PosOrder extends Base {
             lines: this.lines.map((l) => ({
                 ...l.getDisplayData(),
                 isSelected: l.isSelected(),
-                imageSrc: `/web/image/product.product/${l.product_id.id}/image_128`,
+                imageSrc: l.product_id.image_128
+                    ? `/web/image/product.product/${l.product_id.id}/image_128`
+                    : false,
             })),
             finalized: this.finalized,
             amount: formatCurrency(this.get_total_with_tax() || 0),

--- a/addons/point_of_sale/static/src/customer_display/styles.scss
+++ b/addons/point_of_sale/static/src/customer_display/styles.scss
@@ -53,3 +53,7 @@ li {
         max-width: 100%;
     }
 }
+
+.o_line_infos {
+    padding-left: 10px;
+}


### PR DESCRIPTION
When a product has no image and we request his image a default one is returned by the server.

In the customer display we don't want to display this default image.

This commit adds a check to see if the image is the default one and if it is we don't display it.

taskId: 4053605

Before: 
![image](https://github.com/user-attachments/assets/62f3049a-57e4-4e59-b6bc-8e8a3af6890e)

After:
![image](https://github.com/user-attachments/assets/928104b1-0917-420f-a146-1fee4143d4bc)
