### PR TITLE
[IMP] {website_}event{_*}: add extra options in front-end and modify event form

### DIFF
--- a/addons/website_event/static/tests/tours/website_event_align_test.js
+++ b/addons/website_event/static/tests/tours/website_event_align_test.js
@@ -1,0 +1,57 @@
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("website_event_submenu_align_breadcrumb_tour", {
+    url: "/event",
+    steps: () => [{
+        content: 'Go on "Test Event" page',
+        trigger: 'a[href*="/event"]:contains("Test Event"):first',
+        run: "click",
+    }, {
+        trigger: 'body:has(.o_wevent_event)',
+        content: 'Wait for the page to load',
+    },  {
+        content: 'Open editor',
+        trigger: '.o_frontend_to_backend_edit_btn',
+        run: 'click'
+    }, {
+        trigger: '.o-website-btn-custo-primary:contains("Edit")',
+        content: "Click here to enter edit mode for the event page.",
+        run: "click",
+    },{
+        trigger: 'button.o_we_customize_snippet_btn',
+        content: "This is the main container for your event page options.",
+        run: "click",
+    }, {
+        trigger: 'we-button-group[data-dependencies="is_submenu"] .fa-align-left',
+        content: "Click here to align the sub-menu to the left.",
+        run: "click",
+    }, {
+        trigger: 'we-button-group[data-dependencies="is_submenu"] .fa-align-left.active',
+        content: 'Wait for the page to load',
+    }, {
+        trigger: 'we-button-group[data-dependencies="is_submenu"] .fa-align-center',
+        content: "Click here to center-align the sub-menu.",
+        run: "click",
+    }, {
+        trigger: 'we-button-group[data-dependencies="is_submenu"] .fa-align-center.active',
+        content: 'Wait for the page to load',
+    }, {
+        trigger: 'we-button-group[data-dependencies="is_submenu"] .fa-align-right',
+        content: "Click here to align the sub-menu to the right.",
+        run: "click",
+    }, {
+        trigger: 'we-button-group[data-dependencies="is_submenu"] .fa-align-right.active',
+        content: 'Wait for the page to load',
+    }, {
+        trigger: 'we-button[data-customize-website-views="website_event.breadcrumb_template"] we-checkbox',
+        content: "Toggle this checkbox to show or hide breadcrumbs on the event page.",
+        run: "click",
+    }, {
+        trigger: 'we-button[data-customize-website-views="website_event.breadcrumb_template"]:not(.active)',
+        content: 'Wait for the breadcrumbs to be turned off',
+    }, {
+        trigger: "button[data-action=save]",
+        content: "Once you click on save, your event page is updated.",
+        run: "click",
+    }]
+});

--- a/addons/website_event/tests/test_website_event.py
+++ b/addons/website_event/tests/test_website_event.py
@@ -78,6 +78,14 @@ class TestUi(HttpCaseWithUserDemo, HttpCaseWithUserPortal):
         self.assertEqual(specific_view.website_meta_title, "Hello, world!")
         self.assertEqual(event.website_meta_title, False)
 
+    def test_website_event_submenu_align_breadcrumb(self):
+        self.env['event.event'].create({
+            'name': 'Test Event',
+            'is_published': True,
+            'website_menu': True,
+        })
+        self.start_tour('/event', 'website_event_submenu_align_breadcrumb_tour', login='admin')
+
     def test_website_event_questions(self):
         """ Will execute the tour that fills up two tickets with a few questions answers
         and then assert that the answers are correctly saved for each attendee. """

--- a/addons/website_event/views/event_templates_page.xml
+++ b/addons/website_event/views/event_templates_page.xml
@@ -24,14 +24,7 @@
     <section id="o_wevent_event_submenu">
         <!-- Mobile -->
         <div id="o_wevent_submenu_mobile" class="container d-flex d-lg-none align-items-center mt-3 mb-3 mb-lg-2">
