### PR TITLE
[IMP] stock: back to basic thd

### DIFF
--- a/addons/mrp_subcontracting/static/src/views/stock_move_one2many.xml
+++ b/addons/mrp_subcontracting/static/src/views/stock_move_one2many.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-inherit="stock.MovesListRenderer.RecordRow" t-inherit-mode="extension">
+        <xpath expr="//tr/t[1]/t[2]/td" position="attributes">
+            <attribute name="t-att-style">column.buttons.some(button => !this.evalInvisible(button.invisible, record)) ? 'width: 30px;' : 'width: 0px;padding: 0px;'</attribute>
+        </xpath>
         <xpath expr="//t[starts-with(@t-if, 'record.resModel') and .//button[@class='btn btn-link fa fa-list']]" position="attributes">
             <attribute name="t-if">column.type === 'opendetailsop' and !record.data.is_subcontract </attribute>
         </xpath>

--- a/addons/stock/models/stock_location.py
+++ b/addons/stock/models/stock_location.py
@@ -17,7 +17,7 @@ class Location(models.Model):
     _description = "Inventory Locations"
     _parent_name = "location_id"
     _parent_store = True
-    _order = 'sequence, complete_name, id'
+    _order = 'complete_name, id'
     _rec_name = 'complete_name'
     _rec_names_search = ['complete_name', 'barcode']
     _check_company_auto = True

--- a/addons/stock/static/src/views/picking_form/stock_move_one2many.xml
+++ b/addons/stock/static/src/views/picking_form/stock_move_one2many.xml
@@ -3,7 +3,7 @@
     <t t-name="stock.MovesListRenderer.RecordRow" t-inherit-mode="primary" t-inherit="web.ListRenderer.RecordRow">
         <xpath expr="//tr/t[1]" position="inside">
             <t t-if="column.type === 'opendetailsop'">
-                <td class="o_data_cell cursor-pointer o_list_button">
+                <td class="o_data_cell cursor-pointer o_list_button" style="width: 30px" t-att-class="{'w-0 p-0': record.data.show_details_visible}">
                     <t t-if="record.resModel === 'stock.move' &amp;&amp; record.data?.show_details_visible">
                         <button name="Open Move" class="btn btn-link fa fa-list" t-on-click="() => props.openRecord(record)"/>
                     </t>


### PR DESCRIPTION
With this PR :
====================
- Remove the location sequence from the order by because including the location
  sequence can create mistakes in the picking order if locations are added.
  Therefore, we rolled back this change.
- Rearrange moves in transfers, as the move button field takes up extra space
  in the line.

Task-id : 4013661
