### PR TITLE
[FIX] uom: allow deletion of uom category

### DIFF
--- a/addons/uom/models/uom_uom.py
+++ b/addons/uom/models/uom_uom.py
@@ -24,7 +24,7 @@ class UoMCategory(models.Model):
             self.uom_ids[0].factor = 1
         else:
             reference_count = sum(uom.uom_type == 'reference' for uom in self.uom_ids)
-            if reference_count == 0 and self._origin.id:
+            if reference_count == 0 and self._origin.id and len(self.uom_ids) > 1:
                 return {
                     'warning': {
                         'title': _('Warning!'),


### PR DESCRIPTION
 before this commit, if user created a new uom category
 and added a uom to this category, then user will not be
 able to delete the created uom and category

steps to reproduce:

* create a uom category
* add a uom to this category
* now try to delete the category, will raise ondelete restrict warning, 
as uom exists in this category
* now if you try to delete the UOM, it wont allow to delete, 
a warning will be raised "should have a reference unit of measure"

after this commit, warning "should have a reference unit of measure" 
will be raised only when there is more than one uom exists in the category. 
this will allow user to delete the uom and then the category


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
