### PR TITLE
[FIX] website_event_sale: check seats availability before payment

### DIFF
--- a/addons/website_event_sale/controllers/__init__.py
+++ b/addons/website_event_sale/controllers/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
 
 from . import main
+from . import payment
 from . import sale

--- a/addons/website_event_sale/controllers/payment.py
+++ b/addons/website_event_sale/controllers/payment.py
@@ -1,0 +1,18 @@
+from odoo.http import request
+from odoo.addons.website_sale.controllers.main import PaymentPortal
+
+
+class PaymentPortalOnsite(PaymentPortal):
+
+    def _validate_transaction_for_order(self, transaction, sale_order_id):
+        """
+        Throws a ValidationError if the user tries to pay for a ticket which isn't available
+        """
+        super()._validate_transaction_for_order(transaction, sale_order_id)
+        sale_order = request.env['sale.order'].browse(sale_order_id).exists()
+        count_per_ticket = request.env['event.registration'].sudo()._read_group(
+            [('sale_order_id', 'in', sale_order.ids), ('state', '!=', 'cancel'), ('event_ticket_id', '!=', False)],
+            ['event_ticket_id'], ['__count']
+        )
+        for ticket, count in count_per_ticket:
+            ticket._check_seats_availability(minimal_availability=count)

--- a/addons/website_event_sale/tests/common.py
+++ b/addons/website_event_sale/tests/common.py
@@ -38,19 +38,36 @@ class TestWebsiteEventSaleCommon(TransactionCase):
             'taxes_id': [(6, 0, cls.zero_tax.ids)],
         })
 
-        cls.event = cls.env['event.event'].create({
-            'date_begin': (Datetime.today() + timedelta(days=5)).strftime('%Y-%m-%d 07:00:00'),
-            'date_end': (Datetime.today() + timedelta(days=5)).strftime('%Y-%m-%d 16:30:00'),
-            'name': 'Pycon',
-            'user_id': cls.env.ref('base.user_admin').id,
-            'website_published': True,
-        })
-        cls.ticket = cls.env['event.event.ticket'].create([{
-            'event_id': cls.event.id,
-            'name': 'Standard',
-            'product_id': cls.product_event.id,
-            'price': 100,
-        }])
+        cls.event, cls.event_2 = cls.env['event.event'].create([
+            {
+                'date_begin': (Datetime.today() + timedelta(days=5)).strftime('%Y-%m-%d 07:00:00'),
+                'date_end': (Datetime.today() + timedelta(days=5)).strftime('%Y-%m-%d 16:30:00'),
+                'name': 'Pycon',
+                'user_id': cls.env.ref('base.user_admin').id,
+                'website_published': True,
+            },
+            {
+                'date_begin': (Datetime.today() + timedelta(days=5)).strftime('%Y-%m-%d 07:00:00'),
+                'date_end': (Datetime.today() + timedelta(days=5)).strftime('%Y-%m-%d 16:30:00'),
+                'name': 'Conference for Architects TEST',
+                'user_id': cls.env.ref('base.user_admin').id,
+                'website_published': True,
+            }
+        ])
+        cls.ticket, cls.ticket_2 = cls.env['event.event.ticket'].create([
+            {
+                'event_id': cls.event.id,
+                'name': 'Standard',
+                'product_id': cls.product_event.id,
+                'price': 100,
+            },
+            {
+                'event_id': cls.event_2.id,
+                'name': 'Standard',
+                'product_id': cls.product_event.id,
+                'price': 1000,
+            }
+        ])
 
         cls.current_website = cls.env['website'].get_current_website()
         cls.pricelist = cls.env['product.pricelist'].create({'name': 'Base Pricelist'})

--- a/addons/website_event_sale/tests/test_frontend_buy_tickets.py
+++ b/addons/website_event_sale/tests/test_frontend_buy_tickets.py
@@ -7,6 +7,8 @@ from datetime import timedelta
 
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo
 from odoo.addons.website_event_sale.tests.common import TestWebsiteEventSaleCommon
+from odoo.addons.payment.tests.http_common import PaymentHttpCommon
+from odoo.tools import mute_logger
 from odoo.fields import Datetime
 
 
@@ -24,28 +26,13 @@ class TestUi(HttpCaseWithUserDemo, TestWebsiteEventSaleCommon):
             'is_published': True,
         })
 
