### PR TITLE
[FIX] pos_restaurant: enable scrolling in floor view

### DIFF
--- a/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.xml
+++ b/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.xml
@@ -63,7 +63,7 @@
             </div>
             <div t-ref="floor-map-scroll" class="overflow-scroll flex-grow-1 flex-shrink-1 flex-basis-0 w-auto" t-attf-style="background: {{activeFloor?.background_color}}"> 
                 <div t-on-click="onClickFloorMap" t-on-touchstart="_onPinchStart" t-on-touchmove="_onPinchMove" t-on-touchend="_onPinchEnd"
-                    class="floor-map position-relative w-100 h-100 overflow-hidden"
+                    class="floor-map position-relative w-100 h-100 overflow-auto"
                     t-ref="floor-map-ref"
                     t-attf-style="height: {{state.floorHeight}} !important; width: {{state.floorWidth}} !important; {{ activeFloor?.floor_background_image and pos.floorPlanStyle !== 'kanban' &amp;&amp; 'background-image: url(' + floorBackround + '); background-size: auto; background-repeat: no-repeat; background-attachment: local;' }}">
                     <t t-if="pos.config.floor_ids?.length > 0">


### PR DESCRIPTION
Currently, if a restaurant has so many table that some are hidden down the screen, it is impossible to scroll down to select the hidden table.

Steps to reproduce:
-------------------
* Open the **Poin of sale** App
* Open restaurant session
* Switch floor view
* Edit plan
* Add many tables such as some are not visible on the screen
* Try scrolling
> Observation: Unable to scroll

Why the fix:
------------
For some reason, the ability to scroll in the floor view was removed with this commit https://github.com/odoo/odoo/commit/b42b0f8b541a13621b671b0b7e57812ef11fc1b2

The value changed from `overflow-auto` to `overflow-hidden` here https://github.com/odoo/odoo/blob/fb4d758ed78211a61ea797759e1fb3b02b51be60/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.xml#L66

opw-4051308