### PR TITLE
[IMP] l10n_pl: Keep currency rate of credit note

### DIFF
--- a/addons/l10n_pl/models/__init__.py
+++ b/addons/l10n_pl/models/__init__.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from . import product
 from . import account_move
+from . import account_move_line
 from . import res_partner
 from . import res_company
 from . import res_config_settings

--- a/addons/l10n_pl/models/account_move.py
+++ b/addons/l10n_pl/models/account_move.py
@@ -25,3 +25,15 @@ class AccountMove(models.Model):
                 record.reversed_entry_id.amount_total < record.amount_total and record.move_type != 'entry':
                 raise ValidationError(_("Credit notes can't have a total amount greater than the invoice's"))
         return super().action_post()
+
+    def _compute_invoice_currency_rate(self):
+        l10n_pl_credit_note = self.filtered(
+            lambda move: (
+                move.country_code == 'PL'
+                and move.reversed_entry_id
+            )
+        )
+        for move in l10n_pl_credit_note:
+            move.invoice_currency_rate = move.reversed_entry_id.invoice_currency_rate
+
+        super(AccountMove, (self - l10n_pl_credit_note))._compute_invoice_currency_rate()

--- a/addons/l10n_pl/models/account_move_line.py
+++ b/addons/l10n_pl/models/account_move_line.py
@@ -1,0 +1,23 @@
+from odoo import models, fields
+
+
+class AccountMoveLine(models.Model):
+    _inherit = "account.move.line"
+
+    def _compute_currency_rate(self):
+        l10n_pl_lines = self.filtered(
+            lambda line: (
+                line.move_id.country_code == 'PL'
+                and line.move_id.reversed_entry_id
+                and line.currency_id
+            )
+        )
+        for line in l10n_pl_lines:
+            line.currency_rate = self.env['res.currency']._get_conversion_rate(
+                    from_currency=line.company_currency_id,
+                    to_currency=line.currency_id,
+                    company=line.company_id,
+                    date=line.move_id.reversed_entry_id.delivery_date or line.move_id.reversed_entry_id.date or fields.Date.context_today(line),
+                )
+
+        super(AccountMoveLine, (self - l10n_pl_lines))._compute_currency_rate()


### PR DESCRIPTION
[IMP] l10n_pl: Keep currency rate of credit note

We need to keep currency rate as the original invoice to improve poland experience

solution: Since we are going to rely on delivery date on the first place to calculate delivery date, We will just calculate the rate based on parameters of the original invoice

task-id#4023114

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr