### PR TITLE
[IMP] website_editor: autosave custom snippet when drag and drap

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -26,6 +26,7 @@ import {
     useEffect,
     useRef,
     useState,
+    onPatched,
 } from "@odoo/owl";
 import { LinkTools } from '@web_editor/js/wysiwyg/widgets/link_tools';
 import { touching, closest, addLoadingEffect as addButtonLoadingEffect } from "@web/core/utils/ui";
@@ -1917,6 +1918,23 @@ class SnippetsMenu extends Component {
             this.props.mountedProm.resolve();
             this.el.classList.add("o_loaded");
             this.el.ownerDocument.body.classList.toggle('editor_has_snippets', !this.folded);
+        });
+
+        // TODO: remove in master and add t-on-blur and also update
+        // `t-att-class`es that has `snippet.rename` in snippet.xml
+        onPatched(() => {
+            const inputEl = this.snippetsAreaRef.el.querySelector("input.text-start");
+            if(inputEl){
+                inputEl.addEventListener("blur", async (ev) => {
+                    this._onConfirmRename(ev);
+                });
+                inputEl.select();
+                const customSnippet = this.snippetsAreaRef.el.querySelector(".oe_snippet_thumbnail.o_we_already_dragging");
+                if(customSnippet){
+                    customSnippet.classList.remove("o_we_already_dragging");
+                    customSnippet.parentNode.classList.add("o_we_draggable");
+                }
+            }
         });
 
         onWillUnmount(() => {
@@ -4259,8 +4277,8 @@ class SnippetsMenu extends Component {
         const input = ev.target.parentElement.querySelector("input");
         const snippetId = parseInt(ev.target.closest(".oe_snippet").dataset.oeSnippetId);
         const snippet = this.snippets.get(snippetId);
-        const newName = input.value;
-        if (newName !== snippet.displayName) {
+        const newName = input.value.trim();
+        if (newName !== snippet.displayName && newName) {
             this._execWithLoadingEffect(async () => {
                 await this.orm.call("ir.ui.view", "rename_snippet", [], {
                     'name': newName,


### PR DESCRIPTION
Specification:
When a user is renaming a custom snippet and tried to drag and drop another snippet, all unsaved changes to the name gets lost.

This PR introduces a feature to autosave the name of the custom snippet. It allows both custom and other snippets to be dragged and dropped, with automatic saving of changes. Additionally, it prevents saving null names to custom snippets.

task-3581814
