### PR TITLE
[FIX] point_of_sale: Widen POS receipt margins

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.scss
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.scss
@@ -7,7 +7,7 @@
 }
 
 @page {
-    margin: 0;
+    padding: 15px;
 }
 
 @media print {


### PR DESCRIPTION
Steps to reproduce:
- Sell any item in POS (Pick item > Payment > Bank > Validate)
- Print receipt with 0 margin (current default) on external printer
- Leftmost part of the receipt is truncated

Why is this an issue:
Frankly, since this issue only occurs on external printers and we haven't had complaints from people using Odoo supported devices (by that I mean connected to an IoT box) this could be considered not to be our problem. The receipt margins have been made smaller since 15.0 though so there could be more people with this issue. I've tried printing one here and it is very slightly cut off, but that might depend on the device.

What this fix does:
This fix aims to reestablish margins as close to the way they were in 15.0 as possible (Don't want to go overboard and cut off the right)
As it was in this commit b29c4a6113a002528aeed1fa59e823172bfce841

opw-3996929

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
