### PR TITLE
[ADD] gs1_epc_nomenclature: GS1 EPC Codec for RFID Tags

### DIFF
--- a/addons/gs1_epc_nomenclature/__init__.py
+++ b/addons/gs1_epc_nomenclature/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/addons/gs1_epc_nomenclature/__manifest__.py
+++ b/addons/gs1_epc_nomenclature/__manifest__.py
@@ -1,0 +1,21 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    'name': 'GS1 - EPC Nomenclature',
+    'version': '1.0',
+    'category': 'Hidden',
+    'summary': 'Parse EPC tags according to the GS1 TDS specifications',
+    'depends': ['barcodes',],
+    'data': [
+        'security/ir.model.access.csv',
+        'data/epc_template_field.xml',
+        'data/epc_template_scheme.xml',
+    ],
+    'installable': True,
+    'assets': {
+        'web.assets_backend': [
+            'gs1_epc_nomenclature/static/src/*.js',
+        ],
+    },
+    'license': 'LGPL-3',
+}

--- a/addons/gs1_epc_nomenclature/data/epc_lookup_table.xml
+++ b/addons/gs1_epc_nomenclature/data/epc_lookup_table.xml
@@ -1,0 +1,175 @@
+<!-- Look-up table : Raw XML to parse -->
+<lookup_table>
+    <partition>
+        <!-- The Partition Table encoding method is used for a segment that appears in the URI as a pair of
+        variable-length numeric fields separated by a dot (".") character, and in the binary encoding as
+        a 3-bit (1 digit) "partition" field followed by two variable length binary integers.
+        -->
+        <sgtin>
+            <key value="0" left_bit="40" left_digit="12" right_bit="4" right_digit="1"/>
+            <key value="1" left_bit="37" left_digit="11" right_bit="7" right_digit="2"/>
+            <key value="2" left_bit="34" left_digit="10" right_bit="10" right_digit="3"/>
+            <key value="3" left_bit="30" left_digit="9" right_bit="14" right_digit="4"/>
+            <key value="4" left_bit="27" left_digit="8" right_bit="17" right_digit="5"/>
+            <key value="5" left_bit="24" left_digit="7" right_bit="20" right_digit="6"/>
+            <key value="6" left_bit="20" left_digit="6" right_bit="24" right_digit="7"/>
+        </sgtin>
+        <sscc>
+            <key value="0" left_bit="40" left_digit="12" right_bit="18" right_digit="5"/>
+            <key value="1" left_bit="37" left_digit="11" right_bit="21" right_digit="6"/>
+            <key value="2" left_bit="34" left_digit="10" right_bit="24" right_digit="7"/>
+            <key value="3" left_bit="30" left_digit="9" right_bit="28" right_digit="8"/>
+            <key value="4" left_bit="27" left_digit="8" right_bit="31" right_digit="9"/>
+            <key value="5" left_bit="24" left_digit="7" right_bit="34" right_digit="10"/>
+            <key value="6" left_bit="20" left_digit="6" right_bit="38" right_digit="11"/>
+        </sscc>
+        <sgln>
+            <key value="0" left_bit="40" left_digit="12" right_bit="1" right_digit="0"/>
+            <key value="1" left_bit="37" left_digit="11" right_bit="4" right_digit="1"/>
+            <key value="2" left_bit="34" left_digit="10" right_bit="7" right_digit="2"/>
+            <key value="3" left_bit="30" left_digit="9" right_bit="11" right_digit="3"/>
+            <key value="4" left_bit="27" left_digit="8" right_bit="14" right_digit="4"/>
+            <key value="5" left_bit="24" left_digit="7" right_bit="17" right_digit="5"/>
+            <key value="6" left_bit="20" left_digit="6" right_bit="21" right_digit="6"/>
+        </sgln>
+        <grai>
+            <key value="0" left_bit="40" left_digit="12" right_bit="4" right_digit="0"/>
+            <key value="1" left_bit="37" left_digit="11" right_bit="7" right_digit="1"/>
+            <key value="2" left_bit="34" left_digit="10" right_bit="10" right_digit="2"/>
+            <key value="3" left_bit="30" left_digit="9" right_bit="14" right_digit="3"/>
+            <key value="4" left_bit="27" left_digit="8" right_bit="17" right_digit="4"/>
+            <key value="5" left_bit="24" left_digit="7" right_bit="20" right_digit="5"/>
+            <key value="6" left_bit="20" left_digit="6" right_bit="24" right_digit="6"/>
+        </grai>
+        <giai96>
+            <key value="0" left_bit="40" left_digit="12" right_bit="42" right_digit="13"/>
+            <key value="1" left_bit="37" left_digit="11" right_bit="45" right_digit="14"/>
+            <key value="2" left_bit="34" left_digit="10" right_bit="48" right_digit="15"/>
+            <key value="3" left_bit="30" left_digit="9" right_bit="52" right_digit="16"/>
+            <key value="4" left_bit="27" left_digit="8" right_bit="55" right_digit="17"/>
+            <key value="5" left_bit="24" left_digit="7" right_bit="58" right_digit="18"/>
+            <key value="6" left_bit="20" left_digit="6" right_bit="62" right_digit="19"/>
+        </giai96>
+        <giai202>
+            <key value="0" left_bit="40" left_digit="12" right_bit="148" right_digit="18"/>
+            <key value="1" left_bit="37" left_digit="11" right_bit="151" right_digit="19"/>
+            <key value="2" left_bit="34" left_digit="10" right_bit="154" right_digit="20"/>
+            <key value="3" left_bit="30" left_digit="9" right_bit="158" right_digit="21"/>
+            <key value="4" left_bit="27" left_digit="8" right_bit="161" right_digit="22"/>
+            <key value="5" left_bit="24" left_digit="7" right_bit="164" right_digit="23"/>
+            <key value="6" left_bit="20" left_digit="6" right_bit="168" right_digit="24"/>
+        </giai202>
+        <gsrn>
+            <key value="0" left_bit="40" left_digit="12" right_bit="18" right_digit="5"/>
+            <key value="1" left_bit="37" left_digit="11" right_bit="21" right_digit="6"/>
+            <key value="2" left_bit="34" left_digit="10" right_bit="24" right_digit="7"/>
+            <key value="3" left_bit="30" left_digit="9" right_bit="28" right_digit="8"/>
+            <key value="4" left_bit="27" left_digit="8" right_bit="31" right_digit="9"/>
+            <key value="5" left_bit="24" left_digit="7" right_bit="34" right_digit="10"/>
+            <key value="6" left_bit="20" left_digit="6" right_bit="38" right_digit="11"/>
+        </gsrn>
+        <gsrnp>
+            <key value="0" left_bit="40" left_digit="12" right_bit="18" right_digit="5"/>
+            <key value="1" left_bit="37" left_digit="11" right_bit="21" right_digit="6"/>
+            <key value="2" left_bit="34" left_digit="10" right_bit="24" right_digit="7"/>
+            <key value="3" left_bit="30" left_digit="9" right_bit="28" right_digit="8"/>
+            <key value="4" left_bit="27" left_digit="8" right_bit="31" right_digit="9"/>
+            <key value="5" left_bit="24" left_digit="7" right_bit="34" right_digit="10"/>
+            <key value="6" left_bit="20" left_digit="6" right_bit="38" right_digit="11"/>
+        </gsrnp>
+        <gdti>
+            <key value="0" left_bit="40" left_digit="12" right_bit="1" right_digit="0"/>
+            <key value="1" left_bit="37" left_digit="11" right_bit="4" right_digit="1"/>
+            <key value="2" left_bit="34" left_digit="10" right_bit="7" right_digit="2"/>
+            <key value="3" left_bit="30" left_digit="9" right_bit="11" right_digit="3"/>
+            <key value="4" left_bit="27" left_digit="8" right_bit="14" right_digit="4"/>
+            <key value="5" left_bit="24" left_digit="7" right_bit="17" right_digit="5"/>
+            <key value="6" left_bit="20" left_digit="6" right_bit="21" right_digit="6"/>
+        </gdti>
+        <cpi_96>
+            <key value="0" left_bit="40" left_digit="12" right_bit="11" right_digit="3"/>
+            <key value="1" left_bit="37" left_digit="11" right_bit="14" right_digit="4"/>
+            <key value="2" left_bit="34" left_digit="10" right_bit="17" right_digit="5"/>
+            <key value="3" left_bit="30" left_digit="9" right_bit="21" right_digit="6"/>
+            <key value="4" left_bit="27" left_digit="8" right_bit="24" right_digit="7"/>
+            <key value="5" left_bit="24" left_digit="7" right_bit="27" right_digit="8"/>
+            <key value="6" left_bit="20" left_digit="6" right_bit="31" right_digit="9"/>
+        </cpi_96>
+        <cpi_var>
+            <key value="0" left_bit="40" left_digit="12" right_bit="114" right_digit="18"/>
+            <key value="1" left_bit="37" left_digit="11" right_bit="120" right_digit="19"/>
+            <key value="2" left_bit="34" left_digit="10" right_bit="126" right_digit="20"/>
+            <key value="3" left_bit="30" left_digit="9" right_bit="132" right_digit="21"/>
+            <key value="4" left_bit="27" left_digit="8" right_bit="138" right_digit="22"/>
+            <key value="5" left_bit="24" left_digit="7" right_bit="144" right_digit="23"/>
+            <key value="6" left_bit="20" left_digit="6" right_bit="150" right_digit="24"/>
+        </cpi_var>
+        <sgcn>
+            <key value="0" left_bit="40" left_digit="12" right_bit="1" right_digit="0"/>
+            <key value="1" left_bit="37" left_digit="11" right_bit="4" right_digit="1"/>
+            <key value="2" left_bit="34" left_digit="10" right_bit="7" right_digit="2"/>
+            <key value="3" left_bit="30" left_digit="9" right_bit="11" right_digit="3"/>
+            <key value="4" left_bit="27" left_digit="8" right_bit="14" right_digit="4"/>
+            <key value="5" left_bit="24" left_digit="7" right_bit="17" right_digit="5"/>
+            <key value="6" left_bit="20" left_digit="6" right_bit="21" right_digit="6"/>
+        </sgcn>
+        <itip>
+            <key value="0" left_bit="40" left_digit="12" right_bit="4" right_digit="1"/>
+            <key value="1" left_bit="37" left_digit="11" right_bit="7" right_digit="2"/>
+            <key value="2" left_bit="34" left_digit="10" right_bit="10" right_digit="3"/>
+            <key value="3" left_bit="30" left_digit="9" right_bit="14" right_digit="4"/>
+            <key value="4" left_bit="27" left_digit="8" right_bit="17" right_digit="5"/>
+            <key value="5" left_bit="24" left_digit="7" right_bit="20" right_digit="6"/>
+            <key value="6" left_bit="20" left_digit="6" right_bit="24" right_digit="7"/>
+        </itip>
+    </partition>
+    <aidc>
+        <header>
+            <key value="0" digits="2" next_bits="0" />
+            <key value="1" digits="2" next_bits="0" />
+            <key value="2" digits="2" next_bits="0" />
+            <key value="10" digits="2" next_bits="0" />
+            <key value="11" digits="2" next_bits="0" />
+            <key value="12" digits="2" next_bits="0" />
+            <key value="13" digits="2" next_bits="0" />
+            <key value="15" digits="2" next_bits="0" />
+            <key value="16" digits="2" next_bits="0" />
+            <key value="17" digits="2" next_bits="0" />
+            <key value="20" digits="2" next_bits="0" />
+            <key value="21" digits="2" next_bits="0" />
+            <key value="22" digits="2" next_bits="0" />
+            <key value="23" digits="3" next_bits="4" />
+            <key value="24" digits="3" next_bits="4" />
+            <key value="25" digits="3" next_bits="4" />
+            <key value="30" digits="2" next_bits="0" />
+            <key value="31" digits="4" next_bits="8" />
+            <key value="32" digits="4" next_bits="8" />
+            <key value="33" digits="4" next_bits="8" />
+            <key value="34" digits="4" next_bits="8" />
+            <key value="35" digits="4" next_bits="8" />
+            <key value="36" digits="4" next_bits="8" />
+            <key value="37" digits="2" next_bits="0" />
+            <key value="39" digits="4" next_bits="8" />
+            <key value="40" digits="3" next_bits="4" />
+            <key value="41" digits="3" next_bits="4" />
+            <key value="42" digits="3" next_bits="4" />
+            <key value="43" digits="4" next_bits="8" />
+            <key value="70" digits="4" next_bits="8" />
+            <key value="71" digits="3" next_bits="4" />
+            <key value="72" digits="4" next_bits="8" />
+            <key value="80" digits="4" next_bits="8" />
+            <key value="81" digits="4" next_bits="8" />
+            <key value="82" digits="4" next_bits="8" />
+            <key value="90" digits="2" next_bits="0" />
+            <key value="91" digits="2" next_bits="0" />
+            <key value="92" digits="2" next_bits="0" />
+            <key value="93" digits="2" next_bits="0" />
+            <key value="94" digits="2" next_bits="0" />
+            <key value="95" digits="2" next_bits="0" />
+            <key value="96" digits="2" next_bits="0" />
+            <key value="97" digits="2" next_bits="0" />
+            <key value="98" digits="2" next_bits="0" />
+            <key value="99" digits="2" next_bits="0" />
+        </header>
+    </aidc>
+</lookup_table>

