### PR TITLE
[FIX] purchase_stock: error compute_all with python tax

### DIFF
--- a/addons/purchase_stock/models/stock.py
+++ b/addons/purchase_stock/models/stock.py
@@ -46,7 +46,7 @@ class StockMove(models.Model):
             price_unit = line.price_unit
             if line.taxes_id:
                 qty = line.product_qty or 1
-                price_unit = line.taxes_id.with_context(round=False).compute_all(price_unit, currency=line.order_id.currency_id, quantity=qty)['total_void']
+                price_unit = line.taxes_id.with_context(round=False).compute_all(price_unit, currency=line.order_id.currency_id, quantity=qty, product=self.product_id)['total_void']
                 price_unit = float_round(price_unit / qty, precision_digits=price_unit_prec)
             if line.product_uom.id != line.product_id.uom_id.id:
                 price_unit *= line.product_uom.factor / line.product_id.uom_id.factor


### PR DESCRIPTION
We get an error when trying to validate a dropship
for a product having python tax.

Steps:

- Create a python tax T of type purchase with
  python code being `result = product.weight * 0.1`
- Create a storable product P, with tax T as purchase tax,
  set a vendor and activate dropshipping
- Create and confirme a SO for product P, confirm the related PO
  then try to validate the related dropship
-> We get an User Error (AttributeError: NoneType object has no
attribute weight)

This is because `_compute_all` is called without `product_id` parameter,
leading to the error in `account_tax_python._compute_amount` when trying
to acces the `weight` attribute.

opw-4029025
