### PR TITLE
[FIX] web_editor: don't double escape characters in snippet titles

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -2462,7 +2462,7 @@ var SnippetsMenu = Widget.extend({
             .addClass('oe_snippet')
             .each((i, el) => {
                 const $snippet = $(el);
-                const name = _.escape(el.getAttribute('name'));
+                const name = el.getAttribute('name');
                 const thumbnailSrc = _.escape(el.dataset.oeThumbnail);
                 const $sbody = $snippet.children().addClass('oe_snippet_body');
                 const isCustomSnippet = !!el.closest('#snippet_custom');
@@ -2496,7 +2496,7 @@ var SnippetsMenu = Widget.extend({
                 const $thumbnail = $(`
                     <div class="oe_snippet_thumbnail">
                         <div class="oe_snippet_thumbnail_img" style="background-image: url(${thumbnailSrc});"/>
-                        <span class="oe_snippet_thumbnail_title">${name}</span>
+                        <span class="oe_snippet_thumbnail_title">${_.escape(name)}</span>
                     </div>
                 `);
                 $snippet.prepend($thumbnail);


### PR DESCRIPTION
Currently, when website snippets were translated and they had special characters in them, they would be escaped before adding them as the `data-name` attribute of the snippet, which escaped them again. When the snippet would be selected, the sidebar would get that `data-name` attribute and use it as the title, resulting in the characters still being escaped.

This commit fixes that by not escaping the name beforehand, but only when used in raw HTML.

Example of the problem (Mur d'images):
![image](https://github.com/user-attachments/assets/0dde728f-82e0-45e0-bca0-4b2daaaf91d8)