--- a/addons/gs1_epc_nomenclature/data/epc_template_field.xml
+++ b/addons/gs1_epc_nomenclature/data/epc_template_field.xml
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- [TDS 2.1] https://ref.gs1.org/standards/tds/ -->
+<odoo>
+    <data noupdate="1">
+        <!-- Notes : -->
+        <!-- All current schemes have a header of 8 bits fixed length. -->
+        <!-- However, part §14.2 of [TDS 2.1] specify this may evolve in the future. -->
+        <!-- Although, in this case, there will still be a first header of 8 bits equal to 0xFF, -->
+        <!-- such that we'll can specify the remaining of the longer header as a new field, -->
+        <!-- without heavily affecting the structure and behavior chosen here.-->
+        <record id="gs1_epc_template_field_header" model="gs1.epc.template.field">
+            <field name="name">EPC Header</field>
+            <field name="sequence">0</field>
+            <field name="bit_size_min">8</field>
+            <field name="bit_size_max">8</field>
+            <field name="encoding">integer</field>
+        </record>
+        <record id="gs1_epc_template_field_filter" model="gs1.epc.template.field">
+            <field name="name">Filter</field>
+            <field name="sequence">4</field>
+            <field name="bit_size_min">3</field>
+            <field name="bit_size_max">3</field>
+            <field name="encoding">integer</field>
+            <field name="uri_portion">F</field>
+        </record>
+        <record id="gs1_epc_template_field_partition" model="gs1.epc.template.field">
+            <field name="name">Partition</field>
+            <field name="sequence">6</field>
+            <field name="bit_size_min">3</field>
+            <field name="bit_size_max">3</field>
+            <field name="encoding">partition_table</field>
+        </record>
+        <record id="gs1_epc_template_field_company_prefix" model="gs1.epc.template.field">
+            <field name="name">GS1 Company Prefix</field>
+            <field name="sequence">8</field>
+            <field name="bit_size_min">20</field>
+            <field name="bit_size_max">40</field>
+            <field name="encoding">integer</field>
+            <field name="uri_portion">C</field>
+        </record>
+        <record id="gs1_epc_template_field_item_reference" model="gs1.epc.template.field">
+            <field name="name">Item Reference</field>
+            <field name="sequence">10</field>
+            <field name="bit_size_min">4</field>
+            <field name="bit_size_max">24</field>
+            <field name="encoding">integer</field>
+            <field name="uri_portion">I</field>
+        </record>
+        <record id="gs1_epc_template_field_serial_integer" model="gs1.epc.template.field">
+            <field name="name">Serial (Integer)</field>
+            <field name="sequence">12</field>
+            <field name="bit_size_min">18</field>
+            <field name="bit_size_max">38</field>
+            <field name="encoding">integer</field>
+            <field name="uri_portion">S</field>
+        </record>
+        <record id="gs1_epc_template_field_serial_string" model="gs1.epc.template.field">
+            <field name="name">Serial (Alphanumeric)</field>
+            <field name="sequence">12</field>
+            <field name="bit_size_min">140</field>
+            <field name="bit_size_max">140</field>
+            <field name="encoding">string</field>
+            <field name="uri_portion">S</field>
+        </record>
+        <record id="gs1_epc_template_field_blank" model="gs1.epc.template.field">
+            <field name="name">Blank Filler</field>
+            <field name="sequence">255</field>
+            <field name="bit_size_min">24</field>
+            <field name="bit_size_max">24</field>
+            <field name="encoding">blank</field>
+        </record>
+        <record id="gs1_epc_template_field_location_reference" model="gs1.epc.template.field">
+            <field name="name">Location Reference</field>
+            <field name="sequence">10</field>
+            <field name="bit_size_min">1</field>
+            <field name="bit_size_max">21</field>
+            <field name="encoding">integer</field>
+            <field name="uri_portion">L</field>
+        </record>
+        <record id="gs1_epc_template_field_extension_integer" model="gs1.epc.template.field">
+            <field name="name">Extension (Integer)</field>
+            <field name="sequence">12</field>
+            <field name="bit_size_min">41</field>
+            <field name="bit_size_max">41</field>
+            <field name="encoding">integer</field>
+            <field name="uri_portion">E</field>
+        </record>
+        <record id="gs1_epc_template_field_extension_string" model="gs1.epc.template.field">
+            <field name="name">Extension (Alphanumeric)</field>
+            <field name="sequence">12</field>
+            <field name="bit_size_min">140</field>
+            <field name="bit_size_max">140</field>
+            <field name="encoding">string</field>
+            <field name="uri_portion">E</field>
+        </record>
+        <!-- TODO : >= TDS 2.0 -->
+        <!-- <record id="gs1_epc_template_field_aidc_toggle_bit" model="gs1.epc.template.field"> -->
+            <!-- <field name="name">+Data Toggle</field> -->
+            <!-- <field name="sequence">2</field> Reserve 1 for future -->
+            <!-- <field name="bit_size_min">1</field> -->
+            <!-- <field name="bit_size_max">1</field> -->
+            <!-- <field name="encoding">aidc_toggle_bit</field> -->
+        <!-- </record> -->
+        <!-- <record id="gs1_epc_template_field_aidc_data_header" model="gs1.epc.template.field"> -->
+            <!-- <field name="name">AIDC Data Header</field> -->
+            <!-- <field name="bit_size_min">8</field> -->
+            <!-- <field name="bit_size_max">16</field> -->
+            <!-- <field name="encoding">aidc_header</field> aidc_header is not an actual TDS encoding but is particular, looks like a partition table with a sub-encoding -->
+        <!-- </record> -->
+        <!-- Not an official field but implicit, needed for technical reason -->
+        <!-- <record id="gs1_epc_template_field_aidc_data" model="gs1.epc.template.field"> -->
+            <!-- <field name="name">AIDC Data</field> -->
+            <!-- <field name="bit_size_min">0</field> -->
+            <!-- <field name="bit_size_max">0</field> -->
+            <!-- <field name="encoding">variable_encoding</field> -->
+        <!-- </record> -->
+        <!-- <record id="gs1_epc_template_field_gtin" model="gs1.epc.template.field"> -->
+            <!-- <field name="name">GTIN</field> -->
+            <!-- <field name="sequence">6</field> -->
+            <!-- <field name="bit_size_min">38</field> -->
+            <!-- <field name="bit_size_max">148</field> -->
+            <!-- <field name="encoding">partition</field> -->
+            <!-- <field name="uri_component">F.C</field> -->
+        <!-- </record> -->
+
+    </data>
+</odoo>

