### PR TITLE
[FIX] sign: signature field bad dimensions

### DIFF
--- a/addons/web/static/src/core/signature/name_and_signature.js
+++ b/addons/web/static/src/core/signature/name_and_signature.js
@@ -117,14 +117,6 @@ export class NameAndSignature extends Component {
     }
 
     /**
-     * Load a base64 encoded image, as dataURL, into the signature field.
-     */
-    async fromDataURL() {
-        await this.signaturePad.fromDataURL(...arguments);
-        this.props.signature.isSignatureEmpty = this.isSignatureEmpty;
-    }
-
-    /**
      * Returns the given name after cleaning it by removing characters that
      * are not supposed to be used in a signature. If @see signatureType is set
      * to 'initial', returns the first letter of each word, separated by dots.
@@ -245,14 +237,22 @@ export class NameAndSignature extends Component {
      */
     async printImage(imgSrc) {
         this.clear();
-        // Force the width and height to the canvas size to prevent shrinking
-        // high DPI screens (devicePixelRatio > 1)
-        const options = {
-            width: this.signatureRef.el.width,
-            height: this.signatureRef.el.height,
-            yOffset: 30,
+        const c = this.signaturePad.canvas;
+        const img = new Image();
+        img.onload = () => {
+            const ctx = c.getContext("2d");
+            var ratio = ((img.width / img.height) > (c.width / c.height)) ? c.width / img.width : c.height / img.height;
+            ctx.drawImage( 
+                img,
+                (c.width / 2) - (img.width * ratio / 2),
+                (c.height / 2) - (img.height * ratio / 2)
+                , img.width * ratio
+                , img.height * ratio
+            );
+            this.props.signature.isSignatureEmpty = this.isSignatureEmpty;
         };
-        await this.fromDataURL(imgSrc, options);
+        img.src = imgSrc;
+        this.signaturePad._isEmpty = false;
     }
 
     /**


### PR DESCRIPTION
Before this commit:
When loading a signature, the displayed image would be stretched to fit the signature box, messing up the ratio between width and height.

This commit aims to fix this issue by:
keeping the same ratio between width and height.
and just multiply both of them by the same factor.

Task: 4049758

Before:

![image](https://github.com/user-attachments/assets/14c0408a-1c11-4ab7-acbc-1bbc68a79ca7)
![image](https://github.com/user-attachments/assets/71ce1275-c083-4671-a303-8a0748621604)

After:

![image](https://github.com/user-attachments/assets/a37fc7df-f01e-4b36-b699-867f024e8076)
![image](https://github.com/user-attachments/assets/c4ee6c0f-e601-4080-9967-180ee271fb9b)
