### PR TITLE
[FIX] hr_attendance: disable button if there is no employee

### DIFF
--- a/addons/hr_attendance/static/src/components/attendance_menu/attendance_menu.js
+++ b/addons/hr_attendance/static/src/components/attendance_menu/attendance_menu.js
@@ -49,6 +49,8 @@ export class ActivityMenu extends Component {
             this.state.checkedIn = this.employee.attendance_state === "checked_in";
             this.isFirstAttendance = this.employee.hours_previously_today === 0;
             this.state.isDisplayed = this.employee.display_systray
+        } else {
+            this.state.isDisplayed = false
         }
     }
 


### PR DESCRIPTION
The error occurred when the user was going to check in but didn't find any employee.

Steps to reproduce:
- Install ``hr_attendance`` module(without demo)
- Employees > click on employee and remove ``Related User`` in ``HR Settings``
- Click on the ``systray`` button and ``Check-in``

Traceback: 
``Expected singleton: hr.employee()``

The error occurred at [1] because we couldn't find an employee.

This commit resolves the above error by disabling the button if there is no employee.

[1]- https://github.com/odoo/odoo/blob/b05e203aa8f6956d5bc6606d7df53d74442d727a/addons/hr_attendance/controllers/main.py#L164

sentry-5616192792

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
