### PR TITLE
[IMP] mail: keyboard navigation in messaging menu

### DIFF
--- a/addons/mail/static/src/core/web/messaging_menu.xml
+++ b/addons/mail/static/src/core/web/messaging_menu.xml
@@ -25,16 +25,22 @@
                     <button class="btn btn-link py-1 rounded-0" t-att-class="store.discuss.activeTab === 'main' ? 'fw-bold o-active' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'main'">All</button>
                     <button class="btn btn-link py-1 rounded-0" t-att-class="store.discuss.activeTab === 'chat' ? 'fw-bold o-active' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'chat'">Chats</button>
                     <button class="btn btn-link py-1 rounded-0" t-att-class="store.discuss.activeTab === 'channel' ? 'fw-bold o-active' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'channel'">Channels</button>
-                    <button t-if="threads.length >= 20" class="btn btn-link py-1 rounded-0 text-muted" type="button" t-on-click="toggleSearch"><i class="fa fa-fw fa-search"/></button>
+                    <button t-if="threads.length >= 20 and store.channels.status !== 'fetching'" class="btn btn-link py-1 rounded-0 text-muted" type="button" title="Quick search" t-on-click="toggleSearch"><i class="fa fa-fw fa-search"/></button>
+                    <button t-if="store.channels.status === 'fetching'" class="btn btn-light py-1 rounded-0" disabled="true" type="button"><i class="fa fa-fw fa-circle-o-notch fa-spin"/></button>
                 </t>
             </t>
         </div>
-        <div t-if="!env.inDiscussApp or store.discuss.activeTab !== 'main'" class="d-flex flex-column overflow-auto flex-grow-1 list-group list-group-flush">
+        <div t-if="!env.inDiscussApp or store.discuss.activeTab !== 'main'" class="d-flex flex-column overflow-auto flex-grow-1 list-group list-group-flush" t-ref="notification-list">
             <div t-if="store.channels.status !== 'fetching' and !hasPreviews" class="d-flex justify-content-center py-4 px-2 text-muted">
                 No conversation yet...
             </div>
-            <t t-if="installationRequest.isShown">
+            <div t-if="store.discuss.searchTerm and !threads.length" class="d-flex justify-content-center py-4 px-2 text-muted">
+                No thread found.
+            </div>
+            <t t-set="itemIndex" t-value="0"/>
+            <t t-if="installationRequest.isShown and !store.discuss.searchTerm">
                 <NotificationItem
+                    isActive="state.activeIndex === itemIndex"
                     body="installationRequest.body"
                     displayName="installationRequest.displayName"
                     iconSrc="installationRequest.iconSrc"
@@ -52,9 +58,11 @@
                         </t>
                     </t>
                 </NotificationItem>
+                <t t-set="itemIndex" t-value="itemIndex + 1"/>
             </t>
-            <t t-if="notificationRequest.isShown">
+            <t t-if="notificationRequest.isShown and !store.discuss.searchTerm">
                 <NotificationItem
+                    isActive="state.activeIndex === itemIndex"
                     body="notificationRequest.body"
                     displayName="notificationRequest.displayName"
                     iconSrc="notificationRequest.iconSrc"
@@ -64,10 +72,12 @@
                         <ImStatus persona="notificationRequest.partner" className="'position-absolute top-100 start-100 translate-middle mt-n1 ms-n1'"/>
                     </t>
                 </NotificationItem>
+                <t t-set="itemIndex" t-value="itemIndex + 1"/>
             </t>
             <t t-if="store.discuss.activeTab === 'main' and !env.inDiscussApp and !store.discuss.searchTerm">
                 <t t-foreach="store.failures" t-as="failure" t-key="failure.id">
                     <NotificationItem
+                        isActive="state.activeIndex === itemIndex"
                         body="failure.body"
                         counter="failure.notifications.length > 1 ? failure.notifications.length : undefined"
                         datetime="failure.datetime"
@@ -77,11 +87,13 @@
                         onClick="(isMarkAsRead) => isMarkAsRead ? this.cancelNotifications(failure) : this.onClickFailure(failure)"
                         onSwipeRight="hasTouch() ? { action: () => this.cancelNotifications(failure), icon: 'fa-times-circle', bgColor: 'bg-warning' } : undefined"
                     />
+                    <t t-set="itemIndex" t-value="itemIndex + 1"/>
                 </t>
             </t>
             <t t-foreach="threads" name="threads" t-as="thread" t-key="thread.localId">
                 <t t-set="message" t-value="thread.isChatChannel or (thread.channel_type === 'channel' and thread.needactionMessages.length === 0) ? thread.newestPersistentNotEmptyOfAllMessage : thread.needactionMessages.at(-1)"/>
                 <NotificationItem
+                    isActive="state.activeIndex === itemIndex"
                     body="message?.inlineBody or message?.subtype_description"
                     counter="thread.needactionCounter"
                     datetime="message?.datetime"
