### PR TITLE
[FIX] project_timesheet_holidays: move init from company to post_init

### DIFF
--- a/addons/project_timesheet_holidays/__init__.py
+++ b/addons/project_timesheet_holidays/__init__.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import models
+from odoo import _
 
 
 def post_init(cr, registry):
@@ -18,3 +19,38 @@ def post_init(cr, registry):
             'timesheet_project_id': company.internal_project_id.id,
             'timesheet_task_id': company.leave_timesheet_task_id.id,
         })
+
+    type_ids_ref = env.ref('hr_timesheet.internal_project_default_stage', raise_if_not_found=False)
+    type_ids = [(4, type_ids_ref.id)] if type_ids_ref else []
+    companies = env['res.company'].search(['|', ('internal_project_id', '=', False), ('leave_timesheet_task_id', '=', False)])
+    internal_projects_by_company_dict = None
+    project = env['project.project']
+    for company in companies:
+        company = company.with_company(company)
+        if not company.internal_project_id:
+            if not internal_projects_by_company_dict:
+                internal_projects_by_company_read = project.search_read([
+                    ('name', '=', _('Internal')),
+                    ('allow_timesheets', '=', True),
+                    ('company_id', 'in', companies.ids),
+                ], ['company_id', 'id'])
+                internal_projects_by_company_dict = {res['company_id'][0]: res['id'] for res in internal_projects_by_company_read}
+            project_id = internal_projects_by_company_dict.get(company.id, False)
+            if not project_id:
+                project_id = project.create({
+                    'name': _('Internal'),
+                    'allow_timesheets': True,
+                    'company_id': company.id,
+                    'type_ids': type_ids,
+                }).id
+            company.write({'internal_project_id': project_id})
+        if not company.leave_timesheet_task_id:
+            task = company.env['project.task'].create({
+                'name': _('Time Off'),
+                'project_id': company.internal_project_id.id,
+                'active': True,
+                'company_id': company.id,
+            })
+            company.write({
+                'leave_timesheet_task_id': task.id,
+            })

--- a/addons/project_timesheet_holidays/models/res_company.py
+++ b/addons/project_timesheet_holidays/models/res_company.py
@@ -11,42 +11,6 @@ class Company(models.Model):
         'project.task', string="Time Off Task",
         domain="[('project_id', '=', internal_project_id)]")
 
-    def init(self):
-        type_ids_ref = self.env.ref('hr_timesheet.internal_project_default_stage', raise_if_not_found=False)
-        type_ids = [(4, type_ids_ref.id)] if type_ids_ref else []
-        companies = self.search(['|', ('internal_project_id', '=', False), ('leave_timesheet_task_id', '=', False)])
-        internal_projects_by_company_dict = None
-        Project = self.env['project.project']
-        for company in companies:
-            company = company.with_company(company)
-            if not company.internal_project_id:
-                if not internal_projects_by_company_dict:
-                    internal_projects_by_company_read = Project.search_read([
-                        ('name', '=', _('Internal')),
-                        ('allow_timesheets', '=', True),
-                        ('company_id', 'in', companies.ids),
-                    ], ['company_id', 'id'])
-                    internal_projects_by_company_dict = {res['company_id'][0]: res['id'] for res in internal_projects_by_company_read}
-                project_id = internal_projects_by_company_dict.get(company.id, False)
-                if not project_id:
-                    project_id = Project.create({
-                        'name': _('Internal'),
-                        'allow_timesheets': True,
-                        'company_id': company.id,
-                        'type_ids': type_ids,
-                    }).id
-                company.write({'internal_project_id': project_id})
-            if not company.leave_timesheet_task_id:
-                task = company.env['project.task'].create({
-                    'name': _('Time Off'),
-                    'project_id': company.internal_project_id.id,
-                    'active': True,
-                    'company_id': company.id,
-                })
-                company.write({
-                    'leave_timesheet_task_id': task.id,
-                })
-
     def _create_internal_project_task(self):
         projects = super()._create_internal_project_task()
         for project in projects:


### PR DESCRIPTION
tldr: The init function should not be used in this case for creating records. Doing so results in errors. The content of this init function can be safely moved to the post-init hook

The problem:
In saas~17.2, creating a company with a country can result in the installation of its accompanying localisation. If it is a European country, this will trigger the installation of base_vat too. If project_timesheet_holdiays is installed this can result in the installation of base_vat failing.

The init method described on res_company in project_timesheet_holidays is triggered when the res_partner model is extended, for instance, in base_vat when adding fields. The registry will contain these fields, but the accompanying fields will not yet have been written to the db.

When the project and task are created, a chain of dependencies result in the company's partner being read. In turn, a query is issued using fields from the registry that aren't yet written to the DB, resulting in an SQL error.

Solution:
Move the content of this method to the post-init hook. This is safe to do and works the same way.

task-id: 4060907