### PR TITLE
[FIX] website: display seo notifications on save after publishing a page

### DIFF
--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -801,11 +801,12 @@ class Website(Home):
             raise werkzeug.exceptions.Forbidden()
 
         fields = ['website_meta_title', 'website_meta_description', 'website_meta_keywords', 'website_meta_og_img']
-        if res_model == 'website.page':
-            fields.extend(['website_indexed', 'website_id'])
-
         res = {'can_edit_seo': True}
         record = request.env[res_model].browse(res_id)
+        if res_model == 'website.page':
+            fields.extend(['website_indexed', 'website_id'])
+            res["website_is_published"] = record.website_published
+
         try:
             request.website._check_user_can_modify(record)
         except AccessError:

--- a/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
+++ b/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
@@ -1183,25 +1183,24 @@ export class WysiwygAdapterComponent extends Wysiwyg {
         const isDirty = this._isDirty();
         let callback = () => {
             this.leaveEditMode({ forceLeave: true });
-            const canPublish = this.websiteService.currentWebsite.metadata.canPublish;
-            if (
-                isDirty &&
-                (!canPublish ||
-                    (canPublish && this.websiteService.currentWebsite.metadata.isPublished)) &&
-                this.websiteService.currentWebsite.metadata.canOptimizeSeo
-            ) {
+            if (isDirty) {
                 const {
                     mainObject: { id, model },
+                    canPublish,
                 } = this.websiteService.currentWebsite.metadata;
                 rpc("/website/get_seo_data", {
                     res_id: id,
                     res_model: model,
                 }).then(
-                    (seo_data) =>
+                    (seo_data) => {
+                        if (!(seo_data.website_is_published && canPublish)) {
+                            return;
+                        }
                         checkAndNotifySEO(seo_data, OptimizeSEODialog, {
                             notification: this.notificationService,
                             dialog: this.dialogs,
-                        }),
+                        });
+                    },
                     (error) => {
                         throw error;
                     }

--- a/addons/website/static/tests/tours/website_seo_notification.js
+++ b/addons/website/static/tests/tours/website_seo_notification.js
@@ -1,0 +1,76 @@
+import wTourUtils from "@website/js/tours/tour_utils";
+
+wTourUtils.registerWebsitePreviewTour(
+    "website_seo_notification",
+    {
+        test: true,
+        url: "/",
+    },
+    () => [
+        // Part one checks that the SEO notification is displayed when the page title is not set.
+        {
+            content: "Open new page menu",
+            trigger: ".o_menu_systray .o_new_content_container > a",
+            run: "click",
+        },
+        {
+            content: "Click on new page",
+            trigger: ".o_new_content_element a",
+            run: "click",
+        },
+        {
+            content: "Click on Use this template",
+            trigger: ".o_page_template button.btn-primary",
+            run: "click",
+        },
+        {
+            content: "Insert page name",
+            trigger: ".modal .modal-dialog .modal-body input[type='text']",
+            in_modal: false,
+            run: "edit Test Page",
+        },
+        {
+            trigger: "input[type='text']:value(Test Page)",
+        },
+        {
+            content: "Create page",
+            trigger: ".modal button.btn-primary:contains(create)",
+            in_modal: false,
+            run: "click",
+        },
+        ...wTourUtils.dragNDrop({ id: "s_text_image", name: "Text - Image" }),
+        ...wTourUtils.clickOnSave(),
+        {
+            content: "Publish your website",
+            trigger: ".o_menu_systray_item.o_website_publish_container a",
+            run: "click",
+        },
+        {
+            content: "Check the SEO notification is displayed",
+            trigger: ".o_notification_manager .o_notification:contains('Page title not set.')",
+        },
+        {
+            trigger: "body:not(:has(.o_notification_manager .o_notification))",
+        },
+
+        // Part 2 checks that the SEO notification is not displayed when we are in any page like /my or /shop etc.
+        {
+            content: "Open the dropdown menu",
+            trigger: ":iframe #o_main_nav .navbar-nav .dropdown.o_no_autohide_item > a.dropdown-toggle",
+            run: "click",
+        },
+        {
+            content: "Click on My Account",
+            trigger: ":iframe #o_main_nav .js_usermenu a.dropdown-item.ps-3:contains('My Account')",
+            run: "click",
+        },
+
+        ...wTourUtils.clickOnEditAndWaitEditMode(),
+        ...wTourUtils.dragNDrop({ id: "s_text_image", name: "Image - Text" }),
+
+        {
+            content: "Check the SEO notification should not be displayed",
+            trigger: "body:not(:has(.o_notification_manager .o_notification))",
+        },
+    ]
+);

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -699,3 +699,6 @@ class TestUi(odoo.tests.HttpCase):
 
     def test_website_font_family(self):
         self.start_tour("/", "website_font_family", login="admin")
+
+    def test_website_seo_notification(self):
+        self.start_tour('/', 'website_seo_notification', login='admin')


### PR DESCRIPTION
**Steps to Reproduce:**  
1. Create a new page using the **"New"** button and save it.  
2. Publish the page using the **"Publish/Unpublish"** button.  
3. Enter **Edit** mode (without reloading the page), update the page content, and save.  
4. The SEO notification does not appear.  

**Reason for Change:**  

This PR fixes an issue where SEO notifications were not displayed after creating, publishing, editing, and saving a page. The fix ensures SEO data includes the website's publish status, which was previously missing in [1](https://github.com/odoo/odoo/commit/45ea6e4a4a5c8e314b110a45198fbe3d57bb996e). This update guarantees that the notification appears only when necessary.  

task- 4046471