### PR TITLE
[FIX] account_edi_ubl_cii, l10n_*: Context manager placed a wrong place on invoice import

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3180,12 +3180,11 @@ class AccountMove(models.Model):
             if decoder:
                 try:
                     with self.env.cr.savepoint():
-                        with current_invoice._get_edi_creation() as invoice:
-                            # pylint: disable=not-callable
-                            success = decoder(invoice, file_data, new)
+                        invoice = current_invoice or self.create({})
+                        success = decoder(invoice, file_data, new)
+
                         if success or file_data['type'] == 'pdf':
                             invoice._link_bill_origin_to_purchase_orders(timeout=4)
-
                             invoices |= invoice
                             current_invoice = self.env['account.move']
                             add_file_data_results(file_data, invoice)
@@ -3196,7 +3195,7 @@ class AccountMove(models.Model):
                     raise
                 except Exception:
                     message = _("Error importing attachment '%s' as invoice (decoder=%s)", file_data['filename'], decoder.__name__)
-                    invoice.sudo().message_post(body=message)
+                    current_invoice.sudo().message_post(body=message)
                     _logger.exception(message)
 
             passed_file_data_list.append(file_data)

--- a/addons/account_edi_ubl_cii/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_common.py
@@ -297,7 +297,8 @@ class AccountEdiCommon(models.AbstractModel):
 
         # Update the invoice.
         invoice.move_type = move_type
