### PR TITLE
[IMP] *: deprecate `ustr()`

### DIFF
--- a/addons/auth_ldap/models/res_company_ldap.py
+++ b/addons/auth_ldap/models/res_company_ldap.py
@@ -194,7 +194,7 @@ class CompanyLDAP(models.Model):
         """
 
         return {
-            'name': tools.ustr(ldap_entry[1]['cn'][0]),
+            'name': ldap_entry[1]['cn'][0],
             'login': login,
             'company_id': conf['company'][0]
         }
@@ -210,7 +210,7 @@ class CompanyLDAP(models.Model):
         :return: res_users id
         :rtype: int
         """
-        login = tools.ustr(login.lower().strip())
+        login = login.lower().strip()
         self.env.cr.execute("SELECT id, active FROM res_users WHERE lower(login)=%s", (login,))
         res = self.env.cr.fetchone()
         if res:

--- a/addons/auth_signup/models/res_users.py
+++ b/addons/auth_signup/models/res_users.py
@@ -11,7 +11,6 @@ from dateutil.relativedelta import relativedelta
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
 from odoo.osv import expression
-from odoo.tools.misc import ustr
 from odoo.http import request
 
 from odoo.addons.base.models.ir_mail_server import MailDeliveryException
@@ -159,7 +158,7 @@ class ResUsers(models.Model):
                 return template_user.with_context(no_reset_password=True).copy(values)
         except Exception as e:
             # copy may failed if asked login is not available.
-            raise SignupError(ustr(e))
+            raise SignupError(str(e))
 
     def reset_password(self, login):
         """ retrieve the user corresponding to login (login or email),

--- a/addons/base_geolocalize/models/base_geocoder.py
+++ b/addons/base_geolocalize/models/base_geocoder.py
@@ -144,8 +144,7 @@ class GeoCoder(models.AbstractModel):
             state,
             country
         ]
-        address_list = [item for item in address_list if item]
-        return tools.ustr(', '.join(address_list))
+        return ', '.join(filter(None, address_list))
 
     @api.model
     def _geo_query_address_googlemap(self, street=None, zip=None, city=None, state=None, country=None):

--- a/addons/gamification/models/gamification_challenge.py
+++ b/addons/gamification/models/gamification_challenge.py
@@ -10,7 +10,6 @@ from markupsafe import Markup
 
 from odoo import _, api, exceptions, fields, models
 from odoo.http import SESSION_LIFETIME
-from odoo.tools import ustr
 
 _logger = logging.getLogger(__name__)
 
@@ -190,8 +189,8 @@ class Challenge(models.Model):
     def create(self, vals_list):
         """Overwrite the create method to add the user of groups"""
         for vals in vals_list:
-            if vals.get('user_domain'):
-                users = self._get_challenger_users(ustr(vals.get('user_domain')))
+            if user_domain := vals.get('user_domain'):
+                users = self._get_challenger_users(str(user_domain))
 
                 if not vals.get('user_ids'):
                     vals['user_ids'] = []
@@ -200,14 +199,14 @@ class Challenge(models.Model):
         return super().create(vals_list)
 
     def write(self, vals):
-        if vals.get('user_domain'):
-            users = self._get_challenger_users(ustr(vals.get('user_domain')))
+        if user_domain := vals.get('user_domain'):
+            users = self._get_challenger_users(str(user_domain))
 
             if not vals.get('user_ids'):
                 vals['user_ids'] = []
             vals['user_ids'].extend((4, user.id) for user in users)
 
-        write_res = super(Challenge, self).write(vals)
+        write_res = super().write(vals)
 
         if vals.get('report_message_frequency', 'never') != 'never':
             # _recompute_challenge_users do not set users for challenges with no reports, subscribing them now

--- a/addons/http_routing/models/ir_http.py
+++ b/addons/http_routing/models/ir_http.py
@@ -26,7 +26,7 @@ from odoo.addons.base.models.res_lang import LangData
 from odoo.exceptions import AccessError, MissingError
 from odoo.http import request, Response
 from odoo.osv import expression
-from odoo.tools import ustr, pycompat
+from odoo.tools import pycompat
 
 _logger = logging.getLogger(__name__)
 
@@ -78,11 +78,7 @@ class IrHttp(models.AbstractModel):
             Otherwise it will process string by stripping leading and ending spaces,
             converting unicode chars to ascii, lowering all chars and replacing spaces
             and underscore with hyphen "-".
-            :param s: str
-            :param max_length: int
-            :rtype: str
         """
-        value = ustr(value)
         if slugify_lib:
             # There are 2 different libraries only python-slugify is supported
             try:

--- a/addons/mail/models/fetchmail.py
+++ b/addons/mail/models/fetchmail.py
@@ -184,16 +184,16 @@ odoo_mailgate: "|/path/to/odoo-mailgate.py --host=localhost -u %(uid)d -p PASSWO
                 connection = server.connect(allow_archived=True)
                 server.write({'state': 'done'})
             except UnicodeError as e:
-                raise UserError(_("Invalid server name!\n %s", tools.ustr(e)))
+                raise UserError(_("Invalid server name!\n %s", tools.exception_to_unicode(e)))
             except (gaierror, timeout, IMAP4.abort) as e:
-                raise UserError(_("No response received. Check server information.\n %s", tools.ustr(e)))
+                raise UserError(_("No response received. Check server information.\n %s", tools.exception_to_unicode(e)))
             except (IMAP4.error, poplib.error_proto) as err:
-                raise UserError(_("Server replied with following exception:\n %s", tools.ustr(err)))
+                raise UserError(_("Server replied with following exception:\n %s", tools.exception_to_unicode(err)))
             except SSLError as e:
-                raise UserError(_("An SSL exception occurred. Check SSL/TLS configuration on server port.\n %s", tools.ustr(e)))
+                raise UserError(_("An SSL exception occurred. Check SSL/TLS configuration on server port.\n %s", tools.exception_to_unicode(e)))
             except (OSError, Exception) as err:
                 _logger.info("Failed to connect to %s server %s.", server.server_type, server.name, exc_info=True)
-                raise UserError(_("Connection test failed: %s", tools.ustr(err)))
+                raise UserError(_("Connection test failed: %s", tools.exception_to_unicode(err)))
             finally:
                 try:
                     if connection:

