### PR TITLE
[FIX] sale_loyalty: fix discount issue

### DIFF
--- a/addons/sale_loyalty/models/sale_order.py
+++ b/addons/sale_loyalty/models/sale_order.py
@@ -176,12 +176,20 @@ class SaleOrder(models.Model):
             # non-fixed tax totals. This way fixed taxes will not be discounted
             taxes = line.tax_id.filtered(lambda t: t.amount_type != 'fixed')
             discountable += tax_data['total_excluded'] + sum(
-                tax['amount'] for tax in tax_data['taxes'] if tax['id'] in taxes.ids
+                tax['amount'] for tax in tax_data['taxes']
+                if (
+                    tax['id'] in taxes.ids
+                    or (tax['group'] and tax['group'] in taxes)
+                )
             )
             line_price = line.price_unit * line.product_uom_qty * (1 - (line.discount or 0.0) / 100)
             discountable_per_tax[taxes] += line_price - sum(
                 tax['amount'] for tax in tax_data['taxes']
-                if tax['price_include'] and tax['id'] not in taxes.ids
+                if (
+                    tax['price_include']
+                    and tax['id'] not in taxes.ids
+                    and (not tax['group'] or tax['group'] not in taxes)
+                )
             )
         return discountable, discountable_per_tax
 

--- a/addons/sale_loyalty/tests/common.py
+++ b/addons/sale_loyalty/tests/common.py
@@ -2,8 +2,11 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from collections import defaultdict
-from odoo.addons.sale.tests.test_sale_product_attribute_value_config import TestSaleProductAttributeValueCommon
+
+from odoo import Command
 from odoo.exceptions import ValidationError
+
+from odoo.addons.sale.tests.test_sale_product_attribute_value_config import TestSaleProductAttributeValueCommon
 
 
 class TestSaleCouponCommon(TestSaleProductAttributeValueCommon):
@@ -74,6 +77,12 @@ class TestSaleCouponCommon(TestSaleProductAttributeValueCommon):
             'price_include': False,
         })
 
+        cls.tax_group = cls.env['account.tax'].create({
+            'name': "tax_group",
+            'amount_type': 'group',
+            'children_tax_ids': [Command.set((cls.tax_10pc_incl + cls.tax_10pc_base_incl).ids)],
+        })
+
         #products
         cls.product_A = cls.env['product.product'].create({
             'name': 'Product A',
@@ -94,6 +103,13 @@ class TestSaleCouponCommon(TestSaleProductAttributeValueCommon):
             'list_price': 100,
             'sale_ok': True,
             'taxes_id': [(6, 0, [])],
+        })
+
+        cls.product_D = cls.env['product.product'].create({
+            'name': 'Product D',
+            'list_price': 100,
+            'sale_ok': True,
+            'taxes_id': [(6, 0, [cls.tax_group.id])],
         })
 
         cls.product_gift_card = cls.env['product.product'].create({

--- a/addons/sale_loyalty/tests/test_loyalty.py
+++ b/addons/sale_loyalty/tests/test_loyalty.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.tests import tagged, new_test_user
-from odoo.addons.sale_loyalty.tests.common import TestSaleCouponCommon
-from odoo.tools.float_utils import float_compare
 from odoo import Command
+from odoo.tests import tagged, new_test_user
+from odoo.tools.float_utils import float_compare
+
+from odoo.addons.sale_loyalty.tests.common import TestSaleCouponCommon
 
 @tagged('post_install', '-at_install')
 class TestLoyalty(TestSaleCouponCommon):
@@ -747,6 +748,40 @@ class TestLoyalty(TestSaleCouponCommon):
         self._claim_reward(order, loyalty_program)
         msg = "100% discount on order should reduce total amount to 0"
         self.assertEqual(order.amount_total, 0, msg=msg)
+
+    def test_discount_on_taxes_with_child_tax(self):
+        """
+        Check whether a program discount properly apply when product contain group of tax.
+        """
+        self.env.company.tax_calculation_rounding_method = 'round_globally'
+        loyalty_program = self.env['loyalty.program'].create([{
+            'name': '90% Discount',
+            'program_type': 'loyalty',
+            'trigger': 'auto',
+            'applies_on': 'both',
+            'rule_ids': [(0, 0, {
+                'reward_point_mode': 'unit',
+                'reward_point_amount': 1,
+                'product_ids': [self.product_a.id],
+            })],
+            'reward_ids': [(0, 0, {
+                'reward_type': 'discount',
+                'discount': 90,
+                'discount_mode': 'percent',
+                'discount_applicability': 'order',
+                'required_points': 1,
+            })],
+        }])
+        self.env['loyalty.card'].create({'program_id': loyalty_program.id, 'partner_id': self.partner_a.id, 'points': 2})
+        order = self.env['sale.order'].create({
+            'partner_id': self.partner_a.id,
+            'order_line': [(0, 0, {'product_id': self.product_D.id, 'product_uom_qty': 1})],
+        })
+
+        order._update_programs_and_rewards()
+        self._claim_reward(order, loyalty_program)
+        msg = "Discountable should take child tax amount into account"
+        self.assertEqual(order.amount_total, 10, msg=msg)
 
     def test_ewallet_program_without_trigger_product(self):
         self.ewallet_program.trigger_product_ids = [Command.clear()]


### PR DESCRIPTION
Steps:
- Create group tax (20%) and add two tax in it (10% each) with
Tax included true.
- Create product with 100 price and and set that 20% tax on it.
- Create coupon program with 90 amount on order and generate
coupon.
- Create SO and add SOL with that product now apply
coupon on that SO.

Issue:
- Amount computation is wrong for coupon value which is greater
then that product's tax_excluded(80) and it is only applying
80 instead of 90 because we were not properly computing amount
of child taxed.

Cause:
- Discountable was not properly computed in commit [1]. it was
not taking child tax values into account.

Fix:
- Add condition to properly check discountable values and take
child tax amount into consideration.

[1] https://github.com/odoo/odoo/commit/443097b4db29a4909bb0d0c44040140f08d1e433

opw-4033803