### PR TITLE
[FIX] mrp,stock: include soon-to-start MOs in quantity forecast

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -936,6 +936,12 @@ class MrpProduction(models.Model):
                 and vals.get('date_finished')
                 and rec.move_finished_ids[0].date != vals['date_finished']):
                 rec.move_finished_ids.write({'date': vals['date_finished']})
+            elif (rec.move_finished_ids
+                  and rec.date_finished
+                  and rec.move_finished_ids[0].date != rec.date_finished
+                  and not vals.get('date_finished')):
+                # if no value is specified, do take the workorder duration (etc) into account
+                rec.move_finished_ids.write({'date': rec.date_finished})
         return res
 
     def unlink(self):

--- a/addons/mrp/models/stock_orderpoint.py
+++ b/addons/mrp/models/stock_orderpoint.py
@@ -5,6 +5,7 @@ from odoo import _, api, fields, models
 from odoo.tools.float_utils import float_is_zero
 from odoo.osv.expression import AND
 from dateutil.relativedelta import relativedelta
+from datetime import datetime, time
 
 
 class StockWarehouseOrderpoint(models.Model):
@@ -104,6 +105,7 @@ class StockWarehouseOrderpoint(models.Model):
 
         bom_manufacture = self.env['mrp.bom']._bom_find(orderpoints_without_kit.product_id, bom_type='normal')
         bom_manufacture = self.env['mrp.bom'].concat(*bom_manufacture.values())
+        # add quantities coming from draft MOs
         productions_group = self.env['mrp.production']._read_group(
             [
                 ('bom_id', 'in', bom_manufacture.ids),
@@ -116,6 +118,21 @@ class StockWarehouseOrderpoint(models.Model):
         for orderpoint, uom, product_qty_sum in productions_group:
             res[orderpoint.id] += uom._compute_quantity(
                 product_qty_sum, orderpoint.product_uom, round=False)
+
+        # add quantities coming from confirmed MO to be started but not finished
+        # by the end of the stock forecast
+        in_progress_productions = self.env['mrp.production'].search([
+            ('bom_id', 'in', bom_manufacture.ids),
+            ('state', '=', 'confirmed'),
+            ('orderpoint_id', 'in', orderpoints_without_kit.ids),
+            ('id', 'not in', self.env.context.get('ignore_mo_ids', [])),
+        ])
+        for prod in in_progress_productions:
+            date_start, date_finished, orderpoint = prod.date_start, prod.date_finished, prod.orderpoint_id
+            lead_days_date = datetime.combine(orderpoint.lead_days_date, time.max)
+            if date_start <= lead_days_date < date_finished:
+                res[orderpoint.id] += prod.product_uom_id._compute_quantity(
+                        prod.product_qty, orderpoint.product_uom, round=False)
         return res
 
     def _get_qty_multiple_to_order(self):

--- a/addons/mrp/models/stock_rule.py
+++ b/addons/mrp/models/stock_rule.py
@@ -169,7 +169,6 @@ class StockRule(models.Model):
             'bom_id': bom.id,
             'date_deadline': date_deadline,
             'date_start': date_planned,
-            'date_finished': fields.Datetime.from_string(values['date_planned']),
             'procurement_group_id': False,
             'propagate_cancel': self.propagate_cancel,
             'orderpoint_id': values.get('orderpoint_id', False) and values.get('orderpoint_id').id,

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -352,6 +352,7 @@ class TestMrpOrder(TestMrpCommon):
         production_form.product_uom_id = self.product_6.uom_id
         production = production_form.save()
         self.assertEqual(production.workorder_ids.duration_expected, 90)
+        self.assertEqual([production.date_finished], production.move_finished_ids.mapped('date'))
         mo_form = Form(production)
         mo_form.product_qty = 3
         production = mo_form.save()


### PR DESCRIPTION
Steps
---
1. install `mrp,sales_management`
2. Create a manufacture-routed product P with a manufacturing BOM:
   * Operation OP1, duration = 1 hr
   * some component
3. Create a reording rule for P with a manufacturing route:
   * min qty = 0
   * max qty = 0
4. Create an SO for 15 > Confirm
   * (A MO for 15 P should have been generated)
6. duplicate the SO > Confirm
   * (The **same** MO is now for 30 P)
7. duplicate the SO > Confirm
=> The MO is for 75 P instead of 45

Cause
---
When the reordering rule is triggered, we attempt create a procurement
for the opposite of the forecast quantity of product P and add it to the
MO.
But the reordering rule's visibility days is 0 (default), so once the
MO's expected finished date (now + qty * 1 hr) is tomorrow or more [1]
we do not consider the quantity coming from the MO for the stock
forecast.
Therefore the procurement is for the sum of all the previous orders for
P (ie 15 * 3 = 45), so the MO's quantity will be 30 + 45 = 75 instead of
30 + 15 = 45

[1] (cf commit 1) There is another bug this PR fixes where the date finished
for MOs is not computed at creation time but only at write time,
therefore, we need to be at least on the 3rd SO for the bug to appear.
(The 2nd one writes to the MO)

Fix
---
When computing the quantity in progress for product P, take into account
MOs such that `date_start <= end_of_orderpoint_forecast < date_finished`

\+ [1] Do compute the finished date at creation when it isn't specified in
the vals and do not specify it in the above flow.

opw-4034475