--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -785,7 +785,7 @@ class MailMail(models.Model):
                     error_code = e.args[0]
                     if len(e.args) > 1 and error_code == IrMailServer.NO_VALID_FROM:
                         # log failing email in additional arguments message
-                        failure_reason = tools.ustr(e.args[1])
+                        failure_reason = str(e.args[1])
                     else:
                         failure_reason = error_code
                     if error_code == IrMailServer.NO_VALID_FROM:
@@ -794,7 +794,7 @@ class MailMail(models.Model):
                         failure_type = "mail_from_missing"
                 # generic (unknown) error as fallback
                 if not failure_reason:
-                    failure_reason = tools.ustr(e)
+                    failure_reason = tools.exception_to_unicode(e)
                 if not failure_type:
                     failure_type = "unknown"
 

--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -6,16 +6,15 @@ import datetime
 import json
 import logging
 import psycopg2
+import pytz
+import re
 import smtplib
 import threading
-import re
-import pytz
-
 from collections import defaultdict
+
 from dateutil.parser import parse
 
-from odoo import _, api, fields, models, modules, registry, SUPERUSER_ID
-from odoo import tools
+from odoo import _, api, fields, models, modules, registry, SUPERUSER_ID, tools
 from odoo.addons.base.models.ir_mail_server import MailDeliveryException
 
 _logger = logging.getLogger(__name__)
@@ -627,7 +626,7 @@ class MailMail(models.Model):
                     raise MailDeliveryException(_('Unable to connect to SMTP Server'), exc)
                 else:
                     batch = self.browse(batch_ids)
-                    batch.write({'state': 'exception', 'failure_reason': exc})
+                    batch.write({'state': 'exception', 'failure_reason': tools.exception_to_unicode(exc)})
                     batch._postprocess_sent_message(success_pids=[], failure_type="mail_smtp")
             else:
                 mail_server = self.env['ir.mail_server'].browse(mail_server_id)

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -631,7 +631,7 @@ class Message(models.Model):
                             values['attachment_ids'].append((4, attachment.id))
                             data_to_url[key] = ['/web/image/%s?access_token=%s' % (attachment.id, attachment.access_token), name]
                     return '%s%s alt="%s"' % (data_to_url[key][0], match.group(3), data_to_url[key][1])
-                values['body'] = _image_dataurl.sub(base64_to_boundary, tools.ustr(values['body']))
+                values['body'] = _image_dataurl.sub(base64_to_boundary, values['body'] or '')
 
             # delegate creation of tracking after the create as sudo to avoid access rights issues
             tracking_values_list.append(values.pop('tracking_value_ids', False))

--- a/addons/mail/models/mail_render_mixin.py
+++ b/addons/mail/models/mail_render_mixin.py
@@ -134,10 +134,8 @@ class MailRenderMixin(models.AbstractModel):
         if not html:
             return html
 
-        wrapper = Markup if isinstance(html, Markup) else str
-        html = tools.ustr(html)
-        if isinstance(html, Markup):
-            wrapper = Markup
+        assert isinstance(html, str)
+        Wrapper = html.__class__
 
         def _sub_relative2absolute(match):
             # compute here to do it only if really necessary + cache will ensure it is done only once
