### PR TITLE
[FIX] delivery,website_sale: remove self in controllers

### DIFF
--- a/addons/delivery/__init__.py
+++ b/addons/delivery/__init__.py
@@ -1,4 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import controllers
 from . import models
 from . import wizard

--- a/addons/delivery/controllers/location_selector.py
+++ b/addons/delivery/controllers/location_selector.py
@@ -29,7 +29,7 @@ class LocationSelectorController(Controller):
         """
         order = request.env['sale.order'].browse(order_id)
         if request.geoip.country_code:
-            country = self.env['res.country'].search(
+            country = request.env['res.country'].search(
                 [('code', '=', request.geoip.country_code)], limit=1,
             )
         else:

--- a/addons/website_sale/controllers/delivery.py
+++ b/addons/website_sale/controllers/delivery.py
@@ -140,7 +140,7 @@ class Delivery(WebsiteSale):
         """
         order_sudo = request.website.sale_get_order()
         if request.geoip.country_code:
-            country = self.env['res.country'].search(
+            country = request.env['res.country'].search(
                 [('code', '=', request.geoip.country_code)], limit=1,
             )
         else:


### PR DESCRIPTION
This commit addresses those problems:
- The location selector's controllers wrongly used `self`;
- The controllers' folder was not imported into the `delivery` module.