@@ -102,6 +114,7 @@
                         </t>
                     </t>
                 </NotificationItem>
+                <t t-set="itemIndex" t-value="itemIndex + 1"/>
             </t>
             <t t-if="store.channels.status === 'fetching'">
                 <div class="d-flex align-items-center justify-content-center gap-2 py-4 px-2"><span class="o-visible-short-delay"><i class="fa fa-circle-o-notch fa-spin me-1"/> Loading…</span></div>

--- a/addons/mail/static/src/core/web/messaging_menu_quick_search.xml
+++ b/addons/mail/static/src/core/web/messaging_menu_quick_search.xml
@@ -1,6 +1,6 @@
 <t t-name="mail.MessagingMenuQuickSearch">
     <div class="position-relative w-50 m-1" t-ref="search" t-on-keydown="onKeydownInput">
-        <input t-model="store.discuss.searchTerm" t-ref="autofocus" class="form-control px-1 py-0" placeholder="Quick search..." type="text" />
-        <button class="btn btn-link text-muted p-1 position-absolute top-50 end-0 translate-middle-y" t-on-click="props.onClose"><i class="oi oi-close"/></button>
+        <input t-model="store.discuss.searchTerm" t-ref="autofocus" class="form-control px-1 py-0" placeholder="Quick search…" type="text" />
+        <button class="btn btn-link text-muted p-1 position-absolute top-50 end-0 translate-middle-y" title="Close search" t-on-click="props.onClose"><i class="oi oi-close"/></button>
     </div>
 </t>

--- a/addons/mail/static/src/core/web/notification_item.dark.scss
+++ b/addons/mail/static/src/core/web/notification_item.dark.scss
@@ -2,8 +2,7 @@
     &.o-important {
         background-color: mix($o-gray-200, $o-gray-300) !important;
     }
-
-    &:hover {
+    &:hover, &.o-active {
         background-color: $o-gray-300 !important;
     }
 }

--- a/addons/mail/static/src/core/web/notification_item.js
+++ b/addons/mail/static/src/core/web/notification_item.js
@@ -24,6 +24,7 @@ export class NotificationItem extends Component {
         "onSwipeLeft?",
         "onSwipeRight?",
         "slots?",
+        "isActive?",
     ];
     static defaultProps = {
         counter: 0,

--- a/addons/mail/static/src/core/web/notification_item.scss
+++ b/addons/mail/static/src/core/web/notification_item.scss
@@ -2,7 +2,10 @@
     &.o-important {
         background-color: mix($o-gray-100, $o-gray-200) !important;
     }
-    &:hover {
+    &.o-active {
+        box-shadow: inset 0px 0px 0px 1px rgba($o-action, 0.5);
+    }
+    &:hover, &.o-active {
         background-color: $o-gray-200 !important;
     }
 }

--- a/addons/mail/static/src/core/web/notification_item.xml
+++ b/addons/mail/static/src/core/web/notification_item.xml
@@ -3,7 +3,7 @@
 
 <t t-name="mail.NotificationItem">
     <ActionSwiper onLeftSwipe="props.onSwipeLeft ? props.onSwipeLeft : undefined" onRightSwipe="props.onSwipeRight ? props.onSwipeRight : undefined">
-        <button class="o-mail-NotificationItem list-group-item d-flex cursor-pointer align-items-center bg-view w-100 gap-2" t-att-class="{ 'o-important': props.muted === 0, 'text-muted': props.muted === 1, 'opacity-50': props.muted === 2, 'border-start-0 border-end-0': ui.isSmall, 'border-top-0': props.first, 'p-2 pe-3': !ui.isSmall }" t-on-click="onClick" t-ref="root">
+        <button class="o-mail-NotificationItem list-group-item d-flex cursor-pointer align-items-center bg-view w-100 gap-2" t-att-class="{ 'o-important': props.muted === 0, 'text-muted': props.muted === 1, 'opacity-50': props.muted === 2, 'border-start-0 border-end-0': ui.isSmall, 'border-top-0': props.first, 'p-2 pe-3': !ui.isSmall, 'o-active': props.isActive }" t-on-click="onClick" t-ref="root">
             <div class="position-relative bg-inherit m-1 flex-shrink-0" style="width:40px;height:40px;">
                 <img class="o_avatar w-100 h-100 rounded" alt="Notification Item Image" t-att-src="props.iconSrc"/>
                 <t t-slot="icon"/>


### PR DESCRIPTION
This commit introduces the ability to navigate the messaging menu items with the keyboard: "ArrowDown" / "ArrowUp" for next/previous item, "Tab" for next item, and Enter to simulate click on keyboard-selected item.

task-4056092

![messaging-menu-keyboard](https://github.com/user-attachments/assets/966d4152-7996-442f-89d8-5e6a2cfac2e7)
