### PR TITLE
[FIX] web_editor: prevent page crash on burger menu click in mobile view

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -3962,7 +3962,7 @@ var SnippetsMenu = Widget.extend({
      * @param {Event} ev - a touch event
      */
     _onTouchEvent(ev) {
-        if (ev.touches.length > 1) {
+        if (ev.touches.length > 1 || ev.changedTouches.length < 1) {
             // Ignore multi-touch events.
             return;
         }


### PR DESCRIPTION
Version: 16.0 to master
Browser: Firefox only

Steps to Reproduce:
1. Open website in edit mode (In Desktop)
2. Open inspect element, switch to mobile view (Inspector mobile view)
3. Click burger menu to open
4. Traceback occurs

Reason for Change:
 In Firefox, when the inspector's mobile view is used, it simulates
 touch events. Clicking the burger menu returns undefined, causing an
 error. This PR ensures that the page does not crash by handling the
 undefined case.

task-3980983