### PR TITLE
[FIX] web_unsplash: remove spaces from unsplash url

### DIFF
--- a/addons/web_unsplash/controllers/main.py
+++ b/addons/web_unsplash/controllers/main.py
@@ -105,10 +105,12 @@ class Web_Unsplash(http.Controller):
 
             # /unsplash/5gR788gfd/lion
             url_frags = ['unsplash', key, query]
+            # Do not take spaces into account for url construction
+            url_frags_for_url = ['unsplash', key, query.replace(' ', '')]
 
             attachment_data = {
                 'name': '_'.join(url_frags),
-                'url': '/' + '/'.join(url_frags),
+                'url': '/' + '/'.join(url_frags_for_url),
                 'data': image,
                 'res_id': res_id,
                 'res_model': res_model,


### PR DESCRIPTION
Steps to reproduce:
- Add a "Text-image" snippet on the page.
- Double click on the image to replace it.
- On the media dialog, type 'red car' and choose an unsplash image.

-> The image does not have options like "Shape", "Filter" etc...

At the choose of the image, an attachment is created with its url field set to something like `/unsplash/5gR788gfd/red car.jpg`. The problem is that since [1], `new URL()` is applied on the image source and the `pathname` part of it is given to the `/web_editor/get_image_info` route. Due to it, this route now works with an url like `/unsplash/5gR788gfd/red%20car.jpg` (where the space is encoded). Due to it, the route does not find the linked attachment and the options like "Shape" and "Filter" are not displayed.

The first idea to solve the problem was to create the attachment with an encoded version of the url (`/unsplash/5gR788gfd/red%20car.jpg`). The problem is that such attachment is not correctly fetched from the db and the default image is displayed in such case. This can be understand as the `_get_serve_attachment()` method is called with `request.httprequest.path` that decodes the url
(`/unsplash/5gR788gfd/red car.jpg`). Due to it, the method does not find the attachment and the default image is displayed.

To solve the problem, this commit adapts [2] so that, when a user chooses an unsplash image, the system creates an attachment that has an url field that only contains alphanumeric characters and hyphens.

[1]: https://github.com/odoo/odoo/commit/89c14783846288a2de53f6258a93440e02550b13
[2]: https://github.com/odoo/odoo/commit/55073e3baa97fa1285695233f30044bd7c698858

task-3984743
