### PR TITLE
[FIX] account: set default taxes on existing product also without demo

### DIFF
--- a/addons/account/demo/account_demo.py
+++ b/addons/account/demo/account_demo.py
@@ -19,7 +19,6 @@ class AccountChartTemplate(models.AbstractModel):
         """Generate the demo data related to accounting."""
         # This is a generator because data created here might be referenced by xml_id to data
         # created later but defined in this same function.
-        self._get_demo_data_products(company)
         return {
             'account.move': self._get_demo_data_move(company),
             'account.bank.statement': self._get_demo_data_statement(company),
@@ -56,18 +55,6 @@ class AccountChartTemplate(models.AbstractModel):
                 move.action_post()
             except (UserError, ValidationError):
                 _logger.exception('Error while posting demo data')
-
-    @api.model
-    def _get_demo_data_products(self, company=False):
-        prod_templates = self.env['product.product'].search(self.env['product.product']._check_company_domain(company))
-        if self.env.company.account_sale_tax_id:
-            prod_templates_sale = prod_templates.filtered(
-                lambda p: not p.taxes_id.filtered_domain(p.taxes_id._check_company_domain(company)))
-            prod_templates_sale.write({'taxes_id': [Command.link(self.env.company.account_sale_tax_id.id)]})
-        if self.env.company.account_purchase_tax_id:
-            prod_templates_purchase = prod_templates.filtered(
-                lambda p: not p.supplier_taxes_id.filtered_domain(p.taxes_id._check_company_domain(company)))
-            prod_templates_purchase.write({'supplier_taxes_id': [Command.link(self.env.company.account_purchase_tax_id.id)]})
 
     @api.model
     def _get_demo_data_move(self, company=False):

--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -636,6 +636,20 @@ class AccountChartTemplate(models.AbstractModel):
             company.account_purchase_tax_id = self.env['account.tax'].search([
                 *self.env['account.tax']._check_company_domain(company),
                 ('type_tax_use', 'in', ('purchase', 'all'))], limit=1).id
+        # Set default taxes on products (only on products having already a tax set in another company, as some flows require no tax at all (e.g TIPS in PoS))
+        # We need to browse the product in sudo to check for the taxes_id and supplier_taxes_id fields regardless of the companies record rules
+        # that would, otherwise, just look empty all the time for the current user/company
+        sudoed_products = self.env['product.product'].sudo().search(self.env['product.product']._check_company_domain(company))
+
+        if company.account_sale_tax_id:
+            sudoed_products_sale = sudoed_products.filtered(
+                lambda p: p.taxes_id and not p.taxes_id.filtered_domain(p.taxes_id._check_company_domain(company)))
+            sudoed_products_sale.taxes_id += self.env.company.account_sale_tax_id
+        if company.account_purchase_tax_id:
+            sudoed_products_purchase = sudoed_products.filtered(
+                lambda p: p.supplier_taxes_id and not p.supplier_taxes_id.filtered_domain(p.taxes_id._check_company_domain(company)))
+            sudoed_products_purchase.supplier_taxes_id += self.env.company.account_purchase_tax_id
+
         # Display caba fields if there are caba taxes
         if not company.parent_id and self.env['account.tax'].search([('tax_exigibility', '=', 'on_payment')]):
             company.tax_exigibility = True

--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -639,16 +639,16 @@ class AccountChartTemplate(models.AbstractModel):
         # Set default taxes on products (only on products having already a tax set in another company, as some flows require no tax at all (e.g TIPS in PoS))
         # We need to browse the product in sudo to check for the taxes_id and supplier_taxes_id fields regardless of the companies record rules
         # that would, otherwise, just look empty all the time for the current user/company
-        sudoed_products = self.env['product.product'].sudo().search(self.env['product.product']._check_company_domain(company))
+        sudoed_products = self.env['product.template'].sudo().search(self.env['product.template']._check_company_domain(company))
 
         if company.account_sale_tax_id:
             sudoed_products_sale = sudoed_products.filtered(
                 lambda p: p.taxes_id and not p.taxes_id.filtered_domain(p.taxes_id._check_company_domain(company)))
-            sudoed_products_sale.taxes_id += self.env.company.account_sale_tax_id
+            sudoed_products_sale._force_default_sale_tax(company)
         if company.account_purchase_tax_id:
             sudoed_products_purchase = sudoed_products.filtered(
                 lambda p: p.supplier_taxes_id and not p.supplier_taxes_id.filtered_domain(p.taxes_id._check_company_domain(company)))
-            sudoed_products_purchase.supplier_taxes_id += self.env.company.account_purchase_tax_id
+            sudoed_products_purchase._force_default_purchase_tax(company)
 
         # Display caba fields if there are caba taxes
         if not company.parent_id and self.env['account.tax'].search([('tax_exigibility', '=', 'on_payment')]):

--- a/addons/account/models/product.py
+++ b/addons/account/models/product.py
@@ -118,6 +118,13 @@ class ProductTemplate(models.Model):
                 "If you want to change its Unit of Measure, please archive this product and create a new one."
             ))
 
