### PR TITLE
[FIX] delivery: don't return error when rate can't be fetched

### DIFF
--- a/addons/delivery/wizard/choose_delivery_carrier.py
+++ b/addons/delivery/wizard/choose_delivery_carrier.py
@@ -70,7 +70,7 @@ class ChooseDeliveryCarrier(models.TransientModel):
             self.delivery_message = vals.get('warning_message', False)
             self.delivery_price = vals['price']
             self.display_price = vals['carrier_price']
-            return {}
+            return {'no_rate': vals.get('no_rate', False)}
         return {'error_message': vals['error_message']}
 
     def update_price(self):
@@ -84,6 +84,7 @@ class ChooseDeliveryCarrier(models.TransientModel):
             'res_model': 'choose.delivery.carrier',
             'res_id': self.id,
             'target': 'new',
+            'context': vals,
         }
 
     def button_confirm(self):

--- a/addons/delivery/wizard/choose_delivery_carrier_views.xml
+++ b/addons/delivery/wizard/choose_delivery_carrier_views.xml
@@ -30,7 +30,10 @@
                 <div role="alert" class="alert alert-warning" invisible="invoicing_message == ''">
                     <field name="invoicing_message" nolabel="1"/>
                 </div>
-                <div role="alert" class="alert alert-info" invisible="not delivery_message">
+                <div role="alert" class="alert alert-info" invisible="context.get('no_rate') or not delivery_message">
+                    <field name="delivery_message" nolabel="1"/>
+                </div>
+                <div role="alert" class="alert alert-danger" invisible="not context.get('no_rate') or not delivery_message">
                     <field name="delivery_message" nolabel="1"/>
                 </div>
                 <footer>


### PR DESCRIPTION
In this PR
==================
Some contracts in SendCloud do not have rates. This caused an annoying popup when adding it to the Sales Order.
After this PR, the red banner is displayed with the same message instead of the annoying popup when adding it to the Sales Order.

Enterprise PR: https://github.com/odoo/enterprise/pull/66976
TaskId: 4012182