--- a/addons/gs1_epc_nomenclature/data/epc_template_scheme.xml
+++ b/addons/gs1_epc_nomenclature/data/epc_template_scheme.xml
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- [TDS 2.1] https://ref.gs1.org/standards/tds/2.1.0 -->
+<odoo>
+    <data noupdate="1">
+        <record id="gs1_epc_template_scheme_sgtin96" model="gs1.epc.template.scheme">
+            <field name="name">SGTIN-96</field>
+            <field name="description">Serialised Global Trade Item Number</field>
+            <field name="bit_size_min">96</field> <!-- May be computed based on epc_field_ids-->
+            <field name="bit_size_max">96</field>
+            <field name="header_value" eval="int('30', 16)"/>
+            <field name="partition_table_name">sgtin</field>
+            <field name="uri_pattern_pure">urn:epc:id:sgtin:CompanyPrefix.ItemRefAndIndicator.SerialNumber</field>
+            <field name="uri_pattern_tag">urn:epc:tag:sgtin-96:F.C.I.S</field>
+            <field name="field_template_ids"
+                   eval="[Command.set([
+                            ref('gs1_epc_template_field_header'),
+                            ref('gs1_epc_template_field_filter'),
+                            ref('gs1_epc_template_field_partition'),
+                            ref('gs1_epc_template_field_company_prefix'),
+                            ref('gs1_epc_template_field_item_reference'),
+                            ref('gs1_epc_template_field_serial_integer')
+                         ])]"
+            />
+        </record>
+        <record id="gs1_epc_template_scheme_sgtin198" model="gs1.epc.template.scheme">
+            <field name="name">SGTIN-198</field>
+            <field name="description">Serialised Global Trade Item Number</field>
+            <field name="bit_size_min">198</field>
+            <field name="bit_size_max">198</field>
+            <field name="header_value" eval="int('36', 16)"/>
+            <field name="partition_table_name">sgtin</field>
+            <field name="uri_pattern_pure">urn:epc:id:sgtin:CompanyPrefix.ItemRefAndIndicator.SerialNumber</field>
+            <field name="uri_pattern_tag">urn:epc:tag:sgtin-198:F.C.I.S</field>
+            <field name="field_template_ids"
+                   eval="[Command.set([
+                            ref('gs1_epc_template_field_header'),
+                            ref('gs1_epc_template_field_filter'),
+                            ref('gs1_epc_template_field_partition'),
+                            ref('gs1_epc_template_field_company_prefix'),
+                            ref('gs1_epc_template_field_item_reference'),
+                            ref('gs1_epc_template_field_serial_string')
+                        ])]"
+            />
+        </record>
+        <record id="gs1_epc_template_scheme_sgtin+" model="gs1.epc.template.scheme">
+            <field name="name">SGTIN+</field>
+            <field name="description">Serialised Global Trade Item Number</field>
+            <field name="bit_size_min">76</field>
+            <field name="bit_size_max">216</field>
+            <field name="header_value" eval="int('F7', 16)"/>
+            <field name="aidc_available" eval="True"/>
+
+            <field name="uri_pattern_pure">urn:epc:id:sgtin:GTIN.SerialNumber</field>
+            <field name="uri_pattern_tag">urn:epc:tag:sgtin+:F.GTIN.S</field>
+            <field name="field_template_ids" eval="[Command.set([ref('gs1_epc_template_field_header')])]"/>
+        </record>
+        <record id="gs1_epc_template_scheme_dsgtin+" model="gs1.epc.template.scheme">
+            <field name="name">DSGTIN+</field>
+            <field name="description">Serialised Global Trade Item Number</field>
+            <field name="bit_size_min">96</field>
+            <field name="bit_size_max">236</field>
+            <field name="header_value" eval="int('FB', 16)"/>
+
+            <field name="uri_pattern_pure">urn:epc:id:sgtin:GTIN.SerialNumber</field>
+            <field name="uri_pattern_tag">urn:epc:tag:dsgtin+:F.GTIN.S</field>
+            <field name="field_template_ids" eval="[Command.set([ref('gs1_epc_template_field_header')])]"/>
+        </record>
+        <record id="gs1_epc_template_scheme_sscc96" model="gs1.epc.template.scheme">
+            <field name="name">SSCC-96</field>
+            <field name="description">Serial Shipping Container Code</field>
+            <field name="bit_size_min">96</field>
+            <field name="bit_size_max">96</field>
+            <field name="header_value" eval="int('31', 16)"/>
+            <field name="partition_table_name">sscc</field>
+            <field name="uri_pattern_pure">urn:epc:id:sscc:CompanyPrefix.SerialReference</field>
+            <field name="uri_pattern_tag">urn:epc:tag:sscc-96:F.C.S</field>
+            <field name="field_template_ids"
+                   eval="[Command.set([
+                            ref('gs1_epc_template_field_header'),
+                            ref('gs1_epc_template_field_filter'),
+                            ref('gs1_epc_template_field_partition'),
+                            ref('gs1_epc_template_field_company_prefix'),
+                            ref('gs1_epc_template_field_serial_integer'),
+                            ref('gs1_epc_template_field_blank'),
+                        ])]"
+            />
+        </record>
+        <record id="gs1_epc_template_scheme_sscc+" model="gs1.epc.template.scheme">
+            <field name="name">SSCC+</field>
+            <field name="description">Serial Shipping Container Code</field>
+            <field name="bit_size_min">84</field>
+            <field name="bit_size_max">84</field>
+            <field name="header_value" eval="int('F9', 16)"/>
+
+            <field name="uri_pattern_pure">urn:epc:id:sscc:TODO</field>
+            <field name="uri_pattern_tag">urn:epc:tag:sscc+:TODO</field>
+            <field name="field_template_ids" eval="[Command.set([ref('gs1_epc_template_field_header')])]"/>
+        </record>
+        <record id="gs1_epc_template_scheme_sgln96" model="gs1.epc.template.scheme">
+            <field name="name">SGLN-96</field>
+            <field name="description">Global Location Number</field>
+            <field name="bit_size_min">96</field>
+            <field name="bit_size_max">96</field>
+            <field name="header_value" eval="int('32', 16)"/>
+            <field name="partition_table_name">sgln</field>
+            <field name="uri_pattern_pure">urn:epc:id:sgln:CompanyPrefix.LocationReference.Extension</field>
+            <field name="uri_pattern_tag">urn:epc:tag:sgln-96:F.C.L.E</field>
+            <field name="field_template_ids"
+                   eval="[Command.set([
+                            ref('gs1_epc_template_field_header'),
+                            ref('gs1_epc_template_field_filter'),
+                            ref('gs1_epc_template_field_partition'),
+                            ref('gs1_epc_template_field_company_prefix'),
+                            ref('gs1_epc_template_field_location_reference'),
+                            ref('gs1_epc_template_field_extension_integer'),
+                        ])]"
+            />
+        </record>
+        <record id="gs1_epc_template_scheme_sgln195" model="gs1.epc.template.scheme">
+            <field name="name">SGLN-195</field>
+            <field name="description">Global Location Number</field>
+            <field name="bit_size_min">195</field>
+            <field name="bit_size_max">195</field>
+            <field name="header_value" eval="int('39', 16)"/>
+            <field name="partition_table_name">sgln</field>
+            <field name="uri_pattern_pure">urn:epc:id:sgln:CompanyPrefix.LocationReference.Extension</field>
+            <field name="uri_pattern_tag">urn:epc:tag:sgln-195:F.C.L.E</field>
+            <field name="field_template_ids"
+                   eval="[Command.set([
+                            ref('gs1_epc_template_field_header'),
+                            ref('gs1_epc_template_field_filter'),
+                            ref('gs1_epc_template_field_partition'),
+                            ref('gs1_epc_template_field_company_prefix'),
+                            ref('gs1_epc_template_field_location_reference'),
+                            ref('gs1_epc_template_field_extension_string'),
+                        ])]"
+            />
+        </record>
+        <record id="gs1_epc_template_scheme_sgln+" model="gs1.epc.template.scheme">
+            <field name="name">SGLN+</field>
+            <field name="description">Global Location Number</field>
+            <field name="bit_size_min">72</field>
+            <field name="bit_size_max">212</field>
+            <field name="header_value" eval="int('F2', 16)"/>
+
+            <field name="uri_pattern_pure">urn:epc:id:sgln:Gln.Extension</field>
+            <field name="uri_pattern_tag">urn:epc:tag:sgln+:(414).(254)</field>
+            <field name="field_template_ids" eval="[Command.set([ref('gs1_epc_template_field_header')])]"/>
+        </record>
+    </data>
+</odoo>

--- a/addons/gs1_epc_nomenclature/models/__init__.py
+++ b/addons/gs1_epc_nomenclature/models/__init__.py
@@ -1,0 +1,5 @@
+from . import gs1_epc_field
+from . import gs1_epc_scheme
+from . import gs1_epc_template_field
+from . import gs1_epc_template_scheme
+from . import gs1_epc_utils

--- a/addons/gs1_epc_nomenclature/models/generate_rfid.py
+++ b/addons/gs1_epc_nomenclature/models/generate_rfid.py
@@ -1,0 +1,44 @@
+# Set constants.
+BARCODE_POPULATE = [
+    '6016478556509', '6016478556493', '6016478556523', '6016478559982',
+    '6016478559999', '2300001000008', '6016478556417', '6016478556424',
+    '6016478556431', '6016478556349', '6016478556332', '6016478556400',
+    '6016478556318', '6016478556677', '6016478556530', '6016478556370',
+    '6016478556448', '6016478556387', '6016478556516', '6016478556486',
+    '6016478556455', '6016478556356'
+]
+BARCODE_PRODUCT = [
+    'Large Cabinet', 'Pedal Bin', 'Cabinet with doors - Serial (helpdesk_stock needed)', 'Customized Cabinet (Metric)',
+    'Customized Cabinet (USA)', 'Desk Organizer', 'Customizable Desk (Steel, White)', 'Customizable Desk (Steel, Black)',
+    'Customizable Desk (Aluminium, White)', 'Office Chair Black', 'Individual Workplace', 'Corner Desk Left Sit',
+    'Cable Management Box - Lot (FURN_5555)', 'Cable Management Box - Lot (FURN_5800)', 'Acoustic Bloc Screens (Wood)', 'Large Meeting Table',
+    'Desk Combination', 'Desk Stand with Screen', 'Four Person Desk', 'Drawer',
+    'Drawer Black', 'Three-Seat Sofa'
+]
+RFID_TAG_STRUCT = "urn:epc:tag:sgtin-96:1.{company}.{indicator}{product}.{serial}"
+RFIDS = {}
+
+
+random_sn = True
+start_sn = 0
+
+number_of_rfid_by_products = 20
+
+# Generates the RFID.
+for product, barcode in zip(BARCODE_PRODUCT, BARCODE_POPULATE):
+    serial = 0  # random.randint(start_sn, start_sn+1000) if random_sn else start_sn
+    company = barcode[:-7]
+    barcode = barcode[-7:-1]
+    RFIDS[product] = []
+    for i in range(number_of_rfid_by_products):
+        RFIDS[product].append(RFID_TAG_STRUCT.format(indicator=0, company=int(company), product=int(barcode), serial=serial))
+        serial += 1
+
+message = []
+for product in RFIDS:
+    vals = [{'uri_tag': uri} for uri in product]
+    schemes = model.create(vals)
+    message.append(f"{product},")
+    message.extend(f"{scheme.uri_tag},{scheme.hex_value}" for scheme in schemes)
+
+log('\n'.join(message))

--- a/addons/gs1_epc_nomenclature/models/gs1_epc_field.py
+++ b/addons/gs1_epc_nomenclature/models/gs1_epc_field.py
@@ -1,0 +1,57 @@
+from odoo.addons.gs1_epc_nomenclature.models.gs1_epc_utils import extract_bits
+from odoo import models, fields, api, _
+from odoo.exceptions import UserError
+
+
+class Gs1EpcField(models.TransientModel):
+    _name = 'gs1.epc.field'
+    _description = 'Electronic Product Code Field'
+    _order = 'sequence asc, id desc'
+
+    field_template_id = fields.Many2one(string='Field Template', comodel_name='gs1.epc.template.field', ondelete='cascade', required=True)
+    name = fields.Char(related='field_template_id.name', readonly=True)
+    bit_size = fields.Integer(string='Bit Size', required=True, store=True, readonly=False)  # Known at runtime in some cases : partition, ...
+    char_size = fields.Integer(string='Character Size', default=0 , store=True)
+    offset = fields.Integer(string='Offset')  # TODO : compute based on previous fields bit_size
+    sequence = fields.Integer(string='Sequence', required=True, help='Used to order fields in the Scheme')
+    raw_value = fields.Char(string='Raw Value', help='The raw value of the field represented as a string')  # TODO : Compute & inverse with value through encode/decode methods
+    value = fields.Char(string='Value', help='The value of the field represented as a string')  # TODO : Getter : parse the value based on the encoding -> str, int, ...
+    scheme_id = fields.Many2one(string='Scheme', comodel_name='gs1.epc.scheme', ondelete='cascade', required=True)
+    encoding = fields.Selection(related='field_template_id.encoding', readonly=True)
+    sub_encoding = fields.Selection(
+        string='Sub Encoding Method', required=False, default='000', selection=[
+            ('000', 'Variable-length integer'),
+            ('001', 'Variable-length upper case hexadecimal'),
+            ('010', 'Variable-length lower case hexadecimal'),
+            ('011', 'Variable-length filesafe URI-safe base 64 (see RFC 4648 section 5)'),
+            ('100', 'Variable-length 7-bit ASCII'),
+            ('101', 'Variable-length URN Code 40'),
+        ], help='Sub-Encoding/Decoding method used to parse the field.')
+    partition_table = fields.Char(related='scheme_id.scheme_template_id.partition_table_name', readonly=True)
+
+    def decode(self):
+        previous_field = self._get_previous_field()
+        if previous_field:
+            self.offset = previous_field.offset + previous_field.bit_size
+            self.raw_value = extract_bits(self.scheme_id.raw_value, self.bit_size, self.offset)
+        # base on previous field, compute offset, length, and extract value from scheme.raw_value
+        self.field_template_id.decode(self)
+
+    def encode(self):
+        self.field_template_id.encode(self)
+
+    def _get_next_field(self, depth=1, strict=False):
+        domain = [('scheme_id', '=', self.scheme_id.id), ('sequence', '>', self.sequence)]
+        order = 'sequence asc'
+        return self._get_neighbors(domain, order, depth, strict)
+
+    def _get_previous_field(self, depth=1, strict=False):
+        domain = [('scheme_id', '=', self.scheme_id.id), ('sequence', '<', self.sequence)]
+        order = 'sequence desc'
+        return self._get_neighbors(domain, order, depth, strict)
+
+    def _get_neighbors(self, domain, order, depth, strict):
+        fields = self.scheme_id.field_ids.search(domain, order=order, limit=depth)
+        if strict and len(fields) != depth:
+            raise UserError(_("There's not enough fields in the scheme."))
+        return fields

