### PR TITLE
[FIX] whatsapp: disable captions on audio

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -563,22 +563,29 @@ export class Composer extends Component {
         }
     }
 
+    getpostData(){
+        return  {
+            attachments: this.props.composer.attachments,
+            isNote: this.props.type === "note",
+            mentionedChannels: this.props.composer.mentionedChannels,
+            mentionedPartners: this.props.composer.mentionedPartners,
+            cannedResponseIds: this.props.composer.cannedResponses.map(c => c.id),
+            parentId: this.props.messageToReplyTo?.message?.id,
+        };
+
+    }
+
+    async handleMessageSend(value) {
+        const postData = this.getpostData();
+        await this._sendMessage(value, postData);
+    }
+
     async sendMessage() {
         if (this.props.composer.message) {
             this.editMessage();
             return;
         }
-        await this.processMessage(async (value) => {
-            const postData = {
-                attachments: this.props.composer.attachments,
-                isNote: this.props.type === "note",
-                mentionedChannels: this.props.composer.mentionedChannels,
-                mentionedPartners: this.props.composer.mentionedPartners,
-                cannedResponseIds: this.props.composer.cannedResponses.map((c) => c.id),
-                parentId: this.props.messageToReplyTo?.message?.id,
-            };
-            await this._sendMessage(value, postData);
-        });
+        await this.processMessage((value) => this.handleMessageSend(value));
     }
 
     /**


### PR DESCRIPTION
Whatsapp API doesn't allow to send captions with audio anymore, therefore we should modify the way we handle captions. After this commit audio will be sent first while text message will stay in a composer, it will only be sent after the audio is sent.

task-4007616

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
