### PR TITLE
[FIX] payment: prevent access error when refunding payment transactions

### DIFF
--- a/addons/payment/models/payment_transaction.py
+++ b/addons/payment/models/payment_transaction.py
@@ -328,8 +328,10 @@ class PaymentTransaction(models.Model):
         if any(tx.state != 'done' for tx in self):
             raise ValidationError(_("Only confirmed transactions can be refunded."))
 
+        payment_utils.check_rights_on_recordset(self)
         for tx in self:
-            tx._send_refund_request(amount_to_refund)
+            # In sudo mode because we need to be able to read on acquirer fields.
+            tx.sudo()._send_refund_request(amount_to_refund)
 
     #=== BUSINESS METHODS - PAYMENT FLOW ===#
 

--- a/addons/payment/tests/test_transactions.py
+++ b/addons/payment/tests/test_transactions.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo.exceptions import AccessError
 from odoo.tests import tagged
 
 from odoo.addons.payment.tests.common import PaymentCommon
@@ -7,6 +8,45 @@ from odoo.addons.payment.tests.common import PaymentCommon
 
 @tagged('-at_install', 'post_install')
 class TestTransactions(PaymentCommon):
+
+    def test_capture_allowed_for_authorized_users(self):
+        """ Test that users who have access to a transaction can capture it. """
+        self.acquirer.support_authorization = True
+        tx = self.create_transaction('redirect', state='authorized')
+        user = self._prepare_user(self.internal_user, 'account.group_account_invoice')
+        self._assert_does_not_raise(AccessError, tx.with_user(user).action_capture)
+
+    def test_void_allowed_for_authorized_users(self):
+        """ Test that users who have access to a transaction can void it. """
+        self.acquirer.support_authorization = True
+        tx = self.create_transaction('redirect', state='authorized')
+        user = self._prepare_user(self.internal_user, 'account.group_account_invoice')
+        self._assert_does_not_raise(AccessError, tx.with_user(user).action_void)
+
+    def test_refund_allowed_for_authorized_users(self):
+        """ Test that users who have access to a transaction can refund it. """
+        self.acquirer.support_refund = 'full_only'
+        tx = self.create_transaction('redirect', state='done')
+        user = self._prepare_user(self.internal_user, 'account.group_account_invoice')
+        self._assert_does_not_raise(AccessError, tx.with_user(user).action_refund)
+
+    def test_capture_blocked_for_unauthorized_user(self):
+        """ Test that users who don't have access to a transaction cannot capture it. """
+        self.acquirer.support_authorization = True
+        tx = self.create_transaction('redirect', state='authorized')
+        self.assertRaises(AccessError, tx.with_user(self.internal_user).action_capture)
+
+    def test_void_blocked_for_unauthorized_user(self):
+        """ Test that users who don't have access to a transaction cannot void it. """
+        self.acquirer.support_authorization = True
+        tx = self.create_transaction('redirect', state='authorized')
+        self.assertRaises(AccessError, tx.with_user(self.internal_user).action_void)
+
+    def test_refund_blocked_for_unauthorized_user(self):
+        """ Test that users who don't have access to a transaction cannot refund it. """
+        self.acquirer.support_refund = 'full_only'
+        tx = self.create_transaction('redirect', state='done')
+        self.assertRaises(AccessError, tx.with_user(self.internal_user).action_refund)
 
     def test_refunds_count(self):
         self.acquirer.support_refund = 'full_only'  # Should simply not be False


### PR DESCRIPTION
Users without administrative rights were unable to refund transactions because the call to `_send_refund_request` was made without `sudo`.

This commit adds both the necessary `sudo` to bypass the access rights check on the transaction's payment acquirer and a manual access rights check on the transaction itself to prevent abusing RPC calls.

opw-4033356
