### PR TITLE
[FIX] website_sale_delivery: check carrier before payment

### DIFF
--- a/addons/delivery/models/sale_order.py
+++ b/addons/delivery/models/sale_order.py
@@ -53,6 +53,7 @@ class SaleOrder(models.Model):
                 + '\n'.join(['- %s: %s x %s' % (line.product_id.with_context(display_default_code=False).display_name, line.qty_invoiced, line.price_unit) for line in delivery_lines])
             )
         to_delete.unlink()
+        self.carrier_id = self.env['delivery.carrier']  # reset carrier
 
     def set_delivery_line(self, carrier, amount):
 

--- a/addons/website_sale_delivery/controllers/main.py
+++ b/addons/website_sale_delivery/controllers/main.py
@@ -3,8 +3,8 @@
 
 from odoo import http, _
 from odoo.http import request
-from odoo.addons.website_sale.controllers.main import WebsiteSale
-from odoo.exceptions import UserError
+from odoo.addons.website_sale.controllers.main import WebsiteSale, PaymentPortal
+from odoo.exceptions import UserError, ValidationError
 
 
 class WebsiteSaleDelivery(WebsiteSale):
@@ -133,3 +133,13 @@ class WebsiteSaleDelivery(WebsiteSale):
                 'new_amount_total_raw': order.amount_total,
             }
         return {}
+
+
+class PaymentPortalDelivery(PaymentPortal):
+
+    @http.route()
+    def shop_payment_transaction(self, *args, **kwargs):
+        order = request.website.sale_get_order()
+        if not order.only_services and not order.carrier_id:
+            raise ValidationError(_("No shipping method is selected."))
+        return super().shop_payment_transaction(*args, **kwargs)

--- a/addons/website_sale_delivery/i18n/website_sale_delivery.pot
+++ b/addons/website_sale_delivery/i18n/website_sale_delivery.pot
@@ -126,6 +126,12 @@ msgid ""
 msgstr ""
 
 #. module: website_sale_delivery
+#: code:addons/website_sale_delivery/controllers/main.py:0
+#, python-format
+msgid "No shipping method is selected."
+msgstr ""
+
+#. module: website_sale_delivery
 #: model_terms:ir.ui.view,arch_db:website_sale_delivery.view_delivery_carrier_search_inherit_website_sale_delivery
 msgid "Published"
 msgstr ""

--- a/addons/website_sale_delivery/tests/test_controller.py
+++ b/addons/website_sale_delivery/tests/test_controller.py
@@ -5,9 +5,10 @@ from unittest.mock import patch
 
 from odoo.exceptions import UserError, ValidationError
 from odoo.addons.payment.tests.common import PaymentCommon
-from odoo.addons.website_sale_delivery.controllers.main import WebsiteSaleDelivery
+from odoo.addons.website_sale_delivery.controllers.main import WebsiteSaleDelivery, PaymentPortalDelivery
 from odoo.addons.website.tools import MockRequest
 from odoo.tests import tagged
+from odoo.fields import Command
 
 @tagged('post_install', '-at_install')
 class TestWebsiteSaleDeliveryController(PaymentCommon):
@@ -76,3 +77,22 @@ class TestWebsiteSaleDeliveryController(PaymentCommon):
             self.Controller.cart_update_json(product_id=storable_product.id, add_qty=1)
             with self.assertRaises(ValidationError):
                 self.Controller.shop_payment_validate()
+
+    def test_check_order_delivery_before_payment(self):
+        product = self.env['product.product'].create({
+            'name': 'Test Product',
+            'sale_ok': True,
+            'website_published': True,
+            'lst_price': 1000.0,
+            'standard_price': 800.0,
+        })
+        website = self.website.with_user(self.public_user)
+        with MockRequest(product.with_user(self.public_user).env, website=website):
+            sale_order = self.env['sale.order'].create({
+                'partner_id': self.public_user.id,
+                'order_line': [Command.create({'product_id': product.id})],
+                'access_token': 'test_token',
+            })
+            # Try processing payment with a storable product and no carrier_id
+            with self.assertRaises(ValidationError):
+                PaymentPortalDelivery().shop_payment_transaction(sale_order.id, sale_order.access_token)


### PR DESCRIPTION
Check if the user selected the carrier for storable/consumable products before proceeding to payment.

Backport of [35ea9bf](https://github.com/odoo/odoo/commit/35ea9bfb)

opw-3861697