-            <a t-if="navbar__back_url" t-att-href="navbar__back_url" t-att-title="navbar__back_title or 'Go back'">
-                <i class="oi oi-chevron-left"/>
-                <span t-out="navbar__back_text or 'Go back'"/>
-            </a>
-            <a t-else="" href="/event" title="All Events">
-                <i class="oi oi-chevron-left"/>
-                <span>All Events</span>
-            </a>
+            <div id="mobile_breadcrumb"/>
             <!-- Add Register additional CTA button, in addition to menus -->
             <a t-if="is_rendering_cta"
                 t-att-href="'/event/%s/register' % (slug(event))"
@@ -47,31 +40,17 @@
         <div id="o_wevent_submenu_desktop" class="d-none d-lg-block mt-3 mb-3 mb-lg-2">
             <div class="container">
                 <div class="d-flex align-items-center justify-content-between">
-                    <nav class="d-flex flex-wrap justify-content-between align-items-center gap-2 flex-grow-1">
-                        <ul class="breadcrumb p-0 m-0">
-                            <li class="breadcrumb-item">
-                                <a href="/event" title="Back to All Events">All Events</a>
-                            </li>
-                            <t t-if="navbar__back_url">
-                                <li class="breadcrumb-item">
-                                    <a t-attf-href="/event/{{slug(event)}}" t-attf-title="Back to {{event.name}}" t-field="event.name"/>
-                                </li>
-                                <li class="breadcrumb-item">
-                                    <a t-att-href="navbar__back_url" t-att-title="navbar__back_title" t-out="navbar__back_text"/>
-                                </li>
-                            </t>
-                            <t t-else="">
-                                <li class="breadcrumb-item active" aria-current="page"><span class="pe-3" t-field="event.name"/></li>
-                            </t>
-                        </ul>
-                        <ul t-if="not navbar__back_url" class="nav" t-att-data-menu_name="editable and 'Event Menu'" t-att-data-content_menu_id="editable and event.menu_id.id">
-                            <t t-foreach="event.menu_id.child_id" t-as="submenu">
-                                <t t-call="website.submenu">
-                                    <t t-set="item_class" t-value="'nav-item'"/>
-                                    <t t-set="link_class" t-value="'nav-link text-nowrap'"/>
+                    <nav class="d-flex flex-wrap align-items-center gap-2 flex-grow-1">
+                        <div id="sub_menu">
+                            <ul t-if="not navbar__back_url" class="nav" t-att-data-menu_name="editable and 'Event Menu'" t-att-data-content_menu_id="editable and event.menu_id.id">
+                                <t t-foreach="event.menu_id.child_id" t-as="submenu">
+                                    <t t-call="website.submenu">
+                                        <t t-set="item_class" t-value="'nav-item'"/>
+                                        <t t-set="link_class" t-value="'nav-link text-nowrap'"/>
+                                    </t>
                                 </t>
-                            </t>
-                        </ul>
+                            </ul>
+                        </div>
                     </nav>
 
                     <!-- Workaround to avoid flickering while navigating between pages with and without CTA -->
@@ -86,6 +65,58 @@
             </div>
         </div>
     </section>
