### PR TITLE
[IMP] pos: Weighting pop-up Price/kg consistent with tax incl/excl

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/scale_screen/scale_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/scale_screen/scale_screen.js
@@ -3,6 +3,10 @@ import { usePos } from "@point_of_sale/app/store/pos_hook";
 import { Component, onMounted, onWillUnmount, useState } from "@odoo/owl";
 import { Dialog } from "@web/core/dialog/dialog";
 import { useService } from "@web/core/utils/hooks";
+import {
+    getTaxesAfterFiscalPosition,
+    getTaxesValues,
+} from "@point_of_sale/app/models/utils/tax_utils";
 
 export class ScaleScreen extends Component {
     static template = "point_of_sale.ScaleScreen";
@@ -11,12 +15,12 @@ export class ScaleScreen extends Component {
         getPayload: Function,
         product: Object,
         close: Function,
+        taxIncluded: Boolean,
     };
     setup() {
         this.pos = usePos();
         this.hardwareProxy = useService("hardware_proxy");
         this.state = useState({ weight: 0, tare: 0, tareLoading: false });
-        this.pricePerUom = this.props.product.get_price(this._activePricelist, 1);
         onMounted(this.onMounted);
         onWillUnmount(this.onWillUnmount);
     }
@@ -77,11 +81,7 @@ export class ScaleScreen extends Component {
         return unit;
     }
     get computedPriceString() {
-        return this.env.utils.formatCurrency(this.netWeight * this.pricePerUom);
-    }
-    get productPrice() {
-        const product = this.props.product;
-        return (product ? product.get_price(this._activePricelist, this.state.weight) : 0) || 0;
+        return this.env.utils.formatCurrency(this.netWeight * this.productUnitPrice);
     }
     get productUom() {
         return this.props.product?.uom_id?.name;
@@ -93,5 +93,31 @@ export class ScaleScreen extends Component {
         setTimeout(() => {
             this.state.tareLoading = false;
         }, 3000);
+    }
+    get productUnitPrice() {
+        const product = this.props.product;
+        const priceUnit = product.get_price(this._activePricelist, 1);
+        let taxes = product.taxes_id;
+        if (this.pos.get_order().fiscal_position_id) {
+            taxes = getTaxesAfterFiscalPosition(
+                taxes,
+                this.pos.get_order().fiscal_position_id,
+                this.pos.models
+            );
+        }
+        const taxesData = getTaxesValues(
+            taxes,
+            priceUnit,
+            1,
+            product,
+            this.pos.config._product_default_values,
+            this.pos.company,
+            this.pos.currency
+        );
+        if (this.props.taxIncluded) {
+            return taxesData.total_included;
+        } else {
+            return taxesData.total_excluded;
+        }
     }
 }

--- a/addons/point_of_sale/static/src/app/screens/scale_screen/scale_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/scale_screen/scale_screen.xml
@@ -38,7 +38,7 @@
                 </div>
                 <div class="d-flex px-5 flex-row gap-2 m-2 align-items-center">
                     <div class="product-price w-50 fs-2 text-center"
-                        t-esc="env.utils.formatCurrency(productPrice) + '/' + productUom" />
+                        t-esc="productUnitPrice + '/' + productUom" />
                     <div class="computed-price fd-flex flex-grow-1 p-3 rounded text-center text-bg-info bg-opacity-25 text-info fs-2 fw-bold" t-esc="computedPriceString" />
                 </div>
             </div>

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -690,6 +690,7 @@ export class PosStore extends Reactive {
             if (values.product_id.isScaleAvailable) {
                 const weight = await makeAwaitable(this.env.services.dialog, ScaleScreen, {
                     product: values.product_id,
+                    taxIncluded: this.config.iface_tax_included === "total",
                 });
                 if (!weight) {
                     return;


### PR DESCRIPTION
Adjusted the display logic in the weighting pop-up to reflect whether taxes are included or excluded based on the PoS configuration.

Task ID: 4034961




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
