### PR TITLE
[FIX] bus: reduce gevent worker concurrency

### DIFF
--- a/addons/bus/models/bus_presence.py
+++ b/addons/bus/models/bus_presence.py
@@ -9,7 +9,7 @@ from odoo import tools
 from odoo.service.model import PG_CONCURRENCY_ERRORS_TO_RETRY
 from odoo.tools.misc import DEFAULT_SERVER_DATETIME_FORMAT
 
-UPDATE_PRESENCE_DELAY = 60
+UPDATE_PRESENCE_DELAY = 1200  # 20 minutes
 DISCONNECTION_TIMER = UPDATE_PRESENCE_DELAY + 5
 AWAY_TIMER = 1800  # 30 minutes
 

--- a/addons/bus/static/src/im_status_service.js
+++ b/addons/bus/static/src/im_status_service.js
@@ -4,7 +4,9 @@ import { browser } from "@web/core/browser/browser";
 import { registry } from "@web/core/registry";
 import { timings } from "@bus/misc";
 
-export const UPDATE_BUS_PRESENCE_DELAY = 60000;
+export const UPDATE_BUS_PRESENCE_DELAY = 600000; // 10 minutes
+export const UPDATE_BUS_PRESENCE_JITTER = 600000; // 10 minutes
+
 /**
  * This service updates periodically the user presence in order for the
  * im_status to be up to date.
@@ -32,7 +34,7 @@ export const imStatusService = {
                 throttledUpdateBusPresence,
                 UPDATE_BUS_PRESENCE_DELAY
             );
-        }, UPDATE_BUS_PRESENCE_DELAY);
+        }, UPDATE_BUS_PRESENCE_DELAY + UPDATE_BUS_PRESENCE_JITTER * Math.random());
 
         bus_service.addEventListener("connect", () => {
             // wait for im_status model/ids to be registered before starting.

--- a/addons/bus/static/src/workers/websocket_worker.js
+++ b/addons/bus/static/src/workers/websocket_worker.js
@@ -34,7 +34,7 @@ export const WEBSOCKET_CLOSE_CODES = Object.freeze({
 });
 // Should be incremented on every worker update in order to force
 // update of the worker in browser cache.
-export const WORKER_VERSION = "1.0.7";
+export const WORKER_VERSION = "1.0.8";
 const MAXIMUM_RECONNECT_DELAY = 60000;
 
 /**
@@ -45,7 +45,7 @@ const MAXIMUM_RECONNECT_DELAY = 60000;
  * for SharedWorker and this class implements it.
  */
 export class WebsocketWorker {
-    INITIAL_RECONNECT_DELAY = 1000;
+    INITIAL_RECONNECT_DELAY = 1000 + 30000 * Math.random(); // 1 second + up to 30 seconds of jitter
     RECONNECT_JITTER = 1000;
 
     constructor() {
@@ -388,10 +388,10 @@ export class WebsocketWorker {
      * applied to the reconnect attempts.
      */
     _retryConnectionWithDelay() {
+        this.connectTimeout = setTimeout(this._start.bind(this), this.connectRetryDelay);
         this.connectRetryDelay =
             Math.min(this.connectRetryDelay * 1.5, MAXIMUM_RECONNECT_DELAY) +
             this.RECONNECT_JITTER * Math.random();
-        this.connectTimeout = setTimeout(this._start.bind(this), this.connectRetryDelay);
     }
 
     /**

--- a/addons/bus/websocket.py
+++ b/addons/bus/websocket.py
@@ -35,15 +35,18 @@ _logger = logging.getLogger(__name__)
 
 
 MAX_TRY_ON_POOL_ERROR = 10
-DELAY_ON_POOL_ERROR = 0.03
+DELAY_ON_POOL_ERROR = 0.3
+JITTER_ON_POOL_ERROR = 0.3
 
 
 def acquire_cursor(db):
     """ Try to acquire a cursor up to `MAX_TRY_ON_POOL_ERROR` """
-    for tryno in range(1, MAX_TRY_ON_POOL_ERROR + 1):
+    delay = DELAY_ON_POOL_ERROR
+    for _ in range(MAX_TRY_ON_POOL_ERROR):
         with suppress(PoolError):
             return odoo.registry(db).cursor()
-        time.sleep(random.uniform(DELAY_ON_POOL_ERROR, DELAY_ON_POOL_ERROR * tryno))
+        time.sleep(delay + random.uniform(0, JITTER_ON_POOL_ERROR))
+        delay *= 1.25
     raise PoolError('Failed to acquire cursor after %s retries' % MAX_TRY_ON_POOL_ERROR)
 
 


### PR DESCRIPTION
The gevent worker should be able to handle many databases. Currently,
several points reduce its efficiency:
- When no cursor is available to fetch bus notifications, websockets
retry up to 10 times to acquire one. However, the delay between each
attempt is too short, resulting in minimal chance of recovery when the
connection pool is full.
- The reconnect delay of the websocket worker is too short, causing many
websockets to try to reconnect in a short time frame when the server
restarts.
- The client updates the user presence every minute, which is too
frequent and causes unnecessary load on the server.

This PR fixes these issues by:
- Tweaking the `acquire_cursor` method: improving the  backoff and
increasing wait time to improve recovery chances.
- Increasing the presence update delay to 10 minutes, plus a random
jitter of up to 10 minutes.
- Increasing the websocket worker's initial reconnect delay to 1 second,
plus a random jitter of up to 30 seconds to spread reconnections over
a larger period.