### PR TITLE
[REF] html_editor: find(Previous/Next)Position

### DIFF
--- a/addons/html_editor/static/src/core/delete_plugin.js
+++ b/addons/html_editor/static/src/core/delete_plugin.js
@@ -2,9 +2,10 @@ import { Plugin } from "../plugin";
 import { closestBlock, isBlock } from "../utils/blocks";
 import {
     isAllowedContent,
+    isEditorTab,
     isEmpty,
+    isIconElement,
     isInPre,
-    isNotEditableNode,
     isSelfClosingElement,
     isShrunkBlock,
     isTangible,
@@ -22,10 +23,18 @@ import {
     descendants,
     firstLeaf,
     getCommonAncestor,
-    getFurthestUneditableParent,
     lastLeaf,
+    findFurthest,
 } from "../utils/dom_traversal";
-import { DIRECTIONS, childNodeIndex, leftPos, nodeSize, rightPos } from "../utils/position";
+import {
+    DIRECTIONS,
+    childNodeIndex,
+    endPos,
+    leftPos,
+    nodeSize,
+    rightPos,
+    startPos,
+} from "../utils/position";
 import { CTYPES } from "../utils/content_types";
 
 /**
@@ -82,6 +91,11 @@ export class DeletePlugin extends Plugin {
             (element) => element.matches("[data-oe-type='monetary'] > span"),
         ],
     });
+
+    setup() {
+        this.findPreviousPosition = this.makeFindPositionFn("backward");
+        this.findNextPosition = this.makeFindPositionFn("forward");
+    }
 
     handleCommand(command, payload) {
         switch (command) {
@@ -173,9 +187,9 @@ export class DeletePlugin extends Plugin {
      */
     deleteBackward(selection, granularity) {
         // Normalize selection
-        selection = this.shared.setSelection(selection);
+        const { endContainer, endOffset } = this.shared.setSelection(selection);
 
-        let range = this.getRangeForDeleteBackward(selection, granularity);
+        let range = this.getRangeForDelete(endContainer, endOffset, "backward", granularity);
 
         const resources = {
             character: this.resources["handle_delete_backward"],
@@ -203,9 +217,9 @@ export class DeletePlugin extends Plugin {
      */
     deleteForward(selection, granularity) {
         // Normalize selection
-        selection = this.shared.setSelection(selection);
+        const { startContainer, startOffset } = this.shared.setSelection(selection);
 
-        let range = this.getRangeForDeleteForward(selection, granularity);
+        let range = this.getRangeForDelete(startContainer, startOffset, "forward", granularity);
 
         const resources = {
             character: this.resources["handle_delete_forward"],
@@ -227,64 +241,31 @@ export class DeletePlugin extends Plugin {
         this.setCursorFromRange(range);
     }
 
-    getRangeForDeleteBackward(selection, granularity) {
-        const { endContainer, endOffset } = selection;
-        let startContainer, startOffset;
-
+    getRangeForDelete(node, offset, direction, granularity) {
+        let destContainer, destOffset;
         switch (granularity) {
             case "character":
-                [startContainer, startOffset] = this.findPreviousPosition(endContainer, endOffset);
+                [destContainer, destOffset] = this.findAdjacentPosition(node, offset, direction);
                 break;
             case "word":
-                // @todo @phoenix: write more tests for ctrl+delete
-                ({ startContainer, startOffset } = this.shared.modifySelection(
-                    "extend",
-                    "backward",
-                    "word"
-                ));
+                ({ focusNode: destContainer, focusOffset: destOffset } =
+                    this.shared.modifySelection("extend", direction, "word"));
                 break;
             case "line":
-                [startContainer, startOffset] = this.findPreviousLineBoundary(
-                    endContainer,
-                    endOffset
-                );
+                [destContainer, destOffset] = this.findLineBoundary(node, offset, direction);
                 break;
             default:
                 throw new Error("Invalid granularity");
         }
 
-        if (!startContainer) {
-            [startContainer, startOffset] = [endContainer, endOffset];
+        if (!destContainer) {
+            [destContainer, destOffset] = [node, offset];
         }
-        return { startContainer, startOffset, endContainer, endOffset };
-    }
+        const [startContainer, startOffset, endContainer, endOffset] =
+            direction === "forward"
+                ? [node, offset, destContainer, destOffset]
+                : [destContainer, destOffset, node, offset];
 
-    getRangeForDeleteForward(selection, granularity) {
-        const { startContainer, startOffset } = selection;
-        let endContainer, endOffset;
-
-        switch (granularity) {
-            case "character":
-                [endContainer, endOffset] = this.findNextPosition(startContainer, startOffset);
-                break;
-            case "word":
-                // @todo @phoenix: write more tests for ctrl+delete
-                ({ endContainer, endOffset } = this.shared.modifySelection(
-                    "extend",
-                    "forward",
-                    "word"
-                ));
-                break;
-            case "line":
-                [endContainer, endOffset] = this.findNextLineBoundary(startContainer, startOffset);
-                break;
-            default:
-                throw new Error("Invalid granularity");
-        }
-
-        if (!endContainer) {
-            [endContainer, endOffset] = [startContainer, startOffset];
-        }
         return { startContainer, startOffset, endContainer, endOffset };
     }
 
@@ -916,7 +897,8 @@ export class DeletePlugin extends Plugin {
      */
     expandRangeToIncludeNonEditables(range) {
         const { startContainer, endContainer, commonAncestorContainer: commonAncestor } = range;
-        const startUneditable = getFurthestUneditableParent(startContainer, commonAncestor);
+        const isNonEditable = (node) => !closestElement(node).isContentEditable;
+        const startUneditable = findFurthest(startContainer, commonAncestor, isNonEditable);
         if (startUneditable) {
             // @todo @phoenix: Review this spec. I suggest this instead (no block merge after removing):
             // startContainer = startUneditable.parentElement;
@@ -928,7 +910,7 @@ export class DeletePlugin extends Plugin {
                 range.setStart(commonAncestor, 0);
             }
         }
-        const endUneditable = getFurthestUneditableParent(endContainer, commonAncestor);
+        const endUneditable = findFurthest(endContainer, commonAncestor, isNonEditable);
         if (endUneditable) {
             range.setEndAfter(endUneditable);
         }
@@ -939,161 +921,116 @@ export class DeletePlugin extends Plugin {
     // Find previous/next position
     // --------------------------------------------------------------------------
 
-    // Returns the previous visible position (ex: a previous character, the end
-    // of the previous block, etc.).
-    findPreviousPosition(node, offset, blockSwitch = false) {
-        // Look for a visible character in text node.
-        if (node.nodeType === Node.TEXT_NODE) {
-            // @todo @phoenix: write tests for chars with size > 1 (emoji, etc.)
-            // Use the string iterator to handle surrogate pairs.
-            let index = offset;
-            const chars = [...node.textContent.slice(0, index)];
-            let char = chars.pop();
-            while (char) {
-                index -= char.length;
-                if (this.isVisibleChar(char, node, index)) {
-                    return blockSwitch ? [node, index + char.length] : [node, index];
-                }
-                char = chars.pop();
-            }
-        }
-
-        // Get previous leaf
-        let leaf;
-        if (node.hasChildNodes() && offset) {
-            leaf = lastLeaf(node.childNodes[offset - 1]);
-        } else {
-            leaf = previousLeaf(node, this.editable);
-        }
-        if (!leaf) {
-            return [null, null];
-        }
-        // Skip invisible leafs, keeping track whether a block switch occurred.
-        const endNodeClosestBlock = closestBlock(node);
-        blockSwitch ||= closestBlock(leaf) !== endNodeClosestBlock;
-        while (this.shouldSkip(leaf, blockSwitch)) {
-            leaf = previousLeaf(leaf, this.editable);
-            if (!leaf) {
-                return [null, null];
-            }
-            blockSwitch ||= closestBlock(leaf) !== endNodeClosestBlock;
-        }
-
-        // If part of a contenteditable=false tree, expand selection to delete the root.
-        // If the non-editable is not a block and there was a block switch, reduce the
-        // selection to keep it instead, since the position moved from another block next
-        // to that inline root, there was a sufficient position change.
-        let leafClosestUneditable = closestElement(leaf, isNotEditableNode);
-        const nodeClosestUneditable = closestElement(node, isNotEditableNode);
-        if (leafClosestUneditable && leafClosestUneditable !== nodeClosestUneditable) {
-            // handle nested contenteditable=false elements
-            while (!leafClosestUneditable.parentNode.isContentEditable) {
-                leafClosestUneditable = leafClosestUneditable.parentNode;
-            }
-            return blockSwitch &&
-                !isBlock(leafClosestUneditable) &&
-                closestBlock(leafClosestUneditable) !== endNodeClosestBlock
-                ? rightPos(leafClosestUneditable)
-                : leftPos(leafClosestUneditable);
-        }
-
-        if (leaf.nodeType === Node.ELEMENT_NODE) {
-            return blockSwitch ? rightPos(leaf) : leftPos(leaf);
-        }
-
-        return this.findPreviousPosition(leaf, nodeSize(leaf), blockSwitch);
+    /**
+     * Returns the next/previous position for deletion.
+     *
+     * @param {Node} node
+     * @param {number} offset
+     * @param {"forward"|"backward"} direction
+     * @returns {[Node|null, Number|null]}
+     */
+    findAdjacentPosition(node, offset, direction) {
+        return direction === "forward"
+            ? this.findNextPosition(node, offset)
+            : this.findPreviousPosition(node, offset);
     }
 
-    findNextPosition(node, offset, blockSwitch = false) {
-        // Look for a visible character in text node.
-        if (node.nodeType === Node.TEXT_NODE) {
-            // Use the string iterator to handle surrogate pairs.
-            let index = offset;
-            for (const char of node.textContent.slice(index)) {
-                if (this.isVisibleChar(char, node, index)) {
-                    index += blockSwitch ? 0 : char.length;
-                    return [node, index];
+    /**
+     *  Returns a function to find the adjacent position in the given direction.
+     *
+     * @param {"forward"|"backward"} direction
+     */
+    makeFindPositionFn(direction) {
+        const isDirectionForward = direction === "forward";
+
+        // Define helper functions based on the direction.
+        // Text node helpers.
+        const findVisibleChar = (
+            isDirectionForward ? this.findNextVisibleChar : this.findPreviousVisibleChar
+        ).bind(this);
+        const charLeftPos = (index, char) => index;
+        const charRightPos = (index, char) => index + char.length;
+        const indexBeforeChar = isDirectionForward ? charLeftPos : charRightPos;
+        const indexAfterChar = isDirectionForward ? charRightPos : charLeftPos;
+        const textEdgePos = isDirectionForward ? startPos : endPos;
+        // Leaf helpers.
+        const adjacentLeaf = (isDirectionForward ? this.nextLeaf : this.previousLeaf).bind(this);
+        const adjacentLeafFromPos = (
+            isDirectionForward ? this.nextLeafFromPos : this.previousLeafFromPos
+        ).bind(this);
+        const beforePos = isDirectionForward ? leftPos : rightPos;
+        const afterPos = isDirectionForward ? rightPos : leftPos;
+
+        /**
+         * Returns the next/previous position for deletion.
+         *
+         * "Before" and "after" have different meanings depending on the
+         * direction: before and after mean, respectively, previous and next in
+         * DOM order when direction is "forward", and the other way around when
+         * direction is "backward".
+         *
+         * @param {Node} node
+         * @param {number} offset
+         * @returns {[Node|null, Number|null]}
+         */
+        return function findPosition(node, offset) {
+            if (node.nodeType === Node.TEXT_NODE) {
+                const [char, index] = findVisibleChar(node, offset);
+                if (char) {
+                    return [node, indexAfterChar(index, char)];
                 }
-                index += char.length;
             }
-        }
 
-        // Get next leaf
-        let leaf;
-        if (node.hasChildNodes() && offset < nodeSize(node)) {
-            leaf = firstLeaf(node.childNodes[offset]);
-        } else {
-            leaf = nextLeaf(node, this.editable);
-        }
-        if (!leaf) {
+            // Define context: search is restricted to the closest editable root.
+            const isEditableRoot = (n) => n.isContentEditable && !n.parentNode.isContentEditable;
+            const editableRoot = findUpTo(node, this.editable.parentNode, isEditableRoot);
+
+            let blockSwitch;
+            const nodeClosestBlock = closestBlock(node);
+            let leaf = adjacentLeafFromPos(node, offset, editableRoot);
+            while (leaf) {
+                blockSwitch ||= closestBlock(leaf) !== nodeClosestBlock;
+
+                if (this.shouldSkip(leaf, blockSwitch)) {
+                    leaf = adjacentLeaf(leaf, editableRoot);
+                    continue;
+                }
+
+                if (leaf.nodeType === Node.TEXT_NODE) {
+                    const [char, index] = findVisibleChar(...textEdgePos(leaf));
+                    if (char) {
+                        const idx = (blockSwitch ? indexBeforeChar : indexAfterChar)(index, char);
+                        return [leaf, idx];
+                    }
+                } else if (!leaf.isContentEditable && isBlock(leaf)) {
+                    // E.g. Desired range for deleteForward:
+                    // <p>abc[</p><div contenteditable="false">def</div>]<p>ghi</p>
+                    return afterPos(leaf);
+                } else {
+                    return blockSwitch ? beforePos(leaf) : afterPos(leaf);
+                }
+                leaf = adjacentLeaf(leaf, editableRoot);
+            }
             return [null, null];
-        }
-        // Skip invisible leafs, keeping track whether a block switch occurred.
-        const startNodeClosestBlock = closestBlock(node);
-        blockSwitch ||= closestBlock(leaf) !== startNodeClosestBlock;
-        while (this.shouldSkip(leaf, blockSwitch)) {
-            leaf = nextLeaf(leaf, this.editable);
-            if (!leaf) {
-                return [null, null];
-            }
-            blockSwitch ||= closestBlock(leaf) !== startNodeClosestBlock;
-        }
-
-        // If part of a contenteditable=false tree, expand selection to delete the root.
-        // If the non-editable is not a block and there was a block switch, reduce the
-        // selection to keep it instead, since the position moved from another block to
-        // that inline root, there was a sufficient position change.
-        let leafClosestUneditable = closestElement(leaf, isNotEditableNode);
-        const nodeClosestUneditable = closestElement(node, isNotEditableNode);
-        if (leafClosestUneditable && leafClosestUneditable !== nodeClosestUneditable) {
-            // handle nested contenteditable=false elements
-            while (!leafClosestUneditable.parentNode.isContentEditable) {
-                leafClosestUneditable = leafClosestUneditable.parentNode;
-            }
-            return blockSwitch &&
-                !isBlock(leafClosestUneditable) &&
-                closestBlock(leafClosestUneditable) !== startNodeClosestBlock
-                ? leftPos(leafClosestUneditable)
-                : rightPos(leafClosestUneditable);
-        }
-
-        if (leaf.nodeType === Node.ELEMENT_NODE) {
-            return blockSwitch ? leftPos(leaf) : rightPos(leaf);
-        }
-
-        return this.findNextPosition(leaf, 0, blockSwitch);
+        };
     }
 
-    findPreviousLineBoundary(endContainer, endOffset) {
-        const block = closestBlock(endContainer);
-        let last = endContainer;
-        let node = previousLeaf(endContainer, this.editable);
+    findLineBoundary(container, offset, direction) {
+        const adjacentLeaf = direction === "forward" ? nextLeaf : previousLeaf;
+        const edgeIndex = (node) => (direction === "forward" ? nodeSize(node) : 0);
+        const block = closestBlock(container);
+        let last = container;
+        let node = adjacentLeaf(container, this.editable);
         // look for a BR or a block start
         while (node && node.nodeName !== "BR" && closestBlock(node) === block) {
             last = node;
-            node = previousLeaf(node, this.editable);
+            node = adjacentLeaf(node, this.editable);
         }
-        if (last === endContainer && endOffset === 0) {
-            // Cursor is already next to the line break, go to previous position.
-            return this.findPreviousPosition(endContainer, endOffset);
+        if (last === container && offset === edgeIndex(container)) {
+            // Cursor is already next to the line break, go to following position.
+            return this.findAdjacentPosition(container, offset, direction);
         }
-        return leftPos(last);
-    }
-
-    findNextLineBoundary(startContainer, startOffset) {
-        const block = closestBlock(startContainer);
-        let last = startContainer;
-        let node = nextLeaf(startContainer, this.editable);
-        // look for a BR or a block start
-        while (node && node.nodeName !== "BR" && closestBlock(node) === block) {
-            last = node;
-            node = nextLeaf(node, this.editable);
-        }
-        if (last === startContainer && startOffset === nodeSize(startContainer)) {
-            // Cursor is already next to the line break, go to next position.
-            return this.findNextPosition(startContainer, startOffset);
-        }
-        return rightPos(last);
+        return direction === "forward" ? rightPos(last) : leftPos(last);
     }
 
     // @todo @phoenix: there are not enough tests for visibility of characters
@@ -1148,13 +1085,74 @@ export class DeletePlugin extends Plugin {
         if (leaf.nodeName === "BR" && isFakeLineBreak(leaf)) {
             return true;
         }
-        if (isSelfClosingElement(leaf)) {
+        // @todo: register these as resources by other plugins?
+        if (
+            [isSelfClosingElement, isIconElement, isEditorTab].some((predicate) => predicate(leaf))
+        ) {
             return false;
         }
         if (isEmpty(leaf) || isZWS(leaf)) {
             return true;
         }
         return false;
+    }
+
+    findPreviousVisibleChar(textNode, index) {
+        // @todo @phoenix: write tests for chars with size > 1 (emoji, etc.)
+        // Use the string iterator to handle surrogate pairs.
+        const chars = [...textNode.textContent.slice(0, index)];
+        let char = chars.pop();
+        while (char) {
+            index -= char.length;
+            if (this.isVisibleChar(char, textNode, index)) {
+                return [char, index];
+            }
+            char = chars.pop();
+        }
+        return [null, null];
+    }
+
+    findNextVisibleChar(textNode, index) {
+        // Use the string iterator to handle surrogate pairs.
+        for (const char of textNode.textContent.slice(index)) {
+            if (this.isVisibleChar(char, textNode, index)) {
+                return [char, index];
+            }
+            index += char.length;
+        }
+        return [null, null];
+    }
+
+    // If leaf is part of a contenteditable=false tree, consider its root as the
+    // leaf instead.
+    adjustedLeaf(leaf, refEditableRoot) {
+        const isNonEditable = (node) => !closestElement(node).isContentEditable;
+        const nonEditableRoot = leaf && findFurthest(leaf, refEditableRoot, isNonEditable);
+        return nonEditableRoot || leaf;
+    }
+
+    previousLeaf(node, editableRoot) {
+        return this.adjustedLeaf(previousLeaf(node, editableRoot), editableRoot);
+    }
+
+    nextLeaf(node, editableRoot) {
+        return this.adjustedLeaf(nextLeaf(node, editableRoot), editableRoot);
+    }
+
+    previousLeafFromPos(node, offset, editableRoot) {
+        const leaf =
+            node.hasChildNodes() && offset > 0
+                ? lastLeaf(node.childNodes[offset - 1])
+                : previousLeaf(node, editableRoot);
+        return this.adjustedLeaf(leaf, editableRoot);
+    }
+
+    nextLeafFromPos(node, offset, editableRoot) {
+        const leaf =
+            node.hasChildNodes() && offset < nodeSize(node)
+                ? firstLeaf(node.childNodes[offset])
+                : nextLeaf(node, editableRoot);
+        return this.adjustedLeaf(leaf, editableRoot);
     }
 
     // --------------------------------------------------------------------------

--- a/addons/html_editor/static/src/utils/dom_traversal.js
+++ b/addons/html_editor/static/src/utils/dom_traversal.js
@@ -43,6 +43,21 @@ export function findUpTo(node, limitAncestor, predicate) {
 }
 
 /**
+ * @param {Node} node
+ * @param {HTMLElement} limitAncestor - non inclusive limit ancestor to search for
+ * @param {Function} predicate
+ * @returns {Node|undefined}
+ */
+export function findFurthest(node, limitAncestor, predicate) {
+    const nodes = [];
+    while (node !== limitAncestor) {
+        nodes.push(node);
+        node = node.parentNode;
+    }
+    return nodes.findLast(predicate);
+}
+
+/**
  * Returns the closest HTMLElement of the provided Node. If the predicate is a
  * string, returns the closest HTMLElement that match the predicate selector. If
  * the predicate is a function, returns the closest element that matches the
@@ -295,32 +310,6 @@ export function getAdjacents(node, predicate = (n) => !!n) {
     const previous = getAdjacentPreviousSiblings(node, predicate);
     const next = getAdjacentNextSiblings(node, predicate);
     return predicate(node) ? [...previous.reverse(), node, ...next] : [];
-}
-/**
- * Return the furthest uneditable parent of node contained within parentLimit.
- * @see deleteRange Used to guarantee that uneditables are fully contained in
- * the range (so that it is not possible to partially remove them)
- *
- * @param {Node} node
- * @param {Node} [parentLimit=undefined] non-inclusive furthest parent allowed
- * @returns {Node} uneditable parent if it exists
- */
-export function getFurthestUneditableParent(node, parentLimit) {
-    if (node === parentLimit || (parentLimit && !parentLimit.contains(node))) {
-        return undefined;
-    }
-    let parent = node && node.parentElement;
-    let nonEditableElement;
-    while (parent && (!parentLimit || parent !== parentLimit)) {
-        if (!parent.isContentEditable) {
-            nonEditableElement = parent;
-        }
-        if (parent.classList.contains("odoo-editor-editable")) {
-            break;
-        }
-        parent = parent.parentElement;
-    }
-    return nonEditableElement;
 }
 
 /**

--- a/addons/html_editor/static/tests/delete/find_adjacent_position.test.js
+++ b/addons/html_editor/static/tests/delete/find_adjacent_position.test.js
@@ -1,0 +1,225 @@
+import { describe, expect, test } from "@odoo/hoot";
+import { setupEditor } from "../_helpers/editor";
+import { getContent, setSelection } from "../_helpers/selection";
+import { unformat } from "../_helpers/format";
+
+function findAdjacentPosition(editor, direction) {
+    const deletePlugin = editor.plugins.find((p) => p.constructor.name === "delete");
+    const selection = editor.document.getSelection();
+    const { anchorNode, anchorOffset } = selection;
+
+    return deletePlugin.findAdjacentPosition(anchorNode, anchorOffset, direction);
+}
+
+function assertAdjacentPositions(editor, previous, next) {
+    let [node, offset] = findAdjacentPosition(editor, "forward");
+    setSelection({ anchorNode: node, anchorOffset: offset });
+    expect(getContent(editor.editable)).toBe(next);
+
+    [node, offset] = findAdjacentPosition(editor, "backward");
+    setSelection({ anchorNode: node, anchorOffset: offset });
+    expect(getContent(editor.editable)).toBe(previous);
+}
+
+describe("findAdjacentPosition method", () => {
+    describe("Basic", () => {
+        test("should find adjacent character", async () => {
+            const previous = "<p>a[]bcd</p>";
+            const next = "<p>ab[]cd</p>";
+            const { editor } = await setupEditor(previous);
+            assertAdjacentPositions(editor, previous, next);
+        });
+        test("should find adjacent character (2)", async () => {
+            const previous = "<p>[]abcd</p>";
+            const next = "<p>a[]bcd</p>";
+            const { editor } = await setupEditor(previous);
+            assertAdjacentPositions(editor, previous, next);
+        });
+        test("should find adjacent character in different text node", async () => {
+            const previous = "<p>a[]bcd</p>";
+            const next = "<p>ab[]cd</p>";
+            const { editor, el } = await setupEditor(previous);
+            // Split text node between 'a' and 'b'
+            const textNode = el.firstChild.firstChild;
+            textNode.splitText(1);
+            setSelection({ anchorNode: textNode, anchorOffset: 1 });
+            assertAdjacentPositions(editor, previous, next);
+        });
+        test("should find first position after paragraph break", async () => {
+            const previous = "<p>ab[]</p><p>cd</p>";
+            const next = "<p>ab</p><p>[]cd</p>";
+            const { editor } = await setupEditor(previous);
+            assertAdjacentPositions(editor, previous, next);
+        });
+        test("should not find anything before the first position", async () => {
+            const { editor } = await setupEditor("<p>[]abc</p>");
+            const [node, offset] = findAdjacentPosition(editor, "backward");
+            expect(node).toBe(null);
+            expect(offset).toBe(null);
+        });
+        test("should not find anything after the last position", async () => {
+            const { editor } = await setupEditor("<p>abc[]</p>");
+            const [node, offset] = findAdjacentPosition(editor, "forward");
+            expect(node).toBe(null);
+            expect(offset).toBe(null);
+        });
+        test("should skip invisible character", async () => {
+            const { editor, el } = await setupEditor("<p>d[]\u200bef</p>");
+            const [node, offset] = findAdjacentPosition(editor, "forward");
+            setSelection({ anchorNode: node, anchorOffset: offset });
+            expect(getContent(el)).toBe("<p>d\u200be[]f</p>");
+            // @todo: non-reversible operation (e.g. backward results in
+            // <p>d\u200b[]ef</p>). Should it be?
+        });
+        test("should skip invisible character (2)", async () => {
+            const { editor, el } = await setupEditor("<p>d\u200b[]ef</p>");
+            const [node, offset] = findAdjacentPosition(editor, "backward");
+            setSelection({ anchorNode: node, anchorOffset: offset });
+            expect(getContent(el)).toBe("<p>[]d\u200bef</p>");
+        });
+    });
+    describe("Contenteditable=false elements", () => {
+        describe("Inlines", () => {
+            test("Should find position after the span", async () => {
+                const previous = '<p>a[]<span contenteditable="false">b</span>c</p>';
+                const next = '<p>a<span contenteditable="false">b</span>[]c</p>';
+                const { editor } = await setupEditor(previous);
+                assertAdjacentPositions(editor, previous, next);
+            });
+            test("Should find position after paragraph break", async () => {
+                const previous = '<div><p>a[]</p><span contenteditable="false">b</span></div>';
+                const next = '<div><p>a</p>[]<span contenteditable="false">b</span></div>';
+                const { editor } = await setupEditor(previous);
+                assertAdjacentPositions(editor, previous, next);
+            });
+        });
+        describe("Blocks", () => {
+            test("Should find position after the div", async () => {
+                const { editor, el } = await setupEditor(
+                    '<p>a[]</p><div contenteditable="false">b</div><p>c</p>'
+                );
+                const [node, offset] = findAdjacentPosition(editor, "forward");
+                setSelection({ anchorNode: node, anchorOffset: offset });
+                expect(getContent(el)).toBe(
+                    // This position is not reachable with the keyboard, but
+                    // it's the desirable one to compose a range for deletion,
+                    // allowing to remove the div with deleteForward without
+                    // afecting the paragraph after it.
+                    '<p>a</p><div contenteditable="false">b</div>[]<p>c</p>'
+                );
+            });
+            test("Should find position before the div", async () => {
+                const { editor, el } = await setupEditor(
+                    '<p>a</p><div contenteditable="false">b</div><p>[]c</p>'
+                );
+                const [node, offset] = findAdjacentPosition(editor, "backward");
+                setSelection({ anchorNode: node, anchorOffset: offset });
+                expect(getContent(el)).toBe(
+                    // This position is not reachable with the keyboard, but
+                    // it's the desirable one to compose a range for deletion,
+                    // allowing to remove the div with deleteBackward without
+                    // afecting the paragraph before it.
+                    '<p>a</p>[]<div contenteditable="false">b</div><p>c</p>'
+                );
+            });
+        });
+    });
+    describe("Different editable zones", () => {
+        test("should find adjacent character", async () => {
+            const previous = unformat(`
+                <div contenteditable="false">
+                    <p>abc</p>
+                    <p contenteditable="true">[]def</p>
+                </div>
+                <p>fgh</p>
+            `);
+            const next = unformat(`
+                <div contenteditable="false">
+                    <p>abc</p>
+                    <p contenteditable="true">d[]ef</p>
+                </div>
+                <p>fgh</p>
+            `);
+            const { editor } = await setupEditor(previous);
+            assertAdjacentPositions(editor, previous, next);
+        });
+        test("should not find anything outside the closest editable root", async () => {
+            const { editor } = await setupEditor(
+                unformat(`
+                    <div contenteditable="false">
+                        <p>abc</p>
+                        <p contenteditable="true">[]def</p>
+                    </div>
+                    <p>fgh</p>
+                `)
+            );
+            const [node, offset] = findAdjacentPosition(editor, "backward");
+            expect(node).toBe(null);
+            expect(offset).toBe(null);
+        });
+        test("should not find anything outside the closest editable root (2)", async () => {
+            const { editor } = await setupEditor(
+                unformat(`
+                    <div contenteditable="false">
+                        <p>abc</p>
+                        <p contenteditable="true">def[]</p>
+                    </div>
+                    <p>fgh</p>
+                `)
+            );
+            const [node, offset] = findAdjacentPosition(editor, "forward");
+            expect(node).toBe(null);
+            expect(offset).toBe(null);
+        });
+        test("Should find position before the div", async () => {
+            const { editor, el } = await setupEditor(
+                unformat(`
+                    <div contenteditable="false">
+                        <p>abc</p>
+                        <p contenteditable="true">def</p>
+                    </div>
+                    <p>[]fgh</p>
+                `)
+            );
+            const [node, offset] = findAdjacentPosition(editor, "backward");
+            setSelection({ anchorNode: node, anchorOffset: offset });
+            expect(getContent(el)).toBe(
+                // This position is not reachable with the keyboard, but
+                // it's the desirable one to compose a range for deletion,
+                // allowing to remove the div with deleteBackward
+                unformat(`
+                    []<div contenteditable="false">
+                        <p>abc</p>
+                        <p contenteditable="true">def</p>
+                    </div>
+                    <p>fgh</p>
+                `)
+            );
+        });
+        test("Should find position after the div", async () => {
+            const { editor, el } = await setupEditor(
+                unformat(`
+                    <p>fgh[]</p>
+                    <div contenteditable="false">
+                        <p>abc</p>
+                        <p contenteditable="true">def</p>
+                    </div>
+                `)
+            );
+            const [node, offset] = findAdjacentPosition(editor, "forward");
+            setSelection({ anchorNode: node, anchorOffset: offset });
+            expect(getContent(el)).toBe(
+                // This position is not reachable with the keyboard, but
+                // it's the desirable one to compose a range for deletion,
+                // allowing to remove the div with deleteForward
+                unformat(`
+                    <p>fgh</p>
+                    <div contenteditable="false">
+                        <p>abc</p>
+                        <p contenteditable="true">def</p>
+                    </div>[]
+                `)
+            );
+        });
+    });
+});


### PR DESCRIPTION
These functions are used for defining a range to be deleted when handling deleteBackward and deleteForward. Given a reference position (node and offset), they return the previous or next position. A range can then be composed with these two positions and passed to deleteRange.

This commit refactors these functions, now unified in a single one, (named findAdjacentPosition), parameterized for direction.

Main goals:

1. Remove code duplication. findPreviousPosition and findNextPosition were "mirrored", that is, they had the same logic, differing only on direction of DOM traversal.

2. Simplify control flow for looping over leaf nodes (recursive call was removed).

3. Change behavior around contenteditable=false zones. Now:

- searching for the adjacent position is limited to the editable context (e.g. contenteditable=true zone inside a contenteditable=false zone);

- when looping over leaves, a contenteditable=false tree is considered a single unit (rather than looking into its leaves) to find a position before or after it (as if the whole tree were a single leaf).

4. Add specifications (i.e. tests) to the new findAdjacentPosition function.

Code duplication removal of mirrored functions was also applied to getRangeForDelete(Backward/Forward) and find(Previous/Next)LineBoundary.