@@ -159,7 +157,7 @@ class MailRenderMixin(models.AbstractModel):
                 /(?:[^'")]|(?!&\#34;)|(?!&\#39;))+ # stop at the first closing quote
         )""", re.VERBOSE), _sub_relative2absolute, html)
 
-        return wrapper(html)
+        return Wrapper(html)
 
     @api.model
     def _render_encapsulate(self, layout_xmlid, html, add_context=None, context_record=None):

--- a/addons/mail/models/update.py
+++ b/addons/mail/models/update.py
@@ -1,18 +1,16 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import datetime
 import logging
+from ast import literal_eval
 
 import requests
-
-from ast import literal_eval
 
 from odoo import api, fields, release, SUPERUSER_ID
 from odoo.exceptions import UserError
 from odoo.models import AbstractModel
 from odoo.tools.translate import _
-from odoo.tools import config, ustr
+from odoo.tools import config
 
 _logger = logging.getLogger(__name__)
 
@@ -68,7 +66,7 @@ class PublisherWarrantyContract(AbstractModel):
         Utility method to send a publisher warranty get logs messages.
         """
         msg = self._get_message()
-        arguments = {'arg0': ustr(msg), "action": "update"}
+        arguments = {'arg0': str(msg), "action": "update"}
 
         url = config.get("publisher_warranty_url")
 

--- a/addons/mail/tests/discuss/test_load_messages.py
+++ b/addons/mail/tests/discuss/test_load_messages.py
@@ -13,7 +13,7 @@ class TestLoadMessages(HttpCaseWithUserDemo):
             "channel_member_ids": [Command.create({"partner_id": partner_admin.id})],
         })
         self.env["mail.message"].create([{
-            "body": n,
+            "body": str(n),
             "model": "discuss.channel",
             "pinned_at": odoo.fields.Datetime.now() if n == 1 else None,
             "res_id": channel_id.id,

--- a/addons/mass_mailing/models/mail_mail.py
+++ b/addons/mass_mailing/models/mail_mail.py
@@ -43,6 +43,7 @@ class MailMail(models.Model):
         body = super()._prepare_outgoing_body()
 
         if body and self.mailing_id and self.mailing_trace_ids:
+            Wrapper = body.__class__
             for match in set(re.findall(tools.mail.URL_REGEX, body)):
                 href = match[0]
                 url = match[1]
@@ -50,8 +51,8 @@ class MailMail(models.Model):
                 parsed = werkzeug.urls.url_parse(url, scheme='http')
 
                 if parsed.scheme.startswith('http') and parsed.path.startswith('/r/'):
-                    new_href = href.replace(url, url + '/m/' + str(self.mailing_trace_ids[0].id))
-                    body = body.replace(href, new_href)
+                    new_href = href.replace(url, f"{url}/m/{self.mailing_trace_ids[0].id}")
+                    body = body.replace(Wrapper(href), Wrapper(new_href))
 
             # generate tracking URL
             tracking_url = self._get_tracking_url()

--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -1487,6 +1487,7 @@ class MassMailing(models.Model):
         :param str email: recipient email, used to unsubscribe / blacklist;
         """
         self.ensure_one()
+        assert isinstance(email, str)
         secret = self.env["ir.config_parameter"].sudo().get_param("database.secret")
-        token = (self.env.cr.dbname, self.id, int(document_id), tools.ustr(email))
+        token = (self.env.cr.dbname, self.id, int(document_id), email)
         return hmac.new(secret.encode('utf-8'), repr(token).encode('utf-8'), hashlib.sha512).hexdigest()

--- a/addons/payment/models/payment_transaction.py
+++ b/addons/payment/models/payment_transaction.py
@@ -12,8 +12,7 @@ from markupsafe import Markup
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
-from odoo.tools import consteq, format_amount, ustr
-from odoo.tools.misc import hmac as hmac_tool
+from odoo.tools import format_amount
 
 from odoo.addons.payment import utils as payment_utils
 

--- a/addons/payment/utils.py
+++ b/addons/payment/utils.py
@@ -41,7 +41,7 @@ def check_access_token(access_token, *values):
     :rtype: bool
     """
     authentic_token = generate_access_token(*values)
-    return access_token and consteq(ustr(access_token), authentic_token)
+    return access_token and consteq(access_token, authentic_token)
 
 
 # Availability report.

--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -151,7 +151,7 @@ class PosOrder(models.Model):
                 # do not hide transactional errors, the order(s) won't be saved!
                 raise
             except Exception as e:
-                _logger.error('Could not fully process the POS Order: %s', tools.ustr(e))
+                _logger.error('Could not fully process the POS Order: %s', tools.exception_to_unicode(e))
             self._create_order_picking()
             self._compute_total_cost_in_real_time()
 

--- a/addons/sale_mrp/tests/test_sale_mrp_report.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_report.py
@@ -66,5 +66,5 @@ class TestSaleMrpInvoices(AccountTestInvoicingCommon):
 
         html = self.env['ir.actions.report']._render_qweb_html(
             'account.report_invoice_with_payments', invoice.ids)[0]
-        text = html2plaintext(html)
+        text = html2plaintext(html.decode())
         self.assertRegex(text, r'Product By Lot\n1.00Units\nLOT0001', "There should be a line that specifies 1 x LOT0001")

--- a/addons/web/controllers/export.py
+++ b/addons/web/controllers/export.py
@@ -324,7 +324,7 @@ class Export(http.Controller):
             fields['id'] = parent_field
 
         fields_sequence = sorted(fields.items(),
-            key=lambda field: odoo.tools.ustr(field[1].get('string', '').lower()))
+            key=lambda field: field[1]['string'].lower())
 
         records = []
         for field_name, field in fields_sequence:

--- a/addons/web/controllers/home.py
+++ b/addons/web/controllers/home.py
@@ -3,14 +3,12 @@
 import json
 import logging
 
-
 import odoo
 import odoo.modules.registry
 from odoo import http
 from odoo.exceptions import AccessError
 from odoo.http import request
 from odoo.service import security
-from odoo.tools import ustr
 from odoo.tools.translate import _
 from .utils import ensure_db, _get_login_redirect_url, is_user_internal
 
@@ -77,7 +75,7 @@ class Home(http.Controller):
             request.update_context(lang=lang)
 
         menus = request.env["ir.ui.menu"].load_web_menus(request.session.debug)
-        body = json.dumps(menus, default=ustr)
+        body = json.dumps(menus)
         response = request.make_response(body, [
             # this method must specify a content-type application/json instead of using the default text/html set because
             # the type of the route is set to HTTP, but the rpc is made with a get and expects JSON

--- a/addons/web/controllers/pivot.py
+++ b/addons/web/controllers/pivot.py
@@ -7,7 +7,7 @@ import json
 
 from odoo import http, _
 from odoo.http import content_disposition, request
-from odoo.tools import ustr, osutil
+from odoo.tools import osutil
 from odoo.tools.misc import xlsxwriter
 
 
@@ -87,7 +87,7 @@ class TableExporter(http.Controller):
         # Step 4: writing data
         x = 0
         for row in jdata['rows']:
-            worksheet.write(y, x, row['indent'] * '     ' + ustr(row['title']), header_plain)
+            worksheet.write(y, x, row['indent'] * '     ' + row['title'], header_plain)
             for cell in row['values']:
                 x = x + 1
                 if cell.get('is_bold', False):

--- a/addons/web/controllers/webmanifest.py
+++ b/addons/web/controllers/webmanifest.py
@@ -7,7 +7,7 @@ import mimetypes
 from odoo import http
 from odoo.exceptions import AccessError
 from odoo.http import request
-from odoo.tools import ustr, file_open
+from odoo.tools import file_open
 
 
 class WebManifest(http.Controller):
@@ -62,7 +62,7 @@ class WebManifest(http.Controller):
             'type': 'image/png',
         } for size in icon_sizes]
         manifest['shortcuts'] = self._get_shortcuts()
-        body = json.dumps(manifest, default=ustr)
+        body = json.dumps(manifest)
         response = request.make_response(body, [
             ('Content-Type', 'application/manifest+json'),
         ])

--- a/addons/web/models/ir_http.py
+++ b/addons/web/models/ir_http.py
@@ -6,7 +6,7 @@ import json
 import odoo
 from odoo import api, models, fields
 from odoo.http import request, DEFAULT_MAX_CONTENT_LENGTH
-from odoo.tools import ormcache, ustr, config
+from odoo.tools import ormcache, config
 from odoo.tools.misc import str2bool
 
 
@@ -131,7 +131,7 @@ class Http(models.AbstractModel):
             # with access to the backend ('internal'-type users)
             menus = self.env['ir.ui.menu'].load_menus(request.session.debug)
             ordered_menus = {str(k): v for k, v in menus.items()}
-            menu_json_utf8 = json.dumps(ordered_menus, default=ustr, sort_keys=True).encode()
+            menu_json_utf8 = json.dumps(ordered_menus, sort_keys=True).encode()
             session_info['cache_hashes'].update({
                 "load_menus": hashlib.sha512(menu_json_utf8).hexdigest()[:64], # sha512/256
             })

--- a/addons/web_editor/models/ir_qweb_fields.py
+++ b/addons/web_editor/models/ir_qweb_fields.py
@@ -8,27 +8,24 @@ as well as render a few fields differently.
 Also, adds methods to convert values back to Odoo models.
 """
 
-import babel
 import base64
 import io
 import json
 import logging
 import os
 import re
+from datetime import datetime
 
+import babel
 import pytz
 import requests
-from datetime import datetime
 from lxml import etree, html
 from PIL import Image as I
 from werkzeug import urls
 
-import odoo.modules
-
 from odoo import _, api, models, fields
 from odoo.exceptions import UserError, ValidationError
-from odoo.tools import ustr, posix_to_ldml, pycompat
-from odoo.tools import html_escape as escape
+from odoo.tools import posix_to_ldml, html_escape as escape, pycompat
 from odoo.tools.misc import file_open, get_lang, babel_locale_parse
 
 REMOTE_CONNECTION_TIMEOUT = 2.5
@@ -393,8 +390,6 @@ class Selection(models.AbstractModel):
         value = element.text_content().strip()
         selection = field.get_description(self.env)['selection']
         for k, v in selection:
-            if isinstance(v, str):
-                v = ustr(v)
             if value == v:
                 return k
 

--- a/addons/website_event_track/controllers/webmanifest.py
+++ b/addons/website_event_track/controllers/webmanifest.py
@@ -2,11 +2,9 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import json
-import pytz
 
 from odoo import http
 from odoo.http import request
-from odoo.tools import ustr
 from odoo.tools.misc import file_open
 from odoo.tools.translate import _
 
@@ -36,7 +34,7 @@ class TrackManifest(http.Controller):
             'sizes': size,
             'type': 'image/png',
         } for size in icon_sizes]
-        body = json.dumps(manifest, default=ustr)
+        body = json.dumps(manifest)
         response = request.make_response(body, [
             ('Content-Type', 'application/manifest+json'),
         ])

--- a/addons/website_sale/tests/test_address.py
+++ b/addons/website_sale/tests/test_address.py
@@ -380,7 +380,7 @@ class TestCheckoutAddress(BaseUsersCommon, WebsiteSaleCommon):
             self.assertEqual(new_shipping, so.partner_shipping_id)
 
             # 4. Logged-in user, new billing use same
-            use_same = self.default_billing_address_values | {'use_same': 1}
+            use_same = self.default_billing_address_values | {'use_same': 'true'}
             self.WebsiteSaleController.shop_address_submit(**use_same)
             new_billing_use_same = self._get_last_address(self.demo_partner)
             msg = "New billing use same should have its type set as 'other'"

--- a/odoo/addons/base/controllers/rpc.py
+++ b/odoo/addons/base/controllers/rpc.py
@@ -10,7 +10,7 @@ from markupsafe import Markup
 import odoo
 from odoo.http import Controller, route, dispatch_rpc, request, Response
 from odoo.fields import Date, Datetime, Command
-from odoo.tools import lazy, ustr
+from odoo.tools import lazy
 from odoo.tools.misc import frozendict
 
 # ==========================================================
@@ -78,9 +78,8 @@ class OdooMarshaller(xmlrpc.client.Marshaller):
     # By default, in xmlrpc, bytes are converted to xmlrpc.client.Binary object.
     # Historically, odoo is sending binary as base64 string.
     # In python 3, base64.b64{de,en}code() methods now works on bytes.
-    # Convert them to str to have a consistent behavior between python 2 and python 3.
     def dump_bytes(self, value, write):
-        self.dump_unicode(ustr(value), write)
+        self.dump_unicode(value.decode(), write)
 
     def dump_datetime(self, value, write):
         # override to marshall as a string for backwards compatibility

--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -6,7 +6,7 @@ from urllib.parse import urlparse
 from odoo import api, fields, models, tools, SUPERUSER_ID, _
 from odoo.exceptions import UserError, AccessError
 from odoo.tools.safe_eval import safe_eval, time
-from odoo.tools.misc import find_in_path, ustr
+from odoo.tools.misc import find_in_path
 from odoo.tools import check_barcode_encoding, config, is_html_empty, parse_version, split_every
 from odoo.http import request
 from odoo.osv.expression import NEGATIVE_TERM_OPERATORS, FALSE_DOMAIN
@@ -504,9 +504,8 @@ class IrActionsReport(models.Model):
 
         try:
             wkhtmltopdf = [_get_wkhtmltopdf_bin()] + command_args + files_command_args + paths + [pdf_report_path]
-            process = subprocess.Popen(wkhtmltopdf, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            out, err = process.communicate()
-            err = ustr(err)
+            process = subprocess.Popen(wkhtmltopdf, stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding="utf-8")
+            _out, err = process.communicate()
 
             if process.returncode not in [0, 1]:
                 if process.returncode == -11:

--- a/odoo/addons/base/models/ir_fields.py
+++ b/odoo/addons/base/models/ir_fields.py
@@ -9,7 +9,7 @@ import psycopg2
 import pytz
 
 from odoo import api, Command, fields, models, _
-from odoo.tools import ustr, OrderedSet
+from odoo.tools import OrderedSet
 from odoo.tools.translate import code_translations, _lt
 
 REFERENCING_FIELDS = {None, 'id', '.id'}
@@ -365,7 +365,6 @@ class IrFieldsConverter(models.AbstractModel):
         selection = field.get_description(env)['selection']
 
         for item, label in selection:
-            label = ustr(label)
             if callable(field.selection):
                 labels = [label]
                 for item2, label2 in field._description_selection(self.env):

--- a/odoo/addons/base/models/ir_ui_menu.py
+++ b/odoo/addons/base/models/ir_ui_menu.py
@@ -300,7 +300,7 @@ class IrUiMenu(models.Model):
                     'children', []).append(menu_item['id'])
             attachment = mi_attachment_by_res_id.get(menu_item['id'])
             if attachment:
-                menu_item['web_icon_data'] = attachment['datas']
+                menu_item['web_icon_data'] = attachment['datas'].decode()
                 menu_item['web_icon_data_mimetype'] = attachment['mimetype']
             else:
                 menu_item['web_icon_data'] = False

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -366,7 +366,7 @@ actual arch.
             except (etree.ParseError, ValueError) as e:
                 err = ValidationError(_(
                     "Error while parsing or validating view:\n\n%(error)s",
-                    error=tools.ustr(e),
+                    error=e,
                     view=self.key or self.id,
                 )).with_traceback(e.__traceback__)
                 err.context = getattr(e, 'context', None)
@@ -404,16 +404,18 @@ actual arch.
                     fivelines = "".join(lines[max(0, e.context["line"]-3):e.context["line"]+2])
                     err = ValidationError(_(
                         "Error while validating view near:\n\n%(fivelines)s\n%(error)s",
-                        fivelines=fivelines, error=tools.ustr(e),
+                        fivelines=fivelines, error=e,
                     ))
                     err.context = e.context
                     raise err.with_traceback(e.__traceback__) from None
-                else:
+                elif err.__context__:
                     err = ValidationError(_(
-                        "Error while validating view (%(view)s):\n\n%(error)s", view=self.key or self.id, error=tools.ustr(e.__context__),
+                        "Error while validating view (%(view)s):\n\n%(error)s", view=view.key or view.id, error=e.__context__,
                     ))
                     err.context = {'name': 'invalid view'}
                     raise err.with_traceback(e.__context__.__traceback__) from None
+                else:
+                    raise
 
         return True
 

--- a/odoo/addons/base/models/res_config.py
+++ b/odoo/addons/base/models/res_config.py
@@ -1,16 +1,11 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-
-import json
 import logging
 import re
-
 from ast import literal_eval
-from lxml import etree
 
 from odoo import api, models, _
 from odoo.exceptions import AccessError, RedirectWarning, UserError
-from odoo.tools import ustr
 
 _logger = logging.getLogger(__name__)
 

--- a/odoo/addons/base/tests/test_ir_mail_server.py
+++ b/odoo/addons/base/tests/test_ir_mail_server.py
@@ -126,16 +126,15 @@ class TestIrMailServer(TransactionCase, MockSmtplibCase):
                 subject='Subject',
                 subtype='html',
             )
-            body_alternative = False
+            body_alternative = None
             for part in message.walk():
                 if part.get_content_maintype() == 'multipart':
                     continue  # skip container
                 if part.get_content_type() == 'text/plain':
                     if not part.get_payload():
                         continue
-                    body_alternative = tools.ustr(part.get_content())
                     # remove ending new lines as it just adds noise
-                    body_alternative = body_alternative.strip('\n')
+                    body_alternative = part.get_content().rstrip('\n')
             self.assertEqual(body_alternative, expected)
 
     @mute_logger('odoo.sql_db')

--- a/odoo/addons/base/wizard/base_import_language.py
+++ b/odoo/addons/base/wizard/base_import_language.py
@@ -45,7 +45,7 @@ class BaseLanguageImport(models.TransientModel):
                     raise UserError(
                         _('File "%(file_name)s" not imported due to format mismatch or a malformed file.'
                           ' (Valid formats are .csv, .po)\n\nTechnical Details:\n%(error_message)s',
-                          file_name=base_lang_import.filename, error_message=tools.ustr(e)),
+                          file_name=base_lang_import.filename, error_message=e),
                     )
             translation_importer.save(overwrite=overwrite)
         return True

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -198,7 +198,7 @@ from .modules.module import get_manifest
 from .modules.registry import Registry
 from .service import security, model as service_model
 from .tools import (config, consteq, date_utils, file_path, get_lang,
-                    parse_version, profiler, unique, ustr)
+                    parse_version, profiler, unique, exception_to_unicode)
 from .tools.func import filter_kwargs, lazy_property
 from .tools.misc import submap
 from .tools._vendor import sessions
@@ -442,7 +442,7 @@ def serialize_exception(exception):
     return {
         'name': f'{module}.{name}' if module else name,
         'debug': traceback.format_exc(),
-        'message': ustr(exception),
+        'message': exception_to_unicode(exception),
         'arguments': exception.args,
         'context': getattr(exception, 'context', {}),
     }

--- a/odoo/loglevels.py
+++ b/odoo/loglevels.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-
-import sys
+import contextlib
+import warnings
 
 LOG_NOTSET = 'notset'
 LOG_DEBUG = 'debug'
@@ -14,6 +14,12 @@ LOG_CRITICAL = 'critical'
 # There are here until we refactor tools so that this module doesn't depends on tools.
 
 def get_encodings(hint_encoding='utf-8'):
+    warnings.warn(
+        "Deprecated since Odoo 18. Mostly nonsensical as the "
+        "second/third encoding it yields is latin-1 which always succeeds...",
+        stacklevel=2,
+        category=DeprecationWarning,
+    )
     fallbacks = {
         'latin1': 'latin9',
         'iso-8859-1': 'iso8859-15',
@@ -38,9 +44,6 @@ def get_encodings(hint_encoding='utf-8'):
         if prefenc:
             yield prefenc
 
-# not using pycompat to avoid circular import: pycompat is in tools much of
-# which comes back to import loglevels
-text_type = type(u'')
 def ustr(value, hint_encoding='utf-8', errors='strict'):
     """This method is similar to the builtin `unicode`, except
     that it may try multiple encodings to find one that works
@@ -59,12 +62,21 @@ def ustr(value, hint_encoding='utf-8', errors='strict'):
     :raise: UnicodeError if value cannot be coerced to unicode
     :return: unicode string representing the given value
     """
+    warnings.warn(
+        "Deprecated since Odoo 18: ustr() is a garbage bag of weirdo fallbacks "
+        "which mostly don't do anything as\n"
+        "- the first attempt will always work if errors is not `strict`\n"
+        "- if utf8 fails it moves on to latin-1 which always works\n"
+        "- and it always tries hint-encoding twice",
+        stacklevel=2,
+        category=DeprecationWarning,
+    )
     # We use direct type comparison instead of `isinstance`
     # as much as possible, in order to make the most common
     # cases faster (isinstance/issubclass are significantly slower)
     ttype = type(value)
 
-    if ttype is text_type:
+    if ttype is str:
         return value
 
     # special short-circuit for str, as we still needs to support
@@ -73,32 +85,28 @@ def ustr(value, hint_encoding='utf-8', errors='strict'):
 
         # try hint_encoding first, avoids call to get_encoding()
         # for the most common case
-        try:
+        with contextlib.suppress(Exception):
             return value.decode(hint_encoding, errors=errors)
-        except Exception:
-            pass
 
         # rare: no luck with hint_encoding, attempt other ones
         for ln in get_encodings(hint_encoding):
-            try:
+            with contextlib.suppress(Exception):
                 return value.decode(ln, errors=errors)
-            except Exception:
-                pass
 
     if isinstance(value, Exception):
         return exception_to_unicode(value)
 
     # fallback for non-string values
     try:
-        return text_type(value)
-    except Exception:
-        raise UnicodeError('unable to convert %r' % (value,))
+        return str(value)
+    except Exception as e:
+        raise UnicodeError(f'unable to convert {value!r}') from e
 
 
 def exception_to_unicode(e):
     if getattr(e, 'args', ()):
         return "\n".join((ustr(a) for a in e.args))
     try:
-        return text_type(e)
+        return str(e)
     except Exception:
         return u"Unknown message"

--- a/odoo/loglevels.py
+++ b/odoo/loglevels.py
@@ -105,8 +105,8 @@ def ustr(value, hint_encoding='utf-8', errors='strict'):
 
 def exception_to_unicode(e):
     if getattr(e, 'args', ()):
-        return "\n".join((ustr(a) for a in e.args))
+        return "\n".join(map(str, e.args))
     try:
         return str(e)
     except Exception:
-        return u"Unknown message"
+        return "Unknown message"

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -7307,7 +7307,7 @@ def convert_pgerror_unique(model, fields, info, e):
         constraint, table, ufields = cr_tmp.fetchone() or (None, None, None)
     # if the unique constraint is on an expression or on an other table
     if not ufields or model._table != table:
-        return {'message': tools.ustr(e)}
+        return {'message': tools.exception_to_unicode(e)}
 
     # TODO: add stuff from e.diag.message_hint? provides details about the constraint & duplication values but may be localized...
     if len(ufields) == 1:
@@ -7337,11 +7337,11 @@ def convert_pgerror_constraint(model, fields, info, e):
     sql_constraints = dict([(('%s_%s') % (e.diag.table_name, x[0]), x) for x in model._sql_constraints])
     if e.diag.constraint_name in sql_constraints.keys():
         return {'message': "'%s'" % sql_constraints[e.diag.constraint_name][2]}
-    return {'message': tools.ustr(e)}
+    return {'message': tools.exception_to_unicode(e)}
 
 PGERROR_TO_OE = defaultdict(
     # shape of mapped converters
-    lambda: (lambda model, fvg, info, pgerror: {'message': tools.ustr(pgerror)}), {
+    lambda: (lambda model, fvg, info, pgerror: {'message': tools.exception_to_unicode(pgerror)}), {
     '23502': convert_pgerror_not_null,
     '23505': convert_pgerror_unique,
     '23514': convert_pgerror_constraint,

--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -586,7 +586,7 @@ def load_modules(registry, force_demo=False, status=None, update_module=False):
                 try:
                     View._validate_custom_views(model)
                 except Exception as e:
-                    _logger.warning('invalid custom view(s) for model %s: %s', model, tools.ustr(e))
+                    _logger.warning('invalid custom view(s) for model %s: %s', model, e)
 
         if report.wasSuccessful():
             _logger.info('Modules loaded.')

--- a/odoo/modules/module.py
+++ b/odoo/modules/module.py
@@ -102,7 +102,7 @@ def initialize_sys_path():
 
     # hook odoo.addons on addons paths
     for ad in tools.config['addons_path'].split(','):
-        ad = os.path.normcase(os.path.abspath(tools.ustr(ad.strip())))
+        ad = os.path.normcase(os.path.abspath(ad.strip()))
         if ad not in odoo.addons.__path__:
             odoo.addons.__path__.append(ad)
 
@@ -115,7 +115,7 @@ def initialize_sys_path():
     from odoo import upgrade
     legacy_upgrade_path = os.path.join(base_path, 'base', 'maintenance', 'migrations')
     for up in (tools.config['upgrade_path'] or legacy_upgrade_path).split(','):
-        up = os.path.normcase(os.path.abspath(tools.ustr(up.strip())))
+        up = os.path.normcase(os.path.abspath(up.strip()))
         if os.path.isdir(up) and up not in upgrade.__path__:
             upgrade.__path__.append(up)
 

--- a/odoo/netsvc.py
+++ b/odoo/netsvc.py
@@ -51,7 +51,7 @@ class PostgreSQLHandler(logging.Handler):
         with contextlib.suppress(Exception), tools.mute_logger('odoo.sql_db'), sql_db.db_connect(dbname, allow_uri=True).cursor() as cr:
             # preclude risks of deadlocks
             cr.execute("SET LOCAL statement_timeout = 1000")
-            msg = tools.ustr(record.msg)
+            msg = str(record.msg)
             if record.args:
                 msg = msg % record.args
             traceback = getattr(record, 'exc_text', '')

--- a/odoo/service/db.py
+++ b/odoo/service/db.py
@@ -409,16 +409,15 @@ def list_dbs(force=False):
         return res
 
     chosen_template = odoo.tools.config['db_template']
-    templates_list = tuple(set(['postgres', chosen_template]))
+    templates_list = tuple({'postgres', chosen_template})
     db = odoo.sql_db.db_connect('postgres')
     with closing(db.cursor()) as cr:
         try:
             cr.execute("select datname from pg_database where datdba=(select usesysid from pg_user where usename=current_user) and not datistemplate and datallowconn and datname not in %s order by datname", (templates_list,))
-            res = [odoo.tools.ustr(name) for (name,) in cr.fetchall()]
+            return [name for (name,) in cr.fetchall()]
         except Exception:
             _logger.exception('Listing databases failed:')
-            res = []
-    return res
+            return []
 
 def list_db_incompatible(databases):
     """"Check a list of databases if they are compatible with this version of Odoo

--- a/odoo/sql_db.py
+++ b/odoo/sql_db.py
@@ -347,7 +347,7 @@ class Cursor(BaseCursor):
             res = self._obj.execute(query, params)
         except Exception as e:
             if log_exceptions:
-                _logger.error("bad query: %s\nERROR: %s", tools.ustr(self._obj.query or query), e)
+                _logger.error("bad query: %s\nERROR: %s", self._obj.query or query, e)
             raise
         finally:
             delay = real_time() - start

--- a/odoo/tools/date_utils.py
+++ b/odoo/tools/date_utils.py
@@ -9,7 +9,6 @@ import pytz
 from dateutil.relativedelta import relativedelta, weekdays
 
 from .func import lazy
-from odoo.loglevels import ustr
 
 
 __all__ = [
@@ -217,7 +216,9 @@ def json_default(obj):
         return fields.Date.to_string(obj)
     if isinstance(obj, lazy):
         return obj._value
-    return ustr(obj)
+    if isinstance(obj, bytes):
+        return obj.decode()
+    return str(obj)
 
 
 def date_range(start: D, end: D, step: relativedelta = relativedelta(months=1)) -> Iterator[datetime]:

--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -498,17 +498,16 @@ def append_content_to_html(html, content, plaintext=True, preserve=False, contai
         :param str container_tag: tag to wrap the content into, defaults to `div`.
         :rtype: markupsafe.Markup
     """
-    html = ustr(html)
     if plaintext and preserve:
-        content = u'\n<pre>%s</pre>\n' % misc.html_escape(ustr(content))
+        content = '\n<pre>%s</pre>\n' % misc.html_escape(content)
     elif plaintext:
         content = '\n%s\n' % plaintext2html(content, container_tag)
     else:
         content = re.sub(r'(?i)(</?(?:html|body|head|!\s*DOCTYPE)[^>]*>)', '', content)
-        content = u'\n%s\n' % ustr(content)
+        content = '\n%s\n' % content
     # Force all tags to lowercase
     html = re.sub(r'(</?)(\w+)([ >])',
-        lambda m: '%s%s%s' % (m.group(1), m.group(2).lower(), m.group(3)), html)
+        lambda m: '%s%s%s' % (m[1], m[2].lower(), m[3]), html)
     insert_location = html.find('</body>')
     if insert_location == -1:
         insert_location = html.find('</html>')

--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -3,6 +3,7 @@
 
 import base64
 import collections
+import itertools
 import logging
 import random
 import re
@@ -18,7 +19,6 @@ from lxml import etree, html
 from lxml.html import clean, defs
 from werkzeug import urls
 
-from odoo.loglevels import ustr
 from odoo.tools import misc
 
 __all__ = [
@@ -206,26 +206,24 @@ def html_normalize(src, filter_callback=None):
         document parameter, to be called during normalization in order to
         filter the output document
     """
-
     if not src:
         return src
 
-    src = ustr(src, errors='replace')
     # html: remove encoding attribute inside tags
-    doctype = re.compile(r'(<[^>]*\s)(encoding=(["\'][^"\']*?["\']|[^\s\n\r>]+)(\s[^>]*|/)?>)', re.IGNORECASE | re.DOTALL)
-    src = doctype.sub(u"", src)
+    src = re.sub(r'(<[^>]*\s)(encoding=(["\'][^"\']*?["\']|[^\s\n\r>]+)(\s[^>]*|/)?>)', "", src, re.IGNORECASE | re.DOTALL)
+
+    src = src.replace('--!>', '-->')
+    src = re.sub(r'(<!-->|<!--->)', '<!-- -->', src)
+    # On the specific case of Outlook desktop it adds unnecessary '<o:.*></o:.*>' tags which are parsed
+    # in '<p></p>' which may alter the appearance (eg. spacing) of the mail body
+    src = re.sub(r'</?o:.*?>', '', src)
 
     try:
-        src = src.replace('--!>', '-->')
-        src = re.sub(r'(<!-->|<!--->)', '<!-- -->', src)
-        # On the specific case of Outlook desktop it adds unnecessary '<o:.*></o:.*>' tags which are parsed
-        # in '<p></p>' which may alter the appearance (eg. spacing) of the mail body
-        src = re.sub(r'</?o:.*?>', '', src)
         doc = html.fromstring(src)
     except etree.ParserError as e:
         # HTML comment only string, whitespace only..
         if 'empty' in str(e):
-            return u""
+            return ""
         raise
 
     # perform quote detection before cleaning and class removal
@@ -372,11 +370,13 @@ def html2plaintext(html, body_id=None, encoding='utf-8'):
     ## (c) Fry-IT, www.fry-it.com, 2007
     ## <peter@fry-it.com>
     ## download here: http://www.peterbe.com/plog/html2plaintext
-
-    html = ustr(html or '')
-
-    if not html.strip():
+    if not (html and html.strip()):
         return ''
+
+    if isinstance(html, bytes):
+        html = html.decode(encoding)
+    else:
+        assert isinstance(html, str), f"expected str got {html.__class__.__name__}"
 
     tree = etree.fromstring(html, parser=etree.HTMLParser())
 
@@ -388,25 +388,21 @@ def html2plaintext(html, body_id=None, encoding='utf-8'):
         tree = source[0]
 
     url_index = []
-    i = 0
+    linkrefs = itertools.count(1)
     for link in tree.findall('.//a'):
-        url = link.get('href')
-        if url:
-            i += 1
+        if url := link.get('href'):
             link.tag = 'span'
-            link.text = '%s [%s]' % (link.text, i)
+            link.text = f'{link.text} [{next(linkrefs)}]'
             url_index.append(url)
 
     for img in tree.findall('.//img'):
-        src = img.get('src')
-        if src:
-            i += 1
+        if src := img.get('src'):
             img.tag = 'span'
             img_name = re.search(r'[^/]+(?=\.[a-zA-Z]+(?:\?|$))', src)
-            img.text = '%s [%s]' % (img_name.group(0) if img_name else 'Image', i)
+            img.text = '%s [%s]' % (img_name[0] if img_name else 'Image', next(linkrefs))
             url_index.append(src)
 
-    html = ustr(etree.tostring(tree, encoding=encoding))
+    html = etree.tostring(tree, encoding="unicode")
     # \r char is converted into &#13;, must remove it
     html = html.replace('&#13;', '')
 
@@ -430,10 +426,10 @@ def html2plaintext(html, body_id=None, encoding='utf-8'):
     html = '\n'.join([x.strip() for x in html.splitlines()])
     html = html.replace('\n' * 2, '\n')
 
-    for i, url in enumerate(url_index):
-        if i == 0:
-            html += '\n\n'
-        html += ustr('[%s] %s\n') % (i + 1, url)
+    if url_index:
+        html += '\n\n'
+        for i, url in enumerate(url_index, start=1):
+            html += f'[{i}] {url}\n'
 
     return html.strip()
 
@@ -451,7 +447,8 @@ def plaintext2html(text, container_tag=None):
         embedded into a ``<div>``
     :rtype: markupsafe.Markup
     """
-    text = misc.html_escape(ustr(text))
+    assert isinstance(text, str)
+    text = misc.html_escape(text)
 
     # 1. replace \n and \r
     text = re.sub(r'(\r\n|\r|\n)', '<br/>', text)

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -483,15 +483,31 @@ def mod10r(number):
             report = codec[ (int(digit) + report) % 10 ]
     return result + str((10 - report) % 10)
 
-def str2bool(s, default=None):
-    s = ustr(s).lower()
-    y = 'y yes 1 true t on'.split()
-    n = 'n no 0 false f off'.split()
-    if s not in (y + n):
+
+def str2bool(s: str, default: bool | None = None) -> bool:
+    # allow this (for now?) because it's used for get_param
+    if type(s) is bool:
+        return s
+
+    if not isinstance(s, str):
+        warnings.warn(
+            f"Passed a non-str to `str2bool`: {s}",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
         if default is None:
             raise ValueError('Use 0/1/yes/no/true/false/on/off')
         return bool(default)
-    return s in y
+
+    s = s.lower()
+    if s in ('y', 'yes', '1', 'true', 't', 'on'):
+        return True
+    if s in ('n', 'no', '0', 'false', 'f', 'off'):
+        return False
+    if default is None:
+        raise ValueError('Use 0/1/yes/no/true/false/on/off')
+    return bool(default)
 
 def human_size(sz):
     """
@@ -664,9 +680,8 @@ def remove_accents(input_str):
     meaning of input_str and work only for some cases"""
     if not input_str:
         return input_str
-    input_str = ustr(input_str)
     nkfd_form = unicodedata.normalize('NFKD', input_str)
-    return u''.join([c for c in nkfd_form if not unicodedata.combining(c)])
+    return ''.join(c for c in nkfd_form if not unicodedata.combining(c))
 
 class unquote(str):
     """A subclass of str that implements repr() without enclosing quotation marks

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -100,6 +100,7 @@ __all__ = [
     'ustr',
 ]
 
+
 if TYPE_CHECKING:
     from odoo.addons.base.models.res_lang import LangData
 

--- a/odoo/tools/safe_eval.py
+++ b/odoo/tools/safe_eval.py
@@ -25,8 +25,6 @@ from types import CodeType
 import werkzeug
 from psycopg2 import OperationalError
 
-from .misc import ustr
-
 import odoo
 
 unsafe_eval = eval
@@ -252,7 +250,7 @@ def test_expr(expr, allowed_codes, mode="eval", filename=None):
     except (SyntaxError, TypeError, ValueError):
         raise
     except Exception as e:
-        raise ValueError('"%s" while compiling\n%r' % (ustr(e), expr))
+        raise ValueError('%r while compiling\n%r' % (e, expr))
     assert_valid_codeobj(allowed_codes, code_obj, expr)
     return code_obj
 
@@ -401,7 +399,7 @@ def safe_eval(expr, globals_dict=None, locals_dict=None, mode="eval", nocopy=Fal
     except ZeroDivisionError:
         raise
     except Exception as e:
-        raise ValueError('%s: "%s" while evaluating\n%r' % (ustr(type(e)), ustr(e), expr))
+        raise ValueError('%r while evaluating\n%r' % (e, expr))
 def test_python_expr(expr, mode="eval"):
     try:
         test_expr(expr, _SAFE_OPCODES, mode=mode)
@@ -416,7 +414,7 @@ def test_python_expr(expr, mode="eval"):
             }
             msg = "%s : %s at line %d\n%s" % (type(err).__name__, error['message'], error['lineno'], error['error_line'])
         else:
-            msg = ustr(err)
+            msg = str(err)
         return msg
     return False
 

--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -149,12 +149,6 @@ class UNIX_LINE_TERMINATOR(csv.excel):
 csv.register_dialect("UNIX", UNIX_LINE_TERMINATOR)
 
 
-# FIXME: holy shit this whole thing needs to be cleaned up hard it's a mess
-def encode(s):
-    assert isinstance(s, str)
-    return s
-
-
 # which elements are translated inline
 TRANSLATED_ELEMENTS = {
     'abbr', 'b', 'bdi', 'bdo', 'br', 'cite', 'code', 'data', 'del', 'dfn', 'em',
@@ -1057,7 +1051,7 @@ class TranslationReader:
 
     def __iter__(self):
         for module, source, name, res_id, ttype, comments, _record_id, value in self._to_translate:
-            yield (module, ttype, name, res_id, source, encode(odoo.tools.ustr(value)), comments)
+            yield (module, ttype, name, res_id, source, value, comments)
 
     def _push_translation(self, module, ttype, name, res_id, source, comments=None, record_id=None, value=None):
         """ Insert a translation that will be used in the file generation
@@ -1308,7 +1302,7 @@ class TranslationModuleReader(TranslationReader):
                 lineno, message, comments = extracted[:3]
                 value = translations.get(message, '')
                 self._push_translation(module, trans_type, display_path, lineno,
-                                 encode(message), comments + extra_comments, value=value)
+                                       message, comments + extra_comments, value=value)
         except Exception:
             _logger.exception("Failed to extract terms from %s", fabsolutepath)
         finally:

--- a/odoo/tools/view_validation.py
+++ b/odoo/tools/view_validation.py
@@ -309,9 +309,7 @@ def schema_valid(arch, **kwargs):
     """ Get RNG validator and validate RNG file."""
     validator = relaxng(arch.tag)
     if validator and not validator.validate(arch):
-        result = True
         for error in validator.error_log:
-            _logger.warning(tools.ustr(error))
-            result = False
-        return result
+            _logger.warning("%s", error)
+        return False
     return True


### PR DESCRIPTION
`ustr()` is a pretty crummy function, it's an inefficient bad at its job over-complicated crutch dating to the bad old days of Python 2:

- `ustr` does not work well with string subtypes as it checks for the `str` type by identity so strips the subtype-ness, looking at the log this actually seems to have been an unintended mistake from adding a fastpath some time during the Odoo prehistory (d555fdac0c089a3d99497376e818f58c7e38d59c)
- the intent is to transparently handle strings and bytes returning strings (u-strings in old-python) but since `iso-8859-1` can't fail what it really does is either decode as UTF8 or return whatever mojibake a latin-1 decoding vomitted never even moving to the locale's preferred encoding (not that the odds of that being useful are super high)
- since the addition of a fastpath into bytes decoding it will now try to decode as utf-8, then if that fails try that *again* just in case before moving onto latin-1
- unlike functions like `markupsafe.escape_silent` or `pycompat.to_text` it doesn't treat None/False as aliases for the empty string and it *will* stringify them