### PR TITLE
[IMP] html_editor: implement color picker reset button

### DIFF
--- a/addons/html_editor/static/src/main/font/color_selector.js
+++ b/addons/html_editor/static/src/main/font/color_selector.js
@@ -67,7 +67,7 @@ export class ColorSelector extends Component {
 
     applyColor(color) {
         const mode = this.props.type === "foreground" ? "color" : "background";
-        this.props.dispatch("APPLY_COLOR", { color, mode });
+        this.props.dispatch("APPLY_COLOR", { color: color || "", mode });
     }
 
     onColorApply(ev) {
@@ -82,7 +82,7 @@ export class ColorSelector extends Component {
     onColorPreview(ev) {
         const color = ev.hex ? ev.hex : this.processColorFromEvent(ev);
         const mode = this.props.type === "foreground" ? "color" : "background";
-        this.props.dispatch("COLOR_PREVIEW", { color, mode });
+        this.props.dispatch("COLOR_PREVIEW", { color: color || "", mode });
     }
 
     onColorHover(ev) {

--- a/addons/html_editor/static/src/main/font/color_selector.xml
+++ b/addons/html_editor/static/src/main/font/color_selector.xml
@@ -11,22 +11,27 @@
             </button>
             <t t-set-slot="content">
                 <div class="o_font_color_selector user-select-none">
-                    <div class="mb-1">
-                        <div class="btn btn-sm btn-light ms-1"
+                    <div class="mb-1 d-flex">
+                        <button class="btn btn-sm btn-light ms-1"
                             t-att-class="{active: state.activeTab === 'solid'}"
                             t-on-click="() => this.setTab('solid')">
                             Solid
-                        </div> 
-                        <div class="btn btn-sm btn-light"
+                        </button> 
+                        <button class="btn btn-sm btn-light"
                             t-att-class="{active: state.activeTab === 'custom'}"
                             t-on-click="() => this.setTab('custom')">
                             Custom
-                        </div> 
-                        <div class="btn btn-sm btn-light"
+                        </button> 
+                        <button class="btn btn-sm btn-light"
                             t-att-class="{active: state.activeTab === 'gradient'}"
                             t-on-click="() => this.setTab('gradient')">
                             Gradient
-                        </div> 
+                        </button> 
+                        <button class="btn btn-sm btn-light fa fa-trash me-1" 
+                                title="Reset"
+                                t-on-click="onColorApply"
+                                t-on-mouseover="onColorHover"
+                                t-on-mouseout="onColorHoverOut"/>
                     </div>
                     <div t-ref="colorsWrapper">
                         <t t-if="state.activeTab==='solid'">

--- a/addons/html_editor/static/tests/color_selector.test.js
+++ b/addons/html_editor/static/tests/color_selector.test.js
@@ -108,6 +108,26 @@ test("custom colors used in the editor are shown in the colorpicker", async () =
     );
 });
 
+test("Can reset a color", async () => {
+    const { editor } = await setupEditor(
+        `<p class="tested">
+            <font style="color: rgb(255, 0, 0);">[test]</font>
+        </p>`
+    );
+    await waitFor(".o-we-toolbar");
+    expect("font[style='color: rgb(255, 0, 0);']").toHaveCount(1);
+    expect(".tested").not.toHaveInnerHTML("test");
+    click(".o-select-color-foreground");
+    await animationFrame();
+    click("button.fa-trash");
+    await animationFrame();
+    expect("font[style='color: rgb(255, 0, 0);']").toHaveCount(0);
+    expect(".tested").toHaveInnerHTML("test");
+    editor.dispatch("HISTORY_UNDO");
+    expect("font[style='color: rgb(255, 0, 0);']").toHaveCount(1);
+    expect(".tested").not.toHaveInnerHTML("test");
+});
+
 test.tags("desktop")(
     "selected text color is shown in the toolbar and update when hovering",
     async () => {


### PR DESCRIPTION
This commit add the "Reset" button in the color selector. 
This button allows users to reset the color to the default one.