### PR TITLE
[FIX] point_of_sale: ensure category restriction in product search

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_list/product_list.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_list/product_list.js
@@ -146,23 +146,27 @@ export class ProductsWidget extends Component {
         if (!searchProductWord) {
             return;
         }
+        const domain = [
+            "|",
+            "|",
+            ["name", "ilike", searchProductWord],
+            ["default_code", "ilike", searchProductWord],
+            ["barcode", "ilike", searchProductWord],
+            ["available_in_pos", "=", true],
+            ["sale_ok", "=", true],
+        ];
+
+        const { limit_categories, iface_available_categ_ids } = this.pos.config;
+        if (limit_categories && iface_available_categ_ids.length > 0) {
+            domain.push(["pos_categ_ids", "in", iface_available_categ_ids]);
+        }
 
         try {
             const limit = 30;
             const ProductIds = await this.orm.call(
                 "product.product",
                 "search",
-                [
-                    [
-                        "&",
-                        ["available_in_pos", "=", true],
-                        "|",
-                        "|",
-                        ["name", "ilike", searchProductWord],
-                        ["default_code", "ilike", searchProductWord],
-                        ["barcode", "ilike", searchProductWord],
-                    ],
-                ],
+                [domain],
                 {
                     offset: this.state.currentOffset,
                     limit: limit,


### PR DESCRIPTION
Prior to this commit, performing a search in the PoS and selecting "Search more" would load products not belonging to the restricted categories.

opw-4061359

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