--- a/addons/gs1_epc_nomenclature/models/gs1_epc_scheme.py
+++ b/addons/gs1_epc_nomenclature/models/gs1_epc_scheme.py
@@ -1,0 +1,118 @@
+import re
+
+from odoo.addons.gs1_epc_nomenclature.models.gs1_epc_utils import extract_bits, get_uri_body_elements
+
+from odoo import models, fields, api, Command, _
+from odoo.exceptions import UserError, ValidationError
+
+
+class Gs1EpcScheme(models.TransientModel):
+    _name = 'gs1.epc.scheme'
+    _description = 'Electronic Product Code Scheme'
+    _order = 'id desc'
+
+    scheme_template_id = fields.Many2one(string='Scheme Template', comodel_name='gs1.epc.template.scheme', ondelete='cascade', required=True)
+    name = fields.Char(related='scheme_template_id.name', readonly=True)
+    description = fields.Char(related='scheme_template_id.description', readonly=True)
+    field_ids = fields.One2many(string='Fields', comodel_name='gs1.epc.field', inverse_name='scheme_id', required=True)
+    aidc_enabled = fields.Boolean(string='+AIDC Toggle Bit', default=False)
+    raw_value = fields.Integer(string='Raw Value', help='The raw value of the scheme', compute="_compute_raw_value", inverse="_set_raw_value")
+    hex_value = fields.Char(string='Hex Value', help='The hex value of the scheme', compute="_compute_hex_value")
+    uri_tag = fields.Char(string='Tag URI ', help='EPC Tag URI', compute="_compute_uri_tag", inverse="_set_uri_tag")
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        res = self.env['gs1.epc.scheme']
+        for vals in vals_list:
+            if 'raw_value' not in vals and 'uri_tag' not in vals:
+                continue
+            vals['scheme_template_id'] = self._get_scheme_template(vals).id
+            # if 'raw_value' in vals:
+                # shift_length = vals['raw_value'].bit_length() // 16 - self._missing_epc_bit(vals.raw_value.bit_length())
+                # vals['raw_value'] = vals['raw_value'] >> shift_length
+
+        res = super().create(vals_list)
+        for scheme in res:
+             scheme.field_ids = scheme.scheme_template_id._create_scheme_fields(scheme)
+        return res
+
+    def _get_scheme_template(self, vals):
+        domain = self._get_scheme_template_domain(vals)
+        scheme_template_id = self.env['gs1.epc.template.scheme'].search(domain, limit=1)
+        if not scheme_template_id:
+            raw_value = vals.get('raw_value')
+            uri_tag = vals.get('uri_tag')
+            if raw_value:
+                raise UserError(_('Scheme Template not found for raw_value {raw_value}'))
+            if uri_tag:
+                raise UserError(_('Scheme Template not found for uri_tag {uri_tag}'))
+        if self.uri_tag:
+            scheme_template_id.check_uri_tag(self.uri_tag)
+        return scheme_template_id
+
+    def _get_scheme_template_domain(self, vals):
+        if vals.get('raw_value'):
+            value = vals.get('raw_value')
+            header_length = self.env.ref('gs1_epc_nomenclature.gs1_epc_template_field_header').bit_size_min #FIXME
+            header_value = extract_bits(value, header_length - (self._missing_epc_bit(value.bit_length()) % 8))
+            return [('header_value', '=', header_value)]
+        result = re.search(r'.*:', vals.get('uri_tag'))
+        if result:
+            tag_identifier = result.group(0)
+        else:
+            raise UserError(_("Uri Tag is not valid"))
+        return [('uri_pattern_tag', '=ilike', tag_identifier + '%')]
+
+    @api.depends('scheme_template_id', 'uri_tag')
+    def _compute_raw_value(self):
+        for scheme in self:
+        # Encode uri_tag
+            if scheme.raw_value or not scheme.field_ids or not scheme.scheme_template_id or not scheme.uri_tag:
+                continue
+            if scheme.scheme_template_id.deprecated:
+                raise UserError(_('It is not possible to encode new tag with this scheme as it has been deprecated.'))  # FIXME : make non-blocking, Warn the user instead
+            for field in scheme.field_ids[1:]:
+                field.encode()
+            total_size = scheme._normalize_epc_length(sum(len(field.raw_value) for field in scheme.field_ids))
+            bit_string = ''.join(field.raw_value for field in scheme.field_ids).ljust(total_size, '0')  # Group raw_value of all fields ordered by sequence
+            scheme.raw_value = int(bit_string, 2)
+
+    @api.depends('raw_value')
+    def _compute_hex_value(self):
+        for scheme in self:
+            if scheme.raw_value and scheme.raw_value != 0:
+                scheme.hex_value = f"{scheme.raw_value:x}"
+
+    @api.depends('scheme_template_id', 'raw_value')
+    def _compute_uri_tag(self):
+        # Decode raw_value
+        for scheme in self:
+            if scheme.uri_tag or not scheme.field_ids or not scheme.scheme_template_id or not scheme.raw_value:
+                continue
+            for field in scheme.field_ids[1:]:
+                field.decode()
+
+            uri_values = dict.fromkeys(get_uri_body_elements(scheme.scheme_template_id.uri_pattern_tag))
+            for field in scheme.field_ids[1:]:
+                key = field.field_template_id.uri_portion
+                if key and key in uri_values:
+                    uri_values[key] = field.value
+            scheme.uri_tag = f"urn:epc:tag:{scheme.field_ids[0].value}:{'.'.join(uri_values.values())}"
+            # print(scheme.uri_tag)
+
+    def _set_raw_value(self):
+        self.raw_value = self.raw_value
+
+    def _set_uri_tag(self):
+        self.uri_tag = self.uri_tag
+
+    @classmethod
+    def _normalize_epc_length(cls, raw_length):
+        # EPC encoding must have a multiple of 16 bits.
+        # c.f. [TDS  2.1], §15.1.1
+        return raw_length + cls._missing_epc_bit(raw_length)
+
+    @classmethod
+    def _missing_epc_bit(cls, raw_length):
+        remainder = raw_length % 16
+        return (16 - remainder) if remainder else 0

--- a/addons/gs1_epc_nomenclature/models/gs1_epc_template_field.py
+++ b/addons/gs1_epc_nomenclature/models/gs1_epc_template_field.py
@@ -1,0 +1,156 @@
+import urllib.parse
+
+from odoo.addons.gs1_epc_nomenclature.models.gs1_epc_utils import _search_partition_table, write_bits, ascii_to_bits, bits_to_ascii
+from odoo import models, fields, api, _
+from odoo.exceptions import UserError
+
+class Gs1EpcTemplateField(models.Model):
+    _name = 'gs1.epc.template.field'
+    _description = 'Electronic Product Code Field Template'
+    _order = 'sequence asc, id'
+
+    name = fields.Char(string='Field Name', required=True, help='EPC Scheme Field Name')
+    sequence = fields.Integer(string='Sequence', required=True, help='Used to order fields in the Scheme Template')
+    scheme_template_ids = fields.Many2many(string='Scheme', comodel_name='gs1.epc.template.scheme', required=False)  # Not required for 'header' field
+    bit_size_min = fields.Integer(string='Minimal Size in Bits', required=True, default=0)
+    bit_size_max = fields.Integer(string='Maximal Size in Bits', required=True, default=0)
+    padding = fields.Selection(string='Padding', default='none', selection=[
+        ('none', 'None'),
+        ('left', 'Left'),
+        ('right', 'Right')],)
+    encoding = fields.Selection(
+        string='Encoding Method', required=True, default='integer', selection=[
+            ('integer', 'Integer'),
+            ('string', 'String'),
+            ('partition_table', 'Partition Table'),
+            ('unpadded_partition_table', 'Unpadded Partition Table'),
+            ('string_partition_table', 'String Partition Table'),
+            ('numeric_string', 'Numeric String'),
+            ('6bit', '6-bit CAGE/DODAAC'),
+            ('6bit_var_string', '6-bit Variable String'),
+            ('6bit_var_string_partition_table', '6-bit Variable String Partition Table'),
+            ('fixed_width_integer', 'Fixed Width Integer'),
+            #  >= TDS 2.0
+            ('aidc_toggle_bit', '+AIDC Toggle Bit'),
+            ('fixed_bit_len_integer', 'Fixed-Bit-Length Integer'),
+            ('prioritised_date', 'Prioritised Date'),
+            ('fixed_len_numeric', 'Fixed-Length Numeric'),
+            ('delimited_numeric', 'Delimited/Terminated Numeric'),
+            ('var_len_alphanumeric', 'Variable-Length Alphanumeric'),
+            ('single_data_bit', 'Single Data Bit'),
+            ('6digit_date', '6-Digit Date YYMMDD'),
+            ('10digit_datetime', '10-Digit Datetime YYMMDDhhmm'),
+            ('var_format_date', 'Variable-Format Date / Date Range'),
+            ('var_precision_datetime', 'Variable-Precision Datetime'),
+            ('country_code', 'Country Code ISO 3166-1 Alpha-2'),
+            ('var_len_integer_no_indicator', 'Variable-Length Integer Without Encoding Indicator'),
+            ('opt_minus_bit', 'Optional Minus Sign In Bit'),
+            #  Non-official, technical
+            ('blank', 'Blank Filler'),
+            ('aidc_header', 'AIDC Header'),  # TODO : May be replace by a special case 'Partition Table'
+            ('sub_encoding', 'Sub-Encoding'),  # Some fields encoding is only known at runtime
+        ], help='Encoding/Decoding method used to parse the field.')
+    uri_portion = fields.Char(string='EPC Tag URI Portion', required=False)
+
+    def _process_field(self, field, operation):
+        """
+        Process the given field using the specified operation method.
+
+        Args:
+            field (object): The field to be processed.
+            operation (str): The operation to perform ('encode' or 'decode').
+
+        Raises:
+            Exception: If an error occurs while processing the field.
+            AttributeError: If the specified operation method does not exist.
+
+        Returns:
+            None
+        """
+        method_name = f'_{operation}_{field.encoding}'
+        if hasattr(self, method_name):
+            method = getattr(self, method_name)
+            try:
+                method(field)
+            except Exception as e:
+                raise Exception(f"An error occurred while {operation} with method '{method_name}': {e}")
+        else:
+            raise AttributeError(f"The {operation} method '{method_name}' does not exist.")
+
+    def decode(self, field):
+        """
+        Decode the given field.
+
+        Args:
+            field (object): The field to be decoded.
+
+        Raises:
+            Exception: If an error occurs while decoding the field.
+            AttributeError: If the specified encoding method does not exist.
+
+        Returns:
+            None
+        """
+        self._process_field(field, 'decode')
+
+    def encode(self, field):
+        """
+        Encode the given field.
+
+        Args:
+            field: The field to encode.
+
+        Raises:
+            AttributeError: If the _encode_<encoding> method does not exist.
+            Exception: If an error occurs during the execution of the encoding method.
+        """
+        self._process_field(field, 'encode')
+
+
+    def _encode_integer(self, field):
+        field.raw_value = write_bits(int(field.value), field.bit_size)
+
+    def _encode_string(self, field):
+        formatted_value = ascii_to_bits(urllib.parse.unquote(field.value))
+        field.raw_value = write_bits(formatted_value, field.bit_size, word_size_write=7, pad_side='right')  # TODO : compute/inverse : handle in _set method of field
+
+    def _decode_integer(self, field):
+        field.value = field.raw_value
+        if field.char_size != 0:
+            field.value = field.value.rjust(field.char_size, '0')
+
+    def _decode_string(self, field):
+        normalized_bits = write_bits(int(field.raw_value), int(field.bit_size/7*8), word_size_write=8, word_size_read=7)
+        unescaped_string = bits_to_ascii(normalized_bits)
+        field.value = urllib.parse.quote(unescaped_string, safe='')
+
+    # encode & decode methods for partition tables
+    def _encode_partition_table(self, field):
+        next_fields = field._get_next_field(depth=2, strict=True)
+        field_lengths = [len(field.value) for field in next_fields]
+        partition_key = _search_partition_table(field.partition_table, left_digit=field_lengths[0], right_digit=field_lengths[1], as_dict=True)[0]
+        field.raw_value = write_bits(int(partition_key.get("value")), field.bit_size)
+        next_fields[0].bit_size = partition_key.get("left_bit")
+        next_fields[1].bit_size = partition_key.get("right_bit")
+
+    def _decode_partition_table(self, field):
+        # decode integer => lookup table
+        partition_key = _search_partition_table(field.partition_table, value=field.raw_value, as_dict=True)[0]
+        next_fields = field._get_next_field(depth=2, strict=True)
+        # Set length of the next fields
+        next_fields[0].bit_size = partition_key.get("left_bit")
+        next_fields[0].char_size = partition_key.get("left_digit")
+        next_fields[1].bit_size = partition_key.get("right_bit")
+        next_fields[1].char_size = partition_key.get("right_digit")
+
+    def _decode_aidc_header(self, field):
+        #  Decode the GS1 AI Code (8 to 16 bits to read)
+        #  Lookup Table -> return the encoding method for aidc_data
+        pass
+
+
+    def _encode_blank(self, field):
+        field.raw_value = write_bits(0, field.bit_size)
+
+    def _decode_blank(self, field):
+        field.value = ''

