### PR TITLE
[FIX] account: repartition line amount nulled

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -521,19 +521,20 @@ class AccountTax(models.Model):
             """ Recompute the new base amount based on included fixed/percent amounts and the current base amount. """
             fixed_amount = incl_tax_amounts['fixed_amount']
             division_amount = sum(tax_factor for _i, tax_factor in incl_tax_amounts['division_taxes'])
-            percent_amount = sum(tax_factor for _i, tax_factor in incl_tax_amounts['percent_taxes'])
+            percent_amount = sum(tax_amount * sum_repartition_factor for _i, tax_amount, sum_repartition_factor in incl_tax_amounts['percent_taxes'])
 
             if company.country_code == 'IN':
                 # For the indian case, when facing two percent price-included taxes having the same percentage,
                 # both need to produce the same tax amounts. To do that, the tax amount of those taxes are computed
                 # directly during the first traveling in reversed order.
                 total_tax_amount = 0.0
-                for i, tax_factor in incl_tax_amounts['percent_taxes']:
-                    tax_amount = float_round(base * tax_factor / (100 + percent_amount), precision_rounding=prec)
-                    total_tax_amount += tax_amount
-                    cached_tax_amounts[i] = tax_amount
-                    fixed_amount += tax_amount
-                for i, tax_factor in incl_tax_amounts['percent_taxes']:
+                for i, tax_amount, sum_repartition_factor in incl_tax_amounts['percent_taxes']:
+                    gross_tax_amount = float_round(base * tax_amount / (100 + percent_amount), precision_rounding=prec)
+                    factored_tax_amount = float_round(gross_tax_amount * sum_repartition_factor, precision_rounding=prec)
+                    total_tax_amount += factored_tax_amount
+                    cached_tax_amounts[i] = gross_tax_amount
+                    fixed_amount += factored_tax_amount
+                for i, _tax_amount, _sum_repartition_factor in incl_tax_amounts['percent_taxes']:
                     cached_base_amounts[i] = base - total_tax_amount
                 percent_amount = 0.0
 
@@ -612,7 +613,7 @@ class AccountTax(models.Model):
                     store_included_tax_total = True
                 if self._context.get('force_price_include', tax.price_include):
                     if tax.amount_type == 'percent':
-                        incl_tax_amounts['percent_taxes'].append((i, tax.amount * sum_repartition_factor))
+                        incl_tax_amounts['percent_taxes'].append((i, tax.amount, sum_repartition_factor))
                     elif tax.amount_type == 'division':
                         incl_tax_amounts['division_taxes'].append((i, tax.amount * sum_repartition_factor))
                     elif tax.amount_type == 'fixed':

--- a/addons/account/tests/test_tax.py
+++ b/addons/account/tests/test_tax.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from odoo import Command
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.tests import tagged
 
@@ -1213,4 +1214,36 @@ class TestTax(TestTaxCommon):
         self.assertListEqual(
             [x[0] for x in self.env["account.tax"].name_search("Ten \"tix\"")],
             ten_fixed_tax_tix.ids,
+        )
+
+    def test_repartition_line_in(self):
+        tax = self.env['account.tax'].create({
+            'name': 'tax20',
+            'amount_type': 'percent',
+            'amount': 20,
+            'type_tax_use': 'none',
+            'invoice_repartition_line_ids': [
+                Command.create({'repartition_type': 'base', 'factor_percent': 100.0}),
+                Command.create({'repartition_type': 'tax', 'factor_percent': 100.0}),
+                Command.create({'repartition_type': 'tax', 'factor_percent': -100.0}),
+            ],
+            'refund_repartition_line_ids': [
+                Command.create({'repartition_type': 'base', 'factor_percent': 100.0}),
+                Command.create({'repartition_type': 'tax', 'factor_percent': 100.0}),
+                Command.create({'repartition_type': 'tax', 'factor_percent': -100.0}),
+            ],
+        })
+        self.env.company.country_id = self.env.ref('base.in')
+        res = tax.with_context(force_price_include=True).compute_all(1000.0)
+        self._check_compute_all_results(
+            1000,         # 'total_included'
+            1000,         # 'total_excluded'
+            [
+                # base , amount
+                # ---------------
+                (1000, 200.0),
+                (1000, -200.0),
+                # ---------------
+            ],
+            res
         )


### PR DESCRIPTION
Set Company country to India
Create a TAX as follows
- Amount: 15%
- Included in price: False
- Tax repartition line:
  - 100.00% of tax to 100560 Tax Receivable
  - -100.00% of tax to 999999 Undistributed Profits/Losses
 
Open Bank Reconciliation Widget
Create a statement
Match with Manual operation
Select created tax

Issue: created tax lines have no amount
This occurs because when computing the tax amounts with compute_all
if the configuration of tax is price included (enforced from context)
and the tax is in cache we use the computed amount.
Unfortunately in this particular configuration the amount is 0

opw-3986439

