### PR TITLE
[IMP] l10n_in*: prepare GSTR JSON and Determine GSTR Section

### DIFF
--- a/addons/l10n_in/models/__init__.py
+++ b/addons/l10n_in/models/__init__.py
@@ -10,3 +10,4 @@ from . import res_config_settings
 from . import res_country_state
 from . import res_partner
 from . import uom_uom
+from . import product_product

--- a/addons/l10n_in/models/account_invoice.py
+++ b/addons/l10n_in/models/account_invoice.py
@@ -221,6 +221,24 @@ class AccountMove(models.Model):
             for tag_name in tags_name
         }
 
+    @api.model
+    def _l10n_in_round_value(self, amount, precision_digits=2):
+        """
+            This method is call for rounding.
+            If anything is wrong with rounding then we quick fix in method
+        """
+        value = round(amount, precision_digits)
+        # avoid -0.0
+        return value or 0.0
+
+    @api.model
+    def _l10n_in_extract_digits(self, string):
+        if not string:
+            return string
+        matches = re.findall(r"\d+", string)
+        result = "".join(matches)
+        return result
+
     def _get_name_invoice_report(self):
         self.ensure_one()
         if self.country_code == 'IN':
@@ -272,7 +290,7 @@ class AccountMove(models.Model):
                 if line.product_id.type != 'service':
                     uqc = line.product_uom_id.l10n_in_code and line.product_uom_id.l10n_in_code.split("-")[0] or "OTH"
                 lines_json = {
-                    'hsn_sc': line.l10n_in_hsn_code,
+                    'hsn_sc': self._l10n_in_extract_digits(line.l10n_in_hsn_code),
                     'uqc': uqc,
                     'product_type': line.product_id.type,
                     'qty': line.quantity,

--- a/addons/l10n_in/models/account_invoice.py
+++ b/addons/l10n_in/models/account_invoice.py
@@ -7,6 +7,20 @@ from odoo import api, fields, models, _
 from odoo.exceptions import ValidationError, RedirectWarning, UserError
 from odoo.tools.image import image_data_uri
 
+GSTR_SECTION_SELECTION = [
+    ('b2b_regular', 'B2B Regular'),
+    ('b2b_reverse_charge', 'B2B Reverse Charge'),
+    ('b2cl', 'B2CL(Large)'),
+    ('expwp', 'Export With Payment'),
+    ('expwop', 'Export Without Payment'),
+    ('sezwp', 'Special Economic Zone With Payment'),
+    ('sezwop', 'Special Economic Zone Without Payment'),
+    ('de', 'Deemed Export'),
+    ('b2cs', 'B2CS(Others)'),
+    ('cdnr', 'Credit/Debit Notes Registered'),
+    ('cdnur', 'Credit/Debit Notes Unregistered'),
+]
+
 
 class AccountMove(models.Model):
     _inherit = "account.move"
@@ -30,6 +44,84 @@ class AccountMove(models.Model):
     l10n_in_reseller_partner_id = fields.Many2one('res.partner', 'Reseller', domain=[('vat', '!=', False)], help="Only Registered Reseller")
     l10n_in_journal_type = fields.Selection(string="Journal Type", related='journal_id.type')
     l10n_in_hsn_code_warning = fields.Json(compute="_compute_hsn_code_warning")
+    l10n_in_gstr_json = fields.Json(string='GSTR JSON', copy=False)
+    l10n_in_gstr_section = fields.Selection(selection=GSTR_SECTION_SELECTION, string="GSTR Section", compute="_compute_gstr_section", store=True, readonly=False)
+    has_nil_exempt_nongst = fields.Boolean(
+        string='Has Nil Rated, Exempt or Non Gst Supplies',
+        compute='_compute_has_nil_exempt_nongst',
+        store=True
+    )
+
+    @api.depends('invoice_line_ids', 'invoice_line_ids.tax_ids', 'l10n_in_gst_treatment', 'move_type')
+    def _compute_has_nil_exempt_nongst(self):
+        taxes_tag_ids = self._get_l10n_in_taxes_tags_id_by_name()
+        nil_exempt_nongst_tags = [taxes_tag_ids[key] for key in ['exempt', 'nil_rated', 'non_gst_supplies']]
+        for record in self:
+            record.has_nil_exempt_nongst = record.l10n_in_gst_treatment not in ('overseas', 'special_economic_zone') \
+                and record.move_type in ('out_invoice', 'out_refund', 'out_receipt') \
+                and any(tag in nil_exempt_nongst_tags for tag in record.invoice_line_ids.tax_tag_ids.ids)
+
+    @api.depends('partner_id', 'invoice_line_ids', 'amount_total', 'invoice_line_ids.tax_ids.l10n_in_reverse_charge',
+        'move_type', 'state', 'l10n_in_gst_treatment', 'l10n_in_state_id', 'invoice_line_ids.tax_ids', 'debit_origin_id')
+    def _compute_gstr_section(self):
+        taxes_tag_ids = self._get_l10n_in_taxes_tags_id_by_name()
+        igst_tag_ids = [taxes_tag_ids['base_igst'], taxes_tag_ids['igst']]
+        cess_tag_ids = [taxes_tag_ids['base_cess'], taxes_tag_ids['cess']]
+        gst_tags = igst_tag_ids + cess_tag_ids + [taxes_tag_ids[key] for key in ['base_sgst', 'sgst', 'base_cgst', 'cgst']]
+        nil_and_gst_tags = gst_tags + [taxes_tag_ids[key] for key in ['exempt', 'nil_rated', 'non_gst_supplies']]
+        export_tags = igst_tag_ids + [taxes_tag_ids['zero_rated']] + cess_tag_ids
+        for record in self:
+            gstr_section = ''
+            move_type = record.move_type
+            l10n_in_gst_treatment = record.l10n_in_gst_treatment
+
+            # Determine interstate and intra state conditions
+            is_interstate = record.country_code == "IN" and record.l10n_in_state_id and record.l10n_in_state_id != record.company_id.state_id
+            is_intrastate = record.country_code == "IN" and record.l10n_in_state_id and record.l10n_in_state_id == record.company_id.state_id
+
+            # Detemine line tag and gst related conditions
+            line_tags = record.invoice_line_ids.tax_tag_ids
+            has_gst_tags = any(tag in gst_tags for tag in line_tags.ids)
+            igst_amount = any('IGST' in tag.name for tag in line_tags)
+
+            # Determine the treatment conditions
+            is_unregistered_or_consumer = l10n_in_gst_treatment in ('unregistered', 'consumer')
+            is_b2c_interstate = is_unregistered_or_consumer and is_interstate and (
+                (record.reversed_entry_id and record.reversed_entry_id.amount_total > 250000) or
+                (record.debit_origin_id and record.debit_origin_id.amount_total > 250000) or
+                record.amount_total > 250000)
+            is_regular_or_uin_holder_or_composition = l10n_in_gst_treatment in ("regular", "uin_holders", "composition")
+
+            # Determine move type condition
+            move_type_is_invoice_receipt_refund = move_type in ['out_invoice', 'out_receipt', 'out_refund']
+            move_type_is_invoice_receipt_no_debit = move_type in ['out_invoice', 'out_receipt'] and not record.debit_origin_id and has_gst_tags
+            move_type_is_refund_or_invoice_with_debit = (move_type == 'out_refund' or (move_type == 'out_invoice' and record.debit_origin_id)) and has_gst_tags
+
+            # Conditions for determining l10n_in_gstr_section
+            conditions = [
+                (move_type_is_invoice_receipt_refund and (
+                    (l10n_in_gst_treatment == 'overseas' and any(tag in export_tags for tag in line_tags.ids)) or
+                    (l10n_in_gst_treatment in ('special_economic_zone', 'deemed_export') and any(tag_id == taxes_tag_ids['zero_rated'] for tag_id in line_tags.ids))),
+                    'expwp' if igst_amount else 'expwop'),
+                (move_type_is_invoice_receipt_refund and l10n_in_gst_treatment == 'special_economic_zone' and nil_and_gst_tags,
+                    'sezwp' if igst_amount else 'sezwop'),
+                (move_type_is_invoice_receipt_refund and l10n_in_gst_treatment == 'deemed_export' and has_gst_tags, 'de'),
+                (move_type_is_invoice_receipt_no_debit and is_regular_or_uin_holder_or_composition,
+                    'b2b_reverse_charge' if any(tax.l10n_in_reverse_charge for line in record.invoice_line_ids for tax in line.tax_ids) else 'b2b_regular'),
+                (move_type_is_invoice_receipt_no_debit and is_b2c_interstate, 'b2cl'),
+                (move_type_is_invoice_receipt_refund and is_unregistered_or_consumer and has_gst_tags and (
+                    is_intrastate or (is_interstate and record.amount_total <= 250000)), 'b2cs'),
+                (move_type_is_refund_or_invoice_with_debit and is_regular_or_uin_holder_or_composition, 'cdnr'),
+                (move_type_is_refund_or_invoice_with_debit and is_b2c_interstate, 'cdnur'),
+            ]
+
+            # Evaluate conditions
+            for condition, section in conditions:
+                if condition:
+                    gstr_section = section
+                    break
+
+            record.l10n_in_gstr_section = gstr_section
 
     @api.depends('partner_id', 'partner_id.l10n_in_gst_treatment', 'state')
     def _compute_l10n_in_gst_treatment(self):
@@ -119,6 +211,16 @@ class AccountMove(models.Model):
                 move.l10n_in_hsn_code_warning = {}
         (self - indian_invoice).l10n_in_hsn_code_warning = {}
 
+    @api.model
+    def _get_l10n_in_taxes_tags_id_by_name(self, only_gst_tags=False):
+        tags_name = ['sgst', 'cgst', 'igst', 'cess']
+        if not only_gst_tags:
+            tags_name += [f'base_{tax_name}' for tax_name in tags_name] + ['zero_rated', 'exempt', 'nil_rated', 'non_gst_supplies']
+        return {
+            tag_name: self.env['ir.model.data']._xmlid_to_res_id(f"l10n_in.tax_tag_{tag_name}")
+            for tag_name in tags_name
+        }
+
     def _get_name_invoice_report(self):
         self.ensure_one()
         if self.country_code == 'IN':
@@ -152,7 +254,52 @@ class AccountMove(models.Model):
                     partner_id=move.partner_id.id,
                     name=gst_treatment_name_mapping.get(move.l10n_in_gst_treatment)
                 ))
