### PR TITLE
[FIX] models: raise UserError when error occur while computing custom fields

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -4274,7 +4274,17 @@ Fields:
         return records
 
     def _compute_field_value(self, field):
-        fields.determine(field.compute, self)
+        try:
+            fields.determine(field.compute, self)
+        except Exception as e:
+            if field.name.startswith("x_"):
+                _logger.warning(
+                    'An error occurred while computing the value of the custom field "%s"', field.name, exc_info=True
+                )
+                raise UserError(
+                    _('The below issue occurs while computing the value of the custom field "%s":\n%s', field.name, e)
+                ) from e
+            raise
 
         if field.store and any(self._ids):
             # check constraints of the fields that have been computed


### PR DESCRIPTION
Currently, an exception occurs when the user adds the wrong code to the
compute method of their custom field.

Error:
```
SyntaxError: 'return' outside function (, line 6)
  File "odoo/http.py", line 2248, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1823, in _serve_db
    return self._transactioning(_serve_ir_http, readonly=ro)
  File "odoo/http.py", line 1843, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1821, in _serve_ir_http
    return self._serve_ir_http(rule, args)
  File "odoo/http.py", line 1828, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2053, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 220, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 756, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 38, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 34, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 458, in call_kw
    result = getattr(recs, name)(*args, **kwargs)
  File "addons/web/models/models.py", line 1018, in onchange
    snapshot1 = RecordSnapshot(record, fields_spec)
  File "addons/web/models/models.py", line 1105, in __init__
    self.fetch(name)
  File "addons/web/models/models.py", line 1120, in fetch
    self[field_name] = self.record[field_name]
  File "odoo/models.py", line 6610, in __getitem__
    return self._fields[key].__get__(self, self.env.registry[self._name])
  File "odoo/fields.py", line 1206, in __get__
    self.recompute(record)
  File "odoo/fields.py", line 1421, in recompute
    apply_except_missing(self.compute_value, recs)
  File "odoo/fields.py", line 1394, in apply_except_missing
    func(records)
  File "odoo/fields.py", line 1443, in compute_value
    records._compute_field_value(self)
  File "addons/mail/models/mail_thread.py", line 416, in _compute_field_value
    return super()._compute_field_value(field)
  File "odoo/models.py", line 4936, in _compute_field_value
    fields.determine(field.compute, self)
  File "odoo/fields.py", line 103, in determine
    return needle(records, *args)
  File "odoo/addons/base/models/ir_model.py", line 38, in <lambda>
    func = lambda self: safe_eval(text, SAFE_EVAL_BASE, {'self': self}, mode="exec")
  File "odoo/tools/safe_eval.py", line 388, in safe_eval
    c = test_expr(expr, _SAFE_OPCODES, mode=mode, filename=filename)
  File "odoo/tools/safe_eval.py", line 251, in test_expr
    code_obj = compile(expr, filename or "", mode)
```

When the compute method was triggered, it generated errors like OsError,
IndentationError, ZeroDivisionError, SyntaxError, ect.

This commit raises a UserError with the original error that was generated while executing custom code.

sentry-4915503441, 5068715143, 5613839179, 5492946880






