### PR TITLE
[FIX] sale, sale_loyalty: refine the sale_order_line domain

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -1185,3 +1185,6 @@ class SaleOrderLine(models.Model):
     def _is_not_sellable_line(self):
         # True if the line is a computed line (reward, delivery, ...) that user cannot add manually
         return False
+
+    def _sellable_lines_domain(self):
+        return [('is_downpayment', '=', False)]

--- a/addons/sale_loyalty/models/sale_order_line.py
+++ b/addons/sale_loyalty/models/sale_order_line.py
@@ -114,3 +114,6 @@ class SaleOrderLine(models.Model):
         res = super(SaleOrderLine, self | related_lines).unlink()
         coupons_to_unlink.sudo().unlink()
         return res
+
+    def _sellable_lines_domain(self):
+        return super()._sellable_lines_domain() + [('reward_id', '=', False)]

--- a/addons/sale_project/models/project.py
+++ b/addons/sale_project/models/project.py
@@ -7,6 +7,7 @@ from odoo import api, fields, models, _, _lt
 from odoo.exceptions import ValidationError, AccessError
 from odoo.osv import expression
 from odoo.tools import Query
+from odoo.tools.misc import unquote
 
 from datetime import date
 from functools import reduce
@@ -14,11 +15,24 @@ from functools import reduce
 class Project(models.Model):
     _inherit = 'project.project'
 
+    def _domain_sale_line_id(self):
+        domain = expression.AND([
+            self.env['sale.order.line']._sellable_lines_domain(),
+            [
+                ('is_service', '=', True),
+                ('is_expense', '=', False),
+                ('state', 'in', ['sale', 'done']),
+                ('order_partner_id', '=?', unquote("partner_id")),
+                '|', ('company_id', '=', False), ('company_id', '=', unquote("company_id")),
+            ],
+        ])
+        return str(domain)
+
     allow_billable = fields.Boolean("Billable")
     sale_line_id = fields.Many2one(
         'sale.order.line', 'Sales Order Item', copy=False,
         compute="_compute_sale_line_id", store=True, readonly=False, index='btree_not_null',
-        domain="[('is_service', '=', True), ('is_expense', '=', False), ('state', 'in', ['sale', 'done']), ('order_partner_id', '=?', partner_id), '|', ('company_id', '=', False), ('company_id', '=', company_id)]",
+        domain=_domain_sale_line_id,
         help="Sales order item that will be selected by default on the tasks and timesheets of this project,"
             " except if the employee set on the timesheets is explicitely linked to another sales order item on the project.\n"
             "It can be modified on each task and timesheet entry individually if necessary.")
@@ -607,17 +621,24 @@ class Project(models.Model):
 class ProjectTask(models.Model):
     _inherit = "project.task"
 
+    def _domain_sale_line_id(self):
+        domain = expression.AND([
+            self.env['sale.order.line']._sellable_lines_domain(),
+            [
+                ('company_id', '=', unquote('company_id')),
+                '|', ('order_partner_id', 'child_of', unquote('commercial_partner_id if commercial_partner_id else []')),
+                    ('order_partner_id', '=?', unquote('partner_id')),
+                ('is_service', '=', True), ('is_expense', '=', False), ('state', 'in', ['sale', 'done']),
+            ],
+        ])
+        return str(domain)
+
     sale_order_id = fields.Many2one('sale.order', 'Sales Order', compute='_compute_sale_order_id', store=True, help="Sales order to which the task is linked.")
     sale_line_id = fields.Many2one(
         'sale.order.line', 'Sales Order Item',
         copy=True, tracking=True, index='btree_not_null', recursive=True,
         compute='_compute_sale_line', store=True, readonly=False,
-        domain="""[
-            ('company_id', '=', company_id),
-            '|', ('order_partner_id', 'child_of', commercial_partner_id if commercial_partner_id else []),
-                 ('order_partner_id', '=?', partner_id),
-            ('is_service', '=', True), ('is_expense', '=', False), ('state', 'in', ['sale', 'done'])
-        ]""",
+        domain=_domain_sale_line_id,
         help="Sales Order Item to which the time spent on this task will be added in order to be invoiced to your customer.\n"
              "By default the sales order item set on the project will be selected. In the absence of one, the last prepaid sales order item that has time remaining will be used.\n"
              "Remove the sales order item in order to make this task non billable. You can also change or remove the sales order item of each timesheet entry individually.")

--- a/addons/sale_timesheet/models/project_sale_line_employee_map.py
+++ b/addons/sale_timesheet/models/project_sale_line_employee_map.py
@@ -2,23 +2,33 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models
+from odoo.osv import expression
+from odoo.tools.misc import unquote
 
 
 class ProjectProductEmployeeMap(models.Model):
     _name = 'project.sale.line.employee.map'
     _description = 'Project Sales line, employee mapping'
 
+    def _domain_sale_line_id(self):
+        domain = expression.AND([
+            self.env['sale.order.line']._sellable_lines_domain(),
+            [
+                ('is_service', '=', True),
+                ('is_expense', '=', False),
+                ('state', 'in', ['sale', 'done']),
+                ('order_partner_id', '=?', unquote('partner_id')),
+                '|', ('company_id', '=', False), ('company_id', '=', unquote('company_id')),
+            ],
+        ])
+        return str(domain)
+
     project_id = fields.Many2one('project.project', "Project", required=True)
     employee_id = fields.Many2one('hr.employee', "Employee", required=True)
     sale_line_id = fields.Many2one(
         'sale.order.line', "Sales Order Item",
         compute="_compute_sale_line_id", store=True, readonly=False,
-        domain="""[
-            ('is_service', '=', True),
-            ('is_expense', '=', False),
-            ('state', 'in', ['sale', 'done']),
-            ('order_partner_id', '=?', partner_id),
-            '|', ('company_id', '=', False), ('company_id', '=', company_id)]""")
+        domain=_domain_sale_line_id)
     company_id = fields.Many2one('res.company', string='Company', related='project_id.company_id')
     partner_id = fields.Many2one(related='project_id.partner_id')
     price_unit = fields.Float("Unit Price", compute='_compute_price_unit', store=True, readonly=True)


### PR DESCRIPTION
Steps to reproduce the bug:
1. Install the Sales and Loyalty apps.
2. Create a sales order for 'client x' and assign a loyalty reward to it.
3. Invoice the sales order with a down payment.
4. Navigate to the Helpdesk app and create a ticket for 'client x'.
5. Create a task for the ticket and check the Sales order item list.

Issue:
The sales order item list incorrectly includes down payments and loyalty rewards due to an imprecise domain.

Solution:
Adding a domain function that we can override computed field where it's necessary, to filter the sale_order_line records
accurately.

opw-4001226

enterprise pr : https://github.com/odoo/enterprise/pull/66388