### PR TITLE
[FIX] account: recompute discount lines when changing currency

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -985,11 +985,12 @@ class AccountMoveLine(models.Model):
                 line.discount_allocation_key = frozendict({
                     'account_id': line.account_id.id,
                     'move_id': line.move_id.id,
+                    'currency_rate': line.currency_rate,
                 })
             else:
                 line.discount_allocation_key = False
 
-    @api.depends('account_id', 'company_id', 'discount', 'price_unit', 'quantity')
+    @api.depends('account_id', 'company_id', 'discount', 'price_unit', 'quantity', 'currency_rate')
     def _compute_discount_allocation_needed(self):
         for line in self:
             line.discount_allocation_dirty = True
@@ -1005,6 +1006,7 @@ class AccountMoveLine(models.Model):
                 frozendict({
                     'account_id': line.account_id.id,
                     'move_id': line.move_id.id,
+                    'currency_rate': line.currency_rate,
                 }),
                 {
                     'display_type': 'discount',
@@ -1017,6 +1019,7 @@ class AccountMoveLine(models.Model):
                 frozendict({
                     'move_id': line.move_id.id,
                     'account_id': discount_allocation_account.id,
+                    'currency_rate': line.currency_rate,
                 }),
                 {
                     'display_type': 'discount',


### PR DESCRIPTION
**Steps to reproduce:**
- Install Accounting
- In Accounting settings, configure a separate discount account for invoices
- Create an invoice:
  * Customer: [any]
  * Currency: [a foreign currency] (e.g. EUR)
  * Invoice Lines: [Price: 100€ - Discount: 50%]
- Check the "Journal Items" tab => Amount in currency for the receivable account and the discount account should be 50. Debit and credit should be the corresponding amount in the currency of the company.
- Change the currency of the invoice to the currency of the company
- Save the invoice

**Issue:**
When the currency is changed, all the amounts in currency are simply converted to the currency of the company.
Upon save, the "payment_term" line is recomputed to match with the values on the invoice lines, resulting on an amount of $50 for amount in currency, debit and credit. Which is correct.
However, the recomputation doesn't occur for the discount lines, resulting to an incorrect discount amount.

**Solution:**
Recompute the discount lines if the currency rate is changed.

opw-3881661




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
