### PR TITLE
[FIX] stock: import the quant with the correct SN

### DIFF
--- a/addons/stock/i18n/stock.pot
+++ b/addons/stock/i18n/stock.pot
@@ -8405,6 +8405,13 @@ msgstr ""
 #. odoo-python
 #: code:addons/stock/models/stock_quant.py:0
 #, python-format
+msgid "The Lot/Serial number (%s) is linked to another product."
+msgstr ""
+
+#. module: stock
+#. odoo-python
+#: code:addons/stock/models/stock_quant.py:0
+#, python-format
 msgid ""
 "The Serial Number (%s) is already used in these location(s): %s.\n"
 "\n"

--- a/addons/stock/tests/test_quant.py
+++ b/addons/stock/tests/test_quant.py
@@ -1137,6 +1137,28 @@ class StockQuant(TransactionCase):
         move._action_assign()
         self.assertFalse(move.quantity)
 
+    def test_lot_of_product_different_from_quant(self):
+        """
+        Test that a lot cannot be used in a quant if the product is different.
+        """
+        product_lot_2 = self.env['product.product'].create({
+            'name': 'Product',
+            'type': 'product',
+            'tracking': 'lot',
+        })
+        lot_a = self.env['stock.lot'].create({
+            'name': 'A',
+            'product_id': product_lot_2.id,
+            'product_qty': 5,
+        })
+        with self.assertRaises(ValidationError):
+            self.env['stock.quant'].create({
+                'product_id': self.product_lot.id,
+                'location_id': self.stock_location.id,
+                'quantity': 20.0,
+                'lot_id': lot_a.id,
+            })
+
 
 class StockQuantRemovalStrategy(TransactionCase):
     def setUp(self):


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a storable product “P1” & “P2”, tracked by lot
- Create a quant:
    - Product: “P1”
    - Lot: “Lot A”

- Go to inventory adjustment, import a quant with:
    - Product: “P2”
    - Lot: “Lot A”

Problem:
A quant is created but linked with the record of “Lot A” of product
“P1”, which is incorrect. An existing lot with product “P2” should be
used, or a new one created if none is available. Unfortunately, in the
ORM, the Load function performs a simple name_search and takes the first
one founded, and it does not link the lot name with the related product.

opw-[4028709](https://www.odoo.com/web#id=4028709&view_type=form&model=project.task)