### PR TITLE
[FIX] stock_landed_costs: test_create_landed_cost_from_bill_multi_currencies

### DIFF
--- a/addons/stock_landed_costs/tests/test_stockvaluationlayer.py
+++ b/addons/stock_landed_costs/tests/test_stockvaluationlayer.py
@@ -588,6 +588,7 @@ class TestStockValuationLCFIFOVB(TestStockValuationLCCommon):
         company = self.env.user.company_id
         usd_currency = self.env.ref('base.USD')
         eur_currency = self.env.ref('base.EUR')
+        eur_currency.active = True  # EUR might not be active
 
         company.currency_id = usd_currency
 


### PR DESCRIPTION
The aim of this commit is to fix runbot build error.

Before the commit:
The test could fail if the EUR currency was inactive

After the commit:
The test activate the currency first


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
