### PR TITLE
[IMP] pos: Weighting pop-up Price/kg consistent with tax incl/excl

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/scale_screen/scale_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/scale_screen/scale_screen.xml
@@ -38,7 +38,7 @@
                 </div>
                 <div class="d-flex px-5 flex-row gap-2 m-2 align-items-center">
                     <div class="product-price w-50 fs-2 text-center"
-                        t-esc="env.utils.formatCurrency(productPrice) + '/' + productUom" />
+                        t-esc="productPrice + '/' + productUom" />
                     <div class="computed-price fd-flex flex-grow-1 p-3 rounded text-center text-bg-info bg-opacity-25 text-info fs-2 fw-bold" t-esc="computedPriceString" />
                 </div>
             </div>

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -690,6 +690,7 @@ export class PosStore extends Reactive {
             if (values.product_id.isScaleAvailable) {
                 const weight = await makeAwaitable(this.env.services.dialog, ScaleScreen, {
                     product: values.product_id,
+                    taxIncluded: this.config.iface_tax_included === "total",
                 });
                 if (!weight) {
                     return;


### PR DESCRIPTION
Adjusted the display logic in the weighting pop-up to reflect whether taxes are included or excluded based on the PoS configuration.

Task ID: 4034961





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