--- a/addons/gs1_epc_nomenclature/models/gs1_epc_template_scheme.py
+++ b/addons/gs1_epc_nomenclature/models/gs1_epc_template_scheme.py
@@ -1,0 +1,52 @@
+from odoo.addons.gs1_epc_nomenclature.models.gs1_epc_utils import get_uri_body_elements, get_uri_header, write_bits
+
+from odoo import models, fields, _
+from odoo.exceptions import UserError
+
+
+class Gs1EpcTemplateScheme(models.Model):
+    _name = 'gs1.epc.template.scheme'
+    _description = 'Electronic Product Code Scheme Template'
+    _order = 'id asc'
+
+    name = fields.Char(string='Scheme Name', required=True, help='EPC Scheme Name')
+    description = fields.Char(string='Scheme Description', required=True, help='EPC Scheme Description')
+    header_value = fields.Integer(string='Header Value', required=True, help='EPC Header Value')  #TODO : Not NULL Index
+    bit_size_min = fields.Integer(string='Minimal Size in Bits', required=True)
+    bit_size_max = fields.Integer(string='Maximal Size in Bits', required=True)
+    field_template_ids = fields.Many2many(string='Fields', comodel_name='gs1.epc.template.field', required=True)
+    partition_table_name = fields.Char(string='Partition Table Name', required=False, help='Name of the Partition Table')
+    uri_pattern_pure = fields.Char(string='Pure Identity URI Pattern', required=True, help='EPC Pure Identity URI Pattern')
+    uri_pattern_tag = fields.Char(string='Tag URI Pattern', required=True, help='EPC Tag URI Pattern') #TODO : Not NULL Index
+    aidc_available = fields.Boolean(string='Support AIDC Data', default=False)
+    deprecated = fields.Boolean(string='Deprecated', default=False, help='This scheme has been deprecated. It is still possible to decode tag already using it but not to encode new tag with this scheme.')
+
+    def _create_scheme_fields(self, scheme):
+        field_values = [{
+            'field_template_id': field_template.id,
+            'sequence': seq + 1,
+            'scheme_id': scheme.id,
+            'bit_size': field_template.bit_size_max, #FIXME
+        } for field_template, seq in zip(self.field_template_ids, range(len(self.field_template_ids)))]
+        field_values[0]['raw_value'] = write_bits(self.header_value, field_values[0]['bit_size'])
+        field_values[0]['value'] = get_uri_header(self.uri_pattern_tag)
+        field_values[0]['bit_size'] = self.header_value.bit_length()  # May be less than 8 due to loss of leftmost '0' bit(s) from the EPC code
+        field_ids = self.env['gs1.epc.field'].create(field_values)
+        if scheme.uri_tag:
+            mapped_uri = self.get_mapped_uri_data(scheme.uri_tag)
+            for field in scheme.field_ids[1:]:
+                if field.field_template_id.uri_portion in mapped_uri:
+                    field.value = mapped_uri[field.field_template_id.uri_portion]
+        if not scheme.uri_tag:
+            scheme._compute_uri_tag() # FIXME LATER -___-" or Remove thos f*xsddvz computed field and explicitely assign them
+        return field_ids
+
+    def check_uri_tag(self, uri_tag):
+        # TODO : extend verification => regex,...
+        if len(get_uri_body_elements(self.uri_pattern_tag)) != len(get_uri_body_elements(uri_tag)):
+            raise UserError(_('The URI Tag must have the same number of elements as the Scheme URI Tag.'))
+            # CHECKME & FIXME : No more true for TDS > 2.0 EPC coding : uri replaced by GS1 digital link, + AIDC
+        return True
+
+    def get_mapped_uri_data(self, uri):
+        return dict(zip(get_uri_body_elements(self.uri_pattern_tag), get_uri_body_elements(uri)))

