### PR TITLE
[IMP] sale: show name of payment term on portal if note is null

### DIFF
--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -661,7 +661,7 @@
             <section t-if="sale_order.payment_term_id" class="mt-4">
                 <h4 class="">Payment terms</h4>
                 <hr class="mt-0 mb-1"/>
-                <span t-field="sale_order.payment_term_id.note"/>
+                <span t-field="sale_order.payment_term_id.note or sale_order.payment_term_id.name"/>
             </section>
         </div>
     </template>


### PR DESCRIPTION
### Before this PR:
if note on payment is null, no payment term is showed on portal

### After this PR:
If the note is empty, it is showed the name of payment term



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
