### PR TITLE
[FIX] web: tests - expose GC

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1130,8 +1130,14 @@ class ChromeBrowser:
             '--user-data-dir': user_data_dir,
             '--window-size': window_size,
             '--no-first-run': '',
-            # '--enable-precise-memory-info': '', # uncomment to debug memory leaks in qunit suite
-            # '--js-flags': '--expose-gc', # uncomment to debug memory leaks in qunit suite
+            # '--enable-precise-memory-info': '',  # uncomment to debug memory leaks in unit tests
+            # FIXME: these next flag is temporarily uncommented to allow client
+            # code to manually run garbage collection. This is done as currently
+            # the Chrome unit test process doesn't have access to its available
+            # memory, so it cannot run the GC efficiently and may run out of memory
+            # and crash. These should be re-commented when the process is correctly
+            # configured.
+            '--js-flags': '--expose-gc',  # uncomment to debug memory leaks in unit tests
         }
         if headless:
             switches.update(headless_switches)


### PR DESCRIPTION
This PR exposes the garbage collection to the client code in unit
tests.

This has been done as currently the Chrome process running unit tests
doesn't have access to its available memory, and because of that it
cannot run the garbage collection efficiently and sometimes runs out of
memory and crashes.

As a temporary fix, the tests will manually run the garbage collector
after each suite to ensure that these crashes do not happen.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
