### PR TITLE
[FIX] purchase{_requisition}: cleanup company currency total calc

### DIFF
--- a/addons/purchase_requisition/views/purchase_views.xml
+++ b/addons/purchase_requisition/views/purchase_views.xml
@@ -113,7 +113,7 @@
                 <field name="price_unit" widget="monetary"/>
                 <field name="price_subtotal" string="Total"/>
                 <field name="currency_id" column_invisible="True"/>
-                <field name="price_total_cc"  widget="monetary"/>
+                <field name="price_total_cc" string="Company Total" widget="monetary"/>
                 <field name="company_currency_id" column_invisible="True"/>
                 <button name="action_choose" string="Choose" type="object" class="o_clear_qty_buttons" icon="fa-bullseye"
                     invisible="product_qty &lt;= 0.0"/>


### PR DESCRIPTION
Followup to 202af7c12a768005df3bd97f595ead0a4c4c02b9

- Some depend values were wrong

- New fields should have been separate computes for cleaner code + avoiding trying to change their values when their field dependencies don't have any changes

- Also, remove the obsolete repeat currency conversions from bugfix 5618236ce217406931885a80b3f764eb25369d66 since the newer `price_total_cc` makes it unnecessary, but didn't remove the logic at the time of adding the new field.

Followup to task: 3151579

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