+            move.write({'l10n_in_gstr_json': move.generate_json_data()})
         return posted
+
+    def generate_json_data(self):
+        tags_id = self._get_l10n_in_taxes_tags_id_by_name()
+        hsn_tags = [tags_id[key] for key in ['exempt', 'nil_rated', 'non_gst_supplies', 'base_sgst', 'sgst', 'base_cgst', 'cgst', 'base_igst', 'igst', 'base_cess', 'cess']]
+        for move in self:
+            line_details = []
+            tax_details_by_move = self._get_tax_details([('move_id', '=', move.id)])
+            tax_details = tax_details_by_move.get(move, {})
+            for line, line_tax_details in tax_details.items():
+                if line.display_type != 'product' or not line.tax_ids:
+                    continue
+                base_line_tag_ids = line.tax_tag_ids.ids
+                uqc = "NA"
+                if line.product_id.type != 'service':
+                    uqc = line.product_uom_id.l10n_in_code and line.product_uom_id.l10n_in_code.split("-")[0] or "OTH"
+                lines_json = {
+                    'hsn_sc': line.l10n_in_hsn_code,
+                    'uqc': uqc,
+                    'product_type': line.product_id.type,
+                    'qty': line.quantity,
+                    'zero_rated_type': False,
+                    'include_in_hsn': False,
+                    'base_amount': line_tax_details['base_amount'],
+                    'l10n_in_reverse_charge': line_tax_details['l10n_in_reverse_charge'],
+                    'gst_tax_rate': line_tax_details['gst_tax_rate'],
+                    'igst': line_tax_details['igst'],
+                    'cgst': line_tax_details['cgst'],
+                    'sgst': line_tax_details['sgst'],
+                    'cess': line_tax_details['cess'],
+                    }
+                if any(tag in hsn_tags for tag in base_line_tag_ids):
+                    lines_json['include_in_hsn'] = True
+                if tags_id['nil_rated'] in base_line_tag_ids:
+                    lines_json['zero_rated_type'] = 'nil_rated'
+                elif tags_id['exempt'] in base_line_tag_ids:
+                    lines_json['zero_rated_type'] = 'exempt'
+                elif tags_id['non_gst_supplies'] in base_line_tag_ids:
+                    lines_json['zero_rated_type'] = 'non_gst_supplies'
+                line_details.append(lines_json)
+
+            return {
+                'move_type': move.move_type,
+                'line_details': line_details,
+            }
 
     def _l10n_in_get_warehouse_address(self):
         """Return address where goods are delivered/received for Invoice/Bill"""
