### PR TITLE
[IMP] l10n_it_edi: Make CIG and CUP available for non PA customers

### DIFF
--- a/addons/l10n_it_edi/i18n/it.po
+++ b/addons/l10n_it_edi/i18n/it.po
@@ -1303,6 +1303,17 @@ msgstr ""
 #: code:addons/l10n_it_edi/models/account_move.py:0
 #, python-format
 msgid ""
+"CIG/CUP fields of partner(s) are present, please fill out Origin "
+"Document Type field in the Electronic Invoicing tab."
+msgstr ""
+"Sono presenti i campi CIG/CUP dei partner, compilare il campo "
+"Tipo Documento Origine nella scheda Fatturazione elettronica."
+
+#. module: l10n_it_edi
+#. odoo-python
+#: code:addons/l10n_it_edi/models/account_move.py:0
+#, python-format
+msgid ""
 "Your company's VAT number and Fiscal Code haven't been found in the buyer "
 "and/or seller sections inside the document."
 msgstr ""

--- a/addons/l10n_it_edi/i18n/l10n_it_edi.pot
+++ b/addons/l10n_it_edi/i18n/l10n_it_edi.pot
@@ -1203,6 +1203,15 @@ msgstr ""
 #: code:addons/l10n_it_edi/models/account_move.py:0
 #, python-format
 msgid ""
+"CIG/CUP fields of partner(s) are present, please fill out Origin "
+"Document Type field in the Electronic Invoicing tab."
+msgstr ""
+
+#. module: l10n_it_edi
+#. odoo-python
+#: code:addons/l10n_it_edi/models/account_move.py:0
+#, python-format
+msgid ""
 "Your company's VAT number and Fiscal Code haven't been found in the buyer "
 "and/or seller sections inside the document."
 msgstr ""


### PR DESCRIPTION
A company that is carrying out a project financed with public money has the obligation to have the CUP code (and also the CIG) indicated on the purchase invoices. For non-PA customers, those fields are visible but not required and when filled in, will be presented in the XML.

task-4032771

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
