### PR TITLE
[FIX] website: s_quotes_carousel, remove duplicate background feature

### DIFF
--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -711,7 +711,7 @@
     <t t-set="only_bg_image_exclude" t-value="''"/>
 
     <t t-set="both_bg_color_image_selector" t-value="'section, .carousel-item, .s_masonry_block .row > div, .s_color_blocks_2 .row > div, .parallax, .s_text_cover .row > .o_not_editable'"/>
-    <t t-set="both_bg_color_image_exclude" t-value="base_only_bg_image_selector + ', .s_carousel_wrapper, .s_image_gallery .carousel-item, .s_google_map, .s_map, [data-snippet] :not(.oe_structure) > [data-snippet], .s_masonry_block .s_col_no_resize'"/>
+    <t t-set="both_bg_color_image_exclude" t-value="base_only_bg_image_selector + ', .s_carousel_wrapper, .s_image_gallery .carousel-item, .s_google_map, .s_map, [data-snippet] :not(.oe_structure) > [data-snippet], .s_masonry_block .s_col_no_resize, .s_quotes_carousel_wrapper'"/>
 
     <t t-call="website.snippet_options_background_options">
         <t t-set="selector" t-value="both_bg_color_image_selector"/>


### PR DESCRIPTION
Prior to this commit, the `s_quotes_carousel` had the Background feature twice in the Web editor.

This commit fixes this issue.

task-4063687

| Before | After |
|--------|--------|
| ![Capture d’écran 2024-08-19 à 17 20 02](https://github.com/user-attachments/assets/354a94d1-9290-4651-b6a1-5e1cacc47e40) | ![Capture d’écran 2024-08-19 à 17 19 37](https://github.com/user-attachments/assets/63d9d097-73d7-4a60-8913-5409e388e94d) |




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