@@ -194,3 +341,77 @@ class AccountMove(models.Model):
                 'taxes_data': taxes_data,
             })
         return self.env['account.tax']._l10n_in_get_hsn_summary_table(base_lines, display_uom)
+
+    def _get_tax_details(self, domain):
+        """
+            return {
+                account.move(1): {
+                    account.move.line(1):{
+                        'base_amount': 100,
+                        'gst_tax_rate': 18.00,
+                        'igst': 0.00,
+                        'cgst': 9.00,
+                        'sgst': 9.00,
+                        'cess': 3.33,
+                        'line_tax_details': {tax_details}
+                    }
+                }
+            }
+        """
+        tax_vals_map = {}
+        cgst_tag_ids = [self.env.ref("l10n_in.tax_tag_cgst").id, self.env.ref("l10n_in.tax_tag_base_cgst").id]
+        sgst_tag_ids = [self.env.ref("l10n_in.tax_tag_sgst").id, self.env.ref("l10n_in.tax_tag_base_sgst").id]
+        # Mapping of tax group names to their IDs
+        tax_group_mapping = {
+            group: self.env.ref(f'account.{self.company_id.root_id.id}_{group}_group').id
+            for group in ['igst', 'cgst', 'sgst', 'cess']
+        }
+        journal_items = self.env['account.move.line'].search(domain)
+        tax_details_query, tax_details_params = self.env['account.move.line']._get_query_tax_details_from_domain(domain=[('id', 'in', journal_items.ids)])
+        self._cr.execute(tax_details_query, tax_details_params)
+        tax_details = self._cr.dictfetchall()
+        # Retrieve base lines and tax lines based on tax_details
+        base_lines = self.env['account.move.line'].browse([tax['base_line_id'] for tax in tax_details])
+        tax_lines = self.env['account.move.line'].browse([tax['tax_line_id'] for tax in tax_details])
+        base_lines_map = {line.id: line for line in base_lines}
+        tax_lines_map = {line.id: line for line in tax_lines}
+        for tax_vals in tax_details:
+            base_line = base_lines_map[tax_vals['base_line_id']]
+            tax_line = tax_lines_map[tax_vals['tax_line_id']]
+            journal_items -= base_line
+            journal_items -= tax_line
+            move_id = base_line.move_id
+            tax_vals_map.setdefault(move_id, {}).setdefault(base_line, {
+                'base_amount': tax_vals['base_amount'],
+                'l10n_in_reverse_charge': tax_line.tax_line_id.l10n_in_reverse_charge,
+                'gst_tax_rate': tax_line.group_tax_id.amount or tax_line.tax_line_id.amount,
+                'igst': 0.00,
+                'cgst': 0.00,
+                'sgst': 0.00,
+                'cess': 0.00,
+                'line_tax_details': [],
+            })
+            tax_group = next((tax_group for tax_group, group_id in tax_group_mapping.items() if tax_line.tax_group_id.id == group_id), None)
+            tax_vals['tax_type'] = tax_group.upper() if tax_group else None
+            tax_vals_map[move_id][base_line]['line_tax_details'].append(tax_vals)
+            if tax_group:
+                tax_vals_map[move_id][base_line][tax_group] += tax_vals['tax_amount']
+            # Calculate GST rate for each base line
+            base_tags_ids = base_line.tax_tag_ids.ids
+            if len(base_tags_ids) == 2 and any(tag in base_tags_ids for tag in cgst_tag_ids) and any(tag in base_tags_ids for tag in sgst_tag_ids):
+                tax_vals_map[move_id][base_line]['gst_tax_rate'] = sum(base_line.tax_ids.mapped('amount'))
+
+        # IF line have 0% tax or not have tax then we add it manually
+        for journal_item in journal_items:
+            move_id = journal_item.move_id
+            tax_vals_map.setdefault(move_id, {}).setdefault(journal_item, {
+                'base_amount': journal_item.balance,
+                'l10n_in_reverse_charge': False,
+                'gst_tax_rate': 0.0,
+                'igst': 0.00,
+                'cgst': 0.00,
+                'sgst': 0.00,
+                'cess': 0.00,
+                'line_tax_details': [],
+            })
+        return tax_vals_map

