### PR TITLE
[FIX] l10n_in: duplicate GSTIN + improvement

### DIFF
--- a/addons/l10n_in/i18n/l10n_in.pot
+++ b/addons/l10n_in/i18n/l10n_in.pot
@@ -345,6 +345,12 @@ msgid ""
 msgstr ""
 
 #. module: l10n_in
+#: model_terms:ir.ui.view,arch_db:l10n_in.l10n_in_report_invoice_document_inherit
+msgid "GSTIN:"
+msgstr ""
+
+#. module: l10n_in
+#. odoo-python
 #: code:addons/l10n_in/models/account_invoice.py:0
 #, python-format
 msgid "Go to Company configuration"

--- a/addons/l10n_in/views/report_invoice.xml
+++ b/addons/l10n_in/views/report_invoice.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <template id="l10n_in_report_invoice_document_inherit" inherit_id="account.report_invoice_document" primary="True">
-        <xpath expr="//address[@t-field='o.partner_id']" position="after">
-            <span t-field="o.l10n_in_gstin" t-if="o.company_id.account_fiscal_country_id.code == 'IN'"/>
+        <xpath expr="//div[@name='shipping_address_block']" position="inside">
+            <div t-if="o.company_id.account_fiscal_country_id.code == 'IN' and o.partner_shipping_id.vat">
+                GSTIN: <span t-field="o.partner_shipping_id.vat"/>
+            </div>
         </xpath>
         <xpath expr="//div[@name='address_not_same_as_shipping']//t[@t-set='address']" position="inside">
             <t t-call="l10n_in.place_of_supply"/>


### PR DESCRIPTION
Step to reproduce:

- install l10n_in
- create an invoice
- select an Indian customer with GSTIN
- change delivery address to other indian customer without GSTIN
- print report, call it "report 1"
- change delivery address to other indian customer with GSTIN
- print report, call it "report 2"

Current behavior:

For report 1:

- The GSTIN value of the partner_id appear twice on the report

For report 2:

- The GSTIN value of the partner_id appear twice
- The GSTIN value of the delivery partner does not appear

Expected behavior:

- The GSTIN value of partner_id should not appear twice
- If exist, the GSTIN value of delivery partner should be shown

opw-4027540