### PR TITLE
[IMP] core: simplify implementation of SQL wrapper

### DIFF
--- a/odoo/addons/base/tests/test_sql.py
+++ b/odoo/addons/base/tests/test_sql.py
@@ -57,7 +57,7 @@ class TestSQL(BaseCase):
     def test_sql_idempotence(self):
         sql1 = SQL("SELECT id FROM table WHERE foo=%s AND bar=%s", 42, 'baz')
         sql2 = SQL(sql1)
-        self.assertIs(sql1, sql2)
+        self.assertEqual(sql1, sql2)
 
     def test_sql_unpacking(self):
         sql = SQL("SELECT id FROM table WHERE foo=%s AND bar=%s", 42, 'baz')

--- a/odoo/tools/sql.py
+++ b/odoo/tools/sql.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from odoo.fields import Field
-    from collections.abc import Iterator, Iterable
+    from collections.abc import Iterable
 
 import psycopg2
 
@@ -79,73 +79,78 @@ class SQL:
     its value is a field which the SQL code depends on.  The metadata of a
     wrapper and its parts can be accessed by the iterator ``sql.to_flush``.
     """
-    __slots__ = ('__code', '__args', '__to_flush')
+    __slots__ = ('__code', '__params', '__to_flush')
+
+    __code: str
+    __params: tuple
+    __to_flush: tuple
 
     # pylint: disable=keyword-arg-before-vararg
-    def __new__(cls, code: (str | SQL) = "", /, *args, to_flush: (Field | None) = None, **kwargs):
+    def __init__(self, code: (str | SQL) = "", /, *args, to_flush: (Field | None) = None, **kwargs):
         if isinstance(code, SQL):
-            return code
+            if args or kwargs or to_flush:
+                raise TypeError("SQL() unexpected arguments when code has type SQL")
+            self.__code = code.__code
+            self.__params = code.__params
+            self.__to_flush = code.__to_flush
+            return
 
         # validate the format of code and parameters
         if args and kwargs:
             raise TypeError("SQL() takes either positional arguments, or named arguments")
-        if args:
-            code % tuple("" for arg in args)
-        elif kwargs:
+
+        if kwargs:
             code, args = named_to_positional_printf(code, kwargs)
+        elif not args:
+            code % ()  # check that code does not contain %s
+            self.__code = code
+            self.__params = ()
+            self.__to_flush = () if to_flush is None else (to_flush,)
+            return
 
-        self = object.__new__(cls)
-        self.__code = code
-        self.__args = args
-        self.__to_flush = to_flush
-        return self
+        code_list = []
+        params_list = []
+        to_flush_list = []
+        for arg in args:
+            if isinstance(arg, SQL):
+                code_list.append(arg.__code)
+                params_list.extend(arg.__params)
+                to_flush_list.extend(arg.__to_flush)
+            else:
+                code_list.append("%s")
+                params_list.append(arg)
+        if to_flush is not None:
+            to_flush_list.append(to_flush)
 
-    @property
-    def to_flush(self) -> Iterator[Field]:
-        """ Return an iterator on the fields to flush in the metadata of
-        ``self`` and all of its parts.
-        """
-        for node in self.__postfix():
-            if isinstance(node, SQL) and node.__to_flush is not None:
-                yield node.__to_flush
+        self.__code = code % tuple(code_list)
+        self.__params = tuple(params_list)
+        self.__to_flush = tuple(to_flush_list)
 
     @property
     def code(self) -> str:
         """ Return the combined SQL code string. """
-        stack = []  # stack of intermediate results
-        for node in self.__postfix():
-            if not isinstance(node, SQL):
-                stack.append("%s")
-            elif arity := len(node.__args):
-                stack[-arity:] = [node.__code % tuple(stack[-arity:])]
-            else:
-                stack.append(node.__code)
-        return stack[0]
+        return self.__code
 
     @property
     def params(self) -> list:
         """ Return the combined SQL code params as a list of values. """
-        return [node for node in self.__postfix() if not isinstance(node, SQL)]
+        return list(self.__params)
 
-    def __postfix(self):
-        """ Return a postfix iterator for the SQL tree ``self``. """
-        stack = [(self, False)]
-        while stack:
-            node, ispostfix = stack.pop()
-            if ispostfix or not isinstance(node, SQL):
-                yield node
-            else:
-                stack.append((node, True))
-                stack.extend((arg, False) for arg in reversed(node.__args))
+    @property
+    def to_flush(self) -> Iterable[Field]:
+        """ Return an iterator on the fields to flush in the metadata of
+        ``self`` and all of its parts.
+        """
+        return self.__to_flush
 
     def __repr__(self):
-        return f"SQL({', '.join(map(repr, [self.code, *self.params]))})"
+        return f"SQL({', '.join(map(repr, [self.__code, *self.__params]))})"
 
     def __bool__(self):
         return bool(self.__code)
 
     def __eq__(self, other):
-        return isinstance(other, SQL) and self.code == other.code and self.params == other.params
+        return isinstance(other, SQL) and self.__code == other.__code and self.__params == other.__params
 
     def __iter__(self):
         """ Yields ``self.code`` and ``self.params``. This was introduced for
@@ -164,9 +169,9 @@ class SQL:
         # optimizations for special cases
         if len(args) == 0:
             return SQL()
-        if len(args) == 1:
+        if len(args) == 1 and isinstance(args[0], SQL):
             return args[0]
-        if not self.__args:
+        if not self.__params:
             return SQL(self.__code.join("%s" for arg in args), *args)
         # general case: alternate args with self
         items = [self] * (len(args) * 2 - 1)


### PR DESCRIPTION
Simply don't keep the `SQL` tree, and merge the arguments directly into the code and parameters.  This makes the `SQL` wrapper simpler, faster, and it does not suffer for recursion limit errors.
```py
from odoo.tools import SQL

%timeit (sql := SQL("hello world %s, %s", 4, "ok")), sql.code, sql.params
# before: 3.85 µs ± 11.6 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
# after : 1.35 µs ± 1.14 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)

%timeit (sql := SQL("select * FROM %s WHERE %s", SQL.identifier("ok"), SQL('x > %s', 5))), sql.code, sql.params
# before: 7.81 µs ± 161 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
# after : 3.14 µs ± 45.7 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

%timeit (sql := SQL(",").join([SQL('ok'), *range(30), SQL("qbc%s", 5)])), sql.code, sql.params
# before: 25 µs ± 108 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
# after : 9.97 µs ± 22 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

def complex_sql(size=20):
    if size > 0:
        return SQL("(%s, %s)", complex_sql(size - 1), complex_sql(size - 2))
    return SQL("res")

%timeit (sql := complex_sql()), sql.code, sql.params
# before: 68.5 ms ± 228 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
# after : 29 ms ± 33.6 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```