### PR TITLE
[FIX] l10n_es_edi_facturae: fix test_import_multiple_invoices

### DIFF
--- a/addons/l10n_es_edi_facturae/tests/data/import_multiple_invoices.xml
+++ b/addons/l10n_es_edi_facturae/tests/data/import_multiple_invoices.xml
@@ -44,21 +44,21 @@
       <TaxIdentification>
         <PersonTypeCode>J</PersonTypeCode>
         <ResidenceTypeCode>E</ResidenceTypeCode>
-        <TaxIdentificationNumber>US12345677</TaxIdentificationNumber>
+        <TaxIdentificationNumber>US77654321</TaxIdentificationNumber>
       </TaxIdentification>
       <LegalEntity>
-        <CorporateName>Azure Interior</CorporateName>
-        <TradeName>Azure Interior</TradeName>
+        <CorporateName>Indigo Exterior</CorporateName>
+        <TradeName>Indigo Exterior</TradeName>
         <OverseasAddress>
-          <Address>4557 De Silva St</Address>
+          <Address>4558 De Silva St</Address>
           <PostCodeAndTown>94538 Fremont</PostCodeAndTown>
           <Province>California</Province>
           <CountryCode>USA</CountryCode>
         </OverseasAddress>
         <ContactDetails>
-          <Telephone>8709310505</Telephone>
-          <WebAddress>http://www.azure-interior.com</WebAddress>
-          <ElectronicMail>azure.Interior24@example.com</ElectronicMail>
+          <Telephone>8709310506</Telephone>
+          <WebAddress>http://www.indigo-exterior.com</WebAddress>
+          <ElectronicMail>indigo.exterior@example.com</ElectronicMail>
         </ContactDetails>
       </LegalEntity>
     </BuyerParty>

--- a/addons/l10n_es_edi_facturae/tests/data/import_withholding_invoice.xml
+++ b/addons/l10n_es_edi_facturae/tests/data/import_withholding_invoice.xml
@@ -44,21 +44,21 @@
       <TaxIdentification>
         <PersonTypeCode>J</PersonTypeCode>
         <ResidenceTypeCode>E</ResidenceTypeCode>
-        <TaxIdentificationNumber>US12345677</TaxIdentificationNumber>
+        <TaxIdentificationNumber>US77654321</TaxIdentificationNumber>
       </TaxIdentification>
       <LegalEntity>
-        <CorporateName>Azure Interior</CorporateName>
-        <TradeName>Azure Interior</TradeName>
+        <CorporateName>Indigo Exterior</CorporateName>
+        <TradeName>Indigo Exterior</TradeName>
         <OverseasAddress>
-          <Address>4557 De Silva St</Address>
+          <Address>4558 De Silva St</Address>
           <PostCodeAndTown>94538 Fremont</PostCodeAndTown>
           <Province>California</Province>
           <CountryCode>USA</CountryCode>
         </OverseasAddress>
         <ContactDetails>
-          <Telephone>8709310505</Telephone>
-          <WebAddress>http://www.azure-interior.com</WebAddress>
-          <ElectronicMail>azure.Interior24@example.com</ElectronicMail>
+          <Telephone>8709310506</Telephone>
+          <WebAddress>http://www.indigo-exterior.com</WebAddress>
+          <ElectronicMail>indigo.exterior@example.com</ElectronicMail>
         </ContactDetails>
       </LegalEntity>
     </BuyerParty>

--- a/addons/l10n_es_edi_facturae/tests/test_edi_xml.py
+++ b/addons/l10n_es_edi_facturae/tests/test_edi_xml.py
@@ -57,6 +57,17 @@ class TestEdiFacturaeXmls(AccountTestInvoicingCommon):
             'zip': "5000",
         })
 
+        cls.partner_us = cls.env['res.partner'].create({
+            'name': 'Indigo Exterior',
+            'city': 'Fremont',
+            'zip': '94538',
+            'country_id': cls.env.ref('base.us').id,
+            'state_id': cls.env['res.country.state'].search([('name', '=', 'California')]).id,
+            'email': 'indigo-exterior@example.com',
+            'company_type': 'company',
+            'is_company': True,
+        })
+
         cls.password = "test"
 
         cls.certificate_module = "odoo.addons.l10n_es_edi_facturae.models.l10n_es_edi_facturae_certificate"
@@ -274,15 +285,11 @@ class TestEdiFacturaeXmls(AccountTestInvoicingCommon):
 
         moves += self.env['account.move'].search([('ref', '=', 'INV/2023/00006'), ('company_id', '=', self.company_data['company'].id)], limit=1)
 
-        partner = self.env['res.partner'].search([
-            ('name', '=', 'Azure Interior'),
-            ('email', '=', 'azure.Interior24@example.com'),
-        ])
         currency = self.env['res.currency'].search([('name', '=', 'EUR')])
 
         self.assertRecordValues(moves, [
             {
-                'partner_id': partner.id,
+                'partner_id': self.partner_us.id,
                 'amount_total': 2186.20,
                 'amount_untaxed': 2119.0,
                 'amount_tax': 67.2,
@@ -294,7 +301,7 @@ class TestEdiFacturaeXmls(AccountTestInvoicingCommon):
                 'narration': '<p>Terms and conditions.</p>',
             },
             {
-                'partner_id': partner.id,
+                'partner_id': self.partner_us.id,
                 'amount_total': 1161.60,
                 'amount_untaxed': 960.0,
                 'amount_tax': 201.60,


### PR DESCRIPTION
__Current behavior before commit:__
If `crm` is installed `test_import_multiple_invoices` will fail because the crm demo data are changing the email of the partner `base.res_partner_12` (i.e. Azure Interior)(see [crm_lead_demo.xml][1]). `partner` will therefore be `False`.

__Description of the fix:__
Getting `partner` from the `base.res_partner_12` external id so this test does not depend on modifications from other modules.

__Steps to reproduce the issue:__
Run:
```sh
./odoo/odoo-bin -d test-17 -i crm,l10n_es --test-tags .test_import_multiple_invoices --addons-path=./enterprise,./odoo/addons
```
You will get:
```log
odoo.addons.l10n_es_edi_facturae.tests.test_edi_xml: FAIL: TestEdiFacturaeXmls.test_import_multiple_invoices
Traceback (most recent call last):
  File "/home/odoo/src/odoo/addons/l10n_es_edi_facturae/tests/test_edi_xml.py", line 283, in test_import_multiple_invoices
    self.assertRecordValues(moves, [
  File "/home/odoo/src/odoo/odoo/tests/common.py", line 659, in assertRecordValues
    self.fail('\n'.join(errors))
AssertionError: The records and expected_values do not match.

==== Differences at index 0 ====
---

+++

@@ -1 +1 @@

-partner_id:14
+partner_id:False

==== Differences at index 1 ====
---

+++

@@ -1 +1 @@

-partner_id:14
+partner_id:False
```

opw-4009379

[1]: https://github.com/odoo/odoo/blob/1c8e2555366fe6e6b0d74d6db71a29d09bd5f06a/addons/crm/data/crm_lead_demo.xml#L606
