### PR TITLE
[FIX] account: Add domain to tags in COA list view

### DIFF
--- a/addons/account/views/account_account_views.xml
+++ b/addons/account/views/account_account_views.xml
@@ -98,7 +98,7 @@
                     <field name="internal_group" invisible="1"/>
                     <field name="reconcile" widget="boolean_toggle" attrs="{'invisible': ['|', ('internal_type','=','liquidity'), ('internal_group', '=', 'off_balance')]}"/>
                     <field name="tax_ids" optional="hide" widget="many2many_tags"/>
-                    <field name="tag_ids" optional="hide" widget="many2many_tags"/>
+                    <field name="tag_ids" domain="[('applicability', '=', 'accounts')]" optional="hide" widget="many2many_tags"/>
                     <field name="allowed_journal_ids" optional="hide" widget="many2many_tags"/>
                     <field name="currency_id" options="{'no_create': True}" groups="base.group_multi_currency"/>
                     <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>


### PR DESCRIPTION
In the list view of the Chart of Accounts, the only available tags in the field Tags are the ones applicable to Accounts.

task-4016899


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
