### PR TITLE
[FIX] point_of_sale: change the way to update the fiscal position

### DIFF
--- a/addons/point_of_sale/static/src/app/store/models.js
+++ b/addons/point_of_sale/static/src/app/store/models.js
@@ -180,6 +180,7 @@ export class Product extends PosModel {
         let quantity = 1;
         let comboLines = [];
         let attribute_custom_values = {};
+        let extras = {};
 
         if (code && this.pos.db.product_packaging_by_barcode[code.code]) {
             quantity = this.pos.db.product_packaging_by_barcode[code.code].qty;
@@ -205,6 +206,7 @@ export class Product extends PosModel {
                 return;
             }
             comboLines = payload;
+            extras.price_type = "manual";
         }
         // Gather lot information if required.
         if (this.isTracked()) {
@@ -265,6 +267,7 @@ export class Product extends PosModel {
             price_extra,
             comboLines,
             attribute_value_ids,
+            extras,
         };
     }
     isPricelistItemUsable(item, date) {
@@ -2239,6 +2242,7 @@ export class Order extends PosModel {
                     comboParent,
                     comboLine: line.comboLine,
                     attribute_value_ids: line.attribute_value_ids,
+                    extras: {price_type: "manual"},
                 }
             );
         }

--- a/addons/point_of_sale/static/tests/tours/PosComboTour.js
+++ b/addons/point_of_sale/static/tests/tours/PosComboTour.js
@@ -82,3 +82,40 @@ registry.category("web_tour.tours").add("PosComboPriceTaxIncludedTour", {
         // the split screen is tested in `pos_restaurant`
     ],
 });
+
+registry.category("web_tour.tours").add("PosComboChangeFP", {
+    test: true,
+    steps: () => [
+        ProductScreen.confirmOpeningPopup(),
+
+        ProductScreen.clickDisplayedProduct("Office Combo"),
+        combo.select("Combo Product 2"),
+        combo.select("Combo Product 4"),
+        combo.select("Combo Product 6"),
+        combo.confirm(),
+
+        ProductScreen.selectedOrderlineHas("Office Combo"),
+        ProductScreen.clickOrderline("Combo Product 2"),
+        ProductScreen.selectedOrderlineHas("Combo Product 2", "1.0", "8.33"),
+        ProductScreen.clickOrderline("Combo Product 4"),
+        ProductScreen.selectedOrderlineHas("Combo Product 4", "1.0", "16.67"),
+        ProductScreen.clickOrderline("Combo Product 6"),
+        ProductScreen.selectedOrderlineHas("Combo Product 6", "1.0", "25.00"),
+        ProductScreen.totalAmountIs("50.00"),
+        inLeftSide(Order.hasTax("4.55")),
+
+        // Test than changing the fp, doesn't change the price of the combo
+        ProductScreen.changeFiscalPosition("test fp"),
+        ProductScreen.clickOrderline("Office Combo"),
+        ProductScreen.selectedOrderlineHas("Office Combo"),
+        ProductScreen.clickOrderline("Combo Product 2"),
+        ProductScreen.selectedOrderlineHas("Combo Product 2", "1.0", "8.33"),
+        ProductScreen.clickOrderline("Combo Product 4"),
+        ProductScreen.selectedOrderlineHas("Combo Product 4", "1.0", "16.67"),
+        ProductScreen.clickOrderline("Combo Product 6"),
+        ProductScreen.selectedOrderlineHas("Combo Product 6", "1.0", "25.00"),
+        ProductScreen.totalAmountIs("50.00"),
+        inLeftSide(Order.hasTax("2.38")),
+        ProductScreen.isShown(),
+    ].flat(),
+});

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1200,6 +1200,48 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'FiscalPositionTwoTaxIncluded', login="accountman")
 
+    def test_pos_combo_change_fp(self):
+        """
+        Verify than when the fiscal position is changed,
+        the price of the combo doesn't change and taxes are well taken into account
+        """
+        tax_1 = self.env['account.tax'].create({
+            'name': 'Tax 10%',
+            'amount': 10,
+            'price_include': True,
+            'amount_type': 'percent',
+            'type_tax_use': 'sale',
+        })
+
+        tax_2 = self.env['account.tax'].create({
+            'name': 'Tax 5%',
+            'amount': 5,
+            'price_include': True,
+            'amount_type': 'percent',
+            'type_tax_use': 'sale',
+        })
+
+        setup_pos_combo_items(self)
+        self.office_combo.write({'list_price': 50, 'taxes_id': [(6, 0, [tax_1.id])]})
+        for combo in self.office_combo.combo_ids:  # Set the tax to all the products of the combo
+            for line in combo.combo_line_ids:
+                line.product_id.taxes_id = [(6, 0, [tax_1.id])]
+
+        fiscal_position = self.env['account.fiscal.position'].create({
+            'name': 'test fp',
+            'tax_ids': [(0, 0, {
+                'tax_src_id': tax_1.id,
+                'tax_dest_id': tax_2.id,
+            })],
+        })
+
+        self.main_pos_config.write({
+            'tax_regime_selection': True,
+            'fiscal_position_ids': [(6, 0, [fiscal_position.id])],
+        })
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'PosComboChangeFP', login="pos_user")
+
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):
     browser_size = '375x667'


### PR DESCRIPTION
Current behavior:
When a combo product is on the order and the user change the fiscal position, the prices of the lines of the combo change to get there original prices rather than the price of the combo

Steps to reproduce:
- Install "Point of Sale" app
- Enable "Flexible Taxes" in the shop settings and allow 2 fiscal positions
- Start a session, select one of the fp click on a combo product
- Change the fp, the prices of the orderlines are now the prices of the products themselves and not the prices of the combo

Cause:
After changing the fp, the quantity of al the orderlines are reset

Solution:
After changing the fp, call the function which update the pricelist which update all the prices correctly

opw-4027186


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
