### PR TITLE
[FIX] mail: edit message creating null attachments

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -4523,7 +4523,7 @@ class MailThread(models.AbstractModel):
         attachments = message.attachment_ids.sorted("id")
         broadcast_store = Store(attachments)
         res = {
-            "attachments": {"id": attachment.id for attachment in attachments},
+            "attachments": [{"id": attachment.id} for attachment in attachments],
             "body": message.body,
             "id": message.id,
             "pinned_at": message.pinned_at,


### PR DESCRIPTION
When editing a message, even if there are no attachments, the post will create a null attachment.

This is because the attachments from _message_update_content is an empty object rather than a list so that it is parsed as a record.

![image](https://github.com/user-attachments/assets/a6b595e5-8e05-4619-85e2-cce88e0d70a9)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