-        self.event_2 = self.env['event.event'].create({
-            'name': 'Conference for Architects TEST',
-            'user_id': self.env.ref('base.user_admin').id,
-            'date_begin': (Datetime.today() + timedelta(days=5)).strftime('%Y-%m-%d 07:00:00'),
-            'date_end': (Datetime.today() + timedelta(days=5)).strftime('%Y-%m-%d 16:30:00'),
-            'website_published': True,
-        })
-
-        self.env['event.event.ticket'].create([{
-            'name': 'Standard',
-            'event_id': self.event_2.id,
-            'product_id': self.env.ref('event_sale.product_product_event').id,
-            'start_sale_datetime': (Datetime.today() - timedelta(days=5)).strftime('%Y-%m-%d 07:00:00'),
-            'end_sale_datetime': (Datetime.today() + timedelta(90)).strftime('%Y-%m-%d'),
-            'price': 1000.0,
-        }, {
+        self.env['event.event.ticket'].create({
             'name': 'VIP',
             'event_id': self.event_2.id,
             'product_id': self.env.ref('event_sale.product_product_event').id,
             'end_sale_datetime': (Datetime.today() + timedelta(90)).strftime('%Y-%m-%d'),
             'price': 1500.0,
-        }])
+        })
 
         self.event_3 = self.env['event.event'].create({
             'name': 'Last ticket test',
@@ -132,3 +119,77 @@ class TestUi(HttpCaseWithUserDemo, TestWebsiteEventSaleCommon):
     def test_pricelists_different_currencies(self):
         self.start_tour("/", 'event_sale_pricelists_different_currencies', login='admin')
     # TO DO - add public test with new address when convert to web.tour format.
+
+
+@odoo.tests.common.tagged('post_install', '-at_install')
+class TestRoutes(HttpCaseWithUserDemo, TestWebsiteEventSaleCommon, PaymentHttpCommon):
+
+    @mute_logger('odoo.http')
+    def test_check_seats_avail_before_purchase(self):
+        self.authenticate(None, None)
+
+        so_line_1, so_line_2 = self.env['sale.order.line'].create([
+            {
+                'event_id': self.event.id,
+                'event_ticket_id': self.ticket.id,
+                'name': self.event.name,
+                'order_id': self.so.id,
+                'product_id': self.ticket.product_id.id,
+                'product_uom_qty': 2,
+            },
+            {
+                'event_id': self.event_2.id,
+                'event_ticket_id': self.ticket_2.id,
+                'name': self.event_2.name,
+                'order_id': self.so.id,
+                'product_id': self.ticket_2.product_id.id,
+                'product_uom_qty': 2,
+            },
+        ])
+        self.so._cart_update(line_id=so_line_1.id, product_id=self.ticket.product_id.id, set_qty=1)
+        self.so._cart_update(line_id=so_line_2.id, product_id=self.ticket_2.product_id.id, set_qty=1)
+
+        url = self._build_url(f'/shop/payment/transaction/{self.so.id}')
+        self.assertEqual(self.event.seats_taken, 0)
+        self.assertEqual(self.event_2.seats_taken, 0)
+        self.env['event.registration'].create([
+            {
+                'event_id': self.event.id,
+                'name': 'reg1',
+                'state': 'done',
+            },
+            {
+                'event_id': self.event_2.id,
+                'name': 'reg2',
+                'state': 'done',
+            }
+        ])
+        self.assertEqual(self.event.seats_taken, 1)
+        self.assertEqual(self.event_2.seats_taken, 1)
+        self.ticket.write({
+            'seats_max': 2,
+            'seats_limited': True,
+        })
+        self.ticket_2.write({
+            'seats_max': 2,
+            'seats_limited': True,
+        })
+        self.env['event.registration'].create([
+            {'event_id': e.id, 'sale_order_id': self.so.id, 'partner_id': p.id, 'event_ticket_id': t.id}
+            for p in [(self.partner), (self.partner_admin)]
+            for e, t in [(self.event, self.ticket), (self.event_2, self.ticket_2)]
+        ])
+        route_kwargs = {
+            'provider_id': self.provider.id,
+            'payment_method_id': self.payment_method.id,
+            'token_id': None,
+            'amount': self.so.amount_total,
+            'flow': 'direct',
+            'tokenization_requested': False,
+            'landing_route': '/shop/payment/validate',
+            'is_validation': False,
+            'csrf_token': odoo.http.Request.csrf_token(self),
+            'access_token': self.so._portal_ensure_token(),
+        }
+        with self.assertRaisesRegex(odoo.tests.JsonRpcException, 'odoo.exceptions.ValidationError'):
+            self.make_jsonrpc_request(url, route_kwargs)


### PR DESCRIPTION
Steps to reproduce:
- Install `website_event_sale`
- Go to an event and for one ticket set maximum as 1
- Open event page and purchase a ticket, but don't complete the payment
- Do the same in private navigation
- Click on pay on the two page

Issues:
If you check with stripe payment is processed meaning that the two people are charged however one of them can't get a ticket as there isn't enough tickets available. Fix is to check before sending payment to provider and return error if there's not enough seats. Concurrency issue is not fully solved but would require much more precise timing, and a proper solution wouldn't be stable.

opw-3772093