+    def _force_default_tax(self, companies):
+        default_customer_taxes = companies.filtered('account_sale_tax_id').account_sale_tax_id
+        default_supplier_taxes = companies.filtered('account_purchase_tax_id').account_purchase_tax_id
+        self.taxes_id += default_customer_taxes
+        self.supplier_taxes_id += default_supplier_taxes
+        self.invalidate_recordset(['taxes_id', 'supplier_taxes_id'])
+
     @api.model_create_multi
     def create(self, vals_list):
         products = super().create(vals_list)
@@ -125,18 +132,9 @@ class ProductTemplate(models.Model):
         # have the default taxes of the other companies as well. sudo() is used since we're going to need to fetch all
         # the other companies default taxes which the user may not have access to.
         other_companies = self.env['res.company'].sudo().search([('id', 'not in', self.env.companies.ids)])
-        if not other_companies:
-            return products
-
-        default_customer_tax_ids = other_companies.filtered('account_sale_tax_id').account_sale_tax_id.ids
-        default_supplier_tax_ids = other_companies.filtered('account_purchase_tax_id').account_purchase_tax_id.ids
-
-        products_without_company = products.filtered(lambda p: not p.company_id).sudo()
-        products_without_company.taxes_id = [Command.link(tax) for tax in default_customer_tax_ids]
-        products_without_company.supplier_taxes_id = [Command.link(tax) for tax in default_supplier_tax_ids]
-
-        products_without_company.invalidate_recordset(['taxes_id', 'supplier_taxes_id'])
-        products.invalidate_recordset(['taxes_id', 'supplier_taxes_id'])
+        if other_companies and products:
+            products_without_company = products.filtered(lambda p: not p.company_id).sudo()
+            products_without_company._force_default_tax(other_companies)
         return products
 
 

--- a/addons/hr_expense/tests/test_expenses.py
+++ b/addons/hr_expense/tests/test_expenses.py
@@ -626,7 +626,7 @@ class TestExpenses(TestExpenseCommon):
         expense = expense_form.save()
         self.assertEqual(expense.name, product.display_name)
         self.assertEqual(expense.product_uom_id, product.uom_id)
-        self.assertEqual(expense.tax_ids, product.supplier_taxes_id)
+        self.assertEqual(expense.tax_ids, product.supplier_taxes_id.filtered(lambda t: t.company_id == expense.company_id))
         self.assertEqual(expense.account_id, product._get_product_accounts()['expense'])
 
     def test_attachments_in_move_from_own_expense(self):

--- a/addons/l10n_ar/demo/respinsc_demo.xml
+++ b/addons/l10n_ar/demo/respinsc_demo.xml
@@ -36,6 +36,13 @@
         <value model="res.company" eval="obj().env.ref('l10n_ar.company_ri')"/>
     </function>
 
+    <!-- Products created before the company don't get the default tax set, by default, 
+    although the tests are expecting it... Hence we force it -->
+    <function model="product.template" name="_force_default_tax">
+        <value model="product.template" eval="obj().search([]).ids"/>
+        <value model="res.company" eval="obj().env.ref('l10n_ar.company_ri')"/>
+    </function>
+
     <record id="bank_account_ri" model="res.partner.bank">
         <field name="acc_number">7982898111100056688080</field>
         <field name="partner_id" ref="l10n_ar.partner_ri"/>