-        logs = self._import_fill_invoice_form(invoice, tree, qty_factor)
+        with invoice._get_edi_creation() as invoice:
+            logs = self._import_fill_invoice_form(invoice, tree, qty_factor)
         if invoice:
             body = Markup("<strong>%s</strong>") % \
                 _("Format used to import the invoice: %s",
@@ -312,7 +313,8 @@ class AccountEdiCommon(models.AbstractModel):
         # For UBL, we should override the computed tax amount if it is less than 0.05 different of the one in the xml.
         # In order to support use case where the tax total is adapted for rounding purpose.
         # This has to be done after the first import in order to let Odoo compute the taxes before overriding if needed.
-        self._correct_invoice_tax_amount(tree, invoice)
+        with invoice._get_edi_creation() as invoice:
+            self._correct_invoice_tax_amount(tree, invoice)
 
         # === Import the embedded PDF in the xml if some are found ===
 

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_be.py
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_be.py
@@ -755,7 +755,7 @@ class TestUBLBE(TestUBLCommon, TestAccountMoveSendCommon):
             list_line_discount=[0], list_line_taxes=[tax_21+self.recupel], move_type='out_invoice',
         )
         self._assert_imported_invoice_from_file(
-            subfolder=subfolder, filename='bis3_ecotaxes_case4.xml', amount_total=218.042, amount_tax=39.842,
+            subfolder=subfolder, filename='bis3_ecotaxes_case4.xml', amount_total=218.04, amount_tax=39.84,
             list_line_subtotals=[178.20000000000002], currency_id=self.currency_data['currency'].id,
             list_line_price_unit=[99], list_line_discount=[10], list_line_taxes=[tax_21+self.recupel],
             move_type='out_invoice',

--- a/addons/l10n_it_edi/models/account_move.py
+++ b/addons/l10n_it_edi/models/account_move.py
@@ -807,219 +807,220 @@ class AccountMove(models.Model):
         :param is_new: whether the move is newly created or to be updated
         :returns:      the imported move
         """
-        buyer_seller_info = self._l10n_it_buyer_seller_info()
+        with self._get_edi_creation() as self:
+            buyer_seller_info = self._l10n_it_buyer_seller_info()
 
-        tree = data['xml_tree']
-        company = self.company_id
+            tree = data['xml_tree']
+            company = self.company_id
 
-        # There are 2 cases:
-        # - cron:
-        #     * Move direction (incoming / outgoing) flexible (no 'default_move_type')
-        #     * I.e. used for import from tax agency
-        # - "Upload" button (invoices / bills view)
-        #     * Fixed move direction; the button sets the 'default_move_type'
-        default_move_type = self.env.context.get('default_move_type')
-        if default_move_type is None:
-            incoming_possibilities = [True, False]
-        elif default_move_type in invoice.get_purchase_types(include_receipts=True):
-            incoming_possibilities = [True]
-        elif default_move_type in invoice.get_sale_types(include_receipts=True):
-            incoming_possibilities = [False]
-        else:
-            _logger.warning("Cannot handle default_move_type '%s'.", default_move_type)
-            return
+            # There are 2 cases:
+            # - cron:
+            #     * Move direction (incoming / outgoing) flexible (no 'default_move_type')
+            #     * I.e. used for import from tax agency
+            # - "Upload" button (invoices / bills view)
+            #     * Fixed move direction; the button sets the 'default_move_type'
+            default_move_type = self.env.context.get('default_move_type')
+            if default_move_type is None:
+                incoming_possibilities = [True, False]
+            elif default_move_type in invoice.get_purchase_types(include_receipts=True):
+                incoming_possibilities = [True]
+            elif default_move_type in invoice.get_sale_types(include_receipts=True):
+                incoming_possibilities = [False]
+            else:
+                _logger.warning("Cannot handle default_move_type '%s'.", default_move_type)
+                return
 
-        for incoming in incoming_possibilities:
-            company_role, partner_role = ('buyer', 'seller') if incoming else ('seller', 'buyer')
-            company_info = buyer_seller_info[company_role]
-            vat = get_text(tree, company_info['vat_xpath'])
-            if vat and vat .casefold() in (company.vat or '').casefold():
-                break
-            codice_fiscale = get_text(tree, company_info['codice_fiscale_xpath'])
-            if codice_fiscale and codice_fiscale.casefold() in (company.l10n_it_codice_fiscale or '').casefold():
-                break
-        else:
-            invoice.message_post(body=_("Your company's VAT number and Fiscal Code haven't been found in the buyer and/or seller sections inside the document."))
-            return
+            for incoming in incoming_possibilities:
+                company_role, partner_role = ('buyer', 'seller') if incoming else ('seller', 'buyer')
+                company_info = buyer_seller_info[company_role]
+                vat = get_text(tree, company_info['vat_xpath'])
+                if vat and vat .casefold() in (company.vat or '').casefold():
+                    break
+                codice_fiscale = get_text(tree, company_info['codice_fiscale_xpath'])
+                if codice_fiscale and codice_fiscale.casefold() in (company.l10n_it_codice_fiscale or '').casefold():
+                    break
+            else:
+                invoice.message_post(body=_("Your company's VAT number and Fiscal Code haven't been found in the buyer and/or seller sections inside the document."))
+                return
 
-        # For unsupported document types, just assume in_invoice, and log that the type is unsupported
-        document_type = get_text(tree, '//DatiGeneraliDocumento/TipoDocumento')
-        move_type = self._l10n_it_edi_document_type_mapping().get(document_type, {}).get('import_type')
-        if not move_type:
-            move_type = "in_invoice"
-            _logger.info('Document type not managed: %s. Invoice type is set by default.', document_type)
-        if not incoming and move_type.startswith('in_'):
-            move_type = 'out' + move_type[2:]
+            # For unsupported document types, just assume in_invoice, and log that the type is unsupported
+            document_type = get_text(tree, '//DatiGeneraliDocumento/TipoDocumento')
+            move_type = self._l10n_it_edi_document_type_mapping().get(document_type, {}).get('import_type')
+            if not move_type:
+                move_type = "in_invoice"
+                _logger.info('Document type not managed: %s. Invoice type is set by default.', document_type)
+            if not incoming and move_type.startswith('in_'):
+                move_type = 'out' + move_type[2:]
 
-        self.move_type = move_type
+            self.move_type = move_type
 
-        if self.name and self.name != '/':
-            # the journal might've changed, so we need to recompute the name in case it was set (first entry in journal)
-            self.name = False
-            self._compute_name()
+            if self.name and self.name != '/':
+                # the journal might've changed, so we need to recompute the name in case it was set (first entry in journal)
+                self.name = False
+                self._compute_name()
 
-        # Collect extra info from the XML that may be used by submodules to further put information on the invoice lines
-        extra_info, message_to_log = self._l10n_it_edi_get_extra_info(company, document_type, tree, incoming=incoming)
+            # Collect extra info from the XML that may be used by submodules to further put information on the invoice lines
+            extra_info, message_to_log = self._l10n_it_edi_get_extra_info(company, document_type, tree, incoming=incoming)
 
-        # Partner
-        partner_info = buyer_seller_info[partner_role]
-        vat = get_text(tree, partner_info['vat_xpath'])
-        codice_fiscale = get_text(tree, partner_info['codice_fiscale_xpath'])
-        email = get_text(tree, '//DatiTrasmissione//Email') if partner_info['role'] == 'seller' else ''
-        if partner := self._l10n_it_edi_search_partner(company, vat, codice_fiscale, email):
-            self.partner_id = partner
-        else:
-            message = Markup("<br/>").join((
-                _("Partner not found, useful informations from XML file:"),
-                self._compose_info_message(tree, partner_info['section_xpath'])
-            ))
-            message_to_log.append(message)
-
-        # Numbering attributed by the transmitter
-        if progressive_id := get_text(tree, '//ProgressivoInvio'):
-            self.payment_reference = progressive_id
-
-        # Document Number
-        if number := get_text(tree, './/DatiGeneraliDocumento//Numero'):
-            self.ref = number
-
-        # Currency
-        if currency_str := get_text(tree, './/DatiGeneraliDocumento/Divisa'):
-            currency = self.env.ref('base.%s' % currency_str.upper(), raise_if_not_found=False)
-            if currency != self.env.company.currency_id and currency.active:
-                self.currency_id = currency
-
-        # Date
-        if document_date := get_date(tree, './/DatiGeneraliDocumento/Data'):
-            self.invoice_date = document_date
-        else:
-            message_to_log.append(_("Document date invalid in XML file: %s", document_date))
-
-        # Stamp Duty
-        if stamp_duty := get_text(tree, './/DatiGeneraliDocumento/DatiBollo/ImportoBollo'):
-            self.l10n_it_stamp_duty = float(stamp_duty)
-
-        # Comment
-        for narration in get_text(tree, './/DatiGeneraliDocumento//Causale', many=True):
-            self.narration = '%s%s<br/>' % (self.narration or '', narration)
-
-        # Informations relative to the purchase order, the contract, the agreement,
-        # the reception phase or invoices previously transmitted
-        # <2.1.2> - <2.1.6>
-        for document_type in ['DatiOrdineAcquisto', 'DatiContratto', 'DatiConvenzione', 'DatiRicezione', 'DatiFattureCollegate']:
-            for element in tree.xpath('.//DatiGenerali/' + document_type):
-                message = Markup("{} {}<br/>{}").format(document_type, _("from XML file:"), self._compose_info_message(element, '.'))
+            # Partner
+            partner_info = buyer_seller_info[partner_role]
+            vat = get_text(tree, partner_info['vat_xpath'])
+            codice_fiscale = get_text(tree, partner_info['codice_fiscale_xpath'])
+            email = get_text(tree, '//DatiTrasmissione//Email') if partner_info['role'] == 'seller' else ''
+            if partner := self._l10n_it_edi_search_partner(company, vat, codice_fiscale, email):
+                self.partner_id = partner
+            else:
+                message = Markup("<br/>").join((
+                    _("Partner not found, useful informations from XML file:"),
+                    self._compose_info_message(tree, partner_info['section_xpath'])
+                ))
                 message_to_log.append(message)
 
-        #  Dati DDT. <2.1.8>
-        if elements := tree.xpath('.//DatiGenerali/DatiDDT'):
-            message = Markup("<br/>").join((
-                _("Transport informations from XML file:"),
-                self._compose_info_message(tree, './/DatiGenerali/DatiDDT')
-            ))
-            message_to_log.append(message)
+            # Numbering attributed by the transmitter
+            if progressive_id := get_text(tree, '//ProgressivoInvio'):
+                self.payment_reference = progressive_id
 
-        # Due date. <2.4.2.5>
-        if due_date := get_date(tree, './/DatiPagamento/DettaglioPagamento/DataScadenzaPagamento'):
-            self.invoice_date_due = fields.Date.to_string(due_date)
-        else:
-            message_to_log.append(_("Payment due date invalid in XML file: %s", str(due_date)))
+            # Document Number
+            if number := get_text(tree, './/DatiGeneraliDocumento//Numero'):
+                self.ref = number
 
-        # Information related to the purchase order <2.1.2>
-        if (po_refs := get_text(tree, '//DatiGenerali/DatiOrdineAcquisto/IdDocumento', many=True)):
-            self.invoice_origin = ", ".join(po_refs)
+            # Currency
+            if currency_str := get_text(tree, './/DatiGeneraliDocumento/Divisa'):
+                currency = self.env.ref('base.%s' % currency_str.upper(), raise_if_not_found=False)
+                if currency != self.env.company.currency_id and currency.active:
+                    self.currency_id = currency
 
-        # Total amount. <2.4.2.6>
-        if amount_total := sum([float(x) for x in get_text(tree, './/ImportoPagamento', many=True) if x]):
-            message_to_log.append(_("Total amount from the XML File: %s", amount_total))
+            # Date
+            if document_date := get_date(tree, './/DatiGeneraliDocumento/Data'):
+                self.invoice_date = document_date
+            else:
+                message_to_log.append(_("Document date invalid in XML file: %s", document_date))
 
-        # Bank account. <2.4.2.13>
-        if self.move_type not in ('out_invoice', 'in_refund'):
-            if acc_number := get_text(tree, './/DatiPagamento/DettaglioPagamento/IBAN'):
-                if self.partner_id and self.partner_id.commercial_partner_id:
-                    bank = self.env['res.partner.bank'].search([
-                        ('acc_number', '=', acc_number),
-                        ('partner_id', '=', self.partner_id.commercial_partner_id.id),
-                        ('company_id', 'in', [self.company_id.id, False])
-                    ], order='company_id', limit=1)
-                else:
-                    bank = self.env['res.partner.bank'].search([
-                        ('acc_number', '=', acc_number),
-                        ('company_id', 'in', [self.company_id.id, False])
-                    ], order='company_id', limit=1)
-                if bank:
-                    self.partner_bank_id = bank
-                else:
-                    message = Markup("<br/>").join((
-                        _("Bank account not found, useful informations from XML file:"),
-                        self._compose_info_message(tree, [
-                            './/DatiPagamento//Beneficiario',
-                            './/DatiPagamento//IstitutoFinanziario',
-                            './/DatiPagamento//IBAN',
-                            './/DatiPagamento//ABI',
-                            './/DatiPagamento//CAB',
-                            './/DatiPagamento//BIC',
-                            './/DatiPagamento//ModalitaPagamento'
-                        ])
-                    ))
+            # Stamp Duty
+            if stamp_duty := get_text(tree, './/DatiGeneraliDocumento/DatiBollo/ImportoBollo'):
+                self.l10n_it_stamp_duty = float(stamp_duty)
+
+            # Comment
+            for narration in get_text(tree, './/DatiGeneraliDocumento//Causale', many=True):
+                self.narration = '%s%s<br/>' % (self.narration or '', narration)
+
+            # Informations relative to the purchase order, the contract, the agreement,
+            # the reception phase or invoices previously transmitted
+            # <2.1.2> - <2.1.6>
+            for document_type in ['DatiOrdineAcquisto', 'DatiContratto', 'DatiConvenzione', 'DatiRicezione', 'DatiFattureCollegate']:
+                for element in tree.xpath('.//DatiGenerali/' + document_type):
+                    message = Markup("{} {}<br/>{}").format(document_type, _("from XML file:"), self._compose_info_message(element, '.'))
                     message_to_log.append(message)
-        elif elements := tree.xpath('.//DatiPagamento/DettaglioPagamento'):
-            message = Markup("<br/>").join((
-                _("Bank account not found, useful informations from XML file:"),
-                self._compose_info_message(tree, './/DatiPagamento')
-            ))
-            message_to_log.append(message)
 
-        # Invoice lines. <2.2.1>
-        tag_name = './/DettaglioLinee' if not extra_info['simplified'] else './/DatiBeniServizi'
-        for element in tree.xpath(tag_name):
-            move_line = self.invoice_line_ids.create({
-                'move_id': self.id,
-                'tax_ids': [fields.Command.clear()]})
-            if move_line:
-                message_to_log += self._l10n_it_edi_import_line(element, move_line, extra_info)
+            #  Dati DDT. <2.1.8>
+            if elements := tree.xpath('.//DatiGenerali/DatiDDT'):
+                message = Markup("<br/>").join((
+                    _("Transport informations from XML file:"),
+                    self._compose_info_message(tree, './/DatiGenerali/DatiDDT')
+                ))
+                message_to_log.append(message)
 
-        # Global discount summarized in 1 amount
-        if discount_elements := tree.xpath('.//DatiGeneraliDocumento/ScontoMaggiorazione'):
-            taxable_amount = float(self.tax_totals['amount_untaxed'])
-            discounted_amount = taxable_amount
-            for discount_element in discount_elements:
-                discount_sign = 1
-                if (discount_type := discount_element.xpath('.//Tipo')) and discount_type[0].text == 'MG':
-                    discount_sign = -1
-                if discount_amount := get_text(discount_element, './/Importo'):
-                    discounted_amount -= discount_sign * float(discount_amount)
-                    continue
-                if discount_percentage := get_text(discount_element, './/Percentuale'):
-                    discounted_amount *= 1 - discount_sign * float(discount_percentage) / 100
+            # Due date. <2.4.2.5>
+            if due_date := get_date(tree, './/DatiPagamento/DettaglioPagamento/DataScadenzaPagamento'):
+                self.invoice_date_due = fields.Date.to_string(due_date)
+            else:
+                message_to_log.append(_("Payment due date invalid in XML file: %s", str(due_date)))
 
-            general_discount = discounted_amount - taxable_amount
-            sequence = len(elements) + 1
+            # Information related to the purchase order <2.1.2>
+            if (po_refs := get_text(tree, '//DatiGenerali/DatiOrdineAcquisto/IdDocumento', many=True)):
+                self.invoice_origin = ", ".join(po_refs)
 
-            self.invoice_line_ids = [Command.create({
-                'sequence': sequence,
-                'name': 'SCONTO' if general_discount < 0 else 'MAGGIORAZIONE',
-                'price_unit': general_discount,
-            })]
+            # Total amount. <2.4.2.6>
+            if amount_total := sum(float(x) for x in get_text(tree, './/ImportoPagamento', many=True) if x):
+                message_to_log.append(_("Total amount from the XML File: %s", amount_total))
 
-        for element in tree.xpath('.//Allegati'):
-            attachment_64 = self.env['ir.attachment'].create({
-                'name': get_text(element, './/NomeAttachment'),
-                'datas': str.encode(get_text(element, './/Attachment')),
-                'type': 'binary',
-                'res_model': 'account.move',
-                'res_id': self.id,
-            })
+            # Bank account. <2.4.2.13>
+            if self.move_type not in ('out_invoice', 'in_refund'):
+                if acc_number := get_text(tree, './/DatiPagamento/DettaglioPagamento/IBAN'):
+                    if self.partner_id and self.partner_id.commercial_partner_id:
+                        bank = self.env['res.partner.bank'].search([
+                            ('acc_number', '=', acc_number),
+                            ('partner_id', '=', self.partner_id.commercial_partner_id.id),
+                            ('company_id', 'in', [self.company_id.id, False])
+                        ], order='company_id', limit=1)
+                    else:
+                        bank = self.env['res.partner.bank'].search([
+                            ('acc_number', '=', acc_number),
+                            ('company_id', 'in', [self.company_id.id, False])
+                        ], order='company_id', limit=1)
+                    if bank:
+                        self.partner_bank_id = bank
+                    else:
+                        message = Markup("<br/>").join((
+                            _("Bank account not found, useful informations from XML file:"),
+                            self._compose_info_message(tree, [
+                                './/DatiPagamento//Beneficiario',
+                                './/DatiPagamento//IstitutoFinanziario',
+                                './/DatiPagamento//IBAN',
+                                './/DatiPagamento//ABI',
+                                './/DatiPagamento//CAB',
+                                './/DatiPagamento//BIC',
+                                './/DatiPagamento//ModalitaPagamento'
+                            ])
+                        ))
+                        message_to_log.append(message)
+            elif elements := tree.xpath('.//DatiPagamento/DettaglioPagamento'):
+                message = Markup("<br/>").join((
+                    _("Bank account not found, useful informations from XML file:"),
+                    self._compose_info_message(tree, './/DatiPagamento')
+                ))
+                message_to_log.append(message)
 
-            # no_new_invoice to prevent from looping on the.message_post that would create a new invoice without it
-            self.with_context(no_new_invoice=True).sudo().message_post(
-                body=(_("Attachment from XML")),
-                attachment_ids=[attachment_64.id],
-            )
+            # Invoice lines. <2.2.1>
+            tag_name = './/DettaglioLinee' if not extra_info['simplified'] else './/DatiBeniServizi'
+            for element in tree.xpath(tag_name):
+                move_line = self.invoice_line_ids.create({
+                    'move_id': self.id,
+                    'tax_ids': [fields.Command.clear()]})
+                if move_line:
+                    message_to_log += self._l10n_it_edi_import_line(element, move_line, extra_info)
 
-        for message in message_to_log:
-            self.sudo().message_post(body=message)
-        return self
+            # Global discount summarized in 1 amount
+            if discount_elements := tree.xpath('.//DatiGeneraliDocumento/ScontoMaggiorazione'):
+                taxable_amount = float(self.tax_totals['amount_untaxed'])
+                discounted_amount = taxable_amount
+                for discount_element in discount_elements:
+                    discount_sign = 1
+                    if (discount_type := discount_element.xpath('.//Tipo')) and discount_type[0].text == 'MG':
+                        discount_sign = -1
+                    if discount_amount := get_text(discount_element, './/Importo'):
+                        discounted_amount -= discount_sign * float(discount_amount)
+                        continue
+                    if discount_percentage := get_text(discount_element, './/Percentuale'):
+                        discounted_amount *= 1 - discount_sign * float(discount_percentage) / 100
+
+                general_discount = discounted_amount - taxable_amount
+                sequence = len(elements) + 1
+
+                self.invoice_line_ids = [Command.create({
+                    'sequence': sequence,
+                    'name': 'SCONTO' if general_discount < 0 else 'MAGGIORAZIONE',
+                    'price_unit': general_discount,
+                })]
+
+            for element in tree.xpath('.//Allegati'):
+                attachment_64 = self.env['ir.attachment'].create({
+                    'name': get_text(element, './/NomeAttachment'),
+                    'datas': str.encode(get_text(element, './/Attachment')),
+                    'type': 'binary',
+                    'res_model': 'account.move',
+                    'res_id': self.id,
+                })
+
+                # no_new_invoice to prevent from looping on the.message_post that would create a new invoice without it
+                self.with_context(no_new_invoice=True).sudo().message_post(
+                    body=(_("Attachment from XML")),
+                    attachment_ids=[attachment_64.id],
+                )
+
+            for message in message_to_log:
+                self.sudo().message_post(body=message)
+            return self
 
     @api.model
     def _is_prediction_enabled(self):


### PR DESCRIPTION
When importing an invoice in account_edi_ubl_cii there is a function `_correct_invoice_tax_amount` that if there is a rounding error on the tax line then it would correct it. That method was using tax_line_id but as the context manager was placed in a scope above, dynamic lines wouldn't be still generated and so wouldn't work.

The fix was to remove the context manager from above and replace it in the actual scope. This had to ensure that all other import methods such as it_edi, es_edi, ... would have the context manager in their import functions.

opw-4019601
related: https://github.com/odoo/enterprise/pull/67002
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
