### PR TITLE
[PERF] hr_skills{,_slides}: speed up _recompute_completion

### DIFF
--- a/addons/hr_skills/models/hr_resume_line.py
+++ b/addons/hr_skills/models/hr_resume_line.py
@@ -9,7 +9,7 @@ class ResumeLine(models.Model):
     _description = "Resume line of an employee"
     _order = "line_type_id, date_end desc, date_start desc"
 
-    employee_id = fields.Many2one('hr.employee', required=True, ondelete='cascade')
+    employee_id = fields.Many2one('hr.employee', required=True, ondelete='cascade', index=True)
     name = fields.Char(required=True, translate=True)
     date_start = fields.Date(required=True)
     date_end = fields.Date()

--- a/addons/hr_skills_slides/models/hr_resume_line.py
+++ b/addons/hr_skills_slides/models/hr_resume_line.py
@@ -8,7 +8,7 @@ class ResumeLine(models.Model):
     _inherit = 'hr.resume.line'
 
     display_type = fields.Selection(selection_add=[('course', 'Course')])
-    channel_id = fields.Many2one('slide.channel', string="Course", readonly=True)
+    channel_id = fields.Many2one('slide.channel', string="Course", readonly=True, index='btree_not_null')
     course_url = fields.Char(compute="_compute_course_url", default=False)
 
     @api.depends('channel_id')


### PR DESCRIPTION
## Description
It's really slow to archive a published course with many participants

## Analysis
In `_recompute_completion`, we are recomputing the set of resume lines to check against to see if we should add a new resume line upon completion of a course for *each* employee associated with the course. Also the creation of resume lines is not batched.
There is also *no* indexes of any sort on the `hr.resume.line` model.

## Solution
- Refactor to remove the `search` inside the `for`
- Batch the create
- Add missing indexes

## Benchmark
Archiving a published course with ~30k participants, with a over 100k resume lines in the database.

| No indexes | Before | After | Speed up |
|------------|--------|-------|----------|
| Timings    | 1m39s  | 17s   | 5.8x     |

| With indexes | Before | After | Speed up |
|--------------|--------|-------|----------|
| Timings      | 1m39s  | 4.14s | 23.9x    |

## Reference
task-4043098

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