--- a/addons/l10n_in/models/account_move_line.py
+++ b/addons/l10n_in/models/account_move_line.py
@@ -1,4 +1,5 @@
-from odoo import api, fields, models
+from odoo import api, fields, models, _
+from odoo.exceptions import UserError
 
 
 class AccountMoveLine(models.Model):
@@ -11,3 +12,15 @@ class AccountMoveLine(models.Model):
         for line in self:
             if line.move_id.country_code == 'IN' and line.parent_state == 'draft':
                 line.l10n_in_hsn_code = line.product_id.l10n_in_hsn_code
+
+    def write(self, vals):
+        fields_to_check = {
+            'tax_tag_ids': 'Tax Grids',
+            'l10n_in_hsn_code': 'HSN/SAC Code',
+            'product_uom_id': 'Unit Of Measure'
+        }
+        posted_lines = self.filtered(lambda line: line.parent_state == 'posted')
+        for field in fields_to_check:
+            if field in vals and any(line[field] for line in posted_lines):
+                raise UserError(_('You cannot modify the %s related to a posted journal item. Reset the journal entry to draft to do so.', fields_to_check[field]))
+        return super().write(vals)

--- a/addons/l10n_in/models/product_product.py
+++ b/addons/l10n_in/models/product_product.py
@@ -1,0 +1,14 @@
+from odoo import api, models, _
+from odoo.exceptions import UserError
+
+
+class ProductProduct(models.Model):
+    _inherit = 'product.product'
+
+    @api.onchange('type')
+    def _onchange_type(self):
+        if self.env['account.move.line'].sudo().search_count([
+            ('product_id', '=', self.id), ('parent_state', '=', 'posted')
+        ]):
+            raise UserError(_("You cannot change the product type because there are posted accounting moves associated with this product."))
+        return super()._onchange_type()

