### PR TITLE
[FIX] l10n_cl: fix discount_amount computation

### DIFF
--- a/addons/l10n_cl/models/account_move_line.py
+++ b/addons/l10n_cl/models/account_move_line.py
@@ -86,7 +86,12 @@ class AccountMoveLine(models.Model):
         else:
             price_item_document = price_line_document = 0.0
             price_unit = self.price_unit
-        discount_amount = (price_subtotal / (1 - self.discount / 100)) * self.discount / 100
+
+        if self.discount == 100:
+            price_before_discount = price_unit * self.quantity
+        else:
+            price_before_discount = price_subtotal / (1 - self.discount / 100)
+        discount_amount = price_before_discount * self.discount / 100
         values = {
             'decimal_places': main_currency.decimal_places,
             'price_item': round(price_unit, 6),


### PR DESCRIPTION
We compute the discount amount by calculating the amount before the discount first, and then computing the discount amount from there. If the discount is 100%, we get division by 0 error.

If the discount is 100%, we should compute the amount before the discount using price_unit and quantity.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
