### PR TITLE
[FIX] loyalty: resolve validation error for loyalty description

### DIFF
--- a/addons/loyalty/i18n/loyalty.pot
+++ b/addons/loyalty/i18n/loyalty.pot
@@ -1789,6 +1789,13 @@ msgstr ""
 
 #. module: loyalty
 #. odoo-python
+#: code:addons/loyalty/models/loyalty_reward.py:0
+#, python-format
+msgid "The reward description field cannot be empty."
+msgstr ""
+
+#. module: loyalty
+#. odoo-python
 #: code:addons/loyalty/models/product_product.py:0
 #: code:addons/loyalty/models/product_template.py:0
 #, python-format

--- a/addons/loyalty/models/loyalty_reward.py
+++ b/addons/loyalty/models/loyalty_reward.py
@@ -5,6 +5,7 @@ import ast
 import json
 
 from odoo import _, api, fields, models
+from odoo.exceptions import UserError
 from odoo.osv import expression
 
 class LoyaltyReward(models.Model):
@@ -235,6 +236,12 @@ class LoyaltyReward(models.Model):
     @api.depends("reward_type")
     def _compute_user_has_debug(self):
         self.user_has_debug = self.user_has_groups('base.group_no_one')
+
+    @api.onchange('description')
+    def _ensure_reward_has_description(self):
+        for reward in self:
+            if not reward.description:
+                raise UserError(_("The reward description field cannot be empty."))
 
     def _create_missing_discount_line_products(self):
         # Make sure we create the product that will be used for our discounts


### PR DESCRIPTION
**Steps:**
- Create a new Discount and loyalty program.
- Keep the program type as Buy X Get Y / any other program
- In the rewards pop-up, leave the 'description on the product' empty and click on 'save & close'.
- Try to save the loyalty program. Validation error appears.

**Cause:**
- This occurs because the description is used to set the name of the discount product, but if it's empty, the write method will not get the proper values hence resulting in error.

**Fix:**
- Raise user error if the description field is set to empty.


**Affected Version:** 16.0 - saas~17.4
**opw**-4032798