+</template>
+
+<template id="breadcrumb_template" inherit_id="website_event.navbar">
+    <xpath expr="//div[@id='mobile_breadcrumb']" position="after">
+        <a t-if="navbar__back_url" t-att-href="navbar__back_url" t-att-title="navbar__back_title or 'Go back'">
+            <i class="oi oi-chevron-left"/>
+            <span t-out="navbar__back_text or 'Go back'"/>
+        </a>
+        <a t-else="" href="/event" title="All Events">
+            <i class="oi oi-chevron-left"/>
+            <span>All Events</span>
+        </a>
+    </xpath>
+    <xpath expr="//div[@id='sub_menu']" position="before">
+        <ul class="breadcrumb p-0 m-0">
+            <li class="breadcrumb-item">
+                <a href="/event" title="Back to All Events">All Events</a>
+            </li>
+            <t t-if="navbar__back_url">
+                <li class="breadcrumb-item">
+                    <a t-attf-href="/event/{{slug(event)}}" t-attf-title="Back to {{event.name}}" t-field="event.name"/>
+                </li>
+                <li class="breadcrumb-item">
+                    <a t-att-href="navbar__back_url" t-att-title="navbar__back_title" t-out="navbar__back_text"/>
+                </li>
+            </t>
+            <t t-if="not hide_submenu">
+                <li class="breadcrumb-item" aria-current="page"><a class="pe-3" t-field="event.name" t-att-href="'/event/%s/register' % (slug(event))"/></li>
+            </t>
+            <t t-else="">
+                <li class="breadcrumb-item active" aria-current="page"><span class="pe-3" t-field="event.name"/></li>
+            </t>
+        </ul>
+    </xpath>
+</template>
+
+<template id="submenu_align_left" inherit_id="website_event.navbar" active="False">
+    <xpath expr="//div[@id='sub_menu']" position="attributes">
+        <attribute name="class">ms-0</attribute>
+    </xpath>
+</template>
+
+<template id="submenu_align_center" inherit_id="website_event.navbar" active="False">
+    <xpath expr="//div[@id='sub_menu']" position="attributes">
+        <attribute name="class">mx-auto</attribute>
+    </xpath>
+</template>
+
+<template id="submenu_align_right" inherit_id="website_event.navbar" active="True">
+    <xpath expr="//div[@id='sub_menu']" position="attributes">
+        <attribute name="class">ms-auto</attribute>
+    </xpath>
 </template>
 
 <template id="navbar_dropdown" name="Event Navbar Dropdown">

--- a/addons/website_event/views/snippets/snippets.xml
+++ b/addons/website_event/views/snippets/snippets.xml
@@ -74,7 +74,24 @@
         <!-- Event page  -->
         <div data-js="WebsiteEvent" data-selector="main:has(.o_wevent_event)" data-page-options="true" groups="website.group_website_designer" data-no-check="true" string="Event Page">
             <we-checkbox string="Sub-menu (Specific)"
+                         data-name="is_submenu"
                          data-display-submenu="true"
+                         data-no-preview="true"
+                         data-reload="/"/>
+            <we-button-group string="Align Sub-menu" class="o_we_full_row"
+                             data-dependencies="is_submenu"
+                             data-reload="/">
+                <we-button title="Left" class="fa fa-fw fa-align-left"
+                            data-customize-website-views="website_event.submenu_align_left"/>
+                <we-button title="Center" class="fa fa-fw fa-align-center"
+                            data-customize-website-views="website_event.submenu_align_center"/>
+                <we-button title="Right" class="fa fa-fw fa-align-right"
+                            data-customize-website-views="website_event.submenu_align_right"/>
+            </we-button-group>
+        </div>
+        <div data-selector="main:has(.o_wevent_event)" data-page-options="true" groups="website.group_website_designer" data-no-check="true" string="Event Page">
+            <we-checkbox string="Breadcrumbs"
+                         data-customize-website-views="website_event.breadcrumb_template"
                          data-no-preview="true"
                          data-reload="/"/>
         </div>


### PR DESCRIPTION
\* = booth, exhibitor, meet, track, track_quiz

**Specifications:**
- Allow to hide breadcrumb from the front-end
- Allow to align sub-menu (if sub-menu is true else hidden)
- Modify event form, add sub-menu tab and move sub-menu selection fields to it.

**After this PR:**
- We will be able to enable and disable breadcrumb from the front-end.
- If sub-menu is enabled then we will be able to align sub-menus (right being default).
- Event form view will be updated, 'website_menu' field will be moved down instead of on the top.
- Whenever 'website_menu' is enabled, 'Sub-menu' tab will be enabled.
- All the website_menu selection fields will be moved in the newly created 'Sub-menu' tab.

Task-4010675
