### PR TITLE
[FIX] account: not include taxes in accrued expense calculation

### DIFF
--- a/addons/account/wizard/accrued_orders.py
+++ b/addons/account/wizard/accrued_orders.py
@@ -179,8 +179,18 @@ class AccruedExpenseRevenue(models.TransientModel):
                 for order_line in lines:
                     if is_purchase:
                         account = self._get_computed_account(order, order_line.product_id, is_purchase)
-                        amount = self.company_id.currency_id.round(order_line.qty_to_invoice * order_line.price_unit / rate)
-                        amount_currency = order_line.currency_id.round(order_line.qty_to_invoice * order_line.price_unit)
+                        if any(tax.price_include for tax in order_line.taxes_id):
+                            # As included taxes are not taken into account in the price_unit, we need to compute the price_subtotal
+                            price_subtotal = order_line.taxes_id.compute_all(
+                                order_line.price_unit,
+                                currency=order_line.order_id.currency_id,
+                                quantity=order_line.qty_to_invoice,
+                                product=order_line.product_id,
+                                partner=order_line.order_id.partner_id)['total_excluded']
+                        else:
+                            price_subtotal = order_line.qty_to_invoice * order_line.price_unit
+                        amount = self.company_id.currency_id.round(price_subtotal / rate)
+                        amount_currency = order_line.currency_id.round(price_subtotal)
                         fnames = ['qty_to_invoice', 'qty_received', 'qty_invoiced', 'invoice_lines']
                         label = _('%s - %s; %s Billed, %s Received at %s each', order.name, _ellipsis(order_line.name, 20), order_line.qty_invoiced, order_line.qty_received, formatLang(self.env, order_line.price_unit, currency_obj=order.currency_id))
                     else:

--- a/addons/purchase/tests/test_accrued_purchase_orders.py
+++ b/addons/purchase/tests/test_accrued_purchase_orders.py
@@ -88,3 +88,23 @@ class TestAccruedPurchaseOrders(AccountTestInvoicingCommon):
             {'account_id': self.alt_exp_account.id, 'debit': 1000 / 2, 'credit': 0, 'amount_currency': 1000},
             {'account_id': self.account_revenue.id, 'debit': 0, 'credit': 6000 / 2, 'amount_currency': 0.0},
         ])
+
+    def test_accrued_order_with_tax_included(self):
+        tax_10_included = self.env['account.tax'].create({
+            'name': 'Tax 10% included',
+            'amount': 10.0,
+            'type_tax_use': 'purchase',
+            'price_include': True,
+        })
+        self.purchase_order.order_line.taxes_id = tax_10_included
+        self.purchase_order.order_line.qty_received = 5
+        self.assertRecordValues(self.env['account.move'].search(self.wizard.create_entries()['domain']).line_ids, [
+            # reverse move lines
+            {'account_id': self.account_expense.id, 'debit': 0.0, 'credit': 4545.45},
+            {'account_id': self.alt_exp_account.id, 'debit': 0.0, 'credit': 909.09},
+            {'account_id': self.account_revenue.id, 'debit': 5454.54, 'credit': 0.0},
+            # move lines
+            {'account_id': self.account_expense.id, 'debit': 4545.45, 'credit': 0.0},
+            {'account_id': self.alt_exp_account.id, 'debit': 909.09, 'credit': 0.0},
+            {'account_id': self.account_revenue.id, 'debit': 0.0, 'credit': 5454.54},
+        ])


### PR DESCRIPTION
### Steps to reproduce:
- Install Purchase and Accounting
- Go in Accounting > Configuration > Accounting > Taxes
- Select the line with "Tax Type" equal to "Purchases"
- In advanced options tick "Included in Price"
- In the Purchase app create a new RFQ and add the tax
- Confirm the order and receive the products
- In the Purchase Order form view go in Action > Accrued Expense Entry
- Change the date to a month from now, lines should appear
- These lines have the price including the taxes, it should be without

### Cause:
The calculation of the problematic price is `qty_to_invoice * price_unit`, which is problematic with included taxes.

### Solution:
Instead of calculating the price we use the `price_subtotal` calculated by the `compute_all` method. We can not use `price_subtotal` of the line as it includes the whole quantity and not only the quantity to invoice.

opw-4045737