### PR TITLE
[FIX] stock: Use stock.move.line instead of stock.move to check movements made in the past

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -173,10 +173,11 @@ class Product(models.Model):
         quants_res = dict((item['product_id'][0], (item['quantity'], item['reserved_quantity'])) for item in Quant._read_group(domain_quant, ['product_id', 'quantity', 'reserved_quantity'], ['product_id'], orderby='id'))
         if dates_in_the_past:
             # Calculate the moves that were done before now to calculate back in time (as most questions will be recent ones)
+            MoveLine = self.env['stock.move.line'].with_context(active_test=False)
             domain_move_in_done = [('state', '=', 'done'), ('date', '>', to_date)] + domain_move_in_done
             domain_move_out_done = [('state', '=', 'done'), ('date', '>', to_date)] + domain_move_out_done
-            moves_in_res_past = dict((item['product_id'][0], item['product_qty']) for item in Move._read_group(domain_move_in_done, ['product_id', 'product_qty'], ['product_id'], orderby='id'))
-            moves_out_res_past = dict((item['product_id'][0], item['product_qty']) for item in Move._read_group(domain_move_out_done, ['product_id', 'product_qty'], ['product_id'], orderby='id'))
+            moves_in_res_past = {item['product_id'][0]: item['qty_done'] for item in MoveLine._read_group(domain_move_in_done, ['product_id', 'qty_done'], ['product_id'], orderby='id')}
+            moves_out_res_past = {item['product_id'][0]: item['qty_done'] for item in MoveLine._read_group(domain_move_out_done, ['product_id', 'qty_done'], ['product_id'], orderby='id')}
 
         res = dict()
         for product in self.with_context(prefetch_fields=False):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

The _compute_quantities_dict method calculates product quantities, first quantity_available and then the rest, using a context that can include locations and/or dates. If a location and date are provided in the context, the values are adjusted by discounting movements after that date to obtain the quantities as of a specific date.

Currently, quantities are obtained using stock.move because the projected quantities can be accurate. However, when selecting movements after specific dates, only the executed movements and their actual locations are needed. This is important because the location in stock.move.line is determined when the reservation is made and can be a child location of the one selected in stock.move. Therefore, obtaining data from stock.move instead of stock.move.line can result in imprecise and sometimes incorrect data.

Current behavior before PR:

We have the following configuration in the unit test:

**Warehouse Layout:**
- stock location
  - sublocation_1
  
**Incoming Movement:**
- product_1, 30 units
- from suppliers to sublocation_1
- date 2024-01-02

confirmed, reserved, and executed

**Outgoing Movement:**
- product_1, 3 units
- from stock location (parent) to customers
- date 2024-01-03

confirmed, reserved, and executed.
the reservation is made in the sublocation_1, which is the only one that has stock.

**Problem:**
When retrieving the product with the following context:
- location: sublocation_1
- to_date: 2024-01-01

A qty_available of -3 is returned. This happens because when searching for movements using stock.move and the domain based on the parent_path of the child location, the incoming move is not found since its location_id is the stock (parent) location.

Desired behavior after PR is merged:

Once this patch is implemented, we find the stock.move.line records, which provide accurate information and now return a qty_available of 0, the correct value.

If we run the implemented test on the 16.0 branch, it will fail. However, it has been verified that all other tests continue to function normally and the current calculations are correct.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
CLA in another PR: https://github.com/odoo/odoo/pull/173717