--- a/addons/l10n_uy/demo/account_demo.py
+++ b/addons/l10n_uy/demo/account_demo.py
@@ -14,7 +14,6 @@ class AccountChartTemplate(models.AbstractModel):
     @api.model
     def _get_demo_data(self, company=False):
         if company.account_fiscal_country_id.code == "UY":
-            super()._get_demo_data_products(company)
             return {
                 'res.partner': self._l10n_uy_get_demo_data_res_partner(company),
                 'account.move': self._l10n_uy_get_demo_data_move(company),

--- a/addons/sale/tests/common.py
+++ b/addons/sale/tests/common.py
@@ -116,6 +116,7 @@ class TestSaleCommonBase(TransactionCase):
                 'invoice_policy': 'delivery',
                 'taxes_id': [(6, 0, [])],
                 'supplier_taxes_id': [(6, 0, [])],
+                'company_id': company.id,
             }),
             'product_service_order': cls.env['product.product'].with_company(company).create({
                 'name': 'product_service_order',
@@ -130,6 +131,7 @@ class TestSaleCommonBase(TransactionCase):
                 'invoice_policy': 'order',
                 'taxes_id': [(6, 0, [])],
                 'supplier_taxes_id': [(6, 0, [])],
+                'company_id': company.id,
             }),
             'product_order_cost': cls.env['product.product'].with_company(company).create({
                 'name': 'product_order_cost',
@@ -145,6 +147,7 @@ class TestSaleCommonBase(TransactionCase):
                 'expense_policy': 'cost',
                 'taxes_id': [(6, 0, [])],
                 'supplier_taxes_id': [(6, 0, [])],
+                'company_id': company.id,
             }),
             'product_delivery_cost': cls.env['product.product'].with_company(company).create({
                 'name': 'product_delivery_cost',
@@ -160,6 +163,7 @@ class TestSaleCommonBase(TransactionCase):
                 'expense_policy': 'cost',
                 'taxes_id': [(6, 0, [])],
                 'supplier_taxes_id': [(6, 0, [])],
+                'company_id': company.id,
             }),
             'product_order_sales_price': cls.env['product.product'].with_company(company).create({
                 'name': 'product_order_sales_price',
@@ -175,6 +179,7 @@ class TestSaleCommonBase(TransactionCase):
                 'expense_policy': 'sales_price',
                 'taxes_id': [(6, 0, [])],
                 'supplier_taxes_id': [(6, 0, [])],
+                'company_id': company.id,
             }),
             'product_delivery_sales_price': cls.env['product.product'].with_company(company).create({
                 'name': 'product_delivery_sales_price',
@@ -190,6 +195,7 @@ class TestSaleCommonBase(TransactionCase):
                 'expense_policy': 'sales_price',
                 'taxes_id': [(6, 0, [])],
                 'supplier_taxes_id': [(6, 0, [])],
+                'company_id': company.id,
             }),
             'product_order_no': cls.env['product.product'].with_company(company).create({
                 'name': 'product_order_no',
@@ -205,6 +211,7 @@ class TestSaleCommonBase(TransactionCase):
                 'expense_policy': 'no',
                 'taxes_id': [(6, 0, [])],
                 'supplier_taxes_id': [(6, 0, [])],
+                'company_id': company.id,
             }),
             'product_delivery_no': cls.env['product.product'].with_company(company).create({
                 'name': 'product_delivery_no',
@@ -220,6 +227,7 @@ class TestSaleCommonBase(TransactionCase):
                 'expense_policy': 'no',
                 'taxes_id': [(6, 0, [])],
                 'supplier_taxes_id': [(6, 0, [])],
+                'company_id': company.id,
             }),
         })
 


### PR DESCRIPTION
Previously the code setting the default taxes on product was called only if the database was in demo, which makes zero sense. Without demo data, creating a new company and assigning it its accounting package was not configuring correctly the existing products with the default taxes.

ticket 4037904





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
