### PR TITLE
FIX loss of focus un DPH popover and other overlays

### DIFF
--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -308,7 +308,8 @@ export class SelectionPlugin extends Plugin {
      */
     getEditableSelection({ deep = false } = {}) {
         const selection = this.document.getSelection();
-        if (selection && selection.rangeCount && this.isSelectionInEditable(selection)) {
+        const inEditable = selection && this.isSelectionInEditable(selection);
+        if (inEditable) {
             this.activeSelection = this.makeSelection(selection, true);
         } else if (!this.activeSelection.anchorNode.isConnected) {
             this.activeSelection = this.makeSelection();
@@ -345,6 +346,7 @@ export class SelectionPlugin extends Plugin {
             startOffset,
             endContainer,
             endOffset,
+            inEditable,
             commonAncestorContainer: range.commonAncestorContainer,
             cloneContents: () => range.cloneContents(),
         });

--- a/addons/html_editor/static/src/main/link/link_selection_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_selection_plugin.js
@@ -115,14 +115,16 @@ export class LinkSelectionPlugin extends Plugin {
             !isProtecting(node);
 
         const combinedFilter = (node) => defaultFilter(node) && !exclude(node);
-
-        for (const node of descendants(root).filter(combinedFilter)) {
+        const nodes = descendants(root).filter(combinedFilter);
+        if (nodes.length > 0) {
             const cursors = this.shared.preserveSelection();
-            // Remove all FEFF within a `prepareUpdate` to make sure to make <br>
-            // nodes visible if needed.
-            const restoreSpaces = prepareUpdate(...leftPos(node));
-            cleanTextNode(node, "\uFEFF", cursors);
-            restoreSpaces();
+            for (const node of nodes) {
+                // Remove all FEFF within a `prepareUpdate` to make sure to make <br>
+                // nodes visible if needed.
+                const restoreSpaces = prepareUpdate(...leftPos(node));
+                cleanTextNode(node, "\uFEFF", cursors);
+                restoreSpaces();
+            }
             cursors.restore();
         }
 

--- a/addons/html_editor/static/tests/selection.test.js
+++ b/addons/html_editor/static/tests/selection.test.js
@@ -88,10 +88,9 @@ describe("inEditable", () => {
         const { editor } = await setupEditor("<p>ab[]</p>");
         const selection = document.getSelection();
         let editableSelection = editor.shared.getEditableSelection();
-        selection.setPosition(document.body);
         expect(editableSelection.inEditable).toBe(true);
-        // internal value is updated only after selectionchange event
-        await animationFrame();
+        selection.setPosition(document.body);
+        // value is updated directly !
         editableSelection = editor.shared.getEditableSelection();
         expect(editableSelection.inEditable).toBe(false);
     });


### PR DESCRIPTION
[IMP] html_editor: avoid restore in loop

Restore selection only once during `removeFEFFs` call.

---

[FIX] html_editor: fix loss of focus

When the powerbox open the dynamic placeholder
and there is some links inside the current document,
the `removeFEFFs` function trigger by the CLEAN was
stealing the focus from the dynamic placeholder popover.

To fix this we need ensure `inEditable` is synchronously calculated.
So the `restore()` function from `preserveSelection()` can correctly
prevent a focus steal. (see selection_plugin.js :: 433)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
