### PR TITLE
[FIX] requirements: adapt for 3.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -69,8 +69,8 @@ qrcode==7.4.2 ; python_version >= '3.11'
 reportlab==3.6.8 ; python_version <= '3.10'
 reportlab==3.6.12 ; python_version > '3.10' and python_version < '3.12'
 reportlab==4.1.0 ; python_version >= '3.12' # (Noble) Mostly to have a wheel package
-requests==2.25.1 ;  python_version < '3.12' # versions < 2.25 aren't compatible w/ urllib3 1.26. Bullseye = 2.25.1. min version = 2.22.0 (Focal)
-requests==2.31.0 ; python_version >= '3.12' # (Noble) 
+requests==2.25.1 ;  python_version < '3.11' # versions < 2.25 aren't compatible w/ urllib3 1.26. Bullseye = 2.25.1. min version = 2.22.0 (Focal)
+requests==2.31.0 ; python_version >= '3.11' # (Noble)
 rjsmin==1.1.0 ; python_version < '3.11'  # (jammy)
 rjsmin==1.2.0 ; python_version >= '3.11'
 rl-renderPM==4.0.3 ; sys_platform == 'win32' and python_version >= '3.12'  # Needed by reportlab 4.1.0 but included in deb package


### PR DESCRIPTION
The adaptation for 3.12 broke some of the 3.11 packages compatibility

This commit should fix them.

See #173788 for more info

