### PR TITLE
[FIX] stock: nonsensical client action definition

### DIFF
--- a/addons/stock/static/src/stock_forecasted/stock_forecasted.js
+++ b/addons/stock/static/src/stock_forecasted/stock_forecasted.js
@@ -61,11 +61,14 @@ export class StockForecasted extends Component {
         this.resModel = this.context.active_model || this.context.params?.active_model;
         //Following is used as a fallback when the forecast is not called by an action but through browser's history
         if (!this.resModel) {
-            if (this.props.action.res_model) {
-                const actionModel = await this.orm.read('ir.model', [Number(this.props.action.res_model)], ['model']);
-                if (actionModel[0]?.model) {
-                    this.resModel = actionModel[0].model
+            let resModel = this.props.action.res_model;
+            if (resModel) {
+                if (/^\d+$/.test(resModel)) {
+                    // legacy action definition where res_model is the model id instead of name
+                    const actionModel = await this.orm.read('ir.model', [Number(resModel)], ['model']);
+                    resModel = actionModel[0]?.model;
                 }
+                this.resModel = resModel;
             } else if (this.props.action._originalAction) {
                 const originalContextAction = JSON.parse(this.props.action._originalAction).context;
                 if (typeof originalContextAction === "string") {


### PR DESCRIPTION
res_model is supposed to be the *name* of the model, not the model id
