### PR TITLE
[FIX] mail: special mentions only on channels

### DIFF
--- a/addons/im_livechat/static/tests/embed/livechat_service.test.js
+++ b/addons/im_livechat/static/tests/embed/livechat_service.test.js
@@ -134,7 +134,6 @@ test("Only necessary requests are made when creating a new chat", async () => {
             partner_additional_values: {},
             thread_id: threadId,
             thread_model: "discuss.channel",
-            special_mentions: [],
         })}`,
         `/mail/data - ${JSON.stringify({
             channels_as_member: true, // called because mail/core/web is loaded in test bundle

--- a/addons/mail/controllers/thread.py
+++ b/addons/mail/controllers/thread.py
@@ -75,12 +75,9 @@ class ThreadController(http.Controller):
             key=lambda it: (it["parent_model"] or "", it["res_model"] or "", it["internal"], it["sequence"]),
         )
 
-    def _get_allowed_message_post_params(self):
-        return {"attachment_ids", "body", "message_type", "partner_ids", "subtype_xmlid", "parent_id"}
-
     @http.route("/mail/message/post", methods=["POST"], type="json", auth="public")
     @add_guest_to_context
-    def mail_message_post(self, thread_model, thread_id, post_data, context=None, special_mentions=[], **kwargs):
+    def mail_message_post(self, thread_model, thread_id, post_data, context=None, **kwargs):
         guest = request.env["mail.guest"]._get_guest_from_context()
         guest.env["ir.attachment"].browse(post_data.get("attachment_ids", []))._check_attachments_access(
             kwargs.get("attachment_tokens")
@@ -113,13 +110,11 @@ class ThreadController(http.Controller):
                 kwargs["partner_emails"], kwargs.get("partner_additional_values", {})
             )]
         post_data["partner_ids"] = list(set((post_data.get("partner_ids", [])) + new_partners))
-        if "everyone" in special_mentions:
-            post_data["partner_ids"] = [channel_member.partner_id.id for channel_member in thread.channel_member_ids if channel_member.partner_id]
         message = thread.message_post(
             **{
                 key: value
                 for key, value in post_data.items()
-                if key in self._get_allowed_message_post_params()
+                if key in thread._get_allowed_message_post_params()
             }
         )
         return Store(message, for_current_user=True).get_result()

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -2063,6 +2063,9 @@ class MailThread(models.AbstractModel):
     # MESSAGE POST MAIN
     # ------------------------------------------------------------
 
+    def _get_allowed_message_post_params(self):
+        return {"attachment_ids", "body", "message_type", "partner_ids", "subtype_xmlid", "parent_id"}
+
     @api.returns('mail.message', lambda value: value.id)
     def message_post(self, *,
                      body='', subject=None, message_type='notification',

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -408,24 +408,27 @@ export class Store extends BaseStore {
                 });
             partner_ids.push(...recipientIds);
         }
+        const postData = {
+            body: await prettifyMessageContent(body, validMentions),
+            attachment_ids: attachments.map(({ id }) => id),
+            message_type: "comment",
+            partner_ids,
+            subtype_xmlid: subtype,
+        };
+        if (thread.model === "discuss.channel" && validMentions?.specialMentions) {
+            postData.special_mentions = validMentions.specialMentions;
+        }
         return {
             context: {
                 mail_post_autofollow: !isNote && thread.hasWriteAccess,
             },
-            post_data: {
-                body: await prettifyMessageContent(body, validMentions),
-                attachment_ids: attachments.map(({ id }) => id),
-                message_type: "comment",
-                partner_ids,
-                subtype_xmlid: subtype,
-            },
+            post_data: postData,
             attachment_tokens: attachments.map((attachment) => attachment.accessToken),
             canned_response_ids: cannedResponseIds,
             partner_emails: recipientEmails,
             partner_additional_values: recipientAdditionalValues,
             thread_id: thread.id,
             thread_model: thread.model,
-            special_mentions: validMentions?.specialMentions ?? [],
         };
     }
 

--- a/addons/mail/static/tests/chatter/web/chatter.test.js
+++ b/addons/mail/static/tests/chatter/web/chatter.test.js
@@ -76,7 +76,6 @@ test("can post a message on a record thread", async () => {
             attachment_tokens: [],
             partner_additional_values: {},
             partner_emails: [],
-            special_mentions: [],
             thread_id: partnerId,
             thread_model: "res.partner",
         };
@@ -109,7 +108,6 @@ test("can post a note on a record thread", async () => {
                 partner_ids: [],
                 subtype_xmlid: "mail.mt_note",
             },
-            special_mentions: [],
             attachment_tokens: [],
             canned_response_ids: [],
             partner_additional_values: {},

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -598,16 +598,20 @@ export async function mail_message_post(request) {
         }
     }
     const finalData = {};
-    for (const allowedField of [
+    const allowedParams = [
         "attachment_ids",
         "body",
         "message_type",
         "partner_ids",
         "subtype_xmlid",
         "parent_id",
-    ]) {
-        if (post_data[allowedField] !== undefined) {
-            finalData[allowedField] = post_data[allowedField];
+    ];
+    if (thread_model === "discuss.channel") {
+        allowedParams.push("special_mentions");
+    }
+    for (const allowedParam of allowedParams) {
+        if (post_data[allowedParam] !== undefined) {
+            finalData[allowedParam] = post_data[allowedParam];
         }
     }
     const kwargs = makeKwArgs({ ...finalData, context });

--- a/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
+++ b/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
@@ -767,6 +767,12 @@ export class DiscussChannel extends models.ServerModel {
         this.write([id], {
             last_interest_dt: serializeDateTime(today()),
         });
+        if (kwargs.special_mentions?.includes("everyone")) {
+            kwargs["partner_ids"] = DiscussChannelMember._filter([
+                ["channel_id", "=", channel.id],
+            ]).map((member) => member.partner_id);
+        }
+        delete kwargs.special_mentions;
         const messageId = MailThread.message_post.call(this, [id], kwargs);
         // simulate compute of message_unread_counter
         const memberOfCurrentUser = this._find_or_create_member_for_self(channel.id);

--- a/addons/mail/static/tests/suggestion/suggestion.test.js
+++ b/addons/mail/static/tests/suggestion/suggestion.test.js
@@ -329,4 +329,6 @@ test("Mention with @everyone", async () => {
     await insertText(".o-mail-Composer-input", "@ever");
     await click(".o-mail-Composer-suggestion");
     await contains(".o-mail-Composer-input", { value: "@everyone " });
+    await click(".o-mail-Composer-send:enabled");
+    await contains(".o-mail-Message-bubble.bg-warning-light");
 });


### PR DESCRIPTION
Steps to reproduce:
- Go to a chatter
- Type `@everyone` in the composer
- Send the message 
There is an RPC_ERROR: object has no attribute 'channel_member_ids'

Since `@everyone` is specific to the channels, this commit makes sure the `special_mentions` param is only available in message_post params in channels.

