### PR TITLE
[IMP] stock: Remove default responsible on product

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -656,7 +656,7 @@ class ProductTemplate(models.Model):
         'Track Inventory', store=True, compute='compute_is_storable', readonly=False,
         default=False, precompute=True)
     responsible_id = fields.Many2one(
-        'res.users', string='Responsible', default=lambda self: self.env.uid, company_dependent=True, check_company=True,
+        'res.users', string='Responsible', company_dependent=True, check_company=True,
         help="This user will be responsible of the next activities related to logistic operations for this product.")
     property_stock_production = fields.Many2one(
         'stock.location', "Production Location",


### PR DESCRIPTION
Using a default user on a property will create a lot of property record. It should be done with a simple default property on the field and the company.

However, this field has been created in order to handle configuration mistakes during orderpoint acitivity. But we allow more and more exception. So we decide to remove the default and let the user, only uses it when he needs it.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