--- a/addons/gs1_epc_nomenclature/models/gs1_epc_utils.py
+++ b/addons/gs1_epc_nomenclature/models/gs1_epc_utils.py
@@ -1,0 +1,240 @@
+from functools import wraps
+from lxml import etree
+import math
+import re
+
+
+from odoo.tools.misc import file_path
+
+DEFAULT_BIT_WORD_SIZE = 8
+LSBF = 'little'
+MSBF = 'big'
+DEFAULT_ENDIAN = MSBF
+LOOKUP_TABLE_PATH = file_path('gs1_epc_nomenclature/data/epc_lookup_table.xml')
+
+__all__ = [
+    'get_uri_body_elements',
+    'get_uri_header',
+    '_get_lookup_table',
+    '_get_partition_table',
+    '_search_partition_table',
+    '_parse_xml_as_dict',
+    'write_bits',
+    'extract_bits',
+    '_parse_ascii_string',
+    'ascii_to_bits',
+    'bits_to_ascii',
+]
+
+def xml_to_dict(func):
+    @wraps(func)
+    def wrapper_func(*args, **kwargs):
+        as_dict = kwargs.pop('as_dict', False)
+        xml_element = func(*args, **kwargs)
+        if as_dict:
+            return _parse_xml_as_dict(xml_element)
+        return xml_element
+    return wrapper_func
+
+
+def get_uri_body_elements(uri):
+    """
+    Extract the body's elements of a given GS1 URI as a list.
+    Example : 'urn:epc:id:sgln:123.456.789' => ['123', '456', '789']
+
+    Parameters:
+        uri (str): The URI to be processed.
+
+    Returns:
+        list: A list of strings representing the URI body elements.
+    """
+    uri_body = uri.split(':')[-1]
+    return uri_body.split('.')
+
+def get_uri_header(uri):
+    """
+    Extract the header of a given GS1 URI as a string.
+    Example : 'urn:epc:id:sgln:123.456.789' => 'sgln''
+
+    Parameters:
+        uri (str): The URI to be processed.
+
+    Returns:
+        string: The header of the URI.
+    """
+    return uri.split(':')[-2]
+
+
+def _get_lookup_table():
+    return etree.parse(LOOKUP_TABLE_PATH)
+
+
+@xml_to_dict
+def _get_partition_table(table_name):
+    tree = _get_lookup_table()
+    return tree.xpath(f"//lookup_table/partition/{table_name}/")
+
+
+@xml_to_dict
+def _search_partition_table(table_name, value=None, left_bit=None, left_digit=None, right_bit=None, right_digit=None):
+    tree = _get_lookup_table()
+    xpath_query = f"//lookup_table/partition/{table_name}/key"
+    conditions = []
+    if value is not None:
+        conditions.append(f"@value='{value}'")
+    if left_bit is not None:
+        conditions.append(f"@left_bit='{left_bit}'")
+    if left_digit is not None:
+        conditions.append(f"@left_digit='{left_digit}'")
+    if right_bit is not None:
+        conditions.append(f"@right_bit='{right_bit}'")
+    if right_digit is not None:
+        conditions.append(f"@right_digit='{right_digit}'")
+
+    if conditions:
+        xpath_query += "[" + " and ".join(conditions) + "]"
+
+    return tree.xpath(xpath_query)
+
+
+def _parse_xml_as_dict(element):
+    """Return a list of dicts"""
+    def _element_to_dict(elem):
+        node = {}
+        # Process element's attributes
+        if elem.attrib:
+            node.update((k, v) for k, v in elem.attrib.items())
+        # Process element's children
+        for child in elem:
+            child_dict = _element_to_dict(child)
+            if child.tag not in node:
+                node[child.tag] = child_dict
+            else:
+                if not isinstance(node[child.tag], list):
+                    node[child.tag] = [node[child.tag]]
+                node[child.tag].append(child_dict)
+        # Process element's text content
+        if elem.text and elem.text.strip():
+            text = elem.text.strip()
+            if node:
+                node['text'] = text
+            else:
+                node = text
+        return node
+
+    if isinstance(element, list):
+        return [_element_to_dict(elem) for elem in element]
+    return _element_to_dict(element)
+
+
+def write_bits(value, length, pad_side='left', pad_char='0', word_size_write=DEFAULT_BIT_WORD_SIZE, word_size_read=DEFAULT_BIT_WORD_SIZE, word_pad_side='left', word_pad_char='0'):  # in_word_size, out_word_size
+    """
+    Converts an integer value to its binary representation with a specified length and padding side.
+
+    Args:
+        value (int): The integer value to be converted.
+        length (int): The desired length of the binary representation.
+        pad_side (str, optional): The side on which to pad the final binary representation ('left' or 'right'). Default is 'left'.
+        pad_char (str, optional): The character to use for padding. Default is '0'.
+        word_size (int, optional): The fixed size of the binary representation of each word. Default is 8. Must be in [1,7].
+        N.B. Actually, EPC nomenclature rely on 8-bit words encoding on inputs (ASCII, ...).
+        word_pad_side (str, optional): The side on which to pad the final binary representation of each word ('left' or 'right'). Default is 'left'.
+        word_pad_char (str, optional): The character to use for word padding. Default is '0'.
+    Returns:
+        str: The binary representation of the value with the specified length.
+            If the length is less than the actual length of the binary representation,
+            leading or trailing zeros are added to make it the desired length.
+
+    Raises:
+        ValueError: If the value cannot be represented with the specified length.
+
+    Example:
+        write_bits(5, 8) -> '00000101'
+        write_bits(5, 8, pad_side='right') -> '10100000'
+    """
+    if length <= 0:
+        raise ValueError("Length must be a positive integer")
+    if  word_size_write <= 0 :
+        raise ValueError("Word size must be a positive integer")
+    tot_bits = value.bit_length()
+    if tot_bits > length:
+        raise ValueError(f"Value {value} cannot be represented with {length} bits")
+    if pad_side not in ['left', 'right']:
+        raise ValueError(f"Invalid pad_side '{pad_side}'. Use 'left' or 'right'.")
+    if word_pad_side not in ['left', 'right']:
+        raise ValueError(f"Invalid word_pad_side '{word_pad_side}'. Use 'left' or 'right'.")
+    if pad_char not in ['0', '1']:
+        raise ValueError(f"Invalid pad_char '{pad_char}'. Use '0' or '1'.")
+    if word_pad_char not in ['0', '1']:
+        raise ValueError(f"Invalid word_pad_char '{word_pad_char}'. Use '0' or '1'.")
+    if not isinstance(value, int):
+        raise ValueError(f"Value '{value}' must be an integer")
+
+
+    if length <= word_size_write or word_size_write == word_size_read:
+        bit_string = f"{value:{pad_char}{length}b}"
+    else:
+        smaller = word_size_write < word_size_read
+        word_number = math.ceil(tot_bits / word_size_read)
+        normalized_bits = word_number * word_size_read
+        default_bit_string = f"{value:{0}{normalized_bits}b}"
+        bit_array = []
+        for i in range(word_number):
+            word = default_bit_string[word_size_read*i:word_size_read*(i+1)]
+            if smaller:
+                if int(word[:word_size_read-word_size_write], 2) != 0:
+                    raise ValueError(f"Binary value {word} cannot be represented with {word_size_write} bits")
+                bit_array.append(word[word_size_read-word_size_write:])
+            elif word_pad_side == 'left':
+                bit_array.append(word.rjust(word_size_write, word_pad_char))
+            else:
+                bit_array.append(word.ljust(word_size_write, word_pad_char))
+        bit_string = ''.join(bit_array)
+
+    if pad_side == 'left':
+        padded_bit_string = bit_string.rjust(length, pad_char)  # May seem confusing but rjust = right justify, it so means that the string is padded on the left
+    else:  # pad_side == 'right':
+        padded_bit_string = bit_string.ljust(length, pad_char)
+
+    return padded_bit_string
+
+
+def extract_bits(value, length, offset = 0):
+    tot_bits = value.bit_length()
+    if offset > tot_bits:
+        raise ValueError("Offset cannot be greater than the total number of bits")
+    if length == 0:
+        return 0
+    shift = tot_bits - length - offset
+    res = value >> shift
+    res &= (1 << length) - 1
+    return res
+
+
+def _parse_ascii_string(input_string):
+    """
+    A function that decodes '%xx' encoded characters in an input string and transforms it into a byte literal.
+    Example : '32a%2Fb' => b'32a\x2Fb'
+
+    Args:
+        input_string (str): The input string containing '%xx' encoded characters.
+
+    Returns:
+        bytes: The transformed byte string with decoded characters.
+    """
+    # Define the pattern to match '%xx' where xx is a two-digit hex number
+    pattern = r"%([0-9A-Fa-f]{2})"
+
+    def decode_match(match):
+        hex_value = match.group(1)
+        return chr(int(hex_value, 16))
+
+    # Replace all '%xx' with their corresponding characters
+    decoded_string = re.sub(pattern, decode_match, input_string)
+    return int.from_bytes(decoded_string.encode('ascii'), byteorder=DEFAULT_ENDIAN)
+
+def ascii_to_bits(input_string):
+    return int.from_bytes(input_string.encode('ascii'), byteorder=DEFAULT_ENDIAN)
+
+def bits_to_ascii(input_bitstring):
+    return int(input_bitstring, 2).to_bytes((len(input_bitstring) + 7) // 8, byteorder=DEFAULT_ENDIAN).decode('ascii', errors="replace").replace("\x00", "")

--- a/addons/gs1_epc_nomenclature/security/ir.model.access.csv
+++ b/addons/gs1_epc_nomenclature/security/ir.model.access.csv
@@ -1,0 +1,5 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+gs1_epc_nomenclature.access_gs1_epc_field,access_gs1_epc_field,gs1_epc_nomenclature.model_gs1_epc_field,base.group_user,1,1,1,0
+gs1_epc_nomenclature.access_gs1_epc_scheme,access_gs1_epc_scheme,gs1_epc_nomenclature.model_gs1_epc_scheme,base.group_user,1,1,1,0
+gs1_epc_nomenclature.access_gs1_epc_template_field,access_gs1_epc_template_field,gs1_epc_nomenclature.model_gs1_epc_template_field,base.group_user,1,0,0,0
+gs1_epc_nomenclature.access_gs1_epc_template_scheme,access_gs1_epc_template_scheme,gs1_epc_nomenclature.model_gs1_epc_template_scheme,base.group_user,1,0,0,0

--- a/addons/gs1_epc_nomenclature/static/src/epc_codec_model.js
+++ b/addons/gs1_epc_nomenclature/static/src/epc_codec_model.js
@@ -1,0 +1,237 @@
+const SCHEME_TEMPLATE = {
+    0x30: {
+        'name': 'SGTIN-96',
+        'uri_pattern_tag': 'urn:epc:tag:sgtin-96:F.C.I.S',
+        'uri_pure_tag': 'urn:epc:id:sgtin:C.I.S',
+        'partition': 'sgtin',
+        'fields_template': ['header', 'filter', 'partition', 'company_prefix', 'item_reference', 'serial_integer'],
+        'fields_bit_count': [8, 3, 3, 0, 0, 38], // 0 is for dynamically sized fields
+        'ai_list': {
+            '01': null, // To 'compute'
+            '21': 'serial_integer', // Simply copy
+        },
+    },
+    0x36: {
+        'name': 'SGTIN-198',
+        'uri_pattern_tag': 'urn:epc:tag:sgtin-198:F.C.I.S',
+        'uri_pure_tag': 'urn:epc:id:sgtin:C.I.S',
+        'partition': 'sgtin',
+        'fields_template': ['header', 'filter', 'partition', 'company_prefix', 'item_reference', 'serial_string'],
+        'fields_bit_count': [8, 3, 3, 0, 0, 140],
+        'ai_list': {
+            '01': null,
+            '21': 'serial_string',
+        },
+    },
+    0x31: {
+        'name': 'SSCC-96',
+        'uri_pattern_tag': 'urn:epc:tag:sscc-96:F.C.S',
+        'partition': 'sscc',
+        'fields_template': ['header', 'filter', 'partition', 'company_prefix', 'serial_integer', 'blank'],
+        'fields_bit_count': [8, 3, 3, 0, 0, 24],
+        'ai_list': {
+            '00': null,
+        },
+    },
+    0x32: {
+        'name': 'SGLN-96',
+        'uri_pattern_tag': 'urn:epc:tag:sgln-96:F.C.L.E',
+        'partition': 'sgln',
+        'fields_template': ['header', 'filter', 'partition', 'company_prefix', 'location_reference', 'extension_integer'],
+        'fields_bit_count': [8, 3, 3, 0, 0, 41],
+        'ai_list': {
+            '414': null,
+            '254': 'extension_integer',
+        },
+
+    },
+    0x39: {
+        'name': 'SGLN-195',
+        'uri_pattern_tag': 'urn:epc:tag:sgln-195:F.C.L.E',
+        'partition': 'sgln',
+        'fields_template': ['header', 'filter', 'partition', 'company_prefix', 'location_reference', 'extension_string'],
+        'fields_bit_count': [8, 3, 3, 0, 0, 140],
+        'ai_list': {
+            '414': null,
+            '254': 'extension_string',
+        },
+    },
+}
+
+const FIELD_TEMPLATE = {
+    'header':{
+        'name': 'EPC Header',
+        'encoding': 'integer',
+    },
+    'filter':{
+        'name': 'Filter',
+        'encoding': 'integer',
+        'uri_portion': 'F',
+    },
+    'partition':{
+        'name': 'Partition',
+        'encoding': 'partition_table',
+    },
+    'company_prefix':{
+        'name': 'Company Prefix',
+        'encoding': 'integer',
+        'uri_portion': 'C',
+    },
+    'item_reference':{
+        'name': 'Item Reference',
+        'encoding': 'integer',
+        'uri_portion': 'I',
+    },
+    'serial_integer':{
+        'name': 'Serial (Integer)',
+        'encoding': 'integer',
+        'uri_portion': 'S',
+    },
+    'serial_string':{
+        'name': 'Serial (Alphanumeric)',
+        'encoding': 'string',
+        'uri_portion': 'S',
+    },
+    'blank':{
+        'name': 'Blank Filler',
+        'encoding': 'blank',
+    },
+    'location_reference':{
+        'name': 'Location Reference',
+        'encoding': 'integer',
+        'uri_portion': 'L',
+    },
+    'extension_integer':{
+        'name': 'Extension (Integer)',
+        'encoding': 'integer',
+        'uri_portion': 'E',
+    },
+    'extension_string':{
+        'name': 'Extension (Alphanumeric)',
+        'encoding': 'string',
+        'uri_portion': 'E',
+    },
+}
+
+const PARTITION = {
+    'sgtin': {
+        0: { left_bit: 40, left_digit: 12, right_bit: 4, right_digit: 1 },
+        1: { left_bit: 37, left_digit: 11, right_bit: 7, right_digit: 2 },
+        2: { left_bit: 34, left_digit: 10, right_bit: 10, right_digit: 3 },
+        3: { left_bit: 30, left_digit: 9, right_bit: 14, right_digit: 4 },
+        4: { left_bit: 27, left_digit: 8, right_bit: 17, right_digit: 5 },
+        5: { left_bit: 24, left_digit: 7, right_bit: 20, right_digit: 6 },
+        6: { left_bit: 20, left_digit: 6, right_bit: 24, right_digit: 7 },
+    },
+    'sscc': {
+        0: { left_bit: 40, left_digit: 12, right_bit: 18, right_digit: 5 },
+        1: { left_bit: 37, left_digit: 11, right_bit: 21, right_digit: 6 },
+        2: { left_bit: 34, left_digit: 10, right_bit: 24, right_digit: 7 },
+        3: { left_bit: 30, left_digit: 9, right_bit: 28, right_digit: 8 },
+        4: { left_bit: 27, left_digit: 8, right_bit: 31, right_digit: 9 },
+        5: { left_bit: 24, left_digit: 7, right_bit: 34, right_digit: 10 },
+        6: { left_bit: 20, left_digit: 6, right_bit: 38, right_digit: 11 },
+    },
+    'sgln': {
+        0: { left_bit: 40, left_digit: 12, right_bit: 1, right_digit: 0 },
+        1: { left_bit: 37, left_digit: 11, right_bit: 4, right_digit: 1 },
+        2: { left_bit: 34, left_digit: 10, right_bit: 7, right_digit: 2 },
+        3: { left_bit: 30, left_digit: 9, right_bit: 11, right_digit: 3 },
+        4: { left_bit: 27, left_digit: 8, right_bit: 14, right_digit: 4 },
+        5: { left_bit: 24, left_digit: 7, right_bit: 17, right_digit: 5 },
+        6: { left_bit: 20, left_digit: 6, right_bit: 21, right_digit: 6 },
+    },
+    'grai': {
+        0: { left_bit: 40, left_digit: 12, right_bit: 4, right_digit: 0 },
+        1: { left_bit: 37, left_digit: 11, right_bit: 7, right_digit: 1 },
+        2: { left_bit: 34, left_digit: 10, right_bit: 10, right_digit: 2 },
+        3: { left_bit: 30, left_digit: 9, right_bit: 14, right_digit: 3 },
+        4: { left_bit: 27, left_digit: 8, right_bit: 17, right_digit: 4 },
+        5: { left_bit: 24, left_digit: 7, right_bit: 20, right_digit: 5 },
+        6: { left_bit: 20, left_digit: 6, right_bit: 24, right_digit: 6 },
+    },
+    'giai96': {
+        0: { left_bit: 40, left_digit: 12, right_bit: 42, right_digit: 13 },
+        1: { left_bit: 37, left_digit: 11, right_bit: 45, right_digit: 14 },
+        2: { left_bit: 34, left_digit: 10, right_bit: 48, right_digit: 15 },
+        3: { left_bit: 30, left_digit: 9, right_bit: 52, right_digit: 16 },
+        4: { left_bit: 27, left_digit: 8, right_bit: 55, right_digit: 17 },
+        5: { left_bit: 24, left_digit: 7, right_bit: 58, right_digit: 18 },
+        6: { left_bit: 20, left_digit: 6, right_bit: 62, right_digit: 19 },
+    },
+    'giai202': {
+        0: { left_bit: 40, left_digit: 12, right_bit: 148, right_digit: 18 },
+        1: { left_bit: 37, left_digit: 11, right_bit: 151, right_digit: 19 },
+        2: { left_bit: 34, left_digit: 10, right_bit: 154, right_digit: 20 },
+        3: { left_bit: 30, left_digit: 9, right_bit: 158, right_digit: 21 },
+        4: { left_bit: 27, left_digit: 8, right_bit: 161, right_digit: 22 },
+        5: { left_bit: 24, left_digit: 7, right_bit: 164, right_digit: 23 },
+        6: { left_bit: 20, left_digit: 6, right_bit: 168, right_digit: 24 },
+    },
+    'gsrn': {
+        0: { left_bit: 40, left_digit: 12, right_bit: 18, right_digit: 5 },
+        1: { left_bit: 37, left_digit: 11, right_bit: 21, right_digit: 6 },
+        2: { left_bit: 34, left_digit: 10, right_bit: 24, right_digit: 7 },
+        3: { left_bit: 30, left_digit: 9, right_bit: 28, right_digit: 8 },
+        4: { left_bit: 27, left_digit: 8, right_bit: 31, right_digit: 9 },
+        5: { left_bit: 24, left_digit: 7, right_bit: 34, right_digit: 10 },
+        6: { left_bit: 20, left_digit: 6, right_bit: 38, right_digit: 11 },
+    },
+    'gsrnp': {
+        0: { left_bit: 40, left_digit: 12, right_bit: 18, right_digit: 5 },
+        1: { left_bit: 37, left_digit: 11, right_bit: 21, right_digit: 6 },
+        2: { left_bit: 34, left_digit: 10, right_bit: 24, right_digit: 7 },
+        3: { left_bit: 30, left_digit: 9, right_bit: 28, right_digit: 8 },
+        4: { left_bit: 27, left_digit: 8, right_bit: 31, right_digit: 9 },
+        5: { left_bit: 24, left_digit: 7, right_bit: 34, right_digit: 10 },
+        6: { left_bit: 20, left_digit: 6, right_bit: 38, right_digit: 11 },
+    },
+    'gdti': {
+        0: { left_bit: 40, left_digit: 12, right_bit: 1, right_digit: 0 },
+        1: { left_bit: 37, left_digit: 11, right_bit: 4, right_digit: 1 },
+        2: { left_bit: 34, left_digit: 10, right_bit: 7, right_digit: 2 },
+        3: { left_bit: 30, left_digit: 9, right_bit: 11, right_digit: 3 },
+        4: { left_bit: 27, left_digit: 8, right_bit: 14, right_digit: 4 },
+        5: { left_bit: 24, left_digit: 7, right_bit: 17, right_digit: 5 },
+        6: { left_bit: 20, left_digit: 6, right_bit: 21, right_digit: 6 },
+    },
+    'cpi_96': {
+        0: { left_bit: 40, left_digit: 12, right_bit: 11, right_digit: 3 },
+        1: { left_bit: 37, left_digit: 11, right_bit: 14, right_digit: 4 },
+        2: { left_bit: 34, left_digit: 10, right_bit: 17, right_digit: 5 },
+        3: { left_bit: 30, left_digit: 9, right_bit: 21, right_digit: 6 },
+        4: { left_bit: 27, left_digit: 8, right_bit: 24, right_digit: 7 },
+        5: { left_bit: 24, left_digit: 7, right_bit: 27, right_digit: 8 },
+        6: { left_bit: 20, left_digit: 6, right_bit: 31, right_digit: 9 },
+    },
+    // cpi_var special case : here, right bit is not absolute and rather define the maximum bits.
+    // This is due to '6-bit Variable String Partition Table' encoding of the field.
+    // That's why we should rely on right_digit instead of right_bit in the decode process for this case.
+    'cpi_var': {
+        0: { left_bit: 40, left_digit: 12, right_bit: 114, right_digit: 18 },
+        1: { left_bit: 37, left_digit: 11, right_bit: 120, right_digit: 19 },
+        2: { left_bit: 34, left_digit: 10, right_bit: 126, right_digit: 20 },
+        3: { left_bit: 30, left_digit: 9, right_bit: 132, right_digit: 21 },
+        4: { left_bit: 27, left_digit: 8, right_bit: 138, right_digit: 22 },
+        5: { left_bit: 24, left_digit: 7, right_bit: 144, right_digit: 23 },
+        6: { left_bit: 20, left_digit: 6, right_bit: 150, right_digit: 24 },
+    },
+    'sgcn': {
+        0: { left_bit: 40, left_digit: 12, right_bit: 1, right_digit: 0 },
+        1: { left_bit: 37, left_digit: 11, right_bit: 4, right_digit: 1 },
+        2: { left_bit: 34, left_digit: 10, right_bit: 7, right_digit: 2 },
+        3: { left_bit: 30, left_digit: 9, right_bit: 11, right_digit: 3 },
+        4: { left_bit: 27, left_digit: 8, right_bit: 14, right_digit: 4 },
+        5: { left_bit: 24, left_digit: 7, right_bit: 17, right_digit: 5 },
+        6: { left_bit: 20, left_digit: 6, right_bit: 21, right_digit: 6 },
+    },
+    'itip': {
+        0: { left_bit: 40, left_digit: 12, right_bit: 4, right_digit: 1 },
+        1: { left_bit: 37, left_digit: 11, right_bit: 7, right_digit: 2 },
+        2: { left_bit: 34, left_digit: 10, right_bit: 10, right_digit: 3 },
+        3: { left_bit: 30, left_digit: 9, right_bit: 14, right_digit: 4 },
+        4: { left_bit: 27, left_digit: 8, right_bit: 17, right_digit: 5 },
+        5: { left_bit: 24, left_digit: 7, right_bit: 20, right_digit: 6 },
+        6: { left_bit: 20, left_digit: 6, right_bit: 24, right_digit: 7 },
+    },
+};

--- a/addons/gs1_epc_nomenclature/static/src/epc_codec_service.js
+++ b/addons/gs1_epc_nomenclature/static/src/epc_codec_service.js
@@ -1,0 +1,260 @@
+import { registry } from "@web/core/registry";
+import { SCHEME_TEMPLATE, FIELD_TEMPLATE, PARTITION} from "./epc_codec_model";
+
+// Private
+const DECODING_FUNCTIONS = {
+    'blank': decodeBlank,
+    'integer': decodeInteger,
+    'partition_table': decodePartition,
+    'string': decodeString,
+};
+
+const AI_FUNCTIONS = {
+    '00' : getAi00,
+    '01' : getAi01,
+}
+
+//  Technical Utilities
+function getBitLength(num) {
+    if (num === 0n) return 1;  // Special case for 0
+    let bitLength = 0;
+    while (num > 0n) {
+        num >>= 1n;
+        bitLength++;
+    }
+    return bitLength;
+}
+
+function readBits(value, index, length, bitLength = null) {
+    if (index < 0 || length < 0) {
+        throw new Error("Index and length must be non-negative");
+    }
+    if(bitLength === null){
+        bitLength = getBitLength(value);
+    }
+    const indexEnd = index + length;
+    if (indexEnd > bitLength) {
+        throw new Error("Index range exceeds bit length of the value");
+    }
+    let read = value >> BigInt(bitLength - indexEnd); // Remove the rightmost unwanted part
+    const mask = (1n << BigInt(length)) - 1n; // And Mask to extract the wanted part
+    read &= mask;
+    return read;
+}
+
+// EPC encoding must have a multiple of 16 bits.
+// c.f. [TDS  2.1], §15.1.1
+function missingBits(bitLength, standardSize = 16) {
+    const remainder = bitLength % standardSize;
+    return remainder === 0 ? 0 : (standardSize - remainder);
+}
+
+// Decode Methods
+function decodeField(encoding, model, fieldName) {
+    const decodeFunction = DECODING_FUNCTIONS[encoding];
+    if (decodeFunction) {
+        return decodeFunction(model, fieldName);
+    } else {
+        throw new Error(`No decode function found for encoding: ${encoding}`);
+    }
+}
+
+function decodeBlank(model, fieldName){
+    return null;
+}
+
+function decodeInteger(model, fieldName){
+    const field = model.fields[fieldName];
+    const value = readBits(model.hexValue, field.offset, field.bitSize, model.bitLength);
+    res = value.toString();
+    //Improve later
+    if(field.digits){
+        res = res.padStart(field.digits, '0');
+    }
+    return res;
+}
+
+
+function decodePartition(model, fieldName){
+    const field = model.fields[fieldName];
+    const partition = PARTITION[model.partition];
+    if(partition === undefined){
+        throw new Error(`No partition found for value: ${model.partition}`);
+    }
+    const value = readBits(model.hexValue, field.offset, field.bitSize, model.bitLength);
+    const fieldEntries = Object.entries(model.fields);
+    const fieldIndex = fieldEntries.findIndex(([name]) => name === fieldName);
+    if (fieldIndex === -1 || fieldIndex + 2 >= fieldEntries.length) {
+        throw new Error(`Field ${fieldName} or subsequent fields are not defined.`);
+    }
+    // Update the bitSize of the next two fields based on partition information
+    const [nextFieldName1] = fieldEntries[fieldIndex + 1];
+    const [nextFieldName2] = fieldEntries[fieldIndex + 2];
+    model.fields[nextFieldName1].bitSize = partition[value].left_bit;
+    model.fields[nextFieldName1].digits = partition[value].left_digit;
+    model.fields[nextFieldName2].bitSize = partition[value].right_bit;
+    model.fields[nextFieldName2].digits = partition[value].right_digit;
+
+    return null;
+}
+
+function decodeString(model, fieldName){
+    const field =  model.fields[fieldName];
+    const value = readBits(model.hexValue, field.offset, field.bitSize, model.bitLength);
+    const charLength = field.bitSize / 7;
+    let charCodes = [];
+    // loop read 7 bits at a time
+    for (let i = 0; i < charLength; i++) {
+        charCodes[i] = readBits(value, i * 7, 7, field.bitSize);
+    }
+    // parse to string & decode/unescape to UTF
+    return decodeURIComponent(String.fromCharCode(...charCodes));
+}
+
+// 'Business' Utilities
+function toPureUri(model){
+    const fieldEntries = Object.entries(model.fields);
+    const [uriHeader, uriBody] = getSplitUri(model.template.uri_pure_tag);
+    for (let i = 0; i < fieldEntries.length; i++) {
+        index = uriBody.indexOf(fieldEntries[i][1].uriPortion);
+        if(index !== -1){
+            uriBody[index] = fieldEntries[i][1].value;
+        }
+    }
+    return uriHeader + ':' + uriBody.join('.');
+}
+
+function getSplitUri(uri) {
+    const uriHeader = uri.split(':');
+    const uriBody = uriHeader.pop();
+    return [uriHeader.join(':'), uriBody.split('.')];
+}
+
+function toElementString(model){
+    const aiDict = model.template.ai_list
+    const identifiers = Object.entries(aiDict);
+
+    for(identifier in identifiers){
+        if(aiDict[identifier] === null){
+            elementString += getAi(identifier, model);
+        } else {
+            elementString += ` (${identifier}) ${model.fields[aiDict[identifier]].value}`
+        }
+    }
+    return elementString.trimStart();  // to capture: (?:\((?<key>\d{2,4})\)\s*(?<value>[^\(\)]+)?)\s*
+}
+
+function getAi(identifier, model){
+    const aiFunction = AI_FUNCTIONS[identifier];
+    if (aiFunction) {
+        return aiFunction(model);
+    } else {
+        throw new Error(`No extrapolation function found for the GS1 Application Identifier (${identifier})`);
+    }
+}
+
+function getAi00(model){
+    const companyPrefix = model.fields['company_prefix'];
+    const serialInteger = model.fields['serial_integer'];
+
+    const extensionDigit = serialInteger.value.substr(0, 1);
+    const serialRefRemainder = serialInteger.value.substr(1);
+    const ssccToCheck = extensionDigit + companyPrefix.value + serialRefRemainder;
+    const checkdigit = getGs1Checksum(ssccToCheck);
+    return ' (00) ' + ssccToCheck + checkdigit;
+}
+
+function getAi01(model){
+    // input length : sum of companyPrefix.digits and itemReference.digits is always 13 digits (preserving leading zeroes)
+    // output: 14 digits
+    const companyPrefix = model.fields['company_prefix'];
+    const itemReference = model.fields['item_reference'];
+
+    const indicator = itemReference.value.substr(0, 1);
+    const itemRefRemainder = itemReference.value.substr(1);
+    const gtinToCheck = indicator + companyPrefix.value + itemRefRemainder;
+    const checkdigit = getGs1Checksum(gtinToCheck);
+    return ' (01) ' + gtinToCheck + checkdigit;
+}
+
+function getGs1Checksum(data){
+    // The GS1 specification defines the check digit calculation as follows (cf. [TDS 2.1] §7.3):
+    // d14 = (10 - ((3(d1 + d3 + d5 + d7 + d9 + d11 + d13) + (d2 + d4 + d6 + d8 + d10 + d12)) mod 10) mod 10
+    // However, it should be noted that here the index starts at 0 and not 1.
+    // It is therefore necessary to multiply even numbers instead of odd numbers.
+
+    // Note : same method is used for multiple data structures up to 17 digits (excluding check digits).
+    // Cf. https://ref.gs1.org/standards/genspecs/ §7.9.1
+    // data = data.padStart(17, '0'); //Maybe not optimal, cheat on i value of incoming for loop instead
+    offset = 17 - data.length;
+    let sum = 0;
+    for(let i = 0; i < data.length; i++){
+        const value = parseInt(data.charAt(i))
+        if ((i + offset) % 2 == 0){
+            sum += value * 3;
+        }else{
+            sum += value;
+        }
+    }
+    return ((10 - (sum % 10)) % 10).toString();
+}
+
+//public
+export async function decode(hexString){
+    // Prepare values
+    const hexValue = BigInt('0x' + hexString);
+    const bitLength = getBitLength(hexValue);
+    const headerRealBitCount = 8 - missingBits(bitLength, 8); // compensate for leftmost missing 0
+    const header = readBits(hexValue, 0, headerRealBitCount, bitLength);
+
+    //Find template
+    const template = SCHEME_TEMPLATE[header];
+    if(template == null || template.name !== 'SGTIN-96'){ // FIXME: Only support SGTIN-96 actually
+        return null;
+    }
+
+    // Create & initialize base scheme structure
+    let model = {
+        'hexValue': hexValue,
+        'bitLength': bitLength,
+        'partition': template.partition,
+        'fields': {},
+        'template': template,
+    }
+    for (let i = 0; i < template.fields_template.length; i++) {
+        const fieldName = template.fields_template[i];
+        const FieldTemplate = FIELD_TEMPLATE[fieldName];
+        const fieldBitCount = template.fields_bit_count[i];
+
+        model.fields[fieldName] = {
+            'encoding': FieldTemplate.encoding,
+            'bitSize': i === 0 ? headerRealBitCount : fieldBitCount,
+            'uriPortion': FieldTemplate.uri_portion,
+            'offset': i === 0 ? 0 : null,
+            'value': i === 0 ? header.toString() : null,
+        };
+    }
+
+    // Effectively process fields
+    const fieldEntries = Object.entries(model.fields);
+    for (let i = 1; i < fieldEntries.length; i++) {
+        let [fieldName, fieldInfo] = fieldEntries[i];
+        previousField = fieldEntries[i - 1][1];
+        fieldInfo.offset = previousField.offset + previousField.bitSize;
+        fieldInfo.value = decodeField(fieldInfo.encoding, model, fieldName);
+    }
+
+
+    // return GS1 AI(s) as String
+    if(template.element_string_template != null){
+        return toElementString(model);
+    }
+    return toPureUri(model); // for GID-96, USDOD-96 and ADI-var. Cf. [TDT 2.0] Figure 1-1
+}
+
+export const EPCCodecService = {
+    start() {
+        return {decode}
+    },
+};
+registry.category("services").add("epc_codec", EPCCodecService);


### PR DESCRIPTION
# Current State Overview
<details><summary>$${\color{red}Deferred}$$ Backend/Python</summary>
<p>
Deferred: decoding doesn't make sense in the backend, and manufacturing isn't ready for EPC write automation, such that encoding isn't a priority.

Encode & Decode :

- sgtin-96
- sgtin-198
- sscc-96
- sgln-96
- sgln-195

TODO :
- Replace compute by explicit calls : more efficient and less complicated
- Implement logical segment bit count at scheme template level

Simple test :
```
# model: Electronic Product Code Scheme, gs1.epc.scheme

vals = [
    #SGTIN
    {'uri_tag': "urn:epc:tag:sgtin-96:3.0614141.812345.6789"},
    {'raw_value': 0X3074257bf7194e4000001a85},
    {'uri_tag': "urn:epc:tag:sgtin-198:3.0614141.812345.6789"},
    {'raw_value': 0X3674257bf7194e5b3770e4000000000000000000000000000000},    
    {'uri_tag': "urn:epc:tag:sgtin-198:3.0614141.712345.32a%2Fb"},
    {'raw_value': 0X3674257bf6b7a659b2c2bf100000000000000000000000000000},
    #Others
    {'uri_tag': "urn:epc:tag:sscc-96:3.0614141.1234567890"},
    {'raw_value': 0X3174257bf4499602d2000000},
    {'uri_tag': "urn:epc:tag:sgln-96:3.0614141.12345.5678"},
    {'raw_value': 0X3274257bf46072000000162e},
    {'uri_tag': "urn:epc:tag:sgln-195:3.0614141.12345.32a%2Fb"},
    {'raw_value': 0X3974257bf46072cd9615f8800000000000000000000000000000},
]

schemes = model.create(vals)
message = []
for scheme in schemes:
    message.append(f"Uri : {scheme.uri_tag}\nHex : {scheme.hex_value}\n") # Bit : {scheme.raw_value:b}\n
log('\n'.join(message))
```

Result :
```
Uri : urn:epc:tag:sgtin-96:3.0614141.812345.6789
Hex : 3074257bf7194e4000001a85

Uri : urn:epc:tag:sgtin-96:3.0614141.812345.6789
Hex : 3074257bf7194e4000001a85

Uri : urn:epc:tag:sgtin-198:3.0614141.812345.6789
Hex : 3674257bf7194e5b3770e4000000000000000000000000000000

Uri : urn:epc:tag:sgtin-198:3.0614141.812345.6789
Hex : 3674257bf7194e5b3770e4000000000000000000000000000000

Uri : urn:epc:tag:sgtin-198:3.0614141.712345.32a%2Fb
Hex : 3674257bf6b7a659b2c2bf100000000000000000000000000000

Uri : urn:epc:tag:sgtin-198:3.0614141.712345.32a%2Fb
Hex : 3674257bf6b7a659b2c2bf100000000000000000000000000000

Uri : urn:epc:tag:sscc-96:3.0614141.1234567890
Hex : 3174257bf4499602d2000000

Uri : urn:epc:tag:sscc-96:3.0614141.1234567890
Hex : 3174257bf4499602d2000000

Uri : urn:epc:tag:sgln-96:3.0614141.12345.5678
Hex : 3274257bf46072000000162e

Uri : urn:epc:tag:sgln-96:3.0614141.12345.5678
Hex : 3274257bf46072000000162e

Uri : urn:epc:tag:sgln-195:3.0614141.12345.32a%2Fb
Hex : 3974257bf46072cd9615f8800000000000000000000000000000

Uri : urn:epc:tag:sgln-195:3.0614141.12345.32a%2Fb
Hex : 3974257bf46072cd9615f8800000000000000000000000000000
```
</p>
</details> 

<details><summary>$${\color{orange}In \space Progress}$$ Frontend/Javascript</summary>
<p>
Decode Only :

- sgtin-96
</p>
</details>

To compare and test :
- https://www.gs1.org/services/epc-encoderdecoder
- TDS 2.1, part E.3 (https://ref.gs1.org/standards/tds/2.1.0/, p.242)

[Task #4256189](https://www.odoo.com/odoo/project.task/4256189)

