### PR TITLE
[IMP] base: inject directly groups of the user

### DIFF
--- a/addons/website/models/res_lang.py
+++ b/addons/website/models/res_lang.py
@@ -21,7 +21,8 @@ class Lang(models.Model):
         :return: LangDataDict({code: LangData})
         """
         if request and getattr(request, 'is_frontend', True):
-            lang_ids = self.env['website'].get_current_website().language_ids.sorted('name').ids
+            # get languages while ignoring current language as the one in the context may be invalid
+            lang_ids = self.env['website'].get_current_website().with_context(lang=False).language_ids.sorted('name').ids
             langs = [dict(self.env['res.lang']._get_data(id=id_)) for id_ in lang_ids]
             es_419_exists = any(lang['code'] == 'es_419' for lang in langs)
             already_shortened = []


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Instead of joining with the table containing the groups of the user, we can use directly the property of the `env.user` to get the groups. It's often accessed and should be in the cache.

Current behavior before PR:
select from res_groups_users_rel

Desired behavior after PR is merged:
inject directly known group ids and use the SQL wrapper



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