--- a/addons/l10n_in_pos/models/account_move.py
+++ b/addons/l10n_in_pos/models/account_move.py
@@ -14,3 +14,35 @@ class AccountMove(models.Model):
         for move in to_compute:
             move.l10n_in_state_id = move.company_id.state_id
         return res
+
+    def _post(self, soft=True):
+        posted = super()._post(soft)
+        for move in posted.filtered(lambda m: m.l10n_in_pos_session_ids and m.move_type == 'entry' and m.country_code == 'IN'):
+            move.write({'l10n_in_gstr_json': move.generate_json_data()})
+        return posted
+
+    @api.depends('invoice_line_ids', 'invoice_line_ids.tax_ids', 'l10n_in_gst_treatment', 'move_type')
+    def _compute_has_nil_exempt_nongst(self):
+        taxes_tag_ids = self._get_l10n_in_taxes_tags_id_by_name()
+        nil_exempt_nongst_tags = [taxes_tag_ids[key] for key in ['exempt', 'nil_rated', 'non_gst_supplies']]
+        for record in self:
+            record.has_nil_exempt_nongst = record.l10n_in_gst_treatment not in ('overseas', 'special_economic_zone') \
+                and (record.move_type in ('out_invoice', 'out_refund', 'out_receipt') or (record.move_type == 'entry' and record.l10n_in_pos_session_ids))\
+                and any(tag in nil_exempt_nongst_tags for tag in record.invoice_line_ids.tax_tag_ids.ids)
+
+    @api.depends('partner_id', 'invoice_line_ids', 'amount_total', 'invoice_line_ids.tax_ids.l10n_in_reverse_charge',
+        'move_type', 'state', 'l10n_in_gst_treatment', 'l10n_in_state_id', 'invoice_line_ids.tax_ids', 'debit_origin_id')
+    def _compute_gstr_section(self):
+        super()._compute_gstr_section()
+        taxes_tag_ids = self._get_l10n_in_taxes_tags_id_by_name()
+        gst_tags = [taxes_tag_ids[key] for key in ['base_sgst', 'sgst', 'base_cgst', 'cgst', 'base_igst', 'igst', 'base_cess', 'cess']]
+        for record in self:
+            is_interstate = record.country_code == "IN" and record.l10n_in_state_id and record.l10n_in_state_id != record.company_id.state_id
+            is_intrastate = record.country_code == "IN" and record.l10n_in_state_id and record.l10n_in_state_id == record.company_id.state_id
+            is_unregistered_or_consumer = record.l10n_in_gst_treatment in ('unregistered', 'consumer')
+
+            if ((record.move_type in ['out_invoice', 'out_receipt', 'out_refund'] and is_unregistered_or_consumer)
+                or (record.move_type == 'entry' and (record.l10n_in_pos_session_ids))) \
+                and any(tag in gst_tags for tag in record.line_ids.tax_tag_ids.ids) \
+                and (is_intrastate or (is_interstate and record.amount_total <= 250000)):
+                record.l10n_in_gstr_section = 'b2cs'

