### PR TITLE
[FIX] stock: apply putaway when using form

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -268,7 +268,11 @@ class StockMoveLine(models.Model):
                     smls.package_level_id.location_dest_id = smls.location_dest_id
             else:
                 for sml in smls:
-                    putaway_loc_id = sml.move_id.location_dest_id.with_context(exclude_sml_ids=excluded_smls)._get_putaway_strategy(
+                    if self.env.context.get('prefer_move_line_location'):
+                        location_dest = sml.location_dest_id
+                    else:
+                        location_dest = sml.move_id.location_dest_id
+                    putaway_loc_id = location_dest.with_context(exclude_sml_ids=excluded_smls)._get_putaway_strategy(
                         sml.product_id, quantity=sml.quantity, packaging=sml.move_id.product_packaging_id,
                     )
                     if putaway_loc_id != sml.location_dest_id:


### PR DESCRIPTION
**Current behavior:**
While putaway rules are not currently supported for barcode operation lines created via scanning product, lines created via form have historically supported them.

**Expected behavior:**
Lines created in a barcode operation via the form should have putaway rules applied.

**Steps to reproduce:**
1. Create a putaway rule from WH-STOCK to some internal location which applies to all products

2. Create a receipt in barcode, add some storable product via the form (use the add product button)

3. Validate the transfer

4. Check the product's quants to see that no additional stock is added to the internal location defined on the rule

**Cause of the issue:**
Because move lines create within a barcode will be `picked: True`, in the `_action_assign()` chain, they will never qualify for redirection (thus never having a valid putaway strategy applied).

**Fix:**
Override `action_assign()` in stock_barcode in order to directly call `_apply_putaway_strategy()` on move lines which were created directly in barcode.

opw-4053681