### PR TITLE
[FIX] account: nested group of tax creation

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -8470,6 +8470,12 @@ msgid "Negative value of amount field if payment_type is outbound"
 msgstr ""
 
 #. module: account
+#: code:addons/account/models/account_tax.py:0
+#, python-format
+msgid "Nested group of taxes are not allowed."
+msgstr ""
+
+#. module: account
 #: model:ir.model.fields.selection,name:account.selection__account_bank_statement__state__open
 #: model_terms:ir.ui.view,arch_db:account.view_bank_statement_search
 msgid "New"

--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -205,6 +205,11 @@ class AccountTax(models.Model):
                 for child in tax.children_tax_ids
             ):
                 raise ValidationError(_('The application scope of taxes in a group must be either the same as the group or left empty.'))
+            if any(
+                child.amount_type == 'group'
+                for child in tax.children_tax_ids
+            ):
+                raise ValidationError(_('Nested group of taxes are not allowed.'))
 
     @api.constrains('company_id')
     def _check_company_consistency(self):

--- a/addons/account/tests/test_tax.py
+++ b/addons/account/tests/test_tax.py
@@ -86,16 +86,6 @@ class TestTaxCommon(AccountTestInvoicingCommon):
                 (4, cls.percent_tax_bis.id, 0)
             ]
         })
-        cls.group_of_group_tax = cls.env['account.tax'].create({
-            'name': "Group of group tax",
-            'amount_type': 'group',
-            'amount': 0,
-            'sequence': 7,
-            'children_tax_ids': [
-                (4, cls.group_tax.id, 0),
-                (4, cls.group_tax_bis.id, 0)
-            ]
-        })
         cls.tax_with_no_account = cls.env['account.tax'].create({
             'name': "Tax with no account",
             'amount_type': 'fixed',
@@ -193,24 +183,6 @@ class TestTax(TestTaxCommon):
     @classmethod
     def setUpClass(cls):
         super(TestTax, cls).setUpClass()
-
-    def test_tax_group_of_group_tax(self):
-        self.fixed_tax.include_base_amount = True
-        res = self.group_of_group_tax.compute_all(200.0)
-        self._check_compute_all_results(
-            263,    # 'total_included'
-            200,    # 'total_excluded'
-            [
-                # base , amount     | seq | amount | incl | incl_base
-                # ---------------------------------------------------
-                (200.0, 10.0),    # |  1  |    10  |      |     t
-                (210.0, 21.0),    # |  3  |    10% |      |
-                (210.0, 10.0),    # |  1  |    10  |      |     t
-                (220.0, 22.0),    # |  3  |    10% |      |
-                # ---------------------------------------------------
-            ],
-            res
-        )
 
     def test_tax_group(self):
         res = self.group_tax.compute_all(200.0)


### PR DESCRIPTION
1) Start creating a tax
2) Set the 'Tax Computation' to 'Group of taxes'
3) In 'Definition' tab, select 'Add a line', choose to create a new tax
4) Jumpt to 2

Issue: Nested group of taxes are not allowed
When adding the child tax users cannot choose group of taxes, but we
can't block creation of just a specific type of taxes so we need to
check the type afterward

opw-4060955