--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -358,6 +358,11 @@ class ProductProduct(models.Model):
                 'message': _("The Reference '%s' already exists.", self.default_code),
             }}
 
+    @api.onchange('type')
+    def _onchange_type(self):
+        # Do nothing but needed for inheritance
+        return {}
+
     @api.model_create_multi
     def create(self, vals_list):
         products = super(ProductProduct, self.with_context(create_product_product=False)).create(vals_list)

--- a/addons/sale/models/product_product.py
+++ b/addons/sale/models/product_product.py
@@ -44,11 +44,13 @@ class ProductProduct(models.Model):
 
     @api.onchange('type')
     def _onchange_type(self):
+        res = super()._onchange_type()
         if self._origin and self.sales_count > 0:
-            return {'warning': {
+            res['warning'] = {
                 'title': _("Warning"),
                 'message': _("You cannot change the product's type because it is already used in sales orders.")
-            }}
+            }
+        return res
 
     @api.depends_context('order_id')
     def _compute_product_is_in_sale_order(self):


### PR DESCRIPTION
In this PR the handling of GSTR data has been done by implementing 
the following changes:

- JSON Preparation: Automatically prepares and stores JSON data for each invoice
 upon posting. This facilitates easier retrieval: of details in reports.
- Section Computation: Computes the appropriate GSTR section for each invoice, 
ensuring accurate classification.
-  Validation: Adds validation to prevent editing of fields in posted journal 
items, maintaining data integrity.
- Shifted Methods: Moved `_l10n_in_round_value` and `_l10n_in_edi_extract_digits`
   from the`account.edi.format` model to the `account.move` model.

These improvements streamline the reporting process and enhance the accuracy and
reliability of GSTR-related data.

task id: 3941950
related PR: https://github.com/odoo/enterprise/pull/67004
